### PR TITLE
fix(sentry): safely parse tracing sample rate fallback

### DIFF
--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -44,9 +44,14 @@ def init_sentry() -> None:
     from app.config import get_environment
     from app.version import get_version
 
+    try:
+        sample_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.2"))
+    except ValueError:
+        sample_rate = 0.2
+
     _init_sentry_once(
         dsn=dsn,
         environment=get_environment().value,
         release=f"opensre@{get_version()}",
-        traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.2")),
+        traces_sample_rate=sample_rate,
     )

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -33,3 +33,17 @@ def test_init_sentry_is_idempotent_for_same_config(monkeypatch) -> None:
     assert init_mock.call_args.kwargs["dsn"] == "https://example@sentry.invalid/1"
     assert init_mock.call_args.kwargs["environment"] == "production"
     assert init_mock.call_args.kwargs["traces_sample_rate"] == 0.5
+
+
+def test_init_sentry_invalid_traces_sample_rate_fallback(monkeypatch) -> None:
+    sentry_mod._init_sentry_once.cache_clear()
+    monkeypatch.setenv("SENTRY_DSN", "https://example@sentry.invalid/1")
+    monkeypatch.setenv("SENTRY_TRACES_SAMPLE_RATE", "invalid_value")
+    monkeypatch.setenv("ENV", "production")
+    init_mock = MagicMock()
+    monkeypatch.setitem(sys.modules, "sentry_sdk", SimpleNamespace(init=init_mock))
+
+    sentry_mod.init_sentry()
+
+    init_mock.assert_called_once()
+    assert init_mock.call_args.kwargs["traces_sample_rate"] == 0.2


### PR DESCRIPTION
Fixes 

#729 

### Changes in the PR 
Fixed ValueError during initialization: Wrapped the SENTRY_TRACES_SAMPLE_RATE environment variable parsing in a try...except ValueError block inside app/utils/sentry_sdk.py.
Graceful Fallback: If an invalid string (e.g. invalid_value or 100%) is passed in the environment variable, the initialization no longer crashes the app at startup and gracefully defaults to 0.2.
Added Unit Test Coverage: Included test_init_sentry_invalid_traces_sample_rate_fallback inside tests/test_sentry_init.py which mocks a corrupt .env variable and asserts that the 0.2 fallback behaves properly.


### Screenshots of the UI changes -
N/A - Backend / configuration change only.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

## What problem does my code solve?
Before this PR, deploying the application with an invalid, non-float string in the ```SENTRY_TRACES_SAMPLE_RATE``` environment variable would crash the application unconditionally on startup because ```float("invalid")``` raises an unhandled ```ValueError```.

## What alternative approaches did i consider?
 Considered logging a harsh warning or shutting down manually, but falling back to the standard ```0.2``` trace rate is safest and prevents operational disruptions over minor misconfigurations.

## Why did i choose this specific implementation? 
A ```try...except ValueError``` is the most Pythonic and safe way to handle unsafe string casting without blowing up the initialization loop.

## What are the key functions/components and what do they do?
```init_sentry()``` inside ```app/utils/sentry_sdk.py``` which now encapsulates the casting process safely.
```test_init_sentry_invalid_traces_sample_rate_fallback()``` inside```tests/test_sentry_init.py ```which robustly unit tests this exact edge-case.

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
