### PR TITLE
fix(root-cause): count observability evidence in diagnosis gate

### DIFF
--- a/app/nodes/root_cause_diagnosis/evidence_checker.py
+++ b/app/nodes/root_cause_diagnosis/evidence_checker.py
@@ -145,6 +145,11 @@ def check_evidence_availability(
         or evidence.get("datadog_logs") is not None
         or evidence.get("datadog_monitors") is not None
         or evidence.get("datadog_events") is not None
+        or evidence.get("honeycomb_traces") is not None
+        or evidence.get("coralogix_logs") is not None
+        or evidence.get("coralogix_error_logs") is not None
+        or evidence.get("alertmanager_alerts") is not None
+        or evidence.get("alertmanager_silences") is not None
         or evidence.get("betterstack_logs") is not None
         or evidence.get("s3_object", {}).get("found")
         or evidence.get("s3_audit_payload", {}).get("found")

--- a/tests/nodes/root_cause_diagnosis/test_evidence_checker.py
+++ b/tests/nodes/root_cause_diagnosis/test_evidence_checker.py
@@ -155,3 +155,22 @@ class TestEvidenceAvailabilityArgoCD:
         assert has_tracer is None
         assert has_vendor is True
         assert has_alert is False
+
+
+class TestEvidenceAvailabilityObservabilityStacks:
+    @pytest.mark.parametrize(
+        "evidence_key",
+        [
+            "alertmanager_alerts",
+            "alertmanager_silences",
+            "coralogix_logs",
+            "coralogix_error_logs",
+            "honeycomb_traces",
+        ],
+    )
+    def test_observability_evidence_counts_as_vendor_evidence(self, evidence_key: str) -> None:
+        has_tracer, has_vendor, has_alert = check_evidence_availability({}, {evidence_key: []}, {})
+
+        assert has_tracer is None
+        assert has_vendor is True
+        assert has_alert is False


### PR DESCRIPTION
## Summary
- count `honeycomb_traces`, `coralogix_logs`, `coralogix_error_logs`, `alertmanager_alerts`, and `alertmanager_silences` as diagnosis evidence in `check_evidence_availability()`
- add regression coverage proving those observability outputs now satisfy the diagnosis evidence gate when they are the only gathered evidence
- keep the change scoped to the diagnosis availability gate as a follow-up to the review note on #1095

## Testing
- `.venv/bin/python -m pytest tests/nodes/root_cause_diagnosis/test_evidence_checker.py -vv`
- `make lint`
- `make typecheck`