### PR TITLE
feat: Add analytics opt-out environment variable tests (#1118)

### DIFF
--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -73,9 +73,6 @@ def test_install_main_reuses_shared_install_guard(monkeypatch) -> None:
     assert captured == [{"install_source": "make_install", "entrypoint": "make install"}]
 
 
-from app.analytics import provider
-from app.analytics.events import Event
-
 def test_analytics_disabled_via_opensre_env_var(monkeypatch) -> None:
     # 1. Add a test for OPENSRE_ANALYTICS_DISABLED=1
     monkeypatch.setenv("OPENSRE_ANALYTICS_DISABLED", "1")

--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -71,3 +71,36 @@ def test_install_main_reuses_shared_install_guard(monkeypatch) -> None:
 
     assert exit_code == 0
     assert captured == [{"install_source": "make_install", "entrypoint": "make install"}]
+
+
+from app.analytics import provider
+from app.analytics.events import Event
+
+def test_analytics_disabled_via_opensre_env_var(monkeypatch) -> None:
+    # 1. Add a test for OPENSRE_ANALYTICS_DISABLED=1
+    monkeypatch.setenv("OPENSRE_ANALYTICS_DISABLED", "1")
+    monkeypatch.setenv("DO_NOT_TRACK", "0")
+
+    # 3. Assert the analytics client starts in disabled mode
+    analytics = provider.Analytics()
+    assert analytics._disabled is True
+
+    # 4. Assert calling capture() does not enqueue or send anything
+    assert analytics._queue.empty()
+    analytics.capture(Event.INSTALL_DETECTED)
+    assert analytics._queue.empty()
+
+
+def test_analytics_disabled_via_do_not_track_env_var(monkeypatch) -> None:
+    # 2. Add a test for DO_NOT_TRACK=1
+    monkeypatch.setenv("OPENSRE_ANALYTICS_DISABLED", "0")
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+
+    # 3. Assert the analytics client starts in disabled mode
+    analytics = provider.Analytics()
+    assert analytics._disabled is True
+
+    # 4. Assert calling capture() does not enqueue or send anything
+    assert analytics._queue.empty()
+    analytics.capture(Event.INSTALL_DETECTED)
+    assert analytics._queue.empty()


### PR DESCRIPTION
#1118
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The core problem addressed is to guarantee that the OpenSRE CLI respects user preferences for analytics opt-out, which is crucial for privacy and compliance. The chosen approach involves adding dedicated unit tests to `tests/analytics/test_provider.py`. These tests simulate scenarios where users have opted out via `OPENSRE_ANALYTICS_DISABLED=1` or `DO_NOT_TRACK=1` environment variables. For each scenario, the tests instantiate the `Analytics` provider and assert that its internal `_disabled` flag is set to `True`. Furthermore, they verify that calling the `capture()` method does not enqueue or send any events, ensuring no analytics data is transmitted. This approach provides robust, deterministic validation of the opt-out functionality without making network calls, aligning with the requirements outlined in issue #1118.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
