### PR TITLE
fix(deploy): surface friendly error for missing AWS credentials on EC2 deploy

### DIFF
--- a/app/cli/commands/deploy.py
+++ b/app/cli/commands/deploy.py
@@ -365,7 +365,17 @@ def deploy_ec2(down: bool, branch: str) -> None:
             raise
         raise _ec2_deploy_not_bundled_error() from exc
 
-    outputs = run_deploy(branch=branch)
+    try:
+        outputs = run_deploy(branch=branch)
+    except Exception as exc:
+        if type(exc).__name__ == "NoCredentialsError" and (
+            type(exc).__module__ or ""
+        ).startswith("botocore"):
+            raise click.ClickException(
+                "AWS credentials not found. Run 'aws configure' or set the "
+                "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables."
+            ) from exc
+        raise
     _persist_remote_url(outputs)
 
     remote_url = _build_remote_url(outputs)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `opensre deploy ec2` crashed with a raw `botocore.exceptions.NoCredentialsError` traceback when the user had no AWS credentials configured.
- The error now surfaces as a clean `ClickException` with actionable guidance: run `aws configure` or set `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.

## Root cause

`run_deploy()` calls into the EC2 infrastructure SDK, which calls `boto3` / `botocore` immediately upon entry to enumerate the default VPC. With no credentials in the environment or `~/.aws/`, botocore raises `NoCredentialsError` — uncaught, so it printed as a raw traceback.

## Fix

Wrap the `run_deploy()` call in `deploy_ec2` with a targeted except that matches `botocore.exceptions.NoCredentialsError` by module + class name (avoiding a hard top-level import) and re-raises as `click.ClickException`.

## Test plan

- [ ] Run `opensre deploy ec2` without AWS credentials configured; confirm the error message reads: _"AWS credentials not found. Run 'aws configure' or set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables."_
- [ ] Run with valid credentials; confirm deploy proceeds normally.

Closes #1659

https://claude.ai/code/session_01JDwPRyFyRn8FywHbPBwXMm
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDwPRyFyRn8FywHbPBwXMm)_