### PR TITLE
fix: fail fast on permanent Bedrock errors instead of retrying

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -19,7 +19,14 @@ if TYPE_CHECKING:
     from app.integrations.llm_cli.registry import CLIProviderRegistration
 
 import boto3
-from anthropic import Anthropic, AnthropicBedrock, AuthenticationError, NotFoundError
+from anthropic import (
+    Anthropic,
+    AnthropicBedrock,
+    AuthenticationError,
+    BadRequestError,
+    NotFoundError,
+    PermissionDeniedError,
+)
 from openai import AuthenticationError as OpenAIAuthError
 from openai import NotFoundError as OpenAINotFoundError
 from openai import OpenAI
@@ -325,6 +332,27 @@ class BedrockLLMClient:
                 break
             except GuardrailBlockedError:
                 raise
+            except AuthenticationError as err:
+                raise RuntimeError(
+                    f"Bedrock authentication failed for model '{self._model}'. "
+                    "Check your AWS credentials and region configuration."
+                ) from err
+            except PermissionDeniedError as err:
+                raise RuntimeError(
+                    f"Bedrock access denied for model '{self._model}'. "
+                    "Verify the model is enabled for your AWS account and region."
+                ) from err
+            except NotFoundError as err:
+                raise RuntimeError(
+                    f"Bedrock model '{self._model}' was not found or has reached end of life. "
+                    "Update BEDROCK_REASONING_MODEL / BEDROCK_TOOLCALL_MODEL to a supported model ID."
+                ) from err
+            except BadRequestError as err:
+                raise RuntimeError(
+                    f"Bedrock rejected the request for model '{self._model}': {err}. "
+                    "For newer Claude models, use a cross-region inference profile ID "
+                    "(e.g. 'us.anthropic.claude-opus-4-7-20251101-v1:0') instead of the bare model ID."
+                ) from err
             except Exception as err:
                 last_err = err
                 if attempt == max_attempts - 1:


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `BedrockLLMClient._invoke_anthropic` was retrying `AuthenticationError` (401), `PermissionDeniedError` (403), `NotFoundError` (404), and `BadRequestError` (400) three times before surfacing a generic error message — wasting time on errors that can never succeed with a retry.
- Added fast-fail handlers for each permanent error class with actionable messages, including guidance to use cross-region inference profile IDs for newer Claude models that don't support on-demand throughput (Sentry issues #1723, #1724, #1725).

## Root cause

`_invoke_anthropic` only exempted `GuardrailBlockedError` from the retry loop; all other exceptions fell through to the generic `except Exception` branch that retried up to 3× with exponential backoff.

## Fix

Import `BadRequestError` and `PermissionDeniedError` from `anthropic` and add dedicated `except` clauses for each permanent error type before the generic catch-all, so they surface immediately with a clear, actionable message.

## Test plan

- [ ] `make lint` passes
- [ ] `make typecheck` passes  
- [ ] `uv run python -m pytest tests/services/ -q` passes (592 tests)

Closes #1724

https://claude.ai/code/session_0172GGtu7DxmUv6bHMyPsrbV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0172GGtu7DxmUv6bHMyPsrbV)_