### PR TITLE
fix(ci): stabilize interactive-shell routing/streaming flake on main

### DIFF
--- a/app/cli/interactive_shell/routing/router.py
+++ b/app/cli/interactive_shell/routing/router.py
@@ -52,7 +52,13 @@ InputKind = Literal["slash", "cli_help", "cli_agent", "new_alert", "follow_up"]
 
 # Rule names that are part of the deterministic fast-path and must never be
 # handed to the LLM classifier (they are always correct by definition).
-_FAST_PATH_RULE_NAMES: frozenset[str] = frozenset({"slash_prefix", "bare_command_alias"})
+#
+# "sample_alert_launch" is intentionally included to keep built-in sample alert
+# actions deterministic even when the LLM classifier is noisy around the word
+# "alert".
+_FAST_PATH_RULE_NAMES: frozenset[str] = frozenset(
+    {"slash_prefix", "bare_command_alias", "sample_alert_launch"}
+)
 
 
 def _is_slash_prefix(text: str, _session: RoutingSession) -> bool:

--- a/app/cli/interactive_shell/ui/streaming.py
+++ b/app/cli/interactive_shell/ui/streaming.py
@@ -242,7 +242,19 @@ def stream_to_console(
             try:
                 wrap_patch_stdout = _console_file_is_a_tty(console)
                 try:
-                    _run_throttled_with_live(wrap_patch_stdout=wrap_patch_stdout)
+                    if wrap_patch_stdout:
+                        _run_throttled_with_live(wrap_patch_stdout=True)
+                    else:
+                        # ``force_terminal=True`` with a non-TTY file (StringIO /
+                        # captured test buffer) leaves live refresh artifacts in
+                        # scrollback. Skip in-flight previews there and render once
+                        # at finalize for deterministic output.
+                        _run_throttled_markdown_loop(
+                            preview=_noop_preview,
+                            chunks_iter=chunks_iter,
+                            buffer=buffer,
+                            next_chunk=_next_chunk,
+                        )
                 except NoConsoleScreenBufferError:
                     if wrap_patch_stdout:
                         try:


### PR DESCRIPTION
## Summary
This fixes the current main CI flake seen in the CI workflow test job.

### Root causes addressed
- `sample alert` launch phrases could be reclassified by the LLM path as `new_alert` instead of deterministic `cli_agent`.
- `force_terminal=True` with non-TTY buffers could leak transient markdown frames into captured output, causing intermittent `**...` assertions in streaming tests.

### Changes
- Router: include `sample_alert_launch` in deterministic fast-path rules so it is evaluated before LLM classification.
- Streaming: when terminal rendering is forced but output is not a real TTY, skip live in-flight previews and render once at finalize for stable output.

## Validation
Ran CI-equivalent checks in this worktree:
- `uv run python -m ruff check app/ tests/`
- `uv run python -m ruff format --check app/ tests/`
- `uv run python -m mypy app/`
- `uv run python -m pytest -n auto -v --cov=app --cov-report=term-missing --cov-report=html --ignore=tests/e2e/kubernetes_local_alert_simulation --ignore=tests/synthetic -m "not synthetic"`

All passed locally (6376 passed, 5 skipped).
