### PR TITLE
fix(llm): surface invalid model identifier as operator-actionable error

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -689,7 +689,7 @@ class OpenAILLMClient:
                 ) from err
             except OpenAIBadRequestError as err:
                 _msg = (err.message or "").lower()
-                if "model" in _msg and "invalid" in _msg:
+                if "model identifier" in _msg:
                     raise RuntimeError(
                         f"{self._provider_label} model '{self._model}' was not found. "
                         "Check your configured model name or endpoint."
@@ -779,7 +779,7 @@ class OpenAILLMClient:
                 ) from err
             except OpenAIBadRequestError as err:
                 _msg = (err.message or "").lower()
-                if "model" in _msg and "invalid" in _msg:
+                if "model identifier" in _msg:
                     raise RuntimeError(
                         f"{self._provider_label} model '{self._model}' was not found. "
                         "Check your configured model name or endpoint."

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -431,7 +431,9 @@ class BedrockLLMClient:
                     # ``INVALID_PAYMENT_INSTRUMENT``). Surface the upstream
                     # AWS-provided reason so the user knows which one to fix
                     # — see issue #1808.
-                    aws_message = str(err.response.get("Error", {}).get("Message", "")).strip().rstrip(".")
+                    aws_message = (
+                        str(err.response.get("Error", {}).get("Message", "")).strip().rstrip(".")
+                    )
                     detail = f" Cause: {aws_message}." if aws_message else ""
                     raise RuntimeError(
                         f"Access denied for Bedrock model '{self._model}'.{detail} "
@@ -686,6 +688,12 @@ class OpenAILLMClient:
                     "Check your configured model name or endpoint."
                 ) from err
             except OpenAIBadRequestError as err:
+                _msg = (err.message or "").lower()
+                if "model" in _msg and "invalid" in _msg:
+                    raise RuntimeError(
+                        f"{self._provider_label} model '{self._model}' was not found. "
+                        "Check your configured model name or endpoint."
+                    ) from err
                 raise RuntimeError(
                     f"{self._provider_label} request rejected (HTTP 400): {err.message}"
                 ) from err
@@ -770,6 +778,12 @@ class OpenAILLMClient:
                     "Check your configured model name or endpoint."
                 ) from err
             except OpenAIBadRequestError as err:
+                _msg = (err.message or "").lower()
+                if "model" in _msg and "invalid" in _msg:
+                    raise RuntimeError(
+                        f"{self._provider_label} model '{self._model}' was not found. "
+                        "Check your configured model name or endpoint."
+                    ) from err
                 raise RuntimeError(
                     f"{self._provider_label} request rejected (HTTP 400): {err.message}"
                 ) from err

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -803,6 +803,54 @@ def test_openai_invoke_bad_request_does_not_retry(monkeypatch) -> None:
     assert sleeps == []
 
 
+def test_openai_invoke_invalid_model_identifier_raises_not_found(monkeypatch) -> None:
+    class _Completions:
+        def create(self, **_kwargs):
+            raise _make_fake_openai_bad_request_error(
+                "Error code: 400 - litellm.BadRequestError: AnthropicException - "
+                '{"message":"The provided model identifier is invalid."}'
+            )
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+
+    client = llm_client.OpenAILLMClient(model="relay-ops-claude-opus-4-7")
+    with pytest.raises(RuntimeError, match="Check your configured model name or endpoint"):
+        client.invoke("hello")
+
+
+def test_openai_invoke_stream_invalid_model_identifier_raises_not_found(monkeypatch) -> None:
+    class _Completions:
+        def create(self, **_kwargs):
+            raise _make_fake_openai_bad_request_error(
+                "Error code: 400 - litellm.BadRequestError: AnthropicException - "
+                '{"message":"The provided model identifier is invalid."}'
+            )
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+
+    client = llm_client.OpenAILLMClient(model="relay-ops-claude-opus-4-7")
+    with pytest.raises(RuntimeError, match="Check your configured model name or endpoint"):
+        list(client.invoke_stream("hello"))
+
+
 def test_openai_invoke_stream_yields_delta_content_chunks(monkeypatch) -> None:
     """invoke_stream() routes through the same builder and yields delta.content in order."""
     fake, captured = _make_capturing_openai(chunk_contents=["Hel", "lo, ", "world"])


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

LiteLLM proxies return HTTP 400 with `"The provided model identifier is invalid."` when a model group name (e.g. `relay-ops-claude-opus-4-7`) doesn't resolve to a known Anthropic model ID. This was caught as a generic `OpenAIBadRequestError` and re-raised with a `"request rejected (HTTP 400)"` message that doesn't match any entry in `_OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS`, so every misconfigured relay generated a high-priority Sentry issue.

**Fix:** In both `invoke()` and `invoke_stream()` on `OpenAICompatibleClient`, detect `"model"` + `"invalid"` in the 400 error message and re-raise with `"model '...' was not found. Check your configured model name or endpoint."` — the same message used for 404 errors. That message already matches two patterns in `_OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS`, so Sentry drops these events instead of escalating them.

- `app/services/llm_client.py` — `invoke()` and `invoke_stream()` BadRequest handlers
- `tests/services/test_llm_client.py` — two new tests covering the invalid-model path for invoke and invoke_stream

## Test plan

- [x] `uv run pytest tests/services/test_llm_client.py` — 66 passed (2 new tests added)
- [x] `uv run pytest tests/pipeline/test_runners_sentry.py` — 1 passed
- [x] `uv run ruff check app/ tests/` — all checks passed
- [x] `uv run ruff format --check` — no reformats needed
- [x] `uv run mypy app/services/llm_client.py` — no issues

Closes #1806
Closes #1805

https://claude.ai/code/session_01TdpybhdavfRTPa56dBETM8
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdpybhdavfRTPa56dBETM8)_