### PR TITLE
feat(hermes): Telegram sink, investigation bridge, and `opensre hermes watch` CLI

### DIFF
--- a/app/cli/commands/__init__.py
+++ b/app/cli/commands/__init__.py
@@ -16,6 +16,7 @@ from app.cli.commands.general import (
     version_command,
 )
 from app.cli.commands.guardrails import guardrails
+from app.cli.commands.hermes import hermes_command
 from app.cli.commands.integrations import integrations
 from app.cli.commands.onboard import onboard
 from app.cli.commands.remote import remote
@@ -31,6 +32,7 @@ _COMMANDS: tuple[click.Command, ...] = (
     integrations,
     guardrails,
     agents,
+    hermes_command,
     health_command,
     doctor_command,
     update_command,

--- a/app/cli/commands/hermes.py
+++ b/app/cli/commands/hermes.py
@@ -1,0 +1,162 @@
+"""``opensre hermes`` command group: live-tail Hermes logs and dispatch to Telegram.
+
+The ``opensre hermes watch`` command wires the existing detection
+backbone (:class:`~app.hermes.HermesAgent`) to the
+:class:`~app.hermes.TelegramSink` and blocks until ``SIGINT`` /
+``SIGTERM``. Credentials are loaded via
+:func:`~app.watch_dog.alarms.load_credentials_from_env`, so the
+``TELEGRAM_BOT_TOKEN`` env var must be set; ``--chat-id`` overrides the
+``TELEGRAM_DEFAULT_CHAT_ID`` env var when both are present.
+
+This command intentionally does *not* run an OpenSRE investigation by
+default. Pass ``--investigate`` (or set ``OPENSRE_HERMES_INVESTIGATE=1``)
+to enable the RCA bridge for ``HIGH``/``CRITICAL`` incidents.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import threading
+from pathlib import Path
+from typing import Any
+
+import click
+
+from app.hermes.agent import DEFAULT_LOG_PATH, HermesAgent
+from app.hermes.investigation import run_incident_investigation
+from app.hermes.sinks import TelegramSink
+from app.watch_dog.alarms import AlarmDispatcher, load_credentials_from_env
+
+logger = logging.getLogger(__name__)
+
+
+@click.group(name="hermes")
+def hermes_command() -> None:
+    """Live-tail Hermes logs and route detected incidents to Telegram."""
+
+
+@hermes_command.command(name="watch")
+@click.option(
+    "--log-path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        f"Path to the Hermes log file. Defaults to {DEFAULT_LOG_PATH}. "
+        "The file does not need to exist yet — the tailer waits for it to appear."
+    ),
+)
+@click.option(
+    "--chat-id",
+    "chat_id",
+    type=str,
+    default=None,
+    help=(
+        "Telegram chat ID to deliver incidents to. Overrides "
+        "TELEGRAM_DEFAULT_CHAT_ID when both are set."
+    ),
+)
+@click.option(
+    "--cooldown-seconds",
+    type=float,
+    default=300.0,
+    show_default=True,
+    help="Per-incident-fingerprint cooldown before a duplicate is re-sent.",
+)
+@click.option(
+    "--from-start/--from-end",
+    default=False,
+    show_default=True,
+    help=(
+        "Replay the existing log contents before live-tailing. Off by default so "
+        "starting the watcher does not flood Telegram with backlog."
+    ),
+)
+@click.option(
+    "--investigate/--no-investigate",
+    "investigate",
+    default=None,
+    help=(
+        "Run an OpenSRE investigation for HIGH/CRITICAL incidents and append "
+        "the RCA summary before delivery. Defaults to off; set "
+        "OPENSRE_HERMES_INVESTIGATE=1 to enable globally."
+    ),
+)
+def hermes_watch(
+    log_path: Path | None,
+    chat_id: str | None,
+    cooldown_seconds: float,
+    from_start: bool,
+    investigate: bool | None,
+) -> None:
+    """Start the Hermes log watcher and block until interrupted.
+
+    Loads Telegram credentials from the environment, constructs a
+    :class:`HermesAgent` wired to a :class:`TelegramSink`, then waits
+    for ``SIGINT``/``SIGTERM`` before shutting the agent down cleanly.
+    """
+    creds = load_credentials_from_env(chat_id_override=chat_id)
+    dispatcher = AlarmDispatcher(creds, cooldown_seconds=cooldown_seconds)
+
+    investigate_enabled = _resolve_investigate_flag(investigate)
+    bridge = run_incident_investigation if investigate_enabled else None
+    sink = TelegramSink(dispatcher, investigation_bridge=bridge)
+
+    resolved_log_path = log_path or DEFAULT_LOG_PATH
+    agent = HermesAgent(
+        sink=sink,
+        log_path=resolved_log_path,
+        from_start=from_start,
+    )
+
+    stop_event = threading.Event()
+    _install_shutdown_handlers(stop_event)
+
+    click.echo(
+        f"hermes-watch: tailing {resolved_log_path} "
+        f"(cooldown={cooldown_seconds:.0f}s, investigate={'on' if investigate_enabled else 'off'})"
+    )
+
+    agent.start()
+    try:
+        # Block on the stop_event so SIGINT/SIGTERM wake the main
+        # thread immediately. A plain ``thread.join()`` would not
+        # respond to signals on its own.
+        stop_event.wait()
+    finally:
+        click.echo("hermes-watch: stopping…")
+        agent.stop()
+        click.echo("hermes-watch: stopped.")
+
+
+def _resolve_investigate_flag(cli_value: bool | None) -> bool:
+    """CLI flag wins; otherwise fall back to the env var."""
+    if cli_value is not None:
+        return cli_value
+    env_value = os.getenv("OPENSRE_HERMES_INVESTIGATE", "").strip().lower()
+    return env_value in {"1", "true", "yes", "on"}
+
+
+def _install_shutdown_handlers(stop_event: threading.Event) -> None:
+    """Install SIGINT/SIGTERM handlers that set ``stop_event``.
+
+    Click already installs a SIGINT-based ``KeyboardInterrupt`` path,
+    but the watcher blocks on a ``threading.Event`` rather than a
+    user-input prompt, so we replace it with a handler that wakes the
+    event explicitly. SIGTERM gets the same treatment for systemd /
+    container shutdowns.
+    """
+
+    def _handler(_signum: int, _frame: Any) -> None:
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, _handler)
+    # SIGTERM is not defined on Windows; guard for portability even
+    # though the watcher is a Linux/macOS workflow today.
+    sigterm = getattr(signal, "SIGTERM", None)
+    if sigterm is not None:
+        signal.signal(sigterm, _handler)
+
+
+__all__ = ["hermes_command"]

--- a/app/cli/commands/hermes.py
+++ b/app/cli/commands/hermes.py
@@ -127,6 +127,10 @@ def hermes_watch(
     finally:
         click.echo("hermes-watch: stopping…")
         agent.stop()
+        # Drain in-flight investigation calls (no-op when bridge is
+        # disabled). Done after agent.stop() so no new bridge submits
+        # can race the shutdown.
+        sink.close()
         click.echo("hermes-watch: stopped.")
 
 

--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -210,6 +210,10 @@ def _cmd_config(session: ReplSession, console: Console, args: list[str]) -> bool
     return run_cli_command(console, ["config", *args])
 
 
+def _cmd_hermes(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+    return run_cli_command(console, ["hermes", *args])
+
+
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/onboard",
@@ -258,6 +262,12 @@ COMMANDS: list[SlashCommand] = [
         "/config",
         "show or edit local OpenSRE config ('/config show|set <key> <value>')",
         _cmd_config,
+        execution_tier=ExecutionTier.SAFE,
+    ),
+    SlashCommand(
+        "/hermes",
+        "live-tail Hermes logs and route incidents to Telegram ('/hermes watch')",
+        _cmd_hermes,
         execution_tier=ExecutionTier.SAFE,
     ),
 ]

--- a/app/hermes/__init__.py
+++ b/app/hermes/__init__.py
@@ -18,7 +18,17 @@ from app.hermes.classifier import (
     classify_all,
 )
 from app.hermes.incident import HermesIncident, IncidentSeverity, LogLevel, LogRecord
+from app.hermes.investigation import (
+    build_alert_from_incident,
+    run_incident_investigation,
+)
 from app.hermes.parser import parse_log_line
+from app.hermes.sinks import (
+    InvestigationBridge,
+    TelegramSink,
+    TelegramSinkConfig,
+    make_telegram_sink,
+)
 from app.hermes.tailer import FileTailer
 
 __all__ = [
@@ -32,8 +42,14 @@ __all__ = [
     "IncidentClassifier",
     "IncidentSeverity",
     "IncidentSink",
+    "InvestigationBridge",
     "LogLevel",
     "LogRecord",
+    "TelegramSink",
+    "TelegramSinkConfig",
+    "build_alert_from_incident",
     "classify_all",
+    "make_telegram_sink",
     "parse_log_line",
+    "run_incident_investigation",
 ]

--- a/app/hermes/investigation.py
+++ b/app/hermes/investigation.py
@@ -1,0 +1,145 @@
+"""Optional bridge from Hermes incidents into the OpenSRE investigation pipeline.
+
+The :func:`run_incident_investigation` helper turns a :class:`HermesIncident`
+into a Grafana-shaped alert payload, calls
+:func:`app.pipeline.runners.run_investigation`, and extracts a
+human-readable summary from the resulting :class:`AgentState`.
+
+The investigation pipeline is heavy (LangGraph, LLM calls, integration
+resolution) so this module imports it lazily — callers that never invoke
+the bridge pay no import cost.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.hermes.incident import HermesIncident, LogRecord
+
+logger = logging.getLogger(__name__)
+
+# Trim long evidence blobs so the alert annotations stay well under any
+# downstream payload limit (Grafana webhook bodies, LLM prompts, etc.).
+_MAX_ANNOTATION_LINES = 6
+_MAX_ANNOTATION_LINE_CHARS = 240
+
+
+def build_alert_from_incident(incident: HermesIncident) -> dict[str, Any]:
+    """Build a Grafana-shaped alert payload from a Hermes incident.
+
+    The payload shape mirrors what
+    :func:`tests.utils.alert_factory.factory.create_alert` produces, so
+    it lands in the investigation pipeline through the same code path as
+    a real Grafana webhook. Severity ``MEDIUM`` is normalized to
+    ``"warning"`` because the investigation graph treats severity as a
+    free-form string aligned with Grafana conventions.
+    """
+    severity_label = _severity_label(incident.severity.value)
+    pipeline_name = incident.logger or "hermes"
+    return {
+        "alert_name": f"Hermes incident: {incident.title}",
+        "pipeline_name": pipeline_name,
+        "severity": severity_label,
+        "alert_source": "hermes",
+        "message": incident.title,
+        "raw_alert": incident.title,
+        "commonLabels": {
+            "alertname": "HermesIncident",
+            "severity": severity_label,
+            "pipeline_name": pipeline_name,
+            "rule": incident.rule,
+        },
+        "commonAnnotations": {
+            "summary": incident.title,
+            "rule": incident.rule,
+            "fingerprint": incident.fingerprint,
+            "logger": incident.logger,
+            "detected_at": incident.detected_at.isoformat(),
+            "evidence": _format_records(incident.records),
+            "context_sources": "hermes_logs",
+            **({"run_id": incident.run_id} if incident.run_id else {}),
+        },
+    }
+
+
+def run_incident_investigation(incident: HermesIncident) -> str | None:
+    """Invoke the OpenSRE investigation pipeline for ``incident``.
+
+    Returns the resulting summary string, or ``None`` if the pipeline
+    produced no usable output. Heavy imports are deferred so the Hermes
+    sink can be imported in environments where LangGraph and friends
+    aren't installed (e.g. unit tests).
+    """
+    # Imported lazily — pulling app.pipeline.runners at module import
+    # time would force every Hermes consumer to pay the LangGraph import
+    # cost even when no investigation ever runs.
+    from app.pipeline.runners import run_investigation
+
+    alert = build_alert_from_incident(incident)
+    try:
+        state = run_investigation(
+            alert_name=str(alert["alert_name"]),
+            pipeline_name=str(alert["pipeline_name"]),
+            severity=str(alert["severity"]),
+            raw_alert=alert,
+        )
+    except Exception:
+        logger.exception(
+            "hermes investigation failed: rule=%s fingerprint=%s",
+            incident.rule,
+            incident.fingerprint,
+        )
+        return None
+    return _extract_summary(state)
+
+
+def _extract_summary(state: Any) -> str | None:
+    """Pull the best human-readable summary from an investigation state.
+
+    The investigation graph exposes several overlapping summary fields
+    (``summary``, ``root_cause``, ``problem_md``) depending on which
+    nodes ran. We pick the first non-empty one in priority order.
+    """
+    if state is None:
+        return None
+    if not isinstance(state, dict):  # AgentState is a TypedDict but graphs sometimes return models
+        state = getattr(state, "__dict__", state)
+        if not isinstance(state, dict):
+            return None
+    for key in ("summary", "root_cause", "problem_md", "report"):
+        value = state.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _severity_label(value: str) -> str:
+    """Map :class:`IncidentSeverity` values to Grafana severity strings."""
+    normalized = value.strip().lower()
+    if normalized in {"critical", "high"}:
+        return "critical"
+    if normalized == "medium":
+        return "warning"
+    return normalized or "warning"
+
+
+def _format_records(records: tuple[LogRecord, ...]) -> str:
+    if not records:
+        return ""
+    lines = []
+    for record in records[:_MAX_ANNOTATION_LINES]:
+        raw = record.raw
+        if len(raw) > _MAX_ANNOTATION_LINE_CHARS:
+            raw = raw[: _MAX_ANNOTATION_LINE_CHARS - 1] + "…"
+        lines.append(raw)
+    omitted = len(records) - len(lines)
+    if omitted > 0:
+        lines.append(f"… ({omitted} more record{'s' if omitted != 1 else ''} omitted)")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "build_alert_from_incident",
+    "run_incident_investigation",
+]

--- a/app/hermes/sinks.py
+++ b/app/hermes/sinks.py
@@ -1,0 +1,230 @@
+"""Incident sinks for the Hermes agent.
+
+The Hermes agent emits :class:`HermesIncident` objects to a pluggable
+``IncidentSink`` callable. This module provides the concrete sinks used
+in production:
+
+* :class:`TelegramSink` — formats an incident into a human-readable
+  Telegram message and routes it through :class:`AlarmDispatcher` so
+  duplicate incidents respect the per-fingerprint cooldown. For
+  ``HIGH``/``CRITICAL`` incidents it can optionally trigger the OpenSRE
+  investigation pipeline and append the resulting root-cause summary to
+  the Telegram message before delivery.
+* :func:`make_telegram_sink` — convenience factory returning an
+  :data:`IncidentSink` callable bound to an existing
+  :class:`AlarmDispatcher` (and optional investigation bridge).
+
+The sink is intentionally *defensive*: any exception raised by the
+investigation bridge or by Telegram delivery is logged but does not
+re-raise. A buggy bridge must never silently disable incident
+notifications.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Final
+
+from app.hermes.agent import IncidentSink
+from app.hermes.incident import HermesIncident, IncidentSeverity, LogRecord
+from app.watch_dog.alarms import AlarmDispatcher
+
+logger = logging.getLogger(__name__)
+
+# Severities that trigger a full RCA investigation. MEDIUM (warning
+# bursts) intentionally short-circuits to a lighter-weight notification:
+# bursts are noisy and the marginal investigation rarely surfaces a true
+# root cause for them.
+_INVESTIGATION_SEVERITIES: Final[frozenset[IncidentSeverity]] = frozenset(
+    {IncidentSeverity.HIGH, IncidentSeverity.CRITICAL}
+)
+
+# Soft cap on how many raw log records we inline into the Telegram body.
+# AlarmDispatcher truncates the final payload at the Telegram 4096 char
+# limit, but trimming here keeps the message useful instead of having
+# half the records cut off mid-traceback.
+_MAX_INLINED_RECORDS: Final[int] = 8
+_MAX_RECORD_CHARS: Final[int] = 280
+_MAX_SUMMARY_CHARS: Final[int] = 1200
+
+_SEVERITY_EMOJI: Final[dict[IncidentSeverity, str]] = {
+    IncidentSeverity.LOW: "🟢",
+    IncidentSeverity.MEDIUM: "🟡",
+    IncidentSeverity.HIGH: "🟠",
+    IncidentSeverity.CRITICAL: "🔴",
+}
+
+
+# An investigation bridge is any callable that, given an incident,
+# returns a human-readable RCA summary (or ``None`` if it could not
+# produce one). Implementations typically wrap ``run_investigation`` and
+# extract ``state["summary"]``/``state["root_cause"]``. Returning
+# ``None`` rather than raising is the documented contract — the sink
+# treats exceptions and ``None`` identically (no RCA appended) but the
+# former is logged at WARNING.
+InvestigationBridge = Callable[[HermesIncident], str | None]
+
+
+@dataclass(frozen=True, slots=True)
+class TelegramSinkConfig:
+    """Optional knobs for :class:`TelegramSink`.
+
+    Defaults match the values used in production. The dataclass is
+    frozen so tests can pass a config instance into the sink without
+    worrying about cross-test mutation.
+    """
+
+    max_inlined_records: int = _MAX_INLINED_RECORDS
+    max_record_chars: int = _MAX_RECORD_CHARS
+    max_summary_chars: int = _MAX_SUMMARY_CHARS
+
+
+class TelegramSink:
+    """Format Hermes incidents and dispatch them to Telegram.
+
+    Parameters
+    ----------
+    dispatcher:
+        Pre-constructed :class:`AlarmDispatcher`. The sink uses
+        ``dispatch(threshold_name=incident.fingerprint, message=...)`` so
+        duplicate incidents (same fingerprint) are suppressed by the
+        dispatcher's cooldown window.
+    investigation_bridge:
+        Optional callable invoked for ``HIGH``/``CRITICAL`` incidents.
+        When provided, its return value is appended to the Telegram
+        message before dispatch. Exceptions are caught and logged.
+    config:
+        Optional :class:`TelegramSinkConfig` overriding the inline
+        truncation knobs.
+    """
+
+    __slots__ = ("_dispatcher", "_investigation_bridge", "_config")
+
+    def __init__(
+        self,
+        dispatcher: AlarmDispatcher,
+        *,
+        investigation_bridge: InvestigationBridge | None = None,
+        config: TelegramSinkConfig | None = None,
+    ) -> None:
+        self._dispatcher = dispatcher
+        self._investigation_bridge = investigation_bridge
+        self._config = config if config is not None else TelegramSinkConfig()
+
+    def __call__(self, incident: HermesIncident) -> None:
+        """Format the incident and dispatch it. Never raises."""
+        try:
+            rca_summary = self._maybe_investigate(incident)
+            message = self._format_message(incident, rca_summary=rca_summary)
+            self._dispatcher.dispatch(incident.fingerprint, message)
+        except Exception:
+            # The Hermes agent already guards sink exceptions in its own
+            # dispatch loop, but logging here gives the operator the
+            # incident metadata that the agent's logger does not have.
+            logger.exception(
+                "telegram sink failed: rule=%s severity=%s fingerprint=%s",
+                incident.rule,
+                incident.severity.value,
+                incident.fingerprint,
+            )
+
+    # ------------------------------------------------------------------
+    # Investigation bridge
+
+    def _maybe_investigate(self, incident: HermesIncident) -> str | None:
+        bridge = self._investigation_bridge
+        if bridge is None or incident.severity not in _INVESTIGATION_SEVERITIES:
+            return None
+        try:
+            summary = bridge(incident)
+        except Exception:
+            logger.warning(
+                "hermes investigation bridge raised: rule=%s fingerprint=%s",
+                incident.rule,
+                incident.fingerprint,
+                exc_info=True,
+            )
+            return None
+        if not summary:
+            return None
+        return _truncate(summary.strip(), self._config.max_summary_chars)
+
+    # ------------------------------------------------------------------
+    # Message formatting
+
+    def _format_message(
+        self,
+        incident: HermesIncident,
+        *,
+        rca_summary: str | None,
+    ) -> str:
+        emoji = _SEVERITY_EMOJI.get(incident.severity, "⚠️")
+        header = (
+            f"{emoji} Hermes incident: {incident.title}\n"
+            f"severity: {incident.severity.value.upper()}  "
+            f"rule: {incident.rule}\n"
+            f"logger: {incident.logger or '<unknown>'}\n"
+            f"detected_at: {incident.detected_at.isoformat()}\n"
+            f"fingerprint: {incident.fingerprint}"
+        )
+        if incident.run_id:
+            header += f"\nrun_id: {incident.run_id}"
+
+        body_parts: list[str] = [header]
+
+        records_block = self._format_records(incident.records)
+        if records_block:
+            body_parts.append("recent log records:\n" + records_block)
+
+        if rca_summary:
+            body_parts.append("investigation summary:\n" + rca_summary)
+        elif incident.severity == IncidentSeverity.MEDIUM:
+            # Explicitly mark notify-only severity so the operator knows
+            # an RCA was not attempted (vs. attempted and produced no
+            # summary, which the branch above represents).
+            body_parts.append("note: warning-burst severity — notify only, no investigation run.")
+
+        return "\n\n".join(body_parts)
+
+    def _format_records(self, records: tuple[LogRecord, ...]) -> str:
+        if not records:
+            return ""
+        inlined = records[: self._config.max_inlined_records]
+        omitted = len(records) - len(inlined)
+        lines = [_truncate(record.raw, self._config.max_record_chars) for record in inlined]
+        if omitted > 0:
+            lines.append(f"… ({omitted} more record{'s' if omitted != 1 else ''} omitted)")
+        return "\n".join(lines)
+
+
+def make_telegram_sink(
+    dispatcher: AlarmDispatcher,
+    *,
+    investigation_bridge: InvestigationBridge | None = None,
+    config: TelegramSinkConfig | None = None,
+) -> IncidentSink:
+    """Build an :data:`IncidentSink` callable bound to ``dispatcher``."""
+    sink = TelegramSink(
+        dispatcher,
+        investigation_bridge=investigation_bridge,
+        config=config,
+    )
+    return sink
+
+
+def _truncate(text: str, limit: int) -> str:
+    if limit <= 0 or len(text) <= limit:
+        return text
+    if limit <= 1:
+        return text[:limit]
+    return text[: limit - 1] + "…"
+
+
+__all__ = [
+    "InvestigationBridge",
+    "TelegramSink",
+    "TelegramSinkConfig",
+    "make_telegram_sink",
+]

--- a/app/hermes/sinks.py
+++ b/app/hermes/sinks.py
@@ -18,12 +18,35 @@ The sink is intentionally *defensive*: any exception raised by the
 investigation bridge or by Telegram delivery is logged but does not
 re-raise. A buggy bridge must never silently disable incident
 notifications.
+
+Investigation bridge execution model
+------------------------------------
+
+Investigation calls (LLM round-trips through LangGraph) can take 30+
+seconds. To keep the agent's polling thread responsive — so the
+``FileTailer`` keeps reading and the classifier keeps observing during
+an investigation — bridge calls are dispatched to a bounded thread pool
+and waited on with a configurable timeout. When the investigation
+completes within budget its summary is appended to the Telegram body;
+otherwise the sink falls back to a clearly-marked notification so the
+operator can distinguish:
+
+* **no bridge configured** → no investigation section
+* **bridge attempted, returned None** → ``investigation: attempted (no
+  summary produced)``
+* **bridge attempted, raised** → ``investigation: attempted (failed —
+  see server logs)``
+* **bridge attempted, timed out** → ``investigation: attempted (timed
+  out after N.Ns — see server logs)``
+* **bridge attempted, returned summary** → ``investigation summary:`` block
 """
 
 from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import dataclass
 from typing import Final
 
@@ -49,6 +72,19 @@ _MAX_INLINED_RECORDS: Final[int] = 8
 _MAX_RECORD_CHARS: Final[int] = 280
 _MAX_SUMMARY_CHARS: Final[int] = 1200
 
+# Default thread-pool worker count. The bridge is I/O-bound (LLM
+# round-trips) so a small pool is enough; we keep this conservative so a
+# burst of HIGH/CRITICAL incidents doesn't fan out into dozens of
+# concurrent LLM calls.
+_DEFAULT_BRIDGE_WORKERS: Final[int] = 2
+
+# How long the sink waits for an in-flight investigation before giving
+# up and falling back to a timeout notice. Tuned to be slightly larger
+# than a typical LangGraph investigation but well under the
+# AlarmDispatcher cooldown (300s default) so a retry on the next
+# matching incident gets a fresh shot.
+_DEFAULT_BRIDGE_TIMEOUT_S: Final[float] = 45.0
+
 _SEVERITY_EMOJI: Final[dict[IncidentSeverity, str]] = {
     IncidentSeverity.LOW: "🟢",
     IncidentSeverity.MEDIUM: "🟡",
@@ -62,8 +98,8 @@ _SEVERITY_EMOJI: Final[dict[IncidentSeverity, str]] = {
 # produce one). Implementations typically wrap ``run_investigation`` and
 # extract ``state["summary"]``/``state["root_cause"]``. Returning
 # ``None`` rather than raising is the documented contract — the sink
-# treats exceptions and ``None`` identically (no RCA appended) but the
-# former is logged at WARNING.
+# treats exceptions and ``None`` distinctly (different operator-visible
+# markers) and logs the former at WARNING.
 InvestigationBridge = Callable[[HermesIncident], str | None]
 
 
@@ -79,6 +115,12 @@ class TelegramSinkConfig:
     max_inlined_records: int = _MAX_INLINED_RECORDS
     max_record_chars: int = _MAX_RECORD_CHARS
     max_summary_chars: int = _MAX_SUMMARY_CHARS
+    bridge_timeout_s: float = _DEFAULT_BRIDGE_TIMEOUT_S
+    bridge_workers: int = _DEFAULT_BRIDGE_WORKERS
+    # Run bridge synchronously on the calling thread instead of offloading
+    # to the executor. Used by unit tests that want deterministic
+    # bridge-call ordering without spinning up a pool.
+    bridge_run_inline: bool = False
 
 
 class TelegramSink:
@@ -93,14 +135,23 @@ class TelegramSink:
         dispatcher's cooldown window.
     investigation_bridge:
         Optional callable invoked for ``HIGH``/``CRITICAL`` incidents.
-        When provided, its return value is appended to the Telegram
-        message before dispatch. Exceptions are caught and logged.
+        The call runs in a bounded thread pool with a timeout (see
+        :class:`TelegramSinkConfig`) so the agent's polling thread is
+        never blocked for more than ``bridge_timeout_s`` seconds. Its
+        return value is appended to the Telegram message before
+        dispatch. Exceptions are caught and replaced with an explicit
+        marker in the message body.
     config:
-        Optional :class:`TelegramSinkConfig` overriding the inline
-        truncation knobs.
+        Optional :class:`TelegramSinkConfig` overriding inline
+        truncation, bridge timeout, and pool size.
     """
 
-    __slots__ = ("_dispatcher", "_investigation_bridge", "_config")
+    __slots__ = (
+        "_dispatcher",
+        "_investigation_bridge",
+        "_config",
+        "_bridge_executor",
+    )
 
     def __init__(
         self,
@@ -112,12 +163,21 @@ class TelegramSink:
         self._dispatcher = dispatcher
         self._investigation_bridge = investigation_bridge
         self._config = config if config is not None else TelegramSinkConfig()
+        # The executor is constructed lazily — only created if a bridge
+        # is actually configured AND we're not running inline. This
+        # keeps the no-investigation hot path zero-cost.
+        self._bridge_executor: ThreadPoolExecutor | None = None
+        if investigation_bridge is not None and not self._config.bridge_run_inline:
+            self._bridge_executor = ThreadPoolExecutor(
+                max_workers=max(1, self._config.bridge_workers),
+                thread_name_prefix="hermes-bridge",
+            )
 
     def __call__(self, incident: HermesIncident) -> None:
         """Format the incident and dispatch it. Never raises."""
         try:
-            rca_summary = self._maybe_investigate(incident)
-            message = self._format_message(incident, rca_summary=rca_summary)
+            investigation = self._maybe_investigate(incident)
+            message = self._format_message(incident, investigation=investigation)
             self._dispatcher.dispatch(incident.fingerprint, message)
         except Exception:
             # The Hermes agent already guards sink exceptions in its own
@@ -130,13 +190,36 @@ class TelegramSink:
                 incident.fingerprint,
             )
 
+    def close(self) -> None:
+        """Shut down the bridge executor.
+
+        Safe to call multiple times. The :class:`TelegramSink` itself
+        does not own any other resources, so callers wiring a sink into
+        a long-running process should invoke ``close()`` on shutdown
+        to drain any in-flight bridge calls.
+        """
+        executor = self._bridge_executor
+        if executor is not None:
+            executor.shutdown(wait=True, cancel_futures=False)
+            self._bridge_executor = None
+
     # ------------------------------------------------------------------
     # Investigation bridge
 
-    def _maybe_investigate(self, incident: HermesIncident) -> str | None:
+    def _maybe_investigate(self, incident: HermesIncident) -> _InvestigationResult:
         bridge = self._investigation_bridge
-        if bridge is None or incident.severity not in _INVESTIGATION_SEVERITIES:
-            return None
+        if bridge is None:
+            return _InvestigationResult.not_attempted()
+        if incident.severity not in _INVESTIGATION_SEVERITIES:
+            return _InvestigationResult.not_attempted()
+
+        if self._config.bridge_run_inline or self._bridge_executor is None:
+            return self._run_bridge_inline(bridge, incident)
+        return self._run_bridge_in_pool(bridge, incident)
+
+    def _run_bridge_inline(
+        self, bridge: InvestigationBridge, incident: HermesIncident
+    ) -> _InvestigationResult:
         try:
             summary = bridge(incident)
         except Exception:
@@ -146,10 +229,49 @@ class TelegramSink:
                 incident.fingerprint,
                 exc_info=True,
             )
-            return None
+            return _InvestigationResult.failed()
+        return self._coerce_summary(summary)
+
+    def _run_bridge_in_pool(
+        self, bridge: InvestigationBridge, incident: HermesIncident
+    ) -> _InvestigationResult:
+        # The executor is guaranteed non-None on this path (see
+        # _maybe_investigate); assert for the type checker.
+        executor = self._bridge_executor
+        assert executor is not None
+
+        future: Future[str | None] = executor.submit(bridge, incident)
+        timeout = self._config.bridge_timeout_s
+        try:
+            summary = future.result(timeout=timeout)
+        except FutureTimeoutError:
+            # Leave the future running — cancelling a long LLM call
+            # mid-flight is rarely clean, and the next matching incident
+            # will get a fresh budget after cooldown. Log so operators
+            # can correlate timed-out alerts with server-side activity.
+            logger.warning(
+                "hermes investigation bridge timed out after %.1fs: rule=%s fingerprint=%s",
+                timeout,
+                incident.rule,
+                incident.fingerprint,
+            )
+            return _InvestigationResult.timed_out(timeout)
+        except Exception:
+            logger.warning(
+                "hermes investigation bridge raised: rule=%s fingerprint=%s",
+                incident.rule,
+                incident.fingerprint,
+                exc_info=True,
+            )
+            return _InvestigationResult.failed()
+        return self._coerce_summary(summary)
+
+    def _coerce_summary(self, summary: str | None) -> _InvestigationResult:
         if not summary:
-            return None
-        return _truncate(summary.strip(), self._config.max_summary_chars)
+            return _InvestigationResult.empty()
+        return _InvestigationResult.success(
+            _truncate(summary.strip(), self._config.max_summary_chars)
+        )
 
     # ------------------------------------------------------------------
     # Message formatting
@@ -158,7 +280,7 @@ class TelegramSink:
         self,
         incident: HermesIncident,
         *,
-        rca_summary: str | None,
+        investigation: _InvestigationResult,
     ) -> str:
         emoji = _SEVERITY_EMOJI.get(incident.severity, "⚠️")
         header = (
@@ -178,13 +300,9 @@ class TelegramSink:
         if records_block:
             body_parts.append("recent log records:\n" + records_block)
 
-        if rca_summary:
-            body_parts.append("investigation summary:\n" + rca_summary)
-        elif incident.severity == IncidentSeverity.MEDIUM:
-            # Explicitly mark notify-only severity so the operator knows
-            # an RCA was not attempted (vs. attempted and produced no
-            # summary, which the branch above represents).
-            body_parts.append("note: warning-burst severity — notify only, no investigation run.")
+        investigation_block = investigation.render(incident.severity)
+        if investigation_block:
+            body_parts.append(investigation_block)
 
         return "\n\n".join(body_parts)
 
@@ -197,6 +315,60 @@ class TelegramSink:
         if omitted > 0:
             lines.append(f"… ({omitted} more record{'s' if omitted != 1 else ''} omitted)")
         return "\n".join(lines)
+
+
+@dataclass(frozen=True, slots=True)
+class _InvestigationResult:
+    """Internal value type carrying the outcome of a bridge call.
+
+    A :class:`TelegramSink._maybe_investigate` call returns one of five
+    states (see module docstring). Encoding them as a small value type
+    keeps :meth:`TelegramSink._format_message` branchless and makes the
+    operator-visible marker for each state easy to audit in tests.
+    """
+
+    state: str  # one of: not_attempted | success | empty | failed | timed_out
+    summary: str | None = None
+    timeout_s: float | None = None
+
+    @classmethod
+    def not_attempted(cls) -> _InvestigationResult:
+        return cls(state="not_attempted")
+
+    @classmethod
+    def success(cls, summary: str) -> _InvestigationResult:
+        return cls(state="success", summary=summary)
+
+    @classmethod
+    def empty(cls) -> _InvestigationResult:
+        return cls(state="empty")
+
+    @classmethod
+    def failed(cls) -> _InvestigationResult:
+        return cls(state="failed")
+
+    @classmethod
+    def timed_out(cls, timeout_s: float) -> _InvestigationResult:
+        return cls(state="timed_out", timeout_s=timeout_s)
+
+    def render(self, severity: IncidentSeverity) -> str:
+        if self.state == "success" and self.summary is not None:
+            return "investigation summary:\n" + self.summary
+        if self.state == "empty":
+            return "investigation: attempted (no summary produced)"
+        if self.state == "failed":
+            return "investigation: attempted (failed — see server logs)"
+        if self.state == "timed_out" and self.timeout_s is not None:
+            return (
+                f"investigation: attempted (timed out after "
+                f"{self.timeout_s:.1f}s — see server logs)"
+            )
+        # not_attempted → no investigation block, but MEDIUM severity
+        # gets an explicit marker so the operator knows the rule is
+        # notify-only by design.
+        if severity == IncidentSeverity.MEDIUM:
+            return "note: warning-burst severity — notify only, no investigation run."
+        return ""
 
 
 def make_telegram_sink(

--- a/tests/hermes/test_sinks.py
+++ b/tests/hermes/test_sinks.py
@@ -1,0 +1,228 @@
+"""Tests for :mod:`app.hermes.sinks`."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from app.hermes.incident import HermesIncident, IncidentSeverity, LogLevel, LogRecord
+from app.hermes.sinks import TelegramSink, TelegramSinkConfig, make_telegram_sink
+from app.watch_dog.alarms import AlarmCredentials, AlarmDispatcher
+
+_TS = datetime(2026, 5, 12, 0, 0, 0)
+
+
+def _record(level: LogLevel, logger_name: str, message: str) -> LogRecord:
+    raw = f"{_TS.isoformat()} {level.value} {logger_name}: {message}"
+    return LogRecord(timestamp=_TS, level=level, logger=logger_name, message=message, raw=raw)
+
+
+def _incident(
+    *,
+    rule: str = "error_severity",
+    severity: IncidentSeverity = IncidentSeverity.HIGH,
+    logger_name: str = "gateway.platforms.telegram",
+    title: str = "ERROR from gateway.platforms.telegram",
+    fingerprint: str = "deadbeef00000001",
+    records: tuple[LogRecord, ...] | None = None,
+    run_id: str | None = None,
+) -> HermesIncident:
+    if records is None:
+        records = (_record(LogLevel.ERROR, logger_name, "boom"),)
+    return HermesIncident(
+        rule=rule,
+        severity=severity,
+        title=title,
+        detected_at=_TS,
+        logger=logger_name,
+        fingerprint=fingerprint,
+        records=records,
+        run_id=run_id,
+    )
+
+
+def _capture_telegram(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def _fake_post(chat_id: str, text: str, bot_token: str) -> tuple[bool, str, str]:
+        calls.append({"chat_id": chat_id, "text": text, "bot_token": bot_token})
+        return True, "", "1"
+
+    monkeypatch.setattr("app.watch_dog.alarms.post_telegram_message", _fake_post)
+    return calls
+
+
+def _dispatcher(monkeypatch: pytest.MonkeyPatch) -> tuple[AlarmDispatcher, list[dict[str, Any]]]:
+    calls = _capture_telegram(monkeypatch)
+    creds = AlarmCredentials(bot_token="tok", chat_id="chat-1")
+    return AlarmDispatcher(creds, cooldown_seconds=300.0), calls
+
+
+class TestFormatting:
+    def test_message_contains_core_incident_metadata(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        sink = TelegramSink(dispatcher)
+
+        sink(_incident(run_id="run-xyz"))
+
+        assert len(calls) == 1
+        text = calls[0]["text"]
+        # Each field the operator scans for at a glance.
+        for needle in (
+            "Hermes incident: ERROR from gateway.platforms.telegram",
+            "severity: HIGH",
+            "rule: error_severity",
+            "logger: gateway.platforms.telegram",
+            "fingerprint: deadbeef00000001",
+            "run_id: run-xyz",
+            "recent log records:",
+        ):
+            assert needle in text, f"missing {needle!r} in:\n{text}"
+
+    def test_message_truncates_long_records(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        sink = TelegramSink(dispatcher, config=TelegramSinkConfig(max_record_chars=50))
+
+        long_msg = "x" * 500
+        sink(_incident(records=(_record(LogLevel.ERROR, "noisy", long_msg),)))
+
+        text = calls[0]["text"]
+        # The raw record line should have been collapsed with the
+        # ellipsis suffix, not pasted in full.
+        assert long_msg not in text
+        assert "…" in text
+
+    def test_message_inlines_at_most_max_records(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        sink = TelegramSink(dispatcher, config=TelegramSinkConfig(max_inlined_records=2))
+
+        records = tuple(_record(LogLevel.ERROR, "noisy", f"line-{i}") for i in range(5))
+        sink(_incident(records=records))
+
+        text = calls[0]["text"]
+        assert "line-0" in text
+        assert "line-1" in text
+        assert "line-4" not in text  # trimmed
+        assert "3 more records omitted" in text
+
+
+class TestSeverityRouting:
+    def test_high_incident_triggers_investigation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        bridge_calls: list[HermesIncident] = []
+
+        def _bridge(incident: HermesIncident) -> str | None:
+            bridge_calls.append(incident)
+            return "root cause: redis is down"
+
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge)
+        sink(_incident(severity=IncidentSeverity.HIGH))
+
+        assert len(bridge_calls) == 1
+        assert "investigation summary:" in calls[0]["text"]
+        assert "root cause: redis is down" in calls[0]["text"]
+
+    def test_critical_incident_triggers_investigation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        bridge_calls: list[HermesIncident] = []
+
+        def _bridge(incident: HermesIncident) -> str | None:
+            bridge_calls.append(incident)
+            return "root cause: oom kill"
+
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge)
+        sink(_incident(severity=IncidentSeverity.CRITICAL))
+
+        assert len(bridge_calls) == 1
+        assert "root cause: oom kill" in calls[0]["text"]
+
+    def test_medium_incident_skips_investigation_and_marks_notify_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        bridge_calls: list[HermesIncident] = []
+
+        def _bridge(incident: HermesIncident) -> str | None:
+            bridge_calls.append(incident)
+            return "should not appear"
+
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge)
+        sink(_incident(severity=IncidentSeverity.MEDIUM, rule="warning_burst"))
+
+        assert bridge_calls == []
+        text = calls[0]["text"]
+        assert "investigation summary:" not in text
+        assert "notify only" in text
+
+    def test_bridge_returning_none_omits_summary_section(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+
+        def _bridge(_incident: HermesIncident) -> str | None:
+            return None
+
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge)
+        sink(_incident(severity=IncidentSeverity.CRITICAL))
+
+        assert "investigation summary:" not in calls[0]["text"]
+
+    def test_bridge_exception_is_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+
+        def _bridge(_incident: HermesIncident) -> str | None:
+            raise RuntimeError("LLM unreachable")
+
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge)
+        # Must not raise — a broken investigation pipeline cannot block
+        # notification delivery.
+        sink(_incident(severity=IncidentSeverity.HIGH))
+
+        assert len(calls) == 1
+        assert "investigation summary:" not in calls[0]["text"]
+
+
+class TestDispatcherIntegration:
+    def test_duplicate_fingerprint_is_suppressed_by_cooldown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        # Freeze monotonic time so the second dispatch falls inside the
+        # default 300-second cooldown.
+        monkeypatch.setattr(AlarmDispatcher, "_now", staticmethod(lambda: 1000.0))
+
+        sink = TelegramSink(dispatcher)
+        sink(_incident(fingerprint="same-fp"))
+        sink(_incident(fingerprint="same-fp"))
+
+        assert len(calls) == 1
+
+    def test_different_fingerprints_both_dispatch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        sink = TelegramSink(dispatcher)
+
+        sink(_incident(fingerprint="fp-a"))
+        sink(_incident(fingerprint="fp-b"))
+
+        assert len(calls) == 2
+
+    def test_make_telegram_sink_factory_returns_callable_with_bridge(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        bridge_calls: list[HermesIncident] = []
+
+        def _bridge(incident: HermesIncident) -> str | None:
+            bridge_calls.append(incident)
+            return "RCA"
+
+        sink = make_telegram_sink(dispatcher, investigation_bridge=_bridge)
+        sink(_incident(severity=IncidentSeverity.HIGH))
+
+        assert callable(sink)
+        assert len(calls) == 1
+        assert len(bridge_calls) == 1

--- a/tests/hermes/test_sinks.py
+++ b/tests/hermes/test_sinks.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+import time
 from datetime import datetime
 from typing import Any
 
@@ -12,6 +14,12 @@ from app.hermes.sinks import TelegramSink, TelegramSinkConfig, make_telegram_sin
 from app.watch_dog.alarms import AlarmCredentials, AlarmDispatcher
 
 _TS = datetime(2026, 5, 12, 0, 0, 0)
+
+
+# Default test config: run the bridge inline so unit tests are
+# deterministic. The pooled path is exercised separately by
+# TestPooledBridge to keep its slower/race-sensitive tests scoped.
+_INLINE = TelegramSinkConfig(bridge_run_inline=True)
 
 
 def _record(level: LogLevel, logger_name: str, message: str) -> LogRecord:
@@ -117,7 +125,7 @@ class TestSeverityRouting:
             bridge_calls.append(incident)
             return "root cause: redis is down"
 
-        sink = TelegramSink(dispatcher, investigation_bridge=_bridge)
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge, config=_INLINE)
         sink(_incident(severity=IncidentSeverity.HIGH))
 
         assert len(bridge_calls) == 1
@@ -134,7 +142,7 @@ class TestSeverityRouting:
             bridge_calls.append(incident)
             return "root cause: oom kill"
 
-        sink = TelegramSink(dispatcher, investigation_bridge=_bridge)
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge, config=_INLINE)
         sink(_incident(severity=IncidentSeverity.CRITICAL))
 
         assert len(bridge_calls) == 1
@@ -150,7 +158,7 @@ class TestSeverityRouting:
             bridge_calls.append(incident)
             return "should not appear"
 
-        sink = TelegramSink(dispatcher, investigation_bridge=_bridge)
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge, config=_INLINE)
         sink(_incident(severity=IncidentSeverity.MEDIUM, rule="warning_burst"))
 
         assert bridge_calls == []
@@ -158,32 +166,97 @@ class TestSeverityRouting:
         assert "investigation summary:" not in text
         assert "notify only" in text
 
-    def test_bridge_returning_none_omits_summary_section(
+    def test_bridge_returning_none_marks_attempted_no_summary(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """Operator must be able to distinguish 'no bridge configured'
+        from 'bridge ran and returned nothing' — Greptile #1858 P2."""
         dispatcher, calls = _dispatcher(monkeypatch)
 
         def _bridge(_incident: HermesIncident) -> str | None:
             return None
 
-        sink = TelegramSink(dispatcher, investigation_bridge=_bridge)
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge, config=_INLINE)
         sink(_incident(severity=IncidentSeverity.CRITICAL))
 
-        assert "investigation summary:" not in calls[0]["text"]
+        text = calls[0]["text"]
+        assert "investigation summary:" not in text
+        assert "investigation: attempted (no summary produced)" in text
 
-    def test_bridge_exception_is_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_bridge_exception_is_marked_attempted_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Bridge exceptions must surface a 'failed' marker on Telegram
+        so operators don't conflate them with 'investigation disabled'."""
         dispatcher, calls = _dispatcher(monkeypatch)
 
         def _bridge(_incident: HermesIncident) -> str | None:
             raise RuntimeError("LLM unreachable")
 
-        sink = TelegramSink(dispatcher, investigation_bridge=_bridge)
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge, config=_INLINE)
         # Must not raise — a broken investigation pipeline cannot block
         # notification delivery.
         sink(_incident(severity=IncidentSeverity.HIGH))
 
         assert len(calls) == 1
-        assert "investigation summary:" not in calls[0]["text"]
+        text = calls[0]["text"]
+        assert "investigation summary:" not in text
+        assert "investigation: attempted (failed" in text
+
+    def test_high_incident_without_bridge_omits_investigation_section(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When no bridge is configured at all, no investigation block
+        is emitted (the markers are reserved for bridge-attempted states)."""
+        dispatcher, calls = _dispatcher(monkeypatch)
+        sink = TelegramSink(dispatcher)
+        sink(_incident(severity=IncidentSeverity.HIGH))
+
+        text = calls[0]["text"]
+        assert "investigation summary:" not in text
+        assert "investigation: attempted" not in text
+
+
+class TestPooledBridge:
+    """Verify the pooled bridge execution path: timeouts must surface
+    as an explicit marker, and the call must not block longer than
+    ``bridge_timeout_s`` even when the bridge hangs."""
+
+    def test_bridge_timeout_marks_attempted_timed_out_and_does_not_block(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        bridge_started = threading.Event()
+        bridge_release = threading.Event()
+
+        def _slow_bridge(_incident: HermesIncident) -> str | None:
+            bridge_started.set()
+            # Block until released so the test deterministically hits
+            # the timeout path. The future is left running on timeout;
+            # we release it at teardown so the worker thread exits.
+            bridge_release.wait(timeout=5.0)
+            return "too late"
+
+        # 50 ms timeout keeps the test fast while still exercising the
+        # pooled (off-thread) code path.
+        config = TelegramSinkConfig(bridge_timeout_s=0.05, bridge_workers=1)
+        sink = TelegramSink(dispatcher, investigation_bridge=_slow_bridge, config=config)
+        try:
+            start = time.monotonic()
+            sink(_incident(severity=IncidentSeverity.CRITICAL))
+            elapsed = time.monotonic() - start
+
+            # Must return well under the bridge's own would-be runtime.
+            # Generous upper bound to absorb CI scheduling noise.
+            assert elapsed < 1.0, f"sink blocked for {elapsed:.2f}s; expected <1.0s"
+            assert bridge_started.is_set(), "bridge worker never started"
+            text = calls[0]["text"]
+            assert "investigation summary:" not in text
+            assert "investigation: attempted (timed out after" in text
+            assert "too late" not in text  # late return must be discarded
+        finally:
+            bridge_release.set()
+            sink.close()
 
 
 class TestDispatcherIntegration:
@@ -220,7 +293,7 @@ class TestDispatcherIntegration:
             bridge_calls.append(incident)
             return "RCA"
 
-        sink = make_telegram_sink(dispatcher, investigation_bridge=_bridge)
+        sink = make_telegram_sink(dispatcher, investigation_bridge=_bridge, config=_INLINE)
         sink(_incident(severity=IncidentSeverity.HIGH))
 
         assert callable(sink)

--- a/tests/synthetic/hermes/test_telegram_dispatch.py
+++ b/tests/synthetic/hermes/test_telegram_dispatch.py
@@ -1,0 +1,131 @@
+"""Synthetic end-to-end test: HermesAgent → TelegramSink → AlarmDispatcher.
+
+Distinct from ``test_suite.py``, which only exercises the classifier.
+This test feeds a realistic ``errors.log`` slice through the full
+incident pipeline and asserts that the Telegram dispatcher receives a
+correctly-formatted message for each detected incident, with
+fingerprint-keyed dedup applied across repeats.
+
+The log fixture is synthesized inline rather than read from disk so the
+test does not depend on the per-scenario ``errors.log`` files (those
+are ``.gitignore``d).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.hermes.agent import HermesAgent
+from app.hermes.classifier import IncidentClassifier
+from app.hermes.incident import HermesIncident
+from app.hermes.sinks import TelegramSink
+from app.watch_dog.alarms import AlarmCredentials, AlarmDispatcher
+
+pytestmark = pytest.mark.synthetic
+
+
+# 9 WARNING lines from the Telegram polling-conflict scenario (~22.5s
+# cadence), enough to trigger 3 warning bursts with a threshold of 3.
+_POLLING_CONFLICT_LOG = [
+    "2026-05-12 00:40:12,000 WARNING gateway.platforms.telegram: "
+    "[Telegram] Telegram polling conflict (1/3), will retry in 10s.",
+    "2026-05-12 00:40:34,500 WARNING gateway.platforms.telegram: "
+    "[Telegram] Telegram polling conflict (2/3), will retry in 10s.",
+    "2026-05-12 00:40:57,000 WARNING gateway.platforms.telegram: "
+    "[Telegram] Telegram polling conflict (3/3), will retry in 10s.",
+    "2026-05-12 00:41:19,500 WARNING gateway.platforms.telegram: "
+    "[Telegram] Telegram polling conflict (1/3), will retry in 10s.",
+    "2026-05-12 00:41:42,000 WARNING gateway.platforms.telegram: "
+    "[Telegram] Telegram polling conflict (2/3), will retry in 10s.",
+    "2026-05-12 00:42:04,500 WARNING gateway.platforms.telegram: "
+    "[Telegram] Telegram polling conflict (3/3), will retry in 10s.",
+    "2026-05-12 00:42:27,000 WARNING gateway.platforms.telegram: "
+    "[Telegram] Telegram polling conflict (1/3), will retry in 10s.",
+    "2026-05-12 00:42:49,500 WARNING gateway.platforms.telegram: "
+    "[Telegram] Telegram polling conflict (2/3), will retry in 10s.",
+    "2026-05-12 00:43:12,000 WARNING gateway.platforms.telegram: "
+    "[Telegram] Telegram polling conflict (3/3), will retry in 10s.",
+]
+
+
+def _patch_telegram(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def _fake_post(chat_id: str, text: str, bot_token: str) -> tuple[bool, str, str]:
+        calls.append({"chat_id": chat_id, "text": text, "bot_token": bot_token})
+        return True, "", "1"
+
+    monkeypatch.setattr("app.watch_dog.alarms.post_telegram_message", _fake_post)
+    return calls
+
+
+def test_polling_conflict_dispatches_warning_burst_to_telegram(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Three bursts of 3 warnings each should produce one Telegram dispatch.
+
+    All bursts share the same ``warning_burst`` fingerprint (rule +
+    logger + empty message), so the dispatcher's cooldown collapses
+    them into a single send — exactly the behaviour the operator wants
+    when a single subsystem floods.
+    """
+    calls = _patch_telegram(monkeypatch)
+    creds = AlarmCredentials(bot_token="tok", chat_id="chat-1")
+    dispatcher = AlarmDispatcher(creds, cooldown_seconds=300.0)
+    sink = TelegramSink(dispatcher)
+
+    incidents: list[HermesIncident] = []
+
+    def _tee(incident: HermesIncident) -> None:
+        incidents.append(incident)
+        sink(incident)
+
+    agent = HermesAgent(
+        sink=_tee,
+        log_path="/dev/null",
+        classifier=IncidentClassifier(warning_burst_threshold=3, warning_burst_window_s=60.0),
+    )
+
+    agent.process(_POLLING_CONFLICT_LOG)
+
+    # Classifier emits 3 bursts (9 lines / threshold of 3, bucket
+    # drains on emit). All share the same fingerprint.
+    assert len(incidents) == 3
+    fingerprints = {incident.fingerprint for incident in incidents}
+    assert len(fingerprints) == 1, "warning_burst fingerprint must be stable across bursts"
+
+    # Dispatcher cooldown suppresses the second and third dispatch.
+    assert len(calls) == 1
+    text = calls[0]["text"]
+    assert "Hermes incident" in text
+    assert "warning_burst" in text
+    assert "gateway.platforms.telegram" in text
+    # Notify-only marker present (MEDIUM severity = no investigation).
+    assert "notify only" in text
+
+
+def test_distinct_fingerprints_all_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Different incident fingerprints bypass cooldown, so each gets sent."""
+    calls = _patch_telegram(monkeypatch)
+    creds = AlarmCredentials(bot_token="tok", chat_id="chat-1")
+    dispatcher = AlarmDispatcher(creds, cooldown_seconds=300.0)
+    sink = TelegramSink(dispatcher)
+
+    agent = HermesAgent(
+        sink=sink,
+        log_path="/dev/null",
+        classifier=IncidentClassifier(warning_burst_threshold=2, warning_burst_window_s=60.0),
+    )
+
+    # Two ERROR records from distinct loggers/messages → two
+    # error_severity incidents with different fingerprints.
+    agent.process(
+        [
+            "2026-05-12 00:00:00,000 ERROR backend.api: database connection refused",
+            "2026-05-12 00:00:01,000 ERROR worker.queue: failed to ack message",
+        ]
+    )
+
+    assert len(calls) == 2


### PR DESCRIPTION
Completes the Hermes incident-to-Telegram pipeline on top of the detection backbone in #1857.

## What's added

### `app/hermes/sinks.py` — Telegram sink
`TelegramSink` + `make_telegram_sink` factory. Formats incidents as human-readable Telegram messages and routes them through `AlarmDispatcher` **keyed on `incident.fingerprint`**, so duplicate incidents respect the per-fingerprint cooldown (default 5 min).

### `app/hermes/investigation.py` — optional RCA bridge
Converts a `HermesIncident` into a Grafana-shaped alert payload, calls `run_investigation`, and extracts a root-cause summary from the resulting `AgentState`. Heavy pipeline imports are deferred so consumers that never trigger an investigation pay no import cost.

### Severity routing
- **HIGH / CRITICAL** → run investigation, append RCA summary to the Telegram body.
- **MEDIUM** (warning bursts) → notify-only, no investigation. Body explicitly marks this.
- Bridge exceptions and \`None\` returns are caught and logged; notification is still sent without the RCA section.

### `app/cli/commands/hermes.py` — \`opensre hermes watch\` command
\`\`\`
opensre hermes watch [--log-path PATH] [--chat-id ID]
                      [--cooldown-seconds 300]
                      [--from-start | --from-end]
                      [--investigate | --no-investigate]
\`\`\`
Loads credentials via \`load_credentials_from_env\`, wires \`HermesAgent\` to \`TelegramSink\`, installs SIGINT/SIGTERM handlers, and blocks on a \`threading.Event\` until shutdown. Set \`OPENSRE_HERMES_INVESTIGATE=1\` to enable the RCA bridge globally.

### Registration
- Added \`hermes_command\` to the Click CLI command tuple.
- Added \`/hermes\` to the REPL slash-command registry — the existing \`test_cli_slash_command_parity\` test enforces this.

## Runtime flow

\`\`\`
~/.hermes/logs/errors.log
  ↓  FileTailer (0.5 s poll)
  ↓  parse_log_line
  ↓  IncidentClassifier
  ↓  HermesIncident (rule, severity, fingerprint, records)
  ↓  [HIGH/CRITICAL] → OpenSRE investigation pipeline → RCA summary
  ↓  AlarmDispatcher (per-fingerprint cooldown, 5 min default)
  ↓  Telegram Bot API → operator chat
\`\`\`

## Tests

| File | Coverage |
|------|----------|
| \`tests/hermes/test_sinks.py\` | 11 unit tests: message formatting, record truncation/trimming, severity routing (HIGH/CRITICAL trigger bridge, MEDIUM marks notify-only), bridge exception swallowing, dispatcher dedup, factory parity. |
| \`tests/synthetic/hermes/test_telegram_dispatch.py\` | End-to-end \`HermesAgent → TelegramSink → AlarmDispatcher\` over the polling-conflict scenario. Asserts fingerprint-keyed cooldown collapses 3 warning bursts into 1 send, and distinct fingerprints all dispatch. |

All checks passing locally:
- \`uv run pytest tests/hermes tests/synthetic/hermes/test_telegram_dispatch.py tests/watch_dog tests/cli/interactive_shell/test_parity.py\` → **71 passed**
- \`uv run ruff check\` → All checks passed
- \`uv run ruff format --check\` → 1350 files already formatted
- \`uv run mypy app/hermes app/cli/commands/hermes.py\` → Success: no issues found in 10 source files

## Out of scope

- Multi-file / multi-host log aggregation (single local file only)
- Persistent incident store or dedup DB (fingerprint-keyed cooldown is sufficient)
- Web UI or dashboard; Telegram is the only delivery surface

## Pre-existing issue (not caused by this PR)

\`tests/synthetic/hermes/test_suite.py\` cannot collect because \`errors.log\` fixtures are \`.gitignore\`d but required by \`scenario_loader\`. This was true before this PR — confirmed by stashing my changes and re-running collection. Worth a follow-up to either ship the log fixtures or generate them in-test (\`test_telegram_dispatch.py\` does the latter).