### PR TITLE
fix(llm_cli): raise CLITransientError for kimi EX_TEMPFAIL (exit 75)

### DIFF
--- a/app/cli/interactive_shell/chat/cli_agent.py
+++ b/app/cli/interactive_shell/chat/cli_agent.py
@@ -37,7 +37,7 @@ from app.cli.interactive_shell.ui import (
     stream_to_console,
 )
 from app.cli.support.exception_reporting import report_exception
-from app.integrations.llm_cli.errors import CLITimeoutError
+from app.integrations.llm_cli.errors import CLITimeoutError, CLITransientError
 
 # Cap stored (user, assistant) pairs; list holds 2 entries per turn.
 _MAX_CLI_AGENT_TURNS = 12
@@ -462,7 +462,7 @@ def answer_cli_agent(
         report_exception(
             exc,
             context="interactive_shell.cli_agent.stream",
-            expected=isinstance(exc, CLITimeoutError),
+            expected=isinstance(exc, (CLITimeoutError, CLITransientError)),
         )
         console.print(f"[{ERROR}]assistant failed:[/] {escape(str(exc))}")
         return

--- a/app/integrations/llm_cli/__init__.py
+++ b/app/integrations/llm_cli/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from app.integrations.llm_cli.base import CLIInvocation, CLIProbe
-from app.integrations.llm_cli.errors import CLIAuthenticationRequired
+from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITransientError
 from app.integrations.llm_cli.runner import CLIBackedLLMClient
 
-__all__ = ["CLIAuthenticationRequired", "CLIInvocation", "CLIProbe", "CLIBackedLLMClient"]
+__all__ = ["CLIAuthenticationRequired", "CLITransientError", "CLIInvocation", "CLIProbe", "CLIBackedLLMClient"]

--- a/app/integrations/llm_cli/errors.py
+++ b/app/integrations/llm_cli/errors.py
@@ -23,3 +23,11 @@ class CLIAuthenticationRequired(RuntimeError):
         self.auth_hint = auth_hint
         self.detail = detail
         super().__init__(f"{provider} is not authenticated. {auth_hint} ({detail})")
+
+
+class CLITransientError(RuntimeError):
+    """The CLI subprocess exited with a temporary-failure code (EX_TEMPFAIL / 75).
+
+    Treated as an expected operational failure (not a bug), so callers should
+    not forward it to error-tracking services like Sentry.
+    """

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -13,7 +13,11 @@ from typing import Any
 from pydantic import BaseModel
 
 from app.integrations.llm_cli.base import CLIProbe, LLMCLIAdapter
-from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITimeoutError
+from app.integrations.llm_cli.errors import (
+    CLIAuthenticationRequired,
+    CLITimeoutError,
+    CLITransientError,
+)
 from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 from app.integrations.llm_cli.text import flatten_messages_to_prompt
 from app.llm_reasoning_effort import get_active_reasoning_effort
@@ -173,6 +177,9 @@ class CLIBackedLLMClient:
                 )
             else:
                 message = base
+            # EX_TEMPFAIL (75) — transient; not a code bug, don't send to Sentry.
+            if proc.returncode == 75:
+                raise CLITransientError(message)
             raise RuntimeError(message)
 
         content = self._adapter.parse(stdout=out, stderr=err, returncode=proc.returncode)

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -147,6 +147,10 @@ class CLIBackedLLMClient:
             base = self._adapter.explain_failure(
                 stdout=out, stderr=err, returncode=proc.returncode
             ).strip()
+            # EX_TEMPFAIL (75) is transient; raise before the auth heuristic and
+            # before the auth_probe_unclear augmentation so the message stays clean.
+            if proc.returncode == 75:
+                raise CLITransientError(base)
             # When the failure message signals an auth problem raise
             # CLIAuthenticationRequired so callers (reraise_cli_runtime_error,
             # server endpoints) get structured, actionable handling instead of
@@ -177,9 +181,6 @@ class CLIBackedLLMClient:
                 )
             else:
                 message = base
-            # EX_TEMPFAIL (75) — transient; not a code bug, don't send to Sentry.
-            if proc.returncode == 75:
-                raise CLITransientError(message)
             raise RuntimeError(message)
 
         content = self._adapter.parse(stdout=out, stderr=err, returncode=proc.returncode)

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -367,7 +367,11 @@ def _init_sentry_once(
     """
     import sentry_sdk
 
-    from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITimeoutError
+    from app.integrations.llm_cli.errors import (
+        CLIAuthenticationRequired,
+        CLITimeoutError,
+        CLITransientError,
+    )
 
     with _suppress_langgraph_allowed_objects_warning():
         sentry_sdk.init(
@@ -383,7 +387,7 @@ def _init_sentry_once(
             integrations=_build_sentry_integrations(),
             before_send=_before_send,
             before_breadcrumb=_before_breadcrumb,
-            ignore_errors=[CLIAuthenticationRequired, CLITimeoutError],
+            ignore_errors=[CLIAuthenticationRequired, CLITimeoutError, CLITransientError],
         )
 
 

--- a/tests/integrations/llm_cli/test_kimi_adapter.py
+++ b/tests/integrations/llm_cli/test_kimi_adapter.py
@@ -244,6 +244,53 @@ def test_cli_backed_client_invoke_forwards_kimi_env(mock_run: MagicMock) -> None
     assert "OPENAI_API_KEY" not in env
 
 
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_invoke_exit_code_75_raises_cli_transient_error(mock_run: MagicMock) -> None:
+    """Exit code 75 (EX_TEMPFAIL) must raise CLITransientError, not RuntimeError.
+
+    Sentry ignores CLITransientError so transient kimi failures don't create
+    spurious bug reports (cf. GitHub issues #1866 / #1867).
+    """
+    import pytest
+
+    from app.integrations.llm_cli.errors import CLITransientError
+    from app.integrations.llm_cli.kimi import KimiAdapter
+    from app.integrations.llm_cli.runner import CLIBackedLLMClient
+
+    mock_adapter = MagicMock(spec=KimiAdapter)
+    mock_adapter.name = "kimi"
+    mock_adapter.auth_hint = "Run: kimi login"
+    mock_adapter.detect.return_value = MagicMock(
+        installed=True,
+        bin_path="/usr/bin/kimi",
+        logged_in=True,
+        detail="ok",
+    )
+    mock_adapter.build.return_value = MagicMock(
+        argv=["/usr/bin/kimi", "--print", "--yolo"],
+        stdin="hello",
+        cwd="/tmp",
+        env=None,
+        timeout_sec=30.0,
+    )
+    mock_adapter.explain_failure.return_value = (
+        "kimi exited with code 75. To resume this session: kimi -r abc123"
+    )
+
+    mock_run.return_value = MagicMock(
+        returncode=75,
+        stdout="",
+        stderr="To resume this session: kimi -r abc123",
+    )
+
+    with (
+        patch("app.guardrails.engine.get_guardrail_engine") as gr,
+        pytest.raises(CLITransientError),
+    ):
+        gr.return_value.is_active = False
+        CLIBackedLLMClient(mock_adapter).invoke("hello")
+
+
 def test_parse_and_explain_failure() -> None:
     adapter = KimiAdapter()
 

--- a/tests/integrations/llm_cli/test_kimi_adapter.py
+++ b/tests/integrations/llm_cli/test_kimi_adapter.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from app.integrations.llm_cli.errors import CLITransientError
 from app.integrations.llm_cli.kimi import KimiAdapter
+from app.integrations.llm_cli.runner import CLIBackedLLMClient
 
 
 def _version_proc() -> MagicMock:
@@ -251,12 +255,6 @@ def test_invoke_exit_code_75_raises_cli_transient_error(mock_run: MagicMock) -> 
     Sentry ignores CLITransientError so transient kimi failures don't create
     spurious bug reports (cf. GitHub issues #1866 / #1867).
     """
-    import pytest
-
-    from app.integrations.llm_cli.errors import CLITransientError
-    from app.integrations.llm_cli.kimi import KimiAdapter
-    from app.integrations.llm_cli.runner import CLIBackedLLMClient
-
     mock_adapter = MagicMock(spec=KimiAdapter)
     mock_adapter.name = "kimi"
     mock_adapter.auth_hint = "Run: kimi login"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- kimi exits with code 75 (`EX_TEMPFAIL`) on temporary/recoverable failures, but the runner was raising a bare `RuntimeError` which Sentry captured as a bug (issues #1866 and #1867)
- Added `CLITransientError` to `errors.py` (documented as expected operational failure, like `CLITimeoutError`)
- `runner.py` now raises `CLITransientError` when `returncode == 75` instead of `RuntimeError`
- Added `CLITransientError` to Sentry's `ignore_errors` list in `sentry_sdk.py` so these no longer create bug reports
- Updated `cli_agent.py` to treat `CLITransientError` as `expected=True` (same as `CLITimeoutError`)
- Exported `CLITransientError` from the `llm_cli` package `__init__.py`
- Added a regression test verifying exit code 75 raises `CLITransientError`

## Test plan

- [ ] `uv run pytest tests/integrations/llm_cli/test_kimi_adapter.py -v` — new test `test_invoke_exit_code_75_raises_cli_transient_error` passes
- [ ] `make lint` passes
- [ ] `make typecheck` passes

Closes #1866
Closes #1867

https://claude.ai/code/session_01S2g74fkfjhcGy2zPPduqi9
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2g74fkfjhcGy2zPPduqi9)_