### PR TITLE
fix(llm_cli): suppress Sentry noise for kimi EX_TEMPFAIL (exit code 75)

### DIFF
--- a/app/cli/interactive_shell/chat/cli_agent.py
+++ b/app/cli/interactive_shell/chat/cli_agent.py
@@ -37,7 +37,7 @@ from app.cli.interactive_shell.ui import (
     stream_to_console,
 )
 from app.cli.support.exception_reporting import report_exception
-from app.integrations.llm_cli.errors import CLITimeoutError
+from app.integrations.llm_cli.errors import CLITemporaryError, CLITimeoutError
 
 # Cap stored (user, assistant) pairs; list holds 2 entries per turn.
 _MAX_CLI_AGENT_TURNS = 12
@@ -462,7 +462,7 @@ def answer_cli_agent(
         report_exception(
             exc,
             context="interactive_shell.cli_agent.stream",
-            expected=isinstance(exc, CLITimeoutError),
+            expected=isinstance(exc, (CLITimeoutError, CLITemporaryError)),
         )
         console.print(f"[{ERROR}]assistant failed:[/] {escape(str(exc))}")
         return

--- a/app/integrations/llm_cli/__init__.py
+++ b/app/integrations/llm_cli/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from app.integrations.llm_cli.base import CLIInvocation, CLIProbe
-from app.integrations.llm_cli.errors import CLIAuthenticationRequired
+from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITemporaryError
 from app.integrations.llm_cli.runner import CLIBackedLLMClient
 
-__all__ = ["CLIAuthenticationRequired", "CLIInvocation", "CLIProbe", "CLIBackedLLMClient"]
+__all__ = ["CLIAuthenticationRequired", "CLITemporaryError", "CLIInvocation", "CLIProbe", "CLIBackedLLMClient"]

--- a/app/integrations/llm_cli/errors.py
+++ b/app/integrations/llm_cli/errors.py
@@ -11,6 +11,14 @@ class CLITimeoutError(RuntimeError):
     """
 
 
+class CLITemporaryError(RuntimeError):
+    """The CLI subprocess exited with a transient failure code (e.g. EX_TEMPFAIL / 75).
+
+    Treated as an expected operational failure (not a bug), so callers should
+    not forward it to error-tracking services like Sentry.
+    """
+
+
 class CLIAuthenticationRequired(RuntimeError):
     """CLI probe reported the user is definitely not authenticated (`logged_in=False`).
 

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -13,7 +13,11 @@ from typing import Any
 from pydantic import BaseModel
 
 from app.integrations.llm_cli.base import CLIProbe, LLMCLIAdapter
-from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITimeoutError
+from app.integrations.llm_cli.errors import (
+    CLIAuthenticationRequired,
+    CLITemporaryError,
+    CLITimeoutError,
+)
 from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 from app.integrations.llm_cli.text import flatten_messages_to_prompt
 from app.llm_reasoning_effort import get_active_reasoning_effort
@@ -173,6 +177,8 @@ class CLIBackedLLMClient:
                 )
             else:
                 message = base
+            if proc.returncode == 75:  # EX_TEMPFAIL: transient, not a code bug
+                raise CLITemporaryError(message)
             raise RuntimeError(message)
 
         content = self._adapter.parse(stdout=out, stderr=err, returncode=proc.returncode)

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -147,6 +147,11 @@ class CLIBackedLLMClient:
             base = self._adapter.explain_failure(
                 stdout=out, stderr=err, returncode=proc.returncode
             ).strip()
+            # EX_TEMPFAIL (75) is a transient, retryable failure — handle it
+            # before the auth-keyword heuristic so a 75 exit whose explain_failure
+            # text happens to mention auth doesn't get misclassified.
+            if proc.returncode == 75:
+                raise CLITemporaryError(base)
             # When the failure message signals an auth problem raise
             # CLIAuthenticationRequired so callers (reraise_cli_runtime_error,
             # server endpoints) get structured, actionable handling instead of
@@ -177,8 +182,6 @@ class CLIBackedLLMClient:
                 )
             else:
                 message = base
-            if proc.returncode == 75:  # EX_TEMPFAIL: transient, not a code bug
-                raise CLITemporaryError(message)
             raise RuntimeError(message)
 
         content = self._adapter.parse(stdout=out, stderr=err, returncode=proc.returncode)

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -367,7 +367,11 @@ def _init_sentry_once(
     """
     import sentry_sdk
 
-    from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITimeoutError
+    from app.integrations.llm_cli.errors import (
+        CLIAuthenticationRequired,
+        CLITemporaryError,
+        CLITimeoutError,
+    )
 
     with _suppress_langgraph_allowed_objects_warning():
         sentry_sdk.init(
@@ -383,7 +387,7 @@ def _init_sentry_once(
             integrations=_build_sentry_integrations(),
             before_send=_before_send,
             before_breadcrumb=_before_breadcrumb,
-            ignore_errors=[CLIAuthenticationRequired, CLITimeoutError],
+            ignore_errors=[CLIAuthenticationRequired, CLITemporaryError, CLITimeoutError],
         )
 
 

--- a/tests/integrations/llm_cli/test_kimi_adapter.py
+++ b/tests/integrations/llm_cli/test_kimi_adapter.py
@@ -244,6 +244,44 @@ def test_cli_backed_client_invoke_forwards_kimi_env(mock_run: MagicMock) -> None
     assert "OPENAI_API_KEY" not in env
 
 
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_cli_backed_client_raises_temporary_error_on_exit_75(mock_run: MagicMock) -> None:
+    """EX_TEMPFAIL (75) must raise CLITemporaryError, not RuntimeError, so Sentry ignores it."""
+    import pytest
+
+    from app.integrations.llm_cli.errors import CLITemporaryError
+    from app.integrations.llm_cli.kimi import KimiAdapter
+    from app.integrations.llm_cli.runner import CLIBackedLLMClient
+
+    mock_adapter = MagicMock(spec=KimiAdapter)
+    mock_adapter.name = "kimi"
+    mock_adapter.detect.return_value = MagicMock(
+        installed=True,
+        bin_path="/usr/bin/kimi",
+        logged_in=True,
+        detail="ok",
+    )
+    mock_adapter.build.return_value = MagicMock(
+        argv=["/usr/bin/kimi", "--print", "--yolo"],
+        stdin="hello",
+        cwd="/tmp",
+        env=None,
+        timeout_sec=30.0,
+    )
+    resume_msg = "To resume this session: kimi -r 79229edd-9caf-45af-bb89-04d3f742d063"
+    mock_adapter.explain_failure.return_value = f"kimi exited with code 75. {resume_msg}"
+    mock_run.return_value = MagicMock(returncode=75, stdout=resume_msg, stderr="")
+
+    with (
+        patch("app.guardrails.engine.get_guardrail_engine") as gr,
+        patch.dict(os.environ, {}, clear=False),
+    ):
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(mock_adapter, model="kimi-k2.5", max_tokens=256)
+        with pytest.raises(CLITemporaryError, match="kimi exited with code 75"):
+            client.invoke("hello")
+
+
 def test_parse_and_explain_failure() -> None:
     adapter = KimiAdapter()
 


### PR DESCRIPTION
## Summary

- `kimi` exits with code 75 (`EX_TEMPFAIL`) on transient failures (session limit, temporary service unavailability). The runner was raising a bare `RuntimeError` for all non-zero exit codes, causing these to land in Sentry as bugs (#1866, #1867).
- Introduce `CLITemporaryError` in `app/integrations/llm_cli/errors.py` — same pattern as the existing `CLITimeoutError` (documented as an operational failure, not a bug).
- Raise `CLITemporaryError` when `returncode == 75` in `runner.py` instead of `RuntimeError`.
- Add `CLITemporaryError` to the `ignore_errors` list in `app/utils/sentry_sdk.py` so Sentry ignores it.
- Mark it as `expected` in `cli_agent.py` so the interactive shell handles it gracefully.

## Test plan

- [ ] `tests/integrations/llm_cli/test_kimi_adapter.py::test_cli_backed_client_raises_temporary_error_on_exit_75` — new test verifying `CLITemporaryError` is raised for returncode 75
- [ ] Existing kimi adapter and Sentry init tests still pass
- [ ] `make lint` and `make typecheck` pass

Closes #1866
Closes #1867

https://claude.ai/code/session_014WB3yuf68aRV4LhG5SxjoL

---
_Generated by [Claude Code](https://claude.ai/code/session_014WB3yuf68aRV4LhG5SxjoL)_