### PR TITLE
fix(sentry): suppress kimi session-pause (exit 75) errors from Sentry

### DIFF
--- a/app/integrations/llm_cli/errors.py
+++ b/app/integrations/llm_cli/errors.py
@@ -11,6 +11,14 @@ class CLITimeoutError(RuntimeError):
     """
 
 
+class CLITransientError(RuntimeError):
+    """The CLI subprocess exited with a transient/recoverable failure (e.g. session pause).
+
+    Treated as an expected operational failure (not a bug), so callers should
+    not forward it to error-tracking services like Sentry.
+    """
+
+
 class CLIAuthenticationRequired(RuntimeError):
     """CLI probe reported the user is definitely not authenticated (`logged_in=False`).
 

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -13,7 +13,11 @@ from typing import Any
 from pydantic import BaseModel
 
 from app.integrations.llm_cli.base import CLIProbe, LLMCLIAdapter
-from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITimeoutError
+from app.integrations.llm_cli.errors import (
+    CLIAuthenticationRequired,
+    CLITimeoutError,
+    CLITransientError,
+)
 from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 from app.integrations.llm_cli.text import flatten_messages_to_prompt
 from app.llm_reasoning_effort import get_active_reasoning_effort
@@ -173,6 +177,11 @@ class CLIBackedLLMClient:
                 )
             else:
                 message = base
+            # "To resume this session" signals the CLI paused with saved state
+            # (e.g. kimi exit 75 / EX_TEMPFAIL).  This is a transient operational
+            # condition, not a code bug — raise CLITransientError so Sentry ignores it.
+            if "to resume this session" in message.lower():
+                raise CLITransientError(message)
             raise RuntimeError(message)
 
         content = self._adapter.parse(stdout=out, stderr=err, returncode=proc.returncode)

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -180,7 +180,7 @@ class CLIBackedLLMClient:
             # "To resume this session" signals the CLI paused with saved state
             # (e.g. kimi exit 75 / EX_TEMPFAIL).  This is a transient operational
             # condition, not a code bug — raise CLITransientError so Sentry ignores it.
-            if "to resume this session" in message.lower():
+            if "to resume this session" in base.lower():
                 raise CLITransientError(message)
             raise RuntimeError(message)
 

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -367,7 +367,11 @@ def _init_sentry_once(
     """
     import sentry_sdk
 
-    from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITimeoutError
+    from app.integrations.llm_cli.errors import (
+            CLIAuthenticationRequired,
+            CLITimeoutError,
+            CLITransientError,
+        )
 
     with _suppress_langgraph_allowed_objects_warning():
         sentry_sdk.init(
@@ -383,7 +387,7 @@ def _init_sentry_once(
             integrations=_build_sentry_integrations(),
             before_send=_before_send,
             before_breadcrumb=_before_breadcrumb,
-            ignore_errors=[CLIAuthenticationRequired, CLITimeoutError],
+            ignore_errors=[CLIAuthenticationRequired, CLITimeoutError, CLITransientError],
         )
 
 

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -368,10 +368,10 @@ def _init_sentry_once(
     import sentry_sdk
 
     from app.integrations.llm_cli.errors import (
-            CLIAuthenticationRequired,
-            CLITimeoutError,
-            CLITransientError,
-        )
+        CLIAuthenticationRequired,
+        CLITimeoutError,
+        CLITransientError,
+    )
 
     with _suppress_langgraph_allowed_objects_warning():
         sentry_sdk.init(


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `kimi` exits with code 75 (`EX_TEMPFAIL`) and emits `"To resume this session: kimi -r <UUID>"` when it pauses with saved state (e.g. context/rate limits). This is expected operational behaviour, not a code bug — but it was reaching Sentry as a bare `RuntimeError` (Sentry issues PYTHON-31 / PYTHON-32, GitHub issues #1866 / #1867).
- Add `CLITransientError` to `app/integrations/llm_cli/errors.py` (parallel to the existing `CLITimeoutError`) to represent transient, non-bug CLI failures.
- In `app/integrations/llm_cli/runner.py`, detect the `"to resume this session"` substring in the failure message and raise `CLITransientError` instead of `RuntimeError`.
- Register `CLITransientError` in Sentry's `ignore_errors` list in `app/utils/sentry_sdk.py` so the SDK never forwards these events.

## Test plan

- [ ] Confirm `CLITransientError` is a `RuntimeError` subclass (checked via AST + manual inspection).
- [ ] Verify lint passes: `uv run ruff check app/integrations/llm_cli/errors.py app/integrations/llm_cli/runner.py app/utils/sentry_sdk.py` → All checks passed.
- [ ] CI must pass on this PR before merge.

Closes #1866
Closes #1867

https://claude.ai/code/session_01VMdds2Gqr4bT7LohvJzhYs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMdds2Gqr4bT7LohvJzhYs)_