### PR TITLE
fix(sentry): filter Anthropic quota and kimi session-interrupted errors

### DIFF
--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -62,7 +62,7 @@ _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     # Anthropic hard quota: "You have reached your specified API usage limits."
     re.compile(r"\bapi usage limits\b", re.I),
     # kimi session interrupted mid-run (exit 75); not a code bug, nothing to fix in Sentry.
-    re.compile(r"\bto resume this session\b", re.I),
+    re.compile(r"\bkimi\s+-r\s+[0-9a-f-]{36}\b", re.I),
 )
 
 

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -59,6 +59,10 @@ _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bLLM API request failed after multiple retries\b", re.I),
     # Provider endpoint unreachable (Ollama down, bad URL, SSL misconfiguration).
     re.compile(r"\bcannot connect to .+ api\b", re.I),
+    # Anthropic hard quota: "You have reached your specified API usage limits."
+    re.compile(r"\bapi usage limits\b", re.I),
+    # kimi session interrupted mid-run (exit 75); not a code bug, nothing to fix in Sentry.
+    re.compile(r"\bto resume this session\b", re.I),
 )
 
 

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -667,6 +667,14 @@ def test_before_send_filters_nested_lists_of_dicts() -> None:
             "RuntimeError",
             "Cannot connect to Openrouter API. Check your network connection and that the endpoint URL is reachable.",
         ),
+        (
+            "RuntimeError",
+            "Anthropic request rejected (HTTP 400): Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'You have reached your specified API usage limits. You will regain access on 2026-06-01 at 00:00 UTC.'}, 'request_id': 'req_011CaxxMA8NCSdDvaM2LaRm6'}",
+        ),
+        (
+            "RuntimeError",
+            "kimi exited with code 75. To resume this session: kimi -r 79229edd-9caf-45af-bb89-04d3f742d063",
+        ),
     ],
 )
 def test_before_send_drops_operator_actionable_llm_errors(


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `\bapi usage limits\b` pattern to `_OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS` — drops Anthropic HTTP-400 hard-quota errors ("You have reached your specified API usage limits") before they reach Sentry. Closes #1883, #1885.
- Adds `\bto resume this session\b` pattern — drops kimi exit-75 session-interrupted errors ("To resume this session: kimi -r <uuid>") which are transient CLI lifecycle events, not code bugs. Closes #1866, #1867.

Both follow the existing operator-actionable filter pattern in `app/utils/sentry_sdk.py` (same approach as #1863).

## Test plan

- [ ] `tests/test_sentry_init.py` — two new parametrised cases added to `test_before_send_drops_operator_actionable_llm_errors`; all 56 tests pass locally.
- [ ] `make lint` and `make format-check` pass.

https://claude.ai/code/session_018woMkLkj9RHLiy8bdgPhf5
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018woMkLkj9RHLiy8bdgPhf5)_