### PR TITLE
fix(llm-cli): raise CLITemporaryFailure for subprocess EX_TEMPFAIL (exit 75)

### DIFF
--- a/app/cli/support/cli_error_mapping.py
+++ b/app/cli/support/cli_error_mapping.py
@@ -8,12 +8,18 @@ from typing import NoReturn
 def reraise_cli_runtime_error(exc: BaseException) -> NoReturn:
     """Convert CLI auth/setup failures to structured CLI UX errors."""
     from app.cli.support.errors import OpenSREError
-    from app.integrations.llm_cli.errors import CLIAuthenticationRequired
+    from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITemporaryFailure
 
     if isinstance(exc, CLIAuthenticationRequired):
         raise OpenSREError(
             f"{exc.provider} CLI is not authenticated.",
             suggestion=f"{exc.auth_hint} ({exc.detail})",
+        ) from exc
+
+    if isinstance(exc, CLITemporaryFailure):
+        raise OpenSREError(
+            "CLI tool encountered a temporary failure.",
+            suggestion=str(exc),
         ) from exc
 
     if isinstance(exc, RuntimeError):

--- a/app/integrations/llm_cli/__init__.py
+++ b/app/integrations/llm_cli/__init__.py
@@ -3,7 +3,13 @@
 from __future__ import annotations
 
 from app.integrations.llm_cli.base import CLIInvocation, CLIProbe
-from app.integrations.llm_cli.errors import CLIAuthenticationRequired
+from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITemporaryFailure
 from app.integrations.llm_cli.runner import CLIBackedLLMClient
 
-__all__ = ["CLIAuthenticationRequired", "CLIInvocation", "CLIProbe", "CLIBackedLLMClient"]
+__all__ = [
+    "CLIAuthenticationRequired",
+    "CLITemporaryFailure",
+    "CLIInvocation",
+    "CLIProbe",
+    "CLIBackedLLMClient",
+]

--- a/app/integrations/llm_cli/errors.py
+++ b/app/integrations/llm_cli/errors.py
@@ -23,3 +23,11 @@ class CLIAuthenticationRequired(RuntimeError):
         self.auth_hint = auth_hint
         self.detail = detail
         super().__init__(f"{provider} is not authenticated. {auth_hint} ({detail})")
+
+
+class CLITemporaryFailure(RuntimeError):
+    """The CLI subprocess exited with a transient / recoverable error (e.g. EX_TEMPFAIL 75).
+
+    This is an expected operational condition — not a code bug — so callers
+    should not forward it to error-tracking services like Sentry.
+    """

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -13,7 +13,11 @@ from typing import Any
 from pydantic import BaseModel
 
 from app.integrations.llm_cli.base import CLIProbe, LLMCLIAdapter
-from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITimeoutError
+from app.integrations.llm_cli.errors import (
+    CLIAuthenticationRequired,
+    CLITemporaryFailure,
+    CLITimeoutError,
+)
 from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 from app.integrations.llm_cli.text import flatten_messages_to_prompt
 from app.llm_reasoning_effort import get_active_reasoning_effort
@@ -165,6 +169,12 @@ class CLIBackedLLMClient:
                     auth_hint=self._adapter.auth_hint,
                     detail=base,
                 )
+            # EX_TEMPFAIL (75) signals a transient / recoverable subprocess error.
+            # Raise CLITemporaryFailure so Sentry ignores it and the CLI can
+            # surface a user-friendly message instead of a traceback.
+            if proc.returncode == 75 or "resume this session" in _base_lower:
+                raise CLITemporaryFailure(base)
+
             if auth_probe_unclear:
                 message = (
                     f"{base}\n\n"

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -367,7 +367,11 @@ def _init_sentry_once(
     """
     import sentry_sdk
 
-    from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITimeoutError
+    from app.integrations.llm_cli.errors import (
+        CLIAuthenticationRequired,
+        CLITemporaryFailure,
+        CLITimeoutError,
+    )
 
     with _suppress_langgraph_allowed_objects_warning():
         sentry_sdk.init(
@@ -383,7 +387,7 @@ def _init_sentry_once(
             integrations=_build_sentry_integrations(),
             before_send=_before_send,
             before_breadcrumb=_before_breadcrumb,
-            ignore_errors=[CLIAuthenticationRequired, CLITimeoutError],
+            ignore_errors=[CLIAuthenticationRequired, CLITemporaryFailure, CLITimeoutError],
         )
 
 

--- a/tests/integrations/llm_cli/test_kimi_adapter.py
+++ b/tests/integrations/llm_cli/test_kimi_adapter.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from app.integrations.llm_cli.errors import CLITemporaryFailure
 from app.integrations.llm_cli.kimi import KimiAdapter
+from app.integrations.llm_cli.runner import CLIBackedLLMClient
 
 
 def _version_proc() -> MagicMock:
@@ -250,8 +254,6 @@ def test_parse_and_explain_failure() -> None:
     # Test parse
     assert adapter.parse(stdout="  hello world  \n", stderr="", returncode=0) == "hello world"
 
-    import pytest
-
     with pytest.raises(RuntimeError, match="empty output"):
         adapter.parse(stdout="  ", stderr="", returncode=0)
 
@@ -273,16 +275,7 @@ def test_parse_and_explain_failure() -> None:
     assert fail_empty == "kimi returned no output"
 
 
-@patch("app.integrations.llm_cli.runner.subprocess.run")
-def test_cli_backed_client_raises_cli_temporary_failure_on_exit_code_75(
-    mock_run: MagicMock,
-) -> None:
-    """Exit code 75 (EX_TEMPFAIL) must raise CLITemporaryFailure, not plain RuntimeError."""
-    import pytest
-
-    from app.integrations.llm_cli.errors import CLITemporaryFailure
-    from app.integrations.llm_cli.runner import CLIBackedLLMClient
-
+def _make_temp_failure_adapter(session_id: str) -> MagicMock:
     mock_adapter = MagicMock(spec=KimiAdapter)
     mock_adapter.name = "kimi"
     mock_adapter.auth_hint = "Run: kimi login"
@@ -301,13 +294,45 @@ def test_cli_backed_client_raises_cli_temporary_failure_on_exit_code_75(
         env=None,
         timeout_sec=300.0,
     )
-    session_id = "79229edd-9caf-45af-bb89-04d3f742d063"
     mock_adapter.explain_failure.return_value = (
         f"kimi exited with code 75. To resume this session: kimi -r {session_id}"
     )
+    return mock_adapter
+
+
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_cli_backed_client_raises_cli_temporary_failure_on_exit_code_75(
+    mock_run: MagicMock,
+) -> None:
+    """Exit code 75 (EX_TEMPFAIL) must raise CLITemporaryFailure, not plain RuntimeError."""
+    session_id = "79229edd-9caf-45af-bb89-04d3f742d063"
+    mock_adapter = _make_temp_failure_adapter(session_id)
+    # explain_failure returns plain text (no "resume" phrase) so only the exit-code branch fires.
+    mock_adapter.explain_failure.return_value = "kimi exited with code 75."
+
+    mock_run.return_value = MagicMock(returncode=75, stdout="", stderr="")
+
+    with patch("app.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(mock_adapter, model="kimi-k2.5", max_tokens=256)
+        with pytest.raises(CLITemporaryFailure, match="kimi exited with code 75"):
+            client.invoke("hello")
+
+
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_cli_backed_client_raises_cli_temporary_failure_on_resume_session_message(
+    mock_run: MagicMock,
+) -> None:
+    """'resume this session' in explain_failure output triggers CLITemporaryFailure regardless of exit code."""
+    session_id = "79229edd-9caf-45af-bb89-04d3f742d063"
+    mock_adapter = _make_temp_failure_adapter(session_id)
+    # Non-75 exit code so only the string-match branch fires.
+    mock_adapter.explain_failure.return_value = (
+        f"kimi exited with code 1. To resume this session: kimi -r {session_id}"
+    )
 
     mock_run.return_value = MagicMock(
-        returncode=75,
+        returncode=1,
         stdout=f"To resume this session: kimi -r {session_id}",
         stderr="",
     )
@@ -315,5 +340,5 @@ def test_cli_backed_client_raises_cli_temporary_failure_on_exit_code_75(
     with patch("app.guardrails.engine.get_guardrail_engine") as gr:
         gr.return_value.is_active = False
         client = CLIBackedLLMClient(mock_adapter, model="kimi-k2.5", max_tokens=256)
-        with pytest.raises(CLITemporaryFailure, match="kimi exited with code 75"):
+        with pytest.raises(CLITemporaryFailure, match="resume this session"):
             client.invoke("hello")

--- a/tests/integrations/llm_cli/test_kimi_adapter.py
+++ b/tests/integrations/llm_cli/test_kimi_adapter.py
@@ -271,3 +271,49 @@ def test_parse_and_explain_failure() -> None:
     # Test explain_failure: empty output with code 0
     fail_empty = adapter.explain_failure(stdout="", stderr="", returncode=0)
     assert fail_empty == "kimi returned no output"
+
+
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_cli_backed_client_raises_cli_temporary_failure_on_exit_code_75(
+    mock_run: MagicMock,
+) -> None:
+    """Exit code 75 (EX_TEMPFAIL) must raise CLITemporaryFailure, not plain RuntimeError."""
+    import pytest
+
+    from app.integrations.llm_cli.errors import CLITemporaryFailure
+    from app.integrations.llm_cli.runner import CLIBackedLLMClient
+
+    mock_adapter = MagicMock(spec=KimiAdapter)
+    mock_adapter.name = "kimi"
+    mock_adapter.auth_hint = "Run: kimi login"
+    mock_adapter.binary_env_key = "KIMI_BIN"
+    mock_adapter.install_hint = "uv tool install --python 3.13 kimi-cli"
+    mock_adapter.detect.return_value = MagicMock(
+        installed=True,
+        bin_path="/usr/bin/kimi",
+        logged_in=True,
+        detail="ok",
+    )
+    mock_adapter.build.return_value = MagicMock(
+        argv=["/usr/bin/kimi", "--print", "--yolo"],
+        stdin="hello",
+        cwd="/tmp",
+        env=None,
+        timeout_sec=300.0,
+    )
+    session_id = "79229edd-9caf-45af-bb89-04d3f742d063"
+    mock_adapter.explain_failure.return_value = (
+        f"kimi exited with code 75. To resume this session: kimi -r {session_id}"
+    )
+
+    mock_run.return_value = MagicMock(
+        returncode=75,
+        stdout=f"To resume this session: kimi -r {session_id}",
+        stderr="",
+    )
+
+    with patch("app.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(mock_adapter, model="kimi-k2.5", max_tokens=256)
+        with pytest.raises(CLITemporaryFailure, match="kimi exited with code 75"):
+            client.invoke("hello")


### PR DESCRIPTION
## Summary

- Adds `CLITemporaryFailure(RuntimeError)` to `app/integrations/llm_cli/errors.py` for transient/recoverable subprocess exits
- `CLIBackedLLMClient` now raises `CLITemporaryFailure` instead of bare `RuntimeError` when the exit code is 75 (POSIX `EX_TEMPFAIL`) or the output contains "resume this session"
- Adds `CLITemporaryFailure` to Sentry's `ignore_errors` list so these expected operational conditions are never forwarded to error tracking
- Maps `CLITemporaryFailure` → user-friendly `OpenSREError` in the CLI error handler

## Test plan

- [ ] `test_cli_backed_client_raises_cli_temporary_failure_on_exit_code_75` — verifies exit code 75 raises `CLITemporaryFailure` (not `RuntimeError`)
- [ ] `make test-cov` passes locally
- [ ] `make lint` and `make typecheck` pass

Closes #1866
Closes #1867

---
_Generated by [Claude Code](https://claude.ai/code/session_0114neWBZCJeUYLN32PhivJB)_