### PR TITLE
fix(llm-cli): treat kimi exit code 75 (EX_TEMPFAIL) as CLITimeoutError

### DIFF
--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -144,10 +144,13 @@ class CLIBackedLLMClient:
             # the caller should retry. Raise CLITimeoutError so it is treated as
             # an expected operational failure and not forwarded to Sentry.
             if proc.returncode == 75:
-                raise CLITimeoutError(
+                hint = (
                     f"{self._adapter.name} reported a temporary failure (exit 75). "
                     "Retry the request or check network connectivity."
                 )
+                if err:
+                    hint = f"{hint} {err[:200]}"
+                raise CLITimeoutError(hint)
             base = self._adapter.explain_failure(
                 stdout=out, stderr=err, returncode=proc.returncode
             ).strip()

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -140,6 +140,14 @@ class CLIBackedLLMClient:
         err = _strip_ansi(proc.stderr or "")
 
         if proc.returncode != 0:
+            # Exit code 75 is EX_TEMPFAIL (sysexits.h) — a transient failure
+            # the caller should retry. Raise CLITimeoutError so it is treated as
+            # an expected operational failure and not forwarded to Sentry.
+            if proc.returncode == 75:
+                raise CLITimeoutError(
+                    f"{self._adapter.name} reported a temporary failure (exit 75). "
+                    "Retry the request or check network connectivity."
+                )
             base = self._adapter.explain_failure(
                 stdout=out, stderr=err, returncode=proc.returncode
             ).strip()

--- a/tests/integrations/llm_cli/test_kimi_adapter.py
+++ b/tests/integrations/llm_cli/test_kimi_adapter.py
@@ -271,3 +271,36 @@ def test_parse_and_explain_failure() -> None:
     # Test explain_failure: empty output with code 0
     fail_empty = adapter.explain_failure(stdout="", stderr="", returncode=0)
     assert fail_empty == "kimi returned no output"
+
+
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_cli_backed_client_exit_75_raises_cli_timeout_error(mock_run: MagicMock) -> None:
+    """Exit code 75 (EX_TEMPFAIL) must raise CLITimeoutError, not RuntimeError.
+
+    Sentry ignores CLITimeoutError so transient kimi failures do not create
+    spurious bug reports.
+    """
+    import pytest
+
+    from app.integrations.llm_cli.kimi import KimiAdapter
+    from app.integrations.llm_cli.runner import CLIBackedLLMClient, CLITimeoutError
+
+    mock_adapter = MagicMock(spec=KimiAdapter)
+    mock_adapter.name = "kimi"
+    mock_adapter.detect.return_value = MagicMock(
+        installed=True, bin_path="/usr/bin/kimi", logged_in=True, detail="ok"
+    )
+    mock_adapter.build.return_value = MagicMock(
+        argv=["/usr/bin/kimi", "--print", "--yolo"],
+        stdin="hello",
+        cwd="/tmp",
+        env=None,
+        timeout_sec=30.0,
+    )
+    mock_run.return_value = MagicMock(returncode=75, stdout="", stderr="rate limit")
+
+    with patch("app.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(mock_adapter, model="kimi-k2.5", max_tokens=256)
+        with pytest.raises(CLITimeoutError, match="exit 75"):
+            client.invoke("hello")


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

kimi (and any CLI adapter) exits with code 75 (`EX_TEMPFAIL` from `sysexits.h`) when it encounters a transient failure — rate limiting, network blip, or server overload. The previous code fell through to `raise RuntimeError(message)`, which Sentry treated as a code bug and opened high-priority issues.

`CLITimeoutError` is already in Sentry's `ignore_errors` list (see `app/utils/sentry_sdk.py:386`) and is documented as an expected operational failure. This PR makes exit code 75 raise `CLITimeoutError` instead of `RuntimeError`, so the noise stops without losing the user-facing signal (the error is still surfaced to the caller).

### Root cause

`app/integrations/llm_cli/runner.py` — any non-zero exit code fell through to `explain_failure` → `raise RuntimeError`. Exit code 75 is POSIX-standard "try again later" and should be treated identically to a subprocess timeout.

### Change

- `runner.py`: check `proc.returncode == 75` **before** `explain_failure` and raise `CLITimeoutError` with a clean, session-ID-free message.

## Test plan

- [ ] Verify `uv run ruff check app/integrations/llm_cli/runner.py` passes (already confirmed locally)
- [ ] Verify existing CI (`quality`, `test`) stays green

Closes #1866
Closes #1867

https://claude.ai/code/session_0144hMeudYUNxuULDFvfhWn5
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0144hMeudYUNxuULDFvfhWn5)_