### PR TITLE
fix(llm): handle Anthropic HTTP 400 usage-limit without retry [superseded by #1942]

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 import boto3
 from anthropic import Anthropic, AnthropicBedrock, AuthenticationError, NotFoundError
+from anthropic import BadRequestError as AnthropicBadRequestError
 from openai import AuthenticationError as OpenAIAuthError
 from openai import OpenAI
 from pydantic import BaseModel, ValidationError
@@ -170,6 +171,8 @@ class LLMClient:
                     f"Anthropic model '{self._model}' was not found. "
                     "Check your configured model name and try again."
                 ) from err
+            except AnthropicBadRequestError as err:
+                raise RuntimeError(_format_anthropic_bad_request(err)) from err
             except GuardrailBlockedError:
                 raise
             except Exception as err:
@@ -216,6 +219,8 @@ class LLMClient:
                     f"Anthropic model '{self._model}' was not found. "
                     "Check your configured model name and try again."
                 ) from err
+            except AnthropicBadRequestError as err:
+                raise RuntimeError(_format_anthropic_bad_request(err)) from err
             except GuardrailBlockedError:
                 raise
             except Exception as err:
@@ -417,6 +422,21 @@ class BedrockLLMClient:
         the yield-once fallback satisfies the protocol contract.
         """
         yield self.invoke(prompt_or_messages).content
+
+
+def _format_anthropic_bad_request(err: AnthropicBadRequestError) -> str:
+    """Return a user-facing message for Anthropic HTTP 400 errors.
+
+    Usage-limit errors get a specific message including the renewal date when
+    the API provides one; other 400s fall back to the raw SDK message.
+    """
+    body = getattr(err, "body", None)
+    if isinstance(body, dict):
+        error_obj = body.get("error", {})
+        api_msg = error_obj.get("message", "") if isinstance(error_obj, dict) else ""
+        if "usage limit" in api_msg.lower():
+            return f"Anthropic API usage limit reached. {api_msg}"
+    return f"Anthropic request rejected (HTTP 400): {err.message}"
 
 
 def _format_anthropic_retry_error(err: Exception) -> str:

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -830,3 +830,119 @@ def test_anthropic_invoke_stream_not_found_raises_friendly_runtime_error(monkeyp
     msg = str(exc_info.value)
     assert "was not found" in msg
     assert "Check your configured model name" in msg
+
+
+# LLMClient.invoke / invoke_stream — BadRequestError (HTTP 400) handling
+# ---------------------------------------------------------------------------
+
+
+def _make_bad_request_error(body: dict | None = None) -> Exception:
+    """Return a minimal fake that looks like anthropic.BadRequestError."""
+    err = llm_client.AnthropicBadRequestError.__new__(llm_client.AnthropicBadRequestError)
+    err.status_code = 400  # type: ignore[attr-defined]
+    err.message = str(body)  # type: ignore[attr-defined]
+    err.body = body or {}  # type: ignore[attr-defined]
+    err.request = None  # type: ignore[attr-defined]
+    err.response = None  # type: ignore[attr-defined]
+    return err
+
+
+_USAGE_LIMIT_BODY = {
+    "type": "error",
+    "error": {
+        "type": "invalid_request_error",
+        "message": "You have reached your specified API usage limits. You will regain access on 2026-06-01 at 00:00 UTC.",
+    },
+}
+
+
+class _BadRequestMessages:
+    def __init__(self, body: dict) -> None:
+        self._body = body
+
+    def create(self, **_kwargs) -> None:
+        raise _make_bad_request_error(self._body)
+
+    def stream(self, **_kwargs):
+        raise _make_bad_request_error(self._body)
+
+
+class _UsageLimitAnthropic:
+    def __init__(self, *, api_key: str, timeout: float) -> None:
+        del api_key, timeout
+        self.messages = _BadRequestMessages(_USAGE_LIMIT_BODY)
+
+
+def test_anthropic_invoke_usage_limit_raises_friendly_runtime_error(monkeypatch) -> None:
+    """HTTP 400 usage-limit error must surface a clear message, not a raw SDK repr."""
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "Anthropic", _UsageLimitAnthropic)
+
+    client = llm_client.LLMClient(model="claude-3-5-sonnet-20241022")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        client.invoke("hello")
+
+    msg = str(exc_info.value)
+    assert "usage limit" in msg.lower()
+    assert "You will regain access" in msg
+
+
+def test_anthropic_invoke_usage_limit_does_not_retry(monkeypatch) -> None:
+    """BadRequestError must never be retried — it is a permanent client error."""
+    call_count = 0
+
+    class _CountingMessages:
+        def create(self, **_kwargs) -> None:
+            nonlocal call_count
+            call_count += 1
+            raise _make_bad_request_error(_USAGE_LIMIT_BODY)
+
+    class _CountingAnthropic:
+        def __init__(self, **_kwargs) -> None:
+            self.messages = _CountingMessages()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "Anthropic", _CountingAnthropic)
+    monkeypatch.setattr(llm_client.time, "sleep", lambda _: None)
+
+    client = llm_client.LLMClient(model="claude-3-5-sonnet-20241022")
+
+    with pytest.raises(RuntimeError):
+        client.invoke("hello")
+
+    assert call_count == 1, "BadRequestError must not trigger retries"
+
+
+def test_anthropic_invoke_stream_usage_limit_raises_friendly_runtime_error(monkeypatch) -> None:
+    """HTTP 400 usage-limit during streaming must also surface a clear message."""
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "Anthropic", _UsageLimitAnthropic)
+
+    client = llm_client.LLMClient(model="claude-3-5-sonnet-20241022")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        list(client.invoke_stream("hello"))
+
+    msg = str(exc_info.value)
+    assert "usage limit" in msg.lower()
+
+
+def test_anthropic_invoke_bad_request_non_usage_limit_raises_generic_message(monkeypatch) -> None:
+    """Non-usage-limit HTTP 400 errors fall back to a generic HTTP 400 message."""
+    other_body = {"type": "error", "error": {"type": "invalid_request_error", "message": "Invalid JSON in request."}}
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+
+    class _OtherBadRequestAnthropic:
+        def __init__(self, **_kwargs) -> None:
+            self.messages = _BadRequestMessages(other_body)
+
+    monkeypatch.setattr(llm_client, "Anthropic", _OtherBadRequestAnthropic)
+
+    client = llm_client.LLMClient(model="claude-3-5-sonnet-20241022")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        client.invoke("hello")
+
+    msg = str(exc_info.value)
+    assert "HTTP 400" in msg


### PR DESCRIPTION
## Summary

- `AnthropicBadRequestError` (HTTP 400) was previously caught by the generic `except Exception` retry loop, causing usage-limit errors to be retried multiple times before surfacing a low-signal "request failed" message.
- Added `BadRequestError` import from the `anthropic` SDK and a `_format_anthropic_bad_request()` helper that extracts the human-readable API message. Detects "usage limit" cases specifically and emits a concise message including the Anthropic-provided renewal date.
- `AnthropicBadRequestError` is now caught **before** the generic handler in both `LLMClient.invoke` and `LLMClient.invoke_stream`, so it raises immediately without retrying (HTTP 400 is a permanent client error, never transient).

## Test plan

- [x] 4 new unit tests covering: usage-limit message shape, no-retry guarantee on `invoke`, usage-limit on `invoke_stream`, and generic HTTP 400 fallback
- [x] `uv run pytest tests/services/test_llm_client.py -v` — 36 passed
- [x] `uv run ruff check app/services/llm_client.py tests/services/test_llm_client.py` — no issues

Closes #1883
Closes #1885

https://claude.ai/code/session_01U8EmDosHu51EnFM1vKNMnT

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8EmDosHu51EnFM1vKNMnT)_