### PR TITLE
fix(pipeline): suppress RuntimeError when event loop closes during streaming

### DIFF
--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import queue
 import threading
@@ -119,7 +120,8 @@ async def astream_investigation(
     loop = asyncio.get_running_loop()
 
     def _put(evt: StreamEvent) -> None:
-        loop.call_soon_threadsafe(event_queue.put_nowait, evt)
+        with contextlib.suppress(RuntimeError):  # loop closed (consumer cancelled)
+            loop.call_soon_threadsafe(event_queue.put_nowait, evt)
 
     def _make_node_event(kind: str, node: str, data: dict[str, Any]) -> StreamEvent:
         return StreamEvent(
@@ -255,9 +257,11 @@ async def astream_investigation(
             from app.utils.sentry_sdk import capture_exception
 
             capture_exception(exc)
-            loop.call_soon_threadsafe(event_queue.put_nowait, exc)
+            with contextlib.suppress(RuntimeError):
+                loop.call_soon_threadsafe(event_queue.put_nowait, exc)
         finally:
-            loop.call_soon_threadsafe(event_queue.put_nowait, None)
+            with contextlib.suppress(RuntimeError):
+                loop.call_soon_threadsafe(event_queue.put_nowait, None)
 
     thread = threading.Thread(target=_run_pipeline, daemon=True)
     thread.start()

--- a/tests/pipeline/test_runners_sentry.py
+++ b/tests/pipeline/test_runners_sentry.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import queue
+import threading
 from typing import cast
 
 import pytest
@@ -7,6 +11,50 @@ import pytest
 from app.pipeline import runners
 from app.state import AgentState
 from app.utils import errors
+
+
+def test_call_soon_threadsafe_on_closed_loop_raises_runtime_error() -> None:
+    """Confirm the stdlib raises RuntimeError when scheduling on a closed loop.
+
+    This documents the failure mode that the fix in runners._put / the
+    except+finally blocks guards against."""
+    loop = asyncio.new_event_loop()
+    loop.close()
+    with pytest.raises(RuntimeError):
+        loop.call_soon_threadsafe(lambda: None)
+
+
+def test_astream_investigation_background_thread_safe_on_loop_close() -> None:
+    """_put and the finally sentinel must not raise even when the loop closes
+    before the background thread finishes signalling."""
+
+    def _simulate_run_pipeline(
+        loop: asyncio.AbstractEventLoop,
+        q: queue.Queue[object],
+    ) -> None:
+        try:
+            raise ValueError("boom")
+        except Exception as exc:
+            with contextlib.suppress(RuntimeError):
+                loop.call_soon_threadsafe(q.put_nowait, exc)
+        finally:
+            with contextlib.suppress(RuntimeError):
+                loop.call_soon_threadsafe(q.put_nowait, None)
+
+    q: queue.Queue[object] = queue.Queue()
+    closed_loop = asyncio.new_event_loop()
+    closed_loop.close()
+
+    t = threading.Thread(
+        target=_simulate_run_pipeline, args=(closed_loop, q), daemon=True
+    )
+    t.start()
+    t.join(timeout=2)
+
+    # Thread must finish cleanly with no crash; queue is empty because
+    # call_soon_threadsafe was silently suppressed on the closed loop.
+    assert t.is_alive() is False
+    assert q.empty()
 
 
 def test_run_chat_initializes_sentry_and_captures_unhandled_errors(


### PR DESCRIPTION
Superseded by #1977 — this branch was based on a stale version of `runners.py` (threading approach) that no longer exists on main. #1977 applies the same intent to the current LangGraph-native `astream_investigation`.