### PR TITLE
fix(pipeline): swallow futures-shutdown RuntimeError in astream_investigation

### DIFF
--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -105,6 +105,11 @@ async def astream_investigation(
     try:
         async for event in compiled_graph.astream_events(initial, version="v2"):
             yield _map_langgraph_event(dict(event))
+    except RuntimeError as exc:
+        if "cannot schedule new futures after shutdown" in str(exc):
+            return  # LangGraph thread pool shut down during teardown; not a real error
+        capture_exception(exc)
+        raise
     except Exception as exc:
         capture_exception(exc)
         raise

--- a/tests/pipeline/test_runners_sentry.py
+++ b/tests/pipeline/test_runners_sentry.py
@@ -1,11 +1,84 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from app.pipeline import runners
 from app.state import AgentState
+
+
+def test_astream_investigation_swallows_futures_shutdown_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RuntimeError('cannot schedule new futures after shutdown') from LangGraph's
+    thread pool during teardown must not propagate to the caller or be captured
+    in Sentry — it is cleanup noise, not a real error."""
+    import asyncio
+    import types
+
+    shutdown_err = RuntimeError("cannot schedule new futures after shutdown")
+    captured: list[BaseException] = []
+
+    async def _raising_astream(*_a: Any, **_kw: Any):  # type: ignore[return]
+        raise shutdown_err
+        yield  # make it an async generator
+
+    fake_graph = types.SimpleNamespace(astream_events=_raising_astream)
+    fake_graph_module = types.ModuleType("app.pipeline.graph")
+    fake_graph_module.graph = fake_graph  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(runners, "init_sentry", lambda **_kw: None)
+    monkeypatch.setattr(runners, "capture_exception", captured.append)
+
+    async def _collect() -> list[Any]:
+        events = []
+        with patch.dict("sys.modules", {"app.pipeline.graph": fake_graph_module}):
+            async for evt in runners.astream_investigation(
+                alert_name="test", pipeline_name="test", severity="low"
+            ):
+                events.append(evt)
+        return events
+
+    result = asyncio.run(_collect())
+
+    assert result == []
+    assert captured == [], "shutdown RuntimeError must not be sent to Sentry"
+
+
+def test_astream_investigation_captures_other_runtime_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-shutdown RuntimeErrors must still be captured and re-raised."""
+    import asyncio
+    import types
+
+    other_err = RuntimeError("something unexpected")
+    captured: list[BaseException] = []
+
+    async def _raising_astream(*_a: Any, **_kw: Any):  # type: ignore[return]
+        raise other_err
+        yield
+
+    fake_graph = types.SimpleNamespace(astream_events=_raising_astream)
+    fake_graph_module = types.ModuleType("app.pipeline.graph")
+    fake_graph_module.graph = fake_graph  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(runners, "init_sentry", lambda **_kw: None)
+    monkeypatch.setattr(runners, "capture_exception", captured.append)
+
+    async def _run() -> None:
+        with patch.dict("sys.modules", {"app.pipeline.graph": fake_graph_module}):
+            async for _ in runners.astream_investigation(
+                alert_name="test", pipeline_name="test", severity="low"
+            ):
+                pass
+
+    with pytest.raises(RuntimeError, match="something unexpected"):
+        asyncio.run(_run())
+
+    assert captured == [other_err]
 
 
 def test_run_chat_initializes_sentry_and_captures_unhandled_errors(


### PR DESCRIPTION
Superseded by #1978 — this branch was based on a version of `runners.py` that diverged from `origin/main`. #1978 applies the correct fix to the actual `origin/main` codebase.