### PR TITLE
fix: improve investigate confidence handling for zero-evidence runs

### DIFF
--- a/app/agent/result.py
+++ b/app/agent/result.py
@@ -142,14 +142,23 @@ Evidence keys collected: {", ".join(evidence.keys()) if evidence else "none"}
     def _to_claim_dicts(claims: list[str], status: str) -> list[dict]:
         return [{"claim": c, "validation_status": status} for c in claims if c]
 
+    validated_claims = _to_claim_dicts(schema.validated_claims, "validated")
+    non_validated_claims = _to_claim_dicts(schema.non_validated_claims, "not_validated")
+    validity_score = _resolve_validity_score(
+        llm_validity_score=schema.validity_score,
+        validated_claims=validated_claims,
+        non_validated_claims=non_validated_claims,
+        evidence=evidence,
+    )
+
     return InvestigationResult(
         root_cause=schema.root_cause,
         root_cause_category=schema.root_cause_category,
         causal_chain=schema.causal_chain,
-        validated_claims=_to_claim_dicts(schema.validated_claims, "validated"),
-        non_validated_claims=_to_claim_dicts(schema.non_validated_claims, "not_validated"),
+        validated_claims=validated_claims,
+        non_validated_claims=non_validated_claims,
         remediation_steps=schema.remediation_steps,
-        validity_score=schema.validity_score,
+        validity_score=validity_score,
     )
 
 
@@ -176,3 +185,37 @@ def _parse_via_legacy(
     except Exception as err:
         logger.warning("Legacy parse_root_cause also failed: %s", err)
         return InvestigationResult.unknown(alert_name)
+
+
+def _resolve_validity_score(
+    *,
+    llm_validity_score: float,
+    validated_claims: list[dict[str, Any]],
+    non_validated_claims: list[dict[str, Any]],
+    evidence: dict[str, Any],
+) -> float:
+    """Use LLM score when present; otherwise derive a bounded deterministic fallback."""
+    if llm_validity_score > 0:
+        return max(0.0, min(1.0, float(llm_validity_score)))
+    return _deterministic_validity_fallback(
+        validated_count=len(validated_claims),
+        non_validated_count=len(non_validated_claims),
+        evidence_count=len(evidence),
+    )
+
+
+def _deterministic_validity_fallback(
+    *,
+    validated_count: int,
+    non_validated_count: int,
+    evidence_count: int,
+) -> float:
+    """Compute fallback confidence from evidence coverage and claim quality."""
+    if validated_count <= 0 or evidence_count <= 0:
+        return 0.0
+
+    total_claims = validated_count + max(non_validated_count, 0)
+    claim_ratio = 1.0 if total_claims <= 0 else validated_count / total_claims
+    evidence_factor = min(max(evidence_count, 0) / 5.0, 1.0)
+    score = 0.4 + (0.4 * claim_ratio) + (0.2 * evidence_factor)
+    return min(score, 0.9)

--- a/app/cli/investigation/investigate.py
+++ b/app/cli/investigation/investigate.py
@@ -143,6 +143,9 @@ def run_investigation_cli(
     }
     if state.get("evidence_entries"):
         out["tool_calls"] = state["evidence_entries"]
+    warnings = _build_investigation_warnings(state)
+    if warnings:
+        out["warnings"] = warnings
     if opensre_evaluate:
         ev = state.get("opensre_llm_eval")
         if isinstance(ev, dict) and ev:
@@ -161,6 +164,19 @@ def run_investigation_cli(
                 "reason": "Evaluate was enabled but no judge output was recorded.",
             }
     return out
+
+
+def _build_investigation_warnings(state: AgentState) -> list[str]:
+    """Return user-facing investigation warnings for ambiguous zero-confidence runs."""
+    evidence_entries = state.get("evidence_entries") or []
+    validity_score = float(state.get("validity_score", 0.0) or 0.0)
+    if validity_score > 0 or evidence_entries:
+        return []
+    return [
+        "No tool evidence was collected for this investigation. "
+        "If this alert depends on integrations (for example Datadog, EKS, Grafana, or CloudWatch), "
+        "configure and verify those integrations, then rerun investigate."
+    ]
 
 
 def stream_investigation_cli(

--- a/tests/agent/test_result.py
+++ b/tests/agent/test_result.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from app.agent.result import _extract_last_assistant_text
+from app.agent.result import _deterministic_validity_fallback, _extract_last_assistant_text
 
 
 class _TextBlock:
@@ -31,3 +31,23 @@ def test_extract_last_assistant_text_handles_anthropic_content_blocks() -> None:
     assert _extract_last_assistant_text(messages) == (
         "## Diagnosis\n Root cause: missing telemetry"
     )
+
+
+def test_deterministic_validity_fallback_returns_zero_without_evidence() -> None:
+    assert (
+        _deterministic_validity_fallback(
+            validated_count=3,
+            non_validated_count=0,
+            evidence_count=0,
+        )
+        == 0.0
+    )
+
+
+def test_deterministic_validity_fallback_gives_bounded_nonzero_score() -> None:
+    score = _deterministic_validity_fallback(
+        validated_count=3,
+        non_validated_count=1,
+        evidence_count=4,
+    )
+    assert 0.4 <= score <= 0.9

--- a/tests/cli/test_investigate.py
+++ b/tests/cli/test_investigate.py
@@ -109,7 +109,38 @@ def test_run_investigation_cli_shapes_agent_state(monkeypatch) -> None:
         "root_cause": "bad deploy",
         "is_noise": False,
         "validity_score": 0.0,
+        "warnings": [
+            "No tool evidence was collected for this investigation. If this alert depends on "
+            "integrations (for example Datadog, EKS, Grafana, or CloudWatch), configure and "
+            "verify those integrations, then rerun investigate."
+        ],
     }
+
+
+def test_run_investigation_cli_omits_warning_when_evidence_exists(monkeypatch) -> None:
+    def fake_run_investigation(
+        *,
+        raw_alert: dict[str, object],
+        **_: object,
+    ) -> dict[str, object]:
+        return {
+            "slack_message": "report body",
+            "problem_md": "# problem",
+            "root_cause": "bad deploy",
+            "validity_score": 0.0,
+            "evidence_entries": [{"source": "datadog"}],
+        }
+
+    monkeypatch.setattr("app.cli.investigation.investigate.LLMSettings.from_env", object)
+    monkeypatch.setattr(
+        "app.cli.investigation.investigate._call_run_investigation", fake_run_investigation
+    )
+
+    result = run_investigation_cli(
+        raw_alert={"alert_name": "PayloadAlert"},
+    )
+
+    assert "warnings" not in result
 
 
 def test_run_investigation_cli_evaluate_reports_skip_when_no_rubric(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

add deterministic fallback validity scoring when structured diagnosis returns 0 despite validated claims and collected evidence\n- add CLI warning for investigations that end with 0 confidence and no tool evidence\n- add targeted tests for fallback scoring and CLI warning behavior\n\n## Why\nIssue #1888 reports confidence always showing 0% during , especially with synthetic EKS alerts run outside mock backend harnesses. This change keeps explicit non-zero model scores intact, while improving UX and confidence behavior for evidence-backed runs and surfacing a clear warning when no evidence is collected.\n\n

## Testing

 ============================= test session starts ==============================
platform linux -- Python 3.13.11, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/muddles/Codes/opensre
configfile: pytest.ini
plugins: langsmith-0.8.0, anyio-4.13.0, cov-7.1.0, asyncio-1.3.0, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 18 items

tests/agent/test_result.py ...                                           [ 16%]
tests/cli/test_investigate.py ...............                            [100%]

============================= slowest 20 durations =============================

(20 durations < 0.005s hidden.  Use -vv to show these durations.)
============================== 18 passed in 1.40s ==============================\n- All checks passed!