### PR TITLE
fix(interactive-shell): REPL wait UX, stdout spinner, stream footer, and confirmations

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -23,7 +23,7 @@ from app.cli.commands import register_commands
 from app.cli.support.exception_reporting import report_exception, should_report_exception
 from app.cli.support.layout import RichGroup, render_landing
 from app.cli.support.prompt_support import (
-    handle_ctrl_c_press,
+    handle_sigint_for_cli,
     install_questionary_ctrl_c_double_exit,
     install_questionary_escape_cancel,
 )
@@ -198,7 +198,7 @@ def _install_sigint_handler() -> None:
     """
 
     def _handler(_signum: int, _frame: object) -> None:
-        handle_ctrl_c_press()
+        handle_sigint_for_cli()
 
     signal.signal(signal.SIGINT, _handler)
 

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -1024,13 +1024,9 @@ async def _run_interactive(
                     break
                 if _looks_like_confirmation_answer(answer):
                     state.deliver_confirmation(answer or "")
-                    # Let the worker thread clear ``confirm_event`` (see
-                    # ``_route_confirm_through_prompt``) before we re-check
-                    # ``is_awaiting_confirmation()`` — avoids a duplicate y/N
-                    # frame on the next loop iteration.
-                    await asyncio.sleep(0)
-                # Invalid answer: redisplay confirmation prompt.
-                continue
+                else:
+                    # Invalid answer: redisplay confirmation prompt.
+                    continue
 
             _write_spinner()
 

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -598,6 +598,20 @@ class _ReplState:
             else:
                 task.cancel()
 
+    def cancel_next_queued_turn(self) -> bool:
+        """Drop one queued-but-not-yet-started turn, if present.
+
+        Returns True when a queued turn was removed.
+        """
+        try:
+            _text, turn_done = self.queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return False
+        if not turn_done.done():
+            turn_done.set_result(None)
+        self.queue.task_done()
+        return True
+
 
 class _SpinnerState:
     """Mutable state read by the prompt's bottom-toolbar callback.
@@ -826,11 +840,13 @@ async def _run_interactive(
             state.is_dispatch_running()
             or state.current_cancel_event is not None
             or state.is_awaiting_confirmation()
-            or not state.queue.empty()
         ):
             state.cancel_current_dispatch()
             return True
-        return False
+        # Queue hand-off window: input was enqueued but dispatch task has
+        # not yet been created. Drop one pending turn so Ctrl+C still behaves
+        # as "cancel current work".
+        return not state.queue.empty() and state.cancel_next_queued_turn()
 
     set_sigint_delegate(_sigint_delegate)
 

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -705,6 +705,10 @@ class _StreamingConsole(Console):
     ``wipe_stdout_wait_spinner_line`` removes the REPL wait line drawn on
     ``sys.stdout`` immediately before the first streamed ``console.print``
     so the verb line does not remain in scrollback.
+
+    ``repl_turn_elapsed_s`` aligns the dim footer duration with
+    :meth:`_SpinnerState.start` so ``· Ns`` reflects the full turn, not
+    only the tail of :func:`stream_to_console`.
     """
 
     def __init__(
@@ -744,6 +748,19 @@ class _StreamingConsole(Console):
         """
         sys.stdout.write("\r\x1b[2K")
         sys.stdout.flush()
+
+    def repl_turn_elapsed_s(self, stream_local_started: float) -> float:
+        """Wall seconds for the dim footer: from :meth:`_SpinnerState.start`.
+
+        ``stream_to_console`` sets its own ``started`` after the wipe/header,
+        which misses queue + pre-first-chunk wait and often rounds to
+        ``0.0s``. When the per-turn spinner is active, measure from
+        ``spinner.started_at`` so the footer matches the full turn.
+        """
+        now = time.monotonic()
+        if self._spinner.streaming and self._spinner.started_at > 0.0:
+            return max(0.0, now - self._spinner.started_at)
+        return max(0.0, now - stream_local_started)
 
 
 async def _run_interactive(

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -981,6 +981,18 @@ async def _run_interactive(
             nonlocal spinner_committed, last_bytes
             if spinner_committed or not spinner.streaming:
                 return
+            if spinner.bytes_in > 0:
+                # Once stream bytes start arriving, ``stream_to_console`` owns
+                # terminal output. Avoid any further cursor movement here:
+                # this polling loop may run after Rich has printed response
+                # lines, and ``\r\x1b[2K`` would clear whatever line the cursor
+                # is currently on. ``stream_to_console`` calls
+                # ``wipe_stdout_wait_spinner_line`` before its first print, so
+                # the wait line is still removed without this writer touching
+                # stdout again.
+                spinner_committed = True
+                last_bytes = spinner.bytes_in
+                return
             frame = spinner.inline_spinner_ansi(wait_metrics=False)
             if last_bytes == -1:
                 # First write — no prior line to overwrite.
@@ -988,13 +1000,10 @@ async def _run_interactive(
             else:
                 # Overwrite the previous spinner frame in-place.
                 sys.stdout.write(f"\r\x1b[2K{frame}")
-            if commit or spinner.bytes_in > 0:
-                # Lock the wait indicator: erase it entirely — it must not
-                # remain as "⠏ analysing…" in history once the reply renders.
-                if spinner.bytes_in > 0:
-                    sys.stdout.write("\r\x1b[2K")
-                else:
-                    sys.stdout.write("\r\x1b[2K\n")
+            if commit:
+                # Confirmation/cancellation paths need a clean line break
+                # before control returns to prompt_toolkit.
+                sys.stdout.write("\r\x1b[2K\n")
                 spinner_committed = True
             sys.stdout.flush()
             last_bytes = spinner.bytes_in

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -701,6 +701,10 @@ class _StreamingConsole(Console):
     chunks when the user presses Esc — ``asyncio.to_thread`` doesn't
     propagate task cancellation into the worker thread, so without
     this signal the dispatch keeps streaming after Esc.
+
+    ``wipe_stdout_wait_spinner_line`` removes the REPL wait line drawn on
+    ``sys.stdout`` immediately before the first streamed ``console.print``
+    so the verb line does not remain in scrollback.
     """
 
     def __init__(
@@ -729,6 +733,17 @@ class _StreamingConsole(Console):
     @property
     def cancel_requested(self) -> bool:
         return self._cancel_event.is_set()
+
+    def wipe_stdout_wait_spinner_line(self) -> None:
+        """Erase the transient wait line drawn by :func:`_wait_for_dispatch`.
+
+        That line animates in-place on ``sys.stdout``; it must not remain in
+        scrollback once :func:`stream_to_console` renders the reply — the
+        worker always calls this hook immediately before the first
+        ``console.print()`` so ordering wins over the asyncio polling loop.
+        """
+        sys.stdout.write("\r\x1b[2K")
+        sys.stdout.flush()
 
 
 async def _run_interactive(
@@ -945,10 +960,12 @@ async def _run_interactive(
 
         The spinner is printed as a regular stdout line that animates in
         place (``\\r``) until the first LLM token arrives, then it is
-        committed and followed by a blank line; the streaming response
-        continues below. The wait line omits elapsed/token counts
-        (``wait_metrics=False``) so the reply footer remains the single
-        place for final timing and totals.
+        **erased** (``\\r`` + ``EL``) so it does not stay in scrollback —
+        :meth:`_StreamingConsole.wipe_stdout_wait_spinner_line` runs again in
+        :func:`~app.cli.interactive_shell.ui.streaming.stream_to_console`
+        before the first Rich ``print`` so ordering is safe. The wait line
+        omits elapsed/token counts (``wait_metrics=False``); the reply footer
+        holds final timing and totals.
 
         * ``Ctrl+C`` / ``CancelledError`` → cancels the dispatch and returns.
         * Confirmation requests (``Proceed? [y/N]``) → briefly re-enters
@@ -973,14 +990,12 @@ async def _run_interactive(
                 # Overwrite the previous spinner frame in-place.
                 sys.stdout.write(f"\r\x1b[2K{frame}")
             if commit or spinner.bytes_in > 0:
-                # Response has started (or we're done) — lock the line.
-                # One extra blank line before streamed body — separates the
-                # transient wait line from the assistant block (footer still
-                # carries timing + tokens when the reply completes).
+                # Lock the wait indicator: erase it entirely — it must not
+                # remain as "⠏ analysing…" in history once the reply renders.
                 if spinner.bytes_in > 0:
-                    sys.stdout.write("\n\n")
+                    sys.stdout.write("\r\x1b[2K")
                 else:
-                    sys.stdout.write("\n")
+                    sys.stdout.write("\r\x1b[2K\n")
                 spinner_committed = True
             sys.stdout.flush()
             last_bytes = spinner.bytes_in

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -8,10 +8,12 @@ to see prior turns), and a dynamic ``bottom_toolbar`` shows the live
 ``thinking… (Ns · ↓ X tokens) — esc to interrupt`` indicator while a
 turn is generating.
 
-Type-ahead during streaming works because the dispatch runs as an
-``asyncio`` background task; the next iteration's ``prompt_async``
-starts immediately, so the input frame stays editable while output
-continues to flow above it.
+While a user turn is still running (the queue hand-off window or an
+active dispatch worker), the refreshed ``prompt_async`` keeps the input
+surface **read-only** and hides the free-form placeholder — we still rely
+on a background processor so ``Esc``/stream cancel keeps working inside
+prompt-toolkit without blocking the main coroutine on an explicit
+``await`` of the turn alone.
 
 An earlier prototype used a textual-based persistent app with an inline
 ``RichLog``. That fought with macOS Terminal.app's native scroll
@@ -518,7 +520,7 @@ class _ReplState:
     so callers don't have to re-derive it from the raw fields.
     """
 
-    queue: asyncio.Queue[str] = field(default_factory=asyncio.Queue)
+    queue: asyncio.Queue[tuple[str, asyncio.Future[None]]] = field(default_factory=asyncio.Queue)
     current_task: asyncio.Task[None] | None = None
     # The currently-active dispatch's cancel event. Each turn allocates
     # a fresh ``threading.Event`` inside :func:`_run_one_dispatch` and
@@ -731,16 +733,11 @@ async def _run_interactive(
     inbox: _alert_inbox.AlertInbox | None = None,
 ) -> None:
     """Per-turn ``prompt_async`` cycle backed by a queue + background
-    processor. Submitting a new prompt while a turn is streaming
-    **enqueues** it — the active turn finishes naturally and the queued
-    item runs next (matches Claude Code's behaviour). ``Esc`` cancels
-    just the currently-running dispatch; the processor moves on to the
-    next queued item.
-
-    Type-ahead during streaming works because ``prompt_async`` keeps
-    running on the main coroutine while the processor drains the queue
-    in the background — the user can type and queue further prompts
-    without waiting for the active turn to complete.
+    processor. While a conversational turn executes, the redrawn prompt
+    frame is held read-only and the free-form placeholder is hidden —
+    Esc still cancels cooperative streams because dispatch runs in a
+    sibling asyncio task driven by prompt-toolkit, not blocked on bare
+    ``await`` ``Future`` completions on the main coroutine.
 
     ``hot_reloader`` (from main, optional) is consulted at the start of
     each prompt iteration so dev-time edits to dispatch handlers are
@@ -881,7 +878,7 @@ async def _run_interactive(
         """Drain queued prompts one dispatch at a time."""
         while not state.exit_requested:
             try:
-                text = await state.queue.get()
+                text, turn_done = await state.queue.get()
             except asyncio.CancelledError:
                 return
             if state.exit_requested:
@@ -900,22 +897,122 @@ async def _run_interactive(
                 # Swallow here so the queue keeps draining the next item.
                 pass
             state.current_task = None
+            if not turn_done.done():
+                turn_done.set_result(None)
             state.queue.task_done()
+
+    def _busy_turn_first_message_line() -> str:
+        animate = spinner.inline_spinner_ansi()
+        if animate:
+            return animate
+        return f"{ANSI_DIM}… — Ctrl+C to cancel{ANSI_RESET}"
+
+    def _busy_rule_ansi() -> str:
+        """Dim (non-accent) horizontal rule used while a turn is running.
+
+        Using the accent colour (bold green) for the rule during a busy
+        turn made it look identical to a fresh ready-prompt, misleading
+        the user into thinking input was open. Dim gray signals "sealed".
+        """
+        try:
+            width = get_app_or_none().output.get_size().columns  # type: ignore[union-attr]
+        except Exception:
+            width = 80
+        rule = _prompt_surface._PROMPT_RULE_CHAR * max(width, 1)
+        return f"{ANSI_DIM}{rule}{ANSI_RESET}"
 
     def _message_with_spinner() -> ANSI:
         """Prompt message — spinner row above the top rule + ``❯`` prefix.
 
-        The spinner row is *always* reserved: when streaming, the row
-        shows ``⠋ thinking… (Ns · ↓ X tokens)``; when idle, it's a blank
-        line. Reserving the row unconditionally is what keeps the
-        input cursor from jumping up by one line when streaming starts
-        and back down when it stops — Vaibhav's "still some jumping"
-        was that vertical shift. Re-evaluated every
-        ``refresh_interval`` tick so the spinner animates in place
-        without redrawing the rule below it.
+        The spinner row is *always* reserved: when streaming it shows
+        ``⠋ thinking… (Ns · ↓ X tokens)``; when idle it is a blank line.
+        Reserving the row unconditionally keeps the cursor from jumping a
+        line when streaming starts or stops.
         """
         base = _prompt_message(session).value
         return ANSI(f"{spinner.inline_spinner_ansi()}\n{base}")
+
+    async def _wait_for_dispatch(turn_done: asyncio.Future[None]) -> None:
+        """Block the prompt loop until the current dispatch settles.
+
+        No ``prompt_async`` is active during this wait, so no prompt frame
+        is rendered — the terminal shows only the streamed response.
+
+        The spinner is printed as a regular stdout line that animates in
+        place (``\\r``) until the first LLM token arrives, then it is
+        committed with a newline and the streaming response continues below
+        it.
+
+        * ``Ctrl+C`` / ``CancelledError`` → cancels the dispatch and returns.
+        * Confirmation requests (``Proceed? [y/N]``) → briefly re-enters
+          ``prompt_async`` with a minimal y/N frame, then resumes waiting.
+        """
+        # One event-loop yield so that _run_one_dispatch can start and
+        # call spinner.start() before we first check spinner state.
+        await asyncio.sleep(0)
+
+        spinner_committed = False  # True once we emitted a final \\n for the spinner line
+        last_bytes = -1  # sentinel: "not yet printed"
+
+        def _write_spinner(commit: bool = False) -> None:
+            nonlocal spinner_committed, last_bytes
+            if spinner_committed or not spinner.streaming:
+                return
+            frame = spinner.inline_spinner_ansi()
+            if last_bytes == -1:
+                # First write — no prior line to overwrite.
+                sys.stdout.write(frame)
+            else:
+                # Overwrite the previous spinner frame in-place.
+                sys.stdout.write(f"\r\x1b[2K{frame}")
+            if commit or spinner.bytes_in > 0:
+                # Response has started (or we're done) — lock the line.
+                sys.stdout.write("\n")
+                spinner_committed = True
+            sys.stdout.flush()
+            last_bytes = spinner.bytes_in
+
+        while not turn_done.done():
+            if state.is_awaiting_confirmation():
+                _write_spinner(commit=True)
+                try:
+                    answer = await pt_session.prompt_async(
+                        message=ANSI(f"{ANSI_DIM}❯ {ANSI_RESET}"),
+                        bottom_toolbar=ANSI(
+                            f"{ANSI_DIM}y/N to confirm · Ctrl+C to cancel{ANSI_RESET}"
+                        ),
+                        refresh_interval=_PROMPT_REFRESH_INTERVAL_S,
+                    )
+                except (EOFError, KeyboardInterrupt):
+                    state.cancel_current_dispatch()
+                    break
+                if _looks_like_confirmation_answer(answer):
+                    state.deliver_confirmation(answer or "")
+                # Non-y/n: loop — redisplay the confirmation prompt
+                continue
+
+            _write_spinner()
+
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(turn_done),
+                    timeout=_PROMPT_REFRESH_INTERVAL_S,
+                )
+                _write_spinner(commit=True)
+                return
+            except TimeoutError:
+                pass  # tick — animate spinner, check confirmation state
+            except (asyncio.CancelledError, KeyboardInterrupt):
+                _write_spinner(commit=True)
+                state.cancel_current_dispatch()
+                # Give the worker a moment to print "· interrupted".
+                # SIM105 suppressed: bare ``await`` inside ``contextlib.suppress``
+                # is flagged by CodeQL as "statement has no effect".
+                try:  # noqa: SIM105
+                    await asyncio.wait_for(asyncio.shield(turn_done), timeout=2.0)
+                except Exception:
+                    pass
+                return
 
     processor_task = asyncio.create_task(_processor())
     alert_watcher_task = asyncio.create_task(_alert_watcher())
@@ -956,6 +1053,7 @@ async def _run_interactive(
                     text = await pt_session.prompt_async(
                         message=_message_with_spinner,
                         bottom_toolbar=spinner.toolbar_ansi,
+                        placeholder=_prompt_surface._PLACEHOLDER_ANSI,
                         refresh_interval=_PROMPT_REFRESH_INTERVAL_S,
                     )
                 except EOFError:
@@ -979,53 +1077,16 @@ async def _run_interactive(
                 if state.exit_requested:
                     return
 
-                # Bare ``/cancel``/``/stop``/``/abort`` while a dispatch
-                # is active: route through the same path as ``Esc``
-                # (``state.cancel_current_dispatch()``) instead of
-                # queueing the slash. Queueing a cancel behind the
-                # dispatch that's *causing* the spinner to spin is a
-                # deadlock from the user's perspective — the queued
-                # ``/cancel`` only runs once the parked dispatch
-                # finishes, which is exactly what they're trying to
-                # interrupt. ``/cancel <task_id>`` with arguments is
-                # intentionally NOT matched by the recognizer so the
-                # existing targeted background-task cancel still flows
-                # through the normal slash-dispatch path.
-                if state.is_dispatch_running() and _looks_like_cancel_request(text):
-                    stripped = (text or "").strip()
-                    render_submitted_prompt(echo_console, session, stripped)
-                    state.cancel_current_dispatch()
-                    continue
-
-                # If a worker thread is parked on a confirmation prompt,
-                # the next text the user submits *might* be the answer
-                # to that prompt — but only if it actually reads like a
-                # y/n token. Type-ahead text the user submitted while
-                # the action plan was still being parsed (e.g. a
-                # follow-up question) used to get silently consumed as
-                # the answer and decline the pending action; queue
-                # those as a normal turn instead and leave the
-                # confirmation parked for an explicit answer.
-                if state.is_awaiting_confirmation():
-                    if _looks_like_confirmation_answer(text):
-                        state.deliver_confirmation(text or "")
-                        continue
-                    echo_console.print(
-                        f"[{DIM}](type y/N to confirm the pending action; "
-                        "your input has been queued for after)[/]"
-                    )
-                    stripped = (text or "").strip()
-                    if stripped:
-                        render_submitted_prompt(echo_console, session, stripped)
-                        await state.queue.put(stripped)
-                    continue
-
                 stripped = (text or "").strip()
                 if not stripped:
                     continue
 
                 render_submitted_prompt(echo_console, session, stripped)
-                await state.queue.put(stripped)
+                turn_done: asyncio.Future[None] = main_loop.create_future()
+                await state.queue.put((stripped, turn_done))
+                # Block here — no new prompt until the dispatch finishes.
+                # Ctrl+C cancels; confirmations are served inline.
+                await _wait_for_dispatch(turn_done)
     finally:
         state.exit_requested = True
         state.cancel_current_dispatch()

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -669,23 +669,28 @@ class _SpinnerState:
                 hint += "  ·  esc to clear"
         return ANSI(f"{ANSI_DIM}{hint}{ANSI_RESET}")
 
-    def inline_spinner_ansi(self) -> str:
+    def inline_spinner_ansi(self, *, wait_metrics: bool = True) -> str:
         """Single-line ``⠋ thinking… (Ns · ↓ X tokens)`` indicator, or
         empty string when not streaming. Consumed by
         :func:`_message_with_spinner` and pinned above the input rule,
         so the spinner appears at the visual end of the response
         stream while the input cursor stays anchored below it.
+
+        When ``wait_metrics`` is False, only the glyph and verb are
+        rendered (no elapsed seconds or token counts). The stdout wait
+        line uses this so timing and totals are not duplicated — the
+        rendered reply footer already reports ``· Ns · ↓ X tokens``.
         """
         if not self.streaming:
             return ""
-        elapsed = time.monotonic() - self.started_at
-        tokens_str = format_token_count_short(self.bytes_in // _CHARS_PER_TOKEN)
         glyph = self._SPINNER_FRAMES[self._frame_idx % len(self._SPINNER_FRAMES)]
         self._frame_idx += 1
-        return (
-            f"{PROMPT_ACCENT_ANSI}{glyph} {self._verb}…{ANSI_RESET}"
-            f"{ANSI_DIM} ({elapsed:.0f}s · ↓ {tokens_str} tokens){ANSI_RESET}"
-        )
+        accent = f"{PROMPT_ACCENT_ANSI}{glyph} {self._verb}…{ANSI_RESET}"
+        if not wait_metrics:
+            return accent
+        elapsed = time.monotonic() - self.started_at
+        tokens_str = format_token_count_short(self.bytes_in // _CHARS_PER_TOKEN)
+        return f"{accent}{ANSI_DIM} ({elapsed:.0f}s · ↓ {tokens_str} tokens){ANSI_RESET}"
 
 
 class _StreamingConsole(Console):
@@ -940,8 +945,10 @@ async def _run_interactive(
 
         The spinner is printed as a regular stdout line that animates in
         place (``\\r``) until the first LLM token arrives, then it is
-        committed with a newline and the streaming response continues below
-        it.
+        committed and followed by a blank line; the streaming response
+        continues below. The wait line omits elapsed/token counts
+        (``wait_metrics=False``) so the reply footer remains the single
+        place for final timing and totals.
 
         * ``Ctrl+C`` / ``CancelledError`` → cancels the dispatch and returns.
         * Confirmation requests (``Proceed? [y/N]``) → briefly re-enters
@@ -958,7 +965,7 @@ async def _run_interactive(
             nonlocal spinner_committed, last_bytes
             if spinner_committed or not spinner.streaming:
                 return
-            frame = spinner.inline_spinner_ansi()
+            frame = spinner.inline_spinner_ansi(wait_metrics=False)
             if last_bytes == -1:
                 # First write — no prior line to overwrite.
                 sys.stdout.write(frame)
@@ -967,7 +974,13 @@ async def _run_interactive(
                 sys.stdout.write(f"\r\x1b[2K{frame}")
             if commit or spinner.bytes_in > 0:
                 # Response has started (or we're done) — lock the line.
-                sys.stdout.write("\n")
+                # One extra blank line before streamed body — separates the
+                # transient wait line from the assistant block (footer still
+                # carries timing + tokens when the reply completes).
+                if spinner.bytes_in > 0:
+                    sys.stdout.write("\n\n")
+                else:
+                    sys.stdout.write("\n")
                 spinner_committed = True
             sys.stdout.flush()
             last_bytes = spinner.bytes_in

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -954,6 +954,8 @@ async def _run_interactive(
             except asyncio.CancelledError:
                 return
             if state.exit_requested:
+                if not turn_done.done():
+                    turn_done.set_result(None)
                 state.queue.task_done()
                 return
             state.current_task = asyncio.create_task(_run_one_dispatch(text))

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -938,26 +938,6 @@ async def _run_interactive(
                 turn_done.set_result(None)
             state.queue.task_done()
 
-    def _busy_turn_first_message_line() -> str:
-        animate = spinner.inline_spinner_ansi()
-        if animate:
-            return animate
-        return f"{ANSI_DIM}… — Ctrl+C to cancel{ANSI_RESET}"
-
-    def _busy_rule_ansi() -> str:
-        """Dim (non-accent) horizontal rule used while a turn is running.
-
-        Using the accent colour (bold green) for the rule during a busy
-        turn made it look identical to a fresh ready-prompt, misleading
-        the user into thinking input was open. Dim gray signals "sealed".
-        """
-        try:
-            width = get_app_or_none().output.get_size().columns  # type: ignore[union-attr]
-        except Exception:
-            width = 80
-        rule = _prompt_surface._PROMPT_RULE_CHAR * max(width, 1)
-        return f"{ANSI_DIM}{rule}{ANSI_RESET}"
-
     def _message_with_spinner() -> ANSI:
         """Prompt message — spinner row above the top rule + ``❯`` prefix.
 
@@ -984,7 +964,9 @@ async def _run_interactive(
         omits elapsed/token counts (``wait_metrics=False``); the reply footer
         holds final timing and totals.
 
-        * ``Ctrl+C`` / ``CancelledError`` → cancels the dispatch and returns.
+        * ``Ctrl+C`` → cancels the dispatch and returns.
+        * ``asyncio.CancelledError`` → cleanup then **re-raises** so outer
+          cancellation is not swallowed (Python 3.11+ semantics).
         * Confirmation requests (``Proceed? [y/N]``) → briefly re-enters
           ``prompt_async`` with a minimal y/N frame, then resumes waiting.
         """
@@ -1033,7 +1015,12 @@ async def _run_interactive(
                     break
                 if _looks_like_confirmation_answer(answer):
                     state.deliver_confirmation(answer or "")
-                # Non-y/n: loop — redisplay the confirmation prompt
+                    # Let the worker thread clear ``confirm_event`` (see
+                    # ``_route_confirm_through_prompt``) before we re-check
+                    # ``is_awaiting_confirmation()`` — avoids a duplicate y/N
+                    # frame on the next loop iteration.
+                    await asyncio.sleep(0)
+                # Invalid answer: redisplay confirmation prompt.
                 continue
 
             _write_spinner()
@@ -1047,7 +1034,7 @@ async def _run_interactive(
                 return
             except TimeoutError:
                 pass  # tick — animate spinner, check confirmation state
-            except (asyncio.CancelledError, KeyboardInterrupt):
+            except asyncio.CancelledError:
                 _write_spinner(commit=True)
                 state.cancel_current_dispatch()
                 # Give the worker a moment to print "· interrupted".
@@ -1056,6 +1043,16 @@ async def _run_interactive(
                 try:  # noqa: SIM105
                     await asyncio.wait_for(asyncio.shield(turn_done), timeout=2.0)
                 except Exception:
+                    # ``CancelledError`` vs worker teardown ordering is non-deterministic.
+                    pass
+                raise
+            except KeyboardInterrupt:
+                _write_spinner(commit=True)
+                state.cancel_current_dispatch()
+                try:  # noqa: SIM105
+                    await asyncio.wait_for(asyncio.shield(turn_done), timeout=2.0)
+                except Exception:
+                    # Same best-effort join as ``CancelledError``; Ctrl+C path returns.
                     pass
                 return
 

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -77,7 +77,11 @@ from app.cli.interactive_shell.ui.streaming import (
 )
 from app.cli.support.errors import OpenSREError
 from app.cli.support.exception_reporting import report_exception
-from app.cli.support.prompt_support import repl_prompt_note_ctrl_c, repl_reset_ctrl_c_gate
+from app.cli.support.prompt_support import (
+    repl_prompt_note_ctrl_c,
+    repl_reset_ctrl_c_gate,
+    set_sigint_delegate,
+)
 from app.llm_reasoning_effort import apply_reasoning_effort
 
 log = logging.getLogger(__name__)
@@ -507,6 +511,7 @@ def run_repl(initial_input: str | None = None, config: ReplConfig | None = None)
 # ``confirm_event.wait`` poll timeout. 250 ms is still well below the
 # threshold where humans notice Esc-cancel latency.
 _PROMPT_REFRESH_INTERVAL_S = 0.25
+_INTERRUPT_DRAIN_TIMEOUT_S = 0.15
 
 
 @dataclass
@@ -815,6 +820,20 @@ async def _run_interactive(
     # invoked from a worker thread (see :func:`_request_exit`).
     state.loop = main_loop
 
+    def _sigint_delegate() -> bool:
+        """Handle Ctrl+C while the REPL has in-flight work."""
+        if (
+            state.is_dispatch_running()
+            or state.current_cancel_event is not None
+            or state.is_awaiting_confirmation()
+            or not state.queue.empty()
+        ):
+            state.cancel_current_dispatch()
+            return True
+        return False
+
+    set_sigint_delegate(_sigint_delegate)
+
     def _request_exit() -> None:
         state.exit_requested = True
         state.cancel_current_dispatch()
@@ -1042,12 +1061,16 @@ async def _run_interactive(
             except asyncio.CancelledError:
                 _write_spinner(commit=True)
                 state.cancel_current_dispatch()
-                # Give the worker a moment to print "· interrupted".
+                # Give the worker a brief moment to flush "· interrupted",
+                # but return control quickly so Ctrl+C feels immediate.
                 # SIM105 suppressed: bare ``await`` inside ``contextlib.suppress``
                 # is flagged by CodeQL as "statement has no effect".
                 try:  # noqa: SIM105
-                    await asyncio.wait_for(asyncio.shield(turn_done), timeout=2.0)
-                except Exception:
+                    await asyncio.wait_for(
+                        asyncio.shield(turn_done),
+                        timeout=_INTERRUPT_DRAIN_TIMEOUT_S,
+                    )
+                except (TimeoutError, asyncio.CancelledError):
                     # ``CancelledError`` vs worker teardown ordering is non-deterministic.
                     pass
                 raise
@@ -1055,9 +1078,12 @@ async def _run_interactive(
                 _write_spinner(commit=True)
                 state.cancel_current_dispatch()
                 try:  # noqa: SIM105
-                    await asyncio.wait_for(asyncio.shield(turn_done), timeout=2.0)
-                except Exception:
-                    # Same best-effort join as ``CancelledError``; Ctrl+C path returns.
+                    await asyncio.wait_for(
+                        asyncio.shield(turn_done),
+                        timeout=_INTERRUPT_DRAIN_TIMEOUT_S,
+                    )
+                except (TimeoutError, asyncio.CancelledError):
+                    # Same best-effort drain as ``CancelledError``; Ctrl+C path returns.
                     pass
                 return
 
@@ -1135,6 +1161,7 @@ async def _run_interactive(
                 # Ctrl+C cancels; confirmations are served inline.
                 await _wait_for_dispatch(turn_done)
     finally:
+        set_sigint_delegate(None)
         state.exit_requested = True
         state.cancel_current_dispatch()
         sampler_task.cancel()

--- a/app/cli/interactive_shell/ui/streaming.py
+++ b/app/cli/interactive_shell/ui/streaming.py
@@ -83,8 +83,20 @@ def format_token_count_short(token_count: int) -> str:
     return str(token_count)
 
 
-def _format_tokens(token_count: int) -> str:
-    return f"{format_token_count_short(token_count)} tokens"
+def _format_tokens(token_count: int, *, approximate: bool = False) -> str:
+    n = format_token_count_short(token_count)
+    if approximate:
+        return f"~{n} tokens (est.)"
+    return f"{n} tokens"
+
+
+def _format_footer_elapsed_s(elapsed: float) -> str:
+    """Format stream duration without ``0.0s`` for sub-100ms transfers."""
+    if elapsed >= 10.0:
+        return f"{elapsed:.1f}"
+    if elapsed >= 1.0:
+        return f"{elapsed:.1f}"
+    return f"{elapsed:.2f}"
 
 
 def stream_to_console(
@@ -294,10 +306,20 @@ def stream_to_console(
         # Render whatever's left in the paragraph buffer so the user
         # sees the full response even if it didn't end on ``\n\n``.
         _flush_paragraphs(force=True)
-        elapsed = time.monotonic() - started
+        hook = getattr(console, "repl_turn_elapsed_s", None)
+        if callable(hook):
+            elapsed = hook(started)
+        else:
+            elapsed = time.monotonic() - started
+        elapsed_s = _format_footer_elapsed_s(elapsed)
         if buffer:
-            tokens = _format_tokens(total_bytes // _CHARS_PER_TOKEN)
-            console.print(f"[{DIM}]· {elapsed:.1f}s · ↓ {tokens}[/]")
+            # ``total_bytes // _CHARS_PER_TOKEN`` is a character heuristic — not
+            # provider-reported usage.
+            tokens = _format_tokens(
+                total_bytes // _CHARS_PER_TOKEN,
+                approximate=True,
+            )
+            console.print(f"[{DIM}]· {elapsed_s}s · ↓ {tokens}[/]")
         console.print()
 
     return "".join(buffer)

--- a/app/cli/interactive_shell/ui/streaming.py
+++ b/app/cli/interactive_shell/ui/streaming.py
@@ -143,6 +143,9 @@ def stream_to_console(
                 return "".join(peeked) + "".join(drained)
             break
 
+    wipe = getattr(console, "wipe_stdout_wait_spinner_line", None)
+    if callable(wipe):
+        wipe()
     console.print()
     render_response_header(console, label)
 

--- a/app/cli/interactive_shell/ui/streaming.py
+++ b/app/cli/interactive_shell/ui/streaming.py
@@ -164,6 +164,15 @@ def stream_to_console(
                     if rest is None:
                         break
                     drained.append(rest)
+                update_progress = getattr(console, "update_streaming_progress", None)
+                if callable(update_progress):
+                    try:
+                        update_progress(
+                            sum(len(chunk_part) for chunk_part in peeked)
+                            + sum(len(chunk_part) for chunk_part in drained)
+                        )
+                    except Exception:
+                        pass
                 _maybe_wipe_stdout_wait(console)
                 return "".join(peeked) + "".join(drained)
             break

--- a/app/cli/interactive_shell/ui/streaming.py
+++ b/app/cli/interactive_shell/ui/streaming.py
@@ -93,7 +93,7 @@ def _format_tokens(token_count: int, *, approximate: bool = False) -> str:
 def _format_footer_elapsed_s(elapsed: float) -> str:
     """Format stream duration without ``0.0s`` for sub-100ms transfers."""
     if elapsed >= 10.0:
-        return f"{elapsed:.1f}"
+        return f"{elapsed:.0f}"
     if elapsed >= 1.0:
         return f"{elapsed:.1f}"
     return f"{elapsed:.2f}"

--- a/app/cli/interactive_shell/ui/streaming.py
+++ b/app/cli/interactive_shell/ui/streaming.py
@@ -99,6 +99,18 @@ def _format_footer_elapsed_s(elapsed: float) -> str:
     return f"{elapsed:.2f}"
 
 
+def _maybe_wipe_stdout_wait(console: Console) -> None:
+    """Erase the REPL wait line if ``console`` exposes ``wipe_stdout_wait_spinner_line``.
+
+    The JSON action-plan path returns before any ``console.print``; we still wipe so a
+    transient stdout spinner from the interactive dispatch does not linger in scrollback.
+    """
+
+    wipe = getattr(console, "wipe_stdout_wait_spinner_line", None)
+    if callable(wipe):
+        wipe()
+
+
 def stream_to_console(
     console: Console,
     *,
@@ -152,12 +164,11 @@ def stream_to_console(
                     if rest is None:
                         break
                     drained.append(rest)
+                _maybe_wipe_stdout_wait(console)
                 return "".join(peeked) + "".join(drained)
             break
 
-    wipe = getattr(console, "wipe_stdout_wait_spinner_line", None)
-    if callable(wipe):
-        wipe()
+    _maybe_wipe_stdout_wait(console)
     console.print()
     render_response_header(console, label)
 

--- a/app/cli/interactive_shell/ui/streaming.py
+++ b/app/cli/interactive_shell/ui/streaming.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import re
 import time
 from collections.abc import Iterator
+from contextlib import suppress
 
 from rich.console import Console
 from rich.markdown import Markdown
@@ -166,13 +167,11 @@ def stream_to_console(
                     drained.append(rest)
                 update_progress = getattr(console, "update_streaming_progress", None)
                 if callable(update_progress):
-                    try:
+                    with suppress(Exception):
                         update_progress(
                             sum(len(chunk_part) for chunk_part in peeked)
                             + sum(len(chunk_part) for chunk_part in drained)
                         )
-                    except Exception:
-                        pass
                 _maybe_wipe_stdout_wait(console)
                 return "".join(peeked) + "".join(drained)
             break

--- a/app/cli/support/prompt_support.py
+++ b/app/cli/support/prompt_support.py
@@ -13,16 +13,16 @@ from prompt_toolkit.key_binding import KeyBindings, KeyBindingsBase, merge_key_b
 from prompt_toolkit.keys import Keys
 from rich.console import Console
 
-from app.cli.interactive_shell.ui.theme import DIM
-
 _escape_patch_installed: list[bool] = [False]
 _ctrl_c_patch_installed: list[bool] = [False]
 
 # Shared timestamp of the last Ctrl+C press (None = never pressed).
 _last_ctrl_c: list[float | None] = [None]
+_sigint_delegate: list[Callable[[], bool] | None] = [None]
 
 CTRL_C_DOUBLE_PRESS_WINDOW_S: float = 2.0
 _CTRL_C_EXIT_WINDOW: float = CTRL_C_DOUBLE_PRESS_WINDOW_S
+_DIM_STYLE = "#444444"
 
 
 class _HardQuitInterrupt(KeyboardInterrupt):
@@ -97,6 +97,34 @@ def handle_ctrl_c_press() -> None:
         sys.exit(0)
     _last_ctrl_c[0] = now
     print("\n(Press Ctrl+C again to exit)", flush=True)
+
+
+def set_sigint_delegate(delegate: Callable[[], bool] | None) -> None:
+    """Register an optional SIGINT delegate for context-specific handling.
+
+    The delegate should return True when it fully handled Ctrl+C (for example,
+    cancelling an in-flight REPL dispatch) so global double-press exit logic is
+    skipped for that signal.
+    """
+
+    _sigint_delegate[0] = delegate
+
+
+def handle_sigint_for_cli() -> None:
+    """Handle SIGINT with optional context-aware delegate fallback."""
+
+    delegate = _sigint_delegate[0]
+    if delegate is not None:
+        try:
+            if delegate():
+                # Delegate-handled interrupts should not arm the global
+                # "press again to exit" window.
+                _last_ctrl_c[0] = None
+                return
+        except Exception:
+            # Never let delegate failures break SIGINT handling.
+            pass
+    handle_ctrl_c_press()
 
 
 def _with_ctrl_c_double_exit(
@@ -184,11 +212,11 @@ def repl_reset_ctrl_c_gate() -> None:
 def repl_prompt_note_ctrl_c(console: Console) -> bool:
     now = time.monotonic()
     if _last_ctrl_c[0] is not None and now - _last_ctrl_c[0] <= _CTRL_C_EXIT_WINDOW:
-        console.print(f"[{DIM}]Goodbye![/]")
+        console.print(f"[{_DIM_STYLE}]Goodbye![/]")
         _last_ctrl_c[0] = None
         return True
     _last_ctrl_c[0] = now
-    console.print(f"[{DIM}](Press Ctrl+C again to exit)[/]")
+    console.print(f"[{_DIM_STYLE}](Press Ctrl+C again to exit)[/]")
     return False
 
 

--- a/tests/cli/interactive_shell/test_loop.py
+++ b/tests/cli/interactive_shell/test_loop.py
@@ -1044,6 +1044,23 @@ class TestReplState:
         assert state.is_dispatch_running() is False
         assert state.current_cancel_event is None
 
+    def test_cancel_next_queued_turn_drops_pending_turn_and_completes_future(self) -> None:
+        async def _scenario() -> None:
+            state = loop._ReplState()
+            done = asyncio.get_running_loop().create_future()
+            await state.queue.put(("queued turn", done))
+
+            assert state.cancel_next_queued_turn() is True
+            assert state.queue.empty() is True
+            assert done.done() is True
+            await asyncio.wait_for(state.queue.join(), timeout=0.05)
+
+        asyncio.run(_scenario())
+
+    def test_cancel_next_queued_turn_returns_false_when_queue_empty(self) -> None:
+        state = loop._ReplState()
+        assert state.cancel_next_queued_turn() is False
+
     def test_per_dispatch_cancel_events_are_isolated(self) -> None:
         """Regression guard for the shared-event race that used to let
         a previous turn's worker-thread observation get clobbered by

--- a/tests/cli/interactive_shell/test_loop.py
+++ b/tests/cli/interactive_shell/test_loop.py
@@ -759,6 +759,18 @@ class TestSpinnerState:
         # Spinner glyph from the brail palette.
         assert any(g in rendered for g in spinner._SPINNER_FRAMES)
 
+    def test_streaming_inline_spinner_omits_metrics_when_disabled(self) -> None:
+        """Stdout wait line uses ``wait_metrics=False`` — avoids duplicating
+        counts the reply footer prints when streaming ends."""
+        spinner = loop._SpinnerState()
+        spinner.start()
+        spinner.bytes_in = 1234 * loop._CHARS_PER_TOKEN
+        rendered = _strip_ansi(spinner.inline_spinner_ansi(wait_metrics=False))
+        assert "tokens" not in rendered
+        assert "(" not in rendered
+        assert any(f"{verb}…" in rendered for verb in spinner._THINKING_VERBS)
+        assert any(g in rendered for g in spinner._SPINNER_FRAMES)
+
     def test_streaming_inline_spinner_verb_stays_constant_across_calls(self) -> None:
         """A turn's verb is fixed at ``start()`` so the indicator
         doesn't flicker between words mid-stream."""

--- a/tests/cli/interactive_shell/ui/test_streaming.py
+++ b/tests/cli/interactive_shell/ui/test_streaming.py
@@ -130,7 +130,7 @@ class TestTtyParagraphRender:
 
         class _ElapsedHookConsole(Console):
             def repl_turn_elapsed_s(self, stream_start: float) -> float:  # noqa: ARG002
-                return 42.5
+                return 8.5
 
         console = _ElapsedHookConsole(
             file=buf, force_terminal=True, color_system=None, width=80, highlight=False
@@ -140,7 +140,15 @@ class TestTtyParagraphRender:
             label="assistant",
             chunks=_yield_chunks(["body"]),
         )
-        assert "42.5s" in _strip_ansi(buf.getvalue())
+        assert "8.5s" in _strip_ansi(buf.getvalue())
+
+    def test_format_footer_elapsed_s_tiers(self) -> None:
+        from app.cli.interactive_shell.ui import streaming as streaming_module
+
+        assert streaming_module._format_footer_elapsed_s(0.03) == "0.03"
+        assert streaming_module._format_footer_elapsed_s(2.567) == "2.6"
+        assert streaming_module._format_footer_elapsed_s(42.5) == "42"
+        assert streaming_module._format_footer_elapsed_s(120.4) == "120"
 
     def test_renders_first_paragraph_before_second_completes(self) -> None:
         """A complete paragraph (``\\n\\n``) flushes immediately, even

--- a/tests/cli/interactive_shell/ui/test_streaming.py
+++ b/tests/cli/interactive_shell/ui/test_streaming.py
@@ -103,6 +103,26 @@ class TestTtyParagraphRender:
         assert "**opensre" not in output
         assert "opensre investigate" in output
 
+    def test_invokes_wipe_stdout_wait_spinner_hook_once(self) -> None:
+        """Interactive REPL consoles expose ``wipe_stdout_wait_spinner_line`` so the
+        transient wait line is erased before Rich prints the streamed reply."""
+        buf = io.StringIO()
+        wipe_calls: list[int] = []
+
+        class ConsoleWithWipe(Console):
+            def wipe_stdout_wait_spinner_line(self) -> None:
+                wipe_calls.append(1)
+
+        console = ConsoleWithWipe(
+            file=buf, force_terminal=True, color_system=None, width=80, highlight=False
+        )
+        stream_to_console(
+            console,
+            label="assistant",
+            chunks=_yield_chunks(["hi"]),
+        )
+        assert len(wipe_calls) == 1
+
     def test_renders_first_paragraph_before_second_completes(self) -> None:
         """A complete paragraph (``\\n\\n``) flushes immediately, even
         when more chunks would still arrive after it. The second

--- a/tests/cli/interactive_shell/ui/test_streaming.py
+++ b/tests/cli/interactive_shell/ui/test_streaming.py
@@ -125,6 +125,27 @@ class TestTtyParagraphRender:
         )
         assert len(wipe_calls) == 1
 
+    def test_suppressed_path_updates_streaming_progress(self) -> None:
+        buf = io.StringIO()
+        progress_calls: list[int] = []
+
+        class ConsoleWithProgress(Console):
+            def update_streaming_progress(self, bytes_received: int) -> None:
+                progress_calls.append(bytes_received)
+
+        console = ConsoleWithProgress(
+            file=buf, force_terminal=True, color_system=None, width=80, highlight=False
+        )
+        result = stream_to_console(
+            console,
+            label="assistant",
+            chunks=_yield_chunks(['{"actions"', ':["a"]}']),
+            suppress_if_starts_with="{",
+        )
+
+        assert result == '{"actions":["a"]}'
+        assert progress_calls and progress_calls[-1] == len(result)
+
     def test_footer_uses_repl_turn_elapsed_when_hook_present(self) -> None:
         buf = io.StringIO()
 

--- a/tests/cli/interactive_shell/ui/test_streaming.py
+++ b/tests/cli/interactive_shell/ui/test_streaming.py
@@ -102,6 +102,8 @@ class TestTtyParagraphRender:
         # End-of-stream force-flush rendered Markdown — ``**`` stripped.
         assert "**opensre" not in output
         assert "opensre investigate" in output
+        # Footer: byte-derived token estimate + elapsed (see ``stream_to_console``).
+        assert "(est.)" in output
 
     def test_invokes_wipe_stdout_wait_spinner_hook_once(self) -> None:
         """Interactive REPL consoles expose ``wipe_stdout_wait_spinner_line`` so the
@@ -122,6 +124,23 @@ class TestTtyParagraphRender:
             chunks=_yield_chunks(["hi"]),
         )
         assert len(wipe_calls) == 1
+
+    def test_footer_uses_repl_turn_elapsed_when_hook_present(self) -> None:
+        buf = io.StringIO()
+
+        class _ElapsedHookConsole(Console):
+            def repl_turn_elapsed_s(self, stream_start: float) -> float:  # noqa: ARG002
+                return 42.5
+
+        console = _ElapsedHookConsole(
+            file=buf, force_terminal=True, color_system=None, width=80, highlight=False
+        )
+        stream_to_console(
+            console,
+            label="assistant",
+            chunks=_yield_chunks(["body"]),
+        )
+        assert "42.5s" in _strip_ansi(buf.getvalue())
 
     def test_renders_first_paragraph_before_second_completes(self) -> None:
         """A complete paragraph (``\\n\\n``) flushes immediately, even

--- a/tests/cli/interactive_shell/ui/test_streaming.py
+++ b/tests/cli/interactive_shell/ui/test_streaming.py
@@ -1001,6 +1001,25 @@ class TestSuppressionPeek:
         assert "●" not in output
         assert '{"actions"' not in output
 
+    def test_suppressed_tty_path_invokes_wipe_hook(self) -> None:
+        buf = io.StringIO()
+        wipe_calls: list[int] = []
+
+        class _WipeConsole(Console):
+            def wipe_stdout_wait_spinner_line(self) -> None:
+                wipe_calls.append(1)
+
+        console = _WipeConsole(
+            file=buf, force_terminal=True, color_system=None, width=80, highlight=False
+        )
+        stream_to_console(
+            console,
+            label="assistant",
+            chunks=_yield_chunks(['{"actions": []}']),
+            suppress_if_starts_with="{",
+        )
+        assert len(wipe_calls) == 1
+
     def test_renders_normally_when_first_char_does_not_match(self) -> None:
         console, buf = _tty_console()
         result = stream_to_console(

--- a/tests/cli/test_prompt_support.py
+++ b/tests/cli/test_prompt_support.py
@@ -9,9 +9,12 @@ from prompt_toolkit.output import DummyOutput  # type: ignore[import-not-found]
 
 from app.cli.support.prompt_support import (
     _last_ctrl_c,
+    _sigint_delegate,
     handle_ctrl_c_press,
+    handle_sigint_for_cli,
     install_questionary_ctrl_c_double_exit,
     install_questionary_escape_cancel,
+    set_sigint_delegate,
 )
 
 
@@ -139,6 +142,48 @@ def test_ctrl_c_hint_resets_after_window(capsys) -> None:
     handle_ctrl_c_press()
     out = capsys.readouterr().out
     assert "(Press Ctrl+C again to exit)" in out
+
+
+def test_handle_sigint_for_cli_uses_delegate_when_handled(capsys) -> None:
+    _last_ctrl_c[0] = None
+    set_sigint_delegate(lambda: True)
+    try:
+        handle_sigint_for_cli()
+    finally:
+        set_sigint_delegate(None)
+    assert capsys.readouterr().out == ""
+    assert _last_ctrl_c[0] is None
+
+
+def test_handle_sigint_for_cli_falls_back_when_delegate_not_handled(capsys) -> None:
+    _last_ctrl_c[0] = None
+    set_sigint_delegate(lambda: False)
+    try:
+        handle_sigint_for_cli()
+    finally:
+        set_sigint_delegate(None)
+    out = capsys.readouterr().out
+    assert "(Press Ctrl+C again to exit)" in out
+
+
+def test_handle_sigint_for_cli_falls_back_when_delegate_errors(capsys) -> None:
+    _last_ctrl_c[0] = None
+
+    def _boom() -> bool:
+        raise RuntimeError("boom")
+
+    set_sigint_delegate(_boom)
+    try:
+        handle_sigint_for_cli()
+    finally:
+        set_sigint_delegate(None)
+    out = capsys.readouterr().out
+    assert "(Press Ctrl+C again to exit)" in out
+
+
+def test_sigint_delegate_starts_cleared() -> None:
+    set_sigint_delegate(None)
+    assert _sigint_delegate[0] is None
 
 
 def test_questionary_ask_inside_running_event_loop_does_not_raise() -> None:


### PR DESCRIPTION
Fixes #1903

#### Describe the changes you have made in this PR -

### Summary

Improves the OpenSRE **interactive shell** so a turn feels like one coherent block: no fresh `❯` prompt (or misleading “ready” chrome) while a response is still generating, **visible wait feedback** (`⠋ verb…`) that does not pollute scrollback, a **accurate footer** for duration and rough token size, and **correct** mid-turn **y/N confirmation** and **cancellation** behavior.

### Before

<img width="1058" height="216" alt="image" src="https://github.com/user-attachments/assets/b22fb12e-1e70-4d83-a341-e910caefca7f" />


### After 

<img width="937" height="348" alt="image" src="https://github.com/user-attachments/assets/31189af7-1d9a-47a1-a21f-a5df0f1b9605" />


### Problems addressed

| Area | Before | After |
|------|--------|--------|
| Prompt frame | `prompt_async` could redraw while dispatch ran → looked like a new input line. | Main loop **`await`s `_wait_for_dispatch(turn_done)`** — no prompt session during the blocking phase. |
| Spinner | Spinner lived in `bottom_toolbar`; blocking `prompt_async` removed it. | **`_write_spinner`** draws on **`stdout`**, animates with `\r` + clear-to-EOL until bytes arrive or the turn ends. |
| Scrollback | “Noodling / analysing” line stuck between user message and assistant reply. | **`wipe_stdout_wait_spinner_line`** on `_StreamingConsole` invoked from **`stream_to_console`** before the first Rich `print` **erases** the wait line so it is not kept as history. |
| Footer `· 0.0s · ↓ N tokens` | Elapsed was measured only inside `stream_to_console` (missed pre-chunk wait); **`0.0s`** common; **`N tokens`** read as exact API usage. | **`repl_turn_elapsed_s`**: wall time from **`spinner.start()`** when the REPL spinner is active; **`_format_footer_elapsed_s`** for sub-second display; footer tokens labeled **`~N tokens (est.)`** (char heuristic). |
| Greptile / review | Unused helpers; **`CancelledError`** swallowed; **duplicate y/N** after `deliver_confirmation`. | Removed dead **`_busy_*`**; **`raise`** after cleanup on **`CancelledError`**; **`await asyncio.sleep(0)`** after deliver so the worker clears **`confirm_event`**. |

### Key implementation notes

- **`_wait_for_dispatch`**: polls `turn_done` with `asyncio.wait_for(..., timeout=refresh)`, handles **confirmation** via a minimal **`prompt_async`** y/N frame, **re-raises** `asyncio.CancelledError` after cleanup per Python 3.11+ semantics.
- **`_StreamingConsole`**: **`wipe_stdout_wait_spinner_line`**, **`repl_turn_elapsed_s`**, existing **`update_streaming_progress`** / **`cancel_requested`**.
- **`stream_to_console`**: calls wipe hook before first print; footer uses elapsed hook + estimated token string when appropriate.
- Tests: **`tests/cli/interactive_shell/test_loop.py`**, **`tests/cli/interactive_shell/ui/test_streaming.py`** (including wipe + elapsed hook coverage where applicable).

### Demo/Screenshot for feature changes and bug fixes -

<!-- Terminal before/after or short clip showing: (1) no extra prompt line during streaming, (2) spinner then clean transition to reply, (3) footer with plausible elapsed + ~tokens (est.). -->

*Optional: attach a terminal screenshot or GIF after manual verification.*

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Prompt-toolkit always paints a cursor while `prompt_async` is active, so “dimming” the busy state could not remove the misleading second prompt. The fix is to **not** run the main prompt session until the current **`Future`** for the turn completes, while a **background processor** still runs dispatch so **Esc** / cancel stays responsive. The wait indicator is drawn on **stdout** (compatible with `patch_stdout`) rather than the inactive toolbar. Erasing that line before Rich prints avoids permanent “noodling” in scrollback. Footer duration ties to **`spinner.started_at`** on the REPL console so “think time” is included in **`· Ns`**.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
