### PR TITLE
fix(llm-cli): ruff-format cursor probe and add OSError regression test

### DIFF
--- a/app/integrations/llm_cli/cursor.py
+++ b/app/integrations/llm_cli/cursor.py
@@ -143,9 +143,7 @@ class CursorAdapter:
             if _has_cursor_api_key():
                 logged_in = True
                 reason = (
-                    "timed out"
-                    if isinstance(exc, subprocess.TimeoutExpired)
-                    else f"failed ({exc})"
+                    "timed out" if isinstance(exc, subprocess.TimeoutExpired) else f"failed ({exc})"
                 )
                 detail = (
                     f"Cursor Agent auth probe {reason}; "

--- a/tests/integrations/llm_cli/test_cursor_adapter.py
+++ b/tests/integrations/llm_cli/test_cursor_adapter.py
@@ -221,6 +221,36 @@ def test_detect_status_timeout_with_api_key(mock_which: MagicMock, mock_run: Mag
     assert "CURSOR_API_KEY" in probe.detail
 
 
+@patch("app.integrations.llm_cli.cursor.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_status_oserror_with_api_key_message(
+    mock_which: MagicMock, mock_run: MagicMock
+) -> None:
+    """Headless path must not claim timeout when the CLI raised OSError."""
+    mock_which.return_value = "agent"
+
+    def side_effect(args, **kwargs):
+        if "--version" in args:
+            return _version_proc()
+        if "status" in args:
+            raise OSError("exec format error")
+        return _fallback_proc()
+
+    mock_run.side_effect = side_effect
+
+    with patch.dict(
+        os.environ,
+        {"CURSOR_BIN": "agent", "CURSOR_API_KEY": "ck", "USERPROFILE": r"C:\Users\test"},
+        clear=True,
+    ):
+        probe = CursorAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is True
+    assert "failed" in probe.detail
+    assert "timed out" not in probe.detail.lower()
+
+
 @patch.dict(os.environ, {"CURSOR_API_KEY": ""}, clear=False)
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="agent")
 def test_build_adds_trust_workspace_and_model(mock_which: MagicMock) -> None:


### PR DESCRIPTION
## Summary

Follow-up to **#2001** (merged): CI failed **`ruff format --check`** on `app/integrations/llm_cli/cursor.py` after the Cursor status-probe change. This applies the formatter output.

**Greptile** on #2001 asked to distinguish `TimeoutExpired` vs `OSError` in the headless-auth detail string; that logic is already on `main` from #2001. This PR adds a **regression test** so we do not mis-label a non-timeout failure as "timed out".

## Test plan

- [x] `uv run pytest tests/integrations/llm_cli/test_cursor_adapter.py -q`
- [x] `uv run python -m ruff format --check app/integrations/llm_cli/cursor.py`

Related: #2001