### PR TITLE
fix: max_completion_tokens for o-series models; utf-8 encoding in subprocess

### DIFF
--- a/app/cli/interactive_shell/shell/execution.py
+++ b/app/cli/interactive_shell/shell/execution.py
@@ -52,6 +52,8 @@ def execute_shell_command(
                 executable=os.environ.get("SHELL") or None,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=timeout_seconds,
                 check=False,
             )
@@ -63,6 +65,8 @@ def execute_shell_command(
                 shell=False,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=timeout_seconds,
                 check=False,
             )

--- a/app/sandbox/runner.py
+++ b/app/sandbox/runner.py
@@ -147,6 +147,8 @@ def run_python_sandbox(
             [sys.executable, tmp_path],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=effective_timeout,
         )
         return SandboxResult(

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -54,6 +54,20 @@ def _anthropic_tool_schema(tool: Any) -> dict[str, Any]:
     }
 
 
+def _openai_tokens_param(model: str) -> str:
+    """Return the correct token-limit parameter name for an OpenAI model.
+
+    o1/o3/o4-series reasoning models reject 'max_tokens' and require
+    'max_completion_tokens' (https://platform.openai.com/docs/api-reference).
+    All other models accept either name; we keep 'max_tokens' for them to stay
+    compatible with OpenAI-compatible third-party endpoints that haven't added
+    'max_completion_tokens' yet.
+    """
+    import re
+
+    return "max_completion_tokens" if re.match(r"^o[0-9]", model) else "max_tokens"
+
+
 def _openai_tool_schema(tool: Any) -> dict[str, Any]:
     return {
         "type": "function",
@@ -235,7 +249,7 @@ class OpenAIAgentClient:
 
         kwargs: dict[str, Any] = {
             "model": self._model,
-            "max_tokens": self._max_tokens,
+            _openai_tokens_param(self._model): self._max_tokens,
             "messages": msgs,
         }
         if tools:

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -63,8 +64,6 @@ def _openai_tokens_param(model: str) -> str:
     compatible with OpenAI-compatible third-party endpoints that haven't added
     'max_completion_tokens' yet.
     """
-    import re
-
     return "max_completion_tokens" if re.match(r"^o[0-9]", model) else "max_tokens"
 
 

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -5,7 +5,7 @@ import types
 
 import pytest
 
-from app.services.agent_llm_client import BedrockAgentClient
+from app.services.agent_llm_client import BedrockAgentClient, _openai_tokens_param
 
 
 def _install_fake_anthropic(monkeypatch: pytest.MonkeyPatch) -> types.SimpleNamespace:
@@ -37,6 +37,24 @@ def _install_fake_anthropic(monkeypatch: pytest.MonkeyPatch) -> types.SimpleName
     fake_module.AnthropicBedrock = AnthropicBedrock
     monkeypatch.setitem(sys.modules, "anthropic", fake_module)
     return fake_module
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("o1", "max_completion_tokens"),
+        ("o1-mini", "max_completion_tokens"),
+        ("o3", "max_completion_tokens"),
+        ("o3-mini", "max_completion_tokens"),
+        ("o4-mini", "max_completion_tokens"),
+        ("gpt-4o", "max_tokens"),
+        ("gpt-4-turbo", "max_tokens"),
+        ("gpt-5.4", "max_tokens"),
+        ("openai/o3", "max_tokens"),  # routed via OpenRouter — not a bare o-series name
+    ],
+)
+def test_openai_tokens_param(model: str, expected: str) -> None:
+    assert _openai_tokens_param(model) == expected
 
 
 def test_bedrock_client_requires_region_env(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Closes #2053** — OpenAI o1/o3/o4-series reasoning models reject `max_tokens` with HTTP 400 (`unsupported_parameter`). Added `_openai_tokens_param()` helper in `app/services/agent_llm_client.py` that returns `max_completion_tokens` for models matching `^o[0-9]` (e.g. `o1`, `o1-mini`, `o3`, `o3-mini`, `o4-mini`) and `max_tokens` for all others (GPT-4o, gpt-5.4, OpenRouter-routed models, etc.).
- **Closes #2049** — `subprocess.run` calls in `app/cli/interactive_shell/shell/execution.py` and `app/sandbox/runner.py` used `text=True` without an explicit `encoding`, falling back to the OS locale default (e.g. `gbk` on Chinese Windows). Added `encoding="utf-8", errors="replace"` to both sites, matching the pattern already used in the rest of the codebase.

## Test plan

- [x] `test_openai_tokens_param` parametrized over o-series and gpt-series model names — all 9 cases pass
- [x] Existing Bedrock tests pass
- [x] `ruff check` clean on all changed files
- [x] `make test-cov` green locally

https://claude.ai/code/session_01T85aswjPWKSHobgBNbaW1R
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T85aswjPWKSHobgBNbaW1R)_