### PR TITLE
fix(clickhouse): wrap missing clickhouse-connect import with helpful RuntimeError

### DIFF
--- a/app/integrations/clickhouse.py
+++ b/app/integrations/clickhouse.py
@@ -119,7 +119,13 @@ def clickhouse_config_from_env() -> ClickHouseConfig | None:
 
 def _get_client(config: ClickHouseConfig) -> Any:
     """Create a clickhouse_connect Client from config. Caller must close."""
-    import clickhouse_connect  # type: ignore[import-not-found,import-untyped]
+    try:
+        import clickhouse_connect  # type: ignore[import-not-found,import-untyped]
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "clickhouse-connect is not installed. "
+            "Install it with: pip install 'opensre[clickhouse]'"
+        ) from exc
 
     return clickhouse_connect.get_client(
         host=config.host,

--- a/tests/integrations/test_clickhouse.py
+++ b/tests/integrations/test_clickhouse.py
@@ -1,8 +1,14 @@
 """Unit tests for the ClickHouse integration module."""
 
+import sys
+from unittest.mock import patch
+
+import pytest
+
 from app.integrations.clickhouse import (
     ClickHouseConfig,
     ClickHouseValidationResult,
+    _get_client,
     build_clickhouse_config,
     clickhouse_config_from_env,
 )
@@ -144,3 +150,15 @@ class TestClickHouseValidationResult:
         result = ClickHouseValidationResult(ok=False, detail="Connection refused.")
         assert result.ok is False
         assert result.detail == "Connection refused."
+
+
+class TestGetClient:
+    """Tests for _get_client helper."""
+
+    def test_raises_runtime_error_when_clickhouse_connect_missing(self) -> None:
+        config = ClickHouseConfig(host="localhost")
+        with (
+            patch.dict(sys.modules, {"clickhouse_connect": None}),
+            pytest.raises(RuntimeError, match="clickhouse-connect is not installed"),
+        ):
+            _get_client(config)


### PR DESCRIPTION
## Summary

- `_get_client()` in `app/integrations/clickhouse.py` was doing a bare lazy `import clickhouse_connect` with no error handling, so users without the optional `[clickhouse]` extra got a raw `ModuleNotFoundError` captured in Sentry (PYTHON-51)
- Wraps the import in `try/except ModuleNotFoundError` and re-raises as `RuntimeError` with a clear install hint — mirrors the identical pattern already in `postgresql._get_connection`
- Adds a unit test covering the missing-module path

## Test plan

- [ ] `uv run pytest tests/integrations/test_clickhouse.py` — all 16 tests pass
- [ ] `uv run ruff check app/integrations/clickhouse.py tests/integrations/test_clickhouse.py` — no issues
- [ ] Verify error message reads `clickhouse-connect is not installed. Install it with: pip install 'opensre[clickhouse]'`

Closes #2108

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFrHwJU4uYfDvxnemXv9r1)_