### PR TITLE
refactor: DRY report formatters with shared sections and Discord formatter

### DIFF
--- a/app/delivery/publish_findings/formatters/__init__.py
+++ b/app/delivery/publish_findings/formatters/__init__.py
@@ -1,5 +1,6 @@
 """Formatters for various report sections."""
 
+from app.delivery.publish_findings.formatters.discord import format_discord_message
 from app.delivery.publish_findings.formatters.evidence import (
     format_cited_evidence_section,
 )
@@ -11,6 +12,7 @@ from app.delivery.publish_findings.formatters.report import format_slack_message
 
 __all__ = [
     "format_slack_message",
+    "format_discord_message",
     "format_cited_evidence_section",
     "format_infrastructure_correlation",
     "format_data_lineage_flow",

--- a/app/delivery/publish_findings/formatters/discord.py
+++ b/app/delivery/publish_findings/formatters/discord.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 from typing import Any
 
 from app.delivery.publish_findings.formatters.sections import (
-    _sanitize_for_slack,
     build_report_sections,
 )
 from app.delivery.publish_findings.report_context import ReportContext
@@ -84,7 +83,7 @@ def format_discord_message(ctx: ReportContext) -> tuple[str, list[dict[str, Any]
         embed["fields"].append(
             {
                 "name": "Top Error Log",
-                "value": f"```\n{_truncate(sections.top_log, _DISCORD_FIELD_VALUE_LIMIT)}\n```",
+                "value": f"```\n{_truncate(sections.top_log, _DISCORD_FIELD_VALUE_LIMIT - 8)}\n```",
                 "inline": False,
             }
         )
@@ -92,7 +91,11 @@ def format_discord_message(ctx: ReportContext) -> tuple[str, list[dict[str, Any]
     if sections.findings:
         lines = []
         for c in sections.findings:
-            ev = f" [{', '.join(c.evidence_refs)}]" if c.evidence_refs else ""
+            ev = (
+                f" [{', '.join(e.display_id for e in c.evidence_refs)}]"
+                if c.evidence_refs
+                else ""
+            )
             lines.append(f"• {c.text}{ev}")
         embed["fields"].append(
             {
@@ -129,8 +132,7 @@ def format_discord_message(ctx: ReportContext) -> tuple[str, list[dict[str, Any]
         )
 
     if sections.provenance:
-        sanitized = [_sanitize_for_slack(pl.lstrip("• ").strip()) for pl in sections.provenance]
-        lines = [f"• {s}" for s in sanitized]
+        lines = [f"• {pl.lstrip('• ').strip()}" for pl in sections.provenance]
         embed["fields"].append(
             {
                 "name": "Provenance",
@@ -140,7 +142,7 @@ def format_discord_message(ctx: ReportContext) -> tuple[str, list[dict[str, Any]
         )
 
     if sections.remediation:
-        lines = [f"• {_sanitize_for_slack(s)}" for s in sections.remediation]
+        lines = [f"• {s}" for s in sections.remediation]
         embed["fields"].append(
             {
                 "name": "Recommended Actions",

--- a/app/delivery/publish_findings/formatters/discord.py
+++ b/app/delivery/publish_findings/formatters/discord.py
@@ -21,6 +21,7 @@ from app.delivery.publish_findings.report_context import ReportContext
 _DISCORD_FIELD_VALUE_LIMIT = 1024
 _DISCORD_EMBED_DESC_LIMIT = 4096
 _DISCORD_MAX_FIELDS = 25
+_DISCORD_CONTENT_LIMIT = 2000
 
 _SEVERITY_COLORS: dict[str, int] = {
     "critical": 15158332,
@@ -69,7 +70,6 @@ def format_discord_message(ctx: ReportContext) -> tuple[str, list[dict[str, Any]
     duration_seconds = ctx.get("investigation_duration_seconds")
     alert_id = ctx.get("alert_id")
 
-    _DISCORD_CONTENT_LIMIT = 2000
     content_text = _truncate(
         f"**{alert_name}** — {pipeline_name}\n{sections.root_cause}",
         _DISCORD_CONTENT_LIMIT,
@@ -95,11 +95,7 @@ def format_discord_message(ctx: ReportContext) -> tuple[str, list[dict[str, Any]
     if sections.findings:
         lines = []
         for c in sections.findings:
-            ev = (
-                f" [{', '.join(e.display_id for e in c.evidence_refs)}]"
-                if c.evidence_refs
-                else ""
-            )
+            ev = f" [{', '.join(e.display_id for e in c.evidence_refs)}]" if c.evidence_refs else ""
             lines.append(f"• {c.text}{ev}")
         embed["fields"].append(
             {

--- a/app/delivery/publish_findings/formatters/discord.py
+++ b/app/delivery/publish_findings/formatters/discord.py
@@ -106,11 +106,10 @@ def format_discord_message(ctx: ReportContext) -> tuple[str, list[dict[str, Any]
         )
 
     if sections.non_validated:
-        lines = [f"• {raw.lstrip('• ').strip()}" for raw in sections.non_validated]
         embed["fields"].append(
             {
                 "name": "Non-Validated Claims (Inferred)",
-                "value": _format_field_value(lines),
+                "value": _format_field_value(sections.non_validated),
                 "inline": False,
             }
         )

--- a/app/delivery/publish_findings/formatters/discord.py
+++ b/app/delivery/publish_findings/formatters/discord.py
@@ -1,0 +1,173 @@
+"""Discord report formatter — converts ReportContext into Discord embeds.
+
+Discord uses embeds with fields rather than mrkdwn or HTML. Each section
+becomes an embed field, respecting Discord's limits:
+- Field name: 256 chars max
+- Field value: 1024 chars max
+- Embed description: 4096 chars max
+- Max 25 fields per embed
+- Total embed characters: 6000 max
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.delivery.publish_findings.formatters.sections import (
+    _sanitize_for_slack,
+    build_report_sections,
+)
+from app.delivery.publish_findings.report_context import ReportContext
+
+_DISCORD_FIELD_VALUE_LIMIT = 1024
+_DISCORD_EMBED_DESC_LIMIT = 4096
+_DISCORD_MAX_FIELDS = 25
+
+_SEVERITY_COLORS: dict[str, int] = {
+    "critical": 15158332,
+    "crit": 15158332,
+    "high": 15105570,
+    "error": 15105570,
+    "medium": 15844367,
+    "warning": 15844367,
+    "warn": 15844367,
+    "low": 5763719,
+    "info": 5763719,
+    "none": 9807270,
+    "healthy": 5763719,
+    "normal": 5763719,
+}
+
+
+def _truncate(value: str, limit: int, suffix: str = "…") -> str:
+    if len(value) <= limit:
+        return value
+    room = limit - len(suffix)
+    return value[:room] + suffix if room > 0 else suffix[:limit]
+
+
+def _format_field_value(lines: list[str], prefix: str = "") -> str:
+    """Join lines into a Discord-safe field value, truncated to limit."""
+    text = prefix + "\n".join(lines)
+    return _truncate(text, _DISCORD_FIELD_VALUE_LIMIT)
+
+
+def _severity_color(ctx: ReportContext) -> int:
+    raw = (ctx.get("severity") or "").strip().lower()
+    return _SEVERITY_COLORS.get(raw, 9807270)
+
+
+def format_discord_message(ctx: ReportContext) -> tuple[str, list[dict[str, Any]]]:
+    """Format an RCA report for Discord.
+
+    Returns (content_text, embeds) where embeds is a list of Discord embed dicts.
+    The content_text is a short summary for the message body; the embeds carry
+    the structured report sections.
+    """
+    sections = build_report_sections(ctx)
+    alert_name = ctx.get("alert_name") or "Alert"
+    pipeline_name = ctx.get("pipeline_name") or "unknown"
+    duration_seconds = ctx.get("investigation_duration_seconds")
+    alert_id = ctx.get("alert_id")
+
+    content_text = f"**{alert_name}** — {pipeline_name}\n{sections.root_cause}"
+
+    embed: dict[str, Any] = {
+        "title": _truncate(f"{alert_name} — RCA Report", 256),
+        "color": _severity_color(ctx),
+        "description": _truncate(sections.root_cause, _DISCORD_EMBED_DESC_LIMIT),
+        "fields": [],
+        "footer": {"text": "OpenSRE Investigation"},
+    }
+
+    if sections.top_log:
+        embed["fields"].append({
+            "name": "Top Error Log",
+            "value": f"```\n{_truncate(sections.top_log, _DISCORD_FIELD_VALUE_LIMIT)}\n```",
+            "inline": False,
+        })
+
+    if sections.findings:
+        lines = []
+        for c in sections.findings:
+            ev = f" [{', '.join(c.evidence_refs)}]" if c.evidence_refs else ""
+            lines.append(f"• {c.text}{ev}")
+        embed["fields"].append({
+            "name": "Findings",
+            "value": _format_field_value(lines),
+            "inline": False,
+        })
+
+    if sections.non_validated:
+        lines = [f"• {raw}" for raw in sections.non_validated]
+        embed["fields"].append({
+            "name": "Non-Validated Claims (Inferred)",
+            "value": _format_field_value(lines),
+            "inline": False,
+        })
+
+    if sections.correlation_signals or sections.correlation_drivers:
+        corr_lines: list[str] = []
+        if sections.correlation_signals:
+            corr_lines.append("**Correlated signals:**")
+            corr_lines.extend(sections.correlation_signals)
+        if sections.correlation_drivers:
+            corr_lines.append("**Most likely causal drivers:**")
+            corr_lines.extend(sections.correlation_drivers)
+        embed["fields"].append({
+            "name": "Upstream Correlation",
+            "value": _format_field_value(corr_lines),
+            "inline": False,
+        })
+
+    if sections.provenance:
+        sanitized = [_sanitize_for_slack(pl.lstrip("• ").strip()) for pl in sections.provenance]
+        lines = [f"• {s}" for s in sanitized]
+        embed["fields"].append({
+            "name": "Provenance",
+            "value": _format_field_value(lines),
+            "inline": False,
+        })
+
+    if sections.remediation:
+        lines = [f"• {_sanitize_for_slack(s)}" for s in sections.remediation]
+        embed["fields"].append({
+            "name": "Recommended Actions",
+            "value": _format_field_value(lines),
+            "inline": False,
+        })
+
+    if sections.trace:
+        embed["fields"].append({
+            "name": "Investigation Trace",
+            "value": _format_field_value(sections.trace),
+            "inline": False,
+        })
+
+    if sections.evidence_citations_plain:
+        embed["fields"].append({
+            "name": "Cited Evidence",
+            "value": _truncate(sections.evidence_citations_plain, _DISCORD_FIELD_VALUE_LIMIT),
+            "inline": False,
+        })
+
+    cw_url = ctx.get("cloudwatch_logs_url")
+    if cw_url:
+        embed["fields"].append({
+            "name": "CloudWatch",
+            "value": f"[View logs]({cw_url})",
+            "inline": False,
+        })
+
+    meta_parts: list[str] = []
+    if duration_seconds is not None:
+        meta_parts.append(f"Analyzed in {duration_seconds}s")
+    if alert_id:
+        meta_parts.append(f"Alert: {alert_id}")
+    if meta_parts:
+        embed["footer"]["text"] = " | ".join(meta_parts)
+
+    if len(embed["fields"]) > _DISCORD_MAX_FIELDS:
+        embed["fields"] = embed["fields"][:_DISCORD_MAX_FIELDS]
+
+    return content_text, [embed]

--- a/app/delivery/publish_findings/formatters/discord.py
+++ b/app/delivery/publish_findings/formatters/discord.py
@@ -81,30 +81,36 @@ def format_discord_message(ctx: ReportContext) -> tuple[str, list[dict[str, Any]
     }
 
     if sections.top_log:
-        embed["fields"].append({
-            "name": "Top Error Log",
-            "value": f"```\n{_truncate(sections.top_log, _DISCORD_FIELD_VALUE_LIMIT)}\n```",
-            "inline": False,
-        })
+        embed["fields"].append(
+            {
+                "name": "Top Error Log",
+                "value": f"```\n{_truncate(sections.top_log, _DISCORD_FIELD_VALUE_LIMIT)}\n```",
+                "inline": False,
+            }
+        )
 
     if sections.findings:
         lines = []
         for c in sections.findings:
             ev = f" [{', '.join(c.evidence_refs)}]" if c.evidence_refs else ""
             lines.append(f"• {c.text}{ev}")
-        embed["fields"].append({
-            "name": "Findings",
-            "value": _format_field_value(lines),
-            "inline": False,
-        })
+        embed["fields"].append(
+            {
+                "name": "Findings",
+                "value": _format_field_value(lines),
+                "inline": False,
+            }
+        )
 
     if sections.non_validated:
         lines = [f"• {raw}" for raw in sections.non_validated]
-        embed["fields"].append({
-            "name": "Non-Validated Claims (Inferred)",
-            "value": _format_field_value(lines),
-            "inline": False,
-        })
+        embed["fields"].append(
+            {
+                "name": "Non-Validated Claims (Inferred)",
+                "value": _format_field_value(lines),
+                "inline": False,
+            }
+        )
 
     if sections.correlation_signals or sections.correlation_drivers:
         corr_lines: list[str] = []
@@ -114,50 +120,62 @@ def format_discord_message(ctx: ReportContext) -> tuple[str, list[dict[str, Any]
         if sections.correlation_drivers:
             corr_lines.append("**Most likely causal drivers:**")
             corr_lines.extend(sections.correlation_drivers)
-        embed["fields"].append({
-            "name": "Upstream Correlation",
-            "value": _format_field_value(corr_lines),
-            "inline": False,
-        })
+        embed["fields"].append(
+            {
+                "name": "Upstream Correlation",
+                "value": _format_field_value(corr_lines),
+                "inline": False,
+            }
+        )
 
     if sections.provenance:
         sanitized = [_sanitize_for_slack(pl.lstrip("• ").strip()) for pl in sections.provenance]
         lines = [f"• {s}" for s in sanitized]
-        embed["fields"].append({
-            "name": "Provenance",
-            "value": _format_field_value(lines),
-            "inline": False,
-        })
+        embed["fields"].append(
+            {
+                "name": "Provenance",
+                "value": _format_field_value(lines),
+                "inline": False,
+            }
+        )
 
     if sections.remediation:
         lines = [f"• {_sanitize_for_slack(s)}" for s in sections.remediation]
-        embed["fields"].append({
-            "name": "Recommended Actions",
-            "value": _format_field_value(lines),
-            "inline": False,
-        })
+        embed["fields"].append(
+            {
+                "name": "Recommended Actions",
+                "value": _format_field_value(lines),
+                "inline": False,
+            }
+        )
 
     if sections.trace:
-        embed["fields"].append({
-            "name": "Investigation Trace",
-            "value": _format_field_value(sections.trace),
-            "inline": False,
-        })
+        embed["fields"].append(
+            {
+                "name": "Investigation Trace",
+                "value": _format_field_value(sections.trace),
+                "inline": False,
+            }
+        )
 
     if sections.evidence_citations_plain:
-        embed["fields"].append({
-            "name": "Cited Evidence",
-            "value": _truncate(sections.evidence_citations_plain, _DISCORD_FIELD_VALUE_LIMIT),
-            "inline": False,
-        })
+        embed["fields"].append(
+            {
+                "name": "Cited Evidence",
+                "value": _truncate(sections.evidence_citations_plain, _DISCORD_FIELD_VALUE_LIMIT),
+                "inline": False,
+            }
+        )
 
     cw_url = ctx.get("cloudwatch_logs_url")
     if cw_url:
-        embed["fields"].append({
-            "name": "CloudWatch",
-            "value": f"[View logs]({cw_url})",
-            "inline": False,
-        })
+        embed["fields"].append(
+            {
+                "name": "CloudWatch",
+                "value": f"[View logs]({cw_url})",
+                "inline": False,
+            }
+        )
 
     meta_parts: list[str] = []
     if duration_seconds is not None:

--- a/app/delivery/publish_findings/formatters/discord.py
+++ b/app/delivery/publish_findings/formatters/discord.py
@@ -106,7 +106,7 @@ def format_discord_message(ctx: ReportContext) -> tuple[str, list[dict[str, Any]
         )
 
     if sections.non_validated:
-        lines = [f"• {raw}" for raw in sections.non_validated]
+        lines = [f"• {raw.lstrip('• ').strip()}" for raw in sections.non_validated]
         embed["fields"].append(
             {
                 "name": "Non-Validated Claims (Inferred)",

--- a/app/delivery/publish_findings/formatters/discord.py
+++ b/app/delivery/publish_findings/formatters/discord.py
@@ -69,7 +69,11 @@ def format_discord_message(ctx: ReportContext) -> tuple[str, list[dict[str, Any]
     duration_seconds = ctx.get("investigation_duration_seconds")
     alert_id = ctx.get("alert_id")
 
-    content_text = f"**{alert_name}** — {pipeline_name}\n{sections.root_cause}"
+    _DISCORD_CONTENT_LIMIT = 2000
+    content_text = _truncate(
+        f"**{alert_name}** — {pipeline_name}\n{sections.root_cause}",
+        _DISCORD_CONTENT_LIMIT,
+    )
 
     embed: dict[str, Any] = {
         "title": _truncate(f"{alert_name} — RCA Report", 256),

--- a/app/delivery/publish_findings/formatters/discord.py
+++ b/app/delivery/publish_findings/formatters/discord.py
@@ -189,4 +189,29 @@ def format_discord_message(ctx: ReportContext) -> tuple[str, list[dict[str, Any]
     if len(embed["fields"]) > _DISCORD_MAX_FIELDS:
         embed["fields"] = embed["fields"][:_DISCORD_MAX_FIELDS]
 
+    # Discord enforces a hard 6000-char limit across all embed text.
+    # Trim lower-priority fields if the total exceeds the budget.
+    _DISCORD_TOTAL_EMBED_LIMIT = 6000
+    while True:
+        total = len(embed.get("title", ""))
+        total += len(embed.get("description", ""))
+        total += sum(len(f["name"]) + len(f["value"]) for f in embed["fields"])
+        total += len(embed.get("footer", {}).get("text", ""))
+        if total <= _DISCORD_TOTAL_EMBED_LIMIT:
+            break
+        # Drop the last non-essential field
+        essential = {"Top Error Log", "Findings"}
+        dropped = False
+        for i in range(len(embed["fields"]) - 1, -1, -1):
+            if embed["fields"][i]["name"] not in essential:
+                embed["fields"].pop(i)
+                dropped = True
+                break
+        if not dropped:
+            # Last resort: truncate description
+            embed["description"] = _truncate(
+                embed["description"], _DISCORD_TOTAL_EMBED_LIMIT - total + len(embed["description"])
+            )
+            break
+
     return content_text, [embed]

--- a/app/delivery/publish_findings/formatters/discord.py
+++ b/app/delivery/publish_findings/formatters/discord.py
@@ -22,6 +22,7 @@ _DISCORD_FIELD_VALUE_LIMIT = 1024
 _DISCORD_EMBED_DESC_LIMIT = 4096
 _DISCORD_MAX_FIELDS = 25
 _DISCORD_CONTENT_LIMIT = 2000
+_DISCORD_TOTAL_EMBED_LIMIT = 6000
 
 _SEVERITY_COLORS: dict[str, int] = {
     "critical": 15158332,
@@ -191,7 +192,6 @@ def format_discord_message(ctx: ReportContext) -> tuple[str, list[dict[str, Any]
 
     # Discord enforces a hard 6000-char limit across all embed text.
     # Trim lower-priority fields if the total exceeds the budget.
-    _DISCORD_TOTAL_EMBED_LIMIT = 6000
     while True:
         total = len(embed.get("title", ""))
         total += len(embed.get("description", ""))

--- a/app/delivery/publish_findings/formatters/report.py
+++ b/app/delivery/publish_findings/formatters/report.py
@@ -1,24 +1,27 @@
-"""RCA report formatting for Slack (mrkdwn / Block Kit) and Telegram (HTML)."""
+"""RCA report formatting for Slack (mrkdwn / Block Kit) and Telegram (HTML).
+
+All formatters consume shared section builders from sections.py so that
+claim rendering, provenance formatting, correlation, etc. are defined once.
+"""
 
 import html
 import re
 
 from app.delivery.publish_findings.formatters.base import format_html_link, format_slack_link
-from app.delivery.publish_findings.formatters.evidence import (
-    format_cited_evidence_section,
-    format_cited_evidence_section_html,
-)
 from app.delivery.publish_findings.formatters.infrastructure import (
-    build_investigation_trace,
     format_pod_line,
     get_failed_pods,
 )
+from app.delivery.publish_findings.formatters.sections import (
+    _derive_root_cause_sentence,
+    _sanitize_for_slack,
+    build_report_sections,
+)
 from app.delivery.publish_findings.report_context import ReportContext
-from app.delivery.publish_findings.urls.aws import build_cloudwatch_url
 
 
 def render_cloudwatch_link(ctx: ReportContext) -> str:
-    """Render CloudWatch logs link if available in context."""
+    """Render CloudWatch logs link for Slack mrkdwn."""
     cw_url = ctx.get("cloudwatch_logs_url")
     cw_group = ctx.get("cloudwatch_log_group")
     cw_stream = ctx.get("cloudwatch_log_stream")
@@ -26,6 +29,8 @@ def render_cloudwatch_link(ctx: ReportContext) -> str:
     if cw_url:
         return f"\n*{format_slack_link('CloudWatch Logs', cw_url)}*\n"
     elif cw_group and cw_stream:
+        from app.delivery.publish_findings.urls.aws import build_cloudwatch_url
+
         url = build_cloudwatch_url(ctx)
         view_link = format_slack_link("CloudWatch Logs", url) if url else None
         if view_link:
@@ -35,102 +40,30 @@ def render_cloudwatch_link(ctx: ReportContext) -> str:
     return ""
 
 
-def _format_provenance_lines(ctx: ReportContext) -> list[str]:
-    provenance = ctx.get("source_provenance") or {}
-    lines: list[str] = []
-    for source_name, entry in provenance.items():
-        label = entry.get("label") or source_name.title()
-        summary = entry.get("summary") or ""
-        if summary:
-            lines.append(f"• {label}: {summary}")
-    return lines
+def render_cloudwatch_link_html(ctx: ReportContext) -> str:
+    """Telegram-HTML CloudWatch deep link."""
+    import html as html_mod
 
+    from app.delivery.publish_findings.urls.aws import build_cloudwatch_url
 
-def _format_correlation_lines(ctx: ReportContext) -> tuple[list[str], list[str]]:
-    correlation = ctx.get("correlation") or {}
-    if not isinstance(correlation, dict):
-        return [], []
+    cw_url = ctx.get("cloudwatch_logs_url")
+    cw_group = ctx.get("cloudwatch_log_group")
+    cw_stream = ctx.get("cloudwatch_log_stream")
 
-    raw_signals = correlation.get("correlated_signals") or []
-    raw_drivers = correlation.get("most_likely_causal_drivers") or []
-
-    signal_lines: list[str] = []
-    for signal in raw_signals:
-        if not isinstance(signal, dict):
-            continue
-        name = signal.get("name") or "unknown"
-        source = signal.get("source") or "unknown"
-        score = signal.get("score")
-        score_text = f" score={float(score):.2f}" if isinstance(score, int | float) else ""
-        signal_lines.append(f"• {name} ({source}{score_text})")
-
-    driver_lines: list[str] = []
-    for driver in raw_drivers:
-        if not isinstance(driver, dict):
-            continue
-        name = driver.get("name") or "unknown"
-        confidence = driver.get("confidence")
-        rationale = driver.get("rationale") or ""
-        confidence_text = (
-            f" confidence={float(confidence):.2f}" if isinstance(confidence, int | float) else ""
+    if cw_url:
+        safe = html_mod.escape(str(cw_url), quote=True)
+        return f'\n<b>CloudWatch</b>: <a href="{safe}">View logs</a>\n'
+    if cw_group and cw_stream:
+        url = build_cloudwatch_url(ctx)
+        if url:
+            safe = html_mod.escape(str(url), quote=True)
+            return f'\n<b>CloudWatch</b>: <a href="{safe}">View logs</a>\n'
+        return (
+            f"\n<b>CloudWatch Logs</b>\n"
+            f"Log Group: {html_mod.escape(str(cw_group))}\n"
+            f"Log Stream: {html_mod.escape(str(cw_stream))}\n"
         )
-        suffix = f" — {_sanitize_for_slack(str(rationale))}" if rationale else ""
-        driver_lines.append(f"• {name}{confidence_text}{suffix}")
-
-    return signal_lines, driver_lines
-
-
-# ---------------------------------------------------------------------------
-# Shared section helpers — called by both text and block renderers
-# ---------------------------------------------------------------------------
-
-
-def _render_claim_lines(ctx: ReportContext) -> tuple[list[str], list[str]]:
-    """Return (validated_lines, non_validated_lines) as plain mrkdwn bullet strings.
-
-    Each validated line includes evidence citations like [E1, E2]. Both renderers
-    (format_slack_message and build_slack_blocks) call this to avoid duplicating
-    the catalog-lookup and link-formatting logic.
-    """
-    catalog = ctx.get("evidence_catalog") or {}
-    evidence = ctx.get("evidence") or {}
-
-    validated_lines: list[str] = []
-    for claim_data in ctx.get("validated_claims", []):
-        claim = claim_data.get("claim", "")
-        claim = _resolve_evidence_tags(claim, evidence)
-        claim = _sanitize_for_slack(claim)
-        evidence_ids = claim_data.get("evidence_ids", [])
-        evidence_labels = claim_data.get("evidence_labels", [])
-        evidence_list: list[str] = []
-        if evidence_ids:
-            for eid in evidence_ids:
-                entry = catalog.get(eid, {})
-                disp = entry.get("display_id", eid)
-                url = entry.get("url")
-                evidence_list.append(format_slack_link(disp, url) if url else disp)
-        elif evidence_labels:
-            evidence_list = list(evidence_labels)
-        ev_str = f" [{', '.join(evidence_list)}]" if evidence_list else ""
-        validated_lines.append(f"\u2022 {claim}{ev_str}")
-
-    non_validated_lines: list[str] = [
-        f"\u2022 {_sanitize_for_slack(cd.get('claim', ''))}"
-        for cd in ctx.get("non_validated_claims", [])
-    ]
-
-    return validated_lines, non_validated_lines
-
-
-def _sanitize_for_slack(text: str) -> str:
-    """Convert markdown formatting to Slack mrkdwn.
-
-    Slack does not render # headers, ** bold, or other standard markdown.
-    This converts common patterns to Slack-native formatting.
-    """
-    result = re.sub(r"^#{1,6}\s+(.+)$", r"*\1*", text, flags=re.MULTILINE)
-    result = re.sub(r"\*\*(.+?)\*\*", r"*\1*", result)
-    return result
+    return ""
 
 
 _SLACK_LINK_RE = re.compile(r"<(https?://[^|>]+)(?:\|([^>]+))?>")
@@ -231,59 +164,6 @@ def _severity_telegram_header(ctx: ReportContext) -> str:
     return f"{emoji} <b>{alert}</b> · {pipeline}\n<i>severity: {html.escape(display_sev)}</i>"
 
 
-def _render_claim_lines_telegram(ctx: ReportContext) -> tuple[list[str], list[str]]:
-    catalog = ctx.get("evidence_catalog") or {}
-    evidence = ctx.get("evidence") or {}
-
-    validated_lines: list[str] = []
-    for claim_data in ctx.get("validated_claims", []):
-        claim = claim_data.get("claim", "")
-        claim = _resolve_evidence_tags(claim, evidence)
-        claim = _sanitize_for_slack(claim)
-        evidence_ids = claim_data.get("evidence_ids", [])
-        evidence_labels = claim_data.get("evidence_labels", [])
-        evidence_list: list[str] = []
-        if evidence_ids:
-            for eid in evidence_ids:
-                entry = catalog.get(eid, {})
-                disp = entry.get("display_id", eid)
-                url = entry.get("url")
-                evidence_list.append(format_html_link(str(disp), url or None))
-        elif evidence_labels:
-            evidence_list = [html.escape(str(x)) for x in evidence_labels]
-        ev_str = f" [{', '.join(evidence_list)}]" if evidence_list else ""
-        validated_lines.append(f"• {_to_telegram_html_body(claim)}{ev_str}")
-
-    non_validated_lines: list[str] = []
-    for cd in ctx.get("non_validated_claims", []):
-        raw = _sanitize_for_slack(cd.get("claim", ""))
-        non_validated_lines.append(f"• {_to_telegram_html_body(raw)}")
-
-    return validated_lines, non_validated_lines
-
-
-def render_cloudwatch_link_html(ctx: ReportContext) -> str:
-    """Telegram-HTML CloudWatch deep link, mirroring :func:`render_cloudwatch_link`."""
-    cw_url = ctx.get("cloudwatch_logs_url")
-    cw_group = ctx.get("cloudwatch_log_group")
-    cw_stream = ctx.get("cloudwatch_log_stream")
-
-    if cw_url:
-        safe = html.escape(str(cw_url), quote=True)
-        return f'\n<b>CloudWatch</b>: <a href="{safe}">View logs</a>\n'
-    if cw_group and cw_stream:
-        url = build_cloudwatch_url(ctx)
-        if url:
-            safe = html.escape(str(url), quote=True)
-            return f'\n<b>CloudWatch</b>: <a href="{safe}">View logs</a>\n'
-        return (
-            f"\n<b>CloudWatch Logs</b>\n"
-            f"Log Group: {html.escape(str(cw_group))}\n"
-            f"Log Stream: {html.escape(str(cw_stream))}\n"
-        )
-    return ""
-
-
 def _mrkdwn_section(text: str) -> "dict | None":
     """Build a Slack Block Kit section block with sanitized mrkdwn text.
 
@@ -302,148 +182,7 @@ def _mrkdwn_section(text: str) -> "dict | None":
 
 
 # ---------------------------------------------------------------------------
-# Evidence tag resolution helpers
-# ---------------------------------------------------------------------------
-
-# Maps LLM source name → ordered list of evidence dict keys to try for a log message
-_EVIDENCE_LOG_KEYS: dict[str, list[str]] = {
-    "datadog_logs": ["datadog_error_logs", "datadog_logs"],
-    "datadog": ["datadog_error_logs", "datadog_logs"],
-    "grafana_logs": ["grafana_error_logs", "grafana_logs"],
-    "grafana": ["grafana_error_logs", "grafana_logs"],
-    "cloudwatch_logs": ["cloudwatch_logs"],
-    "cloudwatch": ["cloudwatch_logs"],
-}
-
-
-def _extract_log_message(entry: object) -> str:
-    """Extract a plain string message from a log entry that may be a dict or a string."""
-    if isinstance(entry, dict):
-        return (entry.get("message") or "").strip()
-    return str(entry).strip()
-
-
-def _resolve_evidence_tags(text: str, evidence: dict) -> str:
-    """Replace [evidence: source] tags with the actual log message in a code span.
-
-    Tries error logs first, then all logs for the named source. If no message
-    is found the tag is removed silently to avoid leaking raw LLM annotations.
-    """
-
-    def _replace(m: re.Match) -> str:
-        source = m.group(1).strip().lower()
-        for key in _EVIDENCE_LOG_KEYS.get(source, []):
-            logs = evidence.get(key) or []
-            if logs:
-                msg = _extract_log_message(logs[0])
-                if msg:
-                    return f": `{msg}`"
-        return ""
-
-    return re.sub(r"\s*\[(?i:evidence):\s*([^\]]+)\]", _replace, text).strip()
-
-
-def _get_top_error_log(evidence: dict) -> str | None:
-    """Return the first error log message from available evidence sources."""
-    for key in (
-        "datadog_error_logs",
-        "datadog_logs",
-        "grafana_error_logs",
-        "grafana_logs",
-        "cloudwatch_logs",
-    ):
-        logs = evidence.get(key) or []
-        if logs:
-            msg = _extract_log_message(logs[0])
-            if msg:
-                return msg
-    return None
-
-
-# ---------------------------------------------------------------------------
-# Root cause derivation helpers
-# ---------------------------------------------------------------------------
-
-
-def _first_sentence(text: str) -> str:
-    """Return the first sentence from text, normalized to one line."""
-    cleaned = re.sub(r"(?:^|\s)#{1,6}\s+", " ", text, flags=re.MULTILINE)
-    cleaned = re.sub(
-        r"\b(?:Problem Statement|Summary|Context|Description|Overview)\b[:\s]*",
-        "",
-        cleaned,
-        flags=re.IGNORECASE,
-    )
-    normalized = " ".join(cleaned.split()).strip()
-    if not normalized:
-        return ""
-
-    parts = re.split(r"(?<=[.?!])\s+", normalized, maxsplit=1)
-    sentence = parts[0]
-    sentence = sentence.rstrip(".?!")
-    return sentence
-
-
-def _is_speculative(text: str) -> bool:
-    speculative_terms = (" may ", " might ", " possibly", " possible ", " likely ")
-    lower = f" {text.lower()} "
-    return any(term in lower for term in speculative_terms)
-
-
-def _remove_speculative_words(text: str) -> str:
-    speculative = ("may", "might", "likely", "probably", "possibly")
-    words = text.split()
-    filtered = [w for w in words if w.lower() not in speculative]
-    return " ".join(filtered)
-
-
-def _derive_root_cause_sentence(ctx: ReportContext) -> str:
-    """Derive a concise, single-sentence root cause with causal preference."""
-    root_cause_text = ctx.get("root_cause", "") or ""
-    root_cause_text = re.sub(r"\s*\[(?i:evidence):[^\]]*\]", "", root_cause_text).strip()
-    validated_claims = ctx.get("validated_claims", [])
-
-    if root_cause_text:
-        sentence = _first_sentence(root_cause_text)
-        if sentence and not _is_speculative(sentence):
-            return sentence
-
-    causal_connectors = (
-        " because ",
-        " due to ",
-        " caused ",
-        " resulted in ",
-        " led to ",
-        " root cause ",
-        " failure triggered ",
-    )
-
-    for claim_data in validated_claims:
-        claim = claim_data.get("claim", "") or ""
-        claim = re.sub(r"\s*\[(?i:evidence):[^\]]*\]", "", claim).strip()
-        lower = f" {claim.lower()} "
-        if any(connector in lower for connector in causal_connectors):
-            sentence = _first_sentence(claim)
-            if sentence:
-                return _first_sentence(_remove_speculative_words(sentence))
-
-    if root_cause_text:
-        sentence = _first_sentence(root_cause_text)
-        if sentence:
-            return sentence
-
-    if validated_claims:
-        claim = validated_claims[0].get("claim", "") or ""
-        claim = re.sub(r"\s*\[(?i:evidence):[^\]]*\]", "", claim).strip()
-        sentence = _first_sentence(claim)
-        if sentence:
-            return sentence
-
-    return ""
-
-
-# ---------------------------------------------------------------------------
-# Text renderer (Slack mrkdwn fallback + terminal + ingest report_md)
+# Telegram-specific formatting utilities
 # ---------------------------------------------------------------------------
 
 
@@ -453,62 +192,52 @@ def format_slack_message(ctx: ReportContext) -> str:
     Used as the `text` fallback (notifications, accessibility, terminal, ingest)
     when Block Kit blocks are the primary rendered content.
     """
+    sections = build_report_sections(ctx)
     alert_id = ctx.get("alert_id")
     duration_seconds = ctx.get("investigation_duration_seconds")
-    root_cause_sentence = _derive_root_cause_sentence(ctx)
 
-    if not root_cause_sentence:
-        root_cause_sentence = "Not determined (insufficient evidence)."
-    # Start the report directly with the root cause sentence, without a "Root Cause"
-    # heading line, so that section headings below can carry the visual emphasis.
-    conclusion_block = f"{root_cause_sentence}\n"
-    top_log = _get_top_error_log(ctx.get("evidence") or {})
-    if top_log:
-        conclusion_block += f"`{top_log}`\n"
+    conclusion_block = f"{sections.root_cause}\n"
+    if sections.top_log:
+        conclusion_block += f"`{sections.top_log}`\n"
 
-    validated_lines, non_validated_lines = _render_claim_lines(ctx)
-    if validated_lines:
-        # Use a larger markdown heading so that "Findings" stands out as a section.
-        conclusion_block += "\n## Findings\n" + "\n".join(validated_lines) + "\n"
-    if non_validated_lines:
+    if sections.findings:
+        lines = [f"• {c.text} [{', '.join(c.evidence_refs)}]" if c.evidence_refs else f"• {c.text}" for c in sections.findings]
+        conclusion_block += "\n## Findings\n" + "\n".join(lines) + "\n"
+    if sections.non_validated:
         conclusion_block += (
-            "\n*Non-Validated Claims (Inferred):*\n" + "\n".join(non_validated_lines) + "\n"
+            "\n*Non-Validated Claims (Inferred):*\n" + "\n".join(sections.non_validated) + "\n"
         )
 
-    correlation_signal_lines, correlation_driver_lines = _format_correlation_lines(ctx)
-    if correlation_signal_lines or correlation_driver_lines:
+    if sections.correlation_signals or sections.correlation_drivers:
         conclusion_block += "\n## Upstream Correlation\n"
-        if correlation_signal_lines:
+        if sections.correlation_signals:
             conclusion_block += (
-                "*Correlated signals:*\n" + "\n".join(correlation_signal_lines) + "\n"
+                "*Correlated signals:*\n" + "\n".join(sections.correlation_signals) + "\n"
             )
-        if correlation_driver_lines:
+        if sections.correlation_drivers:
             conclusion_block += (
-                "*Most likely causal drivers:*\n" + "\n".join(correlation_driver_lines) + "\n"
+                "*Most likely causal drivers:*\n" + "\n".join(sections.correlation_drivers) + "\n"
             )
 
-    provenance_lines = _format_provenance_lines(ctx)
     provenance_block = ""
-    if provenance_lines:
+    if sections.provenance:
         provenance_block = (
-            "\n*Provenance:*\n" + _sanitize_for_slack("\n".join(provenance_lines)) + "\n"
+            "\n*Provenance:*\n" + _sanitize_for_slack("\n".join(sections.provenance)) + "\n"
         )
 
-    remediation_steps = ctx.get("remediation_steps", [])
     remediation_block = ""
-    if remediation_steps:
+    if sections.remediation:
         remediation_block = (
             "\n## Recommended Actions\n"
-            + "\n".join(f"• {_sanitize_for_slack(s)}" for s in remediation_steps)
+            + "\n".join(f"• {_sanitize_for_slack(s)}" for s in sections.remediation)
             + "\n"
         )
 
-    trace_steps = build_investigation_trace(ctx)
     trace_block = (
-        "\n## Investigation Trace\n" + "\n".join(trace_steps) + "\n" if trace_steps else ""
+        "\n## Investigation Trace\n" + "\n".join(sections.trace) + "\n" if sections.trace else ""
     )
 
-    cited_section = _sanitize_for_slack(format_cited_evidence_section(ctx))
+    cited_section = _sanitize_for_slack(sections.evidence_citations_plain)
     cloudwatch_link = render_cloudwatch_link(ctx)
     meta_lines = []
     if duration_seconds is not None:
@@ -517,9 +246,6 @@ def format_slack_message(ctx: ReportContext) -> str:
         meta_lines.append(f"*Alert ID:* {alert_id}")
     meta_block = "\n" + "\n".join(meta_lines) if meta_lines else ""
 
-    # Do not prefix with a separate [RCA] title line; the consumer can render
-    # section headings (Root Cause text, Findings, Investigation Trace) with
-    # larger fonts as needed.
     return f"""{conclusion_block}{provenance_block}{remediation_block}{trace_block}
 {cited_section}
 {cloudwatch_link}{meta_block}
@@ -533,6 +259,7 @@ def format_telegram_message(ctx: ReportContext) -> str:
     of Slack mrkdwn (``<url|label>``, ``##`` headings) which render as plain text
     without ``parse_mode``.
     """
+    sections = build_report_sections(ctx)
     duration_seconds = ctx.get("investigation_duration_seconds")
     alert_id = ctx.get("alert_id")
     derived_rc = _derive_root_cause_sentence(ctx)
@@ -540,56 +267,55 @@ def format_telegram_message(ctx: ReportContext) -> str:
 
     parts: list[str] = [_severity_telegram_header(ctx)]
 
-    top_log = _get_top_error_log(ctx.get("evidence") or {})
     baseline_noise = (
         derived_rc
         and _telegram_baseline_repeats_header(ctx, derived_rc)
         and root_cause_sentence != "Not determined (insufficient evidence)."
     )
-    if baseline_noise and not top_log:
+    if baseline_noise and not sections.top_log:
         pass
-    elif baseline_noise and top_log:
-        parts.append("<code>" + html.escape(top_log) + "</code>")
+    elif baseline_noise and sections.top_log:
+        parts.append("<code>" + html.escape(sections.top_log) + "</code>")
     else:
         rc = _to_telegram_html_body(root_cause_sentence)
-        if top_log:
-            rc += "\n<code>" + html.escape(top_log) + "</code>"
+        if sections.top_log:
+            rc += "\n<code>" + html.escape(sections.top_log) + "</code>"
         parts.append(rc)
 
-    validated_lines, non_validated_lines = _render_claim_lines_telegram(ctx)
-    if validated_lines:
-        parts.append("<b>Findings</b>\n" + "\n".join(validated_lines))
-    if non_validated_lines:
-        parts.append("<b>Non-Validated Claims (Inferred)</b>\n" + "\n".join(non_validated_lines))
+    if sections.findings:
+        lines = []
+        for c in sections.findings:
+            ev_str = f" [{', '.join(c.evidence_refs)}]" if c.evidence_refs else ""
+            lines.append(f"• {_to_telegram_html_body(c.text)}{ev_str}")
+        parts.append("<b>Findings</b>\n" + "\n".join(lines))
+    if sections.non_validated:
+        parts.append("<b>Non-Validated Claims (Inferred)</b>\n" + "\n".join(
+            f"• {_to_telegram_html_body(raw)}" for raw in sections.non_validated
+        ))
 
-    provenance_lines = _format_provenance_lines(ctx)
-    if provenance_lines:
+    if sections.provenance:
         prov = "\n".join(
             "• " + _to_telegram_html_body(_sanitize_for_slack(pl.lstrip("• ").strip()))
-            for pl in provenance_lines
+            for pl in sections.provenance
         )
         parts.append("<b>Provenance</b>\n" + prov)
 
-    remediation_steps = ctx.get("remediation_steps", [])
-    if remediation_steps:
+    if sections.remediation:
         ra = "\n".join(
             "• " + _to_telegram_html_body(_sanitize_for_slack(str(step)))
-            for step in remediation_steps
+            for step in sections.remediation
         )
         parts.append("<b>Recommended Actions</b>\n" + ra)
 
-    trace_steps = build_investigation_trace(ctx)
-    if trace_steps:
-        tr = "\n".join(_to_telegram_html_body(step) for step in trace_steps)
+    if sections.trace:
+        tr = "\n".join(_to_telegram_html_body(step) for step in sections.trace)
         parts.append("<b>Investigation Trace</b>\n" + tr)
 
-    cited_block = format_cited_evidence_section_html(ctx).strip()
-    if cited_block:
-        parts.append(cited_block)
+    if sections.evidence_citations_html:
+        parts.append(sections.evidence_citations_html)
 
-    cw_block = render_cloudwatch_link_html(ctx).strip()
-    if cw_block:
-        parts.append(cw_block)
+    if sections.cloudwatch_html:
+        parts.append(sections.cloudwatch_html)
 
     meta_bits: list[str] = []
     if duration_seconds is not None:
@@ -615,9 +341,9 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
     """
     from typing import Any
 
+    sections = build_report_sections(ctx)
     duration_seconds = ctx.get("investigation_duration_seconds")
     alert_id = ctx.get("alert_id")
-    root_cause_sentence = _derive_root_cause_sentence(ctx)
     blocks: list[dict[str, Any]] = []
 
     def _add(block: "dict[str, Any] | None") -> None:
@@ -625,12 +351,9 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
             blocks.append(block)
 
     # ── Root Cause
-    if not root_cause_sentence:
-        root_cause_sentence = "Not determined (insufficient evidence)"
-    rc_text = root_cause_sentence
-    top_log = _get_top_error_log(ctx.get("evidence") or {})
-    if top_log:
-        rc_text += f"\n`{top_log}`"
+    rc_text = sections.root_cause
+    if sections.top_log:
+        rc_text += f"\n`{sections.top_log}`"
     _add(_mrkdwn_section(rc_text))
 
     # ── Failed Pods ──
@@ -652,8 +375,8 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
         _add(_mrkdwn_section("\n".join(pod_lines)))
 
     # ── Validated Claims (Findings) and Non-Validated Claims ──
-    validated_lines, non_validated_lines = _render_claim_lines(ctx)
-    if validated_lines:
+    if sections.findings:
+        lines = [f"• {c.text} [{', '.join(c.evidence_refs)}]" if c.evidence_refs else f"• {c.text}" for c in sections.findings]
         blocks.append({"type": "divider"})
         blocks.append(
             {
@@ -661,12 +384,11 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
                 "text": {"type": "plain_text", "text": "Findings"},
             }
         )
-        _add(_mrkdwn_section("\n".join(validated_lines)))
-    if non_validated_lines:
-        _add(_mrkdwn_section("*Inferred (not yet validated)*\n" + "\n".join(non_validated_lines)))
+        _add(_mrkdwn_section("\n".join(lines)))
+    if sections.non_validated:
+        _add(_mrkdwn_section("*Inferred (not yet validated)*\n" + "\n".join(sections.non_validated)))
 
-    correlation_signal_lines, correlation_driver_lines = _format_correlation_lines(ctx)
-    if correlation_signal_lines or correlation_driver_lines:
+    if sections.correlation_signals or sections.correlation_drivers:
         blocks.append({"type": "divider"})
         blocks.append(
             {
@@ -674,17 +396,16 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
                 "text": {"type": "plain_text", "text": "Upstream Correlation"},
             }
         )
-        if correlation_signal_lines:
-            _add(_mrkdwn_section("*Correlated signals:*\n" + "\n".join(correlation_signal_lines)))
-        if correlation_driver_lines:
+        if sections.correlation_signals:
+            _add(_mrkdwn_section("*Correlated signals:*\n" + "\n".join(sections.correlation_signals)))
+        if sections.correlation_drivers:
             _add(
                 _mrkdwn_section(
-                    "*Most likely causal drivers:*\n" + "\n".join(correlation_driver_lines)
+                    "*Most likely causal drivers:*\n" + "\n".join(sections.correlation_drivers)
                 )
             )
 
-    provenance_lines = _format_provenance_lines(ctx)
-    if provenance_lines:
+    if sections.provenance:
         blocks.append({"type": "divider"})
         blocks.append(
             {
@@ -692,11 +413,10 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
                 "text": {"type": "plain_text", "text": "Provenance"},
             }
         )
-        _add(_mrkdwn_section("\n".join(provenance_lines)))
+        _add(_mrkdwn_section("\n".join(sections.provenance)))
 
     # ── Recommended Actions ──
-    remediation_steps = ctx.get("remediation_steps", [])
-    if remediation_steps:
+    if sections.remediation:
         blocks.append({"type": "divider"})
         blocks.append(
             {
@@ -704,11 +424,10 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
                 "text": {"type": "plain_text", "text": "Recommended Actions"},
             }
         )
-        _add(_mrkdwn_section("\n".join(f"• {_sanitize_for_slack(s)}" for s in remediation_steps)))
+        _add(_mrkdwn_section("\n".join(f"• {_sanitize_for_slack(s)}" for s in sections.remediation)))
 
     # ── Investigation Trace ──
-    trace_steps = build_investigation_trace(ctx)
-    if trace_steps:
+    if sections.trace:
         blocks.append({"type": "divider"})
         blocks.append(
             {
@@ -716,13 +435,12 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
                 "text": {"type": "plain_text", "text": "Investigation Trace"},
             }
         )
-        _add(_mrkdwn_section("\n".join(trace_steps)))
+        _add(_mrkdwn_section("\n".join(sections.trace)))
 
     # ── Cited Evidence ──
-    cited_section = format_cited_evidence_section(ctx).strip()
-    if cited_section:
+    if sections.evidence_citations_plain:
         blocks.append({"type": "divider"})
-        _add(_mrkdwn_section(cited_section))
+        _add(_mrkdwn_section(sections.evidence_citations_plain))
 
     # ── CloudWatch link ──
     cw_link = render_cloudwatch_link(ctx).strip()

--- a/app/delivery/publish_findings/formatters/report.py
+++ b/app/delivery/publish_findings/formatters/report.py
@@ -201,7 +201,10 @@ def format_slack_message(ctx: ReportContext) -> str:
         conclusion_block += f"`{sections.top_log}`\n"
 
     if sections.findings:
-        lines = [f"• {c.text} [{', '.join(c.evidence_refs)}]" if c.evidence_refs else f"• {c.text}" for c in sections.findings]
+        lines = [
+            f"• {c.text} [{', '.join(c.evidence_refs)}]" if c.evidence_refs else f"• {c.text}"
+            for c in sections.findings
+        ]
         conclusion_block += "\n## Findings\n" + "\n".join(lines) + "\n"
     if sections.non_validated:
         conclusion_block += (
@@ -289,9 +292,10 @@ def format_telegram_message(ctx: ReportContext) -> str:
             lines.append(f"• {_to_telegram_html_body(c.text)}{ev_str}")
         parts.append("<b>Findings</b>\n" + "\n".join(lines))
     if sections.non_validated:
-        parts.append("<b>Non-Validated Claims (Inferred)</b>\n" + "\n".join(
-            f"• {_to_telegram_html_body(raw)}" for raw in sections.non_validated
-        ))
+        parts.append(
+            "<b>Non-Validated Claims (Inferred)</b>\n"
+            + "\n".join(f"• {_to_telegram_html_body(raw)}" for raw in sections.non_validated)
+        )
 
     if sections.provenance:
         prov = "\n".join(
@@ -376,7 +380,10 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
 
     # ── Validated Claims (Findings) and Non-Validated Claims ──
     if sections.findings:
-        lines = [f"• {c.text} [{', '.join(c.evidence_refs)}]" if c.evidence_refs else f"• {c.text}" for c in sections.findings]
+        lines = [
+            f"• {c.text} [{', '.join(c.evidence_refs)}]" if c.evidence_refs else f"• {c.text}"
+            for c in sections.findings
+        ]
         blocks.append({"type": "divider"})
         blocks.append(
             {
@@ -386,7 +393,9 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
         )
         _add(_mrkdwn_section("\n".join(lines)))
     if sections.non_validated:
-        _add(_mrkdwn_section("*Inferred (not yet validated)*\n" + "\n".join(sections.non_validated)))
+        _add(
+            _mrkdwn_section("*Inferred (not yet validated)*\n" + "\n".join(sections.non_validated))
+        )
 
     if sections.correlation_signals or sections.correlation_drivers:
         blocks.append({"type": "divider"})
@@ -397,7 +406,9 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
             }
         )
         if sections.correlation_signals:
-            _add(_mrkdwn_section("*Correlated signals:*\n" + "\n".join(sections.correlation_signals)))
+            _add(
+                _mrkdwn_section("*Correlated signals:*\n" + "\n".join(sections.correlation_signals))
+            )
         if sections.correlation_drivers:
             _add(
                 _mrkdwn_section(
@@ -424,7 +435,9 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
                 "text": {"type": "plain_text", "text": "Recommended Actions"},
             }
         )
-        _add(_mrkdwn_section("\n".join(f"• {_sanitize_for_slack(s)}" for s in sections.remediation)))
+        _add(
+            _mrkdwn_section("\n".join(f"• {_sanitize_for_slack(s)}" for s in sections.remediation))
+        )
 
     # ── Investigation Trace ──
     if sections.trace:

--- a/app/delivery/publish_findings/formatters/report.py
+++ b/app/delivery/publish_findings/formatters/report.py
@@ -301,7 +301,9 @@ def format_telegram_message(ctx: ReportContext) -> str:
     if sections.non_validated:
         parts.append(
             "<b>Non-Validated Claims (Inferred)</b>\n"
-            + "\n".join(_to_telegram_html_body(raw) for raw in sections.non_validated)
+            + "\n".join(
+                _to_telegram_html_body(_sanitize_for_slack(raw)) for raw in sections.non_validated
+            )
         )
 
     if sections.provenance:

--- a/app/delivery/publish_findings/formatters/report.py
+++ b/app/delivery/publish_findings/formatters/report.py
@@ -204,9 +204,9 @@ def format_slack_message(ctx: ReportContext) -> str:
         for c in sections.findings:
             if c.evidence_refs:
                 refs = ", ".join(format_slack_link(e.display_id, e.url) for e in c.evidence_refs)
-                lines.append(f"• {c.text} [{refs}]")
+                lines.append(f"• {_sanitize_for_slack(c.text)} [{refs}]")
             else:
-                lines.append(f"• {c.text}")
+                lines.append(f"• {_sanitize_for_slack(c.text)}")
         conclusion_block += "\n## Findings\n" + "\n".join(lines) + "\n"
     if sections.non_validated:
         sanitized_nv = [_sanitize_for_slack(nv) for nv in sections.non_validated]
@@ -296,7 +296,7 @@ def format_telegram_message(ctx: ReportContext) -> str:
                 ev_str = f" [{refs}]"
             else:
                 ev_str = ""
-            lines.append(f"• {_to_telegram_html_body(c.text)}{ev_str}")
+            lines.append(f"• {_to_telegram_html_body(_sanitize_for_slack(c.text))}{ev_str}")
         parts.append("<b>Findings</b>\n" + "\n".join(lines))
     if sections.non_validated:
         parts.append(
@@ -391,9 +391,9 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
         for c in sections.findings:
             if c.evidence_refs:
                 refs = ", ".join(format_slack_link(e.display_id, e.url) for e in c.evidence_refs)
-                lines.append(f"• {c.text} [{refs}]")
+                lines.append(f"• {_sanitize_for_slack(c.text)} [{refs}]")
             else:
-                lines.append(f"• {c.text}")
+                lines.append(f"• {_sanitize_for_slack(c.text)}")
         blocks.append({"type": "divider"})
         blocks.append(
             {

--- a/app/delivery/publish_findings/formatters/report.py
+++ b/app/delivery/publish_findings/formatters/report.py
@@ -209,8 +209,9 @@ def format_slack_message(ctx: ReportContext) -> str:
                 lines.append(f"• {c.text}")
         conclusion_block += "\n## Findings\n" + "\n".join(lines) + "\n"
     if sections.non_validated:
+        sanitized_nv = [_sanitize_for_slack(nv) for nv in sections.non_validated]
         conclusion_block += (
-            "\n*Non-Validated Claims (Inferred):*\n" + "\n".join(sections.non_validated) + "\n"
+            "\n*Non-Validated Claims (Inferred):*\n" + "\n".join(sanitized_nv) + "\n"
         )
 
     if sections.correlation_signals or sections.correlation_drivers:
@@ -300,7 +301,10 @@ def format_telegram_message(ctx: ReportContext) -> str:
     if sections.non_validated:
         parts.append(
             "<b>Non-Validated Claims (Inferred)</b>\n"
-            + "\n".join(f"• {_to_telegram_html_body(raw)}" for raw in sections.non_validated)
+            + "\n".join(
+                f"• {_to_telegram_html_body(raw.lstrip('• ').strip())}"
+                for raw in sections.non_validated
+            )
         )
 
     if sections.provenance:
@@ -402,9 +406,8 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
         )
         _add(_mrkdwn_section("\n".join(lines)))
     if sections.non_validated:
-        _add(
-            _mrkdwn_section("*Inferred (not yet validated)*\n" + "\n".join(sections.non_validated))
-        )
+        sanitized_nv = [_sanitize_for_slack(nv) for nv in sections.non_validated]
+        _add(_mrkdwn_section("*Inferred (not yet validated)*\n" + "\n".join(sanitized_nv)))
 
     if sections.correlation_signals or sections.correlation_drivers:
         blocks.append({"type": "divider"})

--- a/app/delivery/publish_findings/formatters/report.py
+++ b/app/delivery/publish_findings/formatters/report.py
@@ -218,11 +218,15 @@ def format_slack_message(ctx: ReportContext) -> str:
         conclusion_block += "\n## Upstream Correlation\n"
         if sections.correlation_signals:
             conclusion_block += (
-                "*Correlated signals:*\n" + "\n".join(sections.correlation_signals) + "\n"
+                "*Correlated signals:*\n"
+                + "\n".join(_sanitize_for_slack(s) for s in sections.correlation_signals)
+                + "\n"
             )
         if sections.correlation_drivers:
             conclusion_block += (
-                "*Most likely causal drivers:*\n" + "\n".join(sections.correlation_drivers) + "\n"
+                "*Most likely causal drivers:*\n"
+                + "\n".join(_sanitize_for_slack(d) for d in sections.correlation_drivers)
+                + "\n"
             )
 
     provenance_block = ""

--- a/app/delivery/publish_findings/formatters/report.py
+++ b/app/delivery/publish_findings/formatters/report.py
@@ -301,10 +301,7 @@ def format_telegram_message(ctx: ReportContext) -> str:
     if sections.non_validated:
         parts.append(
             "<b>Non-Validated Claims (Inferred)</b>\n"
-            + "\n".join(
-                f"• {_to_telegram_html_body(raw.lstrip('• ').strip())}"
-                for raw in sections.non_validated
-            )
+            + "\n".join(_to_telegram_html_body(raw) for raw in sections.non_validated)
         )
 
     if sections.provenance:

--- a/app/delivery/publish_findings/formatters/report.py
+++ b/app/delivery/publish_findings/formatters/report.py
@@ -13,7 +13,6 @@ from app.delivery.publish_findings.formatters.infrastructure import (
     get_failed_pods,
 )
 from app.delivery.publish_findings.formatters.sections import (
-    _derive_root_cause_sentence,
     _sanitize_for_slack,
     build_report_sections,
 )
@@ -201,10 +200,13 @@ def format_slack_message(ctx: ReportContext) -> str:
         conclusion_block += f"`{sections.top_log}`\n"
 
     if sections.findings:
-        lines = [
-            f"• {c.text} [{', '.join(c.evidence_refs)}]" if c.evidence_refs else f"• {c.text}"
-            for c in sections.findings
-        ]
+        lines = []
+        for c in sections.findings:
+            if c.evidence_refs:
+                refs = ", ".join(format_slack_link(e.display_id, e.url) for e in c.evidence_refs)
+                lines.append(f"• {c.text} [{refs}]")
+            else:
+                lines.append(f"• {c.text}")
         conclusion_block += "\n## Findings\n" + "\n".join(lines) + "\n"
     if sections.non_validated:
         conclusion_block += (
@@ -265,7 +267,7 @@ def format_telegram_message(ctx: ReportContext) -> str:
     sections = build_report_sections(ctx)
     duration_seconds = ctx.get("investigation_duration_seconds")
     alert_id = ctx.get("alert_id")
-    derived_rc = _derive_root_cause_sentence(ctx)
+    derived_rc = sections.root_cause
     root_cause_sentence = derived_rc or "Not determined (insufficient evidence)."
 
     parts: list[str] = [_severity_telegram_header(ctx)]
@@ -288,7 +290,11 @@ def format_telegram_message(ctx: ReportContext) -> str:
     if sections.findings:
         lines = []
         for c in sections.findings:
-            ev_str = f" [{', '.join(c.evidence_refs)}]" if c.evidence_refs else ""
+            if c.evidence_refs:
+                refs = ", ".join(format_html_link(e.display_id, e.url) for e in c.evidence_refs)
+                ev_str = f" [{refs}]"
+            else:
+                ev_str = ""
             lines.append(f"• {_to_telegram_html_body(c.text)}{ev_str}")
         parts.append("<b>Findings</b>\n" + "\n".join(lines))
     if sections.non_validated:
@@ -380,10 +386,13 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
 
     # ── Validated Claims (Findings) and Non-Validated Claims ──
     if sections.findings:
-        lines = [
-            f"• {c.text} [{', '.join(c.evidence_refs)}]" if c.evidence_refs else f"• {c.text}"
-            for c in sections.findings
-        ]
+        lines = []
+        for c in sections.findings:
+            if c.evidence_refs:
+                refs = ", ".join(format_slack_link(e.display_id, e.url) for e in c.evidence_refs)
+                lines.append(f"• {c.text} [{refs}]")
+            else:
+                lines.append(f"• {c.text}")
         blocks.append({"type": "divider"})
         blocks.append(
             {

--- a/app/delivery/publish_findings/formatters/sections.py
+++ b/app/delivery/publish_findings/formatters/sections.py
@@ -272,7 +272,8 @@ def _render_claim_lines(ctx: ReportContext) -> tuple[list[ClaimLine], list[str]]
         validated_lines.append(ClaimLine(text=claim, evidence_refs=evidence_refs))
 
     non_validated_lines: list[str] = [
-        _sanitize_for_slack(cd.get("claim", "")) for cd in ctx.get("non_validated_claims", [])
+        f"\u2022 {_sanitize_for_slack(cd.get('claim', ''))}"
+        for cd in ctx.get("non_validated_claims", [])
     ]
 
     return validated_lines, non_validated_lines

--- a/app/delivery/publish_findings/formatters/sections.py
+++ b/app/delivery/publish_findings/formatters/sections.py
@@ -1,0 +1,377 @@
+"""Channel-agnostic report section builders.
+
+Extracts structured sections from a ReportContext once, so each channel
+formatter (Slack mrkdwn, Telegram HTML, Discord embeds) only applies its
+own markup without duplicating claim rendering, provenance formatting, etc.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.delivery.publish_findings.formatters.evidence import (
+    format_cited_evidence_section,
+    format_cited_evidence_section_html,
+)
+from app.delivery.publish_findings.formatters.infrastructure import (
+    build_investigation_trace,
+)
+from app.delivery.publish_findings.report_context import ReportContext
+from app.delivery.publish_findings.urls.aws import build_cloudwatch_url
+
+# ---------------------------------------------------------------------------
+# Structured section data
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ClaimLine:
+    """A single claim bullet with optional evidence references."""
+
+    text: str
+    evidence_refs: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ReportSections:
+    """All logical sections of an RCA report, channel-agnostic."""
+
+    header: str
+    root_cause: str
+    top_log: str | None
+    findings: list[ClaimLine]
+    non_validated: list[str]
+    correlation_signals: list[str]
+    correlation_drivers: list[str]
+    provenance: list[str]
+    remediation: list[str]
+    trace: list[str]
+    evidence_citations_plain: str
+    evidence_citations_html: str
+    cloudwatch_plain: str
+    cloudwatch_html: str
+    meta_plain: str
+    meta_html: str
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (moved from report.py to avoid duplication)
+# ---------------------------------------------------------------------------
+
+_EVIDENCE_LOG_KEYS: dict[str, list[str]] = {
+    "datadog_logs": ["datadog_error_logs", "datadog_logs"],
+    "datadog": ["datadog_error_logs", "datadog_logs"],
+    "grafana_logs": ["grafana_error_logs", "grafana_logs"],
+    "grafana": ["grafana_error_logs", "grafana_logs"],
+    "cloudwatch_logs": ["cloudwatch_logs"],
+    "cloudwatch": ["cloudwatch_logs"],
+}
+
+
+def _extract_log_message(entry: object) -> str:
+    if isinstance(entry, dict):
+        return (entry.get("message") or "").strip()
+    return str(entry).strip()
+
+
+def _get_top_error_log(evidence: dict) -> str | None:
+    for key in (
+        "datadog_error_logs",
+        "datadog_logs",
+        "grafana_error_logs",
+        "grafana_logs",
+        "cloudwatch_logs",
+    ):
+        logs = evidence.get(key) or []
+        if logs:
+            msg = _extract_log_message(logs[0])
+            if msg:
+                return msg
+    return None
+
+
+def _resolve_evidence_tags(text: str, evidence: dict) -> str:
+    import re
+
+    def _replace(m: re.Match) -> str:
+        source = m.group(1).strip().lower()
+        for key in _EVIDENCE_LOG_KEYS.get(source, []):
+            logs = evidence.get(key) or []
+            if logs:
+                msg = _extract_log_message(logs[0])
+                if msg:
+                    return f": `{msg}`"
+        return ""
+
+    return re.sub(r"\s*\[(?i:evidence):\s*([^\]]+)\]", _replace, text).strip()
+
+
+def _sanitize_for_slack(text: str) -> str:
+    import re
+
+    result = re.sub(r"^#{1,6}\s+(.+)$", r"*\1*", text, flags=re.MULTILINE)
+    result = re.sub(r"\*\*(.+?)\*\*", r"*\1*", result)
+    return result
+
+
+def _first_sentence(text: str) -> str:
+    import re
+
+    cleaned = re.sub(r"(?:^|\s)#{1,6}\s+", " ", text, flags=re.MULTILINE)
+    cleaned = re.sub(
+        r"\b(?:Problem Statement|Summary|Context|Description|Overview)\b[:\s]*",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    normalized = " ".join(cleaned.split()).strip()
+    if not normalized:
+        return ""
+    parts = re.split(r"(?<=[.?!])\s+", normalized, maxsplit=1)
+    sentence = parts[0].rstrip(".?!")
+    return sentence
+
+
+def _is_speculative(text: str) -> bool:
+    speculative_terms = (" may ", " might ", " possibly", " possible ", " likely ")
+    lower = f" {text.lower()} "
+    return any(term in lower for term in speculative_terms)
+
+
+def _remove_speculative_words(text: str) -> str:
+    speculative = ("may", "might", "likely", "probably", "possibly")
+    words = text.split()
+    filtered = [w for w in words if w.lower() not in speculative]
+    return " ".join(filtered)
+
+
+def _derive_root_cause_sentence(ctx: ReportContext) -> str:
+    import re
+
+    root_cause_text = ctx.get("root_cause", "") or ""
+    root_cause_text = re.sub(r"\s*\[(?i:evidence):[^\]]*\]", "", root_cause_text).strip()
+    validated_claims = ctx.get("validated_claims", [])
+
+    if root_cause_text:
+        sentence = _first_sentence(root_cause_text)
+        if sentence and not _is_speculative(sentence):
+            return sentence
+
+    causal_connectors = (
+        " because ",
+        " due to ",
+        " caused ",
+        " resulted in ",
+        " led to ",
+        " root cause ",
+        " failure triggered ",
+    )
+
+    for claim_data in validated_claims:
+        claim = claim_data.get("claim", "") or ""
+        claim = re.sub(r"\s*\[(?i:evidence):[^\]]*\]", "", claim).strip()
+        lower = f" {claim.lower()} "
+        if any(connector in lower for connector in causal_connectors):
+            sentence = _first_sentence(claim)
+            if sentence:
+                return _first_sentence(_remove_speculative_words(sentence))
+
+    if root_cause_text:
+        sentence = _first_sentence(root_cause_text)
+        if sentence:
+            return sentence
+
+    if validated_claims:
+        claim = validated_claims[0].get("claim", "") or ""
+        claim = re.sub(r"\s*\[(?i:evidence):[^\]]*\]", "", claim).strip()
+        sentence = _first_sentence(claim)
+        if sentence:
+            return sentence
+
+    return ""
+
+
+def _format_provenance_lines(ctx: ReportContext) -> list[str]:
+    provenance = ctx.get("source_provenance") or {}
+    lines: list[str] = []
+    for source_name, entry in provenance.items():
+        label = entry.get("label") or source_name.title()
+        summary = entry.get("summary") or ""
+        if summary:
+            lines.append(f"• {label}: {summary}")
+    return lines
+
+
+def _format_correlation_lines(ctx: ReportContext) -> tuple[list[str], list[str]]:
+    correlation = ctx.get("correlation") or {}
+    if not isinstance(correlation, dict):
+        return [], []
+
+    raw_signals = correlation.get("correlated_signals") or []
+    raw_drivers = correlation.get("most_likely_causal_drivers") or []
+
+    signal_lines: list[str] = []
+    for signal in raw_signals:
+        if not isinstance(signal, dict):
+            continue
+        name = signal.get("name") or "unknown"
+        source = signal.get("source") or "unknown"
+        score = signal.get("score")
+        score_text = f" score={float(score):.2f}" if isinstance(score, int | float) else ""
+        signal_lines.append(f"• {name} ({source}{score_text})")
+
+    driver_lines: list[str] = []
+    for driver in raw_drivers:
+        if not isinstance(driver, dict):
+            continue
+        name = driver.get("name") or "unknown"
+        confidence = driver.get("confidence")
+        rationale = driver.get("rationale") or ""
+        confidence_text = (
+            f" confidence={float(confidence):.2f}" if isinstance(confidence, int | float) else ""
+        )
+        suffix = f" — {_sanitize_for_slack(str(rationale))}" if rationale else ""
+        driver_lines.append(f"• {name}{confidence_text}{suffix}")
+
+    return signal_lines, driver_lines
+
+
+def _render_claim_lines(ctx: ReportContext) -> tuple[list[ClaimLine], list[str]]:
+    """Return (validated_claim_lines, non_validated_texts) from shared context.
+
+    This is the single source of truth for claim rendering — both Slack and
+    Telegram formatters consume this instead of maintaining separate copies.
+    """
+    catalog = ctx.get("evidence_catalog") or {}
+    evidence = ctx.get("evidence") or {}
+
+    validated_lines: list[ClaimLine] = []
+    for claim_data in ctx.get("validated_claims", []):
+        claim = claim_data.get("claim", "")
+        claim = _resolve_evidence_tags(claim, evidence)
+        claim = _sanitize_for_slack(claim)
+        evidence_ids = claim_data.get("evidence_ids", [])
+        evidence_labels = claim_data.get("evidence_labels", [])
+        evidence_refs: list[str] = []
+        if evidence_ids:
+            for eid in evidence_ids:
+                entry = catalog.get(eid, {})
+                disp = entry.get("display_id", eid)
+                evidence_refs.append(disp)
+        elif evidence_labels:
+            evidence_refs = [str(x) for x in evidence_labels]
+        validated_lines.append(ClaimLine(text=claim, evidence_refs=evidence_refs))
+
+    non_validated_lines: list[str] = [
+        _sanitize_for_slack(cd.get("claim", ""))
+        for cd in ctx.get("non_validated_claims", [])
+    ]
+
+    return validated_lines, non_validated_lines
+
+
+def _render_cloudwatch_plain(ctx: ReportContext) -> str:
+    cw_url = ctx.get("cloudwatch_logs_url")
+    cw_group = ctx.get("cloudwatch_log_group")
+    cw_stream = ctx.get("cloudwatch_log_stream")
+
+    if cw_url:
+        return "\n*CloudWatch Logs*\n"
+    elif cw_group and cw_stream:
+        url = build_cloudwatch_url(ctx)
+        if url:
+            return "\n*CloudWatch Logs*\n"
+        return f"\n*CloudWatch Logs:*\n* Log Group: {cw_group}\n* Log Stream: {cw_stream}\n"
+    return ""
+
+
+def _render_cloudwatch_html(ctx: ReportContext) -> str:
+    import html as html_mod
+
+    cw_url = ctx.get("cloudwatch_logs_url")
+    cw_group = ctx.get("cloudwatch_log_group")
+    cw_stream = ctx.get("cloudwatch_log_stream")
+
+    if cw_url:
+        safe = html_mod.escape(str(cw_url), quote=True)
+        return f'\n<b>CloudWatch</b>: <a href="{safe}">View logs</a>\n'
+    if cw_group and cw_stream:
+        url = build_cloudwatch_url(ctx)
+        if url:
+            safe = html_mod.escape(str(url), quote=True)
+            return f'\n<b>CloudWatch</b>: <a href="{safe}">View logs</a>\n'
+        return (
+            f"\n<b>CloudWatch Logs</b>\n"
+            f"Log Group: {html_mod.escape(str(cw_group))}\n"
+            f"Log Stream: {html_mod.escape(str(cw_stream))}\n"
+        )
+    return ""
+
+
+def _render_meta_plain(ctx: ReportContext) -> str:
+    duration_seconds = ctx.get("investigation_duration_seconds")
+    alert_id = ctx.get("alert_id")
+    meta_lines: list[str] = []
+    if duration_seconds is not None:
+        meta_lines.append(f"Timing: {duration_seconds}s")
+    if alert_id:
+        meta_lines.append(f"Alert ID: {alert_id}")
+    return "\n".join(meta_lines)
+
+
+def _render_meta_html(ctx: ReportContext) -> str:
+    import html as html_mod
+
+    duration_seconds = ctx.get("investigation_duration_seconds")
+    alert_id = ctx.get("alert_id")
+    meta_bits: list[str] = []
+    if duration_seconds is not None:
+        meta_bits.append(f"Timing: {duration_seconds}s")
+    if alert_id:
+        meta_bits.append(f"Alert ID: {alert_id}")
+    return html_mod.escape(" | ".join(meta_bits)) if meta_bits else ""
+
+
+# ---------------------------------------------------------------------------
+# Main builder
+# ---------------------------------------------------------------------------
+
+
+def build_report_sections(ctx: ReportContext) -> ReportSections:
+    """Extract all logical report sections from context (channel-agnostic)."""
+
+    evidence = ctx.get("evidence") or {}
+
+    root_cause_sentence = _derive_root_cause_sentence(ctx) or "Not determined (insufficient evidence)."
+    top_log = _get_top_error_log(evidence)
+
+    validated_claims, non_validated = _render_claim_lines(ctx)
+    provenance = _format_provenance_lines(ctx)
+    corr_signals, corr_drivers = _format_correlation_lines(ctx)
+    trace = build_investigation_trace(ctx)
+
+    evidence_plain = format_cited_evidence_section(ctx).strip()
+    evidence_html = format_cited_evidence_section_html(ctx).strip()
+    cw_plain = _render_cloudwatch_plain(ctx).strip()
+    cw_html = _render_cloudwatch_html(ctx).strip()
+    meta_plain = _render_meta_plain(ctx)
+    meta_html = _render_meta_html(ctx)
+
+    return ReportSections(
+        header="",
+        root_cause=root_cause_sentence,
+        top_log=top_log,
+        findings=validated_claims,
+        non_validated=non_validated,
+        correlation_signals=corr_signals,
+        correlation_drivers=corr_drivers,
+        provenance=provenance,
+        remediation=ctx.get("remediation_steps", []),
+        trace=trace,
+        evidence_citations_plain=evidence_plain,
+        evidence_citations_html=evidence_html,
+        cloudwatch_plain=cw_plain,
+        cloudwatch_html=cw_html,
+        meta_plain=meta_plain,
+        meta_html=meta_html,
+    )

--- a/app/delivery/publish_findings/formatters/sections.py
+++ b/app/delivery/publish_findings/formatters/sections.py
@@ -238,7 +238,7 @@ def _format_correlation_lines(ctx: ReportContext) -> tuple[list[str], list[str]]
         confidence_text = (
             f" confidence={float(confidence):.2f}" if isinstance(confidence, int | float) else ""
         )
-        suffix = f" — {_sanitize_for_slack(str(rationale))}" if rationale else ""
+        suffix = f" — {str(rationale)}" if rationale else ""
         driver_lines.append(f"• {name}{confidence_text}{suffix}")
 
     return signal_lines, driver_lines
@@ -257,7 +257,8 @@ def _render_claim_lines(ctx: ReportContext) -> tuple[list[ClaimLine], list[str]]
     for claim_data in ctx.get("validated_claims", []):
         claim = claim_data.get("claim", "")
         claim = _resolve_evidence_tags(claim, evidence)
-        claim = _sanitize_for_slack(claim)
+        # Do NOT call _sanitize_for_slack here — this is a channel-agnostic
+        # layer. Each formatter applies its own markup (mrkdwn, HTML, etc.).
         evidence_ids = claim_data.get("evidence_ids", [])
         evidence_labels = claim_data.get("evidence_labels", [])
         evidence_refs: list[EvidenceRef] = []
@@ -272,8 +273,7 @@ def _render_claim_lines(ctx: ReportContext) -> tuple[list[ClaimLine], list[str]]
         validated_lines.append(ClaimLine(text=claim, evidence_refs=evidence_refs))
 
     non_validated_lines: list[str] = [
-        f"\u2022 {_sanitize_for_slack(cd.get('claim', ''))}"
-        for cd in ctx.get("non_validated_claims", [])
+        f"\u2022 {cd.get('claim', '')}" for cd in ctx.get("non_validated_claims", [])
     ]
 
     return validated_lines, non_validated_lines

--- a/app/delivery/publish_findings/formatters/sections.py
+++ b/app/delivery/publish_findings/formatters/sections.py
@@ -25,11 +25,19 @@ from app.delivery.publish_findings.urls.aws import build_cloudwatch_url
 
 
 @dataclass
+class EvidenceRef:
+    """A single evidence reference with optional URL."""
+
+    display_id: str
+    url: str | None = None
+
+
+@dataclass
 class ClaimLine:
     """A single claim bullet with optional evidence references."""
 
     text: str
-    evidence_refs: list[str] = field(default_factory=list)
+    evidence_refs: list[EvidenceRef] = field(default_factory=list)
 
 
 @dataclass
@@ -252,14 +260,15 @@ def _render_claim_lines(ctx: ReportContext) -> tuple[list[ClaimLine], list[str]]
         claim = _sanitize_for_slack(claim)
         evidence_ids = claim_data.get("evidence_ids", [])
         evidence_labels = claim_data.get("evidence_labels", [])
-        evidence_refs: list[str] = []
+        evidence_refs: list[EvidenceRef] = []
         if evidence_ids:
             for eid in evidence_ids:
                 entry = catalog.get(eid, {})
                 disp = entry.get("display_id", eid)
-                evidence_refs.append(disp)
+                url = entry.get("url")
+                evidence_refs.append(EvidenceRef(display_id=disp, url=url or None))
         elif evidence_labels:
-            evidence_refs = [str(x) for x in evidence_labels]
+            evidence_refs = [EvidenceRef(display_id=str(x)) for x in evidence_labels]
         validated_lines.append(ClaimLine(text=claim, evidence_refs=evidence_refs))
 
     non_validated_lines: list[str] = [

--- a/app/delivery/publish_findings/formatters/sections.py
+++ b/app/delivery/publish_findings/formatters/sections.py
@@ -263,8 +263,7 @@ def _render_claim_lines(ctx: ReportContext) -> tuple[list[ClaimLine], list[str]]
         validated_lines.append(ClaimLine(text=claim, evidence_refs=evidence_refs))
 
     non_validated_lines: list[str] = [
-        _sanitize_for_slack(cd.get("claim", ""))
-        for cd in ctx.get("non_validated_claims", [])
+        _sanitize_for_slack(cd.get("claim", "")) for cd in ctx.get("non_validated_claims", [])
     ]
 
     return validated_lines, non_validated_lines
@@ -342,7 +341,9 @@ def build_report_sections(ctx: ReportContext) -> ReportSections:
 
     evidence = ctx.get("evidence") or {}
 
-    root_cause_sentence = _derive_root_cause_sentence(ctx) or "Not determined (insufficient evidence)."
+    root_cause_sentence = (
+        _derive_root_cause_sentence(ctx) or "Not determined (insufficient evidence)."
+    )
     top_log = _get_top_error_log(evidence)
 
     validated_claims, non_validated = _render_claim_lines(ctx)

--- a/app/delivery/publish_findings/node.py
+++ b/app/delivery/publish_findings/node.py
@@ -89,6 +89,7 @@ def generate_report(state: InvestigationState) -> dict:
 
     # Discord delivery — uses integration credentials if configured
     if discord_creds:
+        from app.delivery.publish_findings.formatters.discord import format_discord_message
         from app.utils.discord_delivery import send_discord_report
 
         discord_ctx = state.get("discord_context") or {}
@@ -102,9 +103,11 @@ def generate_report(state: InvestigationState) -> dict:
             bool(bot_token),
         )
         if bot_token and channel_id:
+            discord_content, discord_embeds = format_discord_message(ctx)
             discord_posted, discord_error = send_discord_report(
-                slack_message,
+                discord_content,
                 {"bot_token": bot_token, "channel_id": channel_id, "thread_id": thread_id},
+                embeds=discord_embeds,
             )
             logger.debug(
                 "[publish] discord delivery: posted=%s error=%s", discord_posted, discord_error

--- a/app/delivery/publish_findings/node.py
+++ b/app/delivery/publish_findings/node.py
@@ -104,6 +104,8 @@ def generate_report(state: InvestigationState) -> dict:
         )
         if bot_token and channel_id:
             discord_content, discord_embeds = format_discord_message(ctx)
+            discord_content = masking_ctx.unmask(discord_content)
+            discord_embeds = masking_ctx.unmask_value(discord_embeds)
             discord_posted, discord_error = send_discord_report(
                 discord_content,
                 {"bot_token": bot_token, "channel_id": channel_id, "thread_id": thread_id},

--- a/app/utils/discord_delivery.py
+++ b/app/utils/discord_delivery.py
@@ -105,16 +105,26 @@ _EMBED_TITLE_LIMIT = 256
 _EMBED_DESCRIPTION_LIMIT = 4096
 
 
-def send_discord_report(report: str, discord_ctx: dict[str, Any]) -> tuple[bool, str]:
+def send_discord_report(
+    report: str,
+    discord_ctx: dict[str, Any],
+    *,
+    embeds: list[dict[str, Any]] | None = None,
+) -> tuple[bool, str]:
     channel_id: str = str(discord_ctx.get("channel_id") or "")
     thread_id: str = str(discord_ctx.get("thread_id") or "")
     bot_token: str = str(discord_ctx.get("bot_token") or "")
-    embed = {
-        "title": truncate("Investigation Complete", _EMBED_TITLE_LIMIT, suffix="…"),
-        "color": 15158332,
-        "description": truncate(report, _EMBED_DESCRIPTION_LIMIT, suffix="…"),
-        "footer": {"text": "OpenSRE Investigation"},
-    }
     target = thread_id if thread_id else channel_id
-    post_message_success, error, _ = post_discord_message(target, [embed], bot_token)
+    if embeds:
+        post_message_success, error, _ = post_discord_message(
+            target, embeds, bot_token, content=report
+        )
+    else:
+        embed = {
+            "title": truncate("Investigation Complete", _EMBED_TITLE_LIMIT, suffix="…"),
+            "color": 15158332,
+            "description": truncate(report, _EMBED_DESCRIPTION_LIMIT, suffix="…"),
+            "footer": {"text": "OpenSRE Investigation"},
+        }
+        post_message_success, error, _ = post_discord_message(target, [embed], bot_token)
     return (True, "") if post_message_success else (False, error)

--- a/tests/delivery/test_discord_formatter.py
+++ b/tests/delivery/test_discord_formatter.py
@@ -124,6 +124,19 @@ def test_discord_field_value_respects_1024_limit() -> None:
         assert len(field["value"]) <= 1024
 
 
+def test_discord_top_log_code_fence_respects_limit() -> None:
+    state = _make_state()
+    state["evidence"]["datadog_error_logs"] = [{"message": "X" * 2000}]
+    ctx = build_report_context(state)
+    _, embeds = format_discord_message(ctx)
+
+    for field in embeds[0]["fields"]:
+        if field["name"] == "Top Error Log":
+            assert len(field["value"]) <= 1024
+            assert field["value"].startswith("```\n")
+            assert field["value"].endswith("\n```")
+
+
 def test_discord_field_name_respects_256_limit() -> None:
     state = _make_state()
     ctx = build_report_context(state)

--- a/tests/delivery/test_discord_formatter.py
+++ b/tests/delivery/test_discord_formatter.py
@@ -1,0 +1,173 @@
+"""Tests for the Discord report formatter."""
+
+from __future__ import annotations
+
+from app.delivery.publish_findings.formatters.discord import (
+    format_discord_message,
+)
+from app.delivery.publish_findings.report_context import build_report_context
+
+
+def _make_state() -> dict:
+    return {
+        "pipeline_name": "checkout-service",
+        "alert_name": "Checkout latency spike",
+        "root_cause": "Checkout service was throttled by the upstream API cluster.",
+        "root_cause_category": "dependency_failure",
+        "validity_score": 0.91,
+        "severity": "critical",
+        "validated_claims": [
+            {
+                "claim": "Grafana logs show repeated 500 responses.",
+                "evidence_sources": ["grafana_logs"],
+            }
+        ],
+        "non_validated_claims": [
+            {"claim": "Database connection pool exhausted."},
+        ],
+        "investigation_recommendations": [],
+        "remediation_steps": [
+            "Increase memory limit for payments-api deployment",
+        ],
+        "available_sources": {
+            "grafana": {
+                "grafana_endpoint": "https://myorg.grafana.net",
+                "service_name": "checkout-api",
+            },
+        },
+        "evidence": {
+            "grafana_logs": [
+                {"message": "service unavailable"},
+            ],
+        },
+    }
+
+
+def test_format_discord_message_returns_content_and_embeds() -> None:
+    ctx = build_report_context(_make_state())
+    content, embeds = format_discord_message(ctx)
+
+    assert content
+    assert len(embeds) == 1
+    assert "Checkout latency spike" in content
+
+
+def test_discord_embed_has_required_fields() -> None:
+    ctx = build_report_context(_make_state())
+    content, embeds = format_discord_message(ctx)
+    embed = embeds[0]
+
+    assert embed["title"]
+    assert embed["color"]
+    assert embed["description"]
+    assert embed["fields"]
+    assert embed["footer"]
+
+
+def test_discord_severity_color_for_critical() -> None:
+    state = _make_state()
+    state["severity"] = "critical"
+    ctx = build_report_context(state)
+    _, embeds = format_discord_message(ctx)
+
+    assert embeds[0]["color"] == 15158332  # red
+
+
+def test_discord_severity_color_for_warning() -> None:
+    state = _make_state()
+    state["severity"] = "warning"
+    ctx = build_report_context(state)
+    _, embeds = format_discord_message(ctx)
+
+    assert embeds[0]["color"] == 15844367  # yellow
+
+
+def test_discord_findings_field_present() -> None:
+    ctx = build_report_context(_make_state())
+    _, embeds = format_discord_message(ctx)
+    field_names = [f["name"] for f in embeds[0]["fields"]]
+
+    assert "Findings" in field_names
+
+
+def test_discord_non_validated_field_present() -> None:
+    ctx = build_report_context(_make_state())
+    _, embeds = format_discord_message(ctx)
+    field_names = [f["name"] for f in embeds[0]["fields"]]
+
+    assert "Non-Validated Claims (Inferred)" in field_names
+
+
+def test_discord_remediation_field_present() -> None:
+    ctx = build_report_context(_make_state())
+    _, embeds = format_discord_message(ctx)
+    field_names = [f["name"] for f in embeds[0]["fields"]]
+
+    assert "Recommended Actions" in field_names
+
+
+def test_discord_provenance_field_present() -> None:
+    ctx = build_report_context(_make_state())
+    _, embeds = format_discord_message(ctx)
+    field_names = [f["name"] for f in embeds[0]["fields"]]
+
+    assert "Provenance" in field_names
+
+
+def test_discord_field_value_respects_1024_limit() -> None:
+    state = _make_state()
+    state["remediation_steps"] = ["A" * 2000]
+    ctx = build_report_context(state)
+    _, embeds = format_discord_message(ctx)
+
+    for field in embeds[0]["fields"]:
+        assert len(field["value"]) <= 1024
+
+
+def test_discord_field_name_respects_256_limit() -> None:
+    state = _make_state()
+    ctx = build_report_context(state)
+    _, embeds = format_discord_message(ctx)
+
+    for field in embeds[0]["fields"]:
+        assert len(field["name"]) <= 256
+
+
+def test_discord_embed_description_respects_4096_limit() -> None:
+    state = _make_state()
+    state["root_cause"] = "X" * 5000
+    ctx = build_report_context(state)
+    _, embeds = format_discord_message(ctx)
+
+    assert len(embeds[0]["description"]) <= 4096
+
+
+def test_discord_max_25_fields() -> None:
+    state = _make_state()
+    state["validated_claims"] = [
+        {"claim": f"Claim {i}", "evidence_sources": []}
+        for i in range(30)
+    ]
+    ctx = build_report_context(state)
+    _, embeds = format_discord_message(ctx)
+
+    assert len(embeds[0]["fields"]) <= 25
+
+
+def test_discord_empty_state_produces_minimal_embed() -> None:
+    state = {
+        "pipeline_name": "test",
+        "alert_name": "Test alert",
+        "root_cause": "",
+        "validated_claims": [],
+        "non_validated_claims": [],
+        "remediation_steps": [],
+        "available_sources": {},
+        "evidence": {},
+    }
+    ctx = build_report_context(state)
+    content, embeds = format_discord_message(ctx)
+
+    assert content
+    assert len(embeds) == 1
+    assert embeds[0]["fields"] == []

--- a/tests/delivery/test_discord_formatter.py
+++ b/tests/delivery/test_discord_formatter.py
@@ -144,10 +144,7 @@ def test_discord_embed_description_respects_4096_limit() -> None:
 
 def test_discord_max_25_fields() -> None:
     state = _make_state()
-    state["validated_claims"] = [
-        {"claim": f"Claim {i}", "evidence_sources": []}
-        for i in range(30)
-    ]
+    state["validated_claims"] = [{"claim": f"Claim {i}", "evidence_sources": []} for i in range(30)]
     ctx = build_report_context(state)
     _, embeds = format_discord_message(ctx)
 

--- a/tests/delivery/test_sections.py
+++ b/tests/delivery/test_sections.py
@@ -1,0 +1,134 @@
+"""Tests for the channel-agnostic section builders."""
+
+from __future__ import annotations
+
+from app.delivery.publish_findings.formatters.sections import (
+    ClaimLine,
+    build_report_sections,
+)
+from app.delivery.publish_findings.report_context import build_report_context
+
+
+def _make_state() -> dict:
+    return {
+        "pipeline_name": "checkout-service",
+        "alert_name": "Checkout latency spike",
+        "root_cause": "Checkout service was throttled by the upstream API cluster.",
+        "root_cause_category": "dependency_failure",
+        "validity_score": 0.91,
+        "validated_claims": [
+            {
+                "claim": "Grafana logs show repeated 500 responses.",
+                "evidence_sources": ["grafana_logs"],
+            }
+        ],
+        "non_validated_claims": [
+            {"claim": "Database connection pool exhausted."},
+        ],
+        "investigation_recommendations": [],
+        "remediation_steps": [
+            "Increase memory limit for payments-api deployment",
+            "Add Datadog monitor for memory usage at 80% threshold",
+        ],
+        "available_sources": {
+            "grafana": {
+                "grafana_endpoint": "https://myorg.grafana.net",
+                "service_name": "checkout-api",
+                "pipeline_name": "checkout-service",
+            },
+            "eks": {
+                "cluster_name": "prod-cluster",
+                "namespace": "payments",
+                "region": "us-east-1",
+            },
+        },
+        "evidence": {
+            "grafana_logs": [
+                {"message": "service unavailable"},
+            ],
+        },
+    }
+
+
+def test_build_report_sections_returns_all_fields() -> None:
+    ctx = build_report_context(_make_state())
+    sections = build_report_sections(ctx)
+
+    assert sections.root_cause
+    assert sections.findings
+    assert sections.non_validated
+    assert sections.remediation
+    assert isinstance(sections.findings[0], ClaimLine)
+
+
+def test_findings_include_evidence_refs() -> None:
+    ctx = build_report_context(_make_state())
+    sections = build_report_sections(ctx)
+
+    assert len(sections.findings) == 1
+    claim = sections.findings[0]
+    assert "500 responses" in claim.text
+    assert claim.evidence_refs  # E1 from catalog
+
+
+def test_non_validated_claims_are_sanitized() -> None:
+    ctx = build_report_context(_make_state())
+    sections = build_report_sections(ctx)
+
+    assert len(sections.non_validated) == 1
+    assert "Database connection pool exhausted" in sections.non_validated[0]
+
+
+def test_provenance_lines_populated() -> None:
+    ctx = build_report_context(_make_state())
+    sections = build_report_sections(ctx)
+
+    assert any("Grafana" in p for p in sections.provenance)
+    assert any("AWS EKS" in p for p in sections.provenance)
+
+
+def test_remediation_steps_passed_through() -> None:
+    ctx = build_report_context(_make_state())
+    sections = build_report_sections(ctx)
+
+    assert len(sections.remediation) == 2
+    assert "Increase memory limit" in sections.remediation[0]
+
+
+def test_empty_sections_when_no_data() -> None:
+    state = {
+        "pipeline_name": "test",
+        "alert_name": "Test alert",
+        "root_cause": "",
+        "validated_claims": [],
+        "non_validated_claims": [],
+        "remediation_steps": [],
+        "available_sources": {},
+        "evidence": {},
+    }
+    ctx = build_report_context(state)
+    sections = build_report_sections(ctx)
+
+    assert not sections.findings
+    assert not sections.non_validated
+    assert not sections.provenance
+    assert not sections.remediation
+    assert not sections.trace
+    assert not sections.evidence_citations_plain
+
+
+def test_root_cause_derived_when_empty() -> None:
+    state = {
+        "pipeline_name": "test",
+        "alert_name": "Test alert",
+        "root_cause": "",
+        "validated_claims": [],
+        "non_validated_claims": [],
+        "remediation_steps": [],
+        "available_sources": {},
+        "evidence": {},
+    }
+    ctx = build_report_context(state)
+    sections = build_report_sections(ctx)
+
+    assert sections.root_cause == "Not determined (insufficient evidence)."

--- a/tests/delivery/test_sections.py
+++ b/tests/delivery/test_sections.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from app.delivery.publish_findings.formatters.sections import (
     ClaimLine,
+    EvidenceRef,
     build_report_sections,
 )
 from app.delivery.publish_findings.report_context import build_report_context
@@ -69,6 +70,21 @@ def test_findings_include_evidence_refs() -> None:
     claim = sections.findings[0]
     assert "500 responses" in claim.text
     assert claim.evidence_refs  # E1 from catalog
+    assert isinstance(claim.evidence_refs[0], EvidenceRef)
+    assert claim.evidence_refs[0].display_id == "E1"
+
+
+def test_findings_preserve_evidence_urls() -> None:
+    state = _make_state()
+    state["evidence"]["datadog_logs"] = [{"message": "5xx spike"}]
+    state["available_sources"]["datadog"] = {"site": "datadoghq.com"}
+    ctx = build_report_context(state)
+    sections = build_report_sections(ctx)
+
+    for claim in sections.findings:
+        for ref in claim.evidence_refs:
+            if ref.url:
+                assert ref.url.startswith("http")
 
 
 def test_non_validated_claims_are_sanitized() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1956,7 +1956,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'release'", specifier = ">=1.2.0" },
     { name = "build", marker = "extra == 'release-dist'", specifier = ">=1.2.0" },
     { name = "click", specifier = ">=8.1.0" },
-    { name = "clickhouse-connect", specifier = ">=0.15.1" },
+    { name = "clickhouse-connect", specifier = ">=0.15.1,<1.0.0" },
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = ">=0.15.1" },
     { name = "confluent-kafka", marker = "extra == 'kafka'", specifier = ">=2.14.0" },
     { name = "cryptography", specifier = ">=42.0.0" },


### PR DESCRIPTION
Fixes #2007

#### Describe the changes you have made in this PR -

This PR refactors the RCA report formatting system to follow the DRY principle and adds a dedicated Discord formatter.

**Key changes:**
- Extracted channel-agnostic section builders into `sections.py` with `ReportSections` dataclass and `build_report_sections()` — this is now the single source of truth for claim rendering, provenance formatting, correlation, root cause derivation, etc.
- Consolidated duplicate claim rendering (`_render_claim_lines`) that was previously split between Slack and Telegram formatters
- Added a dedicated Discord formatter (`discord.py`) with embed-based output respecting Discord limits (1024 chars/field, 25 fields max, 4096 char description, severity colors)
- Wired Discord formatter into `node.py` instead of reusing `slack_message` (which was causing Discord to render Slack mrkdwn that does not translate to Discord markdown)
- Updated `discord_delivery.py` to accept optional `embeds` parameter
- Added 20 new tests: 7 for section builders, 13 for Discord formatter

**Impact:**
- `report.py` reduced from 752 to 462 lines
- All 56 delivery tests pass (including 13 existing + 20 new)
- Lint and typecheck clean
- Backwards compatible — existing `format_slack_message()`, `format_telegram_message()`, `build_slack_blocks()` signatures unchanged

### Demo/Screenshot for feature changes and bug fixes -

All existing tests pass:
```
tests/delivery/ - 56 passed in 1.81s
make lint - All checks passed!
make typecheck - Success: no issues found in 583 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem was that Slack, Telegram, and Discord formatters each independently extracted and formatted the same data from `ReportContext` — claims, provenance, correlation, remediation steps, trace, etc. The only difference was the channel-specific markup (mrkdwn vs HTML vs embeds).

I chose to extract a `ReportSections` dataclass that holds all logical sections as plain text (no channel markup), built once from `ReportContext` via `build_report_sections()`. Each formatter then applies its own markup to these sections.

Alternative approaches considered:
1. Template-based approach — too rigid, hard to handle channel-specific logic like Telegram's severity header or Slack's Block Kit
2. Abstract base class with template methods — overkill for this use case
3. Keep current structure and just add Discord — would perpetuate the DRY violation

The chosen approach means adding a new channel (Teams, Mattermost, etc.) requires only writing a new formatter that consumes `ReportSections`.

Key components:
- `sections.py` — `ReportSections` dataclass + `build_report_sections()` + shared helpers (claim rendering, provenance, correlation, root cause derivation)
- `discord.py` — `format_discord_message()` returns `(content_text, embeds)` tuple for Discord API
- `report.py` — refactored to call `build_report_sections()` and apply mrkdwn/HTML
- `node.py` — uses `format_discord_message()` instead of passing `slack_message` to Discord
- `discord_delivery.py` — accepts optional `embeds` parameter

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.