### PR TITLE
fix(wizard): raise friendly PermissionError when .env write is denied

### DIFF
--- a/app/cli/wizard/env_sync.py
+++ b/app/cli/wizard/env_sync.py
@@ -47,7 +47,13 @@ def sync_env_values(
     for key, value in values.items():
         lines = _set_env_value(lines, key, value)
 
-    target_path.write_text("".join(lines), encoding="utf-8")
+    try:
+        target_path.write_text("".join(lines), encoding="utf-8")
+    except PermissionError as exc:
+        raise PermissionError(
+            f"Cannot write to {target_path}: permission denied. "
+            "Check file ownership or run with elevated permissions."
+        ) from exc
     return target_path
 
 
@@ -134,5 +140,11 @@ def sync_provider_env(
     for key, value in values.items():
         lines = _set_env_value(lines, key, value)
 
-    target_path.write_text("".join(lines), encoding="utf-8")
+    try:
+        target_path.write_text("".join(lines), encoding="utf-8")
+    except PermissionError as exc:
+        raise PermissionError(
+            f"Cannot write to {target_path}: permission denied. "
+            "Check file ownership or run with elevated permissions."
+        ) from exc
     return target_path

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import pytest
+
 from app.cli.wizard.config import PROVIDER_BY_VALUE
-from app.cli.wizard.env_sync import sync_provider_env
+from app.cli.wizard.env_sync import sync_env_values, sync_provider_env
 
 
 def test_sync_provider_env_updates_provider_specific_keys(tmp_path) -> None:
@@ -63,6 +67,30 @@ def test_sync_provider_env_codex_writes_codex_model(tmp_path) -> None:
     content = env_path.read_text(encoding="utf-8")
     assert "LLM_PROVIDER=codex\n" in content
     assert "CODEX_MODEL=\n" in content
+
+
+def test_sync_provider_env_permission_error(tmp_path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("LLM_PROVIDER=anthropic\n", encoding="utf-8")
+    with (
+        patch("pathlib.Path.write_text", side_effect=PermissionError("denied")),
+        pytest.raises(PermissionError, match="Cannot write to"),
+    ):
+        sync_provider_env(
+            provider=PROVIDER_BY_VALUE["openai"],
+            model="gpt-5-mini",
+            env_path=env_path,
+        )
+
+
+def test_sync_env_values_permission_error(tmp_path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("KEY=old\n", encoding="utf-8")
+    with (
+        patch("pathlib.Path.write_text", side_effect=PermissionError("denied")),
+        pytest.raises(PermissionError, match="Cannot write to"),
+    ):
+        sync_env_values({"KEY": "new"}, env_path=env_path)
 
 
 def test_sync_provider_env_gemini_cli_writes_model(tmp_path) -> None:

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -72,6 +72,8 @@ def test_sync_provider_env_codex_writes_codex_model(tmp_path) -> None:
 def test_sync_provider_env_permission_error(tmp_path) -> None:
     env_path = tmp_path / ".env"
     env_path.write_text("LLM_PROVIDER=anthropic\n", encoding="utf-8")
+    # PosixPath instances are C-backed and don't allow per-instance attribute
+    # patching, so we patch at the class level.
     with (
         patch("pathlib.Path.write_text", side_effect=PermissionError("denied")),
         pytest.raises(PermissionError, match="Cannot write to"),


### PR DESCRIPTION
## Summary

- `sync_env_values` and `sync_provider_env` in `app/cli/wizard/env_sync.py` both call `Path.write_text` without catching `PermissionError`
- On EC2 SSM sessions (and similar environments) the `.env` file may be owned by another user, causing an unhandled traceback instead of a clear message
- Wrap both `write_text` calls to re-raise with the file path and an actionable hint ("Check file ownership or run with elevated permissions")
- Add two regression tests using `unittest.mock.patch` to verify the friendly error message

## Test plan

- [x] `uv run pytest tests/cli/wizard/test_env_sync.py -v` — all 6 tests pass
- [x] `uv run ruff check app/cli/wizard/env_sync.py tests/cli/wizard/test_env_sync.py` — no issues
- [x] `uv run ruff format --check` — already formatted
- [x] `uv run pyright app/cli/wizard/env_sync.py` — 0 errors

Closes #2066

---
_Generated by [Claude Code](https://claude.ai/code/session_01STaPuqadXvB9kuuvKEpM1K)_