### PR TITLE
fix: add LLMProviderError to suppress Sentry noise for provider timeouts

### DIFF
--- a/app/cli/interactive_shell/chat/cli_agent.py
+++ b/app/cli/interactive_shell/chat/cli_agent.py
@@ -38,6 +38,7 @@ from app.cli.interactive_shell.ui import (
 )
 from app.cli.support.exception_reporting import report_exception
 from app.integrations.llm_cli.errors import CLITimeoutError
+from app.services.llm_client import LLMProviderError
 
 # Cap stored (user, assistant) pairs; list holds 2 entries per turn.
 _MAX_CLI_AGENT_TURNS = 12
@@ -464,7 +465,7 @@ def answer_cli_agent(
         report_exception(
             exc,
             context="interactive_shell.cli_agent.stream",
-            expected=isinstance(exc, CLITimeoutError),
+            expected=isinstance(exc, (CLITimeoutError, LLMProviderError)),
         )
         console.print(f"[{ERROR}]assistant failed:[/] {escape(str(exc))}")
         return

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -98,6 +98,10 @@ class LLMResponse:
     content: str
 
 
+class LLMProviderError(RuntimeError):
+    """Raised when an LLM provider is unreachable or times out (network/config, not a code bug)."""
+
+
 class LLMClient:
     def __init__(
         self, *, model: str, max_tokens: int = 1024, temperature: float | None = None
@@ -750,13 +754,13 @@ class OpenAILLMClient:
                 raise
             except OpenAITimeoutError as err:
                 if attempt == max_attempts - 1:
-                    raise RuntimeError(
+                    raise LLMProviderError(
                         _format_openai_connection_error(err, self._provider_label)
                     ) from err
                 time.sleep(backoff_seconds)
                 backoff_seconds *= 2
             except OpenAIConnectionError as err:
-                raise RuntimeError(
+                raise LLMProviderError(
                     _format_openai_connection_error(err, self._provider_label)
                 ) from err
             except OpenAIRateLimitError as err:
@@ -848,7 +852,7 @@ class OpenAILLMClient:
                 if emitted:
                     raise
                 if attempt == max_attempts - 1:
-                    raise RuntimeError(
+                    raise LLMProviderError(
                         _format_openai_connection_error(err, self._provider_label)
                     ) from err
                 time.sleep(backoff_seconds)
@@ -856,7 +860,7 @@ class OpenAILLMClient:
             except OpenAIConnectionError as err:
                 if emitted:
                     raise
-                raise RuntimeError(
+                raise LLMProviderError(
                     _format_openai_connection_error(err, self._provider_label)
                 ) from err
             except OpenAIRateLimitError as err:

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -363,6 +363,7 @@ def _init_sentry_once(
         CLITimeoutError,
         CLITransientError,
     )
+    from app.services.llm_client import LLMProviderError
 
     sentry_sdk.init(
         dsn=dsn,
@@ -384,6 +385,7 @@ def _init_sentry_once(
             CLIInterruptedError,
             CLITimeoutError,
             CLITransientError,
+            LLMProviderError,
         ],
     )
 


### PR DESCRIPTION
## Summary

- Introduces `LLMProviderError(RuntimeError)` in `app/services/llm_client.py` for Ollama/OpenAI timeout and connection failures
- Raises `LLMProviderError` instead of `RuntimeError` in both `invoke` and `invoke_stream` for `OpenAITimeoutError` / `OpenAIConnectionError` paths
- Adds `LLMProviderError` to Sentry `ignore_errors` in `app/utils/sentry_sdk.py` so provider connectivity issues never create bug reports
- Updates `cli_agent.py` `expected` check to include `LLMProviderError`, preventing even the `capture_exception` call

## Root cause

`OpenAITimeoutError` after 3 retries raised a plain `RuntimeError`. In `cli_agent.py`, `report_exception` was called with `expected=isinstance(exc, CLITimeoutError)` which was `False` for `RuntimeError`, so the event reached Sentry. The user-visible error message was correct; only the Sentry alert was spurious.

## Test plan
- [ ] Existing tests pass: `uv run pytest tests/` (pre-existing `test_sampler` failure unrelated)
- [ ] Configure Ollama with an unreachable endpoint, verify error shows to user but no Sentry event fires

Closes #2175

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMpZKe48ng4X668SMYtnJb)_