### PR TITLE
fix(bedrock): add required `type` field to Bedrock tool schemas

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -254,6 +254,9 @@ class BedrockAgentClient(AnthropicAgentClient):
             "aws-marketplace:ViewSubscriptions and aws-marketplace:Subscribe."
         )
 
+    def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
+        return [{"type": "custom", **_anthropic_tool_schema(t)} for t in tools]
+
     def _bad_request_error_message(self, err: Any) -> str:
         err_str = str(err)
         if "on-demand throughput" in err_str or "inference profile" in err_str.lower():

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -836,3 +836,22 @@ def test_bedrock_bad_request_generic_error_uses_default_message(
     message = str(exc.value)
     assert "Bedrock request rejected (HTTP 400)" in message
     assert "cross-region" not in message
+
+
+def test_bedrock_tool_schemas_include_type_custom(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    client = BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+
+    tool = types.SimpleNamespace(
+        name="my_tool",
+        description="does something",
+        input_schema={"type": "object", "properties": {}},
+    )
+    schemas = client.tool_schemas([tool])
+
+    assert len(schemas) == 1
+    assert schemas[0]["type"] == "custom"
+    assert schemas[0]["name"] == "my_tool"
+    assert schemas[0]["description"] == "does something"
+    assert "input_schema" in schemas[0]


### PR DESCRIPTION
## Summary

- Bedrock's Messages API requires every tool object to include a `type` field (`"type": "custom"`), but `BedrockAgentClient` was inheriting `tool_schemas()` from `AnthropicAgentClient` which omits it, causing HTTP 400 `missing field 'type'` errors on every investigation.
- Override `tool_schemas()` in `BedrockAgentClient` to prepend `"type": "custom"` on each tool schema.
- Add a unit test asserting the override is present.

## Test plan

- [x] `tests/services/test_agent_llm_client.py::test_bedrock_tool_schemas_include_type_custom` — new test verifying the override
- [x] All 33 existing `test_agent_llm_client` tests pass

Closes #2182

---
_Generated by [Claude Code](https://claude.ai/code/session_016PGa4vFiwpYpqFVciXFgLD)_