### PR TITLE
fix(cli): suppress BrokenPipeError when showing ClickException

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -248,7 +248,8 @@ def main(argv: list[str] | None = None) -> int:
     except click.ClickException as exc:
         if _should_capture_cli_exception(exc):
             report_exception(exc, context="cli.main")
-        exc.show()
+        with suppress(BrokenPipeError):
+            exc.show()
         return exc.exit_code
     except click.exceptions.Exit as exc:
         return exc.exit_code

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -507,6 +507,24 @@ def test_default_no_args_enters_repl(monkeypatch) -> None:
     assert landing_calls == [], "REPL should run, not landing page"
 
 
+def test_main_survives_broken_pipe_on_click_exception(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.__main__.capture_first_run_if_needed", lambda: None)
+    monkeypatch.setattr("app.cli.__main__.shutdown_analytics", lambda **_kw: None)
+    monkeypatch.setattr("app.cli.__main__.capture_cli_invoked", lambda *_args: None)
+
+    original_show = click.exceptions.UsageError.show
+
+    def _raise_broken_pipe(self, file=None):  # type: ignore[no-untyped-def]
+        raise BrokenPipeError(32, "Broken pipe")
+
+    monkeypatch.setattr(click.exceptions.UsageError, "show", _raise_broken_pipe)
+
+    exit_code = main(["--definitely-wrong-option"])
+
+    assert exit_code == 2
+    monkeypatch.setattr(click.exceptions.UsageError, "show", original_show)
+
+
 def test_no_reload_flag_passes_reload_disabled(monkeypatch) -> None:
     monkeypatch.setattr("app.cli.__main__.capture_first_run_if_needed", lambda: None)
     monkeypatch.setattr("app.cli.__main__.shutdown_analytics", lambda **_kw: None)


### PR DESCRIPTION
## Summary

- When `exc.show()` writes a Click error to a broken pipe (e.g. `opensre --bad-option | head`), a `BrokenPipeError` is raised inside the `ClickException` handler, escapes uncaught, and generates a spurious Sentry event.
- `suppress` is already imported in `app/cli/__main__.py`; wrap `exc.show()` with `with suppress(BrokenPipeError):` so the write is silently skipped when the pipe is gone — the exit code is still returned correctly.
- Add a unit test that patches `exc.show()` to raise `BrokenPipeError` and asserts `main()` still returns exit code 2 without propagating.

## Test plan

- [x] `tests/cli/test_main.py::test_main_survives_broken_pipe_on_click_exception` — new test
- [x] All 20 `test_main` tests pass

Closes #2184

---
_Generated by [Claude Code](https://claude.ai/code/session_016PGa4vFiwpYpqFVciXFgLD)_