### PR TITLE
fix(sentry): suppress Bedrock token expiry and proxy model-name errors from Sentry

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -498,6 +498,11 @@ class BedrockLLMClient:
                         f"Bedrock model '{self._model}' was not found in the configured region. "
                         "Check the model ID, region, or inference profile."
                     ) from err
+                if code in ("ExpiredTokenException", "TokenRefreshRequired"):
+                    raise RuntimeError(
+                        "Bedrock API request failed: your AWS security token has expired. "
+                        "Refresh your credentials (IAM role, instance profile, or ~/.aws/credentials)."
+                    ) from err
                 if code in ("AccessDeniedException", "UnauthorizedException"):
                     # AccessDeniedException is overloaded on Bedrock: it can mean
                     # missing IAM, missing per-region/per-model Bedrock access
@@ -624,16 +629,18 @@ def _format_anthropic_retry_error(err: Exception) -> str:
 # LiteLLM/Anthropic surfaces an unrecognized model ID as an HTTP 400 with a
 # message containing "The provided model identifier is invalid." (note: the
 # OpenAI-compatible 404 code-path is preferred, but LiteLLM relays 400 here).
-# Detection is intentionally a substring match because there is no stable error
-# code for this case across LiteLLM/Anthropic. Update this constant if upstream
-# rewords the message — the failure mode is "fall through to a generic HTTP 400
+# Self-hosted proxies may use different wording (e.g. "Invalid model name passed
+# in model=..."). Detection is intentionally a substring match because there is
+# no stable error code for this case across proxies. Update this tuple if a new
+# proxy wording appears — the failure mode is "fall through to a generic HTTP 400
 # message that is not Sentry-filtered" (see issue #1806).
-_OPENAI_INVALID_MODEL_IDENTIFIER_PHRASE = "model identifier"
+_OPENAI_INVALID_MODEL_IDENTIFIER_PHRASES = ("model identifier", "invalid model name")
 
 
 def _is_openai_invalid_model_identifier(err: OpenAIBadRequestError) -> bool:
     """True if the OpenAIBadRequestError message indicates an unknown model id."""
-    return _OPENAI_INVALID_MODEL_IDENTIFIER_PHRASE in (err.message or "").lower()
+    msg = (err.message or "").lower()
+    return any(phrase in msg for phrase in _OPENAI_INVALID_MODEL_IDENTIFIER_PHRASES)
 
 
 def _format_openai_connection_error(err: Exception, provider_label: str) -> str:

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -75,6 +75,9 @@ _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     # Bedrock cross-region inference profile misconfiguration (HTTP 400 "on-demand throughput
     # isn't supported") — user must add the 'us.' prefix to their model ID.
     re.compile(r"\brequires a cross-region inference profile\b", re.I),
+    # Bedrock temporary credential expiry (ExpiredTokenException / TokenRefreshRequired).
+    # The IAM role/instance-profile token needs refreshing — operator-actionable, not a code bug.
+    re.compile(r"\bAWS security token has expired\b", re.I),
 )
 
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes three Sentry issues caused by LLM error detection gaps:

- **#2250** — Self-hosted OpenAI-compatible proxies return `"Invalid model name passed in model=..."` (not `"model identifier"`), so `_is_openai_invalid_model_identifier` returned `False` and the raw HTTP 400 body fell through to Sentry instead of the clean "model not found" message.
- **#2258 / #2259** — `ExpiredTokenException` from the Bedrock `converse` API was not specifically handled: the code retried it 3× uselessly then raised a generic `"Bedrock API request failed after 3 attempts: ClientError: ..."` message that matched no Sentry filter pattern.

### Changes

**`app/services/llm_client.py`**
- Replace `_OPENAI_INVALID_MODEL_IDENTIFIER_PHRASE` (single string) with `_OPENAI_INVALID_MODEL_IDENTIFIER_PHRASES` (tuple) covering both `"model identifier"` and `"invalid model name"`, so proxy-specific wording is caught and the clean `RuntimeError` is raised.
- Add an explicit `ExpiredTokenException` / `TokenRefreshRequired` branch in `BedrockLLMClient._invoke_converse` that raises immediately with a user-facing "credentials expired" message (no wasteful retries).

**`app/utils/sentry_sdk.py`**
- Add `re.compile(r"\bAWS security token has expired\b", re.I)` to `_OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS` so the new clean Bedrock message is classified as operator-actionable and suppressed before transport.

## Test plan

- [x] `uv run ruff check app/services/llm_client.py app/utils/sentry_sdk.py` — clean
- [x] `uv run ruff format --check app/services/llm_client.py app/utils/sentry_sdk.py` — clean
- [x] `uv run pytest -k "sentry or llm_client or llm or openai or bedrock or model"` — 887 passed

Closes #2250
Closes #2258
Closes #2259
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWFh7CzkFT1S7qdCpb8JCc)_