### PR TITLE
fix(llm_client): detect 'invalid model name' from OpenAI-compatible proxies as model-not-found

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -624,16 +624,18 @@ def _format_anthropic_retry_error(err: Exception) -> str:
 # LiteLLM/Anthropic surfaces an unrecognized model ID as an HTTP 400 with a
 # message containing "The provided model identifier is invalid." (note: the
 # OpenAI-compatible 404 code-path is preferred, but LiteLLM relays 400 here).
-# Detection is intentionally a substring match because there is no stable error
-# code for this case across LiteLLM/Anthropic. Update this constant if upstream
-# rewords the message — the failure mode is "fall through to a generic HTTP 400
-# message that is not Sentry-filtered" (see issue #1806).
-_OPENAI_INVALID_MODEL_IDENTIFIER_PHRASE = "model identifier"
+# Some OpenAI-compatible proxies instead say "Invalid model name passed in
+# model=...". Detection is a substring match across all known variants because
+# there is no stable error code for this case. The failure mode when a phrase
+# is missing is "fall through to a generic HTTP 400 message that is not
+# Sentry-filtered" (see issue #1806, #2250).
+_OPENAI_INVALID_MODEL_PHRASES = ("model identifier", "invalid model name")
 
 
 def _is_openai_invalid_model_identifier(err: OpenAIBadRequestError) -> bool:
     """True if the OpenAIBadRequestError message indicates an unknown model id."""
-    return _OPENAI_INVALID_MODEL_IDENTIFIER_PHRASE in (err.message or "").lower()
+    msg = (err.message or "").lower()
+    return any(phrase in msg for phrase in _OPENAI_INVALID_MODEL_PHRASES)
 
 
 def _format_openai_connection_error(err: Exception, provider_label: str) -> str:

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -864,6 +864,32 @@ def test_openai_invoke_stream_invalid_model_identifier_raises_not_found(monkeypa
         list(client.invoke_stream("hello"))
 
 
+def test_openai_invoke_invalid_model_name_proxy_raises_not_found(monkeypatch) -> None:
+    """OpenAI-compatible proxies that return 'Invalid model name' are treated as model-not-found."""
+
+    class _Completions:
+        def create(self, **_kwargs):
+            raise _make_fake_openai_bad_request_error(
+                "Error code: 400 - {'error': '/chat/completions: Invalid model name passed in "
+                "model=claude-sonnet-4-6. Call `/v1/models` to view available models for your key.'}"
+            )
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+
+    client = llm_client.OpenAILLMClient(model="claude-sonnet-4-6")
+    with pytest.raises(RuntimeError, match="Check your configured model name or endpoint"):
+        client.invoke("hello")
+
+
 def test_openai_invoke_stream_yields_delta_content_chunks(monkeypatch) -> None:
     """invoke_stream() routes through the same builder and yields delta.content in order."""
     fake, captured = _make_capturing_openai(chunk_contents=["Hel", "lo, ", "world"])


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Sentry issue #2250: `RuntimeError: Openai request rejected (HTTP 400)` surfaced when a user configured an OpenAI-compatible proxy endpoint but passed a Claude model name (`claude-sonnet-4-6`). The proxy returned `"Invalid model name passed in model=..."`, which the existing single-phrase detector (`"model identifier"`) did not match, so the error fell through to a raw HTTP 400 message.
- Replaced `_OPENAI_INVALID_MODEL_IDENTIFIER_PHRASE` (single string) with `_OPENAI_INVALID_MODEL_PHRASES` (tuple) covering both `"model identifier"` (LiteLLM/Anthropic) and `"invalid model name"` (other OpenAI-compatible proxies).
- Users now get the actionable `"Check your configured model name or endpoint"` message instead of the raw API error blob.

## Test plan

- [ ] `test_openai_invoke_invalid_model_identifier_raises_not_found` — existing LiteLLM/Anthropic phrase still caught
- [ ] `test_openai_invoke_stream_invalid_model_identifier_raises_not_found` — streaming path still caught
- [ ] `test_openai_invoke_invalid_model_name_proxy_raises_not_found` — new test for the proxy error phrase from issue #2250

All three pass: `93 passed` in `tests/services/test_llm_client.py`.

Closes #2250
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mu1rchrqXYo7SPtapRWGs7)_