### PR TITLE
fix(llm_client): recognize 'invalid model name' from OpenAI-compatible proxies

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -625,15 +625,17 @@ def _format_anthropic_retry_error(err: Exception) -> str:
 # message containing "The provided model identifier is invalid." (note: the
 # OpenAI-compatible 404 code-path is preferred, but LiteLLM relays 400 here).
 # Detection is intentionally a substring match because there is no stable error
-# code for this case across LiteLLM/Anthropic. Update this constant if upstream
+# code for this case across LiteLLM/Anthropic. Update this set if upstream
 # rewords the message — the failure mode is "fall through to a generic HTTP 400
 # message that is not Sentry-filtered" (see issue #1806).
-_OPENAI_INVALID_MODEL_IDENTIFIER_PHRASE = "model identifier"
+# "model identifier" — OpenAI proper; "invalid model name" — OpenAI-compatible proxies.
+_OPENAI_INVALID_MODEL_PHRASES = frozenset({"model identifier", "invalid model name"})
 
 
 def _is_openai_invalid_model_identifier(err: OpenAIBadRequestError) -> bool:
     """True if the OpenAIBadRequestError message indicates an unknown model id."""
-    return _OPENAI_INVALID_MODEL_IDENTIFIER_PHRASE in (err.message or "").lower()
+    msg = (err.message or "").lower()
+    return any(phrase in msg for phrase in _OPENAI_INVALID_MODEL_PHRASES)
 
 
 def _format_openai_connection_error(err: Exception, provider_label: str) -> str:

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -864,6 +864,32 @@ def test_openai_invoke_stream_invalid_model_identifier_raises_not_found(monkeypa
         list(client.invoke_stream("hello"))
 
 
+def test_openai_invoke_invalid_model_name_proxy_raises_not_found(monkeypatch) -> None:
+    """OpenAI-compatible proxy 'Invalid model name' phrasing triggers the model-not-found path."""
+
+    class _Completions:
+        def create(self, **_kwargs):
+            raise _make_fake_openai_bad_request_error(
+                "Error code: 400 - {'error': '/chat/completions: Invalid model name passed in "
+                "model=claude-sonnet-4-6. Call `/v1/models` to view available models for your key.'}"
+            )
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+
+    client = llm_client.OpenAILLMClient(model="claude-sonnet-4-6")
+    with pytest.raises(RuntimeError, match="Check your configured model name or endpoint"):
+        client.invoke("hello")
+
+
 def test_openai_invoke_stream_yields_delta_content_chunks(monkeypatch) -> None:
     """invoke_stream() routes through the same builder and yields delta.content in order."""
     fake, captured = _make_capturing_openai(chunk_contents=["Hel", "lo, ", "world"])

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -890,6 +890,32 @@ def test_openai_invoke_invalid_model_name_proxy_raises_not_found(monkeypatch) ->
         client.invoke("hello")
 
 
+def test_openai_invoke_stream_invalid_model_name_proxy_raises_not_found(monkeypatch) -> None:
+    """invoke_stream: proxy 'Invalid model name' phrasing triggers the model-not-found path."""
+
+    class _Completions:
+        def create(self, **_kwargs):
+            raise _make_fake_openai_bad_request_error(
+                "Error code: 400 - {'error': '/chat/completions: Invalid model name passed in "
+                "model=claude-sonnet-4-6. Call `/v1/models` to view available models for your key.'}"
+            )
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+
+    client = llm_client.OpenAILLMClient(model="claude-sonnet-4-6")
+    with pytest.raises(RuntimeError, match="Check your configured model name or endpoint"):
+        list(client.invoke_stream("hello"))
+
+
 def test_openai_invoke_stream_yields_delta_content_chunks(monkeypatch) -> None:
     """invoke_stream() routes through the same builder and yields delta.content in order."""
     fake, captured = _make_capturing_openai(chunk_contents=["Hel", "lo, ", "world"])


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Sentry issue #2250: `RuntimeError: Openai request rejected (HTTP 400)` when an OpenAI-compatible proxy rejects a Claude model name
- Root cause: `_is_openai_invalid_model_identifier` only matched OpenAI's own `"model identifier"` phrasing; proxy endpoints (Requesty, LiteLLM, etc.) say `"Invalid model name passed in model=..."` instead
- Fix: extend `_OPENAI_INVALID_MODEL_PHRASES` to cover both patterns, so both produce the actionable `"model was not found / check your configured model name or endpoint"` message instead of the opaque HTTP 400 dump

## Test plan

- [ ] Existing `test_openai_invoke_invalid_model_identifier_raises_not_found` still passes (OpenAI proper phrasing)
- [ ] New `test_openai_invoke_invalid_model_name_proxy_raises_not_found` covers the proxy phrasing from Sentry #2250
- [ ] `uv run pytest tests/services/test_llm_client.py -k invalid_model` — all 3 pass

Closes #2250

https://claude.ai/code/session_019Lih1mVkx7ihLyKLx5Q2wR
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Lih1mVkx7ihLyKLx5Q2wR)_