### PR TITLE
fix: detect OpenRouter "invalid model name" error as model-not-found

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -628,12 +628,16 @@ def _format_anthropic_retry_error(err: Exception) -> str:
 # code for this case across LiteLLM/Anthropic. Update this constant if upstream
 # rewords the message — the failure mode is "fall through to a generic HTTP 400
 # message that is not Sentry-filtered" (see issue #1806).
-_OPENAI_INVALID_MODEL_IDENTIFIER_PHRASE = "model identifier"
+# OpenRouter uses "invalid model name" rather than "model identifier".
+_OPENAI_INVALID_MODEL_PHRASES: frozenset[str] = frozenset(
+    ["model identifier", "invalid model name"]
+)
 
 
 def _is_openai_invalid_model_identifier(err: OpenAIBadRequestError) -> bool:
     """True if the OpenAIBadRequestError message indicates an unknown model id."""
-    return _OPENAI_INVALID_MODEL_IDENTIFIER_PHRASE in (err.message or "").lower()
+    msg = (err.message or "").lower()
+    return any(phrase in msg for phrase in _OPENAI_INVALID_MODEL_PHRASES)
 
 
 def _format_openai_connection_error(err: Exception, provider_label: str) -> str:

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -864,6 +864,75 @@ def test_openai_invoke_stream_invalid_model_identifier_raises_not_found(monkeypa
         list(client.invoke_stream("hello"))
 
 
+def test_is_openai_invalid_model_identifier_matches_both_phrases() -> None:
+    """Both the LiteLLM/Anthropic and OpenRouter phrasings must be detected."""
+    openai_err = _make_fake_openai_bad_request_error(
+        "The provided model identifier is invalid."
+    )
+    openrouter_err = _make_fake_openai_bad_request_error(
+        "{'error': '/chat/completions: Invalid model name passed in model=claude-sonnet-4-6.'}"
+    )
+    unrelated_err = _make_fake_openai_bad_request_error("content policy violation")
+
+    assert llm_client._is_openai_invalid_model_identifier(openai_err)
+    assert llm_client._is_openai_invalid_model_identifier(openrouter_err)
+    assert not llm_client._is_openai_invalid_model_identifier(unrelated_err)
+
+
+def test_openai_invoke_openrouter_invalid_model_name_raises_not_found(monkeypatch) -> None:
+    """OpenRouter's 'Invalid model name' 400 error maps to the user-friendly not-found message."""
+
+    class _Completions:
+        def create(self, **_kwargs):
+            raise _make_fake_openai_bad_request_error(
+                "Error code: 400 - {'error': {'message': \"{'error': '/chat/completions: "
+                "Invalid model name passed in model=claude-sonnet-4-6.'}\"}}"
+            )
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+
+    client = llm_client.OpenAILLMClient(model="claude-sonnet-4-6")
+    with pytest.raises(RuntimeError, match="Check your configured model name or endpoint"):
+        client.invoke("hello")
+
+
+def test_openai_invoke_stream_openrouter_invalid_model_name_raises_not_found(
+    monkeypatch,
+) -> None:
+    """Same detection in the streaming path."""
+
+    class _Completions:
+        def create(self, **_kwargs):
+            raise _make_fake_openai_bad_request_error(
+                "Error code: 400 - {'error': {'message': \"{'error': '/chat/completions: "
+                "Invalid model name passed in model=claude-sonnet-4-6.'}\"}}"
+            )
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+
+    client = llm_client.OpenAILLMClient(model="claude-sonnet-4-6")
+    with pytest.raises(RuntimeError, match="Check your configured model name or endpoint"):
+        list(client.invoke_stream("hello"))
+
+
 def test_openai_invoke_stream_yields_delta_content_chunks(monkeypatch) -> None:
     """invoke_stream() routes through the same builder and yields delta.content in order."""
     fake, captured = _make_capturing_openai(chunk_contents=["Hel", "lo, ", "world"])

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -866,9 +866,7 @@ def test_openai_invoke_stream_invalid_model_identifier_raises_not_found(monkeypa
 
 def test_is_openai_invalid_model_identifier_matches_both_phrases() -> None:
     """Both the LiteLLM/Anthropic and OpenRouter phrasings must be detected."""
-    openai_err = _make_fake_openai_bad_request_error(
-        "The provided model identifier is invalid."
-    )
+    openai_err = _make_fake_openai_bad_request_error("The provided model identifier is invalid.")
     openrouter_err = _make_fake_openai_bad_request_error(
         "{'error': '/chat/completions: Invalid model name passed in model=claude-sonnet-4-6.'}"
     )


### PR DESCRIPTION
## Summary

- `_is_openai_invalid_model_identifier` only matched OpenAI's wording `"model identifier"`, so OpenRouter's `"Invalid model name"` 400 error fell through to the raw, confusing `"request rejected (HTTP 400): ..."` RuntimeError
- Users who set `OPENROUTER_MODEL` (or `OPENROUTER_REASONING_MODEL`) to an Anthropic model ID like `claude-sonnet-4-6` now get the clear `"model was not found — check your configured model name or endpoint"` message instead
- Changed the single string constant to a `frozenset` and updated the check to match any phrase in the set; the detection function signature and callers are unchanged

Closes #2250

## Test plan

- [ ] `make lint` passes
- [ ] `make typecheck` passes
- [ ] `make format-check` passes
- [ ] `make test-cov` — 7121 passed, 37 skipped

https://claude.ai/code/session_01MBWJaYXG2ECanz1ELKS4Rp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBWJaYXG2ECanz1ELKS4Rp)_