### PR TITLE
fix(bedrock): add missing type field to Anthropic tool schema

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -53,6 +53,7 @@ class AgentLLMResponse:
 
 def _anthropic_tool_schema(tool: Any) -> dict[str, Any]:
     return {
+        "type": "custom",
         "name": tool.name,
         "description": tool.description,
         "input_schema": tool.public_input_schema,

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -876,3 +876,23 @@ def test_openai_empty_choices_raises_runtime_error(
 
     with pytest.raises(RuntimeError, match="unexpected response"):
         client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+
+def test_anthropic_tool_schema_includes_type_custom() -> None:
+    """Regression: Bedrock's API validator rejects tool defs missing the 'type' field."""
+    from app.services.agent_llm_client import AnthropicAgentClient
+
+    fake_tool = types.SimpleNamespace(
+        name="get_logs",
+        description="Fetch log entries",
+        public_input_schema={"type": "object", "properties": {}},
+    )
+    client = AnthropicAgentClient.__new__(AnthropicAgentClient)
+    schemas = client.tool_schemas([fake_tool])
+
+    assert len(schemas) == 1
+    schema = schemas[0]
+    assert schema["type"] == "custom", "Bedrock requires type='custom' on every tool definition"
+    assert schema["name"] == "get_logs"
+    assert schema["description"] == "Fetch log entries"
+    assert "input_schema" in schema


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Bedrock's API endpoint requires each tool definition to include `"type": "custom"` at the root level
- `_anthropic_tool_schema()` was missing this field, causing `BadRequestError: 400 - missing field 'type'` when `BedrockAgentClient` sent tool calls through Bedrock
- `BedrockAgentClient` inherits `tool_schemas()` from `AnthropicAgentClient`, so the fix in the shared helper covers both clients

## Test plan

- [ ] Existing agent tests pass (`tests/agent/`)
- [ ] `BedrockAgentClient` tool calls no longer produce 400 validation errors

Closes #2329
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZjFJycyFacBjSb4hVs9gm)_