### PR TITLE
fix(cli): create parent dirs before writing output JSON

### DIFF
--- a/app/cli/support/args.py
+++ b/app/cli/support/args.py
@@ -51,6 +51,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def write_json(data: Any, path: str | None) -> None:
     """Write JSON to file or stdout."""
     if path:
-        Path(path).write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     else:
         print(json.dumps(data, indent=2))


### PR DESCRIPTION
## Summary

- `write_json` crashed with `FileNotFoundError` when the `--output` path's parent directory did not exist (e.g. `tests/results/`).
- Added `p.parent.mkdir(parents=True, exist_ok=True)` before writing so the directory is created automatically.

## Test plan

- [ ] Run `opensre investigate --output tests/results/foo.json` — previously failed with `FileNotFoundError`, now creates `tests/results/` and writes the file correctly.
- [ ] Existing unit tests pass (`make test-cov`).

Closes #2328

https://claude.ai/code/session_016QaiaP2Azu9YpbeVS37g8P

---
_Generated by [Claude Code](https://claude.ai/code/session_016QaiaP2Azu9YpbeVS37g8P)_