### PR TITLE
fix(cli): create parent dirs before writing JSON output file

### DIFF
--- a/app/cli/support/args.py
+++ b/app/cli/support/args.py
@@ -51,6 +51,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def write_json(data: Any, path: str | None) -> None:
     """Write JSON to file or stdout."""
     if path:
-        Path(path).write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     else:
         print(json.dumps(data, indent=2))

--- a/tests/cli/test_args.py
+++ b/tests/cli/test_args.py
@@ -26,6 +26,15 @@ def test_write_json_writes_to_file(tmp_path: Path) -> None:
     assert output_path.read_text(encoding="utf-8") == json.dumps(payload, indent=2) + "\n"
 
 
+def test_write_json_creates_missing_parent_dirs(tmp_path: Path) -> None:
+    payload = {"status": "ok", "count": 2}
+    output_path = tmp_path / "nested" / "deep" / "result.json"
+
+    write_json(payload, str(output_path))
+
+    assert output_path.read_text(encoding="utf-8") == json.dumps(payload, indent=2) + "\n"
+
+
 @pytest.mark.parametrize(
     ("argv", "expected_error"),
     [


### PR DESCRIPTION
## Summary

- `write_json` in `app/cli/support/args.py` now calls `Path.parent.mkdir(parents=True, exist_ok=True)` before writing the output file, so paths like `tests/results/some_file.json` no longer raise `FileNotFoundError` when the parent directory doesn't exist.

Closes #2328

## Root cause

`Path(path).write_text(...)` raises `FileNotFoundError` when any ancestor directory in the output path is missing. The fix eagerly creates all missing parent directories before the write.

## Test plan

- [x] `uv run pytest tests/cli/ -v` — 1552 passed (1 pre-existing async-plugin skip, 1 pre-existing live-LLM skip)
- [x] `uv run ruff check app/ tests/` — all checks passed
- [x] `uv run ruff format --check app/ tests/` — all files already formatted

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESmDBCzTYpGkfX9c1thuLe)_