### PR TITLE
fix(cli,agent): create output parent dirs and add type to Anthropic tool schema

### DIFF
--- a/app/cli/support/args.py
+++ b/app/cli/support/args.py
@@ -51,6 +51,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def write_json(data: Any, path: str | None) -> None:
     """Write JSON to file or stdout."""
     if path:
-        Path(path).write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        out = Path(path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     else:
         print(json.dumps(data, indent=2))

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -53,6 +53,7 @@ class AgentLLMResponse:
 
 def _anthropic_tool_schema(tool: Any) -> dict[str, Any]:
     return {
+        "type": "custom",
         "name": tool.name,
         "description": tool.description,
         "input_schema": tool.public_input_schema,


### PR DESCRIPTION
## Summary

- **#2328 – FileNotFoundError on `--output` paths**: `write_json` called `Path.write_text` without first ensuring the parent directory exists. Any `--output` path whose parent dir doesn't exist (e.g. `tests/results/foo.json`) crashed with `FileNotFoundError`. Fixed by calling `out.parent.mkdir(parents=True, exist_ok=True)` before writing.

- **#2329 – Bedrock 400 "missing field `type`"**: `_anthropic_tool_schema` omitted the `type` field from each tool dict. The standard Anthropic API treats it as optional, but the Bedrock endpoint is stricter and rejects requests with `Invalid 'tools': missing field 'type'`. Fixed by adding `"type": "custom"` to the returned dict.

## Test plan

- [x] Lint: `uv run ruff check` — clean
- [x] Format: `uv run ruff format --check` — clean
- [x] Type check: `uv run mypy app/cli/support/args.py app/services/agent_llm_client.py` — clean
- [x] `uv run pytest tests/cli/` — 284 passed (1 pre-existing live-LLM error unrelated to these changes)
- [x] `uv run pytest tests/services/` — all relevant tests pass (pre-existing async plugin failures unrelated)

Closes #2328
Closes #2329

---
_Generated by [Claude Code](https://claude.ai/code/session_019viNqazYy6yPLp3LK4SkMq)_