### PR TITLE
docs: investigation tool-calling guide and strict schema contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Before any push or PR creation, follow the mandatory checklist in [CI.md](CI.md)
 | `Makefile`            | Canonical local automation for install, test, verify, deploy, and cleanup targets.                 |
 | `README.md`           | Product overview, install, quick start, high-level capabilities, and links to deeper docs.         |
 | `docs/DEVELOPMENT.md` | Contributor workflows: CI parity commands, dev container, benchmark, deployment, telemetry detail. |
+| `docs/investigation-tool-calling.md` | Investigation ReAct tool schemas, LLM invoke payloads, and message shapes (all providers). |
 | `SETUP.md`            | Machine setup (all platforms, Windows, MCP/OpenClaw, troubleshooting).                             |
 | `CI.md`               | Mandatory pre-push checklist: lint, format, typecheck, tests — agents MUST follow before pushing. |
 | `CONTRIBUTING.md`     | Contribution workflow, branch/PR guidance, and quality expectations.                               |
@@ -163,7 +164,7 @@ Basic steps:
 - If a new feature is shipped (tool, CLI command, pipeline behavior, integration) -> add a `docs/` page or section covering usage, configuration, and examples before the PR is opened.
 - If a new `docs/` page is added or renamed -> register it in `docs/docs.json` under the correct `pages` array in the same PR (path without `.mdx`, e.g. `messaging/whatsapp` for `docs/messaging/whatsapp.mdx`).
 - If an existing feature changes behavior, flags, or config shape -> update the relevant `docs/` page in the same PR; docs and code must stay in sync.
-- If a tool's API or schema changes -> update docs in `docs/` and update the related unit tests, usually under `tests/tools/`.
+- If a tool's API or schema changes -> update docs in `docs/` and update the related unit tests, usually under `tests/tools/`. For investigation LLM tool-calling (any provider), follow [docs/investigation-tool-calling.md](docs/investigation-tool-calling.md).
 - If an integration changes -> update `tests/integrations/` and verify with `make verify-integrations`.
 - If adding a new integration -> follow the New Integration Checklist below before opening the PR for review.
 - If adding new tests -> always place them in `tests/`, never in `app/` (no inline tests).
@@ -200,6 +201,7 @@ The fastest local loop is `make test-cov`, which exercises the non-live unit sui
 - Legacy graph dev server: removed; use `make dev` for a local uvicorn hint or run investigations via the CLI.
 - Docker requirement: Several targets, including the Grafana local stack and Chaos Mesh workflows, require a running Docker daemon.
 - Docs navigation: Adding an `.mdx` file under `docs/` is not enough — Mintlify only shows pages listed in `docs/docs.json`. Forgetting the `pages` entry leaves the doc unreachable from the site sidebar.
+- Investigation tool schemas: draft-07 JSON Schema (e.g. `"type": ["object", "null"]`) can pass loose checks but fail the LLM API on first invoke because **all** available investigation tools are sent together. Normalize in the provider adapter and extend registry contract tests; see [docs/investigation-tool-calling.md](docs/investigation-tool-calling.md).
 
 ## 6. New Integration Checklist
 

--- a/app/services/AGENTS.md
+++ b/app/services/AGENTS.md
@@ -4,6 +4,9 @@ Use this directory when adding or updating an **API-backed** LLM provider (Anthr
 OpenAI-compatible, Bedrock, etc.). For subprocess CLIs, use
 `app/integrations/llm_cli/AGENTS.md`.
 
+For investigation **tool calling** (schemas, invoke payloads, message shapes—all providers), see
+[docs/investigation-tool-calling.md](../../docs/investigation-tool-calling.md).
+
 Primary reference for provider discovery:
 
 - [https://docs.openclaw.ai/providers](https://docs.openclaw.ai/providers)
@@ -15,6 +18,8 @@ Primary reference for provider discovery:
 | ---------------------------- | --------------------------------------------------------------------------------- |
 | `app/config.py`              | Declares `LLMProvider`, provider env vars, defaults, and validation requirements. |
 | `app/services/llm_client.py` | Routes `LLM_PROVIDER` to the runtime client implementation.                       |
+| `app/services/agent_llm_client.py` | Investigation ReAct loop: tool-calling clients (`get_agent_llm`).              |
+| `app/agent/investigation.py` | Seed tool calls and provider-specific assistant / tool-result messages.           |
 | `app/cli/wizard/config.py`   | Defines onboarding metadata (`SUPPORTED_PROVIDERS`) and model choices.            |
 | `app/cli/wizard/env_sync.py` | Keeps `.env` values in sync when provider/model changes.                          |
 
@@ -23,9 +28,8 @@ Primary reference for provider discovery:
 
 1. Add provider literal to `LLMProvider` and normalization/validation paths in `app/config.py`.
 2. Add provider metadata in `app/cli/wizard/config.py` (`ProviderOption`, model env vars, defaults).
-3. Add runtime routing in `app/services/llm_client.py`:
-  - OpenAI-compatible providers should use `OpenAILLMClient` with provider base URL + key env var.
-  - Provider-specific SDKs can use a dedicated client class if needed.
+3. Add runtime routing in `app/services/llm_client.py` and, for investigation tool calling,
+   `app/services/agent_llm_client.py` (see [investigation-tool-calling.md](../../docs/investigation-tool-calling.md)).
 4. Update `.env` sync behavior if you introduce new model/API env keys.
 5. Add or update tests under `tests/services/` (and wizard tests if onboarding changes) for the new provider path.
 
@@ -35,4 +39,3 @@ Primary reference for provider discovery:
 - Use one source of truth for provider defaults in `app/config.py`.
 - Treat API keys as secrets: store in keychain via existing credential helpers, not in plaintext docs.
 - Prefer OpenAI-compatible client path for providers exposing compatible APIs.
-

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,6 +36,10 @@ Before a PR, run at least `make lint`, `make format-check`, `make typecheck`, an
 
 Routing precedence, postprocessing transforms, compatibility seams, and the rule-extension checklist are documented in [`docs/routing-policy-architecture.md`](https://github.com/Tracer-Cloud/opensre/blob/main/docs/routing-policy-architecture.md).
 
+## Investigation tool calling
+
+Tool schemas, provider adapters (`agent_llm_client.py`), and investigation message shapes are documented in [`docs/investigation-tool-calling.md`](investigation-tool-calling.md) (all LLM providers, not vendor-specific).
+
 ## Interactive shell: REPL watchdog demo
 
 PR reviewers expect a **visible demo** (terminal log or screenshot) in the PR under **Demo/Screenshot**, not only tests. Copy the exact steps from this section into your PR description, then attach your terminal output or recording.

--- a/docs/investigation-tool-calling.md
+++ b/docs/investigation-tool-calling.md
@@ -1,0 +1,134 @@
+# Investigation tool calling
+
+Contributor guide for the investigation ReAct loop: tool schemas, LLM invoke payloads, and
+conversation messages. Applies to **every** provider the agent uses (Anthropic, OpenAI-compatible,
+CLI-backed, Bedrock, and future clients)—not one vendor.
+
+## Architecture
+
+The investigation agent does **not** call integration APIs through the LLM. The flow is:
+
+1. **Tools** — `get_registered_tools("investigation")`, filtered with `tool.is_available(...)`.
+2. **Schemas** — `llm.tool_schemas(tools)` from `get_agent_llm()` in `app/services/agent_llm_client.py`.
+   Each client class shapes schemas for its API (function definitions, tool specs, CLI prompt JSON, etc.).
+3. **Invoke** — `llm.invoke(messages, system=..., tools=tool_schemas)`; the model returns tool calls.
+4. **Execute** — Tools run locally; results are appended as user/assistant turns the **same** client can read on the next invoke.
+5. **Seed path** — Before the loop, `_build_seed_calls` may inject deterministic tool runs; synthetic
+   assistant + tool-result messages must match the active client (`app/agent/investigation.py`).
+
+```text
+investigation.py  →  get_agent_llm()  →  *AgentClient.tool_schemas / invoke
+                    ↓
+              app/tools/*  (input_schema, extract_params, run)
+```
+
+### Where code lives
+
+| Concern | Location |
+| -------- | -------- |
+| Provider routing | `app/services/agent_llm_client.py` (`get_agent_llm`, client classes) |
+| Chat / non-agent LLM | `app/services/llm_client.py` (separate path—changes here do not fix investigation) |
+| Investigation loop & message dispatch | `app/agent/investigation.py` |
+| Provider-specific schema/message helpers | Next to the client implementing `tool_schemas()` (strict normalizers live beside that client) |
+| Tool definitions | `app/tools/` (`input_schema`, `public_input_schema`) |
+
+When adding a provider, implement **both** `tool_schemas()` and the message shapes `investigation.py`
+already branches on (or extend those branches). Do not assume one vendor’s JSON tool format works elsewhere.
+
+## Why bugs are easy to miss
+
+- **JSON Schema draft-07 vs API strictness** — Tool authors often use patterns that validate in draft-07
+  (`"type": ["object", "null"]`, `anyOf`, `nullable`, implicit objects, bare `items: {}`). A given
+  LLM API may require a **single string** `type`, explicit `items`, and a closed set of keys. Unit
+  tests that only check “has properties” miss union `type` arrays.
+- **All tools in one request** — Investigation sends **every available** tool schema in a single invoke.
+  One invalid schema fails the whole call (HTTP 400, “invalid tools”, etc.) even when the alert never
+  uses that tool.
+- **Multiple code paths** — Fixes in `llm_client.py`, chat, or routing do not apply to
+  `agent_llm_client.py` unless wired there. Provider-specific normalizers must run in `tool_schemas()`
+  (or shared helpers the client calls).
+- **Contract tests can lag APIs** — Registry-wide schema tests must encode the **strictest** rules your
+  shipped adapters enforce. Extend assertions when production shows a new rejection reason.
+
+## Tool `input_schema` (authoring)
+
+When adding or changing tools under `app/tools/`:
+
+- [ ] **Top-level** — Investigation tools use `type: object` with a `properties` dict.
+- [ ] **Single `type`** — Prefer one string per node (`"string"`, `"object"`, `"array"`). Avoid
+      `"type": ["object", "null"]`; use optional fields via `anyOf`/`oneOf`, omit from `required`, or
+      document that a provider adapter will normalize (and add adapter + test in the same PR).
+- [ ] **Arrays** — Always set `items` with an explicit `type` or `properties` (never empty `{}`).
+- [ ] **Composites** — `$ref`, `$defs`, `allOf`, `anyOf`, `oneOf`, `nullable` may need a normalizer
+      in the client adapter; do not add them to public schemas without updating that adapter and tests.
+- [ ] **Stability** — Tool call `id` values must stay consistent between the assistant turn that
+      requests tools and the following tool-result turn for that provider’s format.
+
+Run tool unit tests under `tests/tools/`. After schema changes, run the registry **strict adapter**
+contract (uses the strictest normalizer currently wired in the repo):
+
+```bash
+uv run python -m pytest tests/services/test_investigation_tool_schemas.py -q
+```
+
+Shared assertions live in `tests/services/investigation_tool_schema_contract.py`. When you add a
+stricter provider adapter, point `test_investigation_tool_schemas.py` at its normalizer and extend
+the contract module if the API rejects new patterns.
+
+## Provider adapters (`agent_llm_client.py`)
+
+Each `*AgentClient` should own:
+
+| Responsibility | Notes |
+| ---------------- | ----- |
+| `tool_schemas(tools)` | Map `RegisteredTool` / `public_input_schema` → API payload. Never pass raw schemas if the API is strict. |
+| `invoke(..., tools=...)` | Attach schemas the API expects; handle retries and map errors to `RuntimeError` with actionable text. |
+| Message compatibility | Investigation builds history via `_build_synthetic_assistant_tool_call_msg`, `_build_assistant_msg`, `_build_tool_result_messages`—each must match your invoke parser. |
+
+Checklist when adding or changing a client:
+
+- [ ] `tool_schemas` output matches what `invoke` sends (no duplicate or divergent normalization).
+- [ ] New JSON Schema patterns in tools → update the adapter normalizer **and** contract tests in the same PR.
+- [ ] Serialized payload round-trips like the SDK will send it (e.g. `json.dumps` on the tools list).
+- [ ] Validation errors from the API (“missing field type”, “invalid tools”) → treat as schema/adapter bugs first.
+- [ ] Throttling / rate limits: align with existing retry policy in sibling clients.
+
+Provider-specific modules (e.g. strict JSON Schema helpers) stay beside the client; keep investigation
+logic in `investigation.py` as dispatch only.
+
+## Investigation messages (`investigation.py`)
+
+- [ ] **Same `ToolCall.id`** across synthetic seed assistant message, tool results, and evidence keys.
+- [ ] **Provider-specific IDs** — Use opaque ids only when the client requires them (e.g. length/format);
+      keep stable `seed_{tool.name}` (or equivalent) where history/tests expect predictable ids.
+- [ ] **Block vs string content** — Some APIs require content as structured blocks, not raw strings
+      (including after guardrails). Match what `invoke` already produced earlier in the thread.
+- [ ] **`zip(tool_calls, results, strict=True)`** when pairing calls to results.
+
+Extend `tests/agent/test_investigation.py` when you add a client branch for synthetic/assistant messages.
+
+## Verification
+
+Minimum before merging schema or client changes:
+
+```bash
+uv run python -m pytest tests/services/test_investigation_tool_schemas.py -q
+uv run python -m pytest tests/services/test_agent_llm_client.py tests/agent/test_investigation.py -q
+```
+
+When touching a specific provider, also verify end-to-end with that provider configured:
+
+```bash
+uv run opensre
+# /investigate <fixture.json>   # interactive shell
+# or: opensre investigate -i <fixture.json>
+```
+
+Use the same `LLM_PROVIDER` / model users report in issues; unit tests alone are not enough for
+adapter strictness gaps.
+
+## Related docs
+
+- [app/services/AGENTS.md](../app/services/AGENTS.md) — API provider wiring and env keys
+- [app/integrations/llm_cli/AGENTS.md](../app/integrations/llm_cli/AGENTS.md) — subprocess CLI providers
+- [AGENTS.md](../AGENTS.md) — repo map and PR checklist

--- a/tests/services/investigation_tool_schema_contract.py
+++ b/tests/services/investigation_tool_schema_contract.py
@@ -1,0 +1,72 @@
+"""Shared strict JSON Schema contract for investigation tool definitions.
+
+Used by provider-specific normalizers (e.g. strict HTTP tool-spec APIs) and by the
+registry-wide test in ``test_investigation_tool_schemas.py``. Not tied to a single vendor.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from app.tools.registry import get_registered_tools
+
+# Keys stripped by the strictest investigation schema normalizer in the tree today.
+# When a new adapter is stricter, extend this set and the assertions below together.
+STRICT_UNSUPPORTED_SCHEMA_KEYS = frozenset(
+    {
+        "title",
+        "$schema",
+        "$defs",
+        "definitions",
+        "$ref",
+        "not",
+        "nullable",
+    }
+)
+
+
+def assert_strict_tool_schema_node(node: Any, *, path: str) -> None:
+    """Enforce invariants strict LLM tool-schema APIs expect (string ``type``, typed arrays)."""
+    if not isinstance(node, dict):
+        return
+    for key in node:
+        assert key not in STRICT_UNSUPPORTED_SCHEMA_KEYS, f"{path}: unsupported key {key!r}"
+
+    schema_type = node.get("type")
+    assert not isinstance(schema_type, list), f"{path}: type must not be a list {schema_type!r}"
+    if "properties" in node:
+        assert schema_type == "object", f"{path}: properties without type object"
+        properties = node["properties"]
+        assert isinstance(properties, dict), f"{path}: properties must be a dict"
+        for name, child in properties.items():
+            assert_strict_tool_schema_node(child, path=f"{path}.{name}")
+
+    if schema_type == "array":
+        items = node.get("items")
+        assert isinstance(items, dict), f"{path}: array missing typed items"
+        assert "type" in items or "properties" in items, f"{path}: array items lack type"
+        assert_strict_tool_schema_node(items, path=f"{path}[]")
+    elif isinstance(node.get("items"), dict):
+        assert_strict_tool_schema_node(node["items"], path=f"{path}[]")
+
+
+def assert_all_investigation_tools_satisfy_strict_adapter(
+    *,
+    normalize_schema: Callable[[dict[str, Any] | None], dict[str, Any]],
+    build_tool_specs: Callable[[list[Any]], list[dict[str, Any]]],
+) -> None:
+    """Every investigation tool must normalize and serialize under *strict* adapter rules."""
+    tools = get_registered_tools("investigation")
+    assert tools, "expected at least one investigation tool"
+
+    for tool in tools:
+        schema = normalize_schema(tool.public_input_schema)
+        assert schema.get("type") == "object", tool.name
+        assert isinstance(schema.get("properties"), dict), tool.name
+        assert_strict_tool_schema_node(schema, path=tool.name)
+
+    specs = build_tool_specs(tools)
+    assert len(specs) == len(tools)
+    json.dumps({"tools": specs})

--- a/tests/services/test_investigation_tool_schemas.py
+++ b/tests/services/test_investigation_tool_schemas.py
@@ -1,0 +1,33 @@
+"""Registry-wide contract: investigation tool schemas vs strict LLM adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+
+from app.services.bedrock_converse import build_converse_tool_specs, normalize_tool_input_schema
+from app.tools.registry import clear_tool_registry_cache
+from tests.services.investigation_tool_schema_contract import (
+    assert_all_investigation_tools_satisfy_strict_adapter,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_tool_registry() -> Generator[None]:
+    clear_tool_registry_cache()
+    yield
+    clear_tool_registry_cache()
+
+
+def test_all_investigation_tool_schemas_satisfy_strict_adapter_invariants() -> None:
+    """All investigation tools must pass the strictest shipped schema normalizer.
+
+    Today that normalizer lives in ``bedrock_converse`` (strict JSON Schema tool specs).
+    When a stricter provider adapter is added, point this test at its
+    ``normalize_*`` / ``build_*_tool_specs`` helpers instead.
+    """
+    assert_all_investigation_tools_satisfy_strict_adapter(
+        normalize_schema=normalize_tool_input_schema,
+        build_tool_specs=build_converse_tool_specs,
+    )


### PR DESCRIPTION
## Summary

- Add [docs/investigation-tool-calling.md](docs/investigation-tool-calling.md) — provider-neutral guide for investigation tool schemas, LLM invoke payloads, and message shapes
- Link from `AGENTS.md`, `app/services/AGENTS.md`, and `docs/DEVELOPMENT.md`
- Add `tests/services/investigation_tool_schema_contract.py` and `tests/services/test_investigation_tool_schemas.py` (generic registry contract; uses strictest normalizer from #2381)

## Merge order

**Merge after #2381** ([fix(bedrock): Converse agent client…](https://github.com/Tracer-Cloud/opensre/pull/2381)).

Then **rebase this branch onto `main`** and remove the duplicate registry test `test_all_investigation_tool_schemas_satisfy_converse_invariants` from `tests/services/test_bedrock_converse.py` (same coverage lives in `test_investigation_tool_schemas.py`).

Until #2381 is on `main`, CI for `test_investigation_tool_schemas.py` will fail (imports `app.services.bedrock_converse`).

## Test plan

- [ ] After rebase post-#2381: `uv run python -m pytest tests/services/test_investigation_tool_schemas.py -q`
- [ ] `make lint` / `make format-check`