### PR TITLE
fix(analytics): catch SSL errors in worker loop and drain pending queue

### DIFF
--- a/app/analytics/provider.py
+++ b/app/analytics/provider.py
@@ -771,27 +771,40 @@ class Analytics:
         self._worker = worker
 
     def _worker_loop(self) -> None:
-        with httpx.Client(timeout=_SEND_TIMEOUT, trust_env=False) as client:
-            while True:
-                item = self._queue.get()
-                if item is None:
-                    self._queue.task_done()
-                    break
-                try:
-                    self._send(client, item)
-                finally:
-                    self._queue.task_done()
-                    self._mark_done()
+        try:
+            with httpx.Client(timeout=_SEND_TIMEOUT, trust_env=False) as client:
+                while True:
+                    item = self._queue.get()
+                    if item is None:
+                        self._queue.task_done()
+                        break
+                    try:
+                        self._send(client, item)
+                    finally:
+                        self._queue.task_done()
+                        self._mark_done()
+                while True:
+                    try:
+                        item = self._queue.get_nowait()
+                    except queue.Empty:
+                        return
+                    try:
+                        if item is not None:
+                            self._send(client, item)
+                    finally:
+                        self._queue.task_done()
+                        self._mark_done()
+        except Exception as exc:
+            # SSL init failure or other fatal worker error — analytics is non-critical.
+            # Drain the queue so any callers blocked on _drained are unblocked.
+            _log_failure("posthog_worker", exc)
             while True:
                 try:
                     item = self._queue.get_nowait()
                 except queue.Empty:
-                    return
-                try:
-                    if item is not None:
-                        self._send(client, item)
-                finally:
-                    self._queue.task_done()
+                    break
+                self._queue.task_done()
+                if item is not None:
                     self._mark_done()
 
     def _send(self, client: httpx.Client, item: _Envelope) -> None:

--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -993,3 +993,48 @@ def test_capture_coerces_invalid_property_values(
     invalid = [line for line in failure_lines if line.startswith("invalid_property")]
     assert any("drop_object" in line for line in invalid)
     assert all("drop_none" not in line for line in invalid)
+
+
+def test_worker_ssl_init_failure_drains_queue_and_logs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """SSLError during httpx.Client creation must be caught, logged, and drain the queue."""
+    monkeypatch.delenv("OPENSRE_ANALYTICS_DISABLED", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+    monkeypatch.setattr(provider.atexit, "register", lambda _func: None)
+
+    ssl_error = Exception("SSLError: unknown error (_ssl.c:3134)")
+    # Gate used to ensure the item is in the queue before the worker tries to build the client.
+    item_enqueued = threading.Event()
+
+    class _BrokenClient:
+        def __init__(self, *_args, **_kwargs) -> None:
+            item_enqueued.wait(timeout=2.0)
+            raise ssl_error
+
+        def __enter__(self) -> _BrokenClient:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+    monkeypatch.setattr(provider.httpx, "Client", _BrokenClient)
+
+    failure_stages: list[str] = []
+    monkeypatch.setattr(
+        provider,
+        "_log_failure",
+        lambda stage, _exc, **_kw: failure_stages.append(stage),
+    )
+
+    analytics = provider.Analytics()
+    analytics.capture(Event.CLI_INVOKED)
+    item_enqueued.set()  # unblock the worker so it fails with item already in the queue
+    if analytics._worker is not None:
+        analytics._worker.join(timeout=3.0)
+
+    assert analytics._pending == 0
+    assert analytics._drained.is_set()
+    assert "posthog_worker" in failure_stages


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- When `httpx.Client()` raises an `SSLError` during context entry (broken system SSL on some Windows/Python builds), the analytics worker thread crashed without decrementing `_pending` or setting `_drained`, leaving `shutdown()` blocked until its timeout and the unhandled exception reported to Sentry on every analytics event.
- Wrap `_worker_loop`'s body in a `try/except` so any fatal init error is logged via `_log_failure` and remaining queued items are drained, unblocking callers waiting on `_drained`.
- Add a regression test that uses a `threading.Event` gate to guarantee the item is in the queue before the SSL failure fires, making the drain assertion race-free.

## Test plan

- [ ] `uv run pytest tests/analytics/test_provider.py -x -q` — all 42 tests pass including the new `test_worker_ssl_init_failure_drains_queue_and_logs`
- [ ] Pre-existing `tests/agents/test_sampler.py::test_sampler_stores_snapshots` failure is unrelated (missing `pytest-asyncio` plugin) and present on `main` before this change

Closes #2403

https://claude.ai/code/session_01SgNyT4N3NcTedQzUsrJ6hK
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgNyT4N3NcTedQzUsrJ6hK)_