### PR TITLE
fix(deps): add pytest-asyncio to default uv dev group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ ignore_names = [
 dev = [
     "pre-commit>=4.0.0",
     "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.1.0",
     "types-psutil>=7.2.2.20260408",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1972,6 +1972,7 @@ release-dist = [
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "types-psutil" },
 ]
@@ -2050,6 +2051,7 @@ provides-extras = ["dev", "release-dist", "release-binary", "release", "opensre-
 dev = [
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "types-psutil", specifier = ">=7.2.2.20260408" },
 ]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `[dependency-groups] dev` (installed by plain `uv sync`) was missing `pytest-asyncio`, even though `tests/agents/` contains 28 async test functions marked with `@pytest.mark.asyncio`
- `pytest-asyncio>=1.3.0` was only in `[project.optional-dependencies] dev` (used by `pip install .[dev]` and `uv sync --extra dev`), so bare `uv sync` environments left the runner absent
- Every async test in `tests/agents/test_sampler.py`, `tests/services/test_datadog_async_client.py`, `tests/remote/`, and `tests/cli/` failed with: `Failed: async def functions are not natively supported`

**Fix:** add `pytest-asyncio>=1.3.0` to `[dependency-groups] dev` so it is present in all install paths.

## Test plan

- [x] `uv run python -m pytest tests/ -q --ignore=tests/e2e --ignore=tests/synthetic --ignore=tests/deployment --ignore=tests/chaos_engineering` → 7426 passed, 36 skipped
- [x] `uv run ruff check app/ tests/` → All checks passed
- [x] `uv lock` → resolves without changes (package was already in lockfile under the `dev` extra)

https://claude.ai/code/session_01Eprcx3gSnqQMQQ3qAwjqWM
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eprcx3gSnqQMQQ3qAwjqWM)_