### PR TITLE
fix(analytics): skip Sentry capture for transient PostHog 5xx errors

### DIFF
--- a/app/analytics/provider.py
+++ b/app/analytics/provider.py
@@ -818,9 +818,11 @@ class Analytics:
             _log_failure("posthog_send", exc, event=item.event)
         except httpx.HTTPStatusError as exc:
             _log_failure("posthog_send", exc, event=item.event)
-            # 4xx errors (e.g. 403 Forbidden) are operational/config issues on
-            # the PostHog side; only report 5xx server errors to Sentry.
-            if exc.response.status_code >= 500:
+            # 502/503/504 are transient gateway/overload errors — log only.
+            # Other 5xx (500, 501, …) indicate a real server-side problem.
+            _TRANSIENT_5XX = {502, 503, 504}
+            status = exc.response.status_code
+            if status >= 500 and status not in _TRANSIENT_5XX:
                 _capture_sentry_failure(exc)
         except Exception as exc:
             _log_failure("posthog_send", exc, event=item.event)


### PR DESCRIPTION
## Summary

- 502/503/504 responses from PostHog are transient gateway/overload errors — the same class as `TransportError` — and should not be reported to Sentry as application bugs
- Only non-transient `5xx` codes (500, 501, etc.) indicate a real server-side problem worth tracking
- This eliminates spurious Sentry noise from PostHog infrastructure hiccups

## Test plan

- [ ] `uv run ruff check app/analytics/provider.py` — passes
- [ ] `uv run pyright app/analytics/provider.py` — 0 errors
- [ ] Analytics unit tests pass (failure in `test_sampler.py` is pre-existing, unrelated)

Closes #2281

---
_Generated by [Claude Code](https://claude.ai/code/session_017GjZMX1ZrkqiSRZ9yayet1)_