### PR TITLE
docs(agents): remove desktop agent references

### DIFF
--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -46,21 +46,10 @@ claude --output-format stream-json …
 Equals-form flags (e.g. `claude --resume=<session-id>`,
 `claude --print=<prompt>`) are accepted for any flag in the list above.
 
-The Claude Desktop GUI and its Electron helpers are filtered out
-cross-platform — `Claude.app/Contents/`, `Claude Helper (Renderer)`,
-`/snap/claude/`, `/usr/lib/claude-desktop`, AppImage mount points
-(`/.mount_Claude…`), and the Windows `Program Files\Claude\` /
-`AppData\Local\Programs\Claude\` install locations are recognized as
-desktop artifacts and never labeled as `claude-code`. The negative filter
-matches against `argv[0]` only, so a CLI installed under a Claude-flavored
-prefix (for example `/opt/Claude/claude`) is still surfaced.
-
 ### Loose mode (`--all`)
 
 `opensre agents scan --all` relaxes the argv requirements so that helper and
 broker processes whose argv contains agent-shaped tokens are also surfaced.
-The Claude Desktop / Electron negative filter is still applied — `--all`
-never mislabels desktop processes as `claude-code`.
 
 ### Registering discovered sessions
 


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

Removed documentation in `docs/agents.mdx` that described Claude Desktop GUI / Electron process filtering during `opensre agents scan`. OpenSRE does not support desktop-based agents, so those references are misleading and unnecessary.

Changes:
- Removed the strict-mode paragraph about filtering Claude Desktop install paths and Electron helpers
- Removed loose-mode notes about the desktop negative filter

### Demo/Screenshot for feature changes and bug fixes - 

Docs-only change; no runtime behavior change. The updated scan section now documents CLI discovery and `--all` loose mode without desktop-agent context.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The agents docs previously explained how scan excludes Claude Desktop GUI processes from being labeled as `claude-code`. Since desktop agents are out of scope for OpenSRE, that section was removed rather than rewritten. The strict and loose mode sections now focus only on CLI invocation shapes and `--all` behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.