### PR TITLE
fix(agent): guard against unexpected non-Message response from Anthropic API

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -176,9 +176,16 @@ class AnthropicAgentClient:
         else:
             raise RuntimeError(f"{self.provider_name} invocation failed") from last_err
 
+        content_blocks = getattr(response, "content", None)
+        if not isinstance(content_blocks, list):
+            raise RuntimeError(
+                f"{self.provider_name} returned an unexpected response type "
+                f"{type(response).__name__!r} (expected a Message with a content list). "
+                "Check Anthropic SDK version compatibility."
+            )
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
-        for block in response.content:
+        for block in content_blocks:
             block_type = getattr(block, "type", None)
             if block_type == "text":
                 text_parts.append(block.text)
@@ -188,8 +195,8 @@ class AnthropicAgentClient:
         return AgentLLMResponse(
             content="".join(text_parts),
             tool_calls=tool_calls,
-            stop_reason=str(response.stop_reason),
-            raw_content=response.content,
+            stop_reason=str(getattr(response, "stop_reason", "end_turn")),
+            raw_content=content_blocks,
         )
 
     @staticmethod

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -539,6 +539,22 @@ def test_unrelated_type_error_is_retried_and_wrapped(
     assert call_count == 3, "non-auth TypeError should be retried like a generic exception"
 
 
+def test_anthropic_unexpected_response_type_raises_clear_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    client = AnthropicAgentClient(model="claude-sonnet-4-6")
+    # Simulate the bug: messages.create() returns a plain string instead of a Message object
+    client._client = types.SimpleNamespace(
+        messages=types.SimpleNamespace(create=lambda **_: "some unexpected string")
+    )
+
+    with pytest.raises(RuntimeError, match="unexpected response type.*str"):
+        client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+
 @pytest.mark.parametrize(
     "provider", ["codex", "opencode", "claude-code", "kimi", "cursor", "gemini-cli", "copilot"]
 )

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -555,6 +555,28 @@ def test_anthropic_unexpected_response_type_raises_clear_error(
         client.invoke(messages=[{"role": "user", "content": "hi"}])
 
 
+def test_anthropic_missing_stop_reason_defaults_to_end_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    client = AnthropicAgentClient(model="claude-sonnet-4-6")
+    # Response has a valid content list but no stop_reason attribute.
+    fake_response = types.SimpleNamespace(
+        content=[types.SimpleNamespace(type="text", text="hello")]
+        # stop_reason intentionally absent
+    )
+    client._client = types.SimpleNamespace(
+        messages=types.SimpleNamespace(create=lambda **_: fake_response)
+    )
+
+    result = client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    assert result.content == "hello"
+    assert result.stop_reason == "end_turn"
+
+
 @pytest.mark.parametrize(
     "provider", ["codex", "opencode", "claude-code", "kimi", "cursor", "gemini-cli", "copilot"]
 )


### PR DESCRIPTION
## Summary

- `AnthropicAgentClient.invoke` accessed `response.content` directly after the retry loop, producing an opaque `AttributeError: 'str' object has no attribute 'content'` when the SDK returned an unexpected type
- Replace the bare attribute access with a `getattr` type-guard; raise a descriptive `RuntimeError` that names the actual type returned — consistent with the defensive `getattr(response, "content", [])` pattern already used in `llm_client.py`
- Also guards `response.stop_reason` with `getattr(..., "end_turn")` for the same reason
- Adds a regression test that reproduces the exact failure from Sentry

## Test plan

- [x] `uv run pytest tests/services/test_agent_llm_client.py -v` — 41 passed
- [x] `make lint` — clean
- [x] `make format-check` — clean
- [x] `make typecheck` — no issues

Closes #2414
Closes #2415

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFxVCRkB9MqqzPu15NGiKb)_