### PR TITLE
fix(cli): align /list tables after inline REPL menus

### DIFF
--- a/app/cli/interactive_shell/command_registry/integrations.py
+++ b/app/cli/interactive_shell/command_registry/integrations.py
@@ -8,10 +8,7 @@ from rich.markup import escape
 from app.cli.interactive_shell.command_registry import repl_data
 from app.cli.interactive_shell.command_registry.cli_parity import run_cli_command
 from app.cli.interactive_shell.command_registry.types import ExecutionTier, SlashCommand
-from app.cli.interactive_shell.config.tool_catalog import (
-    build_tool_catalog,
-    format_tool_catalog_text,
-)
+from app.cli.interactive_shell.config.tool_catalog import build_tool_catalog
 from app.cli.interactive_shell.runtime import ReplSession
 from app.cli.interactive_shell.ui import (
     BOLD_BRAND,
@@ -23,6 +20,7 @@ from app.cli.interactive_shell.ui import (
     render_integrations_table,
     render_mcp_table,
     render_models_table,
+    render_tools_table,
     repl_table,
 )
 from app.cli.interactive_shell.ui.choice_menu import (
@@ -120,12 +118,9 @@ def _interactive_list_menu(_session: ReplSession, console: Console) -> bool:
             render_integrations_table(console, results)
             render_mcp_table(console, results)
             render_models_table(console, repl_data.load_llm_settings())
+            render_tools_table(console, build_tool_catalog())
         elif sub == "tools":
-            catalog = build_tool_catalog()
-            if not catalog:
-                repl_print(console, "[dim]no tools registered.[/dim]")
-            else:
-                repl_print(console, format_tool_catalog_text(catalog), markup=False)
+            render_tools_table(console, build_tool_catalog())
         repl_section_break(console)
 
 
@@ -319,11 +314,7 @@ def _cmd_list(session: ReplSession, console: Console, args: list[str]) -> bool:
         return True
 
     if sub in ("tools", "tool"):
-        catalog = build_tool_catalog()
-        if not catalog:
-            console.print(f"[{DIM}]no tools registered.[/]")
-            return True
-        console.print(format_tool_catalog_text(catalog), markup=False)
+        render_tools_table(console, build_tool_catalog())
         return True
 
     if sub and sub not in ("", "all"):

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -131,7 +131,6 @@ class StreamingConsole(Console):
         high column. Rich output that follows (tables, follow-up status lines,
         section rules) must start at column zero or lines appear broken.
         """
-        use_terminal = False
         if not self._spinner.streaming:
             from app.cli.interactive_shell.ui.choice_menu import (
                 ensure_tty_column_zero,
@@ -153,11 +152,10 @@ class StreamingConsole(Console):
                 prepare_repl_output_line()
             if sys.stdout.isatty() and "width" not in kwargs:
                 kwargs["width"] = _repl_table_width(self)
-            use_terminal = repl_tty_interactive()
-        if use_terminal:
-            with repl_terminal_console_file(self):
-                super().print(*args, **kwargs)
-            return
+            if repl_tty_interactive():
+                with repl_terminal_console_file(self):
+                    super().print(*args, **kwargs)
+                return
         super().print(*args, **kwargs)
 
 

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -132,12 +132,11 @@ class StreamingConsole(Console):
         section rules) must start at column zero or lines appear broken.
         """
         use_terminal = False
-        previous_file = self.file
         if not self._spinner.streaming:
             from app.cli.interactive_shell.ui.choice_menu import (
                 ensure_tty_column_zero,
                 prepare_repl_output_line,
-                repl_terminal_stdout,
+                repl_terminal_console_file,
                 repl_tty_interactive,
             )
             from app.cli.interactive_shell.ui.rendering import (
@@ -154,15 +153,12 @@ class StreamingConsole(Console):
                 prepare_repl_output_line()
             if sys.stdout.isatty() and "width" not in kwargs:
                 kwargs["width"] = _repl_table_width(self)
-            terminal = repl_terminal_stdout()
-            use_terminal = repl_tty_interactive() and self.file is not terminal
-            if use_terminal:
-                self.file = terminal
-        try:
-            super().print(*args, **kwargs)
-        finally:
-            if use_terminal:
-                self.file = previous_file
+            use_terminal = repl_tty_interactive()
+        if use_terminal:
+            with repl_terminal_console_file(self):
+                super().print(*args, **kwargs)
+            return
+        super().print(*args, **kwargs)
 
 
 async def run_interactive(

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -131,10 +131,14 @@ class StreamingConsole(Console):
         high column. Rich output that follows (tables, follow-up status lines,
         section rules) must start at column zero or lines appear broken.
         """
+        use_terminal = False
+        previous_file = self.file
         if not self._spinner.streaming:
             from app.cli.interactive_shell.ui.choice_menu import (
                 ensure_tty_column_zero,
                 prepare_repl_output_line,
+                repl_terminal_stdout,
+                repl_tty_interactive,
             )
             from app.cli.interactive_shell.ui.rendering import (
                 _repl_output_already_prepared,
@@ -150,7 +154,15 @@ class StreamingConsole(Console):
                 prepare_repl_output_line()
             if sys.stdout.isatty() and "width" not in kwargs:
                 kwargs["width"] = _repl_table_width(self)
-        super().print(*args, **kwargs)
+            terminal = repl_terminal_stdout()
+            use_terminal = repl_tty_interactive() and self.file is not terminal
+            if use_terminal:
+                self.file = terminal
+        try:
+            super().print(*args, **kwargs)
+        finally:
+            if use_terminal:
+                self.file = previous_file
 
 
 async def run_interactive(

--- a/app/cli/interactive_shell/ui/__init__.py
+++ b/app/cli/interactive_shell/ui/__init__.py
@@ -15,6 +15,7 @@ from app.cli.interactive_shell.ui.rendering import (
     render_integrations_table,
     render_mcp_table,
     render_models_table,
+    render_tools_table,
     repl_table,
 )
 from app.cli.interactive_shell.ui.streaming import (
@@ -65,6 +66,7 @@ __all__ = [
     "render_integrations_table",
     "render_mcp_table",
     "render_models_table",
+    "render_tools_table",
     "repl_choose_one",
     "repl_section_break",
     "repl_table",

--- a/app/cli/interactive_shell/ui/choice_menu.py
+++ b/app/cli/interactive_shell/ui/choice_menu.py
@@ -14,8 +14,12 @@ import os
 import select
 import shutil
 import sys
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any, Literal, cast
 
+from prompt_toolkit.patch_stdout import StdoutProxy
 from rich.console import Console
 from rich.markup import escape
 
@@ -52,10 +56,35 @@ def repl_terminal_stdout() -> Any:
     control sequences synchronously on the underlying terminal stream.
     """
     stdout = sys.stdout
-    original = getattr(stdout, "original_stdout", None)
-    if original is not None:
-        return original
+    if isinstance(stdout, StdoutProxy):
+        return stdout.original_stdout or sys.__stdout__
     return stdout
+
+
+_TERMINAL_CONSOLE_FILE_LOCK = threading.RLock()
+
+
+@contextmanager
+def swap_console_file(console: Console, file: Any) -> Iterator[None]:
+    """Swap ``console.file`` under a lock for synchronous terminal rendering."""
+    with _TERMINAL_CONSOLE_FILE_LOCK:
+        previous_file = console.file
+        console.file = file
+        try:
+            yield
+        finally:
+            console.file = previous_file
+
+
+@contextmanager
+def repl_terminal_console_file(console: Console) -> Iterator[None]:
+    """Temporarily route Rich output through the real terminal stream."""
+    terminal = repl_terminal_stdout()
+    if repl_tty_interactive() and console.file is not terminal:
+        with swap_console_file(console, terminal):
+            yield
+        return
+    yield
 
 
 def ensure_tty_column_zero() -> None:
@@ -202,6 +231,13 @@ def write_menu_line(text: str = "") -> None:
 
 
 def _erase_menu_block(height: int) -> None:
+    if repl_tty_interactive():
+        out = repl_terminal_stdout()
+        if height:
+            out.write(f"\r\x1b[{height}A\r\x1b[J")
+        out.write("\x1b[0G")
+        out.flush()
+        return
     if height:
         sys.stdout.write(f"\r\x1b[{height}A\r\x1b[J")
     reset_tty_column()
@@ -350,7 +386,9 @@ __all__ = [
     "ensure_tty_column_zero",
     "prepare_repl_output_line",
     "repl_section_break",
+    "repl_terminal_console_file",
     "repl_terminal_stdout",
+    "swap_console_file",
     "repl_tty_interactive",
     "reset_tty_column",
     "write_menu_line",

--- a/app/cli/interactive_shell/ui/choice_menu.py
+++ b/app/cli/interactive_shell/ui/choice_menu.py
@@ -54,6 +54,9 @@ def repl_terminal_stdout() -> Any:
     the proxy, leaving the cursor on a high column and wrapping the first
     character of each row to the far right. Post-menu output must write cursor
     control sequences synchronously on the underlying terminal stream.
+
+    ``StdoutProxy.original_stdout`` is the supported escape hatch in
+    ``prompt_toolkit.patch_stdout`` for reaching the wrapped stream.
     """
     stdout = sys.stdout
     if isinstance(stdout, StdoutProxy):
@@ -231,7 +234,8 @@ def write_menu_line(text: str = "") -> None:
 
 
 def _erase_menu_block(height: int) -> None:
-    if repl_tty_interactive():
+    if isinstance(sys.stdout, StdoutProxy):
+        sys.stdout.flush()
         out = repl_terminal_stdout()
         if height:
             out.write(f"\r\x1b[{height}A\r\x1b[J")

--- a/app/cli/interactive_shell/ui/choice_menu.py
+++ b/app/cli/interactive_shell/ui/choice_menu.py
@@ -41,6 +41,23 @@ def repl_tty_interactive() -> bool:
     return bool(sys.stdin.isatty() and sys.stdout.isatty())
 
 
+def repl_terminal_stdout() -> Any:
+    """Return the real terminal stdout, bypassing ``StdoutProxy`` when patched.
+
+    ``prompt_toolkit.patch_stdout`` replaces ``sys.stdout`` with a buffered proxy
+    that flushes asynchronously on a worker thread. Rich tables rendered from a
+    dispatch worker thread can reach the terminal before a ``\\r`` reset queued on
+    the proxy, leaving the cursor on a high column and wrapping the first
+    character of each row to the far right. Post-menu output must write cursor
+    control sequences synchronously on the underlying terminal stream.
+    """
+    stdout = sys.stdout
+    original = getattr(stdout, "original_stdout", None)
+    if original is not None:
+        return original
+    return stdout
+
+
 def ensure_tty_column_zero() -> None:
     """Reset the cursor column before Rich output when a TTY is active."""
     if repl_tty_interactive():
@@ -50,8 +67,9 @@ def ensure_tty_column_zero() -> None:
 def prepare_repl_output_line() -> None:
     """Begin Rich output on a new line after inline menu I/O."""
     if repl_tty_interactive():
-        sys.stdout.write(_TERMINAL_NEWLINE)
-        reset_tty_column()
+        out = repl_terminal_stdout()
+        out.write("\n\x1b[0G")
+        out.flush()
 
 
 def repl_section_break(console: Console) -> None:
@@ -196,8 +214,9 @@ def reset_tty_column() -> None:
     high column. Rich output that follows must start at column zero or tables
     render as a diagonal block of leading whitespace.
     """
-    sys.stdout.write("\r")
-    sys.stdout.flush()
+    out = repl_terminal_stdout()
+    out.write("\x1b[0G")
+    out.flush()
 
 
 def erase_menu_lines(height: int) -> None:
@@ -331,6 +350,7 @@ __all__ = [
     "ensure_tty_column_zero",
     "prepare_repl_output_line",
     "repl_section_break",
+    "repl_terminal_stdout",
     "repl_tty_interactive",
     "reset_tty_column",
     "write_menu_line",

--- a/app/cli/interactive_shell/ui/choice_menu.py
+++ b/app/cli/interactive_shell/ui/choice_menu.py
@@ -64,6 +64,18 @@ def repl_terminal_stdout() -> Any:
     return stdout
 
 
+def _menu_stdout() -> Any:
+    """Return the stream for synchronous inline menu draw/erase I/O.
+
+    When ``patch_stdout`` is active, menu bytes must bypass ``StdoutProxy`` so
+    draw and erase sequences reach the terminal in order without racing the
+    proxy's async write thread.
+    """
+    if isinstance(sys.stdout, StdoutProxy):
+        return repl_terminal_stdout()
+    return sys.stdout
+
+
 _TERMINAL_CONSOLE_FILE_LOCK = threading.RLock()
 
 
@@ -222,10 +234,11 @@ def _menu_height(crumb: str, labels: list[str]) -> int:
 
 def _write_menu_line(text: str = "") -> None:
     """Write a menu line at column zero even while the terminal is in raw mode."""
+    out = _menu_stdout()
     if text:
-        sys.stdout.write(f"\r{text}{_TERMINAL_NEWLINE}")
+        out.write(f"\r{text}{_TERMINAL_NEWLINE}")
         return
-    sys.stdout.write(_TERMINAL_NEWLINE)
+    out.write(_TERMINAL_NEWLINE)
 
 
 def write_menu_line(text: str = "") -> None:
@@ -234,17 +247,11 @@ def write_menu_line(text: str = "") -> None:
 
 
 def _erase_menu_block(height: int) -> None:
-    if isinstance(sys.stdout, StdoutProxy):
-        sys.stdout.flush()
-        out = repl_terminal_stdout()
-        if height:
-            out.write(f"\r\x1b[{height}A\r\x1b[J")
-        out.write("\x1b[0G")
-        out.flush()
-        return
+    out = _menu_stdout()
     if height:
-        sys.stdout.write(f"\r\x1b[{height}A\r\x1b[J")
-    reset_tty_column()
+        out.write(f"\r\x1b[{height}A\r\x1b[J")
+    out.write("\x1b[0G")
+    out.flush()
 
 
 def reset_tty_column() -> None:
@@ -272,7 +279,6 @@ def _draw_menu(
     index: int,
     erase_lines: int,
 ) -> None:
-    out = sys.stdout
     w = _cols()
     if erase_lines:
         _erase_menu_block(erase_lines)
@@ -297,14 +303,13 @@ def _draw_menu(
             _write_menu_line(f"{DIM_COUNTER_ANSI}{padded}{ANSI_RESET}")
     _write_menu_line()
     _write_menu_line(f"{DIM_COUNTER_ANSI}{_HINT}{ANSI_RESET}")
-    out.flush()
+    _menu_stdout().flush()
 
 
 def _erase_menu(crumb: str, labels: list[str]) -> None:
     """Move cursor up to the start of this menu block and wipe it."""
     height = _menu_height(crumb, labels)
     _erase_menu_block(height)
-    sys.stdout.flush()
 
 
 # ── picker loop ──────────────────────────────────────────────────────────────

--- a/app/cli/interactive_shell/ui/rendering.py
+++ b/app/cli/interactive_shell/ui/rendering.py
@@ -86,44 +86,25 @@ def _prepare_tty_for_rich(console: Console) -> int:
 
 def print_repl_table(console: Console, table: Table, *, width: int | None = None) -> None:
     """Print a Rich table using REPL-safe TTY width."""
-    from app.cli.interactive_shell.ui.choice_menu import repl_terminal_stdout, repl_tty_interactive
+    from app.cli.interactive_shell.ui.choice_menu import repl_terminal_console_file
 
     width = width if width is not None else _prepare_tty_for_rich(console)
     if table.width is None:
         table.width = width
-    terminal = repl_terminal_stdout()
-    use_terminal = repl_tty_interactive() and console.file is not terminal
-    if use_terminal:
-        previous_file = console.file
-        console.file = terminal
-        try:
-            _console_print_prepared(console, table, width=width)
-        finally:
-            console.file = previous_file
-        return
-    _console_print_prepared(console, table, width=width)
+    with repl_terminal_console_file(console):
+        _console_print_prepared(console, table, width=width)
 
 
 def repl_print(console: Console, *objects: Any, **kwargs: Any) -> None:
     """Print via Rich after resetting the TTY column (inline-menu safe)."""
     from app.cli.interactive_shell.ui.choice_menu import (
         prepare_repl_output_line,
-        repl_terminal_stdout,
-        repl_tty_interactive,
+        repl_terminal_console_file,
     )
 
     prepare_repl_output_line()
-    terminal = repl_terminal_stdout()
-    use_terminal = repl_tty_interactive() and console.file is not terminal
-    if use_terminal:
-        previous_file = console.file
-        console.file = terminal
-        try:
-            _console_print_prepared(console, *objects, **kwargs)
-        finally:
-            console.file = previous_file
-        return
-    _console_print_prepared(console, *objects, **kwargs)
+    with repl_terminal_console_file(console):
+        _console_print_prepared(console, *objects, **kwargs)
 
 
 def render_integrations_table(console: Console, results: list[dict[str, str]]) -> None:
@@ -203,12 +184,15 @@ def render_tools_table(console: Console, catalog: list[ToolCatalogEntry]) -> Non
     table = repl_table(title="Tools", title_style=BOLD_BRAND, width=width)
     table.add_column("tool", style="bold", no_wrap=True)
     table.add_column("surfaces", style=DIM, no_wrap=True)
-    desc_width = max(20, width - 56)
+    params_width = max(16, min(32, width // 4))
+    table.add_column("params", style=DIM, overflow="fold", max_width=params_width)
+    desc_width = max(20, width - 56 - params_width)
     table.add_column("description", overflow="fold", max_width=desc_width)
     for entry in catalog:
         table.add_row(
             escape(entry.name),
             escape(", ".join(sorted(entry.surfaces))),
+            escape(entry.input_schema_summary),
             escape(entry.description),
         )
     print_repl_table(console, table, width=width)

--- a/app/cli/interactive_shell/ui/rendering.py
+++ b/app/cli/interactive_shell/ui/rendering.py
@@ -32,6 +32,7 @@ def repl_table(**kwargs: Any) -> Table:
         "box": box.MINIMAL_HEAVY_HEAD,
         "show_edge": False,
         "pad_edge": False,
+        "title_justify": "left",
     }
     opts.update(kwargs)
     return Table(**opts)

--- a/app/cli/interactive_shell/ui/rendering.py
+++ b/app/cli/interactive_shell/ui/rendering.py
@@ -12,6 +12,7 @@ from rich.markup import escape
 from rich.table import Table
 from rich.text import Text
 
+from app.cli.interactive_shell.config.tool_catalog import ToolCatalogEntry
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.interaction_models import (
     PlannedAction,
 )
@@ -84,17 +85,43 @@ def _prepare_tty_for_rich(console: Console) -> int:
 
 def print_repl_table(console: Console, table: Table, *, width: int | None = None) -> None:
     """Print a Rich table using REPL-safe TTY width."""
+    from app.cli.interactive_shell.ui.choice_menu import repl_terminal_stdout, repl_tty_interactive
+
     width = width if width is not None else _prepare_tty_for_rich(console)
     if table.width is None:
         table.width = width
+    terminal = repl_terminal_stdout()
+    use_terminal = repl_tty_interactive() and console.file is not terminal
+    if use_terminal:
+        previous_file = console.file
+        console.file = terminal
+        try:
+            _console_print_prepared(console, table, width=width)
+        finally:
+            console.file = previous_file
+        return
     _console_print_prepared(console, table, width=width)
 
 
 def repl_print(console: Console, *objects: Any, **kwargs: Any) -> None:
     """Print via Rich after resetting the TTY column (inline-menu safe)."""
-    from app.cli.interactive_shell.ui.choice_menu import prepare_repl_output_line
+    from app.cli.interactive_shell.ui.choice_menu import (
+        prepare_repl_output_line,
+        repl_terminal_stdout,
+        repl_tty_interactive,
+    )
 
     prepare_repl_output_line()
+    terminal = repl_terminal_stdout()
+    use_terminal = repl_tty_interactive() and console.file is not terminal
+    if use_terminal:
+        previous_file = console.file
+        console.file = terminal
+        try:
+            _console_print_prepared(console, *objects, **kwargs)
+        finally:
+            console.file = previous_file
+        return
     _console_print_prepared(console, *objects, **kwargs)
 
 
@@ -157,15 +184,32 @@ def render_models_table(console: Console, settings: Any) -> None:
     provider = str(getattr(settings, "provider", "unknown"))
     reasoning_model, toolcall_model = resolve_provider_models(settings, provider)
     width = _prepare_tty_for_rich(console)
-    table = repl_table(
-        title="LLM connection", title_style=BOLD_BRAND, show_header=False, width=width
-    )
-    table.add_column("key", style="bold", no_wrap=True)
+    table = repl_table(title="LLM connection", title_style=BOLD_BRAND, width=width)
+    table.add_column("setting", style="bold", no_wrap=True)
     value_width = max(20, width - 24)
     table.add_column("value", overflow="fold", max_width=value_width)
     table.add_row("provider", provider)
     table.add_row("reasoning model", reasoning_model)
     table.add_row("toolcall model", toolcall_model)
+    print_repl_table(console, table, width=width)
+
+
+def render_tools_table(console: Console, catalog: list[ToolCatalogEntry]) -> None:
+    if not catalog:
+        repl_print(console, f"[{DIM}]no tools registered.[/]")
+        return
+    width = _prepare_tty_for_rich(console)
+    table = repl_table(title="Tools", title_style=BOLD_BRAND, width=width)
+    table.add_column("tool", style="bold", no_wrap=True)
+    table.add_column("surfaces", style=DIM, no_wrap=True)
+    desc_width = max(20, width - 56)
+    table.add_column("description", overflow="fold", max_width=desc_width)
+    for entry in catalog:
+        table.add_row(
+            escape(entry.name),
+            escape(", ".join(sorted(entry.surfaces))),
+            escape(entry.description),
+        )
     print_repl_table(console, table, width=width)
 
 
@@ -205,5 +249,6 @@ __all__ = [
     "render_integrations_table",
     "render_mcp_table",
     "render_models_table",
+    "render_tools_table",
     "status_style",
 ]

--- a/tests/cli/interactive_shell/config/test_tool_catalog.py
+++ b/tests/cli/interactive_shell/config/test_tool_catalog.py
@@ -237,7 +237,7 @@ class TestListToolsSlashCommand:
         buf = io.StringIO()
         return Console(file=buf, force_terminal=False, highlight=False), buf
 
-    def test_list_tools_prints_grouped_catalog(self) -> None:
+    def test_list_tools_renders_rich_table_via_slash_command(self) -> None:
         console, buf = self._capture()
         session = ReplSession()
         # Stub the catalog so the test stays decoupled from registry contents.

--- a/tests/cli/interactive_shell/config/test_tool_catalog.py
+++ b/tests/cli/interactive_shell/config/test_tool_catalog.py
@@ -260,8 +260,9 @@ class TestListToolsSlashCommand:
         assert "search_github" in out
         assert "chat, investigation" in out
         assert "Search GitHub code." in out
+        assert "query: string" in out
 
-    def test_list_tools_disables_markup_for_plain_catalog_text(self) -> None:
+    def test_list_tools_escapes_markup_in_rich_table(self) -> None:
         console, buf = self._capture()
         session = ReplSession()
         fake = [

--- a/tests/cli/interactive_shell/config/test_tool_catalog.py
+++ b/tests/cli/interactive_shell/config/test_tool_catalog.py
@@ -256,9 +256,10 @@ class TestListToolsSlashCommand:
         ):
             assert _cmd_list(session, console, ["tools"]) is True
         out = buf.getvalue()
+        assert "Tools" in out
         assert "search_github" in out
-        assert "## investigation" in out
-        assert "## chat" in out
+        assert "chat, investigation" in out
+        assert "Search GitHub code." in out
 
     def test_list_tools_disables_markup_for_plain_catalog_text(self) -> None:
         console, buf = self._capture()

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -422,6 +422,7 @@ class TestListCommand:
         assert "DatadogMetricsTool" in output
         assert "investigation" in output
         assert "Fetch Datadog metrics" in output
+        assert "metric: string" in output
 
     def test_list_tools_empty_shows_hint(self, monkeypatch: object) -> None:
         from app.cli.interactive_shell.command_registry import integrations as m

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -401,6 +401,36 @@ class TestListCommand:
         dispatch_slash("/list models", ReplSession(), console)
         assert "LLM settings unavailable" in buf.getvalue()
 
+    def test_list_tools_renders_rich_table(self, monkeypatch: object) -> None:
+        from app.cli.interactive_shell.command_registry import integrations as m
+        from app.cli.interactive_shell.config.tool_catalog import ToolCatalogEntry
+
+        fake_catalog = [
+            ToolCatalogEntry(
+                name="DatadogMetricsTool",
+                surfaces=("investigation",),
+                description="Fetch Datadog metrics",
+                source_file="app/tools/datadog.py",
+                input_schema_summary="metric: string",
+            ),
+        ]
+        monkeypatch.setattr(m, "build_tool_catalog", lambda: fake_catalog)
+        console, buf = _capture()
+        dispatch_slash("/list tools", ReplSession(), console)
+        output = buf.getvalue()
+        assert "Tools" in output
+        assert "DatadogMetricsTool" in output
+        assert "investigation" in output
+        assert "Fetch Datadog metrics" in output
+
+    def test_list_tools_empty_shows_hint(self, monkeypatch: object) -> None:
+        from app.cli.interactive_shell.command_registry import integrations as m
+
+        monkeypatch.setattr(m, "build_tool_catalog", lambda: [])
+        console, buf = _capture()
+        dispatch_slash("/list tools", ReplSession(), console)
+        assert "no tools registered" in buf.getvalue()
+
     def test_list_default_shows_all_three_sections(self, monkeypatch: object) -> None:
         self._patch_verify(monkeypatch)
         self._patch_llm(monkeypatch)

--- a/tests/cli/interactive_shell/ui/test_choice_menu.py
+++ b/tests/cli/interactive_shell/ui/test_choice_menu.py
@@ -41,24 +41,42 @@ def test_draw_menu_uses_carriage_return_newlines(monkeypatch) -> None:
 
 
 def test_erase_menu_block_resets_to_column_zero(monkeypatch) -> None:
-    out = io.StringIO()
-    monkeypatch.setattr(sys, "stdout", out)
+    terminal = io.StringIO()
+    proxy = io.StringIO()
+    proxy.original_stdout = terminal  # type: ignore[attr-defined]
+    monkeypatch.setattr(sys, "stdout", proxy)
 
     choice_menu._erase_menu("crumb", ["one", "two"])
 
-    rendered = out.getvalue()
+    rendered = proxy.getvalue()
     assert rendered.startswith("\r\x1b[")
     assert "A\r\x1b[J" in rendered
-    assert rendered.endswith("\r")
+    assert terminal.getvalue() == "\x1b[0G"
 
 
 def test_reset_tty_column_writes_carriage_return(monkeypatch) -> None:
-    out = io.StringIO()
-    monkeypatch.setattr(sys, "stdout", out)
+    terminal = io.StringIO()
+    proxy = io.StringIO()
+    proxy.original_stdout = terminal  # type: ignore[attr-defined]
+    monkeypatch.setattr(sys, "stdout", proxy)
 
     choice_menu.reset_tty_column()
 
-    assert out.getvalue() == "\r"
+    assert proxy.getvalue() == ""
+    assert terminal.getvalue() == "\x1b[0G"
+
+
+def test_prepare_repl_output_line_writes_to_terminal_stdout(monkeypatch) -> None:
+    terminal = io.StringIO()
+    proxy = io.StringIO()
+    proxy.original_stdout = terminal  # type: ignore[attr-defined]
+    monkeypatch.setattr(sys, "stdout", proxy)
+    monkeypatch.setattr(choice_menu, "repl_tty_interactive", lambda: True)
+
+    choice_menu.prepare_repl_output_line()
+
+    assert proxy.getvalue() == ""
+    assert terminal.getvalue() == "\n\x1b[0G"
 
 
 def test_pick_ignores_unmapped_keys(monkeypatch) -> None:

--- a/tests/cli/interactive_shell/ui/test_choice_menu.py
+++ b/tests/cli/interactive_shell/ui/test_choice_menu.py
@@ -69,22 +69,21 @@ def test_draw_menu_uses_carriage_return_newlines(monkeypatch) -> None:
 def test_erase_menu_block_resets_to_column_zero(monkeypatch) -> None:
     terminal = io.StringIO()
     proxy = _patch_stdout_proxy(monkeypatch, terminal)
-    monkeypatch.setattr(choice_menu, "repl_tty_interactive", lambda: False)
 
     choice_menu._erase_menu("crumb", ["one", "two"])
 
-    rendered = proxy.getvalue()
+    assert proxy.getvalue() == ""
+    rendered = terminal.getvalue()
     assert rendered.startswith("\r\x1b[")
     assert "A\r\x1b[J" in rendered
-    assert terminal.getvalue() == "\x1b[0G"
+    assert rendered.endswith("\x1b[0G")
 
 
-def test_erase_menu_block_writes_erase_to_terminal_when_interactive(
+def test_erase_menu_block_writes_erase_to_terminal_when_proxy_active(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     terminal = io.StringIO()
     _patch_stdout_proxy(monkeypatch, terminal)
-    monkeypatch.setattr(choice_menu, "repl_tty_interactive", lambda: True)
 
     choice_menu._erase_menu("crumb", ["one", "two"])
 

--- a/tests/cli/interactive_shell/ui/test_choice_menu.py
+++ b/tests/cli/interactive_shell/ui/test_choice_menu.py
@@ -7,9 +7,35 @@ import re
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 from app.cli.interactive_shell.ui import choice_menu
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;:]*[A-Za-z]")
+
+
+class _StdoutProxyStub:
+    """Minimal stand-in for prompt_toolkit.patch_stdout.StdoutProxy in tests."""
+
+    def __init__(self, terminal: io.StringIO) -> None:
+        self.original_stdout = terminal
+        self._buffer = io.StringIO()
+
+    def write(self, text: str) -> int:
+        return self._buffer.write(text)
+
+    def flush(self) -> None:
+        return None
+
+    def getvalue(self) -> str:
+        return self._buffer.getvalue()
+
+
+def _patch_stdout_proxy(monkeypatch: pytest.MonkeyPatch, terminal: io.StringIO) -> _StdoutProxyStub:
+    monkeypatch.setattr(choice_menu, "StdoutProxy", _StdoutProxyStub)
+    proxy = _StdoutProxyStub(terminal)
+    monkeypatch.setattr(sys, "stdout", proxy)
+    return proxy
 
 
 def test_draw_menu_uses_carriage_return_newlines(monkeypatch) -> None:
@@ -42,9 +68,8 @@ def test_draw_menu_uses_carriage_return_newlines(monkeypatch) -> None:
 
 def test_erase_menu_block_resets_to_column_zero(monkeypatch) -> None:
     terminal = io.StringIO()
-    proxy = io.StringIO()
-    proxy.original_stdout = terminal  # type: ignore[attr-defined]
-    monkeypatch.setattr(sys, "stdout", proxy)
+    proxy = _patch_stdout_proxy(monkeypatch, terminal)
+    monkeypatch.setattr(choice_menu, "repl_tty_interactive", lambda: False)
 
     choice_menu._erase_menu("crumb", ["one", "two"])
 
@@ -54,11 +79,22 @@ def test_erase_menu_block_resets_to_column_zero(monkeypatch) -> None:
     assert terminal.getvalue() == "\x1b[0G"
 
 
-def test_reset_tty_column_writes_carriage_return(monkeypatch) -> None:
+def test_erase_menu_block_writes_erase_to_terminal_when_interactive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     terminal = io.StringIO()
-    proxy = io.StringIO()
-    proxy.original_stdout = terminal  # type: ignore[attr-defined]
-    monkeypatch.setattr(sys, "stdout", proxy)
+    _patch_stdout_proxy(monkeypatch, terminal)
+    monkeypatch.setattr(choice_menu, "repl_tty_interactive", lambda: True)
+
+    choice_menu._erase_menu("crumb", ["one", "two"])
+
+    assert "\x1b[" in terminal.getvalue()
+    assert terminal.getvalue().endswith("\x1b[0G")
+
+
+def test_reset_tty_column_writes_cursor_home_sequence(monkeypatch) -> None:
+    terminal = io.StringIO()
+    proxy = _patch_stdout_proxy(monkeypatch, terminal)
 
     choice_menu.reset_tty_column()
 
@@ -68,9 +104,7 @@ def test_reset_tty_column_writes_carriage_return(monkeypatch) -> None:
 
 def test_prepare_repl_output_line_writes_to_terminal_stdout(monkeypatch) -> None:
     terminal = io.StringIO()
-    proxy = io.StringIO()
-    proxy.original_stdout = terminal  # type: ignore[attr-defined]
-    monkeypatch.setattr(sys, "stdout", proxy)
+    proxy = _patch_stdout_proxy(monkeypatch, terminal)
     monkeypatch.setattr(choice_menu, "repl_tty_interactive", lambda: True)
 
     choice_menu.prepare_repl_output_line()

--- a/tests/cli/interactive_shell/ui/test_choice_menu.py
+++ b/tests/cli/interactive_shell/ui/test_choice_menu.py
@@ -66,6 +66,23 @@ def test_draw_menu_uses_carriage_return_newlines(monkeypatch) -> None:
     assert "\r > /integrations list" in plain
 
 
+def test_draw_menu_writes_to_terminal_when_proxy_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    terminal = io.StringIO()
+    proxy = _patch_stdout_proxy(monkeypatch, terminal)
+    monkeypatch.setattr(choice_menu, "_cols", lambda: 80)
+
+    choice_menu._draw_menu(
+        title="integrations",
+        crumb="/integrations",
+        labels=["/integrations list"],
+        index=0,
+        erase_lines=0,
+    )
+
+    assert proxy.getvalue() == ""
+    assert "integrations" in terminal.getvalue()
+
+
 def test_erase_menu_block_resets_to_column_zero(monkeypatch) -> None:
     terminal = io.StringIO()
     proxy = _patch_stdout_proxy(monkeypatch, terminal)
@@ -91,7 +108,7 @@ def test_erase_menu_block_writes_erase_to_terminal_when_proxy_active(
     assert terminal.getvalue().endswith("\x1b[0G")
 
 
-def test_reset_tty_column_writes_cursor_home_sequence(monkeypatch) -> None:
+def test_reset_tty_column_moves_cursor_to_column_zero(monkeypatch) -> None:
     terminal = io.StringIO()
     proxy = _patch_stdout_proxy(monkeypatch, terminal)
 

--- a/tests/cli/interactive_shell/ui/test_rendering.py
+++ b/tests/cli/interactive_shell/ui/test_rendering.py
@@ -8,11 +8,13 @@ import threading
 import pytest
 from rich.console import Console
 
+from app.cli.interactive_shell.config.tool_catalog import ToolCatalogEntry
 from app.cli.interactive_shell.runtime import loop
 from app.cli.interactive_shell.ui.rendering import (
     print_planned_actions,
     render_integrations_table,
     render_mcp_table,
+    render_tools_table,
     repl_print,
     repl_table,
 )
@@ -99,20 +101,24 @@ def test_repl_print_streaming_console_prepares_tty_once_when_interactive(
     )
     repl_print(console, "line")
 
-    assert fake_stdout.writes == ["\r\n", "\r"]
+    assert fake_stdout.writes == ["\n\x1b[0G", "line\n"]
 
 
 def test_render_integrations_table_resets_tty_before_print(monkeypatch) -> None:
     """Regression: padded inline menus leave the cursor at a high column."""
-    resets: list[bool] = []
+    terminal = io.StringIO()
+    proxy = io.StringIO()
 
     monkeypatch.setattr(
-        "app.cli.interactive_shell.ui.choice_menu.prepare_repl_output_line",
-        lambda: resets.append(True),
+        "app.cli.interactive_shell.ui.choice_menu.repl_tty_interactive",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.choice_menu.repl_terminal_stdout",
+        lambda: terminal,
     )
 
-    buf = io.StringIO()
-    console = Console(file=buf, force_terminal=False, width=80)
+    console = Console(file=proxy, force_terminal=False, width=80)
     render_integrations_table(
         console,
         [
@@ -125,20 +131,25 @@ def test_render_integrations_table_resets_tty_before_print(monkeypatch) -> None:
         ],
     )
 
-    assert len(resets) == 1
-    assert "grafana" in buf.getvalue()
+    assert terminal.getvalue().startswith("\n\x1b[0G")
+    assert "grafana" in terminal.getvalue()
+    assert proxy.getvalue() == ""
 
 
 def test_render_mcp_table_prepares_tty_once(monkeypatch) -> None:
-    resets: list[bool] = []
+    terminal = io.StringIO()
+    proxy = io.StringIO()
 
     monkeypatch.setattr(
-        "app.cli.interactive_shell.ui.choice_menu.prepare_repl_output_line",
-        lambda: resets.append(True),
+        "app.cli.interactive_shell.ui.choice_menu.repl_tty_interactive",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.choice_menu.repl_terminal_stdout",
+        lambda: terminal,
     )
 
-    buf = io.StringIO()
-    console = Console(file=buf, force_terminal=False, width=80)
+    console = Console(file=proxy, force_terminal=False, width=80)
     render_mcp_table(
         console,
         [
@@ -151,8 +162,65 @@ def test_render_mcp_table_prepares_tty_once(monkeypatch) -> None:
         ],
     )
 
-    assert len(resets) == 1
-    assert "github" in buf.getvalue()
+    assert terminal.getvalue().startswith("\n\x1b[0G")
+    assert "github" in terminal.getvalue()
+    assert proxy.getvalue() == ""
+
+
+def test_render_tools_table_shows_tool_rows() -> None:
+    catalog = [
+        ToolCatalogEntry(
+            name="MyTool",
+            surfaces=("investigation", "chat"),
+            description="Does something useful",
+            source_file="app/tools/my_tool.py",
+            input_schema_summary="query: string",
+        ),
+        ToolCatalogEntry(
+            name="AnotherTool",
+            surfaces=("investigation",),
+            description="Fetches metrics",
+            source_file="app/tools/another.py",
+            input_schema_summary="(no params)",
+        ),
+    ]
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    render_tools_table(console, catalog)
+    out = buf.getvalue()
+    assert "Tools" in out
+    assert "MyTool" in out
+    assert "AnotherTool" in out
+    assert "chat, investigation" in out
+    assert "Does something useful" in out
+
+
+def test_render_tools_table_empty_shows_hint() -> None:
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    render_tools_table(console, [])
+    assert "no tools registered" in buf.getvalue()
+
+
+def test_render_models_table_has_header_row() -> None:
+    """render_models_table must show column headers for visual parity with other tables."""
+
+    class _FakeLLM:
+        provider = "anthropic"
+        anthropic_reasoning_model = "claude-opus-4"
+        anthropic_toolcall_model = "claude-haiku-4"
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=80)
+    from app.cli.interactive_shell.ui.rendering import render_models_table
+
+    render_models_table(console, _FakeLLM())
+    out = buf.getvalue()
+    # Title and row values
+    assert "LLM connection" in out
+    assert "anthropic" in out
+    # "setting" column header must appear now that show_header is True
+    assert "setting" in out
 
 
 def test_print_planned_actions_formats_kinds() -> None:

--- a/tests/cli/interactive_shell/ui/test_rendering.py
+++ b/tests/cli/interactive_shell/ui/test_rendering.py
@@ -194,6 +194,7 @@ def test_render_tools_table_shows_tool_rows() -> None:
     assert "AnotherTool" in out
     assert "chat, investigation" in out
     assert "Does something useful" in out
+    assert "query: string" in out
 
 
 def test_render_tools_table_empty_shows_hint() -> None:

--- a/tests/cli/interactive_shell/ui/test_rendering.py
+++ b/tests/cli/interactive_shell/ui/test_rendering.py
@@ -23,6 +23,7 @@ from app.cli.interactive_shell.ui.rendering import (
 def test_repl_table_minimal_box() -> None:
     t = repl_table(title="T")
     assert t.title == "T"
+    assert t.title_justify == "left"
 
 
 def test_render_integrations_table_empty_shows_hint() -> None:


### PR DESCRIPTION
Fixes formatting for `/lists`

<img width="1221" height="357" alt="image" src="https://github.com/user-attachments/assets/e2f88241-552b-4ab5-b201-38048b5c90d1" />


#### Describe the changes you have made in this PR -

- Fix broken Rich table rendering after inline `/list` submenu pickers (models, integrations, tools)
- Bypass `prompt_toolkit.patch_stdout` async buffering by writing cursor resets synchronously to the real terminal stdout
- Render post-menu Rich output (tables, status lines) through the underlying terminal stream so bytes are ordered correctly
- Add `render_tools_table` so `/list tools` uses the same Rich table format as other list views
- Show models table column headers (`setting` / `value`) for visual parity

### Demo/Screenshot for feature changes and bug fixes - 

PTY regression test output (inline menu → table under `patch_stdout` + worker thread):

```
LLM connection
setting                                       │ value
provider                                      │ codex
reasoning model                               │ CLI default
toolcall model                                │ CLI default
```

Before this fix, the first character of each row wrapped to the far right (`etting`, `rovider`, etc.) because the cursor reset was queued on `StdoutProxy` while Rich rendered immediately from the dispatch worker thread.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Inline REPL menus pad rows to terminal width, leaving the cursor on a high column. After a submenu selection, Rich tables were rendered from a worker thread while `patch_stdout` buffered cursor-reset bytes asynchronously. The table often reached the terminal before the reset, so each row started at the last column and the first character wrapped to the far right.

The fix adds `repl_terminal_stdout()` to reach the underlying terminal stream, writes `\n\x1b[0G` synchronously before Rich output, and temporarily routes Rich `Console.file` through that stream for post-menu prints. Tools rendering was also converted to a Rich table for consistency with integrations/models/mcp.

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.