### PR TITLE
fix(deps): add httpx[socks] to support SOCKS proxy environments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pydantic-settings>=2.12.0,<3",
     "kubernetes>=28.1.0",
     # HTTP and async
-    "httpx>=0.27.0",
+    "httpx[socks]>=0.27.0",
     "aiohttp>=3.9.0",
     "fastapi>=0.135.3",
     "uvicorn[standard]>=0.30.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1102,6 +1102,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
+]
+
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
@@ -1904,7 +1909,7 @@ dependencies = [
     { name = "filelock" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["socks"] },
     { name = "keyring" },
     { name = "kubernetes" },
     { name = "mcp" },
@@ -2009,7 +2014,7 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.29.0" },
     { name = "google-api-python-client", specifier = ">=2.194.0,<3.0.0" },
     { name = "google-auth", specifier = ">=2.0.0,<3.0.0" },
-    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
     { name = "huggingface-hub", marker = "extra == 'dev'", specifier = ">=0.26.0" },
     { name = "huggingface-hub", marker = "extra == 'opensre-hub'", specifier = ">=0.26.0" },
     { name = "keyring" },
@@ -3378,6 +3383,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Users with `HTTP_PROXY=socks5://...` or `HTTPS_PROXY=socks5://...` hit an `ImportError` the moment the OpenAI (or Anthropic) LLM client is initialised, because both libraries delegate HTTP to `httpx`, which tries to load `socksio` for SOCKS transport support — but that package was not a declared dependency.
- Fix: upgrade `httpx>=0.27.0` → `httpx[socks]>=0.27.0` so `socksio` is installed as part of the standard dependency set and SOCKS proxies just work out of the box.
- `uv.lock` regenerated to include the new `socksio` transitive dependency.

Closes #2474
Closes #2473

## Test plan

- [ ] `make lint` passes (`ruff check app/ tests/`)
- [ ] Existing unit suite passes (`uv run pytest tests/ -x -q --ignore=tests/e2e --ignore=tests/synthetic --ignore=tests/chaos_engineering --ignore=tests/deployment`)
- [ ] Manual: run with `HTTP_PROXY=socks5://127.0.0.1:1080` set — LLM client initialises without `ImportError`

https://claude.ai/code/session_01BFWoCxgLsfWeZwpiwUsgDo

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFWoCxgLsfWeZwpiwUsgDo)_