### PR TITLE
fix(scheduler): mock build_message in executor tests to isolate delivery layer

### DIFF
--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -32,9 +32,11 @@ class TestExecutor:
         )
 
         with (
+            patch("app.scheduler.executor.build_message") as mock_build,
             patch("app.scheduler.executor.resolve_telegram_credentials") as mock_creds,
             patch("app.scheduler.executor._deliver_telegram") as mock_deliver,
         ):
+            mock_build.return_value = "<b>Daily summary</b>"
             mock_creds.return_value = {"bot_token": "fake_token"}
             mock_deliver.return_value = (True, "", "msg_42")
 
@@ -67,7 +69,11 @@ class TestExecutor:
             chat_id="C123456",
         )
 
-        with patch("app.scheduler.executor._deliver_slack") as mock_deliver:
+        with (
+            patch("app.scheduler.executor.build_message") as mock_build,
+            patch("app.scheduler.executor._deliver_slack") as mock_deliver,
+        ):
+            mock_build.return_value = "<b>Daily summary</b>"
             mock_deliver.return_value = (True, "", "ts_123")
             result = execute_task(task, "2026-01-01T09:00")
 
@@ -83,7 +89,11 @@ class TestExecutor:
             chat_id="123456789",
         )
 
-        with patch("app.scheduler.executor._deliver_discord") as mock_deliver:
+        with (
+            patch("app.scheduler.executor.build_message") as mock_build,
+            patch("app.scheduler.executor._deliver_discord") as mock_deliver,
+        ):
+            mock_build.return_value = "<b>Daily summary</b>"
             mock_deliver.return_value = (True, "", "msg_99")
             result = execute_task(task, "2026-01-01T09:00")
 
@@ -99,7 +109,11 @@ class TestExecutor:
             chat_id="-100123",
         )
 
-        with patch("app.scheduler.executor._deliver_telegram") as mock_deliver:
+        with (
+            patch("app.scheduler.executor.build_message") as mock_build,
+            patch("app.scheduler.executor._deliver_telegram") as mock_deliver,
+        ):
+            mock_build.return_value = "<b>Daily summary</b>"
             mock_deliver.return_value = (True, "", "msg_1")
 
             # First execution succeeds

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -54,7 +54,11 @@ class TestExecutor:
             chat_id="-100123",
         )
 
-        with patch("app.scheduler.executor.resolve_telegram_credentials") as mock_creds:
+        with (
+            patch("app.scheduler.executor.build_message") as mock_build,
+            patch("app.scheduler.executor.resolve_telegram_credentials") as mock_creds,
+        ):
+            mock_build.return_value = "<b>Daily summary</b>"
             mock_creds.return_value = {}
             result = execute_task(task, "2026-01-01T09:00")
 
@@ -150,8 +154,13 @@ class TestExecutor:
             chat_id="-100123",
         )
 
-        with patch("app.scheduler.executor._deliver_telegram") as mock_deliver:
+        with (
+            patch("app.scheduler.executor.build_message") as mock_build,
+            patch("app.scheduler.executor._deliver_telegram") as mock_deliver,
+        ):
+            mock_build.return_value = "<b>Daily summary</b>"
             mock_deliver.return_value = (False, "Connection refused", "")
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is False
+        mock_deliver.assert_called_once()


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The four scheduler executor tests (`test_telegram_delivery_success`, `test_slack_delivery_success`, `test_discord_delivery_success`, `test_claim_dedup_prevents_double_execution`) were calling the real `build_message → run_investigation` pipeline, which requires an LLM API key and caused `assert False is True` failures in CI.
- Added `patch("app.scheduler.executor.build_message")` to each affected test so the delivery layer is exercised in isolation, matching the intent of the existing delivery-layer mocks.

## Root cause

`execute_task` calls `build_message(task)` before routing to the provider-specific `_deliver_*` function. The tests mocked `_deliver_*` but not `build_message`, so the live pipeline was invoked and raised `RuntimeError: LLM provider 'anthropic' requires ANTHROPIC_API_KEY to be set`, causing `execute_task` to return `False` instead of `True`.

## Test plan

- [x] `uv run pytest tests/scheduler/test_executor.py -v` → 7 passed
- [x] `make lint` → all checks passed
- [x] `make typecheck` → no issues

Closes #2477

https://claude.ai/code/session_012c3FZ6BaPcKhfGf6yCskBJ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012c3FZ6BaPcKhfGf6yCskBJ)_