### PR TITLE
feat(agents): add SLO breach detection and cooldown mechanism (#1508)

### DIFF
--- a/app/agents/slo_watchdog.py
+++ b/app/agents/slo_watchdog.py
@@ -191,9 +191,7 @@ async def _slo_watchdog_loop(
 
                 key = f"{agent.name}.{breach.slo_type}"
                 if not suppress_slo_alert(key, now):
-                    on_breach(
-                        agent.name, breach
-                    )  # TODO: wrap in asyncio.to_thread when investigation dispatch is added
+                    on_breach(agent.name, breach)
                     register_slo_alert(key, now)
             except Exception:
                 logger.debug(
@@ -205,7 +203,7 @@ async def _slo_watchdog_loop(
         await asyncio.sleep(interval)
 
 
-def start_slo_watchdog_loop(
+def start_slo_watchdog(
     on_breach: Callable[[str, SLOBreach], None], interval: float = 30.0
 ) -> asyncio.Task[None]:
     """Launch the background SLO watchdog and return the cancellable task."""

--- a/app/agents/slo_watchdog.py
+++ b/app/agents/slo_watchdog.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta, tzinfo
+
+from app.agents import AgentRegistry
+from app.agents.config import AgentBudget, load_agents_config
+from app.agents.sampler import get_snapshot
+
+logger = logging.getLogger(__name__)
+
+# Minimum time between repeated alerts for the same agent + SLO pair.
+# After a breach fires, subsequent breaches for the same key are
+# suppressed until this interval elapses.
+_COOL_DOWN_INTERVAL_MINUTES: timedelta = timedelta(minutes=30)
+
+# Maps ``"{agent_name}.{slo_type}"`` → earliest datetime at which
+# that key is eligible to fire again. Populated by ``register_slo_alert``
+# after a breach is dispatched; consulted by ``suppress_slo_alert``
+# before dispatching.
+_alert_trigger_registry: dict[str, datetime] = {}
+
+
+@dataclass(frozen=True)
+class SLOBreach:
+    """Immutable result of a threshold violation.
+
+    ``slo_type`` matches the ``AgentBudget`` field name that was breached.
+    ``detail`` is a human-readable one-liner suitable for REPL banners and
+    alert payloads.
+    """
+
+    slo_type: str
+    detail: str
+
+
+def register_slo_alert(key: str, alert_at: datetime) -> None:
+    """Record that ``key`` fired at ``alert_at``, suppressing re-fire
+    until ``alert_at + _COOL_DOWN_INTERVAL_MINUTES``.
+    Called by the watchdog loop immediately after dispatching an
+    investigation for a breach.  Empty keys are silently ignored
+    (defensive guard against malformed agent names).
+    """
+    if key != "":
+        _alert_trigger_registry[key] = alert_at + _COOL_DOWN_INTERVAL_MINUTES
+
+
+def suppress_slo_alert(key: str, now: datetime) -> bool:
+    """Return True if this breach should be suppressed (still in cooldown).
+    ``key`` is ``"{agent_name}.{slo_type}"`` — the same string passed
+    to ``register_slo_alert`` after a previous dispatch.
+    Returns False (= fire the alert) when:
+      - The key has never been registered (first breach).
+      - The cooldown period has elapsed since the last dispatch.
+    Returns True (= suppress) when:
+      - The key is empty (invalid, defensive guard).
+      - The key was registered and cooldown has not yet expired.
+    """
+
+    # Empty key indicates a programming error upstream; suppress rather
+    # than dispatching an investigation with no agent identity.
+    if key == "":
+        return True
+
+    trigger_time = _alert_trigger_registry.get(key)
+    if trigger_time is not None:
+        return now < trigger_time  # True when now < last trigger_time
+
+    # Key not in registry — first-ever breach for this agent+SLO. Allow it.
+    return False
+
+
+def check_slo_breach(
+    budget: AgentBudget,
+    *,
+    started_at: datetime,
+    now: datetime,
+    last_output_at: datetime | None,
+    hourly_spend_usd: float | None,
+    error_rate_pct: float | None,
+) -> SLOBreach | None:
+    """Return the highest-priority SLO breach for a single agent, or None.
+
+    Checks are evaluated in priority order — progress > cost > error —
+    and the first breach wins.  When multiple SLOs are violated
+    simultaneously, only the most actionable one fires; remaining
+    breaches surface on subsequent watchdog cycles after cooldown.
+
+    ``hourly_spend_usd`` and ``error_rate_pct`` are optional observed
+    values from collectors that do not yet exist; passing ``None``
+    skips that check.  Similarly, a ``None`` threshold in ``budget``
+    means the user has not configured that SLO — the check is skipped
+    regardless of the observed value.
+    """
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware (e.g. datetime.now(UTC)), got naive datetime")
+
+    if started_at.tzinfo is None:
+        raise ValueError(
+            "started_at must be timezone-aware (e.g. datetime.now(UTC)), got naive datetime"
+        )
+
+    # last_output_at is optional, when not provided (collector does not exit), we fall back to using
+    # the process started_at datetime.
+    if last_output_at is None:
+        last_output_at = started_at
+    elif last_output_at.tzinfo is None:
+        raise ValueError(
+            "last_output_at must be timezone-aware (e.g. datetime.now(UTC)), got naive datetime"
+        )
+
+    # Clock skew / negative delta: if now < last_output_at, total_seconds()
+    # is negative and floor-division yields a negative minute count, which
+    # can never >= a non-negative threshold — no false-positive breach.
+    no_progress = (now - last_output_at).total_seconds() // 60
+
+    # Return the first breach found (priority order: progress > cost > error)
+    if budget.progress_minutes is not None and no_progress >= budget.progress_minutes:
+        return SLOBreach(
+            slo_type="progress_minutes",
+            detail=f"{no_progress:.0f}m no progress (threshold: {budget.progress_minutes}m)",
+        )
+    elif (
+        hourly_spend_usd is not None
+        and budget.hourly_budget_usd is not None
+        and hourly_spend_usd >= budget.hourly_budget_usd
+    ):
+        return SLOBreach(
+            slo_type="hourly_budget_usd",
+            detail=f"spent ${hourly_spend_usd:g} (threshold: ${budget.hourly_budget_usd:g}/h)",
+        )
+    elif (
+        error_rate_pct is not None
+        and budget.error_rate_pct is not None
+        and error_rate_pct >= budget.error_rate_pct
+    ):
+        return SLOBreach(
+            slo_type="error_rate_pct",
+            detail=f"{error_rate_pct:.1f}% error rate (threshold: {budget.error_rate_pct:.1f}%)",
+        )
+
+    return None
+
+
+def _get_now(tz: tzinfo = UTC) -> datetime:
+    """Return the current time. Indirected so tests can monkeypatch the clock."""
+    return datetime.now(tz=tz)
+
+
+async def _slo_watchdog_loop(
+    on_breach: Callable[[str, SLOBreach], None], interval: float = 30.0
+) -> None:
+    """Check every registered agent against its configured SLOs each tick.
+    Runs until cancelled. Per-agent failures are logged at debug level
+    and never interrupt the loop — a single misconfigured or dead agent
+    does not tear down the watchdog.
+    On breach (not suppressed by cooldown), ``on_breach(agent_name, breach)``
+    is invoked synchronously. The caller is responsible for rendering the
+    banner and eventually dispatching an investigation.
+    """
+
+    while True:
+        budgets = load_agents_config().agents
+        registry = AgentRegistry()
+        now = _get_now(UTC)
+        for agent in registry.list():
+            try:
+                snapshot = get_snapshot(agent.pid)
+                if snapshot is None:
+                    continue
+
+                budget = budgets.get(agent.name)
+                if budget is None:
+                    continue
+
+                # Stub: collectors for hourly_spend_usd, error_rate_pct, and
+                # last_output_at do not exist yet — all passed as None.
+                breach = check_slo_breach(
+                    budget,
+                    started_at=snapshot.started_at,
+                    now=now,
+                    last_output_at=None,
+                    hourly_spend_usd=None,
+                    error_rate_pct=None,
+                )
+                if breach is None:
+                    continue
+
+                key = f"{agent.name}.{breach.slo_type}"
+                if not suppress_slo_alert(key, now):
+                    on_breach(
+                        agent.name, breach
+                    )  # TODO: wrap in asyncio.to_thread when investigation dispatch is added
+                    register_slo_alert(key, now)
+            except Exception:
+                logger.debug(
+                    "slo check failed for agent %s with pid %d",
+                    agent.name,
+                    agent.pid,
+                    exc_info=True,
+                )
+        await asyncio.sleep(interval)
+
+
+def start_slo_watchdog_loop(
+    on_breach: Callable[[str, SLOBreach], None], interval: float = 30.0
+) -> asyncio.Task[None]:
+    """Launch the background SLO watchdog and return the cancellable task."""
+    return asyncio.create_task(_slo_watchdog_loop(on_breach, interval))

--- a/app/agents/slo_watchdog.py
+++ b/app/agents/slo_watchdog.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime, timedelta, tzinfo
 
 from app.agents import AgentRegistry
 from app.agents.config import AgentBudget, load_agents_config
-from app.agents.sampler import get_snapshot
+from app.agents.sampler import get_snapshot, get_usd_per_hour
 
 logger = logging.getLogger(__name__)
 
@@ -89,9 +89,9 @@ def check_slo_breach(
     simultaneously, only the most actionable one fires; remaining
     breaches surface on subsequent watchdog cycles after cooldown.
 
-    ``hourly_spend_usd`` and ``error_rate_pct`` are optional observed
-    values from collectors that do not yet exist; passing ``None``
-    skips that check.  Similarly, a ``None`` threshold in ``budget``
+    ``error_rate_pct`` is an optional observed value from a collector
+    that do not yet exist; passing ``None`` skips that check.
+    Similarly, a ``None`` threshold in ``budget``
     means the user has not configured that SLO — the check is skipped
     regardless of the observed value.
     """
@@ -103,7 +103,7 @@ def check_slo_breach(
             "started_at must be timezone-aware (e.g. datetime.now(UTC)), got naive datetime"
         )
 
-    # last_output_at is optional, when not provided (collector does not exit), we fall back to using
+    # last_output_at is optional, when not provided (collector does not exist), we fall back to using
     # the process started_at datetime.
     if last_output_at is None:
         last_output_at = started_at
@@ -163,10 +163,21 @@ async def _slo_watchdog_loop(
     """
 
     while True:
-        budgets = load_agents_config().agents
-        registry = AgentRegistry()
+        try:
+            budgets = load_agents_config().agents
+        except Exception:
+            logger.warning("slo watchdog: failed to load agents config", exc_info=True)
+            await asyncio.sleep(interval)
+            continue
+        try:
+            registry = AgentRegistry()
+            agents = registry.list()
+        except Exception:
+            logger.warning("slo watchdog: failed to load agent registry", exc_info=True)
+            await asyncio.sleep(interval)
+            continue
         now = _get_now(UTC)
-        for agent in registry.list():
+        for agent in agents:
             try:
                 snapshot = get_snapshot(agent.pid)
                 if snapshot is None:
@@ -176,14 +187,14 @@ async def _slo_watchdog_loop(
                 if budget is None:
                     continue
 
-                # Stub: collectors for hourly_spend_usd, error_rate_pct, and
+                # Stub: collectors for error_rate_pct, and
                 # last_output_at do not exist yet — all passed as None.
                 breach = check_slo_breach(
                     budget,
                     started_at=snapshot.started_at,
                     now=now,
                     last_output_at=None,
-                    hourly_spend_usd=None,
+                    hourly_spend_usd=get_usd_per_hour(agent.pid),
                     error_rate_pct=None,
                 )
                 if breach is None:
@@ -191,8 +202,8 @@ async def _slo_watchdog_loop(
 
                 key = f"{agent.name}.{breach.slo_type}"
                 if not suppress_slo_alert(key, now):
-                    on_breach(agent.name, breach)
                     register_slo_alert(key, now)
+                    on_breach(agent.name, breach)
             except Exception:
                 logger.debug(
                     "slo check failed for agent %s with pid %d",

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -20,6 +20,7 @@ from rich.console import Console
 from rich.markup import escape
 
 from app.agents.sampler import start_sampler
+from app.agents.slo_watchdog import SLOBreach, start_slo_watchdog
 from app.cli.interactive_shell import alert_inbox as _alert_inbox
 from app.cli.interactive_shell.alert_renderer import drain_and_render_incoming
 from app.cli.interactive_shell.prompting import prompt_surface as _prompt_surface
@@ -298,6 +299,13 @@ async def run_interactive(
     try:
         with patch_stdout(raw=True):
             echo_console = Console(highlight=False, force_terminal=True, color_system="truecolor")
+
+            def _on_slo_breach_callback(agent_name: str, breach: SLOBreach) -> None:
+                echo_console.print(f"[{WARNING}]\\[SLO breach][/] {agent_name}: {breach.detail}")
+                # TODO: wrap in asyncio.to_thread when investigation dispatch is added
+
+            watchdog_task = start_slo_watchdog(on_breach=_on_slo_breach_callback, interval=30.0)
+
             while True:
                 if state.exit_requested:
                     return
@@ -379,6 +387,11 @@ async def run_interactive(
             await sampler_task
         except asyncio.CancelledError:
             # Expected during shutdown after explicit task cancellation.
+            pass
+        watchdog_task.cancel()
+        try:  # noqa: SIM105
+            await watchdog_task
+        except (asyncio.CancelledError, Exception):
             pass
         processor_task.cancel()
         alert_watcher_task.cancel()

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -297,12 +297,18 @@ async def run_interactive(
     processor_task = asyncio.create_task(_processor())
     alert_watcher_task = asyncio.create_task(_alert_watcher())
     try:
+        watchdog_task = None
         with patch_stdout(raw=True):
             echo_console = Console(highlight=False, force_terminal=True, color_system="truecolor")
 
             def _on_slo_breach_callback(agent_name: str, breach: SLOBreach) -> None:
-                echo_console.print(f"[{WARNING}]\\[SLO breach][/] {agent_name}: {breach.detail}")
-                # TODO: wrap in asyncio.to_thread when investigation dispatch is added
+                echo_console.print(
+                    f"[{WARNING}]\\[SLO breach][/] {escape(agent_name)}: {escape(breach.detail)}"
+                )
+                # Investigation dispatch deferred: the agent_incident pipeline node
+                # (from PR #1709) was removed.
+                # Until a dedicated agent_incident node is re-implemented, the watchdog
+                # surfaces breaches as banners only — no automated RCA is triggered.
 
             watchdog_task = start_slo_watchdog(on_breach=_on_slo_breach_callback, interval=30.0)
 
@@ -388,11 +394,13 @@ async def run_interactive(
         except asyncio.CancelledError:
             # Expected during shutdown after explicit task cancellation.
             pass
-        watchdog_task.cancel()
-        try:  # noqa: SIM105
-            await watchdog_task
-        except (asyncio.CancelledError, Exception):
-            pass
+        if watchdog_task is not None:
+            watchdog_task.cancel()
+            try:  # noqa: SIM105
+                await watchdog_task
+            except (asyncio.CancelledError, Exception):
+                # Expected during shutdown after explicit task cancellation.
+                pass
         processor_task.cancel()
         alert_watcher_task.cancel()
         try:

--- a/tests/agents/test_slo_watchdog.py
+++ b/tests/agents/test_slo_watchdog.py
@@ -14,7 +14,7 @@ from app.agents.slo_watchdog import (
     _alert_trigger_registry,
     check_slo_breach,
     register_slo_alert,
-    start_slo_watchdog_loop,
+    start_slo_watchdog,
     suppress_slo_alert,
 )
 
@@ -281,7 +281,7 @@ async def test_slo_watchdog_invokes_callback_on_breach(
     monkeypatch.setattr("app.agents.slo_watchdog.get_snapshot", lambda _pid: fake_snapshot)
     monkeypatch.setattr("app.agents.slo_watchdog._get_now", lambda _tz: now)
 
-    task = start_slo_watchdog_loop(on_breach=on_breach, interval=0.01)
+    task = start_slo_watchdog(on_breach=on_breach, interval=0.01)
     await asyncio.sleep(0.05)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
@@ -318,7 +318,7 @@ async def test_slo_watchdog_does_not_invoke_callback_on_no_snapshot(
     monkeypatch.setattr("app.agents.slo_watchdog.get_snapshot", lambda _pid: None)
     monkeypatch.setattr("app.agents.slo_watchdog._get_now", lambda _tz: now)
 
-    task = start_slo_watchdog_loop(on_breach=on_breach, interval=0.01)
+    task = start_slo_watchdog(on_breach=on_breach, interval=0.01)
     await asyncio.sleep(0.05)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
@@ -353,7 +353,7 @@ async def test_slo_watchdog_does_not_invoke_callback_on_no_budget(
     monkeypatch.setattr("app.agents.slo_watchdog.get_snapshot", lambda _pid: fake_snapshot)
     monkeypatch.setattr("app.agents.slo_watchdog._get_now", lambda _tz: now)
 
-    task = start_slo_watchdog_loop(on_breach=on_breach, interval=0.01)
+    task = start_slo_watchdog(on_breach=on_breach, interval=0.01)
     await asyncio.sleep(0.05)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
@@ -375,7 +375,7 @@ async def test_slo_watchdog_does_not_crash_on_empty_registry(
     monkeypatch.setattr("app.agents.slo_watchdog.AgentRegistry", lambda: registry)
     monkeypatch.setattr("app.agents.slo_watchdog._get_now", lambda _tz: now)
 
-    task = start_slo_watchdog_loop(on_breach=on_breach, interval=0.01)
+    task = start_slo_watchdog(on_breach=on_breach, interval=0.01)
     await asyncio.sleep(0.05)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
@@ -412,7 +412,7 @@ async def test_slo_watchdog_cooldown_suppression(
     monkeypatch.setattr("app.agents.slo_watchdog.get_snapshot", lambda _pid: fake_snapshot)
     monkeypatch.setattr("app.agents.slo_watchdog._get_now", lambda _tz: now)
 
-    task = start_slo_watchdog_loop(on_breach=on_breach, interval=0.01)
+    task = start_slo_watchdog(on_breach=on_breach, interval=0.01)
     await asyncio.sleep(0.05)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):

--- a/tests/agents/test_slo_watchdog.py
+++ b/tests/agents/test_slo_watchdog.py
@@ -255,6 +255,11 @@ def fake_snapshot() -> ProcessSnapshot:
     )
 
 
+@pytest.fixture(autouse=True)
+def clean_up_alert_trigger_registry() -> None:
+    _alert_trigger_registry.clear()
+
+
 @pytest.mark.asyncio
 async def test_slo_watchdog_invokes_callback_on_breach(
     monkeypatch: pytest.MonkeyPatch,
@@ -263,7 +268,7 @@ async def test_slo_watchdog_invokes_callback_on_breach(
     fake_snapshot: ProcessSnapshot,
 ) -> None:
     config.agents = {
-        "claude": AgentBudget(hourly_budget_usd=1, progress_minutes=2, error_rate_pct=3)
+        "claude": AgentBudget(hourly_budget_usd=5, progress_minutes=2, error_rate_pct=3)
     }
     registry.register(
         AgentRecord(
@@ -279,6 +284,7 @@ async def test_slo_watchdog_invokes_callback_on_breach(
     monkeypatch.setattr("app.agents.slo_watchdog.load_agents_config", lambda: config)
     monkeypatch.setattr("app.agents.slo_watchdog.AgentRegistry", lambda: registry)
     monkeypatch.setattr("app.agents.slo_watchdog.get_snapshot", lambda _pid: fake_snapshot)
+    monkeypatch.setattr("app.agents.slo_watchdog.get_usd_per_hour", lambda _pid: 2.0)
     monkeypatch.setattr("app.agents.slo_watchdog._get_now", lambda _tz: now)
 
     task = start_slo_watchdog(on_breach=on_breach, interval=0.01)
@@ -392,7 +398,7 @@ async def test_slo_watchdog_cooldown_suppression(
     fake_snapshot: ProcessSnapshot,
 ) -> None:
     config.agents = {
-        "codex": AgentBudget(hourly_budget_usd=1, progress_minutes=2, error_rate_pct=3)
+        "codex": AgentBudget(hourly_budget_usd=7, progress_minutes=2, error_rate_pct=3)
     }
     registry.register(
         AgentRecord(
@@ -402,14 +408,15 @@ async def test_slo_watchdog_cooldown_suppression(
             registered_at="2026-05-07T12:00:00+00:00",
         )
     )
-    now = datetime(2026, 5, 20, 12, 15, 0, tzinfo=UTC)
-    alert_at = datetime(2026, 5, 20, 12, 5, 0, tzinfo=UTC)
+    now = datetime(2026, 5, 23, 12, 15, 0, tzinfo=UTC)
+    alert_at = datetime(2026, 5, 23, 12, 5, 0, tzinfo=UTC)
     register_slo_alert("codex.progress_minutes", alert_at)
     on_breach = Mock()
 
     monkeypatch.setattr("app.agents.slo_watchdog.load_agents_config", lambda: config)
     monkeypatch.setattr("app.agents.slo_watchdog.AgentRegistry", lambda: registry)
     monkeypatch.setattr("app.agents.slo_watchdog.get_snapshot", lambda _pid: fake_snapshot)
+    monkeypatch.setattr("app.agents.slo_watchdog.get_usd_per_hour", lambda _pid: 2.0)
     monkeypatch.setattr("app.agents.slo_watchdog._get_now", lambda _tz: now)
 
     task = start_slo_watchdog(on_breach=on_breach, interval=0.01)

--- a/tests/agents/test_slo_watchdog.py
+++ b/tests/agents/test_slo_watchdog.py
@@ -1,0 +1,424 @@
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from app.agents import AgentRecord, AgentRegistry
+from app.agents.config import AgentBudget, AgentsConfig
+from app.agents.probe import ProcessSnapshot
+from app.agents.slo_watchdog import (
+    _COOL_DOWN_INTERVAL_MINUTES,
+    SLOBreach,
+    _alert_trigger_registry,
+    check_slo_breach,
+    register_slo_alert,
+    start_slo_watchdog_loop,
+    suppress_slo_alert,
+)
+
+
+@pytest.mark.parametrize(
+    "budget, started_at, now, last_output, hourly_spend_usd, error_rate_pct, expectation",
+    [
+        # breach progress minutes
+        (
+            AgentBudget(hourly_budget_usd=1, progress_minutes=1, error_rate_pct=5),
+            datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # started_at
+            datetime(2026, 5, 14, 12, 5, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 2, 0, tzinfo=UTC),  # last_output_at
+            0.5,
+            2,
+            SLOBreach(slo_type="progress_minutes", detail="3m no progress (threshold: 1m)"),
+        ),
+        # breach hourly budget
+        (
+            AgentBudget(hourly_budget_usd=1, progress_minutes=30, error_rate_pct=5),
+            datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # started_at
+            datetime(2026, 5, 14, 12, 25, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 15, 0, tzinfo=UTC),  # last_output_at
+            3,
+            2,
+            SLOBreach(slo_type="hourly_budget_usd", detail="spent $3 (threshold: $1/h)"),
+        ),
+        # breach error rate
+        (
+            AgentBudget(hourly_budget_usd=5, progress_minutes=30, error_rate_pct=5),
+            datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # started_at
+            datetime(2026, 5, 14, 12, 20, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 15, 0, tzinfo=UTC),  # last_output_at
+            3.5,
+            10,
+            SLOBreach(slo_type="error_rate_pct", detail="10.0% error rate (threshold: 5.0%)"),
+        ),
+        # multiple breaches: progress and hourly budget
+        (
+            AgentBudget(hourly_budget_usd=1, progress_minutes=1, error_rate_pct=5),
+            datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # started_at
+            datetime(2026, 5, 14, 12, 20, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 18, 0, tzinfo=UTC),  # last_output_at
+            2.5,
+            20,
+            SLOBreach(slo_type="progress_minutes", detail="2m no progress (threshold: 1m)"),
+        ),
+        # multiple breaches: hourly budget and error rate
+        (
+            AgentBudget(hourly_budget_usd=1, progress_minutes=10, error_rate_pct=5),
+            datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # started_at
+            datetime(2026, 5, 14, 12, 20, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 18, 0, tzinfo=UTC),  # last_output_at
+            2.5,
+            20,
+            SLOBreach(slo_type="hourly_budget_usd", detail="spent $2.5 (threshold: $1/h)"),
+        ),
+        # last_output_at is not provided (None)
+        (
+            AgentBudget(hourly_budget_usd=1, progress_minutes=5, error_rate_pct=5),
+            datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # started_at
+            datetime(2026, 5, 14, 12, 7, 0, tzinfo=UTC),  # now
+            None,  # last_output_at
+            0.5,
+            2,
+            SLOBreach(slo_type="progress_minutes", detail="7m no progress (threshold: 5m)"),
+        ),
+        # no breach
+        (
+            AgentBudget(hourly_budget_usd=5, progress_minutes=30, error_rate_pct=5),
+            datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # started_at
+            datetime(2026, 5, 14, 12, 29, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 15, 0, tzinfo=UTC),  # last_output_at
+            4,
+            2,
+            None,  # expectation
+        ),
+        # hourly_spend_usd is not provided (None)
+        (
+            AgentBudget(hourly_budget_usd=1, progress_minutes=30, error_rate_pct=5),
+            datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # started_at
+            datetime(2026, 5, 14, 12, 25, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 15, 0, tzinfo=UTC),  # last_output_at
+            None,  # hourly_spend_usd
+            2,
+            None,  # expectation
+        ),
+        # error_rate_pct is not provided (None)
+        (
+            AgentBudget(hourly_budget_usd=1, progress_minutes=30, error_rate_pct=5),
+            datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # started_at
+            datetime(2026, 5, 14, 12, 25, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 15, 0, tzinfo=UTC),  # last_output_at
+            0.5,
+            None,  # error_rate_pct
+            None,  # expectation
+        ),
+        # edge case: now == last_output_at (zero gap)
+        (
+            AgentBudget(hourly_budget_usd=1, progress_minutes=1, error_rate_pct=5),
+            datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # started_at
+            datetime(2026, 5, 14, 12, 5, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 5, 0, tzinfo=UTC),  # last_output_at
+            0.9,
+            2,
+            None,
+        ),
+        # edge case: now < last_output_at (clock skew)
+        (
+            AgentBudget(hourly_budget_usd=5, progress_minutes=1, error_rate_pct=5),
+            datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # started_at
+            datetime(2026, 5, 14, 12, 3, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 5, 0, tzinfo=UTC),  # last_output_at
+            4,
+            2,
+            None,
+        ),
+        # edge case: None agent budget field (progress_minutes is None)
+        (
+            AgentBudget(hourly_budget_usd=1, progress_minutes=None, error_rate_pct=5),
+            datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # started_at
+            datetime(2026, 5, 14, 12, 5, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 2, 0, tzinfo=UTC),  # last_output_at
+            0.5,
+            2,
+            None,
+        ),
+        # edge case: (gap == threshold)
+        (
+            AgentBudget(hourly_budget_usd=1, progress_minutes=1, error_rate_pct=5),
+            datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # started_at
+            datetime(2026, 5, 14, 12, 3, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 2, 0, tzinfo=UTC),  # last_output_at
+            0.5,
+            2,
+            SLOBreach(slo_type="progress_minutes", detail="1m no progress (threshold: 1m)"),
+        ),
+    ],
+)
+def test_check_slo_breach(
+    budget,
+    started_at,
+    now,
+    last_output,
+    hourly_spend_usd,
+    error_rate_pct,
+    expectation,
+) -> None:
+    """Table-driven breach detection covering each SLO type in isolation,
+    priority when multiple breach simultaneously, None observed values
+    (stub collectors), None thresholds (unconfigured SLOs), and boundary
+    edge cases (zero gap, clock skew, exact-threshold).
+    """
+    assert (
+        check_slo_breach(
+            budget,
+            started_at=started_at,
+            now=now,
+            last_output_at=last_output,
+            hourly_spend_usd=hourly_spend_usd,
+            error_rate_pct=error_rate_pct,
+        )
+        == expectation
+    )
+
+
+class TestSuppressSloAlert:
+    @pytest.fixture(autouse=True)
+    def clean_up_alert_trigger_registry(self) -> None:
+        _alert_trigger_registry.clear()
+
+    @pytest.mark.parametrize(
+        "key, alert_at, now, expectation",
+        [
+            # below cool down interval and key exits, suppress alert (true)
+            (
+                "cursor.progress_minutes",
+                datetime(2026, 5, 14, 12, 2, 0, tzinfo=UTC),  # alert_at
+                datetime(2026, 5, 14, 12, 25, 0, tzinfo=UTC),  # now
+                True,
+            ),
+            # above cool down interval and key exists, suppress alert (false)
+            (
+                "cursor.hourly_budget_usd",
+                datetime(2026, 5, 14, 11, 0, 0, tzinfo=UTC),  # alert_at
+                datetime(2026, 5, 14, 12, 31, 0, tzinfo=UTC),  # now
+                False,
+            ),
+            # key is empty, suppress alert (true)
+            (
+                "",  # empty key will not be registered
+                datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # alert_at
+                datetime(2026, 5, 14, 12, 30, 0, tzinfo=UTC),  # now
+                True,
+            ),
+            # edge case: at the boundary, suppress alert (false)
+            (
+                "cursor.error_rate_pct",
+                datetime(2026, 5, 14, 12, 2, 0, tzinfo=UTC),  # alert_at
+                datetime(2026, 5, 14, 12, 32, 0, tzinfo=UTC),  # now
+                False,
+            ),
+        ],
+    )
+    def test_suppress_slo_alert(self, key, alert_at, now, expectation) -> None:
+        register_slo_alert(key, alert_at)
+        assert suppress_slo_alert(key, now) == expectation
+
+    def test_first_breach_not_suppressed(self) -> None:
+        assert (
+            suppress_slo_alert(
+                "claude.hourly_budget_usd", datetime(2026, 5, 19, 19, 0, 0, tzinfo=UTC)
+            )
+            is not True
+        )
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> AgentRegistry:
+    return AgentRegistry(path=tmp_path / "agents.jsonl")
+
+
+@pytest.fixture
+def config() -> AgentsConfig:
+    return AgentsConfig()
+
+
+@pytest.fixture
+def fake_snapshot() -> ProcessSnapshot:
+    return ProcessSnapshot(
+        pid=8421,
+        cpu_percent=23.5,
+        rss_mb=128.0,
+        num_fds=42,
+        num_connections=3,
+        status="running",
+        started_at=datetime(2026, 5, 21, 12, 0, 0, tzinfo=UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_slo_watchdog_invokes_callback_on_breach(
+    monkeypatch: pytest.MonkeyPatch,
+    config: AgentsConfig,
+    registry: AgentRegistry,
+    fake_snapshot: ProcessSnapshot,
+) -> None:
+    config.agents = {
+        "claude": AgentBudget(hourly_budget_usd=1, progress_minutes=2, error_rate_pct=3)
+    }
+    registry.register(
+        AgentRecord(
+            name="claude",
+            pid=8421,
+            command="claude --dangerously-skip-permissions",
+            registered_at="2026-05-07T12:00:00+00:00",
+        )
+    )
+    now = datetime(2026, 5, 21, 12, 5, 0, tzinfo=UTC)
+    on_breach = Mock()
+
+    monkeypatch.setattr("app.agents.slo_watchdog.load_agents_config", lambda: config)
+    monkeypatch.setattr("app.agents.slo_watchdog.AgentRegistry", lambda: registry)
+    monkeypatch.setattr("app.agents.slo_watchdog.get_snapshot", lambda _pid: fake_snapshot)
+    monkeypatch.setattr("app.agents.slo_watchdog._get_now", lambda _tz: now)
+
+    task = start_slo_watchdog_loop(on_breach=on_breach, interval=0.01)
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        _ = await task
+
+    on_breach.assert_called_once_with(
+        "claude", SLOBreach(slo_type="progress_minutes", detail="5m no progress (threshold: 2m)")
+    )
+    assert _alert_trigger_registry["claude.progress_minutes"] == now + _COOL_DOWN_INTERVAL_MINUTES
+
+
+@pytest.mark.asyncio
+async def test_slo_watchdog_does_not_invoke_callback_on_no_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    config: AgentsConfig,
+    registry: AgentRegistry,
+) -> None:
+    config.agents = {
+        "cursor": AgentBudget(hourly_budget_usd=1, progress_minutes=2, error_rate_pct=3)
+    }
+    registry.register(
+        AgentRecord(
+            name="cursor",
+            pid=8421,
+            command="cursor",
+            registered_at="2026-05-09T12:00:00+00:00",
+        )
+    )
+    now = datetime(2026, 5, 21, 11, 0, 0, tzinfo=UTC)
+    on_breach = Mock()
+
+    monkeypatch.setattr("app.agents.slo_watchdog.load_agents_config", lambda: config)
+    monkeypatch.setattr("app.agents.slo_watchdog.AgentRegistry", lambda: registry)
+    monkeypatch.setattr("app.agents.slo_watchdog.get_snapshot", lambda _pid: None)
+    monkeypatch.setattr("app.agents.slo_watchdog._get_now", lambda _tz: now)
+
+    task = start_slo_watchdog_loop(on_breach=on_breach, interval=0.01)
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        _ = await task
+
+    on_breach.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_slo_watchdog_does_not_invoke_callback_on_no_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    config: AgentsConfig,
+    registry: AgentRegistry,
+    fake_snapshot: ProcessSnapshot,
+) -> None:
+    config.agents = {
+        "cursor": AgentBudget(hourly_budget_usd=1, progress_minutes=2, error_rate_pct=3)
+    }
+    registry.register(
+        AgentRecord(
+            name="codex",
+            pid=8421,
+            command="codex",
+            registered_at="2026-05-09T12:00:00+00:00",
+        )
+    )
+    now = datetime(2026, 5, 23, 11, 0, 0, tzinfo=UTC)
+    on_breach = Mock()
+
+    monkeypatch.setattr("app.agents.slo_watchdog.load_agents_config", lambda: config)
+    monkeypatch.setattr("app.agents.slo_watchdog.AgentRegistry", lambda: registry)
+    monkeypatch.setattr("app.agents.slo_watchdog.get_snapshot", lambda _pid: fake_snapshot)
+    monkeypatch.setattr("app.agents.slo_watchdog._get_now", lambda _tz: now)
+
+    task = start_slo_watchdog_loop(on_breach=on_breach, interval=0.01)
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        _ = await task
+
+    on_breach.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_slo_watchdog_does_not_crash_on_empty_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    config: AgentsConfig,
+    registry: AgentRegistry,
+) -> None:
+    now = datetime(2026, 5, 22, 11, 0, 0, tzinfo=UTC)
+    on_breach = Mock()
+
+    monkeypatch.setattr("app.agents.slo_watchdog.load_agents_config", lambda: config)
+    monkeypatch.setattr("app.agents.slo_watchdog.AgentRegistry", lambda: registry)
+    monkeypatch.setattr("app.agents.slo_watchdog._get_now", lambda _tz: now)
+
+    task = start_slo_watchdog_loop(on_breach=on_breach, interval=0.01)
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        _ = await task
+
+    on_breach.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_slo_watchdog_cooldown_suppression(
+    monkeypatch: pytest.MonkeyPatch,
+    config: AgentsConfig,
+    registry: AgentRegistry,
+    fake_snapshot: ProcessSnapshot,
+) -> None:
+    config.agents = {
+        "codex": AgentBudget(hourly_budget_usd=1, progress_minutes=2, error_rate_pct=3)
+    }
+    registry.register(
+        AgentRecord(
+            name="codex",
+            pid=8421,
+            command="codex",
+            registered_at="2026-05-07T12:00:00+00:00",
+        )
+    )
+    now = datetime(2026, 5, 20, 12, 15, 0, tzinfo=UTC)
+    alert_at = datetime(2026, 5, 20, 12, 5, 0, tzinfo=UTC)
+    register_slo_alert("codex.progress_minutes", alert_at)
+    on_breach = Mock()
+
+    monkeypatch.setattr("app.agents.slo_watchdog.load_agents_config", lambda: config)
+    monkeypatch.setattr("app.agents.slo_watchdog.AgentRegistry", lambda: registry)
+    monkeypatch.setattr("app.agents.slo_watchdog.get_snapshot", lambda _pid: fake_snapshot)
+    monkeypatch.setattr("app.agents.slo_watchdog._get_now", lambda _tz: now)
+
+    task = start_slo_watchdog_loop(on_breach=on_breach, interval=0.01)
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        _ = await task
+
+    on_breach.assert_not_called()
+    assert (
+        _alert_trigger_registry["codex.progress_minutes"] == alert_at + _COOL_DOWN_INTERVAL_MINUTES
+    )


### PR DESCRIPTION
Fixes #1508 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR
This PR implements the SLO breach detector (watchdog) for the monitor-local-agents feature. It adds a background async loop that continuously checks every registered agent against its configured SLO thresholds from `agents.yaml` and surfaces a Rich-formatted banner in the REPL when a breach is detected.

### Demo/Screenshot for feature changes and bug fixes
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

#### Before

https://github.com/user-attachments/assets/9dee1557-3966-406d-aba4-e12e218456db

#### After

https://github.com/user-attachments/assets/8e62d880-86a8-414a-898e-9a318529ce66

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

### What ships with this PR
- **Per-agent SLO checking:** The watchdog reads `hourly_budget_usd`, `progress_minutes`, and `error_rate_pct` thresholds from `agents.yaml` and evaluates them every 30 seconds against live agent data.
- **Cost SLO (live):** Wired to the existing `get_usd_per_hour()` token-rate-based cost estimator from the sampler.
- **Progress SLO (inline check):** Compares time elapsed since `started_at` against the user's configured `progress_minutes` threshold. Uses `started_at` as a proxy because no output collector provides `last_output_at` yet — once one exists, the check will use actual last-output time instead of process birth time.
- **Error rate SLO (stub):** Accepted in the function signature but no collector exists yet — `None` is passed and the check is skipped.
- **Cooldown/dedup:** A 30-minute suppression window prevents the same agent+SLO from re-firing. The user sees at most 2 notifications per hour per breach.
- **REPL banner:** Breach notifications render above the prompt via `patch_stdout`, matching the existing alert inbox UX.
- **Graceful degradation:** Missing config, dead agents, empty registry, no snapshots, unconfigured SLOs — all handled without crashing the loop.
### What is deferred
- **Investigation dispatch:** The issue specifies that a breach should trigger an automated investigation via the `agent_incident` pipeline node (shipped in PR #1709). That node was removed in another task. Until a dedicated `agent_incident` node is re-implemented, the watchdog surfaces breaches as banners only — no automated RCA is triggered.
- **`last_output_at` collector:** The progress SLO currently falls back to `started_at` (process birth time), which may produce false-positive "stuck" detections for long-running agents that are actively producing output. A proper output collector will eliminate this limitation.
### Key design decisions
**Pure function + async loop separation:** The breach-check logic (`check_slo_breach`) is a pure function — no asyncio, no side effects, fully testable with table-driven parametrize. The async loop (`_slo_watchdog_loop`) is thin glue that calls the pure function on a timer. This separation makes the core logic easy to test and reason about independently.
**Callback as architectural boundary:** The watchdog module has no knowledge of consoles, Rich, or the REPL. It accepts an `on_breach(agent_name, breach)` callback that the REPL provides. This keeps the `app/agents/` package free of UI dependencies and makes the watchdog reusable from other surfaces (e.g., a daemon or webhook in the future).
**Priority-ordered single-breach return:** When multiple SLOs are violated simultaneously, only the highest-priority one fires (progress > cost > error). This prevents notification storms and ensures the most actionable breach gets attention first. Other breaches surface on subsequent cycles after the cooldown window.
**Cooldown via next-trigger-time:** Rather than storing "last fired at" and computing elapsed time on each check, the registry stores the next eligible fire time directly. Suppression becomes a single comparison (`now < trigger_time`), which is simpler and avoids repeated arithmetic.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
