### PR TITLE
fix(postgresql): actionable error message when psycopg2 missing in frozen binary

### DIFF
--- a/app/integrations/postgresql.py
+++ b/app/integrations/postgresql.py
@@ -123,9 +123,18 @@ def resolve_postgresql_config(
 
 def _get_connection(config: PostgreSQLConfig) -> Any:
     """Create a psycopg2 connection from config. Caller must close."""
+    import sys
+
     try:
         import psycopg2  # type: ignore[import-untyped]
     except ModuleNotFoundError as exc:
+        if getattr(sys, "frozen", False):
+            raise RuntimeError(
+                "psycopg2 is not available in this opensre installation. "
+                "The Homebrew/binary build does not bundle psycopg2. "
+                "To use the PostgreSQL integration, install opensre from PyPI: "
+                "`pip install 'opensre[postgresql]'` or `pip install psycopg2-binary`."
+            ) from exc
         raise RuntimeError(
             "psycopg2 is not installed. Install it with: pip install psycopg2-binary"
         ) from exc


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Sentry issue #2459 showed that users installing `opensre` via Homebrew or the PyInstaller binary got `RuntimeError: psycopg2 is not installed. Install it with: pip install psycopg2-binary` — a command that has no effect on frozen builds since the bundled Python interpreter cannot see host-installed packages.
- Detect `sys.frozen` (set by PyInstaller at runtime) and surface a message that correctly explains the limitation and directs users to a pip/source install.
- Non-frozen (normal Python) installs keep the original message unchanged.

## Test plan

- [ ] All 1142 integration tests pass (`uv run pytest tests/integrations/ -v`)
- [ ] `ruff check` and `ruff format --check` pass on the changed file
- [ ] Manually verify: in a frozen PyInstaller binary environment the new message is shown; in a normal Python env the original message is shown

Closes #2459

https://claude.ai/code/session_01Km8dXEFwL7E6u7tcxssuA5
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Km8dXEFwL7E6u7tcxssuA5)_