### PR TITLE
fix(services): wrap SOCKS proxy ImportError with actionable message

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -408,7 +408,15 @@ class OpenAIAgentClient:
         from app.llm_credentials import resolve_llm_api_key
 
         api_key = resolve_llm_api_key(api_key_env) or api_key_default
-        self._client = OpenAI(api_key=api_key, base_url=base_url, timeout=_CLIENT_TIMEOUT_SEC)
+        try:
+            self._client = OpenAI(api_key=api_key, base_url=base_url, timeout=_CLIENT_TIMEOUT_SEC)
+        except ImportError as err:
+            if "socksio" in str(err).lower():
+                raise RuntimeError(
+                    "Your environment uses a SOCKS proxy but the 'socksio' package is not "
+                    "installed. Run: pip install 'httpx[socks]'"
+                ) from err
+            raise
         self._model = model
         self._max_tokens = max_tokens
 

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -796,12 +796,20 @@ class OpenAILLMClient:
         return True
 
     def _build_client(self, api_key: str) -> OpenAI:
-        return OpenAI(
-            api_key=api_key,
-            base_url=self._base_url,
-            timeout=_CLIENT_TIMEOUT_SEC,
-            default_headers=self._default_headers,
-        )
+        try:
+            return OpenAI(
+                api_key=api_key,
+                base_url=self._base_url,
+                timeout=_CLIENT_TIMEOUT_SEC,
+                default_headers=self._default_headers,
+            )
+        except ImportError as err:
+            if "socksio" in str(err).lower():
+                raise RuntimeError(
+                    "Your environment uses a SOCKS proxy but the 'socksio' package is not "
+                    "installed. Run: pip install 'httpx[socks]'"
+                ) from err
+            raise
 
     def with_config(self, **_kwargs) -> OpenAILLMClient:
         return self

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -53,7 +53,10 @@ class TestExecutor:
             chat_id="-100123",
         )
 
-        with patch("app.scheduler.executor.resolve_telegram_credentials") as mock_creds:
+        with (
+            patch("app.scheduler.executor.build_message", return_value="summary text"),
+            patch("app.scheduler.executor.resolve_telegram_credentials") as mock_creds,
+        ):
             mock_creds.return_value = {}
             result = execute_task(task, "2026-01-01T09:00")
 

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -32,6 +32,7 @@ class TestExecutor:
         )
 
         with (
+            patch("app.scheduler.executor.build_message", return_value="summary text"),
             patch("app.scheduler.executor.resolve_telegram_credentials") as mock_creds,
             patch("app.scheduler.executor._deliver_telegram") as mock_deliver,
         ):
@@ -67,7 +68,10 @@ class TestExecutor:
             chat_id="C123456",
         )
 
-        with patch("app.scheduler.executor._deliver_slack") as mock_deliver:
+        with (
+            patch("app.scheduler.executor.build_message", return_value="summary text"),
+            patch("app.scheduler.executor._deliver_slack") as mock_deliver,
+        ):
             mock_deliver.return_value = (True, "", "ts_123")
             result = execute_task(task, "2026-01-01T09:00")
 
@@ -83,7 +87,10 @@ class TestExecutor:
             chat_id="123456789",
         )
 
-        with patch("app.scheduler.executor._deliver_discord") as mock_deliver:
+        with (
+            patch("app.scheduler.executor.build_message", return_value="summary text"),
+            patch("app.scheduler.executor._deliver_discord") as mock_deliver,
+        ):
             mock_deliver.return_value = (True, "", "msg_99")
             result = execute_task(task, "2026-01-01T09:00")
 
@@ -99,7 +106,10 @@ class TestExecutor:
             chat_id="-100123",
         )
 
-        with patch("app.scheduler.executor._deliver_telegram") as mock_deliver:
+        with (
+            patch("app.scheduler.executor.build_message", return_value="summary text"),
+            patch("app.scheduler.executor._deliver_telegram") as mock_deliver,
+        ):
             mock_deliver.return_value = (True, "", "msg_1")
 
             # First execution succeeds

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -146,8 +146,12 @@ class TestExecutor:
             chat_id="-100123",
         )
 
-        with patch("app.scheduler.executor._deliver_telegram") as mock_deliver:
+        with (
+            patch("app.scheduler.executor.build_message", return_value="summary text"),
+            patch("app.scheduler.executor._deliver_telegram") as mock_deliver,
+        ):
             mock_deliver.return_value = (False, "Connection refused", "")
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is False
+        mock_deliver.assert_called_once()


### PR DESCRIPTION
## Summary

- Catch `ImportError` from httpx's SOCKS proxy check in `OpenAIAgentClient.__init__` and `OpenAILLMClient._build_client`, re-raising as `RuntimeError` with clear install instructions (`pip install 'httpx[socks]'`)
- Fix four pre-existing scheduler test failures where `build_message` (which invokes the LLM pipeline) was not mocked, causing false failures in environments without an API key

## Root cause

When `HTTP_PROXY` or `HTTPS_PROXY` points at a SOCKS URL and `socksio` is not installed, httpx raises a bare `ImportError` that propagates through the OpenAI client constructor. Sentry captures this as an opaque crash with no actionable guidance (Sentry PYTHON-92 / PYTHON-93).

## Test plan

- [x] `make lint` — passes
- [x] `make format-check` — passes
- [x] `make typecheck` — passes
- [x] `uv run pytest tests/services/ tests/tools/ -v` — 749 passed
- [x] `uv run pytest tests/scheduler/test_executor.py -v` — 7 passed (was 4 failed)

Closes #2474
Closes #2473

https://claude.ai/code/session_01PGZPckEus7hsSnLd7nja8n

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGZPckEus7hsSnLd7nja8n)_