### PR TITLE
fix(integrations): skip Sentry report for Discord/Telegram with empty bot_token

### DIFF
--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -507,6 +507,8 @@ def _classify_service_instance(
         return None, None
 
     if key == "discord":
+        if not str(credentials.get("bot_token") or "").strip():
+            return None, None
         try:
             discord_config = DiscordBotConfig.model_validate(
                 {
@@ -519,11 +521,11 @@ def _classify_service_instance(
         except Exception as exc:
             _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
-        if discord_config.bot_token:
-            return discord_config.model_dump(), "discord"
-        return None, None
+        return discord_config.model_dump(), "discord"
 
     if key == "telegram":
+        if not str(credentials.get("bot_token") or "").strip():
+            return None, None
         try:
             tg_config = TelegramBotConfig.model_validate(
                 {
@@ -534,9 +536,7 @@ def _classify_service_instance(
         except Exception as exc:
             _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
-        if tg_config.bot_token:
-            return tg_config.model_dump(), "telegram"
-        return None, None
+        return tg_config.model_dump(), "telegram"
 
     if key == "whatsapp":
         try:

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -119,6 +119,15 @@ _CLASSIFY_PATCH_TARGETS: list[tuple[str, str]] = [
 ]
 
 
+# Discord and Telegram require a non-empty bot_token to reach the model_validate
+# call (empty token exits early without reporting). Supply one so the patched
+# constructor is reached and the Sentry-report path is exercised.
+_CLASSIFY_EXTRA_CREDS: dict[str, dict[str, str]] = {
+    "discord": {"bot_token": "test-discord-token"},
+    "telegram": {"bot_token": "test-telegram-token"},
+}
+
+
 @pytest.mark.parametrize(("integration", "patch_symbol"), _CLASSIFY_PATCH_TARGETS)
 def test_classify_failure_skips_integration_and_reports(
     integration: str,
@@ -134,10 +143,13 @@ def test_classify_failure_skips_integration_and_reports(
 
     monkeypatch.setattr(f"app.integrations._catalog_impl.{patch_symbol}", _boom)
 
+    base_creds = {"endpoint": "https://x", "api_key": "k"}
+    creds = {**base_creds, **_CLASSIFY_EXTRA_CREDS.get(integration, {})}
+
     with patch("app.integrations._catalog_impl.report_exception") as mock_report:
         result = _classify_service_instance(
             integration,
-            {"endpoint": "https://x", "api_key": "k"},
+            creds,
             record_id=f"rec-{integration}",
         )
 
@@ -153,6 +165,21 @@ def test_classify_failure_skips_integration_and_reports(
     assert tags["surface"] == "integration"
     assert mock_report.call_args.kwargs["severity"] == "warning"
     assert mock_report.call_args.kwargs["extras"]["record_id"] == f"rec-{integration}"
+
+
+@pytest.mark.parametrize("integration", ["discord", "telegram"])
+def test_classify_empty_bot_token_silent_skip(integration: str) -> None:
+    """Empty/missing bot_token must silently return (None, None) without a Sentry report.
+
+    An unconfigured integration is not a code bug — reporting it to Sentry creates
+    false alerts for operators (#2437).
+    """
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        result = _classify_service_instance(integration, {}, record_id="rec")
+    assert result == (None, None)
+    assert mock_report.call_count == 0, (
+        f"{integration}: empty bot_token must not trigger a Sentry report"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Root cause**: `_classify_service_instance` called `DiscordBotConfig.model_validate` / `TelegramBotConfig.model_validate` with an empty `bot_token`, which triggered a `ValidationError` that was forwarded to Sentry via `_report_classify_failure` — generating false alerts for every user without Discord/Telegram configured.
- **Fix**: Pre-check for empty/missing `bot_token` and return `(None, None)` silently before calling `model_validate`, mirroring the env-based loader pattern at line 1414. Genuine validation failures (e.g. invalid `public_key` format with a real token) still reach `_report_classify_failure` and Sentry.
- **Tests**: Updated `test_classify_failure_skips_integration_and_reports` to supply a non-empty `bot_token` for discord/telegram so the patched constructor is reached; added `test_classify_empty_bot_token_silent_skip` asserting no Sentry report fires for unconfigured integrations.

## Test plan

- [x] `uv run pytest tests/integrations/test_catalog_silent_fallback_elimination.py` — 53 passed
- [x] `make lint` — all checks passed
- [x] `make typecheck` — no issues in 687 files
- [x] `make format-check` — 1564 files formatted
- [x] `uv run pytest tests/integrations/ tests/tools/ tests/cli/` — 4458 passed

Closes #2437

https://claude.ai/code/session_018Sun7pwWHsDNgbwx1Fueog

---
_Generated by [Claude Code](https://claude.ai/code/session_018Sun7pwWHsDNgbwx1Fueog)_