### PR TITLE
fix(llm): raise descriptive RuntimeError for unexpected Anthropic response format

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -176,9 +176,17 @@ class AnthropicAgentClient:
         else:
             raise RuntimeError(f"{self.provider_name} invocation failed") from last_err
 
+        content_blocks = getattr(response, "content", None)
+        if not isinstance(content_blocks, list):
+            raise RuntimeError(
+                f"{self.provider_name} API returned an unexpected response format: "
+                f"expected 'content' to be a list of blocks, "
+                f"got {type(response).__name__!r} "
+                f"(content type: {type(content_blocks).__name__!r})"
+            )
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
-        for block in response.content:
+        for block in content_blocks:
             block_type = getattr(block, "type", None)
             if block_type == "text":
                 text_parts.append(block.text)

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -116,6 +116,29 @@ def test_bedrock_permission_denied_is_not_retried_and_mentions_marketplace(
     assert "aws-marketplace:Subscribe" in message
 
 
+def test_anthropic_unexpected_response_format_raises_descriptive_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the Anthropic SDK ever returns something without a list .content,
+    invoke() must raise a RuntimeError with a clear message rather than an
+    opaque AttributeError (Sentry PYTHON-8E / PYTHON-8F)."""
+    _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    client = AnthropicAgentClient(model="claude-sonnet-4-6")
+    # Simulate a broken/proxy response that is just a plain string.
+    client._client = types.SimpleNamespace(
+        messages=types.SimpleNamespace(create=lambda **_: "unexpected string response")
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    message = str(exc.value)
+    assert "unexpected response format" in message.lower()
+    assert "str" in message  # type name of the bad response should appear
+
+
 def test_internal_server_error_with_model_billing_fails_fast(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Sentry PYTHON-8E / PYTHON-8F reported `AttributeError: 'str' object has no attribute 'content'` inside `AnthropicAgentClient.invoke` at the line `for block in response.content:`. The error surfaced as an unhelpful `AttributeError` with no indication of which provider or what response was returned.
- Added a `isinstance(content_blocks, list)` guard immediately after the retry loop. When the Anthropic SDK (or a proxy in front of it) returns something that isn't a list of content blocks, we now raise a clear `RuntimeError` that names the unexpected response type and content type.
- Added a regression test (`test_anthropic_unexpected_response_format_raises_descriptive_error`) that simulates the production failure (a plain-string response from the client) and asserts the new error message is raised.

## Test plan

- [x] `uv run pytest tests/services/test_agent_llm_client.py` — 41 tests pass
- [x] `ruff check app/services/agent_llm_client.py tests/services/test_agent_llm_client.py` — no issues
- [x] `mypy app/services/agent_llm_client.py` — no issues

Closes #2415

https://claude.ai/code/session_01PpMWzkABDgPJdWxPmnB4hS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpMWzkABDgPJdWxPmnB4hS)_