### PR TITLE
fix(analytics): suppress SSL/HTTP noise from analytics worker in Sentry

### DIFF
--- a/app/analytics/provider.py
+++ b/app/analytics/provider.py
@@ -771,28 +771,33 @@ class Analytics:
         self._worker = worker
 
     def _worker_loop(self) -> None:
-        with httpx.Client(timeout=_SEND_TIMEOUT, trust_env=False) as client:
-            while True:
-                item = self._queue.get()
-                if item is None:
-                    self._queue.task_done()
-                    break
-                try:
-                    self._send(client, item)
-                finally:
-                    self._queue.task_done()
-                    self._mark_done()
-            while True:
-                try:
-                    item = self._queue.get_nowait()
-                except queue.Empty:
-                    return
-                try:
-                    if item is not None:
+        try:
+            with httpx.Client(timeout=_SEND_TIMEOUT, trust_env=False) as client:
+                while True:
+                    item = self._queue.get()
+                    if item is None:
+                        self._queue.task_done()
+                        break
+                    try:
                         self._send(client, item)
-                finally:
-                    self._queue.task_done()
-                    self._mark_done()
+                    finally:
+                        self._queue.task_done()
+                        self._mark_done()
+                while True:
+                    try:
+                        item = self._queue.get_nowait()
+                    except queue.Empty:
+                        return
+                    try:
+                        if item is not None:
+                            self._send(client, item)
+                    finally:
+                        self._queue.task_done()
+                        self._mark_done()
+        except Exception as exc:
+            # SSL/TLS or other fatal client-init errors — log only so the daemon
+            # thread exits cleanly without surfacing infrastructure noise to Sentry.
+            _log_failure("worker_loop_fatal", exc)
 
     def _send(self, client: httpx.Client, item: _Envelope) -> None:
         properties: Properties = {
@@ -817,11 +822,9 @@ class Analytics:
             # transient infrastructure issues, not application bugs — log only.
             _log_failure("posthog_send", exc, event=item.event)
         except httpx.HTTPStatusError as exc:
+            # PostHog HTTP errors (4xx config issues, 5xx transient infra failures)
+            # are not application bugs — log only, do not surface to Sentry.
             _log_failure("posthog_send", exc, event=item.event)
-            # 4xx errors (e.g. 403 Forbidden) are operational/config issues on
-            # the PostHog side; only report 5xx server errors to Sentry.
-            if exc.response.status_code >= 500:
-                _capture_sentry_failure(exc)
         except Exception as exc:
             _log_failure("posthog_send", exc, event=item.event)
             _capture_sentry_failure(exc)

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -32,6 +32,7 @@ class TestExecutor:
         )
 
         with (
+            patch("app.scheduler.executor.build_message", return_value="Scheduled report"),
             patch("app.scheduler.executor.resolve_telegram_credentials") as mock_creds,
             patch("app.scheduler.executor._deliver_telegram") as mock_deliver,
         ):
@@ -67,7 +68,10 @@ class TestExecutor:
             chat_id="C123456",
         )
 
-        with patch("app.scheduler.executor._deliver_slack") as mock_deliver:
+        with (
+            patch("app.scheduler.executor.build_message", return_value="Scheduled report"),
+            patch("app.scheduler.executor._deliver_slack") as mock_deliver,
+        ):
             mock_deliver.return_value = (True, "", "ts_123")
             result = execute_task(task, "2026-01-01T09:00")
 
@@ -83,7 +87,10 @@ class TestExecutor:
             chat_id="123456789",
         )
 
-        with patch("app.scheduler.executor._deliver_discord") as mock_deliver:
+        with (
+            patch("app.scheduler.executor.build_message", return_value="Scheduled report"),
+            patch("app.scheduler.executor._deliver_discord") as mock_deliver,
+        ):
             mock_deliver.return_value = (True, "", "msg_99")
             result = execute_task(task, "2026-01-01T09:00")
 
@@ -99,7 +106,10 @@ class TestExecutor:
             chat_id="-100123",
         )
 
-        with patch("app.scheduler.executor._deliver_telegram") as mock_deliver:
+        with (
+            patch("app.scheduler.executor.build_message", return_value="Scheduled report"),
+            patch("app.scheduler.executor._deliver_telegram") as mock_deliver,
+        ):
             mock_deliver.return_value = (True, "", "msg_1")
 
             # First execution succeeds

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -53,7 +53,10 @@ class TestExecutor:
             chat_id="-100123",
         )
 
-        with patch("app.scheduler.executor.resolve_telegram_credentials") as mock_creds:
+        with (
+            patch("app.scheduler.executor.build_message", return_value="Scheduled report"),
+            patch("app.scheduler.executor.resolve_telegram_credentials") as mock_creds,
+        ):
             mock_creds.return_value = {}
             result = execute_task(task, "2026-01-01T09:00")
 
@@ -146,8 +149,12 @@ class TestExecutor:
             chat_id="-100123",
         )
 
-        with patch("app.scheduler.executor._deliver_telegram") as mock_deliver:
+        with (
+            patch("app.scheduler.executor.build_message", return_value="Scheduled report"),
+            patch("app.scheduler.executor._deliver_telegram") as mock_deliver,
+        ):
             mock_deliver.return_value = (False, "Connection refused", "")
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is False
+        mock_deliver.assert_called_once()


### PR DESCRIPTION
## Summary

- **Wrap `_worker_loop` in `try/except`** so SSL/TLS errors during `httpx.Client` initialisation exit the daemon thread cleanly instead of escaping to Sentry's thread exception hook (Closes #2403)
- **Remove `_capture_sentry_failure` for PostHog 5xx responses**: transient `502 Bad Gateway` / `504 Gateway Timeout` errors from PostHog's infrastructure are not application bugs — logging is sufficient (Closes #2281)
- **Fix 4 failing scheduler executor tests** that called the real investigation pipeline and failed without LLM credentials — add `build_message` mock so tests run offline

## Root causes

**#2403 — SSLError in analytics worker**
`_worker_loop` opened the `httpx.Client` without any outer `try/except`. When the SSL stack raised an error during client initialisation, the exception escaped the daemon thread and was captured by Sentry's `threading.excepthook` as an uncaught exception. Fix: wrap the entire loop body so SSL/fatal errors exit cleanly and are only logged.

**#2281 — 502 Bad Gateway from PostHog**
The `_send` method explicitly called `_capture_sentry_failure` for PostHog 5xx responses. A `502` from PostHog is a transient load-balancer hiccup, not an application bug. Fix: remove the Sentry capture for HTTP status errors; they are already logged via `_log_failure`.

## Test plan

- [ ] `uv run pytest tests/scheduler/ tests/analytics/ -q` — all green
- [ ] `uv run ruff check app/ tests/` — no lint errors
- [ ] Verify #2403 and #2281 no longer recur in Sentry after deploy

https://claude.ai/code/session_01DvTYxp9h6w4sYgTy6QFMb4

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvTYxp9h6w4sYgTy6QFMb4)_