### PR TITLE
fix: handle missing Unix sockets in agent bus

### DIFF
--- a/app/agents/bus.py
+++ b/app/agents/bus.py
@@ -45,6 +45,7 @@ else:
 logger = logging.getLogger(__name__)
 
 DEFAULT_BUS_SOCKET_PATH: Path = OPENSRE_HOME_DIR / "agents-bus.sock"
+UNIX_SOCKET_AVAILABLE: bool = hasattr(socket, "AF_UNIX")
 
 #: Bus message wire-format version. Bump when ``BusMessage`` fields change shape.
 BUS_SCHEMA_VERSION: int = 1
@@ -58,6 +59,17 @@ _MAX_FRAME_BYTES: int = 64 * 1024
 #: unresponsive and evicted, so one wedged client cannot stall fan-out for
 #: every other publisher's reader thread.
 _BROADCAST_WRITE_TIMEOUT_SECONDS: float = 0.2
+
+
+def _unix_socket_family() -> int:
+    """Return the Unix-domain socket family or raise a clear platform error."""
+    family = getattr(socket, "AF_UNIX", None)
+    if family is None:
+        raise OSError(
+            getattr(errno, "EAFNOSUPPORT", errno.EINVAL),
+            "agent bus requires Unix-domain socket support (socket.AF_UNIX is unavailable)",
+        )
+    return int(family)
 
 
 @dataclass(frozen=True)
@@ -261,7 +273,7 @@ class BusServer:
         if self._running.is_set():
             return
         _ensure_parent_dir(self._path)
-        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener = socket.socket(_unix_socket_family(), socket.SOCK_STREAM)
         try:
             listener.bind(str(self._path))
         except OSError:
@@ -548,7 +560,7 @@ def _ensure_broker(path: Path) -> BusServer | None:
 
 def _connect_client(path: Path, timeout: float) -> socket.socket:
     """Open a blocking UDS connection to the broker at ``path``."""
-    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client = socket.socket(_unix_socket_family(), socket.SOCK_STREAM)
     client.settimeout(timeout)
     try:
         client.connect(str(path))

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -28,6 +28,11 @@ from app.agents.bus import (
     subscribe,
 )
 
+_REQUIRES_UNIX_SOCKET = pytest.mark.skipif(
+    not bus_module.UNIX_SOCKET_AVAILABLE,
+    reason="agent bus uses Unix-domain sockets (socket.AF_UNIX is unavailable)",
+)
+
 
 @pytest.fixture
 def sock_path() -> Iterator[Path]:
@@ -147,6 +152,27 @@ class TestBusMessage:
         assert msg.data["k"] == 1
 
 
+class TestUnsupportedPlatforms:
+    def test_connect_client_reports_missing_unix_socket_support(
+        self, sock_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delattr(socket, "AF_UNIX", raising=False)
+
+        with pytest.raises(OSError, match="socket.AF_UNIX is unavailable"):
+            bus_module._connect_client(sock_path, timeout=0.01)
+
+    def test_start_reports_missing_unix_socket_support(
+        self, sock_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delattr(socket, "AF_UNIX", raising=False)
+
+        server = BusServer(sock_path)
+        with pytest.raises(OSError, match="socket.AF_UNIX is unavailable"):
+            server.start()
+        assert not server.is_running
+
+
+@_REQUIRES_UNIX_SOCKET
 class TestBusServerLifecycle:
     def test_start_binds_socket_and_stop_unlinks(self, sock_path: Path) -> None:
         server = BusServer(sock_path)
@@ -223,6 +249,7 @@ class TestBusServerLifecycle:
             bus_module._ensure_broker(sock_path)
 
 
+@_REQUIRES_UNIX_SOCKET
 class TestLivenessProbe:
     def test_socket_is_live_does_not_create_phantom_subscriber(self, sock_path: Path) -> None:
         # _socket_is_live used to make a real connection on every probe; under
@@ -252,6 +279,7 @@ class TestLivenessProbe:
         assert not _socket_is_live(sock_path)
 
 
+@_REQUIRES_UNIX_SOCKET
 class TestPublisherCache:
     def test_burst_of_publishes_reuses_one_connection(self, sock_path: Path) -> None:
         # Each publish() previously opened a fresh UDS connection, which the
@@ -413,6 +441,7 @@ class TestPublisherCache:
         assert len(seen) == total, f"frame loss or corruption: got {len(seen)} unique of {total}"
 
 
+@_REQUIRES_UNIX_SOCKET
 class TestPublishSubscribe:
     def test_round_trip_one_publisher_one_subscriber(self, sock_path: Path) -> None:
         received: queue.Queue[BusMessage] = queue.Queue()
@@ -677,6 +706,7 @@ class TestPublishSubscribe:
             server.stop()
 
 
+@_REQUIRES_UNIX_SOCKET
 class TestBrokerElectionRace:
     def test_concurrent_cold_start_election_does_not_orphan_a_broker(self, sock_path: Path) -> None:
         # Cold-start race: two processes both observe ``_socket_is_live``
@@ -827,6 +857,7 @@ class TestBrokerElectionRace:
             child.wait(timeout=5.0)
 
 
+@_REQUIRES_UNIX_SOCKET
 class TestBrokerSelfElection:
     def test_stale_socket_file_is_unlinked_and_rebound(self, sock_path: Path) -> None:
         sock_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Fixes #1850

#### Describe the changes you have made in this PR -
- Add an explicit Unix-domain socket capability guard before the agent bus creates server/client sockets.
- Return a clear OSError when socket.AF_UNIX is unavailable instead of raising AttributeError.
- Add regression tests for missing socket.AF_UNIX and skip Unix-socket-heavy bus tests on platforms that cannot support them.

### Demo/Screenshot for feature changes and bug fixes -
Terminal validation:

```
env -u PYTHONHOME -u PYTHONPATH -u LD_LIBRARY_PATH uv run pytest tests/agents/test_bus.py -q
40 passed in 7.80s

env -u PYTHONHOME -u PYTHONPATH -u LD_LIBRARY_PATH uv run pytest tests/agents -v
541 passed in 40.78s

env -u PYTHONHOME -u PYTHONPATH -u LD_LIBRARY_PATH make lint
All checks passed!

env -u PYTHONHOME -u PYTHONPATH -u LD_LIBRARY_PATH make format-check
1564 files already formatted

env -u PYTHONHOME -u PYTHONPATH -u LD_LIBRARY_PATH make typecheck
Success: no issues found in 687 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug happened because the agent bus assumed socket.AF_UNIX exists before creating Unix-domain sockets. On Windows/Python environments without that attribute, /agents bus and related tests fail with AttributeError before the CLI can present a useful error.

This PR keeps the existing Unix-socket implementation unchanged on supported platforms, but routes socket family lookup through a small helper that raises a clear OSError when AF_UNIX is unavailable. The existing /agents bus command already catches OSError and renders a user-facing bus error. The tests now cover that unsupported-platform path directly and mark socket-backed bus tests as Unix-socket-only so Windows test-cov can skip them cleanly.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
