### PR TITLE
fix: revert OPENSRE_HOME_DIR to ~/.opensre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,7 @@ tasks/
 app/memories
 .aider*
 .worktrees/
+.claude/worktrees/
 
 # Node dev tooling
 node_modules/

--- a/app/agents/config.py
+++ b/app/agents/config.py
@@ -1,4 +1,4 @@
-"""Per-agent SLO + pricing config loaded from ``~/.config/opensre/agents.yaml``.
+"""Per-agent SLO + pricing config loaded from ``~/.opensre/agents.yaml``.
 
 ``hourly_budget_usd`` is reserved for the future budget-alarm
 feature (the dashboard's ``$/hr`` column shows observed cost, not the
@@ -47,7 +47,7 @@ class AgentBudget(StrictConfigModel):
 
 
 class AgentsConfig(StrictConfigModel):
-    """Top-level shape of ``~/.config/opensre/agents.yaml``."""
+    """Top-level shape of ``~/.opensre/agents.yaml``."""
 
     agents: dict[str, AgentBudget] = Field(default_factory=dict)
 

--- a/app/agents/coordination.py
+++ b/app/agents/coordination.py
@@ -47,7 +47,7 @@ class BranchClaim:
 class BranchClaims:
     """JSONL-backed registry of branch ownership claims by local AI agents.
 
-    Persists to ``~/.config/opensre/branch_claims.jsonl`` by default.
+    Persists to ``~/.opensre/branch_claims.jsonl`` by default.
     The file is fully rewritten on both claim (to avoid duplicates on re-claim)
     and release operations.
     """

--- a/app/agents/registry.py
+++ b/app/agents/registry.py
@@ -59,7 +59,7 @@ class AgentRecord:
 class AgentRegistry:
     """JSONL-backed registry of locally running AI agent processes.
 
-    Persists to ``~/.config/opensre/agents.jsonl`` by default.  The file is
+    Persists to ``~/.opensre/agents.jsonl`` by default.  The file is
     append-only for ``register`` and fully rewritten on ``forget`` / ``clear``.
     """
 

--- a/app/agents/sweep.py
+++ b/app/agents/sweep.py
@@ -2,7 +2,7 @@
 
 Run once at REPL boot. Idempotent — running twice in a row is a no-op
 the second time. Removes ``AgentRegistry`` entries whose PIDs no longer
-exist plus lockfiles in ``~/.config/opensre/agents/`` that correspond
+exist plus lockfiles in ``~/.opensre/agents/`` that correspond
 to dead PIDs.
 
 Liveness is checked via ``pid_exists`` rather than ``probe()``

--- a/app/analytics/provider.py
+++ b/app/analytics/provider.py
@@ -24,16 +24,12 @@ import httpx
 
 from app.analytics.events import Event
 from app.cli.wizard.store import get_store_path
-from app.constants import LEGACY_OPENSRE_HOME_DIR
 from app.constants.posthog import POSTHOG_CAPTURE_API_KEY, POSTHOG_HOST
 from app.version import get_version
 
 _CONFIG_DIR = get_store_path().parent
 _ANONYMOUS_ID_PATH = _CONFIG_DIR / "anonymous_id"
 _FIRST_RUN_PATH = _CONFIG_DIR / "installed"
-_LEGACY_CONFIG_DIR = LEGACY_OPENSRE_HOME_DIR
-_LEGACY_ANONYMOUS_ID_PATH = _LEGACY_CONFIG_DIR / "anonymous_id"
-_LEGACY_FIRST_RUN_PATH = _LEGACY_CONFIG_DIR / "installed"
 
 _QUEUE_SIZE = 128
 _SEND_TIMEOUT = 2.0
@@ -117,12 +113,9 @@ def _is_existing_install(
     *,
     config_dir_existed: bool,
     install_marker_existed: bool,
-    legacy_config_dir_existed: bool,
-    legacy_install_marker_existed: bool,
 ) -> bool:
     return (
-        (config_dir_existed and install_marker_existed)
-        or (legacy_config_dir_existed and legacy_install_marker_existed)
+        config_dir_existed and install_marker_existed
     ) and not _first_run_marker_created_this_process
 
 
@@ -132,28 +125,20 @@ def _queue_user_id_load_failure(
     config_dir_existed: bool,
     install_marker_existed: bool,
     anonymous_id_path_existed: bool,
-    legacy_config_dir_existed: bool,
-    legacy_install_marker_existed: bool,
-    legacy_anonymous_id_path_existed: bool,
 ) -> None:
     if not _is_existing_install(
         config_dir_existed=config_dir_existed,
         install_marker_existed=install_marker_existed,
-        legacy_config_dir_existed=legacy_config_dir_existed,
-        legacy_install_marker_existed=legacy_install_marker_existed,
     ):
         return
     _pending_user_id_load_failures.append(
         {
             "reason": reason,
-            "config_dir": "~/.config/opensre",
-            "anonymous_id_path": "~/.config/opensre/anonymous_id",
+            "config_dir": "~/.opensre",
+            "anonymous_id_path": "~/.opensre/anonymous_id",
             "config_dir_existed": config_dir_existed,
             "install_marker_existed": install_marker_existed,
             "anonymous_id_path_existed": anonymous_id_path_existed,
-            "legacy_config_dir_existed": legacy_config_dir_existed,
-            "legacy_install_marker_existed": legacy_install_marker_existed,
-            "legacy_anonymous_id_path_existed": legacy_anonymous_id_path_existed,
             "anonymous_id_loaded": False,
         }
     )
@@ -177,18 +162,6 @@ def _valid_anonymous_id(value: str) -> str | None:
 
 def _read_persisted_anonymous_id(path: Path) -> str | None:
     return _valid_anonymous_id(path.read_text(encoding="utf-8"))
-
-
-def _load_legacy_anonymous_id() -> str | None:
-    if not _path_exists(_LEGACY_ANONYMOUS_ID_PATH):
-        return None
-    with contextlib.suppress(OSError):
-        legacy_id = _read_persisted_anonymous_id(_LEGACY_ANONYMOUS_ID_PATH)
-        if legacy_id is not None:
-            with contextlib.suppress(OSError):
-                _write_text_atomic(_ANONYMOUS_ID_PATH, legacy_id)
-            return legacy_id
-    return None
 
 
 def _fsync_parent_dir(path: Path) -> None:
@@ -270,9 +243,6 @@ def _write_new_anonymous_id(
 def _compute_anonymous_identity() -> _AnonymousIdentity:
     config_dir_existed = _path_exists(_CONFIG_DIR)
     install_marker_existed = _path_exists(_FIRST_RUN_PATH)
-    legacy_config_dir_existed = _path_exists(_LEGACY_CONFIG_DIR)
-    legacy_install_marker_existed = _path_exists(_LEGACY_FIRST_RUN_PATH)
-    legacy_anonymous_id_path_existed = _path_exists(_LEGACY_ANONYMOUS_ID_PATH)
     try:
         _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
         anonymous_id_path_existed = _ANONYMOUS_ID_PATH.exists()
@@ -285,26 +255,16 @@ def _compute_anonymous_identity() -> _AnonymousIdentity:
                 config_dir_existed=config_dir_existed,
                 install_marker_existed=install_marker_existed,
                 anonymous_id_path_existed=anonymous_id_path_existed,
-                legacy_config_dir_existed=legacy_config_dir_existed,
-                legacy_install_marker_existed=legacy_install_marker_existed,
-                legacy_anonymous_id_path_existed=legacy_anonymous_id_path_existed,
             )
-        if legacy_id := _load_legacy_anonymous_id():
-            return _AnonymousIdentity(legacy_id, "disk")
         if _is_existing_install(
             config_dir_existed=config_dir_existed,
             install_marker_existed=install_marker_existed,
-            legacy_config_dir_existed=legacy_config_dir_existed,
-            legacy_install_marker_existed=legacy_install_marker_existed,
         ):
             _queue_user_id_load_failure(
                 "missing_anonymous_id",
                 config_dir_existed=config_dir_existed,
                 install_marker_existed=install_marker_existed,
                 anonymous_id_path_existed=anonymous_id_path_existed,
-                legacy_config_dir_existed=legacy_config_dir_existed,
-                legacy_install_marker_existed=legacy_install_marker_existed,
-                legacy_anonymous_id_path_existed=legacy_anonymous_id_path_existed,
             )
         new_id = str(uuid.uuid4())
         return _write_new_anonymous_id(
@@ -317,9 +277,6 @@ def _compute_anonymous_identity() -> _AnonymousIdentity:
             config_dir_existed=config_dir_existed,
             install_marker_existed=install_marker_existed,
             anonymous_id_path_existed=_path_exists(_ANONYMOUS_ID_PATH),
-            legacy_config_dir_existed=legacy_config_dir_existed,
-            legacy_install_marker_existed=legacy_install_marker_existed,
-            legacy_anonymous_id_path_existed=legacy_anonymous_id_path_existed,
         )
         return _AnonymousIdentity(str(uuid.uuid4()), "none")
 
@@ -459,7 +416,7 @@ def _event_log_path() -> Path:
     """Resolve the event log path lazily so tests can monkeypatch ``_CONFIG_DIR``.
 
     The log lives next to ``anonymous_id`` and ``analytics_errors.log`` under
-    ``~/.config/opensre/`` (or the equivalent on other platforms) rather than
+    ``~/.opensre/`` (or the equivalent on other platforms) rather than
     in the user's current working directory. This prevents a stray
     ``posthog_events.txt`` from showing up in every shell where the user runs
     ``opensre``, and keeps related telemetry artifacts in one place.

--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -137,7 +137,7 @@ def _capture_accepted_cli_invocation(ctx: click.Context) -> None:
     type=click.Choice(["classic", "pinned"]),
     default=None,
     help="Interactive-shell layout: 'classic' (scrolling) or 'pinned' (fixed "
-    "input bar). Overrides OPENSRE_LAYOUT env var and ~/.config/opensre/config.yml.",
+    "input bar). Overrides OPENSRE_LAYOUT env var and ~/.opensre/config.yml.",
 )
 @click.pass_context
 def cli(

--- a/app/cli/commands/config.py
+++ b/app/cli/commands/config.py
@@ -1,4 +1,4 @@
-"""CLI commands for LLM/env config and local ~/.config/opensre/config.yml."""
+"""CLI commands for LLM/env config and local ~/.opensre/config.yml."""
 
 from __future__ import annotations
 
@@ -148,14 +148,14 @@ def _set_nested_key(data: dict[str, Any], dotted_key: str, value: Any) -> dict[s
 @click.group(name="config", invoke_without_command=True)
 @click.pass_context
 def config_command(ctx: click.Context) -> None:
-    """LLM/environment config by default; subcommands manage ~/.config/opensre/config.yml."""
+    """LLM/environment config by default; subcommands manage ~/.opensre/config.yml."""
     if ctx.invoked_subcommand is None:
         _emit_llm_config()
 
 
 @config_command.command(name="show")
 def config_show() -> None:
-    """Show local ~/.config/opensre/config.yml values."""
+    """Show local ~/.opensre/config.yml values."""
     from app.cli.support.context import is_json_output
 
     payload = _load_config()
@@ -175,7 +175,7 @@ def config_show() -> None:
 @click.argument("key")
 @click.argument("value")
 def config_set(key: str, value: str) -> None:
-    """Set one local config key in ~/.config/opensre/config.yml."""
+    """Set one local config key in ~/.opensre/config.yml."""
     key = key.strip()
     coerced = _coerce_value(key, value)
     data = _load_config()

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -265,7 +265,7 @@ def _cmd_agents_release(session: ReplSession, console: Console, args: list[str])
 
 
 def _cmd_agents_budget(session: ReplSession, console: Console, args: list[str]) -> bool:
-    """View or edit per-agent budgets stored in ``~/.config/opensre/agents.yaml``.
+    """View or edit per-agent budgets stored in ``~/.opensre/agents.yaml``.
 
     No args -> render the current budgets as a table. Two args
     (``<agent> <usd>``) -> set ``hourly_budget_usd`` for that agent and

--- a/app/cli/interactive_shell/command_registry/slash_catalog.py
+++ b/app/cli/interactive_shell/command_registry/slash_catalog.py
@@ -82,7 +82,7 @@ _MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
         "User asks to compact, trim, or free memory from session history",
     ),
     "/config": _mcp(
-        "Show or edit local OpenSRE configuration (~/.config/opensre/config.yml). "
+        "Show or edit local OpenSRE configuration (~/.opensre/config.yml). "
         "Subcommands: show, set <key> <value>.",
         "User asks to view or change OpenSRE config settings",
         anti_examples=("User asks how to configure an integration (may need assistant_handoff)",),

--- a/app/cli/interactive_shell/config/repl_config.py
+++ b/app/cli/interactive_shell/config/repl_config.py
@@ -24,7 +24,7 @@ WHATS_NEW: tuple[str, ...] = (
 
 
 def _read_config_file() -> dict[str, Any]:
-    """Read the interactive section from ~/.config/opensre/config.yml.
+    """Read the interactive section from ~/.opensre/config.yml.
 
     Returns an empty dict if the file is missing, unreadable, or malformed.
     Failures are always silent — a bad config file must never crash the CLI.
@@ -61,13 +61,13 @@ class ReplConfig:
         When False the REPL is skipped and ``opensre`` falls back to
         ``render_landing()``.  Controlled by ``--no-interactive`` CLI flag,
         the ``OPENSRE_INTERACTIVE`` env var, or ``interactive.enabled`` in
-        ``~/.config/opensre/config.yml``.
+        ``~/.opensre/config.yml``.
 
     layout : str  ("classic" | "pinned")
         Which renderer to use.  Only ``classic`` is wired today; ``pinned``
         is accepted and stored so the flag round-trips cleanly once P3 lands.
         Controlled by ``--layout`` CLI option, ``OPENSRE_LAYOUT`` env var, or
-        ``interactive.layout`` in ``~/.config/opensre/config.yml``.
+        ``interactive.layout`` in ``~/.opensre/config.yml``.
     """
 
     enabled: bool = True
@@ -97,7 +97,7 @@ class ReplConfig:
         Priority (highest wins):
             1. CLI flag   — ``cli_enabled`` / ``cli_layout`` params
             2. Env var    — ``OPENSRE_INTERACTIVE`` / ``OPENSRE_LAYOUT``
-            3. Config file — ``~/.config/opensre/config.yml`` ``interactive`` section
+            3. Config file — ``~/.opensre/config.yml`` ``interactive`` section
             4. Built-in defaults (enabled=True, layout="classic")
         """
         file_conf = _read_config_file()

--- a/app/cli/interactive_shell/history/policy.py
+++ b/app/cli/interactive_shell/history/policy.py
@@ -3,7 +3,7 @@
 Built-in redaction patterns + a ``RedactingFileHistory`` that subclasses
 ``prompt_toolkit.FileHistory`` to apply redaction before each entry is
 persisted. Settings resolve from env vars and the ``interactive.history``
-section of ``~/.config/opensre/config.yml``; built-in defaults keep
+section of ``~/.opensre/config.yml``; built-in defaults keep
 redaction on, persistence on, and entries capped at 5000.
 """
 

--- a/app/cli/support/feedback.py
+++ b/app/cli/support/feedback.py
@@ -378,7 +378,7 @@ def prompt_investigation_feedback(
 ) -> None:
     """Prompt for RCA accuracy feedback; never raises.
 
-    Stores each response to ``~/.config/opensre/feedback.jsonl`` and emits
+    Stores each response to ``~/.opensre/feedback.jsonl`` and emits
     ``investigation_feedback_submitted`` to PostHog with investigation
     provenance (run_id, alert_name, validity_score, root_cause_category, …)
     and user context (user_id, user_email, org_id when available on

--- a/app/cli/support/uninstall.py
+++ b/app/cli/support/uninstall.py
@@ -40,7 +40,7 @@ def _pip_uninstall() -> int:
 
 
 def _data_dirs() -> list[Path]:
-    return [OPENSRE_HOME_DIR, LEGACY_TRACER_HOME_DIR]
+    return [OPENSRE_HOME_DIR, LEGACY_TRACER_HOME_DIR, Path.home() / ".config" / "opensre"]
 
 
 def run_uninstall(*, yes: bool = False) -> int:

--- a/app/constants/__init__.py
+++ b/app/constants/__init__.py
@@ -24,8 +24,7 @@ from app.constants.sentry import (
     SENTRY_TRACES_SAMPLE_RATE,
 )
 
-OPENSRE_HOME_DIR: Path = Path.home() / ".config" / "opensre"
-LEGACY_OPENSRE_HOME_DIR: Path = Path.home() / ".opensre"
+OPENSRE_HOME_DIR: Path = Path.home() / ".opensre"
 LEGACY_TRACER_HOME_DIR: Path = Path.home() / ".tracer"
 INTEGRATIONS_STORE_PATH: Path = OPENSRE_HOME_DIR / "integrations.json"
 LEGACY_INTEGRATIONS_STORE_PATH: Path = LEGACY_TRACER_HOME_DIR / "integrations.json"
@@ -49,7 +48,6 @@ __all__ = [
     "DEFAULT_POSTHOG_TIMEOUT_SECONDS",
     "DEFAULT_POSTHOG_URL",
     "INTEGRATIONS_STORE_PATH",
-    "LEGACY_OPENSRE_HOME_DIR",
     "LEGACY_INTEGRATIONS_STORE_PATH",
     "LEGACY_TRACER_HOME_DIR",
     "ensure_opensre_tmp_dir",

--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -1962,7 +1962,7 @@ def resolve_effective_integrations(
     store_integrations: list[dict[str, Any]] | None = None,
     env_integrations: list[dict[str, Any]] | None = None,
 ) -> dict[str, dict[str, Any]]:
-    """Resolve effective local integrations from ~/.config/opensre and environment variables."""
+    """Resolve effective local integrations from ~/.opensre and environment variables."""
     store_records = (
         list(store_integrations) if store_integrations is not None else load_integrations()
     )

--- a/app/integrations/cli.py
+++ b/app/integrations/cli.py
@@ -1,4 +1,4 @@
-"""Interactive CLI for managing local integrations (~/.config/opensre/integrations.json).
+"""Interactive CLI for managing local integrations (~/.opensre/integrations.json).
 
 Usage:
     python -m app.integrations setup <service>

--- a/app/integrations/store.py
+++ b/app/integrations/store.py
@@ -1,6 +1,6 @@
 """Local integration credential store.
 
-Integrations are stored in ~/.config/opensre/integrations.json.
+Integrations are stored in ~/.opensre/integrations.json.
 
 File format (v2 — see ``_migrate_record_v1_to_v2`` for the v1 shape):
 {

--- a/app/integrations/verify.py
+++ b/app/integrations/verify.py
@@ -64,7 +64,7 @@ VERIFIER_REGISTRY: dict[str, VerifierFn] = {
 
 
 def resolve_effective_integrations() -> dict[str, dict[str, Any]]:
-    """Resolve effective local integrations from ~/.config/opensre and environment variables."""
+    """Resolve effective local integrations from ~/.opensre and environment variables."""
     return _resolve_effective_integrations()
 
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -120,7 +120,7 @@ opensre remote ops logs --follow
 
 Events are tagged with `entrypoint`, `opensre.runtime`, and `deployment_method`. Sensitive headers, paths, and secret-shaped keys are scrubbed before send.
 
-A random install ID is stored under `~/.config/opensre/anonymous_id`. PostHog `distinct_id` is scoped to that ID. Telemetry is off in GitHub Actions and pytest.
+A random install ID is stored under `~/.opensre/anonymous_id`. PostHog `distinct_id` is scoped to that ID. Telemetry is off in GitHub Actions and pytest.
 
 ### Kill-switch matrix
 
@@ -148,7 +148,7 @@ Set `OPENSRE_DEPLOYMENT_METHOD` to `railway`, `ec2`, `vercel`, or `local` (defau
 
 ### Local PostHog event log
 
-By default, outbound PostHog payloads are also appended to `~/.config/opensre/posthog_events.txt` (rotates at 1000 lines). Disable:
+By default, outbound PostHog payloads are also appended to `~/.opensre/posthog_events.txt` (rotates at 1000 lines). Disable:
 
 ```bash
 export OPENSRE_ANALYTICS_LOG_EVENTS=0

--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -318,8 +318,8 @@ global FIFO ordering.
 
 ### Transport
 
-- **Socket**: Unix-domain stream socket at `~/.config/opensre/agents-bus.sock`.
-- **PID sidecar**: `~/.config/opensre/agents-bus.sock.pid` (mode `0600`). The
+- **Socket**: Unix-domain stream socket at `~/.opensre/agents-bus.sock`.
+- **PID sidecar**: `~/.opensre/agents-bus.sock.pid` (mode `0600`). The
   broker writes its PID here on `start()` and removes it on `stop()`. The
   liveness probe used by every `publish()` / `subscribe()` reads this file
   rather than connecting to the socket — connection probing would otherwise
@@ -396,7 +396,7 @@ Publishers without a Python dependency on OpenSRE can connect directly:
 python - <<'EOF'
 import json, os, socket, uuid, datetime
 sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-sock.connect(os.path.expanduser("~/.config/opensre/agents-bus.sock"))
+sock.connect(os.path.expanduser("~/.opensre/agents-bus.sock"))
 sock.sendall((json.dumps({
     "agent": "claude-code:8421",
     "topic": "finding",

--- a/docs/argocd.mdx
+++ b/docs/argocd.mdx
@@ -52,7 +52,7 @@ OpenSRE rejects ambiguous auth configuration. Do not set a bearer token and user
 
 ### Option 2: Persistent store
 
-You can also add Argo CD to `~/.config/opensre/integrations.json`:
+You can also add Argo CD to `~/.opensre/integrations.json`:
 
 ```json
 {
@@ -180,7 +180,7 @@ Fetches Argo CD server-side diff output for one application.
 ## Security best practices
 
 - Use a dedicated read-only Argo CD account or token for OpenSRE.
-- Store credentials in `.env` or `~/.config/opensre/integrations.json`, not in source code.
+- Store credentials in `.env` or `~/.opensre/integrations.json`, not in source code.
 - Use `https://` for remote Argo CD URLs. Plain `http://` is accepted only for loopback or localhost development URLs.
 - Do not disable `ARGOCD_VERIFY_SSL` for production instances.
 - OpenSRE redacts bearer tokens, passwords, token-like strings, and Kubernetes `Secret` diffs before surfacing Argo CD errors or diff evidence.

--- a/docs/azure-monitor.mdx
+++ b/docs/azure-monitor.mdx
@@ -38,7 +38,7 @@ AZURE_MAX_RESULTS=100                          # optional, capped at 200
 
 ### Option 2: Persistent store
 
-Credentials are persisted to `~/.config/opensre/integrations.json` with `0o600` permissions:
+Credentials are persisted to `~/.opensre/integrations.json` with `0o600` permissions:
 
 ```json
 {

--- a/docs/betterstack.mdx
+++ b/docs/betterstack.mdx
@@ -42,7 +42,7 @@ BETTERSTACK_SOURCES=t123456_myapp,t123456_gateway
 
 ### Option 3: Persistent store
 
-Credentials are persisted to `~/.config/opensre/integrations.json` with `0o600` permissions:
+Credentials are persisted to `~/.opensre/integrations.json` with `0o600` permissions:
 
 ```json
 {
@@ -135,7 +135,7 @@ The verify step issues a cheap probe (`SELECT 1 FORMAT JSONEachRow`) against the
 ## Security best practices
 
 - Use a **dedicated ClickHouse HTTP client credential** for OpenSRE — not your personal dashboard login.
-- Keep the credential pair out of source control — use `.env` or the persistent store (`~/.config/opensre/integrations.json`).
+- Keep the credential pair out of source control — use `.env` or the persistent store (`~/.opensre/integrations.json`).
 - The integration is **read-only**: OpenSRE only issues `SELECT` statements against `remote(...)` and `s3Cluster(...)` table functions.
 - Source identifiers are allowlisted against `^[A-Za-z0-9_]+$` before being interpolated into SQL, preventing identifier-injection attacks from the alert payload.
 - Rotate credentials periodically via the Better Stack dashboard.

--- a/docs/cron.mdx
+++ b/docs/cron.mdx
@@ -102,7 +102,7 @@ This ensures exactly-once delivery even when multiple scheduler instances run co
 
 Credentials are resolved lazily at delivery time in this priority order:
 
-1. **Integration store** — `~/.config/opensre/integrations.json` (configured via `opensre integrations`)
+1. **Integration store** — `~/.opensre/integrations.json` (configured via `opensre integrations`)
 2. **Environment variables** — `TELEGRAM_BOT_TOKEN`, `SLACK_BOT_TOKEN`, `DISCORD_BOT_TOKEN`
 3. **Task params** — credentials stored in the task definition (not recommended)
 
@@ -120,8 +120,8 @@ This means you don't need to pass credentials at `cron add` time — they're pic
 
 ## Persistence
 
-- **Task definitions** are stored in `~/.config/opensre/scheduler_tasks.json` (JSON + filelock)
-- **Execution history** is stored in `~/.config/opensre/scheduler.db` (SQLite with WAL mode)
+- **Task definitions** are stored in `~/.opensre/scheduler_tasks.json` (JSON + filelock)
+- **Execution history** is stored in `~/.opensre/scheduler.db` (SQLite with WAL mode)
 - Both survive process restarts — `opensre cron list` and `opensre cron logs` read from disk
 
 ## REPL

--- a/docs/guardrails/README.md
+++ b/docs/guardrails/README.md
@@ -18,20 +18,20 @@ opensre guardrails rules
 
 ## How it works
 
-1. Rules are loaded from `~/.config/opensre/guardrails.yml` on first LLM call
+1. Rules are loaded from `~/.opensre/guardrails.yml` on first LLM call
 2. Before every LLM API request, all message content is scanned against the rules
 3. Depending on the rule action:
    - **redact**: matched text is replaced with `[REDACTED:<rule_name>]`
    - **block**: the request is rejected with a `GuardrailBlockedError`
    - **audit**: the match is logged but text passes through unchanged
-4. All matches are written to `~/.config/opensre/guardrail_audit.jsonl`
+4. All matches are written to `~/.opensre/guardrail_audit.jsonl`
 
 If no `guardrails.yml` exists, all content passes through unchanged with zero
 overhead.
 
 ## Configuration
 
-The config file lives at `~/.config/opensre/guardrails.yml`. Each rule can use
+The config file lives at `~/.opensre/guardrails.yml`. Each rule can use
 regex patterns, keyword lists, or both.
 
 ```yaml
@@ -82,7 +82,7 @@ rules:
 
 ### `opensre guardrails init`
 
-Creates a starter `~/.config/opensre/guardrails.yml` with common patterns for AWS
+Creates a starter `~/.opensre/guardrails.yml` with common patterns for AWS
 keys, credit cards, private keys, and API tokens. Does not overwrite an
 existing config.
 
@@ -104,7 +104,7 @@ Lists all configured rules with their action and status.
 
 ### `opensre guardrails audit`
 
-Shows recent entries from the audit log at `~/.config/opensre/guardrail_audit.jsonl`.
+Shows recent entries from the audit log at `~/.opensre/guardrail_audit.jsonl`.
 
 ## Health check
 
@@ -113,8 +113,8 @@ Shows recent entries from the audit log at `~/.config/opensre/guardrail_audit.js
 ```
 CLI
   environment: development
-  integration store: ~/.config/opensre/integrations.json
-  guardrails: 5 rules active (~/.config/opensre/guardrails.yml)
+  integration store: ~/.opensre/integrations.json
+  guardrails: 5 rules active (~/.opensre/guardrails.yml)
 ```
 
 ## Coverage

--- a/docs/helm.mdx
+++ b/docs/helm.mdx
@@ -17,7 +17,7 @@ OpenSRE runs the **Helm 3** command-line client on the machine where the agent e
 
 ## Setup
 
-Configure Helm like other local integrations: environment variables and/or `~/.config/opensre/integrations.json`.
+Configure Helm like other local integrations: environment variables and/or `~/.opensre/integrations.json`.
 
 ### Option 1: Environment variables
 
@@ -52,7 +52,7 @@ HELM_MANIFEST_MAX_CHARS=600000
 
 ### Option 2: Persistent store
 
-Add an active `helm` record to `~/.config/opensre/integrations.json`:
+Add an active `helm` record to `~/.opensre/integrations.json`:
 
 ```json
 {

--- a/docs/interactive-shell-privacy.mdx
+++ b/docs/interactive-shell-privacy.mdx
@@ -12,7 +12,7 @@ The OpenSRE interactive shell persists every line you type to a history file so 
 - caps how many entries are kept (oldest pruned)
 - offers a one-shot `/history clear` to wipe the file on demand
 
-The history file lives at `~/.config/opensre/interactive_history`.
+The history file lives at `~/.opensre/interactive_history`.
 
 ## Defaults
 
@@ -58,7 +58,7 @@ Redaction applies only to **persistent history**. The line you typed is still pa
 Settings resolve from (highest wins):
 
 1. Environment variables
-2. The `interactive.history` block in `~/.config/opensre/config.yml`
+2. The `interactive.history` block in `~/.opensre/config.yml`
 3. Built-in defaults
 
 ### Environment variables
@@ -81,7 +81,7 @@ interactive:
 
 ## Threat model
 
-The history file is **plain text on local disk** at `~/.config/opensre/interactive_history`, with the user's default file permissions. Built-in redaction targets common token shapes only — it is not a substitute for proper secret handling. Treat the file as confidential and be aware:
+The history file is **plain text on local disk** at `~/.opensre/interactive_history`, with the user's default file permissions. Built-in redaction targets common token shapes only — it is not a substitute for proper secret handling. Treat the file as confidential and be aware:
 
 - A determined attacker with read access to your home directory can still read pre-existing entries written before redaction was enabled.
 - Redaction cannot detect tokens that look like normal text (for example a natural-language password). Don't paste secrets you wouldn't be comfortable seeing in a system log.

--- a/docs/jira.mdx
+++ b/docs/jira.mdx
@@ -22,7 +22,7 @@ Select **Jira** when prompted and provide your base URL, email, API token, and p
 
 ### Option 2: Persistent store
 
-Add to `~/.config/opensre/integrations.json`:
+Add to `~/.opensre/integrations.json`:
 
 ```json
 {
@@ -72,5 +72,5 @@ For Jira Data Center/Server, use a personal access token from **Profile** → **
 ## Security best practices
 
 - Use a **dedicated Jira user** for OpenSRE with only the permissions it needs (create and comment on issues).
-- Store credentials in `~/.config/opensre/integrations.json`, not in source code or environment variables.
+- Store credentials in `~/.opensre/integrations.json`, not in source code or environment variables.
 - Rotate the API token periodically.

--- a/docs/mariadb.mdx
+++ b/docs/mariadb.mdx
@@ -45,7 +45,7 @@ MARIADB_SSL=true
 
 ### Option 3: Persistent store
 
-Credentials are automatically persisted to `~/.config/opensre/integrations.json` with `0o600` permissions:
+Credentials are automatically persisted to `~/.opensre/integrations.json` with `0o600` permissions:
 
 ```json
 {

--- a/docs/messaging/index.mdx
+++ b/docs/messaging/index.mdx
@@ -38,7 +38,7 @@ Discord and Telegram credentials can also be set directly in `.env` instead of (
 
 ```bash
 # Slack — read as a fallback when no Slack entry exists in
-# ~/.config/opensre/integrations.json
+# ~/.opensre/integrations.json
 SLACK_WEBHOOK_URL=
 
 # Discord
@@ -63,7 +63,7 @@ TWILIO_SMS_MESSAGING_SERVICE_SID=
 TWILIO_SMS_DEFAULT_TO=
 ```
 
-After editing `.env`, run `opensre integrations verify <service>` (e.g. `opensre integrations verify telegram`, `opensre integrations verify whatsapp`, or `opensre integrations verify twilio`) to confirm the credentials work. Note that `opensre doctor` only inspects the integrations store (`~/.config/opensre/integrations.json`), so it does **not** detect env-var-only configurations like Telegram, WhatsApp, Twilio SMS, or Slack-via-`SLACK_WEBHOOK_URL`.
+After editing `.env`, run `opensre integrations verify <service>` (e.g. `opensre integrations verify telegram`, `opensre integrations verify whatsapp`, or `opensre integrations verify twilio`) to confirm the credentials work. Note that `opensre doctor` only inspects the integrations store (`~/.opensre/integrations.json`), so it does **not** detect env-var-only configurations like Telegram, WhatsApp, Twilio SMS, or Slack-via-`SLACK_WEBHOOK_URL`.
 
 ---
 

--- a/docs/messaging/slack.mdx
+++ b/docs/messaging/slack.mdx
@@ -42,14 +42,14 @@ You have two equivalent paths:
     ```bash
     opensre integrations setup slack
     ```
-    Paste the webhook URL when prompted. The credentials are persisted to `~/.config/opensre/integrations.json`.
+    Paste the webhook URL when prompted. The credentials are persisted to `~/.opensre/integrations.json`.
   </Tab>
   <Tab title="Manual env var">
     Add to `.env`:
     ```bash
     SLACK_WEBHOOK_URL=https://hooks.slack.com/services/<workspace-id>/<binding-id>/<secret>
     ```
-    OpenSRE reads this at startup as a fallback when no Slack entry exists in `~/.config/opensre/integrations.json`. If you have previously run `opensre integrations setup slack`, remove that entry first (`opensre integrations remove slack`) or the env var will be ignored.
+    OpenSRE reads this at startup as a fallback when no Slack entry exists in `~/.opensre/integrations.json`. If you have previously run `opensre integrations setup slack`, remove that entry first (`opensre integrations remove slack`) or the env var will be ignored.
   </Tab>
   <Tab title="Onboarding wizard">
     ```bash

--- a/docs/messaging/telegram.mdx
+++ b/docs/messaging/telegram.mdx
@@ -6,7 +6,7 @@ description: "Deliver investigation findings to a Telegram chat or channel."
 OpenSRE's Telegram integration delivers investigation findings to any chat your bot has been added to — useful for mobile-first on-call rotations and personal alerting.
 
 <Note>
-Unlike Slack and Discord, Telegram is **not** included in the interactive `opensre onboard` wizard today. Configure it via environment variables or by editing `~/.config/opensre/integrations.json` directly. Tracked at [#1481](https://github.com/Tracer-Cloud/opensre/issues/1481).
+Unlike Slack and Discord, Telegram is **not** included in the interactive `opensre onboard` wizard today. Configure it via environment variables or by editing `~/.opensre/integrations.json` directly. Tracked at [#1481](https://github.com/Tracer-Cloud/opensre/issues/1481).
 </Note>
 
 ---

--- a/docs/mongodb.mdx
+++ b/docs/mongodb.mdx
@@ -41,7 +41,7 @@ MONGODB_TLS=true
 
 ### Option 3: Persistent store
 
-Integrations are automatically persisted to `~/.config/opensre/integrations.json`:
+Integrations are automatically persisted to `~/.opensre/integrations.json`:
 
 ```json
 {

--- a/docs/multi-instance-integrations.mdx
+++ b/docs/multi-instance-integrations.mdx
@@ -26,7 +26,7 @@ Supported env vars: `GRAFANA_INSTANCES`, `DD_INSTANCES`, `HONEYCOMB_INSTANCES`, 
 
 When `<SERVICE>_INSTANCES` is set, the legacy single-instance vars for that service (e.g. `GRAFANA_INSTANCE_URL`, `GRAFANA_READ_TOKEN`) are ignored. If the JSON is invalid the loader logs a warning and falls back to the legacy vars.
 
-### 2. Store file (`~/.config/opensre/integrations.json`)
+### 2. Store file (`~/.opensre/integrations.json`)
 
 The store uses a v2 schema with multiple instances per record:
 

--- a/docs/mysql.mdx
+++ b/docs/mysql.mdx
@@ -45,7 +45,7 @@ MYSQL_SSL_MODE=preferred   # preferred, required, or disabled
 
 ### Option 3: Persistent store
 
-Integrations are automatically persisted to `~/.config/opensre/integrations.json`:
+Integrations are automatically persisted to `~/.opensre/integrations.json`:
 
 ```json
 {

--- a/docs/postgresql.mdx
+++ b/docs/postgresql.mdx
@@ -45,7 +45,7 @@ POSTGRESQL_SSL_MODE=prefer   # prefer, require, or disable
 
 ### Option 3: Persistent store
 
-Integrations are automatically persisted to `~/.config/opensre/integrations.json`:
+Integrations are automatically persisted to `~/.opensre/integrations.json`:
 
 ```json
 {

--- a/docs/prefect.mdx
+++ b/docs/prefect.mdx
@@ -22,7 +22,7 @@ Select **Prefect** when prompted and provide your API URL and API key.
 
 ### Option 2: Persistent store
 
-Add to `~/.config/opensre/integrations.json`:
+Add to `~/.opensre/integrations.json`:
 
 ```json
 {
@@ -87,4 +87,4 @@ When OpenSRE investigates a Prefect-related alert, three diagnostic tools are av
 
 - Use a **service account API key** rather than a personal key.
 - For self-hosted, restrict network access to the Prefect API to trusted IPs.
-- Store credentials in `~/.config/opensre/integrations.json`, not in source code.
+- Store credentials in `~/.opensre/integrations.json`, not in source code.

--- a/docs/rabbitmq.mdx
+++ b/docs/rabbitmq.mdx
@@ -51,7 +51,7 @@ RABBITMQ_VERIFY_SSL=true
 
 ### Option 3: Persistent store
 
-Credentials are automatically persisted to `~/.config/opensre/integrations.json` with `0o600` permissions:
+Credentials are automatically persisted to `~/.opensre/integrations.json` with `0o600` permissions:
 
 ```json
 {

--- a/tests/agents/test_config.py
+++ b/tests/agents/test_config.py
@@ -21,7 +21,7 @@ from app.agents.config import (
 @pytest.fixture(autouse=True)
 def isolated_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     """Autouse: redirect ``agents_config_path`` at a per-test tmp file so
-    tests never touch the developer's real ``~/.config/opensre/agents.yaml``.
+    tests never touch the developer's real ``~/.opensre/agents.yaml``.
     Tests that need the path itself can still request it by name.
     """
     target = tmp_path / "agents.yaml"

--- a/tests/agents/test_sweep.py
+++ b/tests/agents/test_sweep.py
@@ -20,7 +20,7 @@ _DEAD_PID = 2**31 - 1
 @pytest.fixture
 def isolated_registry(tmp_path: Path) -> AgentRegistry:
     """An ``AgentRegistry`` writing to a tmp dir so tests don't touch
-    the developer's real ``~/.config/opensre/agents.jsonl``."""
+    the developer's real ``~/.opensre/agents.jsonl``."""
     return AgentRegistry(path=tmp_path / "agents.jsonl")
 
 

--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -27,10 +27,6 @@ def _reset_anonymous_id_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
     provider._pending_user_id_load_failures.clear()
     monkeypatch.setattr(provider, "_event_log_state", provider._EventLogState())
     monkeypatch.setattr(provider, "_FIRST_RUN_PATH", tmp_path / "installed")
-    legacy_dir = tmp_path / "legacy-opensre"
-    monkeypatch.setattr(provider, "_LEGACY_CONFIG_DIR", legacy_dir)
-    monkeypatch.setattr(provider, "_LEGACY_ANONYMOUS_ID_PATH", legacy_dir / "anonymous_id")
-    monkeypatch.setattr(provider, "_LEGACY_FIRST_RUN_PATH", legacy_dir / "installed")
     yield
     provider.shutdown_analytics(flush=False)
     provider._instance = None
@@ -294,11 +290,6 @@ def test_existing_install_missing_anonymous_id_captures_posthog_error(
     monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
     monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
     monkeypatch.setattr(provider, "_FIRST_RUN_PATH", tmp_path / "installed")
-    monkeypatch.setattr(provider, "_LEGACY_CONFIG_DIR", tmp_path / ".opensre")
-    monkeypatch.setattr(
-        provider, "_LEGACY_ANONYMOUS_ID_PATH", tmp_path / ".opensre" / "anonymous_id"
-    )
-    monkeypatch.setattr(provider, "_LEGACY_FIRST_RUN_PATH", tmp_path / ".opensre" / "installed")
     monkeypatch.setattr(provider.atexit, "register", lambda _func: None)
     (tmp_path / "installed").touch()
     posted_payloads = _stub_httpx_client(monkeypatch)
@@ -314,8 +305,8 @@ def test_existing_install_missing_anonymous_id_captures_posthog_error(
     assert len(user_id_errors) == 1
     properties = user_id_errors[0]["properties"]
     assert properties["reason"] == "missing_anonymous_id"
-    assert properties["config_dir"] == "~/.config/opensre"
-    assert properties["anonymous_id_path"] == "~/.config/opensre/anonymous_id"
+    assert properties["config_dir"] == "~/.opensre"
+    assert properties["anonymous_id_path"] == "~/.opensre/anonymous_id"
     assert properties["config_dir_existed"] is True
     assert properties["install_marker_existed"] is True
     assert properties["anonymous_id_path_existed"] is False
@@ -342,27 +333,6 @@ def test_first_run_missing_anonymous_id_does_not_capture_posthog_error(
         for payload in posted_payloads
         if payload["json"].get("event") == Event.USER_ID_LOAD_FAILED.value
     ] == []
-
-
-def test_legacy_anonymous_id_is_loaded_into_config_path(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    config_dir = tmp_path / ".config" / "opensre"
-    legacy_dir = tmp_path / ".opensre"
-    legacy_id = "11111111-2222-3333-4444-555555555555"
-    legacy_dir.mkdir()
-    (legacy_dir / "installed").touch()
-    (legacy_dir / "anonymous_id").write_text(legacy_id, encoding="utf-8")
-    monkeypatch.setattr(provider, "_CONFIG_DIR", config_dir)
-    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", config_dir / "anonymous_id")
-    monkeypatch.setattr(provider, "_FIRST_RUN_PATH", config_dir / "installed")
-    monkeypatch.setattr(provider, "_LEGACY_CONFIG_DIR", legacy_dir)
-    monkeypatch.setattr(provider, "_LEGACY_ANONYMOUS_ID_PATH", legacy_dir / "anonymous_id")
-    monkeypatch.setattr(provider, "_LEGACY_FIRST_RUN_PATH", legacy_dir / "installed")
-
-    assert provider._get_or_create_anonymous_id() == legacy_id
-    assert (config_dir / "anonymous_id").read_text(encoding="utf-8") == legacy_id
-    assert provider._pending_user_id_load_failures == []
 
 
 def test_anonymous_id_replaces_non_uuid_persisted_file(
@@ -887,7 +857,7 @@ def test_event_log_writes_to_config_dir_not_cwd(monkeypatch, tmp_path: Path) -> 
 
 def test_event_log_creates_config_dir_on_first_write(monkeypatch, tmp_path: Path) -> None:
     """``_CONFIG_DIR`` may not exist on a fresh install — first write must mkdir it."""
-    config_dir = tmp_path / "fresh-install" / ".config" / "opensre"
+    config_dir = tmp_path / "fresh-install" / ".opensre"
     assert not config_dir.exists()
 
     monkeypatch.setenv("OPENSRE_ANALYTICS_LOG_EVENTS", "1")

--- a/tests/benchmarks/_framework/smoke.py
+++ b/tests/benchmarks/_framework/smoke.py
@@ -175,7 +175,7 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"    final_diagnosis.root_cause={run.final_diagnosis.get('root_cause')!r}")
             except Exception as exc:
                 print(f"  ✗ run_investigation failed: {exc}")
-                print("    Check: ~/.config/opensre/integrations.json + LLM API key")
+                print("    Check: ~/.opensre/integrations.json + LLM API key")
                 return 2
         else:
             run = _fake_run_result(case)

--- a/tests/cli/interactive_shell/test_agents_commands.py
+++ b/tests/cli/interactive_shell/test_agents_commands.py
@@ -31,7 +31,7 @@ def _capture() -> tuple[Console, io.StringIO]:
 def _isolate_registry(monkeypatch: pytest.MonkeyPatch, path: Path) -> AgentRegistry:
     """Point the slash command's ``AgentRegistry()`` constructor at
     ``path`` so tests don't read the developer's real
-    ``~/.config/opensre/agents.jsonl``. Returns the registry instance
+    ``~/.opensre/agents.jsonl``. Returns the registry instance
     that the test can populate.
     """
     registry = AgentRegistry(path=path)
@@ -50,7 +50,7 @@ def isolated_agents_yaml(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Pat
     """Autouse: redirect ``agents_config_path()`` to a per-test tmp path so
     ``/agents`` (which now reads ``agents.yaml`` for the ``$/hr`` cell)
     and ``/agents budget`` never touch the developer's real
-    ``~/.config/opensre/agents.yaml``.
+    ``~/.opensre/agents.yaml``.
     """
     target = tmp_path / "agents.yaml"
     monkeypatch.setattr(config_mod, "agents_config_path", lambda: target)

--- a/tests/cli/interactive_shell/ui/test_agents_view.py
+++ b/tests/cli/interactive_shell/ui/test_agents_view.py
@@ -28,7 +28,7 @@ from app.cli.interactive_shell.ui.agents_view import _build_agents_table
 def isolated_agents_yaml(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     """Autouse: redirect ``agents_config_path`` to a per-test tmp file
     so the rendering tests don't read the developer's real
-    ``~/.config/opensre/agents.yaml`` (which would let real budgets
+    ``~/.opensre/agents.yaml`` (which would let real budgets
     leak into the placeholder assertions and create cross-machine
     flakes).
     """

--- a/tests/cli/interactive_shell/ui/test_agents_view_integration.py
+++ b/tests/cli/interactive_shell/ui/test_agents_view_integration.py
@@ -9,7 +9,7 @@ fixture on disk.
 
 The only stubs are :func:`app.agents.probe.cwd_for_pid` and
 :func:`started_at_for_pid` (no real PIDs in a unit test) and the
-``AgentRegistry`` lookup (no real ``~/.config/opensre/agents.jsonl``).
+``AgentRegistry`` lookup (no real ``~/.opensre/agents.jsonl``).
 Everything else exercises production code.
 """
 

--- a/tests/cli/test_uninstall.py
+++ b/tests/cli/test_uninstall.py
@@ -234,6 +234,18 @@ def test_uninstall_command_short_yes_flag() -> None:
     assert result.exit_code == 0
 
 
+def test_data_dirs_includes_legacy_config_opensre_path() -> None:
+    from app.cli.support.uninstall import _data_dirs
+
+    paths = _data_dirs()
+    path_strs = [str(p) for p in paths]
+    assert any(".opensre" in s for s in path_strs), "main ~/.opensre path missing"
+    assert any(".tracer" in s for s in path_strs), "legacy ~/.tracer path missing"
+    assert any(
+        ".config" in s and "opensre" in s for s in path_strs
+    ), "~/.config/opensre cleanup path missing"
+
+
 def test_uninstall_help_describes_command() -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["uninstall", "--help"])

--- a/tests/cli/test_uninstall.py
+++ b/tests/cli/test_uninstall.py
@@ -241,9 +241,9 @@ def test_data_dirs_includes_legacy_config_opensre_path() -> None:
     path_strs = [str(p) for p in paths]
     assert any(".opensre" in s for s in path_strs), "main ~/.opensre path missing"
     assert any(".tracer" in s for s in path_strs), "legacy ~/.tracer path missing"
-    assert any(
-        ".config" in s and "opensre" in s for s in path_strs
-    ), "~/.config/opensre cleanup path missing"
+    assert any(".config" in s and "opensre" in s for s in path_strs), (
+        "~/.config/opensre cleanup path missing"
+    )
 
 
 def test_uninstall_help_describes_command() -> None:

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -86,11 +86,11 @@ class CliSandbox:
 
     @property
     def integration_store_path(self) -> Path:
-        return self.home / ".config" / "opensre" / "integrations.json"
+        return self.home / ".opensre" / "integrations.json"
 
     @property
     def wizard_store_path(self) -> Path:
-        return self.home / ".config" / "opensre" / "opensre.json"
+        return self.home / ".opensre" / "opensre.json"
 
     def seed_integrations(self, integrations: list[dict[str, object]]) -> None:
         self.integration_store_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/deployment/ec2/test_streaming_e2e.py
+++ b/tests/deployment/ec2/test_streaming_e2e.py
@@ -88,7 +88,7 @@ class TestEC2Streaming:
         )
 
     def test_saved_url_matches_deployment(self, ec2_deployment: dict[str, Any]) -> None:
-        """The deploy step should persist the deployed remote URL to ~/.config/opensre."""
+        """The deploy step should persist the deployed remote URL to ~/.opensre."""
         ip = ec2_deployment["PublicIpAddress"]
 
         assert load_remote_url() == normalize_url(ip)

--- a/tests/integrations/test_store_migration.py
+++ b/tests/integrations/test_store_migration.py
@@ -127,7 +127,7 @@ def test_missing_file_yields_empty_v2_store(tmp_path: Path) -> None:
 
 
 def test_legacy_store_is_moved_to_opensre_path(tmp_path: Path) -> None:
-    store_file = tmp_path / ".config" / "opensre" / "integrations.json"
+    store_file = tmp_path / ".opensre" / "integrations.json"
     legacy_store_file = tmp_path / ".tracer" / "integrations.json"
     _write_store(
         legacy_store_file,


### PR DESCRIPTION
## Summary

- Reverts `OPENSRE_HOME_DIR` from `~/.config/opensre` back to `~/.opensre`
- The move to `~/.config/opensre` was introduced incidentally in #1348 (an analytics fix PR) and was not an intentional migration
- Removes `LEGACY_OPENSRE_HOME_DIR` constant (was `~/.opensre`, now the main path again)
- Removes the `~/.opensre` → `~/.config/opensre` anonymous-ID migration code from `analytics/provider.py` since it's no longer needed
- Updates all docstrings, help text, tests, and docs across the codebase

## Edge case handled

`uninstall._data_dirs()` now includes `~/.config/opensre` as an extra cleanup path, so users who ran opensre between #1348 and this fix will have that directory removed on uninstall.

## Files changed

- `app/constants/__init__.py` — path reverted, `LEGACY_OPENSRE_HOME_DIR` removed
- `app/analytics/provider.py` — legacy migration code removed, hardcoded path strings updated
- `app/cli/support/uninstall.py` — `~/.config/opensre` added to cleanup list
- `app/integrations/store.py` — module docstring updated
- 14 app Python files — docstrings/comments updated
- 9 test files — path constructions and assertions updated
- 20 doc files — all `~/.config/opensre` references updated

## Test plan

- [x] `make lint` — clean
- [x] `make typecheck` — 0 issues across 687 source files
- [x] `pytest tests/analytics/test_provider.py tests/integrations/test_store_migration.py tests/cli/test_uninstall.py` — 65/65 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)