### PR TITLE
feat: add Groq LLM provider configuration

### DIFF
--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -148,8 +148,6 @@ NVIDIA_MODELS = (
 GROQ_MODELS = (
     ModelOption(value=GROQ_REASONING_MODEL, label="Llama 3.3 70B Versatile"),
     ModelOption(value="llama-3.1-8b-instant", label="Llama 3.1 8B Instant"),
-    ModelOption(value="mixtral-8x7b-32768", label="Mixtral 8x7B"),
-    ModelOption(value="gemma2-9b-it", label="Gemma 2 9B IT"),
 )
 
 BEDROCK_MODELS = (

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -15,6 +15,7 @@ from app.config import (
     DEFAULT_OLLAMA_HOST,
     DEFAULT_OLLAMA_MODEL,
     GEMINI_REASONING_MODEL,
+    GROQ_REASONING_MODEL,
     NVIDIA_REASONING_MODEL,
     OPENAI_REASONING_MODEL,
     OPENROUTER_REASONING_MODEL,
@@ -142,6 +143,13 @@ NVIDIA_MODELS = (
         label="Nemotron 3 Super 120B (5x higher throughput for agentic AI)",
     ),
     ModelOption(value="nvidia/nemotron-3-nano-30b-a3b", label="Nemotron 3 Nano 30B"),
+)
+
+GROQ_MODELS = (
+    ModelOption(value=GROQ_REASONING_MODEL, label="Llama 3.3 70B Versatile"),
+    ModelOption(value="llama-3.1-8b-instant", label="Llama 3.1 8B Instant"),
+    ModelOption(value="mixtral-8x7b-32768", label="Mixtral 8x7B"),
+    ModelOption(value="gemma2-9b-it", label="Gemma 2 9B IT"),
 )
 
 BEDROCK_MODELS = (
@@ -484,6 +492,19 @@ SUPPORTED_PROVIDERS = (
         # credential_kind="none" causes flow.py to skip the credential prompt
         # entirely.  Region is picked up from AWS_DEFAULT_REGION / ~/.aws/config.
         credential_kind="none",
+        allow_custom_models=True,
+    ),
+    ProviderOption(
+        value="groq",
+        label="Groq",
+        group="Hosted providers",
+        api_key_env="GROQ_API_KEY",
+        model_env="GROQ_REASONING_MODEL",
+        default_model=GROQ_REASONING_MODEL,
+        models=GROQ_MODELS,
+        legacy_model_env="GROQ_MODEL",
+        toolcall_model_env="GROQ_TOOLCALL_MODEL",
+        classification_model_env="GROQ_CLASSIFICATION_MODEL",
         allow_custom_models=True,
     ),
     ProviderOption(

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -148,6 +148,10 @@ NVIDIA_MODELS = (
 GROQ_MODELS = (
     ModelOption(value=GROQ_REASONING_MODEL, label="Llama 3.3 70B Versatile"),
     ModelOption(value="llama-3.1-8b-instant", label="Llama 3.1 8B Instant"),
+    ModelOption(value="openai/gpt-oss-120b", label="GPT-OSS 120B"),
+    ModelOption(value="openai/gpt-oss-20b", label="GPT-OSS 20B"),
+    ModelOption(value="qwen/qwen3-32b", label="Qwen3 32B"),
+    ModelOption(value="meta-llama/llama-4-scout-17b-16e-instruct", label="Llama 4 Scout 17B"),
 )
 
 BEDROCK_MODELS = (

--- a/app/config.py
+++ b/app/config.py
@@ -125,12 +125,18 @@ MINIMAX_REASONING_MODEL = "MiniMax-M2.7"
 MINIMAX_CLASSIFICATION_MODEL = "MiniMax-M2.7-highspeed"
 MINIMAX_TOOLCALL_MODEL = "MiniMax-M2.7-highspeed"
 
+# Groq model constants
+GROQ_REASONING_MODEL = "llama-3.3-70b-versatile"
+GROQ_CLASSIFICATION_MODEL = "llama-3.3-70b-versatile"
+GROQ_TOOLCALL_MODEL = "llama-3.1-8b-instant"
+
 # Base URLs for OpenAI-compatible providers
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 DEEPSEEK_BASE_URL = "https://api.deepseek.com"  # no /v1 — DeepSeek serves the OpenAI-compatible API at the root path
 GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 NVIDIA_BASE_URL = "https://integrate.api.nvidia.com/v1"
 MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+GROQ_BASE_URL = "https://api.groq.com/openai/v1"
 
 # Amazon Bedrock model constants (US cross-region inference profile IDs)
 BEDROCK_REASONING_MODEL = "us.anthropic.claude-sonnet-4-6"
@@ -151,6 +157,7 @@ LLMProvider = Literal[
     "ollama",
     "bedrock",
     "minimax",
+    "groq",
     "codex",
     "cursor",
     "claude-code",
@@ -181,6 +188,7 @@ LLM_PROVIDER_API_KEY_ENVS = {
     "gemini": "GEMINI_API_KEY",
     "nvidia": "NVIDIA_API_KEY",
     "minimax": "MINIMAX_API_KEY",
+    "groq": "GROQ_API_KEY",
 }
 DEFAULT_LLM_RESOLUTION_FALLBACK_PROVIDERS: tuple[str, ...] = ("openai", "anthropic")
 
@@ -216,6 +224,7 @@ def _llm_settings_env_payload(provider: str) -> dict[str, object]:
         "gemini_api_key": resolve_llm_api_key("GEMINI_API_KEY"),
         "nvidia_api_key": resolve_llm_api_key("NVIDIA_API_KEY"),
         "minimax_api_key": resolve_llm_api_key("MINIMAX_API_KEY"),
+        "groq_api_key": resolve_llm_api_key("GROQ_API_KEY"),
         "anthropic_reasoning_model": os.getenv(
             "ANTHROPIC_REASONING_MODEL", ANTHROPIC_REASONING_MODEL
         ).strip()
@@ -313,6 +322,21 @@ def _llm_settings_env_payload(provider: str) -> dict[str, object]:
             os.getenv("MINIMAX_MODEL", MINIMAX_TOOLCALL_MODEL),
         ).strip()
         or MINIMAX_TOOLCALL_MODEL,
+        "groq_reasoning_model": os.getenv(
+            "GROQ_REASONING_MODEL",
+            os.getenv("GROQ_MODEL", GROQ_REASONING_MODEL),
+        ).strip()
+        or GROQ_REASONING_MODEL,
+        "groq_classification_model": os.getenv(
+            "GROQ_CLASSIFICATION_MODEL",
+            os.getenv("GROQ_MODEL", GROQ_CLASSIFICATION_MODEL),
+        ).strip()
+        or GROQ_CLASSIFICATION_MODEL,
+        "groq_toolcall_model": os.getenv(
+            "GROQ_TOOLCALL_MODEL",
+            os.getenv("GROQ_MODEL", GROQ_TOOLCALL_MODEL),
+        ).strip()
+        or GROQ_TOOLCALL_MODEL,
         "bedrock_reasoning_model": os.getenv(
             "BEDROCK_REASONING_MODEL", BEDROCK_REASONING_MODEL
         ).strip()
@@ -356,6 +380,7 @@ class LLMSettings(StrictConfigModel):
     gemini_api_key: str = ""
     nvidia_api_key: str = ""
     minimax_api_key: str = ""
+    groq_api_key: str = ""
     ollama_model: str = DEFAULT_OLLAMA_MODEL
     ollama_host: str = DEFAULT_OLLAMA_HOST
     anthropic_reasoning_model: str = ANTHROPIC_REASONING_MODEL
@@ -379,6 +404,9 @@ class LLMSettings(StrictConfigModel):
     minimax_reasoning_model: str = MINIMAX_REASONING_MODEL
     minimax_classification_model: str = MINIMAX_CLASSIFICATION_MODEL
     minimax_toolcall_model: str = MINIMAX_TOOLCALL_MODEL
+    groq_reasoning_model: str = GROQ_REASONING_MODEL
+    groq_classification_model: str = GROQ_CLASSIFICATION_MODEL
+    groq_toolcall_model: str = GROQ_TOOLCALL_MODEL
     bedrock_reasoning_model: str = BEDROCK_REASONING_MODEL
     bedrock_classification_model: str = BEDROCK_CLASSIFICATION_MODEL
     bedrock_toolcall_model: str = BEDROCK_TOOLCALL_MODEL
@@ -406,6 +434,7 @@ class LLMSettings(StrictConfigModel):
             "ollama",
             "bedrock",
             "minimax",
+            "groq",
             "codex",
             "cursor",
             "claude-code",
@@ -437,6 +466,7 @@ class LLMSettings(StrictConfigModel):
             "gemini": self.gemini_api_key,
             "nvidia": self.nvidia_api_key,
             "minimax": self.minimax_api_key,
+            "groq": self.groq_api_key,
         }
         if provider_to_key[self.provider]:
             return self

--- a/app/config.py
+++ b/app/config.py
@@ -569,6 +569,13 @@ DEEPSEEK_LLM_CONFIG = LLMModelConfig(
     max_tokens=DEFAULT_MAX_TOKENS,
 )
 
+GROQ_LLM_CONFIG = LLMModelConfig(
+    reasoning_model=GROQ_REASONING_MODEL,
+    classification_model=GROQ_CLASSIFICATION_MODEL,
+    toolcall_model=GROQ_TOOLCALL_MODEL,
+    max_tokens=DEFAULT_MAX_TOKENS,
+)
+
 GEMINI_LLM_CONFIG = LLMModelConfig(
     reasoning_model=GEMINI_REASONING_MODEL,
     classification_model=GEMINI_CLASSIFICATION_MODEL,

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -727,7 +727,7 @@ def get_agent_llm() -> _AgentClientType:
             model=settings.openai_reasoning_model,
             max_tokens=OPENAI_LLM_CONFIG.max_tokens,
         )
-    elif provider in ("openrouter", "deepseek", "gemini", "nvidia", "minimax", "ollama"):
+    elif provider in ("openrouter", "deepseek", "gemini", "nvidia", "minimax", "groq", "ollama"):
         # All OpenAI-compatible providers
         _agent_client = _create_openai_compat_client(settings, provider)
     elif provider == "bedrock":
@@ -764,6 +764,7 @@ def _create_openai_compat_client(settings: Any, provider: str) -> OpenAIAgentCli
     from app.config import (
         DEEPSEEK_BASE_URL,
         GEMINI_BASE_URL,
+        GROQ_BASE_URL,
         MINIMAX_BASE_URL,
         NVIDIA_BASE_URL,
         OPENROUTER_BASE_URL,
@@ -779,6 +780,7 @@ def _create_openai_compat_client(settings: Any, provider: str) -> OpenAIAgentCli
         "gemini": (GEMINI_BASE_URL, "GEMINI_API_KEY", settings.gemini_reasoning_model),
         "nvidia": (NVIDIA_BASE_URL, "NVIDIA_API_KEY", settings.nvidia_reasoning_model),
         "minimax": (MINIMAX_BASE_URL, "MINIMAX_API_KEY", settings.minimax_reasoning_model),
+        "groq": (GROQ_BASE_URL, "GROQ_API_KEY", settings.groq_reasoning_model),
     }
     if provider == "ollama":
         host = settings.ollama_host.rstrip("/")

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -42,6 +42,7 @@ from app.config import (
     DEEPSEEK_BASE_URL,
     GEMINI_BASE_URL,
     GROQ_BASE_URL,
+    GROQ_LLM_CONFIG,
     MINIMAX_BASE_URL,
     NVIDIA_BASE_URL,
     OPENAI_LLM_CONFIG,
@@ -1341,7 +1342,7 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
             temperature=1.0,
         )
     elif provider == "groq":
-        config = OPENAI_LLM_CONFIG
+        config = GROQ_LLM_CONFIG
         return OpenAILLMClient(
             model=_select_model(settings, "groq", model_type),
             model_fallback=_fallback_model("groq"),

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -41,6 +41,7 @@ from app.config import (
     ANTHROPIC_LLM_CONFIG,
     DEEPSEEK_BASE_URL,
     GEMINI_BASE_URL,
+    GROQ_BASE_URL,
     MINIMAX_BASE_URL,
     NVIDIA_BASE_URL,
     OPENAI_LLM_CONFIG,
@@ -1338,6 +1339,15 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
             base_url=MINIMAX_BASE_URL,
             api_key_env="MINIMAX_API_KEY",
             temperature=1.0,
+        )
+    elif provider == "groq":
+        config = OPENAI_LLM_CONFIG
+        return OpenAILLMClient(
+            model=_select_model(settings, "groq", model_type),
+            model_fallback=_fallback_model("groq"),
+            max_tokens=config.max_tokens,
+            base_url=GROQ_BASE_URL,
+            api_key_env="GROQ_API_KEY",
         )
     elif provider == "ollama":
         from app.config import OLLAMA_LLM_CONFIG


### PR DESCRIPTION

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

This PR introduces **Groq** as a first-class supported LLM provider in OpenSRE. Groq offers exceptionally low-latency inference for powerful open-weight models (like `llama-3.3-70b-versatile`) and generous free tiers, making it highly accessible for independent researchers and small-scale SRE deployments. 

Specifically, this PR:
- Adds `GROQ_API_KEY` and relevant Groq model constants (reasoning, classification, toolcall) to `app/config.py`.
- Registers Groq as a "Hosted provider" in the CLI onboarding wizard (`app/cli/wizard/config.py`), seamlessly injecting it into the `opensre onboard` flow immediately following the Bedrock configuration.
- Maps Groq to the existing OpenAI-compatible ReAct/Agent loops in `app/services/agent_llm_client.py`.
- Routes Groq to the robust `OpenAILLMClient` in `app/services/llm_client.py`, utilizing its native tool-calling integrations

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->
<img width="889" height="368" alt="Screenshot from 2026-05-24 14-29-33" src="https://github.com/user-attachments/assets/33052fdf-1c87-4498-bda2-ed9f22459c41" />
Groq added

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->
**Problem Solved:** OpenSRE did not natively support Groq. While users could theoretically hack around this by overriding the generic OpenAI base URL, providing first-class support vastly improves the developer experience and onboarding UX for users who rely on Groq's low-latency API for agentic workflows.

**Alternative Approaches:** I considered implementing a standalone Groq API client, but realized Groq's endpoint (`https://api.groq.com/openai/v1`) is highly compatible with the OpenAI API specification. 

**Why this specific implementation:** By leveraging OpenSRE's existing OpenAI-compatible wrappers (`OpenAIAgentClient` and `OpenAILLMClient`), I was able to implement full Groq support with zero new vendor boilerplate. It inherits all of the platform's robust JSON schema parsing, retry logic, and tool-calling infrastructure automatically. 

**Key components touched:**
- `SUPPORTED_PROVIDERS`: Extended to add the interactive CLI menu option.
- `_create_openai_compat_client()` & `_create_llm_client()`: Added routing logic to instantiate the OpenAI client with Groq's base URL and credentials. 
- Shadowing Fix: Ensured `OPENAI_LLM_CONFIG` was not improperly shadowed as a local variable during the client initialization block.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
