### PR TITLE
fix(wizard): update stale model lists for Anthropic, OpenAI, and OpenRouter

### DIFF
--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -85,15 +85,15 @@ ANTHROPIC_MODELS = (
 
 # Source: https://platform.openai.com/docs/models
 OPENAI_MODELS = (
-    ModelOption(value="gpt-5.5", label="GPT-5.5"),
     ModelOption(value=OPENAI_REASONING_MODEL, label="GPT-5.4 mini"),
+    ModelOption(value="gpt-5.5", label="GPT-5.5"),
     ModelOption(value="gpt-5.4", label="GPT-5.4"),
     ModelOption(value="gpt-5.4-nano", label="GPT-5.4 nano"),
     ModelOption(value="gpt-5.3-codex", label="GPT-5.3-Codex"),
     ModelOption(value="gpt-5.2-codex", label="GPT-5.2-Codex"),
 )
 
-# Source: https://openrouter.ai/api/v1/models (OpenRouter uses dot-separated versions)
+# Source: https://openrouter.ai/api/v1/models
 OPENROUTER_MODELS = (
     ModelOption(value=OPENROUTER_REASONING_MODEL, label="OpenRouter Auto (smart routing)"),
     ModelOption(value="openai/gpt-5.5", label="GPT-5.5 (via OpenRouter)"),

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -84,13 +84,13 @@ ANTHROPIC_MODELS = (
 )
 
 # Source: https://platform.openai.com/docs/models
+# Codex model IDs are intentionally omitted here: OpenSRE's direct OpenAI
+# provider uses Chat Completions, while Codex models require a different API path.
 OPENAI_MODELS = (
     ModelOption(value=OPENAI_REASONING_MODEL, label="GPT-5.4 mini"),
     ModelOption(value="gpt-5.5", label="GPT-5.5"),
     ModelOption(value="gpt-5.4", label="GPT-5.4"),
     ModelOption(value="gpt-5.4-nano", label="GPT-5.4 nano"),
-    ModelOption(value="gpt-5.3-codex", label="GPT-5.3-Codex"),
-    ModelOption(value="gpt-5.2-codex", label="GPT-5.2-Codex"),
 )
 
 # Source: https://openrouter.ai/api/v1/models

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -76,24 +76,29 @@ class ProviderOption:
     allow_custom_models: bool = False
 
 
+# Source: https://docs.anthropic.com/en/docs/about-claude/models/overview
 ANTHROPIC_MODELS = (
     ModelOption(value=ANTHROPIC_REASONING_MODEL, label="Claude Opus 4.7"),
-    ModelOption(value="claude-sonnet-4-20250514", label="Claude Sonnet 4"),
+    ModelOption(value="claude-sonnet-4-6", label="Claude Sonnet 4.6"),
+    ModelOption(value="claude-haiku-4-5", label="Claude Haiku 4.5"),
 )
 
+# Source: https://platform.openai.com/docs/models
 OPENAI_MODELS = (
     ModelOption(value=OPENAI_REASONING_MODEL, label="GPT-5.4 mini"),
     ModelOption(value="gpt-5.4", label="GPT-5.4"),
     ModelOption(value="gpt-5.4-nano", label="GPT-5.4 nano"),
     ModelOption(value="gpt-5.3-codex", label="GPT-5.3-Codex"),
+    ModelOption(value="gpt-5.2-codex", label="GPT-5.2-Codex (API-key auth)"),
 )
 
+# Source: https://openrouter.ai/models — retired Claude 4.5/4.6 IDs replaced with current
 OPENROUTER_MODELS = (
     ModelOption(value=OPENROUTER_REASONING_MODEL, label="OpenRouter Auto (smart routing)"),
     ModelOption(value="openai/gpt-5.2", label="GPT-5.2 (via OpenRouter)"),
-    ModelOption(value="anthropic/claude-opus-4.6", label="Claude Opus 4.6 (via OpenRouter)"),
-    ModelOption(value="anthropic/claude-sonnet-4.5", label="Claude Sonnet 4.5 (via OpenRouter)"),
-    ModelOption(value="anthropic/claude-haiku-4.5", label="Claude Haiku 4.5 (via OpenRouter)"),
+    ModelOption(value="anthropic/claude-opus-4-7", label="Claude Opus 4.7 (via OpenRouter)"),
+    ModelOption(value="anthropic/claude-sonnet-4-6", label="Claude Sonnet 4.6 (via OpenRouter)"),
+    ModelOption(value="anthropic/claude-haiku-4-5", label="Claude Haiku 4.5 (via OpenRouter)"),
     ModelOption(
         value="google/gemini-3.1-pro-preview", label="Gemini 3.1 Pro (preview, via OpenRouter)"
     ),

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -93,13 +93,13 @@ OPENAI_MODELS = (
     ModelOption(value="gpt-5.2-codex", label="GPT-5.2-Codex"),
 )
 
-# Source: https://openrouter.ai/models — retired Claude 4.5/4.6 IDs replaced with current
+# Source: https://openrouter.ai/api/v1/models (OpenRouter uses dot-separated versions)
 OPENROUTER_MODELS = (
     ModelOption(value=OPENROUTER_REASONING_MODEL, label="OpenRouter Auto (smart routing)"),
     ModelOption(value="openai/gpt-5.5", label="GPT-5.5 (via OpenRouter)"),
-    ModelOption(value="anthropic/claude-opus-4-7", label="Claude Opus 4.7 (via OpenRouter)"),
-    ModelOption(value="anthropic/claude-sonnet-4-6", label="Claude Sonnet 4.6 (via OpenRouter)"),
-    ModelOption(value="anthropic/claude-haiku-4-5", label="Claude Haiku 4.5 (via OpenRouter)"),
+    ModelOption(value="anthropic/claude-opus-4.7", label="Claude Opus 4.7 (via OpenRouter)"),
+    ModelOption(value="anthropic/claude-sonnet-4.6", label="Claude Sonnet 4.6 (via OpenRouter)"),
+    ModelOption(value="anthropic/claude-haiku-4.5", label="Claude Haiku 4.5 (via OpenRouter)"),
     ModelOption(
         value="google/gemini-3.1-pro-preview", label="Gemini 3.1 Pro (preview, via OpenRouter)"
     ),

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -85,17 +85,18 @@ ANTHROPIC_MODELS = (
 
 # Source: https://platform.openai.com/docs/models
 OPENAI_MODELS = (
+    ModelOption(value="gpt-5.5", label="GPT-5.5"),
     ModelOption(value=OPENAI_REASONING_MODEL, label="GPT-5.4 mini"),
     ModelOption(value="gpt-5.4", label="GPT-5.4"),
     ModelOption(value="gpt-5.4-nano", label="GPT-5.4 nano"),
     ModelOption(value="gpt-5.3-codex", label="GPT-5.3-Codex"),
-    ModelOption(value="gpt-5.2-codex", label="GPT-5.2-Codex (API-key auth)"),
+    ModelOption(value="gpt-5.2-codex", label="GPT-5.2-Codex"),
 )
 
 # Source: https://openrouter.ai/models — retired Claude 4.5/4.6 IDs replaced with current
 OPENROUTER_MODELS = (
     ModelOption(value=OPENROUTER_REASONING_MODEL, label="OpenRouter Auto (smart routing)"),
-    ModelOption(value="openai/gpt-5.2", label="GPT-5.2 (via OpenRouter)"),
+    ModelOption(value="openai/gpt-5.5", label="GPT-5.5 (via OpenRouter)"),
     ModelOption(value="anthropic/claude-opus-4-7", label="Claude Opus 4.7 (via OpenRouter)"),
     ModelOption(value="anthropic/claude-sonnet-4-6", label="Claude Sonnet 4.6 (via OpenRouter)"),
     ModelOption(value="anthropic/claude-haiku-4-5", label="Claude Haiku 4.5 (via OpenRouter)"),


### PR DESCRIPTION
HUMAN:

This PR proposes a small update as per linked issue, to the main LLM lists in the onboarding flow. From my tests, the discussion in the issue and agent's tests below, `-codex` models actually use Responses via direct OpenAI, which is incompatible with regular "openai-compatible" (heh) chat completions API, so I checked and removed it. It's not clear to me that it ever worked, sorry. 🤷 
OpenRouter and Anthropic work; OpenAI other models, including GPT-5.5, work.

Fixes #2398

---

<details>
<summary> AGENT: tests and doc links </summary>

## Summary

Update the onboarding wizard model picker lists so the offered model IDs better match the runtime paths OpenSRE actually supports today.

### Anthropic

- Replace deprecated/stale `claude-sonnet-4-20250514` with `claude-sonnet-4-6`.
- Add `claude-haiku-4-5`, which was missing from the picker.
- Add a source comment pointing to Anthropic's model overview.

### OpenAI

- Add `gpt-5.5` to the direct OpenAI picker.
- Remove Codex model IDs from the direct OpenAI picker.
  - `gpt-5.3-codex` and `gpt-5.2-codex` are visible in OpenAI's model catalog and work through the Responses API.
  - OpenSRE's direct `LLM_PROVIDER=openai` runtime currently uses Chat Completions (`client.chat.completions.create(...)`), and OpenAI rejects those Codex IDs on `/v1/chat/completions` as non-chat models.
  - Until OpenSRE has a Responses API path, Codex IDs should not be offered as direct OpenAI picker choices.
- Add a source comment pointing to OpenAI's model docs, plus an inline note explaining why Codex IDs are intentionally omitted.

### OpenRouter

- Replace stale OpenRouter picker entries with current catalog entries:
  - `openai/gpt-5.2` → `openai/gpt-5.5`
  - `anthropic/claude-opus-4.6` → `anthropic/claude-opus-4.7`
  - `anthropic/claude-sonnet-4.5` → `anthropic/claude-sonnet-4.6`
- Keep `anthropic/claude-haiku-4.5`.
- Add a source comment pointing to OpenRouter's model catalog endpoint.

## Demo/Screenshot for feature changes and bug fixes

Data-only change — no UI behavior changes. The wizard dropdown choices are updated; no new picker behavior is introduced.

## Verification

### Config import smoke check

```bash
uv run python - <<'PY'
from app.cli.wizard.config import PROVIDER_BY_VALUE
models = [m.value for m in PROVIDER_BY_VALUE['openai'].models]
print(models)
assert 'gpt-5.3-codex' not in models
assert 'gpt-5.2-codex' not in models
PY
```

### Codex model runtime check

Using the OpenAI SDK directly against Chat Completions, both Codex IDs were rejected as non-chat models:

```text
MODEL gpt-5.3-codex
  ERROR NotFoundError Error code: 404 - This is not a chat model and thus not supported in the v1/chat/completions endpoint.
MODEL gpt-5.2-codex
  ERROR NotFoundError Error code: 404 - This is not a chat model and thus not supported in the v1/chat/completions endpoint.
```

Using the Responses API with the same model IDs succeeded, confirming the IDs exist but are incompatible with OpenSRE's current direct OpenAI Chat Completions path.

</details>

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Small model-list/data update. The OpenAI picker now avoids Codex IDs because the current OpenSRE direct OpenAI runtime uses Chat Completions, while these Codex IDs require a different API path.

---

_This PR description was updated by an AI agent (OpenHands) on behalf of the user._

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
