### PR TITLE
fix: clear stale investigation footer after completion

### DIFF
--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -644,6 +644,7 @@ class _EventLogDisplay:
             console=self._console,
             refresh_per_second=10,
             auto_refresh=True,
+            transient=True,
             # Clip the live area to the terminal height so Rich never tries to
             # scroll back past more lines than it rendered.
             vertical_overflow="ellipsis",

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -615,12 +615,9 @@ def test_finish_text_mode_survives_non_ascii_mark(
     assert buf.getvalue()  # something was written, no exception raised
 
 
-def test_event_log_display_live_is_transient(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_event_log_display_live_is_transient() -> None:
     """Verify that _EventLogDisplay initializes the Rich Live region with transient=True."""
     from unittest.mock import patch
-
-    monkeypatch.setattr(output, "get_output_format", lambda: "rich")
-    monkeypatch.setattr(output, "_repl_progress_active", lambda: False)
 
     with patch("rich.live.Live.start"), patch("rich.live.Live.stop"):
         display = output._EventLogDisplay()

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -613,3 +613,18 @@ def test_finish_text_mode_survives_non_ascii_mark(
     monkeypatch.setattr("sys.stdout", buf)
     _safe_print("  ● diagnose_root_cause  1.2s")  # matches the _finish output format
     assert buf.getvalue()  # something was written, no exception raised
+
+
+def test_event_log_display_live_is_transient(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that _EventLogDisplay initializes the Rich Live region with transient=True."""
+    from unittest.mock import patch
+
+    monkeypatch.setattr(output, "get_output_format", lambda: "rich")
+    monkeypatch.setattr(output, "_repl_progress_active", lambda: False)
+
+    with patch("rich.live.Live.start"), patch("rich.live.Live.stop"):
+        display = output._EventLogDisplay()
+        try:
+            assert display._live.transient is True
+        finally:
+            display.stop()


### PR DESCRIPTION
Fixes #2117

#### Describe the changes you have made in this PR -

This PR fixes the stale investigation footer remaining visible after investigation completion.

Previously, `_EventLogDisplay` used Rich's default `Live` behavior, which keeps the final rendered frame visible after `Live.stop()`. As a result, the stale `INVESTIGATE` footer and divider remained on screen, causing the final RCA report to render below outdated live UI content.

This change enables `transient=True` for `_EventLogDisplay`, allowing Rich to automatically clear the temporary live region once the investigation finishes.

A focused regression test was also added to verify that `_EventLogDisplay` initializes the `Live` display with `transient=True`.

### Demo/Screenshot for feature changes and bug fixes -

Before:

* stale `INVESTIGATE` footer remained visible after investigation completion

After:

* temporary live footer is cleared cleanly before rendering the final RCA report

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

* [ ] No, I wrote all the code myself
* [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

* [x] I have reviewed every single line of the AI-generated code
* [x] I can explain the purpose and logic of each function/component I added
* [x] I have tested edge cases and understand how the code handles them
* [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue was caused by Rich `Live` retaining the final rendered frame after `stop()` when `transient=False` (default behavior). Since `_EventLogDisplay` uses a temporary live region for active investigation progress, the stale footer remained visible after investigation completion.

I considered manual terminal clearing approaches, but those would introduce unnecessary terminal-specific logic and additional maintenance complexity. Rich already provides a native mechanism for temporary live regions through `transient=True`, which cleanly removes the active live display while preserving previously printed completed steps.

The implementation therefore only adds `transient=True` to `_EventLogDisplay` and introduces a focused regression test verifying the `Live` display is initialized as transient.

---

## Checklist before requesting a review

* [x] I have added proper PR title and linked to the issue
* [x] I have performed a self-review of my code
* [x] I can explain the purpose of every function, class, and logic block I added
* [x] I understand why my changes work and have tested them thoroughly
* [x] I have considered potential edge cases and how my code handles them
* [x] If it is a core feature, I have added thorough tests
* [x] My code follows the project's style guidelines and conventions
