### PR TITLE
fix(cli): update config command to capture output

### DIFF
--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -251,7 +251,9 @@ def _cmd_uninstall(session: ReplSession, console: Console, args: list[str]) -> b
 
 
 def _cmd_config(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(console, ["config", *args])
+    # Non-interactive click.echo only; capture so output reaches the REPL buffer
+    # instead of the child's inherited stdout while prompt_toolkit redraws.
+    return run_cli_command(console, ["config", *args], capture_output=True)
 
 
 def _cmd_messaging(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001

--- a/app/cli/interactive_shell/runtime/dispatch.py
+++ b/app/cli/interactive_shell/runtime/dispatch.py
@@ -78,7 +78,9 @@ _EXCLUSIVE_STDIN_SUBCOMMANDS: frozenset[tuple[str, str]] = frozenset(
         ("/mcp", "connect"),
     }
 )
-_WAIT_FOR_COMPLETION_COMMANDS: frozenset[str] = frozenset({"/exit", "/quit", "/update", "/onboard"})
+_WAIT_FOR_COMPLETION_COMMANDS: frozenset[str] = frozenset(
+    {"/exit", "/quit", "/update", "/onboard", "/config"}
+)
 
 
 class DispatchCancelled(Exception):

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1680,6 +1680,8 @@ class TestRunCliCommand:
         ) -> subprocess.CompletedProcess[str]:
             del check, timeout, text, encoding, errors
             assert capture_output is True
+            assert cmd[:3] == [sys.executable, "-m", "app.cli"]
+            assert cmd[3:] == ["config", "show"]
             return subprocess.CompletedProcess(
                 cmd,
                 0,

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1662,25 +1662,35 @@ class TestRunCliCommand:
         assert m.run_cli_command(console, ["update"], subprocess_timeout=30.0) is True
         assert "already up to date" in buf.getvalue()
 
-    def test_interactive_delegate_does_not_capture_output(
+    def test_config_delegate_captures_output(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from app.cli.interactive_shell.command_registry import cli_parity as m
 
-        run_kwargs: list[dict[str, object]] = []
-
-        def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-            run_kwargs.append({"cmd": cmd, **kwargs})
-            return subprocess.CompletedProcess(cmd, 0)
+        def _fake_run(
+            cmd: list[str],
+            *,
+            check: bool,
+            timeout: float | None,
+            capture_output: bool,
+            text: bool,
+            encoding: str,
+            errors: str,
+        ) -> subprocess.CompletedProcess[str]:
+            del check, timeout, text, encoding, errors
+            assert capture_output is True
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="Provider : cursor\n",
+                stderr="",
+            )
 
         monkeypatch.setattr(m.subprocess, "run", _fake_run)
         console, buf = _capture()
-        assert m.run_cli_command(console, ["config", "show"]) is True
-        assert run_kwargs == [
-            {"cmd": [sys.executable, "-m", "app.cli", "config", "show"], "check": False}
-        ]
-        assert buf.getvalue() == "\n\n"
+        assert m._cmd_config(ReplSession(), console, ["show"]) is True
+        assert "Provider : cursor" in buf.getvalue()
 
     def test_capture_output_replays_stdout_through_console_without_timeout(
         self,

--- a/tests/cli/interactive_shell/test_terminal_runtime_routing.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime_routing.py
@@ -149,6 +149,13 @@ def test_dispatch_needs_exclusive_stdin_for_config(
 
     assert loop_dispatch.dispatch_needs_exclusive_stdin("/config", session) is True
     assert loop_dispatch.dispatch_needs_exclusive_stdin("/config show", session) is True
+    assert (
+        loop_dispatch.dispatch_needs_exclusive_stdin(
+            "/config set interactive.layout pinned",
+            session,
+        )
+        is True
+    )
 
 
 def test_dispatch_one_turn_routes_to_cli_help_for_help_questions(

--- a/tests/cli/interactive_shell/test_terminal_runtime_routing.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime_routing.py
@@ -138,6 +138,19 @@ def test_dispatch_needs_exclusive_stdin_for_onboard(
     assert loop_dispatch.dispatch_needs_exclusive_stdin("/onboard local_llm", session) is True
 
 
+def test_dispatch_needs_exclusive_stdin_for_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``/config`` delegates to a subprocess; block the next prompt until output
+    is printed so config lines do not overlap the pinned input bar.
+    """
+    monkeypatch.setattr(loop_dispatch, "repl_tty_interactive", lambda: True)
+    session = ReplSession()
+
+    assert loop_dispatch.dispatch_needs_exclusive_stdin("/config", session) is True
+    assert loop_dispatch.dispatch_needs_exclusive_stdin("/config show", session) is True
+
+
 def test_dispatch_one_turn_routes_to_cli_help_for_help_questions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
/fix #2287 
This pull request improves how the `/config` command is handled in the interactive shell, ensuring its output is properly captured and displayed in the REPL buffer without interfering with the prompt. It also updates the runtime to treat `/config` as a command that requires exclusive access to input, preventing UI glitches. Tests have been updated and added to verify this behavior.

**Command handling improvements:**

* Changed `_cmd_config` in `cli_parity.py` to always capture output when running the `config` command, ensuring REPL output is correctly displayed and not lost during prompt redraws.
* Added `/config` to the set of commands in `dispatch.py` that require waiting for completion and exclusive stdin, preventing output overlap with the input bar.

**Testing updates:**

* Added a new test in `test_terminal_runtime_routing.py` to confirm that `/config` and `/config show` require exclusive stdin, blocking the prompt until output is printed.
* Updated the test in `test_commands.py` to ensure the config delegate captures output and that the correct output appears in the REPL buffer.
<img width="696" height="275" alt="Screenshot 2026-05-25 at 4 57 11 PM" src="https://github.com/user-attachments/assets/5d796605-76e3-4be5-95d0-f419a9155fdf" />

