### PR TITLE
fix(postgresql): include psycopg2 in frozen builds

### DIFF
--- a/packaging/opensre.spec
+++ b/packaging/opensre.spec
@@ -18,6 +18,8 @@ def _is_runtime_submodule(module_name: str) -> bool:
 
 hiddenimports = collect_submodules("app", filter=_is_runtime_submodule)
 hiddenimports += collect_submodules("sentry_sdk")
+hiddenimports += collect_submodules("psycopg2")
+hiddenimports += collect_submodules("psycopg2_binary")
 datas = collect_data_files("app")
 
 block_cipher = None


### PR DESCRIPTION
## Summary

Bundle `psycopg2` into the PyInstaller build so PostgreSQL integrations work in frozen/Homebrew binaries.

## Changes

Added:

* `collect_submodules("psycopg2")`
* `collect_submodules("psycopg2_binary")`

to `hiddenimports` in `packaging/opensre.spec`.

## Verification

Before fix:

```text
ModuleNotFoundError: No module named 'psycopg2'
RuntimeError: psycopg2 is not installed
```

After rebuilding the binary:

```text
.\dist\opensre.exe integrations verify postgresql

STATUS: missing
DETAIL: Not configured in local store or env.
```

This confirms the PostgreSQL integration now loads successfully in the frozen executable and proceeds to configuration validation.
