### PR TITLE
refactor(llm-cli): extract shared timeout constants + env parser

### DIFF
--- a/app/integrations/llm_cli/AGENTS.md
+++ b/app/integrations/llm_cli/AGENTS.md
@@ -13,6 +13,7 @@ Use this package when adding a new **non-interactive** LLM that shells out to a 
 | `subprocess_env.py` | Filtered `env` passed to CLI subprocesses (`build_cli_subprocess_env`). Extend `_SAFE_SUBPROCESS_ENV_PREFIXES` here when a CLI needs vendor-specific env prefixes. |
 | `env_overrides.py` | Optional explicit HTTP/API keys merged into `CLIInvocation.env` when `build_cli_subprocess_env` would drop them (shared tuples + `nonempty_env_values`). |
 | `timeout_utils.py`   | Shared timeout env parsing (`resolve_timeout_from_env` for default + clamp behavior). |
+| `probe_utils.py`     | Shared subprocess probe helpers (currently `run_version_probe` for `<binary> --version`). |
 | `binary_resolver.py` | Shared executable resolution helpers (`env -> PATH -> fallback paths`).                     |
 | `runner.py`          | `CLIBackedLLMClient`: guardrails, `detect()`, `subprocess.run`, ANSI strip, `LLMResponse`.  |
 | `text.py`            | `flatten_messages_to_prompt` for stdin from chat-style payloads.                            |

--- a/app/integrations/llm_cli/AGENTS.md
+++ b/app/integrations/llm_cli/AGENTS.md
@@ -8,9 +8,11 @@ Use this package when adding a new **non-interactive** LLM that shells out to a 
 | File                 | Role                                                                                        |
 | -------------------- | ------------------------------------------------------------------------------------------- |
 | `base.py`            | `LLMCLIAdapter` protocol, `CLIProbe`, `CLIInvocation`.                                      |
+| `constants.py`       | Shared runner/adapter constants (probe-cache TTL, tempfail retry knobs, common timeout defaults). |
 | `registry.py`        | `CLI_PROVIDER_REGISTRY`: maps `LLM_PROVIDER` → `adapter_factory` + optional `model_env_key`. `opensre doctor` uses `get_cli_provider_registration()` so any key in this registry is treated as CLI-backed—do not hardcode provider IDs in `doctor.py`. |
 | `subprocess_env.py` | Filtered `env` passed to CLI subprocesses (`build_cli_subprocess_env`). Extend `_SAFE_SUBPROCESS_ENV_PREFIXES` here when a CLI needs vendor-specific env prefixes. |
 | `env_overrides.py` | Optional explicit HTTP/API keys merged into `CLIInvocation.env` when `build_cli_subprocess_env` would drop them (shared tuples + `nonempty_env_values`). |
+| `timeout_utils.py`   | Shared timeout env parsing (`resolve_timeout_from_env` for default + clamp behavior). |
 | `binary_resolver.py` | Shared executable resolution helpers (`env -> PATH -> fallback paths`).                     |
 | `runner.py`          | `CLIBackedLLMClient`: guardrails, `detect()`, `subprocess.run`, ANSI strip, `LLMResponse`.  |
 | `text.py`            | `flatten_messages_to_prompt` for stdin from chat-style payloads.                            |
@@ -155,4 +157,3 @@ CODEX_BIN=
 - `tests/integrations/llm_cli/` — adapter and runner unit tests; mock `subprocess` / `shutil.which` as needed.
 - Platform-specific assertions must patch `app.integrations.llm_cli.binary_resolver.sys.platform` (not `codex.sys.platform`), because resolution lives in `binary_resolver.py`.
 - `npm_prefix_bin_dirs` is `@lru_cache`d; tests that vary env or platform should call `npm_prefix_bin_dirs.cache_clear()` before each case (or use a shared autouse fixture) to avoid stale cache across tests.
-

--- a/app/integrations/llm_cli/AGENTS.md
+++ b/app/integrations/llm_cli/AGENTS.md
@@ -14,6 +14,7 @@ Use this package when adding a new **non-interactive** LLM that shells out to a 
 | `env_overrides.py` | Optional explicit HTTP/API keys merged into `CLIInvocation.env` when `build_cli_subprocess_env` would drop them (shared tuples + `nonempty_env_values`). |
 | `timeout_utils.py`   | Shared timeout env parsing (`resolve_timeout_from_env` for default + clamp behavior). |
 | `probe_utils.py`     | Shared subprocess probe helpers (currently `run_version_probe` for `<binary> --version`). |
+| `semver_utils.py`    | Shared semver helpers (`parse_semver_three_part`, `semver_to_tuple`). |
 | `binary_resolver.py` | Shared executable resolution helpers (`env -> PATH -> fallback paths`).                     |
 | `runner.py`          | `CLIBackedLLMClient`: guardrails, `detect()`, `subprocess.run`, ANSI strip, `LLMResponse`.  |
 | `text.py`            | `flatten_messages_to_prompt` for stdin from chat-style payloads.                            |

--- a/app/integrations/llm_cli/antigravity_cli.py
+++ b/app/integrations/llm_cli/antigravity_cli.py
@@ -32,7 +32,6 @@ was removed between Gemini CLI and Antigravity CLI — stdout is plain text now.
 from __future__ import annotations
 
 import os
-import re
 import subprocess
 
 from app.integrations.llm_cli.base import CLIInvocation, CLIProbe
@@ -45,42 +44,34 @@ from app.integrations.llm_cli.binary_resolver import (
 from app.integrations.llm_cli.binary_resolver import (
     resolve_cli_binary,
 )
+from app.integrations.llm_cli.constants import (
+    DEFAULT_EXEC_TIMEOUT_SEC as _DEFAULT_EXEC_TIMEOUT_SEC,
+)
+from app.integrations.llm_cli.constants import (
+    MAX_EXEC_TIMEOUT_SEC as _MAX_EXEC_TIMEOUT_SEC,
+)
+from app.integrations.llm_cli.constants import (
+    MIN_EXEC_TIMEOUT_SEC as _MIN_EXEC_TIMEOUT_SEC,
+)
+from app.integrations.llm_cli.probe_utils import run_version_probe
+from app.integrations.llm_cli.semver_utils import parse_semver_three_part, semver_to_tuple
 from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
+from app.integrations.llm_cli.timeout_utils import resolve_timeout_from_env
 
-_ANTIGRAVITY_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 _PROBE_TIMEOUT_SEC = 20.0
 _AUTH_HINT = "Run: agy (interactive Google Sign-In) or set GEMINI_API_KEY for keyless fallback."
-_DEFAULT_EXEC_TIMEOUT_SEC = 120.0
-_MIN_EXEC_TIMEOUT_SEC = 30.0
-_MAX_EXEC_TIMEOUT_SEC = 600.0
 # Buffer so the Python-side subprocess timeout sits above ``agy --print-timeout``
 # and lets the CLI emit its own clean timeout message instead of being SIGKILL'd.
 _SUBPROCESS_TIMEOUT_BUFFER_SEC = 10.0
 
 
-def _ver_tuple(version: str) -> tuple[int, int, int]:
-    parts = [int(m) for m in re.findall(r"\d+", version)][:3]
-    while len(parts) < 3:
-        parts.append(0)
-    return parts[0], parts[1], parts[2]
-
-
-def _parse_semver(text: str) -> str | None:
-    m = _ANTIGRAVITY_VERSION_RE.search(text)
-    return m.group(1) if m else None
-
-
 def _resolve_exec_timeout_seconds() -> float:
-    raw = os.environ.get("ANTIGRAVITY_CLI_TIMEOUT_SECONDS", "").strip()
-    if not raw:
-        return _DEFAULT_EXEC_TIMEOUT_SEC
-    try:
-        value = float(raw)
-    except ValueError:
-        return _DEFAULT_EXEC_TIMEOUT_SEC
-    if value <= 0:
-        return _DEFAULT_EXEC_TIMEOUT_SEC
-    return max(_MIN_EXEC_TIMEOUT_SEC, min(value, _MAX_EXEC_TIMEOUT_SEC))
+    return resolve_timeout_from_env(
+        env_key="ANTIGRAVITY_CLI_TIMEOUT_SECONDS",
+        default=_DEFAULT_EXEC_TIMEOUT_SEC,
+        minimum=_MIN_EXEC_TIMEOUT_SEC,
+        maximum=_MAX_EXEC_TIMEOUT_SEC,
+    )
 
 
 def _antigravity_auth_env_overrides() -> dict[str, str]:
@@ -159,38 +150,26 @@ class AntigravityCLIAdapter:
         )
 
     def _probe_binary(self, binary_path: str) -> CLIProbe:
-        try:
-            ver_proc = subprocess.run(
-                [binary_path, "--version"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=_PROBE_TIMEOUT_SEC,
-                check=False,
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
+        version_output, version_error = run_version_probe(
+            binary_path,
+            timeout_sec=_PROBE_TIMEOUT_SEC,
+        )
+        if version_error:
             return CLIProbe(
                 installed=False,
                 version=None,
                 logged_in=None,
                 bin_path=None,
-                detail=f"Could not run `{binary_path} --version`: {exc}",
+                detail=version_error,
             )
 
-        if ver_proc.returncode != 0:
-            err = (ver_proc.stderr or ver_proc.stdout or "").strip()
-            return CLIProbe(
-                installed=False,
-                version=None,
-                logged_in=None,
-                bin_path=None,
-                detail=f"`{binary_path} --version` failed: {err or 'unknown error'}",
-            )
-
-        version = _parse_semver(ver_proc.stdout + ver_proc.stderr)
+        version = parse_semver_three_part(version_output or "")
         upgrade_note = ""
-        if self.min_version and version and _ver_tuple(version) < _ver_tuple(self.min_version):
+        if (
+            self.min_version
+            and version
+            and semver_to_tuple(version) < semver_to_tuple(self.min_version)
+        ):
             upgrade_note = (
                 f" Antigravity CLI {version} is below tested minimum {self.min_version}; "
                 "upgrade: agy update"

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -44,33 +44,36 @@ from app.integrations.llm_cli.binary_resolver import (
 from app.integrations.llm_cli.binary_resolver import (
     resolve_cli_binary,
 )
+from app.integrations.llm_cli.constants import (
+    DEFAULT_EXEC_TIMEOUT_SEC as _DEFAULT_EXEC_TIMEOUT_SEC,
+)
+from app.integrations.llm_cli.constants import (
+    MAX_EXEC_TIMEOUT_SEC as _MAX_EXEC_TIMEOUT_SEC,
+)
+from app.integrations.llm_cli.constants import (
+    MIN_EXEC_TIMEOUT_SEC as _MIN_EXEC_TIMEOUT_SEC,
+)
 from app.integrations.llm_cli.env_overrides import (
     ANTHROPIC_CLI_ENV_KEYS,
     nonempty_env_values,
 )
 from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
+from app.integrations.llm_cli.timeout_utils import resolve_timeout_from_env
 
 _CLAUDE_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 # Claude Code's `--version` does config/cache init that can spike past Codex's 3s
 # budget on cold starts or when another claude process holds shared state.
 _PROBE_TIMEOUT_SEC = 8.0
 _AUTH_HINT = "Run: claude auth login or set ANTHROPIC_API_KEY."
-_DEFAULT_EXEC_TIMEOUT_SEC = 120.0
-_MIN_EXEC_TIMEOUT_SEC = 30.0
-_MAX_EXEC_TIMEOUT_SEC = 600.0
 
 
 def _resolve_exec_timeout_seconds() -> float:
-    raw = os.environ.get("CLAUDE_CODE_TIMEOUT_SECONDS", "").strip()
-    if not raw:
-        return _DEFAULT_EXEC_TIMEOUT_SEC
-    try:
-        value = float(raw)
-    except ValueError:
-        return _DEFAULT_EXEC_TIMEOUT_SEC
-    if value <= 0:
-        return _DEFAULT_EXEC_TIMEOUT_SEC
-    return max(_MIN_EXEC_TIMEOUT_SEC, min(value, _MAX_EXEC_TIMEOUT_SEC))
+    return resolve_timeout_from_env(
+        env_key="CLAUDE_CODE_TIMEOUT_SECONDS",
+        default=_DEFAULT_EXEC_TIMEOUT_SEC,
+        minimum=_MIN_EXEC_TIMEOUT_SEC,
+        maximum=_MAX_EXEC_TIMEOUT_SEC,
+    )
 
 
 def _parse_semver(text: str) -> str | None:

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -57,10 +56,11 @@ from app.integrations.llm_cli.env_overrides import (
     ANTHROPIC_CLI_ENV_KEYS,
     nonempty_env_values,
 )
+from app.integrations.llm_cli.probe_utils import run_version_probe
+from app.integrations.llm_cli.semver_utils import parse_semver_three_part
 from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 from app.integrations.llm_cli.timeout_utils import resolve_timeout_from_env
 
-_CLAUDE_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 # Claude Code's `--version` does config/cache init that can spike past Codex's 3s
 # budget on cold starts or when another claude process holds shared state.
 _PROBE_TIMEOUT_SEC = 8.0
@@ -74,11 +74,6 @@ def _resolve_exec_timeout_seconds() -> float:
         minimum=_MIN_EXEC_TIMEOUT_SEC,
         maximum=_MAX_EXEC_TIMEOUT_SEC,
     )
-
-
-def _parse_semver(text: str) -> str | None:
-    m = _CLAUDE_VERSION_RE.search(text)
-    return m.group(1) if m else None
 
 
 def _anthropic_env_overrides() -> dict[str, str]:
@@ -255,36 +250,20 @@ class ClaudeCodeAdapter:
         )
 
     def _probe_binary(self, binary_path: str) -> CLIProbe:
-        try:
-            ver_proc = subprocess.run(
-                [binary_path, "--version"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=_PROBE_TIMEOUT_SEC,
-                check=False,
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
+        version_output, version_error = run_version_probe(
+            binary_path,
+            timeout_sec=_PROBE_TIMEOUT_SEC,
+        )
+        if version_error:
             return CLIProbe(
                 installed=False,
                 version=None,
                 logged_in=None,
                 bin_path=None,
-                detail=f"Could not run `{binary_path} --version`: {exc}",
+                detail=version_error,
             )
 
-        if ver_proc.returncode != 0:
-            err = (ver_proc.stderr or ver_proc.stdout or "").strip()
-            return CLIProbe(
-                installed=False,
-                version=None,
-                logged_in=None,
-                bin_path=None,
-                detail=f"`{binary_path} --version` failed: {err or 'unknown error'}",
-            )
-
-        version = _parse_semver(ver_proc.stdout + ver_proc.stderr)
+        version = parse_semver_three_part(version_output or "")
         logged_in, auth_detail = _classify_claude_code_auth(binary_path=binary_path)
         auth_env_source = _anthropic_auth_env_source()
         if logged_in is not True and auth_env_source:

--- a/app/integrations/llm_cli/codex.py
+++ b/app/integrations/llm_cli/codex.py
@@ -25,6 +25,7 @@ from app.integrations.llm_cli.env_overrides import (
     OPENAI_PLATFORM_ENV_KEYS,
     nonempty_env_values,
 )
+from app.integrations.llm_cli.probe_utils import run_version_probe
 
 _CODEX_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 _PROBE_TIMEOUT_SEC = 3.0
@@ -114,36 +115,20 @@ class CodexAdapter:
         )
 
     def _probe_binary(self, binary_path: str) -> CLIProbe:
-        try:
-            ver_proc = subprocess.run(
-                [binary_path, "--version"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=_PROBE_TIMEOUT_SEC,
-                check=False,
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
+        version_output, version_error = run_version_probe(
+            binary_path,
+            timeout_sec=_PROBE_TIMEOUT_SEC,
+        )
+        if version_error:
             return CLIProbe(
                 installed=False,
                 version=None,
                 logged_in=None,
                 bin_path=None,
-                detail=f"Could not run `{binary_path} --version`: {exc}",
+                detail=version_error,
             )
 
-        if ver_proc.returncode != 0:
-            err = (ver_proc.stderr or ver_proc.stdout or "").strip()
-            return CLIProbe(
-                installed=False,
-                version=None,
-                logged_in=None,
-                bin_path=None,
-                detail=f"`{binary_path} --version` failed: {err or 'unknown error'}",
-            )
-
-        version = _parse_semver(ver_proc.stdout + ver_proc.stderr)
+        version = _parse_semver(version_output or "")
         upgrade_note = ""
         if self.min_version and version and _ver_tuple(version) < _ver_tuple(self.min_version):
             upgrade_note = (

--- a/app/integrations/llm_cli/codex.py
+++ b/app/integrations/llm_cli/codex.py
@@ -8,7 +8,6 @@ usage-based API key auth as well as ``codex login`` sessions.
 from __future__ import annotations
 
 import os
-import re
 import subprocess
 
 from app.integrations.llm_cli.base import CLIInvocation, CLIProbe
@@ -26,23 +25,10 @@ from app.integrations.llm_cli.env_overrides import (
     nonempty_env_values,
 )
 from app.integrations.llm_cli.probe_utils import run_version_probe
+from app.integrations.llm_cli.semver_utils import parse_semver_three_part, semver_to_tuple
 
-_CODEX_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 _PROBE_TIMEOUT_SEC = 3.0
 _READ_ONLY_SANDBOX = "read-only"
-
-
-def _ver_tuple(version: str) -> tuple[int, int, int]:
-    # Extract all leading digit runs so "1.2.3-beta.4" → (1, 2, 3), "1.2a.3" → (1, 2, 3).
-    parts = [int(m) for m in re.findall(r"\d+", version)][:3]
-    while len(parts) < 3:
-        parts.append(0)
-    return parts[0], parts[1], parts[2]
-
-
-def _parse_semver(text: str) -> str | None:
-    m = _CODEX_VERSION_RE.search(text)
-    return m.group(1) if m else None
 
 
 def _classify_codex_auth(returncode: int, stdout: str, stderr: str) -> tuple[bool | None, str]:
@@ -128,9 +114,13 @@ class CodexAdapter:
                 detail=version_error,
             )
 
-        version = _parse_semver(version_output or "")
+        version = parse_semver_three_part(version_output or "")
         upgrade_note = ""
-        if self.min_version and version and _ver_tuple(version) < _ver_tuple(self.min_version):
+        if (
+            self.min_version
+            and version
+            and semver_to_tuple(version) < semver_to_tuple(self.min_version)
+        ):
             upgrade_note = (
                 f" Codex {version} is below tested minimum {self.min_version}; "
                 f"upgrade: {self.install_hint}@latest"

--- a/app/integrations/llm_cli/constants.py
+++ b/app/integrations/llm_cli/constants.py
@@ -1,0 +1,20 @@
+"""Shared constants for subprocess-backed LLM CLI adapters.
+
+Keep this module focused on values reused by multiple adapters/runner paths.
+Provider-specific constants should remain in each adapter module.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Runner cache/retry knobs.
+PROBE_CACHE_TTL_SEC: Final[float] = 45.0
+EX_TEMPFAIL: Final[int] = 75
+TEMPFAIL_MAX_RETRIES: Final[int] = 2
+TEMPFAIL_BACKOFF_SEC: Final[float] = 2.0
+
+# Shared timeout defaults used by multiple adapters with env-overrides.
+DEFAULT_EXEC_TIMEOUT_SEC: Final[float] = 120.0
+MIN_EXEC_TIMEOUT_SEC: Final[float] = 30.0
+MAX_EXEC_TIMEOUT_SEC: Final[float] = 600.0

--- a/app/integrations/llm_cli/copilot.py
+++ b/app/integrations/llm_cli/copilot.py
@@ -65,8 +65,9 @@ from app.integrations.llm_cli.env_overrides import (
     COPILOT_CLI_ENV_KEYS,
     nonempty_env_values,
 )
+from app.integrations.llm_cli.probe_utils import run_version_probe
+from app.integrations.llm_cli.semver_utils import parse_semver_three_part
 
-_COPILOT_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 _PROBE_TIMEOUT_SEC = 5.0
 _GH_AUTH_TIMEOUT_SEC = 5.0
 
@@ -93,11 +94,6 @@ _GH_LOGGED_OUT_PHRASES = (
 _AUTH_HINT = (
     "Run `copilot login` or `gh auth login`, or set COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN."
 )
-
-
-def _parse_semver(text: str) -> str | None:
-    m = _COPILOT_VERSION_RE.search(text)
-    return m.group(1) if m else None
 
 
 def _has_token_env() -> str | None:
@@ -226,36 +222,20 @@ class CopilotAdapter:
         )
 
     def _probe_binary(self, binary_path: str) -> CLIProbe:
-        try:
-            ver_proc = subprocess.run(
-                [binary_path, "--version"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=_PROBE_TIMEOUT_SEC,
-                check=False,
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
+        version_output, version_error = run_version_probe(
+            binary_path,
+            timeout_sec=_PROBE_TIMEOUT_SEC,
+        )
+        if version_error:
             return CLIProbe(
                 installed=False,
                 version=None,
                 logged_in=None,
                 bin_path=None,
-                detail=f"Could not run `{binary_path} --version`: {exc}",
+                detail=version_error,
             )
 
-        if ver_proc.returncode != 0:
-            err = (ver_proc.stderr or ver_proc.stdout or "").strip()
-            return CLIProbe(
-                installed=False,
-                version=None,
-                logged_in=None,
-                bin_path=None,
-                detail=f"`{binary_path} --version` failed: {err or 'unknown error'}",
-            )
-
-        version = _parse_semver(ver_proc.stdout + ver_proc.stderr)
+        version = parse_semver_three_part(version_output or "")
         logged_in, auth_detail = _classify_copilot_auth()
         return CLIProbe(
             installed=True,

--- a/app/integrations/llm_cli/cursor.py
+++ b/app/integrations/llm_cli/cursor.py
@@ -15,6 +15,7 @@ from app.integrations.llm_cli.binary_resolver import (
 )
 from app.integrations.llm_cli.binary_resolver import resolve_cli_binary
 from app.integrations.llm_cli.env_overrides import CURSOR_CLI_ENV_KEYS, nonempty_env_values
+from app.integrations.llm_cli.probe_utils import run_version_probe
 
 _CURSOR_VERSION_RE = re.compile(r"(\d{4}\.\d{2}\.\d{2}-[a-zA-Z0-9]+|\d+\.\d+\.\d+)")
 # `agent status` often hits the network and prints a short spinner; ~4s locally is common,
@@ -90,37 +91,17 @@ class CursorAdapter:
                 ),
             )
 
-        try:
-            version_proc = subprocess.run(
-                [binary, "--version"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=_PROBE_TIMEOUT_SEC,
-                check=False,
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
+        version_output, version_error = run_version_probe(binary, timeout_sec=_PROBE_TIMEOUT_SEC)
+        if version_error:
             return CLIProbe(
                 installed=False,
                 version=None,
                 logged_in=None,
                 bin_path=None,
-                detail=f"Could not run `{binary} --version`: {exc}",
+                detail=version_error,
             )
 
-        if version_proc.returncode != 0:
-            err = (version_proc.stderr or version_proc.stdout or "").strip()
-            return CLIProbe(
-                installed=False,
-                version=None,
-                logged_in=None,
-                bin_path=None,
-                detail=f"`{binary} --version` failed: {err or 'unknown error'}",
-            )
-
-        version_output = version_proc.stdout + version_proc.stderr
-        version = _parse_version(version_output)
+        version = _parse_version(version_output or "")
 
         if not version:
             return CLIProbe(

--- a/app/integrations/llm_cli/gemini_cli.py
+++ b/app/integrations/llm_cli/gemini_cli.py
@@ -30,14 +30,21 @@ from app.integrations.llm_cli.binary_resolver import (
 from app.integrations.llm_cli.binary_resolver import (
     resolve_cli_binary,
 )
+from app.integrations.llm_cli.constants import (
+    DEFAULT_EXEC_TIMEOUT_SEC as _DEFAULT_EXEC_TIMEOUT_SEC,
+)
+from app.integrations.llm_cli.constants import (
+    MAX_EXEC_TIMEOUT_SEC as _MAX_EXEC_TIMEOUT_SEC,
+)
+from app.integrations.llm_cli.constants import (
+    MIN_EXEC_TIMEOUT_SEC as _MIN_EXEC_TIMEOUT_SEC,
+)
 from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
+from app.integrations.llm_cli.timeout_utils import resolve_timeout_from_env
 
 _GEMINI_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 _PROBE_TIMEOUT_SEC = 20.0
 _AUTH_HINT = "Run: gemini (interactive login) or set GEMINI_API_KEY."
-_DEFAULT_EXEC_TIMEOUT_SEC = 120.0
-_MIN_EXEC_TIMEOUT_SEC = 30.0
-_MAX_EXEC_TIMEOUT_SEC = 600.0
 # Source: https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/
 _SUNSET_NOTE = (
     " Note: Gemini CLI stops serving Pro/Ultra and free users on 2026-06-18; "
@@ -51,16 +58,12 @@ def _parse_semver(text: str) -> str | None:
 
 
 def _resolve_exec_timeout_seconds() -> float:
-    raw = os.environ.get("GEMINI_CLI_TIMEOUT_SECONDS", "").strip()
-    if not raw:
-        return _DEFAULT_EXEC_TIMEOUT_SEC
-    try:
-        value = float(raw)
-    except ValueError:
-        return _DEFAULT_EXEC_TIMEOUT_SEC
-    if value <= 0:
-        return _DEFAULT_EXEC_TIMEOUT_SEC
-    return max(_MIN_EXEC_TIMEOUT_SEC, min(value, _MAX_EXEC_TIMEOUT_SEC))
+    return resolve_timeout_from_env(
+        env_key="GEMINI_CLI_TIMEOUT_SECONDS",
+        default=_DEFAULT_EXEC_TIMEOUT_SEC,
+        minimum=_MIN_EXEC_TIMEOUT_SEC,
+        maximum=_MAX_EXEC_TIMEOUT_SEC,
+    )
 
 
 def _gemini_auth_env_overrides() -> dict[str, str]:

--- a/app/integrations/llm_cli/gemini_cli.py
+++ b/app/integrations/llm_cli/gemini_cli.py
@@ -39,6 +39,7 @@ from app.integrations.llm_cli.constants import (
 from app.integrations.llm_cli.constants import (
     MIN_EXEC_TIMEOUT_SEC as _MIN_EXEC_TIMEOUT_SEC,
 )
+from app.integrations.llm_cli.probe_utils import run_version_probe
 from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 from app.integrations.llm_cli.timeout_utils import resolve_timeout_from_env
 
@@ -156,36 +157,20 @@ class GeminiCLIAdapter:
         )
 
     def _probe_binary(self, binary_path: str) -> CLIProbe:
-        try:
-            ver_proc = subprocess.run(
-                [binary_path, "--version"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=_PROBE_TIMEOUT_SEC,
-                check=False,
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
+        version_output, version_error = run_version_probe(
+            binary_path,
+            timeout_sec=_PROBE_TIMEOUT_SEC,
+        )
+        if version_error:
             return CLIProbe(
                 installed=False,
                 version=None,
                 logged_in=None,
                 bin_path=None,
-                detail=f"Could not run `{binary_path} --version`: {exc}",
+                detail=version_error,
             )
 
-        if ver_proc.returncode != 0:
-            err = (ver_proc.stderr or ver_proc.stdout or "").strip()
-            return CLIProbe(
-                installed=False,
-                version=None,
-                logged_in=None,
-                bin_path=None,
-                detail=f"`{binary_path} --version` failed: {err or 'unknown error'}",
-            )
-
-        version = _parse_semver(ver_proc.stdout + ver_proc.stderr)
+        version = _parse_semver(version_output or "")
         probe_env = build_cli_subprocess_env(_gemini_auth_env_overrides())
         try:
             auth_proc = subprocess.run(

--- a/app/integrations/llm_cli/gemini_cli.py
+++ b/app/integrations/llm_cli/gemini_cli.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import subprocess
 
 from app.integrations.llm_cli.base import CLIInvocation, CLIProbe
@@ -40,10 +39,10 @@ from app.integrations.llm_cli.constants import (
     MIN_EXEC_TIMEOUT_SEC as _MIN_EXEC_TIMEOUT_SEC,
 )
 from app.integrations.llm_cli.probe_utils import run_version_probe
+from app.integrations.llm_cli.semver_utils import parse_semver_three_part
 from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 from app.integrations.llm_cli.timeout_utils import resolve_timeout_from_env
 
-_GEMINI_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 _PROBE_TIMEOUT_SEC = 20.0
 _AUTH_HINT = "Run: gemini (interactive login) or set GEMINI_API_KEY."
 # Source: https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/
@@ -51,11 +50,6 @@ _SUNSET_NOTE = (
     " Note: Gemini CLI stops serving Pro/Ultra and free users on 2026-06-18; "
     "paid Gemini Code Assist remains supported. Consider antigravity-cli (agy)."
 )
-
-
-def _parse_semver(text: str) -> str | None:
-    m = _GEMINI_VERSION_RE.search(text)
-    return m.group(1) if m else None
 
 
 def _resolve_exec_timeout_seconds() -> float:
@@ -170,7 +164,7 @@ class GeminiCLIAdapter:
                 detail=version_error,
             )
 
-        version = _parse_semver(version_output or "")
+        version = parse_semver_three_part(version_output or "")
         probe_env = build_cli_subprocess_env(_gemini_auth_env_overrides())
         try:
             auth_proc = subprocess.run(

--- a/app/integrations/llm_cli/kimi.py
+++ b/app/integrations/llm_cli/kimi.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import os
 import pathlib
-import re
 import subprocess
 import sys
 import tomllib
@@ -19,24 +18,12 @@ from app.integrations.llm_cli.binary_resolver import (
     default_cli_fallback_paths as _default_cli_fallback_paths,
 )
 from app.integrations.llm_cli.binary_resolver import resolve_cli_binary
+from app.integrations.llm_cli.probe_utils import run_version_probe
+from app.integrations.llm_cli.semver_utils import parse_semver_three_part, semver_to_tuple
 
 logger = logging.getLogger(__name__)
 
-_KIMI_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 _PROBE_TIMEOUT_SEC = 3.0
-
-
-def _ver_tuple(version: str) -> tuple[int, int, int]:
-    """Convert a semver string into a comparable (major, minor, patch) tuple."""
-    parts = [int(m) for m in re.findall(r"\d+", version)][:3]
-    while len(parts) < 3:
-        parts.append(0)
-    return parts[0], parts[1], parts[2]
-
-
-def _parse_semver(text: str) -> str | None:
-    m = _KIMI_VERSION_RE.search(text)
-    return m.group(1) if m else None
 
 
 def _classify_kimi_login_status(
@@ -154,38 +141,26 @@ class KimiAdapter:
         )
 
     def _probe_binary(self, binary_path: str) -> CLIProbe:
-        try:
-            ver_proc = subprocess.run(
-                [binary_path, "--version"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=_PROBE_TIMEOUT_SEC,
-                check=False,
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
+        version_output, version_error = run_version_probe(
+            binary_path,
+            timeout_sec=_PROBE_TIMEOUT_SEC,
+        )
+        if version_error:
             return CLIProbe(
                 installed=False,
                 version=None,
                 logged_in=None,
                 bin_path=None,
-                detail=f"Could not run `{binary_path} --version`: {exc}",
+                detail=version_error,
             )
 
-        if ver_proc.returncode != 0:
-            err = (ver_proc.stderr or ver_proc.stdout or "").strip()
-            return CLIProbe(
-                installed=False,
-                version=None,
-                logged_in=None,
-                bin_path=None,
-                detail=f"`{binary_path} --version` failed: {err or 'unknown error'}",
-            )
-
-        version = _parse_semver(ver_proc.stdout + ver_proc.stderr)
+        version = parse_semver_three_part(version_output or "")
         upgrade_note = ""
-        if self.min_version and version and _ver_tuple(version) < _ver_tuple(self.min_version):
+        if (
+            self.min_version
+            and version
+            and semver_to_tuple(version) < semver_to_tuple(self.min_version)
+        ):
             upgrade_note = (
                 f" Kimi Code CLI {version} is below tested minimum {self.min_version}; "
                 f"upgrade: uv tool upgrade kimi-cli"

--- a/app/integrations/llm_cli/opencode.py
+++ b/app/integrations/llm_cli/opencode.py
@@ -26,16 +26,12 @@ from app.integrations.llm_cli.env_overrides import (
     HTTP_LLM_PROVIDER_ENV_KEYS,
     nonempty_env_values,
 )
+from app.integrations.llm_cli.probe_utils import run_version_probe
+from app.integrations.llm_cli.semver_utils import parse_semver_three_part
 
-_OPENCODE_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 _ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
 _PROBE_TIMEOUT_SEC = 8.0
 _AUTH_LIST_TIMEOUT_SEC = 25.0
-
-
-def _parse_semver(text: str) -> str | None:
-    m = _OPENCODE_VERSION_RE.search(text)
-    return m.group(1) if m else None
 
 
 def _strip_ansi(text: str) -> str:
@@ -139,36 +135,20 @@ class OpenCodeAdapter:
         )
 
     def _probe_binary(self, binary_path: str) -> CLIProbe:
-        try:
-            ver_proc = subprocess.run(
-                [binary_path, "--version"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=_PROBE_TIMEOUT_SEC,
-                check=False,
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
+        version_output, version_error = run_version_probe(
+            binary_path,
+            timeout_sec=_PROBE_TIMEOUT_SEC,
+        )
+        if version_error:
             return CLIProbe(
                 installed=False,
                 version=None,
                 logged_in=None,
                 bin_path=None,
-                detail=f"Could not run `{binary_path} --version`: {exc}",
+                detail=version_error,
             )
 
-        if ver_proc.returncode != 0:
-            err = (ver_proc.stderr or ver_proc.stdout or "").strip()
-            return CLIProbe(
-                installed=False,
-                version=None,
-                logged_in=None,
-                bin_path=None,
-                detail=f"`{binary_path} --version` failed: {err or 'unknown error'}",
-            )
-
-        version = _parse_semver(ver_proc.stdout + ver_proc.stderr)
+        version = parse_semver_three_part(version_output or "")
         logged_in, auth_detail = _probe_opencode_auth_via_cli(binary_path)
 
         return CLIProbe(

--- a/app/integrations/llm_cli/probe_utils.py
+++ b/app/integrations/llm_cli/probe_utils.py
@@ -1,0 +1,31 @@
+"""Shared subprocess probe helpers for CLI adapters."""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def run_version_probe(binary_path: str, *, timeout_sec: float) -> tuple[str | None, str | None]:
+    """Run ``<binary> --version`` and return ``(combined_output, error_detail)``.
+
+    ``error_detail`` is suitable for ``CLIProbe.detail`` when the version probe
+    fails. On success, ``combined_output`` is ``stdout + stderr``.
+    """
+    try:
+        proc = subprocess.run(
+            [binary_path, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_sec,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return None, f"Could not run `{binary_path} --version`: {exc}"
+
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip()
+        return None, f"`{binary_path} --version` failed: {err or 'unknown error'}"
+
+    return (proc.stdout or "") + (proc.stderr or ""), None

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -13,6 +13,18 @@ from typing import Any
 from pydantic import BaseModel
 
 from app.integrations.llm_cli.base import CLIProbe, LLMCLIAdapter
+from app.integrations.llm_cli.constants import (
+    EX_TEMPFAIL as _EX_TEMPFAIL,
+)
+from app.integrations.llm_cli.constants import (
+    PROBE_CACHE_TTL_SEC as _PROBE_CACHE_TTL_SEC,
+)
+from app.integrations.llm_cli.constants import (
+    TEMPFAIL_BACKOFF_SEC as _TEMPFAIL_BACKOFF_SEC,
+)
+from app.integrations.llm_cli.constants import (
+    TEMPFAIL_MAX_RETRIES as _TEMPFAIL_MAX_RETRIES,
+)
 from app.integrations.llm_cli.errors import (
     CLIAuthenticationRequired,
     CLIInterruptedError,
@@ -27,14 +39,10 @@ logger = logging.getLogger(__name__)
 
 _ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
 _REDACTED_PROMPT_ARG = "<redacted-prompt>"
-# Avoid re-running `detect()` (two subprocess probes) on every invoke during long investigations.
-_PROBE_CACHE_TTL_SEC = 45.0
-
+# Avoid re-running `detect()` (two subprocess probes) on every invoke during long
+# investigations. Value is defined in shared constants.
 # POSIX EX_TEMPFAIL (75): the subprocess hit a transient error and can be retried.
 # kimi uses this when a session dies mid-flight ("To resume this session: kimi -r …").
-_EX_TEMPFAIL = 75
-_TEMPFAIL_MAX_RETRIES = 2
-_TEMPFAIL_BACKOFF_SEC = 2.0
 
 # Back-compat name for tests and imports that expect this symbol on runner.
 _build_subprocess_env = build_cli_subprocess_env

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -211,7 +211,7 @@ class CLIBackedLLMClient:
             # Exit code 75 is EX_TEMPFAIL (sysexits.h) — a transient failure
             # the caller should retry. Raise CLITimeoutError so it is treated as
             # an expected operational failure and not forwarded to Sentry.
-            if proc.returncode == 75:
+            if proc.returncode == _EX_TEMPFAIL:
                 hint = (
                     f"{self._adapter.name} reported a temporary failure (exit 75). "
                     "Retry the request or check network connectivity."

--- a/app/integrations/llm_cli/semver_utils.py
+++ b/app/integrations/llm_cli/semver_utils.py
@@ -1,0 +1,21 @@
+"""Shared semver parsing/comparison helpers for CLI adapters."""
+
+from __future__ import annotations
+
+import re
+
+_SEMVER_THREE_PART_RE = re.compile(r"(\d+\.\d+\.\d+)")
+
+
+def parse_semver_three_part(text: str) -> str | None:
+    """Extract ``major.minor.patch`` from arbitrary version output text."""
+    match = _SEMVER_THREE_PART_RE.search(text or "")
+    return match.group(1) if match else None
+
+
+def semver_to_tuple(version: str) -> tuple[int, int, int]:
+    """Convert a semver-ish string into a comparable (major, minor, patch) tuple."""
+    parts = [int(m) for m in re.findall(r"\d+", version)][:3]
+    while len(parts) < 3:
+        parts.append(0)
+    return parts[0], parts[1], parts[2]

--- a/app/integrations/llm_cli/timeout_utils.py
+++ b/app/integrations/llm_cli/timeout_utils.py
@@ -1,0 +1,28 @@
+"""Shared helpers for timeout environment parsing."""
+
+from __future__ import annotations
+
+import os
+
+
+def resolve_timeout_from_env(
+    *,
+    env_key: str,
+    default: float,
+    minimum: float,
+    maximum: float,
+) -> float:
+    """Resolve timeout from an env var with defaulting + clamping.
+
+    Invalid, empty, and non-positive values fall back to ``default``.
+    """
+    raw = os.environ.get(env_key, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    if value <= 0:
+        return default
+    return max(minimum, min(value, maximum))

--- a/tests/integrations/llm_cli/test_probe_utils.py
+++ b/tests/integrations/llm_cli/test_probe_utils.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from app.integrations.llm_cli.probe_utils import run_version_probe
+
+
+@patch("app.integrations.llm_cli.probe_utils.subprocess.run")
+def test_run_version_probe_success(mock_run: MagicMock) -> None:
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["/bin/tool", "--version"],
+        returncode=0,
+        stdout="1.2.3\n",
+        stderr="",
+    )
+
+    output, detail = run_version_probe("/bin/tool", timeout_sec=3.0)
+
+    assert output == "1.2.3\n"
+    assert detail is None
+
+
+@patch("app.integrations.llm_cli.probe_utils.subprocess.run")
+def test_run_version_probe_nonzero(mock_run: MagicMock) -> None:
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["/bin/tool", "--version"],
+        returncode=2,
+        stdout="",
+        stderr="broken",
+    )
+
+    output, detail = run_version_probe("/bin/tool", timeout_sec=3.0)
+
+    assert output is None
+    assert detail == "`/bin/tool --version` failed: broken"
+
+
+@patch("app.integrations.llm_cli.probe_utils.subprocess.run")
+def test_run_version_probe_timeout(mock_run: MagicMock) -> None:
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["/bin/tool", "--version"], timeout=3.0)
+
+    output, detail = run_version_probe("/bin/tool", timeout_sec=3.0)
+
+    assert output is None
+    assert detail is not None
+    assert detail.startswith("Could not run `/bin/tool --version`:")
+
+
+@patch("app.integrations.llm_cli.probe_utils.subprocess.run")
+def test_run_version_probe_oserror(mock_run: MagicMock) -> None:
+    mock_run.side_effect = OSError("no exec")
+
+    output, detail = run_version_probe("/bin/tool", timeout_sec=3.0)
+
+    assert output is None
+    assert detail == "Could not run `/bin/tool --version`: no exec"

--- a/tests/integrations/llm_cli/test_semver_utils.py
+++ b/tests/integrations/llm_cli/test_semver_utils.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from app.integrations.llm_cli.semver_utils import parse_semver_three_part, semver_to_tuple
+
+
+def test_parse_semver_three_part_finds_version() -> None:
+    assert parse_semver_three_part("tool v1.2.3-beta") == "1.2.3"
+
+
+def test_parse_semver_three_part_returns_none_when_missing() -> None:
+    assert parse_semver_three_part("no version here") is None
+
+
+def test_semver_to_tuple_handles_missing_parts() -> None:
+    assert semver_to_tuple("1") == (1, 0, 0)
+    assert semver_to_tuple("1.2") == (1, 2, 0)
+
+
+def test_semver_to_tuple_handles_suffixes() -> None:
+    assert semver_to_tuple("1.2.3-beta.4") == (1, 2, 3)

--- a/tests/integrations/llm_cli/test_timeout_utils.py
+++ b/tests/integrations/llm_cli/test_timeout_utils.py
@@ -23,6 +23,16 @@ def test_resolve_timeout_from_env_defaults_when_invalid(monkeypatch) -> None:
     ) == 120.0
 
 
+def test_resolve_timeout_from_env_defaults_when_non_positive(monkeypatch) -> None:
+    monkeypatch.setenv("X_TIMEOUT", "0")
+    assert resolve_timeout_from_env(
+        env_key="X_TIMEOUT",
+        default=120.0,
+        minimum=30.0,
+        maximum=600.0,
+    ) == 120.0
+
+
 def test_resolve_timeout_from_env_clamps(monkeypatch) -> None:
     monkeypatch.setenv("X_TIMEOUT", "1")
     assert resolve_timeout_from_env(

--- a/tests/integrations/llm_cli/test_timeout_utils.py
+++ b/tests/integrations/llm_cli/test_timeout_utils.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from app.integrations.llm_cli.timeout_utils import resolve_timeout_from_env
+
+
+def test_resolve_timeout_from_env_defaults_when_missing(monkeypatch) -> None:
+    monkeypatch.delenv("X_TIMEOUT", raising=False)
+    assert resolve_timeout_from_env(
+        env_key="X_TIMEOUT",
+        default=120.0,
+        minimum=30.0,
+        maximum=600.0,
+    ) == 120.0
+
+
+def test_resolve_timeout_from_env_defaults_when_invalid(monkeypatch) -> None:
+    monkeypatch.setenv("X_TIMEOUT", "oops")
+    assert resolve_timeout_from_env(
+        env_key="X_TIMEOUT",
+        default=120.0,
+        minimum=30.0,
+        maximum=600.0,
+    ) == 120.0
+
+
+def test_resolve_timeout_from_env_clamps(monkeypatch) -> None:
+    monkeypatch.setenv("X_TIMEOUT", "1")
+    assert resolve_timeout_from_env(
+        env_key="X_TIMEOUT",
+        default=120.0,
+        minimum=30.0,
+        maximum=600.0,
+    ) == 30.0
+
+    monkeypatch.setenv("X_TIMEOUT", "9999")
+    assert resolve_timeout_from_env(
+        env_key="X_TIMEOUT",
+        default=120.0,
+        minimum=30.0,
+        maximum=600.0,
+    ) == 600.0
+
+
+def test_resolve_timeout_from_env_uses_value(monkeypatch) -> None:
+    monkeypatch.setenv("X_TIMEOUT", "180")
+    assert resolve_timeout_from_env(
+        env_key="X_TIMEOUT",
+        default=120.0,
+        minimum=30.0,
+        maximum=600.0,
+    ) == 180.0

--- a/tests/integrations/llm_cli/test_timeout_utils.py
+++ b/tests/integrations/llm_cli/test_timeout_utils.py
@@ -5,57 +5,75 @@ from app.integrations.llm_cli.timeout_utils import resolve_timeout_from_env
 
 def test_resolve_timeout_from_env_defaults_when_missing(monkeypatch) -> None:
     monkeypatch.delenv("X_TIMEOUT", raising=False)
-    assert resolve_timeout_from_env(
-        env_key="X_TIMEOUT",
-        default=120.0,
-        minimum=30.0,
-        maximum=600.0,
-    ) == 120.0
+    assert (
+        resolve_timeout_from_env(
+            env_key="X_TIMEOUT",
+            default=120.0,
+            minimum=30.0,
+            maximum=600.0,
+        )
+        == 120.0
+    )
 
 
 def test_resolve_timeout_from_env_defaults_when_invalid(monkeypatch) -> None:
     monkeypatch.setenv("X_TIMEOUT", "oops")
-    assert resolve_timeout_from_env(
-        env_key="X_TIMEOUT",
-        default=120.0,
-        minimum=30.0,
-        maximum=600.0,
-    ) == 120.0
+    assert (
+        resolve_timeout_from_env(
+            env_key="X_TIMEOUT",
+            default=120.0,
+            minimum=30.0,
+            maximum=600.0,
+        )
+        == 120.0
+    )
 
 
 def test_resolve_timeout_from_env_defaults_when_non_positive(monkeypatch) -> None:
     monkeypatch.setenv("X_TIMEOUT", "0")
-    assert resolve_timeout_from_env(
-        env_key="X_TIMEOUT",
-        default=120.0,
-        minimum=30.0,
-        maximum=600.0,
-    ) == 120.0
+    assert (
+        resolve_timeout_from_env(
+            env_key="X_TIMEOUT",
+            default=120.0,
+            minimum=30.0,
+            maximum=600.0,
+        )
+        == 120.0
+    )
 
 
 def test_resolve_timeout_from_env_clamps(monkeypatch) -> None:
     monkeypatch.setenv("X_TIMEOUT", "1")
-    assert resolve_timeout_from_env(
-        env_key="X_TIMEOUT",
-        default=120.0,
-        minimum=30.0,
-        maximum=600.0,
-    ) == 30.0
+    assert (
+        resolve_timeout_from_env(
+            env_key="X_TIMEOUT",
+            default=120.0,
+            minimum=30.0,
+            maximum=600.0,
+        )
+        == 30.0
+    )
 
     monkeypatch.setenv("X_TIMEOUT", "9999")
-    assert resolve_timeout_from_env(
-        env_key="X_TIMEOUT",
-        default=120.0,
-        minimum=30.0,
-        maximum=600.0,
-    ) == 600.0
+    assert (
+        resolve_timeout_from_env(
+            env_key="X_TIMEOUT",
+            default=120.0,
+            minimum=30.0,
+            maximum=600.0,
+        )
+        == 600.0
+    )
 
 
 def test_resolve_timeout_from_env_uses_value(monkeypatch) -> None:
     monkeypatch.setenv("X_TIMEOUT", "180")
-    assert resolve_timeout_from_env(
-        env_key="X_TIMEOUT",
-        default=120.0,
-        minimum=30.0,
-        maximum=600.0,
-    ) == 180.0
+    assert (
+        resolve_timeout_from_env(
+            env_key="X_TIMEOUT",
+            default=120.0,
+            minimum=30.0,
+            maximum=600.0,
+        )
+        == 180.0
+    )


### PR DESCRIPTION
## Summary
- extract shared LLM CLI constants into `app/integrations/llm_cli/constants.py`
- add `resolve_timeout_from_env(...)` in `app/integrations/llm_cli/timeout_utils.py`
- wire `runner.py`, `claude_code.py`, and `gemini_cli.py` to shared constants/helpers without behavior changes
- update `app/integrations/llm_cli/AGENTS.md` layout docs
- add unit coverage for timeout helper in `tests/integrations/llm_cli/test_timeout_utils.py`

## Rebase
- rebased onto latest `main` including antigravity/gemini sunset changes

## Validation
- `make lint`
- `make typecheck`
- `uv run pytest tests/integrations/llm_cli/test_timeout_utils.py tests/integrations/llm_cli/test_gemini_cli_adapter.py tests/integrations/llm_cli/test_claude_code_adapter.py tests/integrations/llm_cli/test_runner.py`
