### PR TITLE
fix(postgresql): include psycopg2 in frozen builds

### DIFF
--- a/packaging/opensre.spec
+++ b/packaging/opensre.spec
@@ -19,7 +19,6 @@ def _is_runtime_submodule(module_name: str) -> bool:
 hiddenimports = collect_submodules("app", filter=_is_runtime_submodule)
 hiddenimports += collect_submodules("sentry_sdk")
 hiddenimports += collect_submodules("psycopg2")
-hiddenimports += collect_submodules("psycopg2_binary")
 datas = collect_data_files("app")
 
 block_cipher = None

--- a/packaging/opensre.spec
+++ b/packaging/opensre.spec
@@ -18,6 +18,8 @@ def _is_runtime_submodule(module_name: str) -> bool:
 
 hiddenimports = collect_submodules("app", filter=_is_runtime_submodule)
 hiddenimports += collect_submodules("sentry_sdk")
+hiddenimports += collect_submodules("psycopg2")
+hiddenimports += collect_submodules("psycopg2_binary")
 datas = collect_data_files("app")
 
 block_cipher = None


### PR DESCRIPTION
Summary

Include psycopg2 in PyInstaller frozen builds so PostgreSQL integrations work correctly in packaged/Homebrew binaries.

Changes

Added:

collect_submodules("psycopg2")

to hiddenimports in packaging/opensre.spec.

Fixes

Addresses #2459 where frozen binaries could not import psycopg2 even when psycopg2-binary was installed on the host system.
