### PR TITLE
fix: map Groq base URL in wizard validation

### DIFF
--- a/app/cli/wizard/validation.py
+++ b/app/cli/wizard/validation.py
@@ -66,6 +66,10 @@ def _get_provider_base_url(provider_value: str) -> str | None:
         from app.config import NVIDIA_BASE_URL
 
         return NVIDIA_BASE_URL
+    if provider_value == "groq":
+        from app.config import GROQ_BASE_URL
+
+        return GROQ_BASE_URL
     return None
 
 
@@ -148,7 +152,7 @@ def validate_provider_credentials(
                 ok=True, detail="Anthropic API key validated.", sample_response=sample_text
             )
 
-        # All OpenAI-compatible providers (openai, openrouter, deepseek, gemini, nvidia)
+        # All OpenAI-compatible providers (openai, openrouter, deepseek, gemini, nvidia, groq)
         base_url = _get_provider_base_url(provider.value)
         openai_client = openai_client_cls(api_key=api_key, base_url=base_url, timeout=30.0)
         # Only native OpenAI reasoning models use max_completion_tokens; others use max_tokens

--- a/tests/cli/wizard/test_validation.py
+++ b/tests/cli/wizard/test_validation.py
@@ -7,6 +7,7 @@ from openai import AuthenticationError as OpenAIAuthError
 
 from app.cli.wizard.config import PROVIDER_BY_VALUE
 from app.cli.wizard.validation import _get_provider_base_url, validate_provider_credentials
+from app.config import GROQ_BASE_URL
 
 
 @pytest.fixture(autouse=True)
@@ -178,4 +179,4 @@ def test_get_provider_base_url_deepseek() -> None:
 
 
 def test_get_provider_base_url_groq() -> None:
-    assert _get_provider_base_url("groq") == "https://api.groq.com/openai/v1"
+    assert _get_provider_base_url("groq") == GROQ_BASE_URL

--- a/tests/cli/wizard/test_validation.py
+++ b/tests/cli/wizard/test_validation.py
@@ -175,3 +175,7 @@ def test_validate_provider_credentials_returns_success_for_valid_openai_key(monk
 
 def test_get_provider_base_url_deepseek() -> None:
     assert _get_provider_base_url("deepseek") == "https://api.deepseek.com"
+
+
+def test_get_provider_base_url_groq() -> None:
+    assert _get_provider_base_url("groq") == "https://api.groq.com/openai/v1"


### PR DESCRIPTION
Fixes #2522 


Added Groq to the provider base URL mapping.

### Demo/Screenshot for feature changes and bug fixes - 
<img width="903" height="723" alt="Screenshot 2026-05-26 at 2 20 46 PM" src="https://github.com/user-attachments/assets/b2c4c140-0295-455b-a0bf-fbae305d5206" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve? Grok was supported but validation ent requests to openai endpoint since it resolved to None.
- What alternative approaches did you consider? None
- Why did you choose this specific implementation? I followed the pattern for how it was done for deepseek, openrouter, nvidia, gemini.
- What are the key functions/components and what do they do? _get_provider_base_url() maps providers to their urls.

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
