### PR TITLE
fix(cli): avoid autocomplete overlap with inline picker menus

### DIFF
--- a/app/cli/interactive_shell/prompting/prompt_surface.py
+++ b/app/cli/interactive_shell/prompting/prompt_surface.py
@@ -31,6 +31,7 @@ from app.cli.interactive_shell.ui import (
     PROMPT_ACCENT_ANSI,
     PROMPT_FRAME_ANSI,
     TEXT,
+    repl_tty_interactive,
 )
 
 _PROMPT_RULE_CHAR = "─"
@@ -190,6 +191,10 @@ class ShellCompleter(Completer):
         if len(parts) <= 2:
             cmd_name = parts[0].lower()
             raw_arg = "" if trailing_space or len(parts) < 2 else parts[1]
+
+            if _suppress_empty_arg_completions_for_inline_picker(cmd_name, raw_arg):
+                return
+
             if cmd_name in ("/investigate", "/save"):
                 if cmd_name == "/investigate":
                     entry = SLASH_COMMANDS.get(cmd_name)
@@ -304,6 +309,27 @@ def _build_prompt_style() -> Style:
 
 
 _PLACEHOLDER_ANSI = ANSI(f"{ANSI_DIM}Type a message, /command, or paste an alert{ANSI_RESET}")
+
+# Commands where bare invocation opens an inline picker in TTY mode.
+_INLINE_PICKER_COMMANDS: frozenset[str] = frozenset(
+    {
+        "/history",
+        "/integrations",
+        "/investigate",
+        "/list",
+        "/mcp",
+        "/model",
+        "/template",
+        "/tests",
+        "/trust",
+        "/verbose",
+    }
+)
+
+
+def _suppress_empty_arg_completions_for_inline_picker(cmd_name: str, raw_arg: str) -> bool:
+    """Hide first-arg autocomplete when bare slash command opens inline picker."""
+    return repl_tty_interactive() and not raw_arg and cmd_name in _INLINE_PICKER_COMMANDS
 
 
 def _build_prompt_session(_session: ReplSession | None = None) -> PromptSession[str]:

--- a/tests/cli/interactive_shell/test_terminal_runtime.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime.py
@@ -207,6 +207,36 @@ def test_shell_completer_suggests_subcommands_for_list() -> None:
     assert names == ["integrations", "mcp", "models", "tools"]
 
 
+def test_shell_completer_hides_inline_picker_autocomplete_in_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(prompt_surface, "repl_tty_interactive", lambda: True)
+
+    completions = list(
+        ShellCompleter().get_completions(
+            Document("/model "),
+            CompleteEvent(text_inserted=True),
+        )
+    )
+
+    assert completions == []
+
+
+def test_shell_completer_keeps_inline_picker_autocomplete_when_arg_started(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(prompt_surface, "repl_tty_interactive", lambda: True)
+
+    completions = list(
+        ShellCompleter().get_completions(
+            Document("/model s"),
+            CompleteEvent(text_inserted=True),
+        )
+    )
+
+    assert sorted({c.text for c in completions}) == ["set", "show"]
+
+
 def test_shell_completer_suggests_effort_levels() -> None:
     completions = list(
         ShellCompleter().get_completions(


### PR DESCRIPTION
Fixes #

<!-- No linked issue for this small UX follow-up. -->

#### Describe the changes you have made in this PR -
- Suppressed first-argument autocomplete for bare slash commands that open inline picker menus in TTY mode.
- Kept autocomplete enabled once the user starts typing an explicit argument.
- Added regression tests covering both behaviors.

### Demo/Screenshot for feature changes and bug fixes - 
Terminal proof:

```bash
make lint
make format-check
make typecheck
uv run python -m pytest tests/cli/interactive_shell/test_terminal_runtime.py -q
# 137 passed
```

## Previously
<img width="699" height="126" alt="image" src="https://github.com/user-attachments/assets/2708c154-2565-49d8-b4f7-d011641dac5b" />

## Now
Remove autocomplete when menu is there 

<img width="381" height="191" alt="image" src="https://github.com/user-attachments/assets/91cd1967-a54f-497d-9926-f29eb6c28118" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- **Problem solved:** TTY users were seeing two competing UI surfaces (prompt-toolkit autocomplete + inline picker) for the same interaction, which is confusing.
- **Alternatives considered:** (1) remove autocomplete for these commands entirely, (2) keep both surfaces. I rejected (1) because typed-arg flows still benefit from completion, and (2) because it creates UX conflict.
- **Chosen approach:** suppress only empty first-arg completions for commands whose bare form opens an inline picker in TTY.
- **Key changes:** centralized picker-command list + guard in `ShellCompleter`; tests verify suppression on bare command and preservation once argument typing starts.

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
