### PR TITLE
fix(llm-cli): CLI investigate timeouts and graceful LLM errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ Temporary Items
 **/.wrangler/
 
 # Project specific
+.antigravitycli/
 output/
 .cloudopsbench-results/
 .bench-results/

--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from typing import Any
 
+from app.agent.llm_invoke_errors import LLMInvokeFailure, classify_llm_invoke_failure
 from app.agent.prompt import build_system_prompt, format_alert_context
 from app.agent.result import InvestigationResult, parse_diagnosis
 from app.cli.support.output import debug_print, get_tracker
@@ -167,58 +168,21 @@ class ConnectedInvestigationAgent:
             try:
                 response = llm.invoke(messages, system=system, tools=tool_schemas)
 
-            except RuntimeError as err:
-                err_msg = str(err).lower()
-                if ("model" in err_msg and "not found" in err_msg) or "404" in err_msg:
-                    error_msg = (
-                        "Error: The AI model was not found (404). "
-                        "If using a local LLM, verify the model name in your .env file."
-                    )
-                    remediation_steps = [
-                        "Check your .env configuration",
-                        "Verify the model name is correct",
-                        "Ensure the model is downloaded locally",
-                        "Confirm your provider supports this model",
-                    ]
-                    tracker.error("investigation_agent", message="Failed: Model not found")
-                elif "does not support tool" in err_msg or "only supports single tool" in err_msg:
-                    error_msg = (
-                        "Error: The configured model does not support tool calling. "
-                        "The investigation agent requires a model with native tool-calling support."
-                    )
-                    remediation_steps = [
-                        "Switch to a model that supports tool calling (e.g. claude-opus-4-7, gpt-4o)",
-                        "For Ollama: use llama3.1, qwen2.5, or another tool-call-capable model",
-                        "Check your LLM_MODEL or LLM_PROVIDER setting in .env",
-                    ]
-                    tracker.error(
-                        "investigation_agent", message="Failed: Model does not support tools"
-                    )
-                else:
+            except Exception as err:
+                failure = classify_llm_invoke_failure(err)
+                if failure is None:
                     raise
-                _emit(
-                    "agent_end",
-                    {
-                        "root_cause": error_msg,
-                        "validity_score": 0.0,
-                        "root_cause_category": "Configuration Error",
-                    },
+                updates = _degraded_investigation_from_llm_failure(
+                    failure,
+                    err=err,
+                    tracker=tracker,
+                    _emit=_emit,
+                    evidence=evidence,
+                    evidence_entries=evidence_entries,
+                    messages=messages,
+                    executed_hypotheses=executed_hypotheses,
+                    tool_context=tool_context,
                 )
-                updates = {
-                    "root_cause": error_msg,
-                    "root_cause_category": "Configuration Error",
-                    "causal_chain": [f"Model API returned error: {str(err)}"],
-                    "validated_claims": [],
-                    "non_validated_claims": [],
-                    "remediation_steps": remediation_steps,
-                    "validity_score": 0.0,
-                    "investigation_recommendations": [],
-                    "evidence": evidence,
-                    "evidence_entries": [e.model_dump() for e in evidence_entries],
-                    "agent_messages": messages,
-                    "executed_hypotheses": executed_hypotheses,
-                }
-                updates.update(tool_context)
                 return updates
 
             messages.append(_build_assistant_msg(llm, response))
@@ -295,6 +259,47 @@ class ConnectedInvestigationAgent:
 
 
 InvestigationAgent = ConnectedInvestigationAgent
+
+
+def _degraded_investigation_from_llm_failure(
+    failure: LLMInvokeFailure,
+    *,
+    err: BaseException,
+    tracker: Any,
+    _emit: Callable[[str, dict[str, Any]], None],
+    evidence: dict[str, Any],
+    evidence_entries: list[EvidenceEntry],
+    messages: list[dict[str, Any]],
+    executed_hypotheses: list[dict[str, Any]],
+    tool_context: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a partial investigation state when an LLM invoke fails operatively."""
+    tracker.error("investigation_agent", message=failure.tracker_message)
+    error_msg = f"Error: {failure.user_message}"
+    _emit(
+        "agent_end",
+        {
+            "root_cause": error_msg,
+            "validity_score": 0.0,
+            "root_cause_category": failure.root_cause_category,
+        },
+    )
+    updates = {
+        "root_cause": error_msg,
+        "root_cause_category": failure.root_cause_category,
+        "causal_chain": [f"LLM invoke failed: {err!s}"],
+        "validated_claims": [],
+        "non_validated_claims": [],
+        "remediation_steps": failure.remediation_steps,
+        "validity_score": 0.0,
+        "investigation_recommendations": [],
+        "evidence": evidence,
+        "evidence_entries": [e.model_dump() for e in evidence_entries],
+        "agent_messages": messages,
+        "executed_hypotheses": executed_hypotheses,
+    }
+    updates.update(tool_context)
+    return updates
 
 
 def _get_available_tools(

--- a/app/agent/llm_invoke_errors.py
+++ b/app/agent/llm_invoke_errors.py
@@ -1,0 +1,187 @@
+"""Classify LLM invoke failures for investigation and CLI error mapping."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LLMInvokeFailure:
+    """User-facing investigation failure derived from an LLM invoke exception."""
+
+    user_message: str
+    tracker_message: str
+    remediation_steps: list[str]
+    root_cause_category: str = "Configuration Error"
+
+
+def _timeout_remediation(detail: str) -> list[str]:
+    return [
+        detail,
+        "CLI providers: raise the per-provider timeout env "
+        "(e.g. GEMINI_CLI_TIMEOUT_SECONDS, CLAUDE_CODE_TIMEOUT_SECONDS, "
+        "ANTIGRAVITY_CLI_TIMEOUT_SECONDS; clamped 30–600 where supported).",
+        "API providers (Anthropic, OpenAI, etc.): each ReAct turn is limited to "
+        "~90s per HTTP request; retry or switch to a faster model if turns time out.",
+        "Investigation runs many LLM and tool steps — total wall time can be several minutes.",
+    ]
+
+
+def _looks_like_timeout(exc: BaseException) -> bool:
+    from anthropic import APITimeoutError
+
+    if isinstance(exc, TimeoutError):
+        return True
+    try:
+        from openai import APITimeoutError as OpenAITimeoutError
+    except ImportError:
+        OpenAITimeoutError = ()  # type: ignore[misc, assignment]
+    else:
+        if isinstance(exc, OpenAITimeoutError):
+            return True
+
+    if isinstance(exc, APITimeoutError):
+        return True
+
+    text = str(exc).lower()
+    if "timed out" in text or "timeout" in text:
+        return True
+    cause: BaseException | None = exc
+    while cause is not None:
+        if isinstance(cause, TimeoutError):
+            return True
+        next_cause = cause.__cause__ or cause.__context__
+        if next_cause is cause:
+            break
+        cause = next_cause if isinstance(next_cause, BaseException) else None
+    return False
+
+
+def classify_llm_invoke_failure(exc: BaseException) -> LLMInvokeFailure | None:
+    """Return a structured failure when *exc* is a known operational LLM error."""
+    from app.integrations.llm_cli.errors import (
+        CLIAuthenticationRequired,
+        CLIInterruptedError,
+        CLITimeoutError,
+    )
+
+    if isinstance(exc, CLIAuthenticationRequired):
+        return LLMInvokeFailure(
+            user_message=(
+                f"The {exc.provider} CLI is not authenticated, so the investigation "
+                "could not call the model."
+            ),
+            tracker_message="Failed: CLI not authenticated",
+            remediation_steps=[
+                exc.auth_hint,
+                exc.detail,
+                "Run `opensre doctor` to verify CLI installation and auth.",
+            ],
+        )
+
+    if isinstance(exc, CLITimeoutError):
+        detail = str(exc).strip() or "The CLI subprocess exceeded its time limit."
+        return LLMInvokeFailure(
+            user_message=f"Investigation stopped: {detail}",
+            tracker_message="Failed: LLM timed out",
+            remediation_steps=_timeout_remediation(detail),
+            root_cause_category="Investigation Error",
+        )
+
+    if isinstance(exc, CLIInterruptedError):
+        return LLMInvokeFailure(
+            user_message="Investigation was interrupted while waiting for the LLM CLI.",
+            tracker_message="Failed: LLM interrupted",
+            remediation_steps=["Retry the investigation when ready."],
+            root_cause_category="Investigation Error",
+        )
+
+    if not isinstance(exc, RuntimeError):
+        if _looks_like_timeout(exc):
+            detail = str(exc).strip() or "The LLM request timed out."
+            return LLMInvokeFailure(
+                user_message=f"Investigation stopped: {detail}",
+                tracker_message="Failed: LLM timed out",
+                remediation_steps=_timeout_remediation(detail),
+                root_cause_category="Investigation Error",
+            )
+        return None
+
+    err_msg = str(exc).lower()
+    raw = str(exc)
+
+    if ("model" in err_msg and "not found" in err_msg) or "404" in err_msg:
+        if "anthropic" in err_msg and "was not found" in err_msg:
+            return LLMInvokeFailure(
+                user_message=raw.strip()
+                or "Anthropic model was not found. Check your configured model name.",
+                tracker_message="Failed: Model not found",
+                remediation_steps=[
+                    "Verify your model name in ANTHROPIC_REASONING_MODEL or "
+                    "ANTHROPIC_TOOLCALL_MODEL environment variables.",
+                    "Confirm the model ID is valid for your Anthropic account.",
+                ],
+            )
+        return LLMInvokeFailure(
+            user_message=(
+                "The configured AI model was not found (404). "
+                "If using a local LLM, verify the model name in your .env file."
+            ),
+            tracker_message="Failed: Model not found",
+            remediation_steps=[
+                "Check your .env configuration",
+                "Verify the model name is correct",
+                "Ensure the model is downloaded locally",
+                "Confirm your provider supports this model",
+            ],
+        )
+
+    if "does not support tool" in err_msg or "only supports single tool" in err_msg:
+        return LLMInvokeFailure(
+            user_message=(
+                "The configured model does not support tool calling. "
+                "The investigation agent requires a model with native tool-calling support."
+            ),
+            tracker_message="Failed: Model does not support tools",
+            remediation_steps=[
+                "Switch to a model that supports tool calling (e.g. claude-opus-4-7, gpt-4o)",
+                "For Ollama: use llama3.1, qwen2.5, or another tool-call-capable model",
+                "Check your LLM_MODEL or LLM_PROVIDER setting in .env",
+            ],
+        )
+
+    if "rate limit" in err_msg:
+        return LLMInvokeFailure(
+            user_message="The LLM provider rate-limited this investigation request.",
+            tracker_message="Failed: LLM rate limited",
+            remediation_steps=[
+                "Wait a few minutes and retry.",
+                "Reduce parallel load or switch to a higher quota tier if available.",
+            ],
+            root_cause_category="Investigation Error",
+        )
+
+    if (
+        "not authenticated" in err_msg
+        or "authentication" in err_msg
+        or ("api key" in err_msg and "invalid" in err_msg)
+    ):
+        return LLMInvokeFailure(
+            user_message=f"Investigation stopped: LLM authentication failed. {raw}",
+            tracker_message="Failed: LLM authentication",
+            remediation_steps=[
+                "Verify API keys or CLI login for your LLM_PROVIDER.",
+                "Run `opensre doctor` to check provider configuration.",
+            ],
+        )
+
+    if _looks_like_timeout(exc):
+        detail = raw.strip() or "The LLM request timed out."
+        return LLMInvokeFailure(
+            user_message=f"Investigation stopped: {detail}",
+            tracker_message="Failed: LLM timed out",
+            remediation_steps=_timeout_remediation(detail),
+            root_cause_category="Investigation Error",
+        )
+
+    return None

--- a/app/agent/llm_invoke_errors.py
+++ b/app/agent/llm_invoke_errors.py
@@ -17,11 +17,15 @@ class LLMInvokeFailure:
 
 def _timeout_remediation() -> list[str]:
     return [
-        "CLI providers: raise the per-provider timeout env "
-        "(e.g. GEMINI_CLI_TIMEOUT_SECONDS, CLAUDE_CODE_TIMEOUT_SECONDS, "
-        "ANTIGRAVITY_CLI_TIMEOUT_SECONDS; clamped 30–600 where supported).",
-        "API providers (Anthropic, OpenAI, etc.): each ReAct turn is limited to "
-        "~90s per HTTP request; retry or switch to a faster model if turns time out.",
+        (
+            "CLI providers: raise the per-provider timeout env "
+            + "(e.g. GEMINI_CLI_TIMEOUT_SECONDS, CLAUDE_CODE_TIMEOUT_SECONDS, "
+            + "ANTIGRAVITY_CLI_TIMEOUT_SECONDS; clamped 30–600 where supported)."
+        ),
+        (
+            "API providers (Anthropic, OpenAI, etc.): each ReAct turn is limited to "
+            + "~90s per HTTP request; retry or switch to a faster model if turns time out."
+        ),
         "Investigation runs many LLM and tool steps — total wall time can be several minutes.",
     ]
 
@@ -119,8 +123,10 @@ def classify_llm_invoke_failure(exc: BaseException) -> LLMInvokeFailure | None:
                 or "Anthropic model was not found. Check your configured model name.",
                 tracker_message="Failed: Model not found",
                 remediation_steps=[
-                    "Verify your model name in ANTHROPIC_REASONING_MODEL or "
-                    "ANTHROPIC_TOOLCALL_MODEL environment variables.",
+                    (
+                        "Verify your model name in ANTHROPIC_REASONING_MODEL or "
+                        + "ANTHROPIC_TOOLCALL_MODEL environment variables."
+                    ),
                     "Confirm the model ID is valid for your Anthropic account.",
                 ],
             )

--- a/app/agent/llm_invoke_errors.py
+++ b/app/agent/llm_invoke_errors.py
@@ -15,9 +15,8 @@ class LLMInvokeFailure:
     root_cause_category: str = "Configuration Error"
 
 
-def _timeout_remediation(detail: str) -> list[str]:
+def _timeout_remediation() -> list[str]:
     return [
-        detail,
         "CLI providers: raise the per-provider timeout env "
         "(e.g. GEMINI_CLI_TIMEOUT_SECONDS, CLAUDE_CODE_TIMEOUT_SECONDS, "
         "ANTIGRAVITY_CLI_TIMEOUT_SECONDS; clamped 30–600 where supported).",
@@ -28,20 +27,23 @@ def _timeout_remediation(detail: str) -> list[str]:
 
 
 def _looks_like_timeout(exc: BaseException) -> bool:
-    from anthropic import APITimeoutError
-
     if isinstance(exc, TimeoutError):
         return True
     try:
+        from anthropic import APITimeoutError as AnthropicTimeoutError
+    except ImportError:
+        pass
+    else:
+        if isinstance(exc, AnthropicTimeoutError):
+            return True
+
+    try:
         from openai import APITimeoutError as OpenAITimeoutError
     except ImportError:
-        OpenAITimeoutError = ()  # type: ignore[misc, assignment]
+        pass
     else:
         if isinstance(exc, OpenAITimeoutError):
             return True
-
-    if isinstance(exc, APITimeoutError):
-        return True
 
     text = str(exc).lower()
     if "timed out" in text or "timeout" in text:
@@ -84,7 +86,7 @@ def classify_llm_invoke_failure(exc: BaseException) -> LLMInvokeFailure | None:
         return LLMInvokeFailure(
             user_message=f"Investigation stopped: {detail}",
             tracker_message="Failed: LLM timed out",
-            remediation_steps=_timeout_remediation(detail),
+            remediation_steps=_timeout_remediation(),
             root_cause_category="Investigation Error",
         )
 
@@ -102,7 +104,7 @@ def classify_llm_invoke_failure(exc: BaseException) -> LLMInvokeFailure | None:
             return LLMInvokeFailure(
                 user_message=f"Investigation stopped: {detail}",
                 tracker_message="Failed: LLM timed out",
-                remediation_steps=_timeout_remediation(detail),
+                remediation_steps=_timeout_remediation(),
                 root_cause_category="Investigation Error",
             )
         return None
@@ -180,7 +182,7 @@ def classify_llm_invoke_failure(exc: BaseException) -> LLMInvokeFailure | None:
         return LLMInvokeFailure(
             user_message=f"Investigation stopped: {detail}",
             tracker_message="Failed: LLM timed out",
-            remediation_steps=_timeout_remediation(detail),
+            remediation_steps=_timeout_remediation(),
             root_cause_category="Investigation Error",
         )
 

--- a/app/cli/support/cli_error_mapping.py
+++ b/app/cli/support/cli_error_mapping.py
@@ -7,6 +7,7 @@ from typing import NoReturn
 
 def reraise_cli_runtime_error(exc: BaseException) -> NoReturn:
     """Convert CLI auth/setup failures to structured CLI UX errors."""
+    from app.agent.llm_invoke_errors import classify_llm_invoke_failure
     from app.cli.support.errors import OpenSREError
     from app.integrations.llm_cli.errors import CLIAuthenticationRequired
 
@@ -15,6 +16,15 @@ def reraise_cli_runtime_error(exc: BaseException) -> NoReturn:
             f"{exc.provider} CLI is not authenticated.",
             suggestion=f"{exc.auth_hint} ({exc.detail})",
         ) from exc
+
+    classified = classify_llm_invoke_failure(exc)
+    if classified is not None:
+        suggestion = (
+            "\n".join(classified.remediation_steps)
+            if classified.remediation_steps
+            else None
+        )
+        raise OpenSREError(classified.user_message, suggestion=suggestion) from exc
 
     if isinstance(exc, RuntimeError):
         msg = str(exc).lower()

--- a/app/cli/support/cli_error_mapping.py
+++ b/app/cli/support/cli_error_mapping.py
@@ -20,9 +20,7 @@ def reraise_cli_runtime_error(exc: BaseException) -> NoReturn:
     classified = classify_llm_invoke_failure(exc)
     if classified is not None:
         suggestion = (
-            "\n".join(classified.remediation_steps)
-            if classified.remediation_steps
-            else None
+            "\n".join(classified.remediation_steps) if classified.remediation_steps else None
         )
         raise OpenSREError(classified.user_message, suggestion=suggestion) from exc
 

--- a/app/integrations/llm_cli/codex.py
+++ b/app/integrations/llm_cli/codex.py
@@ -20,6 +20,7 @@ from app.integrations.llm_cli.binary_resolver import (
 from app.integrations.llm_cli.binary_resolver import (
     resolve_cli_binary,
 )
+from app.integrations.llm_cli.constants import DEFAULT_EXEC_TIMEOUT_SEC
 from app.integrations.llm_cli.env_overrides import (
     OPENAI_PLATFORM_ENV_KEYS,
     nonempty_env_values,
@@ -91,7 +92,7 @@ class CodexAdapter:
     install_hint = "npm i -g @openai/codex"
     auth_hint = "Run: codex login"
     min_version: str | None = None
-    default_exec_timeout_sec = 120.0
+    default_exec_timeout_sec = DEFAULT_EXEC_TIMEOUT_SEC
 
     def _resolve_binary(self) -> str | None:
         return resolve_cli_binary(

--- a/app/integrations/llm_cli/constants.py
+++ b/app/integrations/llm_cli/constants.py
@@ -14,7 +14,7 @@ EX_TEMPFAIL: Final[int] = 75
 TEMPFAIL_MAX_RETRIES: Final[int] = 2
 TEMPFAIL_BACKOFF_SEC: Final[float] = 2.0
 
-# Shared timeout defaults used by multiple adapters with env-overrides.
-DEFAULT_EXEC_TIMEOUT_SEC: Final[float] = 120.0
+# Shared default for CLI subprocess invokes (investigation ReAct sends large prompts).
+DEFAULT_EXEC_TIMEOUT_SEC: Final[float] = 300.0
 MIN_EXEC_TIMEOUT_SEC: Final[float] = 30.0
 MAX_EXEC_TIMEOUT_SEC: Final[float] = 600.0

--- a/app/integrations/llm_cli/copilot.py
+++ b/app/integrations/llm_cli/copilot.py
@@ -65,6 +65,7 @@ from app.integrations.llm_cli.env_overrides import (
     COPILOT_CLI_ENV_KEYS,
     nonempty_env_values,
 )
+from app.integrations.llm_cli.constants import DEFAULT_EXEC_TIMEOUT_SEC
 from app.integrations.llm_cli.probe_utils import run_version_probe
 from app.integrations.llm_cli.semver_utils import parse_semver_three_part
 
@@ -212,7 +213,7 @@ class CopilotAdapter:
     install_hint = "npm i -g @github/copilot"
     auth_hint = _AUTH_HINT.removesuffix(".")
     min_version: str | None = None
-    default_exec_timeout_sec = 180.0
+    default_exec_timeout_sec = DEFAULT_EXEC_TIMEOUT_SEC
 
     def _resolve_binary(self) -> str | None:
         return resolve_cli_binary(

--- a/app/integrations/llm_cli/copilot.py
+++ b/app/integrations/llm_cli/copilot.py
@@ -60,12 +60,12 @@ from app.integrations.llm_cli.binary_resolver import (
 from app.integrations.llm_cli.binary_resolver import (
     resolve_cli_binary,
 )
+from app.integrations.llm_cli.constants import DEFAULT_EXEC_TIMEOUT_SEC
 from app.integrations.llm_cli.env_overrides import (
     COPILOT_CLI_CONFIG_ENV_KEYS,
     COPILOT_CLI_ENV_KEYS,
     nonempty_env_values,
 )
-from app.integrations.llm_cli.constants import DEFAULT_EXEC_TIMEOUT_SEC
 from app.integrations.llm_cli.probe_utils import run_version_probe
 from app.integrations.llm_cli.semver_utils import parse_semver_three_part
 

--- a/app/integrations/llm_cli/cursor.py
+++ b/app/integrations/llm_cli/cursor.py
@@ -14,6 +14,7 @@ from app.integrations.llm_cli.binary_resolver import (
     default_cli_fallback_paths as _default_cli_fallback_paths,
 )
 from app.integrations.llm_cli.binary_resolver import resolve_cli_binary
+from app.integrations.llm_cli.constants import DEFAULT_EXEC_TIMEOUT_SEC
 from app.integrations.llm_cli.env_overrides import CURSOR_CLI_ENV_KEYS, nonempty_env_values
 from app.integrations.llm_cli.probe_utils import run_version_probe
 
@@ -68,7 +69,7 @@ class CursorAdapter:
     install_hint = "Install Cursor Agent with: curl https://cursor.com/install -fsS | bash"
     auth_hint = "Run: agent login."
     min_version: str | None = None
-    default_exec_timeout_sec = 300.0
+    default_exec_timeout_sec = DEFAULT_EXEC_TIMEOUT_SEC
 
     def _resolve_binary(self) -> str | None:
         return resolve_cli_binary(

--- a/app/integrations/llm_cli/kimi.py
+++ b/app/integrations/llm_cli/kimi.py
@@ -18,6 +18,7 @@ from app.integrations.llm_cli.binary_resolver import (
     default_cli_fallback_paths as _default_cli_fallback_paths,
 )
 from app.integrations.llm_cli.binary_resolver import resolve_cli_binary
+from app.integrations.llm_cli.constants import DEFAULT_EXEC_TIMEOUT_SEC
 from app.integrations.llm_cli.probe_utils import run_version_probe
 from app.integrations.llm_cli.semver_utils import parse_semver_three_part, semver_to_tuple
 
@@ -131,7 +132,7 @@ class KimiAdapter:
     install_hint = "uv tool install --python 3.13 kimi-cli"
     auth_hint = "Run: kimi login"
     min_version: str | None = "1.40.0"
-    default_exec_timeout_sec = 300.0
+    default_exec_timeout_sec = DEFAULT_EXEC_TIMEOUT_SEC
 
     def _resolve_binary(self) -> str | None:
         return resolve_cli_binary(

--- a/app/integrations/llm_cli/opencode.py
+++ b/app/integrations/llm_cli/opencode.py
@@ -22,6 +22,7 @@ from app.integrations.llm_cli.binary_resolver import (
 from app.integrations.llm_cli.binary_resolver import (
     resolve_cli_binary,
 )
+from app.integrations.llm_cli.constants import DEFAULT_EXEC_TIMEOUT_SEC
 from app.integrations.llm_cli.env_overrides import (
     HTTP_LLM_PROVIDER_ENV_KEYS,
     nonempty_env_values,
@@ -125,7 +126,7 @@ class OpenCodeAdapter:
     )
     auth_hint = "Run: opencode auth login (interactive) or configure provider API keys / auth.json"
     min_version: str | None = None
-    default_exec_timeout_sec = 120.0
+    default_exec_timeout_sec = DEFAULT_EXEC_TIMEOUT_SEC
 
     def _resolve_binary(self) -> str | None:
         return resolve_cli_binary(

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -192,6 +192,8 @@ Run any local model exposed by an [Ollama](https://ollama.com/) daemon. No API k
 
 CLI-backed providers shell out to a vendor CLI instead of an HTTP API. They authenticate via the vendor's own login command; OpenSRE detects the binary on `PATH` (or via an explicit env var) and reuses the existing session.
 
+**Investigation timeouts:** Each ReAct turn runs one full CLI subprocess with the system prompt, tool schemas, and conversation history. The shared default subprocess budget is **300 seconds** (Python adds a small buffer). Override per provider when needed, for example `GEMINI_CLI_TIMEOUT_SECONDS`, `CLAUDE_CODE_TIMEOUT_SECONDS`, or `ANTIGRAVITY_CLI_TIMEOUT_SECONDS` (clamped 30–600 where the adapter supports it).
+
 ### OpenAI Codex
 
 ```bash
@@ -250,7 +252,7 @@ agy                       # interactive launch triggers Google Sign-In; token ca
 agy update
 # Optional overrides (all blank-by-default):
 export ANTIGRAVITY_CLI_BIN=
-export ANTIGRAVITY_CLI_TIMEOUT_SECONDS=120   # clamped 30–600; maps to `--print-timeout {N}s`
+export ANTIGRAVITY_CLI_TIMEOUT_SECONDS=300   # default 300; clamped 30–600; maps to `--print-timeout {N}s`
 # Note: ANTIGRAVITY_CLI_MODEL is registered for forward-compat but currently no-op
 # (agy v1.0.2 does not expose --model in headless `-p` mode). Each invocation uses
 # whatever model is persisted in agy's local config; switch it interactively with

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -12,6 +12,7 @@ from app.agent.investigation import (
     _build_synthetic_assistant_tool_call_msg,
     _run_parallel,
 )
+from app.integrations.llm_cli.errors import CLITimeoutError
 from app.services.agent_llm_client import CLIBackedAgentClient, ToolCall
 
 
@@ -111,6 +112,65 @@ def test_run_re_raises_unmatched_runtime_error() -> None:
             agent.run(state)
 
     mock_tracker.error.assert_not_called()
+
+
+def test_run_gracefully_handles_cli_timeout() -> None:
+    mock_llm = MagicMock()
+    mock_llm.invoke.side_effect = CLITimeoutError("antigravity-cli CLI timed out after 300s.")
+    mock_llm.tool_schemas.return_value = []
+
+    mock_tracker = MagicMock()
+
+    with (
+        patch("app.agent.investigation.get_agent_llm", return_value=mock_llm),
+        patch("app.agent.investigation.get_tracker", return_value=mock_tracker),
+    ):
+        agent = ConnectedInvestigationAgent()
+        result = agent.run(
+            {
+                "alert_name": "Test alert",
+                "pipeline_name": "test-pipeline",
+                "severity": "critical",
+                "resolved_integrations": {},
+            }
+        )
+
+    mock_tracker.error.assert_called_once_with(
+        "investigation_agent", message="Failed: LLM timed out"
+    )
+    assert result["root_cause_category"] == "Investigation Error"
+    assert "timed out" in result["root_cause"].lower()
+    assert result["remediation_steps"]
+
+
+def test_run_gracefully_handles_api_timeout_runtime_error() -> None:
+    mock_llm = MagicMock()
+    mock_llm.invoke.side_effect = RuntimeError(
+        "Anthropic API failed after 3 attempts: Request timed out."
+    )
+    mock_llm.tool_schemas.return_value = []
+
+    mock_tracker = MagicMock()
+
+    with (
+        patch("app.agent.investigation.get_agent_llm", return_value=mock_llm),
+        patch("app.agent.investigation.get_tracker", return_value=mock_tracker),
+    ):
+        agent = ConnectedInvestigationAgent()
+        result = agent.run(
+            {
+                "alert_name": "Test alert",
+                "pipeline_name": "test-pipeline",
+                "severity": "critical",
+                "resolved_integrations": {},
+            }
+        )
+
+    mock_tracker.error.assert_called_once_with(
+        "investigation_agent", message="Failed: LLM timed out"
+    )
+    assert result["root_cause_category"] == "Investigation Error"
+    assert "timed out" in result["root_cause"].lower()
 
 
 @pytest.mark.parametrize(

--- a/tests/agent/test_llm_invoke_errors.py
+++ b/tests/agent/test_llm_invoke_errors.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from unittest.mock import patch
+
+from app.agent.llm_invoke_errors import _looks_like_timeout, classify_llm_invoke_failure
+from app.integrations.llm_cli.errors import CLITimeoutError
+
+
+def test_timeout_remediation_does_not_repeat_user_message() -> None:
+    failure = classify_llm_invoke_failure(CLITimeoutError("gemini-cli CLI timed out after 300s."))
+    assert failure is not None
+    assert "timed out after 300s" in failure.user_message
+    assert failure.remediation_steps
+    assert not any("timed out after 300s" in step for step in failure.remediation_steps)
+
+
+def test_looks_like_timeout_without_anthropic_sdk() -> None:
+    """Classifier must not import anthropic at module level or break when SDK is absent."""
+    fake_anthropic = ModuleType("anthropic")
+    with patch.dict(sys.modules, {"anthropic": fake_anthropic}):
+        assert _looks_like_timeout(TimeoutError("deadline")) is True
+        assert _looks_like_timeout(RuntimeError("request timed out")) is True

--- a/tests/cli/test_cli_error_mapping.py
+++ b/tests/cli/test_cli_error_mapping.py
@@ -4,6 +4,7 @@ import pytest
 
 from app.cli.support.cli_error_mapping import reraise_cli_runtime_error
 from app.cli.support.errors import OpenSREError
+from app.integrations.llm_cli.errors import CLITimeoutError
 
 
 def test_anthropic_model_not_found_raises_opensre_error() -> None:
@@ -35,11 +36,15 @@ def test_anthropic_model_not_found_suggestion_guides_env_vars() -> None:
     assert "ANTHROPIC_TOOLCALL_MODEL" in exc_info.value.suggestion
 
 
-def test_non_anthropic_model_not_found_does_not_match() -> None:
-    """A 'model not found' error from a non-Anthropic provider must not trigger the Anthropic branch."""
+def test_non_anthropic_model_not_found_maps_to_generic_opensre_error() -> None:
+    """A 'model not found' error from a non-Anthropic provider uses the generic 404 guidance."""
     exc = RuntimeError("OpenAI model 'gpt-99' was not found. Check your configuration.")
-    with pytest.raises(RuntimeError):
+    with pytest.raises(OpenSREError) as exc_info:
         reraise_cli_runtime_error(exc)
+
+    assert "not found" in str(exc_info.value).lower()
+    assert exc_info.value.suggestion is not None
+    assert "ANTHROPIC_REASONING_MODEL" not in exc_info.value.suggestion
 
 
 def test_cli_not_found_still_maps_correctly() -> None:
@@ -49,6 +54,17 @@ def test_cli_not_found_still_maps_correctly() -> None:
         reraise_cli_runtime_error(exc)
 
     assert "CLI tool is not installed" in str(exc_info.value)
+
+
+def test_cli_timeout_maps_to_opensre_error() -> None:
+    exc = CLITimeoutError("gemini-cli CLI timed out after 300s.")
+    with pytest.raises(OpenSREError) as exc_info:
+        reraise_cli_runtime_error(exc)
+
+    err = exc_info.value
+    assert "timed out" in str(err).lower()
+    assert err.suggestion is not None
+    assert "GEMINI_CLI_TIMEOUT_SECONDS" in err.suggestion
 
 
 def test_bedrock_model_not_available_maps_to_opensre_error() -> None:

--- a/tests/integrations/llm_cli/test_antigravity_cli_adapter.py
+++ b/tests/integrations/llm_cli/test_antigravity_cli_adapter.py
@@ -199,12 +199,12 @@ def test_build_basic_invocation(_mock_which: MagicMock) -> None:
     assert inv.argv[0] == "/usr/bin/agy"
     assert "-p" in inv.argv
     assert "--print-timeout" in inv.argv
-    # Default timeout: 120s
+    # Default timeout: shared DEFAULT_EXEC_TIMEOUT_SEC (300s)
     idx = inv.argv.index("--print-timeout")
-    assert inv.argv[idx + 1] == "120s"
+    assert inv.argv[idx + 1] == "300s"
     assert inv.stdin is None
     # subprocess timeout has +10s buffer over agy's own --print-timeout
-    assert inv.timeout_sec == 130.0
+    assert inv.timeout_sec == 310.0
 
 
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/agy")
@@ -230,7 +230,7 @@ def test_build_omits_model_and_output_format_and_stateful_flags(
 def test_resolve_exec_timeout_default() -> None:
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("ANTIGRAVITY_CLI_TIMEOUT_SECONDS", None)
-        assert _resolve_exec_timeout_seconds() == 120.0
+        assert _resolve_exec_timeout_seconds() == 300.0
 
 
 def test_resolve_exec_timeout_clamps_low_and_high() -> None:

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -596,7 +596,7 @@ def test_build_basic_invocation(_mock_which: MagicMock) -> None:
     assert "--output-format" in inv.argv
     assert "text" in inv.argv
     assert inv.stdin == "explain this alert"
-    assert inv.timeout_sec == 120.0
+    assert inv.timeout_sec == 300.0
 
 
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/claude")

--- a/tests/integrations/llm_cli/test_codex_adapter.py
+++ b/tests/integrations/llm_cli/test_codex_adapter.py
@@ -665,7 +665,7 @@ def test_npm_prefix_bin_dirs_unix_uses_prefix_bin() -> None:
 def test_codex_default_exec_timeout_is_shorter(mock_which) -> None:
     """Default timeout is asserted without requiring a real codex binary on CI PATH."""
     inv = CodexAdapter().build(prompt="p", model=None, workspace="")
-    assert inv.timeout_sec == 120.0
+    assert inv.timeout_sec == 300.0
     mock_which.assert_called()
 
 

--- a/tests/integrations/llm_cli/test_gemini_cli_adapter.py
+++ b/tests/integrations/llm_cli/test_gemini_cli_adapter.py
@@ -198,13 +198,13 @@ def test_build_basic_invocation(_mock_which: MagicMock) -> None:
     assert "--output-format" in inv.argv
     assert "json" in inv.argv
     assert inv.stdin is None
-    assert inv.timeout_sec == 120.0
+    assert inv.timeout_sec == 300.0
 
 
 def test_resolve_exec_timeout_default() -> None:
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("GEMINI_CLI_TIMEOUT_SECONDS", None)
-        assert _resolve_exec_timeout_seconds() == 120.0
+        assert _resolve_exec_timeout_seconds() == 300.0
 
 
 def test_resolve_exec_timeout_clamps_low_and_high() -> None:

--- a/tests/integrations/llm_cli/test_opencode_adapter.py
+++ b/tests/integrations/llm_cli/test_opencode_adapter.py
@@ -253,7 +253,7 @@ def test_build_basic_invocation(mock_which: MagicMock) -> None:
     assert inv.argv[0] == "/usr/bin/opencode"
     assert "run" in inv.argv
     assert inv.stdin == "explain this alert"
-    assert inv.timeout_sec == 120.0
+    assert inv.timeout_sec == 300.0
 
 
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/opencode")


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

- Add `.antigravitycli/` to `.gitignore` so local Antigravity CLI config/symlinks are never committed (directory was untracked locally; not on `main`).
- Raise shared `DEFAULT_EXEC_TIMEOUT_SEC` from 120s to **300s** for all CLI-backed providers (investigation ReAct turns send large prompts per subprocess).
- Wire codex, opencode, copilot, cursor, and kimi adapters to the shared constant (were hardcoded 120/180/300).
- Add `classify_llm_invoke_failure()` and return a degraded investigation state on operational LLM errors (CLI timeout, API timeout, auth, rate limit, model config) instead of an uncaught traceback.
- Map the same failures to `OpenSREError` with remediation suggestions in `reraise_cli_runtime_error`.
- Document the 300s per-turn CLI timeout and env overrides in `docs/llm-providers.mdx`.

### Demo/Screenshot for feature changes and bug fixes -

Before: `opensre investigate` with a CLI timeout could surface a raw `CLITimeoutError` / traceback.

After: investigation ends with category **Investigation Error**, a clear root-cause message, and remediation steps (timeout env vars, API ~90s per-turn note). REPL shows `investigation failed:` plus suggestion text.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Investigation slowness (e.g. 248s wall time) is mostly many LLM + tool turns, not a single global cap. Per-turn CLI subprocess timeouts were too tight at 120s for large tool-schema prompts. Bumping the shared constant fixes all CLI adapters consistently.

Timeouts and other operational LLM failures previously fell through `except RuntimeError` and re-raised. `CLITimeoutError` is a `RuntimeError` subclass but was not handled. A small classifier centralizes failure detection for both the agent (degraded state) and CLI mapping (`OpenSREError`).

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions