### PR TITLE
fix(wizard): add Groq base URL to provider validation

### DIFF
--- a/app/cli/wizard/validation.py
+++ b/app/cli/wizard/validation.py
@@ -66,6 +66,10 @@ def _get_provider_base_url(provider_value: str) -> str | None:
         from app.config import NVIDIA_BASE_URL
 
         return NVIDIA_BASE_URL
+    if provider_value == "groq":
+        from app.config import GROQ_BASE_URL
+
+        return GROQ_BASE_URL
     return None
 
 

--- a/tests/cli/wizard/test_validation.py
+++ b/tests/cli/wizard/test_validation.py
@@ -174,4 +174,17 @@ def test_validate_provider_credentials_returns_success_for_valid_openai_key(monk
 
 
 def test_get_provider_base_url_deepseek() -> None:
-    assert _get_provider_base_url("deepseek") == "https://api.deepseek.com"
+    from app.config import DEEPSEEK_BASE_URL
+
+    assert _get_provider_base_url("deepseek") == DEEPSEEK_BASE_URL
+
+
+def test_get_provider_base_url_groq() -> None:
+    from app.config import GROQ_BASE_URL
+
+    assert _get_provider_base_url("groq") == GROQ_BASE_URL
+
+
+def test_get_provider_base_url_openai_returns_none() -> None:
+    """Native OpenAI should return None (uses default base_url)."""
+    assert _get_provider_base_url("openai") is None


### PR DESCRIPTION
Fixes #2522

#### Describe the changes you have made in this PR -

The wizard validation was missing the Groq provider branch in `_get_provider_base_url()`, causing API key validation to hit the native OpenAI endpoint instead of Groq's endpoint.

- `validation.py`: Add `groq` branch returning `GROQ_BASE_URL` in `_get_provider_base_url()`, matching the existing pattern for openrouter/deepseek/gemini/nvidia
- `test_validation.py`: Add test for Groq base URL resolution (imports from config per review feedback on #2528); update existing deepseek test to import from config for consistency; add test verifying native OpenAI returns `None`

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/cli/wizard/test_validation.py -v
collected 7 items

tests/cli/wizard/test_validation.py::test_get_provider_base_url_deepseek PASSED
tests/cli/wizard/test_validation.py::test_get_provider_base_url_groq PASSED
tests/cli/wizard/test_validation.py::test_get_provider_base_url_openai_returns_none PASSED

7 passed in 2.52s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions