### PR TITLE
enhancement(cli): add guided template menu for bare opensre investigate

### DIFF
--- a/app/cli/investigation/payload.py
+++ b/app/cli/investigation/payload.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -84,11 +85,50 @@ def load_stdin() -> dict[str, Any]:
 
 def load_interactive() -> dict[str, Any]:
     """Prompt the user to paste an alert payload."""
-    print("Paste the alert JSON payload, then press Ctrl-D when finished.", file=sys.stderr)
+    eof_hint = "Ctrl-Z then Enter" if os.name == "nt" else "Ctrl-D"
+
+    print(f"Paste the alert JSON payload, then press {eof_hint} when finished.", file=sys.stderr)
     raw_text = sys.stdin.read()
     if not raw_text.strip():
         raise SystemExit("No alert JSON was provided in interactive mode.")
     return parse_payload_text(raw_text, "interactive input")
+
+def load_guided_menu() -> dict[str, Any]:
+    """Interactive guided investigation menu."""
+
+    print("\nNo alert input detected.\n")
+
+    print("Choose an option:")
+    print("1. Use bundled demo alert")
+    print("2. Paste JSON interactively")
+    print("3. Load alert from file")
+    print("4. Exit")
+
+    choice = input("\nEnter choice (1-4): ").strip()
+
+    if choice == "1":
+        demo = bundled_demo_alert_path()
+
+        if demo is None:
+            raise SystemExit("Bundled demo alert not found.")
+
+        return load_file(str(demo))
+
+    if choice == "2":
+        return load_interactive()
+
+    if choice == "3":
+        path = input("Enter alert file path: ").strip()
+
+        if not path:
+            raise SystemExit("No file path provided.")
+
+        return load_file(path)
+
+    if choice == "4":
+        raise SystemExit(0)
+
+    raise SystemExit("Invalid selection.")
 
 
 def load_payload(
@@ -106,8 +146,5 @@ def load_payload(
     if input_path:
         return load_file(input_path)
     if sys.stdin.isatty():
-        raise SystemExit(
-            "No alert input provided. Use --input/-i <file>, --input-json <json>, "
-            "--interactive to paste JSON, or pipe alert JSON on stdin."
-        )
+        return load_guided_menu()
     return load_stdin()

--- a/packaging/opensre.spec
+++ b/packaging/opensre.spec
@@ -19,7 +19,6 @@ def _is_runtime_submodule(module_name: str) -> bool:
 hiddenimports = collect_submodules("app", filter=_is_runtime_submodule)
 hiddenimports += collect_submodules("sentry_sdk")
 hiddenimports += collect_submodules("psycopg2")
-hiddenimports += collect_submodules("psycopg2_binary")
 datas = collect_data_files("app")
 
 block_cipher = None

--- a/packaging/opensre.spec
+++ b/packaging/opensre.spec
@@ -18,6 +18,8 @@ def _is_runtime_submodule(module_name: str) -> bool:
 
 hiddenimports = collect_submodules("app", filter=_is_runtime_submodule)
 hiddenimports += collect_submodules("sentry_sdk")
+hiddenimports += collect_submodules("psycopg2")
+hiddenimports += collect_submodules("psycopg2_binary")
 datas = collect_data_files("app")
 
 block_cipher = None

--- a/tests/cli/test_interactive.py
+++ b/tests/cli/test_interactive.py
@@ -417,3 +417,24 @@ def test_confirm_run_prints_openclaw_preflight_messages(monkeypatch, capsys) -> 
     output = capsys.readouterr().out
     assert "OpenClaw preflight: unavailable." in output
     assert "Fix: verify openclaw." in output
+    
+    
+def test_load_payload_uses_guided_menu(monkeypatch) -> None:
+    from app.cli.investigation.payload import load_payload
+    import app.cli.investigation.payload as alert_loader
+
+    monkeypatch.setattr(
+        alert_loader.sys.stdin,
+        "isatty",
+        lambda: True,
+    )
+
+    monkeypatch.setattr(
+        alert_loader,
+        "load_guided_menu",
+        lambda: {"demo": True},
+    )
+
+    result = load_payload(None, None, False)
+
+    assert result == {"demo": True}    


### PR DESCRIPTION
## Summary

Adds a guided interactive menu when `opensre investigate` is run without input in a TTY environment.

Users can now:

* use the bundled demo alert
* paste JSON interactively
* load alerts from a file

Non-interactive environments preserve the existing strict behavior.

## Changes

* added guided menu flow for empty TTY sessions
* preserved stdin behavior for non-TTY usage
* improved Windows interactive EOF instructions
* added CLI test coverage for guided menu flow
