### PR TITLE
fix(cli): Investigation live footer now remains at absolute bottom 

### DIFF
--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -312,21 +312,37 @@ def render_completed_investigation_footer() -> None:
     )
 
 
-def stop_display(*, capture_footer: bool = True) -> None:
-    """Stop any running live display. Call before printing final report output."""
+def stop_display(
+    *,
+    capture_footer: bool = True,
+    clear_pending_footer: bool = False,
+) -> None:
+    """Stop any running live display. Call before printing final report output.
+
+    ``capture_footer`` decides whether to snapshot the *current* display so a
+    later report can re-print it below. ``clear_pending_footer`` is a separate,
+    opt-in switch used by cancel paths to drop any *previously* captured
+    snapshot — it never fires automatically, so tearing down a secondary
+    display (e.g. a module singleton during streaming) does not erase a
+    snapshot owned by a different tracker.
+    """
     global _active_display, _tracker
     if _tracker is not None:
         _tracker._stop_toggle_watcher()
         if _tracker.has_active_display:
             _tracker.stop(
                 capture_footer=capture_footer,
-                clear_pending_footer=not capture_footer,
+                clear_pending_footer=clear_pending_footer,
             )
             return
     if _active_display is not None:
         if capture_footer:
             _capture_completed_footer_snapshot(_active_display)
+        elif clear_pending_footer:
+            clear_pending_completed_footer()
         _active_display.stop()
+    elif clear_pending_footer:
+        clear_pending_completed_footer()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -995,9 +1011,14 @@ class ProgressTracker:
         self,
         *,
         capture_footer: bool = True,
-        clear_pending_footer: bool = True,
+        clear_pending_footer: bool = False,
     ) -> None:
-        """Stop the active live display if running."""
+        """Stop the active live display if running.
+
+        ``clear_pending_footer`` defaults to ``False`` so tearing down one
+        tracker never silently drops a snapshot owned by another tracker.
+        Cancel paths set it explicitly to clean up after an interrupted run.
+        """
         self._stop_toggle_watcher()
         if self._display:
             if capture_footer:
@@ -1006,7 +1027,7 @@ class ProgressTracker:
                 clear_pending_completed_footer()
             self._display.stop()
             self._display = None
-        elif not capture_footer and clear_pending_footer:
+        elif clear_pending_footer:
             clear_pending_completed_footer()
 
     def _stop_toggle_watcher(self) -> None:
@@ -1308,7 +1329,7 @@ def get_tracker(*, reset: bool = False) -> ProgressTracker:
     global _tracker
     if _tracker is None or reset:
         if reset and _tracker is not None:
-            _tracker.stop(capture_footer=False)
+            _tracker.stop(capture_footer=False, clear_pending_footer=True)
         _tracker = ProgressTracker()
     return _tracker
 

--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -205,6 +205,7 @@ def _elapsed_hms(seconds: float) -> str:
 
 _live_console: Console | None = None
 _active_display: _EventLogDisplay | None = None  # forward-declared below
+_pending_completed_footer: InvestigationFooterSnapshot | None = None
 _stdin_watcher_suppression_depth = 0
 _stdin_watcher_lock = threading.Lock()
 _tool_detail_toggle_callbacks: list[Callable[[], None]] = []
@@ -277,15 +278,49 @@ def unregister_live_console(expected: Console | None) -> None:
         _live_console = None
 
 
+def _capture_completed_footer_snapshot(
+    display: _EventLogDisplay | _ReplEventLogDisplay,
+) -> None:
+    """Remember footer metadata so it can be re-printed below the final report."""
+    global _pending_completed_footer
+    _pending_completed_footer = InvestigationFooterSnapshot(
+        phase=display._current_phase,
+        elapsed_total=time.monotonic() - display._t0,
+        model=display._model,
+        mode=display._mode,
+    )
+
+
+def render_completed_investigation_footer() -> None:
+    """Print the investigation status footer below the RCA report (absolute bottom)."""
+    global _pending_completed_footer
+    snap = _pending_completed_footer
+    if snap is None or _is_silent_output():
+        return
+    _pending_completed_footer = None
+    render_divider()
+    render_footer(
+        snap.phase,
+        snap.elapsed_total,
+        snap.model,
+        snap.mode,
+        show_cancel=False,
+    )
+
+
 def stop_display() -> None:
     """Stop any running live display. Call before printing final report output."""
     global _active_display, _tracker
     if _tracker is not None:
         _tracker._stop_toggle_watcher()
         if _tracker.has_active_display:
+            display = _tracker._display
+            if display is not None:
+                _capture_completed_footer_snapshot(display)
             _tracker.stop()
             return
     if _active_display is not None:
+        _capture_completed_footer_snapshot(_active_display)
         _active_display.stop()
 
 
@@ -304,7 +339,14 @@ def render_divider(width: int = 80) -> None:
         _safe_print("─" * width)
 
 
-def render_footer(phase: str, elapsed: float, model: str, mode: str) -> None:
+def render_footer(
+    phase: str,
+    elapsed: float,
+    model: str,
+    mode: str,
+    *,
+    show_cancel: bool = True,
+) -> None:
     """Print the persistent status footer line."""
     if _is_silent_output():
         return
@@ -316,10 +358,14 @@ def render_footer(phase: str, elapsed: float, model: str, mode: str) -> None:
         if model:
             t.append(f"{model}  ", style=SECONDARY)
         t.append(f"{mode}  ", style=SECONDARY)
-        t.append("esc to cancel", style=DIM)
+        t.append("ctrl+o tool details", style=DIM)
+        if show_cancel:
+            t.append("  ", style=DIM)
+            t.append("esc to cancel", style=DIM)
         _get_console().print(t)
     else:
-        _safe_print(f"● {phase}  {elapsed:.1f}s  {model}  {mode}")
+        suffix = "  esc to cancel" if show_cancel else ""
+        _safe_print(f"● {phase}  {elapsed:.1f}s  {model}  {mode}{suffix}")
 
 
 def render_event(
@@ -879,6 +925,16 @@ def _make_event_log_display(*, t0: float) -> _EventLogDisplay | _ReplEventLogDis
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+@dataclass(frozen=True)
+class InvestigationFooterSnapshot:
+    """Footer metadata captured when tearing down the live progress display."""
+
+    phase: str
+    elapsed_total: float
+    model: str
+    mode: str
+
+
 @dataclass
 class ProgressEvent:
     node_name: str
@@ -924,6 +980,7 @@ class ProgressTracker:
         """Stop the active live display if running."""
         self._stop_toggle_watcher()
         if self._display:
+            _capture_completed_footer_snapshot(self._display)
             self._display.stop()
             self._display = None
 
@@ -947,6 +1004,7 @@ class ProgressTracker:
                 # Stop the animated display so the final report prints cleanly below
                 self._stop_toggle_watcher()
                 if self._display:
+                    _capture_completed_footer_snapshot(self._display)
                     self._display.stop()
                     self._display = None
             else:

--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -318,7 +318,10 @@ def stop_display(*, capture_footer: bool = True) -> None:
     if _tracker is not None:
         _tracker._stop_toggle_watcher()
         if _tracker.has_active_display:
-            _tracker.stop(capture_footer=capture_footer)
+            _tracker.stop(
+                capture_footer=capture_footer,
+                clear_pending_footer=not capture_footer,
+            )
             return
     if _active_display is not None:
         if capture_footer:
@@ -988,17 +991,22 @@ class ProgressTracker:
         """Return True if the live display is currently running."""
         return self._display is not None
 
-    def stop(self, *, capture_footer: bool = True) -> None:
+    def stop(
+        self,
+        *,
+        capture_footer: bool = True,
+        clear_pending_footer: bool = True,
+    ) -> None:
         """Stop the active live display if running."""
         self._stop_toggle_watcher()
         if self._display:
             if capture_footer:
                 _capture_completed_footer_snapshot(self._display)
-            else:
+            elif clear_pending_footer:
                 clear_pending_completed_footer()
             self._display.stop()
             self._display = None
-        elif not capture_footer:
+        elif not capture_footer and clear_pending_footer:
             clear_pending_completed_footer()
 
     def _stop_toggle_watcher(self) -> None:

--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -279,11 +279,14 @@ def unregister_live_console(expected: Console | None) -> None:
 
 def stop_display() -> None:
     """Stop any running live display. Call before printing final report output."""
-    global _active_display
+    global _active_display, _tracker
+    if _tracker is not None:
+        _tracker._stop_toggle_watcher()
+        if _tracker.has_active_display:
+            _tracker.stop()
+            return
     if _active_display is not None:
         _active_display.stop()
-    if "_tracker" in globals() and _tracker is not None:
-        _tracker._stop_toggle_watcher()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -644,6 +647,9 @@ class _EventLogDisplay:
             console=self._console,
             refresh_per_second=10,
             auto_refresh=True,
+            # Remove the live region (phase footer, active-step spinners) on stop so
+            # the final RCA report does not sit below a stale "esc to cancel" line.
+            transient=True,
             # Clip the live area to the terminal height so Rich never tries to
             # scroll back past more lines than it rendered.
             vertical_overflow="ellipsis",
@@ -656,6 +662,10 @@ class _EventLogDisplay:
         global _live_console, _active_display
         if self._live.is_started:
             self._live.stop()
+        # Belt-and-suspenders: some terminals / patch_stdout paths may leave the
+        # last Live frame (phase footer) visible even after transient stop.
+        with contextlib.suppress(Exception):
+            self._console.clear_live()
         if _live_console is self._console:
             _live_console = None
         if _active_display is self:

--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -662,10 +662,6 @@ class _EventLogDisplay:
         global _live_console, _active_display
         if self._live.is_started:
             self._live.stop()
-        # Belt-and-suspenders: some terminals / patch_stdout paths may leave the
-        # last Live frame (phase footer) visible even after transient stop.
-        with contextlib.suppress(Exception):
-            self._console.clear_live()
         if _live_console is self._console:
             _live_console = None
         if _active_display is self:

--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -286,6 +286,8 @@ def _capture_completed_footer_snapshot(
     display: _EventLogDisplay | _ReplEventLogDisplay,
 ) -> None:
     """Remember footer metadata so it can be re-printed below the final report."""
+    if _completed_footer_pending.snapshot is not None:
+        return
     _completed_footer_pending.snapshot = InvestigationFooterSnapshot(
         phase=display._current_phase,
         elapsed_total=time.monotonic() - display._t0,
@@ -310,16 +312,17 @@ def render_completed_investigation_footer() -> None:
     )
 
 
-def stop_display() -> None:
+def stop_display(*, capture_footer: bool = True) -> None:
     """Stop any running live display. Call before printing final report output."""
     global _active_display, _tracker
     if _tracker is not None:
         _tracker._stop_toggle_watcher()
         if _tracker.has_active_display:
-            _tracker.stop(capture_footer=True)
+            _tracker.stop(capture_footer=capture_footer)
             return
     if _active_display is not None:
-        _capture_completed_footer_snapshot(_active_display)
+        if capture_footer:
+            _capture_completed_footer_snapshot(_active_display)
         _active_display.stop()
 
 

--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -205,7 +205,6 @@ def _elapsed_hms(seconds: float) -> str:
 
 _live_console: Console | None = None
 _active_display: _EventLogDisplay | None = None  # forward-declared below
-_pending_completed_footer: InvestigationFooterSnapshot | None = None
 _stdin_watcher_suppression_depth = 0
 _stdin_watcher_lock = threading.Lock()
 _tool_detail_toggle_callbacks: list[Callable[[], None]] = []
@@ -278,12 +277,16 @@ def unregister_live_console(expected: Console | None) -> None:
         _live_console = None
 
 
+def clear_pending_completed_footer() -> None:
+    """Drop any captured footer snapshot (e.g. after cancel without a final report)."""
+    _completed_footer_pending.snapshot = None
+
+
 def _capture_completed_footer_snapshot(
     display: _EventLogDisplay | _ReplEventLogDisplay,
 ) -> None:
     """Remember footer metadata so it can be re-printed below the final report."""
-    global _pending_completed_footer
-    _pending_completed_footer = InvestigationFooterSnapshot(
+    _completed_footer_pending.snapshot = InvestigationFooterSnapshot(
         phase=display._current_phase,
         elapsed_total=time.monotonic() - display._t0,
         model=display._model,
@@ -293,11 +296,10 @@ def _capture_completed_footer_snapshot(
 
 def render_completed_investigation_footer() -> None:
     """Print the investigation status footer below the RCA report (absolute bottom)."""
-    global _pending_completed_footer
-    snap = _pending_completed_footer
+    snap = _completed_footer_pending.snapshot
     if snap is None or _is_silent_output():
         return
-    _pending_completed_footer = None
+    _completed_footer_pending.snapshot = None
     render_divider()
     render_footer(
         snap.phase,
@@ -314,10 +316,7 @@ def stop_display() -> None:
     if _tracker is not None:
         _tracker._stop_toggle_watcher()
         if _tracker.has_active_display:
-            display = _tracker._display
-            if display is not None:
-                _capture_completed_footer_snapshot(display)
-            _tracker.stop()
+            _tracker.stop(capture_footer=True)
             return
     if _active_display is not None:
         _capture_completed_footer_snapshot(_active_display)
@@ -936,6 +935,16 @@ class InvestigationFooterSnapshot:
 
 
 @dataclass
+class _CompletedFooterPending:
+    """Holder for the post-report footer snapshot (avoids module-level global churn)."""
+
+    snapshot: InvestigationFooterSnapshot | None = None
+
+
+_completed_footer_pending = _CompletedFooterPending()
+
+
+@dataclass
 class ProgressEvent:
     node_name: str
     elapsed_ms: int
@@ -976,13 +985,18 @@ class ProgressTracker:
         """Return True if the live display is currently running."""
         return self._display is not None
 
-    def stop(self) -> None:
+    def stop(self, *, capture_footer: bool = True) -> None:
         """Stop the active live display if running."""
         self._stop_toggle_watcher()
         if self._display:
-            _capture_completed_footer_snapshot(self._display)
+            if capture_footer:
+                _capture_completed_footer_snapshot(self._display)
+            else:
+                clear_pending_completed_footer()
             self._display.stop()
             self._display = None
+        elif not capture_footer:
+            clear_pending_completed_footer()
 
     def _stop_toggle_watcher(self) -> None:
         if self._toggle_watcher is not None:
@@ -1283,7 +1297,7 @@ def get_tracker(*, reset: bool = False) -> ProgressTracker:
     global _tracker
     if _tracker is None or reset:
         if reset and _tracker is not None:
-            _tracker.stop()
+            _tracker.stop(capture_footer=False)
         _tracker = ProgressTracker()
     return _tracker
 
@@ -1302,7 +1316,8 @@ def set_silent_tracker() -> None:
     """
     global _tracker
     if _tracker is not None:
-        _tracker.stop()
+        _tracker.stop(capture_footer=False)
+    clear_pending_completed_footer()
     _tracker = ProgressTracker.__new__(ProgressTracker)
     _tracker.events = []
     _tracker._start_times = {}

--- a/app/delivery/__init__.py
+++ b/app/delivery/__init__.py
@@ -18,7 +18,12 @@ def deliver(state: InvestigationState) -> dict[str, Any]:
 
     Returns state updates with slack_message and report fields.
     """
+    from app.cli.support.output import stop_display
     from app.delivery.publish_findings.node import generate_report
+
+    # CLI deliver() does not pass through tracker.start("publish_findings"), so
+    # tear down the live progress footer before formatting the final report.
+    stop_display()
 
     state_dict = dict(state)
 

--- a/app/delivery/publish_findings/renderers/terminal.py
+++ b/app/delivery/publish_findings/renderers/terminal.py
@@ -132,6 +132,10 @@ def render_report(slack_message: str, root_cause_category: str | None = None) ->
     else:
         _render_plain_report(slack_message, root_cause_category=root_cause_category)
 
+    from app.cli.support.output import render_completed_investigation_footer
+
+    render_completed_investigation_footer()
+
 
 def _render_rich_report(slack_message: str, root_cause_category: str | None = None) -> None:
     _ = root_cause_category

--- a/app/remote/renderer.py
+++ b/app/remote/renderer.py
@@ -454,7 +454,7 @@ class StreamRenderer:
             if not _interrupted:
                 self._print_report()
             else:
-                self._tracker.stop(capture_footer=False)
+                self._tracker.stop(capture_footer=False, clear_pending_footer=True)
         return dict(self._final_state)
 
     def _handle_event(self, event: StreamEvent) -> None:

--- a/app/remote/renderer.py
+++ b/app/remote/renderer.py
@@ -451,9 +451,10 @@ class StreamRenderer:
             # report the user has been watching stream live would be
             # silently discarded before the exception propagates.
             self._finish_active_node()
-            self._tracker.stop()
             if not _interrupted:
                 self._print_report()
+            else:
+                self._tracker.stop()
         return dict(self._final_state)
 
     def _handle_event(self, event: StreamEvent) -> None:
@@ -781,6 +782,11 @@ class StreamRenderer:
     def _print_report(self) -> None:
         from app.cli.support.output import stop_display
 
+        # StreamRenderer owns its own ProgressTracker instance (not the module-level
+        # singleton used by stop_display). Stop it here so the live footer is torn
+        # down before printing the report, while still capturing a footer snapshot
+        # that the report renderer can re-print at the absolute bottom.
+        self._tracker.stop()
         stop_display()
 
         slack_message = self._final_state.get("slack_message") or self._final_state.get(

--- a/app/remote/renderer.py
+++ b/app/remote/renderer.py
@@ -782,12 +782,11 @@ class StreamRenderer:
     def _print_report(self) -> None:
         from app.cli.support.output import stop_display
 
-        # StreamRenderer owns its own ProgressTracker instance (not the module-level
-        # singleton used by stop_display). Stop it here so the live footer is torn
-        # down before printing the report, while still capturing a footer snapshot
-        # that the report renderer can re-print at the absolute bottom.
-        self._tracker.stop()
-        stop_display()
+        # StreamRenderer owns its own ProgressTracker (not the module singleton).
+        # Capture footer metadata from this tracker first; then tear down any
+        # module-level display without overwriting that snapshot.
+        self._tracker.stop(capture_footer=True)
+        stop_display(capture_footer=False)
 
         slack_message = self._final_state.get("slack_message") or self._final_state.get(
             "report", ""

--- a/app/remote/renderer.py
+++ b/app/remote/renderer.py
@@ -782,23 +782,30 @@ class StreamRenderer:
     def _print_report(self) -> None:
         from app.cli.support.output import stop_display
 
-        # StreamRenderer owns its own ProgressTracker (not the module singleton).
-        # Capture footer metadata from this tracker first; then tear down any
-        # module-level display without overwriting that snapshot.
-        self._tracker.stop(capture_footer=True)
-        stop_display(capture_footer=False)
-
         slack_message = self._final_state.get("slack_message") or self._final_state.get(
             "report", ""
         )
         root_cause_category = self._final_state.get("root_cause_category")
 
         if not slack_message:
+            # No report to print → nothing to anchor a footer below. Tear down
+            # this run's displays *without* capturing, and explicitly clear any
+            # pending snapshot so a noise-classified or zero-event investigation
+            # in a REPL session does not leak its captured phase / elapsed time
+            # into the next investigation's footer (Greptile P1 on PR #2538).
+            self._tracker.stop(capture_footer=False, clear_pending_footer=True)
+            stop_display(capture_footer=False, clear_pending_footer=True)
             if self._final_state.get("is_noise"):
                 _print_info("Alert classified as noise — no investigation needed.")
             elif self._events_received == 0:
                 _print_info("No events received from the remote agent.")
             return
+
+        # StreamRenderer owns its own ProgressTracker (not the module singleton).
+        # Capture footer metadata from this tracker first; then tear down any
+        # module-level display without overwriting that snapshot.
+        self._tracker.stop(capture_footer=True)
+        stop_display(capture_footer=False)
 
         from app.delivery.publish_findings.renderers.terminal import render_report as _render
 

--- a/app/remote/renderer.py
+++ b/app/remote/renderer.py
@@ -173,7 +173,7 @@ class _DiagnoseStreamRenderer:
 
         # Shrink the gap: stop previous display immediately before starting new one
         if self._tracker is not None:
-            self._tracker.stop()
+            self._tracker.stop(capture_footer=False)
         else:
             stop_display()
 
@@ -454,7 +454,7 @@ class StreamRenderer:
             if not _interrupted:
                 self._print_report()
             else:
-                self._tracker.stop()
+                self._tracker.stop(capture_footer=False)
         return dict(self._final_state)
 
     def _handle_event(self, event: StreamEvent) -> None:

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -281,6 +281,29 @@ def test_stop_display_clears_stale_footer_via_tracker_path(
     assert "FINDINGS" in out
 
 
+def test_capture_footer_snapshot_does_not_overwrite_existing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First capture wins so a later stop_display cannot clobber StreamRenderer metadata."""
+    monkeypatch.setattr(output, "get_output_format", lambda: "rich")
+    monkeypatch.setattr(output, "_repl_progress_active", lambda: False)
+
+    output._completed_footer_pending.snapshot = output.InvestigationFooterSnapshot(
+        phase="INVESTIGATE",
+        elapsed_total=12.0,
+        model="m",
+        mode="local",
+    )
+    tracker = output.ProgressTracker()
+    monkeypatch.setattr(output, "_tracker", tracker)
+    tracker.start("correlate_upstream")
+    output.stop_display()
+
+    snap = output._completed_footer_pending.snapshot
+    assert snap is not None
+    assert snap.phase == "INVESTIGATE"
+
+
 def test_tracker_stop_without_capture_clears_pending_footer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -297,7 +297,7 @@ def test_capture_footer_snapshot_does_not_overwrite_existing(
     tracker = output.ProgressTracker()
     monkeypatch.setattr(output, "_tracker", tracker)
     tracker.start("correlate_upstream")
-    output.stop_display()
+    output.stop_display(capture_footer=True)
 
     snap = output._completed_footer_pending.snapshot
     assert snap is not None
@@ -316,7 +316,7 @@ def test_tracker_stop_without_capture_clears_pending_footer(
     tracker.stop(capture_footer=True)
     assert output._completed_footer_pending.snapshot is not None
 
-    tracker.stop(capture_footer=False)
+    tracker.stop(capture_footer=False, clear_pending_footer=True)
     assert output._completed_footer_pending.snapshot is None
 
 

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -252,6 +252,34 @@ def test_stop_display_clears_stale_investigation_footer(
     assert "FINDINGS" in out
 
 
+def test_stop_display_clears_stale_footer_via_tracker_path(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Regression for #2117 on the ``_tracker``-owned display branch."""
+    monkeypatch.setattr(output, "get_output_format", lambda: "rich")
+    monkeypatch.setattr(output, "_repl_progress_active", lambda: False)
+    monkeypatch.setattr(output, "_tracker", None)
+    monkeypatch.setattr(output, "_active_display", None)
+    monkeypatch.setattr(output, "_live_console", None)
+
+    tracker = output.ProgressTracker()
+    monkeypatch.setattr(output, "_tracker", tracker)
+    try:
+        tracker.start("diagnose_root_cause")
+        assert tracker._display is not None
+        tracker._display._live.refresh()
+        output.stop_display()
+        print("FINDINGS: payments_etl could not be confirmed")
+    finally:
+        output.stop_display()
+
+    out = _strip_ansi(capsys.readouterr().out)
+    before_findings, _, _after = out.partition("FINDINGS")
+    assert "esc to cancel" not in before_findings
+    assert "FINDINGS" in out
+
+
 @pytest.mark.usefixtures("force_text_mode")
 def test_tracker_start_prints_node_label_in_text_mode(
     capsys: pytest.CaptureFixture[str],

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -34,6 +34,7 @@ def _isolate_output_state(monkeypatch: pytest.MonkeyPatch) -> None:
     # The module-level ``_tracker`` is a session-scoped singleton; without resetting it
     # a tracker created in an earlier test would leak its ``_rich`` flag into later ones.
     monkeypatch.setattr(output, "_tracker", None)
+    monkeypatch.setattr(output, "_pending_completed_footer", None)
     monkeypatch.setattr(output, "_stdin_watcher_suppression_depth", 0)
     monkeypatch.setattr(output, "_tool_detail_toggle_callbacks", [])
 
@@ -278,6 +279,59 @@ def test_stop_display_clears_stale_footer_via_tracker_path(
     before_findings, _, _after = out.partition("FINDINGS")
     assert "esc to cancel" not in before_findings
     assert "FINDINGS" in out
+
+
+def test_tracker_stop_preserves_footer_for_completed_render(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """StreamRenderer stops the tracker after printing; capture must happen in stop()."""
+    monkeypatch.setattr(output, "get_output_format", lambda: "rich")
+    monkeypatch.setattr(output, "_repl_progress_active", lambda: False)
+
+    tracker = output.ProgressTracker()
+    monkeypatch.setattr(output, "_tracker", tracker)
+    tracker.start("correlate_upstream")
+    tracker.stop()
+
+    output.render_completed_investigation_footer()
+
+    out = _strip_ansi(capsys.readouterr().out)
+    assert "●" in out
+    assert "CORRELATE" in out or "DIAGNOSE" in out
+    assert "ctrl+o tool details" in out
+    assert "esc to cancel" not in out
+
+
+def test_render_report_prints_completed_footer_below_report(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Footer belongs below the RCA report after investigation completes."""
+    monkeypatch.setattr(output, "get_output_format", lambda: "rich")
+    monkeypatch.setattr(output, "_repl_progress_active", lambda: False)
+
+    tracker = output.ProgressTracker()
+    monkeypatch.setattr(output, "_tracker", tracker)
+    tracker.start("correlate_upstream")
+    tracker.complete(
+        "correlate_upstream",
+        output.ProgressEvent(node_name="correlate_upstream", elapsed_ms=1),
+    )
+
+    from app.delivery.publish_findings.renderers.terminal import render_report
+
+    render_report("REPORT HEADLINE\n\n  Findings\n    · one")
+
+    out = _strip_ansi(capsys.readouterr().out)
+    report_pos = out.find("REPORT HEADLINE")
+    footer_pos = out.rfind("●")
+    assert report_pos >= 0
+    assert footer_pos > report_pos
+    after_report = out[report_pos:footer_pos]
+    assert "esc to cancel" not in after_report
+    assert "CORRELATE" in out[footer_pos:] or "DIAGNOSE" in out[footer_pos:]
+    assert "ctrl+o tool details" in out[footer_pos:]
 
 
 @pytest.mark.usefixtures("force_text_mode")

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -227,6 +227,31 @@ async def test_repl_safe_progress_scope_propagates_to_asyncio_thread() -> None:
         assert await asyncio.to_thread(output._repl_progress_active) is True
 
 
+def test_stop_display_clears_stale_investigation_footer(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Regression for #2117: live phase footer must not persist above the RCA report."""
+    monkeypatch.setattr(output, "get_output_format", lambda: "rich")
+    monkeypatch.setattr(output, "_repl_progress_active", lambda: False)
+    monkeypatch.setattr(output, "_active_display", None)
+    monkeypatch.setattr(output, "_live_console", None)
+
+    display = output._EventLogDisplay()
+    try:
+        display.step_start("diagnose_root_cause")
+        display._live.refresh()
+        output.stop_display()
+        print("FINDINGS: payments_etl could not be confirmed")
+    finally:
+        output.stop_display()
+
+    out = _strip_ansi(capsys.readouterr().out)
+    before_findings, _, _after = out.partition("FINDINGS")
+    assert "esc to cancel" not in before_findings
+    assert "FINDINGS" in out
+
+
 @pytest.mark.usefixtures("force_text_mode")
 def test_tracker_start_prints_node_label_in_text_mode(
     capsys: pytest.CaptureFixture[str],

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -307,7 +307,7 @@ def test_capture_footer_snapshot_does_not_overwrite_existing(
 def test_tracker_stop_without_capture_clears_pending_footer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cancelled runs must not leave a footer snapshot for the next investigation."""
+    """Cancelled runs explicitly opt in to clearing the pending snapshot."""
     monkeypatch.setattr(output, "get_output_format", lambda: "rich")
     monkeypatch.setattr(output, "_repl_progress_active", lambda: False)
 
@@ -318,6 +318,32 @@ def test_tracker_stop_without_capture_clears_pending_footer(
 
     tracker.stop(capture_footer=False, clear_pending_footer=True)
     assert output._completed_footer_pending.snapshot is None
+
+
+def test_stop_display_without_capture_does_not_clear_other_tracker_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tearing down a *different* tracker via stop_display must not silently
+    erase the pending snapshot owned by the caller (REPL two-tracker bug)."""
+    monkeypatch.setattr(output, "get_output_format", lambda: "rich")
+    monkeypatch.setattr(output, "_repl_progress_active", lambda: False)
+
+    output._completed_footer_pending.snapshot = output.InvestigationFooterSnapshot(
+        phase="CORRELATE_UP",
+        elapsed_total=5.5,
+        model="m",
+        mode="local",
+    )
+
+    module_tracker = output.ProgressTracker()
+    monkeypatch.setattr(output, "_tracker", module_tracker)
+    module_tracker.start("investigation_agent")
+
+    output.stop_display(capture_footer=False)
+
+    snap = output._completed_footer_pending.snapshot
+    assert snap is not None, "stop_display(capture_footer=False) must preserve pending snapshot"
+    assert snap.phase == "CORRELATE_UP"
 
 
 def test_tracker_stop_preserves_footer_for_completed_render(

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -34,7 +34,7 @@ def _isolate_output_state(monkeypatch: pytest.MonkeyPatch) -> None:
     # The module-level ``_tracker`` is a session-scoped singleton; without resetting it
     # a tracker created in an earlier test would leak its ``_rich`` flag into later ones.
     monkeypatch.setattr(output, "_tracker", None)
-    monkeypatch.setattr(output, "_pending_completed_footer", None)
+    monkeypatch.setattr(output, "_completed_footer_pending", output._CompletedFooterPending())
     monkeypatch.setattr(output, "_stdin_watcher_suppression_depth", 0)
     monkeypatch.setattr(output, "_tool_detail_toggle_callbacks", [])
 
@@ -281,6 +281,22 @@ def test_stop_display_clears_stale_footer_via_tracker_path(
     assert "FINDINGS" in out
 
 
+def test_tracker_stop_without_capture_clears_pending_footer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelled runs must not leave a footer snapshot for the next investigation."""
+    monkeypatch.setattr(output, "get_output_format", lambda: "rich")
+    monkeypatch.setattr(output, "_repl_progress_active", lambda: False)
+
+    tracker = output.ProgressTracker()
+    tracker.start("correlate_upstream")
+    tracker.stop(capture_footer=True)
+    assert output._completed_footer_pending.snapshot is not None
+
+    tracker.stop(capture_footer=False)
+    assert output._completed_footer_pending.snapshot is None
+
+
 def test_tracker_stop_preserves_footer_for_completed_render(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -314,10 +330,7 @@ def test_render_report_prints_completed_footer_below_report(
     tracker = output.ProgressTracker()
     monkeypatch.setattr(output, "_tracker", tracker)
     tracker.start("correlate_upstream")
-    tracker.complete(
-        "correlate_upstream",
-        output.ProgressEvent(node_name="correlate_upstream", elapsed_ms=1),
-    )
+    tracker.complete("correlate_upstream")
 
     from app.delivery.publish_findings.renderers.terminal import render_report
 

--- a/tests/remote/test_renderer.py
+++ b/tests/remote/test_renderer.py
@@ -472,6 +472,31 @@ class TestStreamRendererCleanupOnException:
 
         assert output_mod._completed_footer_pending.snapshot is None
 
+    @patch("app.remote.renderer.Live")
+    @patch("app.cli.support.output._EventLogDisplay")
+    @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "rich"})
+    def test_print_report_preserves_stream_footer_when_singleton_display_active(
+        self, _mock_display, _mock_live
+    ) -> None:
+        """stop_display(capture_footer=False) must not clear StreamRenderer snapshot."""
+        from app.cli.support import output as output_mod
+
+        renderer = StreamRenderer(local=True)
+        renderer._tracker.start("correlate_upstream")
+
+        # Simulate an independent module-level tracker that still has a display.
+        output_mod._tracker = output_mod.ProgressTracker()
+        output_mod._tracker.start("investigation_agent")
+        renderer._final_state = {
+            "slack_message": "RCA REPORT HEADLINE\n\n  Findings\n    · one",
+        }
+
+        renderer._print_report()
+
+        # Footer renderer consumes the captured snapshot; it should not be dropped
+        # before rendering due to the singleton tracker shutdown.
+        assert output_mod._completed_footer_pending.snapshot is None
+
     @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "text"})
     def test_print_report_skipped_on_keyboard_interrupt(self) -> None:
         """_print_report must NOT run when the user presses Ctrl+C."""

--- a/tests/remote/test_renderer.py
+++ b/tests/remote/test_renderer.py
@@ -476,15 +476,21 @@ class TestStreamRendererCleanupOnException:
     @patch("app.cli.support.output._EventLogDisplay")
     @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "rich"})
     def test_print_report_preserves_stream_footer_when_singleton_display_active(
-        self, _mock_display, _mock_live
+        self, _mock_display, _mock_live, capfd: pytest.CaptureFixture[str]
     ) -> None:
-        """stop_display(capture_footer=False) must not clear StreamRenderer snapshot."""
+        """REPL scenario: stop_display(capture_footer=False) must not erase the snapshot
+        StreamRenderer's tracker just captured. Verify the footer actually renders below
+        the report rather than only asserting snapshot is None (which the cleared-and-dropped
+        bug path would also satisfy).
+        """
         from app.cli.support import output as output_mod
 
         renderer = StreamRenderer(local=True)
         renderer._tracker.start("correlate_upstream")
 
-        # Simulate an independent module-level tracker that still has a display.
+        # Simulate an independent module-level tracker that still has a display
+        # (this mirrors the REPL keeping a singleton tracker alive while
+        # StreamRenderer owns its own tracker for the current investigation).
         output_mod._tracker = output_mod.ProgressTracker()
         output_mod._tracker.start("investigation_agent")
         renderer._final_state = {
@@ -493,8 +499,19 @@ class TestStreamRendererCleanupOnException:
 
         renderer._print_report()
 
-        # Footer renderer consumes the captured snapshot; it should not be dropped
-        # before rendering due to the singleton tracker shutdown.
+        out, _ = capfd.readouterr()
+        report_pos = out.find("RCA REPORT HEADLINE")
+        footer_pos = out.rfind("●")
+        assert report_pos >= 0, "report body must be rendered"
+        assert footer_pos > report_pos, (
+            "completed footer must be rendered AFTER the report — "
+            "if this fails, the module singleton tracker erased the captured snapshot"
+        )
+        assert "ctrl+o tool details" in out[footer_pos:]
+        assert "esc to cancel" not in out[report_pos:footer_pos]
+        # Snapshot is consumed (set to None) by render_completed_investigation_footer
+        # only as a side effect of *rendering* — combined with the footer text check
+        # above, that closes the false-positive gap from the previous assertion.
         assert output_mod._completed_footer_pending.snapshot is None
 
     @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "text"})

--- a/tests/remote/test_renderer.py
+++ b/tests/remote/test_renderer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterator
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -27,6 +28,31 @@ def _make_event(
         kind=kind,
         tags=tags or [],
     )
+
+
+def _stub_footer_fields(
+    display: Any,
+    *,
+    phase: str = "INVESTIGATE",
+    model: str = "test-model",
+    mode: str = "remote",
+) -> None:
+    """Pin a mocked ``_EventLogDisplay``'s footer-related fields to short strings.
+
+    ``_capture_completed_footer_snapshot`` reads ``_current_phase``, ``_t0``,
+    ``_model`` and ``_mode`` straight off the display. When the test patches
+    ``_EventLogDisplay`` with a ``MagicMock`` and leaves these attributes as
+    auto-spec'd ``MagicMock`` children, their reprs contain the platform's
+    object IDs and Rich wraps the resulting footer line on narrow terminals
+    (capfd defaults to 80 columns). That wrap silently broke contiguous-text
+    assertions like ``"ctrl+o tool details" in footer_slice``.
+    """
+    import time as _time
+
+    display._current_phase = phase
+    display._t0 = _time.monotonic()
+    display._model = model
+    display._mode = mode
 
 
 def _investigation_events() -> Iterator[StreamEvent]:
@@ -487,6 +513,16 @@ class TestStreamRendererCleanupOnException:
 
         renderer = StreamRenderer(local=True)
         renderer._tracker.start("correlate_upstream")
+        # Pin the mocked display's footer fields to deterministic short strings
+        # so the rendered footer line stays short enough to fit on one row at
+        # the default 80-column console width that pytest's capfd uses. Without
+        # this pin, the MagicMock attribute reprs (containing long platform-
+        # specific object IDs) push "ctrl+o tool details" off the right edge
+        # and Rich wraps it onto its own line, breaking the contiguous-text
+        # assertion below. Patching ``_EventLogDisplay`` makes every constructor
+        # call return the *same* MagicMock instance, so this single stub also
+        # pins the module-singleton tracker's display fields below.
+        _stub_footer_fields(renderer._tracker._display)
 
         # Simulate an independent module-level tracker that still has a display
         # (this mirrors the REPL keeping a singleton tracker alive while
@@ -512,6 +548,59 @@ class TestStreamRendererCleanupOnException:
         # Snapshot is consumed (set to None) by render_completed_investigation_footer
         # only as a side effect of *rendering* — combined with the footer text check
         # above, that closes the false-positive gap from the previous assertion.
+        assert output_mod._completed_footer_pending.snapshot is None
+
+    @patch("app.remote.renderer.Live")
+    @patch("app.cli.support.output._EventLogDisplay")
+    @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "rich"})
+    def test_print_report_noise_alert_does_not_leak_footer_to_next_run(
+        self, _mock_display, _mock_live
+    ) -> None:
+        """REPL regression: a noise-classified investigation must not leave a
+        stale footer snapshot that the *next* investigation's report would
+        carry — the first-capture-wins guard in
+        ``_capture_completed_footer_snapshot`` would otherwise pin the wrong
+        phase / elapsed_time below a real RCA report (Greptile P1 on PR #2538).
+        """
+        from app.cli.support import output as output_mod
+
+        renderer = StreamRenderer(local=True)
+        renderer._tracker.start("extract_alert")
+        _stub_footer_fields(renderer._tracker._display, phase="LOAD")
+
+        # First investigation: classified as noise → no slack_message → early
+        # return path inside ``_print_report``. Prior to the fix this path
+        # still captured a snapshot and left it in ``_completed_footer_pending``.
+        renderer._final_state = {"is_noise": True, "alert_name": "noise-alert"}
+        renderer._print_report()
+
+        assert output_mod._completed_footer_pending.snapshot is None, (
+            "noise-classified early return must not leave a stale footer "
+            "snapshot for the next investigation to inherit"
+        )
+
+    @patch("app.remote.renderer.Live")
+    @patch("app.cli.support.output._EventLogDisplay")
+    @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "rich"})
+    def test_print_report_no_events_does_not_leak_footer_to_next_run(
+        self, _mock_display, _mock_live
+    ) -> None:
+        """REPL regression: a zero-events investigation must also clear its
+        own pending snapshot — sibling case to the noise-alert path. Together
+        these two paths close the early-return leak flagged by Greptile P1.
+        """
+        from app.cli.support import output as output_mod
+
+        renderer = StreamRenderer(local=True)
+        renderer._tracker.start("investigation_agent")
+        _stub_footer_fields(renderer._tracker._display)
+        # No slack_message, no is_noise — falls into the "No events received"
+        # branch. The bug was that this branch returned without clearing the
+        # snapshot captured at the top of ``_print_report``.
+        renderer._final_state = {}
+
+        renderer._print_report()
+
         assert output_mod._completed_footer_pending.snapshot is None
 
     @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "text"})

--- a/tests/remote/test_renderer.py
+++ b/tests/remote/test_renderer.py
@@ -456,9 +456,7 @@ class TestStreamRendererCleanupOnException:
     @patch("app.remote.renderer.Live")
     @patch("app.cli.support.output._EventLogDisplay")
     @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "rich"})
-    def test_interrupt_clears_pending_footer_snapshot(
-        self, _mock_display, _mock_live
-    ) -> None:
+    def test_interrupt_clears_pending_footer_snapshot(self, _mock_display, _mock_live) -> None:
         """Regression: Ctrl+C must not leave a footer snapshot for the next RCA."""
         from app.cli.support import output as output_mod
 

--- a/tests/remote/test_renderer.py
+++ b/tests/remote/test_renderer.py
@@ -453,6 +453,27 @@ class TestStreamRendererCleanupOnException:
             "accumulated state from before the failure must be retained"
         )
 
+    @patch("app.remote.renderer.Live")
+    @patch("app.cli.support.output._EventLogDisplay")
+    @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "rich"})
+    def test_interrupt_clears_pending_footer_snapshot(
+        self, _mock_display, _mock_live
+    ) -> None:
+        """Regression: Ctrl+C must not leave a footer snapshot for the next RCA."""
+        from app.cli.support import output as output_mod
+
+        renderer = StreamRenderer(local=True)
+        renderer._tracker.start("investigation_agent")
+
+        def stream_raises_keyboard_interrupt() -> Iterator[StreamEvent]:
+            yield _make_event("metadata", data={"run_id": "r-ki-footer"})
+            raise KeyboardInterrupt
+
+        with pytest.raises(KeyboardInterrupt):
+            renderer.render_stream(stream_raises_keyboard_interrupt())
+
+        assert output_mod._completed_footer_pending.snapshot is None
+
     @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "text"})
     def test_print_report_skipped_on_keyboard_interrupt(self) -> None:
         """_print_report must NOT run when the user presses Ctrl+C."""

--- a/tests/remote/test_renderer.py
+++ b/tests/remote/test_renderer.py
@@ -482,6 +482,28 @@ class TestStreamRendererCleanupOnException:
         )
         assert renderer.final_state.get("alert_name") == "interrupted-alert"
 
+    @patch("app.remote.renderer.Live")
+    @patch("app.cli.support.output._EventLogDisplay")
+    @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "rich"})
+    def test_render_stream_prints_completed_footer_below_report(
+        self, _mock_display, _mock_live, capfd: pytest.CaptureFixture[str]
+    ) -> None:
+        """Regression for #2117: footer must appear after the report, not be dropped."""
+        renderer = StreamRenderer(local=True)
+        renderer._tracker.start("correlate_upstream")
+        renderer._final_state = {
+            "slack_message": "RCA REPORT HEADLINE\n\n  Findings\n    · one",
+        }
+
+        renderer.render_stream(iter([_make_event("end")]))
+
+        out, _ = capfd.readouterr()
+        report_pos = out.find("RCA REPORT HEADLINE")
+        footer_pos = out.rfind("●")
+        assert report_pos >= 0
+        assert footer_pos > report_pos
+        assert "esc to cancel" not in out[report_pos:footer_pos]
+
 
 def _diagnose_streaming_events() -> Iterator[StreamEvent]:
     """Simulate the diagnose node emitting token deltas before chain end."""


### PR DESCRIPTION
/fix #2117 
This pull request improves the handling and cleanup of the live phase footer in the CLI output, ensuring that no stale UI elements (like the "esc to cancel" line) remain visible above the final RCA report. It also adds a regression test to prevent this issue from reoccurring.

**Live display cleanup improvements:**

* Updated `stop_display()` in `app/cli/support/output.py` to ensure the live region and any active phase footers are properly stopped and cleared before printing the final report, including stopping the toggle watcher and clearing the live console. [[1]](diffhunk://#diff-cd2ca604c030dd850ba3a1558e52a13a6fca62e77936c8f9314ffe19fd9bb354L282-L286) [[2]](diffhunk://#diff-cd2ca604c030dd850ba3a1558e52a13a6fca62e77936c8f9314ffe19fd9bb354R665-R668)
* Set the `transient=True` option on the live display in `_EventLogDisplay` to automatically remove the live region when stopping, preventing stale UI lines.
* Ensured `stop_display()` is called in the CLI delivery flow before generating the final report in `app/delivery/__init__.py`.

**Testing and regression coverage:**

* Added a regression test `test_stop_display_clears_stale_investigation_footer` to verify that the live phase footer does not persist above the RCA report output.

before
<img width="592" height="428" alt="Screenshot 2026-05-26 at 7 10 12 PM" src="https://github.com/user-attachments/assets/5911e514-7fff-4741-811b-47df1d31e54b" />

after
<img width="913" height="600" alt="Screenshot 2026-05-26 at 10 14 09 PM" src="https://github.com/user-attachments/assets/0b3deeff-ddd1-4ffd-b033-9ee24bb978d2" />
