### PR TITLE
fix(cli): make integrations setup accept telegram, whatsapp, twilio

### DIFF
--- a/app/cli/support/constants.py
+++ b/app/cli/support/constants.py
@@ -6,10 +6,12 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     MANAGED_INTEGRATION_SERVICES: tuple[str, ...]
+    SETUP_SERVICES: tuple[str, ...]
     VERIFY_SERVICES: tuple[str, ...]
 
-# MANAGED_INTEGRATION_SERVICES and VERIFY_SERVICES are PEP 562 lazy module
-# attributes resolved by `__getattr__` below; ruff's F822 check can't see them.
+# MANAGED_INTEGRATION_SERVICES, SETUP_SERVICES and VERIFY_SERVICES are PEP 562
+# lazy module attributes resolved by `__getattr__` below; ruff's F822 check
+# can't see them.
 __all__ = (
     "ALERT_TEMPLATE_CHOICES",
     "MANAGED_INTEGRATION_SERVICES",
@@ -36,47 +38,28 @@ SAMPLE_ALERT_OPTIONS: tuple[tuple[str, str], ...] = (
     ("splunk", "Splunk - payments service error spike"),
 )
 
-SETUP_SERVICES: tuple[str, ...] = (
-    "alertmanager",
-    "aws",
-    "betterstack",
-    "coralogix",
-    "datadog",
-    "discord",
-    "grafana",
-    "github",
-    "gitlab",
-    "honeycomb",
-    "incident_io",
-    "mariadb",
-    "mongodb",
-    "mongodb_atlas",
-    "mysql",
-    "openclaw",
-    "opensearch",
-    "postgresql",
-    "rabbitmq",
-    "rds",
-    "sentry",
-    "slack",
-    "tracer",
-    "vercel",
-)
-
 
 def __getattr__(name: str) -> tuple[str, ...]:
-    # VERIFY_SERVICES and MANAGED_INTEGRATION_SERVICES are sourced from the
-    # runtime integration registry so the CLI's positional-arg `click.Choice`
-    # validators stay in sync with what cmd_verify can actually dispatch.
-    # Eagerly importing `app.integrations.registry` here creates a circular
-    # import (registry -> _verification_adapters -> github_mcp -> app.cli.*).
-    # Deferring to first access lets `app.cli` finish bootstrapping. See #1973.
+    # SETUP_SERVICES, VERIFY_SERVICES and MANAGED_INTEGRATION_SERVICES are
+    # sourced from the runtime integration registry so the CLI's positional-arg
+    # `click.Choice` validators stay in sync with what cmd_setup / cmd_verify
+    # can actually dispatch. Eagerly importing `app.integrations.registry` here
+    # creates a circular import (registry -> _verification_adapters ->
+    # github_mcp -> app.cli.*). Deferring to first access lets `app.cli` finish
+    # bootstrapping. See #1973 (verify) and #2537 (setup).
+    if name == "SETUP_SERVICES":
+        from app.integrations.registry import SUPPORTED_SETUP_SERVICES
+
+        return SUPPORTED_SETUP_SERVICES
     if name == "VERIFY_SERVICES":
         from app.integrations.registry import SUPPORTED_VERIFY_SERVICES
 
         return SUPPORTED_VERIFY_SERVICES
     if name == "MANAGED_INTEGRATION_SERVICES":
-        from app.integrations.registry import SUPPORTED_VERIFY_SERVICES
+        from app.integrations.registry import (
+            SUPPORTED_SETUP_SERVICES,
+            SUPPORTED_VERIFY_SERVICES,
+        )
 
-        return tuple(sorted(set(SETUP_SERVICES) | set(SUPPORTED_VERIFY_SERVICES)))
+        return tuple(sorted(set(SUPPORTED_SETUP_SERVICES) | set(SUPPORTED_VERIFY_SERVICES)))
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/cli/test_integrations.py
+++ b/tests/cli/test_integrations.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from app.cli.__main__ import cli
-from app.cli.support.constants import VERIFY_SERVICES
+from app.cli.support.constants import SETUP_SERVICES, VERIFY_SERVICES
 from app.integrations.cli import _HANDLERS, _setup_openclaw, _setup_vercel
 
 
@@ -147,6 +147,60 @@ def test_setup_openclaw_saves_credentials(monkeypatch) -> None:
     ]
 
 
+def test_integrations_setup_accepts_telegram() -> None:
+    runner = CliRunner()
+
+    with (
+        patch("app.cli.commands.integrations.capture_integration_setup_started"),
+        patch("app.cli.commands.integrations.capture_integration_setup_completed"),
+        patch("app.cli.commands.integrations.capture_integration_verified"),
+        patch("app.integrations.cli.cmd_setup") as mock_setup,
+        patch("app.integrations.cli.cmd_verify", return_value=0) as mock_verify,
+    ):
+        mock_setup.return_value = "telegram"
+        result = runner.invoke(cli, ["integrations", "setup", "telegram"])
+
+    assert result.exit_code == 0
+    mock_setup.assert_called_once_with("telegram")
+    mock_verify.assert_called_once_with("telegram")
+
+
+def test_integrations_setup_accepts_whatsapp() -> None:
+    runner = CliRunner()
+
+    with (
+        patch("app.cli.commands.integrations.capture_integration_setup_started"),
+        patch("app.cli.commands.integrations.capture_integration_setup_completed"),
+        patch("app.cli.commands.integrations.capture_integration_verified"),
+        patch("app.integrations.cli.cmd_setup") as mock_setup,
+        patch("app.integrations.cli.cmd_verify", return_value=0) as mock_verify,
+    ):
+        mock_setup.return_value = "whatsapp"
+        result = runner.invoke(cli, ["integrations", "setup", "whatsapp"])
+
+    assert result.exit_code == 0
+    mock_setup.assert_called_once_with("whatsapp")
+    mock_verify.assert_called_once_with("whatsapp")
+
+
+def test_integrations_setup_accepts_twilio() -> None:
+    runner = CliRunner()
+
+    with (
+        patch("app.cli.commands.integrations.capture_integration_setup_started"),
+        patch("app.cli.commands.integrations.capture_integration_setup_completed"),
+        patch("app.cli.commands.integrations.capture_integration_verified"),
+        patch("app.integrations.cli.cmd_setup") as mock_setup,
+        patch("app.integrations.cli.cmd_verify", return_value=0) as mock_verify,
+    ):
+        mock_setup.return_value = "twilio"
+        result = runner.invoke(cli, ["integrations", "setup", "twilio"])
+
+    assert result.exit_code == 0
+    mock_setup.assert_called_once_with("twilio")
+    mock_verify.assert_called_once_with("twilio")
+
+
 def test_integrations_setup_skips_auto_verify_for_unverifiable_service() -> None:
     runner = CliRunner()
 
@@ -256,3 +310,12 @@ def test_verify_services_includes_previously_missing_integrations() -> None:
         "supabase",
     }
     assert previously_missing <= set(VERIFY_SERVICES)
+
+
+def test_setup_services_includes_previously_missing_integrations() -> None:
+    # #2537: telegram, whatsapp and twilio had handlers and registry entries
+    # but were rejected by Click because the CLI's hardcoded SETUP_SERVICES
+    # tuple had drifted. Anchor them here so a revert to a hardcoded tuple —
+    # or accidental removal from the registry — fails this test loudly.
+    previously_missing = {"telegram", "twilio", "whatsapp"}
+    assert previously_missing <= set(SETUP_SERVICES)

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -42,6 +42,15 @@ def test_registry_supported_lists_are_derived_from_specs() -> None:
     assert set(VERIFIER_REGISTRY) == set(SUPPORTED_VERIFY_SERVICES)
 
 
+def test_every_setup_spec_has_handler() -> None:
+    # #2537: a spec with `setup_order` but no matching `_HANDLERS` entry lets
+    # Click accept a service that cmd_setup cannot dispatch. Anchor the
+    # inverse-drift here.
+    from app.integrations.cli import _HANDLERS
+
+    assert set(SUPPORTED_SETUP_SERVICES) <= set(_HANDLERS)
+
+
 def test_registry_preserves_aliases_and_special_case_buckets() -> None:
     assert service_key("github_mcp") == "github"
     assert service_key("carologix") == "coralogix"


### PR DESCRIPTION
Fixes #2537

#### Describe the changes you have made in this PR -

`opensre integrations setup telegram` (and `whatsapp`, `twilio`) was rejected by `click.Choice` before the handler could run. Root cause: `SETUP_SERVICES` in `app/cli/support/constants.py` was a hardcoded tuple that had drifted from the runtime registry. I derived it from `SUPPORTED_SETUP_SERVICES` via the same PEP 562 `__getattr__` shim that fixed the `verify` side in #1973, so the click positional choices match what `cmd_setup` can dispatch by construction.

Regression coverage:
- `tests/cli/test_integrations.py`: CLI acceptance tests for the three services plus a `previously_missing` anchor mirroring the existing `test_verify_services_includes_previously_missing_integrations`.
- `tests/integrations/test_registry.py`: invariant `set(SUPPORTED_SETUP_SERVICES) <= set(_HANDLERS)` so any future spec declaring `setup_order` must also register a handler.

Side-effects of removing the hardcoded list:
- `azure_sql` and `signoz` (handlers and `setup_order` already present, but unreachable via the positional command) become reachable — siblings of the same drift.
- `rabbitmq` is no longer advertised in `--help`: it never had a handler in `_HANDLERS`, so the previous behaviour was a false advertisement followed by a `"Usage: setup ..."` death one layer deeper.

### Demo/Screenshot for feature changes and bug fixes -

**Before** — parent commit `8bdbc9bd`. `click.Choice` rejects `telegram` (exit 2):

![before](https://vhs.charm.sh/vhs-1PhM8MlIHD6hS8WGSXMOiJ.gif)

**After** — fix branch. Telegram appears in the choices and the command reaches the handler prompt:

![after](https://vhs.charm.sh/vhs-YfQagIHIeY2IgQCN2B5Gs.gif)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is structural: three registries must agree — the click positional choices (`SETUP_SERVICES` in `app/cli/support/constants.py`), the dispatcher (`_HANDLERS` in `app/integrations/cli.py`), and the registry-derived list (`SUPPORTED_SETUP_SERVICES` from `INTEGRATION_SPECS`). The first was hand-maintained and had drifted. The same shape of bug was already fixed for the verify branch in #1973 by replacing the hardcoded tuple with a PEP 562 `__getattr__` shim that lazily imports the registry-derived list (lazy because eager import creates a circular dependency through `_verification_adapters → github_mcp → app.cli.*`). I followed that pattern verbatim for `SETUP_SERVICES`, which keeps the click validator and the runtime dispatcher consistent by construction.

I considered two alternatives:
- Add the three names to the hardcoded tuple. That is what produced the bug; the next addition would re-introduce it.
- Intersect at the click layer (`SETUP_SERVICES = SUPPORTED_SETUP_SERVICES ∩ _HANDLERS`). `VERIFY_SERVICES` resolves to `SUPPORTED_VERIFY_SERVICES` directly; asymmetry between the two click validators would be confusing, and a registry invariant test is cleaner than an intersection silently swallowing handler-less specs.

The new `test_every_setup_spec_has_handler` enforces that invariant. Together with the CLI acceptance tests and the `previously_missing` anchor (mirroring the one #1973 added for verify), the three registries can drift again only if the regression anchors are also reverted.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
