### PR TITLE
fix(repl): blank prompt prefix during suppressed-spinner dispatch (#2…

### DIFF
--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -94,6 +94,43 @@ def _contains_cpr_sequence(text: str | None) -> bool:
     return bool(text and _CPR_SEQUENCE_RE.search(text))
 
 
+def _build_prompt_message(
+    *,
+    session: ReplSession,
+    state: ReplState,
+    spinner: SpinnerState,
+) -> ANSI:
+    """Build the prompt message shown above the cursor line each refresh.
+
+    The first row is one of three things, in priority order:
+
+    1. The pending confirmation question — replaces the prefix when the runtime
+       is awaiting a y/N answer.
+    2. The streaming spinner (``pondering…``) — drawn while the REPL owns the
+       footer for an ordinary turn.
+    3. The idle hint (``/ for commands  ·  ↑↓ history``) — drawn only when no
+       dispatch is in flight.
+
+    During an in-flight dispatch where the spinner has been suppressed (because
+    a nested renderer such as the Rich Live investigation footer or the
+    append-only progress display now owns the bottom of the terminal) the row
+    is left blank rather than falling back to the idle hint.  Keeping the slot
+    empty stops the prompt from redrawing shortcut text on every refresh
+    cycle, which otherwise fights the investigation footer for the same row
+    and produces a visible flash.
+    """
+    base = _prompt_surface._prompt_message(session).value
+    if state.is_awaiting_confirmation():
+        return ANSI(f"{state.confirm_prompt_text}\n{base}")
+    if spinner.streaming:
+        prefix = spinner.inline_spinner_ansi()
+    elif state.is_dispatch_running():
+        prefix = ""
+    else:
+        prefix = spinner.idle_hint_ansi()
+    return ANSI(f"{prefix}\n{base}")
+
+
 class StreamingConsole(Console):
     """Console adapter for streaming progress + cancellation checks."""
 
@@ -286,12 +323,7 @@ async def run_interactive(
             state.queue.task_done()
 
     def _message_with_spinner() -> ANSI:
-        base = _prompt_surface._prompt_message(session).value
-        if state.is_awaiting_confirmation():
-            confirm_text = state.confirm_prompt_text
-            return ANSI(f"{confirm_text}\n{base}")
-        prefix = spinner.inline_spinner_ansi() or spinner.idle_hint_ansi()
-        return ANSI(f"{prefix}\n{base}")
+        return _build_prompt_message(session=session, state=state, spinner=spinner)
 
     processor_task = asyncio.create_task(_processor())
     alert_watcher_task = asyncio.create_task(_alert_watcher())
@@ -398,4 +430,4 @@ async def run_interactive(
             log.debug("Alert watcher shutdown raised exception: %s", exc)
 
 
-__all__ = ["StreamingConsole", "run_interactive"]
+__all__ = ["StreamingConsole", "_build_prompt_message", "run_interactive"]

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -102,22 +102,20 @@ def _build_prompt_message(
 ) -> ANSI:
     """Build the prompt message shown above the cursor line each refresh.
 
-    The first row is one of three things, in priority order:
+    The first row is one of four things, in priority order:
 
     1. The pending confirmation question — replaces the prefix when the runtime
        is awaiting a y/N answer.
     2. The streaming spinner (``pondering…``) — drawn while the REPL owns the
        footer for an ordinary turn.
-    3. The idle hint (``/ for commands  ·  ↑↓ history``) — drawn only when no
+    3. A blank row — drawn when a dispatch is in flight but the spinner has
+       been suppressed because a nested renderer (the Rich Live investigation
+       footer or the append-only progress display) now owns the bottom of the
+       terminal.  Keeping the slot empty stops the prompt from redrawing
+       shortcut text on every refresh cycle, which otherwise fights the
+       investigation footer for the same row and produces a visible flash.
+    4. The idle hint (``/ for commands  ·  ↑↓ history``) — drawn only when no
        dispatch is in flight.
-
-    During an in-flight dispatch where the spinner has been suppressed (because
-    a nested renderer such as the Rich Live investigation footer or the
-    append-only progress display now owns the bottom of the terminal) the row
-    is left blank rather than falling back to the idle hint.  Keeping the slot
-    empty stops the prompt from redrawing shortcut text on every refresh
-    cycle, which otherwise fights the investigation footer for the same row
-    and produces a visible flash.
     """
     base = _prompt_surface._prompt_message(session).value
     if state.is_awaiting_confirmation():
@@ -430,4 +428,4 @@ async def run_interactive(
             log.debug("Alert watcher shutdown raised exception: %s", exc)
 
 
-__all__ = ["StreamingConsole", "_build_prompt_message", "run_interactive"]
+__all__ = ["StreamingConsole", "run_interactive"]

--- a/tests/cli/interactive_shell/test_terminal_runtime.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import io
 import re
 import threading
@@ -901,6 +902,132 @@ def _extract_glyph(ansi_text: str, frames: tuple[str, ...]) -> str:
         if g in plain:
             return g
     return ""
+
+
+# ── Prompt-message composition tests ─────────────────────────────────────────
+
+
+class TestBuildPromptMessage:
+    """``_build_prompt_message`` decides the prefix row shown above the prompt
+    rule on every prompt-toolkit refresh.  When a nested live renderer (the
+    Rich Live investigation footer or the append-only progress display) owns
+    the bottom of the terminal during a dispatch, the prefix must stay blank
+    so the prompt does not flash shortcut text against the footer on every
+    refresh cycle.  Regression cover for #2116.
+    """
+
+    def _build(
+        self,
+        *,
+        streaming: bool = False,
+        dispatch_running: bool = False,
+        awaiting_confirmation: bool = False,
+        confirm_text: str = "",
+    ) -> str:
+        spinner = loop_state.SpinnerState()
+        if streaming:
+            spinner.start()
+        state = loop_state.ReplState()
+        if dispatch_running:
+
+            async def _scenario() -> str:
+                async def _slow() -> None:
+                    await asyncio.sleep(0.5)
+
+                state.current_task = asyncio.create_task(_slow())
+                try:
+                    if awaiting_confirmation:
+                        state.begin_confirmation(threading.Event(), confirm_text)
+                    rendered = loop_module._build_prompt_message(
+                        session=ReplSession(),
+                        state=state,
+                        spinner=spinner,
+                    ).value
+                finally:
+                    state.current_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await state.current_task
+                return rendered
+
+            return asyncio.run(_scenario())
+        if awaiting_confirmation:
+            state.begin_confirmation(threading.Event(), confirm_text)
+        return loop_module._build_prompt_message(
+            session=ReplSession(),
+            state=state,
+            spinner=spinner,
+        ).value
+
+    def test_idle_shows_idle_hint_prefix(self) -> None:
+        rendered = self._build()
+        assert "/ for commands" in _strip_ansi(rendered)
+
+    def test_streaming_shows_spinner_prefix(self) -> None:
+        rendered = self._build(streaming=True)
+        plain = _strip_ansi(rendered)
+        # The verb varies per turn — accept any.
+        assert any(f"{verb}…" in plain for verb in loop_state.SpinnerState._THINKING_VERBS)
+        # Idle hint must not leak into the streaming prefix.
+        assert "/ for commands" not in plain
+
+    def test_dispatch_running_with_spinner_keeps_spinner(self) -> None:
+        """While a dispatch owns the spinner (no nested live renderer has
+        suppressed it yet), the prefix continues to animate the verb."""
+        rendered = self._build(streaming=True, dispatch_running=True)
+        plain = _strip_ansi(rendered)
+        assert any(f"{verb}…" in plain for verb in loop_state.SpinnerState._THINKING_VERBS)
+
+    def test_dispatch_running_with_suppressed_spinner_uses_blank_prefix(self) -> None:
+        """Regression for #2116: when ``suppress_prompt_spinner`` has stopped
+        the REPL spinner because a nested live renderer now owns the footer,
+        the idle hint must NOT come back — it would flash against the
+        investigation footer on every prompt refresh.  The prefix slot is
+        kept blank instead, while the rule + cursor line stay where the user
+        expects them.
+        """
+        rendered = self._build(streaming=False, dispatch_running=True)
+        plain = _strip_ansi(rendered)
+        # The shortcut hint is the specific thing that would flash; ensure
+        # it's gone from the prefix slot.
+        assert "/ for commands" not in plain
+        assert "↑↓ history" not in plain
+        # Streaming spinner verbs must not appear either — the spinner is
+        # suppressed in this state, and falling back to it would re-introduce
+        # the same flashing footer overlap that the suppression was meant to
+        # prevent.
+        assert not any(f"{verb}…" in plain for verb in loop_state.SpinnerState._THINKING_VERBS)
+        # Cursor row + rule should still be there so the user can type.
+        assert "❯" in plain
+
+    def test_confirmation_takes_priority_over_dispatch_blank(self) -> None:
+        """The y/N confirmation banner must still appear even while a
+        dispatch is running — otherwise the user has no way to see what
+        they're confirming.
+        """
+        rendered = self._build(
+            dispatch_running=True,
+            awaiting_confirmation=True,
+            confirm_text="Confirm run RCA investigation",
+        )
+        plain = _strip_ansi(rendered)
+        assert "Confirm run RCA investigation" in plain
+
+    def test_prefix_row_height_is_constant(self) -> None:
+        """prompt_toolkit's cursor management relies on the prefix slot being
+        exactly one row tall.  All states — idle, streaming, dispatch with
+        suppressed spinner — must keep the prefix to a single line above the
+        rule + cursor row.
+        """
+        cases: tuple[tuple[str, str], ...] = (
+            ("idle", self._build()),
+            ("streaming", self._build(streaming=True)),
+            ("dispatch-suppressed", self._build(dispatch_running=True)),
+        )
+        for label, rendered in cases:
+            prefix = rendered.split("\n", 1)[0]
+            assert "\n" not in prefix, (
+                f"prefix slot must be one row tall in state {label!r}, got: {prefix!r}"
+            )
 
 
 # ── Streaming-console adapter tests ──────────────────────────────────────────


### PR DESCRIPTION
Fixes #2116

#### Describe the changes you have made in this PR -

The REPL prompt's "reserved first row" was falling back to `idle_hint_ansi()` (`/ for commands  ·  ↑↓ history`) on every `prompt_async` refresh tick (every 0.25s) — *including while a dispatch was running with the streaming spinner suppressed*. The spinner is suppressed whenever a nested live renderer (the Rich Live investigation footer or the append-only progress display) is about to own the bottom of the terminal. With the spinner off, the prompt kept redrawing shortcut text on the same rows the investigation footer was animating on, which produced the visible flash reported in #2116.

Changes:

- `app/cli/interactive_shell/runtime/loop.py`
  - Extracted the prompt-message composition out of the nested `_message_with_spinner` closure into a module-level helper `_build_prompt_message(session, state, spinner)`. The closure now just delegates, so the `prompt_async(message=…)` wiring is unchanged.
  - New rule for the prefix slot: when a dispatch is in flight **and** the spinner has been suppressed, the slot stays blank instead of falling back to the idle hint. Confirmation banners and the streaming spinner still take priority. Idle behavior (no dispatch running) is unchanged.
  - Slot height stays exactly one row in every state, so prompt-toolkit's cursor management continues to work and stale spinner lines do not accumulate.
- `tests/cli/interactive_shell/test_terminal_runtime.py`
  - New `TestBuildPromptMessage` class with 6 cases covering: idle, streaming, dispatch with active spinner, dispatch with suppressed spinner (the #2116 regression), confirmation banner priority over the blank prefix, and constant 1-row prefix height across all states.

### Demo/Screenshot for feature changes and bug fixes -
before
<img width="1051" height="259" alt="image" src="https://github.com/user-attachments/assets/ff3645e5-66a0-416b-81b8-7d31ce017b0b" />

after
<img width="1048" height="332" alt="image" src="https://github.com/user-attachments/assets/4fbdef90-1533-4b27-b48d-5f466396d5e5" />


before
<img width="977" height="216" alt="image" src="https://github.com/user-attachments/assets/a8c76736-8e59-42fb-9725-583256899f80" />


after
<img width="1041" height="620" alt="image" src="https://github.com/user-attachments/assets/eb65100f-0e2a-459f-a0cf-b8b22c79cff1" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is a race between two independent renderers writing to the same terminal rows:

1. The REPL's `prompt_async` redraws its "message" every `PROMPT_REFRESH_INTERVAL_S` (0.25s) so the spinner can animate. The message is built by `_message_with_spinner`, which historically returned `inline_spinner_ansi() or idle_hint_ansi()` as the prefix above the prompt rule.
2. During an investigation triggered from a paste-alert turn, a nested progress renderer takes over and `console.suppress_prompt_spinner()` is called. That sets `spinner.streaming = False`, so on the next prompt refresh the prefix silently fell back to the idle hint — and that hint is what the user saw flashing against the live footer.

Alternatives I considered:

- **Stop `prompt_async` entirely during dispatches.** Rejected — confirmation prompts, follow-up typing, and `esc to cancel` all rely on the prompt staying live. PR #2470 already split exclusive vs non-exclusive stdin paths for the same reason.
- **Lower `refresh_interval` during dispatch.** Rejected — `refresh_interval` is set once at `prompt_async` call time and isn't safe to mutate dynamically; and we still need 0.25s ticks for the streaming spinner animation in pure chat turns.
- **Remove the idle hint entirely.** Rejected — when no dispatch is running it's a useful affordance for new users.

I chose the minimum-surface fix: keep the existing idle hint, but treat "dispatch running with spinner suppressed" as a fourth explicit state where the prefix is blank. This is symmetric with how `is_awaiting_confirmation()` already takes over the same slot. The helper was lifted out of the closure so the four-state logic is unit-testable directly, not just observable via integration tests of `run_interactive`.

Key components I added:

- `_build_prompt_message(session, state, spinner) -> ANSI` — pure function over the runtime state. Returns the confirmation banner, the streaming spinner, an empty prefix, or the idle hint, in that priority order. Always 1 row tall.
- `TestBuildPromptMessage` — exercises each branch. The regression test for #2116 is `test_dispatch_running_with_suppressed_spinner_uses_blank_prefix`, which asserts that neither `/ for commands` nor the streaming verbs leak into the prefix when a dispatch is in flight without an active spinner.

Edge cases checked:

- **Confirmation during dispatch** — the y/N banner still wins over the blank prefix (`test_confirmation_takes_priority_over_dispatch_blank`).
- **Dispatch with the spinner still active** — the streaming verb is still shown, so pure chat turns are unaffected (`test_dispatch_running_with_spinner_keeps_spinner`).
- **Slot height** — verified to be exactly one row in idle, streaming, and dispatch-suppressed states (`test_prefix_row_height_is_constant`) so prompt-toolkit's renderer doesn't misplace the cursor between transitions.
- **Bare `/investigate`** — already routed via `dispatch_needs_exclusive_stdin`, so `prompt_async` is parked at `await state.queue.join()` during the picker + investigation. This path is unaffected and continues to use the full Rich Live region.

Gate results on this branch:

- `make lint` — passed
- `make format-check` — passed
- `make typecheck` — passed (687 source files)
- `uv run pytest tests/cli/` non-live — 1584 passed, 27 deselected (the deselected cases are `test_live_llm_planner_matches_prompt_contract`, which require `OPENAI_API_KEY` and fail identically on `main`)

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
