### PR TITLE
fix(utils):  catch OverflowError in safe_int +  unit tests

### DIFF
--- a/app/utils/coercion.py
+++ b/app/utils/coercion.py
@@ -9,5 +9,5 @@ def safe_int(value: Any, default: int) -> int:
     """Return ``value`` coerced to ``int`` or ``default`` on bad input."""
     try:
         return int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return default

--- a/tests/utils/test_coercion.py
+++ b/tests/utils/test_coercion.py
@@ -43,6 +43,8 @@ def test_safe_int_returns_coerced_value(value: Any, default: int, expected: int)
         "some string",
         # wrong type entirely
         object(),
+        # decimal-shaped string
+        "3.14",
     ],
 )
 def test_safe_int_returns_default_on_bad_input(value: Any) -> None:
@@ -64,13 +66,23 @@ def test_safe_int_returns_default_on_overflow(value: Any) -> None:
 
 
 def test_safe_int_treats_bool_as_int_subclass() -> None:
-    assert safe_int(True, 999) == 1
-    assert safe_int(False, 999) == 0
+    true_result = safe_int(True, 999)
+    assert true_result == 1
+    assert type(true_result) is int
+
+    false_result = safe_int(False, 999)
+    assert false_result == 0
+    assert type(false_result) is int
 
 
 def test_safe_int_truncates_float_toward_zero() -> None:
-    assert safe_int(3.9, 0) == 3
-    assert safe_int(-3.9, 0) == -3
+    positive_result = safe_int(3.9, 0)
+    assert positive_result == 3
+    assert type(positive_result) is int
+
+    negative_result = safe_int(-3.9, 0)
+    assert negative_result == -3
+    assert type(negative_result) is int
 
 
 def test_safe_int_returns_default_unchanged_for_negative_value() -> None:

--- a/tests/utils/test_coercion.py
+++ b/tests/utils/test_coercion.py
@@ -48,7 +48,19 @@ def test_safe_int_returns_coerced_value(value: Any, default: int, expected: int)
 def test_safe_int_returns_default_on_bad_input(value: Any) -> None:
     result = safe_int(value, 999)
     assert result == 999
-    assert type(result) is int
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # float infinity raises OverflowError from int()
+        float("inf"),
+        float("-inf"),
+    ],
+)
+def test_safe_int_returns_default_on_overflow(value: Any) -> None:
+    result = safe_int(value, 999)
+    assert result == 999
 
 
 def test_safe_int_treats_bool_as_int_subclass() -> None:
@@ -76,3 +88,4 @@ def test_safe_int_exception_domain() -> None:
 
     assert safe_int(_Raises(TypeError("should get caught")), 111) == 111
     assert safe_int(_Raises(ValueError("should get caught")), 999) == 999
+    assert safe_int(_Raises(OverflowError("should get caught")), 333) == 333

--- a/tests/utils/test_coercion.py
+++ b/tests/utils/test_coercion.py
@@ -1,0 +1,78 @@
+"""Tests for the safe_int coercion helper."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.utils.coercion import safe_int
+
+
+@pytest.mark.parametrize(
+    "value,default,expected",
+    [
+        # int passes through unchanged
+        (5, 0, 5),
+        # zero is preserved
+        (0, 99, 0),
+        # negative int passes through unchanged
+        (-7, 0, -7),
+        # integer string parses to int
+        ("25", 0, 25),
+        # signed integer string parses
+        ("-1", 0, -1),
+        # integer with whitespace passes through
+        ("  42  ", 0, 42),
+    ],
+)
+def test_safe_int_returns_coerced_value(value: Any, default: int, expected: int) -> None:
+    result = safe_int(value, default)
+    assert result == expected
+    assert type(result) is int
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # missing or unset
+        None,
+        # present but empty
+        "",
+        # non-numeric value
+        "some string",
+        # wrong type entirely
+        object(),
+    ],
+)
+def test_safe_int_returns_default_on_bad_input(value: Any) -> None:
+    result = safe_int(value, 999)
+    assert result == 999
+    assert type(result) is int
+
+
+def test_safe_int_treats_bool_as_int_subclass() -> None:
+    assert safe_int(True, 999) == 1
+    assert safe_int(False, 999) == 0
+
+
+def test_safe_int_truncates_float_toward_zero() -> None:
+    assert safe_int(3.9, 0) == 3
+    assert safe_int(-3.9, 0) == -3
+
+
+def test_safe_int_returns_default_unchanged_for_negative_value() -> None:
+    assert safe_int(None, -12) == -12
+
+
+def test_safe_int_exception_domain() -> None:
+    # TypeError + ValueError
+    class _Raises:
+        def __init__(self, exc: BaseException) -> None:
+            self._exc = exc
+
+        def __int__(self) -> int:
+            raise self._exc
+
+    assert safe_int(_Raises(TypeError("should get caught")), 111) == 111
+    assert safe_int(_Raises(ValueError("should get caught")), 999) == 999


### PR DESCRIPTION
Fixes #2593
  
### Summary

fix safe_int's OverflowError gap in `app/utils/coercion.py` and add unit tests for safe_int coercion helper in `tests/utils/test_coercion.py` covering:
- overflow inputs (float('inf'), float('-inf'))
- happy-path inputs (int passthrough, integer string parse, signed values, whitespace-padded strings)
- type edge cases (None, empty string, non-numeric string, wrong type passed in)
- boundary values (zero, negative ints, negative default, bool subclass, float truncation toward zero)
