### PR TITLE
docs: document abstract stub contracts

### DIFF
--- a/app/agents/meters/__init__.py
+++ b/app/agents/meters/__init__.py
@@ -96,7 +96,7 @@ class TokenMeter(Protocol):
     """
 
     def parse_chunk(self, chunk: str, /) -> int:
-        """Return newly observed token count from ``chunk``; never mutate unrelated PID state."""
+        """Return newly observed token count from ``chunk``; must not mutate any per-PID parser state."""
         raise NotImplementedError
 
     def sample_chunk(self, chunk: str, /, *, pid: int | None = None) -> TokenSample:

--- a/app/agents/meters/__init__.py
+++ b/app/agents/meters/__init__.py
@@ -96,15 +96,19 @@ class TokenMeter(Protocol):
     """
 
     def parse_chunk(self, chunk: str, /) -> int:
+        """Return newly observed token count from ``chunk``; never mutate unrelated PID state."""
         raise NotImplementedError
 
     def sample_chunk(self, chunk: str, /, *, pid: int | None = None) -> TokenSample:
+        """Return parsed usage/model data for ``chunk`` and optional ``pid`` without negative counts."""
         raise NotImplementedError
 
     def forget(self, pid: int, /) -> None:
+        """Drop any parser state for ``pid`` so future samples start from a clean stream boundary."""
         raise NotImplementedError
 
     def known_pids(self) -> list[int]:
+        """Return PIDs with retained parser state; callers may use this for cleanup bookkeeping."""
         raise NotImplementedError
 
 

--- a/app/agents/token_sources/__init__.py
+++ b/app/agents/token_sources/__init__.py
@@ -41,12 +41,15 @@ class TokenSource(Protocol):
     """
 
     def read_new_chunk(self, pid: int, /) -> str | None:
+        """Return new output bytes for ``pid``, ``""`` for idle, or ``None`` when unobservable."""
         raise NotImplementedError
 
     def forget(self, pid: int, /) -> None:
+        """Drop all read-position state for ``pid`` without affecting other active processes."""
         raise NotImplementedError
 
     def known_pids(self) -> list[int]:
+        """Return PIDs with retained source state so callers can reconcile stale processes."""
         raise NotImplementedError
 
 

--- a/app/remote/ops.py
+++ b/app/remote/ops.py
@@ -56,10 +56,12 @@ class RemoteOpsProvider(ABC):
 
     @abstractmethod
     def status(self, scope: RemoteServiceScope) -> ServiceStatus:
+        """Return normalized service status for ``scope`` without streaming provider output."""
         raise NotImplementedError
 
     @abstractmethod
     def logs(self, scope: RemoteServiceScope, *, lines: int, follow: bool) -> None:
+        """Stream the latest ``lines`` logs for ``scope`` and honor ``follow`` for interactive tails."""
         raise NotImplementedError
 
     @abstractmethod
@@ -74,6 +76,7 @@ class RemoteOpsProvider(ABC):
 
     @abstractmethod
     def restart(self, scope: RemoteServiceScope) -> RestartResult:
+        """Request a provider restart for ``scope`` and return a normalized acknowledgement."""
         raise NotImplementedError
 
 


### PR DESCRIPTION
This PR was prepared with AI assistance under human supervision. I kept the change small and included the checks I ran below.

Closes #2585.

## Summary
- add concise method docstrings to the TokenMeter protocol stubs
- add concise method docstrings to the TokenSource protocol stubs
- add concise method docstrings to RemoteOpsProvider abstract stubs that raise NotImplementedError

## Checks
- git diff --check
- python -m compileall app\agents\meters\__init__.py app\agents\token_sources\__init__.py app\remote\ops.py
- uv run --extra dev ruff check app/ tests/
- uv run --extra dev mypy app/

Note: make is not installed in this Windows environment, so I ran the equivalent commands from the Makefile directly through uv.