### PR TITLE
tests: document xfail(strict=False) root cause in RDS and EKS axis2 s…

### DIFF
--- a/tests/synthetic/eks/test_suite_axis2.py
+++ b/tests/synthetic/eks/test_suite_axis2.py
@@ -35,8 +35,22 @@ _ALL_SCENARIOS = load_all_scenarios()
 _LLM_ATTEMPTS = 2
 
 # Difficulty threshold above which the LLM is expected to struggle.
-# Failures at or above this difficulty are the gap signal —
-# they should not gate CI (strict=False xfail).
+#
+# Root-cause explanation (see GitHub issue #2599):
+# These are NOT infrastructure-dependent or randomly flaky tests.
+# Scenarios at difficulty >= _XFAIL_DIFFICULTY require the LLM to perform
+# multi-hop reasoning across adversarial SelectiveEKSBackend/SelectiveDatadogBackend
+# responses. Current LLMs fail these at a predictable rate — that failure rate
+# is the benchmark gap signal this suite was designed to measure.
+#
+# xfail(strict=False) is therefore intentional:
+#   - Failures keep CI green (expected, part of the gap metric).
+#   - Passes are recorded as xpass bonuses when the model improves.
+#   - Once a difficulty tier passes reliably, raise _XFAIL_DIFFICULTY or
+#     remove the mark for that tier to enforce the regression gate.
+#
+# make test-cov excludes tests/synthetic entirely (--ignore=tests/synthetic)
+# so these marks have no impact on coverage CI.
 _XFAIL_DIFFICULTY = 3
 
 

--- a/tests/synthetic/rds_postgres/test_suite_axis2.py
+++ b/tests/synthetic/rds_postgres/test_suite_axis2.py
@@ -36,8 +36,22 @@ _ALL_SCENARIOS = load_all_scenarios()
 _LLM_ATTEMPTS = 2
 
 # Difficulty threshold above which the LLM is expected to struggle.
-# Failures at or above this difficulty are the gap signal —
-# they should not gate CI (strict=False xfail).
+#
+# Root-cause explanation (see GitHub issue #2599):
+# These are NOT infrastructure-dependent or randomly flaky tests.
+# Scenarios at difficulty >= _XFAIL_DIFFICULTY require the LLM to perform
+# multi-hop reasoning across adversarial SelectiveGrafanaBackend responses.
+# Current LLMs fail these at a predictable rate — that failure rate is the
+# benchmark gap signal this suite was designed to measure.
+#
+# xfail(strict=False) is therefore intentional:
+#   - Failures keep CI green (expected, part of the gap metric).
+#   - Passes are recorded as xpass bonuses when the model improves.
+#   - Once a difficulty tier passes reliably, raise _XFAIL_DIFFICULTY or
+#     remove the mark for that tier to enforce the regression gate.
+#
+# make test-cov excludes tests/synthetic entirely (--ignore=tests/synthetic)
+# so these marks have no impact on coverage CI.
 _XFAIL_DIFFICULTY = 3
 
 


### PR DESCRIPTION
Closes #2599

## Changes
Expanded the `_XFAIL_DIFFICULTY` comment block in both axis2 suites to 
document the root cause of the xfail(strict=False) marks.

## Root Cause
These marks are NOT caused by infrastructure flakiness. Investigation 
shows they are intentional benchmark design — scenarios at difficulty >= 3 
require multi-hop reasoning across adversarial selective backends. Current 
LLMs fail these at a predictable rate; that failure rate is the gap signal 
the suite was built to measure.

## Acceptance Criteria
- [x] Root cause identified and documented as a comment on the xfail mark
- [x] Properly scoped — xfail(strict=False) confirmed intentional, no removal needed
- [x] make test-cov passes (tests/synthetic already excluded via --ignore=tests/synthetic)
- [x] make lint passes (comments only, no code changed)

## AI Usage
- [Yes] Yes, I used AI assistance
- [Yes] I have reviewed every single line
- [Yes] I can explain the purpose and logic of each change
- [Yes] I have tested edge cases and understand how the code handles them

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [ Yes] I have added proper PR title and linked to the issue
- [ Yes] I have performed a self-review of my code
- [ Yes] **I can explain the purpose of every function, class, and logic block I added**
- [ Yes] I understand why my changes work and have tested them thoroughly
- [ Yes] I have considered potential edge cases and how my code handles them
- [ Yes] If it is a core feature, I have added thorough tests
- [Yes ] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
