### PR TITLE
test(delivery): expand terminal renderer coverage

### DIFF
--- a/tests/delivery/test_terminal_renderer.py
+++ b/tests/delivery/test_terminal_renderer.py
@@ -114,25 +114,36 @@ def test_rich_line_with_links_emits_link_span_for_labeled_url() -> None:
     assert link_spans, "expected a styled link span for the labeled URL"
 
 
+# NOTE: documents current behavior, not desired behavior.
+#
+# `_URL_RE = r"https?://\S+"` greedily matches trailing punctuation because
+# `.`, `,`, `;`, `)` are all non-whitespace. The renderer then `rstrip`s those
+# characters off the URL used in the link span, but `sub_cursor` still advances
+# to `m.end()` — so the punctuation is dropped from `result.plain` as well.
+#
+# A future fix that re-emits the stripped characters into the plain text should
+# update the `expected_plain` column below to include the trailing punctuation.
 @pytest.mark.parametrize(
-    "raw, expected_url",
+    "raw, expected_url, expected_plain",
     [
-        # Trailing punctuation is stripped from the URL captured into the link span,
-        # while the visible plain text still contains the punctuation that followed
-        # the URL.
-        ("see https://example.com.", "https://example.com"),
-        ("see https://example.com, then go.", "https://example.com"),
-        ("see https://example.com; done", "https://example.com"),
-        ("see (https://example.com)", "https://example.com"),
+        ("see https://example.com.", "https://example.com", "see https://example.com"),
+        (
+            "see https://example.com, then go.",
+            "https://example.com",
+            "see https://example.com then go.",
+        ),
+        ("see https://example.com; done", "https://example.com", "see https://example.com done"),
+        ("see (https://example.com)", "https://example.com", "see (https://example.com"),
     ],
 )
 def test_rich_line_with_links_strips_trailing_punctuation_from_bare_url(
-    raw: str, expected_url: str
+    raw: str, expected_url: str, expected_plain: str
 ) -> None:
     result = _rich_line_with_links(raw)
 
     link_spans = [span for span in result.spans if f"link {expected_url} " in str(span.style)]
     assert link_spans, f"expected a styled link span for the bare URL {expected_url!r}"
+    assert result.plain == expected_plain
 
 
 def test_rich_line_with_links_emits_link_span_for_bare_url() -> None:

--- a/tests/delivery/test_terminal_renderer.py
+++ b/tests/delivery/test_terminal_renderer.py
@@ -1,9 +1,176 @@
 from __future__ import annotations
 
-from app.delivery.publish_findings.renderers.terminal import _strip_mrkdwn
+import pytest
+
+from app.delivery.publish_findings.renderers.terminal import (
+    _rich_line_with_links,
+    _strip_mrkdwn,
+    _strip_slack_links,
+    render_report,
+)
 
 
 def test_strip_mrkdwn_does_not_cross_lines_with_metric_regex() -> None:
     text = 'Run `{__name__=~"pipeline_runs_.*"}`\n\n*Cited Evidence:*'
 
     assert _strip_mrkdwn(text).endswith("\n\nCited Evidence:")
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # Bold markers — the only formatting the function actually strips.
+        ("*bold*", "bold"),
+        ("text *bold* more", "text bold more"),
+        ("*one*\n*two*", "one\ntwo"),
+        # Italic, inline code, and fenced code are not handled by the renderer
+        # and must pass through verbatim. These assertions document that
+        # contract so a future change is forced to update the tests too.
+        ("_italic_", "_italic_"),
+        ("`code`", "`code`"),
+        ("```block```", "```block```"),
+        # Nested formatting: only bold is unwrapped; the inner italic markers
+        # remain because the renderer does not touch them.
+        ("*bold _italic_*", "bold _italic_"),
+        # Empty and whitespace-only inputs are returned unchanged.
+        ("", ""),
+        ("   ", "   "),
+        ("\n\n", "\n\n"),
+        # Unicode and emoji content is preserved when wrappers are stripped.
+        ("*café*", "café"),
+        ("*🎉 party 🎉*", "🎉 party 🎉"),
+        ("héllo wörld", "héllo wörld"),
+        # No markdown -> pure passthrough.
+        ("hello world", "hello world"),
+        ("plain text with no markers at all.", "plain text with no markers at all."),
+        # A lone `*` without a closing partner is left as-is.
+        ("a * b", "a * b"),
+        # The bold regex must not span newlines (regression test for the
+        # existing happy-path case, kept parametrized for symmetry).
+        ("*line1\nline2*", "*line1\nline2*"),
+    ],
+)
+def test_strip_mrkdwn(raw: str, expected: str) -> None:
+    assert _strip_mrkdwn(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # Bare URL link -> the URL alone.
+        ("<https://example.com>", "https://example.com"),
+        # Labeled link -> "label (url)".
+        ("<https://example.com|Example>", "Example (https://example.com)"),
+        # Labeled link embedded in surrounding prose.
+        (
+            "Click <https://example.com|here> for details.",
+            "Click here (https://example.com) for details.",
+        ),
+        # Multiple links in the same string are each rewritten.
+        (
+            "<https://a.test|A> and <https://b.test|B>",
+            "A (https://a.test) and B (https://b.test)",
+        ),
+        # No Slack-style link -> passthrough (including bare URLs, which
+        # _strip_slack_links is not responsible for).
+        ("plain text", "plain text"),
+        (
+            "https://example.com without angle brackets",
+            "https://example.com without angle brackets",
+        ),
+        # Empty input.
+        ("", ""),
+    ],
+)
+def test_strip_slack_links(raw: str, expected: str) -> None:
+    assert _strip_slack_links(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw, expected_plain",
+    [
+        # Plain text round-trips as-is.
+        ("hello world", "hello world"),
+        # Labeled Slack link is rendered using the label, not the URL.
+        ("Click <https://example.com|here>!", "Click here!"),
+        # Bare URL is preserved verbatim in the plain projection.
+        ("see https://example.com for details", "see https://example.com for details"),
+        # Bare Slack link (no label) falls back to the URL.
+        ("<https://example.com>", "https://example.com"),
+        # Empty string yields empty plain text.
+        ("", ""),
+    ],
+)
+def test_rich_line_with_links_plain_projection(raw: str, expected_plain: str) -> None:
+    result = _rich_line_with_links(raw)
+
+    assert result.plain == expected_plain
+
+
+def test_rich_line_with_links_emits_link_span_for_labeled_url() -> None:
+    result = _rich_line_with_links("Click <https://example.com|here>!")
+
+    link_spans = [span for span in result.spans if "link https://example.com" in str(span.style)]
+    assert link_spans, "expected a styled link span for the labeled URL"
+
+
+@pytest.mark.parametrize(
+    "raw, expected_url",
+    [
+        # Trailing punctuation is stripped from the URL captured into the link span,
+        # while the visible plain text still contains the punctuation that followed
+        # the URL.
+        ("see https://example.com.", "https://example.com"),
+        ("see https://example.com, then go.", "https://example.com"),
+        ("see https://example.com; done", "https://example.com"),
+        ("see (https://example.com)", "https://example.com"),
+    ],
+)
+def test_rich_line_with_links_strips_trailing_punctuation_from_bare_url(
+    raw: str, expected_url: str
+) -> None:
+    result = _rich_line_with_links(raw)
+
+    link_spans = [span for span in result.spans if f"link {expected_url} " in str(span.style)]
+    assert link_spans, f"expected a styled link span for the bare URL {expected_url!r}"
+
+
+def test_rich_line_with_links_emits_link_span_for_bare_url() -> None:
+    result = _rich_line_with_links("see https://example.com for details")
+
+    link_spans = [span for span in result.spans if "link https://example.com" in str(span.style)]
+    assert link_spans, "expected a styled link span for the bare URL"
+    assert result.plain == "see https://example.com for details"
+
+
+def test_render_report_plain_mode_strips_mrkdwn_and_slack_links(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("TRACER_OUTPUT_FORMAT", "text")
+
+    slack_message = (
+        "## Findings\n"
+        "- *high* cpu on <https://dashboards.example.com|grafana>\n"
+        "*Cited Evidence:*\n"
+        "- <https://logs.example.com|loki>\n"
+    )
+
+    render_report(slack_message)
+
+    out = capsys.readouterr().out
+    # Bold markers stripped; Slack links rewritten to "label (url)".
+    assert "*high*" not in out
+    assert "high cpu on grafana (https://dashboards.example.com)" in out
+    assert "Cited Evidence:" in out
+    assert "<https://logs.example.com|loki>" not in out
+    assert "loki (https://logs.example.com)" in out
+
+
+def test_render_report_empty_message_prints_no_report_generated(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("TRACER_OUTPUT_FORMAT", "text")
+
+    render_report("")
+
+    assert "No report generated." in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Expands `tests/delivery/test_terminal_renderer.py` from a single happy-path test to comprehensive coverage of the formatting helpers and the public `render_report` entry point.

Closes #2596

## What's covered

- `_strip_mrkdwn` — bold, italic, code, block code, nested formatting, empty/whitespace, unicode/emoji, passthrough, lone-`*`, and the regression that the bold regex must not span newlines.
- `_strip_slack_links` — bare URL, labeled link, embedded link, multiple links, non-Slack URL passthrough, empty input.
- `_rich_line_with_links` — plain projection across labeled / bare / empty inputs; trailing-punctuation behavior on bare URLs (both URL stripping in the link span **and** the resulting `result.plain` projection); styled link-span emission for both labeled and bare URLs.
- `render_report` — integration smoke tests of the plain-mode path (Slack-mrkdwn → cleaned terminal output) and the empty-message early-return.

The italic / inline-code / fenced-code passthrough assertions intentionally document that `_strip_mrkdwn` only handles bold today — so any future change to extend the helper will be forced to update the tests too.

## Test plan

- [x] `uv run pytest tests/delivery/test_terminal_renderer.py -v` — **38 passed in 1.37s**
- [x] `make lint` — **All checks passed**
- [x] `make format-check` — **1575 files already formatted**
- [x] `make typecheck` — **Success: no issues found in 693 source files**
- [x] `make test-cov` — **7744 passed, 33 skipped in 103.50s; 77% coverage**. The 64 reported errors are all from `app/cli/interactive_shell/routing/tests/test_routing_scenarios.py` requiring `ANTHROPIC_API_KEY` to be set in the local environment — flagged as expected/environmental in [CLAUDE.md](https://github.com/Tracer-Cloud/opensre/blob/main/CLAUDE.md#L35), not a regression introduced by this PR.

---

## Self-review walkthrough

### Block 1 — Import update

```python
from app.delivery.publish_findings.renderers.terminal import (
    _rich_line_with_links,
    _strip_mrkdwn,
    _strip_slack_links,
    render_report,
)
```

Pulls in the three pure helpers plus the public `render_report` entry.

### Block 2 — `test_rich_line_with_links_strips_trailing_punctuation_from_bare_url`

Pins the behavior at `terminal.py:40`: `url = m.group(0).rstrip(".,;)")`. When a bare URL appears mid-sentence followed by punctuation, the URL captured into the link span must not include that punctuation (otherwise users clicking `https://example.com.` 404 out).

**Updated after Greptile review** (commit `4bcc6596`): the parametrized case now also asserts `result.plain`, documenting that the same trailing characters are dropped from the plain projection as well — a known quirk of how `sub_cursor = m.end()` advances past the greedy `\S+` match. A future fix that re-emits those characters into plain text should update the `expected_plain` column to include them.

4 parametrized cases (URL stripping + plain projection):

| Input | URL in span | `result.plain` |
|---|---|---|
| `"see https://example.com."` | `https://example.com` | `"see https://example.com"` |
| `"see https://example.com, then go."` | `https://example.com` | `"see https://example.com then go."` |
| `"see https://example.com; done"` | `https://example.com` | `"see https://example.com done"` |
| `"see (https://example.com)"` | `https://example.com` | `"see (https://example.com"` |

### Block 3 — `test_rich_line_with_links_emits_link_span_for_bare_url`

Sister to the existing `test_rich_line_with_links_emits_link_span_for_labeled_url`. The labeled-URL test only exercises the first branch in `_rich_line_with_links` (the `_SLACK_LINK_RE` loop at `terminal.py:25-32`). This test exercises the **second branch** (`_URL_RE` loop at `terminal.py:37-42`) and additionally asserts `result.plain` round-trips verbatim.

### Block 4 — `test_render_report_plain_mode_strips_mrkdwn_and_slack_links`

End-to-end smoke test of the public `render_report` API — none of the earlier tests exercised it.

Mechanics:

- `monkeypatch.setenv("TRACER_OUTPUT_FORMAT", "text")` — forces the plain branch in `get_output_format()` (`output.py:60-66`). Without this, the test would behave differently depending on whether pytest captures stdout (CI vs. local TTY).
- `capsys.readouterr().out` — captures what `render_report` printed.
- Input is a realistic snippet (a `## Findings` section + a `*Cited Evidence:*` block with Slack links).
- Assertions confirm **both** transforms in `_render_plain_report` at `terminal.py:206` fire correctly: bold markers stripped (`*high*` gone) **and** Slack links rewritten to `label (url)` form.

### Block 5 — `test_render_report_empty_message_prints_no_report_generated`

Covers the early-return path at `terminal.py:121-128` — when `slack_message` is empty/falsy, the renderer prints `"No report generated."` instead of dispatching. Without this test, that branch would be dead-coverage.

---

### Edge cases considered

| Edge | Where it's pinned |
|---|---|
| Bold regex must not span newlines | `test_strip_mrkdwn` case `"*line1\nline2*"` |
| Lone `*` without a closing partner | `test_strip_mrkdwn` case `"a * b"` |
| Empty + whitespace-only input | All three helpers + `render_report` empty case |
| Unicode + emoji in formatted text | `test_strip_mrkdwn` `"*café*"`, `"*🎉 party 🎉*"` |
| Italic/code/fenced **not** stripped (deliberate) | Documented in `test_strip_mrkdwn` with comments |
| Multiple Slack links in one string | `test_strip_slack_links` case `"<a> and <b>"` |
| Bare URL with trailing punctuation (URL span + plain projection) | `test_rich_line_with_links_strips_trailing_punctuation_from_bare_url` (4 cases) |
| TTY-dependent output format | `monkeypatch.setenv("TRACER_OUTPUT_FORMAT", "text")` makes both `render_report` tests deterministic |