### PR TITLE
tests: add URL validation coverage

### DIFF
--- a/tests/utils/test_url_validation.py
+++ b/tests/utils/test_url_validation.py
@@ -91,8 +91,13 @@ def test_is_loopback_host_returns_true_for_localhost_and_loopback_ips(host: str)
         "8.8.8.8",
         "",
         "localhost.example.com",
-        "127.0.0.1:8080",
     ],
 )
 def test_is_loopback_host_returns_false_for_non_loopback_hosts(host: str):
     assert is_loopback_host(host) is False
+
+
+def test_is_loopback_host_returns_false_for_host_port_string():
+    # 127.0.0.1 is loopback, but is_loopback_host expects a bare host;
+    # ip_address() raises ValueError on "host:port" input so False is returned.
+    assert is_loopback_host("127.0.0.1:8080") is False

--- a/tests/utils/test_url_validation.py
+++ b/tests/utils/test_url_validation.py
@@ -1,0 +1,98 @@
+import pytest
+
+from app.utils.url_validation import (
+    is_loopback_host,
+    validate_https_or_loopback_http_url,
+)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com",
+        "https://example.com/healthz",
+        "https://example.com:8443/api/v1",
+        "https://user:password@example.com/private",
+    ],
+)
+def test_validate_https_or_loopback_http_url_accepts_https_urls(url: str):
+    assert validate_https_or_loopback_http_url(url, service_name="Test Service") == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost",
+        "http://localhost:3000/callback",
+        "http://127.0.0.1:8080/api",
+        "http://[::1]:9090/metrics",
+        "http://user:password@localhost:8000/private",
+    ],
+)
+def test_validate_https_or_loopback_http_url_accepts_loopback_http_urls(url: str):
+    assert validate_https_or_loopback_http_url(url, service_name="Test Service") == url
+
+
+def test_validate_https_or_loopback_http_url_returns_empty_for_empty_url():
+    assert validate_https_or_loopback_http_url("", service_name="Test Service") == ""
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.com",
+        "example.com/path",
+        "not a url",
+        "https:///missing-host",
+        "ftp://example.com",
+    ],
+)
+def test_validate_https_or_loopback_http_url_rejects_invalid_urls(url: str):
+    with pytest.raises(
+        ValueError,
+        match="Test Service base_url must use https:// unless targeting localhost/loopback.",
+    ):
+        validate_https_or_loopback_http_url(url, service_name="Test Service")
+
+
+def test_validate_https_or_loopback_http_url_uses_custom_field_name_in_error():
+    with pytest.raises(
+        ValueError,
+        match="Test Service webhook_url must use https:// unless targeting localhost/loopback.",
+    ):
+        validate_https_or_loopback_http_url(
+            "http://example.com",
+            service_name="Test Service",
+            field_name="webhook_url",
+        )
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "localhost",
+        " LOCALHOST ",
+        "127.0.0.1",
+        "127.255.255.255",
+        "::1",
+        "[::1]",
+    ],
+)
+def test_is_loopback_host_returns_true_for_localhost_and_loopback_ips(host: str):
+    assert is_loopback_host(host) is True
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "example.com",
+        "10.0.0.1",
+        "192.168.1.10",
+        "8.8.8.8",
+        "",
+        "localhost.example.com",
+        "127.0.0.1:8080",
+    ],
+)
+def test_is_loopback_host_returns_false_for_non_loopback_hosts(host: str):
+    assert is_loopback_host(host) is False


### PR DESCRIPTION
Fixes #2592

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Added `tests/utils/test_url_validation.py` with focused coverage for `app/utils/url_validation.py`, including:

- Valid HTTPS URLs with paths, ports, and auth credentials
- Loopback HTTP URLs for localhost, IPv4 loopback, IPv6 loopback, ports, paths, and auth credentials
- Invalid URL forms such as missing schemes, unsupported schemes, non-loopback HTTP, and missing hosts
- Empty URL behavior
- `is_loopback_host` helper behavior for localhost, loopback IPs, bracketed IPv6, and non-loopback hosts

### Demo/Screenshot for feature changes and bug fixes -
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

```text
$ make lint
All checks passed!

$ make format-check
1576 files already formatted

$ make typecheck
Success: no issues found in 693 source files

$ make test-scope
Changed files (1):
  tests/utils/test_url_validation.py
Running scoped tests: tests/utils/test_url_validation.py
29 passed in 0.05s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The PR adds direct unit coverage for the existing URL validation helpers.

<details>
<summary>AGENT: OpenHands generated this implementation summary and validation notes.</summary>

The test matrix mirrors the helper's contract: HTTPS URLs are accepted when a network location is present, plaintext HTTP is accepted only for loopback hosts, empty values are preserved as optional configuration, and other URL shapes raise the existing `ValueError`. Helper-level tests cover normalization of localhost casing/whitespace, bracketed IPv6 loopback handling, and non-loopback host rejection.

</details>

_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
