### PR TITLE
fix(cli): clear live footer before printing final RCA report

### DIFF
--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -644,6 +644,7 @@ class _EventLogDisplay:
             console=self._console,
             refresh_per_second=10,
             auto_refresh=True,
+            transient=True,
             # Clip the live area to the terminal height so Rich never tries to
             # scroll back past more lines than it rendered.
             vertical_overflow="ellipsis",


### PR DESCRIPTION
## Summary

- Fixes #2117: the `● INVESTIGATE … ctrl+o tool details  esc to cancel` footer was left visible above the final RCA report after an investigation completed.
- Root cause: `_EventLogDisplay` used Rich `Live` with `transient=False` (default). When `stop()` was called at `publish_findings` time, Rich committed the last-rendered live area — blank line + divider + footer — to stdout. The report then printed below the stale footer.
- Fix: add `transient=True` to the `Live` constructor. Rich erases the dynamic region via cursor-up sequences on stop, leaving only the permanently-printed completed-step rows. `_DiagnoseStreamRenderer`'s `Live` in `renderer.py` keeps `transient=False` intentionally — its streaming Markdown reasoning must remain visible.

**Before:**
```
0:21  ✓  [INVEST]  Investigation  18.2s

┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 ● INVESTIGATE  2:05  local  ctrl+o tool details  esc to cancel   ← stale footer

  The Grafana alert is firing because…
```

**After:**
```
0:21  ✓  [INVEST]  Investigation  18.2s

  The Grafana alert is firing because…
```

## Test plan

- [x] `make lint` passes
- [x] Live run: `uv run opensre investigate -i tests/e2e/rca/pipeline_failure_rate_high.md` — confirmed no stale footer between last step line and RCA report
- [x] Searched captured pane output for `INVESTIGATE`, `ctrl+o`, `esc to cancel` after completion — zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)