### PR TITLE
feat(cli): capture and render investigation phase footer in final RCA report

### DIFF
--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -209,6 +209,27 @@ _stdin_watcher_suppression_depth = 0
 _stdin_watcher_lock = threading.Lock()
 _tool_detail_toggle_callbacks: list[Callable[[], None]] = []
 
+# Snapshot of the live phase footer at the moment its display was torn down so
+# that ``render_completed_investigation_footer()`` can re-render it at the
+# absolute bottom of the final RCA report. Cleared once consumed.
+_completed_footer_snapshot: tuple[str, float, str, str] | None = None
+
+
+def _capture_footer_snapshot(display: Any) -> None:
+    """Record the phase footer fields visible the moment a live display stops."""
+    global _completed_footer_snapshot
+    if display is None:
+        return
+    t0 = getattr(display, "_t0", None)
+    if t0 is None:
+        return
+    _completed_footer_snapshot = (
+        getattr(display, "_current_phase", ""),
+        time.monotonic() - t0,
+        getattr(display, "_model", ""),
+        getattr(display, "_mode", "local"),
+    )
+
 
 @contextlib.contextmanager
 def suppress_stdin_watchers() -> Iterator[None]:
@@ -301,8 +322,20 @@ def render_divider(width: int = 80) -> None:
         _safe_print("─" * width)
 
 
-def render_footer(phase: str, elapsed: float, model: str, mode: str) -> None:
-    """Print the persistent status footer line."""
+def render_footer(
+    phase: str,
+    elapsed: float,
+    model: str,
+    mode: str,
+    *,
+    show_cancel: bool = True,
+) -> None:
+    """Print the persistent status footer line.
+
+    ``show_cancel=False`` is used by ``render_completed_investigation_footer()``
+    when the investigation has already finished, so "esc to cancel" no longer
+    applies.
+    """
     if _is_silent_output():
         return
     if get_output_format() == "rich":
@@ -313,10 +346,27 @@ def render_footer(phase: str, elapsed: float, model: str, mode: str) -> None:
         if model:
             t.append(f"{model}  ", style=SECONDARY)
         t.append(f"{mode}  ", style=SECONDARY)
-        t.append("esc to cancel", style=DIM)
+        if show_cancel:
+            t.append("esc to cancel", style=DIM)
         _get_console().print(t)
     else:
         _safe_print(f"● {phase}  {elapsed:.1f}s  {model}  {mode}")
+
+
+def render_completed_investigation_footer() -> None:
+    """Print the captured phase footer once, at the absolute bottom of the report.
+
+    Consumes the snapshot recorded when the investigation's live display was
+    torn down. A no-op if no snapshot exists (e.g. silent runs, cancelled
+    investigations with no report, or callers that have already rendered).
+    """
+    global _completed_footer_snapshot
+    snapshot, _completed_footer_snapshot = _completed_footer_snapshot, None
+    if snapshot is None or _is_silent_output():
+        return
+    phase, elapsed, model, mode = snapshot
+    render_divider()
+    render_footer(phase, elapsed, model, mode, show_cancel=False)
 
 
 def render_event(
@@ -655,6 +705,7 @@ class _EventLogDisplay:
 
     def stop(self) -> None:
         global _live_console, _active_display
+        _capture_footer_snapshot(self)
         if self._live.is_started:
             self._live.stop()
         if _live_console is self._console:
@@ -790,7 +841,7 @@ class _ReplEventLogDisplay:
         self._console = Console(highlight=False)
 
     def stop(self) -> None:
-        return
+        _capture_footer_snapshot(self)
 
     def _emit(self, line: Text | Any) -> None:
         from app.cli.interactive_shell.ui.choice_menu import prepare_repl_output_line

--- a/app/delivery/publish_findings/renderers/terminal.py
+++ b/app/delivery/publish_findings/renderers/terminal.py
@@ -113,7 +113,7 @@ def _render_rich_evidence_item(console: Console, line: str) -> None:
 
 def render_report(slack_message: str, root_cause_category: str | None = None) -> None:
     """Render the final RCA report to terminal."""
-    from app.cli.support.output import stop_display
+    from app.cli.support.output import render_completed_investigation_footer, stop_display
 
     stop_display()
     fmt = get_output_format()
@@ -131,6 +131,10 @@ def render_report(slack_message: str, root_cause_category: str | None = None) ->
         _render_rich_report(slack_message, root_cause_category=root_cause_category)
     else:
         _render_plain_report(slack_message, root_cause_category=root_cause_category)
+
+    # Print the investigation phase footer at the absolute bottom of the
+    # RCA report (without "esc to cancel" — the investigation is complete).
+    render_completed_investigation_footer()
 
 
 def _render_rich_report(slack_message: str, root_cause_category: str | None = None) -> None:


### PR DESCRIPTION
/fix #2611 
This pull request adds the ability to display the investigation phase footer at the absolute bottom of the final RCA report, ensuring that status information is preserved even after the live display ends. It introduces a mechanism to capture and later re-render the footer, and updates the report rendering logic accordingly.

**Footer snapshot and rendering enhancements:**

* Added `_capture_footer_snapshot` and `_completed_footer_snapshot` to record the phase footer's state when the live display is stopped, enabling its later use in the report. (`app/cli/support/output.py`) [[1]](diffhunk://#diff-cd2ca604c030dd850ba3a1558e52a13a6fca62e77936c8f9314ffe19fd9bb354R212-R232) [[2]](diffhunk://#diff-cd2ca604c030dd850ba3a1558e52a13a6fca62e77936c8f9314ffe19fd9bb354R708) [[3]](diffhunk://#diff-cd2ca604c030dd850ba3a1558e52a13a6fca62e77936c8f9314ffe19fd9bb354L793-R844)
* Introduced `render_completed_investigation_footer` to print the captured footer at the bottom of the RCA report, omitting the "esc to cancel" message since the investigation is finished. (`app/cli/support/output.py`)
* Modified `render_footer` to accept a `show_cancel` parameter, allowing conditional display of the "esc to cancel" prompt. (`app/cli/support/output.py`) [[1]](diffhunk://#diff-cd2ca604c030dd850ba3a1558e52a13a6fca62e77936c8f9314ffe19fd9bb354L304-R338) [[2]](diffhunk://#diff-cd2ca604c030dd850ba3a1558e52a13a6fca62e77936c8f9314ffe19fd9bb354R349-R371)

**Integration with report rendering:**

* Updated `render_report` to call `render_completed_investigation_footer` after displaying the RCA report, ensuring the footer is shown at the report's end. (`app/delivery/publish_findings/renderers/terminal.py`) [[1]](diffhunk://#diff-c55634aea3217fcc3c2de560325e2db7e8cd7c1865a6929ad882f7eeb98ea6cbL116-R116) [[2]](diffhunk://#diff-c55634aea3217fcc3c2de560325e2db7e8cd7c1865a6929ad882f7eeb98ea6cbR135-R138)

<img width="732" height="659" alt="Screenshot 2026-05-27 at 4 24 36 PM" src="https://github.com/user-attachments/assets/194ff769-3f0c-4a68-8db9-376c6792fcc9" />

