### PR TITLE
feat(.env.example): add ANTIGRAVITY_CLI_BIN and ANTIGRAVITY_CLI_MODEL…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@
 
 # Provider used for LLM calls. Common values: anthropic, openai, openrouter,
 # deepseek, gemini, nvidia, minimax, bedrock, ollama, codex, claude-code,
-# opencode, kimi, copilot.
+# opencode, kimi, copilot, antigravity-cli.
 LLM_PROVIDER=anthropic
 
 # Codex CLI works for `opensre investigate` after `codex login`.

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,16 @@ CLAUDE_CODE_BIN=
 # Leave GEMINI_CLI_MODEL empty to use the CLI's configured default model.
 GEMINI_CLI_MODEL=
 GEMINI_CLI_BIN=
+
+# Antigravity CLI (agy) works for `opensre investigate` after running `agy`
+# (browser OAuth on first run; token cached by OS keyring).
+# Install: curl -fsSL https://antigravity.google/cli/install.sh | bash
+# Leave ANTIGRAVITY_CLI_MODEL empty to use agy's currently configured model.
+# Note: ANTIGRAVITY_CLI_MODEL is forward-compat; agy v1.0.2 does not yet expose
+# --model in headless mode. Switch models interactively via `/models` inside agy.
+ANTIGRAVITY_CLI_MODEL=
+ANTIGRAVITY_CLI_BIN=
+
 # OpenCode CLI works for `opensre investigate` after `opencode auth login`.
 # Leave OPENCODE_MODEL empty to use the CLI's currently configured model
 OPENCODE_MODEL=

--- a/tests/integrations/llm_cli/test_antigravity_cli_adapter.py
+++ b/tests/integrations/llm_cli/test_antigravity_cli_adapter.py
@@ -353,3 +353,45 @@ def test_detect_auth_probe_uses_filtered_subprocess_env(
     assert env["GOOGLE_CLOUD_PROJECT"] == "proj-x"
     assert env["GEMINI_API_KEY"] == "gk-test"
     assert "RANDOM_SECRET" not in env
+
+
+def test_antigravity_cli_model_forwarded_to_subprocess() -> None:
+    """ANTIGRAVITY_CLI_MODEL must reach CLI subprocesses via the safe-prefix allowlist."""
+    with patch.dict(
+        os.environ,
+        {
+            "ANTIGRAVITY_CLI_MODEL": "gemini-3.5-flash",
+            "ANTIGRAVITY_CLI_BIN": "/usr/bin/agy",
+            "ANTIGRAVITY_CLI_TIMEOUT_SECONDS": "240",
+        },
+        clear=False,
+    ):
+        env = build_cli_subprocess_env(None)
+
+    assert env["ANTIGRAVITY_CLI_MODEL"] == "gemini-3.5-flash"
+    assert env["ANTIGRAVITY_CLI_BIN"] == "/usr/bin/agy"
+    assert env["ANTIGRAVITY_CLI_TIMEOUT_SECONDS"] == "240"
+
+
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/agy")
+def test_antigravity_build_absent_env_uses_defaults(_mock_which: MagicMock) -> None:
+    """When ANTIGRAVITY_CLI_BIN, _MODEL, and _TIMEOUT_SECONDS are all absent, build()
+    resolves the binary via PATH and uses the default 300s timeout."""
+    env_strip = {k: v for k, v in os.environ.items() if not k.startswith("ANTIGRAVITY_CLI_")}
+    with patch.dict(os.environ, env_strip, clear=True):
+        inv = AntigravityCLIAdapter().build(prompt="test prompt", model=None, workspace="")
+
+    assert inv.argv[0] == "/usr/bin/agy"
+    idx = inv.argv.index("--print-timeout")
+    assert inv.argv[idx + 1] == "300s"
+    assert inv.timeout_sec == 310.0
+
+
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/agy")
+def test_antigravity_empty_model_env_treated_as_absent(_mock_which: MagicMock) -> None:
+    """An empty ANTIGRAVITY_CLI_MODEL must not produce a --model flag in argv,
+    consistent with how other CLI providers treat empty model env vars."""
+    with patch.dict(os.environ, {"ANTIGRAVITY_CLI_MODEL": ""}, clear=False):
+        inv = AntigravityCLIAdapter().build(prompt="p", model="", workspace="")
+
+    assert "--model" not in inv.argv

--- a/tests/integrations/llm_cli/test_antigravity_cli_adapter.py
+++ b/tests/integrations/llm_cli/test_antigravity_cli_adapter.py
@@ -361,16 +361,12 @@ def test_antigravity_cli_model_forwarded_to_subprocess() -> None:
         os.environ,
         {
             "ANTIGRAVITY_CLI_MODEL": "gemini-3.5-flash",
-            "ANTIGRAVITY_CLI_BIN": "/usr/bin/agy",
-            "ANTIGRAVITY_CLI_TIMEOUT_SECONDS": "240",
         },
         clear=False,
     ):
         env = build_cli_subprocess_env(None)
 
     assert env["ANTIGRAVITY_CLI_MODEL"] == "gemini-3.5-flash"
-    assert env["ANTIGRAVITY_CLI_BIN"] == "/usr/bin/agy"
-    assert env["ANTIGRAVITY_CLI_TIMEOUT_SECONDS"] == "240"
 
 
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/agy")


### PR DESCRIPTION
<!-- Suggested PR Title: feat(.env.example): add ANTIGRAVITY_CLI_BIN and ANTIGRAVITY_CLI_MODEL (#2540) -->
Fixes #2540

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Add the missing `ANTIGRAVITY_CLI_MODEL` and `ANTIGRAVITY_CLI_BIN` env vars to `.env.example`, consistent with every other CLI provider (Codex, Claude Code, Gemini CLI, OpenCode, Cursor, Kimi, Copilot).

**Problem:** Antigravity CLI was the only CLI provider without entries in `.env.example`, making setup less discoverable and causing misconfiguration during onboarding.

**Changes:**

1. **`.env.example`** — Added Antigravity CLI section (lines 36–43) with `ANTIGRAVITY_CLI_MODEL=` and `ANTIGRAVITY_CLI_BIN=` plus clear setup comments, placed after Gemini CLI and before OpenCode (matching wizard provider ordering).

2. **`tests/integrations/llm_cli/test_antigravity_cli_adapter.py`** — Added 3 new tests:
   - `test_antigravity_cli_model_forwarded_to_subprocess` — verifies `ANTIGRAVITY_CLI_MODEL` reaches CLI subprocesses via the `ANTIGRAVITY_` safe-prefix allowlist
   - `test_antigravity_build_absent_env_uses_defaults` — verifies absent env vars fall back correctly (PATH resolution, 300s default timeout)
   - `test_antigravity_empty_model_env_treated_as_absent` — verifies empty model string does not produce a `--model` flag, consistent with other CLI providers

**No existing variables removed or renamed.** Purely additive (2 files, +52 lines).

**Why no adapter/registry/docs changes:** The adapter code (`antigravity_cli.py`), registry, subprocess env forwarding, wizard config, banner, and docs (`llm-providers.mdx`) already handle both variables correctly — only `.env.example` was missing.

### Demo/Screenshot for feature changes and bug fixes -

**Live Verification — `opensre doctor` detects `antigravity-cli` using the new environment configuration:**
<img width="1920" height="1080" alt="pr_body1" src="https://github.com/user-attachments/assets/806a704a-0b6e-445b-800f-0b92f715d682" />

*The above screenshot shows a local test where a mock `agy` binary is created and registered via `ANTIGRAVITY_CLI_BIN=$(pwd)/mock_agy.py`. Running `opensre doctor` with `LLM_PROVIDER=antigravity-cli` successfully validates and reports the provider as ready, verifying that our new environment configuration keys are correctly resolved and parsed by OpenSRE.*

**Live Video Demo:**
<video src="https://github.com/user-attachments/assets/604d0201-ea29-40fd-81ae-c163ba0cda45" controls width="100%"></video>

*A short video demonstration showing the creation of the mock binary, running `opensre doctor` with custom configuration variables inline, and successful verification output.*

**Before (upstream main):** Antigravity CLI missing between Gemini CLI (line 34) and OpenCode (line 35):
*See files changed or current `.env.example` line diff.*

**After (this PR):** Antigravity CLI section added at lines 36–43:
*See file updates.*

**Test results — 25/25 passed (3 new tests highlighted):**
<img width="1689" height="961" alt="pr_test1" src="https://github.com/user-attachments/assets/51f65aa4-3e09-4835-b08d-607971538fee" />

**CI checklist — all green:**
<img width="1689" height="961" alt="pr_test2" src="https://github.com/user-attachments/assets/85887036-4c2b-4fc5-a78d-4e09da4082f9" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue reported that `ANTIGRAVITY_CLI_BIN` and `ANTIGRAVITY_CLI_MODEL` were missing from `.env.example` while every other CLI provider had entries. I audited every file that references these env vars:

- **Adapter** (`app/integrations/llm_cli/antigravity_cli.py`) — already reads `ANTIGRAVITY_CLI_BIN` (line 138, 147) and documents `ANTIGRAVITY_CLI_MODEL` as forward-compat (line 11).
- **Registry** (`app/integrations/llm_cli/registry.py`) — already registers `model_env_key="ANTIGRAVITY_CLI_MODEL"` (line 80).
- **Subprocess env** (`app/integrations/llm_cli/subprocess_env.py`) — `"ANTIGRAVITY_"` prefix already in the safe allowlist (line 64).
- **Wizard** (`app/cli/wizard/config.py`) — `ANTIGRAVITY_CLI_MODELS` tuple and `model_env="ANTIGRAVITY_CLI_MODEL"` already wired (lines 288, 602).
- **Docs** (`docs/llm-providers.mdx`) — already documents both vars (lines 245–270).

Conclusion: only `.env.example` was missing entries. The fix is purely additive — 10 lines in `.env.example` matching the exact comment style of peer CLI providers (Gemini CLI, Claude Code, Codex). Three tests were added to cover acceptance criteria gaps: model env forwarding, absent env fallback, and empty value handling.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
