### PR TITLE
refactor(strings): remove mixed f-string and .format() expressions

### DIFF
--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/llm_client.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/llm_client.py
@@ -46,7 +46,7 @@ def _call_llm(sanitised_text: str, session: Any) -> str | None:
         )
         return None
 
-    prompt = f"{_system_prompt()}\n\n{_USER_TEMPLATE.format(text=sanitised_text)}"
+    prompt = _system_prompt() + "\n\n" + _USER_TEMPLATE.format(text=sanitised_text)
     try:
         client = get_llm_for_classification().bind_tools(_tool_specs_for_provider(session))
         response = client.invoke(prompt)

--- a/app/cli/support/update.py
+++ b/app/cli/support/update.py
@@ -130,7 +130,7 @@ def run_update(*, check_only: bool = False, yes: bool = False) -> int:
 
     print(f"  current: {current}")
     print(f"  latest:  {latest}")
-    print(f"  release: {_RELEASE_URL.format(latest)}")
+    print("  release: " + _RELEASE_URL.format(latest))
 
     if check_only:
         return 1
@@ -155,7 +155,7 @@ def run_update(*, check_only: bool = False, yes: bool = False) -> int:
     rc = _upgrade_via_install_script(latest)
     if rc == 0:
         print(f"  updated: {current} -> {latest}")
-        print(f"  release notes: {_RELEASE_URL.format(latest)}")
+        print("  release notes: " + _RELEASE_URL.format(latest))
     else:
         print(f"  install script failed (exit {rc}).", file=sys.stderr)
         if _is_windows():


### PR DESCRIPTION
Three lines across two files mixed f-string syntax with .format() in the same expression, which the style guide flags as inconsistent.

- llm_client.py: replace f-string wrapping _USER_TEMPLATE.format() with plain concatenation
- update.py (x2): replace f-strings wrapping _RELEASE_URL.format() with plain string concatenation

extract.py and prompt.py already use .format() correctly on module-level constants and are unchanged.

Relates to #2587

#### Describe the changes you have made in this PR -

Fixed three expressions across two files that mixed f-string syntax with `.format()` in the same expression.

- `llm_client.py`: replace f-string wrapping `_USER_TEMPLATE.format()` with plain concatenation
- `update.py` (x2): replace f-strings wrapping `_RELEASE_URL.format()` with plain string concatenation

`extract.py` and `prompt.py` were reviewed and are already correct — `.format()` on module-level constants is the intended pattern per the issue.

### Demo/Screenshot for feature changes and bug fixes -

`llm_client.py` before/after:
```
# before
prompt = f"{_system_prompt()}\n\n{_USER_TEMPLATE.format(text=sanitised_text)}"

# after
prompt = _system_prompt() + "\n\n" + _USER_TEMPLATE.format(text=sanitised_text)
```

`update.py` before/after:
```
# before
print(f"  release: {_RELEASE_URL.format(latest)}")
print(f"  release notes: {_RELEASE_URL.format(latest)}")

# after
print("  release: " + _RELEASE_URL.format(latest))
print("  release notes: " + _RELEASE_URL.format(latest))
```

No behaviour change — output is identical.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue flags expressions where an f-string wraps a `.format()` call — two interpolation styles mixed in one expression. Since the constants (`_USER_TEMPLATE`, `_RELEASE_URL`) are defined at module level as plain strings with no variables, the outer f-string is redundant. Removing it and using concatenation leaves a single consistent style per expression with no change in behaviour.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
