### PR TITLE
fix: pass snapshot.last_output_at to compute_status in agents view

### DIFF
--- a/app/agents/probe.py
+++ b/app/agents/probe.py
@@ -50,6 +50,7 @@ class ProcessSnapshot:
     num_connections: int | None
     status: str
     started_at: datetime
+    last_output_at: datetime | None = None
 
 
 def pid_exists(pid: int) -> bool:

--- a/app/cli/interactive_shell/ui/agents_view.py
+++ b/app/cli/interactive_shell/ui/agents_view.py
@@ -101,13 +101,12 @@ def _build_agents_table(records: Iterable[AgentRecord]) -> Table:
     for record in materialized:
         snapshot = get_snapshot(record.pid)
         if snapshot is not None:
-            # last_output_at requires a background collector that tracks when each agent last wrote
-            # to stdout — not yet implemented. Until that lands, the fallback to snapshot.started_at
-            # means the heuristic overestimates silence duration for agents that are actively producing output.
+            # Use output freshness when a collector provides it; otherwise
+            # compute_status falls back to the snapshot start time.
             status = compute_status(
                 snapshot,
                 now,
-                last_output_at=None,
+                last_output_at=snapshot.last_output_at,
                 idle_after_s=120,
                 stuck_after_s=480,
             )

--- a/app/cli/interactive_shell/ui/agents_view.py
+++ b/app/cli/interactive_shell/ui/agents_view.py
@@ -101,8 +101,8 @@ def _build_agents_table(records: Iterable[AgentRecord]) -> Table:
     for record in materialized:
         snapshot = get_snapshot(record.pid)
         if snapshot is not None:
-            # Use output freshness when a collector provides it; otherwise
-            # compute_status falls back to the snapshot start time.
+            # Use output freshness when available; otherwise the status
+            # heuristic falls back to the process start time.
             status = compute_status(
                 snapshot,
                 now,
@@ -112,7 +112,8 @@ def _build_agents_table(records: Iterable[AgentRecord]) -> Table:
             )
             status_msg = ""
             if status is Status.STUCK:
-                status_msg = f"{_format_uptime(now - snapshot.started_at)} no progress"
+                anchor = snapshot.last_output_at or snapshot.started_at
+                status_msg = f"{_format_uptime(now - anchor)} no progress"
 
             uptime_cell = _format_uptime(now - snapshot.started_at)
             cpu_cell = f"{snapshot.cpu_percent:.1f}"

--- a/tests/cli/interactive_shell/ui/test_agents_view.py
+++ b/tests/cli/interactive_shell/ui/test_agents_view.py
@@ -9,7 +9,7 @@ this function.
 from __future__ import annotations
 
 import io
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -197,6 +197,34 @@ def test_table_shows_live_probe_data_when_snapshot_exists(monkeypatch: pytest.Mo
     # in the view code, so ``compute_status`` returns STUCK with a
     # progress-time annotation (from the upstream status heuristic).
     assert rendered_cells[2:] == ["2h0m", "23.5", "-", "-", "[red]stuck (2h0m no progress)[/red]"]
+
+
+def test_recent_agent_output_keeps_status_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    fixed_now = datetime(2026, 5, 10, 14, 0, 0, tzinfo=UTC)
+
+    class FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, _tz=None):  # type: ignore[override]
+            return fixed_now
+
+    monkeypatch.setattr(agents_view_mod, "datetime", FrozenDatetime)
+
+    fake_snapshot = ProcessSnapshot(
+        pid=8421,
+        cpu_percent=23.5,
+        rss_mb=128.0,
+        num_fds=42,
+        num_connections=3,
+        status="running",
+        started_at=fixed_now - timedelta(hours=2),
+        last_output_at=fixed_now - timedelta(seconds=30),
+    )
+    monkeypatch.setattr(agents_view_mod, "get_snapshot", lambda _pid: fake_snapshot)
+
+    table, _ = _render([AgentRecord(name="cursor", pid=8444, command="cursor")])
+    rendered_cells = [list(col.cells)[0] for col in table.columns]
+
+    assert rendered_cells[6] == "[green]active[/green]"
 
 
 def test_table_shows_tokens_and_cost_when_tracker_has_data(

--- a/tests/cli/interactive_shell/ui/test_agents_view.py
+++ b/tests/cli/interactive_shell/ui/test_agents_view.py
@@ -226,6 +226,36 @@ def test_recent_agent_output_keeps_status_active(monkeypatch: pytest.MonkeyPatch
     assert rendered_cells[6] == "[green]active[/green]"
 
 
+def test_stuck_message_anchors_to_last_output_at_not_started_at(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixed_now = datetime(2026, 5, 10, 14, 0, 0, tzinfo=UTC)
+
+    class FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, _tz=None):  # type: ignore[override]
+            return fixed_now
+
+    monkeypatch.setattr(agents_view_mod, "datetime", FrozenDatetime)
+
+    fake_snapshot = ProcessSnapshot(
+        pid=8421,
+        cpu_percent=5.0,
+        rss_mb=64.0,
+        num_fds=10,
+        num_connections=1,
+        status="running",
+        started_at=fixed_now - timedelta(hours=3),
+        last_output_at=fixed_now - timedelta(minutes=10),
+    )
+    monkeypatch.setattr(agents_view_mod, "get_snapshot", lambda _pid: fake_snapshot)
+
+    table, _ = _render([AgentRecord(name="cursor", pid=8444, command="cursor")])
+    rendered_cells = [list(col.cells)[0] for col in table.columns]
+
+    assert rendered_cells[6] == "[red]stuck (10m no progress)[/red]"
+
+
 def test_table_shows_tokens_and_cost_when_tracker_has_data(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/cli/interactive_shell/ui/test_agents_view.py
+++ b/tests/cli/interactive_shell/ui/test_agents_view.py
@@ -193,9 +193,8 @@ def test_table_shows_live_probe_data_when_snapshot_exists(monkeypatch: pytest.Mo
     # tracker entry exists for this PID — the snapshot fixture covers
     # only the resource side. The full live-data case is covered by
     # ``test_table_shows_tokens_and_cost_when_tracker_has_data``.
-    # Status: started_at is 2 h ago and ``last_output_at`` is ``None``
-    # in the view code, so ``compute_status`` returns STUCK with a
-    # progress-time annotation (from the upstream status heuristic).
+    # Without recent output activity, the status heuristic falls back
+    # to the process start time and renders STUCK with a progress-time annotation.
     assert rendered_cells[2:] == ["2h0m", "23.5", "-", "-", "[red]stuck (2h0m no progress)[/red]"]
 
 


### PR DESCRIPTION
Summary

The `/agents` view previously hardcoded `last_output_at=None` when calling `compute_status()`.

This meant long-running agents could be rendered as `stuck` even when they had recent output activity available in the snapshot layer. The view was effectively discarding output freshness information before status classification.

Changes

* add optional `last_output_at` field to `ProcessSnapshot`
* pass `snapshot.last_output_at` into `compute_status()`
* add regression coverage for recently active agents

Why this matters

This improves operational correctness for the `/agents` dashboard and removes a hardcoded `None` path in the view layer.

The goal is not to implement output collection yet, but to ensure the rendering layer correctly uses freshness data once collectors provide it.

Notes

This PR does not implement population of `last_output_at` in the probe/collector layer yet.

Collector-side timestamp population is intentionally left for follow-up work. This PR focuses on fixing the view-layer status propagation path.

Tests

```bash
pytest tests/cli/interactive_shell/test_agents_commands.py tests/cli/interactive_shell/ui/test_agents_view.py -q
```

Result:

```text
73 passed
```
<img width="1502" height="444" alt="Ekran görüntüsü 2026-05-27 211604" src="https://github.com/user-attachments/assets/1ce85852-d065-4f59-974a-b20b1b52ec6f" />
<img width="1529" height="911" alt="Ekran görüntüsü 2026-05-27 211614" src="https://github.com/user-attachments/assets/e10f89be-156b-46bd-a35f-f83d5c1a4a28" />
