### PR TITLE
tests: add unit tests for app/utils/tool_trace.py and app/utils/traci…

### DIFF
--- a/tests/utils/test_tool_trace.py
+++ b/tests/utils/test_tool_trace.py
@@ -1,0 +1,116 @@
+"""Tests for tool trace formatting and redaction helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.utils.tool_trace import (
+    format_json_preview,
+    format_tool_trace_entry,
+    redact_sensitive,
+)
+
+SENSITIVE_KEYS = [
+    "api_key",
+    "api-key",
+    "apiKey",
+    "token",
+    "secret",
+    "password",
+    "credential",
+    "authorization",
+    "auth_header",
+]
+
+
+def test_redact_sensitive_recurses_into_nested_collections() -> None:
+    value: dict[str, Any] = {
+        **dict.fromkeys(SENSITIVE_KEYS, "do-not-leak"),
+        "_internal": object(),
+        "backend": object(),
+        "mcp_backend": object(),
+        "nested": {"token": "secret-token", "safe": "visible"},
+        "items": [{"password": "hidden"}, ("public", {"_client": object()})],
+    }
+
+    redacted = redact_sensitive(value)
+
+    for key in SENSITIVE_KEYS:
+        assert redacted[key] == "[redacted]"
+    assert redacted["_internal"] == "[runtime object]"
+    assert redacted["backend"] == "[runtime object]"
+    assert redacted["mcp_backend"] == "[runtime object]"
+    assert redacted["nested"] == {"token": "[redacted]", "safe": "visible"}
+    assert redacted["items"] == [
+        {"password": "[redacted]"},
+        ["public", {"_client": "[runtime object]"}],
+    ]
+
+
+def test_redact_sensitive_handles_scalars_and_regex_precedence() -> None:
+    for scalar in (123, "plain", None, True):
+        assert redact_sensitive(scalar) is scalar
+    assert redact_sensitive({"_token": "secret-token"}) == {"_token": "[redacted]"}
+
+
+def test_format_json_preview_redacts_truncates_and_stringifies() -> None:
+    preview = format_json_preview(
+        {"query": "service:error", "credential": "super-secret", "count": 2}
+    )
+    assert '"query": "service:error"' in preview
+    assert '"credential": "[redacted]"' in preview
+    assert '"count": 2' in preview
+    assert "super-secret" not in preview
+
+    truncated = format_json_preview({"message": "x" * 100}, max_chars=50)
+    assert len(truncated) <= 50
+    assert truncated.endswith("... [truncated]")
+
+    stringified = format_json_preview({"values": {1, 2}})
+    assert '"values":' in stringified
+    assert "1" in stringified
+    assert "2" in stringified
+
+
+def test_format_tool_trace_entry_populates_fields_and_collapses_previews() -> None:
+    assert format_tool_trace_entry({"tool_name": "primary", "key": "fallback"}).startswith(
+        "- `primary`"
+    )
+    assert format_tool_trace_entry({"key": "fallback"}).startswith("- `fallback`")
+    assert format_tool_trace_entry({}).startswith("- `tool`")
+    assert format_tool_trace_entry({"loop_iteration": -1}).startswith("- `tool` (seed)")
+    assert format_tool_trace_entry({"loop_iteration": 2}).startswith(
+        "- `tool` (iteration 2)"
+    )
+
+    entry = {
+        "tool_name": "kubernetes_logs",
+        "loop_iteration": 3,
+        "tool_args": {"namespace": "prod", "token": "hidden"},
+        "data": {"status": "ok", "events": [1, 2]},
+    }
+
+    formatted = format_tool_trace_entry(entry)
+
+    assert formatted.startswith("- `kubernetes_logs` (iteration 3)")
+    assert "namespace" in formatted
+    assert "[redacted]" in formatted
+    assert "hidden" not in formatted
+    assert "status" in formatted
+    assert "events" in formatted
+    assert formatted.count("\n") == 2
+
+
+def test_format_tool_trace_entry_handles_empty_trace_record_and_output_limit() -> None:
+    formatted = format_tool_trace_entry({})
+    assert formatted == "- `tool` (iteration None)\n  input: `{}`\n  output: `null`"
+
+    limited = format_tool_trace_entry(
+        {
+            "tool_name": "large_tool",
+            "loop_iteration": 1,
+            "data": {"output": "x" * 200},
+        },
+        max_output_chars=60,
+    )
+    assert "... [truncated]" in limited

--- a/tests/utils/test_tool_trace.py
+++ b/tests/utils/test_tool_trace.py
@@ -85,7 +85,7 @@ def test_format_tool_trace_entry_populates_fields_and_collapses_previews() -> No
         "- `primary`"
     )
     assert format_tool_trace_entry({"key": "fallback"}).startswith("- `fallback`")
-    assert format_tool_trace_entry({}).startswith("- `tool`")
+    assert format_tool_trace_entry({}).startswith("- `tool` (iteration None)")
     assert format_tool_trace_entry({"loop_iteration": -1}).startswith("- `tool` (seed)")
     assert format_tool_trace_entry({"loop_iteration": 2}).startswith(
         "- `tool` (iteration 2)"
@@ -111,7 +111,7 @@ def test_format_tool_trace_entry_populates_fields_and_collapses_previews() -> No
 
 def test_format_tool_trace_entry_handles_empty_trace_record_and_output_limit() -> None:
     formatted = format_tool_trace_entry({})
-    assert formatted.startswith("- `tool`")
+    assert formatted.startswith("- `tool` (iteration None)")
     assert "\n  input: `{}`" in formatted
     assert "\n  output: `" in formatted
     assert formatted.count("\n") == 2

--- a/tests/utils/test_tool_trace.py
+++ b/tests/utils/test_tool_trace.py
@@ -48,9 +48,17 @@ def test_redact_sensitive_recurses_into_nested_collections() -> None:
 
 
 def test_redact_sensitive_handles_scalars_and_regex_precedence() -> None:
-    for scalar in (123, "plain", None, True):
-        assert redact_sensitive(scalar) is scalar
+    for scalar in (123, "plain"):
+        assert redact_sensitive(scalar) == scalar
+    assert redact_sensitive(None) is None
+    assert redact_sensitive(True) is True
     assert redact_sensitive({"_token": "secret-token"}) == {"_token": "[redacted]"}
+
+    # substring match — "access_token_count" contains "token" -> redacted
+    assert redact_sensitive({"access_token_count": "val"}) == {"access_token_count": "[redacted]"}
+
+    # no sensitive substring -> not redacted
+    assert redact_sensitive({"count_only": "val"}) == {"count_only": "val"}
 
 
 def test_format_json_preview_redacts_truncates_and_stringifies() -> None:
@@ -64,7 +72,7 @@ def test_format_json_preview_redacts_truncates_and_stringifies() -> None:
 
     truncated = format_json_preview({"message": "x" * 100}, max_chars=50)
     assert len(truncated) <= 50
-    assert truncated.endswith("... [truncated]")
+    assert truncated.endswith("\n... [truncated]")
 
     stringified = format_json_preview({"values": {1, 2}})
     assert '"values":' in stringified
@@ -103,7 +111,10 @@ def test_format_tool_trace_entry_populates_fields_and_collapses_previews() -> No
 
 def test_format_tool_trace_entry_handles_empty_trace_record_and_output_limit() -> None:
     formatted = format_tool_trace_entry({})
-    assert formatted == "- `tool` (iteration None)\n  input: `{}`\n  output: `null`"
+    assert formatted.startswith("- `tool`")
+    assert "\n  input: `{}`" in formatted
+    assert "\n  output: `" in formatted
+    assert formatted.count("\n") == 2
 
     limited = format_tool_trace_entry(
         {
@@ -113,4 +124,6 @@ def test_format_tool_trace_entry_handles_empty_trace_record_and_output_limit() -
         },
         max_output_chars=60,
     )
+    assert limited.startswith("- `large_tool` (iteration 1)")
     assert "... [truncated]" in limited
+    assert limited.count("\n") == 2

--- a/tests/utils/test_tool_trace.py
+++ b/tests/utils/test_tool_trace.py
@@ -87,9 +87,7 @@ def test_format_tool_trace_entry_populates_fields_and_collapses_previews() -> No
     assert format_tool_trace_entry({"key": "fallback"}).startswith("- `fallback`")
     assert format_tool_trace_entry({}).startswith("- `tool` (iteration None)")
     assert format_tool_trace_entry({"loop_iteration": -1}).startswith("- `tool` (seed)")
-    assert format_tool_trace_entry({"loop_iteration": 2}).startswith(
-        "- `tool` (iteration 2)"
-    )
+    assert format_tool_trace_entry({"loop_iteration": 2}).startswith("- `tool` (iteration 2)")
 
     entry = {
         "tool_name": "kubernetes_logs",

--- a/tests/utils/test_tracing.py
+++ b/tests/utils/test_tracing.py
@@ -9,6 +9,8 @@ def test_traceable_returns_identity_decorator() -> None:
     def traced_function() -> str:
         return "ok"
 
+    # Identity check is intentional: traceable() is a no-op and must
+    # return the original function unchanged, not a functools.wraps wrapper
     assert traceable()(traced_function) is traced_function
     assert traceable("investigation-step", extra="x")(traced_function) is traced_function
 

--- a/tests/utils/test_tracing.py
+++ b/tests/utils/test_tracing.py
@@ -1,0 +1,24 @@
+"""Tests for no-op tracing helpers."""
+
+from __future__ import annotations
+
+from app.utils.tracing import traceable
+
+
+def test_traceable_returns_identity_decorator() -> None:
+    def traced_function() -> str:
+        return "ok"
+
+    assert traceable()(traced_function) is traced_function
+    assert traceable("investigation-step", extra="x")(traced_function) is traced_function
+
+
+def test_traceable_preserves_args_kwargs_return_value_and_metadata() -> None:
+    @traceable("span-name")
+    def traced_function(value: int, *, suffix: str) -> str:
+        """Original docstring."""
+        return f"{value}{suffix}"
+
+    assert traced_function(7, suffix="ms") == "7ms"
+    assert traced_function.__name__ == "traced_function"
+    assert traced_function.__doc__ == "Original docstring."


### PR DESCRIPTION
tests: add unit tests for app/utils/tool_trace.py and app/utils/tracing.py

Fixes #2594

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
Added comprehensive unit tests for `app/utils/tool_trace.py` and `app/utils/tracing.py` inside `tests/utils/`. The tests verify:
- Redacting sensitive keys recursively in collections.
- Formatting JSON previews correctly including truncation.
- Tool trace entry formatting and UI output limits.
- Validating the `traceable` decorator acts as a no-op identity decorator preserving metadata.

### Demo/Screenshot for feature changes and bug fixes - 
<img width="974" height="588" alt="image" src="https://github.com/user-attachments/assets/91a8f75e-31d7-457d-aad8-3a3666db1b45" />
<img width="970" height="500" alt="image" src="https://github.com/user-attachments/assets/41a512ba-4fd4-42c5-b429-bf1354b0f1e8" />
<img width="970" height="500" alt="image" src="https://github.com/user-attachments/assets/41a512ba-4fd4-42c5-b429-bf1354b0f1e8" />

<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [X ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [X ] I have reviewed every single line of the AI-generated code
- [ X] I can explain the purpose and logic of each function/component I added
- [ X] I have tested edge cases and understand how the code handles them
- [ X] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:

- What problem does your code solve?
 
The code solves the lack of test coverage for the tool tracing and general tracing utilities . Without these tests, any regressions such as accidentally leaking sensitive API keys in the logs, breaking JSON formatting, or stripping function metadata when applying the tracing decorator would go unnoticed until they caused issues in production. 

- What alternative approaches did you consider?

 I considered relying purely on the existing integration and end-to-end (E2E) tests to catch issues with tool tracing implicitly. However, E2E tests are heavy, slow, and often fail to cover obscure edge cases, such as deeply nested dictionaries containing credentials or edge-case string truncations.

- Why did you choose this specific implementation?
 
I chose to implement focused, isolated unit tests using pytest because it aligns with the project's testing standards and provides immediate, fast feedback.

- What are the key functions/components and what do they do?
 
test_redact_sensitive_* : Validates that redact_sensitive successfully identifies and masks secret keys (token, password, api_key) even when deeply nested inside lists or dictionaries, while leaving normal values and scalar types intact.

test_format_json_preview_*: Ensures that format_json_preview properly serializes data, applies character limits with exact truncation suffixes (... [truncated]), and ensures secrets are not exposed in the preview.
test_format_tool_trace_entry_*: Checks that individual tool execution steps are cleanly formatted into Markdown lists, handles missing loop iterations/args gracefully, and respects output length caps.

test_traceable_*: Ensures the @traceable decorator acts as a safe identity function. It verifies that decorated functions retain their original arguments, return values, and essential metadata (like __name__ and __doc__).
This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [ x] I have added proper PR title and linked to the issue
- [ x] I have performed a self-review of my code
- [ x] **I can explain the purpose of every function, class, and logic block I added**
- [ x] I understand why my changes work and have tested them thoroughly
- [ x] I have considered potential edge cases and how my code handles them
- [ x] If it is a core feature, I have added thorough tests
- [ x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
