### PR TITLE
feat: local session persistence for chat history

### DIFF
--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -242,6 +242,7 @@ _EFFORT_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("max", "alias for xhigh"),
 )
 
+
 def _cmd_sessions(_session: ReplSession, console: Console, _args: list[str]) -> bool:
     from datetime import datetime
 

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -42,8 +42,11 @@ def _cmd_clear(session: ReplSession, console: Console, _args: list[str]) -> bool
 
 
 def _cmd_reset(session: ReplSession, console: Console, _args: list[str]) -> bool:
+    from app.cli.interactive_shell.sessions.store import SessionStore
+
+    SessionStore.flush(session)
     session.clear()
-    console.print(f"[{DIM}]session state cleared.[/]")
+    console.print(f"[{DIM}]session state cleared — new session started.[/]")
     return True
 
 
@@ -239,6 +242,63 @@ _EFFORT_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("max", "alias for xhigh"),
 )
 
+def _cmd_sessions(_session: ReplSession, console: Console, _args: list[str]) -> bool:
+    from datetime import datetime
+
+    from app.cli.interactive_shell.sessions.store import SessionStore
+
+    entries = SessionStore.load_recent(20)
+    if not entries:
+        console.print(f"[{DIM}]No sessions recorded yet.[/]")
+        return True
+
+    table = repl_table(title="Recent sessions\n", title_style=BOLD_BRAND)
+    table.add_column("#", style="bold", justify="right")
+    table.add_column("Session ID", style="bold")
+    table.add_column("Started")
+    table.add_column("Duration")
+    table.add_column("Turns", justify="right")
+    table.add_column("Investigations", justify="right")
+
+    for i, entry in enumerate(entries, start=1):
+        sid = entry["session_id"]
+        short_id = sid[:8] if len(sid) >= 8 else sid
+
+        started_raw = entry.get("started_at") or ""
+        try:
+            started_dt = datetime.fromisoformat(started_raw)
+            started_str = started_dt.astimezone().strftime("%Y-%m-%d %H:%M")
+        except Exception:
+            started_str = started_raw[:16] if started_raw else "—"
+
+        duration_secs = entry.get("duration_secs")
+        if duration_secs is None:
+            duration_str = "—"
+        elif duration_secs < 60:
+            duration_str = f"{duration_secs}s"
+        elif duration_secs < 3600:
+            duration_str = f"{duration_secs // 60}m {duration_secs % 60}s"
+        else:
+            h = duration_secs // 3600
+            m = (duration_secs % 3600) // 60
+            duration_str = f"{h}h {m}m"
+
+        total = entry.get("total_turns")
+        investigations = entry.get("investigation_turns")
+
+        table.add_row(
+            str(i),
+            short_id,
+            started_str,
+            duration_str,
+            str(total) if total is not None else "—",
+            str(investigations) if investigations is not None else "—",
+        )
+
+    print_repl_table(console, table)
+    return True
+
+
 COMMANDS: list[SlashCommand] = [
     SlashCommand("/clear", "Clear the screen and re-render the banner.", _cmd_clear),
     SlashCommand("/reset", "Clear session state.", _cmd_reset, notes=("Trust mode is preserved.",)),
@@ -270,6 +330,7 @@ COMMANDS: list[SlashCommand] = [
         first_arg_completions=_VERBOSE_FIRST_ARGS,
     ),
     SlashCommand("/compact", "Trim old session history to free memory.", _cmd_compact),
+    SlashCommand("/sessions", "List recent REPL sessions.", _cmd_sessions),
 ]
 
 __all__ = ["COMMANDS"]

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -44,8 +44,9 @@ def _cmd_clear(session: ReplSession, console: Console, _args: list[str]) -> bool
 def _cmd_reset(session: ReplSession, console: Console, _args: list[str]) -> bool:
     from app.cli.interactive_shell.sessions.store import SessionStore
 
-    SessionStore.flush(session)
-    session.clear()
+    SessionStore.flush(session)  # close current session file
+    session.clear()  # rotate session_id + started_at
+    SessionStore.open_session(session)  # open new session file immediately
     console.print(f"[{DIM}]session state cleared — new session started.[/]")
     return True
 
@@ -243,8 +244,8 @@ _EFFORT_FIRST_ARGS: tuple[tuple[str, str], ...] = (
 )
 
 
-def _cmd_sessions(_session: ReplSession, console: Console, _args: list[str]) -> bool:
-    from datetime import datetime
+def _cmd_sessions(session: ReplSession, console: Console, _args: list[str]) -> bool:
+    from datetime import UTC, datetime
 
     from app.cli.interactive_shell.sessions.store import SessionStore
 
@@ -264,6 +265,7 @@ def _cmd_sessions(_session: ReplSession, console: Console, _args: list[str]) -> 
     for i, entry in enumerate(entries, start=1):
         sid = entry["session_id"]
         short_id = sid[:8] if len(sid) >= 8 else sid
+        is_current = sid == session.session_id
 
         started_raw = entry.get("started_at") or ""
         try:
@@ -273,6 +275,17 @@ def _cmd_sessions(_session: ReplSession, console: Console, _args: list[str]) -> 
             started_str = started_raw[:16] if started_raw else "—"
 
         duration_secs = entry.get("duration_secs")
+        if is_current:
+            try:
+                elapsed = int(
+                    (
+                        datetime.now(UTC) - datetime.fromtimestamp(session.started_at, tz=UTC)
+                    ).total_seconds()
+                )
+                duration_secs = elapsed
+            except Exception:
+                pass
+
         if duration_secs is None:
             duration_str = "—"
         elif duration_secs < 60:
@@ -286,10 +299,11 @@ def _cmd_sessions(_session: ReplSession, console: Console, _args: list[str]) -> 
 
         total = entry.get("total_turns")
         investigations = entry.get("investigation_turns")
+        sid_col = f"{short_id} [{HIGHLIGHT}](current)[/]" if is_current else short_id
 
         table.add_row(
             str(i),
-            short_id,
+            sid_col,
             started_str,
             duration_str,
             str(total) if total is not None else "—",

--- a/app/cli/interactive_shell/command_registry/slash_catalog.py
+++ b/app/cli/interactive_shell/command_registry/slash_catalog.py
@@ -215,6 +215,12 @@ _MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
         "Save the last investigation report to a file path. Requires confirmation.",
         "User asks to export or save the last investigation to disk",
     ),
+    "/sessions": _mcp(
+        "List recent REPL sessions stored on disk. Shows session ID, start time, duration, "
+        "total turns, and investigation count for each session.",
+        "User asks to see past sessions, session history, or what was run in previous sessions",
+        anti_examples=("User asks for the current session status (use /status)",),
+    ),
     "/status": _mcp(
         "Show REPL session status: provider, models, trust mode, and active flags.",
         "User asks for session status",

--- a/app/cli/interactive_shell/prompt_logging/recorder.py
+++ b/app/cli/interactive_shell/prompt_logging/recorder.py
@@ -144,9 +144,12 @@ def _sanitize_text(text: str, *, config: PromptLogConfig) -> str:
 
 
 def _session_id(session: Any) -> str:
-    value = getattr(session, "_prompt_log_session_id", None)
-    if isinstance(value, str) and value:
-        return value
-    session_id = str(uuid.uuid4())
-    session._prompt_log_session_id = session_id
-    return session_id
+    # Prefer the stable first-class field set at ReplSession construction.
+    # Fall back to the legacy side-channel for non-ReplSession callers.
+    sid = getattr(session, "session_id", None) or getattr(session, "_prompt_log_session_id", None)
+    if isinstance(sid, str) and sid:
+        return sid
+    sid = str(uuid.uuid4())
+    with contextlib.suppress(AttributeError):
+        session._prompt_log_session_id = sid
+    return sid

--- a/app/cli/interactive_shell/runtime/entrypoint.py
+++ b/app/cli/interactive_shell/runtime/entrypoint.py
@@ -62,6 +62,9 @@ async def repl_main(initial_input: str | None = None, _config: ReplConfig | None
         if alert_listener_handle is not None:
             alert_listener_handle.stop()
             _alert_inbox.set_current_inbox(None)
+        from app.cli.interactive_shell.sessions.store import SessionStore
+
+        SessionStore.flush(session)
 
 
 def run_repl(initial_input: str | None = None, config: ReplConfig | None = None) -> int:

--- a/app/cli/interactive_shell/runtime/entrypoint.py
+++ b/app/cli/interactive_shell/runtime/entrypoint.py
@@ -31,6 +31,11 @@ async def repl_main(initial_input: str | None = None, _config: ReplConfig | None
     if initial_input:
         return run_initial_input(initial_input, session)
 
+    # Open the session file now that we know this is an interactive REPL run.
+    from app.cli.interactive_shell.sessions.store import SessionStore
+
+    SessionStore.open_session(session)
+
     alert_listener_handle: _alert_inbox.AlertListenerHandle | None = None
     inbox: _alert_inbox.AlertInbox | None = None
     if cfg.alert_listener_enabled:

--- a/app/cli/interactive_shell/runtime/entrypoint.py
+++ b/app/cli/interactive_shell/runtime/entrypoint.py
@@ -16,6 +16,7 @@ from app.cli.interactive_shell.runtime.dispatch import run_initial_input
 from app.cli.interactive_shell.runtime.loop import run_interactive
 from app.cli.interactive_shell.runtime.session import ReplSession
 from app.cli.interactive_shell.runtime.tasks import TaskRegistry
+from app.cli.interactive_shell.sessions.store import SessionStore
 from app.cli.interactive_shell.ui import DIM, render_banner
 
 log = logging.getLogger(__name__)
@@ -32,8 +33,6 @@ async def repl_main(initial_input: str | None = None, _config: ReplConfig | None
         return run_initial_input(initial_input, session)
 
     # Open the session file now that we know this is an interactive REPL run.
-    from app.cli.interactive_shell.sessions.store import SessionStore
-
     SessionStore.open_session(session)
 
     alert_listener_handle: _alert_inbox.AlertListenerHandle | None = None
@@ -67,8 +66,6 @@ async def repl_main(initial_input: str | None = None, _config: ReplConfig | None
         if alert_listener_handle is not None:
             alert_listener_handle.stop()
             _alert_inbox.set_current_inbox(None)
-        from app.cli.interactive_shell.sessions.store import SessionStore
-
         SessionStore.flush(session)
 
 

--- a/app/cli/interactive_shell/runtime/session.py
+++ b/app/cli/interactive_shell/runtime/session.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -39,6 +41,12 @@ class ReplSession:
     questions), accumulated infra context (service names, clusters observed),
     trust mode flag, and a short interaction history for /status.
     """
+
+    session_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    """Stable UUID for this session. Rotated on /reset so each logical session gets its own ID."""
+
+    started_at: float = field(default_factory=time.time)
+    """Unix timestamp of when this session (or post-reset sub-session) began."""
 
     history: list[dict[str, Any]] = field(default_factory=list)
     """Each entry has type, text, and ok fields for shell, slash, alert, and chat turns."""
@@ -219,6 +227,9 @@ class ReplSession:
         self.pending_prompt_default = None
         self.last_synthetic_observation_path = None
         # trust_mode and reasoning_effort are intentionally preserved across /reset
+        # Rotate session identity so the new post-reset session gets its own ID and file.
+        self.session_id = str(uuid.uuid4())
+        self.started_at = time.time()
 
     def record_intervention(self, kind: InterventionKind) -> None:
         """Increment the per-kind intervention counter (Ctrl-C or correction)."""

--- a/app/cli/interactive_shell/runtime/session.py
+++ b/app/cli/interactive_shell/runtime/session.py
@@ -152,6 +152,9 @@ class ReplSession:
         For "incoming_alert", use record_incoming_alert() instead to preserve metadata.
         """
         self.history.append({"type": kind, "text": text, "ok": ok})
+        from app.cli.interactive_shell.sessions.store import SessionStore
+
+        SessionStore.append_turn(self, kind, text)
 
     def record_incoming_alert(self, alert: IncomingAlert) -> None:
         """Append a full IncomingAlert with all metadata to session history.
@@ -162,6 +165,9 @@ class ReplSession:
         """
         # Record to history with alert text
         self.history.append({"type": "incoming_alert", "text": alert.text, "ok": True})
+        from app.cli.interactive_shell.sessions.store import SessionStore
+
+        SessionStore.append_turn(self, "incoming_alert", alert.text)
 
         # Store the full alert object to preserve all metadata
         self.incoming_alerts.append(alert)

--- a/app/cli/interactive_shell/runtime/session.py
+++ b/app/cli/interactive_shell/runtime/session.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from app.cli.interactive_shell.alert_inbox import IncomingAlert
 
 from app.cli.interactive_shell.runtime.tasks import TaskRegistry
+from app.cli.interactive_shell.sessions.store import SessionStore
 from app.llm_reasoning_effort import ReasoningEffortChoice
 
 InterventionKind = Literal["ctrl_c", "correction"]
@@ -152,8 +153,6 @@ class ReplSession:
         For "incoming_alert", use record_incoming_alert() instead to preserve metadata.
         """
         self.history.append({"type": kind, "text": text, "ok": ok})
-        from app.cli.interactive_shell.sessions.store import SessionStore
-
         SessionStore.append_turn(self, kind, text)
 
     def record_incoming_alert(self, alert: IncomingAlert) -> None:
@@ -165,8 +164,6 @@ class ReplSession:
         """
         # Record to history with alert text
         self.history.append({"type": "incoming_alert", "text": alert.text, "ok": True})
-        from app.cli.interactive_shell.sessions.store import SessionStore
-
         SessionStore.append_turn(self, "incoming_alert", alert.text)
 
         # Store the full alert object to preserve all metadata

--- a/app/cli/interactive_shell/sessions/__init__.py
+++ b/app/cli/interactive_shell/sessions/__init__.py
@@ -1,0 +1,1 @@
+"""Local session persistence for the interactive shell."""

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -148,12 +148,14 @@ class SessionStore:
             return []
 
         # Sort by mtime descending so we only read the n most recent files
-        # instead of every file in the directory.
-        all_paths = sorted(
-            sessions_dir.glob("*.jsonl"),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        )
+        # instead of every file in the directory. Guard against files that
+        # disappear between the glob and the stat call (concurrent delete).
+        def _mtime(p: Path) -> float:
+            with contextlib.suppress(OSError):
+                return p.stat().st_mtime
+            return 0.0
+
+        all_paths = sorted(sessions_dir.glob("*.jsonl"), key=_mtime, reverse=True)
 
         results: list[dict[str, Any]] = []
         for path in all_paths[: n * 2]:  # 2× buffer for skipped/malformed files

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -1,4 +1,15 @@
-"""Per-session persistence: one JSONL file per session under ~/.opensre/sessions/."""
+"""Per-session persistence: one JSONL file per session under ~/.opensre/sessions/.
+
+Design: incremental writes.
+- open_session()  — writes session_start immediately when the REPL starts
+- append_turn()   — appends one turn record on every session.record() call
+- flush()         — writes session_end on REPL exit or /reset;
+                    deletes the file if no turns were recorded (empty session)
+
+This means the current session file always exists on disk while the REPL is
+running, so /sessions shows it without any synthetic in-memory tricks, and
+future session-switching can read any file uniformly.
+"""
 
 from __future__ import annotations
 
@@ -26,70 +37,106 @@ def _session_path(session_id: str) -> Path:
     return _sessions_dir() / f"{session_id}.jsonl"
 
 
-def _now_iso() -> str:
-    return datetime.now(UTC).isoformat()
-
-
-def _build_records(session: ReplSession) -> list[dict[str, Any]]:
-    started_iso = datetime.fromtimestamp(session.started_at, tz=UTC).isoformat()
-    ended_iso = _now_iso()
-    duration_secs = max(0, int(datetime.now(UTC).timestamp() - session.started_at))
-
-    records: list[dict[str, Any]] = [
-        {
-            "type": "session_start",
-            "session_id": session.session_id,
-            "started_at": started_iso,
-            "opensre_version": get_version(),
-        }
-    ]
-
-    chat_turns = 0
-    investigation_turns = 0
-    for entry in session.history:
-        kind = entry.get("type", "unknown")
-        text = str(entry.get("text", ""))[:_MAX_PROMPT_CHARS]
-        records.append({"type": "turn", "kind": kind, "text": text})
-        if kind == "chat":
-            chat_turns += 1
-        elif kind in ("alert", "incoming_alert"):
-            investigation_turns += 1
-
-    records.append(
-        {
-            "type": "session_end",
-            "ended_at": ended_iso,
-            "duration_secs": duration_secs,
-            "total_turns": len(session.history),
-            "chat_turns": chat_turns,
-            "investigation_turns": investigation_turns,
-        }
-    )
-    return records
-
-
 class SessionStore:
     @staticmethod
-    def flush(session: ReplSession) -> None:
-        """Write the complete session file. Skips if session has no turns."""
+    def open_session(session: ReplSession) -> None:
+        """Write session_start record, creating the session file on disk.
+
+        Called once at REPL start and again after every /reset (which rotates
+        the session_id). Suppresses all I/O errors so the REPL never crashes.
+        """
         with contextlib.suppress(Exception):
-            if not session.history:
-                return
-            records = _build_records(session)
             path = _session_path(session.session_id)
             path.parent.mkdir(parents=True, exist_ok=True)
+            record = {
+                "type": "session_start",
+                "session_id": session.session_id,
+                "started_at": datetime.fromtimestamp(session.started_at, tz=UTC).isoformat(),
+                "opensre_version": get_version(),
+            }
             with path.open("w", encoding="utf-8") as fh:
-                for record in records:
-                    fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    @staticmethod
+    def append_turn(session: ReplSession, kind: str, text: str) -> None:
+        """Append one turn record to the open session file.
+
+        Called by ReplSession.record() and record_incoming_alert() on every
+        interaction. No-ops silently if the file does not exist (e.g. the
+        non-interactive initial_input path that never calls open_session).
+        """
+        with contextlib.suppress(Exception):
+            path = _session_path(session.session_id)
+            if not path.exists():
+                return
+            record = {
+                "type": "turn",
+                "kind": kind,
+                "text": text[:_MAX_PROMPT_CHARS],
+            }
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    @staticmethod
+    def flush(session: ReplSession) -> None:
+        """Write session_end and close the session file.
+
+        If no turns were recorded (the user opened and immediately quit),
+        the session file is deleted to avoid cluttering the sessions directory.
+        Called on REPL exit (entrypoint.py finally block) and /reset
+        (before session.clear() rotates the ID).
+        """
+        with contextlib.suppress(Exception):
+            path = _session_path(session.session_id)
+            if not path.exists():
+                return
+
+            lines = path.read_text(encoding="utf-8").splitlines()
+
+            # Count stats from the turn records already on disk
+            chat_turns = 0
+            investigation_turns = 0
+            total_turns = 0
+            for line in lines:
+                with contextlib.suppress(json.JSONDecodeError):
+                    rec = json.loads(line)
+                    if rec.get("type") != "turn":
+                        continue
+                    total_turns += 1
+                    kind = rec.get("kind", "")
+                    if kind == "chat":
+                        chat_turns += 1
+                    elif kind in ("alert", "incoming_alert"):
+                        investigation_turns += 1
+
+            if total_turns == 0:
+                # Empty session — nothing useful happened; remove the file.
+                path.unlink(missing_ok=True)
+                return
+
+            now = datetime.now(UTC)
+            started_at = datetime.fromtimestamp(session.started_at, tz=UTC)
+            duration_secs = max(0, int((now - started_at).total_seconds()))
+
+            record = {
+                "type": "session_end",
+                "ended_at": now.isoformat(),
+                "duration_secs": duration_secs,
+                "total_turns": total_turns,
+                "chat_turns": chat_turns,
+                "investigation_turns": investigation_turns,
+            }
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
 
     @staticmethod
     def load_recent(n: int = 20) -> list[dict[str, Any]]:
         """Return up to n session summaries, newest first.
 
-        Each entry contains keys from session_start merged with session_end
-        (duration_secs, total_turns, chat_turns, investigation_turns).
-        Sessions without a session_end record (e.g. crashed) are included
-        with those fields set to None.
+        For completed sessions (have session_end), stats come from that record.
+        For in-progress or crashed sessions (no session_end), stats are
+        computed by scanning the turn records in the file so /sessions always
+        shows accurate counts for the current session.
         """
         sessions_dir = _sessions_dir()
         if not sessions_dir.exists():
@@ -103,31 +150,54 @@ class SessionStore:
                     continue
 
                 start_record: dict[str, Any] | None = None
-                end_record: dict[str, Any] | None = None
-
                 with contextlib.suppress(json.JSONDecodeError):
                     start_record = json.loads(lines[0])
 
+                if start_record is None or start_record.get("type") != "session_start":
+                    continue
+
+                # Check if the last line is a session_end
+                end_record: dict[str, Any] | None = None
                 with contextlib.suppress(json.JSONDecodeError):
                     last = json.loads(lines[-1])
                     if last.get("type") == "session_end":
                         end_record = last
 
-                if start_record is None or start_record.get("type") != "session_start":
-                    continue
+                if end_record is not None:
+                    total_turns = end_record.get("total_turns")
+                    chat_turns = end_record.get("chat_turns")
+                    investigation_turns = end_record.get("investigation_turns")
+                    duration_secs = end_record.get("duration_secs")
+                else:
+                    # In-progress or crashed — count from turn records
+                    total_turns = 0
+                    chat_turns = 0
+                    investigation_turns = 0
+                    for line in lines[1:]:
+                        with contextlib.suppress(json.JSONDecodeError):
+                            rec = json.loads(line)
+                            if rec.get("type") != "turn":
+                                continue
+                            total_turns += 1
+                            kind = rec.get("kind", "")
+                            if kind == "chat":
+                                chat_turns += 1
+                            elif kind in ("alert", "incoming_alert"):
+                                investigation_turns += 1
+                    duration_secs = None
 
-                entry: dict[str, Any] = {
-                    "session_id": start_record.get("session_id", path.stem),
-                    "started_at": start_record.get("started_at"),
-                    "opensre_version": start_record.get("opensre_version"),
-                    "duration_secs": end_record.get("duration_secs") if end_record else None,
-                    "total_turns": end_record.get("total_turns") if end_record else None,
-                    "chat_turns": end_record.get("chat_turns") if end_record else None,
-                    "investigation_turns": end_record.get("investigation_turns")
-                    if end_record
-                    else None,
-                }
-                results.append(entry)
+                results.append(
+                    {
+                        "session_id": start_record.get("session_id", path.stem),
+                        "started_at": start_record.get("started_at"),
+                        "opensre_version": start_record.get("opensre_version"),
+                        "duration_secs": duration_secs,
+                        "total_turns": total_turns,
+                        "chat_turns": chat_turns,
+                        "investigation_turns": investigation_turns,
+                        "is_ended": end_record is not None,
+                    }
+                )
 
         results.sort(key=lambda x: x.get("started_at") or "", reverse=True)
         return results[:n]

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -81,10 +81,9 @@ class SessionStore:
     def flush(session: ReplSession) -> None:
         """Write session_end and close the session file.
 
-        If no turns were recorded (the user opened and immediately quit),
-        the session file is deleted to avoid cluttering the sessions directory.
-        Called on REPL exit (entrypoint.py finally block) and /reset
-        (before session.clear() rotates the ID).
+        Idempotent: no-ops if session_end is already the last line, so
+        double-calling (e.g. /reset flow + entrypoint finally) is safe.
+        If no turns were recorded the file is deleted instead.
         """
         with contextlib.suppress(Exception):
             path = _session_path(session.session_id)
@@ -92,6 +91,12 @@ class SessionStore:
                 return
 
             lines = path.read_text(encoding="utf-8").splitlines()
+
+            # Idempotency guard — already finalized, nothing to do.
+            if lines:
+                with contextlib.suppress(json.JSONDecodeError):
+                    if json.loads(lines[-1]).get("type") == "session_end":
+                        return
 
             # Count stats from the turn records already on disk
             chat_turns = 0
@@ -142,8 +147,16 @@ class SessionStore:
         if not sessions_dir.exists():
             return []
 
+        # Sort by mtime descending so we only read the n most recent files
+        # instead of every file in the directory.
+        all_paths = sorted(
+            sessions_dir.glob("*.jsonl"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+
         results: list[dict[str, Any]] = []
-        for path in sessions_dir.glob("*.jsonl"):
+        for path in all_paths[: n * 2]:  # 2× buffer for skipped/malformed files
             with contextlib.suppress(Exception):
                 lines = path.read_text(encoding="utf-8").splitlines()
                 if not lines:

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -123,7 +123,9 @@ class SessionStore:
                     "duration_secs": end_record.get("duration_secs") if end_record else None,
                     "total_turns": end_record.get("total_turns") if end_record else None,
                     "chat_turns": end_record.get("chat_turns") if end_record else None,
-                    "investigation_turns": end_record.get("investigation_turns") if end_record else None,
+                    "investigation_turns": end_record.get("investigation_turns")
+                    if end_record
+                    else None,
                 }
                 results.append(entry)
 

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -1,0 +1,131 @@
+"""Per-session persistence: one JSONL file per session under ~/.opensre/sessions/."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from app.version import get_version
+
+if TYPE_CHECKING:
+    from app.cli.interactive_shell.runtime.session import ReplSession
+
+_MAX_PROMPT_CHARS = 200
+
+
+def _sessions_dir() -> Path:
+    from app.constants import OPENSRE_HOME_DIR
+
+    return OPENSRE_HOME_DIR / "sessions"
+
+
+def _session_path(session_id: str) -> Path:
+    return _sessions_dir() / f"{session_id}.jsonl"
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _build_records(session: ReplSession) -> list[dict[str, Any]]:
+    started_iso = datetime.fromtimestamp(session.started_at, tz=UTC).isoformat()
+    ended_iso = _now_iso()
+    duration_secs = max(0, int(datetime.now(UTC).timestamp() - session.started_at))
+
+    records: list[dict[str, Any]] = [
+        {
+            "type": "session_start",
+            "session_id": session.session_id,
+            "started_at": started_iso,
+            "opensre_version": get_version(),
+        }
+    ]
+
+    chat_turns = 0
+    investigation_turns = 0
+    for entry in session.history:
+        kind = entry.get("type", "unknown")
+        text = str(entry.get("text", ""))[:_MAX_PROMPT_CHARS]
+        records.append({"type": "turn", "kind": kind, "text": text})
+        if kind == "chat":
+            chat_turns += 1
+        elif kind in ("alert", "incoming_alert"):
+            investigation_turns += 1
+
+    records.append(
+        {
+            "type": "session_end",
+            "ended_at": ended_iso,
+            "duration_secs": duration_secs,
+            "total_turns": len(session.history),
+            "chat_turns": chat_turns,
+            "investigation_turns": investigation_turns,
+        }
+    )
+    return records
+
+
+class SessionStore:
+    @staticmethod
+    def flush(session: ReplSession) -> None:
+        """Write the complete session file. Skips if session has no turns."""
+        with contextlib.suppress(Exception):
+            if not session.history:
+                return
+            records = _build_records(session)
+            path = _session_path(session.session_id)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("w", encoding="utf-8") as fh:
+                for record in records:
+                    fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    @staticmethod
+    def load_recent(n: int = 20) -> list[dict[str, Any]]:
+        """Return up to n session summaries, newest first.
+
+        Each entry contains keys from session_start merged with session_end
+        (duration_secs, total_turns, chat_turns, investigation_turns).
+        Sessions without a session_end record (e.g. crashed) are included
+        with those fields set to None.
+        """
+        sessions_dir = _sessions_dir()
+        if not sessions_dir.exists():
+            return []
+
+        results: list[dict[str, Any]] = []
+        for path in sessions_dir.glob("*.jsonl"):
+            with contextlib.suppress(Exception):
+                lines = path.read_text(encoding="utf-8").splitlines()
+                if not lines:
+                    continue
+
+                start_record: dict[str, Any] | None = None
+                end_record: dict[str, Any] | None = None
+
+                with contextlib.suppress(json.JSONDecodeError):
+                    start_record = json.loads(lines[0])
+
+                with contextlib.suppress(json.JSONDecodeError):
+                    last = json.loads(lines[-1])
+                    if last.get("type") == "session_end":
+                        end_record = last
+
+                if start_record is None or start_record.get("type") != "session_start":
+                    continue
+
+                entry: dict[str, Any] = {
+                    "session_id": start_record.get("session_id", path.stem),
+                    "started_at": start_record.get("started_at"),
+                    "opensre_version": start_record.get("opensre_version"),
+                    "duration_secs": end_record.get("duration_secs") if end_record else None,
+                    "total_turns": end_record.get("total_turns") if end_record else None,
+                    "chat_turns": end_record.get("chat_turns") if end_record else None,
+                    "investigation_turns": end_record.get("investigation_turns") if end_record else None,
+                }
+                results.append(entry)
+
+        results.sort(key=lambda x: x.get("started_at") or "", reverse=True)
+        return results[:n]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -86,6 +86,7 @@
               "remote-runtime-investigation",
               "masking",
               "interactive-shell-privacy",
+              "sessions",
               "agents",
               "cron",
               "multi-instance-integrations"

--- a/docs/sessions.mdx
+++ b/docs/sessions.mdx
@@ -1,0 +1,131 @@
+---
+title: 'Session History'
+description: 'How OpenSRE records your REPL sessions locally, what is stored, and how to view past sessions with /sessions'
+---
+
+## Overview
+
+Every time you start the OpenSRE interactive shell, a new session is created and recorded to disk. Each session captures:
+
+- When it started and how long it lasted
+- Every interaction — chats, investigations, slash commands, incoming alerts
+- Aggregate counts (total turns, investigations run)
+
+Sessions are stored as JSONL files under `~/.opensre/sessions/`. They are written **incrementally** — the file exists on disk from the moment the REPL starts, so `/sessions` always shows the current session alongside past ones.
+
+## Session lifecycle
+
+| Event | What happens |
+| --- | --- |
+| REPL starts | `session_start` record written immediately; file created at `~/.opensre/sessions/<session-id>.jsonl` |
+| Each interaction | One `turn` record appended to the open file |
+| `/reset` | Current session closed (`session_end` written); new session file opened with a fresh ID |
+| REPL exits | `session_end` written; file is deleted if no turns were recorded (empty session) |
+| REPL crash | File remains with all turns up to the crash but no `session_end` — stats computed from the turn records |
+
+## Session file format
+
+Each session is a JSONL file (one JSON object per line).
+
+**`session_start` — first line**
+
+```json
+{
+  "type": "session_start",
+  "session_id": "3f8a1c2d-...",
+  "started_at": "2024-01-15T10:00:00+00:00",
+  "opensre_version": "0.1"
+}
+```
+
+**`turn` — one per interaction**
+
+```json
+{
+  "type": "turn",
+  "kind": "chat",
+  "text": "why is CPU spiking on prod-api?"
+}
+```
+
+Turn `kind` values:
+
+| Kind | Description |
+| --- | --- |
+| `chat` | Free-text message routed to the LLM assistant |
+| `alert` | Investigation triggered by an alert payload |
+| `incoming_alert` | Alert received via the HTTP listener |
+| `slash` | Slash command (`/status`, `/reset`, etc.) |
+| `shell` | Shell command executed via the terminal runtime |
+
+Text is truncated to 200 characters. No response content is stored — only the prompt/input.
+
+**`session_end` — last line (when session closed cleanly)**
+
+```json
+{
+  "type": "session_end",
+  "ended_at": "2024-01-15T10:42:00+00:00",
+  "duration_secs": 2520,
+  "total_turns": 8,
+  "chat_turns": 5,
+  "investigation_turns": 2
+}
+```
+
+A session without a `session_end` record (crash or ongoing) is still valid — `/sessions` computes `total_turns`, `chat_turns`, and `investigation_turns` by scanning the `turn` records directly.
+
+## /sessions command
+
+Run `/sessions` inside the REPL to list recent sessions:
+
+```
+/sessions
+```
+
+```
+  Recent sessions
+
+   #  Session ID  Started            Duration  Turns  Investigations
+   ─────────────────────────────────────────────────────────────────
+   1  3f8a1c2d    2024-01-15 10:00   42m 0s    8      2
+      (current)
+   2  9b2e4f7a    2024-01-14 14:30   1h 5m     15     4
+   3  c1d3e8f2    2024-01-13 09:10   12m 3s    3      0
+```
+
+The current session is marked `(current)` with a live-updating elapsed time. Sessions without a `session_end` (crash or in-progress) show accurate turn counts computed from the file.
+
+Up to 20 sessions are shown, newest first.
+
+## Storage location
+
+```
+~/.opensre/sessions/
+  3f8a1c2d-ab12-....jsonl   ← current session (in progress)
+  9b2e4f7a-cd34-....jsonl   ← previous session
+  c1d3e8f2-ef56-....jsonl
+  ...
+```
+
+Each file is named after its UUID session ID. Files are plain text and human-readable.
+
+## What is NOT stored
+
+- LLM response content (stored separately in `~/.opensre/prompt_log.jsonl` if prompt logging is enabled)
+- Full alert payloads or investigation results (stored in `~/.opensre/investigations/`)
+- Secrets or credentials — session text is stored as typed; enable prompt log redaction if needed
+
+## Linking sessions to other data
+
+The `session_id` in each session file matches the `session_id` field in `~/.opensre/prompt_log.jsonl`. This means you can correlate a session's turn list with the full prompt/response pairs and token usage recorded in the prompt log.
+
+```bash
+# Find all prompt log entries for a given session
+grep '"session_id": "3f8a1c2d"' ~/.opensre/prompt_log.jsonl
+```
+
+## Related
+
+- [Interactive Shell Privacy](/interactive-shell-privacy) — command history redaction and persistence controls
+- [Prompt Logging](/configuration/environment-variables) — full prompt/response logging configuration

--- a/tests/cli/interactive_shell/sessions/test_store.py
+++ b/tests/cli/interactive_shell/sessions/test_store.py
@@ -127,6 +127,19 @@ def test_flush_noop_when_file_missing(tmp_path: Path) -> None:
         SessionStore.flush(session)  # no open_session called — must not raise
 
 
+def test_flush_is_idempotent(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "hi")
+        SessionStore.flush(session)
+        SessionStore.flush(session)  # second call must not append another session_end
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    end_records = [r for r in records if r["type"] == "session_end"]
+    assert len(end_records) == 1, "flush() must be idempotent — only one session_end"
+
+
 # ── session.record() wiring ───────────────────────────────────────────────────
 
 

--- a/tests/cli/interactive_shell/sessions/test_store.py
+++ b/tests/cli/interactive_shell/sessions/test_store.py
@@ -1,0 +1,255 @@
+"""Tests for SessionStore: flush and load_recent."""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+from app.cli.interactive_shell.runtime.session import ReplSession
+from app.cli.interactive_shell.sessions.store import SessionStore
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_session(history: list[dict] | None = None) -> ReplSession:
+    s = ReplSession()
+    if history:
+        s.history.extend(history)
+    return s
+
+
+def _read_lines(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+# ── flush ─────────────────────────────────────────────────────────────────────
+
+
+def test_flush_skips_empty_session(tmp_path: Path) -> None:
+    session = _make_session()
+    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
+        SessionStore.flush(session)
+    assert list(tmp_path.glob("*.jsonl")) == [], "no file written for empty session"
+
+
+def test_flush_writes_correct_structure(tmp_path: Path) -> None:
+    session = _make_session(
+        [
+            {"type": "chat", "text": "hello world", "ok": True},
+            {"type": "alert", "text": "HighCPU on prod", "ok": True},
+            {"type": "slash", "text": "/status", "ok": True},
+        ]
+    )
+    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
+        SessionStore.flush(session)
+
+    files = list(tmp_path.glob("*.jsonl"))
+    assert len(files) == 1
+
+    records = _read_lines(files[0])
+    assert records[0]["type"] == "session_start"
+    assert records[0]["session_id"] == session.session_id
+
+    turn_records = [r for r in records if r["type"] == "turn"]
+    assert len(turn_records) == 3
+    assert turn_records[0]["kind"] == "chat"
+    assert turn_records[1]["kind"] == "alert"
+    assert turn_records[2]["kind"] == "slash"
+
+    end = records[-1]
+    assert end["type"] == "session_end"
+    assert end["total_turns"] == 3
+    assert end["chat_turns"] == 1
+    assert end["investigation_turns"] == 1
+
+
+def test_flush_truncates_long_prompt(tmp_path: Path) -> None:
+    long_text = "x" * 500
+    session = _make_session([{"type": "chat", "text": long_text, "ok": True}])
+    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
+        SessionStore.flush(session)
+
+    files = list(tmp_path.glob("*.jsonl"))
+    records = _read_lines(files[0])
+    turn = next(r for r in records if r["type"] == "turn")
+    assert len(turn["text"]) == 200
+
+
+def test_flush_uses_session_session_id_as_filename(tmp_path: Path) -> None:
+    session = _make_session([{"type": "chat", "text": "hi", "ok": True}])
+    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
+        SessionStore.flush(session)
+
+    expected_file = tmp_path / f"{session.session_id}.jsonl"
+    assert expected_file.exists()
+
+
+def test_flush_never_raises_on_bad_path() -> None:
+    session = _make_session([{"type": "chat", "text": "hi", "ok": True}])
+    with patch(
+        "app.cli.interactive_shell.sessions.store._sessions_dir",
+        return_value=Path("/nonexistent/cannot/write/here"),
+    ):
+        SessionStore.flush(session)  # must not raise
+
+
+# ── load_recent ───────────────────────────────────────────────────────────────
+
+
+def test_load_recent_returns_empty_when_no_dir(tmp_path: Path) -> None:
+    missing = tmp_path / "no_sessions"
+    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=missing):
+        result = SessionStore.load_recent()
+    assert result == []
+
+
+def test_load_recent_returns_sessions_newest_first(tmp_path: Path) -> None:
+    for started in ["2024-01-01T10:00:00+00:00", "2024-01-02T10:00:00+00:00"]:
+        sid = str(uuid.uuid4())
+        path = tmp_path / f"{sid}.jsonl"
+        path.write_text(
+            "\n".join(
+                [
+                    json.dumps({"type": "session_start", "session_id": sid, "started_at": started}),
+                    json.dumps({"type": "turn", "kind": "chat", "text": "hi"}),
+                    json.dumps(
+                        {
+                            "type": "session_end",
+                            "ended_at": started,
+                            "duration_secs": 60,
+                            "total_turns": 1,
+                            "chat_turns": 1,
+                            "investigation_turns": 0,
+                        }
+                    ),
+                ]
+            )
+            + "\n"
+        )
+
+    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
+        results = SessionStore.load_recent()
+
+    assert len(results) == 2
+    assert results[0]["started_at"] > results[1]["started_at"]
+
+
+def test_load_recent_handles_crashed_session(tmp_path: Path) -> None:
+    sid = str(uuid.uuid4())
+    path = tmp_path / f"{sid}.jsonl"
+    path.write_text(
+        json.dumps(
+            {
+                "type": "session_start",
+                "session_id": sid,
+                "started_at": "2024-01-01T10:00:00+00:00",
+            }
+        )
+        + "\n"
+        + json.dumps({"type": "turn", "kind": "chat", "text": "hi"})
+        + "\n"
+    )
+
+    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
+        results = SessionStore.load_recent()
+
+    assert len(results) == 1
+    assert results[0]["total_turns"] is None
+    assert results[0]["duration_secs"] is None
+
+
+def test_load_recent_skips_malformed_files(tmp_path: Path) -> None:
+    (tmp_path / "bad.jsonl").write_text("this is not json\nalso not json\n")
+    (tmp_path / "empty.jsonl").write_text("")
+
+    sid = str(uuid.uuid4())
+    path = tmp_path / f"{sid}.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "session_start",
+                        "session_id": sid,
+                        "started_at": "2024-01-03T10:00:00+00:00",
+                    }
+                ),
+                json.dumps({"type": "turn", "kind": "chat", "text": "ok"}),
+                json.dumps(
+                    {
+                        "type": "session_end",
+                        "ended_at": "2024-01-03T10:01:00+00:00",
+                        "duration_secs": 60,
+                        "total_turns": 1,
+                        "chat_turns": 1,
+                        "investigation_turns": 0,
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+
+    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
+        results = SessionStore.load_recent()
+
+    assert len(results) == 1
+    assert results[0]["session_id"] == sid
+
+
+def test_load_recent_respects_n_limit(tmp_path: Path) -> None:
+    for _ in range(5):
+        sid = str(uuid.uuid4())
+        path = tmp_path / f"{sid}.jsonl"
+        path.write_text(
+            json.dumps(
+                {
+                    "type": "session_start",
+                    "session_id": sid,
+                    "started_at": "2024-01-01T10:00:00+00:00",
+                }
+            )
+            + "\n"
+            + json.dumps({"type": "turn", "kind": "chat", "text": "hi"})
+            + "\n"
+            + json.dumps(
+                {
+                    "type": "session_end",
+                    "ended_at": "2024-01-01T10:01:00+00:00",
+                    "duration_secs": 60,
+                    "total_turns": 1,
+                    "chat_turns": 1,
+                    "investigation_turns": 0,
+                }
+            )
+            + "\n"
+        )
+
+    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
+        results = SessionStore.load_recent(n=3)
+
+    assert len(results) == 3
+
+
+# ── ReplSession session_id rotation ──────────────────────────────────────────
+
+
+def test_repl_session_has_stable_session_id() -> None:
+    s = ReplSession()
+    assert isinstance(s.session_id, str)
+    assert len(s.session_id) > 0
+    assert s.started_at <= time.time()
+
+
+def test_repl_session_rotates_id_on_clear() -> None:
+    s = ReplSession()
+    original_id = s.session_id
+    original_started = s.started_at
+    s.history.append({"type": "chat", "text": "hi", "ok": True})
+    time.sleep(0.01)
+    s.clear()
+    assert s.session_id != original_id
+    assert s.started_at >= original_started

--- a/tests/cli/interactive_shell/sessions/test_store.py
+++ b/tests/cli/interactive_shell/sessions/test_store.py
@@ -1,4 +1,4 @@
-"""Tests for SessionStore: flush and load_recent."""
+"""Tests for SessionStore: incremental writes (open_session, append_turn, flush, load_recent)."""
 
 from __future__ import annotations
 
@@ -14,186 +14,207 @@ from app.cli.interactive_shell.sessions.store import SessionStore
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 
-def _make_session(history: list[dict] | None = None) -> ReplSession:
-    s = ReplSession()
-    if history:
-        s.history.extend(history)
-    return s
+def _make_session() -> ReplSession:
+    return ReplSession()
 
 
 def _read_lines(path: Path) -> list[dict]:
     return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
 
 
-# ── flush ─────────────────────────────────────────────────────────────────────
+def _patch_dir(tmp_path: Path):
+    return patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path)
 
 
-def test_flush_skips_empty_session(tmp_path: Path) -> None:
+# ── open_session ──────────────────────────────────────────────────────────────
+
+
+def test_open_session_creates_file_with_session_start(tmp_path: Path) -> None:
     session = _make_session()
-    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
-        SessionStore.flush(session)
-    assert list(tmp_path.glob("*.jsonl")) == [], "no file written for empty session"
-
-
-def test_flush_writes_correct_structure(tmp_path: Path) -> None:
-    session = _make_session(
-        [
-            {"type": "chat", "text": "hello world", "ok": True},
-            {"type": "alert", "text": "HighCPU on prod", "ok": True},
-            {"type": "slash", "text": "/status", "ok": True},
-        ]
-    )
-    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
-        SessionStore.flush(session)
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
 
     files = list(tmp_path.glob("*.jsonl"))
     assert len(files) == 1
-
     records = _read_lines(files[0])
     assert records[0]["type"] == "session_start"
     assert records[0]["session_id"] == session.session_id
 
-    turn_records = [r for r in records if r["type"] == "turn"]
-    assert len(turn_records) == 3
-    assert turn_records[0]["kind"] == "chat"
-    assert turn_records[1]["kind"] == "alert"
-    assert turn_records[2]["kind"] == "slash"
 
-    end = records[-1]
-    assert end["type"] == "session_end"
-    assert end["total_turns"] == 3
-    assert end["chat_turns"] == 1
-    assert end["investigation_turns"] == 1
+def test_open_session_uses_session_id_as_filename(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+    assert (tmp_path / f"{session.session_id}.jsonl").exists()
 
 
-def test_flush_truncates_long_prompt(tmp_path: Path) -> None:
-    long_text = "x" * 500
-    session = _make_session([{"type": "chat", "text": long_text, "ok": True}])
-    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
-        SessionStore.flush(session)
+def test_open_session_never_raises_on_bad_path() -> None:
+    session = _make_session()
+    with patch(
+        "app.cli.interactive_shell.sessions.store._sessions_dir",
+        return_value=Path("/nonexistent/cannot/write"),
+    ):
+        SessionStore.open_session(session)  # must not raise
 
-    files = list(tmp_path.glob("*.jsonl"))
-    records = _read_lines(files[0])
+
+# ── append_turn ───────────────────────────────────────────────────────────────
+
+
+def test_append_turn_adds_record_to_existing_file(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "hello world")
+        SessionStore.append_turn(session, "alert", "HighCPU on prod")
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    turns = [r for r in records if r["type"] == "turn"]
+    assert len(turns) == 2
+    assert turns[0] == {"type": "turn", "kind": "chat", "text": "hello world"}
+    assert turns[1] == {"type": "turn", "kind": "alert", "text": "HighCPU on prod"}
+
+
+def test_append_turn_truncates_long_text(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "x" * 500)
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
     turn = next(r for r in records if r["type"] == "turn")
     assert len(turn["text"]) == 200
 
 
-def test_flush_uses_session_session_id_as_filename(tmp_path: Path) -> None:
-    session = _make_session([{"type": "chat", "text": "hi", "ok": True}])
-    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
+def test_append_turn_noop_when_file_missing(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        # Do NOT call open_session — file doesn't exist
+        SessionStore.append_turn(session, "chat", "hello")
+    assert not list(tmp_path.glob("*.jsonl")), "no file should be created"
+
+
+# ── flush ─────────────────────────────────────────────────────────────────────
+
+
+def test_flush_writes_session_end(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "q1")
+        SessionStore.append_turn(session, "alert", "alert1")
         SessionStore.flush(session)
 
-    expected_file = tmp_path / f"{session.session_id}.jsonl"
-    assert expected_file.exists()
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    end = records[-1]
+    assert end["type"] == "session_end"
+    assert end["total_turns"] == 2
+    assert end["chat_turns"] == 1
+    assert end["investigation_turns"] == 1
 
 
-def test_flush_never_raises_on_bad_path() -> None:
-    session = _make_session([{"type": "chat", "text": "hi", "ok": True}])
-    with patch(
-        "app.cli.interactive_shell.sessions.store._sessions_dir",
-        return_value=Path("/nonexistent/cannot/write/here"),
-    ):
-        SessionStore.flush(session)  # must not raise
+def test_flush_deletes_file_when_no_turns(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.flush(session)
+
+    assert not (tmp_path / f"{session.session_id}.jsonl").exists()
+
+
+def test_flush_noop_when_file_missing(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.flush(session)  # no open_session called — must not raise
+
+
+# ── session.record() wiring ───────────────────────────────────────────────────
+
+
+def test_session_record_calls_append_turn(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        session.record("chat", "what's wrong with prod?")
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    turns = [r for r in records if r["type"] == "turn"]
+    assert len(turns) == 1
+    assert turns[0]["kind"] == "chat"
+    assert turns[0]["text"] == "what's wrong with prod?"
 
 
 # ── load_recent ───────────────────────────────────────────────────────────────
 
 
 def test_load_recent_returns_empty_when_no_dir(tmp_path: Path) -> None:
-    missing = tmp_path / "no_sessions"
-    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=missing):
+    with _patch_dir(tmp_path / "missing"):
         result = SessionStore.load_recent()
     assert result == []
 
 
-def test_load_recent_returns_sessions_newest_first(tmp_path: Path) -> None:
-    for started in ["2024-01-01T10:00:00+00:00", "2024-01-02T10:00:00+00:00"]:
-        sid = str(uuid.uuid4())
-        path = tmp_path / f"{sid}.jsonl"
-        path.write_text(
-            "\n".join(
-                [
-                    json.dumps({"type": "session_start", "session_id": sid, "started_at": started}),
-                    json.dumps({"type": "turn", "kind": "chat", "text": "hi"}),
-                    json.dumps(
-                        {
-                            "type": "session_end",
-                            "ended_at": started,
-                            "duration_secs": 60,
-                            "total_turns": 1,
-                            "chat_turns": 1,
-                            "investigation_turns": 0,
-                        }
-                    ),
-                ]
-            )
-            + "\n"
-        )
+def test_load_recent_counts_turns_for_in_progress_session(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "hi")
+        SessionStore.append_turn(session, "alert", "OOM")
+        # No flush — session still in progress
 
-    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
-        results = SessionStore.load_recent()
-
-    assert len(results) == 2
-    assert results[0]["started_at"] > results[1]["started_at"]
-
-
-def test_load_recent_handles_crashed_session(tmp_path: Path) -> None:
-    sid = str(uuid.uuid4())
-    path = tmp_path / f"{sid}.jsonl"
-    path.write_text(
-        json.dumps(
-            {
-                "type": "session_start",
-                "session_id": sid,
-                "started_at": "2024-01-01T10:00:00+00:00",
-            }
-        )
-        + "\n"
-        + json.dumps({"type": "turn", "kind": "chat", "text": "hi"})
-        + "\n"
-    )
-
-    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
         results = SessionStore.load_recent()
 
     assert len(results) == 1
-    assert results[0]["total_turns"] is None
+    assert results[0]["total_turns"] == 2
+    assert results[0]["chat_turns"] == 1
+    assert results[0]["investigation_turns"] == 1
     assert results[0]["duration_secs"] is None
+    assert results[0]["is_ended"] is False
+
+
+def test_load_recent_uses_session_end_stats_when_available(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "hi")
+        SessionStore.flush(session)
+
+        results = SessionStore.load_recent()
+
+    assert results[0]["is_ended"] is True
+    assert results[0]["total_turns"] == 1
+    assert results[0]["duration_secs"] is not None
+
+
+def test_load_recent_returns_newest_first(tmp_path: Path) -> None:
+    for started in ["2024-01-01T10:00:00+00:00", "2024-01-02T10:00:00+00:00"]:
+        sid = str(uuid.uuid4())
+        (tmp_path / f"{sid}.jsonl").write_text(
+            json.dumps({"type": "session_start", "session_id": sid, "started_at": started})
+            + "\n"
+            + json.dumps({"type": "turn", "kind": "chat", "text": "hi"})
+            + "\n"
+        )
+
+    with _patch_dir(tmp_path):
+        results = SessionStore.load_recent()
+
+    assert results[0]["started_at"] > results[1]["started_at"]
 
 
 def test_load_recent_skips_malformed_files(tmp_path: Path) -> None:
-    (tmp_path / "bad.jsonl").write_text("this is not json\nalso not json\n")
+    (tmp_path / "bad.jsonl").write_text("not json\n")
     (tmp_path / "empty.jsonl").write_text("")
 
     sid = str(uuid.uuid4())
-    path = tmp_path / f"{sid}.jsonl"
-    path.write_text(
-        "\n".join(
-            [
-                json.dumps(
-                    {
-                        "type": "session_start",
-                        "session_id": sid,
-                        "started_at": "2024-01-03T10:00:00+00:00",
-                    }
-                ),
-                json.dumps({"type": "turn", "kind": "chat", "text": "ok"}),
-                json.dumps(
-                    {
-                        "type": "session_end",
-                        "ended_at": "2024-01-03T10:01:00+00:00",
-                        "duration_secs": 60,
-                        "total_turns": 1,
-                        "chat_turns": 1,
-                        "investigation_turns": 0,
-                    }
-                ),
-            ]
+    (tmp_path / f"{sid}.jsonl").write_text(
+        json.dumps(
+            {"type": "session_start", "session_id": sid, "started_at": "2024-01-01T10:00:00+00:00"}
         )
+        + "\n"
+        + json.dumps({"type": "turn", "kind": "chat", "text": "ok"})
         + "\n"
     )
 
-    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
+    with _patch_dir(tmp_path):
         results = SessionStore.load_recent()
 
     assert len(results) == 1
@@ -203,8 +224,7 @@ def test_load_recent_skips_malformed_files(tmp_path: Path) -> None:
 def test_load_recent_respects_n_limit(tmp_path: Path) -> None:
     for _ in range(5):
         sid = str(uuid.uuid4())
-        path = tmp_path / f"{sid}.jsonl"
-        path.write_text(
+        (tmp_path / f"{sid}.jsonl").write_text(
             json.dumps(
                 {
                     "type": "session_start",
@@ -215,41 +235,55 @@ def test_load_recent_respects_n_limit(tmp_path: Path) -> None:
             + "\n"
             + json.dumps({"type": "turn", "kind": "chat", "text": "hi"})
             + "\n"
-            + json.dumps(
-                {
-                    "type": "session_end",
-                    "ended_at": "2024-01-01T10:01:00+00:00",
-                    "duration_secs": 60,
-                    "total_turns": 1,
-                    "chat_turns": 1,
-                    "investigation_turns": 0,
-                }
-            )
-            + "\n"
         )
 
-    with patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path):
-        results = SessionStore.load_recent(n=3)
-
-    assert len(results) == 3
+    with _patch_dir(tmp_path):
+        assert len(SessionStore.load_recent(n=3)) == 3
 
 
-# ── ReplSession session_id rotation ──────────────────────────────────────────
+# ── /reset lifecycle ──────────────────────────────────────────────────────────
+
+
+def test_reset_closes_old_session_and_opens_new(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        session.record("chat", "pre-reset question")
+        sid1 = session.session_id
+
+        # Simulate /reset
+        SessionStore.flush(session)
+        session.clear()
+        SessionStore.open_session(session)
+        sid2 = session.session_id
+
+        session.record("chat", "post-reset question")
+
+    assert sid1 != sid2
+    # Old session file has session_end
+    old_records = _read_lines(tmp_path / f"{sid1}.jsonl")
+    assert old_records[-1]["type"] == "session_end"
+    # New session file exists with turn but no session_end yet
+    new_records = _read_lines(tmp_path / f"{sid2}.jsonl")
+    assert new_records[0]["type"] == "session_start"
+    assert any(r["type"] == "turn" for r in new_records)
+    assert new_records[-1]["type"] != "session_end"
+
+
+# ── ReplSession field behaviour ───────────────────────────────────────────────
 
 
 def test_repl_session_has_stable_session_id() -> None:
-    s = ReplSession()
-    assert isinstance(s.session_id, str)
-    assert len(s.session_id) > 0
+    s = _make_session()
+    assert isinstance(s.session_id, str) and len(s.session_id) > 0
     assert s.started_at <= time.time()
 
 
 def test_repl_session_rotates_id_on_clear() -> None:
-    s = ReplSession()
+    s = _make_session()
     original_id = s.session_id
-    original_started = s.started_at
     s.history.append({"type": "chat", "text": "hi", "ok": True})
     time.sleep(0.01)
     s.clear()
     assert s.session_id != original_id
-    assert s.started_at >= original_started
+    assert s.started_at <= time.time()


### PR DESCRIPTION
Closes #2642

## Summary

- Each REPL session now gets a stable UUID, set at startup and rotated on `/reset`
- Sessions are flushed to `~/.opensre/sessions/<session_id>.jsonl` on REPL exit or `/reset`
- `/reset` creates a **new** session (old one is saved, new ID begins)
- New `/sessions` slash command lists recent sessions in a table

## Session file format

```jsonl
{"type":"session_start","session_id":"abc-1234","started_at":"2024-01-01T10:00:00Z","opensre_version":"0.1"}
{"type":"turn","kind":"chat","text":"why is CPU spiking on prod-api?"}
{"type":"turn","kind":"alert","text":"HighCPU alert fired on prod-api-1"}
{"type":"session_end","ended_at":"2024-01-01T10:42:00Z","duration_secs":2520,"total_turns":2,"chat_turns":1,"investigation_turns":1}
```

## Files changed

| File | Change |
|---|---|
| `app/cli/interactive_shell/sessions/store.py` | New — `SessionStore.flush()` + `load_recent()` |
| `app/cli/interactive_shell/runtime/session.py` | Add `session_id`, `started_at`; rotate on `clear()` |
| `app/cli/interactive_shell/runtime/entrypoint.py` | Wire flush in `finally` block |
| `app/cli/interactive_shell/command_registry/session_cmds.py` | Flush before `/reset`; add `/sessions` command |
| `app/cli/interactive_shell/command_registry/slash_catalog.py` | Register `/sessions` with LLM metadata |
| `app/cli/interactive_shell/prompt_logging/recorder.py` | Use stable `session.session_id` |
| `tests/cli/interactive_shell/sessions/test_store.py` | 12 unit tests |

## Test plan

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] 12 new unit tests pass (flush, load_recent, crash recovery, malformed files, n-limit, ID rotation)
- [x] Integration smoke: two sessions with `/reset` between them — both files written, `/sessions` lists both correctly

## Follow-up

Session resume, cross-session search, and token tracking tracked in #2643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)