### PR TITLE
chore: add ReplTestHarness for REPL slash command tests

### DIFF
--- a/tests/cli/interactive_shell/conftest.py
+++ b/tests/cli/interactive_shell/conftest.py
@@ -3,8 +3,49 @@
 from __future__ import annotations
 
 import sys
+from dataclasses import dataclass
+from io import StringIO
 
 import pytest
+from rich.console import Console
+
+from app.cli.interactive_shell.runtime.session import ReplSession
+
+
+@dataclass
+class ReplTestHarness:
+    session: ReplSession
+    console: Console
+    output: StringIO
+
+    def run(self, cmd_fn, args=()) -> bool:
+        return cmd_fn(
+            self.session,
+            self.console,
+            list(args),
+        )
+
+    def printed(self) -> str:
+        return self.output.getvalue()
+
+
+@pytest.fixture
+def repl_harness() -> ReplTestHarness:
+    output = StringIO()
+
+    console = Console(
+        file=output,
+        force_terminal=False,
+        highlight=False,
+    )
+
+    session = ReplSession()
+
+    return ReplTestHarness(
+        session=session,
+        console=console,
+        output=output,
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -30,11 +30,24 @@ def _capture() -> tuple[Console, io.StringIO]:
 
 
 class TestDispatchSlash:
-    def test_exit_returns_false(self) -> None:
-        session = ReplSession()
-        console, _ = _capture()
-        assert dispatch_slash("/exit", session, console) is False
-        assert dispatch_slash("/quit", session, console) is False
+    def test_exit_returns_false(self, repl_harness) -> None:
+        assert (
+            dispatch_slash(
+                "/exit",
+                repl_harness.session,
+                repl_harness.console,
+            )
+            is False
+        )
+
+        assert (
+            dispatch_slash(
+                "/quit",
+                repl_harness.session,
+                repl_harness.console,
+            )
+            is False
+        )
 
     def test_help_lists_all_commands(self) -> None:
         session = ReplSession()


### PR DESCRIPTION
Fixes #2645 

#### Describe the changes you have made in this PR -

Implemented a shared `ReplTestHarness` and `repl_harness` pytest fixture for interactive shell tests in `tests/cli/interactive_shell/conftest.py`.

### Changes made:
- Added `ReplTestHarness` dataclass containing:
  - `session` (`ReplSession`)
  - `console` (`rich.console.Console`)
  - `output` (`StringIO` capture buffer)

- Added helper methods:
  - `run()` to execute slash command handlers using the existing `(session, console, args)` signature
  - `printed()` to retrieve captured console output for assertions

- Added reusable `repl_harness` pytest fixture

- Migrated initial slash command tests in `tests/cli/interactive_shell/test_commands.py` to use the shared harness as proof of value

This reduces repeated boilerplate around constructing `ReplSession`, `Console`, and `StringIO` across REPL slash command tests and makes future tests easier to write and maintain.

---

#### Test run

Verified by running:

```bash
pytest tests/cli/interactive_shell/test_commands.py -v
```

All updated tests pass successfully.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance

---

### Explain your implementation approach:

This PR introduces a reusable `ReplTestHarness` fixture to centralize repeated setup logic used across REPL slash command tests.

Previously, multiple tests manually created:
- `ReplSession`
- `Console`
- `StringIO` output buffers

The new harness groups these together in a lightweight dataclass and exposes helper methods to:
- run slash command handlers consistently
- access captured console output for assertions

I chose this approach because it keeps test setup reusable while preserving the existing command handler signature `(session, console, args) -> bool`.

This makes tests shorter, easier to read, and easier to maintain while avoiding duplicated boilerplate across files.


Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
