### PR TITLE
Chore/repl test harness

### DIFF
--- a/tests/cli/interactive_shell/conftest.py
+++ b/tests/cli/interactive_shell/conftest.py
@@ -3,8 +3,49 @@
 from __future__ import annotations
 
 import sys
+from dataclasses import dataclass
+from io import StringIO
 
 import pytest
+from rich.console import Console
+
+from app.cli.interactive_shell.runtime.session import ReplSession
+
+
+@dataclass
+class ReplTestHarness:
+    session: ReplSession
+    console: Console
+    output: StringIO
+
+    def run(self, cmd_fn, args=()) -> bool:
+        return cmd_fn(
+            self.session,
+            self.console,
+            list(args),
+        )
+
+    def printed(self) -> str:
+        return self.output.getvalue()
+
+
+@pytest.fixture
+def repl_harness() -> ReplTestHarness:
+    output = StringIO()
+
+    console = Console(
+        file=output,
+        force_terminal=False,
+        highlight=False,
+    )
+
+    session = ReplSession()
+
+    return ReplTestHarness(
+        session=session,
+        console=console,
+        output=output,
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cli/interactive_shell/conftest.py
+++ b/tests/cli/interactive_shell/conftest.py
@@ -20,9 +20,9 @@ class ReplTestHarness:
     output: StringIO
 
     def run(
-    self,
-    cmd_fn: Callable[[ReplSession, Console, list[str]], bool],
-    args: tuple[str, ...] = (),
+        self,
+        cmd_fn: Callable[[ReplSession, Console, list[str]], bool],
+        args: tuple[str, ...] = (),
     ) -> bool:
         return cmd_fn(
             self.session,

--- a/tests/cli/interactive_shell/conftest.py
+++ b/tests/cli/interactive_shell/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from io import StringIO
 
@@ -18,7 +19,11 @@ class ReplTestHarness:
     console: Console
     output: StringIO
 
-    def run(self, cmd_fn, args=()) -> bool:
+    def run(
+    self,
+    cmd_fn: Callable[[ReplSession, Console, list[str]], bool],
+    args: tuple[str, ...] = (),
+    ) -> bool:
         return cmd_fn(
             self.session,
             self.console,

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -18,6 +18,7 @@ from app.cli.interactive_shell.command_registry.investigation import (
     _validate_investigate_args,
     _validate_save_args,
 )
+
 from app.cli.interactive_shell.command_registry.tasks_cmds import _validate_cancel_args
 from app.cli.interactive_shell.commands import SLASH_COMMANDS, dispatch_slash
 from app.cli.interactive_shell.runtime.session import ReplSession
@@ -48,6 +49,13 @@ class TestDispatchSlash:
             )
             is False
         )
+
+    def test_status_with_harness_run(self, repl_harness) -> None:
+        cmd = SLASH_COMMANDS["/status"]
+
+        repl_harness.run(cmd.handler)
+
+        assert "Session status" in repl_harness.printed()
 
     def test_help_lists_all_commands(self) -> None:
         session = ReplSession()
@@ -329,6 +337,7 @@ class TestDispatchSlash:
         assert "save failed" in buf.getvalue()
         assert len(captured_errors) == 1
         assert isinstance(captured_errors[0], RuntimeError)
+
 
 
 class TestListCommand:

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -30,11 +30,24 @@ def _capture() -> tuple[Console, io.StringIO]:
 
 
 class TestDispatchSlash:
-    def test_exit_returns_false(self) -> None:
-        session = ReplSession()
-        console, _ = _capture()
-        assert dispatch_slash("/exit", session, console) is False
-        assert dispatch_slash("/quit", session, console) is False
+    def test_exit_returns_false(self, repl_harness) -> None:
+        assert (
+            dispatch_slash(
+                "/exit",
+                repl_harness.session,
+                repl_harness.console,
+            )
+            is False
+        )
+
+        assert (
+            dispatch_slash(
+                "/quit",
+                repl_harness.session,
+                repl_harness.console,
+            )
+            is False
+        )
 
     def test_help_lists_all_commands(self) -> None:
         session = ReplSession()

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -18,7 +18,6 @@ from app.cli.interactive_shell.command_registry.investigation import (
     _validate_investigate_args,
     _validate_save_args,
 )
-
 from app.cli.interactive_shell.command_registry.tasks_cmds import _validate_cancel_args
 from app.cli.interactive_shell.commands import SLASH_COMMANDS, dispatch_slash
 from app.cli.interactive_shell.runtime.session import ReplSession
@@ -53,8 +52,9 @@ class TestDispatchSlash:
     def test_status_with_harness_run(self, repl_harness) -> None:
         cmd = SLASH_COMMANDS["/status"]
 
-        repl_harness.run(cmd.handler)
+        result = repl_harness.run(cmd.handler)
 
+        assert result is True
         assert "Session status" in repl_harness.printed()
 
     def test_help_lists_all_commands(self) -> None:


### PR DESCRIPTION
Follow-up to #2648 addressing Greptile review feedback.

Changes:
- added explicit `Callable` typing for `ReplTestHarness.run`
- added a test exercising `repl_harness.run()` using the `/status` command handler
