### PR TITLE
feat(cli): guided investigate picker + strict interactive payload validation

### DIFF
--- a/app/cli/investigation/payload.py
+++ b/app/cli/investigation/payload.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from app.cli.support.constants import SAMPLE_ALERT_OPTIONS
+
 _DEMO_ALERT_FILENAME = "alert.json"
 
 
@@ -41,6 +43,8 @@ def parse_payload_text(raw_text: str, source_label: str) -> dict[str, Any]:
         ) from exc
     if not isinstance(data, dict):
         raise SystemExit(f"Alert payload from {source_label} must be a JSON object.")
+    if not data:
+        raise SystemExit(f"Alert payload from {source_label} must be a non-empty JSON object.")
     return data
 
 
@@ -84,13 +88,132 @@ def load_stdin() -> dict[str, Any]:
 
 def load_interactive() -> dict[str, Any]:
     """Prompt the user to paste an alert payload."""
-    print("Paste the alert JSON payload, then press Ctrl-D when finished.", file=sys.stderr)
-    raw_text = sys.stdin.read()
+    if not sys.stdin.isatty():
+        print("Paste the alert JSON payload, then press Ctrl-D when finished.", file=sys.stderr)
+        raw_text = sys.stdin.read()
+    else:
+        print(
+            "Paste the alert JSON payload. Press Enter on an empty line when finished.",
+            file=sys.stderr,
+        )
+        lines: list[str] = []
+        while True:
+            try:
+                line = input()
+            except EOFError:
+                break
+            except KeyboardInterrupt as exc:
+                raise SystemExit(0) from exc
+            if not line.strip():
+                break
+            lines.append(line)
+        raw_text = "\n".join(lines)
     if not raw_text.strip():
         raise SystemExit("No alert JSON was provided in interactive mode.")
     return parse_payload_text(raw_text, "interactive input")
 
 
+def _render_guided_menu() -> list[tuple[int, str]]:
+    """Render the bare investigate guided menu and return option mapping."""
+    options: list[tuple[int, str]] = [(1, f"demo:{_DEMO_ALERT_FILENAME}")]
+    print("No alert input provided. Choose an investigation input source:", file=sys.stderr)
+    print(f"  1) {_DEMO_ALERT_FILENAME} (bundled demo alert file)", file=sys.stderr)
+
+    next_index = 2
+    for template_name, label in SAMPLE_ALERT_OPTIONS:
+        options.append((next_index, f"template:{template_name}"))
+        print(f"  {next_index}) {label}", file=sys.stderr)
+        next_index += 1
+
+    options.append((next_index, "custom_file"))
+    print(f"  {next_index}) Custom file path", file=sys.stderr)
+    next_index += 1
+
+    options.append((next_index, "paste_json"))
+    print(f"  {next_index}) Paste JSON now", file=sys.stderr)
+    next_index += 1
+
+    options.append((next_index, "cancel"))
+    print(f"  {next_index}) Cancel", file=sys.stderr)
+    return options
+
+
+def _guided_menu_choices() -> list[tuple[str, str]]:
+    """Return guided menu targets and labels for inline picker UIs."""
+    choices: list[tuple[str, str]] = [
+        (f"demo:{_DEMO_ALERT_FILENAME}", f"{_DEMO_ALERT_FILENAME} (bundled demo alert file)"),
+    ]
+    for template_name, label in SAMPLE_ALERT_OPTIONS:
+        choices.append((f"template:{template_name}", label))
+    choices.extend(
+        [
+            ("custom_file", "Custom file path"),
+            ("paste_json", "Paste JSON now"),
+            ("cancel", "Cancel"),
+        ]
+    )
+    return choices
+
+
+def _supports_inline_picker() -> bool:
+    """Return whether we can safely render an inline terminal picker."""
+    return bool(sys.stdin.isatty() and sys.stdout.isatty())
+
+
+def _choose_guided_target() -> str:
+    """Choose a guided menu target using inline picker when available."""
+    choices = _guided_menu_choices()
+    if _supports_inline_picker():
+        import questionary
+
+        selected = questionary.select(
+            "Choose an investigation input source:",
+            choices=[
+                questionary.Choice(label, value=target)
+                for target, label in choices
+            ],
+        ).ask()
+        if selected is None:
+            raise SystemExit(0)
+        return str(selected)
+
+    while True:
+        options = _render_guided_menu()
+        valid_choices = {str(index): target for index, target in options}
+        try:
+            choice = input("Select an option: ").strip()
+        except (EOFError, KeyboardInterrupt) as exc:
+            raise SystemExit(0) from exc
+        target = valid_choices.get(choice)
+        if target is None:
+            print("Invalid selection. Enter one of the menu numbers.", file=sys.stderr)
+            continue
+        return target
+
+
+def _choose_guided_payload() -> dict[str, Any]:
+    from app.cli.investigation.alert_templates import build_alert_template
+
+    while True:
+        target = _choose_guided_target()
+        if target.startswith("demo:"):
+            return load_file(target.split(":", maxsplit=1)[1])
+        if target.startswith("template:"):
+            return build_alert_template(target.split(":", maxsplit=1)[1])
+        if target == "custom_file":
+            try:
+                custom_path = input("Alert file path: ").strip()
+            except (EOFError, KeyboardInterrupt) as exc:
+                raise SystemExit(0) from exc
+            if not custom_path:
+                print("Alert file path cannot be empty.", file=sys.stderr)
+                continue
+            return load_file(custom_path)
+        if target == "paste_json":
+            return load_interactive()
+        if target == "cancel":
+            raise SystemExit(0)
+        raise SystemExit("No alert input selected.")
 def load_payload(
     input_path: str | None,
     input_json: str | None,
@@ -106,8 +229,5 @@ def load_payload(
     if input_path:
         return load_file(input_path)
     if sys.stdin.isatty():
-        raise SystemExit(
-            "No alert input provided. Use --input/-i <file>, --input-json <json>, "
-            "--interactive to paste JSON, or pipe alert JSON on stdin."
-        )
+        return _choose_guided_payload()
     return load_stdin()

--- a/app/cli/investigation/payload.py
+++ b/app/cli/investigation/payload.py
@@ -115,7 +115,9 @@ def load_interactive() -> dict[str, Any]:
             if not isinstance(parsed_candidate, dict):
                 raise SystemExit("Alert payload from interactive input must be a JSON object.")
             if not parsed_candidate:
-                raise SystemExit("Alert payload from interactive input must be a non-empty JSON object.")
+                raise SystemExit(
+                    "Alert payload from interactive input must be a non-empty JSON object."
+                )
             return parsed_candidate
         raw_text = "\n".join(lines)
     if not raw_text.strip():
@@ -178,10 +180,7 @@ def _choose_guided_target() -> str:
 
         selected = questionary.select(
             "Choose an investigation input source:",
-            choices=[
-                questionary.Choice(label, value=target)
-                for target, label in choices
-            ],
+            choices=[questionary.Choice(label, value=target) for target, label in choices],
         ).ask()
         if selected is None:
             raise SystemExit(0)

--- a/app/cli/investigation/payload.py
+++ b/app/cli/investigation/payload.py
@@ -93,7 +93,7 @@ def load_interactive() -> dict[str, Any]:
         raw_text = sys.stdin.read()
     else:
         print(
-            "Paste the alert JSON payload. Press Enter on an empty line when finished.",
+            "Paste the alert JSON payload. It auto-submits once valid JSON is complete.",
             file=sys.stderr,
         )
         lines: list[str] = []
@@ -107,6 +107,16 @@ def load_interactive() -> dict[str, Any]:
             if not line.strip():
                 break
             lines.append(line)
+            candidate = "\n".join(lines)
+            try:
+                parsed_candidate: Any = json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(parsed_candidate, dict):
+                raise SystemExit("Alert payload from interactive input must be a JSON object.")
+            if not parsed_candidate:
+                raise SystemExit("Alert payload from interactive input must be a non-empty JSON object.")
+            return parsed_candidate
         raw_text = "\n".join(lines)
     if not raw_text.strip():
         raise SystemExit("No alert JSON was provided in interactive mode.")
@@ -214,6 +224,8 @@ def _choose_guided_payload() -> dict[str, Any]:
         if target == "cancel":
             raise SystemExit(0)
         raise SystemExit("No alert input selected.")
+
+
 def load_payload(
     input_path: str | None,
     input_json: str | None,

--- a/tests/cli/test_investigation_payload.py
+++ b/tests/cli/test_investigation_payload.py
@@ -57,7 +57,8 @@ def test_load_payload_tty_guided_menu_cancel_exits_zero(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("app.cli.investigation.payload.sys.stdin.isatty", lambda: True)
-    answers = iter(["10"])
+    cancel_index = str(1 + len(SAMPLE_ALERT_OPTIONS) + 3)
+    answers = iter([cancel_index])
     monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
 
     with pytest.raises(SystemExit) as exc_info:

--- a/tests/cli/test_investigation_payload.py
+++ b/tests/cli/test_investigation_payload.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from app.cli.investigation.payload import load_payload
+from app.cli.support.constants import SAMPLE_ALERT_OPTIONS
+
+
+def test_load_payload_tty_guided_menu_template_choice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.cli.investigation.payload.sys.stdin.isatty", lambda: True)
+    answers = iter(["2"])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+
+    payload = load_payload(input_path=None, input_json=None, interactive=False)
+
+    assert payload["alert_source"] == "generic"
+    assert payload["alert_name"]
+
+
+def test_load_payload_tty_guided_menu_custom_file_choice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.cli.investigation.payload.sys.stdin.isatty", lambda: True)
+    custom_file_index = str(1 + len(SAMPLE_ALERT_OPTIONS) + 1)
+    answers = iter([custom_file_index, "alerts/custom.json"])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+    monkeypatch.setattr(
+        "app.cli.investigation.payload.load_file",
+        lambda path: {"loaded_from": path},
+    )
+
+    payload = load_payload(input_path=None, input_json=None, interactive=False)
+
+    assert payload == {"loaded_from": "alerts/custom.json"}
+
+
+def test_load_payload_without_tty_uses_stdin_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.cli.investigation.payload.sys.stdin.isatty", lambda: False)
+    monkeypatch.setattr(
+        "app.cli.investigation.payload.load_stdin",
+        lambda: {"alert_name": "from-stdin"},
+    )
+
+    payload = load_payload(input_path=None, input_json=None, interactive=False)
+
+    assert payload == {"alert_name": "from-stdin"}
+
+
+def test_load_payload_tty_guided_menu_cancel_exits_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.cli.investigation.payload.sys.stdin.isatty", lambda: True)
+    answers = iter(["10"])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+
+    with pytest.raises(SystemExit) as exc_info:
+        load_payload(input_path=None, input_json=None, interactive=False)
+
+    assert exc_info.value.code == 0
+
+
+def test_load_payload_tty_guided_menu_inline_picker_template_choice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.cli.investigation.payload.sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("app.cli.investigation.payload.sys.stdout.isatty", lambda: True)
+
+    class _FakeQuestionary:
+        class Choice:
+            def __init__(self, _label: str, value: str) -> None:
+                self.value = value
+
+        @staticmethod
+        def select(_prompt: str, *, choices: list[object]) -> SimpleNamespace:
+            assert choices
+            return SimpleNamespace(ask=lambda: "template:generic")
+
+    monkeypatch.setitem(sys.modules, "questionary", _FakeQuestionary())
+
+    payload = load_payload(input_path=None, input_json=None, interactive=False)
+
+    assert payload["alert_source"] == "generic"
+
+
+def test_load_payload_input_json_empty_object_raises() -> None:
+    with pytest.raises(SystemExit, match="non-empty JSON object"):
+        load_payload(input_path=None, input_json="{}", interactive=False)
+
+
+def test_load_payload_interactive_tty_empty_payload_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.cli.investigation.payload.sys.stdin.isatty", lambda: True)
+    answers = iter([""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+    with pytest.raises(SystemExit, match="No alert JSON was provided in interactive mode"):
+        load_payload(input_path=None, input_json=None, interactive=True)
+
+
+def test_load_payload_interactive_tty_multiline_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.cli.investigation.payload.sys.stdin.isatty", lambda: True)
+    answers = iter(['{"alert_name":"x",', '"severity":"critical"}', ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+    payload = load_payload(input_path=None, input_json=None, interactive=True)
+
+    assert payload == {"alert_name": "x", "severity": "critical"}

--- a/tests/cli/test_investigation_payload.py
+++ b/tests/cli/test_investigation_payload.py
@@ -109,9 +109,27 @@ def test_load_payload_interactive_tty_multiline_json(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("app.cli.investigation.payload.sys.stdin.isatty", lambda: True)
-    answers = iter(['{"alert_name":"x",', '"severity":"critical"}', ""])
-    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    answers = iter(['{"alert_name":"x",', '"severity":"critical"}'])
+
+    def _fake_input(_prompt: str = "") -> str:
+        try:
+            return next(answers)
+        except StopIteration as exc:  # pragma: no cover - defensive guard
+            raise AssertionError("interactive parser requested an unexpected extra line") from exc
+
+    monkeypatch.setattr("builtins.input", _fake_input)
 
     payload = load_payload(input_path=None, input_json=None, interactive=True)
 
     assert payload == {"alert_name": "x", "severity": "critical"}
+
+
+def test_load_payload_interactive_tty_empty_object_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.cli.investigation.payload.sys.stdin.isatty", lambda: True)
+    answers = iter(["{}"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+    with pytest.raises(SystemExit, match="non-empty JSON object"):
+        load_payload(input_path=None, input_json=None, interactive=True)

--- a/tests/cli/test_investigation_payload.py
+++ b/tests/cli/test_investigation_payload.py
@@ -13,6 +13,7 @@ def test_load_payload_tty_guided_menu_template_choice(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("app.cli.investigation.payload.sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("app.cli.investigation.payload.sys.stdout.isatty", lambda: False)
     answers = iter(["2"])
     monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
 
@@ -26,6 +27,7 @@ def test_load_payload_tty_guided_menu_custom_file_choice(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("app.cli.investigation.payload.sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("app.cli.investigation.payload.sys.stdout.isatty", lambda: False)
     custom_file_index = str(1 + len(SAMPLE_ALERT_OPTIONS) + 1)
     answers = iter([custom_file_index, "alerts/custom.json"])
     monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
@@ -57,6 +59,7 @@ def test_load_payload_tty_guided_menu_cancel_exits_zero(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("app.cli.investigation.payload.sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("app.cli.investigation.payload.sys.stdout.isatty", lambda: False)
     cancel_index = str(1 + len(SAMPLE_ALERT_OPTIONS) + 3)
     answers = iter([cancel_index])
     monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))


### PR DESCRIPTION
Fixes #2532

#### Describe the changes you have made in this PR -
- Added a guided investigation input menu for `opensre investigate` when no input is provided in a TTY.
  - Uses an inline picker (`questionary.select`) in interactive terminals.
  - Falls back to the existing numbered menu in non-inline environments.
- Hardened alert payload validation:
  - Rejects empty JSON objects (`{}`) with a clear error.
  - Keeps strict invalid-JSON parsing with line/column errors.
- Fixed interactive “Paste JSON now” flow getting stuck in TTY:
  - In TTY mode it now reads line-by-line and completes on an empty line.
  - Non-TTY behavior still supports Ctrl-D streamed input.
- Added focused CLI payload tests for:
  - Inline picker selection path.
  - Empty-object rejection.
  - TTY empty interactive payload failure.
  - TTY multiline JSON success.

### Demo/Screenshot for feature changes and bug fixes - 
<img width="1538" height="796" alt="image" src="https://github.com/user-attachments/assets/16124d9f-fbbe-477b-907b-82dcebe976d1" />

[Screencast from 29-05-26 01:26:37 AM IST.webm](https://github.com/user-attachments/assets/d02307b8-5c83-4d28-b552-8c71c7c674ee)



Manual UX behavior:
- `uv run opensre investigate` (TTY, no input) now opens an inline picker menu.
- Choosing “Paste JSON now” accepts multiline JSON and submits on blank line.
- Submitting `{}` now exits with: `Alert payload from interactive input must be a non-empty JSON object.`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- Problem: the previous fallback text menu was clunky, and the paste-json path could block/hang for TTY users; also `{}` payloads were accepted.
- Alternatives considered:
  1) Keep strict command flags only and return error when no input is provided.
  2) Keep only numeric menu.
  3) Add inline picker with fallback and keep old behavior for non-interactive environments.
- Chosen approach: (3), because it improves UX without breaking scripted/non-TTY usage.
- Key logic:
  - `_choose_guided_target()` picks from inline picker or fallback numeric menu.
  - `parse_payload_text()` now rejects empty JSON objects.
  - `load_interactive()` has separate TTY vs non-TTY collection behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
