### PR TITLE
fix(agent): preserve Alertmanager evidence

### DIFF
--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -375,12 +375,16 @@ def _build_seed_calls(
     if not alert_source:
         return []
 
-    target_sources = set(_ALERT_SOURCE_TO_TOOL_SOURCES.get(alert_source, []))
+    target_sources = _ALERT_SOURCE_TO_TOOL_SOURCES.get(alert_source, [])
     if not target_sources:
         return []
 
     resolved = state.get("resolved_integrations") or {}
-    seed_tools = [t for t in tools if str(t.source) in target_sources]
+    source_priority = {source: index for index, source in enumerate(target_sources)}
+    seed_tools = sorted(
+        (t for t in tools if str(t.source) in source_priority),
+        key=lambda item: source_priority[str(item.source)],
+    )
     if not seed_tools:
         return []
 
@@ -614,6 +618,7 @@ def _merge_tool_evidence(
         evidence["alertmanager_silences"] = output.get("silences", [])
         evidence["alertmanager_active_silences"] = output.get("active_silences", [])
         evidence["alertmanager_silences_total"] = output.get("total", 0)
+        return
 
 
 def _build_assistant_msg(llm: Any, response: Any) -> dict[str, Any]:

--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -32,7 +32,7 @@ _ALERT_SOURCE_TO_TOOL_SOURCES: dict[str, list[str]] = {
     "datadog": ["datadog"],
     "cloudwatch": ["cloudwatch"],
     "eks": ["eks"],
-    "alertmanager": ["grafana", "cloudwatch"],
+    "alertmanager": ["alertmanager", "grafana", "cloudwatch"],
     "sentry": ["sentry"],
     "honeycomb": ["honeycomb"],
     "coralogix": ["coralogix"],
@@ -602,6 +602,18 @@ def _merge_tool_evidence(
 
     if tool_name == "query_grafana_service_names":
         evidence["grafana_service_names"] = output.get("service_names", [])
+        return
+
+    if tool_name == "alertmanager_alerts":
+        evidence["alertmanager_alerts"] = output.get("alerts", [])
+        evidence["alertmanager_firing_alerts"] = output.get("firing_alerts", [])
+        evidence["alertmanager_alerts_total"] = output.get("total", 0)
+        return
+
+    if tool_name == "alertmanager_silences":
+        evidence["alertmanager_silences"] = output.get("silences", [])
+        evidence["alertmanager_active_silences"] = output.get("active_silences", [])
+        evidence["alertmanager_silences_total"] = output.get("total", 0)
 
 
 def _build_assistant_msg(llm: Any, response: Any) -> dict[str, Any]:

--- a/app/agent/prompt.py
+++ b/app/agent/prompt.py
@@ -65,7 +65,7 @@ _ALERT_SOURCE_TO_TOOL_SOURCES: dict[str, list[str]] = {
     "datadog": ["datadog"],
     "cloudwatch": ["cloudwatch", "ec2", "rds"],
     "eks": ["eks", "ec2"],
-    "alertmanager": ["eks", "cloudwatch", "grafana"],
+    "alertmanager": ["alertmanager", "eks", "cloudwatch", "grafana"],
     "sentry": ["sentry"],
     "honeycomb": ["honeycomb"],
     "coralogix": ["coralogix"],

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -9,7 +9,9 @@ import pytest
 from app.agent.investigation import (
     ConnectedInvestigationAgent,
     _availability_view,
+    _build_seed_calls,
     _build_synthetic_assistant_tool_call_msg,
+    _merge_tool_evidence,
     _run_parallel,
 )
 from app.integrations.llm_cli.errors import CLITimeoutError
@@ -54,6 +56,73 @@ def test_build_synthetic_assistant_json_for_cli_backed_client() -> None:
     assert '"tool_calls"' in msg["content"]
     assert "query_eks" in msg["content"]
     assert "seed_t" in msg["content"]
+
+
+def test_alertmanager_alert_seeds_alertmanager_tools_first() -> None:
+    alertmanager_tool = MagicMock()
+    alertmanager_tool.name = "alertmanager_alerts"
+    alertmanager_tool.source = "alertmanager"
+    alertmanager_tool.extract_params.return_value = {
+        "base_url": "http://localhost:9093",
+        "bearer_token": "secret",
+    }
+
+    grafana_tool = MagicMock()
+    grafana_tool.name = "query_grafana_logs"
+    grafana_tool.source = "grafana"
+    grafana_tool.extract_params.return_value = {"service_name": "api"}
+
+    state = {
+        "alert_source": "alertmanager",
+        "resolved_integrations": {
+            "alertmanager": {
+                "base_url": "http://localhost:9093",
+                "bearer_token": "secret",
+            },
+            "grafana": {"url": "http://localhost:3000"},
+        },
+    }
+
+    calls = _build_seed_calls(state, [alertmanager_tool, grafana_tool], object())
+
+    assert [call.name for call in calls] == ["alertmanager_alerts", "query_grafana_logs"]
+    assert calls[0].input == {"base_url": "http://localhost:9093"}
+    alertmanager_tool.extract_params.assert_called_once_with(state["resolved_integrations"])
+
+
+def test_alertmanager_tool_output_is_promoted_to_evidence_keys() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "source": "alertmanager",
+        "available": True,
+        "alerts": [
+            {
+                "status": "active",
+                "labels": {"alertname": "AppPostgresDown", "namespace": "app"},
+                "annotations": {"description": "Postgres StatefulSet has 0 ready replicas."},
+            }
+        ],
+        "firing_alerts": [
+            {
+                "status": "active",
+                "labels": {"alertname": "AppPostgresDown", "namespace": "app"},
+            }
+        ],
+        "total": 1,
+    }
+
+    _merge_tool_evidence(evidence, "alertmanager_alerts", output, {"base_url": "http://am:9093"})
+
+    assert evidence["alertmanager_alerts"] == output["alerts"]
+    assert evidence["alertmanager_firing_alerts"] == output["firing_alerts"]
+    assert evidence["alertmanager_alerts_total"] == 1
+    assert evidence["tool_outputs"] == [
+        {
+            "tool_name": "alertmanager_alerts",
+            "tool_args": {"base_url": "http://am:9093"},
+            "data": output,
+        }
+    ]
 
 
 def test_run_gracefully_handles_model_not_found_runtime_error() -> None:

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -83,7 +83,7 @@ def test_alertmanager_alert_seeds_alertmanager_tools_first() -> None:
         },
     }
 
-    calls = _build_seed_calls(state, [alertmanager_tool, grafana_tool], object())
+    calls = _build_seed_calls(state, [grafana_tool, alertmanager_tool], object())
 
     assert [call.name for call in calls] == ["alertmanager_alerts", "query_grafana_logs"]
     assert calls[0].input == {"base_url": "http://localhost:9093"}

--- a/tests/agent/test_prompt.py
+++ b/tests/agent/test_prompt.py
@@ -43,3 +43,21 @@ def test_alert_context_surfaces_v2_contract_hints_for_tool_selection() -> None:
     assert "source_id=aws_rds" in context
     assert "evidence=deployment_metadata" in context
     assert "avoid=Use this tool to inspect SQL query text or Postgres locks." in context
+
+
+def test_alertmanager_context_starts_with_alertmanager_tools() -> None:
+    context = format_alert_context(
+        {
+            "alert_name": "AppPostgresDown",
+            "alert_source": "alertmanager",
+            "pipeline_name": "backend",
+            "severity": "critical",
+            "resolved_integrations": {
+                "alertmanager": {"base_url": "http://localhost:9093"},
+            },
+        }
+    )
+
+    assert "Call these tools first (from: alertmanager" in context
+    assert "`alertmanager_alerts`" in context
+    assert "`alertmanager_silences`" in context


### PR DESCRIPTION
Fixes #2408

#### Describe the changes you have made in this PR -

- Seed Alertmanager tools first for Alertmanager-origin alerts so the agent starts with the primary integration data.
- Preserve `alertmanager_alerts` and `alertmanager_silences` outputs as first-class evidence keys for diagnosis/report generation.
- Add regression coverage for Alertmanager seed ordering and evidence promotion.

Root cause: Alertmanager tool calls could return firing alerts, but the agent evidence merge path did not expose those results under the report-facing Alertmanager evidence keys. That left downstream diagnosis without the structured Alertmanager evidence it needed, matching the `Insufficient evidence` behavior reported in #2408.

### Demo/Screenshot for feature changes and bug fixes -

Validation run from a clean Linux/WSL clone on top of current `upstream/main`:

```text
make lint
# All checks passed!

make format-check
# 1581 files already formatted

make typecheck
# Success: no issues found in 694 source files

make test-scope
# 566 passed in 40.68s
```

A full `make test-cov` was also attempted locally earlier, but it does not complete in this environment because live routing tests require `ANTHROPIC_API_KEY`; the CI.md scoped harness for this diff is `make test-scope`, which passes.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

This keeps the fix narrow to the current agent path. Alertmanager is added to the alert-source seed map so `alertmanager_alerts` and `alertmanager_silences` are selected before the LLM loop for Alertmanager alerts. The evidence merge function now maps those tool results into explicit `alertmanager_*` keys, mirroring the existing Grafana evidence promotion pattern. Tests cover both the tool selection behavior and the evidence structure used by downstream diagnosis/reporting.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.