### PR TITLE
feat(sessions): enrich session files with full conversation for /resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,7 @@ Basic steps:
 - If a new feature is shipped (tool, CLI command, pipeline behavior, integration) -> add a `docs/` page or section covering usage, configuration, and examples before the PR is opened.
 - If a new `docs/` page is added or renamed -> register it in `docs/docs.json` under the correct `pages` array in the same PR (path without `.mdx`, e.g. `messaging/whatsapp` for `docs/messaging/whatsapp.mdx`).
 - If an existing feature changes behavior, flags, or config shape -> update the relevant `docs/` page in the same PR; docs and code must stay in sync.
+- When writing or editing a `docs/` page -> write for **users, not contributors**. Open with a command quick-reference table (command | what it does) if the page covers CLI commands. Follow with brief practical examples. Keep internal file formats, JSONL schemas, and implementation details out of user-facing pages — move those to `docs/DEVELOPMENT.md` or a contributor-only reference file if truly needed.
 - If a tool's API or schema changes -> update docs in `docs/` and update the related unit tests, usually under `tests/tools/`. For investigation LLM tool-calling (any provider), follow [docs/investigation-tool-calling.md](docs/investigation-tool-calling.md).
 - If an integration changes -> update `tests/integrations/` and verify with `make verify-integrations`.
 - If adding a new integration -> follow the New Integration Checklist below before opening the PR for review.

--- a/app/cli/interactive_shell/command_registry/__init__.py
+++ b/app/cli/interactive_shell/command_registry/__init__.py
@@ -65,6 +65,10 @@ _MERGED_SEQUENCE = tuple(
 
 SLASH_COMMANDS: dict[str, SlashCommand] = {cmd.name: cmd for cmd in _MERGED_SEQUENCE}
 
+# Slash commands that adopt a different session file must record the turn after
+# the handler settles session identity (see /resume).
+_DEFER_SLASH_RECORDING: frozenset[str] = frozenset({"/resume"})
+
 
 def dispatch_slash(
     command_line: str,
@@ -143,7 +147,8 @@ def dispatch_slash(
             session.record("slash", stripped, ok=False)
             return True
     if policy_precleared:
-        session.record("slash", stripped, ok=True)
+        if name not in _DEFER_SLASH_RECORDING:
+            session.record("slash", stripped, ok=True)
         return cmd.handler(session, console, args)
     tier = resolve_slash_execution_tier(name, args, cmd.execution_tier)
     policy = evaluate_slash_tier(tier)
@@ -157,7 +162,8 @@ def dispatch_slash(
     ):
         session.record("slash", stripped, ok=False)
         return True
-    session.record("slash", stripped, ok=True)
+    if name not in _DEFER_SLASH_RECORDING:
+        session.record("slash", stripped, ok=True)
     return cmd.handler(session, console, args)
 
 

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -432,19 +432,47 @@ def _apply_resume_data(data: dict, session: ReplSession, console: Console) -> bo
     session.resumed_from_name = name
 
     # ── Print full conversation so the user knows what context was loaded ──────
+    # Merge turn_detail records (all recorded turns, full text) with
+    # cli_agent_messages from the snapshot (captures turns that may not have a
+    # matching turn_detail — e.g. processed before enrichment, or Codex path).
+    # Result: the user sees every exchange that happened in the session.
+    turn_details = data.get("turn_details") or []
+    display_pairs: list[tuple[str, str]] = []
+    seen_prompts: set[str] = set()
+
+    for td in turn_details:
+        if td.get("kind") in ("chat", "cli_agent", "cli_help", "follow_up", "alert"):
+            prompt = td.get("prompt") or ""
+            response = td.get("response") or ""
+            if prompt:
+                display_pairs.append(("user", prompt))
+                seen_prompts.add(prompt)
+            if response:
+                display_pairs.append(("assistant", response))
+
+    # Append any snapshot messages not already covered by turn_detail records.
+    for role, text in messages:
+        if role == "user" and text not in seen_prompts:
+            display_pairs.append(("user", text))
+            seen_prompts.add(text)
+        elif role == "assistant" and display_pairs and display_pairs[-1][0] == "user":
+            # Only append assistant reply if the preceding user turn was just added.
+            display_pairs.append(("assistant", text))
+
     source = "snapshot" if has_snapshot else "turn records"
     name_str = f" · {escape(name)}" if name else ""
     console.print(
         f"[{HIGHLIGHT}]resumed session {short_id}{name_str}[/] "
-        f"[{DIM}]({len(messages)} messages from {source})[/]"
+        f"[{DIM}]({len(messages)} messages in context from {source})[/]"
     )
-    console.print(f"[{DIM}]─── conversation history ────────────────────────────────────[/]")
-    for role, text in messages:
-        if role == "user":
-            console.print(f"[{HIGHLIGHT}]you[/]  {escape(text)}")
-        else:
-            console.print(f"[{DIM}]sre[/]  {escape(text)}")
-    console.print(f"[{DIM}]─────────────────────────────────────────────────────────────[/]")
+    if display_pairs:
+        console.print(f"[{DIM}]─── conversation history ─────────────────────────────────[/]")
+        for role, text in display_pairs:
+            if role == "user":
+                console.print(f"[{HIGHLIGHT}]you[/]  {escape(text)}")
+            else:
+                console.print(f"[{DIM}]sre[/]  {escape(text)}")
+        console.print(f"[{DIM}]─────────────────────────────────────────────────────────[/]")
 
     if context:
         console.print(

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -462,15 +462,16 @@ def _render_resumed_session_history(
         console.print(f"[{DIM}]─────────────────────────────────────────────────────────[/]")
         return
 
-    seen_prompts: set[str] = set()
+    has_pending_user = False
     for role, text in messages:
-        if role == "user" and text not in seen_prompts:
+        if role == "user":
             console.print(f"[bold {HIGHLIGHT}]❯[/] {escape(text)}")
-            seen_prompts.add(text)
-        elif role == "assistant":
+            has_pending_user = True
+        elif role == "assistant" and has_pending_user:
             render_response_header(console, "assistant")
             with console.use_theme(MARKDOWN_THEME):
                 console.print(Markdown(text, code_theme="ansi_dark"))
+            has_pending_user = False
     console.print(f"[{DIM}]─────────────────────────────────────────────────────────[/]")
 
 

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -1,4 +1,4 @@
-"""Slash commands: session control and status (/status, /reset, /clear, /trust, …)."""
+"""Slash commands: session control and status (/status, /new, /clear, /trust, …)."""
 
 from __future__ import annotations
 
@@ -41,22 +41,13 @@ def _cmd_clear(session: ReplSession, console: Console, _args: list[str]) -> bool
     return True
 
 
-def _cmd_reset(session: ReplSession, console: Console, _args: list[str]) -> bool:
-    from app.cli.interactive_shell.sessions.store import SessionStore
-
-    SessionStore.flush(session)  # close current session file
-    session.clear()  # rotate session_id + started_at, clears all context
-    SessionStore.open_session(session)  # open new session file immediately
-    console.print(f"[{DIM}]session state cleared — new session started.[/]")
-    return True
-
-
 def _cmd_new(session: ReplSession, console: Console, _args: list[str]) -> bool:
     """Start a new session while preserving the current LLM conversation context.
 
-    Unlike /reset (which clears everything), /new keeps cli_agent_messages and
+    Unlike /clear (which only clears the screen), /new rotates the session ID
+    and resets all session state while keeping cli_agent_messages and
     accumulated_context so a resumed or in-progress conversation continues
-    seamlessly in a fresh session file with a new session ID.
+    seamlessly in a fresh session file.
     """
     from app.cli.interactive_shell.sessions.store import SessionStore
 
@@ -561,7 +552,6 @@ def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool
 
 COMMANDS: list[SlashCommand] = [
     SlashCommand("/clear", "Clear the screen and re-render the banner.", _cmd_clear),
-    SlashCommand("/reset", "Clear session state.", _cmd_reset, notes=("Trust mode is preserved.",)),
     SlashCommand(
         "/trust",
         "Manage trust mode.",
@@ -608,7 +598,7 @@ COMMANDS: list[SlashCommand] = [
         "Start a new session while keeping the current conversation context.",
         _cmd_new,
         notes=(
-            "Unlike /reset, /new preserves cli_agent_messages and accumulated infra context.",
+            "Unlike /clear, /new rotates the session ID and resets state while keeping LLM context.",
             "Use after /resume to continue a conversation in a clean session file.",
         ),
     ),

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+from collections import deque
 
 from rich.console import Console
 from rich.markup import escape
@@ -432,13 +433,13 @@ def _render_resumed_session_history(
     console.print(f"[{DIM}]─── conversation history ─────────────────────────────────[/]")
 
     if history:
-        assistant_by_user: dict[str, str] = {}
+        assistant_by_user: dict[str, deque[str]] = {}
         pending_user: str | None = None
         for role, text in messages:
             if role == "user":
                 pending_user = text
             elif role == "assistant" and pending_user is not None:
-                assistant_by_user.setdefault(pending_user, text)
+                assistant_by_user.setdefault(pending_user, deque()).append(text)
                 pending_user = None
 
         for rec in history:
@@ -450,7 +451,10 @@ def _render_resumed_session_history(
             if kind not in _HISTORY_DISPLAY_CHAT_KINDS or not text:
                 continue
             console.print(f"[bold {HIGHLIGHT}]❯[/] {escape(text)}")
-            response = _response_for_prompt(turn_details, text) or assistant_by_user.get(text, "")
+            response = _response_for_prompt(turn_details, text)
+            if not response:
+                queued = assistant_by_user.get(text)
+                response = queued.popleft() if queued else ""
             if response:
                 render_response_header(console, "assistant")
                 with console.use_theme(MARKDOWN_THEME):
@@ -495,6 +499,8 @@ def _apply_resume_data(
             console.print(
                 f"[{DIM}]tip: turn_detail records are only written when prompt logging is enabled.[/]"
             )
+        if slash_command:
+            session.record("slash", slash_command, ok=False)
         return True
 
     existing = session.cli_agent_messages

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -314,6 +314,71 @@ def _cmd_sessions(session: ReplSession, console: Console, _args: list[str]) -> b
     return True
 
 
+def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool:
+    from app.cli.interactive_shell.sessions.store import SessionStore
+
+    if not args:
+        console.print(f"[{DIM}]usage: /resume <session-id-prefix>[/]")
+        console.print(f"[{DIM}]run /sessions to list session IDs.[/]")
+        return True
+
+    prefix = args[0].strip()
+    data = SessionStore.load_session(prefix)
+
+    if data is None:
+        # Check whether prefix is ambiguous (multiple matches)
+        sessions_dir = None
+        try:
+            from app.constants import OPENSRE_HOME_DIR
+
+            sessions_dir = OPENSRE_HOME_DIR / "sessions"
+        except Exception:
+            pass
+        if sessions_dir and sessions_dir.exists():
+            matches = [p for p in sessions_dir.glob("*.jsonl") if p.stem.startswith(prefix)]
+            if len(matches) > 1:
+                console.print(
+                    f"[{WARNING}]ambiguous prefix '{escape(prefix)}' matches {len(matches)} sessions — "
+                    "use more characters.[/]"
+                )
+                return True
+        console.print(f"[{ERROR}]session '{escape(prefix)}' not found.[/]")
+        return True
+
+    messages = data.get("cli_agent_messages") or []
+    context = data.get("accumulated_context") or {}
+    has_snapshot = data.get("has_snapshot", False)
+    sid = data.get("session_id", prefix)
+    short_id = sid[:8] if len(sid) >= 8 else sid
+
+    if not messages and not context:
+        console.print(
+            f"[{DIM}]session {short_id} has no conversation to resume "
+            "(no chat turns or context found).[/]"
+        )
+        return True
+
+    # Restore conversation context into the current session.
+    session.cli_agent_messages = list(messages)
+    session.accumulated_context = dict(context)
+
+    source = "snapshot" if has_snapshot else "turn records"
+    console.print(
+        f"[{HIGHLIGHT}]resumed session {short_id}[/] "
+        f"[{DIM}]({len(messages)} messages from {source})[/]"
+    )
+    if context:
+        console.print(
+            f"[{DIM}]accumulated context restored:[/] "
+            + ", ".join(f"{k}={escape(str(v))}" for k, v in sorted(context.items()))
+        )
+    console.print(f"[{DIM}]conversation context loaded — continue asking questions.[/]")
+    return True
+
+
+_RESUME_FIRST_ARGS: tuple[tuple[str, str], ...] = ()  # dynamic — session ID prefixes
+
+
 COMMANDS: list[SlashCommand] = [
     SlashCommand("/clear", "Clear the screen and re-render the banner.", _cmd_clear),
     SlashCommand("/reset", "Clear session state.", _cmd_reset, notes=("Trust mode is preserved.",)),
@@ -346,6 +411,17 @@ COMMANDS: list[SlashCommand] = [
     ),
     SlashCommand("/compact", "Trim old session history to free memory.", _cmd_compact),
     SlashCommand("/sessions", "List recent REPL sessions.", _cmd_sessions),
+    SlashCommand(
+        "/resume",
+        "Resume a previous session by restoring its conversation context.",
+        _cmd_resume,
+        usage=("/resume <session-id-prefix>",),
+        notes=(
+            "Restores cli_agent_messages and accumulated infra context from the chosen session.",
+            "The first 8 characters of a session ID (shown by /sessions) are enough.",
+            "Does not replace turns already in the current session.",
+        ),
+    ),
 ]
 
 __all__ = ["COMMANDS"]

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 
 from rich.console import Console
@@ -278,6 +279,23 @@ def _format_duration(duration_secs: int | None) -> str:
     return f"{h}h {m}m"
 
 
+def _record_resume_slash(
+    session: ReplSession,
+    args: list[str],
+    *,
+    ok: bool = True,
+    picked_id: str | None = None,
+) -> None:
+    """Record /resume in the active session file after identity is settled."""
+    if picked_id:
+        text = f"/resume {picked_id[:8]}"
+    elif args:
+        text = f"/resume {' '.join(args)}"
+    else:
+        text = "/resume"
+    session.record("slash", text, ok=ok)
+
+
 def _cmd_sessions(session: ReplSession, console: Console, _args: list[str]) -> bool:
     from datetime import UTC, datetime
 
@@ -377,10 +395,88 @@ def _interactive_resume_menu(session: ReplSession, console: Console) -> bool:
     if picked is None or picked == "done":
         return True
 
-    return _do_resume(picked, session, console)
+    slash_command = f"/resume {picked[:8]}"
+    if not _do_resume(picked, session, console, slash_command=slash_command):
+        _record_resume_slash(session, [], picked_id=picked, ok=False)
+    return True
 
 
-def _apply_resume_data(data: dict, session: ReplSession, console: Console) -> bool:
+_HISTORY_DISPLAY_CHAT_KINDS: frozenset[str] = frozenset(
+    {"chat", "cli_agent", "cli_help", "follow_up", "alert", "incoming_alert"}
+)
+
+
+def _response_for_prompt(turn_details: list[dict], prompt: str) -> str:
+    for detail in turn_details:
+        if detail.get("prompt") == prompt:
+            return str(detail.get("response") or "")
+    return ""
+
+
+def _render_resumed_session_history(
+    console: Console,
+    *,
+    history: list[dict],
+    turn_details: list[dict],
+    messages: list[tuple[str, str]],
+) -> None:
+    """Render prior session activity in REPL turn order, including slash commands."""
+    from rich.markdown import Markdown
+
+    from app.cli.interactive_shell.ui.streaming import render_response_header
+    from app.cli.interactive_shell.ui.theme import MARKDOWN_THEME
+
+    if not history and not messages:
+        return
+
+    console.print(f"[{DIM}]─── conversation history ─────────────────────────────────[/]")
+
+    if history:
+        assistant_by_user: dict[str, str] = {}
+        pending_user: str | None = None
+        for role, text in messages:
+            if role == "user":
+                pending_user = text
+            elif role == "assistant" and pending_user is not None:
+                assistant_by_user.setdefault(pending_user, text)
+                pending_user = None
+
+        for rec in history:
+            kind = rec.get("kind", "")
+            text = rec.get("text") or ""
+            if kind == "slash":
+                console.print(f"[bold]$ {escape(text)}[/bold]")
+                continue
+            if kind not in _HISTORY_DISPLAY_CHAT_KINDS or not text:
+                continue
+            console.print(f"[bold {HIGHLIGHT}]❯[/] {escape(text)}")
+            response = _response_for_prompt(turn_details, text) or assistant_by_user.get(text, "")
+            if response:
+                render_response_header(console, "assistant")
+                with console.use_theme(MARKDOWN_THEME):
+                    console.print(Markdown(response, code_theme="ansi_dark"))
+        console.print(f"[{DIM}]─────────────────────────────────────────────────────────[/]")
+        return
+
+    seen_prompts: set[str] = set()
+    for role, text in messages:
+        if role == "user" and text not in seen_prompts:
+            console.print(f"[bold {HIGHLIGHT}]❯[/] {escape(text)}")
+            seen_prompts.add(text)
+        elif role == "assistant":
+            render_response_header(console, "assistant")
+            with console.use_theme(MARKDOWN_THEME):
+                console.print(Markdown(text, code_theme="ansi_dark"))
+    console.print(f"[{DIM}]─────────────────────────────────────────────────────────[/]")
+
+
+def _apply_resume_data(
+    data: dict,
+    session: ReplSession,
+    console: Console,
+    *,
+    slash_command: str | None = None,
+) -> bool:
     """Apply loaded session data into the running session and print a summary."""
     messages = data.get("cli_agent_messages") or []
     context = data.get("accumulated_context") or {}
@@ -408,13 +504,24 @@ def _apply_resume_data(data: dict, session: ReplSession, console: Console) -> bo
             "they will be replaced by the resumed context.[/]"
         )
 
-    # Rotate to a fresh continuation session so the resumed context has a clean
-    # home and /sessions shows a clear chain.  Flush the current session first
-    # (preserving its own history on disk); empty sessions are deleted by flush().
+    from datetime import datetime
+
     from app.cli.interactive_shell.sessions.store import SessionStore
 
-    SessionStore.flush(session)
-    session.clear()
+    target_sid = sid
+    if session.session_id != target_sid:
+        # Close the current session file before switching identity.
+        SessionStore.flush(session)
+        session.clear(rotate_identity=False)
+        session.session_id = target_sid
+        started_raw = data.get("started_at")
+        if started_raw:
+            with contextlib.suppress(Exception):
+                session.started_at = datetime.fromisoformat(started_raw).timestamp()
+        SessionStore.reopen_session(target_sid)
+    else:
+        session.clear(rotate_identity=False)
+        session.session_id = target_sid
 
     # Restore LLM conversation thread so the next prompt has full prior context.
     session.cli_agent_messages = list(messages)
@@ -426,40 +533,6 @@ def _apply_resume_data(data: dict, session: ReplSession, console: Console) -> bo
     if history:
         session.history = list(history) + session.history
 
-    # Store the resumed session's name so /sessions can display it for the current
-    # session before it has accumulated its own first turn.
-    session.resumed_from_name = name
-
-    SessionStore.open_session(session)
-
-    # ── Print full conversation so the user knows what context was loaded ──────
-    # Merge turn_detail records (all recorded turns, full text) with
-    # cli_agent_messages from the snapshot (captures turns that may not have a
-    # matching turn_detail — e.g. processed before enrichment, or Codex path).
-    # Result: the user sees every exchange that happened in the session.
-    turn_details = data.get("turn_details") or []
-    display_pairs: list[tuple[str, str]] = []
-    seen_prompts: set[str] = set()
-
-    for td in turn_details:
-        if td.get("kind") in ("chat", "cli_agent", "cli_help", "follow_up", "alert"):
-            prompt = td.get("prompt") or ""
-            response = td.get("response") or ""
-            if prompt:
-                display_pairs.append(("user", prompt))
-                seen_prompts.add(prompt)
-            if response:
-                display_pairs.append(("assistant", response))
-
-    # Append any snapshot messages not already covered by turn_detail records.
-    for role, text in messages:
-        if role == "user" and text not in seen_prompts:
-            display_pairs.append(("user", text))
-            seen_prompts.add(text)
-        elif role == "assistant" and display_pairs and display_pairs[-1][0] == "user":
-            # Only append assistant reply if the preceding user turn was just added.
-            display_pairs.append(("assistant", text))
-
     source = "snapshot" if has_snapshot else "turn records"
     name_str = f" · {escape(name)}" if name else ""
     console.print(
@@ -467,33 +540,32 @@ def _apply_resume_data(data: dict, session: ReplSession, console: Console) -> bo
         f"[{DIM}]({len(messages)} messages in context from {source})[/]"
     )
 
-    # Display conversation history in the same REPL format used for new turns so
-    # the user sees a continuous flow: `❯ prompt` / `● assistant` for each pair.
-    if display_pairs:
-        from rich.markdown import Markdown
-
-        from app.cli.interactive_shell.ui.streaming import render_response_header
-        from app.cli.interactive_shell.ui.theme import MARKDOWN_THEME
-
-        console.print(f"[{DIM}]─── conversation history ─────────────────────────────────[/]")
-        for role, text in display_pairs:
-            if role == "user":
-                console.print(f"[bold {HIGHLIGHT}]❯[/] {escape(text)}")
-            else:
-                render_response_header(console, "assistant")
-                with console.use_theme(MARKDOWN_THEME):
-                    console.print(Markdown(text, code_theme="ansi_dark"))
-        console.print(f"[{DIM}]─────────────────────────────────────────────────────────[/]")
+    _render_resumed_session_history(
+        console,
+        history=history,
+        turn_details=data.get("turn_details") or [],
+        messages=list(messages),
+    )
 
     if context:
         console.print(
             f"[{DIM}]accumulated context restored:[/] "
             + ", ".join(f"{escape(k)}={escape(str(v))}" for k, v in sorted(context.items()))
         )
+
+    if slash_command:
+        session.record("slash", slash_command)
+
     return True
 
 
-def _do_resume(prefix: str, session: ReplSession, console: Console) -> bool:
+def _do_resume(
+    prefix: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    slash_command: str | None = None,
+) -> bool:
     """Load session by ID prefix and restore context into the running session."""
     from app.cli.interactive_shell.sessions.store import SessionStore
 
@@ -507,8 +579,8 @@ def _do_resume(prefix: str, session: ReplSession, console: Console) -> bool:
             )
         else:
             console.print(f"[{ERROR}]session '{escape(prefix)}' not found.[/]")
-        return True
-    return _apply_resume_data(data, session, console)
+        return False
+    return _apply_resume_data(data, session, console, slash_command=slash_command)
 
 
 def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool:
@@ -518,6 +590,7 @@ def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool
     if not args:
         console.print(f"[{DIM}]usage: /resume <session-id-prefix>[/]")
         console.print(f"[{DIM}]run /sessions to list session IDs.[/]")
+        _record_resume_slash(session, args)
         return True
 
     prefix = args[0].strip()
@@ -528,6 +601,7 @@ def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool
             f"[{DIM}]session {prefix[:8]} is the current session — "
             "run /sessions to pick a previous one.[/]"
         )
+        _record_resume_slash(session, args)
         return True
 
     data = None
@@ -551,6 +625,7 @@ def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool
                 f"[{WARNING}]'{escape(prefix)}' matches {len(candidates)} sessions by name — "
                 "use a session ID prefix or be more specific.[/]"
             )
+            _record_resume_slash(session, args, ok=False)
             return True
 
     if data is None:
@@ -562,9 +637,12 @@ def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool
             )
         else:
             console.print(f"[{ERROR}]session '{escape(prefix)}' not found.[/]")
+        _record_resume_slash(session, args, ok=False)
         return True
 
-    return _apply_resume_data(data, session, console)
+    slash_command = f"/resume {' '.join(args)}" if args else "/resume"
+    _apply_resume_data(data, session, console, slash_command=slash_command)
+    return True
 
 
 COMMANDS: list[SlashCommand] = [

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -45,9 +45,40 @@ def _cmd_reset(session: ReplSession, console: Console, _args: list[str]) -> bool
     from app.cli.interactive_shell.sessions.store import SessionStore
 
     SessionStore.flush(session)  # close current session file
-    session.clear()  # rotate session_id + started_at
+    session.clear()  # rotate session_id + started_at, clears all context
     SessionStore.open_session(session)  # open new session file immediately
     console.print(f"[{DIM}]session state cleared — new session started.[/]")
+    return True
+
+
+def _cmd_new(session: ReplSession, console: Console, _args: list[str]) -> bool:
+    """Start a new session while preserving the current LLM conversation context.
+
+    Unlike /reset (which clears everything), /new keeps cli_agent_messages and
+    accumulated_context so a resumed or in-progress conversation continues
+    seamlessly in a fresh session file with a new session ID.
+    """
+    from app.cli.interactive_shell.sessions.store import SessionStore
+
+    # Snapshot what we want to carry forward before clear() wipes it.
+    saved_messages = list(session.cli_agent_messages)
+    saved_context = dict(session.accumulated_context)
+    saved_resumed_name = session.resumed_from_name
+
+    SessionStore.flush(session)  # close current session file
+    session.clear()  # rotate session_id + started_at, clear all state
+
+    # Re-inject the preserved context into the new session.
+    session.cli_agent_messages = saved_messages
+    session.accumulated_context = saved_context
+    session.resumed_from_name = saved_resumed_name
+
+    SessionStore.open_session(session)  # open new session file
+    console.print(
+        f"[{DIM}]new session started[/] [{HIGHLIGHT}]—[/] [{DIM}]conversation context carried forward.[/]"
+    )
+    if saved_messages:
+        console.print(f"[{DIM}]  {len(saved_messages)} messages in context · type to continue[/]")
     return True
 
 
@@ -281,6 +312,10 @@ def _cmd_sessions(session: ReplSession, console: Console, _args: list[str]) -> b
         is_current = sid == session.session_id
 
         name = entry.get("name") or ""
+        # For the current session with no own turns yet, fall back to the name
+        # of the most recently resumed session so the user has context.
+        if is_current and not name and session.resumed_from_name:
+            name = f"↩ {session.resumed_from_name}"
         if is_current:
             name_col = f"[{DIM}](current)[/]" if not name else f"{escape(name)} [{DIM}](current)[/]"
         else:
@@ -392,18 +427,33 @@ def _apply_resume_data(data: dict, session: ReplSession, console: Console) -> bo
     if history:
         session.history = list(history) + session.history
 
+    # Store the resumed session's name so /sessions can display it for the current
+    # session before it has accumulated its own first turn.
+    session.resumed_from_name = name
+
+    # ── Print full conversation so the user knows what context was loaded ──────
     source = "snapshot" if has_snapshot else "turn records"
     name_str = f" · {escape(name)}" if name else ""
     console.print(
         f"[{HIGHLIGHT}]resumed session {short_id}{name_str}[/] "
         f"[{DIM}]({len(messages)} messages from {source})[/]"
     )
+    console.print(f"[{DIM}]─── conversation history ────────────────────────────────────[/]")
+    for role, text in messages:
+        if role == "user":
+            console.print(f"[{HIGHLIGHT}]you[/]  {escape(text)}")
+        else:
+            console.print(f"[{DIM}]sre[/]  {escape(text)}")
+    console.print(f"[{DIM}]─────────────────────────────────────────────────────────────[/]")
+
     if context:
         console.print(
             f"[{DIM}]accumulated context restored:[/] "
             + ", ".join(f"{escape(k)}={escape(str(v))}" for k, v in sorted(context.items()))
         )
-    console.print(f"[{DIM}]conversation context loaded — continue asking questions.[/]")
+    console.print(
+        f"[{DIM}]tip: type[/] [{HIGHLIGHT}]/new[/] [{DIM}]to start a clean session that continues this context.[/]"
+    )
     return True
 
 
@@ -435,6 +485,15 @@ def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool
         return True
 
     prefix = args[0].strip()
+
+    # Guard: resuming the active session onto itself is a no-op at best.
+    if session.session_id.startswith(prefix):
+        console.print(
+            f"[{DIM}]session {prefix[:8]} is the current session — "
+            "run /sessions to pick a previous one.[/]"
+        )
+        return True
+
     data = None
 
     # Try ID prefix first, then fall back to name substring match
@@ -514,6 +573,15 @@ COMMANDS: list[SlashCommand] = [
             "Bare /resume opens an interactive session picker in a TTY.",
             "Accepts a session ID prefix or a name substring (e.g. /resume redis).",
             "Replaces the current session's LLM conversation context; warns if messages exist.",
+        ),
+    ),
+    SlashCommand(
+        "/new",
+        "Start a new session while keeping the current conversation context.",
+        _cmd_new,
+        notes=(
+            "Unlike /reset, /new preserves cli_agent_messages and accumulated infra context.",
+            "Use after /resume to continue a conversation in a clean session file.",
         ),
     ),
 ]

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -326,23 +326,15 @@ def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool
     data = SessionStore.load_session(prefix)
 
     if data is None:
-        # Check whether prefix is ambiguous (multiple matches)
-        sessions_dir = None
-        try:
-            from app.constants import OPENSRE_HOME_DIR
-
-            sessions_dir = OPENSRE_HOME_DIR / "sessions"
-        except Exception:
-            pass
-        if sessions_dir and sessions_dir.exists():
-            matches = [p for p in sessions_dir.glob("*.jsonl") if p.stem.startswith(prefix)]
-            if len(matches) > 1:
-                console.print(
-                    f"[{WARNING}]ambiguous prefix '{escape(prefix)}' matches {len(matches)} sessions — "
-                    "use more characters.[/]"
-                )
-                return True
-        console.print(f"[{ERROR}]session '{escape(prefix)}' not found.[/]")
+        # Distinguish "not found" from "ambiguous prefix" using a single store query.
+        n = SessionStore.count_prefix_matches(prefix)
+        if n > 1:
+            console.print(
+                f"[{WARNING}]ambiguous prefix '{escape(prefix)}' matches {n} sessions — "
+                "use more characters.[/]"
+            )
+        else:
+            console.print(f"[{ERROR}]session '{escape(prefix)}' not found.[/]")
         return True
 
     messages = data.get("cli_agent_messages") or []
@@ -356,9 +348,20 @@ def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool
             f"[{DIM}]session {short_id} has no conversation to resume "
             "(no chat turns or context found).[/]"
         )
+        if not data.get("turn_details") and not has_snapshot:
+            console.print(
+                f"[{DIM}]tip: turn_detail records are only written when prompt logging is enabled.[/]"
+            )
         return True
 
-    # Restore conversation context into the current session.
+    # Warn if replacing an active conversation — cli_agent_messages is fully replaced.
+    existing = session.cli_agent_messages
+    if existing:
+        console.print(
+            f"[{WARNING}]current session has {len(existing)} messages — "
+            "they will be replaced by the resumed context.[/]"
+        )
+
     session.cli_agent_messages = list(messages)
     session.accumulated_context = dict(context)
 
@@ -374,9 +377,6 @@ def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool
         )
     console.print(f"[{DIM}]conversation context loaded — continue asking questions.[/]")
     return True
-
-
-_RESUME_FIRST_ARGS: tuple[tuple[str, str], ...] = ()  # dynamic — session ID prefixes
 
 
 COMMANDS: list[SlashCommand] = [
@@ -419,7 +419,7 @@ COMMANDS: list[SlashCommand] = [
         notes=(
             "Restores cli_agent_messages and accumulated infra context from the chosen session.",
             "The first 8 characters of a session ID (shown by /sessions) are enough.",
-            "Does not replace turns already in the current session.",
+            "Replaces the current session's LLM conversation context; warns if messages exist.",
         ),
     ),
 ]

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -408,6 +408,14 @@ def _apply_resume_data(data: dict, session: ReplSession, console: Console) -> bo
             "they will be replaced by the resumed context.[/]"
         )
 
+    # Rotate to a fresh continuation session so the resumed context has a clean
+    # home and /sessions shows a clear chain.  Flush the current session first
+    # (preserving its own history on disk); empty sessions are deleted by flush().
+    from app.cli.interactive_shell.sessions.store import SessionStore
+
+    SessionStore.flush(session)
+    session.clear()
+
     # Restore LLM conversation thread so the next prompt has full prior context.
     session.cli_agent_messages = list(messages)
 
@@ -421,6 +429,8 @@ def _apply_resume_data(data: dict, session: ReplSession, console: Console) -> bo
     # Store the resumed session's name so /sessions can display it for the current
     # session before it has accumulated its own first turn.
     session.resumed_from_name = name
+
+    SessionStore.open_session(session)
 
     # ── Print full conversation so the user knows what context was loaded ──────
     # Merge turn_detail records (all recorded turns, full text) with
@@ -456,13 +466,23 @@ def _apply_resume_data(data: dict, session: ReplSession, console: Console) -> bo
         f"[{HIGHLIGHT}]resumed session {short_id}{name_str}[/] "
         f"[{DIM}]({len(messages)} messages in context from {source})[/]"
     )
+
+    # Display conversation history in the same REPL format used for new turns so
+    # the user sees a continuous flow: `❯ prompt` / `● assistant` for each pair.
     if display_pairs:
+        from rich.markdown import Markdown
+
+        from app.cli.interactive_shell.ui.streaming import render_response_header
+        from app.cli.interactive_shell.ui.theme import MARKDOWN_THEME
+
         console.print(f"[{DIM}]─── conversation history ─────────────────────────────────[/]")
         for role, text in display_pairs:
             if role == "user":
-                console.print(f"[{HIGHLIGHT}]you[/]  {escape(text)}")
+                console.print(f"[bold {HIGHLIGHT}]❯[/] {escape(text)}")
             else:
-                console.print(f"[{DIM}]sre[/]  {escape(text)}")
+                render_response_header(console, "assistant")
+                with console.use_theme(MARKDOWN_THEME):
+                    console.print(Markdown(text, code_theme="ansi_dark"))
         console.print(f"[{DIM}]─────────────────────────────────────────────────────────[/]")
 
     if context:
@@ -470,9 +490,6 @@ def _apply_resume_data(data: dict, session: ReplSession, console: Console) -> bo
             f"[{DIM}]accumulated context restored:[/] "
             + ", ".join(f"{escape(k)}={escape(str(v))}" for k, v in sorted(context.items()))
         )
-    console.print(
-        f"[{DIM}]tip: type[/] [{HIGHLIGHT}]/new[/] [{DIM}]to start a clean session that continues this context.[/]"
-    )
     return True
 
 

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -244,6 +244,18 @@ _EFFORT_FIRST_ARGS: tuple[tuple[str, str], ...] = (
 )
 
 
+def _format_duration(duration_secs: int | None) -> str:
+    if duration_secs is None:
+        return "—"
+    if duration_secs < 60:
+        return f"{duration_secs}s"
+    if duration_secs < 3600:
+        return f"{duration_secs // 60}m {duration_secs % 60}s"
+    h = duration_secs // 3600
+    m = (duration_secs % 3600) // 60
+    return f"{h}h {m}m"
+
+
 def _cmd_sessions(session: ReplSession, console: Console, _args: list[str]) -> bool:
     from datetime import UTC, datetime
 
@@ -257,6 +269,7 @@ def _cmd_sessions(session: ReplSession, console: Console, _args: list[str]) -> b
     table = repl_table(title="Recent sessions\n", title_style=BOLD_BRAND)
     table.add_column("#", style="bold", justify="right")
     table.add_column("Session ID", style="bold")
+    table.add_column("Name")
     table.add_column("Started")
     table.add_column("Duration")
     table.add_column("Turns", justify="right")
@@ -266,6 +279,12 @@ def _cmd_sessions(session: ReplSession, console: Console, _args: list[str]) -> b
         sid = entry["session_id"]
         short_id = sid[:8] if len(sid) >= 8 else sid
         is_current = sid == session.session_id
+
+        name = entry.get("name") or ""
+        if is_current:
+            name_col = f"[{DIM}](current)[/]" if not name else f"{escape(name)} [{DIM}](current)[/]"
+        else:
+            name_col = escape(name) if name else f"[{DIM}]—[/]"
 
         started_raw = entry.get("started_at") or ""
         try:
@@ -286,26 +305,15 @@ def _cmd_sessions(session: ReplSession, console: Console, _args: list[str]) -> b
             except Exception:
                 pass
 
-        if duration_secs is None:
-            duration_str = "—"
-        elif duration_secs < 60:
-            duration_str = f"{duration_secs}s"
-        elif duration_secs < 3600:
-            duration_str = f"{duration_secs // 60}m {duration_secs % 60}s"
-        else:
-            h = duration_secs // 3600
-            m = (duration_secs % 3600) // 60
-            duration_str = f"{h}h {m}m"
-
         total = entry.get("total_turns")
         investigations = entry.get("investigation_turns")
-        sid_col = f"{short_id} [{HIGHLIGHT}](current)[/]" if is_current else short_id
 
         table.add_row(
             str(i),
-            sid_col,
+            short_id,
+            name_col,
             started_str,
-            duration_str,
+            _format_duration(duration_secs),
             str(total) if total is not None else "—",
             str(investigations) if investigations is not None else "—",
         )
@@ -314,19 +322,44 @@ def _cmd_sessions(session: ReplSession, console: Console, _args: list[str]) -> b
     return True
 
 
-def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool:
+def _interactive_resume_menu(session: ReplSession, console: Console) -> bool:
+    """Show a numbered list of recent sessions and resume the selected one."""
+    from datetime import datetime
+
     from app.cli.interactive_shell.sessions.store import SessionStore
 
-    if not args:
-        console.print(f"[{DIM}]usage: /resume <session-id-prefix>[/]")
-        console.print(f"[{DIM}]run /sessions to list session IDs.[/]")
+    entries = [e for e in SessionStore.load_recent(10) if e["session_id"] != session.session_id]
+    if not entries:
+        console.print(f"[{DIM}]No previous sessions to resume.[/]")
         return True
 
-    prefix = args[0].strip()
-    data = SessionStore.load_session(prefix)
+    choices: list[tuple[str, str]] = []
+    for entry in entries:
+        sid = entry["session_id"]
+        short_id = sid[:8]
+        name = entry.get("name") or f"[{short_id}]"
+        started_raw = entry.get("started_at") or ""
+        try:
+            started_str = datetime.fromisoformat(started_raw).astimezone().strftime("%m-%d %H:%M")
+        except Exception:
+            started_str = "—"
+        label = f"{name[:40]:<40}  {short_id}  {started_str}"
+        choices.append((sid, label))
+    choices.append(("done", "done"))
 
+    picked = repl_choose_one(title="resume session", breadcrumb="/resume", choices=choices)
+    if picked is None or picked == "done":
+        return True
+
+    return _do_resume(picked, session, console)
+
+
+def _do_resume(prefix: str, session: ReplSession, console: Console) -> bool:
+    """Load session by ID prefix and restore context into the running session."""
+    from app.cli.interactive_shell.sessions.store import SessionStore
+
+    data = SessionStore.load_session(prefix)
     if data is None:
-        # Distinguish "not found" from "ambiguous prefix" using a single store query.
         n = SessionStore.count_prefix_matches(prefix)
         if n > 1:
             console.print(
@@ -342,6 +375,7 @@ def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool
     has_snapshot = data.get("has_snapshot", False)
     sid = data.get("session_id", prefix)
     short_id = sid[:8] if len(sid) >= 8 else sid
+    name = data.get("name") or ""
 
     if not messages and not context:
         console.print(
@@ -354,7 +388,6 @@ def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool
             )
         return True
 
-    # Warn if replacing an active conversation — cli_agent_messages is fully replaced.
     existing = session.cli_agent_messages
     if existing:
         console.print(
@@ -366,14 +399,103 @@ def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool
     session.accumulated_context = dict(context)
 
     source = "snapshot" if has_snapshot else "turn records"
+    name_str = f" · {escape(name)}" if name else ""
     console.print(
-        f"[{HIGHLIGHT}]resumed session {short_id}[/] "
+        f"[{HIGHLIGHT}]resumed session {short_id}{name_str}[/] "
         f"[{DIM}]({len(messages)} messages from {source})[/]"
     )
     if context:
         console.print(
             f"[{DIM}]accumulated context restored:[/] "
-            + ", ".join(f"{k}={escape(str(v))}" for k, v in sorted(context.items()))
+            + ", ".join(f"{escape(k)}={escape(str(v))}" for k, v in sorted(context.items()))
+        )
+    console.print(f"[{DIM}]conversation context loaded — continue asking questions.[/]")
+    return True
+
+
+def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool:
+    if not args and repl_tty_interactive():
+        return _interactive_resume_menu(session, console)
+
+    if not args:
+        console.print(f"[{DIM}]usage: /resume <session-id-prefix>[/]")
+        console.print(f"[{DIM}]run /sessions to list session IDs.[/]")
+        return True
+
+    prefix = args[0].strip()
+    data = None
+
+    # Try ID prefix first, then fall back to name substring match
+    from app.cli.interactive_shell.sessions.store import SessionStore
+
+    data = SessionStore.load_session(prefix)
+    if data is None and len(prefix) >= 3:
+        # Name substring match — find sessions whose derived name contains the query
+        candidates = [
+            e
+            for e in SessionStore.load_recent(20)
+            if prefix.lower() in (e.get("name") or "").lower()
+            and e["session_id"] != session.session_id
+        ]
+        if len(candidates) == 1:
+            data = SessionStore.load_session(candidates[0]["session_id"])
+        elif len(candidates) > 1:
+            console.print(
+                f"[{WARNING}]'{escape(prefix)}' matches {len(candidates)} sessions by name — "
+                "use a session ID prefix or be more specific.[/]"
+            )
+            return True
+
+    if data is None:
+        n = SessionStore.count_prefix_matches(prefix)
+        if n > 1:
+            console.print(
+                f"[{WARNING}]ambiguous prefix '{escape(prefix)}' matches {n} sessions — "
+                "use more characters.[/]"
+            )
+        else:
+            console.print(f"[{ERROR}]session '{escape(prefix)}' not found.[/]")
+        return True
+
+    # Restore the loaded session into the current session.
+    messages = data.get("cli_agent_messages") or []
+    context = data.get("accumulated_context") or {}
+    has_snapshot = data.get("has_snapshot", False)
+    sid = data.get("session_id", prefix)
+    short_id = sid[:8] if len(sid) >= 8 else sid
+    name = data.get("name") or ""
+
+    if not messages and not context:
+        console.print(
+            f"[{DIM}]session {short_id} has no conversation to resume "
+            "(no chat turns or context found).[/]"
+        )
+        if not data.get("turn_details") and not has_snapshot:
+            console.print(
+                f"[{DIM}]tip: turn_detail records are only written when prompt logging is enabled.[/]"
+            )
+        return True
+
+    existing = session.cli_agent_messages
+    if existing:
+        console.print(
+            f"[{WARNING}]current session has {len(existing)} messages — "
+            "they will be replaced by the resumed context.[/]"
+        )
+
+    session.cli_agent_messages = list(messages)
+    session.accumulated_context = dict(context)
+
+    source = "snapshot" if has_snapshot else "turn records"
+    name_str = f" · {escape(name)}" if name else ""
+    console.print(
+        f"[{HIGHLIGHT}]resumed session {short_id}{name_str}[/] "
+        f"[{DIM}]({len(messages)} messages from {source})[/]"
+    )
+    if context:
+        console.print(
+            f"[{DIM}]accumulated context restored:[/] "
+            + ", ".join(f"{escape(k)}={escape(str(v))}" for k, v in sorted(context.items()))
         )
     console.print(f"[{DIM}]conversation context loaded — continue asking questions.[/]")
     return True
@@ -418,7 +540,8 @@ COMMANDS: list[SlashCommand] = [
         usage=("/resume <session-id-prefix>",),
         notes=(
             "Restores cli_agent_messages and accumulated infra context from the chosen session.",
-            "The first 8 characters of a session ID (shown by /sessions) are enough.",
+            "Bare /resume opens an interactive session picker in a TTY.",
+            "Accepts a session ID prefix or a name substring (e.g. /resume redis).",
             "Replaces the current session's LLM conversation context; warns if messages exist.",
         ),
     ),

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -354,26 +354,13 @@ def _interactive_resume_menu(session: ReplSession, console: Console) -> bool:
     return _do_resume(picked, session, console)
 
 
-def _do_resume(prefix: str, session: ReplSession, console: Console) -> bool:
-    """Load session by ID prefix and restore context into the running session."""
-    from app.cli.interactive_shell.sessions.store import SessionStore
-
-    data = SessionStore.load_session(prefix)
-    if data is None:
-        n = SessionStore.count_prefix_matches(prefix)
-        if n > 1:
-            console.print(
-                f"[{WARNING}]ambiguous prefix '{escape(prefix)}' matches {n} sessions — "
-                "use more characters.[/]"
-            )
-        else:
-            console.print(f"[{ERROR}]session '{escape(prefix)}' not found.[/]")
-        return True
-
+def _apply_resume_data(data: dict, session: ReplSession, console: Console) -> bool:
+    """Apply loaded session data into the running session and print a summary."""
     messages = data.get("cli_agent_messages") or []
     context = data.get("accumulated_context") or {}
+    history = data.get("history") or []
     has_snapshot = data.get("has_snapshot", False)
-    sid = data.get("session_id", prefix)
+    sid = data.get("session_id", "")
     short_id = sid[:8] if len(sid) >= 8 else sid
     name = data.get("name") or ""
 
@@ -395,8 +382,15 @@ def _do_resume(prefix: str, session: ReplSession, console: Console) -> bool:
             "they will be replaced by the resumed context.[/]"
         )
 
+    # Restore LLM conversation thread so the next prompt has full prior context.
     session.cli_agent_messages = list(messages)
+
+    # Restore infra context (service, cluster, region) accumulated in old session.
     session.accumulated_context = dict(context)
+
+    # Restore turn stubs into history so /status shows prior interaction count.
+    if history:
+        session.history = list(history) + session.history
 
     source = "snapshot" if has_snapshot else "turn records"
     name_str = f" · {escape(name)}" if name else ""
@@ -411,6 +405,24 @@ def _do_resume(prefix: str, session: ReplSession, console: Console) -> bool:
         )
     console.print(f"[{DIM}]conversation context loaded — continue asking questions.[/]")
     return True
+
+
+def _do_resume(prefix: str, session: ReplSession, console: Console) -> bool:
+    """Load session by ID prefix and restore context into the running session."""
+    from app.cli.interactive_shell.sessions.store import SessionStore
+
+    data = SessionStore.load_session(prefix)
+    if data is None:
+        n = SessionStore.count_prefix_matches(prefix)
+        if n > 1:
+            console.print(
+                f"[{WARNING}]ambiguous prefix '{escape(prefix)}' matches {n} sessions — "
+                "use more characters.[/]"
+            )
+        else:
+            console.print(f"[{ERROR}]session '{escape(prefix)}' not found.[/]")
+        return True
+    return _apply_resume_data(data, session, console)
 
 
 def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool:
@@ -457,48 +469,7 @@ def _cmd_resume(session: ReplSession, console: Console, args: list[str]) -> bool
             console.print(f"[{ERROR}]session '{escape(prefix)}' not found.[/]")
         return True
 
-    # Restore the loaded session into the current session.
-    messages = data.get("cli_agent_messages") or []
-    context = data.get("accumulated_context") or {}
-    has_snapshot = data.get("has_snapshot", False)
-    sid = data.get("session_id", prefix)
-    short_id = sid[:8] if len(sid) >= 8 else sid
-    name = data.get("name") or ""
-
-    if not messages and not context:
-        console.print(
-            f"[{DIM}]session {short_id} has no conversation to resume "
-            "(no chat turns or context found).[/]"
-        )
-        if not data.get("turn_details") and not has_snapshot:
-            console.print(
-                f"[{DIM}]tip: turn_detail records are only written when prompt logging is enabled.[/]"
-            )
-        return True
-
-    existing = session.cli_agent_messages
-    if existing:
-        console.print(
-            f"[{WARNING}]current session has {len(existing)} messages — "
-            "they will be replaced by the resumed context.[/]"
-        )
-
-    session.cli_agent_messages = list(messages)
-    session.accumulated_context = dict(context)
-
-    source = "snapshot" if has_snapshot else "turn records"
-    name_str = f" · {escape(name)}" if name else ""
-    console.print(
-        f"[{HIGHLIGHT}]resumed session {short_id}{name_str}[/] "
-        f"[{DIM}]({len(messages)} messages from {source})[/]"
-    )
-    if context:
-        console.print(
-            f"[{DIM}]accumulated context restored:[/] "
-            + ", ".join(f"{escape(k)}={escape(str(v))}" for k, v in sorted(context.items()))
-        )
-    console.print(f"[{DIM}]conversation context loaded — continue asking questions.[/]")
-    return True
+    return _apply_resume_data(data, session, console)
 
 
 COMMANDS: list[SlashCommand] = [

--- a/app/cli/interactive_shell/command_registry/slash_catalog.py
+++ b/app/cli/interactive_shell/command_registry/slash_catalog.py
@@ -207,6 +207,17 @@ _MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
         "User asks about remote deployment status, health, or operations",
         anti_examples=("Vague connect to X without remote/hosted context (assistant_handoff)",),
     ),
+    "/new": _mcp(
+        "Start a new session while preserving the current LLM conversation context and "
+        "accumulated infra context. Unlike /reset (which clears everything), /new keeps "
+        "the conversation thread so you can continue seamlessly in a fresh session file.",
+        "User wants to continue a conversation in a new session after /resume",
+        "User asks to start a new session without losing their current conversation",
+        anti_examples=(
+            "User wants to clear everything and start fresh (use /reset)",
+            "User asks to list sessions (use /sessions)",
+        ),
+    ),
     "/resume": _mcp(
         "Restore the conversation context from a previous session. "
         "Bare /resume opens an interactive numbered picker. "

--- a/app/cli/interactive_shell/command_registry/slash_catalog.py
+++ b/app/cli/interactive_shell/command_registry/slash_catalog.py
@@ -207,6 +207,16 @@ _MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
         "User asks about remote deployment status, health, or operations",
         anti_examples=("Vague connect to X without remote/hosted context (assistant_handoff)",),
     ),
+    "/resume": _mcp(
+        "Restore the conversation context from a previous session. "
+        "Pass the first 8+ characters of the session ID shown by /sessions.",
+        "User asks to resume or continue a previous session by session ID",
+        "User wants to pick up where they left off in an earlier REPL session",
+        anti_examples=(
+            "User asks to list sessions (use /sessions)",
+            "User asks to reset the current session (use /reset)",
+        ),
+    ),
     "/reset": _mcp(
         "Clear session state while preserving trust mode.",
         "User asks to reset session state or start fresh in the REPL",

--- a/app/cli/interactive_shell/command_registry/slash_catalog.py
+++ b/app/cli/interactive_shell/command_registry/slash_catalog.py
@@ -209,12 +209,12 @@ _MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
     ),
     "/new": _mcp(
         "Start a new session while preserving the current LLM conversation context and "
-        "accumulated infra context. Unlike /reset (which clears everything), /new keeps "
-        "the conversation thread so you can continue seamlessly in a fresh session file.",
+        "accumulated infra context. Rotates the session ID and resets all session state "
+        "while keeping the conversation thread so you can continue seamlessly in a fresh session file.",
         "User wants to continue a conversation in a new session after /resume",
         "User asks to start a new session without losing their current conversation",
         anti_examples=(
-            "User wants to clear everything and start fresh (use /reset)",
+            "User wants to clear the screen (use /clear)",
             "User asks to list sessions (use /sessions)",
         ),
     ),
@@ -228,12 +228,8 @@ _MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
         "User types /resume with no argument to pick from a list",
         anti_examples=(
             "User asks to list sessions (use /sessions)",
-            "User asks to reset the current session (use /reset)",
+            "User asks to start a new session keeping context (use /new)",
         ),
-    ),
-    "/reset": _mcp(
-        "Clear session state while preserving trust mode.",
-        "User asks to reset session state or start fresh in the REPL",
     ),
     "/save": _mcp(
         "Save the last investigation report to a file path. Requires confirmation.",

--- a/app/cli/interactive_shell/command_registry/slash_catalog.py
+++ b/app/cli/interactive_shell/command_registry/slash_catalog.py
@@ -209,9 +209,12 @@ _MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
     ),
     "/resume": _mcp(
         "Restore the conversation context from a previous session. "
-        "Pass the first 8+ characters of the session ID shown by /sessions.",
-        "User asks to resume or continue a previous session by session ID",
+        "Bare /resume opens an interactive numbered picker. "
+        "Pass a session ID prefix or a name substring to resume directly "
+        "(e.g. /resume 9b2e4f7a or /resume redis).",
+        "User asks to resume or continue a previous session",
         "User wants to pick up where they left off in an earlier REPL session",
+        "User types /resume with no argument to pick from a list",
         anti_examples=(
             "User asks to list sessions (use /sessions)",
             "User asks to reset the current session (use /reset)",

--- a/app/cli/interactive_shell/prompt_logging/recorder.py
+++ b/app/cli/interactive_shell/prompt_logging/recorder.py
@@ -17,6 +17,14 @@ from app.version import get_version
 
 _SUPPORTED_ROUTE_KINDS = frozenset({"cli_agent", "cli_help", "follow_up", "new_alert"})
 
+# Maps PromptRecorder route_kind → session turn kind stored in turn_detail records.
+_ROUTE_TO_SESSION_KIND: dict[str, str] = {
+    "cli_agent": "chat",
+    "cli_help": "chat",
+    "follow_up": "follow_up",
+    "new_alert": "alert",
+}
+
 
 @dataclass(frozen=True, slots=True)
 class LlmRunInfo:
@@ -90,6 +98,7 @@ class PromptRecorder:
         if self._flushed:
             return
         self._flushed = True
+        latency_ms = self._latency_ms or int((time.monotonic() - self._start) * 1000)
         record = {
             "ts": datetime.now(UTC).isoformat(),
             "session_id": self._session_id,
@@ -99,7 +108,7 @@ class PromptRecorder:
             "response": self._response,
             "model": self._model or "",
             "provider": self._provider or "",
-            "latency_ms": self._latency_ms or int((time.monotonic() - self._start) * 1000),
+            "latency_ms": latency_ms,
             "input_tokens": self._input_tokens,
             "output_tokens": self._output_tokens,
             "opensre_version": get_version(),
@@ -107,6 +116,23 @@ class PromptRecorder:
         if self._config.local_enabled:
             with contextlib.suppress(OSError):
                 append_prompt_log_record(path=self._config.log_path, record=record)
+
+        # Also write enriched turn to the session file so /resume can restore context.
+        with contextlib.suppress(Exception):
+            from app.cli.interactive_shell.sessions.store import SessionStore
+
+            session_kind = _ROUTE_TO_SESSION_KIND.get(self._route_kind, self._route_kind)
+            SessionStore.append_turn_detail(
+                self._session_id,
+                session_kind,
+                self._prompt,
+                response=self._response or None,
+                turn_id=self._turn_id,
+                model=self._model or None,
+                provider=self._provider or None,
+                latency_ms=latency_ms,
+            )
+
         if self._config.posthog_enabled:
             with contextlib.suppress(Exception):
                 capture_ai_generation(

--- a/app/cli/interactive_shell/prompt_logging/recorder.py
+++ b/app/cli/interactive_shell/prompt_logging/recorder.py
@@ -74,6 +74,11 @@ class PromptRecorder:
     ) -> PromptRecorder | None:
         config = PromptLogConfig.load()
         if not config.enabled or route_kind not in _SUPPORTED_ROUTE_KINDS:
+            # When prompt logging is fully disabled, no recorder is created and
+            # no turn_detail records are written to the session file. This means
+            # the crash-recovery fallback in load_session() will produce empty
+            # cli_agent_messages for sessions that crashed before flush(). The
+            # conversation_snapshot written at clean exit is unaffected.
             return None
         return cls(
             config=config,

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/errors.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/errors.py
@@ -27,8 +27,18 @@ class PlannerUnavailable(RoutingDegradeError):
     reason_tag = "routing_degrade.planner_unavailable"
 
 
+class PlannerLLMError(Exception):
+    """LLM call inside the action planner failed.
+
+    Carries a user-friendly message (already enriched by the failure
+    classifier) so the caller can display it inside the assistant block
+    instead of emitting a raw log warning above the response.
+    """
+
+
 __all__ = [
     "ParseError",
+    "PlannerLLMError",
     "PlannerUnavailable",
     "PolicyError",
     "RoutingDegradeError",

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/agent_actions.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/agent_actions.py
@@ -7,7 +7,9 @@ from dataclasses import dataclass
 from typing import Any
 
 from rich.console import Console
+from rich.markup import escape
 
+from app.cli.interactive_shell.routing.handle_message_with_agent.errors import PlannerLLMError
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.interaction_models import (
     PlannedAction,
 )
@@ -162,6 +164,12 @@ def _render_plan_denied(console: Console) -> None:
     )
 
 
+def _render_planner_llm_error(console: Console, message: str) -> None:
+    console.print()
+    render_response_header(console, "assistant")
+    console.print(f"[yellow]{escape(message)}[/]")
+
+
 def _tool_args_for_action(action: PlannedAction) -> dict[str, Any]:
     if action.args:
         return dict(action.args)
@@ -276,7 +284,12 @@ def execute_cli_actions(
             else _coerce_action_plan_decision(planned)
         )
     else:
-        plan = _coerce_action_plan_decision(_plan_actions(message, session))
+        try:
+            plan = _coerce_action_plan_decision(_plan_actions(message, session))
+        except PlannerLLMError as exc:
+            _render_planner_llm_error(console, str(exc))
+            session.record("cli_agent", message, ok=False)
+            return True
     plan = _enforce_plan_fail_closed_policy(plan)
     actions = list(plan.actions)
     has_unhandled_clause = plan.has_unhandled_clause
@@ -328,7 +341,23 @@ def execute_cli_actions_with_metrics(
             else _coerce_action_plan_decision(planned)
         )
     else:
-        plan = _coerce_action_plan_decision(_plan_actions(message, session))
+        try:
+            plan = _coerce_action_plan_decision(_plan_actions(message, session))
+        except PlannerLLMError as exc:
+            _render_planner_llm_error(console, str(exc))
+            session.record("cli_agent", message, ok=False)
+            capture_terminal_actions_executed(
+                planned_count=0,
+                executed_count=0,
+                executed_success_count=0,
+            )
+            return TerminalActionExecutionResult(
+                planned_count=0,
+                executed_count=0,
+                executed_success_count=0,
+                has_unhandled_clause=True,
+                handled=True,
+            )
     plan = _enforce_plan_fail_closed_policy(plan)
     actions = list(plan.actions)
     has_unhandled_clause = plan.has_unhandled_clause

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/agent_actions.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/agent_actions.py
@@ -164,10 +164,21 @@ def _render_plan_denied(console: Console) -> None:
     )
 
 
+_CLI_AGENT_MSG_CAP = 24  # mirrors _MAX_CLI_AGENT_TURNS * 2 in cli_agent.py
+
+
 def _render_planner_llm_error(console: Console, message: str) -> None:
     console.print()
     render_response_header(console, "assistant")
     console.print(f"[yellow]{escape(message)}[/]")
+
+
+def _persist_error_turn(session: ReplSession, user_text: str, error_text: str) -> None:
+    """Record a failed assistant turn in cli_agent_messages so /resume can display it."""
+    session.cli_agent_messages.append(("user", user_text))
+    session.cli_agent_messages.append(("assistant", error_text))
+    if len(session.cli_agent_messages) > _CLI_AGENT_MSG_CAP:
+        session.cli_agent_messages[:] = session.cli_agent_messages[-_CLI_AGENT_MSG_CAP:]
 
 
 def _tool_args_for_action(action: PlannedAction) -> dict[str, Any]:
@@ -287,7 +298,9 @@ def execute_cli_actions(
         try:
             plan = _coerce_action_plan_decision(_plan_actions(message, session))
         except PlannerLLMError as exc:
-            _render_planner_llm_error(console, str(exc))
+            error_text = str(exc)
+            _render_planner_llm_error(console, error_text)
+            _persist_error_turn(session, message, error_text)
             session.record("cli_agent", message, ok=False)
             return True
     plan = _enforce_plan_fail_closed_policy(plan)
@@ -344,7 +357,9 @@ def execute_cli_actions_with_metrics(
         try:
             plan = _coerce_action_plan_decision(_plan_actions(message, session))
         except PlannerLLMError as exc:
-            _render_planner_llm_error(console, str(exc))
+            error_text = str(exc)
+            _render_planner_llm_error(console, error_text)
+            _persist_error_turn(session, message, error_text)
             session.record("cli_agent", message, ok=False)
             capture_terminal_actions_executed(
                 planned_count=0,

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/llm_client.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/llm_client.py
@@ -52,9 +52,15 @@ def _call_llm(sanitised_text: str, session: Any) -> str | None:
         response = client.invoke(prompt)
         return response.content.strip()
     except Exception as exc:
-        logger.warning(
+        logger.debug(
             "llm_action_planner: LLM call failed (%s): %s",
             type(exc).__name__,
             exc,
         )
-        return None
+        # Raise a typed error so the caller can surface the reason in the
+        # assistant block instead of printing a raw log warning above it.
+        from app.cli.interactive_shell.routing.handle_message_with_agent.errors import (
+            PlannerLLMError,
+        )
+
+        raise PlannerLLMError(str(exc)) from exc

--- a/app/cli/interactive_shell/runtime/dispatch.py
+++ b/app/cli/interactive_shell/runtime/dispatch.py
@@ -68,7 +68,6 @@ _EXCLUSIVE_STDIN_MENU_COMMANDS: frozenset[str] = frozenset(
         "/context",
         "/agents",
         "/compact",
-        "/reset",
         "/welcome",
         "/sessions",
         "/resume",

--- a/app/cli/interactive_shell/runtime/dispatch.py
+++ b/app/cli/interactive_shell/runtime/dispatch.py
@@ -70,6 +70,8 @@ _EXCLUSIVE_STDIN_MENU_COMMANDS: frozenset[str] = frozenset(
         "/compact",
         "/reset",
         "/welcome",
+        "/sessions",
+        "/resume",
     }
 )
 _EXCLUSIVE_STDIN_SUBCOMMANDS: frozenset[tuple[str, str]] = frozenset(

--- a/app/cli/interactive_shell/runtime/dispatch.py
+++ b/app/cli/interactive_shell/runtime/dispatch.py
@@ -72,6 +72,7 @@ _EXCLUSIVE_STDIN_MENU_COMMANDS: frozenset[str] = frozenset(
         "/welcome",
         "/sessions",
         "/resume",
+        "/new",
     }
 )
 _EXCLUSIVE_STDIN_SUBCOMMANDS: frozenset[tuple[str, str]] = frozenset(

--- a/app/cli/interactive_shell/runtime/session.py
+++ b/app/cli/interactive_shell/runtime/session.py
@@ -49,6 +49,10 @@ class ReplSession:
     started_at: float = field(default_factory=time.time)
     """Unix timestamp of when this session (or post-reset sub-session) began."""
 
+    resumed_from_name: str = ""
+    """Name of the most recently resumed session. Used by /sessions to display a
+    fallback name for the current session before it has its own first turn."""
+
     history: list[dict[str, Any]] = field(default_factory=list)
     """Each entry has type, text, and ok fields for shell, slash, alert, and chat turns."""
 
@@ -200,6 +204,7 @@ class ReplSession:
         """Reset the session to a fresh state (used by /reset)."""
         self.history_generation += 1
         self.history.clear()
+        self.resumed_from_name = ""
         self.last_state = None
         self.last_route_decision = None
         self.last_assistant_intent = None

--- a/app/cli/interactive_shell/runtime/session.py
+++ b/app/cli/interactive_shell/runtime/session.py
@@ -200,8 +200,8 @@ class ReplSession:
             if value:
                 self.accumulated_context[key] = value
 
-    def clear(self) -> None:
-        """Reset the session to a fresh state (used by /new)."""
+    def clear(self, *, rotate_identity: bool = True) -> None:
+        """Reset the session to a fresh state (used by /new and /resume)."""
         self.history_generation += 1
         self.history.clear()
         self.resumed_from_name = ""
@@ -235,9 +235,10 @@ class ReplSession:
         self.pending_prompt_default = None
         self.last_synthetic_observation_path = None
         # trust_mode and reasoning_effort are intentionally preserved across /new
-        # Rotate session identity so the new post-reset session gets its own ID and file.
-        self.session_id = str(uuid.uuid4())
-        self.started_at = time.time()
+        if rotate_identity:
+            # Rotate session identity so the new post-reset session gets its own ID and file.
+            self.session_id = str(uuid.uuid4())
+            self.started_at = time.time()
 
     def record_intervention(self, kind: InterventionKind) -> None:
         """Increment the per-kind intervention counter (Ctrl-C or correction)."""

--- a/app/cli/interactive_shell/runtime/session.py
+++ b/app/cli/interactive_shell/runtime/session.py
@@ -44,7 +44,7 @@ class ReplSession:
     """
 
     session_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    """Stable UUID for this session. Rotated on /reset so each logical session gets its own ID."""
+    """Stable UUID for this session. Rotated on /new so each logical session gets its own ID."""
 
     started_at: float = field(default_factory=time.time)
     """Unix timestamp of when this session (or post-reset sub-session) began."""
@@ -105,7 +105,7 @@ class ReplSession:
     """Recent in-flight and completed shell tasks for /tasks and /cancel."""
 
     history_generation: int = 0
-    """Incremented on /reset so background synthetic watchers can skip stale history writes."""
+    """Incremented on /new so background synthetic watchers can skip stale history writes."""
 
     terminal_turn_count: int = 0
     terminal_fallback_count: int = 0
@@ -201,7 +201,7 @@ class ReplSession:
                 self.accumulated_context[key] = value
 
     def clear(self) -> None:
-        """Reset the session to a fresh state (used by /reset)."""
+        """Reset the session to a fresh state (used by /new)."""
         self.history_generation += 1
         self.history.clear()
         self.resumed_from_name = ""
@@ -216,7 +216,7 @@ class ReplSession:
         self.cli_agent_messages.clear()
         self.incoming_alerts.clear()
         # Keep persisted cross-session task history on disk intact.
-        # /reset is session-scoped, so swap in a fresh in-memory registry
+        # /new is session-scoped, so swap in a fresh in-memory registry
         # that reuses the same backing store (if any) so /tasks still shows history.
         persist_path = self.task_registry._persist_path
         self.task_registry = (
@@ -234,7 +234,7 @@ class ReplSession:
         self.correction_intervention_count = 0
         self.pending_prompt_default = None
         self.last_synthetic_observation_path = None
-        # trust_mode and reasoning_effort are intentionally preserved across /reset
+        # trust_mode and reasoning_effort are intentionally preserved across /new
         # Rotate session identity so the new post-reset session gets its own ID and file.
         self.session_id = str(uuid.uuid4())
         self.started_at = time.time()

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -30,6 +30,11 @@ if TYPE_CHECKING:
 
 _NAME_MAX_CHARS = 50
 
+# Turn kinds that represent user-initiated chat messages.  session.record() is
+# called with the route kind, not a normalised "chat" label, so this set must
+# cover all routes that produce conversational turns.
+_CHAT_KINDS: frozenset[str] = frozenset({"chat", "cli_agent", "cli_help", "follow_up"})
+
 
 def _sessions_dir() -> Path:
     from app.constants import OPENSRE_HOME_DIR
@@ -51,19 +56,18 @@ def _derive_name(lines: list[str]) -> str:
     for line in lines[1:]:
         with contextlib.suppress(json.JSONDecodeError):
             rec = json.loads(line)
-            if rec.get("type") == "turn_detail" and rec.get("kind") in (
-                "chat",
-                "alert",
-                "follow_up",
-            ):
+            if rec.get("type") == "turn_detail" and rec.get("kind") in _CHAT_KINDS | {"alert"}:
                 text = (rec.get("prompt") or "").strip().replace("\n", " ")
                 if text:
                     return text[:_NAME_MAX_CHARS] + ("…" if len(text) > _NAME_MAX_CHARS else "")
-    # Fall back to turn stub text
+    # Fall back to turn stub text (covers cli_agent/cli_help/follow_up/alert kinds)
     for line in lines[1:]:
         with contextlib.suppress(json.JSONDecodeError):
             rec = json.loads(line)
-            if rec.get("type") == "turn" and rec.get("kind") in ("chat", "alert", "incoming_alert"):
+            if rec.get("type") == "turn" and rec.get("kind") in _CHAT_KINDS | {
+                "alert",
+                "incoming_alert",
+            }:
                 text = (rec.get("text") or "").strip().replace("\n", " ")
                 if text:
                     return text[:_NAME_MAX_CHARS] + ("…" if len(text) > _NAME_MAX_CHARS else "")
@@ -187,7 +191,7 @@ class SessionStore:
                     if rec_type == "turn":
                         total_turns += 1
                         kind = rec.get("kind", "")
-                        if kind == "chat":
+                        if kind in _CHAT_KINDS:
                             chat_turns += 1
                         elif kind in ("alert", "incoming_alert"):
                             investigation_turns += 1

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -6,6 +6,7 @@ Design: incremental writes.
 - append_turn_detail() — appends a full turn record (prompt + response) for /resume
 - flush()              — writes conversation_snapshot + session_end on exit or /new;
                          deletes the file if no turns were recorded (empty session)
+- reopen_session()     — strips trailing session_end so /resume can append to the file
 - load_recent()        — returns up to n session summaries for /sessions display
 - load_session()       — reads a full session file and extracts conversation for /resume
 
@@ -95,6 +96,25 @@ class SessionStore:
                 fh.write(json.dumps(record, ensure_ascii=False) + "\n")
 
     @staticmethod
+    def _session_is_finalized(path: Path) -> bool:
+        if not path.exists():
+            return False
+        with contextlib.suppress(Exception):
+            lines = path.read_text(encoding="utf-8").splitlines()
+            if not lines:
+                return False
+            with contextlib.suppress(json.JSONDecodeError):
+                return json.loads(lines[-1]).get("type") == "session_end"
+        return False
+
+    @staticmethod
+    def _ensure_session_open(session_id: str) -> None:
+        """Reopen a finalized session file so append paths can continue writing."""
+        path = _session_path(session_id)
+        if SessionStore._session_is_finalized(path):
+            SessionStore.reopen_session(session_id)
+
+    @staticmethod
     def append_turn(session: ReplSession, kind: str, text: str) -> None:
         """Append a turn stub to the session file for stats counting.
 
@@ -106,6 +126,7 @@ class SessionStore:
             path = _session_path(session.session_id)
             if not path.exists():
                 return
+            SessionStore._ensure_session_open(session.session_id)
             record = {
                 "type": "turn",
                 "kind": kind,
@@ -231,6 +252,41 @@ class SessionStore:
             }
             with path.open("a", encoding="utf-8") as fh:
                 fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    @staticmethod
+    def reopen_session(session_id: str) -> None:
+        """Reopen a finalized session file so new turns append to the same file.
+
+        Strips trailing ``conversation_snapshot`` and ``session_end`` records
+        written by :meth:`flush`. No-op when the file is missing or still open.
+        """
+        with contextlib.suppress(Exception):
+            path = _session_path(session_id)
+            if not path.exists():
+                return
+
+            lines = path.read_text(encoding="utf-8").splitlines()
+            if not lines:
+                return
+
+            changed = False
+            with contextlib.suppress(json.JSONDecodeError):
+                if json.loads(lines[-1]).get("type") == "session_end":
+                    lines.pop()
+                    changed = True
+
+            if lines:
+                with contextlib.suppress(json.JSONDecodeError):
+                    if json.loads(lines[-1]).get("type") == "conversation_snapshot":
+                        lines.pop()
+                        changed = True
+
+            if not changed:
+                return
+
+            with path.open("w", encoding="utf-8") as fh:
+                for line in lines:
+                    fh.write(line + "\n")
 
     @staticmethod
     def load_recent(n: int = 20) -> list[dict[str, Any]]:

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -283,6 +283,20 @@ class SessionStore:
         return results[:n]
 
     @staticmethod
+    def count_prefix_matches(prefix: str) -> int:
+        """Return how many session files whose stem starts with prefix.
+
+        Used by /resume to distinguish 'not found' (0) from 'ambiguous' (>1)
+        without re-scanning the directory with a fragile inline import.
+        """
+        sessions_dir = _sessions_dir()
+        if not sessions_dir.exists():
+            return 0
+        with contextlib.suppress(OSError):
+            return sum(1 for p in sessions_dir.glob("*.jsonl") if p.stem.startswith(prefix))
+        return 0
+
+    @staticmethod
     def load_session(session_id_prefix: str) -> dict[str, Any] | None:
         """Load a session file and extract conversation data for /resume.
 

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -208,14 +208,16 @@ class SessionStore:
             duration_secs = max(0, int((now - started_at).total_seconds()))
 
             # Write conversation snapshot so /resume can restore exact LLM context.
-            if session.cli_agent_messages or session.accumulated_context:
-                snapshot: dict[str, Any] = {"type": "conversation_snapshot"}
-                if session.cli_agent_messages:
-                    snapshot["cli_agent_messages"] = [list(m) for m in session.cli_agent_messages]
-                if session.accumulated_context:
-                    snapshot["accumulated_context"] = dict(session.accumulated_context)
-                with path.open("a", encoding="utf-8") as fh:
-                    fh.write(json.dumps(snapshot, ensure_ascii=False) + "\n")
+            # Isolated suppress: a serialization failure must not prevent session_end.
+            with contextlib.suppress(Exception):
+                if session.cli_agent_messages or session.accumulated_context:
+                    snapshot: dict[str, Any] = {"type": "conversation_snapshot"}
+                    if session.cli_agent_messages:
+                        snapshot["cli_agent_messages"] = [list(m) for m in session.cli_agent_messages]
+                    if session.accumulated_context:
+                        snapshot["accumulated_context"] = dict(session.accumulated_context)
+                    with path.open("a", encoding="utf-8") as fh:
+                        fh.write(json.dumps(snapshot, ensure_ascii=False) + "\n")
 
             record = {
                 "type": "session_end",

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -4,7 +4,7 @@ Design: incremental writes.
 - open_session()       — writes session_start immediately when the REPL starts
 - append_turn()        — appends a turn stub (kind + text) for stats counting
 - append_turn_detail() — appends a full turn record (prompt + response) for /resume
-- flush()              — writes conversation_snapshot + session_end on exit or /reset;
+- flush()              — writes conversation_snapshot + session_end on exit or /new;
                          deletes the file if no turns were recorded (empty session)
 - load_recent()        — returns up to n session summaries for /sessions display
 - load_session()       — reads a full session file and extracts conversation for /resume
@@ -79,7 +79,7 @@ class SessionStore:
     def open_session(session: ReplSession) -> None:
         """Write session_start record, creating the session file on disk.
 
-        Called once at REPL start and again after every /reset (which rotates
+        Called once at REPL start and again after every /new (which rotates
         the session_id). Suppresses all I/O errors so the REPL never crashes.
         """
         with contextlib.suppress(Exception):
@@ -161,7 +161,7 @@ class SessionStore:
         """Write conversation_snapshot + session_end and close the session file.
 
         Idempotent: no-ops if session_end is already the last line, so
-        double-calling (e.g. /reset flow + entrypoint finally) is safe.
+        double-calling (e.g. /new flow + entrypoint finally) is safe.
         If no turns were recorded the file is deleted instead.
         Writes a conversation_snapshot record before session_end so /resume
         can restore cli_agent_messages and accumulated_context exactly.

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -1,10 +1,13 @@
 """Per-session persistence: one JSONL file per session under ~/.opensre/sessions/.
 
 Design: incremental writes.
-- open_session()  — writes session_start immediately when the REPL starts
-- append_turn()   — appends one turn record on every session.record() call
-- flush()         — writes session_end on REPL exit or /reset;
-                    deletes the file if no turns were recorded (empty session)
+- open_session()       — writes session_start immediately when the REPL starts
+- append_turn()        — appends a turn stub (kind + text) for stats counting
+- append_turn_detail() — appends a full turn record (prompt + response) for /resume
+- flush()              — writes conversation_snapshot + session_end on exit or /reset;
+                         deletes the file if no turns were recorded (empty session)
+- load_recent()        — returns up to n session summaries for /sessions display
+- load_session()       — reads a full session file and extracts conversation for /resume
 
 This means the current session file always exists on disk while the REPL is
 running, so /sessions shows it without any synthetic in-memory tricks, and
@@ -23,8 +26,6 @@ from app.version import get_version
 
 if TYPE_CHECKING:
     from app.cli.interactive_shell.runtime.session import ReplSession
-
-_MAX_PROMPT_CHARS = 200
 
 
 def _sessions_dir() -> Path:
@@ -59,11 +60,11 @@ class SessionStore:
 
     @staticmethod
     def append_turn(session: ReplSession, kind: str, text: str) -> None:
-        """Append one turn record to the open session file.
+        """Append a turn stub to the session file for stats counting.
 
-        Called by ReplSession.record() and record_incoming_alert() on every
-        interaction. No-ops silently if the file does not exist (e.g. the
-        non-interactive initial_input path that never calls open_session).
+        Called by ReplSession.record() on every interaction. Stubs carry kind
+        and the full input text (no truncation). No-ops silently if the file
+        does not exist (e.g. the non-interactive initial_input path).
         """
         with contextlib.suppress(Exception):
             path = _session_path(session.session_id)
@@ -72,18 +73,62 @@ class SessionStore:
             record = {
                 "type": "turn",
                 "kind": kind,
-                "text": text[:_MAX_PROMPT_CHARS],
+                "text": text,
             }
             with path.open("a", encoding="utf-8") as fh:
                 fh.write(json.dumps(record, ensure_ascii=False) + "\n")
 
     @staticmethod
+    def append_turn_detail(
+        session_id: str,
+        kind: str,
+        prompt: str,
+        *,
+        response: str | None = None,
+        turn_id: str | None = None,
+        model: str | None = None,
+        provider: str | None = None,
+        latency_ms: int | None = None,
+    ) -> None:
+        """Append a full turn record (prompt + response) for /resume reconstruction.
+
+        Called by PromptRecorder.flush() after each LLM turn completes.
+        These records make session files self-contained: /resume can rebuild
+        cli_agent_messages from turn_detail records when no conversation_snapshot
+        is present (e.g. old files or crash before flush).
+        No-ops silently if the session file does not exist.
+        """
+        with contextlib.suppress(Exception):
+            path = _session_path(session_id)
+            if not path.exists():
+                return
+            record: dict[str, Any] = {
+                "type": "turn_detail",
+                "kind": kind,
+                "prompt": prompt,
+            }
+            if response is not None:
+                record["response"] = response
+            if turn_id is not None:
+                record["turn_id"] = turn_id
+            if model is not None:
+                record["model"] = model
+            if provider is not None:
+                record["provider"] = provider
+            if latency_ms is not None:
+                record["latency_ms"] = latency_ms
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    @staticmethod
     def flush(session: ReplSession) -> None:
-        """Write session_end and close the session file.
+        """Write conversation_snapshot + session_end and close the session file.
 
         Idempotent: no-ops if session_end is already the last line, so
         double-calling (e.g. /reset flow + entrypoint finally) is safe.
         If no turns were recorded the file is deleted instead.
+        Writes a conversation_snapshot record before session_end so /resume
+        can restore cli_agent_messages and accumulated_context exactly.
         """
         with contextlib.suppress(Exception):
             path = _session_path(session.session_id)
@@ -98,23 +143,26 @@ class SessionStore:
                     if json.loads(lines[-1]).get("type") == "session_end":
                         return
 
-            # Count stats from the turn records already on disk
+            # Count stats from turn stub records.
             chat_turns = 0
             investigation_turns = 0
             total_turns = 0
+            detail_turns = 0
             for line in lines:
                 with contextlib.suppress(json.JSONDecodeError):
                     rec = json.loads(line)
-                    if rec.get("type") != "turn":
-                        continue
-                    total_turns += 1
-                    kind = rec.get("kind", "")
-                    if kind == "chat":
-                        chat_turns += 1
-                    elif kind in ("alert", "incoming_alert"):
-                        investigation_turns += 1
+                    rec_type = rec.get("type")
+                    if rec_type == "turn":
+                        total_turns += 1
+                        kind = rec.get("kind", "")
+                        if kind == "chat":
+                            chat_turns += 1
+                        elif kind in ("alert", "incoming_alert"):
+                            investigation_turns += 1
+                    elif rec_type == "turn_detail":
+                        detail_turns += 1
 
-            if total_turns == 0:
+            if total_turns == 0 and detail_turns == 0:
                 # Empty session — nothing useful happened; remove the file.
                 path.unlink(missing_ok=True)
                 return
@@ -122,6 +170,16 @@ class SessionStore:
             now = datetime.now(UTC)
             started_at = datetime.fromtimestamp(session.started_at, tz=UTC)
             duration_secs = max(0, int((now - started_at).total_seconds()))
+
+            # Write conversation snapshot so /resume can restore exact LLM context.
+            if session.cli_agent_messages or session.accumulated_context:
+                snapshot: dict[str, Any] = {"type": "conversation_snapshot"}
+                if session.cli_agent_messages:
+                    snapshot["cli_agent_messages"] = [list(m) for m in session.cli_agent_messages]
+                if session.accumulated_context:
+                    snapshot["accumulated_context"] = dict(session.accumulated_context)
+                with path.open("a", encoding="utf-8") as fh:
+                    fh.write(json.dumps(snapshot, ensure_ascii=False) + "\n")
 
             record = {
                 "type": "session_end",
@@ -171,12 +229,18 @@ class SessionStore:
                 if start_record is None or start_record.get("type") != "session_start":
                     continue
 
-                # Check if the last line is a session_end
                 end_record: dict[str, Any] | None = None
+                has_snapshot = False
                 with contextlib.suppress(json.JSONDecodeError):
                     last = json.loads(lines[-1])
                     if last.get("type") == "session_end":
                         end_record = last
+
+                for line in lines:
+                    with contextlib.suppress(json.JSONDecodeError):
+                        if json.loads(line).get("type") == "conversation_snapshot":
+                            has_snapshot = True
+                            break
 
                 if end_record is not None:
                     total_turns = end_record.get("total_turns")
@@ -211,8 +275,99 @@ class SessionStore:
                         "chat_turns": chat_turns,
                         "investigation_turns": investigation_turns,
                         "is_ended": end_record is not None,
+                        "has_snapshot": has_snapshot,
                     }
                 )
 
         results.sort(key=lambda x: x.get("started_at") or "", reverse=True)
         return results[:n]
+
+    @staticmethod
+    def load_session(session_id_prefix: str) -> dict[str, Any] | None:
+        """Load a session file and extract conversation data for /resume.
+
+        Accepts a prefix of the session ID (e.g. the first 8 chars shown by
+        /sessions). Returns None if no match found or the prefix is ambiguous.
+
+        Resolution order for cli_agent_messages:
+        1. conversation_snapshot (written at clean exit) — exact fidelity
+        2. turn_detail records (written per-turn by PromptRecorder) — fallback
+           for old files pre-enrichment or sessions that crashed before flush
+
+        Returned dict keys:
+          session_id, started_at, cli_agent_messages (list[tuple[str,str]]),
+          accumulated_context, history (turn stubs), turn_details, has_snapshot
+        """
+        sessions_dir = _sessions_dir()
+        if not sessions_dir.exists():
+            return None
+
+        target_path: Path | None = None
+        for path in sessions_dir.glob("*.jsonl"):
+            if path.stem.startswith(session_id_prefix):
+                if target_path is not None:
+                    return None  # ambiguous prefix — caller should ask for more chars
+                target_path = path
+
+        if target_path is None:
+            return None
+
+        with contextlib.suppress(Exception):
+            lines = target_path.read_text(encoding="utf-8").splitlines()
+            if not lines:
+                return None
+
+            start_record: dict[str, Any] | None = None
+            with contextlib.suppress(json.JSONDecodeError):
+                start_record = json.loads(lines[0])
+
+            if start_record is None or start_record.get("type") != "session_start":
+                return None
+
+            cli_agent_messages: list[tuple[str, str]] = []
+            accumulated_context: dict[str, Any] = {}
+            history: list[dict[str, Any]] = []
+            turn_details: list[dict[str, Any]] = []
+            has_snapshot = False
+
+            for line in lines[1:]:
+                with contextlib.suppress(json.JSONDecodeError):
+                    rec = json.loads(line)
+                    rec_type = rec.get("type")
+                    if rec_type == "turn":
+                        history.append(rec)
+                    elif rec_type == "turn_detail":
+                        turn_details.append(rec)
+                    elif rec_type == "conversation_snapshot":
+                        has_snapshot = True
+                        msgs = rec.get("cli_agent_messages")
+                        if msgs:
+                            cli_agent_messages = [
+                                (str(m[0]), str(m[1])) for m in msgs if len(m) >= 2
+                            ]
+                        ctx = rec.get("accumulated_context")
+                        if ctx and isinstance(ctx, dict):
+                            accumulated_context = ctx
+
+            # Fall back to turn_detail reconstruction when no snapshot exists.
+            if not cli_agent_messages and turn_details:
+                for td in turn_details:
+                    if td.get("kind") in ("chat", "follow_up"):
+                        prompt = td.get("prompt") or ""
+                        response = td.get("response") or ""
+                        if prompt:
+                            cli_agent_messages.append(("user", prompt))
+                        if response:
+                            cli_agent_messages.append(("assistant", response))
+
+            return {
+                "session_id": start_record.get("session_id", target_path.stem),
+                "started_at": start_record.get("started_at"),
+                "cli_agent_messages": cli_agent_messages,
+                "accumulated_context": accumulated_context,
+                "history": history,
+                "turn_details": turn_details,
+                "has_snapshot": has_snapshot,
+            }
+
+        return None

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -356,7 +356,7 @@ class SessionStore:
                                 continue
                             total_turns += 1
                             kind = rec.get("kind", "")
-                            if kind == "chat":
+                            if kind in _CHAT_KINDS:
                                 chat_turns += 1
                             elif kind in ("alert", "incoming_alert"):
                                 investigation_turns += 1

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -213,7 +213,9 @@ class SessionStore:
                 if session.cli_agent_messages or session.accumulated_context:
                     snapshot: dict[str, Any] = {"type": "conversation_snapshot"}
                     if session.cli_agent_messages:
-                        snapshot["cli_agent_messages"] = [list(m) for m in session.cli_agent_messages]
+                        snapshot["cli_agent_messages"] = [
+                            list(m) for m in session.cli_agent_messages
+                        ]
                     if session.accumulated_context:
                         snapshot["accumulated_context"] = dict(session.accumulated_context)
                     with path.open("a", encoding="utf-8") as fh:

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -104,7 +104,8 @@ class SessionStore:
             if not lines:
                 return False
             with contextlib.suppress(json.JSONDecodeError):
-                return json.loads(lines[-1]).get("type") == "session_end"
+                record = json.loads(lines[-1])
+                return isinstance(record, dict) and record.get("type") == "session_end"
         return False
 
     @staticmethod

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -28,6 +28,9 @@ if TYPE_CHECKING:
     from app.cli.interactive_shell.runtime.session import ReplSession
 
 
+_NAME_MAX_CHARS = 50
+
+
 def _sessions_dir() -> Path:
     from app.constants import OPENSRE_HOME_DIR
 
@@ -36,6 +39,35 @@ def _sessions_dir() -> Path:
 
 def _session_path(session_id: str) -> Path:
     return _sessions_dir() / f"{session_id}.jsonl"
+
+
+def _derive_name(lines: list[str]) -> str:
+    """Derive a human-readable session name from the first substantive turn.
+
+    Prefers turn_detail.prompt (full text) over the turn stub. Falls back
+    to the session ID stem if no usable turn exists.
+    """
+    # Prefer first turn_detail (has full prompt, no truncation)
+    for line in lines[1:]:
+        with contextlib.suppress(json.JSONDecodeError):
+            rec = json.loads(line)
+            if rec.get("type") == "turn_detail" and rec.get("kind") in (
+                "chat",
+                "alert",
+                "follow_up",
+            ):
+                text = (rec.get("prompt") or "").strip().replace("\n", " ")
+                if text:
+                    return text[:_NAME_MAX_CHARS] + ("…" if len(text) > _NAME_MAX_CHARS else "")
+    # Fall back to turn stub text
+    for line in lines[1:]:
+        with contextlib.suppress(json.JSONDecodeError):
+            rec = json.loads(line)
+            if rec.get("type") == "turn" and rec.get("kind") in ("chat", "alert", "incoming_alert"):
+                text = (rec.get("text") or "").strip().replace("\n", " ")
+                if text:
+                    return text[:_NAME_MAX_CHARS] + ("…" if len(text) > _NAME_MAX_CHARS else "")
+    return ""
 
 
 class SessionStore:
@@ -268,6 +300,7 @@ class SessionStore:
                 results.append(
                     {
                         "session_id": start_record.get("session_id", path.stem),
+                        "name": _derive_name(lines),
                         "started_at": start_record.get("started_at"),
                         "opensre_version": start_record.get("opensre_version"),
                         "duration_secs": duration_secs,
@@ -300,8 +333,8 @@ class SessionStore:
     def load_session(session_id_prefix: str) -> dict[str, Any] | None:
         """Load a session file and extract conversation data for /resume.
 
-        Accepts a prefix of the session ID (e.g. the first 8 chars shown by
-        /sessions). Returns None if no match found or the prefix is ambiguous.
+        Accepts a session ID prefix (e.g. the first 8 chars shown by /sessions).
+        Returns None if no match found or the prefix is ambiguous.
 
         Resolution order for cli_agent_messages:
         1. conversation_snapshot (written at clean exit) — exact fidelity
@@ -309,7 +342,7 @@ class SessionStore:
            for old files pre-enrichment or sessions that crashed before flush
 
         Returned dict keys:
-          session_id, started_at, cli_agent_messages (list[tuple[str,str]]),
+          session_id, name, started_at, cli_agent_messages (list[tuple[str,str]]),
           accumulated_context, history (turn stubs), turn_details, has_snapshot
         """
         sessions_dir = _sessions_dir()
@@ -376,6 +409,7 @@ class SessionStore:
 
             return {
                 "session_id": start_record.get("session_id", target_path.stem),
+                "name": _derive_name(lines),
                 "started_at": start_record.get("started_at"),
                 "cli_agent_messages": cli_agent_messages,
                 "accumulated_context": accumulated_context,

--- a/app/integrations/llm_cli/failure_classifier.py
+++ b/app/integrations/llm_cli/failure_classifier.py
@@ -1,0 +1,85 @@
+"""Generic failure classifier for LLM CLI and API errors.
+
+Scans stdout/stderr (or an exception message) for known error categories and
+returns a short, actionable hint.  The runner calls this after
+``adapter.explain_failure()`` so every CLI adapter gets the same enrichment
+without each one reimplementing pattern matching.
+
+The same ``classify_llm_failure`` function can be reused from LLM API clients
+that catch HTTP 429 / 401 responses.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Patterns ordered by specificity — first match wins.
+_QUOTA_RE = re.compile(
+    r"quota|rate.?limit|429|too many request|insufficient_quota|"
+    r"out of credit|billing|usage limit|spending limit|plan limit|"
+    r"exceeded.*limit|limit.*exceeded|maximum.*usage|api.*usage",
+    re.IGNORECASE,
+)
+_AUTH_RE = re.compile(
+    r"unauthorized|401|invalid.?api.?key|api.?key.*invalid|"
+    r"authentication.?fail|not authenticated|not logged.?in|"
+    r"no credentials|token.*expired|expired.*token|invalid.?token|"
+    r"permission denied|access denied|403|forbidden",
+    re.IGNORECASE,
+)
+_CONTEXT_RE = re.compile(
+    r"context.?length|context.?window|max.?token|token.?limit|"
+    r"too.?long|input.*exceed|prompt.*too.?large|reduce.*context|"
+    r"string too long",
+    re.IGNORECASE,
+)
+_NETWORK_RE = re.compile(
+    r"network.*error|connection.*refused|dns.*fail|unreachable|"
+    r"no route to host|connection reset|ssl.*error|certificate.*error|"
+    r"name.*resolution|getaddrinfo",
+    re.IGNORECASE,
+)
+
+
+def classify_llm_failure(
+    stdout: str,
+    stderr: str,
+    returncode: int,
+) -> str | None:
+    """Return a short actionable hint for a known failure category, or None.
+
+    Args:
+        stdout: Process stdout, ANSI-stripped (pass empty string for API errors).
+        stderr: Process stderr, ANSI-stripped (or the raw exception message).
+        returncode: Exit code (use 1 for API / non-subprocess errors).
+
+    Returns:
+        A one-sentence user-facing hint, or ``None`` if no pattern matched.
+    """
+    combined = f"{stdout}\n{stderr}".strip()
+
+    if _QUOTA_RE.search(combined):
+        return "quota or rate limit exceeded — check your plan/billing or wait before retrying"
+    if _AUTH_RE.search(combined):
+        return "authentication failed — verify your API key or re-login with the provider CLI"
+    if _CONTEXT_RE.search(combined):
+        return "prompt too long — shorten the input or reduce accumulated context (/context to inspect)"
+    if _NETWORK_RE.search(combined):
+        return "network error — check connectivity and provider status"
+
+    # Fallback: if the only output is a version banner or a very short string
+    # with no error keywords, the CLI likely exited silently — the most common
+    # causes are exhausted quota or an expired auth session.
+    if returncode not in (0, 130) and (
+        not combined
+        or (
+            len(combined) < 120
+            and not re.search(r"error|fail|exception|invalid", combined, re.IGNORECASE)
+        )
+    ):
+        return (
+            "no error detail from the CLI — most likely quota exhausted or expired auth; "
+            "check your plan/credits or re-login"
+        )
+
+    return None

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -30,6 +30,7 @@ from app.integrations.llm_cli.errors import (
     CLIInterruptedError,
     CLITimeoutError,
 )
+from app.integrations.llm_cli.failure_classifier import classify_llm_failure
 from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 from app.integrations.llm_cli.text import flatten_messages_to_prompt
 from app.llm_reasoning_effort import get_active_reasoning_effort
@@ -244,6 +245,12 @@ class CLIBackedLLMClient:
                     auth_hint=self._adapter.auth_hint,
                     detail=base,
                 )
+            # Replace the raw exit-code message with an actionable description
+            # when a known failure category is detected (quota, auth, context,
+            # network). Unknown failures fall through with the raw message.
+            hint = classify_llm_failure(out, err, proc.returncode)
+            if hint:
+                base = f"{self._adapter.name}: {hint} (exit {proc.returncode})"
             if auth_probe_unclear:
                 message = (
                     f"{base}\n\n"

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -248,9 +248,9 @@ class CLIBackedLLMClient:
             # Replace the raw exit-code message with an actionable description
             # when a known failure category is detected (quota, auth, context,
             # network). Unknown failures fall through with the raw message.
-            hint = classify_llm_failure(out, err, proc.returncode)
-            if hint:
-                base = f"{self._adapter.name}: {hint} (exit {proc.returncode})"
+            failure_hint = classify_llm_failure(out, err, proc.returncode)
+            if failure_hint is not None:
+                base = f"{self._adapter.name}: {failure_hint} (exit {proc.returncode})"
             if auth_probe_unclear:
                 message = (
                     f"{base}\n\n"

--- a/docs/investigation-tool-calling.md
+++ b/docs/investigation-tool-calling.md
@@ -130,6 +130,6 @@ adapter strictness gaps.
 
 ## Related docs
 
-- [app/services/AGENTS.md](../app/services/AGENTS.md) — API provider wiring and env keys
-- [app/integrations/llm_cli/AGENTS.md](../app/integrations/llm_cli/AGENTS.md) — subprocess CLI providers
-- [AGENTS.md](../AGENTS.md) — repo map and PR checklist
+- [app/services/AGENTS.md](https://github.com/Tracer-Cloud/opensre/blob/main/app/services/AGENTS.md) — API provider wiring and env keys
+- [app/integrations/llm_cli/AGENTS.md](https://github.com/Tracer-Cloud/opensre/blob/main/app/integrations/llm_cli/AGENTS.md) — subprocess CLI providers
+- [AGENTS.md](https://github.com/Tracer-Cloud/opensre/blob/main/AGENTS.md) — repo map and PR checklist

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -280,7 +280,7 @@ In the TTY REPL (`opensre` with no subcommand), `/effort` stores a **session** p
 | `low`, `medium`, `high`, `xhigh` | same string |
 | `max` | `xhigh` |
 
-Run `/effort` alone to show the current choice (or `(default)` when unset) and the usage line. `/reset` clears investigation state but **keeps** `/effort` (and trust mode), consistent with other session prefs.
+Run `/effort` alone to show the current choice (or `(default)` when unset) and the usage line. `/new` starts a fresh session but **keeps** `/effort` (and trust mode), consistent with other session prefs.
 
 Outside the REPL, optional defaults use the environment variable:
 

--- a/docs/sessions.mdx
+++ b/docs/sessions.mdx
@@ -43,6 +43,8 @@ When you want to continue a past investigation or conversation, use `/resume` wi
 /resume 9b2e4f7a
 ```
 
+In a TTY, bare `/resume` opens an interactive picker of recent sessions. New turns after a resume append to that same session file — `/resume` does not create a duplicate entry in `/sessions`.
+
 OpenSRE restores the conversation so the assistant remembers what you were working on. It displays the past exchanges so you can see where you left off, then lets you continue typing:
 
 ```

--- a/docs/sessions.mdx
+++ b/docs/sessions.mdx
@@ -181,6 +181,20 @@ If the prefix matches multiple sessions, `/resume` asks for more characters. If 
 
 Each file is named after its UUID session ID. Files are plain text and human-readable.
 
+## /resume and prompt logging
+
+`turn_detail` records (prompt + response per LLM turn) are written by the prompt logging layer. If prompt logging is fully disabled (`OPENSRE_PROMPT_LOG_DISABLED=1`), no `turn_detail` records are written during the session. The `conversation_snapshot` record written at clean exit (`/exit` or `/reset`) is **not** affected by this setting — it is always written when `cli_agent_messages` is non-empty.
+
+Concretely:
+
+| Scenario | `/resume` result |
+| --- | --- |
+| Clean exit with chat turns | Full context from `conversation_snapshot` |
+| Crash before exit (logging enabled) | Partial context from `turn_detail` fallback |
+| Crash before exit (logging disabled) | No conversation context recoverable |
+
+If `/resume` reports "no conversation to resume" for a session that had chat turns, check whether prompt logging was disabled during that session.
+
 ## What is NOT stored
 
 - Secrets or credentials — session text is stored as typed; enable prompt log redaction if needed

--- a/docs/sessions.mdx
+++ b/docs/sessions.mdx
@@ -21,7 +21,7 @@ Sessions are stored as JSONL files under `~/.opensre/sessions/`. They are writte
 | REPL starts | `session_start` record written immediately; file created at `~/.opensre/sessions/<session-id>.jsonl` |
 | Each interaction | One `turn` stub appended for stats |
 | Each LLM reply | One `turn_detail` record appended with full prompt + response |
-| `/reset` | Current session closed (`conversation_snapshot` + `session_end` written); new session file opened with a fresh ID |
+| `/new` | Current session closed (`conversation_snapshot` + `session_end` written); new session file opened with a fresh ID, LLM context carried forward |
 | REPL exits | `conversation_snapshot` + `session_end` written; file deleted if no turns were recorded |
 | REPL crash | File remains with all turns up to the crash but no `session_end` — stats computed from turn records; `/resume` falls back to `turn_detail` records |
 
@@ -57,7 +57,7 @@ Turn `kind` values:
 | `chat` | Free-text message routed to the LLM assistant |
 | `alert` | Investigation triggered by an alert payload |
 | `incoming_alert` | Alert received via the HTTP listener |
-| `slash` | Slash command (`/status`, `/reset`, etc.) |
+| `slash` | Slash command (`/status`, `/new`, etc.) |
 | `shell` | Shell command executed via the terminal runtime |
 
 **`turn_detail` — full prompt + response (written after each LLM turn)**
@@ -78,7 +78,7 @@ Turn `kind` values:
 `turn_detail` kind values mirror `turn` kinds: `chat`, `alert`, `follow_up`.
 These records make session files self-contained — `/resume` can restore conversation context from them even without a `conversation_snapshot`.
 
-**`conversation_snapshot` — written at clean exit or `/reset`**
+**`conversation_snapshot` — written at clean exit or `/new`**
 
 ```json
 {
@@ -183,7 +183,7 @@ Each file is named after its UUID session ID. Files are plain text and human-rea
 
 ## /resume and prompt logging
 
-`turn_detail` records (prompt + response per LLM turn) are written by the prompt logging layer. If prompt logging is fully disabled (`OPENSRE_PROMPT_LOG_DISABLED=1`), no `turn_detail` records are written during the session. The `conversation_snapshot` record written at clean exit (`/exit` or `/reset`) is **not** affected by this setting — it is always written when `cli_agent_messages` is non-empty.
+`turn_detail` records (prompt + response per LLM turn) are written by the prompt logging layer. If prompt logging is fully disabled (`OPENSRE_PROMPT_LOG_DISABLED=1`), no `turn_detail` records are written during the session. The `conversation_snapshot` record written at clean exit (`/exit` or `/new`) is **not** affected by this setting — it is always written when `cli_agent_messages` is non-empty.
 
 Concretely:
 

--- a/docs/sessions.mdx
+++ b/docs/sessions.mdx
@@ -1,119 +1,21 @@
 ---
 title: 'Session History'
-description: 'How OpenSRE records your REPL sessions locally, what is stored, and how to resume past sessions with /sessions and /resume'
+description: 'Pick up any past conversation exactly where you left off — browse recent sessions, restore context, and start fresh.'
 ---
 
-## Overview
+## Commands at a glance
 
-Every time you start the OpenSRE interactive shell, a new session is created and recorded to disk. Each session captures:
-
-- When it started and how long it lasted
-- Every interaction — chats, investigations, slash commands, incoming alerts
-- Full prompt and response text for each LLM turn (for `/resume`)
-- Aggregate counts (total turns, investigations run)
-
-Sessions are stored as JSONL files under `~/.opensre/sessions/`. They are written **incrementally** — the file exists on disk from the moment the REPL starts, so `/sessions` always shows the current session alongside past ones.
-
-## Session lifecycle
-
-| Event | What happens |
+| Command | What it does |
 | --- | --- |
-| REPL starts | `session_start` record written immediately; file created at `~/.opensre/sessions/<session-id>.jsonl` |
-| Each interaction | One `turn` stub appended for stats |
-| Each LLM reply | One `turn_detail` record appended with full prompt + response |
-| `/new` | Current session closed (`conversation_snapshot` + `session_end` written); new session file opened with a fresh ID, LLM context carried forward |
-| REPL exits | `conversation_snapshot` + `session_end` written; file deleted if no turns were recorded |
-| REPL crash | File remains with all turns up to the crash but no `session_end` — stats computed from turn records; `/resume` falls back to `turn_detail` records |
+| `/sessions` | List your recent REPL sessions with name, duration, and turn counts |
+| `/resume <id>` | Restore a past session's conversation so you can keep asking questions |
+| `/new` | Start a fresh session while carrying forward the current conversation context |
 
-## Session file format
+---
 
-Each session is a JSONL file (one JSON object per line).
+## Browsing past sessions — `/sessions`
 
-**`session_start` — first line**
-
-```json
-{
-  "type": "session_start",
-  "session_id": "3f8a1c2d-...",
-  "started_at": "2024-01-15T10:00:00+00:00",
-  "opensre_version": "0.1"
-}
-```
-
-**`turn` — one per interaction (stats stub)**
-
-```json
-{
-  "type": "turn",
-  "kind": "chat",
-  "text": "why is CPU spiking on prod-api?"
-}
-```
-
-Turn `kind` values:
-
-| Kind | Description |
-| --- | --- |
-| `chat` | Free-text message routed to the LLM assistant |
-| `alert` | Investigation triggered by an alert payload |
-| `incoming_alert` | Alert received via the HTTP listener |
-| `slash` | Slash command (`/status`, `/new`, etc.) |
-| `shell` | Shell command executed via the terminal runtime |
-
-**`turn_detail` — full prompt + response (written after each LLM turn)**
-
-```json
-{
-  "type": "turn_detail",
-  "kind": "chat",
-  "turn_id": "9f1e2a3b-...",
-  "prompt": "why is CPU spiking on prod-api?",
-  "response": "Root cause: the JVM heap is exhausted due to a connection pool leak...",
-  "model": "claude-3-5-sonnet",
-  "provider": "anthropic",
-  "latency_ms": 2341
-}
-```
-
-`turn_detail` kind values mirror `turn` kinds: `chat`, `alert`, `follow_up`.
-These records make session files self-contained — `/resume` can restore conversation context from them even without a `conversation_snapshot`.
-
-**`conversation_snapshot` — written at clean exit or `/new`**
-
-```json
-{
-  "type": "conversation_snapshot",
-  "cli_agent_messages": [
-    ["user", "why is CPU spiking?"],
-    ["assistant", "Root cause: ..."]
-  ],
-  "accumulated_context": {
-    "service": "prod-api",
-    "cluster": "us-east-1"
-  }
-}
-```
-
-This record captures the exact LLM conversation thread and accumulated infra context for `/resume`. It is the preferred source for restoration — more reliable than reconstructing from `turn_detail` records.
-
-**`session_end` — last line (when session closed cleanly)**
-
-```json
-{
-  "type": "session_end",
-  "ended_at": "2024-01-15T10:42:00+00:00",
-  "duration_secs": 2520,
-  "total_turns": 8,
-  "chat_turns": 5,
-  "investigation_turns": 2
-}
-```
-
-A session without a `session_end` record (crash or ongoing) is still valid — `/sessions` computes stats by scanning the `turn` records directly, and `/resume` falls back to `turn_detail` reconstruction.
-
-## /sessions command
-
-Run `/sessions` inside the REPL to list recent sessions:
+Run `/sessions` inside the interactive shell to see your recent history:
 
 ```
 /sessions
@@ -122,95 +24,103 @@ Run `/sessions` inside the REPL to list recent sessions:
 ```
   Recent sessions
 
-   #  Session ID  Started            Duration  Turns  Investigations
-   ─────────────────────────────────────────────────────────────────
-   1  3f8a1c2d    2024-01-15 10:00   42m 0s    8      2
-      (current)
-   2  9b2e4f7a    2024-01-14 14:30   1h 5m     15     4
-   3  c1d3e8f2    2024-01-13 09:10   12m 3s    3      0
+   #  Session ID  Name                           Started            Duration  Turns
+   ─────────────────────────────────────────────────────────────────────────────────
+   1  3f8a1c2d    (current)                      2024-01-15 10:00   42m       8
+   2  9b2e4f7a    why is CPU spiking on prod-api  2024-01-14 14:30   1h 5m    15
+   3  c1d3e8f2    investigate OOM killer          2024-01-13 09:10   12m       3
 ```
 
-The current session is marked `(current)` with a live-updating elapsed time. Sessions without a `session_end` (crash or in-progress) show accurate turn counts computed from the file.
+Up to 20 sessions are shown, newest first. The current session updates its elapsed time live.
 
-Up to 20 sessions are shown, newest first.
+---
 
-## /resume command
+## Resuming a past session — `/resume`
 
-Restore the conversation context from a past session into the current REPL:
-
-```
-/resume <session-id-prefix>
-```
-
-The first 8 characters of a session ID (shown by `/sessions`) are enough:
+When you want to continue a past investigation or conversation, use `/resume` with the first few characters of the session ID shown in `/sessions`:
 
 ```
 /resume 9b2e4f7a
 ```
 
+OpenSRE restores the conversation so the assistant remembers what you were working on. It displays the past exchanges so you can see where you left off, then lets you continue typing:
+
 ```
-resumed session 9b2e4f7a (14 messages from snapshot)
-accumulated context restored: cluster=us-east-1, service=prod-api
-conversation context loaded — continue asking questions.
+resumed session 9b2e4f7a · why is CPU spiking on prod-api (14 messages)
+─── conversation history ────────────────────────────────────
+❯ why is CPU spiking on prod-api?
+● assistant
+The root cause is a connection pool leak in the orders service...
+─────────────────────────────────────────────────────────────
 ```
 
-**What `/resume` restores:**
+**What gets restored:**
 
-| Field | Restored |
+| | Restored by `/resume` |
 | --- | --- |
-| LLM conversation thread (`cli_agent_messages`) | Yes — from `conversation_snapshot` or `turn_detail` fallback |
-| Accumulated infra context (service, cluster, region) | Yes — from `conversation_snapshot` |
-| Turn history (`/status` display) | No — current session keeps its own history |
-| Trust mode, reasoning effort | No — these are session preferences, not conversation state |
+| Full conversation context (what you asked, what the assistant said) | ✅ Yes |
+| Infra context (service name, cluster, region learned mid-session) | ✅ Yes |
+| Trust mode, reasoning effort | ❌ No — these are per-session preferences |
 
-**Restoration order:**
-1. `conversation_snapshot` record — written at clean exit, exact fidelity
-2. `turn_detail` records — fallback for old files or sessions that crashed before flush
-
-If the prefix matches multiple sessions, `/resume` asks for more characters. If the session has no conversation content (slash-command-only session), a warning is shown.
-
-## Storage location
+You can also search by name instead of ID:
 
 ```
-~/.opensre/sessions/
-  3f8a1c2d-ab12-....jsonl   ← current session (in progress)
-  9b2e4f7a-cd34-....jsonl   ← previous session
-  c1d3e8f2-ef56-....jsonl
-  ...
+/resume redis        # resumes the session whose name contains "redis"
+/resume cpu spike    # matches by name substring
 ```
 
-Each file is named after its UUID session ID. Files are plain text and human-readable.
+If the prefix is ambiguous (matches more than one session), OpenSRE will ask you to be more specific.
 
-## /resume and prompt logging
+---
 
-`turn_detail` records (prompt + response per LLM turn) are written by the prompt logging layer. If prompt logging is fully disabled (`OPENSRE_PROMPT_LOG_DISABLED=1`), no `turn_detail` records are written during the session. The `conversation_snapshot` record written at clean exit (`/exit` or `/new`) is **not** affected by this setting — it is always written when `cli_agent_messages` is non-empty.
+## Starting fresh with context — `/new`
 
-Concretely:
+`/new` closes the current session and opens a new one, but carries the conversation forward so you don't lose context:
 
-| Scenario | `/resume` result |
+```
+/new
+```
+
+```
+new session started — conversation context carried forward.
+  14 messages in context · type to continue
+```
+
+Use `/new` after a long session to keep things tidy in `/sessions` without losing your place in the conversation.
+
+**`/new` vs `/clear`:**
+
+| Command | What it does |
 | --- | --- |
-| Clean exit with chat turns | Full context from `conversation_snapshot` |
-| Crash before exit (logging enabled) | Partial context from `turn_detail` fallback |
-| Crash before exit (logging disabled) | No conversation context recoverable |
+| `/clear` | Clears the terminal screen only — session and context unchanged |
+| `/new` | Opens a new session file; conversation context carried forward |
 
-If `/resume` reports "no conversation to resume" for a session that had chat turns, check whether prompt logging was disabled during that session.
+---
 
-## What is NOT stored
+## What OpenSRE saves
 
-- Secrets or credentials — session text is stored as typed; enable prompt log redaction if needed
-- Full investigation results (stored in `~/.opensre/investigations/`)
-- Token counts — tracked in `~/.opensre/prompt_log.jsonl` (prompt logging must be enabled)
+Each session records:
 
-## Linking sessions to other data
+- When it started and ended, and how long it ran
+- Every message you sent and every response from the assistant
+- Infra context discovered during investigations (service names, cluster names, regions)
+- Turn counts for investigations and chats
 
-The `session_id` in each session file matches the `session_id` field in `~/.opensre/prompt_log.jsonl`. This means you can correlate a session's turn list with token usage and latency recorded in the prompt log.
+Sessions are stored as files under `~/.opensre/sessions/`. Each file is plain text and human-readable.
 
-```bash
-# Find all prompt log entries for a given session
-grep '"session_id": "3f8a1c2d"' ~/.opensre/prompt_log.jsonl
-```
+---
+
+## Privacy and what is NOT saved
+
+- **Secrets or credentials** — session text is stored as typed; enable prompt log redaction if needed
+- **Full investigation results** — stored separately under `~/.opensre/investigations/`
+- **Token usage** — tracked in `~/.opensre/prompt_log.jsonl` when prompt logging is enabled
+
+See [Interactive Shell Privacy](/interactive-shell-privacy) for redaction controls.
+
+---
 
 ## Related
 
-- [Interactive Shell Privacy](/interactive-shell-privacy) — command history redaction and persistence controls
+- [Interactive Shell Privacy](/interactive-shell-privacy) — command history and redaction settings
 - [Prompt Logging](/configuration/environment-variables) — full prompt/response logging configuration

--- a/docs/sessions.mdx
+++ b/docs/sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Session History'
-description: 'How OpenSRE records your REPL sessions locally, what is stored, and how to view past sessions with /sessions'
+description: 'How OpenSRE records your REPL sessions locally, what is stored, and how to resume past sessions with /sessions and /resume'
 ---
 
 ## Overview
@@ -9,6 +9,7 @@ Every time you start the OpenSRE interactive shell, a new session is created and
 
 - When it started and how long it lasted
 - Every interaction — chats, investigations, slash commands, incoming alerts
+- Full prompt and response text for each LLM turn (for `/resume`)
 - Aggregate counts (total turns, investigations run)
 
 Sessions are stored as JSONL files under `~/.opensre/sessions/`. They are written **incrementally** — the file exists on disk from the moment the REPL starts, so `/sessions` always shows the current session alongside past ones.
@@ -18,10 +19,11 @@ Sessions are stored as JSONL files under `~/.opensre/sessions/`. They are writte
 | Event | What happens |
 | --- | --- |
 | REPL starts | `session_start` record written immediately; file created at `~/.opensre/sessions/<session-id>.jsonl` |
-| Each interaction | One `turn` record appended to the open file |
-| `/reset` | Current session closed (`session_end` written); new session file opened with a fresh ID |
-| REPL exits | `session_end` written; file is deleted if no turns were recorded (empty session) |
-| REPL crash | File remains with all turns up to the crash but no `session_end` — stats computed from the turn records |
+| Each interaction | One `turn` stub appended for stats |
+| Each LLM reply | One `turn_detail` record appended with full prompt + response |
+| `/reset` | Current session closed (`conversation_snapshot` + `session_end` written); new session file opened with a fresh ID |
+| REPL exits | `conversation_snapshot` + `session_end` written; file deleted if no turns were recorded |
+| REPL crash | File remains with all turns up to the crash but no `session_end` — stats computed from turn records; `/resume` falls back to `turn_detail` records |
 
 ## Session file format
 
@@ -38,7 +40,7 @@ Each session is a JSONL file (one JSON object per line).
 }
 ```
 
-**`turn` — one per interaction**
+**`turn` — one per interaction (stats stub)**
 
 ```json
 {
@@ -58,7 +60,41 @@ Turn `kind` values:
 | `slash` | Slash command (`/status`, `/reset`, etc.) |
 | `shell` | Shell command executed via the terminal runtime |
 
-Text is truncated to 200 characters. No response content is stored — only the prompt/input.
+**`turn_detail` — full prompt + response (written after each LLM turn)**
+
+```json
+{
+  "type": "turn_detail",
+  "kind": "chat",
+  "turn_id": "9f1e2a3b-...",
+  "prompt": "why is CPU spiking on prod-api?",
+  "response": "Root cause: the JVM heap is exhausted due to a connection pool leak...",
+  "model": "claude-3-5-sonnet",
+  "provider": "anthropic",
+  "latency_ms": 2341
+}
+```
+
+`turn_detail` kind values mirror `turn` kinds: `chat`, `alert`, `follow_up`.
+These records make session files self-contained — `/resume` can restore conversation context from them even without a `conversation_snapshot`.
+
+**`conversation_snapshot` — written at clean exit or `/reset`**
+
+```json
+{
+  "type": "conversation_snapshot",
+  "cli_agent_messages": [
+    ["user", "why is CPU spiking?"],
+    ["assistant", "Root cause: ..."]
+  ],
+  "accumulated_context": {
+    "service": "prod-api",
+    "cluster": "us-east-1"
+  }
+}
+```
+
+This record captures the exact LLM conversation thread and accumulated infra context for `/resume`. It is the preferred source for restoration — more reliable than reconstructing from `turn_detail` records.
 
 **`session_end` — last line (when session closed cleanly)**
 
@@ -73,7 +109,7 @@ Text is truncated to 200 characters. No response content is stored — only the 
 }
 ```
 
-A session without a `session_end` record (crash or ongoing) is still valid — `/sessions` computes `total_turns`, `chat_turns`, and `investigation_turns` by scanning the `turn` records directly.
+A session without a `session_end` record (crash or ongoing) is still valid — `/sessions` computes stats by scanning the `turn` records directly, and `/resume` falls back to `turn_detail` reconstruction.
 
 ## /sessions command
 
@@ -98,6 +134,41 @@ The current session is marked `(current)` with a live-updating elapsed time. Ses
 
 Up to 20 sessions are shown, newest first.
 
+## /resume command
+
+Restore the conversation context from a past session into the current REPL:
+
+```
+/resume <session-id-prefix>
+```
+
+The first 8 characters of a session ID (shown by `/sessions`) are enough:
+
+```
+/resume 9b2e4f7a
+```
+
+```
+resumed session 9b2e4f7a (14 messages from snapshot)
+accumulated context restored: cluster=us-east-1, service=prod-api
+conversation context loaded — continue asking questions.
+```
+
+**What `/resume` restores:**
+
+| Field | Restored |
+| --- | --- |
+| LLM conversation thread (`cli_agent_messages`) | Yes — from `conversation_snapshot` or `turn_detail` fallback |
+| Accumulated infra context (service, cluster, region) | Yes — from `conversation_snapshot` |
+| Turn history (`/status` display) | No — current session keeps its own history |
+| Trust mode, reasoning effort | No — these are session preferences, not conversation state |
+
+**Restoration order:**
+1. `conversation_snapshot` record — written at clean exit, exact fidelity
+2. `turn_detail` records — fallback for old files or sessions that crashed before flush
+
+If the prefix matches multiple sessions, `/resume` asks for more characters. If the session has no conversation content (slash-command-only session), a warning is shown.
+
 ## Storage location
 
 ```
@@ -112,13 +183,13 @@ Each file is named after its UUID session ID. Files are plain text and human-rea
 
 ## What is NOT stored
 
-- LLM response content (stored separately in `~/.opensre/prompt_log.jsonl` if prompt logging is enabled)
-- Full alert payloads or investigation results (stored in `~/.opensre/investigations/`)
 - Secrets or credentials — session text is stored as typed; enable prompt log redaction if needed
+- Full investigation results (stored in `~/.opensre/investigations/`)
+- Token counts — tracked in `~/.opensre/prompt_log.jsonl` (prompt logging must be enabled)
 
 ## Linking sessions to other data
 
-The `session_id` in each session file matches the `session_id` field in `~/.opensre/prompt_log.jsonl`. This means you can correlate a session's turn list with the full prompt/response pairs and token usage recorded in the prompt log.
+The `session_id` in each session file matches the `session_id` field in `~/.opensre/prompt_log.jsonl`. This means you can correlate a session's turn list with token usage and latency recorded in the prompt log.
 
 ```bash
 # Find all prompt log entries for a given session

--- a/tests/cli/interactive_shell/runtime/test_tasks.py
+++ b/tests/cli/interactive_shell/runtime/test_tasks.py
@@ -196,7 +196,7 @@ class TestTaskRegistry:
         assert loaded.status == TaskStatus.CANCELLED
         assert (12345, 15) not in calls
 
-    def test_session_reset_does_not_truncate_persistent_task_store(
+    def test_session_new_does_not_truncate_persistent_task_store(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
@@ -212,16 +212,16 @@ class TestTaskRegistry:
 
         session.clear()
 
-        # /reset must keep the on-disk store intact: a fresh persistent registry
+        # /new must keep the on-disk store intact: a fresh persistent registry
         # still finds the task, and the session's swapped-in registry continues
         # to surface persisted history via its disk-backed merge so /tasks does
-        # not "forget" the user's prior runs after a session reset.
+        # not "forget" the user's prior runs after /new.
         reloaded = TaskRegistry.persistent()
         [loaded] = reloaded.list_recent()
         assert loaded.task_id == task.task_id
         assert loaded.command == "opensre tests"
-        [visible_after_reset] = session.task_registry.list_recent()
-        assert visible_after_reset.task_id == task.task_id
+        [visible_after_new] = session.task_registry.list_recent()
+        assert visible_after_new.task_id == task.task_id
 
 
 class TestSlashTaskCommands:

--- a/tests/cli/interactive_shell/sessions/test_resume_scenarios.py
+++ b/tests/cli/interactive_shell/sessions/test_resume_scenarios.py
@@ -106,12 +106,16 @@ class TestResumeScenarioMatrix:
             )
 
         target_turns = _read_turns(isolated_sessions / f"{target_id}.jsonl")
-        assert any(t.get("kind") == "slash" and t.get("text", "").startswith("/resume") for t in target_turns)
+        assert any(
+            t.get("kind") == "slash" and t.get("text", "").startswith("/resume")
+            for t in target_turns
+        )
         assert session.cli_agent_messages[0] == ("user", "why is redis slow?")
         assert session.accumulated_context == {"service": "redis"}
 
     def test_scenario_post_resume_slash_and_chat_append_to_target(
-        self, isolated_sessions: Path,
+        self,
+        isolated_sessions: Path,
     ) -> None:
         """After /resume, further slash commands and chat turns land on the same file."""
         target_id = "bbbb2222-3333-4444-5555-666677778888"
@@ -130,10 +134,14 @@ class TestResumeScenarioMatrix:
         assert "slash" in kinds
         assert kinds.count("slash") >= 2
         assert "chat" in kinds
-        assert target_path.read_text(encoding="utf-8").strip().splitlines()[-1].find("session_end") == -1
+        assert (
+            target_path.read_text(encoding="utf-8").strip().splitlines()[-1].find("session_end")
+            == -1
+        )
 
     def test_scenario_empty_starter_session_removed_on_resume(
-        self, isolated_sessions: Path,
+        self,
+        isolated_sessions: Path,
     ) -> None:
         """A brand-new REPL with no turns should not leave a junk file after /resume."""
         target_id = "cccc3333-4444-5555-6666-777788889999"
@@ -166,7 +174,8 @@ class TestResumeScenarioMatrix:
         assert any(t.get("text") == "/resume OOM" for t in target_turns)
 
     def test_scenario_resume_not_found_records_on_current(
-        self, isolated_sessions: Path,
+        self,
+        isolated_sessions: Path,
     ) -> None:
         session = ReplSession()
         current_id = session.session_id
@@ -183,7 +192,8 @@ class TestResumeScenarioMatrix:
         assert session.history[-1]["ok"] is False
 
     def test_scenario_resume_current_session_guard(
-        self, isolated_sessions: Path,
+        self,
+        isolated_sessions: Path,
     ) -> None:
         session = ReplSession()
         _open_current(session)
@@ -198,7 +208,8 @@ class TestResumeScenarioMatrix:
         assert any(t.get("text", "").startswith("/resume") for t in turns)
 
     def test_scenario_resume_empty_target_does_not_switch(
-        self, isolated_sessions: Path,
+        self,
+        isolated_sessions: Path,
     ) -> None:
         empty_id = "eeee5555-6666-7777-8888-999900001111"
         path = isolated_sessions / f"{empty_id}.jsonl"
@@ -227,7 +238,8 @@ class TestResumeScenarioMatrix:
         assert "no conversation to resume" in buf.getvalue()
 
     def test_scenario_chain_resume_two_targets(
-        self, isolated_sessions: Path,
+        self,
+        isolated_sessions: Path,
     ) -> None:
         """Resume session A, then resume session B — each gets its own /resume slash turn."""
         id_a = "ffff6666-7777-8888-9999-000011112222"
@@ -252,7 +264,8 @@ class TestResumeScenarioMatrix:
         assert session.cli_agent_messages[0] == ("user", "session B question")
 
     def test_scenario_active_session_with_turns_flushed_without_resume_slash(
-        self, isolated_sessions: Path,
+        self,
+        isolated_sessions: Path,
     ) -> None:
         """Switching away from a session that had real turns preserves them without /resume."""
         target_id = "22228888-9999-0000-1111-222233334444"
@@ -269,7 +282,9 @@ class TestResumeScenarioMatrix:
         old_turns = _read_turns(isolated_sessions / f"{current_id}.jsonl")
         assert any(t["kind"] == "chat" for t in old_turns)
         assert not any(t.get("kind") == "slash" for t in old_turns)
-        assert (isolated_sessions / f"{current_id}.jsonl").read_text(encoding="utf-8").find("session_end") != -1
+        assert (isolated_sessions / f"{current_id}.jsonl").read_text(encoding="utf-8").find(
+            "session_end"
+        ) != -1
 
 
 @pytest.mark.integration

--- a/tests/cli/interactive_shell/sessions/test_resume_scenarios.py
+++ b/tests/cli/interactive_shell/sessions/test_resume_scenarios.py
@@ -1,0 +1,310 @@
+"""End-to-end /resume scenario tests: session identity, JSONL turns, slash recording."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+from app.cli.interactive_shell.commands import dispatch_slash
+from app.cli.interactive_shell.runtime.session import ReplSession
+from app.cli.interactive_shell.sessions.store import SessionStore
+
+
+def _capture() -> tuple[Console, io.StringIO]:
+    buf = io.StringIO()
+    return Console(file=buf, force_terminal=False, highlight=False), buf
+
+
+def _read_turns(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and json.loads(line).get("type") == "turn"
+    ]
+
+
+def _write_finalized_session(
+    sessions_dir: Path,
+    session_id: str,
+    *,
+    chat_text: str = "why is redis slow?",
+    messages: list[tuple[str, str]] | None = None,
+    context: dict[str, str] | None = None,
+) -> Path:
+    """Create a closed session file that /resume can load."""
+    path = sessions_dir / f"{session_id}.jsonl"
+    msgs = messages or [("user", chat_text), ("assistant", "check connection pool")]
+    ctx = context or {"service": "redis"}
+    lines = [
+        json.dumps(
+            {
+                "type": "session_start",
+                "session_id": session_id,
+                "started_at": "2026-05-29T10:00:00+00:00",
+            }
+        ),
+        json.dumps({"type": "turn", "kind": "chat", "text": chat_text}),
+        json.dumps(
+            {
+                "type": "conversation_snapshot",
+                "cli_agent_messages": [list(m) for m in msgs],
+                "accumulated_context": ctx,
+            }
+        ),
+        json.dumps({"type": "session_end", "total_turns": 1}),
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def isolated_sessions(tmp_path: Path) -> Path:
+    """Sessions directory with SessionStore patched for the test."""
+    directory = tmp_path / "sessions"
+    directory.mkdir()
+    with patch(
+        "app.cli.interactive_shell.sessions.store._sessions_dir",
+        return_value=directory,
+    ):
+        yield directory
+
+
+def _open_current(session: ReplSession) -> None:
+    SessionStore.open_session(session)
+
+
+class TestResumeScenarioMatrix:
+    """Scenario coverage for /resume session adoption and JSONL persistence."""
+
+    def test_scenario_fresh_repl_resumes_prior_session(self, isolated_sessions: Path) -> None:
+        """Fresh REPL session resumes a prior session: adopt ID, slash on target only."""
+        target_id = "aaaa1111-2222-3333-4444-555566667777"
+        _write_finalized_session(isolated_sessions, target_id, chat_text="why is redis slow?")
+
+        session = ReplSession()
+        current_id = session.session_id
+        _open_current(session)
+
+        console, buf = _capture()
+        assert dispatch_slash(f"/resume {target_id[:8]}", session, console) is True
+
+        assert session.session_id == target_id
+        assert "resumed session" in buf.getvalue()
+
+        current_path = isolated_sessions / f"{current_id}.jsonl"
+        if current_path.exists():
+            assert not any(
+                t.get("kind") == "slash" and "/resume" in t.get("text", "")
+                for t in _read_turns(current_path)
+            )
+
+        target_turns = _read_turns(isolated_sessions / f"{target_id}.jsonl")
+        assert any(t.get("kind") == "slash" and t.get("text", "").startswith("/resume") for t in target_turns)
+        assert session.cli_agent_messages[0] == ("user", "why is redis slow?")
+        assert session.accumulated_context == {"service": "redis"}
+
+    def test_scenario_post_resume_slash_and_chat_append_to_target(
+        self, isolated_sessions: Path,
+    ) -> None:
+        """After /resume, further slash commands and chat turns land on the same file."""
+        target_id = "bbbb2222-3333-4444-5555-666677778888"
+        _write_finalized_session(isolated_sessions, target_id)
+
+        session = ReplSession()
+        _open_current(session)
+        console, _ = _capture()
+
+        dispatch_slash(f"/resume {target_id[:8]}", session, console)
+        dispatch_slash("/status", session, console)
+        session.record("chat", "follow-up question after resume")
+
+        target_path = isolated_sessions / f"{target_id}.jsonl"
+        kinds = [t["kind"] for t in _read_turns(target_path)]
+        assert "slash" in kinds
+        assert kinds.count("slash") >= 2
+        assert "chat" in kinds
+        assert target_path.read_text(encoding="utf-8").strip().splitlines()[-1].find("session_end") == -1
+
+    def test_scenario_empty_starter_session_removed_on_resume(
+        self, isolated_sessions: Path,
+    ) -> None:
+        """A brand-new REPL with no turns should not leave a junk file after /resume."""
+        target_id = "cccc3333-4444-5555-6666-777788889999"
+        _write_finalized_session(isolated_sessions, target_id)
+
+        session = ReplSession()
+        starter_id = session.session_id
+        _open_current(session)
+        console, _ = _capture()
+
+        dispatch_slash(f"/resume {target_id[:8]}", session, console)
+
+        starter_path = isolated_sessions / f"{starter_id}.jsonl"
+        assert not starter_path.exists()
+        assert session.session_id == target_id
+
+    def test_scenario_resume_by_name_substring(self, isolated_sessions: Path) -> None:
+        target_id = "dddd4444-5555-6666-7777-888899990000"
+        _write_finalized_session(isolated_sessions, target_id, chat_text="investigate OOM killer")
+
+        session = ReplSession()
+        _open_current(session)
+        console, buf = _capture()
+
+        dispatch_slash("/resume OOM", session, console)
+
+        assert session.session_id == target_id
+        assert "resumed session" in buf.getvalue()
+        target_turns = _read_turns(isolated_sessions / f"{target_id}.jsonl")
+        assert any(t.get("text") == "/resume OOM" for t in target_turns)
+
+    def test_scenario_resume_not_found_records_on_current(
+        self, isolated_sessions: Path,
+    ) -> None:
+        session = ReplSession()
+        current_id = session.session_id
+        _open_current(session)
+        console, buf = _capture()
+
+        dispatch_slash("/resume deadbeef", session, console)
+
+        assert session.session_id == current_id
+        assert "not found" in buf.getvalue()
+        turns = _read_turns(isolated_sessions / f"{current_id}.jsonl")
+        assert turns[-1]["kind"] == "slash"
+        assert turns[-1]["text"] == "/resume deadbeef"
+        assert session.history[-1]["ok"] is False
+
+    def test_scenario_resume_current_session_guard(
+        self, isolated_sessions: Path,
+    ) -> None:
+        session = ReplSession()
+        _open_current(session)
+        session.record("chat", "still working here")
+        console, buf = _capture()
+
+        dispatch_slash(f"/resume {session.session_id[:8]}", session, console)
+
+        assert "current session" in buf.getvalue()
+        assert session.session_id  # unchanged
+        turns = _read_turns(isolated_sessions / f"{session.session_id}.jsonl")
+        assert any(t.get("text", "").startswith("/resume") for t in turns)
+
+    def test_scenario_resume_empty_target_does_not_switch(
+        self, isolated_sessions: Path,
+    ) -> None:
+        empty_id = "eeee5555-6666-7777-8888-999900001111"
+        path = isolated_sessions / f"{empty_id}.jsonl"
+        path.write_text(
+            json.dumps(
+                {
+                    "type": "session_start",
+                    "session_id": empty_id,
+                    "started_at": "2026-05-29T10:00:00+00:00",
+                }
+            )
+            + "\n"
+            + json.dumps({"type": "session_end", "total_turns": 0})
+            + "\n",
+            encoding="utf-8",
+        )
+
+        session = ReplSession()
+        current_id = session.session_id
+        _open_current(session)
+        console, buf = _capture()
+
+        dispatch_slash(f"/resume {empty_id[:8]}", session, console)
+
+        assert session.session_id == current_id
+        assert "no conversation to resume" in buf.getvalue()
+
+    def test_scenario_chain_resume_two_targets(
+        self, isolated_sessions: Path,
+    ) -> None:
+        """Resume session A, then resume session B — each gets its own /resume slash turn."""
+        id_a = "ffff6666-7777-8888-9999-000011112222"
+        id_b = "11117777-8888-9999-0000-111122223333"
+        _write_finalized_session(isolated_sessions, id_a, chat_text="session A question")
+        _write_finalized_session(isolated_sessions, id_b, chat_text="session B question")
+
+        session = ReplSession()
+        _open_current(session)
+        console, _ = _capture()
+
+        dispatch_slash(f"/resume {id_a[:8]}", session, console)
+        assert session.session_id == id_a
+
+        dispatch_slash(f"/resume {id_b[:8]}", session, console)
+        assert session.session_id == id_b
+
+        turns_a = _read_turns(isolated_sessions / f"{id_a}.jsonl")
+        turns_b = _read_turns(isolated_sessions / f"{id_b}.jsonl")
+        assert any("/resume" in t.get("text", "") for t in turns_a)
+        assert any("/resume" in t.get("text", "") for t in turns_b)
+        assert session.cli_agent_messages[0] == ("user", "session B question")
+
+    def test_scenario_active_session_with_turns_flushed_without_resume_slash(
+        self, isolated_sessions: Path,
+    ) -> None:
+        """Switching away from a session that had real turns preserves them without /resume."""
+        target_id = "22228888-9999-0000-1111-222233334444"
+        _write_finalized_session(isolated_sessions, target_id)
+
+        session = ReplSession()
+        current_id = session.session_id
+        _open_current(session)
+        session.record("chat", "work in progress")
+        console, _ = _capture()
+
+        dispatch_slash(f"/resume {target_id[:8]}", session, console)
+
+        old_turns = _read_turns(isolated_sessions / f"{current_id}.jsonl")
+        assert any(t["kind"] == "chat" for t in old_turns)
+        assert not any(t.get("kind") == "slash" for t in old_turns)
+        assert (isolated_sessions / f"{current_id}.jsonl").read_text(encoding="utf-8").find("session_end") != -1
+
+
+@pytest.mark.integration
+class TestResumeLiveRepl:
+    """Live REPL smoke test via ReplDriver with isolated HOME."""
+
+    def test_live_resume_round_trip(self, tmp_path: Path) -> None:
+        from tests.utils.repl_driver import ReplDriver
+
+        home = tmp_path / "home"
+        home.mkdir()
+        sessions_dir = home / ".opensre" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        target_id = "live9999-aaaa-bbbb-cccc-ddddeeeeffff"
+        _write_finalized_session(sessions_dir, target_id, chat_text="live redis investigation")
+
+        with ReplDriver(home=home, startup_wait=10.0) as repl:
+            if repl.contains("Press Enter to continue"):
+                repl.send("", wait=3.0)
+                repl.reset_output()
+
+            repl.send("/sessions", wait=3.0)
+            assert repl.contains("live9999") or repl.contains("live redis")
+
+            repl.reset_output()
+            repl.send(f"/resume {target_id[:8]}", wait=4.0)
+            assert repl.contains("resumed session")
+            assert repl.contains("live redis investigation")
+
+            repl.reset_output()
+            repl.send("/status", wait=2.0)
+            assert repl.contains("interactions")
+
+        target_path = sessions_dir / f"{target_id}.jsonl"
+        assert target_path.exists()
+        turns = _read_turns(target_path)
+        assert any(t.get("kind") == "slash" and "/resume" in t.get("text", "") for t in turns)
+        assert any(t.get("kind") == "slash" and "/status" in t.get("text", "") for t in turns)

--- a/tests/cli/interactive_shell/sessions/test_store.py
+++ b/tests/cli/interactive_shell/sessions/test_store.py
@@ -74,15 +74,16 @@ def test_append_turn_adds_record_to_existing_file(tmp_path: Path) -> None:
     assert turns[1] == {"type": "turn", "kind": "alert", "text": "HighCPU on prod"}
 
 
-def test_append_turn_truncates_long_text(tmp_path: Path) -> None:
+def test_append_turn_stores_full_text_without_truncation(tmp_path: Path) -> None:
     session = _make_session()
+    long_text = "x" * 500
     with _patch_dir(tmp_path):
         SessionStore.open_session(session)
-        SessionStore.append_turn(session, "chat", "x" * 500)
+        SessionStore.append_turn(session, "chat", long_text)
 
     records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
     turn = next(r for r in records if r["type"] == "turn")
-    assert len(turn["text"]) == 200
+    assert len(turn["text"]) == 500
 
 
 def test_append_turn_noop_when_file_missing(tmp_path: Path) -> None:
@@ -91,6 +92,54 @@ def test_append_turn_noop_when_file_missing(tmp_path: Path) -> None:
         # Do NOT call open_session — file doesn't exist
         SessionStore.append_turn(session, "chat", "hello")
     assert not list(tmp_path.glob("*.jsonl")), "no file should be created"
+
+
+# ── append_turn_detail ────────────────────────────────────────────────────────
+
+
+def test_append_turn_detail_writes_full_prompt_and_response(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn_detail(
+            session.session_id,
+            "chat",
+            "how do I debug high CPU?",
+            response="Root cause is a memory leak.",
+            turn_id="abc-123",
+            model="claude-3-5",
+            provider="anthropic",
+            latency_ms=1500,
+        )
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    detail = next(r for r in records if r["type"] == "turn_detail")
+    assert detail["kind"] == "chat"
+    assert detail["prompt"] == "how do I debug high CPU?"
+    assert detail["response"] == "Root cause is a memory leak."
+    assert detail["turn_id"] == "abc-123"
+    assert detail["model"] == "claude-3-5"
+    assert detail["provider"] == "anthropic"
+    assert detail["latency_ms"] == 1500
+
+
+def test_append_turn_detail_omits_none_fields(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn_detail(session.session_id, "chat", "hi")
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    detail = next(r for r in records if r["type"] == "turn_detail")
+    assert "response" not in detail
+    assert "turn_id" not in detail
+    assert "model" not in detail
+
+
+def test_append_turn_detail_noop_when_file_missing(tmp_path: Path) -> None:
+    with _patch_dir(tmp_path):
+        SessionStore.append_turn_detail("nonexistent-id", "chat", "hi")
+    assert not list(tmp_path.glob("*.jsonl"))
 
 
 # ── flush ─────────────────────────────────────────────────────────────────────
@@ -112,6 +161,36 @@ def test_flush_writes_session_end(tmp_path: Path) -> None:
     assert end["investigation_turns"] == 1
 
 
+def test_flush_writes_conversation_snapshot_when_messages_present(tmp_path: Path) -> None:
+    session = _make_session()
+    session.cli_agent_messages = [("user", "hello"), ("assistant", "hi there")]
+    session.accumulated_context = {"service": "api", "cluster": "prod"}
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "hello")
+        SessionStore.flush(session)
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    snapshot = next((r for r in records if r["type"] == "conversation_snapshot"), None)
+    assert snapshot is not None
+    assert snapshot["cli_agent_messages"] == [["user", "hello"], ["assistant", "hi there"]]
+    assert snapshot["accumulated_context"] == {"service": "api", "cluster": "prod"}
+    # snapshot must come before session_end
+    types = [r["type"] for r in records]
+    assert types.index("conversation_snapshot") < types.index("session_end")
+
+
+def test_flush_skips_snapshot_when_no_messages(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "hi")
+        SessionStore.flush(session)
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    assert not any(r["type"] == "conversation_snapshot" for r in records)
+
+
 def test_flush_deletes_file_when_no_turns(tmp_path: Path) -> None:
     session = _make_session()
     with _patch_dir(tmp_path):
@@ -119,6 +198,17 @@ def test_flush_deletes_file_when_no_turns(tmp_path: Path) -> None:
         SessionStore.flush(session)
 
     assert not (tmp_path / f"{session.session_id}.jsonl").exists()
+
+
+def test_flush_keeps_file_when_only_turn_details(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        # turn_detail only (no stub) — should NOT delete the file
+        SessionStore.append_turn_detail(session.session_id, "chat", "hello", response="hi")
+        SessionStore.flush(session)
+
+    assert (tmp_path / f"{session.session_id}.jsonl").exists()
 
 
 def test_flush_noop_when_file_missing(tmp_path: Path) -> None:
@@ -197,6 +287,31 @@ def test_load_recent_uses_session_end_stats_when_available(tmp_path: Path) -> No
     assert results[0]["duration_secs"] is not None
 
 
+def test_load_recent_reports_has_snapshot_true(tmp_path: Path) -> None:
+    session = _make_session()
+    session.cli_agent_messages = [("user", "hi"), ("assistant", "hello")]
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "hi")
+        SessionStore.flush(session)
+
+        results = SessionStore.load_recent()
+
+    assert results[0]["has_snapshot"] is True
+
+
+def test_load_recent_reports_has_snapshot_false_without_conversation(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "hi")
+        SessionStore.flush(session)
+
+        results = SessionStore.load_recent()
+
+    assert results[0]["has_snapshot"] is False
+
+
 def test_load_recent_returns_newest_first(tmp_path: Path) -> None:
     for started in ["2024-01-01T10:00:00+00:00", "2024-01-02T10:00:00+00:00"]:
         sid = str(uuid.uuid4())
@@ -252,6 +367,107 @@ def test_load_recent_respects_n_limit(tmp_path: Path) -> None:
 
     with _patch_dir(tmp_path):
         assert len(SessionStore.load_recent(n=3)) == 3
+
+
+# ── load_session ──────────────────────────────────────────────────────────────
+
+
+def test_load_session_returns_none_for_missing_prefix(tmp_path: Path) -> None:
+    with _patch_dir(tmp_path):
+        assert SessionStore.load_session("nonexistent") is None
+
+
+def test_load_session_returns_none_when_no_dir(tmp_path: Path) -> None:
+    with _patch_dir(tmp_path / "missing"):
+        assert SessionStore.load_session("abc") is None
+
+
+def test_load_session_restores_from_conversation_snapshot(tmp_path: Path) -> None:
+    session = _make_session()
+    session.cli_agent_messages = [("user", "how is prod?"), ("assistant", "prod is healthy")]
+    session.accumulated_context = {"service": "api"}
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "how is prod?")
+        SessionStore.flush(session)
+
+        data = SessionStore.load_session(session.session_id[:8])
+
+    assert data is not None
+    assert data["has_snapshot"] is True
+    assert data["cli_agent_messages"] == [
+        ("user", "how is prod?"),
+        ("assistant", "prod is healthy"),
+    ]
+    assert data["accumulated_context"] == {"service": "api"}
+
+
+def test_load_session_fallback_to_turn_details_when_no_snapshot(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn_detail(
+            session.session_id, "chat", "debug high CPU", response="It's a leak"
+        )
+        # Flush without cli_agent_messages — no snapshot written
+        SessionStore.flush(session)
+
+        data = SessionStore.load_session(session.session_id[:8])
+
+    assert data is not None
+    assert data["has_snapshot"] is False
+    messages = data["cli_agent_messages"]
+    assert ("user", "debug high CPU") in messages
+    assert ("assistant", "It's a leak") in messages
+
+
+def test_load_session_ambiguous_prefix_returns_none(tmp_path: Path) -> None:
+    # Two sessions sharing the same prefix
+    for _ in range(2):
+        sid = "aaaabbbb" + str(uuid.uuid4())[8:]
+        (tmp_path / f"{sid}.jsonl").write_text(
+            json.dumps(
+                {
+                    "type": "session_start",
+                    "session_id": sid,
+                    "started_at": "2024-01-01T10:00:00+00:00",
+                }
+            )
+            + "\n"
+        )
+    with _patch_dir(tmp_path):
+        result = SessionStore.load_session("aaaa")
+    assert result is None
+
+
+def test_load_session_includes_history_and_turn_details(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "hello")
+        SessionStore.append_turn_detail(session.session_id, "chat", "hello", response="hi")
+        SessionStore.flush(session)
+
+        data = SessionStore.load_session(session.session_id)
+
+    assert data is not None
+    assert len(data["history"]) == 1
+    assert data["history"][0]["kind"] == "chat"
+    assert len(data["turn_details"]) == 1
+    assert data["turn_details"][0]["response"] == "hi"
+
+
+def test_load_session_matches_full_id(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "hi")
+        SessionStore.flush(session)
+
+        data = SessionStore.load_session(session.session_id)
+
+    assert data is not None
+    assert data["session_id"] == session.session_id
 
 
 # ── /reset lifecycle ──────────────────────────────────────────────────────────

--- a/tests/cli/interactive_shell/sessions/test_store.py
+++ b/tests/cli/interactive_shell/sessions/test_store.py
@@ -161,6 +161,22 @@ def test_flush_writes_session_end(tmp_path: Path) -> None:
     assert end["investigation_turns"] == 1
 
 
+def test_flush_counts_cli_agent_turns_as_chat(tmp_path: Path) -> None:
+    """execution.py records kind='cli_agent' for chat turns — must count as chat_turns."""
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "cli_agent", "why is redis slow?")
+        SessionStore.append_turn(session, "cli_help", "how do I use /resume?")
+        SessionStore.append_turn(session, "follow_up", "what else?")
+        SessionStore.flush(session)
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    end = records[-1]
+    assert end["chat_turns"] == 3
+    assert end["investigation_turns"] == 0
+
+
 def test_flush_writes_conversation_snapshot_when_messages_present(tmp_path: Path) -> None:
     session = _make_session()
     session.cli_agent_messages = [("user", "hello"), ("assistant", "hi there")]
@@ -472,6 +488,18 @@ def test_load_recent_derives_name_from_turn_detail(tmp_path: Path) -> None:
         results = SessionStore.load_recent()
 
     assert results[0]["name"] == "why is redis slow?"
+
+
+def test_load_recent_derives_name_from_cli_agent_turn(tmp_path: Path) -> None:
+    """execution.py calls session.record('cli_agent', text) for real chat turns."""
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "cli_agent", "debug the OOM killer on prod")
+
+        results = SessionStore.load_recent()
+
+    assert results[0]["name"] == "debug the OOM killer on prod"
 
 
 def test_load_recent_derives_name_from_turn_stub_when_no_detail(tmp_path: Path) -> None:

--- a/tests/cli/interactive_shell/sessions/test_store.py
+++ b/tests/cli/interactive_shell/sessions/test_store.py
@@ -593,6 +593,30 @@ def test_load_session_matches_full_id(tmp_path: Path) -> None:
     assert data["session_id"] == session.session_id
 
 
+# ── flush resilience ─────────────────────────────────────────────────────────
+
+
+def test_flush_writes_session_end_even_when_snapshot_serialization_fails(
+    tmp_path: Path,
+) -> None:
+    """P1: a snapshot serialization failure must not prevent session_end from being written."""
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        session.record("chat", "hello")
+        # Inject a non-JSON-serializable value into accumulated_context so
+        # json.dumps(snapshot) raises TypeError inside the inner suppress block.
+        session.accumulated_context["bad"] = object()  # type: ignore[assignment]
+
+        SessionStore.flush(session)
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    types = [r["type"] for r in records]
+    # snapshot may be absent (serialization failed), but session_end must be present.
+    assert "session_end" in types
+    assert records[-1]["type"] == "session_end"
+
+
 # ── /new lifecycle ────────────────────────────────────────────────────────────
 
 

--- a/tests/cli/interactive_shell/sessions/test_store.py
+++ b/tests/cli/interactive_shell/sessions/test_store.py
@@ -246,6 +246,50 @@ def test_flush_is_idempotent(tmp_path: Path) -> None:
     assert len(end_records) == 1, "flush() must be idempotent — only one session_end"
 
 
+def test_append_turn_reopens_finalized_session(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        session.record("chat", "hello")
+        SessionStore.flush(session)
+        session.record("slash", "/status")
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    types = [r["type"] for r in records]
+    assert types.count("session_end") == 0
+    assert records[-1] == {"type": "turn", "kind": "slash", "text": "/status"}
+
+
+def test_reopen_session_strips_trailing_end_and_snapshot(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        session.record("chat", "hello")
+        SessionStore.flush(session)
+        SessionStore.reopen_session(session.session_id)
+        session.record("chat", "continued")
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    types = [r["type"] for r in records]
+    assert types.count("session_end") == 0
+    assert types.count("conversation_snapshot") == 0
+    assert types[-1] == "turn"
+    assert records[-1]["text"] == "continued"
+
+
+def test_reopen_session_noop_for_open_session(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        session.record("chat", "hello")
+        SessionStore.reopen_session(session.session_id)
+        session.record("chat", "still open")
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    assert records[-1]["text"] == "still open"
+    assert all(r["type"] != "session_end" for r in records)
+
+
 # ── session.record() wiring ───────────────────────────────────────────────────
 
 

--- a/tests/cli/interactive_shell/sessions/test_store.py
+++ b/tests/cli/interactive_shell/sessions/test_store.py
@@ -457,6 +457,33 @@ def test_load_session_includes_history_and_turn_details(tmp_path: Path) -> None:
     assert data["turn_details"][0]["response"] == "hi"
 
 
+def test_count_prefix_matches_returns_correct_count(tmp_path: Path) -> None:
+    for _ in range(3):
+        sid = str(uuid.uuid4())
+        (tmp_path / f"{sid}.jsonl").write_text(
+            json.dumps(
+                {
+                    "type": "session_start",
+                    "session_id": sid,
+                    "started_at": "2024-01-01T10:00:00+00:00",
+                }
+            )
+            + "\n"
+        )
+    with _patch_dir(tmp_path):
+        # Full UUID prefix matches exactly one
+        first_sid = list(tmp_path.glob("*.jsonl"))[0].stem
+        assert SessionStore.count_prefix_matches(first_sid[:8]) == 1
+        # Very short prefix may match multiple — no assertion on count, just that it doesn't raise
+        count = SessionStore.count_prefix_matches("")
+        assert count == 3
+
+
+def test_count_prefix_matches_returns_zero_for_missing_dir(tmp_path: Path) -> None:
+    with _patch_dir(tmp_path / "missing"):
+        assert SessionStore.count_prefix_matches("abc") == 0
+
+
 def test_load_session_matches_full_id(tmp_path: Path) -> None:
     session = _make_session()
     with _patch_dir(tmp_path):

--- a/tests/cli/interactive_shell/sessions/test_store.py
+++ b/tests/cli/interactive_shell/sessions/test_store.py
@@ -319,15 +319,16 @@ def test_load_recent_counts_turns_for_in_progress_session(tmp_path: Path) -> Non
     session = _make_session()
     with _patch_dir(tmp_path):
         SessionStore.open_session(session)
-        SessionStore.append_turn(session, "chat", "hi")
+        SessionStore.append_turn(session, "cli_agent", "hi")
+        SessionStore.append_turn(session, "chat", "follow-up")
         SessionStore.append_turn(session, "alert", "OOM")
         # No flush — session still in progress
 
         results = SessionStore.load_recent()
 
     assert len(results) == 1
-    assert results[0]["total_turns"] == 2
-    assert results[0]["chat_turns"] == 1
+    assert results[0]["total_turns"] == 3
+    assert results[0]["chat_turns"] == 2
     assert results[0]["investigation_turns"] == 1
     assert results[0]["duration_secs"] is None
     assert results[0]["is_ended"] is False

--- a/tests/cli/interactive_shell/sessions/test_store.py
+++ b/tests/cli/interactive_shell/sessions/test_store.py
@@ -593,23 +593,23 @@ def test_load_session_matches_full_id(tmp_path: Path) -> None:
     assert data["session_id"] == session.session_id
 
 
-# ── /reset lifecycle ──────────────────────────────────────────────────────────
+# ── /new lifecycle ────────────────────────────────────────────────────────────
 
 
-def test_reset_closes_old_session_and_opens_new(tmp_path: Path) -> None:
+def test_new_closes_old_session_and_opens_new(tmp_path: Path) -> None:
     session = _make_session()
     with _patch_dir(tmp_path):
         SessionStore.open_session(session)
-        session.record("chat", "pre-reset question")
+        session.record("chat", "pre-new question")
         sid1 = session.session_id
 
-        # Simulate /reset
+        # Simulate /new (flush → clear → open_session)
         SessionStore.flush(session)
         session.clear()
         SessionStore.open_session(session)
         sid2 = session.session_id
 
-        session.record("chat", "post-reset question")
+        session.record("chat", "post-new question")
 
     assert sid1 != sid2
     # Old session file has session_end

--- a/tests/cli/interactive_shell/sessions/test_store.py
+++ b/tests/cli/interactive_shell/sessions/test_store.py
@@ -457,6 +457,74 @@ def test_load_session_includes_history_and_turn_details(tmp_path: Path) -> None:
     assert data["turn_details"][0]["response"] == "hi"
 
 
+# ── session name derivation ───────────────────────────────────────────────────
+
+
+def test_load_recent_derives_name_from_turn_detail(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "why is redis slow?")
+        SessionStore.append_turn_detail(
+            session.session_id, "chat", "why is redis slow?", response="It's a memory issue"
+        )
+
+        results = SessionStore.load_recent()
+
+    assert results[0]["name"] == "why is redis slow?"
+
+
+def test_load_recent_derives_name_from_turn_stub_when_no_detail(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "alert", "HighCPU on prod-api-1")
+
+        results = SessionStore.load_recent()
+
+    assert results[0]["name"] == "HighCPU on prod-api-1"
+
+
+def test_load_recent_name_truncated_at_50_chars(tmp_path: Path) -> None:
+    session = _make_session()
+    long_prompt = "a" * 60
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", long_prompt)
+
+        results = SessionStore.load_recent()
+
+    assert results[0]["name"] == "a" * 50 + "…"
+
+
+def test_load_recent_name_empty_for_slash_only_session(tmp_path: Path) -> None:
+    sid = str(uuid.uuid4())
+    (tmp_path / f"{sid}.jsonl").write_text(
+        json.dumps(
+            {"type": "session_start", "session_id": sid, "started_at": "2024-01-01T10:00:00+00:00"}
+        )
+        + "\n"
+        + json.dumps({"type": "turn", "kind": "slash", "text": "/status"})
+        + "\n"
+    )
+    with _patch_dir(tmp_path):
+        results = SessionStore.load_recent()
+    assert results[0]["name"] == ""
+
+
+def test_load_session_includes_name(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "debug the OOM killer")
+        SessionStore.flush(session)
+
+        data = SessionStore.load_session(session.session_id[:8])
+
+    assert data is not None
+    assert data["name"] == "debug the OOM killer"
+
+
 def test_count_prefix_matches_returns_correct_count(tmp_path: Path) -> None:
     for _ in range(3):
         sid = str(uuid.uuid4())

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1327,9 +1327,7 @@ class TestInvestigateFileCommand:
 class TestResumeCommand:
     """Tests for /resume command — session rotation and context restoration."""
 
-    def test_apply_resume_rotates_session_and_restores_context(
-        self, tmp_path: Path
-    ) -> None:
+    def test_apply_resume_rotates_session_and_restores_context(self, tmp_path: Path) -> None:
         """_apply_resume_data must flush the current session, rotate to a new one,
         and restore cli_agent_messages + accumulated_context from the old session."""
         import json
@@ -1404,9 +1402,7 @@ class TestResumeCommand:
         assert session.session_id == old_id
         assert "no conversation to resume" in buf.getvalue()
 
-    def test_apply_resume_displays_history_in_repl_format(
-        self, tmp_path: Path
-    ) -> None:
+    def test_apply_resume_displays_history_in_repl_format(self, tmp_path: Path) -> None:
         """History display must use `❯ user` / `● assistant` REPL format rather
         than the old `you / sre` compact text format."""
         from unittest.mock import patch

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1325,11 +1325,11 @@ class TestInvestigateFileCommand:
 
 
 class TestResumeCommand:
-    """Tests for /resume command — session rotation and context restoration."""
+    """Tests for /resume command — session adoption and context restoration."""
 
-    def test_apply_resume_rotates_session_and_restores_context(self, tmp_path: Path) -> None:
-        """_apply_resume_data must flush the current session, rotate to a new one,
-        and restore cli_agent_messages + accumulated_context from the old session."""
+    def test_apply_resume_adopts_target_session_and_restores_context(self, tmp_path: Path) -> None:
+        """_apply_resume_data must flush the current session, adopt the target ID,
+        reopen its file, and restore cli_agent_messages + accumulated_context."""
         import json
         from unittest.mock import patch
 
@@ -1338,6 +1338,7 @@ class TestResumeCommand:
 
         session = ReplSession()
         old_id = session.session_id
+        target_id = "old-abc-1234567890"
 
         with patch(
             "app.cli.interactive_shell.sessions.store._sessions_dir",
@@ -1346,35 +1347,65 @@ class TestResumeCommand:
             SessionStore.open_session(session)
             session.record("chat", "pre-resume turn")
 
-            data = {
-                "session_id": "old-abc-123456",
-                "name": "Old Chat",
-                "cli_agent_messages": [("user", "hello"), ("assistant", "hi")],
-                "accumulated_context": {"service": "redis"},
-                "history": [{"type": "turn", "kind": "chat", "text": "hello"}],
-                "turn_details": [],
-                "has_snapshot": True,
-            }
-            console, buf = _capture()
-            result = _apply_resume_data(data, session, console)
+            # Pre-create a finalized target session file to resume into.
+            target_path = tmp_path / f"{target_id}.jsonl"
+            target_path.write_text(
+                "\n".join(
+                    [
+                        json.dumps(
+                            {
+                                "type": "session_start",
+                                "session_id": target_id,
+                                "started_at": "2026-05-29T10:00:00+00:00",
+                            }
+                        ),
+                        json.dumps({"type": "turn", "kind": "chat", "text": "hello"}),
+                        json.dumps(
+                            {
+                                "type": "conversation_snapshot",
+                                "cli_agent_messages": [["user", "hello"], ["assistant", "hi"]],
+                                "accumulated_context": {"service": "redis"},
+                            }
+                        ),
+                        json.dumps({"type": "session_end", "total_turns": 1}),
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
 
-            # Old session file must be finalized
+            data = SessionStore.load_session(target_id[:8])
+            assert data is not None
+
+            console, buf = _capture()
+            slash_command = f"/resume {target_id[:8]}"
+            result = _apply_resume_data(data, session, console, slash_command=slash_command)
+
+            # Current (empty-ish) session file must be finalized without /resume turn
             old_records = [
                 json.loads(line)
                 for line in (tmp_path / f"{old_id}.jsonl").read_text().splitlines()
                 if line.strip()
             ]
             assert old_records[-1]["type"] == "session_end"
+            assert not any(r.get("kind") == "slash" for r in old_records if r.get("type") == "turn")
 
-            # New session file is created for the continuation session
-            new_file = tmp_path / f"{session.session_id}.jsonl"
-            assert new_file.exists()
+            # Target session is reopened — slash turn recorded on resumed session
+            assert session.session_id == target_id
+            target_records = [
+                json.loads(line)
+                for line in target_path.read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+            assert target_records[0]["type"] == "session_start"
+            assert target_records[-1]["type"] == "turn"
+            assert target_records[-1]["kind"] == "slash"
+            assert target_records[-1]["text"].startswith("/resume")
 
         assert result is True
-        assert session.session_id != old_id
+        assert session.session_id == target_id
         assert session.cli_agent_messages == [("user", "hello"), ("assistant", "hi")]
         assert session.accumulated_context == {"service": "redis"}
-        assert session.resumed_from_name == "Old Chat"
         output = buf.getvalue()
         assert "resumed session" in output
         assert "old-abc" in output
@@ -1403,21 +1434,24 @@ class TestResumeCommand:
         assert "no conversation to resume" in buf.getvalue()
 
     def test_apply_resume_displays_history_in_repl_format(self, tmp_path: Path) -> None:
-        """History display must use `❯ user` / `● assistant` REPL format rather
-        than the old `you / sre` compact text format."""
+        """History display uses REPL turn order and includes slash commands."""
         from unittest.mock import patch
 
         from app.cli.interactive_shell.command_registry.session_cmds import _apply_resume_data
+        from app.cli.interactive_shell.sessions.store import SessionStore
 
         data = {
-            "session_id": "display-test-abc",
+            "session_id": "display-test-abc123456789",
             "name": "My Session",
             "cli_agent_messages": [
                 ("user", "what is opensre?"),
                 ("assistant", "OpenSRE is a tool"),
             ],
             "accumulated_context": {},
-            "history": [],
+            "history": [
+                {"type": "turn", "kind": "slash", "text": "/status"},
+                {"type": "turn", "kind": "chat", "text": "what is opensre?"},
+            ],
             "turn_details": [],
             "has_snapshot": True,
         }
@@ -1428,18 +1462,47 @@ class TestResumeCommand:
             "app.cli.interactive_shell.sessions.store._sessions_dir",
             return_value=tmp_path,
         ):
+            SessionStore.open_session(session)
             _apply_resume_data(data, session, console)
 
         output = buf.getvalue()
-        # New format uses ❯ for user messages and ● assistant header
         assert "❯" in output
         assert "assistant" in output
-        # Old compact format ("you  " / "sre  ") must not appear
+        assert "$ /status" in output
         assert "you  " not in output
         assert "sre  " not in output
-        # Content is present
         assert "what is opensre?" in output
         assert "OpenSRE is a tool" in output
+
+
+    def test_planner_llm_error_persisted_to_cli_agent_messages(self) -> None:
+        """PlannerLLMError must be added to cli_agent_messages so /resume can show it."""
+        from unittest.mock import patch
+
+        from app.cli.interactive_shell.routing.handle_message_with_agent.errors import (
+            PlannerLLMError,
+        )
+        from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.agent_actions import (
+            execute_cli_actions,
+        )
+
+        session = ReplSession()
+        console, _ = _capture()
+
+        def _raise(*_args: object, **_kwargs: object) -> None:
+            raise PlannerLLMError("codex: quota or rate limit exceeded (exit 1)")
+
+        with patch(
+            "app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.agent_actions._plan_actions",
+            side_effect=_raise,
+        ):
+            execute_cli_actions("check cpu usage", session, console)
+
+        # The error turn must be recorded in cli_agent_messages for /resume
+        assert len(session.cli_agent_messages) == 2
+        assert session.cli_agent_messages[0] == ("user", "check cpu usage")
+        assert session.cli_agent_messages[1][0] == "assistant"
+        assert "quota" in session.cli_agent_messages[1][1]
 
 
 class TestHistoryCommand:

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -153,18 +153,18 @@ class TestDispatchSlash:
         assert "default config:" in output
         assert "anthropic does not use reasoning-effort overrides" in output
 
-    def test_reset_clears_session(self) -> None:
+    def test_new_clears_session(self) -> None:
         session = ReplSession()
         session.record("alert", "test")
         session.last_state = {"x": 1}
         session.trust_mode = True
         console, _ = _capture()
 
-        dispatch_slash("/reset", session, console)
+        dispatch_slash("/new", session, console)
 
         assert session.history == []
         assert session.last_state is None
-        assert session.trust_mode is True  # reset keeps trust mode
+        assert session.trust_mode is True  # /new keeps trust mode
 
     def test_status_shows_session_fields(self) -> None:
         session = ReplSession()

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1474,6 +1474,37 @@ class TestResumeCommand:
         assert "what is opensre?" in output
         assert "OpenSRE is a tool" in output
 
+    def test_apply_resume_no_history_keeps_user_assistant_pairs_with_duplicate_prompts(
+        self,
+    ) -> None:
+        """No-history rendering should not emit orphaned assistant blocks."""
+        from app.cli.interactive_shell.command_registry.session_cmds import _apply_resume_data
+
+        data = {
+            "session_id": "display-no-history-abc123",
+            "name": "No History",
+            "cli_agent_messages": [
+                ("user", "repeat"),
+                ("assistant", "first answer"),
+                ("user", "repeat"),
+                ("assistant", "second answer"),
+            ],
+            "accumulated_context": {},
+            "history": [],
+            "turn_details": [],
+            "has_snapshot": True,
+        }
+
+        session = ReplSession()
+        console, buf = _capture()
+        _apply_resume_data(data, session, console)
+
+        output = buf.getvalue()
+        assert output.count("❯ repeat") == 2
+        assert output.count("assistant") == 2
+        assert "first answer" in output
+        assert "second answer" in output
+
     def test_planner_llm_error_persisted_to_cli_agent_messages(self) -> None:
         """PlannerLLMError must be added to cli_agent_messages so /resume can show it."""
         from unittest.mock import patch

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1324,6 +1324,128 @@ class TestInvestigateFileCommand:
 # Task 4 — Session-state commands
 
 
+class TestResumeCommand:
+    """Tests for /resume command — session rotation and context restoration."""
+
+    def test_apply_resume_rotates_session_and_restores_context(
+        self, tmp_path: Path
+    ) -> None:
+        """_apply_resume_data must flush the current session, rotate to a new one,
+        and restore cli_agent_messages + accumulated_context from the old session."""
+        import json
+        from unittest.mock import patch
+
+        from app.cli.interactive_shell.command_registry.session_cmds import _apply_resume_data
+        from app.cli.interactive_shell.sessions.store import SessionStore
+
+        session = ReplSession()
+        old_id = session.session_id
+
+        with patch(
+            "app.cli.interactive_shell.sessions.store._sessions_dir",
+            return_value=tmp_path,
+        ):
+            SessionStore.open_session(session)
+            session.record("chat", "pre-resume turn")
+
+            data = {
+                "session_id": "old-abc-123456",
+                "name": "Old Chat",
+                "cli_agent_messages": [("user", "hello"), ("assistant", "hi")],
+                "accumulated_context": {"service": "redis"},
+                "history": [{"type": "turn", "kind": "chat", "text": "hello"}],
+                "turn_details": [],
+                "has_snapshot": True,
+            }
+            console, buf = _capture()
+            result = _apply_resume_data(data, session, console)
+
+            # Old session file must be finalized
+            old_records = [
+                json.loads(line)
+                for line in (tmp_path / f"{old_id}.jsonl").read_text().splitlines()
+                if line.strip()
+            ]
+            assert old_records[-1]["type"] == "session_end"
+
+            # New session file is created for the continuation session
+            new_file = tmp_path / f"{session.session_id}.jsonl"
+            assert new_file.exists()
+
+        assert result is True
+        assert session.session_id != old_id
+        assert session.cli_agent_messages == [("user", "hello"), ("assistant", "hi")]
+        assert session.accumulated_context == {"service": "redis"}
+        assert session.resumed_from_name == "Old Chat"
+        output = buf.getvalue()
+        assert "resumed session" in output
+        assert "old-abc" in output
+
+    def test_apply_resume_noop_when_no_messages_or_context(self) -> None:
+        """When the session has no conversation, _apply_resume_data must return
+        early without rotating the session."""
+        from app.cli.interactive_shell.command_registry.session_cmds import _apply_resume_data
+
+        session = ReplSession()
+        old_id = session.session_id
+
+        data: dict = {
+            "session_id": "empty-sid",
+            "name": "",
+            "cli_agent_messages": [],
+            "accumulated_context": {},
+            "history": [],
+            "turn_details": [],
+            "has_snapshot": False,
+        }
+        console, buf = _capture()
+        _apply_resume_data(data, session, console)
+
+        assert session.session_id == old_id
+        assert "no conversation to resume" in buf.getvalue()
+
+    def test_apply_resume_displays_history_in_repl_format(
+        self, tmp_path: Path
+    ) -> None:
+        """History display must use `❯ user` / `● assistant` REPL format rather
+        than the old `you / sre` compact text format."""
+        from unittest.mock import patch
+
+        from app.cli.interactive_shell.command_registry.session_cmds import _apply_resume_data
+
+        data = {
+            "session_id": "display-test-abc",
+            "name": "My Session",
+            "cli_agent_messages": [
+                ("user", "what is opensre?"),
+                ("assistant", "OpenSRE is a tool"),
+            ],
+            "accumulated_context": {},
+            "history": [],
+            "turn_details": [],
+            "has_snapshot": True,
+        }
+        session = ReplSession()
+        console, buf = _capture()
+
+        with patch(
+            "app.cli.interactive_shell.sessions.store._sessions_dir",
+            return_value=tmp_path,
+        ):
+            _apply_resume_data(data, session, console)
+
+        output = buf.getvalue()
+        # New format uses ❯ for user messages and ● assistant header
+        assert "❯" in output
+        assert "assistant" in output
+        # Old compact format ("you  " / "sre  ") must not appear
+        assert "you  " not in output
+        assert "sre  " not in output
+        # Content is present
+        assert "what is opensre?" in output
+        assert "OpenSRE is a tool" in output
+
+
 class TestHistoryCommand:
     def test_empty_history_says_so(
         self,

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1474,7 +1474,6 @@ class TestResumeCommand:
         assert "what is opensre?" in output
         assert "OpenSRE is a tool" in output
 
-
     def test_planner_llm_error_persisted_to_cli_agent_messages(self) -> None:
         """PlannerLLMError must be added to cli_agent_messages so /resume can show it."""
         from unittest.mock import patch

--- a/tests/cli/interactive_shell/ui/test_help_menu.py
+++ b/tests/cli/interactive_shell/ui/test_help_menu.py
@@ -156,11 +156,11 @@ def test_draw_help_menu_uses_bounded_viewport_and_category_context(monkeypatch) 
 
 def test_draw_help_menu_expands_selected_command_inline(monkeypatch) -> None:
     command = SlashCommand(
-        "/reset",
-        "Clear session state.",
+        "/new",
+        "Start a new session keeping conversation context.",
         lambda *_args: True,
-        usage=("/reset",),
-        notes=("Trust mode is preserved.",),
+        usage=("/new",),
+        notes=("Unlike /clear, /new preserves the LLM conversation context.",),
     )
     rows = help_menu._flatten_help_rows([("Session", [command])])
     out = io.StringIO()
@@ -176,12 +176,12 @@ def test_draw_help_menu_expands_selected_command_inline(monkeypatch) -> None:
     )
 
     plain = _ANSI_RE.sub("", out.getvalue())
-    assert "/reset" in plain
-    assert "> ▾ /reset" in plain
-    assert "│ Clear session state." in plain
+    assert "/new" in plain
+    assert "> ▾ /new" in plain
+    assert "│ Start a new session" in plain
     assert help_menu._render_grid_row("", "usage:", 90) in plain
     assert "usage:" in plain
-    assert "Trust mode is preserved." in plain
+    assert "LLM conversation context" in plain
 
 
 def test_draw_help_menu_marks_expandable_and_plain_commands(monkeypatch) -> None:

--- a/tests/integrations/llm_cli/test_codex_adapter.py
+++ b/tests/integrations/llm_cli/test_codex_adapter.py
@@ -464,7 +464,12 @@ def test_cli_backed_client_invoke_raises_cli_authentication_required_when_logged
 def test_cli_backed_client_unclear_auth_no_double_period_when_explain_failure_trailing_period(
     mock_run: MagicMock,
 ) -> None:
-    """When explain_failure ends with '.', avoid composing '..'."""
+    """No double period in the composed error message.
+
+    When stderr contains an auth-related term ('unauthorized'), the failure
+    classifier replaces the raw exit-code text with a clean, actionable message
+    — so neither the original trailing period nor a '..' can appear.
+    """
     from app.integrations.llm_cli.runner import CLIBackedLLMClient
 
     mock_adapter = MagicMock()
@@ -499,7 +504,9 @@ def test_cli_backed_client_unclear_auth_no_double_period_when_explain_failure_tr
 
     msg = str(exc_info.value)
     assert ".." not in msg
-    assert "code 1." in msg
+    # "unauthorized" in stderr → classifier produces a clean auth hint instead
+    # of the raw "exited with code 1." text.
+    assert "authentication failed" in msg or "(exit 1)" in msg
     assert "Auth status could not be verified" in msg
 
 

--- a/tests/integrations/llm_cli/test_runner.py
+++ b/tests/integrations/llm_cli/test_runner.py
@@ -91,3 +91,60 @@ def test_cli_llm_spawn_log_redacts_prompt_equals_form(mock_run: MagicMock, caplo
     assert spawn.provider == "mock-cli"
     assert spawn.argv == ["/usr/bin/mock-cli", "--prompt=<redacted-prompt>", "--model", "gpt-5.1"]
     assert all(prompt not in arg for arg in spawn.argv)
+
+
+# ── failure_classifier enrichment ──────────────────────────────────────────────
+
+
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_runner_enriches_quota_error_with_actionable_message(mock_run: MagicMock) -> None:
+    """exit 1 with quota-related stderr → readable message replaces raw exit-code text."""
+    import pytest
+
+    mock_adapter = MagicMock()
+    mock_adapter.name = "codex"
+    mock_adapter.detect.return_value = _mock_probe()
+    mock_adapter.build.return_value = MagicMock(
+        argv=("/usr/bin/codex", "exec", "-"),
+        stdin="hello",
+        cwd="/tmp",
+        env=None,
+        timeout_sec=30.0,
+    )
+    mock_adapter.explain_failure.return_value = "codex exec exited with code 1. some quota error"
+    mock_run.return_value = MagicMock(
+        returncode=1, stdout="", stderr="429 Too Many Requests: quota exceeded"
+    )
+
+    with patch("app.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(mock_adapter)
+        with pytest.raises(RuntimeError, match="quota or rate limit exceeded"):
+            client.invoke("hello")
+
+
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_runner_enriches_silent_exit_with_version_banner_only(mock_run: MagicMock) -> None:
+    """exit 1 with only a version banner (no error keywords) → quota/auth fallback hint."""
+    import pytest
+
+    mock_adapter = MagicMock()
+    mock_adapter.name = "codex"
+    mock_adapter.detect.return_value = _mock_probe()
+    mock_adapter.build.return_value = MagicMock(
+        argv=("/usr/bin/codex", "exec", "-"),
+        stdin="hello",
+        cwd="/tmp",
+        env=None,
+        timeout_sec=30.0,
+    )
+    mock_adapter.explain_failure.return_value = (
+        "codex exec exited with code 1. OpenAI Codex v0.134.0"
+    )
+    mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="OpenAI Codex v0.134.0")
+
+    with patch("app.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(mock_adapter)
+        with pytest.raises(RuntimeError, match="quota exhausted or expired auth"):
+            client.invoke("hello")

--- a/tests/utils/repl_driver.py
+++ b/tests/utils/repl_driver.py
@@ -58,9 +58,11 @@ _ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 _REPO_ROOT = Path(__file__).parent.parent.parent
 
 
-def _load_env() -> dict[str, str]:
+def _load_env(*, home: str | None = None) -> dict[str, str]:
     """Merge .env into a copy of the current environment."""
     env = dict(os.environ)
+    if home is not None:
+        env["HOME"] = home
     env_file = _REPO_ROOT / ".env"
     if env_file.exists():
         env.update({k: v for k, v in dotenv_values(env_file).items() if v is not None})
@@ -75,9 +77,11 @@ class ReplDriver:
         *,
         startup_wait: float = 6.0,
         cwd: Path | None = None,
+        home: Path | None = None,
     ) -> None:
         self._startup_wait = startup_wait
         self._cwd = str(cwd or _REPO_ROOT)
+        self._home = str(home) if home is not None else None
         self._master: int | None = None
         self._proc: subprocess.Popen[bytes] | None = None
         self._raw: bytes = b""
@@ -94,7 +98,7 @@ class ReplDriver:
                 stdin=slave,
                 stdout=slave,
                 stderr=slave,
-                env=_load_env(),
+                env=_load_env(home=self._home),
                 cwd=self._cwd,
             )
         finally:


### PR DESCRIPTION
## Summary

- Removes 200-char truncation cap — full prompt text stored in session files
- Adds `turn_detail` records (prompt + response + model/latency metadata) written by `PromptRecorder.flush()` so every LLM turn is captured in the session file
- Adds `conversation_snapshot` record at flush/reset — serialises `cli_agent_messages` and `accumulated_context` for exact `/resume` fidelity
- Adds `/resume <session-id-prefix>` command — restores LLM conversation context and accumulated infra context from any past session
- `load_session()` resolves by prefix, reads snapshot first, falls back to `turn_detail` reconstruction for old files or crash-before-flush sessions
- 35 tests (up from 20), covering all new record types, snapshot/fallback paths, ambiguous prefix handling, and `/reset` lifecycle

## Session file format (after this PR)

```jsonl
{"type":"session_start","session_id":"...","started_at":"...","opensre_version":"0.1"}
{"type":"turn","kind":"chat","text":"why is CPU spiking?"}
{"type":"turn_detail","kind":"chat","prompt":"why is CPU spiking?","response":"Root cause: JVM heap...","model":"claude-3-5","latency_ms":1800}
{"type":"conversation_snapshot","cli_agent_messages":[["user","..."],["assistant","..."]],"accumulated_context":{"service":"api"}}
{"type":"session_end","ended_at":"...","duration_secs":120,"total_turns":1,"chat_turns":1,"investigation_turns":0}
```

## Demo
[Screencast from 29-05-26 08:55:20 PM IST.webm](https://github.com/user-attachments/assets/aab6afff-58e0-44e4-873b-b23983f340e8)


## Test plan

- [ ] `uv run python -m pytest tests/cli/interactive_shell/sessions/ -v` — 35 tests pass
- [ ] `make lint && make typecheck` — clean
- [ ] Start REPL, send a chat message, exit, `cat ~/.opensre/sessions/<id>.jsonl` — verify `turn_detail` and `conversation_snapshot` present
- [ ] Start fresh REPL, run `/sessions`, copy 8-char prefix, run `/resume <prefix>` — verify context restored and LLM knows prior conversation

Closes #2643
Depends on #2642 (already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)