### PR TITLE
chore(testing): add ReplDriver utility and TESTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,17 +75,7 @@ Before any push or PR creation, follow the mandatory checklist in [CI.md](CI.md)
 - `app/watch_dog/` — Watchdog feature: per-threshold Telegram alarm dispatch with cooldown, sitting on top of `app/utils/telegram_delivery.py`.
 - `app/webapp.py` — Web-facing application entrypoint; the `opensre` CLI is `app/cli/__main__.py`.
 
-`tests/` is organized by capability boundary rather than by framework:
-
-- `tests/tools/` — Tool behavior, registry, and helper coverage.
-- `tests/integrations/` — Integration config, verification, store, selector, and client tests.
-- `tests/e2e/` — Live end-to-end scenarios against real services and infrastructure.
-- `tests/synthetic/` — Fixture-driven synthetic RCA scenarios with no live infrastructure.
-- `tests/deployment/` — Deployment validation and infrastructure lifecycle tests.
-- `tests/chaos_engineering/` — Chaos lab and experiment orchestration tests and assets.
-- `tests/cli/` — CLI-specific behavior, smoke tests, and command wiring.
-- `tests/utils/` — Shared test utilities, fixtures, and local helpers.
-- `tests/nodes/`, `tests/services/`, `tests/remote/`, `tests/sandbox/`, `tests/guardrails/`, `tests/entrypoints/` — Feature-specific coverage for the corresponding app layers.
+`tests/` — organized by capability boundary; full layout in [TESTING.md § Test Layout](TESTING.md#test-layout).
 
 ## 2. Entry Points
 
@@ -180,11 +170,12 @@ Full testing guide: **[TESTING.md](TESTING.md)** — commands, test layout, live
 
 Quick reference:
 
-- Unit tests: `make test-cov`
-- Integration tests: `make verify-integrations`
+- Scoped tests (recommended): `make test-scope`
+- Full unit suite: `make test-cov`
+- Integration checks: `make verify-integrations`
 - E2E / RCA: `make test-rca FILE=<name>`
-- Lint + typecheck: `make check`
 - Live REPL behavior (slash commands, session display): use `ReplDriver` — see [TESTING.md § Live REPL Testing](TESTING.md#live-repl-testing--repldriver)
+- Pre-push (lint, format, typecheck): see [CI.md](CI.md)
 
 ## 5. Footguns (common mistakes to avoid)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,30 +6,12 @@
 - Run **`uv run opensre …`** from the repo root while developing — preferred approach, uses this checkout even if another `opensre` is on your `PATH`.
 - Use **`uv run python …`** for any Python commands.
 
-## Lint & Format
-
-- Lint: `make lint` (or fix: `ruff check app/ tests/ --fix`)
-- Format check: `make format-check`
-- Auto-format locally: `make format`
-- Type check: `make typecheck`
-- One-shot quality gate: `make check`
-
-## Testing
-
-- Test: `make test-cov`
-- Test real alerts: `make test-rca`
-
 ## Code Style
 
 - Use strict typing, follow DRY principle
 - One clear purpose per file (separation of concerns)
 
-### Before Push
-
-Before any push or PR creation, follow the mandatory checklist in [CI.md](CI.md).
-
-- `CI.md` is the source of truth for push/PR readiness.
-- Do not skip required checks.
+Before any push or PR creation follow **[CI.md](CI.md)** — lint, format, typecheck, and test commands all live there.
 
 ## 1. Repo Map
 
@@ -47,7 +29,7 @@ Before any push or PR creation, follow the mandatory checklist in [CI.md](CI.md)
 | `docs/investigation-tool-calling.md` | Investigation ReAct tool schemas, LLM invoke payloads, and message shapes (all providers). |
 | `SETUP.md`            | Machine setup (all platforms, Windows, MCP/OpenClaw, troubleshooting).                             |
 | `CI.md`               | Mandatory pre-push checklist: lint, format, typecheck, tests — agents MUST follow before pushing. |
-| `TESTING.md`          | Full testing guide: commands, test layout, `ReplDriver` for live REPL verification.               |
+| `TESTING.md`          | Test layout, `ReplDriver` for live REPL verification, routing rules, and CI-only path notes.      |
 | `CONTRIBUTING.md`     | Contribution workflow, branch/PR guidance, and quality expectations.                               |
 
 `app/` one level deeper:
@@ -188,5 +170,4 @@ When adding a new integration, a PR is only ready when:
 - Docs added under `docs/` and registered in `docs/docs.json` `pages`
 - Screenshot or demo GIF showing the integration working
 - E2E or synthetic test added
-- `make verify-integrations` passes
-- `make lint` and `make typecheck` pass
+- CI checks pass (see [CI.md](CI.md))

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,12 +170,10 @@ Full testing guide: **[TESTING.md](TESTING.md)** — commands, test layout, live
 
 Quick reference:
 
-- Scoped tests (recommended): `make test-scope`
-- Full unit suite: `make test-cov`
-- Integration checks: `make verify-integrations`
+- Local unit suite: `make test-cov`
 - E2E / RCA: `make test-rca FILE=<name>`
 - Live REPL behavior (slash commands, session display): use `ReplDriver` — see [TESTING.md § Live REPL Testing](TESTING.md#live-repl-testing--repldriver)
-- Pre-push (lint, format, typecheck): see [CI.md](CI.md)
+- Pre-push (lint, format, typecheck, scoped tests): see [CI.md](CI.md)
 
 ## 5. Footguns (common mistakes to avoid)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,6 @@ Before any push or PR creation follow **[CI.md](CI.md)** — lint, format, typec
 - `app/watch_dog/` — Watchdog feature: per-threshold Telegram alarm dispatch with cooldown, sitting on top of `app/utils/telegram_delivery.py`.
 - `app/webapp.py` — Web-facing application entrypoint; the `opensre` CLI is `app/cli/__main__.py`.
 
-`tests/` — organized by capability boundary; full layout in [TESTING.md § Test Layout](TESTING.md#test-layout).
-
 ## 2. Entry Points
 
 ### Adding a Tool

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Before any push or PR creation follow **[CI.md](CI.md)** — lint, format, typec
 | `docs/investigation-tool-calling.md` | Investigation ReAct tool schemas, LLM invoke payloads, and message shapes (all providers). |
 | `SETUP.md`            | Machine setup (all platforms, Windows, MCP/OpenClaw, troubleshooting).                             |
 | `CI.md`               | Mandatory pre-push checklist: lint, format, typecheck, tests — agents MUST follow before pushing. |
-| `TESTING.md`          | Test layout, `ReplDriver` for live REPL verification, routing rules, and CI-only path notes.      |
+| `TESTING.md`          | `ReplDriver` reference: API, usage patterns, wait-time guide, and limitations.                    |
 | `CONTRIBUTING.md`     | Contribution workflow, branch/PR guidance, and quality expectations.                               |
 
 `app/` one level deeper:
@@ -146,7 +146,7 @@ Basic steps:
 
 ## 4. Testing
 
-Test commands and push checklist: **[CI.md](CI.md)**. Test layout, `ReplDriver` for live REPL verification, routing rules, and CI-only paths: **[TESTING.md](TESTING.md)**.
+Test commands, routing rules, CI-only paths: **[CI.md](CI.md)**. Live REPL testing with `ReplDriver`: **[TESTING.md](TESTING.md)**.
 
 ## 5. Footguns (common mistakes to avoid)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,14 +166,7 @@ Basic steps:
 
 ## 4. Testing
 
-Full testing guide: **[TESTING.md](TESTING.md)** — commands, test layout, live REPL testing with `ReplDriver`, routing rules, and CI-only paths.
-
-Quick reference:
-
-- Local unit suite: `make test-cov`
-- E2E / RCA: `make test-rca FILE=<name>`
-- Live REPL behavior (slash commands, session display): use `ReplDriver` — see [TESTING.md § Live REPL Testing](TESTING.md#live-repl-testing--repldriver)
-- Pre-push (lint, format, typecheck, scoped tests): see [CI.md](CI.md)
+Test commands and push checklist: **[CI.md](CI.md)**. Test layout, `ReplDriver` for live REPL verification, routing rules, and CI-only paths: **[TESTING.md](TESTING.md)**.
 
 ## 5. Footguns (common mistakes to avoid)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Before any push or PR creation, follow the mandatory checklist in [CI.md](CI.md)
 | `docs/investigation-tool-calling.md` | Investigation ReAct tool schemas, LLM invoke payloads, and message shapes (all providers). |
 | `SETUP.md`            | Machine setup (all platforms, Windows, MCP/OpenClaw, troubleshooting).                             |
 | `CI.md`               | Mandatory pre-push checklist: lint, format, typecheck, tests — agents MUST follow before pushing. |
+| `TESTING.md`          | Full testing guide: commands, test layout, `ReplDriver` for live REPL verification.               |
 | `CONTRIBUTING.md`     | Contribution workflow, branch/PR guidance, and quality expectations.                               |
 
 `app/` one level deeper:
@@ -170,28 +171,20 @@ Basic steps:
 - If adding new tests -> always place them in `tests/`, never in `app/` (no inline tests).
 - If CI-only tests are added -> mark them with the right pytest marker or place them in the appropriate e2e/synthetic/chaos folder so they do not run in the default local suite.
 - If investigation branching or loop behavior changes -> update `app/pipeline/pipeline.py` and the tests for that path.
+- If adding or changing interactive REPL behavior (slash commands, session management, display output) -> use `ReplDriver` from `tests/utils/repl_driver.py` for live verification alongside unit tests; see [TESTING.md](TESTING.md).
 - If pushing or creating a PR -> follow the full pre-push checklist in [CI.md](CI.md).
 
 ## 4. Testing
 
-### Commands
+Full testing guide: **[TESTING.md](TESTING.md)** — commands, test layout, live REPL testing with `ReplDriver`, routing rules, and CI-only paths.
+
+Quick reference:
 
 - Unit tests: `make test-cov`
 - Integration tests: `make verify-integrations`
-- E2E tests: `make test-rca` or `make test-full`
-- Synthetic (no live infra): `make test-synthetic`
-- Single RCA test: `make test-rca FILE=<name>`
-- Lint: `make lint`
-- Type check: `make typecheck`
-- Routing live tests: always run with live coverage enabled by default. Do not use deselection
-  filters like `-k "not live_llm"` for routing scenario runs.
-- Do not make routing scenario tests pass by forcing deterministic shortcuts or bypassing live
-  planner behavior. Fix failures by improving planner/tool correctness or updating fixtures only
-  when behavior changes are explicitly intended and approved.
-
-### Fast Local Testing
-
-The fastest local loop is `make test-cov`, which exercises the non-live unit suite and skips the heavier live-infra paths. When you need a specific RCA scenario, use `make test-rca FILE=<fixture>` with one of the bundled alert fixtures under `tests/e2e/rca/`.
+- E2E / RCA: `make test-rca FILE=<name>`
+- Lint + typecheck: `make check`
+- Live REPL behavior (slash commands, session display): use `ReplDriver` — see [TESTING.md § Live REPL Testing](TESTING.md#live-repl-testing--repldriver)
 
 ## 5. Footguns (common mistakes to avoid)
 

--- a/CI.md
+++ b/CI.md
@@ -86,6 +86,20 @@ make verify-integrations
 
 You may run `make check` as a final pass, but it is heavier (`test-full`) than the required harness.
 
+## 6) Routing tests
+
+Routing live tests always run with live coverage enabled. Do not use deselection filters like `-k "not live_llm"`. Fix failures by improving planner/tool correctness or updating fixtures only when behavior changes are explicitly approved.
+
+## 7) CI-only tests
+
+Some paths require live infrastructure and are excluded from `make test-cov`:
+
+- Kubernetes / EKS scenarios (`tests/e2e/`)
+- Chaos Mesh workflows (`tests/chaos_engineering/`)
+- Docker-dependent Grafana stack tests
+
+Mark CI-only tests with the appropriate pytest marker or place them in the correct folder so they do not run locally by default.
+
 ## Precedence
 
 If readiness instructions conflict across docs, **this file wins** for push/PR checks.

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,16 +6,7 @@ See [AGENTS.md](AGENTS.md) for the full repo map and contribution rules.
 
 ---
 
-## Commands
-
-| Goal | Command |
-| --- | --- |
-| Full unit suite + coverage | `make test-cov` |
-| Single RCA scenario | `make test-rca FILE=<fixture>` |
-| All E2E scenarios | `make test-rca` or `make test-full` |
-| Synthetic (no live infra) | `make test-synthetic` |
-
-`make test-cov` is the default local loop — skips live-infra paths (Kubernetes, EKS, chaos) that only run in CI. For pre-push checks (lint, format, typecheck, scoped tests), see [CI.md](CI.md).
+For all test and push commands, see [CI.md](CI.md).
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,40 +1,14 @@
-# Testing Guide
-
-Reference for the opensre test suite: what to run, where tests live, and how to verify interactive REPL behavior.
-
-See [AGENTS.md](AGENTS.md) for the full repo map and contribution rules.
-
----
-
-For all test and push commands, see [CI.md](CI.md).
-
----
-
-## Test Layout
-
-Tests are organized by capability boundary, not by framework:
-
-| Path | What it covers |
-| --- | --- |
-| `tests/cli/` | CLI behavior, REPL commands, smoke tests |
-| `tests/cli/interactive_shell/sessions/` | Session store, `/sessions`, `/resume` |
-| `tests/tools/` | Tool behavior, registry, schema validation |
-| `tests/integrations/` | Integration config, verification, store, selectors |
-| `tests/e2e/` | Live end-to-end scenarios against real services |
-| `tests/synthetic/` | Fixture-driven RCA with no live infrastructure |
-| `tests/deployment/` | Deployment validation and lifecycle |
-| `tests/chaos_engineering/` | Chaos experiments |
-| `tests/utils/` | Shared test utilities and fixtures |
-
----
-
-## Live REPL Testing — `ReplDriver`
+# Live REPL Testing — `ReplDriver`
 
 Some interactive shell behavior cannot be covered by unit tests with mocked consoles: rendered table layout, slash command output, session display, `/resume` confirmation messages. Use `ReplDriver` for these.
 
 **Location:** `tests/utils/repl_driver.py`
 
-### How it works
+For test commands and CI checks, see [CI.md](CI.md).
+
+---
+
+## How it works
 
 `ReplDriver` uses Python's built-in `pty` module to create a pseudo-terminal. The REPL process sees a real TTY (so `prompt_toolkit` starts normally and `sys.stdin.isatty()` passes), while the test controls the master end — writing commands and reading rendered output.
 
@@ -45,7 +19,7 @@ test ◀──read───  master fd  ◀──  opensre renders via prompt_to
 
 ANSI escape codes are stripped before storing output, so assertions work on plain text.
 
-### Basic usage
+## Basic usage
 
 ```python
 from tests.utils.repl_driver import ReplDriver
@@ -62,7 +36,7 @@ def test_resume_restores_context():
 
 `ReplDriver` sends `/exit` automatically on `__exit__`.
 
-### API
+## API
 
 | Method / Property | Description |
 | --- | --- |
@@ -75,26 +49,26 @@ def test_resume_restores_context():
 | `lines()` | Non-empty visible lines from `text` |
 | `reset_output()` | Clear captured output between test phases |
 
-### Choosing wait times
+## Choosing wait times
 
 | Command type | `wait` |
 | --- | --- |
 | Slash commands (`/sessions`, `/resume`, `/status`) | `2.0–3.0s` |
 | LLM-backed commands (avoid in automated tests) | `15–25s` |
 
-### When to use ReplDriver
+## When to use
 
 ✅ Adding or changing a slash command → verify rendered output  
 ✅ Session management (`/sessions`, `/resume`, `/reset`) → verify display  
 ✅ Banner or prompt formatting changes → screenshot / string check  
 
-### When NOT to use ReplDriver
+## When NOT to use
 
 ❌ Logic testable with a mocked `Console` — keep those in `tests/cli/`  
 ❌ Storage / state correctness — use `tmp_path` + `SessionStore` directly  
 ❌ Tests that need a real LLM response — latency makes pty timing unreliable; use `make test-rca` instead  
 
-### Two-phase pattern
+## Two-phase pattern
 
 For features that touch both storage and display, test each layer separately:
 
@@ -114,26 +88,8 @@ with ReplDriver() as repl:
     assert repl.contains("conversation context loaded")
 ```
 
-### Limitations
+## Limitations
 
 - `prompt_toolkit` may drop characters typed before the input loop is ready. The default `startup_wait=6.0s` covers normal startup; increase on slow machines.
 - ANSI stripping is regex-based — exotic escape sequences may leave artifacts. Check `repl.text` if an assertion unexpectedly fails.
 - The driver shares the host's `~/.opensre/sessions/` directory. Use a patched `_sessions_dir` in storage tests to avoid cross-test contamination.
-
----
-
-## Routing Tests
-
-Routing live tests always run with live coverage enabled. Do not use deselection filters like `-k "not live_llm"`. Fix failures by improving planner/tool correctness or updating fixtures only when behavior changes are explicitly approved.
-
----
-
-## CI-Only Tests
-
-Some paths require live infrastructure and are excluded from `make test-cov`:
-
-- Kubernetes / EKS scenarios (`tests/e2e/`)
-- Chaos Mesh workflows (`tests/chaos_engineering/`)
-- Docker-dependent Grafana stack tests
-
-Mark CI-only tests with the appropriate pytest marker or place them in the correct folder so they do not run locally by default.

--- a/TESTING.md
+++ b/TESTING.md
@@ -10,16 +10,12 @@ See [AGENTS.md](AGENTS.md) for the full repo map and contribution rules.
 
 | Goal | Command |
 | --- | --- |
-| Scoped tests (recommended) | `make test-scope` |
 | Full unit suite + coverage | `make test-cov` |
-| Integration checks | `make verify-integrations` |
 | Single RCA scenario | `make test-rca FILE=<fixture>` |
 | All E2E scenarios | `make test-rca` or `make test-full` |
 | Synthetic (no live infra) | `make test-synthetic` |
 
-The fastest local loop is `make test-scope` (maps changed files to the minimal pytest invocation) or `make test-cov` for the full unit suite. Both skip live-infra paths (Kubernetes, EKS, chaos) that only run in CI.
-
-> For pre-push readiness (lint, format, typecheck), see [CI.md](CI.md) — that file is the single source of truth for push/PR checks.
+`make test-cov` is the default local loop — skips live-infra paths (Kubernetes, EKS, chaos) that only run in CI. For pre-push checks (lint, format, typecheck, scoped tests), see [CI.md](CI.md).
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -10,16 +10,16 @@ See [AGENTS.md](AGENTS.md) for the full repo map and contribution rules.
 
 | Goal | Command |
 | --- | --- |
+| Scoped tests (recommended) | `make test-scope` |
 | Full unit suite + coverage | `make test-cov` |
 | Integration checks | `make verify-integrations` |
 | Single RCA scenario | `make test-rca FILE=<fixture>` |
 | All E2E scenarios | `make test-rca` or `make test-full` |
 | Synthetic (no live infra) | `make test-synthetic` |
-| Lint | `make lint` |
-| Type check | `make typecheck` |
-| Everything (lint + format + typecheck + tests) | `make check` |
 
-The fastest local loop is `make test-cov`. It skips live-infra paths (Kubernetes, EKS, chaos) that only run in CI.
+The fastest local loop is `make test-scope` (maps changed files to the minimal pytest invocation) or `make test-cov` for the full unit suite. Both skip live-infra paths (Kubernetes, EKS, chaos) that only run in CI.
+
+> For pre-push readiness (lint, format, typecheck), see [CI.md](CI.md) — that file is the single source of truth for push/PR checks.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,152 @@
+# Testing Guide
+
+Reference for the opensre test suite: what to run, where tests live, and how to verify interactive REPL behavior.
+
+See [AGENTS.md](AGENTS.md) for the full repo map and contribution rules.
+
+---
+
+## Commands
+
+| Goal | Command |
+| --- | --- |
+| Full unit suite + coverage | `make test-cov` |
+| Integration checks | `make verify-integrations` |
+| Single RCA scenario | `make test-rca FILE=<fixture>` |
+| All E2E scenarios | `make test-rca` or `make test-full` |
+| Synthetic (no live infra) | `make test-synthetic` |
+| Lint | `make lint` |
+| Type check | `make typecheck` |
+| Everything (lint + format + typecheck + tests) | `make check` |
+
+The fastest local loop is `make test-cov`. It skips live-infra paths (Kubernetes, EKS, chaos) that only run in CI.
+
+---
+
+## Test Layout
+
+Tests are organized by capability boundary, not by framework:
+
+| Path | What it covers |
+| --- | --- |
+| `tests/cli/` | CLI behavior, REPL commands, smoke tests |
+| `tests/cli/interactive_shell/sessions/` | Session store, `/sessions`, `/resume` |
+| `tests/tools/` | Tool behavior, registry, schema validation |
+| `tests/integrations/` | Integration config, verification, store, selectors |
+| `tests/e2e/` | Live end-to-end scenarios against real services |
+| `tests/synthetic/` | Fixture-driven RCA with no live infrastructure |
+| `tests/deployment/` | Deployment validation and lifecycle |
+| `tests/chaos_engineering/` | Chaos experiments |
+| `tests/utils/` | Shared test utilities and fixtures |
+
+---
+
+## Live REPL Testing — `ReplDriver`
+
+Some interactive shell behavior cannot be covered by unit tests with mocked consoles: rendered table layout, slash command output, session display, `/resume` confirmation messages. Use `ReplDriver` for these.
+
+**Location:** `tests/utils/repl_driver.py`
+
+### How it works
+
+`ReplDriver` uses Python's built-in `pty` module to create a pseudo-terminal. The REPL process sees a real TTY (so `prompt_toolkit` starts normally and `sys.stdin.isatty()` passes), while the test controls the master end — writing commands and reading rendered output.
+
+```
+test ──write──▶  master fd  ──▶  slave fd (opensre's stdin/stdout/stderr)
+test ◀──read───  master fd  ◀──  opensre renders via prompt_toolkit
+```
+
+ANSI escape codes are stripped before storing output, so assertions work on plain text.
+
+### Basic usage
+
+```python
+from tests.utils.repl_driver import ReplDriver
+
+def test_resume_restores_context():
+    with ReplDriver() as repl:
+        repl.send("/sessions", wait=3.0)
+        assert repl.contains("Session ID")
+
+        repl.send("/resume abc1234", wait=3.0)
+        assert repl.contains("resumed session abc1234")
+        assert repl.contains("conversation context loaded")
+```
+
+`ReplDriver` sends `/exit` automatically on `__exit__`.
+
+### API
+
+| Method / Property | Description |
+| --- | --- |
+| `ReplDriver(startup_wait=6.0)` | Create driver; `startup_wait` covers banner + event-loop startup |
+| `start()` | Start the REPL process (called by `__enter__`) |
+| `send(cmd, wait=2.0)` | Type a command + newline; drain output for `wait` seconds |
+| `close()` | Send `/exit`, wait for process exit (called by `__exit__`) |
+| `text` | Full ANSI-stripped output captured so far |
+| `contains(s)` | `True` if `s` appears anywhere in `text` |
+| `lines()` | Non-empty visible lines from `text` |
+| `reset_output()` | Clear captured output between test phases |
+
+### Choosing wait times
+
+| Command type | `wait` |
+| --- | --- |
+| Slash commands (`/sessions`, `/resume`, `/status`) | `2.0–3.0s` |
+| LLM-backed commands (avoid in automated tests) | `15–25s` |
+
+### When to use ReplDriver
+
+✅ Adding or changing a slash command → verify rendered output  
+✅ Session management (`/sessions`, `/resume`, `/reset`) → verify display  
+✅ Banner or prompt formatting changes → screenshot / string check  
+
+### When NOT to use ReplDriver
+
+❌ Logic testable with a mocked `Console` — keep those in `tests/cli/`  
+❌ Storage / state correctness — use `tmp_path` + `SessionStore` directly  
+❌ Tests that need a real LLM response — latency makes pty timing unreliable; use `make test-rca` instead  
+
+### Two-phase pattern
+
+For features that touch both storage and display, test each layer separately:
+
+```python
+# Phase 1 — storage correctness (fast, no REPL)
+session = ReplSession()
+SessionStore.open_session(session)
+session.record("chat", "why is redis slow?")
+SessionStore.flush(session)
+data = SessionStore.load_session(session.session_id[:8])
+assert data["has_snapshot"] is True
+
+# Phase 2 — display correctness (ReplDriver)
+with ReplDriver() as repl:
+    repl.send(f"/resume {session.session_id[:8]}", wait=3.0)
+    assert repl.contains("resumed session")
+    assert repl.contains("conversation context loaded")
+```
+
+### Limitations
+
+- `prompt_toolkit` may drop characters typed before the input loop is ready. The default `startup_wait=6.0s` covers normal startup; increase on slow machines.
+- ANSI stripping is regex-based — exotic escape sequences may leave artifacts. Check `repl.text` if an assertion unexpectedly fails.
+- The driver shares the host's `~/.opensre/sessions/` directory. Use a patched `_sessions_dir` in storage tests to avoid cross-test contamination.
+
+---
+
+## Routing Tests
+
+Routing live tests always run with live coverage enabled. Do not use deselection filters like `-k "not live_llm"`. Fix failures by improving planner/tool correctness or updating fixtures only when behavior changes are explicitly approved.
+
+---
+
+## CI-Only Tests
+
+Some paths require live infrastructure and are excluded from `make test-cov`:
+
+- Kubernetes / EKS scenarios (`tests/e2e/`)
+- Chaos Mesh workflows (`tests/chaos_engineering/`)
+- Docker-dependent Grafana stack tests
+
+Mark CI-only tests with the appropriate pytest marker or place them in the correct folder so they do not run locally by default.

--- a/tests/utils/repl_driver.py
+++ b/tests/utils/repl_driver.py
@@ -112,6 +112,7 @@ class ReplDriver:
                 self._proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 self._proc.kill()
+                self._proc.wait()
         if self._master is not None:
             with contextlib.suppress(OSError):
                 os.close(self._master)

--- a/tests/utils/repl_driver.py
+++ b/tests/utils/repl_driver.py
@@ -104,11 +104,9 @@ class ReplDriver:
     def close(self, exit_wait: float = 3.0) -> None:
         """Send /exit and wait for the process to finish."""
         if self._master is not None and self._proc is not None:
-            try:
+            with contextlib.suppress(OSError):
                 os.write(self._master, b"/exit\n")
                 self._drain(exit_wait)
-            except OSError:
-                pass
         if self._proc is not None:
             try:
                 self._proc.wait(timeout=5)

--- a/tests/utils/repl_driver.py
+++ b/tests/utils/repl_driver.py
@@ -27,8 +27,8 @@ Design notes:
 - os.pty creates a master/slave pair; slave is given to opensre as its
   stdin/stdout/stderr so prompt_toolkit sees a real TTY.
 - select() drains output non-blockingly so we never block forever.
-- ANSI escape codes are stripped before storing in self._output so
-  assertions work on plain text.
+- ANSI escape codes are stripped lazily via the `text` property from
+  self._raw, so assertions always work on plain text.
 - .env is loaded from the repo root so live LLM providers work.
 - startup_wait=6.0 covers banner rendering + async event-loop startup.
   Increase it if tests are flaky on slow CI machines.
@@ -52,6 +52,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from dotenv import dotenv_values
+
 _ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 _REPO_ROOT = Path(__file__).parent.parent.parent
 
@@ -60,14 +62,8 @@ def _load_env() -> dict[str, str]:
     """Merge .env into a copy of the current environment."""
     env = dict(os.environ)
     env_file = _REPO_ROOT / ".env"
-    if not env_file.exists():
-        return env
-    for line in env_file.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, _, val = line.partition("=")
-        env[key.strip()] = val.strip()
+    if env_file.exists():
+        env.update({k: v for k, v in dotenv_values(env_file).items() if v is not None})
     return env
 
 
@@ -92,15 +88,17 @@ class ReplDriver:
         """Start the REPL process and wait for the banner to render."""
         master, slave = pty.openpty()
         self._master = master
-        self._proc = subprocess.Popen(
-            ["uv", "run", "opensre"],
-            stdin=slave,
-            stdout=slave,
-            stderr=slave,
-            env=_load_env(),
-            cwd=self._cwd,
-        )
-        os.close(slave)
+        try:
+            self._proc = subprocess.Popen(
+                ["uv", "run", "opensre"],
+                stdin=slave,
+                stdout=slave,
+                stderr=slave,
+                env=_load_env(),
+                cwd=self._cwd,
+            )
+        finally:
+            os.close(slave)
         self._drain(startup_wait if startup_wait is not None else self._startup_wait)
 
     def close(self, exit_wait: float = 3.0) -> None:
@@ -173,6 +171,8 @@ class ReplDriver:
             if r:
                 try:
                     chunk = os.read(self._master, 8192)
+                    if not chunk:
+                        break
                     self._raw += chunk
                 except OSError:
                     break

--- a/tests/utils/repl_driver.py
+++ b/tests/utils/repl_driver.py
@@ -1,0 +1,178 @@
+"""ReplDriver: pty-based driver for live interactive REPL testing.
+
+Fakes a TTY so opensre's isatty() check passes, then sends commands and
+captures rendered output. Use this for any test that needs to verify
+interactive REPL behavior — slash commands, session management, live
+display output — that unit tests with mocked consoles cannot cover.
+
+Usage (context manager, recommended)::
+
+    from tests.utils.repl_driver import ReplDriver
+
+    with ReplDriver() as repl:
+        repl.send("/sessions", wait=3.0)
+        repl.send("/resume abc1234", wait=3.0)
+        assert repl.contains("resumed session")
+        assert repl.contains("conversation context loaded")
+
+Usage (manual)::
+
+    repl = ReplDriver()
+    repl.start(startup_wait=6.0)
+    repl.send("/status", wait=2.0)
+    output = repl.text          # ANSI-stripped full output so far
+    repl.close()
+
+Design notes:
+- os.pty creates a master/slave pair; slave is given to opensre as its
+  stdin/stdout/stderr so prompt_toolkit sees a real TTY.
+- select() drains output non-blockingly so we never block forever.
+- ANSI escape codes are stripped before storing in self._output so
+  assertions work on plain text.
+- .env is loaded from the repo root so live LLM providers work.
+- startup_wait=6.0 covers banner rendering + async event-loop startup.
+  Increase it if tests are flaky on slow CI machines.
+
+When NOT to use this:
+- Unit tests that mock the console — keep those in tests/cli/.
+- Tests that only need SessionStore / ReplSession — use tmp_path fixtures.
+- Tests that need a real LLM response — use make test-rca instead;
+  LLM latency makes pty timing unreliable.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import pty
+import re
+import select
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+_ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+_REPO_ROOT = Path(__file__).parent.parent.parent
+
+
+def _load_env() -> dict[str, str]:
+    """Merge .env into a copy of the current environment."""
+    env = dict(os.environ)
+    env_file = _REPO_ROOT / ".env"
+    if not env_file.exists():
+        return env
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        env[key.strip()] = val.strip()
+    return env
+
+
+class ReplDriver:
+    """Context-manager driver for a live opensre REPL process."""
+
+    def __init__(
+        self,
+        *,
+        startup_wait: float = 6.0,
+        cwd: Path | None = None,
+    ) -> None:
+        self._startup_wait = startup_wait
+        self._cwd = str(cwd or _REPO_ROOT)
+        self._master: int | None = None
+        self._proc: subprocess.Popen[bytes] | None = None
+        self._raw: bytes = b""
+
+    # ── lifecycle ─────────────────────────────────────────────────────────────
+
+    def start(self, startup_wait: float | None = None) -> None:
+        """Start the REPL process and wait for the banner to render."""
+        master, slave = pty.openpty()
+        self._master = master
+        self._proc = subprocess.Popen(
+            ["uv", "run", "opensre"],
+            stdin=slave,
+            stdout=slave,
+            stderr=slave,
+            env=_load_env(),
+            cwd=self._cwd,
+        )
+        os.close(slave)
+        self._drain(startup_wait if startup_wait is not None else self._startup_wait)
+
+    def close(self, exit_wait: float = 3.0) -> None:
+        """Send /exit and wait for the process to finish."""
+        if self._master is not None and self._proc is not None:
+            try:
+                os.write(self._master, b"/exit\n")
+                self._drain(exit_wait)
+            except OSError:
+                pass
+        if self._proc is not None:
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+        if self._master is not None:
+            with contextlib.suppress(OSError):
+                os.close(self._master)
+        self._master = None
+        self._proc = None
+
+    def __enter__(self) -> ReplDriver:
+        self.start()
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
+
+    # ── interaction ───────────────────────────────────────────────────────────
+
+    def send(self, command: str, *, wait: float = 2.0) -> None:
+        """Type a command (newline appended) and wait for output to settle."""
+        if self._master is None:
+            raise RuntimeError("ReplDriver not started — call start() or use as context manager")
+        os.write(self._master, (command + "\n").encode())
+        self._drain(wait)
+
+    # ── output access ─────────────────────────────────────────────────────────
+
+    @property
+    def text(self) -> str:
+        """Full captured output with ANSI escape codes stripped."""
+        return _ANSI_ESCAPE.sub("", self._raw.decode("utf-8", errors="replace"))
+
+    def contains(self, substring: str) -> bool:
+        """Return True if substring appears anywhere in the stripped output."""
+        return substring in self.text
+
+    def lines(self) -> list[str]:
+        """Non-empty visible lines from the stripped output."""
+        return [line for line in self.text.splitlines() if line.strip()]
+
+    def reset_output(self) -> None:
+        """Clear captured output (useful between phases of a multi-step test)."""
+        self._raw = b""
+
+    # ── internals ─────────────────────────────────────────────────────────────
+
+    def _drain(self, timeout: float) -> None:
+        """Read all available output from the pty master until timeout."""
+        if self._master is None:
+            return
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            try:
+                r, _, _ = select.select([self._master], [], [], min(remaining, 0.2))
+            except (ValueError, OSError):
+                break
+            if r:
+                try:
+                    chunk = os.read(self._master, 8192)
+                    self._raw += chunk
+                except OSError:
+                    break


### PR DESCRIPTION
## Summary

- **`tests/utils/repl_driver.py`** — reusable pty-based driver for live REPL testing. Fakes a TTY so `prompt_toolkit` starts normally; sends commands, strips ANSI, exposes `contains()` / `lines()` for clean assertions. Context-manager lifecycle, `.env` loaded automatically.
- **`TESTING.md`** — standalone testing reference extracted from `AGENTS.md`: commands, test layout, full `ReplDriver` API, two-phase pattern (storage unit test + display live test), limitations.
- **`AGENTS.md`** — `§4 Testing` replaced with a short link to `TESTING.md`; `TESTING.md` added to repo map; rule added for interactive REPL changes.

## Why a separate file

`AGENTS.md` was getting long. `TESTING.md` keeps testing detail in one place that's easy to update without touching the main reference doc. Pattern follows `CI.md` and `CONTRIBUTING.md`.

## Usage

```python
from tests.utils.repl_driver import ReplDriver

with ReplDriver() as repl:
    repl.send("/sessions", wait=3.0)
    repl.send("/resume abc1234", wait=3.0)
    assert repl.contains("resumed session abc1234")
    assert repl.contains("conversation context loaded")
```

## Test plan

- [ ] `make lint && make format-check` — clean
- [ ] `uv run python -c "from tests.utils.repl_driver import ReplDriver; print('ok')"` — imports cleanly
- [ ] No existing tests broken (`make test-cov`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)