### PR TITLE
feat(cli): add quick access commands to interactive shell help

### DIFF
--- a/app/cli/interactive_shell/command_registry/help.py
+++ b/app/cli/interactive_shell/command_registry/help.py
@@ -19,6 +19,23 @@ from app.cli.interactive_shell.ui.help_menu import (
     render_section_detail,
 )
 
+QUICK_ACCESS_COMMANDS: list[str] = [
+    "/investigate",
+    "/integrations",
+    "/model",
+    "/health",
+    "/watch",
+    "/status",
+    "/help",
+]
+
+
+def _quick_access_section() -> HelpSection:
+    from app.cli.interactive_shell.command_registry import SLASH_COMMANDS
+
+    cmds = [SLASH_COMMANDS[n] for n in QUICK_ACCESS_COMMANDS if n in SLASH_COMMANDS]
+    return ("Quick Access", cmds)
+
 
 def _raw_help_sections() -> list[HelpSection]:
     from app.cli.interactive_shell.command_registry.agents import COMMANDS as AGENTS_CMDS
@@ -36,6 +53,7 @@ def _raw_help_sections() -> list[HelpSection]:
     from app.cli.interactive_shell.command_registry.watch_cmds import COMMANDS as WATCH_CMDS
 
     return [
+        _quick_access_section(),
         ("Help", list(COMMANDS)),
         ("Session", list(SESSION_CMDS)),
         ("Integrations & Models", list(INT_CMDS) + list(MODEL_CMDS)),
@@ -142,4 +160,4 @@ COMMANDS: list[SlashCommand] = [
     SlashCommand("/?", "Shortcut for /help.", _cmd_help, execution_tier=ExecutionTier.EXEMPT),
 ]
 
-__all__ = ["COMMANDS"]
+__all__ = ["COMMANDS", "QUICK_ACCESS_COMMANDS"]

--- a/app/cli/interactive_shell/command_registry/help.py
+++ b/app/cli/interactive_shell/command_registry/help.py
@@ -67,17 +67,27 @@ def _raw_help_sections() -> list[HelpSection]:
     ]
 
 
+_QUICK_ACCESS_SECTION_NAME = "Quick Access"
+
+
 def _help_sections() -> list[HelpSection]:
-    """Return user-visible help sections with duplicate command names hidden."""
+    """Return user-visible help sections with duplicate command names hidden.
+
+    The "Quick Access" section is intentionally exempted from the dedup set so
+    its curated commands remain visible in their canonical sections too (e.g.
+    ``/help investigation`` still contains ``/investigate``).
+    """
     seen: set[str] = set()
     sections: list[HelpSection] = []
     for section_name, commands in _raw_help_sections():
         visible: list[SlashCommand] = []
+        is_quick_access = section_name == _QUICK_ACCESS_SECTION_NAME
         for command in commands:
             if command.name in seen:
                 continue
-            seen.add(command.name)
             visible.append(command)
+            if not is_quick_access:
+                seen.add(command.name)
         sections.append((section_name, visible))
     return sections
 

--- a/app/cli/interactive_shell/prompting/prompt_surface.py
+++ b/app/cli/interactive_shell/prompting/prompt_surface.py
@@ -17,6 +17,8 @@ from prompt_toolkit.styles import Style
 from rich.console import Console
 from rich.text import Text
 
+from app.cli.interactive_shell.command_registry.help import QUICK_ACCESS_COMMANDS
+from app.cli.interactive_shell.command_registry.types import SlashCommand
 from app.cli.interactive_shell.commands import SLASH_COMMANDS
 from app.cli.interactive_shell.history import load_prompt_history
 from app.cli.interactive_shell.routing.resolve_cli_command.catalog import BARE_COMMAND_ALIASES
@@ -148,6 +150,19 @@ def _short_meta(text: str, max_len: int = 54) -> str:
     return text if len(text) <= max_len else text[: max_len - 1] + "…"
 
 
+# Precomputed at import time so bare-`/` completions never rebuild it per keystroke.
+_QUICK_ACCESS_SET: frozenset[str] = frozenset(QUICK_ACCESS_COMMANDS)
+
+
+def _slash_completion(cmd: SlashCommand, start_position: int) -> Completion:
+    return Completion(
+        cmd.name,
+        start_position=start_position,
+        display=cmd.name,
+        display_meta=_short_meta(cmd.description),
+    )
+
+
 class ShellCompleter(Completer):
     """Tab-completion for slash commands, subcommands, file paths, and bare aliases."""
 
@@ -178,14 +193,19 @@ class ShellCompleter(Completer):
         trailing_space = text != text.rstrip(" ")
         if len(parts) == 1 and not trailing_space:
             needle = parts[0].lower()
-            for cmd in SLASH_COMMANDS.values():
-                if cmd.name.lower().startswith(needle):
-                    yield Completion(
-                        cmd.name,
-                        start_position=-len(parts[0]),
-                        display=cmd.name,
-                        display_meta=_short_meta(cmd.description),
-                    )
+            if needle == "/":
+                # Bare `/`: show most important commands first, then the rest.
+                for name in QUICK_ACCESS_COMMANDS:
+                    cmd = SLASH_COMMANDS.get(name)
+                    if cmd is not None:
+                        yield _slash_completion(cmd, -1)
+                for cmd in SLASH_COMMANDS.values():
+                    if cmd.name not in _QUICK_ACCESS_SET:
+                        yield _slash_completion(cmd, -1)
+            else:
+                for cmd in SLASH_COMMANDS.values():
+                    if cmd.name.lower().startswith(needle):
+                        yield _slash_completion(cmd, -len(parts[0]))
             return
 
         if len(parts) <= 2:


### PR DESCRIPTION
This pull request adds a "Quick Access" feature to the interactive shell's help and tab-completion system, making the most important slash commands more visible and accessible to users. It introduces a prioritized list of commands that are shown first when the user types `/` and updates the help output to include a dedicated "Quick Access" section.

Enhancements to command discoverability and completion:

**Quick Access commands and help display**
* Introduced a `QUICK_ACCESS_COMMANDS` list to define the most important slash commands for quick access, and exposed it in the module's public API. [[1]](diffhunk://#diff-9e2cbc889ee941c65cdcf75526effe75259edb26a1ba05e6884ca4b0936b0faeR22-R38) [[2]](diffhunk://#diff-9e2cbc889ee941c65cdcf75526effe75259edb26a1ba05e6884ca4b0936b0faeL145-R163)
* Added a `_quick_access_section()` function and updated the help sections to include a new "Quick Access" section at the top of the help output, highlighting these commands. [[1]](diffhunk://#diff-9e2cbc889ee941c65cdcf75526effe75259edb26a1ba05e6884ca4b0936b0faeR22-R38) [[2]](diffhunk://#diff-9e2cbc889ee941c65cdcf75526effe75259edb26a1ba05e6884ca4b0936b0faeR56)

**Tab-completion improvements**
* Updated the shell completer so that when the user types a bare `/`, the quick access commands are shown first in the completion list, followed by the rest of the available slash commands. This uses a precomputed `frozenset` for efficiency. [[1]](diffhunk://#diff-050274405abce8f3fe98421bbd72464b1d6035106b814b542e3503286cbc3c83R20-R21) [[2]](diffhunk://#diff-050274405abce8f3fe98421bbd72464b1d6035106b814b542e3503286cbc3c83R153-R165) [[3]](diffhunk://#diff-050274405abce8f3fe98421bbd72464b1d6035106b814b542e3503286cbc3c83R196-R208)
* Refactored completion code to use a helper function `_slash_completion` for consistency and maintainability. [[1]](diffhunk://#diff-050274405abce8f3fe98421bbd72464b1d6035106b814b542e3503286cbc3c83R153-R165) [[2]](diffhunk://#diff-050274405abce8f3fe98421bbd72464b1d6035106b814b542e3503286cbc3c83R196-R208)


<img width="938" height="637" alt="Screenshot 2026-05-29 at 6 21 18 PM" src="https://github.com/user-attachments/assets/e3349d3e-62e7-4263-86c5-bb163a51fbe4" />

