### PR TITLE
fix: cascade-delete TaskRun records when removing a ScheduledTask

### DIFF
--- a/app/scheduler/claim_store.py
+++ b/app/scheduler/claim_store.py
@@ -131,8 +131,31 @@ def get_runs(task_id: str, limit: int = 20, db_path: Path | None = None) -> list
         conn.close()
 
 
+def delete_runs(task_id: str, db_path: Path | None = None) -> int:
+    """Delete all task-run records for a given task ID.
+
+    Returns the number of deleted rows. Safe to call when no DB or table
+    exists (returns 0). Idempotent — subsequent calls return 0.
+    """
+    path = db_path or _default_db_path()
+    if not path.exists():
+        return 0
+    conn = _connect(path)
+    try:
+        _ensure_schema(conn)
+        cursor = conn.execute(
+            "DELETE FROM task_runs WHERE task_id = ?",
+            (task_id,),
+        )
+        conn.commit()
+        return cursor.rowcount
+    finally:
+        conn.close()
+
+
 __all__ = [
     "complete_run",
+    "delete_runs",
     "get_runs",
     "try_claim",
 ]

--- a/app/scheduler/store.py
+++ b/app/scheduler/store.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from filelock import FileLock
 
 from app.constants import OPENSRE_HOME_DIR
-from app.scheduler.claim_store import delete_runs
+from app.scheduler.claim_store import _DB_FILENAME, delete_runs
 from app.scheduler.types import ScheduledTask
 
 logger = logging.getLogger(__name__)
@@ -99,7 +99,7 @@ def remove_task(task_id: str, store_path: Path | None = None) -> bool:
 
     # Cascade: remove orphaned TaskRun records from the SQLite claim store.
     # Derive the DB path from the same directory as the JSON store.
-    db_path = path.with_name("scheduler.db")
+    db_path = path.with_name(_DB_FILENAME)
     try:
         deleted = delete_runs(task_id, db_path)
         if deleted:

--- a/app/scheduler/store.py
+++ b/app/scheduler/store.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from filelock import FileLock
 
 from app.constants import OPENSRE_HOME_DIR
+from app.scheduler.claim_store import delete_runs
 from app.scheduler.types import ScheduledTask
 
 logger = logging.getLogger(__name__)
@@ -79,7 +80,13 @@ def add_task(task: ScheduledTask, store_path: Path | None = None) -> ScheduledTa
 
 
 def remove_task(task_id: str, store_path: Path | None = None) -> bool:
-    """Remove a task by ID. Returns True if found and removed."""
+    """Remove a task by ID and cascade-delete its run records.
+
+    Returns True if the task was found and removed from the JSON store.
+    Cascade deletion of ``TaskRun`` records in the SQLite claim store is
+    best-effort — a warning is logged on failure but the return value
+    reflects only the JSON-store result.
+    """
     path = store_path or _default_store_path()
     lock = FileLock(_lock_path(path))
     with lock:
@@ -89,6 +96,23 @@ def remove_task(task_id: str, store_path: Path | None = None) -> bool:
         if len(raw) == original_len:
             return False
         _save_raw(path, raw)
+
+    # Cascade: remove orphaned TaskRun records from the SQLite claim store.
+    # Derive the DB path from the same directory as the JSON store.
+    db_path = path.with_name("scheduler.db")
+    try:
+        deleted = delete_runs(task_id, db_path)
+        if deleted:
+            logger.info("Cascade-deleted %d run(s) for removed task %s", deleted, task_id)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Failed to cascade-delete runs for task %s (DB: %s); "
+            "orphaned runs may remain",
+            task_id,
+            db_path,
+            exc_info=True,
+        )
+
     return True
 
 

--- a/app/scheduler/store.py
+++ b/app/scheduler/store.py
@@ -106,8 +106,7 @@ def remove_task(task_id: str, store_path: Path | None = None) -> bool:
             logger.info("Cascade-deleted %d run(s) for removed task %s", deleted, task_id)
     except Exception:  # noqa: BLE001
         logger.warning(
-            "Failed to cascade-delete runs for task %s (DB: %s); "
-            "orphaned runs may remain",
+            "Failed to cascade-delete runs for task %s (DB: %s); orphaned runs may remain",
             task_id,
             db_path,
             exc_info=True,

--- a/tests/scheduler/test_claim_store.py
+++ b/tests/scheduler/test_claim_store.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from app.scheduler.claim_store import complete_run, get_runs, try_claim
+from app.scheduler.claim_store import complete_run, delete_runs, get_runs, try_claim
 from app.scheduler.types import TaskStatus
 
 
@@ -91,6 +91,36 @@ class TestClaimStore:
     def test_get_runs_empty(self, db_path: Path) -> None:
         runs = get_runs("nonexistent", db_path=db_path)
         assert runs == []
+
+    def test_delete_runs_removes_only_matching_task(self, db_path: Path) -> None:
+        try_claim("task1", "2026-01-01T09:00", db_path=db_path)
+        try_claim("task2", "2026-01-01T09:00", db_path=db_path)
+        assert len(get_runs("task1", db_path=db_path)) == 1
+        assert len(get_runs("task2", db_path=db_path)) == 1
+
+        deleted = delete_runs("task1", db_path=db_path)
+        assert deleted == 1
+
+        # task1 runs are gone
+        assert get_runs("task1", db_path=db_path) == []
+        # task2 runs are untouched
+        assert len(get_runs("task2", db_path=db_path)) == 1
+
+    def test_delete_runs_idempotent(self, db_path: Path) -> None:
+        try_claim("task1", "2026-01-01T09:00", db_path=db_path)
+        assert delete_runs("task1", db_path=db_path) == 1
+        assert delete_runs("task1", db_path=db_path) == 0
+
+    def test_delete_runs_empty_db(self, db_path: Path) -> None:
+        assert delete_runs("nonexistent", db_path=db_path) == 0
+
+    def test_delete_runs_deletes_multiple_runs(self, db_path: Path) -> None:
+        for i in range(3):
+            fire_time = f"2026-01-01T{i:02d}:00"
+            try_claim("task1", fire_time, db_path=db_path)
+
+        assert delete_runs("task1", db_path=db_path) == 3
+        assert get_runs("task1", db_path=db_path) == []
 
 
 class TestConcurrency:

--- a/tests/scheduler/test_store.py
+++ b/tests/scheduler/test_store.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from app.scheduler.claim_store import try_claim
 from app.scheduler.store import add_task, get_task, list_tasks, remove_task, update_task
 from app.scheduler.types import Provider, ScheduledTask, TaskKind
 
@@ -13,6 +14,10 @@ from app.scheduler.types import Provider, ScheduledTask, TaskKind
 @pytest.fixture()
 def store_path(tmp_path: Path) -> Path:
     return tmp_path / "scheduler_tasks.json"
+
+
+def _db_path(store_path: Path) -> Path:
+    return store_path.with_name("scheduler.db")
 
 
 class TestStore:
@@ -61,6 +66,57 @@ class TestStore:
         add_task(task, store_path)
         assert remove_task(task.id, store_path) is True
         assert list_tasks(store_path) == []
+
+    def test_remove_task_cascade_deletes_runs(self, store_path: Path) -> None:
+        """Removing a task must also remove its TaskRun records."""
+        task = ScheduledTask(
+            kind=TaskKind.DAILY_SUMMARY,
+            cron="0 9 * * *",
+            provider=Provider.TELEGRAM,
+            chat_id="-100",
+        )
+        add_task(task, store_path)
+
+        db_path = _db_path(store_path)
+        try_claim(task.id, "2026-01-01T09:00", db_path=db_path)
+        try_claim(task.id, "2026-01-01T10:00", db_path=db_path)
+
+        assert remove_task(task.id, store_path) is True
+
+        # Runs are gone
+        from app.scheduler.claim_store import get_runs
+
+        assert get_runs(task.id, db_path=db_path) == []
+
+    def test_remove_task_cascade_does_not_affect_other_tasks(self, store_path: Path) -> None:
+        """Removing one task's runs must not delete another task's runs."""
+        task_a = ScheduledTask(
+            id="task-a",
+            kind=TaskKind.DAILY_SUMMARY,
+            cron="0 9 * * *",
+            provider=Provider.TELEGRAM,
+            chat_id="-100",
+        )
+        task_b = ScheduledTask(
+            id="task-b",
+            kind=TaskKind.WEEKLY_AUDIT,
+            cron="0 8 * * 1",
+            provider=Provider.SLACK,
+            chat_id="C123",
+        )
+        add_task(task_a, store_path)
+        add_task(task_b, store_path)
+
+        db_path = _db_path(store_path)
+        try_claim("task-a", "2026-01-01T09:00", db_path=db_path)
+        try_claim("task-b", "2026-01-01T09:00", db_path=db_path)
+
+        assert remove_task("task-a", store_path) is True
+
+        from app.scheduler.claim_store import get_runs
+
+        assert get_runs("task-a", db_path=db_path) == []
+        assert len(get_runs("task-b", db_path=db_path)) == 1
 
     def test_remove_nonexistent(self, store_path: Path) -> None:
         assert remove_task("nonexistent", store_path) is False

--- a/tests/scheduler/test_store.py
+++ b/tests/scheduler/test_store.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from app.scheduler.claim_store import try_claim
+from app.scheduler.claim_store import get_runs, try_claim
 from app.scheduler.store import add_task, get_task, list_tasks, remove_task, update_task
 from app.scheduler.types import Provider, ScheduledTask, TaskKind
 
@@ -83,9 +83,6 @@ class TestStore:
 
         assert remove_task(task.id, store_path) is True
 
-        # Runs are gone
-        from app.scheduler.claim_store import get_runs
-
         assert get_runs(task.id, db_path=db_path) == []
 
     def test_remove_task_cascade_does_not_affect_other_tasks(self, store_path: Path) -> None:
@@ -112,8 +109,6 @@ class TestStore:
         try_claim("task-b", "2026-01-01T09:00", db_path=db_path)
 
         assert remove_task("task-a", store_path) is True
-
-        from app.scheduler.claim_store import get_runs
 
         assert get_runs("task-a", db_path=db_path) == []
         assert len(get_runs("task-b", db_path=db_path)) == 1


### PR DESCRIPTION
Fixes #2668

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

`remove_task()` was only deleting the `ScheduledTask` from the JSON store but leaving orphaned `TaskRun` records in the SQLite claim store. Added `delete_runs()` to `claim_store.py` and wired it into `remove_task()` so run history is cleaned up when a task is deleted.

Changes:

* `app/scheduler/claim_store.py` — added `delete_runs(task_id, db_path)` that deletes all `TaskRun` rows for a given task
* `app/scheduler/store.py` — `remove_task()` now calls `delete_runs()` after removing the task from JSON; best-effort, logs warning on failure, return value unchanged
* `tests/scheduler/test_claim_store.py` — 4 new tests for `delete_runs` (scoped delete, idempotent, empty DB, multi-run)
* `tests/scheduler/test_store.py` — 2 new tests for cascade (deletes runs, doesn't affect other tasks)

### Demo/Screenshot for feature changes and bug fixes -

```bash
$ pytest tests/scheduler/test_claim_store.py tests/scheduler/test_store.py -v
======================= 27 passed in 1.38s ========================
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

* [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

* [x] I have reviewed every single line of the AI-generated code
* [x] I can explain the purpose and logic of each function/component I added
* [x] I have tested edge cases and understand how the code handles them
* [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The `TaskRun` records live in a separate SQLite DB (`scheduler.db`) with a `task_id` reference to the parent `ScheduledTask`. When the parent is deleted, those records become inaccessible orphans.

Two changes:

1. `delete_runs()` — a focused SQL DELETE scoped by `task_id`. Returns rowcount, no-ops if DB doesn't exist, idempotent.

2. `remove_task()` — derives the SQLite path from the JSON store's directory and calls `delete_runs()` after the JSON write succeeds. Wrapped in `try/except` so a DB failure doesn't revert the JSON deletion — orphaned runs are acceptable (waste space) but a stuck task is not.

---

## Checklist before requesting a review

* [x] I have added proper PR title and linked to the issue
* [x] I have performed a self-review of my code
* [x] **I can explain the purpose of every function, class, and logic block I added**
* [x] I understand why my changes work and have tested them thoroughly
* [x] I have considered potential edge cases and how my code handles them
* [x] If it is a core feature, I have added thorough tests
* [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
