### PR TITLE
fix(integrations): TrelloConfig inherits StrictConfigModel instead of BaseModel

### DIFF
--- a/app/integrations/trello.py
+++ b/app/integrations/trello.py
@@ -4,16 +4,17 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import BaseModel, Field, field_validator
+from pydantic import Field, field_validator
 
 from app.integrations._validation_helpers import report_validation_failure
+from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_TRELLO_BASE_URL = "https://api.trello.com/1"
 
 
-class TrelloConfig(BaseModel):
+class TrelloConfig(StrictConfigModel):
     """Normalized Trello connection settings."""
 
     base_url: str = DEFAULT_TRELLO_BASE_URL


### PR DESCRIPTION
Closes #2670

TrelloConfig in `app/integrations/trello.py` inherits from `pydantic.BaseModel` directly, while every other integration config model in the project (81 usages) inherits from `StrictConfigModel`.

## Changes

- Replace `BaseModel` with `StrictConfigModel`
- Add `from app.strict_config import StrictConfigModel` import

`TrelloConfig` now gains:
- Unknown field rejection with helpful suggestions
- Automatic string stripping