### PR TITLE
fix(integrations): TrelloConfig inherits StrictConfigModel instead of BaseModel

### DIFF
--- a/app/integrations/trello.py
+++ b/app/integrations/trello.py
@@ -4,16 +4,17 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import BaseModel, Field, field_validator
+from pydantic import Field, field_validator
 
 from app.integrations._validation_helpers import report_validation_failure
+from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_TRELLO_BASE_URL = "https://api.trello.com/1"
 
 
-class TrelloConfig(BaseModel):
+class TrelloConfig(StrictConfigModel):
     """Normalized Trello connection settings."""
 
     base_url: str = DEFAULT_TRELLO_BASE_URL

--- a/tests/integrations/test_trello.py
+++ b/tests/integrations/test_trello.py
@@ -1,5 +1,6 @@
 import httpx
 import pytest
+from pydantic import ValidationError
 
 from app.integrations.trello import (
     DEFAULT_TRELLO_BASE_URL,
@@ -38,6 +39,25 @@ def test_build_trello_config_defaults() -> None:
     assert config.board_id == ""
     assert config.list_id == ""
     assert config.timeout_seconds == 15.0
+
+
+def test_trello_config_rejects_unknown_field() -> None:
+    with pytest.raises(ValidationError):
+        TrelloConfig(api_key="k", token="t", bogus_field="x")  # type: ignore[call-arg]
+
+
+def test_trello_config_strips_string_fields() -> None:
+    config = TrelloConfig(
+        api_key="  key  ",
+        token="  token  ",
+        board_id="  board  ",
+        list_id="  list  ",
+    )
+
+    assert config.api_key == "key"
+    assert config.token == "token"
+    assert config.board_id == "board"
+    assert config.list_id == "list"
 
 
 def test_trello_config_from_env(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Change `TrelloConfig` to inherit `StrictConfigModel` for consistency with other integrations.
- Add tests for unknown-field rejection and string stripping.

Fixes #2670

## Test plan
- [x] `uv run pytest tests/integrations/test_trello.py -v`
- [x] `uv run ruff check app/integrations/trello.py tests/integrations/test_trello.py`
- [x] `uv run mypy app/integrations/trello.py`