### PR TITLE
fix: secure Discord interactions & implement Slack signature verifica…

### DIFF
--- a/app/cli/commands/messaging.py
+++ b/app/cli/commands/messaging.py
@@ -8,73 +8,16 @@ import click
 from rich.console import Console
 
 from app.integrations.messaging_security import (
-    MessagingIdentityPolicy,
     MessagingPlatform,
     generate_pairing_code,
     hash_pairing_code,
+    load_identity_policy,
+    save_identity_policy,
 )
-from app.integrations.store import get_integration, upsert_instance
 
 _console = Console(highlight=False)
 
 _PLATFORM_CHOICES = [p.value for p in MessagingPlatform]
-
-
-def _load_identity_policy(service: str) -> tuple[dict | None, MessagingIdentityPolicy]:
-    """Load the integration record and its identity policy."""
-    record = get_integration(service)
-    if record is None:
-        return None, MessagingIdentityPolicy()
-
-    credentials = record.get("credentials", {})
-    raw_policy = credentials.get("identity_policy")
-    if raw_policy and isinstance(raw_policy, dict):
-        policy = MessagingIdentityPolicy.model_validate(raw_policy)
-    else:
-        policy = MessagingIdentityPolicy()
-    return record, policy
-
-
-def _save_identity_policy(
-    service: str, record: dict | None, policy: MessagingIdentityPolicy
-) -> None:
-    """Persist the identity policy back into the integration store.
-
-    Uses upsert_instance for both new and existing records to ensure a
-    consistent code path. When no record exists, upsert_instance creates
-    one automatically. This avoids the problem where a later
-    upsert_integration call (e.g. from the wizard) would replace the
-    stub record and silently drop the identity_policy.
-    """
-    if record is None:
-        # No existing record — upsert_instance will create one.
-        upsert_instance(
-            service,
-            {
-                "name": "default",
-                "tags": {},
-                "credentials": {"identity_policy": policy.model_dump(mode="json")},
-            },
-        )
-    else:
-        # Read the existing instance name and credentials, merge the policy,
-        # and write back only that instance.
-        instances = record.get("instances", [])
-        first_instance = instances[0] if instances else {}
-        instance_name = (
-            first_instance.get("name", "default") if isinstance(first_instance, dict) else "default"
-        )
-        credentials = dict(record.get("credentials", {}))
-        credentials["identity_policy"] = policy.model_dump(mode="json")
-        upsert_instance(
-            service,
-            {
-                "name": instance_name,
-                "tags": first_instance.get("tags", {}) if isinstance(first_instance, dict) else {},
-                "credentials": credentials,
-            },
-            record_id=record.get("id"),
-        )
 
 
 @click.group("messaging")
@@ -98,7 +41,7 @@ def pair_command(platform: str) -> None:
     the allowed-users list.
     """
     service = platform.lower()
-    record, policy = _load_identity_policy(service)
+    record, policy = load_identity_policy(service)
 
     was_disabled = not policy.inbound_enabled
 
@@ -110,7 +53,7 @@ def pair_command(platform: str) -> None:
     policy.require_dm_pairing = True
     policy.inbound_enabled = True
 
-    _save_identity_policy(service, record, policy)
+    save_identity_policy(service, record, policy)
 
     if was_disabled:
         _console.print(f"[yellow]Note: inbound messaging has been enabled for {platform}.[/yellow]")
@@ -137,7 +80,7 @@ def pair_command(platform: str) -> None:
 def allow_command(platform: str, user_id: str) -> None:
     """Manually add a user to the allowed-users list (bypasses DM pairing)."""
     service = platform.lower()
-    record, policy = _load_identity_policy(service)
+    record, policy = load_identity_policy(service)
 
     if user_id in policy.allowed_user_ids:
         _console.print(
@@ -148,7 +91,7 @@ def allow_command(platform: str, user_id: str) -> None:
     was_disabled = not policy.inbound_enabled
     policy.allowed_user_ids.append(user_id)
     policy.inbound_enabled = True
-    _save_identity_policy(service, record, policy)
+    save_identity_policy(service, record, policy)
 
     if was_disabled:
         _console.print(f"[yellow]Note: inbound messaging has been enabled for {platform}.[/yellow]")
@@ -173,7 +116,7 @@ def allow_command(platform: str, user_id: str) -> None:
 def revoke_command(platform: str, user_id: str) -> None:
     """Remove a user from the allowed-users list."""
     service = platform.lower()
-    record, policy = _load_identity_policy(service)
+    record, policy = load_identity_policy(service)
 
     if user_id not in policy.allowed_user_ids:
         _console.print(
@@ -187,7 +130,7 @@ def revoke_command(platform: str, user_id: str) -> None:
     policy.pairing_secret_hash = None
     policy.pairing_created_at = None
     policy.pairing_attempts = 0
-    _save_identity_policy(service, record, policy)
+    save_identity_policy(service, record, policy)
 
     _console.print(f"[green]Removed user {user_id} from {platform} allowed list.[/green]")
 
@@ -203,7 +146,7 @@ def revoke_command(platform: str, user_id: str) -> None:
 def status_command(platform: str) -> None:
     """Show the current messaging security status for a platform."""
     service = platform.lower()
-    record, policy = _load_identity_policy(service)
+    record, policy = load_identity_policy(service)
 
     _console.print(f"\n[bold]Messaging Security Status — {platform}[/bold]\n")
 

--- a/app/integrations/messaging_security.py
+++ b/app/integrations/messaging_security.py
@@ -23,6 +23,7 @@ from enum import StrEnum
 
 from pydantic import Field
 
+from app.integrations.store import get_integration, upsert_instance
 from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
@@ -356,3 +357,93 @@ def audit_log_inbound_message(
         reason,
         message_hash or "N/A",
     )
+
+
+def load_identity_policy(service: str) -> tuple[dict | None, MessagingIdentityPolicy]:
+    """Load the integration record and its identity policy."""
+    record = get_integration(service)
+    if record is None:
+        return None, MessagingIdentityPolicy()
+
+    credentials = record.get("credentials", {})
+    raw_policy = credentials.get("identity_policy")
+    if raw_policy and isinstance(raw_policy, dict):
+        policy = MessagingIdentityPolicy.model_validate(raw_policy)
+    else:
+        policy = MessagingIdentityPolicy()
+    return record, policy
+
+
+def save_identity_policy(
+    service: str, record: dict | None, policy: MessagingIdentityPolicy
+) -> None:
+    """Persist the identity policy back into the integration store.
+
+    Uses upsert_instance for both new and existing records to ensure a
+    consistent code path. When no record exists, upsert_instance creates
+    one automatically.
+    """
+    if record is None:
+        # No existing record — upsert_instance will create one.
+        upsert_instance(
+            service,
+            {
+                "name": "default",
+                "tags": {},
+                "credentials": {"identity_policy": policy.model_dump(mode="json")},
+            },
+        )
+    else:
+        # Read the existing instance name and credentials, merge the policy,
+        # and write back only that instance.
+        instances = record.get("instances", [])
+        first_instance = instances[0] if instances else {}
+        instance_name = (
+            first_instance.get("name", "default") if isinstance(first_instance, dict) else "default"
+        )
+        credentials = dict(record.get("credentials", {}))
+        credentials["identity_policy"] = policy.model_dump(mode="json")
+        upsert_instance(
+            service,
+            {
+                "name": instance_name,
+                "tags": first_instance.get("tags", {}) if isinstance(first_instance, dict) else {},
+                "credentials": credentials,
+            },
+            record_id=record.get("id"),
+        )
+
+
+def verify_slack_signature(
+    *,
+    signing_secret: str,
+    timestamp: str,
+    body: bytes,
+    signature: str,
+) -> bool:
+    """Verify the authenticity of an incoming Slack Events API request.
+
+    Prevents forged requests by computing HMAC-SHA256 of 'v0:{timestamp}:{body}'
+    and doing a constant-time comparison against the 'X-Slack-Signature' header.
+    """
+    if not signing_secret:
+        logger.warning("Slack signing secret is empty; rejecting signature verification.")
+        return False
+
+    # Prevent replay attacks: Reject requests older than 5 minutes (300 seconds)
+    try:
+        ts_float = float(timestamp)
+        if abs(time.time() - ts_float) > 300:
+            logger.warning("Slack request timestamp %s is outside the valid window.", timestamp)
+            return False
+    except ValueError:
+        logger.warning("Invalid Slack request timestamp header: %r", timestamp)
+        return False
+
+    sig_basestring = f"v0:{timestamp}:".encode() + body
+    computed = (
+        "v0="
+        + hmac.HMAC(signing_secret.encode("utf-8"), sig_basestring, hashlib.sha256).hexdigest()
+    )
+
+    return hmac.compare_digest(computed, signature)

--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -12,6 +12,7 @@ Start with::
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json as _json
 import logging
 import os
@@ -48,6 +49,13 @@ from app.analytics.cli import capture_investigation_failed, track_investigation
 from app.analytics.source import EntrypointSource, TriggerMode
 from app.cli.support.cli_error_mapping import reraise_cli_runtime_error
 from app.cli.support.errors import OpenSREError
+from app.integrations.messaging_security import (
+    audit_log_inbound_message,
+    authorize_inbound_message,
+    complete_pairing,
+    load_identity_policy,
+    save_identity_policy,
+)
 from app.remote.error_reporting import report_remote_exception
 from app.remote.vercel_poller import (
     VercelInvestigationCandidate,
@@ -201,12 +209,23 @@ class InvestigationMeta(BaseModel):
     alert_name: str
 
 
+class DiscordUser(BaseModel):
+    id: str
+    username: str
+
+
+class DiscordMember(BaseModel):
+    user: DiscordUser
+
+
 class DiscordInteraction(BaseModel):
     type: int
     data: dict[str, Any] | None = None
     token: str | None = None
     application_id: str | None = None
     channel_id: str | None = None
+    member: DiscordMember | None = None
+    user: DiscordUser | None = None
 
 
 class DeepHealthCheck(BaseModel):
@@ -268,12 +287,61 @@ def _discord_post_followup(
 
 
 async def _run_discord_investigation(interaction: DiscordInteraction) -> None:
-    """Background task: run investigation from a Discord slash command and post results."""
+    """Background task: run investigation from a Discord slash command and post results after validation."""
+    user_id = None
+    if interaction.user:
+        user_id = interaction.user.id
+    elif interaction.member:
+        user_id = interaction.member.user.id
+    user_id = user_id or "unknown"
+    app_id = interaction.application_id or _DISCORD_APPLICATION_ID
+
     # Extract the alert value from slash command options
     options = (interaction.data or {}).get("options", [])
     alert_raw = next(
         (str(opt.get("value", "")) for opt in options if opt.get("name") == "alert"), ""
     )
+
+    # 2. Check Security Policy
+    record, policy = load_identity_policy("discord")
+    auth_result = authorize_inbound_message(
+        policy=policy,
+        user_id=user_id,
+        chat_id=interaction.channel_id,
+        message_text=alert_raw,
+    )
+
+    message_hash = hashlib.sha256(alert_raw.encode("utf-8")).hexdigest() if alert_raw else None
+    audit_log_inbound_message(
+        platform="discord",
+        user_id=user_id,
+        chat_id=interaction.channel_id,
+        message_hash=message_hash,
+        authorized=auth_result.allowed,
+        reason=auth_result.reason,
+    )
+
+    # 3. Handle Pairing Attempts
+    if auth_result.is_pairing_attempt:
+        parts = alert_raw.strip().split()
+        code = parts[1] if len(parts) > 1 else ""
+
+        success, message = complete_pairing(policy=policy, user_id=user_id, code=code)
+        save_identity_policy("discord", record, policy)
+
+        if app_id and interaction.token:
+            _discord_post_followup(app_id, interaction.token, content=message)
+        return
+
+    # 4. Handle Rejected Senders
+    if not auth_result.allowed:
+        if app_id and interaction.token:
+            _discord_post_followup(
+                app_id,
+                interaction.token,
+                content=f"Access denied: {auth_result.reason}",
+            )
+        return
 
     # Accept JSON alert payload or plain-text description
     try:
@@ -292,7 +360,6 @@ async def _run_discord_investigation(interaction: DiscordInteraction) -> None:
     except Exception as exc:
         capture_exception(exc)
         logger.exception("[discord] background investigation failed")
-        app_id = interaction.application_id or _DISCORD_APPLICATION_ID
         if app_id and interaction.token:
             _discord_post_followup(
                 app_id,
@@ -320,7 +387,6 @@ async def _run_discord_investigation(interaction: DiscordInteraction) -> None:
     }
 
     # Post via interaction followup webhook (the deferred response requires this)
-    app_id = interaction.application_id or _DISCORD_APPLICATION_ID
     if app_id and interaction.token:
         await asyncio.to_thread(_discord_post_followup, app_id, interaction.token, embeds=[embed])
 

--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -312,15 +312,6 @@ async def _run_discord_investigation(interaction: DiscordInteraction) -> None:
     )
 
     message_hash = hashlib.sha256(alert_raw.encode("utf-8")).hexdigest() if alert_raw else None
-    audit_log_inbound_message(
-        platform="discord",
-        user_id=user_id,
-        chat_id=interaction.channel_id,
-        message_hash=message_hash,
-        authorized=auth_result.allowed,
-        reason=auth_result.reason,
-    )
-
     # 3. Handle Pairing Attempts
     if auth_result.is_pairing_attempt:
         parts = alert_raw.strip().split()
@@ -329,9 +320,29 @@ async def _run_discord_investigation(interaction: DiscordInteraction) -> None:
         success, message = complete_pairing(policy=policy, user_id=user_id, code=code)
         save_identity_policy("discord", record, policy)
 
+        # Log actual cryptographic verification outcome!
+        audit_log_inbound_message(
+            platform="discord",
+            user_id=user_id,
+            chat_id=interaction.channel_id,
+            message_hash=message_hash,
+            authorized=success,
+            reason=f"Pairing attempt: {message}",
+        )
+
         if app_id and interaction.token:
             _discord_post_followup(app_id, interaction.token, content=message)
         return
+
+    # Log audit trail for regular commands
+    audit_log_inbound_message(
+        platform="discord",
+        user_id=user_id,
+        chat_id=interaction.channel_id,
+        message_hash=message_hash,
+        authorized=auth_result.allowed,
+        reason=auth_result.reason,
+    )
 
     # 4. Handle Rejected Senders
     if not auth_result.allowed:

--- a/tests/integrations/test_messaging_security.py
+++ b/tests/integrations/test_messaging_security.py
@@ -352,3 +352,151 @@ class TestMessagingPlatform:
         assert MessagingPlatform.TELEGRAM.value == "telegram"
         assert MessagingPlatform.SLACK.value == "slack"
         assert MessagingPlatform.DISCORD.value == "discord"
+
+
+# ---------------------------------------------------------------------------
+# Slack signature verification & policy store helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestVerifySlackSignature:
+    def test_verify_slack_signature_valid(self) -> None:
+        import hashlib
+        import hmac
+
+        from app.integrations.messaging_security import verify_slack_signature
+
+        secret = "slack_secret_123"
+        ts = str(int(time.time()))
+        body = b"token=gIkuvaNzQIHg97ATvDxqgjtO&team_id=T0001"
+
+        # Calculate valid signature
+        sig_basestring = f"v0:{ts}:".encode() + body
+        sig = "v0=" + hmac.HMAC(secret.encode("utf-8"), sig_basestring, hashlib.sha256).hexdigest()
+
+        assert (
+            verify_slack_signature(signing_secret=secret, timestamp=ts, body=body, signature=sig)
+            is True
+        )
+
+    def test_verify_slack_signature_invalid(self) -> None:
+        from app.integrations.messaging_security import verify_slack_signature
+
+        secret = "slack_secret_123"
+        ts = str(int(time.time()))
+        body = b"some body content"
+
+        assert (
+            verify_slack_signature(
+                signing_secret=secret, timestamp=ts, body=body, signature="v0=invalid_hex_signature"
+            )
+            is False
+        )
+
+    def test_verify_slack_signature_missing_secret(self) -> None:
+        from app.integrations.messaging_security import verify_slack_signature
+
+        ts = str(int(time.time()))
+        body = b"some body content"
+
+        assert (
+            verify_slack_signature(
+                signing_secret="", timestamp=ts, body=body, signature="v0=whatever"
+            )
+            is False
+        )
+
+    def test_verify_slack_signature_replay_attack_rejected(self) -> None:
+        import hashlib
+        import hmac
+
+        from app.integrations.messaging_security import verify_slack_signature
+
+        secret = "slack_secret_123"
+        # 6 minutes ago
+        ts = str(int(time.time()) - 360)
+        body = b"replay payload"
+
+        sig_basestring = f"v0:{ts}:".encode() + body
+        sig = "v0=" + hmac.HMAC(secret.encode("utf-8"), sig_basestring, hashlib.sha256).hexdigest()
+
+        assert (
+            verify_slack_signature(signing_secret=secret, timestamp=ts, body=body, signature=sig)
+            is False
+        )
+
+
+class TestIdentityPolicyStoreHelpers:
+    def test_load_identity_policy_no_record(self) -> None:
+        from unittest.mock import patch
+
+        from app.integrations.messaging_security import load_identity_policy
+
+        with patch("app.integrations.messaging_security.get_integration", return_value=None):
+            record, policy = load_identity_policy("slack")
+            assert record is None
+            assert isinstance(policy, MessagingIdentityPolicy)
+            assert policy.inbound_enabled is False
+
+    def test_load_identity_policy_with_record(self) -> None:
+        from unittest.mock import patch
+
+        from app.integrations.messaging_security import load_identity_policy
+
+        fake_record = {
+            "id": "rec-123",
+            "credentials": {
+                "identity_policy": {"allowed_user_ids": ["U123"], "inbound_enabled": True}
+            },
+        }
+
+        with patch("app.integrations.messaging_security.get_integration", return_value=fake_record):
+            record, policy = load_identity_policy("slack")
+            assert record == fake_record
+            assert policy.allowed_user_ids == ["U123"]
+            assert policy.inbound_enabled is True
+
+    def test_save_identity_policy_new_record(self) -> None:
+        from unittest.mock import patch
+
+        from app.integrations.messaging_security import save_identity_policy
+
+        policy = MessagingIdentityPolicy(allowed_user_ids=["U999"], inbound_enabled=True)
+
+        with patch("app.integrations.messaging_security.upsert_instance") as mock_upsert:
+            save_identity_policy("slack", None, policy)
+            mock_upsert.assert_called_once_with(
+                "slack",
+                {
+                    "name": "default",
+                    "tags": {},
+                    "credentials": {"identity_policy": policy.model_dump(mode="json")},
+                },
+            )
+
+    def test_save_identity_policy_existing_record(self) -> None:
+        from unittest.mock import patch
+
+        from app.integrations.messaging_security import save_identity_policy
+
+        fake_record = {
+            "id": "rec-123",
+            "instances": [{"name": "prod-bot", "tags": {"env": "prod"}}],
+            "credentials": {"bot_token": "xoxb-123"},
+        }
+        policy = MessagingIdentityPolicy(allowed_user_ids=["U999"], inbound_enabled=True)
+
+        with patch("app.integrations.messaging_security.upsert_instance") as mock_upsert:
+            save_identity_policy("slack", fake_record, policy)
+            mock_upsert.assert_called_once_with(
+                "slack",
+                {
+                    "name": "prod-bot",
+                    "tags": {"env": "prod"},
+                    "credentials": {
+                        "bot_token": "xoxb-123",
+                        "identity_policy": policy.model_dump(mode="json"),
+                    },
+                },
+                record_id="rec-123",
+            )

--- a/tests/remote/test_discord_interactions.py
+++ b/tests/remote/test_discord_interactions.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 from nacl.signing import SigningKey
+
+from app.integrations.messaging_security import AuthorizationResult
 
 _INTERACTION_TOKEN = "test-interaction-token"
 
@@ -207,6 +210,10 @@ async def test_run_discord_investigation_posts_followup_on_success(
 
     monkeypatch.setattr("app.remote.server._execute_investigation", _fake_execute)
     monkeypatch.setattr("app.remote.server._discord_post_followup", _fake_followup)
+    monkeypatch.setattr(
+        "app.remote.server.authorize_inbound_message",
+        lambda **_kw: AuthorizationResult(allowed=True, reason="Test bypass"),
+    )
 
     await _run_discord_investigation(interaction)
 
@@ -243,6 +250,10 @@ async def test_run_discord_investigation_parses_plain_text_alert(
 
     monkeypatch.setattr("app.remote.server._execute_investigation", _fake_execute)
     monkeypatch.setattr("app.remote.server._discord_post_followup", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        "app.remote.server.authorize_inbound_message",
+        lambda **_kw: AuthorizationResult(allowed=True, reason="Test bypass"),
+    )
 
     await _run_discord_investigation(interaction)
 
@@ -275,6 +286,10 @@ async def test_run_discord_investigation_posts_failure_message_on_exception(
 
     monkeypatch.setattr("app.remote.server._execute_investigation", _raise)
     monkeypatch.setattr("app.remote.server._discord_post_followup", _fake_followup)
+    monkeypatch.setattr(
+        "app.remote.server.authorize_inbound_message",
+        lambda **_kw: AuthorizationResult(allowed=True, reason="Test bypass"),
+    )
 
     await _run_discord_investigation(interaction)
 
@@ -308,6 +323,10 @@ async def test_run_discord_investigation_noise_uses_grey_color(
 
     monkeypatch.setattr("app.remote.server._execute_investigation", _fake_execute)
     monkeypatch.setattr("app.remote.server._discord_post_followup", _fake_followup)
+    monkeypatch.setattr(
+        "app.remote.server.authorize_inbound_message",
+        lambda **_kw: AuthorizationResult(allowed=True, reason="Test bypass"),
+    )
 
     await _run_discord_investigation(interaction)
 
@@ -352,3 +371,152 @@ def test_discord_post_followup_warns_on_non_200(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr("httpx.post", _fake_post)
     # Should not raise
     _discord_post_followup("app-id", "token", content="hello")
+
+
+# ---------------------------------------------------------------------------
+# Discord inbound security policy & pairing tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_discord_investigation_blocked_by_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.integrations.messaging_security import MessagingIdentityPolicy
+    from app.remote.server import DiscordInteraction, _run_discord_investigation
+
+    interaction = DiscordInteraction(
+        type=2,
+        token=_INTERACTION_TOKEN,
+        application_id="app-id",
+        channel_id="chan-1",
+        user={"id": "unpaired-user-id", "username": "unpaired"},
+        data={"options": [{"name": "alert", "value": "CPU spike"}]},
+    )
+
+    policy = MessagingIdentityPolicy(
+        inbound_enabled=True,
+        require_dm_pairing=True,
+        allowed_user_ids=[],
+    )
+
+    execute_called = False
+    followup_messages = []
+
+    def _fake_load(*_a: Any) -> tuple[dict | None, MessagingIdentityPolicy]:
+        return None, policy
+
+    def _fake_execute(**_kw: Any) -> tuple[dict[str, Any], str, str, str]:
+        nonlocal execute_called
+        execute_called = True
+        return {}, "CPU spike", "default", "high"
+
+    def _fake_followup(_app_id: str, _token: str, *, content: str = "", **_kw: Any) -> None:
+        followup_messages.append(content)
+
+    monkeypatch.setattr("app.remote.server.load_identity_policy", _fake_load)
+    monkeypatch.setattr("app.remote.server._execute_investigation", _fake_execute)
+    monkeypatch.setattr("app.remote.server._discord_post_followup", _fake_followup)
+
+    await _run_discord_investigation(interaction)
+
+    assert execute_called is False
+    assert len(followup_messages) == 1
+    assert "Access denied" in followup_messages[0]
+    assert "No users have been paired" in followup_messages[0]
+
+
+@pytest.mark.asyncio
+async def test_run_discord_investigation_success_when_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.integrations.messaging_security import MessagingIdentityPolicy
+    from app.remote.server import DiscordInteraction, _run_discord_investigation
+
+    interaction = DiscordInteraction(
+        type=2,
+        token=_INTERACTION_TOKEN,
+        application_id="app-id",
+        channel_id="chan-1",
+        member={"user": {"id": "allowed-user-id", "username": "allowed"}},
+        data={"options": [{"name": "alert", "value": "CPU spike"}]},
+    )
+
+    policy = MessagingIdentityPolicy(
+        inbound_enabled=True,
+        require_dm_pairing=True,
+        allowed_user_ids=["allowed-user-id"],
+    )
+
+    execute_called = False
+
+    def _fake_load(*_a: Any) -> tuple[dict | None, MessagingIdentityPolicy]:
+        return None, policy
+
+    def _fake_execute(**_kw: Any) -> tuple[dict[str, Any], str, str, str]:
+        nonlocal execute_called
+        execute_called = True
+        return (
+            {"root_cause": "leak", "report": "fixed", "is_noise": False},
+            "CPU spike",
+            "default",
+            "high",
+        )
+
+    monkeypatch.setattr("app.remote.server.load_identity_policy", _fake_load)
+    monkeypatch.setattr("app.remote.server._execute_investigation", _fake_execute)
+    monkeypatch.setattr("app.remote.server._discord_post_followup", lambda *_a, **_kw: None)
+
+    await _run_discord_investigation(interaction)
+
+    assert execute_called is True
+
+
+@pytest.mark.asyncio
+async def test_run_discord_investigation_pairing_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.integrations.messaging_security import MessagingIdentityPolicy, hash_pairing_code
+    from app.remote.server import DiscordInteraction, _run_discord_investigation
+
+    code = "PAIR99"
+    interaction = DiscordInteraction(
+        type=2,
+        token=_INTERACTION_TOKEN,
+        application_id="app-id",
+        channel_id="chan-1",
+        user={"id": "pairing-user-id", "username": "pairing"},
+        data={"options": [{"name": "alert", "value": f"/pair {code}"}]},
+    )
+
+    policy = MessagingIdentityPolicy(
+        inbound_enabled=True,
+        require_dm_pairing=True,
+        pairing_secret_hash=hash_pairing_code(code),
+        pairing_created_at=time.time(),
+    )
+
+    saved_policy = None
+    followup_messages = []
+
+    def _fake_load(*_a: Any) -> tuple[dict | None, MessagingIdentityPolicy]:
+        return {"id": "rec-123"}, policy
+
+    def _fake_save(_platform: str, _record: dict | None, pol: MessagingIdentityPolicy) -> None:
+        nonlocal saved_policy
+        saved_policy = pol
+
+    def _fake_followup(_app_id: str, _token: str, *, content: str = "", **_kw: Any) -> None:
+        followup_messages.append(content)
+
+    monkeypatch.setattr("app.remote.server.load_identity_policy", _fake_load)
+    monkeypatch.setattr("app.remote.server.save_identity_policy", _fake_save)
+    monkeypatch.setattr("app.remote.server._discord_post_followup", _fake_followup)
+
+    await _run_discord_investigation(interaction)
+
+    assert len(followup_messages) == 1
+    assert "Pairing successful" in followup_messages[0]
+    assert saved_policy is not None
+    assert "pairing-user-id" in saved_policy.allowed_user_ids
+    assert saved_policy.pairing_secret_hash is None


### PR DESCRIPTION
Fixes #2678

#### Describe the changes you have made in this PR -
- **Discord Interaction Gating:** Gated the active `/discord/interactions` command endpoint in [app/remote/server.py](file:///e:/Chirag/openSource/opensre/app/remote/server.py) behind `authorize_inbound_message()` identity checking and allowlists.
- **Native Slash-Command Pairing:** Added inline support for `/pair <code>` checks within the Discord interaction runner. Valid code submissions update the policy and grant allowed user access dynamically via `complete_pairing()`.
- **Promoted Policy Store Helpers:** Extracted local, private policy load/save functions from CLI commands (`app/cli/commands/messaging.py`) and promoted them to public, shared helpers (`load_identity_policy` and `save_identity_policy`) in [app/integrations/messaging_security.py](file:///e:/Chirag/openSource/opensre/app/integrations/messaging_security.py).
- **Slack HMAC Signature Check:** Implemented `verify_slack_signature` utilizing HMAC-SHA256 of incoming header signatures against the configured `signing_secret` with a 5-minute request timestamp check to protect against replay attacks.
- **Secure Audit Trails:** Integrated structured logging using `audit_log_inbound_message()` for all inbound interaction events.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->

#### 🧪 All 56 Automated Pytests Passed Successfully:
```bash
$ uv run pytest tests/integrations/test_messaging_security.py tests/remote/test_discord_interactions.py

collected 56 items
tests/integrations/test_messaging_security.py::TestMessagingIdentityPolicy::test_default_policy_has_empty_allowlists PASSED
tests/integrations/test_messaging_security.py::TestMessagingIdentityPolicy::test_policy_with_allowed_users PASSED
tests/integrations/test_messaging_security.py::TestMessagingIdentityPolicy::test_policy_serialization_roundtrip PASSED
tests/integrations/test_messaging_security.py::TestMessagingIdentityPolicy::test_policy_back_compat_empty_dict_loads PASSED
tests/integrations/test_pairing_code::test_generate_pairing_code_length PASSED
...
tests/remote/test_discord_interactions.py::test_run_discord_investigation_blocked_by_policy PASSED
tests/remote/test_discord_interactions.py::test_run_discord_investigation_success_when_allowed PASSED
tests/remote/test_discord_interactions.py::test_run_discord_investigation_pairing_attempt PASSED

============================= 56 passed in 8.51s ==============================
```

#### 🔍 Mypy Static Type Checking Passed (Strict Typing):
```bash
$ uv run python -m mypy app/
mypy.ini: note: unused section(s): [mypy-apscheduler]
Success: no issues found in 696 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
### 1. Problem Solved
This PR plugs a critical security gating gap where `app/integrations/messaging_security.py`'s allowlist policies and DM pairing code validation were completely un-utilized (no callers in `app/`). The active Discord interactions endpoint processed command investigations globally, creating an active authorization bypass.

### 2. Alternative Approaches Considered
- **Option A (Full chatbot loop webhook):** Implementing full inbound Slack events and Telegram webhook hooks. This was rejected due to excessive scope creep for a security patch; chatbot event routines are mapped to a separate, larger epic (Issue #1482).
- **Option B (Dormant Clean-up):** Removing `messaging_security.py` altogether. This was rejected because the pairing, hashing, and allowed-users flows represent robust foundations needed for conversational safety down the line.
- **Chosen Approach (Option C):** We secured the only currently active public surface (Discord interactions) using the pre-designed policy, refactored store loading/saving helpers so they are shared and DRY, and implemented standard Slack request signature verification using HMAC-SHA256 so that future event handlers under #1482 have a secure-by-default helper ready to go.

### 3. Key Components Added
- **`verify_slack_signature`:** Validates request signatures by calculating `HMAC-SHA256` of `v0:{timestamp}:{body}` with constant-time comparison. Prevents replay attacks by checking timestamp drift.
- **`load_identity_policy` & `save_identity_policy`:** Unified wrappers for querying and persistence of user identity allowlists, shared smoothly between CLI subcommands and remote endpoints.
- **`DiscordInteraction` Pydantic models:** Extended standard structures (`DiscordMember`, `DiscordUser`) to capture platform-native user IDs.
- **`_run_discord_investigation` gating:** Intercepts slash command requests to authorize senders. Implements pairing commands dynamically in-stream and triggers `audit_log_inbound_message()` for audit trails.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
```