### PR TITLE
feat(llm): add custom OpenAI- and Anthropic-compatible providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@
 
 # Provider used for LLM calls. Common values: anthropic, openai, openrouter,
 # deepseek, gemini, nvidia, minimax, bedrock, ollama, codex, claude-code,
-# opencode, kimi, copilot, antigravity-cli.
+# opencode, kimi, copilot, antigravity-cli, custom-openai, custom-anthropic.
 LLM_PROVIDER=anthropic
 
 # Codex CLI works for `opensre investigate` after `codex login`.
@@ -138,6 +138,36 @@ GROQ_MODEL=
 GROQ_REASONING_MODEL=
 GROQ_CLASSIFICATION_MODEL=
 GROQ_TOOLCALL_MODEL=
+
+# Custom OpenAI-compatible endpoint (e.g., LiteLLM, vLLM, LocalAI, Ollama with OpenAI API)
+# Set `LLM_PROVIDER=custom-openai` to use a custom OpenAI-compatible API endpoint.
+# Examples:
+#   - LiteLLM proxy: CUSTOM_OPENAI_BASE_URL=http://localhost:4000/v1
+#   - vLLM server: CUSTOM_OPENAI_BASE_URL=http://localhost:8000/v1
+#   - Other OpenAI-compatible APIs
+# CUSTOM_OPENAI_BASE_URL and CUSTOM_OPENAI_MODEL are required for this provider —
+# there is no universal default, so set the model name your endpoint actually serves.
+# Per-tier overrides (REASONING/CLASSIFICATION/TOOLCALL) are optional and fall back to
+# CUSTOM_OPENAI_MODEL.
+CUSTOM_OPENAI_API_KEY=
+CUSTOM_OPENAI_BASE_URL=
+CUSTOM_OPENAI_MODEL=
+CUSTOM_OPENAI_REASONING_MODEL=
+CUSTOM_OPENAI_CLASSIFICATION_MODEL=
+CUSTOM_OPENAI_TOOLCALL_MODEL=
+
+# Custom Anthropic-compatible endpoint (e.g., LiteLLM proxy for Anthropic models)
+# Set `LLM_PROVIDER=custom-anthropic` to use a custom Anthropic-compatible API endpoint.
+# Example: CUSTOM_ANTHROPIC_BASE_URL=http://localhost:4000
+# CUSTOM_ANTHROPIC_BASE_URL and CUSTOM_ANTHROPIC_MODEL are required for this provider —
+# set the model name your endpoint actually serves. Per-tier overrides are optional and
+# fall back to CUSTOM_ANTHROPIC_MODEL.
+CUSTOM_ANTHROPIC_API_KEY=
+CUSTOM_ANTHROPIC_BASE_URL=
+CUSTOM_ANTHROPIC_MODEL=
+CUSTOM_ANTHROPIC_REASONING_MODEL=
+CUSTOM_ANTHROPIC_CLASSIFICATION_MODEL=
+CUSTOM_ANTHROPIC_TOOLCALL_MODEL=
 
 # --- First integrations to set up ------------------------------------------
 

--- a/app/config.py
+++ b/app/config.py
@@ -147,6 +147,19 @@ BEDROCK_TOOLCALL_MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 DEFAULT_OLLAMA_MODEL = "llama3.2"
 DEFAULT_OLLAMA_HOST = "http://localhost:11434"
 
+# Custom providers point at a bring-your-own endpoint (LiteLLM, vLLM, LocalAI,
+# internal gateways), so there is no safe default model name — a hard-coded
+# default would silently send an identifier the endpoint does not serve and fail
+# with a confusing model-not-found error. These default to empty and the user
+# must configure CUSTOM_*_MODEL; LLMSettings validation enforces it up front.
+CUSTOM_OPENAI_REASONING_MODEL = ""
+CUSTOM_OPENAI_CLASSIFICATION_MODEL = ""
+CUSTOM_OPENAI_TOOLCALL_MODEL = ""
+
+CUSTOM_ANTHROPIC_REASONING_MODEL = ""
+CUSTOM_ANTHROPIC_CLASSIFICATION_MODEL = ""
+CUSTOM_ANTHROPIC_TOOLCALL_MODEL = ""
+
 LLMProvider = Literal[
     "anthropic",
     "openai",
@@ -166,6 +179,8 @@ LLMProvider = Literal[
     "opencode",
     "kimi",
     "copilot",
+    "custom-openai",
+    "custom-anthropic",
 ]
 
 KEYLESS_LLM_PROVIDERS = frozenset(
@@ -191,6 +206,8 @@ LLM_PROVIDER_API_KEY_ENVS = {
     "nvidia": "NVIDIA_API_KEY",
     "minimax": "MINIMAX_API_KEY",
     "groq": "GROQ_API_KEY",
+    "custom-openai": "CUSTOM_OPENAI_API_KEY",
+    "custom-anthropic": "CUSTOM_ANTHROPIC_API_KEY",
 }
 DEFAULT_LLM_RESOLUTION_FALLBACK_PROVIDERS: tuple[str, ...] = ("openai", "anthropic")
 
@@ -227,6 +244,10 @@ def _llm_settings_env_payload(provider: str) -> dict[str, object]:
         "nvidia_api_key": resolve_llm_api_key("NVIDIA_API_KEY"),
         "minimax_api_key": resolve_llm_api_key("MINIMAX_API_KEY"),
         "groq_api_key": resolve_llm_api_key("GROQ_API_KEY"),
+        "custom_openai_api_key": resolve_llm_api_key("CUSTOM_OPENAI_API_KEY"),
+        "custom_anthropic_api_key": resolve_llm_api_key("CUSTOM_ANTHROPIC_API_KEY"),
+        "custom_openai_base_url": os.getenv("CUSTOM_OPENAI_BASE_URL", "").strip(),
+        "custom_anthropic_base_url": os.getenv("CUSTOM_ANTHROPIC_BASE_URL", "").strip(),
         "anthropic_reasoning_model": os.getenv(
             "ANTHROPIC_REASONING_MODEL", ANTHROPIC_REASONING_MODEL
         ).strip()
@@ -351,6 +372,36 @@ def _llm_settings_env_payload(provider: str) -> dict[str, object]:
             "BEDROCK_TOOLCALL_MODEL", BEDROCK_TOOLCALL_MODEL
         ).strip()
         or BEDROCK_TOOLCALL_MODEL,
+        "custom_openai_reasoning_model": os.getenv(
+            "CUSTOM_OPENAI_REASONING_MODEL",
+            os.getenv("CUSTOM_OPENAI_MODEL", CUSTOM_OPENAI_REASONING_MODEL),
+        ).strip()
+        or CUSTOM_OPENAI_REASONING_MODEL,
+        "custom_openai_classification_model": os.getenv(
+            "CUSTOM_OPENAI_CLASSIFICATION_MODEL",
+            os.getenv("CUSTOM_OPENAI_MODEL", CUSTOM_OPENAI_CLASSIFICATION_MODEL),
+        ).strip()
+        or CUSTOM_OPENAI_CLASSIFICATION_MODEL,
+        "custom_openai_toolcall_model": os.getenv(
+            "CUSTOM_OPENAI_TOOLCALL_MODEL",
+            os.getenv("CUSTOM_OPENAI_MODEL", CUSTOM_OPENAI_TOOLCALL_MODEL),
+        ).strip()
+        or CUSTOM_OPENAI_TOOLCALL_MODEL,
+        "custom_anthropic_reasoning_model": os.getenv(
+            "CUSTOM_ANTHROPIC_REASONING_MODEL",
+            os.getenv("CUSTOM_ANTHROPIC_MODEL", CUSTOM_ANTHROPIC_REASONING_MODEL),
+        ).strip()
+        or CUSTOM_ANTHROPIC_REASONING_MODEL,
+        "custom_anthropic_classification_model": os.getenv(
+            "CUSTOM_ANTHROPIC_CLASSIFICATION_MODEL",
+            os.getenv("CUSTOM_ANTHROPIC_MODEL", CUSTOM_ANTHROPIC_CLASSIFICATION_MODEL),
+        ).strip()
+        or CUSTOM_ANTHROPIC_CLASSIFICATION_MODEL,
+        "custom_anthropic_toolcall_model": os.getenv(
+            "CUSTOM_ANTHROPIC_TOOLCALL_MODEL",
+            os.getenv("CUSTOM_ANTHROPIC_MODEL", CUSTOM_ANTHROPIC_TOOLCALL_MODEL),
+        ).strip()
+        or CUSTOM_ANTHROPIC_TOOLCALL_MODEL,
         "ollama_model": os.getenv("OLLAMA_MODEL", DEFAULT_OLLAMA_MODEL).strip()
         or DEFAULT_OLLAMA_MODEL,
         "ollama_host": os.getenv("OLLAMA_HOST", DEFAULT_OLLAMA_HOST).strip() or DEFAULT_OLLAMA_HOST,
@@ -383,6 +434,10 @@ class LLMSettings(StrictConfigModel):
     nvidia_api_key: str = ""
     minimax_api_key: str = ""
     groq_api_key: str = ""
+    custom_openai_api_key: str = ""
+    custom_anthropic_api_key: str = ""
+    custom_openai_base_url: str = ""
+    custom_anthropic_base_url: str = ""
     ollama_model: str = DEFAULT_OLLAMA_MODEL
     ollama_host: str = DEFAULT_OLLAMA_HOST
     anthropic_reasoning_model: str = ANTHROPIC_REASONING_MODEL
@@ -412,6 +467,12 @@ class LLMSettings(StrictConfigModel):
     bedrock_reasoning_model: str = BEDROCK_REASONING_MODEL
     bedrock_classification_model: str = BEDROCK_CLASSIFICATION_MODEL
     bedrock_toolcall_model: str = BEDROCK_TOOLCALL_MODEL
+    custom_openai_reasoning_model: str = CUSTOM_OPENAI_REASONING_MODEL
+    custom_openai_classification_model: str = CUSTOM_OPENAI_CLASSIFICATION_MODEL
+    custom_openai_toolcall_model: str = CUSTOM_OPENAI_TOOLCALL_MODEL
+    custom_anthropic_reasoning_model: str = CUSTOM_ANTHROPIC_REASONING_MODEL
+    custom_anthropic_classification_model: str = CUSTOM_ANTHROPIC_CLASSIFICATION_MODEL
+    custom_anthropic_toolcall_model: str = CUSTOM_ANTHROPIC_TOOLCALL_MODEL
     max_tokens: int = Field(default=DEFAULT_MAX_TOKENS, gt=0)
 
     @field_validator("ollama_host", mode="before")
@@ -445,6 +506,8 @@ class LLMSettings(StrictConfigModel):
             "opencode",
             "kimi",
             "copilot",
+            "custom-openai",
+            "custom-anthropic",
         )
         if provider in valid_providers:
             return provider
@@ -470,12 +533,58 @@ class LLMSettings(StrictConfigModel):
             "nvidia": self.nvidia_api_key,
             "minimax": self.minimax_api_key,
             "groq": self.groq_api_key,
+            "custom-openai": self.custom_openai_api_key,
+            "custom-anthropic": self.custom_anthropic_api_key,
         }
         if provider_to_key[self.provider]:
             return self
 
         env_var = get_llm_provider_api_key_env(self.provider)
         raise ValueError(f"LLM provider '{self.provider}' requires {env_var} to be set.")
+
+    @model_validator(mode="after")
+    def _require_custom_provider_endpoint(self) -> "LLMSettings":
+        """Custom providers target a bring-your-own endpoint, so there is no safe
+        default base URL or model. Require the base URL and a model for *every*
+        tier at settings-load time rather than failing at first inference with a
+        confusing connection / model-not-found error.
+
+        Setting ``CUSTOM_*_MODEL`` populates all three tiers; per-tier overrides
+        layer on top. Checking every tier (not just reasoning) closes the gap
+        where a lone ``CUSTOM_*_REASONING_MODEL`` would leave the classification
+        and toolcall tiers empty and only surface at their first call.
+        """
+        custom_requirements = {
+            "custom-openai": (
+                self.custom_openai_base_url,
+                (
+                    self.custom_openai_reasoning_model,
+                    self.custom_openai_classification_model,
+                    self.custom_openai_toolcall_model,
+                ),
+                "CUSTOM_OPENAI_BASE_URL",
+                "CUSTOM_OPENAI_MODEL",
+            ),
+            "custom-anthropic": (
+                self.custom_anthropic_base_url,
+                (
+                    self.custom_anthropic_reasoning_model,
+                    self.custom_anthropic_classification_model,
+                    self.custom_anthropic_toolcall_model,
+                ),
+                "CUSTOM_ANTHROPIC_BASE_URL",
+                "CUSTOM_ANTHROPIC_MODEL",
+            ),
+        }
+        requirement = custom_requirements.get(self.provider)
+        if requirement is None:
+            return self
+        base_url, tier_models, base_url_env, model_env = requirement
+        if not base_url:
+            raise ValueError(f"LLM provider '{self.provider}' requires {base_url_env} to be set.")
+        if not all(tier_models):
+            raise ValueError(f"LLM provider '{self.provider}' requires {model_env} to be set.")
+        return self
 
     @classmethod
     def from_env(cls) -> "LLMSettings":

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -727,9 +727,33 @@ def get_agent_llm() -> _AgentClientType:
             model=settings.openai_reasoning_model,
             max_tokens=OPENAI_LLM_CONFIG.max_tokens,
         )
-    elif provider in ("openrouter", "deepseek", "gemini", "nvidia", "minimax", "groq", "ollama"):
+    elif provider in (
+        "openrouter",
+        "deepseek",
+        "gemini",
+        "nvidia",
+        "minimax",
+        "groq",
+        "ollama",
+        "custom-openai",
+    ):
         # All OpenAI-compatible providers
         _agent_client = _create_openai_compat_client(settings, provider)
+    elif provider == "custom-anthropic":
+        from anthropic import Anthropic
+
+        from app.config import DEFAULT_MAX_TOKENS
+        from app.llm_credentials import resolve_llm_api_key
+
+        # base_url, model, and API key presence are enforced by LLMSettings validation.
+        base_url = settings.custom_anthropic_base_url.rstrip("/")
+        api_key = resolve_llm_api_key("CUSTOM_ANTHROPIC_API_KEY")
+        custom_client = Anthropic(api_key=api_key, base_url=base_url, timeout=_CLIENT_TIMEOUT_SEC)
+        _agent_client = AnthropicAgentClient(
+            model=settings.custom_anthropic_reasoning_model,
+            max_tokens=settings.max_tokens or DEFAULT_MAX_TOKENS,
+            client=custom_client,
+        )
     elif provider == "bedrock":
         from app.config import BEDROCK_LLM_CONFIG
         from app.services.llm_client import _is_anthropic_bedrock_model
@@ -790,6 +814,16 @@ def _create_openai_compat_client(settings: Any, provider: str) -> OpenAIAgentCli
             base_url=f"{host}/v1",
             api_key_env="OLLAMA_API_KEY",
             api_key_default="ollama",
+        )
+    if provider == "custom-openai":
+        # base_url, model, and API key presence are enforced by LLMSettings validation.
+        from app.config import DEFAULT_MAX_TOKENS
+
+        return OpenAIAgentClient(
+            model=settings.custom_openai_reasoning_model,
+            max_tokens=settings.max_tokens or DEFAULT_MAX_TOKENS,
+            base_url=settings.custom_openai_base_url.rstrip("/"),
+            api_key_env="CUSTOM_OPENAI_API_KEY",
         )
     base_url, api_key_env, model = provider_map[provider]
     return OpenAIAgentClient(model=model, base_url=base_url, api_key_env=api_key_env)

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -158,15 +158,34 @@ class LLMResponse:
 
 class LLMClient:
     def __init__(
-        self, *, model: str, max_tokens: int = 1024, temperature: float | None = None
+        self,
+        *,
+        model: str,
+        max_tokens: int = 1024,
+        temperature: float | None = None,
+        base_url: str | None = None,
+        api_key_env: str = "ANTHROPIC_API_KEY",
     ) -> None:
-        api_key = resolve_llm_api_key("ANTHROPIC_API_KEY")
+        self._api_key_env = api_key_env
+        self._base_url = base_url
+        api_key = resolve_llm_api_key(api_key_env)
         self._api_key = api_key
-        self._client = Anthropic(api_key=api_key, timeout=_CLIENT_TIMEOUT_SEC)
+        self._client = self._build_client(api_key)
         self._model = model
         self._max_tokens = max_tokens
         self._temperature = temperature
         self._bound_tools: list[dict[str, Any]] = []
+
+    def _build_client(self, api_key: str) -> Anthropic:
+        """Construct an Anthropic client, applying the optional base_url override.
+
+        ``base_url`` is only forwarded when set so the default Anthropic path
+        keeps its original call shape; custom-anthropic providers (LiteLLM, vLLM
+        proxies, etc.) supply a base_url that must survive credential refreshes.
+        """
+        if self._base_url:
+            return Anthropic(api_key=api_key, base_url=self._base_url, timeout=_CLIENT_TIMEOUT_SEC)
+        return Anthropic(api_key=api_key, timeout=_CLIENT_TIMEOUT_SEC)
 
     def with_config(self, **_kwargs) -> LLMClient:
         return self
@@ -179,14 +198,14 @@ class LLMClient:
         return self
 
     def _ensure_client(self) -> None:
-        api_key = resolve_llm_api_key("ANTHROPIC_API_KEY")
+        api_key = resolve_llm_api_key(self._api_key_env)
         if not api_key:
             raise RuntimeError(
-                "Missing ANTHROPIC_API_KEY. Set it in your environment, .env, or secure local keychain before running LLM steps."
+                f"Missing {self._api_key_env}. Set it in your environment, .env, or secure local keychain before running LLM steps."
             )
         if api_key != self._api_key:
             self._api_key = api_key
-            self._client = Anthropic(api_key=api_key, timeout=_CLIENT_TIMEOUT_SEC)
+            self._client = self._build_client(api_key)
 
     def _build_request_kwargs(self, prompt_or_messages: Any) -> dict[str, Any]:
         """Refresh credentials, normalize messages, apply guardrails, and build API kwargs.
@@ -233,7 +252,7 @@ class LLMClient:
                 break
             except AuthenticationError as err:
                 raise RuntimeError(
-                    "Anthropic authentication failed. Check ANTHROPIC_API_KEY in your environment or .env."
+                    f"Anthropic authentication failed. Check {self._api_key_env} in your environment or .env."
                 ) from err
             except NotFoundError as err:
                 raise RuntimeError(
@@ -307,7 +326,7 @@ class LLMClient:
                 return
             except AuthenticationError as err:
                 raise RuntimeError(
-                    "Anthropic authentication failed. Check ANTHROPIC_API_KEY in your environment or .env."
+                    f"Anthropic authentication failed. Check {self._api_key_env} in your environment or .env."
                 ) from err
             except NotFoundError as err:
                 raise RuntimeError(
@@ -1362,6 +1381,30 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
             base_url=f"{host}/v1",
             api_key_env="OLLAMA_API_KEY",
             api_key_default="ollama",
+        )
+    elif provider == "custom-openai":
+        # base_url, model, and API key presence are enforced by LLMSettings
+        # validation, so this branch can assume a configured endpoint.
+        from app.config import DEFAULT_MAX_TOKENS
+
+        return OpenAILLMClient(
+            model=_select_model(settings, "custom_openai", model_type),
+            model_fallback=_fallback_model("custom_openai"),
+            max_tokens=settings.max_tokens or DEFAULT_MAX_TOKENS,
+            base_url=settings.custom_openai_base_url.rstrip("/"),
+            api_key_env="CUSTOM_OPENAI_API_KEY",
+        )
+    elif provider == "custom-anthropic":
+        # base_url, model, and API key presence are enforced by LLMSettings
+        # validation. LLMClient resolves CUSTOM_ANTHROPIC_API_KEY itself and the
+        # base_url override survives credential refreshes via _build_client.
+        from app.config import DEFAULT_MAX_TOKENS
+
+        return LLMClient(
+            model=_select_model(settings, "custom_anthropic", model_type),
+            max_tokens=settings.max_tokens or DEFAULT_MAX_TOKENS,
+            base_url=settings.custom_anthropic_base_url.rstrip("/"),
+            api_key_env="CUSTOM_ANTHROPIC_API_KEY",
         )
     elif provider == "bedrock":
         from app.config import BEDROCK_LLM_CONFIG

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -371,6 +371,93 @@ def test_anthropic_llm_client_reads_secure_local_api_key(monkeypatch) -> None:
     assert _FakeAnthropic.last_api_key == "stored-anthropic-key"
 
 
+class _BaseURLCapturingAnthropic:
+    """Anthropic double that records the api_key and base_url it was built with."""
+
+    def __init__(self, *, api_key: str, timeout: float, base_url: str | None = None) -> None:
+        self.api_key = api_key
+        self.timeout = timeout
+        self.base_url = base_url
+        self.messages = _FakeAnthropicMessages()
+
+
+def test_custom_anthropic_client_keeps_base_url_and_custom_key(monkeypatch) -> None:
+    """Regression: the custom-anthropic provider must keep its base_url and use
+    CUSTOM_ANTHROPIC_API_KEY — not ANTHROPIC_API_KEY — even after _ensure_client()
+    refreshes credentials on the first invoke.
+
+    Before the fix, LLMClient was hardwired to ANTHROPIC_API_KEY: _ensure_client()
+    raised "Missing ANTHROPIC_API_KEY" (the normal case for these users) or
+    rebuilt the client and dropped the base_url override.
+    """
+    from app.config import LLMSettings
+
+    settings = LLMSettings.model_validate(
+        {
+            "provider": "custom-anthropic",
+            "custom_anthropic_api_key": "sk-ant-custom",
+            "custom_anthropic_base_url": "https://proxy.example.com",
+            "custom_anthropic_reasoning_model": "claude-proxy-model",
+            "custom_anthropic_classification_model": "claude-proxy-model",
+            "custom_anthropic_toolcall_model": "claude-proxy-model",
+        }
+    )
+    monkeypatch.setattr(llm_client, "resolve_llm_settings", lambda: settings)
+    monkeypatch.setattr(
+        llm_client,
+        "resolve_llm_api_key",
+        lambda env_var: "sk-ant-custom" if env_var == "CUSTOM_ANTHROPIC_API_KEY" else "",
+    )
+    monkeypatch.setattr(llm_client, "Anthropic", _BaseURLCapturingAnthropic)
+
+    client = llm_client._create_llm_client("reasoning")
+    # _ensure_client() runs on every invoke; pre-fix this raised on the missing
+    # ANTHROPIC_API_KEY and/or rebuilt the client without the base_url.
+    client._ensure_client()
+
+    assert client._model == "claude-proxy-model"
+    assert client._api_key_env == "CUSTOM_ANTHROPIC_API_KEY"
+    assert client._client.api_key == "sk-ant-custom"
+    assert client._client.base_url == "https://proxy.example.com"
+
+
+def test_custom_anthropic_client_keeps_base_url_after_key_rotation(monkeypatch) -> None:
+    """Regression: when _ensure_client() rebuilds the client after a credential
+    rotation, the custom base_url must be re-applied. Before the fix the rebuild
+    constructed a plain Anthropic(api_key=...) and silently dropped the override.
+    """
+    from app.config import LLMSettings
+
+    settings = LLMSettings.model_validate(
+        {
+            "provider": "custom-anthropic",
+            "custom_anthropic_api_key": "sk-ant-key-1",
+            "custom_anthropic_base_url": "https://proxy.example.com",
+            "custom_anthropic_reasoning_model": "claude-proxy-model",
+            "custom_anthropic_classification_model": "claude-proxy-model",
+            "custom_anthropic_toolcall_model": "claude-proxy-model",
+        }
+    )
+    state = {"key": "sk-ant-key-1"}
+    monkeypatch.setattr(llm_client, "resolve_llm_settings", lambda: settings)
+    monkeypatch.setattr(
+        llm_client,
+        "resolve_llm_api_key",
+        lambda env_var: state["key"] if env_var == "CUSTOM_ANTHROPIC_API_KEY" else "",
+    )
+    monkeypatch.setattr(llm_client, "Anthropic", _BaseURLCapturingAnthropic)
+
+    client = llm_client._create_llm_client("reasoning")
+    assert client._client.base_url == "https://proxy.example.com"
+
+    # Rotate the credential so the next _ensure_client() rebuilds the client.
+    state["key"] = "sk-ant-key-2"
+    client._ensure_client()
+
+    assert client._client.api_key == "sk-ant-key-2"  # rebuilt with the rotated key
+    assert client._client.base_url == "https://proxy.example.com"  # override preserved
+
+
 def test_minimax_llm_client_reads_api_key_and_base_url(monkeypatch) -> None:
     monkeypatch.setattr(
         llm_client,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from app.config import LLMSettings, has_credentials_for_active_llm_provider, resolve_llm_settings
+from app.config import (
+    CUSTOM_ANTHROPIC_REASONING_MODEL,
+    CUSTOM_OPENAI_REASONING_MODEL,
+    LLMSettings,
+    has_credentials_for_active_llm_provider,
+    resolve_llm_settings,
+)
 
 
 def test_llm_settings_reject_provider_typos_with_suggestion() -> None:
@@ -19,6 +25,123 @@ def test_llm_settings_reject_provider_typos_with_suggestion() -> None:
 def test_llm_settings_require_api_key_for_selected_provider() -> None:
     with pytest.raises(ValidationError, match="OPENAI_API_KEY"):
         LLMSettings.model_validate({"provider": "openai"})
+
+
+def test_llm_settings_custom_providers_have_no_default_model() -> None:
+    """Custom providers target a BYO endpoint, so they ship no default model — a
+    hard-coded default would silently send an identifier the endpoint does not
+    serve and fail with a confusing model-not-found error."""
+    assert CUSTOM_OPENAI_REASONING_MODEL == ""
+    assert CUSTOM_ANTHROPIC_REASONING_MODEL == ""
+
+
+def test_llm_settings_custom_openai_provider_accepted() -> None:
+    settings = LLMSettings.model_validate(
+        {
+            "provider": "custom-openai",
+            "custom_openai_api_key": "sk-custom-test",
+            "custom_openai_base_url": "https://api.example.com/v1",
+            "custom_openai_reasoning_model": "my-local-model",
+            "custom_openai_classification_model": "my-local-model",
+            "custom_openai_toolcall_model": "my-local-model",
+        }
+    )
+    assert settings.provider == "custom-openai"
+    assert settings.custom_openai_api_key == "sk-custom-test"
+    assert settings.custom_openai_base_url == "https://api.example.com/v1"
+    assert settings.custom_openai_reasoning_model == "my-local-model"
+
+
+def test_llm_settings_require_custom_openai_api_key() -> None:
+    with pytest.raises(ValidationError, match="CUSTOM_OPENAI_API_KEY"):
+        LLMSettings.model_validate({"provider": "custom-openai"})
+
+
+def test_llm_settings_require_custom_openai_base_url() -> None:
+    with pytest.raises(ValidationError, match="CUSTOM_OPENAI_BASE_URL"):
+        LLMSettings.model_validate(
+            {"provider": "custom-openai", "custom_openai_api_key": "sk-custom-test"}
+        )
+
+
+def test_llm_settings_require_custom_openai_model() -> None:
+    with pytest.raises(ValidationError, match="CUSTOM_OPENAI_MODEL"):
+        LLMSettings.model_validate(
+            {
+                "provider": "custom-openai",
+                "custom_openai_api_key": "sk-custom-test",
+                "custom_openai_base_url": "https://api.example.com/v1",
+            }
+        )
+
+
+def test_llm_settings_reject_custom_openai_partial_tier_model() -> None:
+    """A lone per-tier override must not satisfy the model requirement: the
+    classification/toolcall tiers would be left empty and only fail at their
+    first call. Setting CUSTOM_OPENAI_MODEL (which fills every tier) is required."""
+    with pytest.raises(ValidationError, match="CUSTOM_OPENAI_MODEL"):
+        LLMSettings.model_validate(
+            {
+                "provider": "custom-openai",
+                "custom_openai_api_key": "sk-custom-test",
+                "custom_openai_base_url": "https://api.example.com/v1",
+                "custom_openai_reasoning_model": "only-reasoning",
+            }
+        )
+
+
+def test_llm_settings_custom_anthropic_provider_accepted() -> None:
+    settings = LLMSettings.model_validate(
+        {
+            "provider": "custom-anthropic",
+            "custom_anthropic_api_key": "sk-ant-custom",
+            "custom_anthropic_base_url": "https://api.example.com",
+            "custom_anthropic_reasoning_model": "my-proxy-model",
+            "custom_anthropic_classification_model": "my-proxy-model",
+            "custom_anthropic_toolcall_model": "my-proxy-model",
+        }
+    )
+    assert settings.provider == "custom-anthropic"
+    assert settings.custom_anthropic_api_key == "sk-ant-custom"
+    assert settings.custom_anthropic_base_url == "https://api.example.com"
+    assert settings.custom_anthropic_reasoning_model == "my-proxy-model"
+
+
+def test_llm_settings_require_custom_anthropic_api_key() -> None:
+    with pytest.raises(ValidationError, match="CUSTOM_ANTHROPIC_API_KEY"):
+        LLMSettings.model_validate({"provider": "custom-anthropic"})
+
+
+def test_llm_settings_require_custom_anthropic_base_url() -> None:
+    with pytest.raises(ValidationError, match="CUSTOM_ANTHROPIC_BASE_URL"):
+        LLMSettings.model_validate(
+            {"provider": "custom-anthropic", "custom_anthropic_api_key": "sk-ant-custom"}
+        )
+
+
+def test_llm_settings_require_custom_anthropic_model() -> None:
+    with pytest.raises(ValidationError, match="CUSTOM_ANTHROPIC_MODEL"):
+        LLMSettings.model_validate(
+            {
+                "provider": "custom-anthropic",
+                "custom_anthropic_api_key": "sk-ant-custom",
+                "custom_anthropic_base_url": "https://api.example.com",
+            }
+        )
+
+
+def test_llm_settings_reject_custom_anthropic_partial_tier_model() -> None:
+    """A lone per-tier override must not satisfy the model requirement; setting
+    CUSTOM_ANTHROPIC_MODEL (which fills every tier) is required."""
+    with pytest.raises(ValidationError, match="CUSTOM_ANTHROPIC_MODEL"):
+        LLMSettings.model_validate(
+            {
+                "provider": "custom-anthropic",
+                "custom_anthropic_api_key": "sk-ant-custom",
+                "custom_anthropic_base_url": "https://api.example.com",
+                "custom_anthropic_reasoning_model": "only-reasoning",
+            }
+        )
 
 
 def test_llm_settings_from_env_uses_secure_local_api_key(monkeypatch) -> None:


### PR DESCRIPTION
Fixes #2682

#### Describe the changes you have made in this PR -

Adds two new LLM providers — **`custom-openai`** and **`custom-anthropic`** — so OpenSRE can talk to any OpenAI- or Anthropic-compatible endpoint (LiteLLM proxy, vLLM, LocalAI, internal gateways) configured purely through environment variables, with no hard-coded base URL.

**Configuration — `app/config.py`, `.env.example`**
- Registers `custom-openai` / `custom-anthropic` in the `LLMProvider` literal and the settings provider validator.
- Adds API-key env mapping (`CUSTOM_OPENAI_API_KEY`, `CUSTOM_ANTHROPIC_API_KEY`) and base-URL settings (`CUSTOM_*_BASE_URL`).
- These providers point at a bring-your-own endpoint, so there is **no safe default model** — `LLMSettings` validation requires `CUSTOM_*_BASE_URL` **and** `CUSTOM_*_MODEL` (alongside the API key) at settings-load time, so a misconfiguration fails fast with a clear message instead of hitting the endpoint with a model name it doesn't serve. Per-tier `CUSTOM_*_{REASONING,CLASSIFICATION,TOOLCALL}_MODEL` overrides are optional and fall back to `CUSTOM_*_MODEL`.

**Sync client — `app/services/llm_client.py`**
- `custom-openai` reuses `OpenAILLMClient` with the custom `base_url` + key env — the same pattern already used by `openrouter`/`deepseek`/`minimax`.
- `custom-anthropic` builds an `LLMClient` that forwards `base_url` and `api_key_env`. `LLMClient.__init__` / `_ensure_client` now thread these through a small `_build_client` helper so the base-URL override **survives the per-invoke credential refresh** and the correct key env is read. The default Anthropic path is byte-for-byte unchanged (base_url only forwarded when set).

**Agent loop — `app/services/agent_llm_client.py`**
- `custom-openai` joins the existing OpenAI-compatible branch; `custom-anthropic` injects an `Anthropic(base_url=…)` client into `AnthropicAgentClient`.

**Tests — `tests/test_config.py`, `tests/services/test_llm_client.py`**
- Provider acceptance plus base-URL / model / API-key requirement validation for both providers.
- Two regression tests proving the `custom-anthropic` sync client keeps its `base_url` and uses `CUSTOM_ANTHROPIC_API_KEY` (not `ANTHROPIC_API_KEY`) — both after `_ensure_client()` runs on the first invoke and after a credential rotation rebuilds the client.

### Demo/Screenshot for feature changes and bug fixes -

Local checks (per CONTRIBUTING.md):

```
$ make lint
.venv/bin/python -m ruff check app/ tests/
All checks passed!

$ make format-check
.venv/bin/python -m ruff format --check app/ tests/
1564 files already formatted

$ make typecheck
.venv/bin/python -m mypy app/
Success: no issues found in 687 source files

# Tests covering the changed code (config + sync client + agent client)
$ pytest tests/services/test_llm_client.py tests/services/test_agent_llm_client.py tests/test_config.py
178 passed in 0.98s
```

> Note: the full `make test-cov` run additionally exercises `live_llm` / `integration`
> tests (real model calls needing provider credentials such as `ANTHROPIC_API_KEY`) and
> CLI smoke tests that shell out to the installed `opensre` binary. Both are
> environment-gated and unrelated to this change — the smoke failures (e.g. `opensre -h`
> hitting the subprocess timeout) reproduce identically on the clean base commit with none
> of this PR's changes applied. The new providers are fully covered by the unit tests
> above, which all pass.

Example usage:

```bash
# LiteLLM proxy via OpenAI-compatible API
LLM_PROVIDER=custom-openai
CUSTOM_OPENAI_BASE_URL=http://localhost:4000/v1
CUSTOM_OPENAI_API_KEY=your-litellm-key
CUSTOM_OPENAI_MODEL=gpt-5.4

# Anthropic-compatible proxy
LLM_PROVIDER=custom-anthropic
CUSTOM_ANTHROPIC_BASE_URL=https://proxy.example.com
CUSTOM_ANTHROPIC_API_KEY=your-proxy-key
CUSTOM_ANTHROPIC_MODEL=claude-opus-4-7
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: OpenSRE only supports providers with hard-coded base URLs, so teams behind an OpenAI/Anthropic-compatible gateway (LiteLLM, vLLM, internal proxy) can't point it at their own endpoint.

The `custom-openai` side was straightforward — the codebase already constructs `OpenAILLMClient` with a custom `base_url` and `api_key_env` for `openrouter`/`deepseek`/`minimax`, so this provider reuses that path verbatim. Both the sync client and the agent loop's `_create_openai_compat_client` get a branch that reads `CUSTOM_OPENAI_BASE_URL` and `CUSTOM_OPENAI_API_KEY`.

The `custom-anthropic` side needed more care. The agent loop already accepts an injected Anthropic client, so that path just constructs `Anthropic(base_url=…)` and hands it to `AnthropicAgentClient`. The sync `LLMClient`, however, was hard-wired to `ANTHROPIC_API_KEY` and rebuilt its Anthropic client on every invoke inside `_ensure_client()` — so simply overriding the private `_client` attribute would not survive: the first refresh would drop the custom `base_url` and demand `ANTHROPIC_API_KEY`. I considered keeping the override hack, but it's fragile and reaches into private state. Instead I gave `LLMClient` first-class `base_url` and `api_key_env` parameters (mirroring `OpenAILLMClient`) and routed both the initial build and the refresh through a `_build_client` helper, so the override is durable and the correct key env is used. `base_url` is only forwarded to the SDK when set, keeping the default Anthropic path identical. A regression test pins this behavior (it would have raised `Missing ANTHROPIC_API_KEY` before the change).

On configuration: because a custom endpoint can serve arbitrary model names, there is no sensible default model — so rather than ship a placeholder that 404s on first use, the per-provider model constants default to empty and `LLMSettings` validation requires `CUSTOM_*_BASE_URL` and `CUSTOM_*_MODEL` up front, surfacing misconfiguration at load time. The provider branches then assume a validated endpoint, which also removes the redundant per-branch base-URL/key checks.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---
