### PR TITLE
feat(bench): Uploading bench dataset into S3, not downloading in CI

### DIFF
--- a/.github/workflows/benchmark-image.yml
+++ b/.github/workflows/benchmark-image.yml
@@ -1,8 +1,12 @@
-name: bench (build + push image)
+name: Benchmark image — build + push to ECR
 
-# Builds infra/bench/Dockerfile.bench and pushes the resulting image to ECR. Triggered
-# automatically on changes to the bench code (or the Dockerfile itself) and
-# manually via workflow_dispatch.
+# Builds infra/bench/Dockerfile.bench and pushes the resulting image to the
+# opensre-bench ECR repository. The bench container is what
+# `Benchmark run (manual)` invokes on AWS Fargate, so this workflow's
+# output is the input to that one.
+#
+# Triggered automatically on changes to the bench code (or the Dockerfile
+# itself) and manually via workflow_dispatch.
 #
 # After the image is pushed, update the task definition by re-applying the
 # Terraform with the new tag:

--- a/.github/workflows/benchmark-run.yml
+++ b/.github/workflows/benchmark-run.yml
@@ -1,16 +1,34 @@
-name: Benchmark run (manual)
+name: Benchmark — run on Fargate
 
-# Manually-triggered benchmark run. Costs real money — caller picks the
-# config and dev_mode flag. Never auto-triggered.
+# Manually-triggered benchmark run on AWS Fargate.
+#
+# Why ECS RunTask instead of running on a GitHub-hosted ubuntu runner:
+# a full Cloud-OpsBench grid runs for hours and writes hundreds of MB of
+# artifacts — Fargate handles it cleanly, has the AWS Secrets Manager
+# entries already wired in via infra/bench/, and writes to the
+# per-run S3 bucket. The workflow's job is just to launch the task and
+# print where to watch.
 #
 # Trigger from the GitHub UI:
 #   Actions → "Benchmark run (manual)" → Run workflow → fill inputs
+#
+# Pre-reqs (one-time, see infra/bench/README.md):
+#   - infra/bench/ Terraform applied
+#   - Bench image pushed to ECR via benchmark-image.yml
+#   - Repo secrets seeded into AWS Secrets Manager via benchmark-seed-secret.yml
+#   - Repo variables set:
+#       AWS_ACCOUNT_ID, BENCH_ECS_CLUSTER, BENCH_TASK_DEFINITION_FAMILY,
+#       BENCH_SUBNET_IDS (comma-separated), BENCH_SECURITY_GROUP_ID
 
 on:
   workflow_dispatch:
     inputs:
+      image_tag:
+        description: 'ECR image tag to run (default = latest)'
+        required: true
+        default: 'latest'
       config:
-        description: 'Path to YAML config'
+        description: 'Path to YAML config inside the container'
         required: true
         default: 'tests/benchmarks/configs/example.yml'
       dev_mode:
@@ -20,55 +38,116 @@ on:
 
 permissions:
   contents: read
+  id-token: write           # required for AWS OIDC role assumption
+
+concurrency:
+  group: benchmark-run
+  cancel-in-progress: false
 
 jobs:
-  run:
+  launch:
+    name: launch ECS task
+    if: github.repository == 'Tracer-Cloud/opensre'
     runs-on: ubuntu-latest
-    timeout-minutes: 360
+    timeout-minutes: 15     # we only LAUNCH the task; we don't wait for it
+
+    env:
+      AWS_REGION: us-east-1
+
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+      - name: Configure AWS credentials (OIDC role assumption)
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/opensre-bench-github-actions
+          role-session-name: bench-run-${{ github.run_id }}
+          aws-region: us-east-1
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: uv sync --frozen --extra dev
-
-      - name: Download Cloud-OpsBench corpus
-        run: make download-cloudopsbench-hf
-
-      - name: Run benchmark
+      - name: Verify image tag exists in ECR
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-          # Bind workflow inputs to env vars rather than interpolating them
-          # directly into the run: script. GitHub Actions expands ${{ ... }}
-          # at YAML-parse time (before the shell sees it), so a malicious
-          # value like ``foo.yml"; rm -rf / "`` would inject shell commands.
-          # Env-var expansion happens inside the shell, which respects the
-          # double-quote around "$CONFIG_PATH".
-          CONFIG_PATH: ${{ inputs.config }}
-          DEV_FLAG: ${{ inputs.dev_mode == true && '--dev' || '' }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
-          uv run python -m tests.benchmarks._framework.cli run \
-            "$CONFIG_PATH" \
-            $DEV_FLAG
+          if ! aws ecr describe-images \
+                --repository-name opensre-bench \
+                --image-ids imageTag="$IMAGE_TAG" \
+                >/dev/null 2>&1; then
+            echo "::error::Image tag $IMAGE_TAG not found in ECR repo opensre-bench."
+            echo "::error::Push it via the 'bench (build + push image)' workflow first."
+            exit 1
+          fi
 
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: bench-results-${{ github.run_id }}
-          path: .bench-results/
-          retention-days: 30
+      - name: Launch ECS RunTask
+        # Inputs bound to env vars so the shell does the interpolation —
+        # GitHub Actions template syntax (${{ ... }}) is expanded before
+        # the shell sees it, which would let a crafted input inject shell
+        # metacharacters. Env vars are quoted at use-site.
+        env:
+          BENCH_CONFIG: ${{ inputs.config }}
+          BENCH_DEV_FLAG: ${{ inputs.dev_mode == true && '--dev' || '' }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          CLUSTER: ${{ vars.BENCH_ECS_CLUSTER }}
+          TASK_FAMILY: ${{ vars.BENCH_TASK_DEFINITION_FAMILY }}
+          SUBNETS: ${{ vars.BENCH_SUBNET_IDS }}
+          SECURITY_GROUP: ${{ vars.BENCH_SECURITY_GROUP_ID }}
+        run: |
+          set -euo pipefail
+
+          # Overrides JSON: container env vars passed at runtime. The
+          # container's entrypoint reads BENCH_CONFIG + BENCH_DEV_FLAG
+          # and invokes:
+          #   uv run python -m tests.benchmarks._framework.cli run \
+          #     "$BENCH_CONFIG" $BENCH_DEV_FLAG
+          OVERRIDES=$(jq -nc \
+            --arg config "$BENCH_CONFIG" \
+            --arg dev_flag "$BENCH_DEV_FLAG" \
+            --arg image_tag "$IMAGE_TAG" \
+            '{
+              containerOverrides: [{
+                name: "bench",
+                environment: [
+                  {name: "BENCH_CONFIG", value: $config},
+                  {name: "BENCH_DEV_FLAG", value: $dev_flag},
+                  {name: "BENCH_IMAGE_TAG", value: $image_tag}
+                ]
+              }]
+            }')
+
+          TASK_ARN=$(aws ecs run-task \
+            --cluster "$CLUSTER" \
+            --task-definition "$TASK_FAMILY" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SECURITY_GROUP],assignPublicIp=ENABLED}" \
+            --overrides "$OVERRIDES" \
+            --query 'tasks[0].taskArn' \
+            --output text)
+
+          if [ -z "$TASK_ARN" ] || [ "$TASK_ARN" = "None" ]; then
+            echo "::error::run-task returned no taskArn"
+            exit 1
+          fi
+
+          TASK_ID="${TASK_ARN##*/}"
+          echo "task_arn=$TASK_ARN" >> "$GITHUB_OUTPUT"
+          echo "task_id=$TASK_ID" >> "$GITHUB_OUTPUT"
+
+          # Job summary — visible in the workflow run page
+          {
+            echo "## Bench run launched"
+            echo ""
+            echo "- Image tag: \`$IMAGE_TAG\`"
+            echo "- Config: \`$BENCH_CONFIG\`"
+            echo "- Dev mode: \`${BENCH_DEV_FLAG:-(off)}\`"
+            echo "- Task ARN: \`$TASK_ARN\`"
+            echo ""
+            echo "### Watch it"
+            echo ""
+            echo "Stream logs locally:"
+            echo ""
+            echo '```bash'
+            echo "aws logs tail /ecs/opensre-bench --follow"
+            echo '```'
+            echo ""
+            echo "Or via AWS Console:"
+            echo "https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/$CLUSTER/tasks/$TASK_ID"
+            echo ""
+            echo "Artifacts land in the bench S3 bucket under \`runs/\` when the task completes."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/benchmark-run.yml
+++ b/.github/workflows/benchmark-run.yml
@@ -23,10 +23,6 @@ name: Benchmark — run on Fargate
 on:
   workflow_dispatch:
     inputs:
-      image_tag:
-        description: 'ECR image tag to run (default = latest)'
-        required: true
-        default: 'latest'
       config:
         description: 'Path to YAML config inside the container'
         required: true
@@ -35,6 +31,15 @@ on:
         description: 'Dev mode (skip integrity gates, no pre-reg needed)'
         type: boolean
         default: true
+
+# Note: there is intentionally no `image_tag` input here. ECS RunTask
+# container overrides do NOT support overriding the image URI — that lives
+# on the task definition itself. The image actually pulled is whatever
+# was registered the last time `terraform apply -var=image_tag=<tag>` ran
+# in infra/bench/. Adding a workflow input here would silently mislead
+# operators into thinking they control the image per run. To change the
+# image, push it via `Benchmark image — build + push to ECR`, then re-apply
+# Terraform with the new tag.
 
 permissions:
   contents: read
@@ -62,19 +67,6 @@ jobs:
           role-session-name: bench-run-${{ github.run_id }}
           aws-region: us-east-1
 
-      - name: Verify image tag exists in ECR
-        env:
-          IMAGE_TAG: ${{ inputs.image_tag }}
-        run: |
-          if ! aws ecr describe-images \
-                --repository-name opensre-bench \
-                --image-ids imageTag="$IMAGE_TAG" \
-                >/dev/null 2>&1; then
-            echo "::error::Image tag $IMAGE_TAG not found in ECR repo opensre-bench."
-            echo "::error::Push it via the 'bench (build + push image)' workflow first."
-            exit 1
-          fi
-
       - name: Launch ECS RunTask
         # Inputs bound to env vars so the shell does the interpolation —
         # GitHub Actions template syntax (${{ ... }}) is expanded before
@@ -83,13 +75,19 @@ jobs:
         env:
           BENCH_CONFIG: ${{ inputs.config }}
           BENCH_DEV_FLAG: ${{ inputs.dev_mode == true && '--dev' || '' }}
-          IMAGE_TAG: ${{ inputs.image_tag }}
           CLUSTER: ${{ vars.BENCH_ECS_CLUSTER }}
           TASK_FAMILY: ${{ vars.BENCH_TASK_DEFINITION_FAMILY }}
           SUBNETS: ${{ vars.BENCH_SUBNET_IDS }}
           SECURITY_GROUP: ${{ vars.BENCH_SECURITY_GROUP_ID }}
         run: |
           set -euo pipefail
+
+          # Surface the image the task definition will actually pull, so
+          # operators see the truth (not a workflow input that ECS ignores).
+          IMAGE_URI=$(aws ecs describe-task-definition \
+            --task-definition "$TASK_FAMILY" \
+            --query 'taskDefinition.containerDefinitions[0].image' \
+            --output text)
 
           # Overrides JSON: container env vars passed at runtime. The
           # container's entrypoint reads BENCH_CONFIG + BENCH_DEV_FLAG
@@ -99,14 +97,12 @@ jobs:
           OVERRIDES=$(jq -nc \
             --arg config "$BENCH_CONFIG" \
             --arg dev_flag "$BENCH_DEV_FLAG" \
-            --arg image_tag "$IMAGE_TAG" \
             '{
               containerOverrides: [{
                 name: "bench",
                 environment: [
                   {name: "BENCH_CONFIG", value: $config},
-                  {name: "BENCH_DEV_FLAG", value: $dev_flag},
-                  {name: "BENCH_IMAGE_TAG", value: $image_tag}
+                  {name: "BENCH_DEV_FLAG", value: $dev_flag}
                 ]
               }]
             }')
@@ -133,7 +129,7 @@ jobs:
           {
             echo "## Bench run launched"
             echo ""
-            echo "- Image tag: \`$IMAGE_TAG\`"
+            echo "- Image (from task definition): \`$IMAGE_URI\`"
             echo "- Config: \`$BENCH_CONFIG\`"
             echo "- Dev mode: \`${BENCH_DEV_FLAG:-(off)}\`"
             echo "- Task ARN: \`$TASK_ARN\`"
@@ -150,4 +146,6 @@ jobs:
             echo "https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/$CLUSTER/tasks/$TASK_ID"
             echo ""
             echo "Artifacts land in the bench S3 bucket under \`runs/\` when the task completes."
+            echo ""
+            echo "_To change the running image: push a new tag via \`Benchmark image — build + push to ECR\`, then \`cd infra/bench && terraform apply -var=image_tag=<tag>\`._"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/benchmark-seed-secret.yml
+++ b/.github/workflows/benchmark-seed-secret.yml
@@ -1,10 +1,13 @@
-name: bench (seed secret)
+name: Benchmark secret — seed GitHub repo secret into AWS Secrets Manager
 
 # Manually-triggered workflow that copies a GitHub repo secret into AWS
-# Secrets Manager at opensre-bench/llm/<secret>. The `secret` dropdown
-# enforces which target is valid — must match one of the four IAM-granted
-# secret ARNs in infra/bench/iam_oidc.tf (anthropic / openai / deepseek /
-# hf_token).
+# Secrets Manager at opensre-bench/llm/<secret>. The bench container reads
+# its LLM API keys from Secrets Manager at runtime; this workflow is how
+# you put them there without touching a developer laptop.
+#
+# The `secret` dropdown enforces which target is valid — must match one
+# of the four IAM-granted secret ARNs in infra/bench/iam_oidc.tf
+# (anthropic / openai / deepseek / hf_token).
 #
 # Why a workflow instead of a developer running `aws secretsmanager
 # put-secret-value` locally: keeps keys off developer laptops + out of

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include .env
 export
 
-.PHONY: install onboard benchmark benchmark-update-readme test test-full demo alert-template investigate-alert opensre-hub-fetch opensre-hub-export opensre-hub-investigate verify-integrations check-docker grafana-local-up grafana-local-down grafana-local-seed clean lint format deploy deploy-lambda deploy-prefect deploy-flink destroy destroy-lambda destroy-prefect destroy-flink prefect-local-test simulate-k8s-alert test-k8s-local test-k8s test-k8s-datadog chaos-mesh-up chaos-mesh-down chaos-engineering-apply chaos-engineering-delete chaos-lab-up chaos-lab-down chaos-experiment-list chaos-experiment-up chaos-experiment-down deploy-dd-monitors cleanup-dd-monitors deploy-eks destroy-eks test-k8s-eks datadog-demo crashloop-demo regen-trigger-config test-rca test-rca-grafana test-synthetic test-rds-synthetic test-cli-smoke deploy-vercel destroy-vercel test-vercel deploy-ec2 destroy-ec2 test-ec2 deploy-ec2-hello destroy-ec2-hello deploy-remote destroy-remote deploy-bedrock destroy-bedrock test-bedrock download-cloudopsbench-hf validate-cloudopsbench test-openclaw test-openclaw-synthetic test-hermes test-hermes-synthetic
+.PHONY: install onboard benchmark benchmark-update-readme test test-full demo alert-template investigate-alert opensre-hub-fetch opensre-hub-export opensre-hub-investigate verify-integrations check-docker grafana-local-up grafana-local-down grafana-local-seed clean lint format deploy deploy-lambda deploy-prefect deploy-flink destroy destroy-lambda destroy-prefect destroy-flink prefect-local-test simulate-k8s-alert test-k8s-local test-k8s test-k8s-datadog chaos-mesh-up chaos-mesh-down chaos-engineering-apply chaos-engineering-delete chaos-lab-up chaos-lab-down chaos-experiment-list chaos-experiment-up chaos-experiment-down deploy-dd-monitors cleanup-dd-monitors deploy-eks destroy-eks test-k8s-eks datadog-demo crashloop-demo regen-trigger-config test-rca test-rca-grafana test-synthetic test-rds-synthetic test-cli-smoke deploy-vercel destroy-vercel test-vercel deploy-ec2 destroy-ec2 test-ec2 deploy-ec2-hello destroy-ec2-hello deploy-remote destroy-remote deploy-bedrock destroy-bedrock test-bedrock download-cloudopsbench-hf mirror-cloudopsbench-s3 validate-cloudopsbench test-openclaw test-openclaw-synthetic test-hermes test-hermes-synthetic
 
 
 ifneq ($(wildcard .venv/bin/python),)
@@ -75,6 +75,18 @@ CLOUDOPSBENCH_BENCHMARK_DIR ?= $(CLOUDOPSBENCH_DATASET_DIR)/benchmark
 CLOUDOPSBENCH_HF_INCLUDE ?= benchmark/**
 CLOUDOPSBENCH_LIMIT ?=
 
+# S3 mirror of the CloudOpsBench corpus from
+# https://huggingface.co/datasets/tracer-cloud/cloud-ops-bench-dataset.
+# The Fargate bench task reads the corpus from S3 at startup (faster
+# than HF, no rate limits, no HF_TOKEN at runtime).
+#
+# Suggested bucket name: cloud-ops-bench-dataset (matches the HF name).
+# S3 bucket names are GLOBALLY unique — if cloud-ops-bench-dataset is
+# already taken, fall back to a variant like
+# tracer-cloud-cloud-ops-bench-dataset or opensre-bench-corpus.
+BENCH_S3_BUCKET ?= cloud-ops-bench-dataset
+BENCH_S3_PREFIX ?=
+
 opensre-hub-fetch:
 	$(PYTHON) infra/opensre-dataset/fetch_opensre_hub_alert.py --prefix "$(OPENSRE_QUERY_PREFIX)" --output "$(OPENSRE_HUB_ALERT)" --index $(OPENSRE_HUB_INDEX)
 
@@ -142,7 +154,40 @@ test-cloudopsbench:
 # Download Cloud-OpsBench benchmark data from Hugging Face.
 download-cloudopsbench-hf:
 	@command -v hf >/dev/null 2>&1 || { echo "Install the Hugging Face CLI with: pip install 'huggingface_hub[cli]'"; exit 1; }
+	@if [ -z "$$HF_TOKEN" ]; then \
+	  echo "  ⚠ HF_TOKEN not set — falling back to anonymous HF access (~60 req/min limit; expect 429 retries on this dataset)."; \
+	  echo "  Tip: export HF_TOKEN=hf_... (or set the GH repo secret) to get ~1000 req/min and a ~3x speedup."; \
+	fi
 	hf download "$(CLOUDOPSBENCH_HF_DATASET_ID)" --repo-type dataset --local-dir "$(CLOUDOPSBENCH_DATASET_DIR)" --include "$(CLOUDOPSBENCH_HF_INCLUDE)"
+
+# Mirror the locally-downloaded corpus to S3, keyed by HF revision SHA.
+# Run this once at setup + again whenever the upstream HF dataset is
+# revised. The Fargate bench task pulls from this S3 prefix at startup
+# instead of re-downloading from HF every time.
+#
+# Pre-req:
+#   - aws CLI configured (`aws sts get-caller-identity` works)
+#   - `make download-cloudopsbench-hf` has been run at least once
+#   - BENCH_S3_BUCKET is set (from `cd infra/bench && terraform output -raw results_bucket_name`)
+mirror-cloudopsbench-s3: download-cloudopsbench-hf
+	@command -v aws >/dev/null 2>&1 || { echo "Install AWS CLI: https://aws.amazon.com/cli/"; exit 1; }
+	@if [ -z "$(BENCH_S3_BUCKET)" ]; then \
+	  echo "  ✗ BENCH_S3_BUCKET is not set. Get the value with:"; \
+	  echo "      cd infra/bench && terraform output -raw results_bucket_name"; \
+	  echo "  Then re-run:  BENCH_S3_BUCKET=<value> make mirror-cloudopsbench-s3"; \
+	  exit 1; \
+	fi
+	@if [ ! -d "$(CLOUDOPSBENCH_BENCHMARK_DIR)" ]; then \
+	  echo "  ✗ $(CLOUDOPSBENCH_BENCHMARK_DIR) not found — run 'make download-cloudopsbench-hf' first."; \
+	  exit 1; \
+	fi
+	@HF_REV=$$($(PYTHON) -c "from huggingface_hub import HfApi; print(HfApi().dataset_info('$(CLOUDOPSBENCH_HF_DATASET_ID)').sha)") && \
+	  PREFIX="$(BENCH_S3_PREFIX)" && \
+	  DEST="s3://$(BENCH_S3_BUCKET)$${PREFIX:+/$$PREFIX}/$$HF_REV/" && \
+	  echo "  → Pinning to HF revision: $$HF_REV" && \
+	  echo "  → Syncing to $$DEST" && \
+	  aws s3 sync "$(CLOUDOPSBENCH_BENCHMARK_DIR)/" "$$DEST" --no-progress && \
+	  echo "  ✓ Mirror complete. Pin BENCH_CORPUS_HF_REVISION=$$HF_REV in the Fargate task definition."
 
 validate-cloudopsbench:
 	$(PYTHON) -m tests.benchmarks.cloudopsbench.run_suite --benchmark-dir "$(CLOUDOPSBENCH_BENCHMARK_DIR)" --validate-only
@@ -562,6 +607,7 @@ help:
 	@echo "  make test-hermes     - Run Hermes synthetic + e2e suites"
 	@echo "  make test-hermes-synthetic - Run Hermes RCA synthetic suite only (no-key deterministic path)"
 	@echo "  make download-cloudopsbench-hf - Download Cloud-OpsBench from Hugging Face"
+	@echo "  make mirror-cloudopsbench-s3   - Mirror Cloud-OpsBench to S3 (set BENCH_S3_BUCKET)"
 	@echo "  make test-cloudopsbench - Run the Cloud-OpsBench synthetic RCA suite"
 	@echo "  make clean           - Clean up cache files"
 	@echo "  make lint            - Lint code with ruff"

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ CLOUDOPSBENCH_LIMIT ?=
 # already taken, fall back to a variant like
 # tracer-cloud-cloud-ops-bench-dataset or opensre-bench-corpus.
 BENCH_S3_BUCKET ?= cloud-ops-bench-dataset
-BENCH_S3_PREFIX ?=
 
 opensre-hub-fetch:
 	$(PYTHON) infra/opensre-dataset/fetch_opensre_hub_alert.py --prefix "$(OPENSRE_QUERY_PREFIX)" --output "$(OPENSRE_HUB_ALERT)" --index $(OPENSRE_HUB_INDEX)
@@ -182,8 +181,7 @@ mirror-cloudopsbench-s3: download-cloudopsbench-hf
 	  exit 1; \
 	fi
 	@HF_REV=$$($(PYTHON) -c "from huggingface_hub import HfApi; print(HfApi().dataset_info('$(CLOUDOPSBENCH_HF_DATASET_ID)').sha)") && \
-	  PREFIX="$(BENCH_S3_PREFIX)" && \
-	  DEST="s3://$(BENCH_S3_BUCKET)$${PREFIX:+/$$PREFIX}/$$HF_REV/" && \
+	  DEST="s3://$(BENCH_S3_BUCKET)/$$HF_REV/" && \
 	  echo "  → Pinning to HF revision: $$HF_REV" && \
 	  echo "  → Syncing to $$DEST" && \
 	  aws s3 sync "$(CLOUDOPSBENCH_BENCHMARK_DIR)/" "$$DEST" --no-progress && \

--- a/infra/bench/Dockerfile.bench
+++ b/infra/bench/Dockerfile.bench
@@ -87,18 +87,27 @@ RUN apt-get update \
     && apt-get -y upgrade \
     && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir 'awscli==1.34.6'
+    && pip install --no-cache-dir 'awscli==1.45.19'
+
+# Non-root user for the bench process
+# beyond `bench`'s home. UID 10001 is well above any system UID range.
+RUN groupadd --system --gid 10001 bench \
+    && useradd --system --uid 10001 --gid 10001 --home-dir /app --shell /usr/sbin/nologin bench
 
 # Copy the prepared venv + source from the builder stage in one go.
 # The venv at /app/.venv has the project installed and all deps available.
 # PATH (set above) makes /app/.venv/bin take precedence over system python.
-COPY --from=builder /app /app
+# --chown so the bench user can write to /app at runtime (entrypoint.sh
+# writes the corpus under tests/benchmarks/cloudopsbench/benchmark/).
+COPY --from=builder --chown=bench:bench /app /app
 
 # Entrypoint wrapper: pulls the corpus from S3 before invoking the bench
 # CLI. Required env (set by the ECS task definition):
 #   BENCH_CORPUS_S3_BUCKET, BENCH_CORPUS_HF_REVISION
-COPY infra/bench/entrypoint.sh /app/entrypoint.sh
+COPY --chown=bench:bench infra/bench/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
+
+USER bench
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 

--- a/infra/bench/Dockerfile.bench
+++ b/infra/bench/Dockerfile.bench
@@ -75,28 +75,33 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-# Runtime deps: only ca-certificates (for TLS to LLM provider APIs +
-# Hugging Face Hub API calls). No build-essential, no curl, no compilers.
+# Runtime deps: ca-certificates (for TLS to LLM provider APIs) + awscli
+# (the entrypoint pulls the Cloud-OpsBench corpus from S3 at task startup —
+# see entrypoint.sh). No build-essential, no curl, no compilers.
 # `apt-get upgrade` pulls latest patched base-image packages (libcap2,
 # libsystemd0, etc.) -- same reason as in the builder stage.
+#
+# awscli is installed via pip (small, single Python tool) rather than apt
+# or the v2 binary bundle (which adds ~80 MB). Pinned for reproducibility.
 RUN apt-get update \
     && apt-get -y upgrade \
     && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-# Hugging Face Hub is consumed via HTTPS API per call -- no local dataset
-# cache baked into the image. If a task needs to control HF cache location
-# at runtime, set HF_HOME via the ECS task definition env, not here.
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir 'awscli==1.34.6'
 
 # Copy the prepared venv + source from the builder stage in one go.
 # The venv at /app/.venv has the project installed and all deps available.
 # PATH (set above) makes /app/.venv/bin take precedence over system python.
 COPY --from=builder /app /app
 
-# Bench framework CLI lives at tests/benchmarks/_framework/cli.py.
-# Invoke via the venv's python directly (PATH = /app/.venv/bin first).
-ENTRYPOINT ["python", "-m", "tests.benchmarks._framework.cli"]
+# Entrypoint wrapper: pulls the corpus from S3 before invoking the bench
+# CLI. Required env (set by the ECS task definition):
+#   BENCH_CORPUS_S3_BUCKET, BENCH_CORPUS_HF_REVISION
+COPY infra/bench/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
-# Default args - show CLI help if no subcommand passed. Override via ECS
-# task `command` for actual runs.
+ENTRYPOINT ["/app/entrypoint.sh"]
+
+# Default args passed to the bench CLI -- show CLI help if no subcommand
+# passed. Override via ECS task `command` for actual runs.
 CMD ["--help"]

--- a/infra/bench/entrypoint.sh
+++ b/infra/bench/entrypoint.sh
@@ -37,7 +37,20 @@ aws s3 sync \
   --no-progress \
   --region "${AWS_REGION:-us-east-1}"
 END=$(date +%s)
-echo "→ Corpus ready in $((END - START))s ($(find "$CORPUS_DEST" -type f | wc -l) files)"
+
+# `aws s3 sync` exits 0 even when the source prefix is empty or absent —
+# without an explicit count check, the bench CLI would then start against
+# an empty corpus and fail with a confusing "case not found" downstream
+# error. Fail loudly here with a precise diagnostic instead.
+CORPUS_FILE_COUNT=$(find "$CORPUS_DEST" -type f | wc -l | tr -d ' ')
+echo "→ Corpus ready in $((END - START))s (${CORPUS_FILE_COUNT} files)"
+
+if [ "$CORPUS_FILE_COUNT" -eq 0 ]; then
+  echo "FATAL: s3://${CORPUS_BUCKET}/${CORPUS_REV}/ contained no files." >&2
+  echo "Run \`HF_TOKEN=... make mirror-cloudopsbench-s3\` from a developer machine" >&2
+  echo "with BENCH_S3_BUCKET=${CORPUS_BUCKET} to seed this revision." >&2
+  exit 1
+fi
 
 echo "→ Invoking bench CLI: python -m tests.benchmarks._framework.cli $*"
 exec python -m tests.benchmarks._framework.cli "$@"

--- a/infra/bench/entrypoint.sh
+++ b/infra/bench/entrypoint.sh
@@ -52,5 +52,27 @@ if [ "$CORPUS_FILE_COUNT" -eq 0 ]; then
   exit 1
 fi
 
-echo "→ Invoking bench CLI: python -m tests.benchmarks._framework.cli $*"
+# Bench CLI invocation has two valid shapes:
+#
+#   1. ECS RunTask (production path) — the workflow injects BENCH_CONFIG +
+#      BENCH_DEV_FLAG as containerOverrides env vars. The Dockerfile CMD
+#      ["--help"] is left in place, so "$@" would be just "--help" — not
+#      what we want. We construct the real invocation from the env vars
+#      and the bench framework's CLI subcommand schema.
+#
+#   2. Local `docker run` (developer path) — the operator passes
+#      positional args directly (e.g. `docker run … run /cfg.yml --dev`).
+#      BENCH_CONFIG is unset, so we fall through to "$@".
+#
+# Without this branch the env-var path silently runs `--help` and exits 0,
+# leaving the workflow green and the operator confused about why no bench
+# happened.
+if [ -n "${BENCH_CONFIG:-}" ]; then
+  echo "→ Invoking bench CLI from env: cli run ${BENCH_CONFIG} ${BENCH_DEV_FLAG:-}"
+  # BENCH_DEV_FLAG is either '--dev' or '' — left unquoted so empty value
+  # expands to no arg at all (vs an empty-string positional).
+  exec python -m tests.benchmarks._framework.cli run "$BENCH_CONFIG" ${BENCH_DEV_FLAG:-}
+fi
+
+echo "→ Invoking bench CLI from CMD/args: python -m tests.benchmarks._framework.cli $*"
 exec python -m tests.benchmarks._framework.cli "$@"

--- a/infra/bench/entrypoint.sh
+++ b/infra/bench/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Bench Fargate task entrypoint — pull the corpus from S3 then exec the CLI.
+#
+# Why this exists: the bench Docker image deliberately does NOT bake the
+# Cloud-OpsBench corpus into the image. Coupling image rebuilds to dataset
+# revisions would slow every push and bloat the image by ~3 GB. Instead we
+# mirror the corpus into S3 once per HF revision and pull it at task
+# startup — fast (~30 s same-region S3 sync vs ~10 min HF rate-limited
+# download), no HF_TOKEN needed at runtime, and the revision pin in
+# BENCH_CORPUS_HF_REVISION matches what provenance.json records for
+# reproducibility.
+#
+# Required env (set by the ECS task definition):
+#   BENCH_CORPUS_S3_BUCKET   — bucket holding the mirror
+#   BENCH_CORPUS_HF_REVISION — HF commit SHA used as the S3 path prefix
+
+set -euo pipefail
+
+CORPUS_BUCKET="${BENCH_CORPUS_S3_BUCKET:-}"
+CORPUS_REV="${BENCH_CORPUS_HF_REVISION:-}"
+
+if [ -z "$CORPUS_BUCKET" ] || [ -z "$CORPUS_REV" ]; then
+  echo "FATAL: BENCH_CORPUS_S3_BUCKET and BENCH_CORPUS_HF_REVISION must be set in the task definition." >&2
+  exit 1
+fi
+
+# The CloudOpsBench adapter reads from tests/benchmarks/cloudopsbench/benchmark/
+# (relative to the working dir baked into the image).
+CORPUS_DEST="tests/benchmarks/cloudopsbench/benchmark"
+mkdir -p "$CORPUS_DEST"
+
+echo "→ Pulling corpus from s3://${CORPUS_BUCKET}/${CORPUS_REV}/ to ${CORPUS_DEST}"
+START=$(date +%s)
+aws s3 sync \
+  "s3://${CORPUS_BUCKET}/${CORPUS_REV}/" \
+  "$CORPUS_DEST" \
+  --no-progress \
+  --region "${AWS_REGION:-us-east-1}"
+END=$(date +%s)
+echo "→ Corpus ready in $((END - START))s ($(find "$CORPUS_DEST" -type f | wc -l) files)"
+
+echo "→ Invoking bench CLI: python -m tests.benchmarks._framework.cli $*"
+exec python -m tests.benchmarks._framework.cli "$@"

--- a/infra/bench/fargate.tf
+++ b/infra/bench/fargate.tf
@@ -90,6 +90,9 @@ resource "aws_ecs_task_definition" "bench" {
       environment = [
         { name = "AWS_REGION", value = var.region },
         { name = "BENCH_RESULTS_BUCKET", value = aws_s3_bucket.results.bucket },
+        # entrypoint.sh reads these two and runs `aws s3 sync` before the CLI
+        { name = "BENCH_CORPUS_S3_BUCKET", value = var.corpus_bucket_name },
+        { name = "BENCH_CORPUS_HF_REVISION", value = var.corpus_hf_revision },
         { name = "DEEPSEEK_BASE_URL", value = "https://api.deepseek.com" },
       ]
 

--- a/infra/bench/iam_task.tf
+++ b/infra/bench/iam_task.tf
@@ -73,3 +73,32 @@ resource "aws_iam_role_policy" "task_results_rw" {
   role   = aws_iam_role.task.id
   policy = data.aws_iam_policy_document.task_results_rw.json
 }
+
+# Read-only access to the corpus mirror bucket. The entrypoint runs
+# `aws s3 sync` against s3://<corpus_bucket>/<corpus_hf_revision>/ at task
+# startup. Read-only is enough — the corpus is populated out-of-band by
+# `make mirror-cloudopsbench-s3` from a developer machine.
+#
+# Bucket-scoped, not account-scoped, so a future bucket addition would
+# require an explicit Terraform diff.
+data "aws_iam_policy_document" "task_corpus_read" {
+  statement {
+    sid       = "ReadCorpusObjects"
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::${var.corpus_bucket_name}/*"]
+  }
+
+  statement {
+    sid       = "ListCorpusBucket"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket", "s3:GetBucketLocation"]
+    resources = ["arn:aws:s3:::${var.corpus_bucket_name}"]
+  }
+}
+
+resource "aws_iam_role_policy" "task_corpus_read" {
+  name   = "corpus-read"
+  role   = aws_iam_role.task.id
+  policy = data.aws_iam_policy_document.task_corpus_read.json
+}

--- a/infra/bench/s3.tf
+++ b/infra/bench/s3.tf
@@ -42,3 +42,47 @@ resource "aws_s3_bucket_public_access_block" "results" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+# Lifecycle policy — versioning is ON for safety (accidental overwrite of a
+# published run can be recovered) but old versions otherwise accumulate
+# forever. Two rules:
+#
+#   1. Expire noncurrent (overwritten / deleted) versions after 90 days.
+#      The 90-day window is long enough for a real "oops we need to
+#      restore" to be noticed; after that, the cost of keeping every
+#      historical version outweighs the recovery value.
+#
+#   2. Abort incomplete multipart uploads after 1 day. Failed large
+#      uploads leave orphaned multipart parts that are billed for
+#      storage but invisible in the console.
+#
+# Current-version objects are NEVER expired — published bench artifacts
+# stay forever, matching the pre-registration's reproducibility promise.
+resource "aws_s3_bucket_lifecycle_configuration" "results" {
+  bucket = aws_s3_bucket.results.id
+
+  rule {
+    id     = "expire-noncurrent-versions-after-90-days"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+  }
+
+  rule {
+    id     = "abort-incomplete-multipart-uploads-after-1-day"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+
+  # Lifecycle configuration requires versioning to already be configured.
+  depends_on = [aws_s3_bucket_versioning.results]
+}

--- a/infra/bench/variables.tf
+++ b/infra/bench/variables.tf
@@ -29,15 +29,27 @@ variable "log_retention_days" {
 }
 
 variable "task_cpu" {
-  description = "Fargate task vCPU units. 4096 = 4 vCPU. Bench is API-bound, not CPU-bound; this is sized for parallel async, not throughput."
+  description = "Fargate task vCPU units. 2048 = 2 vCPU. Bench is API-bound (waits on LLM responses), not CPU-bound — 2 vCPU is sufficient for parallel async dispatch and roughly halves the per-run Fargate cost vs 4 vCPU. Bump to 4096 if you observe sustained 100% CPU in CloudWatch metrics."
+  type        = string
+  default     = "2048"
+}
+
+variable "task_memory" {
+  description = "Fargate task memory in MiB. 4096 = 4 GiB. State Snapshot data (~500 MB corpus on disk) + per-cell async state fits comfortably in 4 GB. Bump to 8192 if OOMKilled errors appear in CloudWatch."
   type        = string
   default     = "4096"
 }
 
-variable "task_memory" {
-  description = "Fargate task memory in MiB. 8192 = 8 GiB. Headroom for State Snapshot data + per-cell async state."
+variable "corpus_bucket_name" {
+  description = "S3 bucket holding the Cloud-OpsBench corpus mirror. The Fargate task entrypoint pulls from s3://<this>/<corpus_hf_revision>/ at startup instead of downloading from Hugging Face (which is slow and rate-limited)."
   type        = string
-  default     = "8192"
+  default     = "cloud-ops-bench-dataset"
+}
+
+variable "corpus_hf_revision" {
+  description = "Hugging Face commit SHA pinned for this run. Must match a prefix that exists in s3://<corpus_bucket_name>/, populated by `make mirror-cloudopsbench-s3`. provenance.json records the same value so the artifact and the corpus are reproducibly paired."
+  type        = string
+  default     = "ce0ded4f196f01e176cf1d69ec15c2db42b2a677"
 }
 
 variable "image_tag" {

--- a/infra/bench/variables.tf
+++ b/infra/bench/variables.tf
@@ -47,9 +47,14 @@ variable "corpus_bucket_name" {
 }
 
 variable "corpus_hf_revision" {
-  description = "Hugging Face commit SHA pinned for this run. Must match a prefix that exists in s3://<corpus_bucket_name>/, populated by `make mirror-cloudopsbench-s3`. provenance.json records the same value so the artifact and the corpus are reproducibly paired."
+  description = "Hugging Face commit SHA pinned for this run. Must match a prefix that exists in s3://<corpus_bucket_name>/, populated by `make mirror-cloudopsbench-s3`. provenance.json records the same value so the artifact and the corpus are reproducibly paired. The default SHA must be present in S3 before the first Fargate run — see tests/benchmarks/AWS_BENCH_SETUP.md."
   type        = string
   default     = "ce0ded4f196f01e176cf1d69ec15c2db42b2a677"
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{40}$", var.corpus_hf_revision))
+    error_message = "corpus_hf_revision must be a 40-character lowercase hex SHA (HF git-style commit), e.g. ce0ded4f196f01e176cf1d69ec15c2db42b2a677."
+  }
 }
 
 variable "image_tag" {

--- a/tests/benchmarks/AWS_BENCH_S3_CORPUS_CACHE.md
+++ b/tests/benchmarks/AWS_BENCH_S3_CORPUS_CACHE.md
@@ -1,0 +1,156 @@
+# Follow-up: cache the CloudOpsBench corpus in S3
+
+> **Status:** proposal — not implemented yet. Ship after the
+> `infra/bench/` Fargate path produces its first successful run.
+
+## Problem
+
+Each ECS task currently has to fetch ~few hundred MB of CloudOpsBench
+data from Hugging Face at startup, because:
+
+1. `infra/bench/Dockerfile.bench` does NOT bake the dataset into the
+   image (and shouldn't — that would couple image rebuilds to dataset
+   revisions and add ~500 MB to every push).
+2. The container's `ENTRYPOINT` jumps straight into the CLI with no
+   download step, so the corpus has to be present at runtime.
+3. Anonymous HF Hub access caps at ~60 requests/min — the existing
+   `make download-cloudopsbench-hf` for the 1,000+ file corpus hits HTTP
+   429 rate limits about a third of the way through and falls into
+   232-second backoff retries.
+
+Setting `HF_TOKEN` (the quick fix already shipped in the Makefile)
+raises the cap to ~1000 req/min and should kill the 429s, but it still
+makes every Fargate task wait several minutes for the same data and
+ties the run to HF availability + ongoing rate-limit policy.
+
+## Proposal: mirror the corpus to the existing bench S3 bucket
+
+The bench Terraform already provisions an S3 bucket for run artifacts
+(see [`infra/bench/`](../../infra/bench/)). Add a `corpus/` prefix and
+keep one immutable copy per HF revision.
+
+```
+s3://opensre-bench/
+├── corpus/
+│   └── cloudopsbench/
+│       └── <hf-revision-sha>/
+│           ├── boutique/
+│           │   ├── admission/
+│           │   ├── infrastructure/
+│           │   ├── performance/
+│           │   ├── runtime/
+│           │   ├── scheduling/
+│           │   ├── service-routing/
+│           │   └── startup/
+│           └── README.md
+└── runs/
+    └── <date>-<sha>/
+        ├── report.json
+        ├── report.md
+        ├── report.html
+        ├── provenance.json
+        └── cases/*.json
+```
+
+The HF-revision-keyed prefix matches what `provenance.json` already
+records (`dataset.hf_revision`), so a published report literally
+points at the immutable corpus snapshot it used.
+
+## Architecture
+
+### A. One-time bootstrap (run from a laptop or as a workflow)
+
+```bash
+# Pull from HF with HF_TOKEN, then push to S3 at the revision-keyed prefix.
+make download-cloudopsbench-hf
+HF_REV=$(huggingface-cli scan-cache | grep cloud-ops-bench-dataset | awk '{print $NF}')
+aws s3 sync \
+    tests/benchmarks/cloudopsbench/benchmark/ \
+    "s3://opensre-bench/corpus/cloudopsbench/${HF_REV}/" \
+    --no-progress
+```
+
+Run this:
+- Once at setup
+- Again whenever the upstream HF dataset is revised (rarely)
+
+Could become a workflow `benchmark-corpus-mirror.yml` triggered manually
+or on a monthly schedule. ~30 lines, mirrors the
+`benchmark-seed-secret.yml` pattern (OIDC role + aws CLI).
+
+### B. Container entrypoint change
+
+Replace the direct CLI entrypoint with a small bash wrapper that pulls
+the corpus from S3 first, then invokes the CLI:
+
+```dockerfile
+# infra/bench/Dockerfile.bench (sketch)
+COPY infra/bench/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+```bash
+#!/usr/bin/env bash
+# infra/bench/entrypoint.sh
+set -euo pipefail
+
+CORPUS_REV="${BENCH_CORPUS_HF_REVISION:-}"
+if [ -z "$CORPUS_REV" ]; then
+  echo "BENCH_CORPUS_HF_REVISION env var is required (set by task definition)." >&2
+  exit 1
+fi
+
+CORPUS_DEST="tests/benchmarks/cloudopsbench/benchmark"
+mkdir -p "$CORPUS_DEST"
+
+echo "→ Pulling corpus from S3 at revision ${CORPUS_REV}"
+aws s3 sync \
+    "s3://opensre-bench/corpus/cloudopsbench/${CORPUS_REV}/" \
+    "$CORPUS_DEST" \
+    --no-progress
+
+echo "→ Launching benchmark CLI"
+exec python -m tests.benchmarks._framework.cli "$@"
+```
+
+### C. Task definition update
+
+Add `BENCH_CORPUS_HF_REVISION` to the container's env in the Terraform
+task definition. Pin to the exact HF revision so a re-run never silently
+picks up a newer corpus.
+
+## Benefits
+
+| Property | Today (HF download at runtime) | After (S3 mirror) |
+|---|---|---|
+| Time to start a run | ~5-10 min, sometimes longer with 429s | ~30 s |
+| Reproducibility | HF Hub availability dependency | Immutable per S3 revision prefix |
+| Rate-limit risk | High under `HF_TOKEN`; severe without | None at this scale |
+| HF_TOKEN required at task runtime | Yes | No |
+| S3 monthly cost | $0 | ~$0.02 (500 MB Standard storage) |
+| Image size | unchanged | unchanged |
+
+## Migration plan
+
+1. Bootstrap the S3 prefix from a laptop using the bash above (~5 min)
+2. Update `Dockerfile.bench` to use the entrypoint wrapper
+3. Rebuild + push the image via `benchmark-image.yml` with the new tag
+4. Add `BENCH_CORPUS_HF_REVISION` to the Terraform task definition;
+   apply it
+5. Test: launch a bench run, confirm the corpus arrives in <1 min and the
+   CLI sees all 452 cases
+6. Remove the `make download-cloudopsbench-hf` step from any CI workflow
+   that no longer needs it
+
+## Open questions for the user
+
+- **Should we keep multiple HF revisions in S3?** Storage is cheap;
+  yes is the default, lets us reproduce older runs.
+- **Should the bootstrap workflow run on a schedule (e.g., monthly) to
+  catch upstream revisions automatically?** Or stay manual to preserve
+  pre-registration's revision lock?
+- **Is the bench S3 bucket fine to host the corpus, or should we add
+  a separate `opensre-bench-corpus` bucket?** Same bucket means one
+  IAM resource to grant; separate bucket means lifecycle policies can
+  differ (corpus is permanent, runs/ probably expire after 90 days).

--- a/tests/benchmarks/AWS_BENCH_S3_CORPUS_CACHE.md
+++ b/tests/benchmarks/AWS_BENCH_S3_CORPUS_CACHE.md
@@ -1,7 +1,14 @@
-# Follow-up: cache the CloudOpsBench corpus in S3
+# Cache the CloudOpsBench corpus in S3 (design notes)
 
-> **Status:** proposal — not implemented yet. Ship after the
-> `infra/bench/` Fargate path produces its first successful run.
+> **Status:** implemented. `entrypoint.sh`, the Dockerfile changes,
+> `infra/bench/{fargate,iam_task,variables}.tf`, and the
+> `make mirror-cloudopsbench-s3` target all ship in the same PR.
+> See [AWS_BENCH_SETUP.md](AWS_BENCH_SETUP.md) for the one-time bootstrap
+> steps before the first Fargate run.
+>
+> This document is kept as the design rationale — useful for reviewers
+> trying to understand the trade-off vs baking the corpus into the image
+> or downloading from Hugging Face at runtime.
 
 ## Problem
 

--- a/tests/benchmarks/AWS_BENCH_SETUP.md
+++ b/tests/benchmarks/AWS_BENCH_SETUP.md
@@ -1,0 +1,78 @@
+# Setting up AWS bench (one-time)
+
+The benchmark runs on AWS Fargate so you don't tie up your laptop or a
+GitHub-hosted runner for hours. This is the five-step setup before
+**Benchmark run (manual)** can launch anything. Do each step once;
+re-runs of the actual benchmark only need step 5.
+
+## 1. Apply Terraform
+
+Provisions the ECS cluster, S3 artifact bucket, Secrets Manager entries,
+IAM roles, CloudWatch log group, and OIDC trust for the GitHub Actions roles.
+
+```bash
+cd infra/bench/
+terraform init
+terraform apply
+```
+
+See [infra/bench/README.md](../../infra/bench/README.md) for backend bucket
++ DynamoDB lock requirements.
+
+## 2. Seed the LLM API keys into AWS Secrets Manager
+
+The container reads keys from Secrets Manager at runtime — never from the
+workflow. Add `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DEEPSEEK_API_KEY`,
+`HF_TOKEN` as **GitHub repo secrets** (Settings → Secrets and variables →
+Actions → Secrets), then run the seeding workflow once per key:
+
+```bash
+gh workflow run benchmark-seed-secret.yml -f secret=anthropic_api_key
+gh workflow run benchmark-seed-secret.yml -f secret=openai_api_key
+gh workflow run benchmark-seed-secret.yml -f secret=deepseek_api_key
+gh workflow run benchmark-seed-secret.yml -f secret=hf_token
+```
+
+## 3. Build and push the bench container image to ECR
+
+```bash
+gh workflow run benchmark-image.yml
+```
+
+This also runs automatically on changes to bench code or the Dockerfile.
+
+## 4. Set the four repo variables
+
+These live under Settings → Secrets and variables → Actions → **Variables**
+(not Secrets — they're not sensitive). Grab the values from Terraform:
+
+```bash
+cd infra/bench/
+echo "BENCH_ECS_CLUSTER             = $(terraform output -raw ecs_cluster_name)"
+echo "BENCH_TASK_DEFINITION_FAMILY  = $(terraform output -raw task_definition_family)"
+echo "BENCH_SUBNET_IDS              = $(terraform output -json subnet_ids | jq -r 'join(",")')"
+echo "BENCH_SECURITY_GROUP_ID       = $(terraform output -raw security_group_id)"
+```
+
+Paste each value into a new repo variable with the matching name.
+`AWS_ACCOUNT_ID` is already set (the seed-secret workflow uses it).
+
+## 5. Launch a benchmark
+
+```bash
+gh workflow run benchmark-run.yml \
+    -f image_tag=latest \
+    -f config=tests/benchmarks/configs/example.yml \
+    -f dev_mode=true
+```
+
+Or use the GitHub UI: Actions → **Benchmark run (manual)** → Run workflow.
+
+The workflow exits as soon as the task launches. Watch live logs with:
+
+```bash
+aws logs tail /ecs/opensre-bench --follow
+```
+
+Artifacts land in the bench S3 bucket under `runs/<date>-<sha>/` when the
+task finishes.

--- a/tests/benchmarks/AWS_BENCH_SETUP.md
+++ b/tests/benchmarks/AWS_BENCH_SETUP.md
@@ -1,9 +1,13 @@
 # Setting up AWS bench (one-time)
 
 The benchmark runs on AWS Fargate so you don't tie up your laptop or a
-GitHub-hosted runner for hours. This is the five-step setup before
-**Benchmark run (manual)** can launch anything. Do each step once;
-re-runs of the actual benchmark only need step 5.
+GitHub-hosted runner for hours. This is the six-step setup before
+**Benchmark — run on Fargate** can launch anything. Do each step once;
+re-runs of the actual benchmark only need step 6.
+
+> **Whenever the upstream HF dataset gets a new revision**, re-run step 5
+> (mirror to S3) AND bump `corpus_hf_revision` in `infra/bench/variables.tf`
+> (or pass it as `-var=corpus_hf_revision=<new-sha>` to `terraform apply`).
 
 ## 1. Apply Terraform
 
@@ -57,16 +61,36 @@ echo "BENCH_SECURITY_GROUP_ID       = $(terraform output -raw security_group_id)
 Paste each value into a new repo variable with the matching name.
 `AWS_ACCOUNT_ID` is already set (the seed-secret workflow uses it).
 
-## 5. Launch a benchmark
+## 5. Mirror the Cloud-OpsBench corpus to S3
+
+The Fargate task pulls the corpus from S3 at startup (not from Hugging
+Face — same-region S3 sync is ~30 s vs ~10 min HF rate-limited download).
+Seed the S3 prefix once from a developer machine:
+
+```bash
+# From the repo root
+export HF_TOKEN=hf_...           # see tests/benchmarks/README.md
+make download-cloudopsbench-hf   # local copy of the dataset
+make mirror-cloudopsbench-s3     # auto-detects HF revision SHA + uploads
+                                 # to s3://cloud-ops-bench-dataset/<sha>/
+```
+
+The output prints the HF revision SHA. If it differs from the default in
+`infra/bench/variables.tf` (`corpus_hf_revision`), update the default or
+override per apply: `terraform apply -var=corpus_hf_revision=<sha>`.
+
+The corpus bucket needs to exist before this step. Create it once if
+you don't have it: `aws s3 mb s3://cloud-ops-bench-dataset --region us-east-1`.
+
+## 6. Launch a benchmark
 
 ```bash
 gh workflow run benchmark-run.yml \
-    -f image_tag=latest \
     -f config=tests/benchmarks/configs/example.yml \
     -f dev_mode=true
 ```
 
-Or use the GitHub UI: Actions → **Benchmark run (manual)** → Run workflow.
+Or use the GitHub UI: Actions → **Benchmark — run on Fargate** → Run workflow.
 
 The workflow exits as soon as the task launches. Watch live logs with:
 

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -1,5 +1,10 @@
 # Running a benchmark
 
+## Where the corpus lives
+
+- **Hugging Face (upstream):** [tracer-cloud/cloud-ops-bench-dataset](https://huggingface.co/datasets/tracer-cloud/cloud-ops-bench-dataset)
+- **AWS S3 mirror:** `s3://cloud-ops-bench-dataset/<hf-revision-sha>/` — the same corpus, revision-pinned, used by the Fargate bench task at startup (faster than HF, no rate limits, no `HF_TOKEN` needed at runtime). Populated by `make mirror-cloudopsbench-s3`.
+
 ```bash
 # One-time setup
 make install
@@ -35,7 +40,7 @@ guide.
 
 ## Running from GitHub CI
 
-Trigger from **Actions → "Benchmark run (manual)" → Run workflow**. Fill in
+Trigger from **Actions → "Benchmark — run on Fargate" → Run workflow**. Fill in
 the config path and the dev_mode toggle. Artifacts upload as
 `bench-results-<run-id>.zip` (30-day retention).
 

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -41,8 +41,11 @@ guide.
 ## Running from GitHub CI
 
 Trigger from **Actions → "Benchmark — run on Fargate" → Run workflow**. Fill in
-the config path and the dev_mode toggle. Artifacts upload as
-`bench-results-<run-id>.zip` (30-day retention).
+the config path and the dev_mode toggle. The workflow launches an ECS task and
+exits in under a minute — the actual bench runs on Fargate. Watch live logs
+with `aws logs tail /ecs/opensre-bench --follow`, or via the AWS Console under
+ECS → Clusters → opensre-bench → Tasks. Results land in the bench results S3
+bucket under `runs/<date>-<sha>/` when the task finishes.
 
 One-time setup before the first CI run: add repo secrets `ANTHROPIC_API_KEY`,
 `OPENAI_API_KEY`, `DEEPSEEK_API_KEY` (only the ones your config needs).


### PR DESCRIPTION
Fixes #2074 partial (not completed)

### Describe the changes you have made in this PR

S3 corpus mirror. The Cloud-OpsBench dataset (~3 GB, 3362 files) is now mirrored from Hugging Face to s3://cloud-ops-bench-dataset/<hf-revision>/. 

Dockerfile entrypoint wrapper that pulls the corpus from S3 before invoking the CLI. The image no longer bakes in the dataset.

Terraform cost optimizations: Fargate right-sized from 4 vCPU / 8 GB to 2 vCPU / 4 GB (bench is API-bound, not CPU-bound — saves ~50% per run), S3 lifecycle policy added to expire noncurrent versions after 90 days. Plus a small 

IAM policy granting the task read access to the corpus bucket.

And in AWS:

Did you use AI assistance? 

☑ Yes, I used AI assistance (continue below)

If you used AI assistance:

☑ I have reviewed every single line of the AI-generated code
☑ I can explain the purpose and logic of each function/component I added
☑ I have tested edge cases and understand how the code handles them
☑ I have modified the AI output to follow this project's coding standards and conventions

Explain your implementation approach:

Terraform changes are scoped to infra/bench/ only, per the team convention.

Checklist before requesting a review
☑ I have added proper PR title and linked to the issue
☑ I have performed a self-review of my code
☑ I can explain the purpose of every function, class, and logic block I added
☑ I understand why my changes work and have tested them thoroughly
☑ I have considered potential edge cases and how my code handles them
☑ If it is a core feature, I have added thorough tests
☑ My code follows the project's style guidelines and conventions


Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
