### PR TITLE
fix(messaging): enforce pairing brute-force counter persistence structurally  

### DIFF
--- a/app/integrations/messaging_security.py
+++ b/app/integrations/messaging_security.py
@@ -19,6 +19,7 @@ import os
 import secrets
 import string
 import time
+from collections.abc import Callable
 from enum import StrEnum
 
 from pydantic import Field
@@ -279,10 +280,14 @@ def complete_pairing(
     attempts, the pairing code is invalidated. Codes also expire after
     PAIRING_CODE_TTL_SECONDS.
 
-    IMPORTANT: The caller MUST persist the updated policy after every call,
-    regardless of the return value. Failed attempts increment
-    pairing_attempts; if the caller only persists on success, the counter
-    resets on the next load and brute-force protection is defeated.
+    This function mutates ``policy`` in place (incrementing
+    ``pairing_attempts`` on failure, clearing the secret on success or
+    invalidation) but does NOT persist it. The mutation is only durable if
+    the updated policy is written back to storage after every call. Callers
+    SHOULD use :func:`complete_pairing_with_persistence` so persistence is
+    guaranteed structurally rather than by convention — if persistence is
+    skipped on failed attempts, the counter resets on the next load and
+    brute-force protection is silently defeated.
     """
     if not policy.pairing_secret_hash:
         return False, "No pairing is pending. Ask the operator to run `opensre messaging pair`."
@@ -326,6 +331,52 @@ def complete_pairing(
 
     logger.info("DM pairing completed for user %s", user_id)
     return True, "Pairing successful! You can now interact with the bot."
+
+
+def complete_pairing_with_persistence(
+    *,
+    policy: MessagingIdentityPolicy,
+    user_id: str,
+    code: str,
+    persist: Callable[[MessagingIdentityPolicy], None],
+) -> tuple[bool, str]:
+    """Run :func:`complete_pairing` and guarantee the policy is persisted.
+
+    This is the preferred entry point for any inbound handler. It makes
+    brute-force protection a structural property of the code path rather
+    than a caller convention: ``persist`` is invoked in a ``finally`` block,
+    so the mutated ``policy`` (including a failed-attempt increment) is
+    written back on success, on failure, AND when ``complete_pairing`` or
+    ``persist`` itself raises. This closes the footgun where persisting only
+    on success would reset ``pairing_attempts`` on the next load and defeat
+    the brute-force limit.
+
+    Args:
+        policy: The identity policy to mutate. Modified in place.
+        user_id: Platform-native stable user ID attempting to pair.
+        code: The pairing code supplied by the user.
+        persist: Callback that durably writes ``policy`` back to storage.
+            Invoked exactly once, after the attempt is evaluated, regardless
+            of outcome. A failure inside ``persist`` is logged and re-raised
+            so the caller is not misled into thinking the counter was saved.
+
+    Returns:
+        The ``(success, message)`` tuple from :func:`complete_pairing`.
+    """
+    try:
+        return complete_pairing(policy=policy, user_id=user_id, code=code)
+    finally:
+        try:
+            persist(policy)
+        except Exception:
+            # Surface persistence failures loudly: a silently dropped write
+            # would re-open the brute-force window the wrapper exists to close.
+            logger.exception(
+                "Failed to persist messaging identity policy after pairing attempt "
+                "for user %s; brute-force counter may not be durable",
+                user_id,
+            )
+            raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integrations/test_messaging_security.py
+++ b/tests/integrations/test_messaging_security.py
@@ -505,6 +505,39 @@ class TestCompletePairingWithPersistence:
                 policy=policy, user_id="u", code=code, persist=failing_persist
             )
 
+    def test_double_failure_persist_replaces_original_with_context(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When both complete_pairing and persist raise, persist wins but original is __context__.
+
+        Python's finally semantics mean the persist exception replaces the
+        in-flight complete_pairing exception. The original is preserved as
+        __context__ so it remains visible in tracebacks. This test documents
+        that behavior explicitly (Greptile P2 review feedback).
+        """
+        import app.integrations.messaging_security as ms
+
+        def raising_pairing(**_kwargs: object) -> tuple[bool, str]:
+            raise ValueError("pairing logic exploded")
+
+        def raising_persist(_policy: MessagingIdentityPolicy) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(ms, "complete_pairing", raising_pairing)
+
+        policy = MessagingIdentityPolicy(inbound_enabled=True)
+
+        # The persist exception is what surfaces to the caller.
+        with pytest.raises(OSError, match="disk full") as exc_info:
+            complete_pairing_with_persistence(
+                policy=policy, user_id="u", code="X", persist=raising_persist
+            )
+
+        # The original pairing exception is preserved as __context__.
+        assert exc_info.value.__context__ is not None
+        assert isinstance(exc_info.value.__context__, ValueError)
+        assert "pairing logic exploded" in str(exc_info.value.__context__)
+
 
 # ---------------------------------------------------------------------------
 # Platform enum tests

--- a/tests/integrations/test_messaging_security.py
+++ b/tests/integrations/test_messaging_security.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import time
 
+import pytest
+
 from app.integrations.messaging_security import (
     _MAX_PAIRING_ATTEMPTS,
     _PAIRING_CODE_TTL_SECONDS,
@@ -13,6 +15,7 @@ from app.integrations.messaging_security import (
     RejectionBehavior,
     authorize_inbound_message,
     complete_pairing,
+    complete_pairing_with_persistence,
     generate_pairing_code,
     hash_pairing_code,
     verify_pairing_code,
@@ -340,6 +343,167 @@ class TestCompletePairing:
         assert success is False
         assert "expired" in message.lower()
         assert policy.pairing_secret_hash is None
+
+
+# ---------------------------------------------------------------------------
+# Persistence-aware pairing wrapper tests
+# ---------------------------------------------------------------------------
+
+
+class _FakePolicyStore:
+    """In-memory stand-in for a durable identity-policy store.
+
+    Simulates a real persistence boundary: callers mutate a loaded policy,
+    then must write it back. ``load`` always returns a fresh object parsed
+    from the last saved snapshot, so any mutation that was not persisted is
+    lost across a load — exactly the failure mode the wrapper must prevent.
+    """
+
+    def __init__(self, policy: MessagingIdentityPolicy) -> None:
+        self._snapshot = policy.model_dump(mode="json")
+        self.save_calls = 0
+
+    def load(self) -> MessagingIdentityPolicy:
+        return MessagingIdentityPolicy.model_validate(self._snapshot)
+
+    def save(self, policy: MessagingIdentityPolicy) -> None:
+        self.save_calls += 1
+        self._snapshot = policy.model_dump(mode="json")
+
+
+class TestCompletePairingWithPersistence:
+    def test_persists_on_success(self) -> None:
+        code = "OK0001"
+        store = _FakePolicyStore(
+            MessagingIdentityPolicy(
+                inbound_enabled=True,
+                pairing_secret_hash=hash_pairing_code(code),
+                pairing_created_at=time.time(),
+            )
+        )
+        policy = store.load()
+        success, _ = complete_pairing_with_persistence(
+            policy=policy, user_id="new_user", code=code, persist=store.save
+        )
+        assert success is True
+        assert store.save_calls == 1
+        # Reload from the store: the successful pairing is durable.
+        reloaded = store.load()
+        assert "new_user" in reloaded.allowed_user_ids
+        assert reloaded.pairing_secret_hash is None
+
+    def test_persists_on_failed_attempt(self) -> None:
+        """A wrong code must persist the incremented counter, not just on success."""
+        store = _FakePolicyStore(
+            MessagingIdentityPolicy(
+                inbound_enabled=True,
+                pairing_secret_hash=hash_pairing_code("CORRECT"),
+                pairing_created_at=time.time(),
+            )
+        )
+        policy = store.load()
+        success, _ = complete_pairing_with_persistence(
+            policy=policy, user_id="attacker", code="WRONG1", persist=store.save
+        )
+        assert success is False
+        assert store.save_calls == 1
+        # The increment survived the round-trip through the store.
+        assert store.load().pairing_attempts == 1
+
+    def test_brute_force_invalidated_across_reload_boundaries(self) -> None:
+        """Drive failed attempts each on a freshly loaded policy.
+
+        This is the core regression for issue #2677: each attempt loads a
+        fresh policy from the store (as a stateless request handler would),
+        mutates it, and persists via the wrapper. The counter must accumulate
+        and the code must be invalidated after _MAX_PAIRING_ATTEMPTS — proving
+        protection does not depend on the caller reusing one in-memory object.
+        """
+        store = _FakePolicyStore(
+            MessagingIdentityPolicy(
+                inbound_enabled=True,
+                pairing_secret_hash=hash_pairing_code("SECRET"),
+                pairing_created_at=time.time(),
+            )
+        )
+        for i in range(_MAX_PAIRING_ATTEMPTS):
+            policy = store.load()  # stateless reload before each attempt
+            success, _ = complete_pairing_with_persistence(
+                policy=policy, user_id="attacker", code=f"WRONG{i}", persist=store.save
+            )
+            assert success is False
+
+        final = store.load()
+        assert final.pairing_secret_hash is None
+        # A subsequent guess with the (now cleared) code cannot succeed.
+        success, message = complete_pairing_with_persistence(
+            policy=store.load(), user_id="attacker", code="SECRET", persist=store.save
+        )
+        assert success is False
+        assert "no pairing" in message.lower()
+
+    def test_naive_persist_only_on_success_would_defeat_protection(self) -> None:
+        """Contrast test: persisting only on success never invalidates the code.
+
+        Documents the exact footgun the wrapper removes. Using bare
+        complete_pairing and skipping persistence on failure, a fresh reload
+        each attempt resets pairing_attempts, so the code is never invalidated.
+        """
+        store = _FakePolicyStore(
+            MessagingIdentityPolicy(
+                inbound_enabled=True,
+                pairing_secret_hash=hash_pairing_code("SECRET"),
+                pairing_created_at=time.time(),
+            )
+        )
+        for i in range(_MAX_PAIRING_ATTEMPTS * 3):
+            policy = store.load()
+            success, _ = complete_pairing(policy=policy, user_id="attacker", code=f"WRONG{i}")
+            assert success is False
+            # Naive caller: only persists on success → nothing saved here.
+
+        # Counter never accumulated; code is still live and brute-forceable.
+        assert store.load().pairing_attempts == 0
+        assert store.load().pairing_secret_hash is not None
+
+    def test_persist_called_when_complete_pairing_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """persist runs even if the inner call raises (finally semantics)."""
+        import app.integrations.messaging_security as ms
+
+        calls: list[str] = []
+
+        def boom(_policy: MessagingIdentityPolicy) -> None:
+            calls.append("persisted")
+
+        def raising(**_kwargs: object) -> tuple[bool, str]:
+            raise RuntimeError("inner failure")
+
+        monkeypatch.setattr(ms, "complete_pairing", raising)
+
+        policy = MessagingIdentityPolicy(inbound_enabled=True)
+        with pytest.raises(RuntimeError, match="inner failure"):
+            complete_pairing_with_persistence(policy=policy, user_id="u", code="X", persist=boom)
+
+        assert calls == ["persisted"]
+
+    def test_persist_failure_is_raised_not_swallowed(self) -> None:
+        """If the persist callback fails, the error must propagate."""
+        code = "OK0002"
+        policy = MessagingIdentityPolicy(
+            inbound_enabled=True,
+            pairing_secret_hash=hash_pairing_code(code),
+            pairing_created_at=time.time(),
+        )
+
+        def failing_persist(_policy: MessagingIdentityPolicy) -> None:
+            raise OSError("disk full")
+
+        with pytest.raises(OSError, match="disk full"):
+            complete_pairing_with_persistence(
+                policy=policy, user_id="u", code=code, persist=failing_persist
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2677

#### Describe the changes you have made in this PR -

Added `complete_pairing_with_persistence()` in `app/integrations/messaging_security.py` a wrapper around `complete_pairing()` that accepts a `persist` callback and invokes it in a `finally` block. This guarantees the mutated identity policy (including failed-attempt counter increments) is written back to storage on every outcome: success, failure, and exception. The previous design relied on a docstring instruction ("caller MUST persist after every call") which is a fragile contract that any future integrator could silently violate by persisting only on success resetting the counter on reload and defeating brute-force protection.

**Key changes:**
- `app/integrations/messaging_security.py`: Added `complete_pairing_with_persistence(policy, user_id, code, persist)` with `finally`-based persistence guarantee. Updated `complete_pairing()` docstring to direct callers to the wrapper.
- `tests/integrations/test_messaging_security.py`: Added `TestCompletePairingWithPersistence` class with a `_FakePolicyStore` simulating a real load/save boundary, including:
  - Persistence on success and on failed attempts
  - Core regression: drives `_MAX_PAIRING_ATTEMPTS` failures each on a freshly reloaded policy, asserting the code is invalidated across reload boundaries
  - Contrast test documenting the naive "persist only on success" footgun
  - `finally` semantics when the inner call raises
  - Propagation of persist callback failures

### Demo/Screenshot for feature changes and bug fixes -
<img width="1660" height="551" alt="image" src="https://github.com/user-attachments/assets/7c4e5b31-39b9-43f0-9894-531e0197aeb8" />




| Scenario                        | Before (docstring contract) | After (structural wrapper) |
|---------------------------------|-----------------------------|----------------------------|
| Caller persists only on success | Counter resets → unlimited guesses | persist() in finally → counter always durable |
| Process crashes mid-attempt     | Counter lost                | Same (out of scope, noted) |
| 5 wrong guesses across reloads  | Code stays valid forever    | Code invalidated ✓         |

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem:** `complete_pairing()` mutates the policy in-place (incrementing `pairing_attempts` on failure, clearing the hash on success/invalidation) but leaves persistence to the caller. If a caller only persists on success, the counter resets to 0 on the next load, allowing unlimited brute-force guesses the 5-attempt limit becomes theater.

**Alternatives considered:**
1. Having `complete_pairing()` itself own persistence rejected because it would require injecting a storage dependency into a currently pure function, breaking existing callers and test ergonomics.
2. Returning a typed "must-persist" result object rejected because it still relies on the caller to act on it; a forgotten `.persist()` call is the same footgun in a different shape.

**Chosen approach:** A thin wrapper (`complete_pairing_with_persistence`) that takes a `persist: Callable` and calls it in `finally`. This makes persistence a structural property of the code path without modifying the existing `complete_pairing()` signature. Future inbound handlers (issue #1482) use the wrapper; the raw function remains available for unit tests that don't need I/O.

**Key components:**
- `complete_pairing_with_persistence()`: Calls `complete_pairing()` in a `try` block, then unconditionally calls `persist(policy)` in `finally`. If `persist` raises, the exception is logged and re-raised so the caller knows the write failed.
- `_FakePolicyStore` (test helper): Simulates a real persistence boundary `load()` always returns a fresh object from the last saved snapshot, so mutations not persisted are lost across loads. This is the exact failure mode the wrapper prevents.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---
