### PR TITLE
refactor(discord-payload): remove REPO_STARS from payload and workflow

### DIFF
--- a/.github/scripts/build-discord-payload.py
+++ b/.github/scripts/build-discord-payload.py
@@ -2,7 +2,7 @@
 """Build the Discord release announcement JSON payload.
 
 Reads from environment variables set by the GitHub Actions step:
-  RELEASE_TAG, RELEASE_URL, REPO_STARS,
+  RELEASE_TAG, RELEASE_URL,
   DISCORD_RELEASES_ROLE_ID, DISCORD_RELEASE_LOGO_EMOJI, DISCORD_RELEASE_LOGO_URL,
   CHANGELOG_FILE  — path to DISCORD_NARRATIVE.md or GENERATED_CHANGELOG.md
 """
@@ -16,7 +16,6 @@ MAX_CHANGELOG_CHARS = 1400
 
 tag = os.environ["RELEASE_TAG"]
 url = os.environ["RELEASE_URL"]
-stars = os.environ.get("REPO_STARS", "0")
 role_id = os.environ.get("DISCORD_RELEASES_ROLE_ID", "")
 logo_emoji = os.environ.get("DISCORD_RELEASE_LOGO_EMOJI", "")
 logo_url = os.environ.get("DISCORD_RELEASE_LOGO_URL", "")
@@ -39,8 +38,7 @@ content = (
     mention
     + logo_prefix
     + f"🚀 **opensre {bt}{tag}{bt} is live**\n"
-    + f"🔗 {url}\n"
-    + f"⭐ {stars} stars\n\n"
+    + f"🔗 {url}\n\n"
     + changelog
 )
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -472,7 +472,6 @@ jobs:
           DISCORD_RELEASE_LOGO_URL: ${{ secrets.DISCORD_RELEASE_LOGO_URL }}
           RELEASE_TAG: ${{ needs.prepare.outputs.tag_name }}
           RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.prepare.outputs.tag_name }}
-          REPO_STARS: ${{ github.event.repository.stargazers_count }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
This pull request simplifies the Discord release announcement process by removing the display of repository star counts from the release payload and related workflow steps. The main focus is on cleaning up unused environment variables and streamlining the release message.

**Discord release payload and workflow simplification:**

* Removed all references to repository star counts from the Discord release announcement script (`.github/scripts/build-discord-payload.py`). This includes eliminating the `REPO_STARS` environment variable and the line displaying the star count in the release message. [[1]](diffhunk://#diff-1f32c43d474c1a2a3a17c1bf5e5de1b199eb474fbfc3da2b997214d44811ec30L5-R5) [[2]](diffhunk://#diff-1f32c43d474c1a2a3a17c1bf5e5de1b199eb474fbfc3da2b997214d44811ec30L19) [[3]](diffhunk://#diff-1f32c43d474c1a2a3a17c1bf5e5de1b199eb474fbfc3da2b997214d44811ec30L42-R41)
* Updated the GitHub Actions workflow (`.github/workflows/release.yml`) to stop passing the `REPO_STARS` environment variable to the release announcement script.