### PR TITLE
feat: upgrade MiniMax default reasoning model to M3

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -121,7 +121,7 @@ NVIDIA_CLASSIFICATION_MODEL = "meta/llama-3.1-70b-instruct"
 NVIDIA_TOOLCALL_MODEL = "meta/llama-3.1-8b-instruct"
 
 # MiniMax model constants
-MINIMAX_REASONING_MODEL = "MiniMax-M2.7"
+MINIMAX_REASONING_MODEL = "MiniMax-M3"
 MINIMAX_CLASSIFICATION_MODEL = "MiniMax-M2.7-highspeed"
 MINIMAX_TOOLCALL_MODEL = "MiniMax-M2.7-highspeed"
 

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -15,7 +15,7 @@ OpenSRE is provider-agnostic: bring your own model. Selection is controlled by t
 | DeepSeek     | `deepseek`     | `DEEPSEEK_API_KEY`              | `deepseek-v4-pro`                             | `deepseek-v4-flash`                             |
 | Google Gemini| `gemini`       | `GEMINI_API_KEY`                | `gemini-3.1-pro-preview`                      | `gemini-3.1-flash-lite-preview`                 |
 | NVIDIA NIM   | `nvidia`       | `NVIDIA_API_KEY`                | `meta/llama-3.1-405b-instruct`                | `meta/llama-3.1-8b-instruct`                    |
-| MiniMax      | `minimax`      | `MINIMAX_API_KEY`               | `MiniMax-M2.7`                                | `MiniMax-M2.7-highspeed`                        |
+| MiniMax      | `minimax`      | `MINIMAX_API_KEY`               | `MiniMax-M3`                                  | `MiniMax-M2.7-highspeed`                        |
 | Amazon Bedrock| `bedrock`     | AWS IAM (`AWS_REGION`)          | `us.anthropic.claude-sonnet-4-6`              | `us.anthropic.claude-haiku-4-5-20251001-v1:0`   |
 | Ollama (local)| `ollama`     | None (local daemon)             | `llama3.2`                                    | `llama3.2`                                      |
 | OpenAI Codex CLI| `codex`    | `codex login` (CLI)             | Codex CLI default                             | Codex CLI default                               |
@@ -149,9 +149,9 @@ Uses NVIDIA's OpenAI-compatible API at `https://integrate.api.nvidia.com/v1`. Br
 export LLM_PROVIDER=minimax
 export MINIMAX_API_KEY=...
 # Optional override (single value applies to both slots if set):
-export MINIMAX_MODEL=MiniMax-M2.7
+export MINIMAX_MODEL=MiniMax-M3
 # Or per-slot:
-export MINIMAX_REASONING_MODEL=MiniMax-M2.7
+export MINIMAX_REASONING_MODEL=MiniMax-M3
 export MINIMAX_TOOLCALL_MODEL=MiniMax-M2.7-highspeed
 ```
 

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -380,7 +380,7 @@ def test_minimax_llm_client_reads_api_key_and_base_url(monkeypatch) -> None:
     monkeypatch.setattr(llm_client, "OpenAI", _FakeOpenAI)
 
     client = llm_client.OpenAILLMClient(
-        model="MiniMax-M2.7",
+        model="MiniMax-M3",
         base_url="https://api.minimax.io/v1",
         api_key_env="MINIMAX_API_KEY",
         temperature=1.0,
@@ -400,7 +400,7 @@ def test_minimax_llm_client_temperature_is_set(monkeypatch) -> None:
     monkeypatch.setattr(llm_client, "OpenAI", _FakeOpenAI)
 
     client = llm_client.OpenAILLMClient(
-        model="MiniMax-M2.7",
+        model="MiniMax-M3",
         base_url="https://api.minimax.io/v1",
         api_key_env="MINIMAX_API_KEY",
         temperature=1.0,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -82,7 +82,7 @@ def test_llm_settings_minimax_provider_accepted() -> None:
     )
     assert settings.provider == "minimax"
     assert settings.minimax_api_key == "mm-test-key"
-    assert settings.minimax_reasoning_model == "MiniMax-M2.7"
+    assert settings.minimax_reasoning_model == "MiniMax-M3"
     assert settings.minimax_toolcall_model == "MiniMax-M2.7-highspeed"
 
 


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

Bumps the MiniMax default reasoning model from `MiniMax-M2.7` to the new flagship `MiniMax-M3`. The high-speed slots used for classification and tool calling stay on `MiniMax-M2.7-highspeed` because there is no M3 high-speed variant yet.

Changes:
- `app/config.py` — `MINIMAX_REASONING_MODEL` default constant
- `docs/llm-providers.mdx` — provider table row and environment variable example
- `tests/test_config.py` and `tests/services/test_llm_client.py` — update the unit-test assertions that pinned the old default model name

`MINIMAX_BASE_URL` (`https://api.minimax.io/v1`), the temperature handling, and the high-speed model defaults are intentionally left untouched.

### Demo/Screenshot for feature changes and bug fixes -

Local checks:

```
$ uv run python -m pytest tests/test_config.py::test_llm_settings_minimax_provider_accepted \
    tests/services/test_llm_client.py::test_minimax_llm_client_reads_api_key_and_base_url \
    tests/services/test_llm_client.py::test_minimax_llm_client_temperature_is_set -v
... 3 passed in 16.31s

$ uv run python -m ruff check app/config.py tests/test_config.py tests/services/test_llm_client.py
All checks passed!

$ uv run python -m ruff format --check app/config.py tests/test_config.py tests/services/test_llm_client.py
3 files already formatted

$ uv run python -m mypy app/config.py
Success: no issues found in 1 source file
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The change is a small constant + docs + test bump for the default MiniMax reasoning model. I scanned the repo for every place that still pinned `MiniMax-M2.7` for the reasoning slot (`rg -i 'MiniMax-M'`), grouped the hits into the three categories that actually carry the default (`app/config.py` constant, user docs, and unit-test assertions), and updated only those. I deliberately kept `MINIMAX_CLASSIFICATION_MODEL` / `MINIMAX_TOOLCALL_MODEL` on `MiniMax-M2.7-highspeed` because MiniMax has not shipped an M3 high-speed counterpart, and routed model identifiers in `app/cli/wizard/config.py` (OpenRouter / OpenCode Zen entries) were left alone because they belong to those third-party routers' namespaces, not the direct minimax provider.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.