### PR TITLE
fix(repl): forward confirm_fn to slash dispatch to prevent /integrations verify hang

### DIFF
--- a/app/cli/interactive_shell/runtime/execution.py
+++ b/app/cli/interactive_shell/runtime/execution.py
@@ -157,7 +157,13 @@ def execute_routed_turn(
         if not cmd_text:
             cmd_text = text.strip()
         try:
-            should_continue = dispatch_slash(cmd_text, session, console)
+            # ``confirm_fn`` must be forwarded so confirmation-gated slash commands
+            # (e.g. ``/integrations verify``, an ELEVATED tier command) route their
+            # "Proceed? [Y/n]" prompt through the REPL's event-based handoff. Without
+            # it, ``execution_allowed`` falls back to a blocking ``input()`` on the
+            # dispatch worker thread, which deadlocks against prompt_toolkit's
+            # ``patch_stdout(raw=True)`` main loop and freezes the REPL (issue #2694).
+            should_continue = dispatch_slash(cmd_text, session, console, confirm_fn=confirm_fn)
         except Exception as exc:
             report_exception(exc, context="interactive_shell.slash_dispatch")
             console.print(

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -132,7 +132,17 @@ class StreamingConsole(Console):
         high column. Rich output that follows (tables, follow-up status lines,
         section rules) must start at column zero or lines appear broken.
         """
-        if not self._spinner.streaming:
+        from rich.file_proxy import FileProxy
+
+        # When a Rich redirect (e.g. ``console.status`` / ``Live``) is active it
+        # replaces ``sys.stdout`` with a ``FileProxy`` whose ``write`` routes back
+        # into ``console.print``. The cursor-prep below writes to ``sys.stdout``,
+        # so running it under such a redirect recurses infinitely:
+        #   print → prepare_repl_output_line → sys.stdout.write → FileProxy.write
+        #   → console.print → print → …  (issue #2694 follow-up)
+        # Rich owns the cursor during a redirect, so skip the manual prep entirely
+        # and delegate straight to Rich.
+        if not self._spinner.streaming and not isinstance(sys.stdout, FileProxy):
             from app.cli.interactive_shell.ui.choice_menu import (
                 ensure_tty_column_zero,
                 prepare_repl_output_line,

--- a/tests/cli/interactive_shell/test_terminal_runtime.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import io
 import re
+import sys
 import threading
 import time
 from pathlib import Path
@@ -50,6 +51,41 @@ def test_streaming_console_status_does_not_recurse(monkeypatch) -> None:
     )
     with console.status("working", spinner="dots"):
         pass
+
+
+def test_streaming_console_print_does_not_recurse_under_stdout_redirect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the #2694 follow-up RecursionError.
+
+    A confirmation-gated command whose handler uses ``console.status`` (e.g.
+    ``/integrations verify``) installs a Rich ``FileProxy`` over ``sys.stdout``
+    whose ``write`` routes back into ``console.print``. ``StreamingConsole.print``
+    must not run its manual cursor-prep (which writes to ``sys.stdout``) under such
+    a redirect, otherwise it recurses infinitely:
+    print → prepare_repl_output_line → sys.stdout.write → FileProxy.write → print.
+    """
+    from rich.file_proxy import FileProxy
+
+    from app.cli.interactive_shell.ui import choice_menu as _choice_menu
+
+    spinner = loop_state.SpinnerState()
+    console = loop_module.StreamingConsole(
+        spinner,
+        threading.Event(),
+        force_terminal=True,
+        width=80,
+    )
+    real_stdout = sys.stdout
+    proxy = FileProxy(console, real_stdout)
+    # Force the interactive-TTY cursor-prep path that writes to sys.stdout, then
+    # redirect sys.stdout through the proxy so any such write would recurse.
+    monkeypatch.setattr(_choice_menu, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(proxy, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr(sys, "stdout", proxy)
+
+    # Must not raise RecursionError.
+    console.print("output while a console.status redirect is active")
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/interactive_shell/test_terminal_runtime.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime.py
@@ -540,6 +540,47 @@ def test_dispatch_one_turn_reports_slash_dispatch_error(
     assert isinstance(captured_errors[0], RuntimeError)
 
 
+def test_dispatch_one_turn_forwards_confirm_fn_to_slash_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for #2694.
+
+    Confirmation-gated slash commands (e.g. ``/integrations verify``) must route
+    their "Proceed? [Y/n]" prompt through the caller-supplied ``confirm_fn`` (the
+    REPL's event-based handoff). If ``execute_routed_turn`` drops ``confirm_fn`` when
+    calling ``dispatch_slash``, ``execution_allowed`` falls back to a blocking
+    ``input()`` on the dispatch worker thread and freezes the REPL.
+    """
+    from rich.console import Console
+
+    captured: dict[str, object] = {}
+
+    def _capture(*_args: object, **kwargs: object) -> bool:
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.runtime.execution.dispatch_slash",
+        _capture,
+    )
+
+    def _sentinel_confirm(_prompt: str) -> str:
+        return "y"
+
+    session = ReplSession()
+    console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+
+    loop_dispatch.dispatch_one_turn(
+        "/integrations verify",
+        session,
+        console,
+        on_exit=lambda: None,
+        confirm_fn=_sentinel_confirm,
+    )
+
+    assert captured.get("confirm_fn") is _sentinel_confirm
+
+
 def test_dispatch_one_turn_calls_on_exit_when_slash_returns_false(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes #2694

#### Describe the changes you have made in this PR -

`/integrations verify` froze the interactive REPL at the `Proceed? [Y/n]` confirmation prompt (Ctrl+C also dead). This PR fixes that, plus a follow-up `RecursionError` it exposed.

**Fix 1 — the deadlock.** The REPL dispatches each command on a worker thread (`asyncio.to_thread`) while prompt_toolkit owns the terminal in raw mode (`patch_stdout(raw=True)`) on the main loop. Confirmations are designed to hand control back to the main loop via a `threading.Event` (`route_confirm_through_prompt`), supplied as `confirm_fn`. `execute_routed_turn` forwarded `confirm_fn` to its `cli_agent`, `cli_help`, and `new_alert` branches but **dropped it on the slash branch**, so `execution_allowed` fell back to a blocking `input()` on the worker thread — deadlocking the REPL. `/integrations verify` is the only ELEVATED slash command, so it was the one that hung.

**Fix 2 — RecursionError (found in review by @Devesh36).** Once the prompt no longer hangs, answering `Y` reaches the verify handler, which wraps work in `console.status(...)`. Rich's status redirects `sys.stdout` to a `FileProxy` whose `write()` calls `console.print`, and `StreamingConsole.print` runs manual TTY cursor-prep that writes to `sys.stdout` — recursing infinitely:
`print → prepare_repl_output_line → sys.stdout.write → FileProxy.write → console.print → …`
This was latent (the handler was unreachable behind the hang). Fix: `StreamingConsole.print` skips the manual cursor-prep when `sys.stdout` is a Rich `FileProxy` — during a Rich-managed redirect Rich owns the cursor, so the prep is both unnecessary and recursive.

### Demo/Screenshot for feature changes and bug fixes -

**Before** (confirm-fix only, commit `c8906139`): answering `Y` crashes the command
```
❯ /integrations verify
Proceed? [Y/n] y
command error: maximum recursion depth exceeded (the REPL is still running)
```

**After** (this PR): confirmation is accepted, the verify table renders, REPL stays responsive
```
❯ /integrations verify
Confirm /integrations verify — this command may change configuration or run heavy work

Integrations
service       │ source │ status  │ detail
━━━━━━━━━━━━━━┿━━━━━━━━┿━━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
alertmanager  │ -      │ missing │ Not configured in local store or env.
grafana       │ -      │ missing │ Not configured in local store or env.
datadog       │ -      │ missing │ Not configured in local store or env.
…
40 integration(s) need attention.
❯
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem:** see "Describe the changes" above — a dropped `confirm_fn` caused a worker-thread `input()` deadlock, and a Rich `FileProxy` redirect caused infinite recursion in `StreamingConsole.print`.

**Alternatives considered:** (1) Change the global `DEFAULT_CONFIRM_FN` away from `input()` — rejected, because `input()` is correct for non-REPL CLI contexts (e.g. running `opensre integrations verify` in a normal terminal). (2) Detect the event-loop context inside `execution_allowed` — rejected as over-engineering; the handoff already exists and just needed to be reached. (3) Disable `console.status` in the verify handler — rejected; the recursion is a general `StreamingConsole` bug, so fixing it at the source covers every status-using command.

**Why this implementation:** Forwarding `confirm_fn` is the minimal fix, symmetric with the three sibling branches and the other `dispatch_slash` callers — it reuses the existing, tested handoff. Skipping cursor-prep under a `FileProxy` redirect targets the recursion at its root in `StreamingConsole.print`.

**Key components touched:**
- `app/cli/interactive_shell/runtime/execution.py` — `execute_routed_turn` now passes `confirm_fn` into `dispatch_slash` on the slash branch.
- `app/cli/interactive_shell/runtime/loop.py` — `StreamingConsole.print` skips the manual cursor-prep when `sys.stdout` is a Rich `FileProxy` redirect (fixes the RecursionError).
- `tests/cli/interactive_shell/test_terminal_runtime.py` — `test_dispatch_one_turn_forwards_confirm_fn_to_slash_dispatch` (confirm_fn is forwarded) and `test_streaming_console_print_does_not_recurse_under_stdout_redirect` (no recursion under a FileProxy redirect).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
<img width="1383" height="717" alt="Screenshot 2026-06-02 at 12 16 17 PM" src="https://github.com/user-attachments/assets/752588a4-66b0-4d17-ae3a-f456509aed9e" />
