### PR TITLE
feat(llm): support custom OpenAI- and Anthropic-compatible API endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,28 @@ GROQ_REASONING_MODEL=
 GROQ_CLASSIFICATION_MODEL=
 GROQ_TOOLCALL_MODEL=
 
+# Custom OpenAI-compatible endpoint (LiteLLM proxy, vLLM, LocalAI, internal gateway)
+# Set `LLM_PROVIDER=custom-openai` above. BASE_URL and API_KEY are required.
+# Model defaults to the OpenAI tier defaults; set CUSTOM_OPENAI_MODEL for a single
+# model across tiers, or the per-tier vars to override individually.
+CUSTOM_OPENAI_BASE_URL=
+CUSTOM_OPENAI_API_KEY=
+CUSTOM_OPENAI_MODEL=
+CUSTOM_OPENAI_REASONING_MODEL=
+CUSTOM_OPENAI_CLASSIFICATION_MODEL=
+CUSTOM_OPENAI_TOOLCALL_MODEL=
+
+# Custom Anthropic-compatible endpoint (proxy / gateway in front of the Anthropic API)
+# Set `LLM_PROVIDER=custom-anthropic` above. BASE_URL and API_KEY are required.
+# Model defaults to the Anthropic tier defaults; set CUSTOM_ANTHROPIC_MODEL for a
+# single model across tiers, or the per-tier vars to override individually.
+CUSTOM_ANTHROPIC_BASE_URL=
+CUSTOM_ANTHROPIC_API_KEY=
+CUSTOM_ANTHROPIC_MODEL=
+CUSTOM_ANTHROPIC_REASONING_MODEL=
+CUSTOM_ANTHROPIC_CLASSIFICATION_MODEL=
+CUSTOM_ANTHROPIC_TOOLCALL_MODEL=
+
 # --- First integrations to set up ------------------------------------------
 
 # For a first real RCA run, one of Grafana / Datadog / Honeycomb / Coralogix

--- a/app/config.py
+++ b/app/config.py
@@ -130,6 +130,22 @@ GROQ_REASONING_MODEL = "llama-3.3-70b-versatile"
 GROQ_CLASSIFICATION_MODEL = "llama-3.3-70b-versatile"
 GROQ_TOOLCALL_MODEL = "llama-3.1-8b-instant"
 
+# Custom OpenAI-compatible endpoint model constants (LiteLLM / vLLM / LocalAI /
+# internal gateways). Base URL and API key are supplied via env; the model
+# defaults mirror the OpenAI tier defaults and are overridable per tier via
+# CUSTOM_OPENAI_{REASONING,CLASSIFICATION,TOOLCALL}_MODEL or CUSTOM_OPENAI_MODEL.
+CUSTOM_OPENAI_REASONING_MODEL = OPENAI_REASONING_MODEL
+CUSTOM_OPENAI_CLASSIFICATION_MODEL = OPENAI_CLASSIFICATION_MODEL
+CUSTOM_OPENAI_TOOLCALL_MODEL = OPENAI_TOOLCALL_MODEL
+
+# Custom Anthropic-compatible endpoint model constants (proxy / gateway in front
+# of the Anthropic API). Base URL and API key are supplied via env; the model
+# defaults mirror the Anthropic tier defaults and are overridable per tier via
+# CUSTOM_ANTHROPIC_{REASONING,CLASSIFICATION,TOOLCALL}_MODEL or CUSTOM_ANTHROPIC_MODEL.
+CUSTOM_ANTHROPIC_REASONING_MODEL = ANTHROPIC_REASONING_MODEL
+CUSTOM_ANTHROPIC_CLASSIFICATION_MODEL = ANTHROPIC_CLASSIFICATION_MODEL
+CUSTOM_ANTHROPIC_TOOLCALL_MODEL = ANTHROPIC_TOOLCALL_MODEL
+
 # Base URLs for OpenAI-compatible providers
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 DEEPSEEK_BASE_URL = "https://api.deepseek.com"  # no /v1 — DeepSeek serves the OpenAI-compatible API at the root path
@@ -158,6 +174,8 @@ LLMProvider = Literal[
     "bedrock",
     "minimax",
     "groq",
+    "custom-openai",
+    "custom-anthropic",
     "codex",
     "cursor",
     "claude-code",
@@ -191,6 +209,14 @@ LLM_PROVIDER_API_KEY_ENVS = {
     "nvidia": "NVIDIA_API_KEY",
     "minimax": "MINIMAX_API_KEY",
     "groq": "GROQ_API_KEY",
+    "custom-openai": "CUSTOM_OPENAI_API_KEY",
+    "custom-anthropic": "CUSTOM_ANTHROPIC_API_KEY",
+}
+# Custom OpenAI/Anthropic-compatible providers require a user-supplied base URL
+# in addition to an API key. Maps provider -> (settings attr, env var).
+CUSTOM_ENDPOINT_BASE_URL_ENVS: dict[str, tuple[str, str]] = {
+    "custom-openai": ("custom_openai_base_url", "CUSTOM_OPENAI_BASE_URL"),
+    "custom-anthropic": ("custom_anthropic_base_url", "CUSTOM_ANTHROPIC_BASE_URL"),
 }
 DEFAULT_LLM_RESOLUTION_FALLBACK_PROVIDERS: tuple[str, ...] = ("openai", "anthropic")
 
@@ -339,6 +365,40 @@ def _llm_settings_env_payload(provider: str) -> dict[str, object]:
             os.getenv("GROQ_MODEL", GROQ_TOOLCALL_MODEL),
         ).strip()
         or GROQ_TOOLCALL_MODEL,
+        "custom_openai_api_key": resolve_llm_api_key("CUSTOM_OPENAI_API_KEY"),
+        "custom_anthropic_api_key": resolve_llm_api_key("CUSTOM_ANTHROPIC_API_KEY"),
+        "custom_openai_base_url": os.getenv("CUSTOM_OPENAI_BASE_URL", "").strip(),
+        "custom_anthropic_base_url": os.getenv("CUSTOM_ANTHROPIC_BASE_URL", "").strip(),
+        "custom_openai_reasoning_model": os.getenv(
+            "CUSTOM_OPENAI_REASONING_MODEL",
+            os.getenv("CUSTOM_OPENAI_MODEL", CUSTOM_OPENAI_REASONING_MODEL),
+        ).strip()
+        or CUSTOM_OPENAI_REASONING_MODEL,
+        "custom_openai_classification_model": os.getenv(
+            "CUSTOM_OPENAI_CLASSIFICATION_MODEL",
+            os.getenv("CUSTOM_OPENAI_MODEL", CUSTOM_OPENAI_CLASSIFICATION_MODEL),
+        ).strip()
+        or CUSTOM_OPENAI_CLASSIFICATION_MODEL,
+        "custom_openai_toolcall_model": os.getenv(
+            "CUSTOM_OPENAI_TOOLCALL_MODEL",
+            os.getenv("CUSTOM_OPENAI_MODEL", CUSTOM_OPENAI_TOOLCALL_MODEL),
+        ).strip()
+        or CUSTOM_OPENAI_TOOLCALL_MODEL,
+        "custom_anthropic_reasoning_model": os.getenv(
+            "CUSTOM_ANTHROPIC_REASONING_MODEL",
+            os.getenv("CUSTOM_ANTHROPIC_MODEL", CUSTOM_ANTHROPIC_REASONING_MODEL),
+        ).strip()
+        or CUSTOM_ANTHROPIC_REASONING_MODEL,
+        "custom_anthropic_classification_model": os.getenv(
+            "CUSTOM_ANTHROPIC_CLASSIFICATION_MODEL",
+            os.getenv("CUSTOM_ANTHROPIC_MODEL", CUSTOM_ANTHROPIC_CLASSIFICATION_MODEL),
+        ).strip()
+        or CUSTOM_ANTHROPIC_CLASSIFICATION_MODEL,
+        "custom_anthropic_toolcall_model": os.getenv(
+            "CUSTOM_ANTHROPIC_TOOLCALL_MODEL",
+            os.getenv("CUSTOM_ANTHROPIC_MODEL", CUSTOM_ANTHROPIC_TOOLCALL_MODEL),
+        ).strip()
+        or CUSTOM_ANTHROPIC_TOOLCALL_MODEL,
         "bedrock_reasoning_model": os.getenv(
             "BEDROCK_REASONING_MODEL", BEDROCK_REASONING_MODEL
         ).strip()
@@ -409,6 +469,16 @@ class LLMSettings(StrictConfigModel):
     groq_reasoning_model: str = GROQ_REASONING_MODEL
     groq_classification_model: str = GROQ_CLASSIFICATION_MODEL
     groq_toolcall_model: str = GROQ_TOOLCALL_MODEL
+    custom_openai_api_key: str = ""
+    custom_anthropic_api_key: str = ""
+    custom_openai_base_url: str = ""
+    custom_anthropic_base_url: str = ""
+    custom_openai_reasoning_model: str = CUSTOM_OPENAI_REASONING_MODEL
+    custom_openai_classification_model: str = CUSTOM_OPENAI_CLASSIFICATION_MODEL
+    custom_openai_toolcall_model: str = CUSTOM_OPENAI_TOOLCALL_MODEL
+    custom_anthropic_reasoning_model: str = CUSTOM_ANTHROPIC_REASONING_MODEL
+    custom_anthropic_classification_model: str = CUSTOM_ANTHROPIC_CLASSIFICATION_MODEL
+    custom_anthropic_toolcall_model: str = CUSTOM_ANTHROPIC_TOOLCALL_MODEL
     bedrock_reasoning_model: str = BEDROCK_REASONING_MODEL
     bedrock_classification_model: str = BEDROCK_CLASSIFICATION_MODEL
     bedrock_toolcall_model: str = BEDROCK_TOOLCALL_MODEL
@@ -437,6 +507,8 @@ class LLMSettings(StrictConfigModel):
             "bedrock",
             "minimax",
             "groq",
+            "custom-openai",
+            "custom-anthropic",
             "codex",
             "cursor",
             "claude-code",
@@ -461,6 +533,16 @@ class LLMSettings(StrictConfigModel):
     def _require_api_key_for_selected_provider(self) -> "LLMSettings":
         if self.provider in KEYLESS_LLM_PROVIDERS:
             return self  # local, IAM, or CLI-provider auth is handled outside API keys
+        # Custom OpenAI/Anthropic-compatible endpoints additionally require a
+        # user-supplied base URL — a missing one is a hard misconfiguration
+        # (not a swap-in-another-provider situation), so fail loudly.
+        base_url_spec = CUSTOM_ENDPOINT_BASE_URL_ENVS.get(self.provider)
+        if base_url_spec is not None:
+            attr, base_url_env = base_url_spec
+            if not getattr(self, attr):
+                raise ValueError(
+                    f"LLM provider '{self.provider}' requires {base_url_env} to be set."
+                )
         provider_to_key = {
             "anthropic": self.anthropic_api_key,
             "openai": self.openai_api_key,
@@ -470,6 +552,8 @@ class LLMSettings(StrictConfigModel):
             "nvidia": self.nvidia_api_key,
             "minimax": self.minimax_api_key,
             "groq": self.groq_api_key,
+            "custom-openai": self.custom_openai_api_key,
+            "custom-anthropic": self.custom_anthropic_api_key,
         }
         if provider_to_key[self.provider]:
             return self
@@ -576,6 +660,20 @@ GROQ_LLM_CONFIG = LLMModelConfig(
     reasoning_model=GROQ_REASONING_MODEL,
     classification_model=GROQ_CLASSIFICATION_MODEL,
     toolcall_model=GROQ_TOOLCALL_MODEL,
+    max_tokens=DEFAULT_MAX_TOKENS,
+)
+
+CUSTOM_OPENAI_LLM_CONFIG = LLMModelConfig(
+    reasoning_model=CUSTOM_OPENAI_REASONING_MODEL,
+    classification_model=CUSTOM_OPENAI_CLASSIFICATION_MODEL,
+    toolcall_model=CUSTOM_OPENAI_TOOLCALL_MODEL,
+    max_tokens=DEFAULT_MAX_TOKENS,
+)
+
+CUSTOM_ANTHROPIC_LLM_CONFIG = LLMModelConfig(
+    reasoning_model=CUSTOM_ANTHROPIC_REASONING_MODEL,
+    classification_model=CUSTOM_ANTHROPIC_CLASSIFICATION_MODEL,
+    toolcall_model=CUSTOM_ANTHROPIC_TOOLCALL_MODEL,
     max_tokens=DEFAULT_MAX_TOKENS,
 )
 

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -743,10 +743,11 @@ def get_agent_llm() -> _AgentClientType:
         from anthropic import Anthropic
 
         from app.config import CUSTOM_ANTHROPIC_LLM_CONFIG
-        from app.llm_credentials import resolve_llm_api_key
 
+        # settings is the single source of truth: the key was already resolved and
+        # validated during LLMSettings construction, so reuse it here.
         client = Anthropic(
-            api_key=resolve_llm_api_key("CUSTOM_ANTHROPIC_API_KEY"),
+            api_key=settings.custom_anthropic_api_key,
             base_url=settings.custom_anthropic_base_url,
             timeout=_CLIENT_TIMEOUT_SEC,
         )
@@ -816,7 +817,7 @@ def _create_openai_compat_client(settings: Any, provider: str) -> OpenAIAgentCli
             api_key_env="OLLAMA_API_KEY",
             api_key_default="ollama",
         )
-    if provider == "custom-openai":
+    elif provider == "custom-openai":
         # Base URL is user-supplied (LiteLLM / vLLM / LocalAI / gateway), not a
         # hard-coded constant like the other OpenAI-compatible providers.
         return OpenAIAgentClient(

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -727,9 +727,34 @@ def get_agent_llm() -> _AgentClientType:
             model=settings.openai_reasoning_model,
             max_tokens=OPENAI_LLM_CONFIG.max_tokens,
         )
-    elif provider in ("openrouter", "deepseek", "gemini", "nvidia", "minimax", "groq", "ollama"):
+    elif provider in (
+        "openrouter",
+        "deepseek",
+        "gemini",
+        "nvidia",
+        "minimax",
+        "groq",
+        "ollama",
+        "custom-openai",
+    ):
         # All OpenAI-compatible providers
         _agent_client = _create_openai_compat_client(settings, provider)
+    elif provider == "custom-anthropic":
+        from anthropic import Anthropic
+
+        from app.config import CUSTOM_ANTHROPIC_LLM_CONFIG
+        from app.llm_credentials import resolve_llm_api_key
+
+        client = Anthropic(
+            api_key=resolve_llm_api_key("CUSTOM_ANTHROPIC_API_KEY"),
+            base_url=settings.custom_anthropic_base_url,
+            timeout=_CLIENT_TIMEOUT_SEC,
+        )
+        _agent_client = AnthropicAgentClient(
+            model=settings.custom_anthropic_reasoning_model,
+            max_tokens=CUSTOM_ANTHROPIC_LLM_CONFIG.max_tokens,
+            client=client,
+        )
     elif provider == "bedrock":
         from app.config import BEDROCK_LLM_CONFIG
         from app.services.llm_client import _is_anthropic_bedrock_model
@@ -790,6 +815,14 @@ def _create_openai_compat_client(settings: Any, provider: str) -> OpenAIAgentCli
             base_url=f"{host}/v1",
             api_key_env="OLLAMA_API_KEY",
             api_key_default="ollama",
+        )
+    if provider == "custom-openai":
+        # Base URL is user-supplied (LiteLLM / vLLM / LocalAI / gateway), not a
+        # hard-coded constant like the other OpenAI-compatible providers.
+        return OpenAIAgentClient(
+            model=settings.custom_openai_reasoning_model,
+            base_url=settings.custom_openai_base_url,
+            api_key_env="CUSTOM_OPENAI_API_KEY",
         )
     base_url, api_key_env, model = provider_map[provider]
     return OpenAIAgentClient(model=model, base_url=base_url, api_key_env=api_key_env)

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -158,11 +158,21 @@ class LLMResponse:
 
 class LLMClient:
     def __init__(
-        self, *, model: str, max_tokens: int = 1024, temperature: float | None = None
+        self,
+        *,
+        model: str,
+        max_tokens: int = 1024,
+        temperature: float | None = None,
+        base_url: str | None = None,
+        api_key_env: str = "ANTHROPIC_API_KEY",
     ) -> None:
-        api_key = resolve_llm_api_key("ANTHROPIC_API_KEY")
+        # base_url is set for Anthropic-compatible gateways (custom-anthropic);
+        # api_key_env lets those gateways authenticate with their own key env var.
+        self._api_key_env = api_key_env
+        self._base_url = base_url
+        api_key = resolve_llm_api_key(api_key_env)
         self._api_key = api_key
-        self._client = Anthropic(api_key=api_key, timeout=_CLIENT_TIMEOUT_SEC)
+        self._client = Anthropic(api_key=api_key, base_url=base_url, timeout=_CLIENT_TIMEOUT_SEC)
         self._model = model
         self._max_tokens = max_tokens
         self._temperature = temperature
@@ -179,14 +189,16 @@ class LLMClient:
         return self
 
     def _ensure_client(self) -> None:
-        api_key = resolve_llm_api_key("ANTHROPIC_API_KEY")
+        api_key = resolve_llm_api_key(self._api_key_env)
         if not api_key:
             raise RuntimeError(
-                "Missing ANTHROPIC_API_KEY. Set it in your environment, .env, or secure local keychain before running LLM steps."
+                f"Missing {self._api_key_env}. Set it in your environment, .env, or secure local keychain before running LLM steps."
             )
         if api_key != self._api_key:
             self._api_key = api_key
-            self._client = Anthropic(api_key=api_key, timeout=_CLIENT_TIMEOUT_SEC)
+            self._client = Anthropic(
+                api_key=api_key, base_url=self._base_url, timeout=_CLIENT_TIMEOUT_SEC
+            )
 
     def _build_request_kwargs(self, prompt_or_messages: Any) -> dict[str, Any]:
         """Refresh credentials, normalize messages, apply guardrails, and build API kwargs.
@@ -1349,6 +1361,27 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
             max_tokens=config.max_tokens,
             base_url=GROQ_BASE_URL,
             api_key_env="GROQ_API_KEY",
+        )
+    elif provider == "custom-openai":
+        from app.config import CUSTOM_OPENAI_LLM_CONFIG
+
+        config = CUSTOM_OPENAI_LLM_CONFIG
+        return OpenAILLMClient(
+            model=_select_model(settings, "custom_openai", model_type),
+            model_fallback=_fallback_model("custom_openai"),
+            max_tokens=config.max_tokens,
+            base_url=settings.custom_openai_base_url,
+            api_key_env="CUSTOM_OPENAI_API_KEY",
+        )
+    elif provider == "custom-anthropic":
+        from app.config import CUSTOM_ANTHROPIC_LLM_CONFIG
+
+        config = CUSTOM_ANTHROPIC_LLM_CONFIG
+        return LLMClient(
+            model=_select_model(settings, "custom_anthropic", model_type),
+            max_tokens=config.max_tokens,
+            base_url=settings.custom_anthropic_base_url,
+            api_key_env="CUSTOM_ANTHROPIC_API_KEY",
         )
     elif provider == "ollama":
         from app.config import OLLAMA_LLM_CONFIG

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -580,6 +580,78 @@ def test_get_agent_llm_routes_deepseek_to_openai_compatible_client(
     assert captured["api_key_env"] == "DEEPSEEK_API_KEY"
 
 
+def test_get_agent_llm_routes_custom_openai_to_supplied_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services import agent_llm_client as alc
+
+    captured: dict[str, object] = {}
+
+    class _FakeOpenAIAgentClient:
+        def __init__(
+            self,
+            model: str,
+            max_tokens: int = 4096,
+            base_url: str | None = None,
+            api_key_env: str = "OPENAI_API_KEY",
+            api_key_default: str = "",
+        ) -> None:
+            captured.update(
+                {
+                    "model": model,
+                    "max_tokens": max_tokens,
+                    "base_url": base_url,
+                    "api_key_env": api_key_env,
+                    "api_key_default": api_key_default,
+                }
+            )
+
+    monkeypatch.setattr(alc, "OpenAIAgentClient", _FakeOpenAIAgentClient)
+    monkeypatch.setenv("LLM_PROVIDER", "custom-openai")
+    monkeypatch.setenv("CUSTOM_OPENAI_API_KEY", "sk-custom")
+    monkeypatch.setenv("CUSTOM_OPENAI_BASE_URL", "http://gateway:4000/v1")
+    monkeypatch.setenv("CUSTOM_OPENAI_REASONING_MODEL", "my-reasoner")
+
+    alc.reset_agent_client()
+    client = alc.get_agent_llm()
+
+    assert isinstance(client, _FakeOpenAIAgentClient)
+    assert captured["model"] == "my-reasoner"
+    assert captured["base_url"] == "http://gateway:4000/v1"
+    assert captured["api_key_env"] == "CUSTOM_OPENAI_API_KEY"
+    alc.reset_agent_client()
+
+
+def test_get_agent_llm_routes_custom_anthropic_to_anthropic_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import types
+
+    from app.services import agent_llm_client as alc
+
+    fake_anthropic = _install_fake_anthropic(monkeypatch)
+    captured: dict[str, object] = {}
+
+    class _CapturingAnthropic:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+            self.messages = types.SimpleNamespace(create=lambda **_: None)
+
+    fake_anthropic.Anthropic = _CapturingAnthropic
+    monkeypatch.setenv("LLM_PROVIDER", "custom-anthropic")
+    monkeypatch.setenv("CUSTOM_ANTHROPIC_API_KEY", "sk-ant-custom")
+    monkeypatch.setenv("CUSTOM_ANTHROPIC_BASE_URL", "https://proxy.example.com")
+    monkeypatch.setenv("CUSTOM_ANTHROPIC_REASONING_MODEL", "claude-proxy")
+
+    alc.reset_agent_client()
+    client = alc.get_agent_llm()
+
+    assert isinstance(client, alc.AnthropicAgentClient)
+    # The Anthropic SDK client must be built against the user-supplied base URL.
+    assert captured["base_url"] == "https://proxy.example.com"
+    alc.reset_agent_client()
+
+
 @pytest.mark.parametrize(
     "provider",
     [

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -15,7 +15,7 @@ class _FakeAnthropicMessages:
 class _FakeAnthropic:
     last_api_key: str | None = None
 
-    def __init__(self, *, api_key: str, timeout: float) -> None:
+    def __init__(self, *, api_key: str, timeout: float, **_kwargs: object) -> None:
         _FakeAnthropic.last_api_key = api_key
         self.timeout = timeout
         self.messages = _FakeAnthropicMessages()
@@ -456,7 +456,7 @@ def _make_capturing_anthropic(
             return _StreamCM()
 
     class _Anthropic:
-        def __init__(self, *, api_key: str, timeout: float) -> None:
+        def __init__(self, *, api_key: str, timeout: float, **_kwargs: object) -> None:
             self.api_key = api_key
             self.timeout = timeout
             self.messages = _Messages()
@@ -1142,6 +1142,43 @@ def test_create_llm_client_deepseek_reasoning_sets_toolcall_fallback(monkeypatch
         llm_client.reset_llm_singletons()
 
 
+def test_create_llm_client_custom_openai_uses_supplied_base_url(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "custom-openai")
+    monkeypatch.setenv("CUSTOM_OPENAI_API_KEY", "sk-custom")
+    monkeypatch.setenv("CUSTOM_OPENAI_BASE_URL", "http://localhost:4000/v1")
+    monkeypatch.setenv("CUSTOM_OPENAI_REASONING_MODEL", "my-reasoner")
+    monkeypatch.setenv("CUSTOM_OPENAI_TOOLCALL_MODEL", "my-toolcall")
+    llm_client.reset_llm_singletons()
+    try:
+        client = llm_client._create_llm_client("reasoning")
+
+        assert isinstance(client, llm_client.OpenAILLMClient)
+        assert client._model == "my-reasoner"
+        assert client._model_fallback == "my-toolcall"
+        assert client._base_url == "http://localhost:4000/v1"
+        assert client._api_key_env == "CUSTOM_OPENAI_API_KEY"
+    finally:
+        llm_client.reset_llm_singletons()
+
+
+def test_create_llm_client_custom_anthropic_uses_supplied_base_url(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "custom-anthropic")
+    monkeypatch.setenv("CUSTOM_ANTHROPIC_API_KEY", "sk-ant-custom")
+    monkeypatch.setenv("CUSTOM_ANTHROPIC_BASE_URL", "https://proxy.example.com")
+    monkeypatch.setenv("CUSTOM_ANTHROPIC_REASONING_MODEL", "claude-proxy")
+    monkeypatch.setattr(llm_client, "Anthropic", _FakeAnthropic)
+    llm_client.reset_llm_singletons()
+    try:
+        client = llm_client._create_llm_client("reasoning")
+
+        assert isinstance(client, llm_client.LLMClient)
+        assert client._model == "claude-proxy"
+        assert client._base_url == "https://proxy.example.com"
+        assert client._api_key_env == "CUSTOM_ANTHROPIC_API_KEY"
+    finally:
+        llm_client.reset_llm_singletons()
+
+
 def test_create_llm_client_claude_code_wires_cli_adapter(monkeypatch) -> None:
     """Investigation uses ``_create_llm_client`` → registry → ``CLIBackedLLMClient``."""
     monkeypatch.setenv("LLM_PROVIDER", "claude-code")
@@ -1266,7 +1303,7 @@ class _NotFoundMessages:
 
 
 class _NotFoundAnthropic:
-    def __init__(self, *, api_key: str, timeout: float) -> None:
+    def __init__(self, *, api_key: str, timeout: float, **_kwargs: object) -> None:
         del api_key, timeout
         self.messages = _NotFoundMessages("not-a-real-model-xyz")
 
@@ -2245,7 +2282,7 @@ class _BadRequestMessages:
 
 
 class _UsageLimitAnthropic:
-    def __init__(self, *, api_key: str, timeout: float) -> None:
+    def __init__(self, *, api_key: str, timeout: float, **_kwargs: object) -> None:
         del api_key, timeout
         self.messages = _BadRequestMessages(_USAGE_LIMIT_BODY)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,6 +100,75 @@ def test_llm_settings_from_env_minimax(monkeypatch) -> None:
     assert settings.minimax_api_key == "mm-stored-key"
 
 
+def test_llm_settings_custom_openai_provider_accepted() -> None:
+    settings = LLMSettings.model_validate(
+        {
+            "provider": "custom-openai",
+            "custom_openai_api_key": "sk-custom",
+            "custom_openai_base_url": "http://localhost:4000/v1",
+        }
+    )
+    assert settings.provider == "custom-openai"
+    assert settings.custom_openai_base_url == "http://localhost:4000/v1"
+    # Tier defaults mirror the OpenAI tier defaults when unset.
+    assert settings.custom_openai_reasoning_model == "gpt-5.4-mini"
+
+
+def test_llm_settings_custom_anthropic_provider_accepted() -> None:
+    settings = LLMSettings.model_validate(
+        {
+            "provider": "custom-anthropic",
+            "custom_anthropic_api_key": "sk-ant-custom",
+            "custom_anthropic_base_url": "https://proxy.example.com",
+        }
+    )
+    assert settings.provider == "custom-anthropic"
+    assert settings.custom_anthropic_base_url == "https://proxy.example.com"
+    assert settings.custom_anthropic_reasoning_model == "claude-opus-4-7"
+
+
+def test_llm_settings_require_custom_openai_api_key() -> None:
+    with pytest.raises(ValidationError, match="CUSTOM_OPENAI_API_KEY"):
+        LLMSettings.model_validate(
+            {"provider": "custom-openai", "custom_openai_base_url": "http://localhost:4000/v1"}
+        )
+
+
+def test_llm_settings_require_custom_openai_base_url() -> None:
+    with pytest.raises(ValidationError, match="CUSTOM_OPENAI_BASE_URL"):
+        LLMSettings.model_validate(
+            {"provider": "custom-openai", "custom_openai_api_key": "sk-custom"}
+        )
+
+
+def test_llm_settings_require_custom_anthropic_base_url() -> None:
+    with pytest.raises(ValidationError, match="CUSTOM_ANTHROPIC_BASE_URL"):
+        LLMSettings.model_validate(
+            {"provider": "custom-anthropic", "custom_anthropic_api_key": "sk-ant-custom"}
+        )
+
+
+def test_llm_settings_from_env_custom_openai_per_tier_overrides(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "custom-openai")
+    monkeypatch.setenv("CUSTOM_OPENAI_BASE_URL", "http://gateway:4000/v1")
+    # CUSTOM_OPENAI_MODEL is the single-model fallback; the per-tier var wins for its tier.
+    monkeypatch.setenv("CUSTOM_OPENAI_MODEL", "shared-model")
+    monkeypatch.setenv("CUSTOM_OPENAI_REASONING_MODEL", "reasoner-model")
+    monkeypatch.setattr(
+        "app.config.resolve_llm_api_key",
+        lambda env_var: "sk-stored" if env_var == "CUSTOM_OPENAI_API_KEY" else "",
+    )
+
+    settings = LLMSettings.from_env()
+
+    assert settings.provider == "custom-openai"
+    assert settings.custom_openai_api_key == "sk-stored"
+    assert settings.custom_openai_base_url == "http://gateway:4000/v1"
+    assert settings.custom_openai_reasoning_model == "reasoner-model"
+    assert settings.custom_openai_classification_model == "shared-model"
+    assert settings.custom_openai_toolcall_model == "shared-model"
+
+
 @pytest.mark.parametrize(
     "raw_host, expected",
     [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from app.config import LLMSettings, has_credentials_for_active_llm_provider, resolve_llm_settings
+from app.config import (
+    ANTHROPIC_REASONING_MODEL,
+    OPENAI_REASONING_MODEL,
+    LLMSettings,
+    has_credentials_for_active_llm_provider,
+    resolve_llm_settings,
+)
 
 
 def test_llm_settings_reject_provider_typos_with_suggestion() -> None:
@@ -111,7 +117,7 @@ def test_llm_settings_custom_openai_provider_accepted() -> None:
     assert settings.provider == "custom-openai"
     assert settings.custom_openai_base_url == "http://localhost:4000/v1"
     # Tier defaults mirror the OpenAI tier defaults when unset.
-    assert settings.custom_openai_reasoning_model == "gpt-5.4-mini"
+    assert settings.custom_openai_reasoning_model == OPENAI_REASONING_MODEL
 
 
 def test_llm_settings_custom_anthropic_provider_accepted() -> None:
@@ -124,7 +130,8 @@ def test_llm_settings_custom_anthropic_provider_accepted() -> None:
     )
     assert settings.provider == "custom-anthropic"
     assert settings.custom_anthropic_base_url == "https://proxy.example.com"
-    assert settings.custom_anthropic_reasoning_model == "claude-opus-4-7"
+    # Tier defaults mirror the Anthropic tier defaults when unset.
+    assert settings.custom_anthropic_reasoning_model == ANTHROPIC_REASONING_MODEL
 
 
 def test_llm_settings_require_custom_openai_api_key() -> None:
@@ -145,6 +152,16 @@ def test_llm_settings_require_custom_anthropic_base_url() -> None:
     with pytest.raises(ValidationError, match="CUSTOM_ANTHROPIC_BASE_URL"):
         LLMSettings.model_validate(
             {"provider": "custom-anthropic", "custom_anthropic_api_key": "sk-ant-custom"}
+        )
+
+
+def test_llm_settings_require_custom_anthropic_api_key() -> None:
+    with pytest.raises(ValidationError, match="CUSTOM_ANTHROPIC_API_KEY"):
+        LLMSettings.model_validate(
+            {
+                "provider": "custom-anthropic",
+                "custom_anthropic_base_url": "https://proxy.example.com",
+            }
         )
 
 


### PR DESCRIPTION
Fixes #2682

#### Describe the changes you have made in this PR -

Adds two env-var-configured LLM providers so teams routing traffic through an OpenAI- or Anthropic-compatible gateway (LiteLLM proxy, vLLM, LocalAI, internal model gateway) can point OpenSRE at an arbitrary base URL with their own key and model — no longer requiring a fork or misuse of a fixed-base-URL provider.

- **`custom-openai`** — reuses the existing OpenAI-compatible client with `CUSTOM_OPENAI_BASE_URL` / `CUSTOM_OPENAI_API_KEY` (same pattern as `openrouter`/`deepseek`/`minimax`).
- **`custom-anthropic`** — uses the Anthropic SDK with a base-URL override, threaded through **both** the sync LLM client (`LLMClient`) and the agent tool-calling loop (`AnthropicAgentClient`).

Both validate that the API key **and** base URL are set — a missing base URL fails loudly rather than silently falling back to another provider — and support per-tier model overrides via `CUSTOM_*_{REASONING,CLASSIFICATION,TOOLCALL}_MODEL` (falling back to `CUSTOM_*_MODEL`, then the OpenAI/Anthropic tier defaults). Documented in `.env.example`.

Additive only — no existing provider behavior changes. `LLMClient` gains optional `base_url` / `api_key_env` params (defaulting to `ANTHROPIC_API_KEY`) to back `custom-anthropic`.

**Files changed:** `app/config.py`, `app/services/llm_client.py`, `app/services/agent_llm_client.py`, `.env.example`, plus tests in `tests/test_config.py`, `tests/services/test_llm_client.py`, `tests/services/test_agent_llm_client.py`.

### Demo/Screenshot for feature changes and bug fixes -

<!-- Replace with a terminal snippet of `LLM_PROVIDER=custom-openai` pointed at a local OpenAI-compatible endpoint (e.g. Ollama's /v1 or a LiteLLM proxy) running an investigation. The new tests below are also valid proof for config/LLM plumbing: -->

New unit tests (config validation + client construction for both providers and both client factories):
```
tests/test_config.py::test_llm_settings_custom_openai_provider_accepted PASSED
tests/test_config.py::test_llm_settings_custom_anthropic_provider_accepted PASSED
tests/test_config.py::test_llm_settings_require_custom_openai_api_key PASSED
tests/test_config.py::test_llm_settings_require_custom_openai_base_url PASSED
tests/test_config.py::test_llm_settings_require_custom_anthropic_base_url PASSED
tests/test_config.py::test_llm_settings_from_env_custom_openai_per_tier_overrides PASSED
tests/services/test_llm_client.py::test_create_llm_client_custom_openai_uses_supplied_base_url PASSED
tests/services/test_llm_client.py::test_create_llm_client_custom_anthropic_uses_supplied_base_url PASSED
tests/services/test_agent_llm_client.py::test_get_agent_llm_routes_custom_openai_to_supplied_base_url PASSED
tests/services/test_agent_llm_client.py::test_get_agent_llm_routes_custom_anthropic_to_anthropic_client PASSED

```
Full local gate: `make lint` · `make format-check` · `make typecheck` (697 files) · `make test-cov` → **7904 passed, 32 skipped** (the only errors are credential-gated live-LLM routing tests that require a real `ANTHROPIC_API_KEY`, unrelated to this change).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem:** OpenSRE supported a fixed set of providers, each bound to a hard-coded base URL. Teams behind an OpenAI- or Anthropic-compatible gateway (LiteLLM, vLLM, LocalAI, on-prem proxy) had no first-class way to use their own endpoint — they had to fork the client or abuse a provider whose base URL is fixed. This blocks self-hosted/proxied/on-prem deployments where direct calls to the public APIs aren't allowed.

**Approach:** I followed the project's existing provider pattern rather than inventing a new mechanism. The OpenAI-compatible providers (`openrouter`, `deepseek`, `minimax`, etc.) already build a single `OpenAILLMClient`/`OpenAIAgentClient` with a swapped `base_url` and `api_key_env`; `custom-openai` is the same, except the base URL comes from `CUSTOM_OPENAI_BASE_URL` instead of a constant. For `custom-anthropic`, the Anthropic SDK accepts a `base_url`, so I added optional `base_url`/`api_key_env` params to `LLMClient` (defaulting to `ANTHROPIC_API_KEY`, so existing behavior is unchanged) and, for the agent loop, passed a pre-built `Anthropic(base_url=...)` client into the existing `AnthropicAgentClient(client=...)` hook.

**Alternatives considered:** (1) Changing the global default confirm/`input` — N/A here. (2) Making the base URL optional with a silent fallback — rejected: if you explicitly set `LLM_PROVIDER=custom-openai`, a missing base URL is a misconfiguration that should fail loudly, not quietly route elsewhere. (3) A generic `base_url` override on *every* provider — rejected as broader than the issue and riskier; two explicit providers keep validation and defaults clear.

**Key components:**
- `app/config.py` — adds both to the `LLMProvider` literal and validator list, the API-key env map, a `CUSTOM_ENDPOINT_BASE_URL_ENVS` map driving the base-URL-required check, `LLMSettings` fields (keys, base URLs, per-tier models), the env payload (with `CUSTOM_*_MODEL` → per-tier fallback), and `LLMModelConfig` objects.
- `app/services/llm_client.py` — parametrizes `LLMClient` with `base_url`/`api_key_env` and adds the two factory branches in `_create_llm_client`.
- `app/services/agent_llm_client.py` — routes `custom-openai` through `_create_openai_compat_client` and builds a base-URL-overridden Anthropic client for `custom-anthropic`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
