### PR TITLE
feat(grafana): add deployment-annotations tool for change correlation (#2689)

### DIFF
--- a/app/integrations/opensre/csv_grafana_backend.py
+++ b/app/integrations/opensre/csv_grafana_backend.py
@@ -260,6 +260,10 @@ class OpenSRECsvGrafanaBackend:
         traces = [{"traceID": tid, "spans": spans} for tid, spans in span_by_trace.items()]
         return {"traces": traces, "metrics": {}}
 
+    def query_annotations(self, **_: Any) -> list[dict[str, Any]]:
+        # OpenSRE CSV telemetry carries no deploy/config-change annotations.
+        return []
+
     def _default_alert(self) -> dict[str, Any]:
         return {
             "title": "OpenSRE local telemetry",

--- a/app/services/grafana/base.py
+++ b/app/services/grafana/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
+from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import quote
 
@@ -43,6 +44,29 @@ def _extract_rule_queries(rule: dict) -> list[dict]:
                 }
             )
     return queries
+
+
+def _epoch_ms_to_iso(ms: Any) -> str | None:
+    """Convert a Grafana epoch-millisecond timestamp to an ISO 8601 UTC string."""
+    if ms is None:
+        return None
+    try:
+        return datetime.fromtimestamp(int(ms) / 1000, tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _map_annotation(item: dict[str, Any]) -> dict[str, Any]:
+    """Map a raw /api/annotations item to the tool-facing annotation shape."""
+    tags = item.get("tags")
+    return {
+        "time": _epoch_ms_to_iso(item.get("time")),
+        "time_end": _epoch_ms_to_iso(item.get("timeEnd")),
+        "text": item.get("text", ""),
+        "tags": tags if isinstance(tags, list) else [],
+        # Modern UID only; ignore the legacy numeric dashboardId (0 == not attached).
+        "dashboard_uid": item.get("dashboardUID") or None,
+    }
 
 
 class GrafanaClientBase:
@@ -293,6 +317,42 @@ class GrafanaClientBase:
             return rules
         except Exception as e:
             logger.warning("[grafana] Failed to query alert rules: %s", e)
+            return []
+
+    def query_annotations(
+        self,
+        from_ts: int,
+        to_ts: int,
+        tags: list[str] | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Query Grafana annotations in a time window (epoch ms), optional tag filter.
+
+        Mirrors ``query_alert_rules``: a direct ``requests.get`` returning a list.
+        ``/api/annotations`` responds with a JSON array, so ``_make_request`` (which
+        returns a dict) is unsuitable here.
+        """
+        url = f"{self.instance_url}/api/annotations"
+        params: dict[str, Any] = {
+            "from": from_ts,
+            "to": to_ts,
+            "type": "annotation",
+            "limit": limit,
+        }
+        if tags:
+            params["tags"] = tags  # requests repeats the param once per tag
+        try:
+            response = requests.get(
+                url,
+                headers=self._get_auth_headers(),
+                params=params,
+                timeout=10,
+            )
+            response.raise_for_status()
+            data = response.json()
+            return [_map_annotation(item) for item in data if isinstance(item, dict)]
+        except Exception as e:
+            logger.warning("[grafana] Failed to query annotations: %s", e)
             return []
 
     def _get_auth_headers(self) -> dict[str, str]:

--- a/app/tools/GrafanaAnnotationsTool/__init__.py
+++ b/app/tools/GrafanaAnnotationsTool/__init__.py
@@ -1,0 +1,149 @@
+"""Grafana deployment-annotations query tool for change correlation."""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+from app.services.grafana.base import _epoch_ms_to_iso, _map_annotation
+from app.tools.GrafanaLogsTool import (
+    _grafana_available,
+    _grafana_creds,
+    _grafana_source,
+    _resolve_grafana_client,
+)
+from app.tools.tool_decorator import tool
+
+
+def _query_grafana_annotations_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
+    grafana = _grafana_source(sources)
+    return {
+        "time_range_minutes": grafana.get("time_range_minutes", 60),
+        "grafana_backend": grafana.get("_backend"),
+        **_grafana_creds(grafana),
+    }
+
+
+def _query_grafana_annotations_available(sources: dict[str, dict]) -> bool:
+    return _grafana_available(sources)
+
+
+def _normalize_backend_annotations(raw: Any) -> list[dict[str, Any]]:
+    """Normalize fixture/backend ``/api/annotations`` arrays to the client shape."""
+    if not isinstance(raw, list):
+        return []
+    return [_map_annotation(item) for item in raw if isinstance(item, dict)]
+
+
+def _iso_to_epoch_ms(value: str) -> int:
+    """Parse an ISO 8601 timestamp to epoch milliseconds (UTC). Raises ValueError if invalid.
+
+    A timezone-naive value (no ``Z`` / offset) is interpreted as UTC, not host-local time.
+    """
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return int(dt.timestamp() * 1000)
+
+
+@tool(
+    name="query_grafana_annotations",
+    display_name="Grafana annotations",
+    source="grafana",
+    description=(
+        "Query Grafana deployment/config-change annotations to correlate changes with "
+        "an incident — the source-agnostic 'what changed and when' marker."
+    ),
+    use_cases=[
+        "Checking whether a deploy or config change preceded an alert",
+        "Correlating incidents with ArgoCD/Flux/Helm/Terraform/manual changes emitted as annotations",
+        "Building a source-agnostic change timeline alongside the GitHub deploy timeline",
+    ],
+    requires=[],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "from": {
+                "type": "string",
+                "description": "ISO 8601 window start (overrides time_range_minutes)",
+            },
+            "to": {
+                "type": "string",
+                "description": "ISO 8601 window end (overrides time_range_minutes)",
+            },
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "time_range_minutes": {"type": "integer", "default": 60},
+            "limit": {"type": "integer", "default": 100},
+            "grafana_endpoint": {"type": "string"},
+            "grafana_api_key": {"type": "string"},
+        },
+        "required": [],
+    },
+    is_available=_query_grafana_annotations_available,
+    extract_params=_query_grafana_annotations_extract_params,
+)
+def query_grafana_annotations(
+    tags: list[str] | None = None,
+    time_range_minutes: int = 60,
+    limit: int = 100,
+    grafana_endpoint: str | None = None,
+    grafana_api_key: str | None = None,
+    grafana_username: str = "",
+    grafana_password: str = "",
+    grafana_backend: Any = None,
+    **_kwargs: Any,
+) -> dict:
+    """Query Grafana annotations to correlate deploys/config changes with an incident.
+
+    ``from``/``to`` are accepted via the schema (ISO 8601); they are read from
+    ``_kwargs`` because ``from`` is a Python keyword and cannot be a parameter name.
+    When absent, the window defaults to the last ``time_range_minutes``.
+    """
+    if grafana_backend is not None:
+        raw = grafana_backend.query_annotations(tags=tags, limit=limit)
+        annotations = _normalize_backend_annotations(raw)
+        return {
+            "source": "grafana_annotations",
+            "available": True,
+            "annotations": annotations,
+            "total": len(annotations),
+            "raw": raw,
+        }
+
+    client = _resolve_grafana_client(
+        grafana_endpoint, grafana_api_key, grafana_username, grafana_password
+    )
+    if not client or not client.is_configured:
+        return {
+            "source": "grafana_annotations",
+            "available": False,
+            "error": "Grafana integration not configured",
+            "annotations": [],
+        }
+
+    now_ms = int(time.time() * 1000)
+    try:
+        from_iso, to_iso = _kwargs.get("from"), _kwargs.get("to")
+        to_ts = _iso_to_epoch_ms(to_iso) if to_iso else now_ms
+        # Default the window to end at `to` (now if unset), so a `to`-only call still
+        # yields a valid [to - window, to] range rather than from_ts > to_ts.
+        from_ts = _iso_to_epoch_ms(from_iso) if from_iso else to_ts - time_range_minutes * 60 * 1000
+    except (ValueError, TypeError, AttributeError) as e:
+        return {
+            "source": "grafana_annotations",
+            "available": False,
+            "error": f"Invalid timestamp: {e}",
+            "annotations": [],
+        }
+
+    annotations = client.query_annotations(from_ts=from_ts, to_ts=to_ts, tags=tags, limit=limit)
+    return {
+        "source": "grafana_annotations",
+        "available": True,
+        "annotations": annotations,
+        "total": len(annotations),
+        "tags_filter": tags,
+        "from": _epoch_ms_to_iso(from_ts),
+        "to": _epoch_ms_to_iso(to_ts),
+    }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -108,6 +108,7 @@
               "coralogix",
               "datadog",
               "grafana",
+              "grafana_annotations",
               "hermes",
               "honeycomb",
               "incident_io",

--- a/docs/grafana_annotations.mdx
+++ b/docs/grafana_annotations.mdx
@@ -1,0 +1,71 @@
+---
+title: "Grafana Annotations"
+---
+
+Correlate incidents with **deployments and config changes** from any source. OpenSRE reads
+[Grafana annotations](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/annotate-visualizations/) —
+the standard, source-agnostic "what changed and when" marker — so the agent can answer
+_"did a deploy or config change precede this alert?"_ even when the change did **not** come
+from a GitHub push (ArgoCD/Flux syncs, `helm upgrade`, Jenkins/CircleCI jobs, Terraform
+applies, manual hotfixes).
+
+This complements the GitHub deploy timeline, which only sees GitHub-originated deploys.
+
+## Requirements
+
+No new setup or credentials — it reuses your existing **Grafana** integration. If Grafana is
+connected (see [Grafana](/grafana)), the annotations tool is available automatically during
+investigations.
+
+## Parameters
+
+| Parameter            | Description                                                                 |
+| -------------------- | --------------------------------------------------------------------------- |
+| `from`               | ISO 8601 window start (e.g. `2026-05-30T14:00:00Z`). Overrides the default. |
+| `to`                 | ISO 8601 window end. Overrides the default.                                 |
+| `tags`               | Optional list of annotation tags to filter by (e.g. `["deployment"]`).      |
+| `time_range_minutes` | Window size when `from`/`to` are omitted (default `60`, ending now).        |
+| `limit`              | Maximum annotations to return (default `100`).                              |
+
+## Example
+
+```text
+query_grafana_annotations(from="2026-05-30T14:00:00Z", to="2026-05-30T15:00:00Z", tags=["deployment"])
+```
+
+```json
+{
+  "source": "grafana_annotations",
+  "total": 1,
+  "annotations": [
+    {
+      "time": "2026-05-30T14:41:09Z",
+      "time_end": null,
+      "text": "deploy checkout-api v2.8.1",
+      "tags": ["deployment", "checkout-api"],
+      "dashboard_uid": null
+    }
+  ]
+}
+```
+
+Each annotation also carries `time_end` (set only for region annotations) and `dashboard_uid`
+(set only when the annotation is attached to a dashboard); both are `null` otherwise.
+
+The agent uses results like this to flag a likely change-induced regression and tie the
+suspected root cause to a specific deploy.
+
+## Emitting annotations
+
+Make your deploys visible by writing a Grafana annotation when you ship. Most CD tools can
+post to Grafana's annotations API, for example:
+
+```bash
+curl -s -X POST "$GRAFANA_URL/api/annotations" \
+  -H "Authorization: Bearer $GRAFANA_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"time": 1717079669000, "text": "deploy checkout-api v2.8.1", "tags": ["deployment", "checkout-api"]}'
+```
+
+Tagging deploy annotations consistently (e.g. `deployment`) lets the agent filter precisely
+during an investigation.

--- a/tests/synthetic/mock_grafana_backend/backend.py
+++ b/tests/synthetic/mock_grafana_backend/backend.py
@@ -34,11 +34,12 @@ if TYPE_CHECKING:
 class GrafanaBackend(Protocol):
     """Minimal observability interface used by the RDS investigation agent.
 
-    Four methods — one per evidence pillar:
+    Four evidence pillars plus change correlation:
         query_timeseries  → Mimir/Prometheus matrix response
         query_logs        → Loki streams response
         query_alert_rules → Grafana Ruler rules response
         query_traces      → Tempo search response
+        query_annotations → /api/annotations array (deploy/config-change markers)
     """
 
     def query_timeseries(self, query: str = "", **kwargs: Any) -> dict[str, Any]:
@@ -55,6 +56,10 @@ class GrafanaBackend(Protocol):
 
     def query_traces(self, **kwargs: Any) -> dict[str, Any]:
         """Return a Tempo-compatible search response."""
+        pass
+
+    def query_annotations(self, **kwargs: Any) -> list[dict[str, Any]]:
+        """Return a Grafana /api/annotations array (a JSON list, not a dict)."""
         pass
 
 
@@ -181,3 +186,7 @@ class FixtureGrafanaBackend:
 
     def query_traces(self, **_: Any) -> dict[str, Any]:
         return format_tempo_search()
+
+    def query_annotations(self, **_: Any) -> list[dict[str, Any]]:
+        # RDS scenario fixtures declare no deploy/config-change annotations.
+        return []

--- a/tests/synthetic/mock_grafana_backend/selective_backend.py
+++ b/tests/synthetic/mock_grafana_backend/selective_backend.py
@@ -92,6 +92,9 @@ class SelectiveGrafanaBackend:
     def query_traces(self, **_: Any) -> dict[str, Any]:
         return format_tempo_search()
 
+    def query_annotations(self, **_: Any) -> list[dict[str, Any]]:
+        return []
+
     def reset(self) -> None:
         """Clear the queried_metrics audit log (useful for re-running a scenario)."""
         self.queried_metrics = []

--- a/tests/tools/test_grafana_annotations_tool.py
+++ b/tests/tools/test_grafana_annotations_tool.py
@@ -1,0 +1,201 @@
+"""Tests for GrafanaAnnotationsTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.tools.GrafanaAnnotationsTool import (
+    _iso_to_epoch_ms,
+    query_grafana_annotations,
+)
+from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+class TestGrafanaAnnotationsToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return query_grafana_annotations.__opensre_registered_tool__
+
+
+def test_is_available_requires_grafana_creds() -> None:
+    rt = query_grafana_annotations.__opensre_registered_tool__
+    assert rt.is_available({"grafana": {"connection_verified": True}}) is True
+    assert rt.is_available({"grafana": {}}) is False
+    assert rt.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    rt = query_grafana_annotations.__opensre_registered_tool__
+    sources = mock_agent_state()
+    params = rt.extract_params(sources)
+    assert params["grafana_endpoint"] == "https://grafana.example.com"
+    assert params["time_range_minutes"] == 60
+
+
+def test_run_with_backend_maps_wire_shape() -> None:
+    mock_backend = MagicMock()
+    mock_backend.query_annotations.return_value = [
+        {
+            "time": 1717079669000,
+            "timeEnd": None,
+            "text": "deploy checkout-api v2.8.1",
+            "tags": ["deployment", "checkout-api"],
+            "dashboardUID": "abc",
+        }
+    ]
+    result = query_grafana_annotations(grafana_backend=mock_backend)
+    assert result["available"] is True
+    assert "raw" in result
+    assert result["total"] == 1
+    # backend path forwards the filter args (not dropped), so fixtures can filter
+    mock_backend.query_annotations.assert_called_once_with(tags=None, limit=100)
+    annotation = result["annotations"][0]
+    assert isinstance(annotation["time"], str) and annotation["time"].endswith("Z")
+    assert annotation["text"] == "deploy checkout-api v2.8.1"
+    assert annotation["tags"] == ["deployment", "checkout-api"]
+    assert annotation["dashboard_uid"] == "abc"
+
+
+def test_run_no_client() -> None:
+    mock_client = MagicMock()
+    mock_client.is_configured = False
+    with patch(
+        "app.tools.GrafanaAnnotationsTool._resolve_grafana_client", return_value=mock_client
+    ):
+        result = query_grafana_annotations(grafana_endpoint="http://grafana")
+    assert result["available"] is False
+    assert result["annotations"] == []
+
+
+def test_run_happy_path_defaults_now_window() -> None:
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    mock_client.query_annotations.return_value = [
+        {"time": "2026-05-30T14:41:09Z", "text": "deploy", "tags": ["deployment"]}
+    ]
+    with patch(
+        "app.tools.GrafanaAnnotationsTool._resolve_grafana_client", return_value=mock_client
+    ):
+        result = query_grafana_annotations(grafana_endpoint="http://grafana", time_range_minutes=60)
+    assert result["available"] is True
+    assert result["total"] == 1
+    kwargs = mock_client.query_annotations.call_args.kwargs
+    assert isinstance(kwargs["from_ts"], int) and isinstance(kwargs["to_ts"], int)
+    # default window spans exactly time_range_minutes (60 min) in epoch ms
+    assert kwargs["to_ts"] - kwargs["from_ts"] == 60 * 60 * 1000
+
+
+def test_run_with_explicit_from_to_override() -> None:
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    mock_client.query_annotations.return_value = []
+    with patch(
+        "app.tools.GrafanaAnnotationsTool._resolve_grafana_client", return_value=mock_client
+    ):
+        result = query_grafana_annotations(
+            grafana_endpoint="http://grafana",
+            **{"from": "2026-05-30T14:00:00Z", "to": "2026-05-30T15:00:00Z"},
+        )
+    mock_client.query_annotations.assert_called_once_with(
+        from_ts=_iso_to_epoch_ms("2026-05-30T14:00:00Z"),
+        to_ts=_iso_to_epoch_ms("2026-05-30T15:00:00Z"),
+        tags=None,
+        limit=100,
+    )
+    # the returned window echoes ISO-8601 strings, consistent with annotation timestamps
+    assert result["from"] == "2026-05-30T14:00:00Z"
+    assert result["to"] == "2026-05-30T15:00:00Z"
+
+
+def test_run_forwards_tags_filter() -> None:
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    mock_client.query_annotations.return_value = []
+    with patch(
+        "app.tools.GrafanaAnnotationsTool._resolve_grafana_client", return_value=mock_client
+    ):
+        result = query_grafana_annotations(grafana_endpoint="http://grafana", tags=["deployment"])
+    assert result["tags_filter"] == ["deployment"]
+    assert mock_client.query_annotations.call_args.kwargs["tags"] == ["deployment"]
+
+
+def test_run_invalid_timestamp_returns_error() -> None:
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    with patch(
+        "app.tools.GrafanaAnnotationsTool._resolve_grafana_client", return_value=mock_client
+    ):
+        result = query_grafana_annotations(
+            grafana_endpoint="http://grafana", **{"from": "not-a-date"}
+        )
+    assert result["available"] is False
+    assert "Invalid timestamp" in result["error"]
+
+
+def test_iso_to_epoch_ms_treats_naive_as_utc() -> None:
+    # A timezone-naive ISO string must be interpreted as UTC, matching the "Z" form —
+    # never as host-local time (which would silently shift the query window).
+    assert _iso_to_epoch_ms("2026-05-30T14:00:00") == _iso_to_epoch_ms("2026-05-30T14:00:00Z")
+
+
+def test_fixture_backend_implements_query_annotations() -> None:
+    # Regression guard: the synthetic FixtureGrafanaBackend must expose query_annotations
+    # so the backend path returns data instead of an AttributeError. spec= ties this test
+    # to the real class — removing the method makes the attribute access fail here.
+    from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
+
+    backend = MagicMock(spec=FixtureGrafanaBackend)
+    backend.query_annotations.return_value = []
+    result = query_grafana_annotations(grafana_backend=backend)
+    assert result["available"] is True
+    assert result["total"] == 0
+
+
+def test_run_backend_forwards_tags_and_limit() -> None:
+    mock_backend = MagicMock()
+    mock_backend.query_annotations.return_value = []
+    query_grafana_annotations(grafana_backend=mock_backend, tags=["deployment"], limit=50)
+    mock_backend.query_annotations.assert_called_once_with(tags=["deployment"], limit=50)
+
+
+def test_extract_params_surfaces_basic_auth() -> None:
+    rt = query_grafana_annotations.__opensre_registered_tool__
+    sources = mock_agent_state({"grafana": {"username": "admin", "password": "secret"}})
+    params = rt.extract_params(sources)
+    assert params["grafana_username"] == "admin"
+    assert params["grafana_password"] == "secret"
+
+
+def test_run_forwards_basic_auth_to_client() -> None:
+    # Basic-auth Grafana integrations inject username/password; they must reach the client
+    # (otherwise /api/annotations is queried without auth headers and returns 401/empty).
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    mock_client.query_annotations.return_value = []
+    with patch(
+        "app.tools.GrafanaAnnotationsTool._resolve_grafana_client", return_value=mock_client
+    ) as resolve:
+        query_grafana_annotations(
+            grafana_endpoint="http://grafana",
+            grafana_username="admin",
+            grafana_password="secret",
+        )
+    resolve.assert_called_once_with("http://grafana", None, "admin", "secret")
+
+
+def test_run_to_only_anchors_window_before_to() -> None:
+    # A `to`-only call must yield [to - window, to], not from_ts (now-anchored) > to_ts.
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    mock_client.query_annotations.return_value = []
+    with patch(
+        "app.tools.GrafanaAnnotationsTool._resolve_grafana_client", return_value=mock_client
+    ):
+        query_grafana_annotations(
+            grafana_endpoint="http://grafana",
+            time_range_minutes=30,
+            **{"to": "2026-05-30T15:00:00Z"},
+        )
+    to_ts = _iso_to_epoch_ms("2026-05-30T15:00:00Z")
+    kwargs = mock_client.query_annotations.call_args.kwargs
+    assert kwargs["to_ts"] == to_ts
+    assert kwargs["from_ts"] == to_ts - 30 * 60 * 1000

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -938,6 +938,7 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         "query_datadog_monitors",
         "query_elasticsearch_logs",
         "query_grafana_alert_rules",
+        "query_grafana_annotations",
         "query_grafana_logs",
         "query_grafana_metrics",
         "query_grafana_service_names",


### PR DESCRIPTION
Fixes #2689

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

OpenSRE could correlate deploys to incidents **only for GitHub** (`GitDeployTimelineTool`, built on the GitHub REST `since`/`until` window). Any deploy that does **not** originate from a GitHub push — ArgoCD/Flux syncs, `helm upgrade`, Jenkins/CircleCI jobs, Terraform applies, manual hotfixes — was invisible to the agent, a concrete RCA blind spot.

This adds a **read-only Grafana annotations tool** so the agent can answer *"did a deploy/config change precede this alert?"* for deploys from **any** source. Grafana annotations are the standard, source-agnostic "what changed and when" marker. **No new config or dependencies** — it reuses the existing Grafana integration auth.

- **Service layer** — `query_annotations(from_ts, to_ts, tags=None, limit=100)` on `GrafanaClientBase`, mirroring `query_alert_rules()`: a direct `requests.get` returning `list[dict]` (not `_make_request()`, since `/api/annotations` returns a JSON **array**). Module-level `_map_annotation` / `_epoch_ms_to_iso` map each item to `time` / `time_end` / `text` / `tags` / `dashboard_uid` with ISO-8601 UTC timestamps.
- **Tool layer** — `app/tools/GrafanaAnnotationsTool/` (`query_grafana_annotations`), mirroring `GrafanaAlertRulesTool`: reuses the shared `GrafanaLogsTool` helpers, supports the `grafana_backend` fixture path, forwards basic-auth credentials, and accepts a `time_range_minutes` window (default 60, now-anchored) with optional ISO `from`/`to` override. `surfaces` defaults to investigation, consistent with the other Grafana tools.
- **Fixture backends** — `query_annotations` added to the `GrafanaBackend` Protocol and all implementers (`FixtureGrafanaBackend`, `SelectiveGrafanaBackend`, `OpenSRECsvGrafanaBackend`) so the synthetic path is first-class.
- **Docs** — `docs/grafana_annotations.mdx`, registered in `docs/docs.json`.
- **Tests** — `tests/tools/test_grafana_annotations_tool.py` covers schema/availability/extraction, the backend/fixture path, ISO/UTC parsing, basic-auth credential forwarding, and the time-window override. New tool classified in `tests/tools/test_telemetry.py`.

### Demo/Screenshot for feature changes and bug fixes -
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

<img width="1000" height="932" alt="grafana_annotations_demo" src="https://github.com/user-attachments/assets/e1ac4884-52d5-451d-be0c-9b33756db79a" />

`opensre investigate` run against a DB-auth-failure pipeline alert, with a `deploy events_fact v1.4.2 (db credentials rotated)` annotation present in Grafana. The agent autonomously calls `query_grafana_annotations`, finds the deploy, and reports it as the root cause (Cited Evidence lists *"query grafana annotations"*):

> The events_fact pipeline v1.4.2 was deployed with a database credential rotation that was not propagated to the pipeline's runtime configuration, so the load step authenticated with the now-revoked credential — extraction succeeded (128 rows) but the write failed with an authentication error.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!--
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?
-->

The problem is a change-correlation blind spot: most incidents follow a change, but OpenSRE could only see GitHub-origin deploys. Grafana annotations are the natural, source-agnostic signal teams already emit for deploys/config changes, so reading them lets the agent ask "what changed right before this?" for any deploy mechanism.

I deliberately mirrored the existing Grafana stack rather than inventing new patterns. The service method copies the `query_alert_rules()` shape (direct `requests.get` → `list[dict]`) instead of `_make_request()`, because `/api/annotations` returns a JSON array, not an object — using the dict helper would have broken on first call. The tool mirrors `GrafanaAlertRulesTool` and reuses the shared credential/availability helpers from `GrafanaLogsTool`, so it behaves identically to the other Grafana tools (including basic-auth and the synthetic `grafana_backend` fixture path).

Key pieces: `query_annotations()` performs the windowed, optionally tag-filtered fetch; `_map_annotation`/`_epoch_ms_to_iso` normalize Grafana's epoch-ms wire format to readable ISO-8601 UTC; `query_grafana_annotations` resolves the client (or uses an injected backend), defaults the window to `time_range_minutes` ending at `to` (now if unset), and returns `{source, available, annotations, total}`. Edge cases covered by tests include timezone-naive timestamps (coerced to UTC), a `to`-only window, malformed timestamps, and basic-auth credential forwarding.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
