### PR TITLE
fix(repl): resolve /integrations verify hang and recursion error in interactive REPL

### DIFF
--- a/app/cli/interactive_shell/runtime/execution.py
+++ b/app/cli/interactive_shell/runtime/execution.py
@@ -157,7 +157,7 @@ def execute_routed_turn(
         if not cmd_text:
             cmd_text = text.strip()
         try:
-            should_continue = dispatch_slash(cmd_text, session, console)
+            should_continue = dispatch_slash(cmd_text, session, console, confirm_fn=confirm_fn)
         except Exception as exc:
             report_exception(exc, context="interactive_shell.slash_dispatch")
             console.print(

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -17,6 +17,7 @@ from prompt_toolkit import PromptSession
 from prompt_toolkit.formatted_text import ANSI
 from prompt_toolkit.patch_stdout import patch_stdout
 from rich.console import Console
+from rich.file_proxy import FileProxy
 from rich.markup import escape
 
 from app.agents.sampler import start_sampler
@@ -132,7 +133,7 @@ class StreamingConsole(Console):
         high column. Rich output that follows (tables, follow-up status lines,
         section rules) must start at column zero or lines appear broken.
         """
-        if not self._spinner.streaming:
+        if not self._spinner.streaming and not isinstance(sys.stdout, FileProxy):
             from app.cli.interactive_shell.ui.choice_menu import (
                 ensure_tty_column_zero,
                 prepare_repl_output_line,


### PR DESCRIPTION
Fixes #2694 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
This PR fixes a hang in the interactive REPL where /integrations verify would hang at the confirmation prompt ([Y/n]) and render the terminal unresponsive.

The root cause was that `confirm_fn` was not passed into `dispatch_slash` from the slash execution path in `execute_routed_turn`, causing confirmation handling to fall back to a blocking `input()` call on the worker thread.

After fixing this, a second issue surfaced: a recursion error when /integrations verify is run, caused by `StreamingConsole.print` interacting with Rich’s FileProxy stdout redirection and manual cursor-prep logic.

This PR fixes both issues:

Passes `confirm_fn` into `dispatch_slash` to ensure confirmation is handled through the REPL prompt loop instead of blocking input.
Prevents recursion in `StreamingConsole.print` by skipping cursor-prep when stdout is managed by Rich (FileProxy), avoiding print/redirection cycles.

### Demo/Screenshot for feature changes and bug fixes - 
<img width="1080" height="935" alt="integrations verify (proof of work)" src="https://github.com/user-attachments/assets/2763f881-3314-4e28-9ffc-58f9812f01e8" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?
-->
- Fixed REPL hang in /integrations verify caused by missing `confirm_fn` argument in the slash execution path, which caused confirmation input to block on a worker thread.
- The recursion issue was triggered only after fixing the first bug, due to Rich FileProxy wrapping stdout during status rendering.
- An alternative approach i considered was removing `console.status` entirely and switching to plain REPL output but instead chose to keep Rich rendering for UX consistency and targeted the underlying stdout conflict instead.
- The fix ensures REPL output stays stable by avoiding conflicting output handling when Rich is controlling the terminal, preventing recursive print loops.
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
