### PR TITLE
fix(helm): drop `--client` flag from probe — removed in modern Helm CLI

### DIFF
--- a/app/services/helm/client.py
+++ b/app/services/helm/client.py
@@ -23,7 +23,7 @@ _DEFAULT_MANIFEST_CHARS = 600_000
 
 
 def _helm_client_major_version(version_client_output: str) -> int | None:
-    """Best-effort major Helm client version from ``helm version --client`` stdout."""
+    """Best-effort major Helm client version from ``helm version`` stdout."""
     text = version_client_output
     if m := re.search(r'SemVer:"v(\d+)', text):
         return int(m.group(1))
@@ -43,7 +43,7 @@ def _manifest_char_cap() -> int:
 class HelmClient:
     """Runs Helm 3 CLI commands with explicit kubeconfig/context and timeouts.
 
-    Requires Helm 3.x (``helm version --client`` is checked during :meth:`probe_access`).
+    Requires Helm 3.x (``helm version`` is checked during :meth:`probe_access`).
 
     Environment:
         ``HELM_MANIFEST_MAX_CHARS`` — optional integer; minimum 1024; caps ``get_manifest``
@@ -110,16 +110,16 @@ class HelmClient:
             return ProbeResult.missing(
                 f"Helm binary not found ({path!r}). Install Helm or set helm_path to a binary."
             )
-        code, ver_out, err = self._run(["version", "--client"], timeout=_PROBE_VERSION_TIMEOUT)
+        code, ver_out, err = self._run(["version"], timeout=_PROBE_VERSION_TIMEOUT)
         if code != 0:
             detail = (err or "unknown error").strip()
-            return ProbeResult.failed(f"helm version --client failed (exit {code}): {detail}")
+            return ProbeResult.failed(f"helm version failed (exit {code}): {detail}")
 
         combined_ver = f"{ver_out}\n{err or ''}"
         major = _helm_client_major_version(combined_ver)
         if major is not None and major < 3:
             return ProbeResult.failed(
-                "Helm 3.x is required for this integration; `helm version --client` "
+                "Helm 3.x is required for this integration; `helm version` "
                 f"reports a Helm {major}.x client. Install Helm 3 or point helm_path at a Helm 3 "
                 "binary."
             )

--- a/docs/helm.mdx
+++ b/docs/helm.mdx
@@ -6,7 +6,7 @@ description: "Connect Helm 3 so OpenSRE can list releases, inspect status and hi
 OpenSRE runs the **Helm 3** command-line client on the machine where the agent executes. It uses **read-only** subcommands (`helm list`, `helm status`, `helm history`, `helm get values`, `helm get manifest`) with explicit `--kube-context` and `--kubeconfig` flags so investigations target the same cluster your engineers use.
 
 <Note>
-  **Helm 2 is not supported.** Verification checks `helm version --client` and requires a Helm **3.x** client.
+  **Helm 2 is not supported.** Verification checks `helm version` and requires a Helm **3.x** client.
 </Note>
 
 ## Prerequisites
@@ -81,7 +81,7 @@ Add an active `helm` record to `~/.opensre/integrations.json`:
 opensre integrations verify helm
 ```
 
-A passing check runs `helm version --client` (must report Helm 3) and a minimal `helm list -A --max 1 -o json` against your cluster to validate JSON output and reachability.
+A passing check runs `helm version` (must report Helm 3) and a minimal `helm list -A --max 1 -o json` against your cluster to validate JSON output and reachability.
 
 ## Usage in investigations
 

--- a/tests/services/test_helm_client.py
+++ b/tests/services/test_helm_client.py
@@ -60,6 +60,29 @@ def test_helm_probe_passes_when_version_and_list_succeed(
     assert "Helm CLI" in result.detail
 
 
+def test_helm_probe_invokes_helm_version_without_client_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: modern Helm rejects ``helm version --client`` with an unknown-flag error."""
+    monkeypatch.setattr("app.services.helm.client.shutil.which", lambda _name: "/usr/bin/helm")
+    cmds: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> SimpleNamespace:
+        cmds.append(list(cmd))
+        if "version" in cmd:
+            return SimpleNamespace(returncode=0, stdout=_HELM_V3_VERSION_STDOUT, stderr="")
+        if "list" in cmd:
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        return SimpleNamespace(returncode=1, stdout="", stderr="unexpected argv")
+
+    monkeypatch.setattr("app.services.helm.client.subprocess.run", fake_run)
+    _client().probe_access()
+    version_cmds = [c for c in cmds if "version" in c]
+    assert version_cmds, "probe_access did not invoke `helm version`"
+    for vc in version_cmds:
+        assert "--client" not in vc, f"`--client` must not be passed; argv: {vc}"
+
+
 def test_helm_probe_rejects_helm2_client(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("app.services.helm.client.shutil.which", lambda _name: "/usr/bin/helm")
     helm2_out = 'Client: &version.Version{SemVer:"v2.17.0", GitCommit:""}\n'


### PR DESCRIPTION
Fixes #2710

#### Describe the changes you have made in this PR -

`HelmClient.probe_access` was shelling out to `helm version --client`. The `--client` flag was removed from `helm version` in modern Helm releases, so the probe failed with `unknown flag: --client` and `opensre integrations verify` reported helm as `failed` even when Helm was correctly installed.

Changes:

- `app/services/helm/client.py:113`: drop `--client` from the probe argv. `helm version` returns the client version in both Helm 3 and Helm 4 (Helm 3 dropped Tiller, so there is no server side to disambiguate from anymore).
- `app/services/helm/client.py:116, 122, 26, 46`: update error messages and docstrings to match.
- `docs/helm.mdx:9, 84`: same fix in two user-facing references (Note callout + Verify section).
- `tests/services/test_helm_client.py`: added `test_helm_probe_invokes_helm_version_without_client_flag` as a regression. It captures the argv passed to `subprocess.run` and asserts `--client` is never present.

The existing tests faked `subprocess.run` but didn't assert the argv, so they kept passing with the buggy flag. The new test closes that gap.

### Demo/Screenshot for feature changes and bug fixes - 

Before (the bug, reproduced by Hemant in #1973 against Helm 4.1.4):

<img width="541" height="92" alt="image" src="https://github.com/user-attachments/assets/5896252e-978a-4c61-9881-5676c2eb409f" />

After (regression test pinning the new behavior):

<img width="1163" height="683" alt="image" src="https://github.com/user-attachments/assets/03c84869-fae2-4e96-8e25-265fcc9bb4a3" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The probe has to do two things: confirm Helm is installed, and confirm the major version is 3+. The previous code used `helm version --client` for that, which made sense in the Helm 2 era when `helm version` queried both the client and Tiller (the server). Helm 3 dropped Tiller, so `helm version` only ever reports the client now. `--client` became a deprecated no-op, then was removed entirely in later versions, which is what Hemant hit with Helm 4.1.4.

The fix is to call `helm version` with no flag. It returns the same `version.BuildInfo{Version:"vX.Y.Z", ...}` string that the existing `_helm_client_major_version` parser already understands, so the major-version check on the next line works without any other changes.

I considered being more defensive (try `helm version`, fall back to `helm version --client` for very old Helm 3 builds), but `helm version` and `helm version --client` have produced identical output since Helm 3.0.0 — the flag was deprecated immediately in Helm 3 — so the fallback would be dead code.

The new regression test was the more important part of this PR. The existing tests in `tests/services/test_helm_client.py` used `if "version" in cmd` to dispatch fake responses, which matched both the buggy and the fixed argv. The new test records every `subprocess.run` argv and asserts `--client` is never present, so any future code path that reintroduces the flag will fail loudly.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
