### PR TITLE
fix(grok_cli): only promote XAI_API_KEY fallback when auth probe is unclear

### DIFF
--- a/app/integrations/llm_cli/grok_cli.py
+++ b/app/integrations/llm_cli/grok_cli.py
@@ -218,10 +218,12 @@ class GrokCLIAdapter:
                 auth_proc.returncode, auth_proc.stdout, auth_proc.stderr
             )
 
-        # XAI_API_KEY is definitive for headless/CI auth even when the probe is
-        # unclear (e.g. network timeout); promote to authenticated as a fallback.
+        # XAI_API_KEY is definitive for headless/CI auth when the probe result is
+        # *unclear* (network error, timeout). Do NOT promote when the probe
+        # explicitly returned False — XAI_API_KEY may itself be the rejected
+        # credential, and masking that defers the failure to invocation time.
         auth_env_key = _has_explicit_grok_auth_env()
-        if logged_in is not True and auth_env_key:
+        if logged_in is None and auth_env_key:
             logged_in = True
             auth_detail = f"Authenticated via {auth_env_key}."
 

--- a/tests/integrations/llm_cli/test_grok_cli_adapter.py
+++ b/tests/integrations/llm_cli/test_grok_cli_adapter.py
@@ -166,6 +166,25 @@ def test_detect_not_authenticated(mock_which: MagicMock, mock_run: MagicMock) ->
 
 @patch(_SUBPROCESS_RUN)
 @patch(_WHICH)
+def test_detect_api_key_does_not_override_explicit_false(
+    mock_which: MagicMock, mock_run: MagicMock
+) -> None:
+    """XAI_API_KEY must not promote logged_in when the probe explicitly returned False.
+
+    The key itself may be what was rejected; masking that defers the failure
+    to invocation time with a confusing 300s timeout instead of a clear error.
+    """
+    mock_which.return_value = "/usr/bin/grok"
+    mock_run.side_effect = [_version_proc(), _auth_proc(returncode=1, stderr="Error: Unauthorized")]
+
+    with patch.dict(os.environ, {"XAI_API_KEY": "xai-invalid", "GROK_CLI_BIN": ""}, clear=False):
+        probe = GrokCLIAdapter().detect()
+
+    assert probe.logged_in is False
+
+
+@patch(_SUBPROCESS_RUN)
+@patch(_WHICH)
 def test_detect_auth_unclear_on_network_error(mock_which: MagicMock, mock_run: MagicMock) -> None:
     mock_which.return_value = "/usr/bin/grok"
     mock_run.side_effect = [_version_proc(), _auth_proc(returncode=1, stderr="connection refused")]


### PR DESCRIPTION
## Summary

Follow-up to #2717. Addresses the P1 review finding from Greptile.

- The `XAI_API_KEY` fallback in `_probe_binary()` previously promoted `logged_in` to `True` whenever `logged_in is not True` — this includes the explicit `False` case (probe got `Unauthorized` / 401).
- If `XAI_API_KEY` itself is the rejected credential, this masked the failure: the wizard reported "authenticated" but `grok -p` failed at invocation time with a confusing timeout instead of a clear auth error.
- Fix: only promote when `logged_in is None` (network error, timeout, ambiguous output — the intended headless/CI path). An explicit probe rejection stays `False`.

## Test plan

- [ ] Existing 48 tests still pass (no regression)
- [ ] New test `test_detect_api_key_does_not_override_explicit_false`: probe returns `Unauthorized` + `XAI_API_KEY` set → `logged_in` stays `False`
- [ ] Existing `test_detect_logged_in_via_api_key_fallback`: probe returns network error + `XAI_API_KEY` set → `logged_in` promoted to `True` (still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)