### PR TITLE
feat(llm_cli): guard against silent empty-stdout responses in LLM CLI adapters

### DIFF
--- a/app/integrations/llm_cli/antigravity_cli.py
+++ b/app/integrations/llm_cli/antigravity_cli.py
@@ -276,8 +276,13 @@ class AntigravityCLIAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        del stderr, returncode
-        return (stdout or "").strip()
+        result = (stdout or "").strip()
+        if not result:
+            raise RuntimeError(
+                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
+                + " (empty output)"
+            )
+        return result
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         err = (stderr or "").strip()

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -335,8 +335,13 @@ class ClaudeCodeAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        del stderr, returncode
-        return (stdout or "").strip()
+        result = (stdout or "").strip()
+        if not result:
+            raise RuntimeError(
+                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
+                + " (empty output)"
+            )
+        return result
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         err = (stderr or "").strip()

--- a/app/integrations/llm_cli/codex.py
+++ b/app/integrations/llm_cli/codex.py
@@ -221,9 +221,13 @@ class CodexAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        _ = stderr
-        _ = returncode
-        return (stdout or "").strip()
+        result = (stdout or "").strip()
+        if not result:
+            raise RuntimeError(
+                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
+                + " (empty output)"
+            )
+        return result
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         err = (stderr or "").strip()

--- a/app/integrations/llm_cli/copilot.py
+++ b/app/integrations/llm_cli/copilot.py
@@ -319,8 +319,13 @@ class CopilotAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        del stderr, returncode
-        return (stdout or "").strip()
+        result = (stdout or "").strip()
+        if not result:
+            raise RuntimeError(
+                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
+                + " (empty output)"
+            )
+        return result
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         err = (stderr or "").strip()

--- a/app/integrations/llm_cli/gemini_cli.py
+++ b/app/integrations/llm_cli/gemini_cli.py
@@ -259,10 +259,12 @@ class GeminiCLIAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        del stderr, returncode
         text = (stdout or "").strip()
         if not text:
-            return ""
+            raise RuntimeError(
+                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
+                + " (empty output)"
+            )
         try:
             payload = json.loads(text)
         except json.JSONDecodeError:

--- a/app/integrations/llm_cli/opencode.py
+++ b/app/integrations/llm_cli/opencode.py
@@ -218,10 +218,13 @@ class OpenCodeAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        """Extract the agent's final response from stdout."""
-        del stderr, returncode
-        # OpenCode writes the agent's response to stdout; stderr may contain logs
-        return (stdout or "").strip()
+        result = (stdout or "").strip()
+        if not result:
+            raise RuntimeError(
+                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
+                + " (empty output)"
+            )
+        return result
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         err = (stderr or "").strip()

--- a/tests/integrations/llm_cli/test_antigravity_cli_adapter.py
+++ b/tests/integrations/llm_cli/test_antigravity_cli_adapter.py
@@ -391,3 +391,24 @@ def test_antigravity_empty_model_env_treated_as_absent(_mock_which: MagicMock) -
         inv = AntigravityCLIAdapter().build(prompt="p", model="", workspace="")
 
     assert "--model" not in inv.argv
+
+
+def test_parse_returns_stripped_stdout() -> None:
+    adapter = AntigravityCLIAdapter()
+    assert adapter.parse(stdout="  hello world  \n", stderr="", returncode=0) == "hello world"
+
+
+def test_parse_raises_on_empty_stdout() -> None:
+    import pytest
+
+    adapter = AntigravityCLIAdapter()
+    with pytest.raises(RuntimeError, match="empty output"):
+        adapter.parse(stdout="  ", stderr="", returncode=0)
+
+
+def test_parse_raises_on_empty_stdout_surfaces_stderr() -> None:
+    import pytest
+
+    adapter = AntigravityCLIAdapter()
+    with pytest.raises(RuntimeError, match="some stderr detail"):
+        adapter.parse(stdout="", stderr="some stderr detail", returncode=0)

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -832,3 +832,19 @@ def test_claude_prefix_forwarded_to_subprocess() -> None:
 
     assert env["CLAUDE_CODE_MODEL"] == "claude-opus-4-7"
     assert env["CLAUDE_CODE_BIN"] == "/usr/bin/claude"
+
+
+def test_parse_raises_on_empty_stdout() -> None:
+    import pytest
+
+    adapter = ClaudeCodeAdapter()
+    with pytest.raises(RuntimeError, match="empty output"):
+        adapter.parse(stdout="  ", stderr="", returncode=0)
+
+
+def test_parse_raises_on_empty_stdout_surfaces_stderr() -> None:
+    import pytest
+
+    adapter = ClaudeCodeAdapter()
+    with pytest.raises(RuntimeError, match="some stderr detail"):
+        adapter.parse(stdout="", stderr="some stderr detail", returncode=0)

--- a/tests/integrations/llm_cli/test_codex_adapter.py
+++ b/tests/integrations/llm_cli/test_codex_adapter.py
@@ -733,3 +733,20 @@ def test_codex_cli_registry_entry() -> None:
     assert reg is not None
     assert reg.model_env_key == "CODEX_MODEL"
     assert reg.adapter_factory().name == "codex"
+
+
+def test_parse_returns_stripped_stdout() -> None:
+    adapter = CodexAdapter()
+    assert adapter.parse(stdout="  hello world  \n", stderr="", returncode=0) == "hello world"
+
+
+def test_parse_raises_on_empty_stdout() -> None:
+    adapter = CodexAdapter()
+    with pytest.raises(RuntimeError, match="empty output"):
+        adapter.parse(stdout="  ", stderr="", returncode=0)
+
+
+def test_parse_raises_on_empty_stdout_surfaces_stderr() -> None:
+    adapter = CodexAdapter()
+    with pytest.raises(RuntimeError, match="some stderr detail"):
+        adapter.parse(stdout="", stderr="some stderr detail", returncode=0)

--- a/tests/integrations/llm_cli/test_copilot_adapter.py
+++ b/tests/integrations/llm_cli/test_copilot_adapter.py
@@ -664,3 +664,24 @@ def test_subprocess_env_does_not_leak_copilot_token_via_prefix_allowlist(
     assert "COPILOT_BIN" not in env
     assert "ANTHROPIC_API_KEY" not in env
     assert "PATH" in env or os.environ.get("PATH") is None
+
+
+def test_parse_returns_stripped_stdout() -> None:
+    adapter = CopilotAdapter()
+    assert adapter.parse(stdout="  hello world  \n", stderr="", returncode=0) == "hello world"
+
+
+def test_parse_raises_on_empty_stdout() -> None:
+    import pytest
+
+    adapter = CopilotAdapter()
+    with pytest.raises(RuntimeError, match="empty output"):
+        adapter.parse(stdout="  ", stderr="", returncode=0)
+
+
+def test_parse_raises_on_empty_stdout_surfaces_stderr() -> None:
+    import pytest
+
+    adapter = CopilotAdapter()
+    with pytest.raises(RuntimeError, match="some stderr detail"):
+        adapter.parse(stdout="", stderr="some stderr detail", returncode=0)

--- a/tests/integrations/llm_cli/test_gemini_cli_adapter.py
+++ b/tests/integrations/llm_cli/test_gemini_cli_adapter.py
@@ -368,3 +368,15 @@ def test_detect_auth_probe_uses_filtered_subprocess_env(
     assert env["GOOGLE_CLOUD_PROJECT"] == "proj-x"
     assert env["GEMINI_API_KEY"] == "gk-test"
     assert "RANDOM_SECRET" not in env
+
+
+def test_parse_raises_on_empty_stdout() -> None:
+    adapter = GeminiCLIAdapter()
+    with pytest.raises(RuntimeError, match="empty output"):
+        adapter.parse(stdout="  ", stderr="", returncode=0)
+
+
+def test_parse_raises_on_empty_stdout_surfaces_stderr() -> None:
+    adapter = GeminiCLIAdapter()
+    with pytest.raises(RuntimeError, match="some stderr detail"):
+        adapter.parse(stdout="", stderr="some stderr detail", returncode=0)

--- a/tests/integrations/llm_cli/test_opencode_adapter.py
+++ b/tests/integrations/llm_cli/test_opencode_adapter.py
@@ -361,10 +361,12 @@ def test_parse_returns_stripped_stdout() -> None:
 
 
 def test_parse_handles_empty_stdout() -> None:
-    """Should return empty string when stdout is empty."""
+    """Should raise RuntimeError when stdout is empty."""
+    import pytest
+
     adapter = OpenCodeAdapter()
-    result = adapter.parse(stdout="", stderr="", returncode=0)
-    assert result == ""
+    with pytest.raises(RuntimeError, match="empty output"):
+        adapter.parse(stdout="", stderr="", returncode=0)
 
 
 def test_parse_ignores_stderr() -> None:
@@ -642,3 +644,5 @@ def test_adapter_build_does_not_need_to_forward_opencode_vars() -> None:
         assert "OPENCODE_CONFIG" not in inv.env
 
         assert inv.env.get("NO_COLOR") == "1"
+
+

--- a/tests/integrations/llm_cli/test_opencode_adapter.py
+++ b/tests/integrations/llm_cli/test_opencode_adapter.py
@@ -644,5 +644,3 @@ def test_adapter_build_does_not_need_to_forward_opencode_vars() -> None:
         assert "OPENCODE_CONFIG" not in inv.env
 
         assert inv.env.get("NO_COLOR") == "1"
-
-

--- a/tests/integrations/llm_cli/test_opencode_adapter.py
+++ b/tests/integrations/llm_cli/test_opencode_adapter.py
@@ -644,3 +644,11 @@ def test_adapter_build_does_not_need_to_forward_opencode_vars() -> None:
         assert "OPENCODE_CONFIG" not in inv.env
 
         assert inv.env.get("NO_COLOR") == "1"
+
+
+def test_parse_raises_on_empty_stdout_surfaces_stderr() -> None:
+    import pytest
+
+    adapter = OpenCodeAdapter()
+    with pytest.raises(RuntimeError, match="some stderr detail"):
+        adapter.parse(stdout="", stderr="some stderr detail", returncode=0)


### PR DESCRIPTION
## Summary

Closes #2715.

Adopts the `kimi`-style empty-output guard across all LLM CLI adapters that previously returned `""` silently on **exit 0 + empty stdout**:

- `codex` — was silently returning `""`
- `claude_code` — was silently returning `""`
- `copilot` — was silently returning `""`
- `opencode` — was silently returning `""`
- `antigravity_cli` — was silently returning `""`
- `gemini_cli` — was returning `""` on empty text before JSON parsing

Each affected adapter's `parse()` now raises `RuntimeError` via `explain_failure(...) + " (empty output)"` so that stderr is surfaced exactly when the response is blank, without affecting the happy path. `cursor` and `kimi` already had this guard and are unchanged.

## Test plan

- [ ] New `test_parse_raises_on_empty_stdout` and `test_parse_raises_on_empty_stdout_surfaces_stderr` tests added for all 6 fixed adapters
- [ ] Existing `test_parse_handles_empty_stdout` in `test_opencode_adapter.py` updated to assert `RuntimeError` instead of empty-string return
- [ ] `uv run pytest tests/integrations/llm_cli/ -x -q` → 260 passed
- [ ] `uv run ruff check app/integrations/llm_cli/ tests/integrations/llm_cli/` → all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)