### PR TITLE
Fix: REPL /remote command hang in scripted/non-TTY environment

### DIFF
--- a/app/cli/interactive_shell/runtime/dispatch.py
+++ b/app/cli/interactive_shell/runtime/dispatch.py
@@ -143,6 +143,7 @@ def dispatch_one_turn(
     *,
     on_exit: Callable[[], None],
     confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
 ) -> None:
     decision = _router.route_input(text, session)
     kind = decision.route_kind.value
@@ -160,6 +161,7 @@ def dispatch_one_turn(
         on_exit=on_exit,
         confirm_fn=confirm_fn,
         decision=decision,
+        is_tty=is_tty,
     )
 
 
@@ -184,7 +186,7 @@ def run_initial_input(
         if not stripped:
             continue
         render_submitted_prompt(console, session, stripped)
-        dispatch_one_turn(stripped, session, console, on_exit=_early_exit)
+        dispatch_one_turn(stripped, session, console, on_exit=_early_exit, is_tty=False)
         if exit_requested[0]:
             return 0
     return 0

--- a/app/cli/interactive_shell/runtime/execution.py
+++ b/app/cli/interactive_shell/runtime/execution.py
@@ -142,6 +142,7 @@ def execute_routed_turn(
     on_exit: Callable[[], None],
     confirm_fn: Callable[[str], str] | None = None,
     decision: RouteDecision,
+    is_tty: bool | None = None,
 ) -> None:
     """Route + execute one accepted line."""
     kind = decision.route_kind.value
@@ -157,7 +158,7 @@ def execute_routed_turn(
         if not cmd_text:
             cmd_text = text.strip()
         try:
-            should_continue = dispatch_slash(cmd_text, session, console, confirm_fn=confirm_fn)
+            should_continue = dispatch_slash(cmd_text, session, console, confirm_fn=confirm_fn, is_tty=is_tty)
         except Exception as exc:
             report_exception(exc, context="interactive_shell.slash_dispatch")
             console.print(


### PR DESCRIPTION
Closes #2707. 

This PR fixes an issue where running `/remote` commands in non-interactive/scripted environments causes the REPL to hang. The fix passes `is_tty=False` from `run_initial_input` all the way down to `dispatch_slash` to correctly skip interactivity blocks.