### PR TITLE
feat/1494-local-process-introspect

### DIFF
--- a/app/agents/tail.py
+++ b/app/agents/tail.py
@@ -415,6 +415,50 @@ class AttachSession:
         self.close()
 
 
+def read_tail_lines(
+    pid: int,
+    *,
+    max_lines: int = 50,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+) -> list[str]:
+    """Return up to the last ``max_lines`` lines of a pid's stdout file.
+
+    Unlike :func:`attach` — which seeks to EOF to *follow* new output —
+    this reads the existing on-disk tail of the regular file backing fd 1.
+    That history is what the investigation planner needs when it probes a
+    stuck agent after the fact (it never had a live trace session open).
+
+    Resolution and target validation reuse the same path as :func:`attach`,
+    so the contract is identical: :class:`AttachUnsupported` is raised
+    synchronously for any target we can't read (Windows, missing pid,
+    fd is a TTY/pipe/socket, permission denied, file vanished). Reads at
+    most ``max_bytes`` from the end of the file so an enormous log can't
+    blow up memory; the byte window is decoded with ``errors="replace"``
+    and the leading partial line (when the window starts mid-line) is
+    dropped before slicing the last ``max_lines``.
+    """
+    if max_lines <= 0:
+        raise ValueError("max_lines must be positive")
+    target = _resolve_target(pid)
+    try:
+        with open(target.path, "rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            start = max(0, size - max_bytes)
+            fh.seek(start)
+            data = fh.read()
+    except OSError as exc:
+        raise AttachUnsupported(
+            f"cannot read stdout target {target.path}: {exc.strerror or exc}"
+        ) from exc
+    lines = data.decode("utf-8", errors="replace").splitlines()
+    # If we started mid-file the first line is almost certainly the partial
+    # tail of an earlier line — drop it so we never report a truncated line.
+    if start > 0 and lines:
+        lines = lines[1:]
+    return lines[-max_lines:]
+
+
 def attach(
     pid: int,
     *,
@@ -450,4 +494,5 @@ __all__ = [
     "AttachUnsupported",
     "TailBuffer",
     "attach",
+    "read_tail_lines",
 ]

--- a/app/tools/LocalProcessIntrospectTool/__init__.py
+++ b/app/tools/LocalProcessIntrospectTool/__init__.py
@@ -1,0 +1,108 @@
+"""Introspect a local agent process by PID for in-shell incident response.
+
+Phase 5 of the monitor-local-agents roadmap. The OpenSRE investigation
+pipeline is a planner that picks tools to diagnose problems; to run it
+against a stuck *local* agent (Claude Code, Cursor, Aider, Codex, Gemini, …)
+it needs a tool that can look inside a process. This wraps the per-PID probe
+(:mod:`app.agents.probe`) and the on-disk stdout tail
+(:func:`app.agents.tail.read_tail_lines`) as a first-class tool the planner
+can call during an investigation surfaced in the interactive shell.
+
+Not directly user-visible: it appears as a tool call on the diagnosis card
+when the Phase 5 SLO watchdog opens an investigation against a stuck agent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.agents.probe import ProcessSnapshot, probe
+from app.agents.tail import AttachUnsupported, read_tail_lines
+from app.tools.tool_decorator import tool
+
+# Acceptance criterion: return the last 50 stdout lines alongside the snapshot.
+_MAX_STDOUT_LINES = 50
+
+
+def _snapshot_to_dict(snapshot: ProcessSnapshot) -> dict[str, Any]:
+    """Render a :class:`ProcessSnapshot` as JSON-safe primitives.
+
+    ``datetime`` fields become ISO-8601 strings; the ``None``-able resource
+    fields (POSIX-only fds, privileged connection count) pass through as-is.
+    """
+    return {
+        "pid": snapshot.pid,
+        "cpu_percent": snapshot.cpu_percent,
+        "rss_mb": snapshot.rss_mb,
+        "num_fds": snapshot.num_fds,
+        "num_connections": snapshot.num_connections,
+        "status": snapshot.status,
+        "started_at": snapshot.started_at.isoformat(),
+        "last_output_at": (
+            snapshot.last_output_at.isoformat() if snapshot.last_output_at is not None else None
+        ),
+    }
+
+
+@tool(
+    name="local_process_introspect",
+    source="knowledge",
+    description=(
+        "Introspect a local agent process by its PID. Returns a psutil "
+        "resource snapshot (CPU%, resident memory, open file descriptors, "
+        "connection count, status, start time, last-output time) plus the "
+        f"last {_MAX_STDOUT_LINES} lines of the process's stdout. Use this to "
+        "diagnose a stuck, looping, or resource-hungry local agent (Claude "
+        "Code, Cursor, Aider, Codex, Gemini, …) during an in-shell incident."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "pid": {
+                "type": "integer",
+                "description": "Process id of the local agent to introspect.",
+            },
+        },
+        "required": ["pid"],
+    },
+    surfaces=("investigation",),
+    use_cases=[
+        "inspect a stuck local agent's CPU and memory usage during an incident",
+        "read a local agent's recent stdout to find an error or stall point",
+        "confirm whether a local agent process is still alive and making progress",
+    ],
+    outputs={
+        "found": "True when the pid maps to a process we could probe",
+        "snapshot": "psutil resource snapshot, or null when the pid is gone",
+        "stdout_tail": f"List of up to the last {_MAX_STDOUT_LINES} stdout lines",
+        "stdout_available": "True when the stdout tail could be read",
+        "stdout_error": "Reason the stdout tail was unavailable, when applicable",
+    },
+)
+def local_process_introspect(pid: int) -> dict[str, Any]:
+    """Return a resource snapshot and recent stdout for a local process.
+
+    The snapshot and the stdout tail fail independently: a process can be
+    alive and probeable while its stdout is untailable (a TTY, a pipe, or a
+    cross-user fd), so the stdout failure is reported in ``stdout_error``
+    rather than failing the whole call.
+    """
+    snapshot = probe(pid)
+    result: dict[str, Any] = {
+        "source": "knowledge",
+        "pid": pid,
+        "found": snapshot is not None,
+        "snapshot": _snapshot_to_dict(snapshot) if snapshot is not None else None,
+        "stdout_tail": [],
+        "stdout_available": False,
+        "stdout_error": None,
+    }
+    try:
+        result["stdout_tail"] = read_tail_lines(pid, max_lines=_MAX_STDOUT_LINES)
+        result["stdout_available"] = True
+    except AttachUnsupported as exc:
+        result["stdout_error"] = exc.reason
+    return result
+
+
+__all__ = ["local_process_introspect"]

--- a/tests/agents/test_tail.py
+++ b/tests/agents/test_tail.py
@@ -36,6 +36,7 @@ from app.agents.tail import (
     _resolve_target,
     _ResolvedTarget,
     attach,
+    read_tail_lines,
 )
 
 
@@ -559,6 +560,81 @@ class TestAttachIntegration:
             seen = _drain_until(sess, lambda b: b"world" in b, timeout=3.0)
             assert b"world" in seen
         assert not sess._thread.is_alive()  # noqa: SLF001
+
+
+class TestReadTailLines:
+    """``read_tail_lines`` reads the existing on-disk tail (not EOF-follow)."""
+
+    def _patch_target(self, monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+        monkeypatch.setattr(
+            tail_mod,
+            "_resolve_target",
+            lambda pid: _ResolvedTarget(pid=pid, path=path),
+        )
+
+    def test_returns_existing_history(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("alpha\nbeta\ngamma\n")
+        self._patch_target(monkeypatch, log)
+        assert read_tail_lines(1234) == ["alpha", "beta", "gamma"]
+
+    def test_caps_to_last_max_lines(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("".join(f"line {i}\n" for i in range(200)))
+        self._patch_target(monkeypatch, log)
+        lines = read_tail_lines(1234, max_lines=50)
+        assert len(lines) == 50
+        assert lines[0] == "line 150"
+        assert lines[-1] == "line 199"
+
+    def test_drops_leading_partial_line_when_window_clips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A small byte window that starts mid-line must drop the partial
+        # head so we never report a truncated line.
+        log = tmp_path / "agent.log"
+        log.write_text("AAAAAAAAAA\nBBBBBBBBBB\nCCCCCCCCCC\n")
+        self._patch_target(monkeypatch, log)
+        # 25 bytes captures the tail end of the first line plus the last two.
+        lines = read_tail_lines(1234, max_bytes=25)
+        assert lines == ["BBBBBBBBBB", "CCCCCCCCCC"]
+
+    def test_empty_file_returns_empty_list(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("")
+        self._patch_target(monkeypatch, log)
+        assert read_tail_lines(1234) == []
+
+    def test_invalid_utf8_is_replaced(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        log = tmp_path / "agent.log"
+        log.write_bytes(b"good\n\xff\xfe bad\n")
+        self._patch_target(monkeypatch, log)
+        lines = read_tail_lines(1234)
+        assert lines[0] == "good"
+        assert "�" in lines[1]
+
+    def test_rejects_non_positive_max_lines(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("x\n")
+        self._patch_target(monkeypatch, log)
+        with pytest.raises(ValueError, match="max_lines must be positive"):
+            read_tail_lines(1234, max_lines=0)
+
+    def test_propagates_attach_unsupported(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _fail(_pid: int) -> _ResolvedTarget:
+            raise AttachUnsupported("no such pid 9999")
+
+        monkeypatch.setattr(tail_mod, "_resolve_target", _fail)
+        with pytest.raises(AttachUnsupported, match="no such pid 9999"):
+            read_tail_lines(9999)
 
 
 def test_module_thread_cleanup_under_pytest() -> None:

--- a/tests/tools/test_local_process_introspect.py
+++ b/tests/tools/test_local_process_introspect.py
@@ -1,0 +1,138 @@
+"""Tests for the local_process_introspect tool (Phase 5: incident response)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+from app.agents.probe import ProcessSnapshot
+from app.agents.tail import AttachUnsupported
+from app.tools.LocalProcessIntrospectTool import local_process_introspect
+from app.tools.registered_tool import REGISTERED_TOOL_ATTR, RegisteredTool
+from app.tools.registry import get_registered_tool_map
+from tests.tools.conftest import BaseToolContract
+
+_MODULE = "app.tools.LocalProcessIntrospectTool"
+
+
+def _registered() -> RegisteredTool:
+    r = getattr(local_process_introspect, REGISTERED_TOOL_ATTR, None)
+    assert isinstance(r, RegisteredTool)
+    return r
+
+
+def _snapshot(pid: int = 4242) -> ProcessSnapshot:
+    return ProcessSnapshot(
+        pid=pid,
+        cpu_percent=4.2,
+        rss_mb=128.5,
+        num_fds=12,
+        num_connections=3,
+        status="running",
+        started_at=datetime(2026, 6, 4, 9, 0, 0, tzinfo=UTC),
+        last_output_at=datetime(2026, 6, 4, 9, 5, 0, tzinfo=UTC),
+    )
+
+
+class TestLocalProcessIntrospectContract(BaseToolContract):
+    def get_tool_under_test(self) -> RegisteredTool:
+        return _registered()
+
+
+class TestLocalProcessIntrospectMetadata:
+    def test_tool_name(self) -> None:
+        assert _registered().name == "local_process_introspect"
+
+    def test_tool_source(self) -> None:
+        assert _registered().source == "knowledge"
+
+    def test_pid_is_required_integer(self) -> None:
+        schema = _registered().input_schema
+        assert "pid" in schema["required"]
+        assert schema["properties"]["pid"]["type"] == "integer"
+
+    def test_registered_on_investigation_surface(self) -> None:
+        assert "investigation" in _registered().surfaces
+
+    def test_appears_in_registry(self) -> None:
+        # Acceptance: the tool shows up in the auto-discovered registry dump.
+        assert "local_process_introspect" in get_registered_tool_map()
+
+
+class TestLocalProcessIntrospectExecution:
+    def test_returns_snapshot_and_stdout_tail(self) -> None:
+        lines = [f"line {i}" for i in range(50)]
+        with (
+            patch(f"{_MODULE}.probe", return_value=_snapshot()) as mock_probe,
+            patch(f"{_MODULE}.read_tail_lines", return_value=lines) as mock_tail,
+        ):
+            result = local_process_introspect(pid=4242)
+
+        mock_probe.assert_called_once_with(4242)
+        mock_tail.assert_called_once_with(4242, max_lines=50)
+        assert result["found"] is True
+        assert result["source"] == "knowledge"
+        assert result["snapshot"]["pid"] == 4242
+        assert result["snapshot"]["cpu_percent"] == 4.2
+        # datetimes are serialized to ISO-8601 strings (JSON-safe).
+        assert result["snapshot"]["started_at"] == "2026-06-04T09:00:00+00:00"
+        assert result["snapshot"]["last_output_at"] == "2026-06-04T09:05:00+00:00"
+        assert result["stdout_available"] is True
+        assert result["stdout_error"] is None
+        assert result["stdout_tail"] == lines
+        assert len(result["stdout_tail"]) == 50
+
+    def test_missing_process_returns_not_found(self) -> None:
+        with (
+            patch(f"{_MODULE}.probe", return_value=None),
+            patch(
+                f"{_MODULE}.read_tail_lines",
+                side_effect=AttachUnsupported("no such pid 9999"),
+            ),
+        ):
+            result = local_process_introspect(pid=9999)
+
+        assert result["found"] is False
+        assert result["snapshot"] is None
+        assert result["stdout_available"] is False
+        assert result["stdout_error"] == "no such pid 9999"
+        assert result["stdout_tail"] == []
+
+    def test_untailable_stdout_still_returns_snapshot(self) -> None:
+        # A live process whose stdout is a terminal: snapshot succeeds,
+        # the tail fails independently without failing the whole call.
+        with (
+            patch(f"{_MODULE}.probe", return_value=_snapshot()),
+            patch(
+                f"{_MODULE}.read_tail_lines",
+                side_effect=AttachUnsupported("stdout is on a terminal; live tail not supported"),
+            ),
+        ):
+            result = local_process_introspect(pid=4242)
+
+        assert result["found"] is True
+        assert result["snapshot"]["pid"] == 4242
+        assert result["stdout_available"] is False
+        assert result["stdout_error"] == "stdout is on a terminal; live tail not supported"
+        assert result["stdout_tail"] == []
+
+    def test_snapshot_nullable_fields_pass_through(self) -> None:
+        snap = ProcessSnapshot(
+            pid=7,
+            cpu_percent=0.0,
+            rss_mb=1.0,
+            num_fds=None,
+            num_connections=None,
+            status="sleeping",
+            started_at=datetime(2026, 6, 4, 9, 0, 0, tzinfo=UTC),
+            last_output_at=None,
+        )
+        with (
+            patch(f"{_MODULE}.probe", return_value=snap),
+            patch(f"{_MODULE}.read_tail_lines", return_value=[]),
+        ):
+            result = local_process_introspect(pid=7)
+
+        assert result["snapshot"]["num_fds"] is None
+        assert result["snapshot"]["num_connections"] is None
+        assert result["snapshot"]["last_output_at"] is None


### PR DESCRIPTION
Fixes #1506

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
Adds `local_process_introspect`, a registry-discovered investigation tool that
introspects a local agent process by PID and returns a psutil resource snapshot
plus the last 50 lines of its stdout. This is the tool the OpenSRE investigation
planner calls when Phase 5 (incident response) opens an investigation against a
stuck local agent. Part of the **Monitor Local Agents** roadmap.

- **`app/tools/LocalProcessIntrospectTool/__init__.py`** (new) — the `@tool(...)`
  function tool. Auto-discovered by the registry, registered on the
  `investigation` surface. Returns JSON with `snapshot`, `stdout_tail` (≤50
  lines), and `found` / `stdout_available` / `stdout_error`.
- **`app/agents/tail.py`** — new `read_tail_lines(pid, max_lines=50)` helper that
  reads the *existing* on-disk tail of a process's stdout (vs. `attach()`, which
  seeks to EOF to follow live output).
- **Tests** — `tests/tools/test_local_process_introspect.py` and a
  `TestReadTailLines` class in `tests/agents/test_tail.py`.

### Demo/Screenshot for feature changes and bug fixes - 

<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [X] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:

**Problem:** The investigation pipeline is a planner that picks tools to diagnose
problems. To run it against a *stuck local agent*, the planner needs a tool that
can look inside a running process, its resource usage and its recent output.
This issue exposes the existing per-PID probe + stdout tail as a first-class
investigation tool.

**Approach & alternatives:** I reused the two primitives already in the
`app/agents/` package rather than re-implementing process introspection:
`probe()` from `app/agents/probe.py` for the psutil snapshot, and a new
`read_tail_lines()` in `app/agents/tail.py` for stdout. I deliberately did *not*
reuse the existing `attach()` here: `attach()` seeks to EOF to *follow* new live
output (what `/agents trace` needs), whereas an after-the-fact investigation
never had a live session open — it needs the *existing* on-disk history. So
`read_tail_lines()` reads the tail of the file backing fd 1, reusing the same
`_resolve_target()` / `AttachUnsupported` contract as `attach()` for consistency.

**Key design decision : independent failure:** the snapshot and the stdout tail
fail independently. A process can be alive and probeable while its stdout is
untailable (a TTY, a pipe, a cross-user fd, Windows). Rather than failing the
whole tool call, the snapshot failure is reported via `found: false` /
`snapshot: null`, and the stdout failure via `stdout_available: false` +
`stdout_error`. This gives the planner partial signal instead of nothing.

**Key functions:**
- `local_process_introspect(pid)` : the `@tool`-decorated entry point. Calls
  `probe()`, then attempts `read_tail_lines()`, assembling a JSON-safe dict.
- `_snapshot_to_dict()`, renders `ProcessSnapshot` to JSON primitives
  (datetimes → ISO-8601, nullable POSIX-only fields pass through).
- `read_tail_lines(pid, max_lines=50)`, reads at most `max_bytes` (4 MiB) from
  the end of the file so a huge log can't blow up memory, decodes with
  `errors="replace"`, drops the leading partial line when the window starts
  mid-file, and slices the last `max_lines`.

**Edge cases handled & tested:** missing/zombie PID (`found: false`), stdout fd
that is a TTY/pipe/socket or cross-user (`stdout_error`), empty stdout, log
larger than the byte window (partial first line dropped), `max_lines <= 0`
(raises `ValueError`), and registry discovery/schema validation.

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [ X] I have added proper PR title and linked to the issue
- [ X] I have performed a self-review of my code
- [ X] **I can explain the purpose of every function, class, and logic block I added**
- [ X] I understand why my changes work and have tested them thoroughly
- [ X] I have considered potential edge cases and how my code handles them
- [ X] If it is a core feature, I have added thorough tests
- [ X] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
