### PR TITLE
Fix Windows agent tests and e2e deploy helper paths

### DIFF
--- a/app/agents/bus.py
+++ b/app/agents/bus.py
@@ -45,6 +45,9 @@ else:
 logger = logging.getLogger(__name__)
 
 DEFAULT_BUS_SOCKET_PATH: Path = OPENSRE_HOME_DIR / "agents-bus.sock"
+BUS_UNSUPPORTED_MESSAGE: str = (
+    "agent bus requires Unix-domain socket support; this platform does not provide socket.AF_UNIX"
+)
 
 #: Bus message wire-format version. Bump when ``BusMessage`` fields change shape.
 BUS_SCHEMA_VERSION: int = 1
@@ -58,6 +61,16 @@ _MAX_FRAME_BYTES: int = 64 * 1024
 #: unresponsive and evicted, so one wedged client cannot stall fan-out for
 #: every other publisher's reader thread.
 _BROADCAST_WRITE_TIMEOUT_SECONDS: float = 0.2
+
+
+def bus_supported() -> bool:
+    """Return True when this host can create Unix-domain sockets for the bus."""
+    return hasattr(socket, "AF_UNIX")
+
+
+def _require_bus_supported() -> None:
+    if not bus_supported():
+        raise OSError(BUS_UNSUPPORTED_MESSAGE)
 
 
 @dataclass(frozen=True)
@@ -260,6 +273,7 @@ class BusServer:
         """
         if self._running.is_set():
             return
+        _require_bus_supported()
         _ensure_parent_dir(self._path)
         listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
@@ -548,6 +562,7 @@ def _ensure_broker(path: Path) -> BusServer | None:
 
 def _connect_client(path: Path, timeout: float) -> socket.socket:
     """Open a blocking UDS connection to the broker at ``path``."""
+    _require_bus_supported()
     client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     client.settimeout(timeout)
     try:

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -23,7 +23,7 @@ from rich.markup import escape
 from rich.text import Text
 from rich.tree import Tree
 
-from app.agents.bus import BusMessage, subscribe
+from app.agents.bus import BusMessage, bus_supported, subscribe
 from app.agents.config import (
     agents_config_path,
     load_agents_config,
@@ -152,7 +152,7 @@ def _format_bus_message(msg: BusMessage) -> str:
     return " ".join(parts)
 
 
-def _cmd_agents_bus(console: Console) -> bool:
+def _cmd_agents_bus(session: ReplSession, console: Console) -> bool:
     """Live-tail the cross-agent context bus until ``Ctrl-C`` or broker exit.
 
     Self-elects a broker if none is running, then streams each ``BusMessage``
@@ -160,6 +160,14 @@ def _cmd_agents_bus(console: Console) -> bool:
     ``KeyboardInterrupt`` (user detached), broker disconnect (e.g. the
     publishing process exited), or socket error.
     """
+    if not bus_supported():
+        console.print(
+            f"[{ERROR}]cannot tail /agents bus:[/] "
+            "Unix-domain socket support is unavailable on this platform."
+        )
+        session.mark_latest(ok=False, kind="slash")
+        return True
+
     console.print(
         f"[{DIM}]tailing /agents bus — Ctrl-C to exit[/]",
     )
@@ -657,7 +665,7 @@ def _cmd_agents(session: ReplSession, console: Console, args: list[str]) -> bool
     if sub == "budget":
         return _cmd_agents_budget(session, console, args[1:])
     if sub == "bus":
-        return _cmd_agents_bus(console)
+        return _cmd_agents_bus(session, console)
     if sub == "conflicts":
         return _cmd_agents_conflicts(console)
 

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -15,6 +15,10 @@ from pathlib import Path
 import pytest
 
 _POSIX_FCNTL_AVAILABLE = importlib.util.find_spec("fcntl") is not None
+pytestmark = pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"),
+    reason="agent bus requires Unix-domain socket support",
+)
 
 from app.agents import bus as bus_module
 from app.agents.bus import (

--- a/tests/agents/test_tail.py
+++ b/tests/agents/test_tail.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import os
 import queue
+import sys
 import threading
 import time
 from pathlib import Path
@@ -36,6 +37,11 @@ from app.agents.tail import (
     _resolve_target,
     _ResolvedTarget,
     attach,
+)
+
+_WINDOWS_TAIL_TEST_REASON = (
+    "agent trace rejects Windows before POSIX fd/inode tailing; "
+    "these tests exercise platform-specific resolver or rename semantics"
 )
 
 
@@ -160,6 +166,7 @@ class TestParseLsofFd1:
         assert _parse_lsof_fd1("") == (None, None)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason=_WINDOWS_TAIL_TEST_REASON)
 class TestResolveLinuxTarget:
     def test_regular_file_target(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         log = tmp_path / "out.log"
@@ -414,6 +421,8 @@ class TestAttachSession:
         # producer keeps writing to the original inode. The reader holds
         # a fd to that inode and must keep tailing — pathname existence
         # is intentionally not a liveness condition.
+        if sys.platform == "win32":
+            pytest.skip(_WINDOWS_TAIL_TEST_REASON)
         log = tmp_path / "agent.log"
         log.write_text("")
         with self._make_session(log) as sess:

--- a/tests/cli/interactive_shell/test_agents_commands.py
+++ b/tests/cli/interactive_shell/test_agents_commands.py
@@ -99,6 +99,27 @@ class TestAgentsRegistration:
         assert DEFAULT_WINDOW_SECONDS == 10.0
 
 
+class TestAgentsBus:
+    def test_bus_reports_unsupported_platform_without_subscribing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(agents_mod, "bus_supported", lambda: False, raising=False)
+
+        def _unexpected_subscribe() -> object:
+            raise AssertionError("unsupported /agents bus must not call subscribe()")
+
+        monkeypatch.setattr(agents_mod, "subscribe", _unexpected_subscribe)
+
+        sess_obj = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents bus", sess_obj, console) is True
+
+        out = buf.getvalue()
+        assert "cannot tail /agents bus" in out
+        assert "Unix-domain socket" in out
+        assert sess_obj.history[-1]["ok"] is False
+
+
 class TestAgentsDispatch:
     def test_conflicts_with_empty_event_source_renders_empty_state(self) -> None:
         session = ReplSession()

--- a/tests/e2e/test_deploy_helper_paths.py
+++ b/tests/e2e/test_deploy_helper_paths.py
@@ -1,0 +1,78 @@
+"""Regression tests for E2E deploy helper path resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.upstream_apache_flink_ecs.infrastructure_sdk import deploy as flink_deploy
+from tests.e2e.upstream_lambda.infrastructure_sdk import deploy as lambda_deploy
+from tests.e2e.upstream_prefect_ecs_fargate.infrastructure_sdk import deploy as prefect_deploy
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize(
+    "module",
+    [lambda_deploy, prefect_deploy, flink_deploy],
+)
+def test_e2e_deploy_helpers_resolve_repo_root(module: object) -> None:
+    assert module.project_root == REPO_ROOT
+
+
+@pytest.mark.parametrize(
+    ("module", "paths"),
+    [
+        (
+            lambda_deploy,
+            {
+                "SHARED_VENDOR_API_DIR": REPO_ROOT / "tests" / "shared" / "external_vendor_api",
+                "PIPELINE_CODE_DIR": REPO_ROOT
+                / "tests"
+                / "e2e"
+                / "upstream_lambda"
+                / "pipeline_code",
+            },
+        ),
+        (
+            prefect_deploy,
+            {
+                "MOCK_API_CODE": REPO_ROOT / "tests" / "shared" / "external_vendor_api",
+                "TRIGGER_LAMBDA_CODE": REPO_ROOT
+                / "tests"
+                / "e2e"
+                / "upstream_prefect_ecs_fargate"
+                / "pipeline_code"
+                / "trigger_lambda",
+            },
+        ),
+        (
+            flink_deploy,
+            {
+                "FLINK_IMAGE_DOCKERFILE": REPO_ROOT
+                / "tests"
+                / "e2e"
+                / "upstream_apache_flink_ecs"
+                / "infrastructure_code"
+                / "flink_image"
+                / "Dockerfile",
+                "MOCK_API_CODE_DIR": REPO_ROOT / "tests" / "shared" / "external_vendor_api",
+                "TRIGGER_LAMBDA_CODE_DIR": REPO_ROOT
+                / "tests"
+                / "e2e"
+                / "upstream_apache_flink_ecs"
+                / "pipeline_code"
+                / "trigger_lambda",
+            },
+        ),
+    ],
+)
+def test_e2e_deploy_helper_asset_paths_resolve_existing_repo_assets(
+    module: object,
+    paths: dict[str, Path],
+) -> None:
+    for attr, expected in paths.items():
+        actual = getattr(module, attr)
+        assert actual == expected
+        assert actual.exists(), f"{attr} does not exist: {actual}"

--- a/tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py
@@ -18,7 +18,7 @@ import time
 import uuid
 from pathlib import Path
 
-project_root = Path(__file__).resolve().parents[3]
+project_root = Path(__file__).resolve().parents[4]
 
 from tests.shared.infrastructure_sdk import save_outputs
 from tests.shared.infrastructure_sdk.resources import (
@@ -36,6 +36,12 @@ from tests.shared.infrastructure_sdk.resources import (
 STACK_NAME = "tracer-flink-ecs"
 REGION = "us-east-1"
 GRAFANA_SECRET_NAME = "tracer/grafana-cloud"
+TESTS_DIR = project_root / "tests"
+E2E_DIR = TESTS_DIR / "e2e"
+FLINK_SCENARIO_DIR = E2E_DIR / "upstream_apache_flink_ecs"
+FLINK_IMAGE_DOCKERFILE = FLINK_SCENARIO_DIR / "infrastructure_code" / "flink_image" / "Dockerfile"
+MOCK_API_CODE_DIR = TESTS_DIR / "shared" / "external_vendor_api"
+TRIGGER_LAMBDA_CODE_DIR = FLINK_SCENARIO_DIR / "pipeline_code" / "trigger_lambda"
 
 
 def deploy() -> dict:
@@ -151,14 +157,7 @@ def deploy() -> dict:
     # Build and push Docker image
     # Build context is project root to include telemetry packages
     context_dir = project_root
-    dockerfile_path = (
-        project_root
-        / "tests"
-        / "upstream_apache_flink_ecs"
-        / "infrastructure_code"
-        / "flink_image"
-        / "Dockerfile"
-    )
+    dockerfile_path = FLINK_IMAGE_DOCKERFILE
 
     print("  - Building and pushing Docker image (ARM64)...")
     print(f"    Dockerfile: {dockerfile_path}")
@@ -330,7 +329,7 @@ otelcol.exporter.otlphttp "grafana" {
     print("\n[Phase 6] Creating Lambda functions and API Gateways...")
 
     # Mock API Lambda
-    mock_api_code_dir = project_root / "tests/shared/external_vendor_api"
+    mock_api_code_dir = MOCK_API_CODE_DIR
     print(f"  - Bundling Mock API Lambda from: {mock_api_code_dir}")
     mock_api_code = lambda_.bundle_code(mock_api_code_dir)
 
@@ -360,9 +359,7 @@ otelcol.exporter.otlphttp "grafana" {
     print(f"    Mock API URL: {mock_api['invoke_url']}")
 
     # Trigger Lambda
-    trigger_code_dir = (
-        project_root / "tests/e2e/upstream_apache_flink_ecs/pipeline_code/trigger_lambda"
-    )
+    trigger_code_dir = TRIGGER_LAMBDA_CODE_DIR
     requirements_file = trigger_code_dir / "requirements.txt"
     print(f"  - Bundling Trigger Lambda from: {trigger_code_dir}")
     trigger_code = lambda_.bundle_code(trigger_code_dir, requirements_file)

--- a/tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py
@@ -27,10 +27,14 @@ from tests.shared.infrastructure_sdk.resources import api_gateway, iam, lambda_,
 from tests.shared.infrastructure_sdk.resources.iam import get_account_id, put_role_policy
 from tests.shared.infrastructure_sdk.resources.secrets import get_secret_value
 
-project_root = Path(__file__).resolve().parents[3]
+project_root = Path(__file__).resolve().parents[4]
 
 STACK_NAME = "tracer-lambda"
 REGION = "us-east-1"
+TESTS_DIR = project_root / "tests"
+E2E_DIR = TESTS_DIR / "e2e"
+SHARED_VENDOR_API_DIR = TESTS_DIR / "shared" / "external_vendor_api"
+PIPELINE_CODE_DIR = E2E_DIR / "upstream_lambda" / "pipeline_code"
 
 
 def bundle_pipeline_code(pipeline_dir: Path) -> bytes:
@@ -184,17 +188,13 @@ def create_lambda_functions(
     """Create Lambda functions."""
     print("Creating Lambda functions...")
 
-    # Paths
-    shared_dir = project_root / "tests" / "shared" / "external_vendor_api"
-    pipeline_dir = project_root / "tests" / "upstream_lambda" / "pipeline_code"
-
     # Bundle code
     print("  Bundling MockApi Lambda code...")
-    mock_api_zip = lambda_.bundle_code(shared_dir)
+    mock_api_zip = lambda_.bundle_code(SHARED_VENDOR_API_DIR)
 
     print("  Bundling pipeline code (dependencies already vendored)...")
     # Use custom bundling that puts vendored deps at root level
-    pipeline_zip = bundle_pipeline_code(pipeline_dir)
+    pipeline_zip = bundle_pipeline_code(PIPELINE_CODE_DIR)
 
     # Create MockApi Lambda
     print("  Creating MockApiLambda...")
@@ -403,8 +403,7 @@ def deploy() -> dict:
 
     # 3. Create MockApi Lambda and API Gateway first (for URL)
     print("Creating MockApi Lambda...")
-    shared_dir = project_root / "tests" / "shared" / "external_vendor_api"
-    mock_api_zip = lambda_.bundle_code(shared_dir)
+    mock_api_zip = lambda_.bundle_code(SHARED_VENDOR_API_DIR)
 
     mock_api_lambda = lambda_.create_function(
         name=f"{STACK_NAME}-mock-api",
@@ -431,11 +430,10 @@ def deploy() -> dict:
 
     # 4. Create pipeline Lambdas with correct URLs
     print("Creating pipeline Lambda functions...")
-    pipeline_dir = project_root / "tests" / "upstream_lambda" / "pipeline_code"
 
     print("  Bundling pipeline code (dependencies already vendored)...")
     # Use custom bundling that puts vendored deps at root level
-    pipeline_zip = bundle_pipeline_code(pipeline_dir)
+    pipeline_zip = bundle_pipeline_code(PIPELINE_CODE_DIR)
 
     print("  Creating IngesterLambda...")
     ingester_lambda = lambda_.create_function(

--- a/tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py
@@ -23,7 +23,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-project_root = Path(__file__).resolve().parents[3]
+project_root = Path(__file__).resolve().parents[4]
 
 from app.utils.config import load_env
 from tests.shared.infrastructure_sdk import save_outputs
@@ -58,18 +58,12 @@ TRIGGER_LAMBDA_NAME = "tracer-prefect-ecs-trigger"
 
 # Paths
 TESTS_DIR = project_root / "tests"
-PREFECT_DOCKERFILE = (
-    TESTS_DIR
-    / "upstream_prefect_ecs_fargate"
-    / "infrastructure_code"
-    / "prefect_image"
-    / "Dockerfile"
-)
+E2E_DIR = TESTS_DIR / "e2e"
+PREFECT_SCENARIO_DIR = E2E_DIR / "upstream_prefect_ecs_fargate"
+PREFECT_DOCKERFILE = PREFECT_SCENARIO_DIR / "infrastructure_code" / "prefect_image" / "Dockerfile"
 ALLOY_CONFIG_DIR = TESTS_DIR / "shared" / "infrastructure_code" / "alloy_config"
 MOCK_API_CODE = TESTS_DIR / "shared" / "external_vendor_api"
-TRIGGER_LAMBDA_CODE = (
-    TESTS_DIR / "upstream_prefect_ecs_fargate" / "pipeline_code" / "trigger_lambda"
-)
+TRIGGER_LAMBDA_CODE = PREFECT_SCENARIO_DIR / "pipeline_code" / "trigger_lambda"
 
 GRAFANA_ENV_KEYS = [
     "GCLOUD_HOSTED_METRICS_URL",


### PR DESCRIPTION
## Summary
- guard `/agents bus` on platforms without Unix-domain socket support and skip AF_UNIX-only bus tests there
- skip POSIX/Linux-specific tail tests on Windows
- resolve e2e deploy helper asset paths from the repository root and add regression coverage

Fixes #1850
Fixes #1852
Fixes #1418

## Duplicate/upstream check
- refreshed `upstream/main`
- confirmed #1850, #1852, and #1418 are still open and unassigned
- found no open PRs referencing #1850, #1852, or #1418
- confirmed upstream still lacks the bus guard/tail skip guard and still uses `parents[3]` in the deploy helpers

## Validation
- `uv run python -m pytest tests/cli/interactive_shell/test_agents_commands.py tests/agents/test_tail.py tests/agents/test_bus.py tests/e2e/test_deploy_helper_paths.py -q --tb=short` — 107 passed, 49 skipped
- `uv run python -m ruff check app/agents/bus.py app/cli/interactive_shell/command_registry/agents.py tests/agents/test_bus.py tests/agents/test_tail.py tests/cli/interactive_shell/test_agents_commands.py tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py tests/e2e/test_deploy_helper_paths.py`
- `uv run python -m ruff format --check app/agents/bus.py app/cli/interactive_shell/command_registry/agents.py tests/agents/test_bus.py tests/agents/test_tail.py tests/cli/interactive_shell/test_agents_commands.py tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py tests/e2e/test_deploy_helper_paths.py`
- `uv run python -m mypy app/agents/bus.py app/cli/interactive_shell/command_registry/agents.py`