### PR TITLE
feat(bench): Added a separation between opensre logic and benchmarking framework

### DIFF
--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -77,6 +77,26 @@ AgentEventCallback = Callable[[str, dict[str, Any]], None]
 class ConnectedInvestigationAgent:
     """ReAct loop scoped to the tools enabled by connected integrations."""
 
+    def _should_accept_conclusion(
+        self,
+        *,
+        evidence_count: int,  # noqa: ARG002 — used by overrides
+        iteration: int,  # noqa: ARG002 — used by overrides
+    ) -> tuple[bool, str | None]:
+        """Hook: decide what to do when the LLM stops requesting tools.
+
+        Returns ``(accept_conclusion, optional_nudge)``:
+          - ``(True, None)`` — accept the LLM's choice, exit the loop. Default.
+          - ``(False, "...")`` — reject the bail, inject the nudge as a user
+            message, continue the loop. ``MAX_INVESTIGATION_LOOPS`` still
+            caps the worst case so a stubborn model can't infinite-loop.
+
+        Default returns ``(True, None)`` — production agents accept whatever
+        the LLM decides. Subclasses can override to enforce minimum-evidence
+        floors, structured-stage progression, or other termination policies.
+        """
+        return True, None
+
     def run(
         self,
         state: dict[str, Any],
@@ -203,8 +223,16 @@ class ConnectedInvestigationAgent:
             messages.append(_build_assistant_msg(llm, response))
 
             if not response.has_tool_calls:
-                logger.debug("[agent] no tool calls — done after %d iterations", iteration + 1)
-                break
+                accept, nudge = self._should_accept_conclusion(
+                    evidence_count=len(evidence_entries),
+                    iteration=iteration,
+                )
+                if accept:
+                    logger.debug("[agent] no tool calls — done after %d iterations", iteration + 1)
+                    break
+                if nudge is not None:
+                    messages.append({"role": "user", "content": nudge})
+                continue
 
             # Emit tool_start for each pending call before executing
             for tc in response.tool_calls:
@@ -347,8 +375,8 @@ def _enforce_context_budget(
 
     No-op on the happy path: the estimate covers messages + system + tools
     in one pass and returns under the ceiling for normal investigations.
-    Only fires on long CloudOpsBench cases where unbounded tool history
-    has pushed the prompt past the model's limit.
+    Only fires on long investigations where unbounded tool history has
+    pushed the prompt past the model's limit.
     """
     while _estimate_message_tokens(messages, system=system, tools=tools) > _TOKEN_BUDGET_CEILING:
         if not _trim_oldest_tool_pair(messages):

--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -85,11 +85,18 @@ class ConnectedInvestigationAgent:
     ) -> tuple[bool, str | None]:
         """Hook: decide what to do when the LLM stops requesting tools.
 
-        Returns ``(accept_conclusion, optional_nudge)``:
+        Returns ``(accept_conclusion, nudge)``:
           - ``(True, None)`` — accept the LLM's choice, exit the loop. Default.
-          - ``(False, "...")`` — reject the bail, inject the nudge as a user
-            message, continue the loop. ``MAX_INVESTIGATION_LOOPS`` still
+          - ``(False, "...")`` — reject the bail, inject the nudge string as a
+            user message, continue the loop. ``MAX_INVESTIGATION_LOOPS`` still
             caps the worst case so a stubborn model can't infinite-loop.
+
+        **Contract:** ``(False, None)`` is invalid and raises ``ValueError`` at
+        the call site. Rejecting the conclusion without providing a nudge
+        would spin the loop on an unchanged message history until the outer
+        iteration cap, silently burning the token budget. The type system
+        allows ``str | None`` so subclasses can use a single return type;
+        the runtime guard enforces the actual contract.
 
         Default returns ``(True, None)`` — production agents accept whatever
         the LLM decides. Subclasses can override to enforce minimum-evidence
@@ -230,8 +237,20 @@ class ConnectedInvestigationAgent:
                 if accept:
                     logger.debug("[agent] no tool calls — done after %d iterations", iteration + 1)
                     break
-                if nudge is not None:
-                    messages.append({"role": "user", "content": nudge})
+                # Contract: rejecting the conclusion (accept=False) MUST
+                # come with a nudge so the next LLM call sees new context.
+                # Without one the loop would spin on an unchanged message
+                # history until MAX_INVESTIGATION_LOOPS, silently burning
+                # the entire token budget without making progress. Failing
+                # fast keeps buggy hook overrides loud rather than expensive.
+                if nudge is None:
+                    raise ValueError(
+                        f"{type(self).__name__}._should_accept_conclusion returned "
+                        "(False, None) — a nudge string is required when rejecting "
+                        "the conclusion, otherwise the LLM will loop on an unchanged "
+                        "message history until MAX_INVESTIGATION_LOOPS."
+                    )
+                messages.append({"role": "user", "content": nudge})
                 continue
 
             # Emit tool_start for each pending call before executing

--- a/app/agent/llm_invoke_errors.py
+++ b/app/agent/llm_invoke_errors.py
@@ -68,8 +68,8 @@ def classify_llm_invoke_failure(exc: BaseException) -> LLMInvokeFailure | None:
 
     Returns ``None`` to signal the caller should re-raise. In particular,
     :class:`LLMCreditExhaustedError` is intentionally NOT classified — it
-    represents a non-recoverable billing condition that the bench runner
-    (and production agent) must halt on, not wrap into a degraded result.
+    represents a non-recoverable billing condition that callers must halt
+    on, not wrap into a degraded result.
     """
     from app.integrations.llm_cli.errors import (
         CLIAuthenticationRequired,

--- a/app/pipeline/pipeline.py
+++ b/app/pipeline/pipeline.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from app.state import AgentState
+
+if TYPE_CHECKING:
+    # Type-only import — avoids paying the agent module's heavy import cost
+    # at pipeline load while still letting static type-checkers validate
+    # ``agent_class`` injections.
+    from app.agent.investigation import ConnectedInvestigationAgent
 
 logger = logging.getLogger(__name__)
 
@@ -136,7 +142,7 @@ def _build_correlation_config(state: dict[str, Any]) -> dict[str, Any] | None:
 def run_connected_investigation(
     state: AgentState,
     *,
-    agent_class: type | None = None,
+    agent_class: type[ConnectedInvestigationAgent] | None = None,
 ) -> AgentState:
     """Resolve connected integrations → parse alert → agent loop → deliver.
 

--- a/app/pipeline/pipeline.py
+++ b/app/pipeline/pipeline.py
@@ -133,11 +133,20 @@ def _build_correlation_config(state: dict[str, Any]) -> dict[str, Any] | None:
     return {"configurable": {"upstream_evidence_provider": provider}}
 
 
-def run_connected_investigation(state: AgentState) -> AgentState:
+def run_connected_investigation(
+    state: AgentState,
+    *,
+    agent_class: type | None = None,
+) -> AgentState:
     """Resolve connected integrations → parse alert → agent loop → deliver.
 
     All steps mutate a shared state dict. Each step returns a dict of updates
     which are merged in. Pure function: inputs in, state out.
+
+    ``agent_class``: optional override for the investigation agent class.
+    Defaults to :class:`ConnectedInvestigationAgent`. Callers that need a
+    custom termination policy, structured-stage progression, or other
+    agent-level extensions can pass a subclass instead.
     """
     from app.agent.context import resolve_integrations
     from app.agent.extract import extract_alert
@@ -146,6 +155,7 @@ def run_connected_investigation(state: AgentState) -> AgentState:
     from app.delivery import deliver
     from app.utils.sentry_sdk import capture_exception
 
+    agent_class = agent_class or ConnectedInvestigationAgent
     state_any = cast(dict[str, Any], state)
 
     try:
@@ -155,7 +165,7 @@ def run_connected_investigation(state: AgentState) -> AgentState:
         if state_any.get("is_noise"):
             return cast(AgentState, state_any)
 
-        _merge(state_any, ConnectedInvestigationAgent().run(state_any))
+        _merge(state_any, agent_class().run(state_any))
         _merge(
             state_any,
             node_correlate_upstream(

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -80,6 +80,7 @@ def run_investigation(
     openclaw_context: dict[str, Any] | None = None,
     opensre_evaluate: bool = False,
     investigation_metadata: tuple[str, str, str] | None = None,
+    agent_class: type | None = None,
 ) -> AgentState:
     """Run the investigation from a raw alert payload. Pure function: inputs in, state out.
 
@@ -90,6 +91,10 @@ def run_investigation(
             FixtureGrafanaBackend should be injected without real credential resolution.
         investigation_metadata: Optional ``(alert_name, pipeline_name, severity)`` for
             initial state; avoids copying those fields onto ``raw_alert``.
+        agent_class: Optional override for the investigation agent class. Defaults
+            to ``ConnectedInvestigationAgent``. Callers that need a custom
+            termination policy, structured-stage progression, or other
+            agent-level extensions can pass a subclass instead.
     """
     init_sentry(entrypoint="pipeline")
     from app.pipeline.pipeline import run_connected_investigation as _run
@@ -109,7 +114,7 @@ def run_investigation(
         message="run_investigation failed",
         tags={"surface": "pipeline", "component": "app.pipeline.runners"},
     ):
-        return _run(initial)
+        return _run(initial, agent_class=agent_class)
 
 
 def run_chat(state: AgentState, _config: NodeConfig | None = None) -> AgentState:

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -9,13 +9,19 @@ import queue
 import threading
 from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from app.remote.stream import StreamEvent
 from app.state import AgentState, make_initial_state
 from app.types.config import NodeConfig
 from app.utils.errors import report_and_reraise
 from app.utils.sentry_sdk import init_sentry
+
+if TYPE_CHECKING:
+    # Type-only — avoids paying the agent module's heavy import cost at
+    # runner load while still letting static type-checkers validate
+    # ``agent_class`` injections.
+    from app.agent.investigation import ConnectedInvestigationAgent
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +86,7 @@ def run_investigation(
     openclaw_context: dict[str, Any] | None = None,
     opensre_evaluate: bool = False,
     investigation_metadata: tuple[str, str, str] | None = None,
-    agent_class: type | None = None,
+    agent_class: type[ConnectedInvestigationAgent] | None = None,
 ) -> AgentState:
     """Run the investigation from a raw alert payload. Pure function: inputs in, state out.
 

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -56,9 +56,10 @@ def _rate_limit_sleep_seconds(err: BaseException, fallback_backoff: float) -> fl
     jitter ``Uniform(0, fallback_backoff)`` when no hint is available — same
     pattern AWS and the Anthropic/OpenAI SDKs use for transient errors.
 
-    Always adds ±10% jitter even on the server hint: with multiple bench
-    workers, four clients all sleeping for *exactly* the suggested 94ms
-    would still wake up in lockstep and re-trigger the same TPM bucket.
+    Always adds ±10% jitter even on the server hint: with multiple
+    concurrent callers, clients all sleeping for *exactly* the suggested
+    94ms would still wake up in lockstep and re-trigger the same TPM
+    bucket.
 
     Logs which branch produced the sleep duration so operators can audit
     whether the Retry-After path is actually firing (most OpenAI 429s

--- a/app/tools/EKSListClustersTool/__init__.py
+++ b/app/tools/EKSListClustersTool/__init__.py
@@ -16,13 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 def _eks_available(sources: dict[str, dict]) -> bool:
-    # In CloudOpsBench replay mode the EKS surface is served by the case
-    # snapshot via CloudOpsBenchK8sTools. Exposing the real EKS tools too
-    # would have the agent attempt sts:AssumeRole against placeholder ARNs
-    # like arn:aws:iam::placeholder:role/placeholder, which always fails.
-    backend = (sources.get("eks") or {}).get("_backend")
-    if getattr(backend, "is_cloudopsbench_backend", False):
-        return False
     return bool(sources.get("eks", {}).get("connection_verified"))
 
 

--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -25,6 +25,35 @@ _SKIP_MODULE_NAMES = {
     "utils",
 }
 
+# Extension point: callers outside ``app.tools.*`` (e.g. test suites,
+# external benchmark harnesses, downstream integrators) can register
+# additional tool packages by calling
+# :func:`register_external_tool_package`. Registered packages are walked
+# the same way as :mod:`app.tools` — each top-level submodule is imported
+# and any ``@tool``-decorated callables are picked up.
+#
+# Production stays clean: with no external registrations, the registry
+# discovers only ``app.tools.*``. The list is *not* persisted across
+# processes — every fresh import of opensre starts with zero externals.
+_external_tool_packages: list[ModuleType] = []
+
+
+def register_external_tool_package(package: ModuleType) -> None:
+    """Register an additional tool package for registry discovery.
+
+    Call before any ``get_registered_tools()`` consumer in the same
+    process. The registry cache is cleared so the new package's tools
+    appear on the next lookup.
+
+    Production code does NOT call this — it's a hook for test suites
+    and external integrators that ship their own tools but want them
+    routed through opensre's agent loop.
+    """
+    if package not in _external_tool_packages:
+        _external_tool_packages.append(package)
+        clear_tool_registry_cache()
+
+
 # Preserve the current chat surface while the repo migrates toward explicit
 # per-tool surface metadata.
 _LEGACY_CHAT_TOOL_NAMES = {
@@ -46,9 +75,9 @@ _LEGACY_CHAT_TOOL_NAMES = {
 }
 
 
-def _iter_tool_module_names() -> list[str]:
+def _iter_tool_module_names(package: ModuleType) -> list[str]:
     module_names: list[str] = []
-    for module_info in pkgutil.iter_modules(tools_package.__path__):
+    for module_info in pkgutil.iter_modules(package.__path__):
         if module_info.name in _SKIP_MODULE_NAMES:
             continue
         if module_info.name.startswith("_") or module_info.name.endswith("_test"):
@@ -57,8 +86,8 @@ def _iter_tool_module_names() -> list[str]:
     return sorted(module_names)
 
 
-def _import_tool_module(module_name: str) -> ModuleType:
-    return importlib.import_module(f"{tools_package.__name__}.{module_name}")
+def _import_tool_module(package: ModuleType, module_name: str) -> ModuleType:
+    return importlib.import_module(f"{package.__name__}.{module_name}")
 
 
 def _candidate_belongs_to_module(candidate: object, module_name: str) -> bool:
@@ -122,29 +151,35 @@ def _collect_registered_tools_from_module(module: ModuleType) -> list[Registered
 def _load_registry_snapshot() -> tuple[RegisteredTool, ...]:
     tools_by_name: dict[str, RegisteredTool] = {}
 
-    for module_name in _iter_tool_module_names():
-        try:
-            module = _import_tool_module(module_name)
-        except ModuleNotFoundError as exc:
-            logger.warning("[tools] Skipping %s: %s", module_name, exc)
-            continue
-        except Exception as exc:
-            logger.warning(
-                "[tools] Skipping %s due to import failure: %s",
-                module_name,
-                exc,
-                exc_info=True,
-            )
-            continue
-
-        for tool in _collect_registered_tools_from_module(module):
-            if tool.name in tools_by_name:
+    # Walk the canonical tools package, then any externally-registered
+    # packages in the order they were registered. First definition of a
+    # given tool name wins; duplicates are logged and skipped.
+    packages: list[ModuleType] = [tools_package, *_external_tool_packages]
+    for package in packages:
+        for module_name in _iter_tool_module_names(package):
+            try:
+                module = _import_tool_module(package, module_name)
+            except ModuleNotFoundError as exc:
+                logger.warning("[tools] Skipping %s.%s: %s", package.__name__, module_name, exc)
+                continue
+            except Exception as exc:
                 logger.warning(
-                    "[tools] Duplicate tool name '%s' across modules; keeping first definition",
-                    tool.name,
+                    "[tools] Skipping %s.%s due to import failure: %s",
+                    package.__name__,
+                    module_name,
+                    exc,
+                    exc_info=True,
                 )
                 continue
-            tools_by_name[tool.name] = tool
+
+            for tool in _collect_registered_tools_from_module(module):
+                if tool.name in tools_by_name:
+                    logger.warning(
+                        "[tools] Duplicate tool name '%s' across modules; keeping first definition",
+                        tool.name,
+                    )
+                    continue
+                tools_by_name[tool.name] = tool
 
     return tuple(sorted(tools_by_name.values(), key=lambda tool: tool.name))
 

--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -6,6 +6,7 @@ import importlib
 import inspect
 import logging
 import pkgutil
+import threading
 from functools import lru_cache
 from types import ModuleType
 
@@ -36,6 +37,7 @@ _SKIP_MODULE_NAMES = {
 # discovers only ``app.tools.*``. The list is *not* persisted across
 # processes — every fresh import of opensre starts with zero externals.
 _external_tool_packages: list[ModuleType] = []
+_external_registration_lock = threading.Lock()
 
 
 def register_external_tool_package(package: ModuleType) -> None:
@@ -45,11 +47,19 @@ def register_external_tool_package(package: ModuleType) -> None:
     process. The registry cache is cleared so the new package's tools
     appear on the next lookup.
 
+    Idempotent and thread-safe: concurrent callers registering the same
+    package (e.g. multiple workers in a ``ThreadPoolExecutor`` each
+    importing a bench package) won't add duplicate entries that would
+    otherwise produce noisy ``Duplicate tool name`` warnings on every
+    subsequent registry walk.
+
     Production code does NOT call this — it's a hook for test suites
     and external integrators that ship their own tools but want them
     routed through opensre's agent loop.
     """
-    if package not in _external_tool_packages:
+    with _external_registration_lock:
+        if package in _external_tool_packages:
+            return
         _external_tool_packages.append(package)
         clear_tool_registry_cache()
 

--- a/app/tools/utils/availability.py
+++ b/app/tools/utils/availability.py
@@ -20,17 +20,14 @@ def eks_available_or_backend(sources: dict[str, dict]) -> bool:
     support continue to use the narrower check in
     ``app.tools.EKSListClustersTool._eks_available``.
 
-    Exception: in CloudOpsBench replay mode the EKS surface is served by the
-    case snapshot via CloudOpsBenchK8sTools (GetResources, GetClusterConfiguration,
-    etc.). The CloudOpsBenchReplayBackend does not implement the EKS tool API
-    (list_pods, get_pod_logs, ...), so exposing these EKS tools would have the
-    agent call methods that don't exist on the backend.
+    The ``_backend`` slot is reserved for fixture backends that implement
+    the EKS tool API (``list_pods``, ``get_pod_logs``, ...). Other backend
+    types that speak different protocols should be placed in their own
+    distinct source slots and are invisible to this check — the real EKS
+    tools stay deactivated for those modes.
     """
     eks = sources.get("eks", {})
-    backend = eks.get("_backend")
-    if getattr(backend, "is_cloudopsbench_backend", False):
-        return False
-    return bool(eks.get("connection_verified") or backend)
+    return bool(eks.get("connection_verified") or eks.get("_backend"))
 
 
 def datadog_available_or_backend(sources: dict[str, dict]) -> bool:

--- a/app/utils/llm_retry.py
+++ b/app/utils/llm_retry.py
@@ -8,21 +8,20 @@ ad-hoc in others):
      429s with different exception classes but consistent message text.
   2. Retrying with exponential backoff when the recognizer says yes.
 
-Used by:
-  - ``tests/benchmarks/cloudopsbench/predictor.py`` — wraps its one-shot
-    LLM call so the structured-output emitter doesn't silently degrade to
-    None on a transient 429.
-  - ``app/services/agent_llm_client.py`` — uses :func:`is_rate_limit_error`
-    inside its existing retry loop so the investigation loop survives a
-    transient 429 the same way it survives a 500.
-
 Why a helper instead of catching the SDK's typed exceptions everywhere:
 opensre wraps provider exceptions into ``RuntimeError`` at boundaries
 (see e.g. ``AnthropicAgentClient.invoke`` raising
 ``RuntimeError("Anthropic rate limit exceeded: ...")``). Downstream code
-(the predictor, future cross-provider tooling) only sees the wrapped
-text. Matching by text is the only common denominator without taking a
-hard import dependency on every provider's exception module.
+only sees the wrapped text — matching by text is the common denominator
+without taking a hard import dependency on every provider's exception
+module.
+
+The agent LLM client (:mod:`app.services.agent_llm_client`) uses
+:func:`is_rate_limit_error` inside its own retry loop so the
+investigation survives a transient 429 the same way it survives a 500.
+Any code path that performs its own LLM call can wrap it with
+:func:`retry_on_rate_limit` to inherit the same backoff + jitter
+contract.
 """
 
 from __future__ import annotations
@@ -137,9 +136,11 @@ class LLMCreditExhaustedError(Exception):
     equivalent. UNLIKE transient rate-limit errors, retries don't help —
     the operator must top up balance or raise the spending cap.
 
-    Bench runner halts the entire run on first occurrence (continuing burns
-    wall-clock on a dead account and produces no useful data). Production
-    agent surfaces it as a credential / billing error.
+    Long-running orchestrators (multi-cell batches, scheduled investigations)
+    should halt on first occurrence rather than continuing — every subsequent
+    LLM call will fail the same way until the account is topped up.
+    Interactive callers should surface the error to the operator with clear
+    "fix your billing" guidance.
 
     Intentionally NOT a subclass of ``RuntimeError`` so the existing
     catch-all-RuntimeError paths don't accidentally swallow it. Always
@@ -252,12 +253,11 @@ def retry_on_rate_limit[T](
       - ``max_attempts`` retries have exhausted.
 
     Backoff uses **full jitter** (``sleep ~ Uniform(0, backoff)``) rather than
-    deterministic ``time.sleep(backoff)``. With multiple concurrent workers
-    (e.g. the bench runner's ``workers: 4``), a deterministic backoff would
-    have all rate-limited clients wake up at the same instant and retry in
-    lockstep, immediately re-hitting the TPM bucket. Full jitter is the
-    pattern AWS recommends and matches what the Anthropic + OpenAI SDKs do
-    internally.
+    deterministic ``time.sleep(backoff)``. With multiple concurrent callers, a
+    deterministic backoff would have all rate-limited clients wake up at the
+    same instant and retry in lockstep, immediately re-hitting the TPM
+    bucket. Full jitter is the pattern AWS recommends and matches what the
+    Anthropic + OpenAI SDKs do internally.
 
     ``label`` is the short tag used in log messages so callers (predictor,
     agent loop, ...) can be told apart in tail-grep.

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -383,6 +383,51 @@ def test_enforce_context_budget_noop_when_under_ceiling() -> None:
     assert messages == snapshot
 
 
+# --------------------------------------------------------------------------- #
+# Termination hook — production default + override mechanics                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_should_accept_conclusion_production_default_accepts() -> None:
+    """Production default: the agent ALWAYS accepts the LLM's choice to stop.
+    Returning (True, None) is the no-op path; subclasses override to enforce
+    floors or other termination policies."""
+    agent = ConnectedInvestigationAgent()
+    accept, nudge = agent._should_accept_conclusion(evidence_count=0, iteration=0)
+    assert accept is True
+    assert nudge is None
+    # Behavior independent of how many tool calls happened — production
+    # agents trust the LLM.
+    accept, nudge = agent._should_accept_conclusion(evidence_count=100, iteration=15)
+    assert accept is True
+    assert nudge is None
+
+
+def test_should_accept_conclusion_subclass_can_force_continuation() -> None:
+    """Subclasses can return (False, nudge) to keep the loop going.
+    This is what BenchInvestigationAgent does to enforce minimum evidence."""
+
+    class _StrictAgent(ConnectedInvestigationAgent):
+        def _should_accept_conclusion(
+            self,
+            *,
+            evidence_count: int,
+            iteration: int,  # noqa: ARG002 — base signature
+        ) -> tuple[bool, str | None]:
+            if evidence_count >= 5:
+                return True, None
+            return False, f"Only {evidence_count} tool calls so far — keep going."
+
+    agent = _StrictAgent()
+    accept, nudge = agent._should_accept_conclusion(evidence_count=3, iteration=2)
+    assert accept is False
+    assert nudge is not None and "3 tool calls" in nudge
+
+    accept, nudge = agent._should_accept_conclusion(evidence_count=7, iteration=5)
+    assert accept is True
+    assert nudge is None
+
+
 def test_enforce_context_budget_trims_when_over_ceiling() -> None:
     # Each tool turn carries ~1 MB of text (~250k token estimate). One pair
     # is enough to push messages past the 180k ceiling; the function should

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -403,6 +403,51 @@ def test_should_accept_conclusion_production_default_accepts() -> None:
     assert nudge is None
 
 
+def test_invalid_hook_return_false_none_raises_at_call_site() -> None:
+    """Greptile P1: a hook override that returns ``(False, None)`` would
+    spin the loop on an unchanged message history until
+    ``MAX_INVESTIGATION_LOOPS``, silently burning the whole token budget.
+    The call site must raise immediately so buggy overrides fail loud
+    instead of expensive.
+
+    This pins the contract — a future regression that drops the guard
+    fails here instead of in a production token-burn incident."""
+
+    class _BadAgent(ConnectedInvestigationAgent):
+        def _should_accept_conclusion(
+            self,
+            *,
+            evidence_count: int,  # noqa: ARG002 — base signature
+            iteration: int,  # noqa: ARG002 — base signature
+        ) -> tuple[bool, str | None]:
+            return False, None  # invalid — rejects without providing context
+
+    mock_llm = MagicMock()
+    # Empty content + no tool calls → LLM "concludes" → triggers the hook.
+    mock_response = MagicMock()
+    mock_response.has_tool_calls = False
+    mock_response.tool_calls = []
+    mock_response.content = ""
+    mock_response.raw_content = None
+    mock_llm.invoke.return_value = mock_response
+    mock_llm.tool_schemas.return_value = []
+    mock_tracker = MagicMock()
+
+    state = {
+        "alert_name": "Test alert",
+        "pipeline_name": "test-pipeline",
+        "severity": "critical",
+        "resolved_integrations": {},
+    }
+    agent = _BadAgent()
+    with (
+        patch("app.agent.investigation.get_agent_llm", return_value=mock_llm),
+        patch("app.agent.investigation.get_tracker", return_value=mock_tracker),
+        pytest.raises(ValueError, match="_should_accept_conclusion returned"),
+    ):
+        agent.run(state)
+
+
 def test_should_accept_conclusion_subclass_can_force_continuation() -> None:
     """Subclasses can return (False, nudge) to keep the loop going.
     This is what BenchInvestigationAgent does to enforce minimum evidence."""

--- a/tests/benchmarks/_framework/adapters.py
+++ b/tests/benchmarks/_framework/adapters.py
@@ -14,9 +14,15 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    # Type-only import — preserves the framework's "zero ``app.*`` imports"
+    # constraint at runtime while still letting type-checkers validate
+    # that adapter overrides return an investigation-agent subclass.
+    from app.agent.investigation import ConnectedInvestigationAgent
 
 # --------------------------------------------------------------------------- #
 # Mode — opensre+LLM vs LLM-alone. Framework-level concept; same adapter +    #
@@ -265,7 +271,7 @@ class BenchmarkAdapter(ABC):
         comparable reporting across adapters.
         """
 
-    def investigation_agent_class(self) -> type | None:
+    def investigation_agent_class(self) -> type[ConnectedInvestigationAgent] | None:
         """Optional: which investigation agent class should the runner use?
 
         Default ``None`` — let the production pipeline construct its standard

--- a/tests/benchmarks/_framework/adapters.py
+++ b/tests/benchmarks/_framework/adapters.py
@@ -265,6 +265,21 @@ class BenchmarkAdapter(ABC):
         comparable reporting across adapters.
         """
 
+    def investigation_agent_class(self) -> type | None:
+        """Optional: which investigation agent class should the runner use?
+
+        Default ``None`` — let the production pipeline construct its standard
+        :class:`ConnectedInvestigationAgent`. Override when the benchmark
+        needs a stricter termination policy or other agent-level behavior
+        (e.g. CloudOpsBench's minimum-tool-call floor lives in
+        :class:`tests.benchmarks.cloudopsbench.bench_agent.BenchInvestigationAgent`).
+
+        Production code stays clean: the runner just passes whatever the
+        adapter returns to ``run_investigation``. Bench-specific agent logic
+        lives entirely in bench code.
+        """
+        return None
+
     def format_final_answer(
         self,
         case: BenchmarkCase,  # noqa: ARG002 — used by overrides

--- a/tests/benchmarks/_framework/runner.py
+++ b/tests/benchmarks/_framework/runner.py
@@ -378,7 +378,11 @@ class BenchmarkRunner:
         final_state_dict: dict[str, Any] = {}
 
         try:
-            final_state = run_investigation(alert.raw, resolved_integrations=integrations)
+            final_state = run_investigation(
+                alert.raw,
+                resolved_integrations=integrations,
+                agent_class=self.adapter.investigation_agent_class(),
+            )
             final_state_dict = dict(final_state)
         except (CostBudgetExceeded, UnknownModel, LLMCreditExhaustedError):
             # Run-fatal: propagate up to _execute_llm_batch / _run_inner so

--- a/tests/benchmarks/cloudopsbench/__init__.py
+++ b/tests/benchmarks/cloudopsbench/__init__.py
@@ -1,1 +1,20 @@
-"""Cloud-OpsBench synthetic benchmark integration."""
+"""Cloud-OpsBench synthetic benchmark integration.
+
+Importing this package side-effects the opensre tool registry: the
+CloudOpsBench-specific replay tools (under ``tools.k8s``) are registered
+via :func:`app.tools.registry.register_external_tool_package` so the
+agent loop sees them whenever a bench cell runs. Production code that
+never imports ``tests.benchmarks.cloudopsbench`` never sees these tools
+— the registry stays clean.
+
+Keeping this side-effect at the package's ``__init__`` (rather than on
+the first method call) ensures the registration happens before any
+:func:`get_registered_tools` consumer asks for the registry snapshot.
+"""
+
+from __future__ import annotations
+
+from app.tools.registry import register_external_tool_package
+from tests.benchmarks.cloudopsbench import tools as _bench_tools_package
+
+register_external_tool_package(_bench_tools_package)

--- a/tests/benchmarks/cloudopsbench/adapter.py
+++ b/tests/benchmarks/cloudopsbench/adapter.py
@@ -320,7 +320,7 @@ class CloudOpsBenchAdapter(BenchmarkAdapter):
         """The paper's 15 metrics. Validity metrics arrive in Phase C."""
         return _PAPER_METRIC_SCHEMA
 
-    def investigation_agent_class(self) -> type:
+    def investigation_agent_class(self) -> type[BenchInvestigationAgent]:
         """CloudOpsBench uses a stricter agent: minimum-tool-call floor.
 
         See :class:`BenchInvestigationAgent` for the rationale (June-3 bench

--- a/tests/benchmarks/cloudopsbench/adapter.py
+++ b/tests/benchmarks/cloudopsbench/adapter.py
@@ -40,6 +40,7 @@ from tests.benchmarks._framework.adapters import (
     RunContext,
     RunResult,
 )
+from tests.benchmarks.cloudopsbench.bench_agent import BenchInvestigationAgent
 from tests.benchmarks.cloudopsbench.case_loader import (
     BENCHMARK_DIR,
     CloudOpsCase,
@@ -225,8 +226,8 @@ class CloudOpsBenchAdapter(BenchmarkAdapter):
 
     def build_opensre_integrations(self, case: BenchmarkCase) -> dict[str, Any]:
         """Construct a fresh State Snapshot replay backend per case and
-        wire it under the ``eks`` integration key opensre's CloudOpsBench
-        tools (``app/tools/CloudOpsBenchK8sTools/__init__.py``) read from.
+        wire it under the ``eks`` integration key the bench's replay
+        tools (``tests/benchmarks/cloudopsbench/tools/k8s``) read from.
 
         The returned dict is the only place this cell's backend lives;
         the runner passes it back via ``RunContext`` to ``score_case``.
@@ -250,11 +251,16 @@ class CloudOpsBenchAdapter(BenchmarkAdapter):
                 "region": "us-east-1",
                 "cluster_names": [cluster_name],
             },
-            # CloudOpsBenchK8sTools read from here (sources["eks"]["_backend"]).
+            # CloudOpsBenchK8sTools read from sources["eks"]["_bench_backend"].
+            # Deliberately distinct from the ``_backend`` slot used by synthetic
+            # tests — production tool availability checks (_eks_available,
+            # eks_available_or_backend) read only ``_backend`` and
+            # ``connection_verified``, so this key stays invisible to them and
+            # they correctly skip activation for bench cells.
             "eks": {
                 "namespace": legacy.namespace,
                 "cluster_name": cluster_name,
-                "_backend": backend,
+                "_bench_backend": backend,
             },
         }
 
@@ -278,13 +284,13 @@ class CloudOpsBenchAdapter(BenchmarkAdapter):
         per-cell state on the adapter (thread-safe).
         """
         legacy = self._require_case(case)
-        backend = (context.integrations.get("eks") or {}).get("_backend")
+        backend = (context.integrations.get("eks") or {}).get("_bench_backend")
         if not isinstance(backend, CloudOpsBenchReplayBackend):
             return CaseScore(
                 case_id=case.case_id,
                 metrics={},
                 failure_reason=(
-                    "context.integrations missing 'eks._backend' of type "
+                    "context.integrations missing 'eks._bench_backend' of type "
                     "CloudOpsBenchReplayBackend — runner must pass the same "
                     "integrations dict to score_case as it passed to run_investigation"
                 ),
@@ -313,6 +319,16 @@ class CloudOpsBenchAdapter(BenchmarkAdapter):
     def metric_schema(self) -> MetricSchema:
         """The paper's 15 metrics. Validity metrics arrive in Phase C."""
         return _PAPER_METRIC_SCHEMA
+
+    def investigation_agent_class(self) -> type:
+        """CloudOpsBench uses a stricter agent: minimum-tool-call floor.
+
+        See :class:`BenchInvestigationAgent` for the rationale (June-3 bench
+        showed median 4-7 tool calls vs the paper's expected 15-20 winning
+        trajectory). Production code is unaffected — the runner injects this
+        class via the ``agent_class`` parameter on ``run_investigation``.
+        """
+        return BenchInvestigationAgent
 
     def format_final_answer(
         self,

--- a/tests/benchmarks/cloudopsbench/bench_agent.py
+++ b/tests/benchmarks/cloudopsbench/bench_agent.py
@@ -1,0 +1,57 @@
+"""CloudOpsBench-specific investigation agent.
+
+Subclasses :class:`app.agent.investigation.ConnectedInvestigationAgent` to
+enforce a minimum-tool-call floor before the agent is allowed to conclude.
+Production code is untouched — bench-only termination behavior lives here.
+
+Why we need a floor for the bench
+----------------------------------
+Production opensre lets the LLM decide when it has enough evidence. That's
+the right default for real incidents: latency matters, the LLM is usually
+right after a few tool calls, and forcing extra calls wastes tokens.
+
+CloudOpsBench cases are different:
+  - The paper's protocol rewards deep multi-source evidence gathering
+    (15-20 tool calls typical in winning runs).
+  - The June-3 OpenAI bench showed gpt-4o median=7 steps and gpt-5
+    median=4 steps — both producing a1=0 despite the agent's structural
+    advantage over plain LLM.
+  - Tool coverage was 0.20 (gpt-4o) and 0.00 (gpt-5) — agents bailed
+    before exercising the tools the paper measures against.
+
+We force the bench agent to gather more evidence before concluding. The
+loop's outer cap (``MAX_INVESTIGATION_LOOPS``) still bounds the worst
+case, so a stubborn model can't infinite-loop.
+"""
+
+from __future__ import annotations
+
+from app.agent.investigation import ConnectedInvestigationAgent
+
+
+class BenchInvestigationAgent(ConnectedInvestigationAgent):
+    """Bench subclass that requires N tool calls before allowing conclusion.
+
+    Threshold is a class attribute so subclasses or tests can override it
+    without rebuilding the agent instance. Default 8 is calibrated for
+    CloudOpsBench's median win-trajectory (~15-20 tool calls) while
+    leaving headroom: even a perfect 8-call run is within the loop cap.
+    """
+
+    MIN_TOOL_CALLS = 8
+
+    def _should_accept_conclusion(
+        self,
+        *,
+        evidence_count: int,
+        iteration: int,  # noqa: ARG002 — base class signature
+    ) -> tuple[bool, str | None]:
+        if evidence_count >= self.MIN_TOOL_CALLS:
+            return True, None
+        return False, (
+            f"You've gathered {evidence_count} tool result(s) so far. Before "
+            f"concluding, please continue investigating — what dimensions "
+            f"of the system haven't you checked yet? Consider tool sources "
+            f"you haven't queried, or evidence that would support OR "
+            f"contradict your current hypothesis."
+        )

--- a/tests/benchmarks/cloudopsbench/replay_backend.py
+++ b/tests/benchmarks/cloudopsbench/replay_backend.py
@@ -105,9 +105,13 @@ def build_cache_key(tool_name: str, params: dict[str, Any]) -> str:
 
 
 class CloudOpsBenchReplayBackend:
-    """Replay Cloud-OpsBench tool outputs from the official per-case cache."""
+    """Replay Cloud-OpsBench tool outputs from the official per-case cache.
 
-    is_cloudopsbench_backend = True
+    Lives in a dedicated source slot — ``sources["eks"]["_bench_backend"]``
+    rather than ``_backend`` — so production tool availability checks
+    (which read ``_backend``) stay completely unaware of bench backends.
+    No marker attribute needed; the slot IS the identification.
+    """
 
     def __init__(self, case: CloudOpsCase) -> None:
         self.case = case

--- a/tests/benchmarks/cloudopsbench/test_bench_agent.py
+++ b/tests/benchmarks/cloudopsbench/test_bench_agent.py
@@ -1,0 +1,71 @@
+"""Tests for the CloudOpsBench-specific investigation agent subclass."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.agent.investigation import ConnectedInvestigationAgent
+from tests.benchmarks.cloudopsbench.bench_agent import BenchInvestigationAgent
+
+
+def test_bench_agent_is_subclass_of_production_agent() -> None:
+    """Subclass relationship is what lets the bench inject its agent via the
+    pipeline's ``agent_class`` parameter without production code knowing."""
+    assert issubclass(BenchInvestigationAgent, ConnectedInvestigationAgent)
+
+
+def test_bench_agent_blocks_conclusion_below_floor() -> None:
+    """Below MIN_TOOL_CALLS: reject conclusion + emit nudge user message.
+    This is the entire point of the subclass — gpt-5 was bailing after 4
+    tool calls on the June-3 run; the floor forces deeper investigation."""
+    agent = BenchInvestigationAgent()
+    accept, nudge = agent._should_accept_conclusion(evidence_count=3, iteration=2)
+    assert accept is False
+    assert nudge is not None
+    # Nudge text must mention the count so the model knows where it stands.
+    assert "3 tool result" in nudge
+
+
+def test_bench_agent_allows_conclusion_at_threshold() -> None:
+    """Exactly MIN_TOOL_CALLS evidence entries → accept conclusion. The
+    threshold is INCLUSIVE so the agent isn't forced to do extra calls
+    when it has already met the floor."""
+    agent = BenchInvestigationAgent()
+    accept, nudge = agent._should_accept_conclusion(
+        evidence_count=BenchInvestigationAgent.MIN_TOOL_CALLS,
+        iteration=BenchInvestigationAgent.MIN_TOOL_CALLS,
+    )
+    assert accept is True
+    assert nudge is None
+
+
+def test_bench_agent_allows_conclusion_above_threshold() -> None:
+    agent = BenchInvestigationAgent()
+    accept, nudge = agent._should_accept_conclusion(
+        evidence_count=BenchInvestigationAgent.MIN_TOOL_CALLS + 10, iteration=8
+    )
+    assert accept is True
+    assert nudge is None
+
+
+@pytest.mark.parametrize("count", [0, 1, 2, 3, 4, 5, 6, 7])
+def test_bench_agent_rejects_below_floor_for_every_count_under_min(count: int) -> None:
+    """Exhaustive: every count below the floor must be rejected. Guards
+    against a future off-by-one in the floor comparison."""
+    agent = BenchInvestigationAgent()
+    accept, nudge = agent._should_accept_conclusion(evidence_count=count, iteration=count)
+    assert accept is False
+    assert nudge is not None
+
+
+def test_bench_agent_threshold_is_class_attribute_for_easy_override() -> None:
+    """The threshold is a class attribute so a future bench (or one-off
+    experiment) can subclass and tweak it without rebuilding the agent
+    instance or duplicating the hook method."""
+
+    class _RelaxedBench(BenchInvestigationAgent):
+        MIN_TOOL_CALLS = 3
+
+    agent = _RelaxedBench()
+    accept, _ = agent._should_accept_conclusion(evidence_count=3, iteration=2)
+    assert accept is True

--- a/tests/benchmarks/cloudopsbench/tools/k8s/__init__.py
+++ b/tests/benchmarks/cloudopsbench/tools/k8s/__init__.py
@@ -2,8 +2,10 @@
 
 Replays Cloud-OpsBench (Wang et al., arXiv:2603.00468) actions against the
 per-case ``tool_cache.json`` instead of talking to a real EKS cluster.
-The tools are gated on ``is_cloudopsbench_backend`` so they only appear
-to the LLM in replay mode; the real EKS tools take over otherwise.
+The tools are gated on the presence of a backend at
+``sources["eks"]["_bench_backend"]`` — a slot the bench adapter sets and
+production code never populates. The real EKS tools take over in any
+non-bench context.
 
 Each ``@tool`` declaration sets ``injected_params=("cloudops_backend",)``
 so the replay backend is hidden from the LLM's tool-call schema and
@@ -84,16 +86,12 @@ class _CloudOpsBenchBackend(Protocol):
     contract here instead of importing the class keeps ``app/`` runtime
     code free of a dependency on ``tests/``.
 
-    Helpers in this module duck-type via
-    ``getattr(backend, "is_cloudopsbench_backend", False)`` rather than
-    ``isinstance(backend, _CloudOpsBenchBackend)`` — this Protocol exists
-    for human readers and IDE navigation, not for runtime enforcement.
-    Any object exposing the marker attribute participates.
+    Identification is by **dedicated source slot**, not a marker attribute:
+    the bench adapter sets ``sources["eks"]["_bench_backend"]`` (distinct
+    from the synthetic-test ``_backend`` slot), so production tool
+    availability checks stay completely unaware of bench backend types.
+    No ``is_cloudopsbench_backend`` flag needed.
     """
-
-    # Marker attribute. ``True`` on the replay backend; absent (and so
-    # treated as ``False`` via ``getattr`` default) on real EKS sources.
-    is_cloudopsbench_backend: bool
 
     # The Cloud-OpsBench dataset case being replayed. Typed ``Any`` because
     # the Case schema lives outside ``app/`` (see
@@ -109,10 +107,18 @@ class _CloudOpsBenchBackend(Protocol):
 
 
 def _cloudops_backend(sources: dict[str, dict]) -> Any:
-    backend = (sources.get("eks") or {}).get("_backend")
-    if getattr(backend, "is_cloudopsbench_backend", False):
-        return backend
-    return None
+    """Look up the CloudOpsBench replay backend in its dedicated slot.
+
+    The bench adapter sets ``sources["eks"]["_bench_backend"]`` (not
+    ``_backend``) deliberately: ``_backend`` is the slot for synthetic-test
+    fixture backends that share the EKS tool API, and the replay backend
+    speaks a different (paper-protocol) API. Using a separate slot means
+    production tools that read ``_backend`` (``_eks_available``,
+    ``eks_available_or_backend``) stay completely unaware of bench
+    backends — no provider-specific branching needed in their availability
+    checks.
+    """
+    return (sources.get("eks") or {}).get("_bench_backend")
 
 
 def _cloudops_available(sources: dict[str, dict]) -> bool:

--- a/tests/benchmarks/cloudopsbench/tools/k8s/__init__.py
+++ b/tests/benchmarks/cloudopsbench/tools/k8s/__init__.py
@@ -278,8 +278,7 @@ def _run_backend(cloudops_backend: Any, method_name: str, **kwargs: Any) -> dict
     use_cases=[
         "Identify which pods are unhealthy: resource_type='pods' shows STATUS column",
         "Find broken deployments: resource_type='deployments' shows READY vs DESIRED replicas",
-        "Discover failure signals: resource_type='events' shows scheduling errors, "
-        "image pull failures, OOM kills, secret-binding errors",
+        "Discover failure signals: resource_type='events' shows scheduling errors, image pull failures, OOM kills, secret-binding errors",
         "Enumerate services and their selectors: resource_type='services'",
         "Check node health: resource_type='nodes' shows Ready / NotReady / SchedulingDisabled",
     ],
@@ -321,14 +320,10 @@ def get_resources(
         "image tags, and the full status with event log."
     ),
     use_cases=[
-        "Inspect a failing pod's env vars and secret references: "
-        "resource_type='pod', name='<pod-name>'",
-        "Check a deployment's image, replica count, and selectors: "
-        "resource_type='deployment', name='<deployment>'",
-        "Verify a service's port mappings, selectors, and endpoints: "
-        "resource_type='service', name='<service>'",
-        "Examine a StatefulSet's volume claims and pod template: "
-        "resource_type='statefulset', name='<sts-name>'",
+        "Inspect a failing pod's env vars and secret references: resource_type='pod', name='<pod-name>'",
+        "Check a deployment's image, replica count, and selectors: resource_type='deployment', name='<deployment>'",
+        "Verify a service's port mappings, selectors, and endpoints: resource_type='service', name='<service>'",
+        "Examine a StatefulSet's volume claims and pod template: resource_type='statefulset', name='<sts-name>'",
     ],
     requires=["cluster_name"],
     is_available=_cloudops_available,
@@ -362,8 +357,7 @@ def describe_resource(
     ),
     use_cases=[
         "Detect node-level problems: which nodes are NotReady, cordoned, or out of resources",
-        "Diagnose control-plane issues: kubelet down, scheduler offline, "
-        "containerd crashed, kube-proxy unavailable",
+        "Diagnose control-plane issues: kubelet down, scheduler offline, containerd crashed, kube-proxy unavailable",
         "Establish baseline cluster health before narrowing to a specific workload",
     ],
     requires=["cluster_name"],
@@ -388,8 +382,7 @@ def get_cluster_configuration(cloudops_backend: Any) -> dict[str, Any]:
     use_cases=[
         "Identify the affected service: alert tags name the failing component",
         "Establish when the issue started: alert firstSeen timestamp",
-        "See the error pattern: alert message often contains HTTP 5xx, "
-        "OOM, connection refused, etc.",
+        "See the error pattern: alert message often contains HTTP 5xx, OOM, connection refused, etc.",
         "Determine severity: critical vs warning helps prioritize sub-investigations",
     ],
     requires=["cluster_name"],
@@ -412,8 +405,7 @@ def get_alerts(cloudops_backend: Any) -> dict[str, Any]:
         "'no such host', 'OOMKilled', 'image pull backoff', etc.)."
     ),
     use_cases=[
-        "Confirm a suspected MySQL credential issue: look for 'Access denied for user' "
-        "or '1045' MySQL error codes",
+        "Confirm a suspected MySQL credential issue: look for 'Access denied for user' or '1045' MySQL error codes",
         "Confirm a DNS resolution failure: look for 'no such host' or 'DNS resolution failed'",
         "Identify image pull issues: 'ErrImagePull' or 'manifest unknown'",
         "Find HTTP 5xx patterns: 500/502/503/504 grouped by endpoint",
@@ -484,12 +476,9 @@ def get_recent_logs(
         "from 'A is broken because B is broken'."
     ),
     use_cases=[
-        "Trace the cause: which downstream services does the failing "
-        "service depend on? Check those for errors too.",
-        "Trace the impact: which upstream services call the failing one? "
-        "Useful for confirming user-visible impact.",
-        "Identify shared infrastructure: multiple failing services calling "
-        "the same database/cache often points to that shared dep as the cause.",
+        "Trace the cause: which downstream services does the failing service depend on? Check those for errors too.",
+        "Trace the impact: which upstream services call the failing one? Useful for confirming user-visible impact.",
+        "Identify shared infrastructure: multiple failing services calling the same database/cache often points to that shared dep as the cause.",
     ],
     requires=["cluster_name"],
     is_available=_cloudops_available,
@@ -516,8 +505,7 @@ def get_service_dependencies(cloudops_backend: Any, service_name: str) -> dict[s
         "issues that aren't obvious from the high-level describe."
     ),
     use_cases=[
-        "Diagnose a missing secret binding: check 'envFrom' and 'volumes' "
-        "sections for secret references",
+        "Diagnose a missing secret binding: check 'envFrom' and 'volumes' sections for secret references",
         "Find image-tag mistakes: compare the spec's image vs the registered tag",
         "Detect resource-limit misconfigurations: CPU/memory requests and limits",
         "Check init-container ordering and sidecar configurations",
@@ -543,8 +531,7 @@ def get_app_yaml(cloudops_backend: Any, app_name: str) -> dict[str, Any]:
     ),
     use_cases=[
         "Confirm DNS resolution failure: connectivity fails with 'no such host'",
-        "Confirm port-mapping mismatch: connection refused on the Service "
-        "port but pod listens on a different port",
+        "Confirm port-mapping mismatch: connection refused on the Service port but pod listens on a different port",
         "Confirm zero-endpoint failures: 'no endpoints available'",
         "Validate that a fix resolved the connectivity issue",
     ],

--- a/tests/benchmarks/cloudopsbench/tools/k8s/__init__.py
+++ b/tests/benchmarks/cloudopsbench/tools/k8s/__init__.py
@@ -268,8 +268,21 @@ def _run_backend(cloudops_backend: Any, method_name: str, **kwargs: Any) -> dict
 @tool(
     name="GetResources",
     source="eks",
-    description="Replay Cloud-OpsBench GetResources against the case tool_cache.json.",
-    use_cases=["List Kubernetes resources recorded in the benchmark snapshot."],
+    description=(
+        "List Kubernetes resources in the cluster — pods, deployments, "
+        "services, events, nodes, replicasets. Use this FIRST in most "
+        "investigations to identify which workloads are failing, see "
+        "pod status (CrashLoopBackOff, ImagePullBackOff, Pending, "
+        "ContainerCreating), and find recent events that indicate why."
+    ),
+    use_cases=[
+        "Identify which pods are unhealthy: resource_type='pods' shows STATUS column",
+        "Find broken deployments: resource_type='deployments' shows READY vs DESIRED replicas",
+        "Discover failure signals: resource_type='events' shows scheduling errors, "
+        "image pull failures, OOM kills, secret-binding errors",
+        "Enumerate services and their selectors: resource_type='services'",
+        "Check node health: resource_type='nodes' shows Ready / NotReady / SchedulingDisabled",
+    ],
     requires=["cluster_name"],
     input_schema={"type": "object", "properties": {"resource_type": {"type": "string"}}},
     is_available=_cloudops_available,
@@ -300,8 +313,23 @@ def get_resources(
 @tool(
     name="DescribeResource",
     source="eks",
-    description="Replay Cloud-OpsBench DescribeResource against the case tool_cache.json.",
-    use_cases=["Inspect details for a recorded Kubernetes resource."],
+    description=(
+        "Get detailed configuration for a specific named Kubernetes resource "
+        "(pod, deployment, service, statefulset). Use AFTER GetResources "
+        "to investigate WHY a specific workload is failing — shows env "
+        "vars, secret references, volume mounts, container ports, "
+        "image tags, and the full status with event log."
+    ),
+    use_cases=[
+        "Inspect a failing pod's env vars and secret references: "
+        "resource_type='pod', name='<pod-name>'",
+        "Check a deployment's image, replica count, and selectors: "
+        "resource_type='deployment', name='<deployment>'",
+        "Verify a service's port mappings, selectors, and endpoints: "
+        "resource_type='service', name='<service>'",
+        "Examine a StatefulSet's volume claims and pod template: "
+        "resource_type='statefulset', name='<sts-name>'",
+    ],
     requires=["cluster_name"],
     is_available=_cloudops_available,
     extract_params=_extract_describe_resource,
@@ -325,8 +353,19 @@ def describe_resource(
 @tool(
     name="GetClusterConfiguration",
     source="eks",
-    description="Replay Cloud-OpsBench GetClusterConfiguration from tool_cache.json.",
-    use_cases=["Inspect recorded cluster-level configuration."],
+    description=(
+        "Get cluster-level state: node health, control-plane component "
+        "status (kubelet, kube-scheduler, kube-proxy, containerd), and "
+        "system-level conditions. Use when issues appear cluster-wide "
+        "rather than workload-specific — e.g. multiple unrelated services "
+        "failing simultaneously, or scheduling failures across namespaces."
+    ),
+    use_cases=[
+        "Detect node-level problems: which nodes are NotReady, cordoned, or out of resources",
+        "Diagnose control-plane issues: kubelet down, scheduler offline, "
+        "containerd crashed, kube-proxy unavailable",
+        "Establish baseline cluster health before narrowing to a specific workload",
+    ],
     requires=["cluster_name"],
     is_available=_cloudops_available,
     extract_params=_extract_backend,
@@ -339,8 +378,20 @@ def get_cluster_configuration(cloudops_backend: Any) -> dict[str, Any]:
 @tool(
     name="GetAlerts",
     source="eks",
-    description="Replay Cloud-OpsBench GetAlerts from tool_cache.json.",
-    use_cases=["Inspect recorded metric alerts for the case."],
+    description=(
+        "Get the active alerts that triggered this investigation. Call "
+        "this FIRST in every case — the alert message identifies the "
+        "affected service/namespace, severity, error rate, and timestamp. "
+        "Don't reason from the alert headline alone; always pull the "
+        "structured alert data."
+    ),
+    use_cases=[
+        "Identify the affected service: alert tags name the failing component",
+        "Establish when the issue started: alert firstSeen timestamp",
+        "See the error pattern: alert message often contains HTTP 5xx, "
+        "OOM, connection refused, etc.",
+        "Determine severity: critical vs warning helps prioritize sub-investigations",
+    ],
     requires=["cluster_name"],
     is_available=_cloudops_available,
     extract_params=_extract_backend,
@@ -353,8 +404,21 @@ def get_alerts(cloudops_backend: Any) -> dict[str, Any]:
 @tool(
     name="GetErrorLogs",
     source="eks",
-    description="Replay Cloud-OpsBench GetErrorLogs for the benchmark case.",
-    use_cases=["Inspect service error-log summaries recorded in the snapshot."],
+    description=(
+        "Get aggregated error-log signals for a specific service: counts "
+        "and example messages grouped by error type. Use AFTER finding a "
+        "failing service from GetResources/events — error logs typically "
+        "pinpoint the actual root cause (MySQL 'access denied', DNS "
+        "'no such host', 'OOMKilled', 'image pull backoff', etc.)."
+    ),
+    use_cases=[
+        "Confirm a suspected MySQL credential issue: look for 'Access denied for user' "
+        "or '1045' MySQL error codes",
+        "Confirm a DNS resolution failure: look for 'no such host' or 'DNS resolution failed'",
+        "Identify image pull issues: 'ErrImagePull' or 'manifest unknown'",
+        "Find HTTP 5xx patterns: 500/502/503/504 grouped by endpoint",
+        "Detect connection-refused / port-mismatch errors against downstream services",
+    ],
     requires=["cluster_name"],
     is_available=_cloudops_available,
     extract_params=_extract_error_logs,
@@ -376,8 +440,19 @@ def get_error_logs(
 @tool(
     name="GetRecentLogs",
     source="eks",
-    description="Replay Cloud-OpsBench GetRecentLogs for the benchmark case.",
-    use_cases=["Inspect recent service logs recorded in raw_data/logs.json."],
+    description=(
+        "Get the most recent log lines from a service — chronologically "
+        "ordered, unfiltered. Use when GetErrorLogs aggregation isn't "
+        "enough: recent logs show the SEQUENCE of events leading to "
+        "failure, often revealing race conditions, startup ordering "
+        "issues, or transient errors that don't surface in summaries."
+    ),
+    use_cases=[
+        "See the moment of failure: tail logs around the alert timestamp",
+        "Detect startup-sequence problems: container init order, secret/volume mount timing",
+        "Find intermittent errors that aggregate-by-type misses",
+        "Confirm a fix's effect by checking the latest log lines",
+    ],
     requires=["cluster_name"],
     is_available=_cloudops_available,
     extract_params=_extract_recent_logs,
@@ -401,8 +476,21 @@ def get_recent_logs(
 @tool(
     name="GetServiceDependencies",
     source="eks",
-    description="Replay Cloud-OpsBench GetServiceDependencies from tool_cache.json.",
-    use_cases=["Inspect recorded service dependency topology."],
+    description=(
+        "Map a service's upstream and downstream dependencies. Use this "
+        "to trace cascading failures: if service A is failing, what "
+        "calls A (impact blast-radius), and what does A call (potential "
+        "root cause upstream)? Critical for distinguishing 'A is broken' "
+        "from 'A is broken because B is broken'."
+    ),
+    use_cases=[
+        "Trace the cause: which downstream services does the failing "
+        "service depend on? Check those for errors too.",
+        "Trace the impact: which upstream services call the failing one? "
+        "Useful for confirming user-visible impact.",
+        "Identify shared infrastructure: multiple failing services calling "
+        "the same database/cache often points to that shared dep as the cause.",
+    ],
     requires=["cluster_name"],
     is_available=_cloudops_available,
     extract_params=_extract_service_dependencies,
@@ -419,8 +507,21 @@ def get_service_dependencies(cloudops_backend: Any, service_name: str) -> dict[s
 @tool(
     name="GetAppYAML",
     source="eks",
-    description="Replay Cloud-OpsBench GetAppYAML from tool_cache.json.",
-    use_cases=["Inspect recorded YAML for an application service."],
+    description=(
+        "Get the full deployment YAML for an application — shows every "
+        "secret reference, env var, volume mount, image tag, and resource "
+        "limit. Use when DescribeResource doesn't show enough: the raw "
+        "YAML often reveals misconfigured secret bindings, mismatched "
+        "env-var names, wrong image tags, or sidecar/init-container "
+        "issues that aren't obvious from the high-level describe."
+    ),
+    use_cases=[
+        "Diagnose a missing secret binding: check 'envFrom' and 'volumes' "
+        "sections for secret references",
+        "Find image-tag mistakes: compare the spec's image vs the registered tag",
+        "Detect resource-limit misconfigurations: CPU/memory requests and limits",
+        "Check init-container ordering and sidecar configurations",
+    ],
     requires=["cluster_name"],
     is_available=_cloudops_available,
     extract_params=_extract_app_yaml,
@@ -433,8 +534,20 @@ def get_app_yaml(cloudops_backend: Any, app_name: str) -> dict[str, Any]:
 @tool(
     name="CheckServiceConnectivity",
     source="eks",
-    description="Replay Cloud-OpsBench CheckServiceConnectivity from tool_cache.json.",
-    use_cases=["Check recorded service connectivity result."],
+    description=(
+        "Test reachability of a Kubernetes service from inside the "
+        "cluster. Use to confirm suspected service-routing failures: "
+        "DNS resolution problems, port mismatches between Service and "
+        "Pod, sidecar (Istio) port conflicts, or selector mismatches "
+        "that leave a Service with zero endpoints."
+    ),
+    use_cases=[
+        "Confirm DNS resolution failure: connectivity fails with 'no such host'",
+        "Confirm port-mapping mismatch: connection refused on the Service "
+        "port but pod listens on a different port",
+        "Confirm zero-endpoint failures: 'no endpoints available'",
+        "Validate that a fix resolved the connectivity issue",
+    ],
     requires=["cluster_name"],
     is_available=_cloudops_available,
     extract_params=_extract_connectivity,
@@ -458,8 +571,19 @@ def check_service_connectivity(
 @tool(
     name="CheckNodeServiceStatus",
     source="eks",
-    description="Replay Cloud-OpsBench CheckNodeServiceStatus from tool_cache.json.",
-    use_cases=["Check recorded node component status."],
+    description=(
+        "Check the health of a specific Kubernetes control-plane "
+        "component (kubelet, kube-scheduler, kube-proxy, containerd) "
+        "on a named node. Use when GetClusterConfiguration reveals "
+        "node-level issues OR when GetResources shows scheduling "
+        "failures, Pending pods, or NotReady nodes."
+    ),
+    use_cases=[
+        "Diagnose scheduling failures: check kube-scheduler on master nodes",
+        "Diagnose pod-startup failures: check kubelet on the worker node",
+        "Diagnose container-runtime issues: check containerd on the affected node",
+        "Diagnose service-routing failures: check kube-proxy on relevant nodes",
+    ],
     requires=["cluster_name"],
     is_available=_cloudops_available,
     extract_params=_extract_node_status,

--- a/tests/benchmarks/cloudopsbench/tools/test_k8s_tools.py
+++ b/tests/benchmarks/cloudopsbench/tools/test_k8s_tools.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
-from app.tools.CloudOpsBenchK8sTools import get_error_logs, get_recent_logs
+from tests.benchmarks.cloudopsbench.tools.k8s import get_error_logs, get_recent_logs
 
 
 class _Backend:
-    is_cloudopsbench_backend = True
     default_namespace = "boutique"
 
     def __init__(self, process: dict[str, list[str]]) -> None:
@@ -30,7 +29,10 @@ def test_recent_logs_extracts_its_own_service_name() -> None:
             "path2": [],
         }
     )
-    sources = {"eks": {"_backend": backend, "namespace": "boutique"}}
+    # Bench backend lives in its dedicated slot (_bench_backend), distinct
+    # from the synthetic-test ``_backend`` slot. This is what the
+    # slot-separation refactor enforces.
+    sources = {"eks": {"_bench_backend": backend, "namespace": "boutique"}}
 
     error_params = _tool_params(get_error_logs, sources)
     recent_params = _tool_params(get_recent_logs, sources)

--- a/tests/pipeline/test_runners_agent_class.py
+++ b/tests/pipeline/test_runners_agent_class.py
@@ -1,0 +1,116 @@
+"""Regression tests for ``agent_class`` threading through the pipeline.
+
+The investigation pipeline exposes an ``agent_class`` parameter at two
+public surfaces:
+
+  - :func:`app.pipeline.runners.run_investigation`
+  - :func:`app.pipeline.pipeline.run_connected_investigation`
+
+The parameter MUST thread cleanly from the outer ``run_investigation``
+all the way to where the agent is constructed, so callers (e.g. test
+suites, downstream integrators) can substitute a subclass without
+patching internals.
+
+These tests pin that contract — a future refactor that drops the
+parameter or stops forwarding it would fail loudly here instead of
+silently using the production default.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from app.agent.investigation import ConnectedInvestigationAgent
+
+
+class _SentinelAgent(ConnectedInvestigationAgent):
+    """Records whether its constructor + run were invoked."""
+
+    instances_constructed: list[_SentinelAgent] = []
+
+    def __init__(self) -> None:
+        super().__init__()
+        _SentinelAgent.instances_constructed.append(self)
+        self.was_run = False
+
+    def run(  # type: ignore[override]
+        self,
+        state: dict[str, Any],  # noqa: ARG002 — base signature
+        on_event: Any | None = None,  # noqa: ARG002 — base signature
+    ) -> dict[str, Any]:
+        self.was_run = True
+        # Return a benign updates dict — the pipeline merges it into state.
+        return {"sentinel_agent_ran": True}
+
+
+def _reset_sentinel() -> None:
+    _SentinelAgent.instances_constructed.clear()
+
+
+def test_run_connected_investigation_uses_agent_class_when_provided() -> None:
+    """The pipeline must instantiate the override class, not the default."""
+    _reset_sentinel()
+    from app.pipeline.pipeline import run_connected_investigation
+    from app.state.factory import make_initial_state
+
+    state = make_initial_state(raw_alert="alert text")
+    # Avoid running real integration/extraction; mock them to no-ops so the
+    # test focuses on the agent_class threading specifically.
+    with (
+        patch("app.agent.context.resolve_integrations", return_value={}),
+        patch("app.agent.extract.extract_alert", return_value={"is_noise": False}),
+        patch("app.correlation.node.node_correlate_upstream", return_value={}),
+        patch("app.delivery.deliver", return_value={}),
+    ):
+        run_connected_investigation(state, agent_class=_SentinelAgent)
+
+    assert len(_SentinelAgent.instances_constructed) == 1
+    assert _SentinelAgent.instances_constructed[0].was_run is True
+
+
+def test_run_connected_investigation_uses_default_agent_when_class_omitted() -> None:
+    """Production behavior is unchanged: omitting ``agent_class`` constructs
+    :class:`ConnectedInvestigationAgent` (the default)."""
+    _reset_sentinel()
+    from app.pipeline.pipeline import run_connected_investigation
+    from app.state.factory import make_initial_state
+
+    state = make_initial_state(raw_alert="alert text")
+    with (
+        patch("app.agent.context.resolve_integrations", return_value={}),
+        patch("app.agent.extract.extract_alert", return_value={"is_noise": False}),
+        patch(
+            "app.agent.investigation.ConnectedInvestigationAgent.run", return_value={}
+        ) as mock_run,
+        patch("app.correlation.node.node_correlate_upstream", return_value={}),
+        patch("app.delivery.deliver", return_value={}),
+    ):
+        run_connected_investigation(state)  # no agent_class kwarg
+
+    # Sentinel was never used; the production class was.
+    assert _SentinelAgent.instances_constructed == []
+    assert mock_run.called
+
+
+def test_run_investigation_forwards_agent_class_to_pipeline() -> None:
+    """End-to-end: passing ``agent_class`` to the outermost
+    :func:`run_investigation` MUST reach the agent constructor — proves
+    the parameter threads through ``runners.run_investigation`` →
+    ``pipeline.run_connected_investigation`` → ``ConnectedInvestigationAgent``.
+    """
+    _reset_sentinel()
+    from app.pipeline.runners import run_investigation
+
+    with (
+        patch("app.agent.context.resolve_integrations", return_value={}),
+        patch("app.agent.extract.extract_alert", return_value={"is_noise": False}),
+        patch("app.correlation.node.node_correlate_upstream", return_value={}),
+        patch("app.delivery.deliver", return_value={}),
+    ):
+        run_investigation(raw_alert={"alert": "test"}, agent_class=_SentinelAgent)
+
+    assert len(_SentinelAgent.instances_constructed) == 1, (
+        "agent_class did not thread from run_investigation through to the agent — "
+        "a future refactor likely dropped the parameter forwarding."
+    )

--- a/tests/tools/test_availability.py
+++ b/tests/tools/test_availability.py
@@ -38,33 +38,40 @@ class TestEksAvailableOrBackend:
         sources = {"eks": {"connection_verified": False, "_backend": object()}}
         assert eks_available_or_backend(sources) is True
 
-    def test_production_backend_without_cloudops_marker_keeps_eks_available(self) -> None:
-        """Production backends (synthetic test backends, real client wrappers)
-        do NOT have ``is_cloudopsbench_backend = True``. The CloudOpsBench
-        guard added for the bench MUST be a no-op for them — getattr falls
-        back to False, the original verified-or-backend logic still runs.
-        Regression-pin for the bench Bug-2 fix in availability.py."""
-
-        class _ProductionLikeBackend:
-            # Has a marker attribute but it's False — same as no marker
-            # at all from getattr's perspective.
-            is_cloudopsbench_backend = False
-
-        sources = {"eks": {"connection_verified": False, "_backend": _ProductionLikeBackend()}}
-        assert eks_available_or_backend(sources) is True
-
-    def test_cloudops_backend_is_hidden_when_marker_true(self) -> None:
-        """Inverse of the above: when the backend IS the CloudOpsBench
-        replay backend, the EKS surface MUST be hidden (the bench's
-        CloudOpsBenchK8sTools serve the EKS surface against the case
-        snapshot instead — exposing the real EKS tools would have the
-        agent try sts:AssumeRole on placeholder ARNs)."""
-
-        class _CloudOpsBenchBackend:
-            is_cloudopsbench_backend = True
-
-        sources = {"eks": {"connection_verified": True, "_backend": _CloudOpsBenchBackend()}}
+    def test_eks_check_ignores_bench_backend_in_dedicated_slot(self) -> None:
+        """The bench adapter puts its replay backend at ``_bench_backend``,
+        NOT ``_backend``. Production availability checks only look at
+        ``_backend`` and ``connection_verified`` — they must stay completely
+        unaware of bench backends. Regression-pin for the slot-separation
+        refactor (no more ``is_cloudopsbench_backend`` marker checks)."""
+        # Bench-style backend in its own slot — _backend remains None.
+        sources = {"eks": {"_bench_backend": object()}}
         assert eks_available_or_backend(sources) is False
+
+    def test_eks_check_uses_only_backend_and_verified_no_provider_specific_logic(
+        self,
+    ) -> None:
+        """Belt-and-suspenders: the function's full decision MUST be a clean
+        ``bool(connection_verified or _backend)``. No special-case branches,
+        no marker attribute lookups, no provider-aware logic. Adding
+        provider-specific branches here would re-couple production tool
+        availability to bench backend types."""
+        # Connection verified alone → True
+        assert eks_available_or_backend({"eks": {"connection_verified": True}}) is True
+        # Backend alone → True
+        assert eks_available_or_backend({"eks": {"_backend": object()}}) is True
+        # Both → True
+        assert (
+            eks_available_or_backend({"eks": {"connection_verified": True, "_backend": object()}})
+            is True
+        )
+        # Neither → False
+        assert eks_available_or_backend({"eks": {}}) is False
+        # Extra unrelated slots (like _bench_backend) must not affect the result
+        assert (
+            eks_available_or_backend({"eks": {"_bench_backend": object(), "anything": True}})
+            is False
+        )
 
 
 class TestDatadogAvailableOrBackend:

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -534,6 +534,49 @@ def test_register_external_tool_package_adds_tools_to_registry() -> None:
     )
 
 
+def test_register_external_tool_package_is_thread_safe_under_concurrent_calls() -> None:
+    """Greptile P2: the check-then-append used to be a race window — two
+    threads could both pass the ``not in`` check and both append the same
+    package, causing every tool in that package to be logged as a duplicate
+    and silently dropped on subsequent registry walks. The locked version
+    must register exactly once even under high concurrency."""
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    fake_pkg: Any = ModuleType("synthetic.concurrent_registration_pkg")
+    fake_pkg.__path__ = []  # type: ignore[attr-defined] — empty walk, no tools
+
+    barrier = threading.Barrier(parties=8)
+    saved = list(registry_module._external_tool_packages)
+    try:
+        # Make sure the package isn't already registered from a prior test.
+        if fake_pkg in registry_module._external_tool_packages:
+            registry_module._external_tool_packages.remove(fake_pkg)
+
+        def attempt_register() -> None:
+            # Synchronize starts so all threads enter the critical section
+            # within the same scheduling quantum — maximizes race exposure.
+            barrier.wait()
+            registry_module.register_external_tool_package(fake_pkg)
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(attempt_register) for _ in range(8)]
+            for f in futures:
+                f.result()
+
+        # Exactly one registration regardless of how many threads raced.
+        count = registry_module._external_tool_packages.count(fake_pkg)
+        assert count == 1, (
+            f"Expected exactly 1 registration for the same package across 8 "
+            f"concurrent callers, got {count}. The lock around check-then-"
+            f"append is missing or broken."
+        )
+    finally:
+        # Restore the registration list to its pre-test state.
+        registry_module._external_tool_packages[:] = saved
+        registry_module.clear_tool_registry_cache()
+
+
 def test_register_external_tool_package_is_idempotent() -> None:
     """Registering the same package twice doesn't add duplicates."""
     import tests.benchmarks.cloudopsbench.tools as cob_tools_pkg

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -250,9 +250,9 @@ def test_auto_discovery_populates_investigation_and_chat_surfaces(
     module.get_incident_metadata = get_incident_metadata
 
     monkeypatch.setattr(
-        registry_module, "_iter_tool_module_names", lambda: ["fake_discovered_tool"]
+        registry_module, "_iter_tool_module_names", lambda _pkg: ["fake_discovered_tool"]
     )
-    monkeypatch.setattr(registry_module, "_import_tool_module", lambda _name: module)
+    monkeypatch.setattr(registry_module, "_import_tool_module", lambda _pkg, _name: module)
 
     assert [
         tool_def.name for tool_def in registry_module.get_registered_tools("investigation")
@@ -283,9 +283,9 @@ def test_resolve_tool_display_name_prefers_registered_metadata(
     module.get_incident_metadata = get_incident_metadata
 
     monkeypatch.setattr(
-        registry_module, "_iter_tool_module_names", lambda: ["fake_display_name_tool"]
+        registry_module, "_iter_tool_module_names", lambda _pkg: ["fake_display_name_tool"]
     )
-    monkeypatch.setattr(registry_module, "_import_tool_module", lambda _name: module)
+    monkeypatch.setattr(registry_module, "_import_tool_module", lambda _pkg, _name: module)
 
     assert registry_module.resolve_tool_display_name("get_incident_metadata") == "Incident metadata"
 
@@ -339,12 +339,12 @@ def test_registry_regression_duplicate_tool_names_across_modules(
     monkeypatch.setattr(
         registry_module,
         "_iter_tool_module_names",
-        lambda: ["first_module", "second_module"],
+        lambda _pkg: ["first_module", "second_module"],
     )
     monkeypatch.setattr(
         registry_module,
         "_import_tool_module",
-        lambda name: module1 if name == "first_module" else module2,
+        lambda _pkg, name: module1 if name == "first_module" else module2,
     )
 
     with caplog.at_level(logging.WARNING, logger="app.tools.registry"):
@@ -380,7 +380,7 @@ def test_registry_regression_import_failures(
     valid_tool.__module__ = module.__name__
     module.valid_tool = valid_tool
 
-    def mock_import(name: str) -> ModuleType:
+    def mock_import(_pkg: ModuleType, name: str) -> ModuleType:
         if name == "broken_module":
             raise RuntimeError("Module initialization failed")
         return module
@@ -388,7 +388,7 @@ def test_registry_regression_import_failures(
     monkeypatch.setattr(
         registry_module,
         "_iter_tool_module_names",
-        lambda: ["broken_module", "valid_tool"],
+        lambda _pkg: ["broken_module", "valid_tool"],
     )
     monkeypatch.setattr(
         registry_module,
@@ -404,8 +404,11 @@ def test_registry_regression_import_failures(
     assert "valid_tool" in tool_names
     assert registry_module.get_registered_tool_map()["valid_tool"].run() == {"status": "ok"}
 
+    # Log message now includes the package prefix (``app.tools.``) so the
+    # operator can tell WHICH discovery path failed when multiple packages
+    # are registered.
     assert any(
-        "Skipping broken_module" in record.message and record.levelname == "WARNING"
+        "broken_module" in record.message and record.levelname == "WARNING"
         for record in caplog.records
     )
 
@@ -500,3 +503,167 @@ def test_v2_registry_tools_define_output_schema() -> None:
         output_schema = tool_def.output_schema
         assert isinstance(output_schema, dict), f"{tool_def.name} must define output_schema."
         assert output_schema.get("type") == "object"
+
+
+# --------------------------------------------------------------------------- #
+# External tool package registration (extension point for test suites and    #
+# downstream integrators that ship their own tools outside app.tools).        #
+# --------------------------------------------------------------------------- #
+
+
+def test_register_external_tool_package_adds_tools_to_registry() -> None:
+    """A package registered via :func:`register_external_tool_package` has
+    its top-level submodules walked the same way as ``app.tools.*``. This
+    is the mechanism that lets bench-only tool modules live outside ``app/``
+    while still being discoverable by the agent loop when the bench is
+    actively running."""
+    # Importing the cloudopsbench package side-effects registration on its
+    # own (see tests/benchmarks/cloudopsbench/__init__.py), so by the time
+    # this test runs the package is already registered.
+    import tests.benchmarks.cloudopsbench  # noqa: F401 — side-effect import
+    import tests.benchmarks.cloudopsbench.tools as cob_tools_pkg
+
+    # The registered list contains the bench tools package.
+    assert cob_tools_pkg in registry_module._external_tool_packages
+
+    # And the registry actually discovers the bench's GetResources tool.
+    tools = registry_module.get_registered_tools()
+    tool_names = {t.name for t in tools}
+    assert "GetResources" in tool_names, (
+        "bench tools package was registered but its tools didn't surface in the registry"
+    )
+
+
+def test_register_external_tool_package_is_idempotent() -> None:
+    """Registering the same package twice doesn't add duplicates."""
+    import tests.benchmarks.cloudopsbench.tools as cob_tools_pkg
+
+    initial_count = len(registry_module._external_tool_packages)
+    registry_module.register_external_tool_package(cob_tools_pkg)
+    registry_module.register_external_tool_package(cob_tools_pkg)
+    final_count = len(registry_module._external_tool_packages)
+
+    # First call may add (or no-op if already registered); second call must
+    # never add anything beyond the first.
+    assert final_count <= initial_count + 1
+    assert registry_module._external_tool_packages.count(cob_tools_pkg) == 1
+
+
+def test_production_registry_does_not_include_bench_tools_without_import() -> None:
+    """Sanity-check separation: with the bench package *not* imported,
+    only ``app.tools.*`` modules contribute to the registry. The bench
+    tools must be invisible.
+
+    We can't fully un-import the bench in a single test process (other
+    tests in this run may have imported it), but we can verify the
+    registry walks only the canonical package when external registrations
+    are cleared."""
+    saved = list(registry_module._external_tool_packages)
+    try:
+        registry_module._external_tool_packages.clear()
+        registry_module.clear_tool_registry_cache()
+        tools = registry_module.get_registered_tools()
+        tool_names = {t.name for t in tools}
+        # GetResources, GetAlerts, etc. are bench-only; not in app/tools.
+        assert "GetResources" not in tool_names
+        assert "GetAlerts" not in tool_names
+    finally:
+        # Restore so subsequent tests in this module see the bench package.
+        registry_module._external_tool_packages.extend(saved)
+        registry_module.clear_tool_registry_cache()
+
+
+def test_registry_clears_cache_on_external_registration_so_new_tools_appear(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The lru_cache on _load_registry_snapshot would freeze the tool list
+    on the first lookup. register_external_tool_package MUST clear the
+    cache or registrations after that first lookup would be invisible —
+    a silent bug class."""
+    # Prime the cache as the production lifecycle would.
+    initial_tools = registry_module.get_registered_tools()
+    initial_names = {t.name for t in initial_tools}
+
+    # Register a synthetic external package after the cache is warm.
+    fake_pkg: Any = ModuleType("synthetic.tool_pkg_for_cache_test")
+    fake_pkg.__path__ = []  # type: ignore[attr-defined] — empty walk, no tools
+
+    saved = list(registry_module._external_tool_packages)
+    try:
+        registry_module.register_external_tool_package(fake_pkg)
+        # Cache must have been cleared; next lookup re-runs discovery.
+        # No tools to add from fake_pkg, but the call shouldn't crash and
+        # the result shape must be equivalent to before.
+        post_register_tools = registry_module.get_registered_tools()
+        post_register_names = {t.name for t in post_register_tools}
+        # The canonical tools are still there.
+        assert initial_names == post_register_names
+    finally:
+        # Drop the synthetic package from the registration list to avoid
+        # leaking into other tests.
+        registry_module._external_tool_packages[:] = saved
+        registry_module.clear_tool_registry_cache()
+
+
+def test_registry_canonical_tool_wins_when_external_package_redefines_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First registration wins for a given tool name. The canonical
+    ``app.tools.*`` package is walked first, so a downstream integrator
+    can't accidentally shadow a production tool with their own version of
+    the same name — only a clear log warning, original tool preserved."""
+    canonical_tool_name = "ListEKSPodsTool".replace("Tool", "").lower()
+    # Build a fake external package that 'declares' a tool with a name
+    # that overlaps with a known canonical tool. We use the same
+    # discovery path the registry uses, so this is realistic.
+    pre_existing = {t.name for t in registry_module.get_registered_tools()}
+    if "list_eks_pods" not in pre_existing:
+        pytest.skip("Canonical EKS pod tool absent; can't validate shadowing protection.")
+
+    fake_module: Any = ModuleType("synthetic.shadowing_module")
+
+    @tool(name="list_eks_pods", description="external shadow", source="knowledge")
+    def shadow_eks_pods() -> dict[str, str]:
+        return {"shadow": "true"}
+
+    shadow_eks_pods.__module__ = fake_module.__name__
+    fake_module.shadow_eks_pods = shadow_eks_pods
+
+    fake_pkg: Any = ModuleType("synthetic.shadow_pkg")
+    fake_pkg.__path__ = []  # type: ignore[attr-defined]
+
+    # Inject the fake by patching the walk + import.
+    real_iter = registry_module._iter_tool_module_names
+    real_import = registry_module._import_tool_module
+
+    def fake_iter(package: ModuleType) -> list[str]:
+        if package is fake_pkg:
+            return ["shadowing_module"]
+        return real_iter(package)
+
+    def fake_import(package: ModuleType, name: str) -> ModuleType:
+        if package is fake_pkg and name == "shadowing_module":
+            return fake_module
+        return real_import(package, name)
+
+    monkeypatch.setattr(registry_module, "_iter_tool_module_names", fake_iter)
+    monkeypatch.setattr(registry_module, "_import_tool_module", fake_import)
+
+    saved = list(registry_module._external_tool_packages)
+    try:
+        registry_module.register_external_tool_package(fake_pkg)
+        registry_module.clear_tool_registry_cache()
+
+        tool_map = registry_module.get_registered_tool_map()
+        # Canonical tool survives — the shadow was rejected.
+        canonical = tool_map.get("list_eks_pods")
+        assert canonical is not None
+        # Canonical's description is not the shadow's — proves we kept the
+        # original, not the override.
+        assert canonical.description != "external shadow", (
+            f"External package shadowed canonical tool name "
+            f"{canonical_tool_name!r}. First-registration-wins rule broken."
+        )
+    finally:
+        registry_module._external_tool_packages[:] = saved
+        registry_module.clear_tool_registry_cache()

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -807,16 +807,12 @@ _MIGRATED_TOOL_NAMES: frozenset[str] = frozenset(
 # wrapper from #1476, or (b) have no observed swallow pattern. Keep alphabetised.
 _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
     {
-        "CheckNodeServiceStatus",
-        "CheckServiceConnectivity",
-        "DescribeResource",
-        "GetAlerts",
-        "GetAppYAML",
-        "GetClusterConfiguration",
-        "GetErrorLogs",
-        "GetRecentLogs",
-        "GetResources",
-        "GetServiceDependencies",
+        # CloudOpsBench replay tools (CheckNodeServiceStatus, GetResources, ...)
+        # were removed from this list when the bench tool module moved out of
+        # app/tools/ into tests/benchmarks/cloudopsbench/tools/k8s/. They live
+        # there as an external registry package and are only loaded when the
+        # bench is actively imported, so they don't appear in the production
+        # registry that this test enumerates.
         "alertmanager_alerts",
         "alertmanager_silences",
         "argocd_application_diff",
@@ -989,7 +985,18 @@ def test_every_registered_tool_is_migrated_or_allowlisted() -> None:
     """
     from app.tools.registry import get_registered_tool_map
 
-    registered = set(get_registered_tool_map().keys())
+    # Limit the audit to PRODUCTION tools (those defined in ``app.tools.*``).
+    # External packages registered via ``register_external_tool_package``
+    # (e.g. bench-only tools that live under ``tests/benchmarks/``) have
+    # their own classification expectations and aren't part of this
+    # production-telemetry contract. Filtering by ``origin_module`` keeps
+    # this test stable regardless of test order — whether the bench package
+    # has been imported earlier in the session is no longer relevant.
+    registered = {
+        name
+        for name, tool in get_registered_tool_map().items()
+        if tool.origin_module.startswith("app.tools.")
+    }
     classified = _MIGRATED_TOOL_NAMES | _TOOLS_WITHOUT_DELIBERATE_CATCH
 
     unclassified = registered - classified


### PR DESCRIPTION
Fixes #2074 (partial)

#### Describe the changes you have made in this PR -

Refactor that decouples opensre's production code paths from benchmark-specific logic. Production code (`app/`) now has **zero** behavioral knowledge of benchmarking; the bench plugs in via documented extension points.

**What was wrong before**

Earlier iterations of #2074 added bench-aware conditionals into production code:

- `app/tools/EKSListClustersTool` and `app/tools/utils/availability.py` had `getattr(backend, "is_cloudopsbench_backend", False)` guards.
- `app/tools/CloudOpsBenchK8sTools/` — entirely bench-only — lived under `app/tools/` because the tool registry auto-discovered from there.
- The investigation loop terminated as soon as the LLM stopped requesting tools, but the bench needed a minimum-tool-call floor — naturally pushing toward env-var-gated branches inside the production loop.
- Several `app/` docstrings explicitly named bench files and `BenchmarkRunner`.

The principle: **opensre code should have one production behavior; benchmarks are configurations, not special cases inside it.**

**What this PR does**

1. **Termination policy as an extension point.** Added `ConnectedInvestigationAgent._should_accept_conclusion` hook with a `(True, None)` no-op default. Subclasses can override to enforce minimum-evidence floors or other policies. Production behavior unchanged.

2. **`agent_class` parameter threaded through the pipeline.** `run_investigation` and `run_connected_investigation` accept an optional `agent_class` (defaults to `ConnectedInvestigationAgent`) so callers can substitute a subclass without patching internals.

3. **Bench agent in its own module.** `BenchInvestigationAgent` lives in `tests/benchmarks/cloudopsbench/bench_agent.py` and uses the hook to enforce `MIN_TOOL_CALLS = 8` for CloudOpsBench cases (median win-trajectory in the paper protocol is ~15-20 tool calls; the OpenAI bench run on 2026-06-03 showed gpt-4o median=7 / gpt-5 median=4, both bailing too early).

4. **Tool registry extension.** New `register_external_tool_package(pkg)` API in `app/tools/registry.py` walks any registered package the same way it walks `app.tools.*`. Production stays clean — with no external registrations, only `app.tools.*` is discovered.

5. **Moved `CloudOpsBenchK8sTools` out of `app/`.** Now lives at `tests/benchmarks/cloudopsbench/tools/k8s/`. The bench package's `__init__.py` registers the tools as an import side-effect. Production code that never imports `tests.benchmarks.cloudopsbench` never sees those tools.

6. **Bench backend slot separation.** Bench replay backend now lives at `sources["eks"]["_bench_backend"]`, distinct from the synthetic-test `_backend` slot. Production tool availability checks (`_eks_available`, `eks_available_or_backend`) read only their original slots — they're completely unaware that bench backends exist. All `is_cloudopsbench_backend` marker checks deleted from `app/`.

7. **Scrubbed bench references from `app/` docstrings.** Extension points (`agent_class`, hook method, registry extension, slot separation) are documented in generic production-domain terms — "custom termination policies", "downstream integrators", "fixture backends" — not "the bench".

8. **Adapter wiring.** `BenchmarkAdapter` ABC gets an `investigation_agent_class()` method (default `None` = use production). `CloudOpsBenchAdapter` overrides it to return `BenchInvestigationAgent`. The framework runner passes whatever the adapter returns.


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The driving principle: opensre's production code paths should have one behavior, with no bench-specific branches. Benchmarks plug in via documented extension points, not by special-casing the production code.

I considered three patterns for wiring the bench's minimum-tool-call requirement:

Inline conditional with env-var gate (OPENSRE_MIN_INVESTIGATION_STEPS) — rejected because every new bench-specific behavior would add another conditional inside the production loop.
Strategy injection (pass a TerminationPolicy callable into the agent) — considered, but only one current lever fits the policy shape. Adding a strategy interface for a hypothetical second use case is over-engineering.
Subclass + extension hook (what landed) — production exposes a small _should_accept_conclusion hook with a no-op default. Bench provides BenchInvestigationAgent that overrides it. Injected via the existing pipeline's agent_class parameter.

For the bench backend slot collision: the bench originally stored its replay backend at sources["eks"]["_backend"], the slot reserved for synthetic-test fixture backends that share the EKS tool API. The replay backend speaks a different (paper-protocol) API, so production tool availability checks needed is_cloudopsbench_backend guards to distinguish them. The cleaner fix was to give the bench its own slot (_bench_backend) — production checks then remain unaware. All marker-attribute checks deleted from production code.

For moving CloudOpsBenchK8sTools out of app/: the tool registry's auto-discovery walked app.tools.* only. Rather than reroute it, I added a register_external_tool_package(pkg) API that registers additional packages for the same kind of walk. The bench's package __init__.py registers itself as an import side-effect, so the registration only happens when the bench is being used.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
