### PR TITLE
fix(repl): eliminate cold-start stall on first interactive reply

### DIFF
--- a/app/cli/interactive_shell/chat/cli_agent.py
+++ b/app/cli/interactive_shell/chat/cli_agent.py
@@ -537,8 +537,8 @@ def answer_cli_agent(
     prompt = f"{system}\n{integration_guard}{synthetic_block}{user_block}"
 
     try:
-        client = get_llm_for_reasoning()
         started = time.monotonic()
+        client = get_llm_for_reasoning()
         text_str = stream_to_console(
             console,
             label=STREAM_LABEL_ASSISTANT,

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -314,6 +314,13 @@ async def run_interactive(
     processor_task = asyncio.create_task(_processor())
     alert_watcher_task = asyncio.create_task(_alert_watcher())
     spinner_ticker_task = asyncio.create_task(_spinner_ticker())
+
+    async def _llm_warmup() -> None:
+        from app.services.llm_client import warmup_llm_clients
+
+        await asyncio.to_thread(warmup_llm_clients)
+
+    asyncio.create_task(_llm_warmup())
     try:
         with patch_stdout(raw=True):
             echo_console = Console(highlight=False, force_terminal=True, color_system="truecolor")

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -1238,6 +1238,23 @@ def reset_llm_singletons() -> None:
     _llm_for_tools = None
 
 
+def warmup_llm_clients() -> None:
+    """Pre-warm all LLM client singletons (deferred import + init) in one call.
+
+    Safe to call from a background thread; all three getters are idempotent
+    after first init. Suppresses exceptions so warm-up failure never crashes
+    the REPL.
+    """
+    import contextlib
+
+    with contextlib.suppress(Exception):
+        get_llm_for_reasoning()
+    with contextlib.suppress(Exception):
+        get_llm_for_classification()
+    with contextlib.suppress(Exception):
+        get_llm_for_tools()
+
+
 def _get_cli_provider_registration(provider: str) -> CLIProviderRegistration | None:
     """Local import avoids package import cycle (llm_cli __init__ → runner → llm_client)."""
     from app.integrations.llm_cli.registry import get_cli_provider_registration


### PR DESCRIPTION
## Summary

- **Root cause 1 — misleading timer**: `started = time.monotonic()` was placed *after* `get_llm_for_reasoning()`, so the displayed latency footer only measured streaming time (~0.2s) while hiding the ~16s SDK import + client init. Fixed by swapping the two lines in `app/cli/interactive_shell/chat/cli_agent.py`.
- **Root cause 2 — cold start**: On first REPL message, `get_llm_for_reasoning()` triggers a deferred import of the boto3/anthropic/openai SDKs and then instantiates the client singleton — all happening after the user submits their message. Fixed by adding a fourth background `asyncio.create_task` in `app/cli/interactive_shell/runtime/loop.py` that calls `warmup_llm_clients()` via `asyncio.to_thread` while the user reads the banner.
- **New helper `warmup_llm_clients()`** added to `app/services/llm_client.py` — pre-warms all three singletons (reasoning, classification, tools), suppresses all exceptions so warm-up failure never crashes the REPL.

Closes #2082

## Test plan

- [x] `make lint` — clean
- [x] `make typecheck` — clean (711 source files, no issues)
- [x] `make test-cov` — 8020 passed, 33 skipped (64 pre-existing live-LLM errors requiring `ANTHROPIC_API_KEY`, unrelated to this change)
- [ ] Manual: `opensre` → type "hi" → first reply no longer stalls before streaming starts; footer shows honest latency including any remaining init time