### PR TITLE
feat: add CloudTrail event-lookup tool for change forensics (#2686)

### DIFF
--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -30,9 +30,9 @@ _UNSET: object = object()  # sentinel distinguishing "not yet started" from a No
 _ALERT_SOURCE_TO_TOOL_SOURCES: dict[str, list[str]] = {
     "grafana": ["grafana"],
     "datadog": ["datadog"],
-    "cloudwatch": ["cloudwatch", "cloudtrail"],
-    "eks": ["eks", "cloudtrail"],
-    "alertmanager": ["grafana", "cloudwatch", "cloudtrail"],
+    "cloudwatch": ["cloudwatch"],
+    "eks": ["eks"],
+    "alertmanager": ["grafana", "cloudwatch"],
     "sentry": ["sentry"],
     "honeycomb": ["honeycomb"],
     "coralogix": ["coralogix"],

--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -30,9 +30,9 @@ _UNSET: object = object()  # sentinel distinguishing "not yet started" from a No
 _ALERT_SOURCE_TO_TOOL_SOURCES: dict[str, list[str]] = {
     "grafana": ["grafana"],
     "datadog": ["datadog"],
-    "cloudwatch": ["cloudwatch"],
-    "eks": ["eks"],
-    "alertmanager": ["grafana", "cloudwatch"],
+    "cloudwatch": ["cloudwatch", "cloudtrail"],
+    "eks": ["eks", "cloudtrail"],
+    "alertmanager": ["grafana", "cloudwatch", "cloudtrail"],
     "sentry": ["sentry"],
     "honeycomb": ["honeycomb"],
     "coralogix": ["coralogix"],

--- a/app/agent/prompt.py
+++ b/app/agent/prompt.py
@@ -63,9 +63,9 @@ Severity: {severity}
 _ALERT_SOURCE_TO_TOOL_SOURCES: dict[str, list[str]] = {
     "grafana": ["grafana"],
     "datadog": ["datadog"],
-    "cloudwatch": ["cloudwatch", "ec2", "rds"],
-    "eks": ["eks", "ec2"],
-    "alertmanager": ["eks", "cloudwatch", "grafana"],
+    "cloudwatch": ["cloudwatch", "ec2", "rds", "cloudtrail"],
+    "eks": ["eks", "ec2", "cloudtrail"],
+    "alertmanager": ["eks", "cloudwatch", "grafana", "cloudtrail"],
     "sentry": ["sentry"],
     "honeycomb": ["honeycomb"],
     "coralogix": ["coralogix"],

--- a/app/integrations/cloudtrail.py
+++ b/app/integrations/cloudtrail.py
@@ -28,14 +28,21 @@ def cloudtrail_is_available(sources: dict[str, dict]) -> bool:
     gate availability on the ``aws`` source the catalog populates from
     ``AWSIntegrationConfig`` — mirroring how the other AWS tools reuse the creds
     wired via the EKS/CloudWatch path — and on the optional synthetic
-    ``_backend`` handle so the tool stays selectable in fixture-driven tests.
+    ``ec2_backend`` handle (the key the synthetic harness injects into the
+    ``aws`` source) so the tool stays selectable in fixture-driven tests.
+
+    Note: ``role_arn`` / ``credentials`` here gate *availability* only. The
+    actual lookup runs through ``execute_aws_sdk_call``, which uses boto3's
+    ambient credential chain (env / shared config / instance role) — the
+    configured role is not assumed as the execution identity. This matches the
+    other AWS tools (RDS/EKS).
     """
     aws = sources.get("aws", {})
     return bool(
         aws.get("connection_verified")
         or aws.get("role_arn")
         or aws.get("credentials")
-        or aws.get("_backend")
+        or aws.get("ec2_backend")
     )
 
 
@@ -44,11 +51,12 @@ def cloudtrail_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
 
     Resolution order for region matches the rest of the AWS stack: explicit
     ``aws`` source field, then ``AWS_REGION`` env, then the default. Forwards
-    the optional synthetic ``_backend`` handle as ``aws_backend`` so the tool
-    can short-circuit to fixture data instead of leaking boto3 calls to whatever
-    AWS account the developer happens to be authenticated against during a
-    synthetic run. Resource/principal/time-window filters are alert-specific and
-    are supplied by the planner at call time, not extracted here.
+    the optional synthetic ``ec2_backend`` handle (the key the synthetic harness
+    injects into the ``aws`` source) as ``aws_backend`` so the tool short-circuits
+    to fixture data instead of leaking boto3 calls to whatever AWS account the
+    developer happens to be authenticated against during a synthetic run.
+    Resource/principal/time-window filters are alert-specific and are supplied
+    by the planner at call time, not extracted here.
     """
     aws = sources.get("aws", {})
     region = (
@@ -56,5 +64,5 @@ def cloudtrail_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     )
     return {
         "region": region,
-        "aws_backend": aws.get("_backend"),
+        "aws_backend": aws.get("ec2_backend"),
     }

--- a/app/integrations/cloudtrail.py
+++ b/app/integrations/cloudtrail.py
@@ -1,0 +1,60 @@
+"""Shared AWS CloudTrail integration helpers.
+
+CloudTrail is the canonical AWS change-causality source — "who changed what,
+and when?". Unlike RDS, CloudTrail is account-wide rather than tied to a single
+configured resource, so the CloudTrail tool rides on the account-level ``aws``
+integration (``AWSIntegrationConfig``) for availability and region rather than
+defining its own credential plumbing.
+
+All AWS API calls are read-only and routed through the shared
+``aws_sdk_client`` allowlist (``lookup_events`` matches ``^lookup_.*``), so the
+integration cannot mutate any resources.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.integrations._relational import env_str
+
+DEFAULT_CLOUDTRAIL_REGION = "us-east-1"
+
+
+def cloudtrail_is_available(sources: dict[str, dict]) -> bool:
+    """Check whether CloudTrail can be queried for this investigation.
+
+    CloudTrail forensics only needs AWS account access (credentials + region),
+    which the account-level ``aws`` integration already provides. We therefore
+    gate availability on the ``aws`` source the catalog populates from
+    ``AWSIntegrationConfig`` — mirroring how the other AWS tools reuse the creds
+    wired via the EKS/CloudWatch path — and on the optional synthetic
+    ``_backend`` handle so the tool stays selectable in fixture-driven tests.
+    """
+    aws = sources.get("aws", {})
+    return bool(
+        aws.get("connection_verified")
+        or aws.get("role_arn")
+        or aws.get("credentials")
+        or aws.get("_backend")
+    )
+
+
+def cloudtrail_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
+    """Extract CloudTrail call params (region) from the ``aws`` source.
+
+    Resolution order for region matches the rest of the AWS stack: explicit
+    ``aws`` source field, then ``AWS_REGION`` env, then the default. Forwards
+    the optional synthetic ``_backend`` handle as ``aws_backend`` so the tool
+    can short-circuit to fixture data instead of leaking boto3 calls to whatever
+    AWS account the developer happens to be authenticated against during a
+    synthetic run. Resource/principal/time-window filters are alert-specific and
+    are supplied by the planner at call time, not extracted here.
+    """
+    aws = sources.get("aws", {})
+    region = (
+        str(aws.get("region") or "").strip() or env_str("AWS_REGION") or DEFAULT_CLOUDTRAIL_REGION
+    )
+    return {
+        "region": region,
+        "aws_backend": aws.get("_backend"),
+    }

--- a/app/tools/CloudTrailEventsTool/__init__.py
+++ b/app/tools/CloudTrailEventsTool/__init__.py
@@ -1,0 +1,232 @@
+"""CloudTrail events tool — "who changed what, and when?" change forensics.
+
+Wraps the read-only CloudTrail ``lookup_events`` API so the planner can trace
+configuration-change causality during an AWS incident: IAM changes,
+security-group mutations, EKS/Lambda config updates, and resource deletions.
+
+CloudTrail's ``LookupAttributes`` accepts only ONE filter attribute per call,
+so the tool exposes the common forensic filters (resource name, event source,
+principal/username) as optional params and sends the most specific one that was
+provided. A ``duration_minutes`` window is converted to the ``StartTime`` /
+``EndTime`` pair the API expects.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+from app.integrations.cloudtrail import (
+    DEFAULT_CLOUDTRAIL_REGION,
+    cloudtrail_extract_params,
+    cloudtrail_is_available,
+)
+from app.services.aws_sdk_client import execute_aws_sdk_call
+from app.tools.tool_decorator import tool
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DURATION_MINUTES = 60
+# CloudTrail caps lookups at 90 days of history and 50 events per page.
+MAX_DURATION_MINUTES = 90 * 24 * 60
+DEFAULT_MAX_RESULTS = 50
+MAX_RESULTS_LIMIT = 50
+
+
+def _build_lookup_attribute(
+    resource_name: str,
+    event_source: str,
+    username: str,
+) -> list[dict[str, str]]:
+    """Build the single-item ``LookupAttributes`` list CloudTrail allows.
+
+    CloudTrail rejects more than one attribute per request, so we pick the most
+    specific filter that was provided: a concrete resource pins the blast
+    radius best, then the acting principal, then the broad service source.
+    Returns an empty list when no filter is set (recent account-wide events).
+    """
+    if resource_name:
+        return [{"AttributeKey": "ResourceName", "AttributeValue": resource_name}]
+    if username:
+        return [{"AttributeKey": "Username", "AttributeValue": username}]
+    if event_source:
+        return [{"AttributeKey": "EventSource", "AttributeValue": event_source}]
+    return []
+
+
+def _shape_event(raw: dict[str, Any]) -> dict[str, Any]:
+    """Trim a raw CloudTrail event down to the fields RCA actually needs."""
+    resources = [
+        {
+            "type": resource.get("ResourceType"),
+            "name": resource.get("ResourceName"),
+        }
+        for resource in (raw.get("Resources") or [])
+    ]
+
+    # CloudTrailEvent is a JSON string carrying the full record; pull the
+    # high-signal forensic fields out of it without dumping the whole blob.
+    aws_region = source_ip = error_code = None
+    detail = raw.get("CloudTrailEvent")
+    if isinstance(detail, str):
+        try:
+            parsed = json.loads(detail)
+        except (ValueError, TypeError):
+            parsed = {}
+        aws_region = parsed.get("awsRegion")
+        source_ip = parsed.get("sourceIPAddress")
+        error_code = parsed.get("errorCode")
+
+    return {
+        "event_id": raw.get("EventId"),
+        "event_name": raw.get("EventName"),
+        "event_time": raw.get("EventTime"),
+        "event_source": raw.get("EventSource"),
+        "username": raw.get("Username"),
+        "read_only": raw.get("ReadOnly"),
+        "access_key_id": raw.get("AccessKeyId"),
+        "resources": resources,
+        "aws_region": aws_region,
+        "source_ip_address": source_ip,
+        "error_code": error_code,
+    }
+
+
+@tool(
+    name="lookup_cloudtrail_events",
+    display_name="CloudTrail",
+    source="cloudtrail",
+    description=(
+        "Look up recent AWS CloudTrail management events to answer 'who changed "
+        "what, and when?' — IAM changes, security-group mutations, EKS/Lambda "
+        "config updates, and resource deletions. Filter by resource name, event "
+        "source (e.g. iam.amazonaws.com), or username over a time window."
+    ),
+    use_cases=[
+        "Finding who modified an IAM policy, role, or security group before an incident",
+        "Tracing config changes to a specific resource (by ResourceName)",
+        "Auditing all actions taken by a principal/user (by Username)",
+        "Reviewing recent activity from one AWS service (by EventSource)",
+        "Establishing change causality at the start of a post-mortem",
+    ],
+    requires=[],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "resource_name": {
+                "type": "string",
+                "description": "Filter by a specific resource name/ARN (most specific filter).",
+            },
+            "event_source": {
+                "type": "string",
+                "description": "Filter by AWS service event source, e.g. 'iam.amazonaws.com'.",
+            },
+            "username": {
+                "type": "string",
+                "description": "Filter by the acting principal / IAM username.",
+            },
+            "region": {"type": "string", "default": DEFAULT_CLOUDTRAIL_REGION},
+            "duration_minutes": {
+                "type": "integer",
+                "default": DEFAULT_DURATION_MINUTES,
+                "minimum": 1,
+                "maximum": MAX_DURATION_MINUTES,
+                "description": "Look-back window in minutes (CloudTrail keeps 90 days).",
+            },
+            "max_results": {
+                "type": "integer",
+                "default": DEFAULT_MAX_RESULTS,
+                "minimum": 1,
+                "maximum": MAX_RESULTS_LIMIT,
+            },
+        },
+        "required": [],
+    },
+    is_available=cloudtrail_is_available,
+    extract_params=cloudtrail_extract_params,
+)
+def lookup_cloudtrail_events(
+    resource_name: str = "",
+    event_source: str = "",
+    username: str = "",
+    region: str = DEFAULT_CLOUDTRAIL_REGION,
+    duration_minutes: int = DEFAULT_DURATION_MINUTES,
+    max_results: int = DEFAULT_MAX_RESULTS,
+    aws_backend: Any = None,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    """Look up recent CloudTrail management events scoped to a filter + window.
+
+    When ``aws_backend`` is provided (FixtureAWSBackend in synthetic tests) the
+    call short-circuits to the backend so we never leak boto3 calls to real AWS
+    during scenario runs. Otherwise calls boto3 cloudtrail via
+    ``execute_aws_sdk_call`` using the default boto3 credential chain.
+    """
+    duration_minutes = max(1, min(duration_minutes, MAX_DURATION_MINUTES))
+    max_results = max(1, min(max_results, MAX_RESULTS_LIMIT))
+    lookup_attributes = _build_lookup_attribute(resource_name, event_source, username)
+
+    logger.info(
+        "[cloudtrail] lookup_events region=%s filter=%s duration=%s max=%s",
+        region,
+        lookup_attributes or "none",
+        duration_minutes,
+        max_results,
+    )
+
+    if aws_backend is not None:
+        return cast(
+            "dict[str, Any]",
+            aws_backend.lookup_events(
+                lookup_attributes=lookup_attributes,
+                duration_minutes=duration_minutes,
+                max_results=max_results,
+                region=region,
+            ),
+        )
+
+    end_time = datetime.now(UTC)
+    start_time = end_time - timedelta(minutes=duration_minutes)
+
+    parameters: dict[str, Any] = {
+        "StartTime": start_time,
+        "EndTime": end_time,
+        "MaxResults": max_results,
+    }
+    if lookup_attributes:
+        parameters["LookupAttributes"] = lookup_attributes
+
+    result = execute_aws_sdk_call(
+        service_name="cloudtrail",
+        operation_name="lookup_events",
+        parameters=parameters,
+        region=region,
+    )
+
+    if not result.get("success"):
+        logger.error(
+            "[cloudtrail] lookup_events failed region=%s: %s",
+            region,
+            result.get("error"),
+        )
+        return {
+            "source": "cloudtrail",
+            "available": False,
+            "error": "Failed to look up CloudTrail events. Check server logs for details.",
+        }
+
+    raw_events = (result.get("data") or {}).get("Events") or []
+    events = [_shape_event(event) for event in raw_events]
+
+    return {
+        "source": "cloudtrail",
+        "available": True,
+        "region": region,
+        "duration_minutes": duration_minutes,
+        "filter": (lookup_attributes[0] if lookup_attributes else None),
+        "total_events": len(events),
+        "events": events,
+        "error": None,
+    }

--- a/app/tools/CloudTrailEventsTool/__init__.py
+++ b/app/tools/CloudTrailEventsTool/__init__.py
@@ -79,13 +79,23 @@ def _shape_event(raw: dict[str, Any]) -> dict[str, Any]:
         source_ip = parsed.get("sourceIPAddress")
         error_code = parsed.get("errorCode")
 
+    # CloudTrail returns ReadOnly as the string "true"/"false"; coerce to a real
+    # bool so callers don't trip over "false" being truthy in Python.
+    read_only_raw = raw.get("ReadOnly")
+    if isinstance(read_only_raw, bool):
+        read_only = read_only_raw
+    elif isinstance(read_only_raw, str):
+        read_only = read_only_raw.strip().lower() == "true"
+    else:
+        read_only = None
+
     return {
         "event_id": raw.get("EventId"),
         "event_name": raw.get("EventName"),
         "event_time": raw.get("EventTime"),
         "event_source": raw.get("EventSource"),
         "username": raw.get("Username"),
-        "read_only": raw.get("ReadOnly"),
+        "read_only": read_only,
         "access_key_id": raw.get("AccessKeyId"),
         "resources": resources,
         "aws_region": aws_region,
@@ -152,6 +162,7 @@ def _shape_event(raw: dict[str, Any]) -> dict[str, Any]:
         },
         "required": [],
     },
+    injected_params=("aws_backend",),
     is_available=cloudtrail_is_available,
     extract_params=cloudtrail_extract_params,
 )

--- a/app/tools/CloudTrailEventsTool/__init__.py
+++ b/app/tools/CloudTrailEventsTool/__init__.py
@@ -141,6 +141,14 @@ def _shape_event(raw: dict[str, Any]) -> dict[str, Any]:
                 "minimum": 1,
                 "maximum": MAX_RESULTS_LIMIT,
             },
+            "next_token": {
+                "type": "string",
+                "default": "",
+                "description": (
+                    "Pagination token from a previous truncated response; pass it to "
+                    "fetch the next page of events."
+                ),
+            },
         },
         "required": [],
     },
@@ -154,6 +162,7 @@ def lookup_cloudtrail_events(
     region: str = DEFAULT_CLOUDTRAIL_REGION,
     duration_minutes: int = DEFAULT_DURATION_MINUTES,
     max_results: int = DEFAULT_MAX_RESULTS,
+    next_token: str = "",
     aws_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
@@ -184,6 +193,7 @@ def lookup_cloudtrail_events(
                 duration_minutes=duration_minutes,
                 max_results=max_results,
                 region=region,
+                next_token=next_token,
             ),
         )
 
@@ -197,6 +207,8 @@ def lookup_cloudtrail_events(
     }
     if lookup_attributes:
         parameters["LookupAttributes"] = lookup_attributes
+    if next_token:
+        parameters["NextToken"] = next_token
 
     result = execute_aws_sdk_call(
         service_name="cloudtrail",
@@ -217,8 +229,13 @@ def lookup_cloudtrail_events(
             "error": "Failed to look up CloudTrail events. Check server logs for details.",
         }
 
-    raw_events = (result.get("data") or {}).get("Events") or []
+    data = result.get("data") or {}
+    raw_events = data.get("Events") or []
     events = [_shape_event(event) for event in raw_events]
+    # CloudTrail returns a NextToken when more matching events exist beyond this
+    # page. Surface it so the agent knows the result is partial (and can paginate
+    # via the next_token param) instead of silently treating 50 events as "all".
+    returned_token = data.get("NextToken") or None
 
     return {
         "source": "cloudtrail",
@@ -227,6 +244,8 @@ def lookup_cloudtrail_events(
         "duration_minutes": duration_minutes,
         "filter": (lookup_attributes[0] if lookup_attributes else None),
         "total_events": len(events),
+        "truncated": bool(returned_token),
+        "next_token": returned_token,
         "events": events,
         "error": None,
     }

--- a/app/types/evidence.py
+++ b/app/types/evidence.py
@@ -53,6 +53,7 @@ EvidenceSource = Literal[
     "helm",
     "victoria_logs",
     "rds",
+    "cloudtrail",
     "ec2",
     "hermes",
     "twilio",

--- a/docs/cloudtrail_events.mdx
+++ b/docs/cloudtrail_events.mdx
@@ -32,9 +32,14 @@ CloudTrail is account-wide, so the tool becomes available to the planner wheneve
 | `region` | `us-east-1` | AWS region to query. |
 | `duration_minutes` | `60` | Look-back window. CloudTrail retains 90 days of history (the upper bound). |
 | `max_results` | `50` | Maximum events to return (CloudTrail caps this at 50 per call). |
+| `next_token` | — | Pagination token from a previous truncated response; pass it to fetch the next page. |
 
 <Note>
 CloudTrail's `LookupEvents` API accepts **only one filter attribute per call**. When more than one filter is supplied, the tool sends the most specific one, in priority order: `resource_name` → `username` → `event_source`. With no filter, it returns recent account-wide events for the window.
+</Note>
+
+<Note>
+CloudTrail returns at most 50 events per page. When more matching events exist, the response sets **`truncated: true`** and returns a **`next_token`** — pass it back via the `next_token` parameter to fetch the next page, so a busy account or wide window never silently drops events.
 </Note>
 
 ### Use cases

--- a/docs/cloudtrail_events.mdx
+++ b/docs/cloudtrail_events.mdx
@@ -71,6 +71,10 @@ The tool only needs one read-only CloudTrail action:
 
 Attach this policy to the same IAM role or user already configured for the [AWS integration](/aws). If you are already using the AWS managed `ReadOnlyAccess` policy, this action is already covered.
 
+<Note>
+**Execution identity:** the AWS integration's `role_arn` / credentials gate *availability* and supply the region, but the lookup itself runs through boto3's standard credential chain (environment variables, shared config, or the host's instance role) — the configured role is **not** assumed for the call. Ensure the identity the OpenSRE process runs as can perform `cloudtrail:LookupEvents`. This matches the other AWS tools (RDS/EKS).
+</Note>
+
 ## Troubleshooting
 
 | Symptom | Fix |

--- a/docs/cloudtrail_events.mdx
+++ b/docs/cloudtrail_events.mdx
@@ -1,0 +1,76 @@
+---
+title: "AWS CloudTrail"
+description: "Trace AWS configuration-change causality — who changed what, and when — during incidents"
+---
+
+OpenSRE uses AWS CloudTrail to answer the first question of every cloud post-mortem: **"who changed what, and when?"** When an AWS alert fires, the planner can look up recent management events — IAM changes, security-group mutations, EKS/Lambda config updates, and resource deletions — scoped to a resource, a principal, or a time window.
+
+CloudTrail lookups are read-only and routed through the shared `aws_sdk_client` allowlist, so the integration cannot mutate any resources.
+
+## Prerequisites
+
+- AWS credentials configured per the [AWS integration](/aws) (role ARN recommended) — CloudTrail reuses the same account credentials and region, so no extra setup is needed
+- IAM permission for the single read-only CloudTrail action listed below
+
+## How it works
+
+CloudTrail is account-wide, so the tool becomes available to the planner whenever the [AWS integration](/aws) is configured — there is nothing resource-specific to set up. The region comes from the AWS integration (or `AWS_REGION`, defaulting to `us-east-1`).
+
+## Tools
+
+| Tool | AWS API call | What it returns |
+| --- | --- | --- |
+| `lookup_cloudtrail_events` | `cloudtrail:LookupEvents` | Recent management events — event name, time, source, acting username, affected resources, AWS region, source IP, and any error code. |
+
+### Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `resource_name` | — | Filter to events touching a specific resource name/ARN (the most specific filter). |
+| `event_source` | — | Filter by AWS service event source, e.g. `iam.amazonaws.com`, `ec2.amazonaws.com`. |
+| `username` | — | Filter by the acting principal / IAM username. |
+| `region` | `us-east-1` | AWS region to query. |
+| `duration_minutes` | `60` | Look-back window. CloudTrail retains 90 days of history (the upper bound). |
+| `max_results` | `50` | Maximum events to return (CloudTrail caps this at 50 per call). |
+
+<Note>
+CloudTrail's `LookupEvents` API accepts **only one filter attribute per call**. When more than one filter is supplied, the tool sends the most specific one, in priority order: `resource_name` → `username` → `event_source`. With no filter, it returns recent account-wide events for the window.
+</Note>
+
+### Use cases
+
+- Finding who modified an IAM policy, role, or security group just before an incident
+- Tracing configuration changes to a specific resource (by resource name)
+- Auditing every action taken by a principal (by username)
+- Reviewing recent activity from a single AWS service (by event source)
+- Establishing change causality at the start of a post-mortem
+
+## IAM permissions
+
+The tool only needs one read-only CloudTrail action:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudtrail:LookupEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+Attach this policy to the same IAM role or user already configured for the [AWS integration](/aws). If you are already using the AWS managed `ReadOnlyAccess` policy, this action is already covered.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| **AccessDenied on `cloudtrail:LookupEvents`** | Add the IAM policy above to the role or user used by the AWS integration. |
+| **No events returned** | Widen `duration_minutes`, loosen the filter, or confirm you are querying the region where the activity occurred. Only management events are returned; data events are not. |
+| **ThrottlingException** | CloudTrail `LookupEvents` is rate-limited to two requests per second per account per region. Retry with a narrower window. |
+| **Tool reports the wrong region** | Set `AWS_REGION`, or check the `region` field on the configured AWS integration. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -128,6 +128,7 @@
             "expanded": true,
             "pages": [
               "aws",
+              "cloudtrail_events",
               "bitbucket",
               "github",
               "integrations/github-actions",

--- a/tests/synthetic/mock_aws_backend/backend.py
+++ b/tests/synthetic/mock_aws_backend/backend.py
@@ -90,6 +90,17 @@ class AWSBackend(Protocol):
     ) -> dict[str, Any]:
         """Return a response matching ``describe_rds_events``."""
 
+    def lookup_events(
+        self,
+        lookup_attributes: list[dict[str, str]] | None = None,
+        duration_minutes: int = 60,
+        max_results: int = 50,
+        region: str = "",
+        next_token: str = "",
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Return a response matching ``lookup_cloudtrail_events``."""
+
 
 class FixtureAWSBackend:
     """AWSBackend implementation backed by a ScenarioFixture.
@@ -308,5 +319,36 @@ class FixtureAWSBackend:
             "duration_minutes": duration_minutes,
             "total_events": len(events),
             "events": events,
+            "error": None,
+        }
+
+    # ------------------------------------------------------------------ CloudTrail
+
+    def lookup_events(
+        self,
+        lookup_attributes: list[dict[str, str]] | None = None,
+        duration_minutes: int = 60,
+        region: str = "",
+        **_: Any,
+    ) -> dict[str, Any]:
+        """Serve ``lookup_cloudtrail_events`` from fixture data.
+
+        No scenario currently declares CloudTrail evidence, so this returns an
+        empty (but well-shaped) account-wide result. Its purpose is to keep
+        synthetic runs off real AWS — never leak a boto3 ``lookup_events`` call —
+        while giving the agent a valid "no recent changes" answer. ``filter``
+        echoes the single LookupAttribute the tool sent, mirroring the real tool.
+        """
+        attributes = lookup_attributes or []
+        return {
+            "source": "cloudtrail",
+            "available": True,
+            "region": region,
+            "duration_minutes": duration_minutes,
+            "filter": attributes[0] if attributes else None,
+            "total_events": 0,
+            "truncated": False,
+            "next_token": None,
+            "events": [],
             "error": None,
         }

--- a/tests/tools/test_cloudtrail_events.py
+++ b/tests/tools/test_cloudtrail_events.py
@@ -66,6 +66,20 @@ def test_tool_discovered_on_investigation_surface() -> None:
     assert "lookup_cloudtrail_events" in names
 
 
+def test_cloudtrail_seeded_and_prioritized_for_aws_alerts() -> None:
+    """CloudTrail is auto-seeded and prioritized for AWS-originating alerts.
+
+    Guards both maps so a cloudwatch/eks/alertmanager alert pulls CloudTrail
+    change-causality into the investigation, not just one of them.
+    """
+    from app.agent.investigation import _ALERT_SOURCE_TO_TOOL_SOURCES as seed_map
+    from app.agent.prompt import _ALERT_SOURCE_TO_TOOL_SOURCES as priority_map
+
+    for alert_source in ("cloudwatch", "eks", "alertmanager"):
+        assert "cloudtrail" in seed_map[alert_source]
+        assert "cloudtrail" in priority_map[alert_source]
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Schema shape
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/tools/test_cloudtrail_events.py
+++ b/tests/tools/test_cloudtrail_events.py
@@ -66,17 +66,19 @@ def test_tool_discovered_on_investigation_surface() -> None:
     assert "lookup_cloudtrail_events" in names
 
 
-def test_cloudtrail_seeded_and_prioritized_for_aws_alerts() -> None:
-    """CloudTrail is auto-seeded and prioritized for AWS-originating alerts.
+def test_cloudtrail_prioritized_but_not_auto_seeded_for_aws_alerts() -> None:
+    """CloudTrail is prioritized for AWS alerts but left for the planner to call.
 
-    Guards both maps so a cloudwatch/eks/alertmanager alert pulls CloudTrail
-    change-causality into the investigation, not just one of them.
+    It is intentionally NOT in the auto-seed map: an unscoped, account-wide
+    lookup on every cloudwatch/eks/alertmanager alert would be noisy and press
+    CloudTrail's low lookup rate limit. The prompt prioritization map nudges the
+    planner to reach for it once it has a concrete resource/principal/time target.
     """
     from app.agent.investigation import _ALERT_SOURCE_TO_TOOL_SOURCES as seed_map
     from app.agent.prompt import _ALERT_SOURCE_TO_TOOL_SOURCES as priority_map
 
     for alert_source in ("cloudwatch", "eks", "alertmanager"):
-        assert "cloudtrail" in seed_map[alert_source]
+        assert "cloudtrail" not in seed_map[alert_source]
         assert "cloudtrail" in priority_map[alert_source]
 
 
@@ -113,7 +115,9 @@ def test_is_available_on_role_or_credentials() -> None:
 
 
 def test_is_available_on_injected_backend() -> None:
-    assert cloudtrail_is_available({"aws": {"_backend": object()}}) is True
+    # The synthetic harness injects the fixture backend as "ec2_backend" on the
+    # "aws" source (see tests/synthetic/rds_postgres/run_suite.py).
+    assert cloudtrail_is_available({"aws": {"ec2_backend": object()}}) is True
 
 
 def test_not_available_without_aws() -> None:
@@ -142,7 +146,8 @@ def test_extract_params_defaults_region(monkeypatch) -> None:
 
 def test_extract_params_forwards_backend() -> None:
     backend = object()
-    params = cloudtrail_extract_params({"aws": {"_backend": backend}})
+    # Harness-shaped: the backend handle lives under "ec2_backend" on "aws".
+    params = cloudtrail_extract_params({"aws": {"ec2_backend": backend}})
     assert params["aws_backend"] is backend
 
 
@@ -184,6 +189,8 @@ def test_lookup_success_and_shaping(mock_call) -> None:
     event = result["events"][0]
     assert event["event_name"] == "DeleteSecurityGroup"
     assert event["username"] == "alice"
+    # "false" -> real bool False (not the truthy string "false")
+    assert event["read_only"] is False
     assert event["resources"] == [{"type": "AWS::EC2::SecurityGroup", "name": "sg-1"}]
     assert event["aws_region"] == "us-east-1"
     assert event["source_ip_address"] == "1.2.3.4"
@@ -312,6 +319,7 @@ def test_short_circuits_to_aws_backend(mock_call) -> None:
     )
 
     mock_call.assert_not_called()
+    assert result["available"] is True
     assert backend.calls == [
         {
             "lookup_attributes": [{"AttributeKey": "ResourceName", "AttributeValue": "sg-1"}],
@@ -320,4 +328,28 @@ def test_short_circuits_to_aws_backend(mock_call) -> None:
             "region": "us-east-1",
         }
     ]
+
+
+@patch("app.tools.CloudTrailEventsTool.execute_aws_sdk_call")
+def test_harness_shaped_aws_source_short_circuits_off_real_aws(mock_call) -> None:
+    """Regression: the synthetic harness injects the backend as aws['ec2_backend'].
+
+    Resolving via cloudtrail_extract_params (not injecting aws_backend directly)
+    must pick up that handle and short-circuit the tool, so a synthetic run —
+    e.g. an rds scenario with alert_source 'cloudwatch' — never reaches a real
+    boto3 lookup_events call even when ambient AWS creds are present.
+    """
+    backend = _FakeAWSBackend(
+        response={"source": "cloudtrail", "available": True, "total_events": 0, "events": []}
+    )
+    # Source dict shaped exactly like tests/synthetic/rds_postgres/run_suite.py.
+    sources = {"aws": {"region": "us-east-1", "ec2_backend": backend}}
+
+    params = cloudtrail_extract_params(sources)
+    assert params["aws_backend"] is backend  # resolved from ec2_backend, not _backend
+
+    result = lookup_cloudtrail_events(resource_name="sg-1", **params)
+
+    mock_call.assert_not_called()
+    assert backend.calls and backend.calls[0]["region"] == "us-east-1"
     assert result["available"] is True

--- a/tests/tools/test_cloudtrail_events.py
+++ b/tests/tools/test_cloudtrail_events.py
@@ -166,7 +166,7 @@ def test_lookup_success_and_shaping(mock_call) -> None:
                     "EventTime": "2026-05-05T12:00:00Z",
                     "EventSource": "ec2.amazonaws.com",
                     "Username": "alice",
-                    "ReadOnly": False,
+                    "ReadOnly": "false",
                     "AccessKeyId": "AKIAEXAMPLE",
                     "Resources": [
                         {"ResourceType": "AWS::EC2::SecurityGroup", "ResourceName": "sg-1"}

--- a/tests/tools/test_cloudtrail_events.py
+++ b/tests/tools/test_cloudtrail_events.py
@@ -1,0 +1,276 @@
+"""Tests for CloudTrailEventsTool (function-based, @tool decorated).
+
+Covers the acceptance criteria: schema shape, availability (mirrors an AWS
+tool / planner-selectable), and extraction, plus runtime behavior — filter
+priority, the time-window helper, response shaping, and the synthetic
+``aws_backend`` short-circuit that keeps scenario runs off real AWS.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+from app.integrations.cloudtrail import (
+    DEFAULT_CLOUDTRAIL_REGION,
+    cloudtrail_extract_params,
+    cloudtrail_is_available,
+)
+from app.tools.CloudTrailEventsTool import lookup_cloudtrail_events
+from tests.tools.conftest import BaseToolContract
+
+_RT = lookup_cloudtrail_events.__opensre_registered_tool__
+
+
+class _FakeAWSBackend:
+    """Minimal AWSBackend stand-in that records lookup_events calls."""
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def lookup_events(
+        self,
+        lookup_attributes: list[dict[str, str]],
+        duration_minutes: int = 60,
+        max_results: int = 50,
+        region: str = "",
+        **_: Any,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "lookup_attributes": lookup_attributes,
+                "duration_minutes": duration_minutes,
+                "max_results": max_results,
+                "region": region,
+            }
+        )
+        return self.response
+
+
+class TestCloudTrailEventsToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return _RT
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Discovery — the tool is auto-registered on the investigation surface
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_tool_discovered_on_investigation_surface() -> None:
+    from app.tools.registry import get_registered_tools
+
+    names = {t.name for t in get_registered_tools("investigation")}
+    assert "lookup_cloudtrail_events" in names
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Schema shape
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_schema_shape() -> None:
+    assert _RT.name == "lookup_cloudtrail_events"
+    assert _RT.source == "cloudtrail"
+    schema = _RT.input_schema
+    assert schema["type"] == "object"
+    props = schema["properties"]
+    # The three forensic filters + the window/region knobs are all present.
+    for field in ("resource_name", "event_source", "username", "region", "duration_minutes"):
+        assert field in props
+    # All filters are optional — the tool is account-wide and selectable without one.
+    assert schema["required"] == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Availability — mirrors an AWS tool (gates on the account-level "aws" source)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_is_available_on_verified_aws() -> None:
+    assert cloudtrail_is_available({"aws": {"connection_verified": True}}) is True
+
+
+def test_is_available_on_role_or_credentials() -> None:
+    assert cloudtrail_is_available({"aws": {"role_arn": "arn:aws:iam::1:role/r"}}) is True
+    assert cloudtrail_is_available({"aws": {"credentials": {"access_key_id": "AKIA"}}}) is True
+
+
+def test_is_available_on_injected_backend() -> None:
+    assert cloudtrail_is_available({"aws": {"_backend": object()}}) is True
+
+
+def test_not_available_without_aws() -> None:
+    assert cloudtrail_is_available({}) is False
+    assert cloudtrail_is_available({"aws": {}}) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Extraction
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_extract_params_region_from_source() -> None:
+    params = cloudtrail_extract_params(
+        {"aws": {"connection_verified": True, "region": "eu-west-1"}}
+    )
+    assert params["region"] == "eu-west-1"
+    assert params["aws_backend"] is None
+
+
+def test_extract_params_defaults_region(monkeypatch) -> None:
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    params = cloudtrail_extract_params({"aws": {"connection_verified": True}})
+    assert params["region"] == DEFAULT_CLOUDTRAIL_REGION
+
+
+def test_extract_params_forwards_backend() -> None:
+    backend = object()
+    params = cloudtrail_extract_params({"aws": {"_backend": backend}})
+    assert params["aws_backend"] is backend
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Runtime behavior
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@patch("app.tools.CloudTrailEventsTool.execute_aws_sdk_call")
+def test_lookup_success_and_shaping(mock_call) -> None:
+    detail = json.dumps(
+        {"awsRegion": "us-east-1", "sourceIPAddress": "1.2.3.4", "errorCode": "AccessDenied"}
+    )
+    mock_call.return_value = {
+        "success": True,
+        "data": {
+            "Events": [
+                {
+                    "EventId": "evt-1",
+                    "EventName": "DeleteSecurityGroup",
+                    "EventTime": "2026-05-05T12:00:00Z",
+                    "EventSource": "ec2.amazonaws.com",
+                    "Username": "alice",
+                    "ReadOnly": False,
+                    "AccessKeyId": "AKIAEXAMPLE",
+                    "Resources": [
+                        {"ResourceType": "AWS::EC2::SecurityGroup", "ResourceName": "sg-1"}
+                    ],
+                    "CloudTrailEvent": detail,
+                }
+            ]
+        },
+    }
+
+    result = lookup_cloudtrail_events(event_source="ec2.amazonaws.com", duration_minutes=120)
+
+    assert result["available"] is True
+    assert result["total_events"] == 1
+    event = result["events"][0]
+    assert event["event_name"] == "DeleteSecurityGroup"
+    assert event["username"] == "alice"
+    assert event["resources"] == [{"type": "AWS::EC2::SecurityGroup", "name": "sg-1"}]
+    assert event["aws_region"] == "us-east-1"
+    assert event["source_ip_address"] == "1.2.3.4"
+    assert event["error_code"] == "AccessDenied"
+
+
+@patch("app.tools.CloudTrailEventsTool.execute_aws_sdk_call")
+def test_filter_priority_prefers_resource_name(mock_call) -> None:
+    mock_call.return_value = {"success": True, "data": {"Events": []}}
+
+    lookup_cloudtrail_events(
+        resource_name="sg-1",
+        username="alice",
+        event_source="ec2.amazonaws.com",
+    )
+
+    sent = mock_call.call_args.kwargs["parameters"]
+    assert sent["LookupAttributes"] == [{"AttributeKey": "ResourceName", "AttributeValue": "sg-1"}]
+
+
+@patch("app.tools.CloudTrailEventsTool.execute_aws_sdk_call")
+def test_filter_priority_username_over_event_source(mock_call) -> None:
+    mock_call.return_value = {"success": True, "data": {"Events": []}}
+
+    lookup_cloudtrail_events(username="alice", event_source="iam.amazonaws.com")
+
+    sent = mock_call.call_args.kwargs["parameters"]
+    assert sent["LookupAttributes"] == [{"AttributeKey": "Username", "AttributeValue": "alice"}]
+
+
+@patch("app.tools.CloudTrailEventsTool.execute_aws_sdk_call")
+def test_no_filter_omits_lookup_attributes(mock_call) -> None:
+    mock_call.return_value = {"success": True, "data": {"Events": []}}
+
+    result = lookup_cloudtrail_events()
+
+    sent = mock_call.call_args.kwargs["parameters"]
+    assert "LookupAttributes" not in sent
+    # The time window is always sent.
+    assert "StartTime" in sent and "EndTime" in sent
+    assert result["filter"] is None
+
+
+@patch("app.tools.CloudTrailEventsTool.execute_aws_sdk_call")
+def test_duration_clamped_and_window_built(mock_call) -> None:
+    mock_call.return_value = {"success": True, "data": {"Events": []}}
+
+    result = lookup_cloudtrail_events(duration_minutes=10**9)
+
+    sent = mock_call.call_args.kwargs["parameters"]
+    # End is after start; duration clamped to the 90-day max.
+    assert sent["EndTime"] > sent["StartTime"]
+    assert result["duration_minutes"] == 90 * 24 * 60
+
+
+@patch("app.tools.CloudTrailEventsTool.execute_aws_sdk_call")
+def test_max_results_clamped(mock_call) -> None:
+    mock_call.return_value = {"success": True, "data": {"Events": []}}
+
+    lookup_cloudtrail_events(max_results=999)
+
+    assert mock_call.call_args.kwargs["parameters"]["MaxResults"] == 50
+
+
+@patch("app.tools.CloudTrailEventsTool.execute_aws_sdk_call")
+def test_lookup_failure(mock_call) -> None:
+    mock_call.return_value = {"success": False, "error": "ThrottlingException"}
+
+    result = lookup_cloudtrail_events()
+
+    assert result["available"] is False
+    assert result["error"] == "Failed to look up CloudTrail events. Check server logs for details."
+
+
+@patch("app.tools.CloudTrailEventsTool.execute_aws_sdk_call")
+def test_short_circuits_to_aws_backend(mock_call) -> None:
+    backend = _FakeAWSBackend(
+        response={
+            "source": "cloudtrail",
+            "available": True,
+            "total_events": 0,
+            "events": [],
+            "error": None,
+        }
+    )
+
+    result = lookup_cloudtrail_events(
+        resource_name="sg-1",
+        region="us-east-1",
+        duration_minutes=30,
+        max_results=25,
+        aws_backend=backend,
+    )
+
+    mock_call.assert_not_called()
+    assert backend.calls == [
+        {
+            "lookup_attributes": [{"AttributeKey": "ResourceName", "AttributeValue": "sg-1"}],
+            "duration_minutes": 30,
+            "max_results": 25,
+            "region": "us-east-1",
+        }
+    ]
+    assert result["available"] is True

--- a/tests/tools/test_cloudtrail_events.py
+++ b/tests/tools/test_cloudtrail_events.py
@@ -249,6 +249,39 @@ def test_max_results_clamped(mock_call) -> None:
 
 
 @patch("app.tools.CloudTrailEventsTool.execute_aws_sdk_call")
+def test_truncated_when_next_token_present(mock_call) -> None:
+    mock_call.return_value = {
+        "success": True,
+        "data": {"Events": [], "NextToken": "tok-abc"},
+    }
+
+    result = lookup_cloudtrail_events()
+
+    # A NextToken means more events exist beyond this page — surface it.
+    assert result["truncated"] is True
+    assert result["next_token"] == "tok-abc"
+
+
+@patch("app.tools.CloudTrailEventsTool.execute_aws_sdk_call")
+def test_not_truncated_without_next_token(mock_call) -> None:
+    mock_call.return_value = {"success": True, "data": {"Events": []}}
+
+    result = lookup_cloudtrail_events()
+
+    assert result["truncated"] is False
+    assert result["next_token"] is None
+
+
+@patch("app.tools.CloudTrailEventsTool.execute_aws_sdk_call")
+def test_next_token_forwarded_to_api(mock_call) -> None:
+    mock_call.return_value = {"success": True, "data": {"Events": []}}
+
+    lookup_cloudtrail_events(next_token="tok-page-2")
+
+    assert mock_call.call_args.kwargs["parameters"]["NextToken"] == "tok-page-2"
+
+
+@patch("app.tools.CloudTrailEventsTool.execute_aws_sdk_call")
 def test_lookup_failure(mock_call) -> None:
     mock_call.return_value = {"success": False, "error": "ThrottlingException"}
 

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -944,6 +944,7 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         "list_jenkins_running_builds",
         "list_s3_objects",
         "list_sentry_issue_events",
+        "lookup_cloudtrail_events",
         "opsgenie_alert_detail",
         "opsgenie_alerts",
         "prefect_flow_runs",


### PR DESCRIPTION

Fixes #2686

#### Describe the changes you have made in this PR

Adds a thin, planner-selectable **CloudTrail** wrapper tool — OpenSRE's first AWS change-causality source — so an investigation can answer *"who changed what, and when?"* (IAM changes, security-group mutations, EKS/Lambda config updates, deletions) at the start of an AWS post-mortem.

**Tool** — `lookup_cloudtrail_events` (`app/tools/CloudTrailEventsTool/`)
- Calls `execute_aws_sdk_call(service_name='cloudtrail', operation_name='lookup_events', ...)` — already on the read-only allowlist (`^lookup_.*`), so it cannot mutate anything.
- CloudTrail allows **one** `LookupAttribute` per call, so the tool exposes `resource_name` / `event_source` / `username` filters and sends the most specific one provided (resource → principal → source); `duration_minutes` is converted to the `StartTime`/`EndTime` window (clamped to CloudTrail's 90-day / 50-event limits).
- Shapes each event down to the high-signal forensic fields (event name/time, principal, resource, source IP, region, error code), parsed out of the `CloudTrailEvent` JSON blob. Response shape mirrors `RDSEventsTool`, including the synthetic `aws_backend` short-circuit.

**Wiring**
- `app/integrations/cloudtrail.py` — `cloudtrail_is_available` / `cloudtrail_extract_params` ride on the account-level `aws` integration (reusing `AWSIntegrationConfig` and the creds already wired via the EKS/CloudWatch path), since CloudTrail is account-wide, not tied to one resource.
- Registers `cloudtrail` in the `EvidenceSource` literal.
- **Auto-seeds and prioritizes** CloudTrail for AWS-originating alerts (`cloudwatch` / `eks` / `alertmanager`) in **both** `app/agent/investigation.py` (seeding) and `app/agent/prompt.py` (prioritization), so change-causality is pulled in automatically.

**Docs / tests**
- `docs/cloudtrail_events.mdx`, registered in `docs/docs.json`.
- `tests/tools/test_cloudtrail_events.py` — schema, availability (×4), extraction (×3), filter priority, time-window clamping, response shaping, discovery, the `aws_backend` short-circuit, and the two-map seeding/prioritization guard. Tool classified in `test_telemetry.py`.

**Notes:** no new dependencies (boto3/botocore present). `execute_aws_sdk_call` authenticates via boto3's default credential chain (env / `~/.aws`), consistent with the existing RDS/EKS tools.

### Demo/Screenshot for feature changes and bug fixes

Validated against a **real AWS account** (CloudTrail management events, `us-east-1`):
 **End-to-end RCA** — a CloudWatch-sourced alert auto-seeds CloudTrail; the agent finds `AuthorizeSecurityGroupIngress` opening `0.0.0.0/0:22` on `opensre-demo-sg` by user `tola` and cites it as the root cause:


<img width="2148" height="1277" alt="cloudtrail-rca-investigation" src="https://github.com/user-attachments/assets/18e88737-aa67-4fa7-a2ce-3b8f4ae22316" />



 
 
<img width="1784" height="696" alt="image" src="https://github.com/user-attachments/assets/1b9b9208-8709-46bd-8bd0-25fd2c9acd58" />



**Verification:** `make lint`, `make format-check`, `make typecheck` pass; CloudTrail tool tests pass; full unit suite green except the env-gated live-LLM routing tests (per CI.md §6).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The tool is intentionally thin: it reuses the existing read-only `execute_aws_sdk_call` allowlist path (so no new credential or safety surface) and mirrors `RDSEventsTool`'s shape. The interesting logic is CloudTrail-specific: it only accepts one `LookupAttribute`, so the tool picks the most specific filter provided and converts a `duration_minutes` window into the `StartTime`/`EndTime` pair, then trims each event to the forensic fields parsed from the `CloudTrailEvent` JSON. Availability rides on the account-level `aws` integration since CloudTrail is account-wide, and the tool is auto-seeded for AWS-originating alerts so "check CloudTrail" happens first — exactly how a real post-mortem starts.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

