### PR TITLE
fix(cli): remove welcome panel from root help

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -174,7 +174,7 @@ def cli(
             if config.enabled:
                 raise SystemExit(run_repl(config=config))
         click.echo("🚧 OpenSRE is in Public Beta — features may change.", err=True)
-        render_landing()
+        render_landing(cli)
         raise SystemExit(0)
 
 

--- a/app/cli/support/layout.py
+++ b/app/cli/support/layout.py
@@ -79,7 +79,7 @@ def _render_rows(
     rows: Sequence[tuple[str, str]],
     width: int | None = None,
 ) -> None:
-    effective_width = (width or max((len(label) for label, _ in rows), default=0)) + 2
+    effective_width = width + 2 if width is not None else max((len(label) for label, _ in rows), default=0) + 2
     console.print(Text.assemble((f"  {title}:", f"bold {TEXT}")))
     for label, description in rows:
         console.print(

--- a/app/cli/support/layout.py
+++ b/app/cli/support/layout.py
@@ -30,15 +30,6 @@ _LANDING_EXAMPLES: tuple[tuple[str, str], ...] = (
     ("opensre version", "Print detailed version, Python and OS info"),
 )
 
-_SHORT_OPTIONS: tuple[tuple[str, str], ...] = (
-    ("--json, -j", "Emit machine-readable JSON output."),
-    ("--verbose", "Print extra diagnostic information."),
-    ("--debug", "Print debug-level logs and traces."),
-    ("--yes, -y", "Auto-confirm all interactive prompts."),
-    ("--version", "Show the version and exit."),
-    ("-h, --help", "Show this message and exit."),
-)
-
 
 def _commands_from_group(group: click.Group) -> tuple[tuple[str, str], ...]:
     ctx = click.Context(group)
@@ -47,6 +38,20 @@ def _commands_from_group(group: click.Group) -> tuple[tuple[str, str], ...]:
         cmd = group.get_command(ctx, name)
         if cmd is not None and not cmd.hidden:
             rows.append((name, cmd.get_short_help_str(limit=200)))
+    return tuple(rows)
+
+
+def _options_from_command(command: click.Command) -> tuple[tuple[str, str], ...]:
+    ctx = click.Context(command)
+    rows: list[tuple[str, str]] = []
+    for param in command.get_params(ctx):
+        if getattr(param, "hidden", False):
+            continue
+        if not isinstance(param, click.Option):
+            continue
+        record = param.get_help_record(ctx)
+        if record is not None:
+            rows.append(record)
     return tuple(rows)
 
 
@@ -72,12 +77,17 @@ def _render_rows(
     *,
     title: str,
     rows: Sequence[tuple[str, str]],
-    width: int,
+    width: int | None = None,
 ) -> None:
+    effective_width = (width or max((len(label) for label, _ in rows), default=0)) + 2
     console.print(Text.assemble((f"  {title}:", f"bold {TEXT}")))
     for label, description in rows:
         console.print(
-            Text.assemble(("    ", ""), (f"{label:<{width}}", f"bold {BRAND}"), description)
+            Text.assemble(
+                ("    ", ""),
+                (f"{label:<{effective_width}}", f"bold {BRAND}"),
+                description,
+            )
         )
 
 
@@ -85,20 +95,22 @@ def render_help(group: click.Group) -> None:
     """Render the root help view, deriving the command list from the live Click group."""
     console = Console(highlight=False)
     commands = _commands_from_group(group)
-    console.print()
-    console.print(build_ready_panel(console))
+    options = _options_from_command(group)
     console.print()
     _render_usage(console)
     console.print()
     _render_rows(console, title="Commands", rows=commands, width=16)
     console.print()
-    _render_rows(console, title="Options", rows=_SHORT_OPTIONS, width=16)
+    _render_rows(console, title="Options", rows=options)
     console.print()
 
 
 def render_landing() -> None:
     """Render the root landing page shown with no subcommand."""
+    from app.cli.__main__ import cli
+
     console = Console(highlight=False)
+    options = _options_from_command(cli)
     console.print()
     console.print(build_ready_panel(console))
     console.print(
@@ -112,7 +124,7 @@ def render_landing() -> None:
     console.print()
     _render_rows(console, title="Quick start", rows=_LANDING_EXAMPLES, width=42)
     console.print()
-    _render_rows(console, title="Options", rows=_SHORT_OPTIONS, width=42)
+    _render_rows(console, title="Options", rows=options)
     console.print()
 
 

--- a/app/cli/support/layout.py
+++ b/app/cli/support/layout.py
@@ -79,7 +79,9 @@ def _render_rows(
     rows: Sequence[tuple[str, str]],
     width: int | None = None,
 ) -> None:
-    effective_width = width + 2 if width is not None else max((len(label) for label, _ in rows), default=0) + 2
+    effective_width = (
+        width + 2 if width is not None else max((len(label) for label, _ in rows), default=0) + 2
+    )
     console.print(Text.assemble((f"  {title}:", f"bold {TEXT}")))
     for label, description in rows:
         console.print(
@@ -105,12 +107,10 @@ def render_help(group: click.Group) -> None:
     console.print()
 
 
-def render_landing() -> None:
+def render_landing(group: click.Group) -> None:
     """Render the root landing page shown with no subcommand."""
-    from app.cli.__main__ import cli
-
     console = Console(highlight=False)
-    options = _options_from_command(cli)
+    options = _options_from_command(group)
     console.print()
     console.print(build_ready_panel(console))
     console.print(

--- a/tests/cli/test_layout.py
+++ b/tests/cli/test_layout.py
@@ -4,8 +4,8 @@ import click
 
 from app.cli.__main__ import cli
 from app.cli.support.layout import (
-    _SHORT_OPTIONS,
     RichGroup,
+    _options_from_command,
     render_help,
     render_landing,
 )
@@ -20,17 +20,16 @@ def test_render_help_shows_all_registered_commands(monkeypatch, capsys) -> None:
     render_help(cli)
     output = _normalized_output(capsys.readouterr().out)
 
-    assert "OpenSRE" in output
-    assert "Tips for getting started" in output
     assert "Usage: opensre [OPTIONS] [COMMAND] [ARGS]..." in output
     assert "Commands:" in output
     assert "Options:" in output
+    assert "Welcome back" not in output
 
     ctx = click.Context(cli)
     for name in cli.list_commands(ctx):
         assert name in output
 
-    for label, description in _SHORT_OPTIONS:
+    for label, description in _options_from_command(cli):
         assert label in output
         assert description in output
 
@@ -64,7 +63,7 @@ def test_render_landing_shows_header_and_examples(monkeypatch, capsys) -> None:
     assert "Quick start:" in output
     assert "Options:" in output
 
-    for label, description in _SHORT_OPTIONS:
+    for label, description in _options_from_command(cli):
         assert label in output
         assert description in output
 

--- a/tests/cli/test_layout.py
+++ b/tests/cli/test_layout.py
@@ -50,7 +50,7 @@ def test_render_help_command_list_matches_cli_registry(capsys) -> None:
 
 def test_render_landing_shows_header_and_examples(monkeypatch, capsys) -> None:
     monkeypatch.setattr("app.cli.interactive_shell.ui.banner._is_first_run", lambda: True)
-    render_landing()
+    render_landing(cli)
     output = _normalized_output(capsys.readouterr().out)
 
     assert "OpenSRE" in output

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -535,7 +535,7 @@ def test_no_interactive_falls_through_to_landing_page(monkeypatch) -> None:
     landing_calls: list[int] = []
     monkeypatch.setattr(
         "app.cli.__main__.render_landing",
-        lambda: landing_calls.append(1),
+        lambda _group: landing_calls.append(1),
     )
 
     # run_repl must NOT be invoked when config.enabled is False.
@@ -575,7 +575,7 @@ def test_default_no_args_enters_repl(monkeypatch) -> None:
     landing_calls: list[int] = []
     monkeypatch.setattr(
         "app.cli.__main__.render_landing",
-        lambda: landing_calls.append(1),
+        lambda _group: landing_calls.append(1),
     )
 
     with (

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -431,8 +431,11 @@ def test_opensre_help_smoke(cli_sandbox: CliSandbox) -> None:
     result = _run_cli(cli_sandbox, "-h")
 
     assert result.exit_code == 0
+    assert "Welcome back" not in result.stdout
     assert "Commands:" in result.stdout
     assert "integrations" in result.stdout
+    assert "--interactive / --no-interactive" in result.stdout
+    assert "--layout [classic|pinned]" in result.stdout
     assert "update" in result.stdout
 
 


### PR DESCRIPTION
Fixes #2748

#### Describe the changes you have made in this PR -
- remove the interactive welcome/dashboard panel from `opensre -h` so root help renders as help only
- generate the root options list from the live Click command metadata instead of a hardcoded tuple
- keep command coverage tests and smoke coverage aligned with the new help output

### Demo/Screenshot for feature changes and bug fixes - 
```text
$ uv run opensre -h

Usage: opensre [OPTIONS] [COMMAND] [ARGS]...
No COMMAND: start the interactive shell when stdin/stdout are TTYs.

Commands:
  agents
  config
  cron
  ...

Options:
  --version
  -j, --json
  --verbose
  --debug
  -y, --yes
  --interactive / --no-interactive
  --layout [classic|pinned]
  -h, --help
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- The root help output was mixing two concerns: a landing/dashboard panel and the actual CLI help screen. I kept the landing panel for the no-subcommand experience and removed it only from `opensre -h`.
- I replaced the hardcoded root option rows with a helper that reads option help records directly from the Click command object. That keeps root help current when CLI flags change and avoids future drift.
- I updated the layout and smoke tests to assert the new behavior: no welcome panel in help, and presence of live root options like `--interactive / --no-interactive` and `--layout [classic|pinned]`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

### Validation
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/cli/test_layout.py tests/cli/test_main.py::test_main_does_not_capture_analytics_for_help`
- `uv run python -m pytest tests/cli_smoke_test.py -k 'opensre_help_smoke or opensre_landing_page_smoke'`

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
