### PR TITLE
refactor(config): improve LLM provider configuration handling

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -15,7 +15,6 @@ import sys
 from contextlib import suppress
 
 import click
-from dotenv import load_dotenv
 
 from app.analytics.cli import build_cli_invoked_properties, capture_cli_invoked
 from app.analytics.provider import Properties, capture_first_run_if_needed, shutdown_analytics
@@ -27,6 +26,7 @@ from app.cli.support.prompt_support import (
     install_questionary_ctrl_c_double_exit,
     install_questionary_escape_cancel,
 )
+from app.utils.config import load_env
 from app.utils.sentry_sdk import capture_exception, init_sentry
 from app.version import get_version
 
@@ -215,7 +215,7 @@ def _should_capture_cli_exception(exc: click.ClickException) -> bool:
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``opensre`` console script."""
     _ensure_utf8_stdio()
-    load_dotenv(override=False)
+    load_env(override=False)
     cli_argv = list(sys.argv[1:] if argv is None else argv)
     try:
         init_sentry(entrypoint=_sentry_entrypoint_for_invocation(cli_argv))

--- a/app/config.py
+++ b/app/config.py
@@ -200,7 +200,8 @@ DEFAULT_LLM_RESOLUTION_FALLBACK_PROVIDERS: tuple[str, ...] = ("openai", "anthrop
 def get_configured_llm_provider() -> str:
     """Return the active LLM provider from env/project .env."""
     load_env(override=False)
-    return os.getenv("LLM_PROVIDER", "anthropic").strip().lower() or "anthropic"
+    provider = (os.getenv("LLM_PROVIDER") or "").strip().lower()
+    return provider or "anthropic"
 
 
 def get_llm_provider_api_key_env(provider: str | None = None) -> str | None:

--- a/app/utils/cfg_helpers.py
+++ b/app/utils/cfg_helpers.py
@@ -29,7 +29,10 @@ class CfgHelpers:
         Returns:
             str: The provider string.
         """
-        return (os.getenv("LLM_PROVIDER") or "anthropic").strip().lower()
+        from app.utils.config import load_env
+
+        load_env(override=False)
+        return CfgHelpers.get_clean_env_value("LLM_PROVIDER").lower() or "anthropic"
 
     @staticmethod
     def get_clean_env_value(env_key: str) -> str:

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -11,6 +11,8 @@ DEFAULT_INSTANCE_URL = "https://tracerbio.grafana.net"
 DEFAULT_LOKI_UID = "grafanacloud-logs"
 DEFAULT_TEMPO_UID = "grafanacloud-traces"
 DEFAULT_MIMIR_UID = "grafanacloud-prom"
+# Default project .env path — matches ``app.cli.wizard.config.PROJECT_ENV_PATH``.
+_DEFAULT_PROJECT_ENV_PATH = Path(__file__).resolve().parents[2] / ".env"
 
 
 def _get_env(key: str, default: str = "") -> str:
@@ -22,25 +24,50 @@ def get_env(key: str, default: str = "") -> str:
     return _get_env(key, default)
 
 
+def _env_file_paths(env_path: Path | str | None) -> tuple[Path, ...]:
+    """Return ordered, deduplicated .env paths (explicit > package default > cwd)."""
+    if env_path is not None:
+        return (Path(env_path),)
+    explicit = os.getenv("OPENSRE_PROJECT_ENV_PATH", "").strip()
+    if explicit:
+        # When the project env path is explicit, do not merge in the package or cwd
+        # .env files — onboard and CLI subprocess tests rely on that file alone.
+        return (Path(explicit),)
+    paths: list[Path] = [_DEFAULT_PROJECT_ENV_PATH]
+    cwd_env = Path.cwd() / ".env"
+    if cwd_env not in paths:
+        paths.append(cwd_env)
+    return tuple(paths)
+
+
+def _should_apply_env_file_value(key: str, *, override: bool) -> bool:
+    """True when a .env assignment should be applied to ``os.environ``."""
+    if override:
+        return True
+    current = os.environ.get(key)
+    if current is None:
+        return True
+    # Blank shell values (common on Windows) must not block onboarded .env settings.
+    return not current.strip()
+
+
 def load_env(env_path: Path | str | None = None, *, override: bool = False) -> None:
     if os.getenv("GRAFANA_CONFIG_SKIP_ENV_FILE") == "1":
         return
-    if env_path is None:
-        env_path = Path.cwd() / ".env"
-    path = Path(env_path)
-    if not path.exists():
-        return
-    for line in path.read_text().splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#") or stripped.startswith(";"):
+    for path in _env_file_paths(env_path):
+        if not path.exists():
             continue
-        if "=" not in stripped:
-            continue
-        key, value = stripped.split("=", 1)
-        key = key.strip()
-        value = value.strip().strip('"').strip("'")
-        if key and (override or key not in os.environ):
-            os.environ[key] = value
+        for line in path.read_text().splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#") or stripped.startswith(";"):
+                continue
+            if "=" not in stripped:
+                continue
+            key, value = stripped.split("=", 1)
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if key and _should_apply_env_file_value(key, override=override):
+                os.environ[key] = value
 
 
 def get_account_read_token(account_id: str) -> str:

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -12,7 +12,7 @@ DEFAULT_LOKI_UID = "grafanacloud-logs"
 DEFAULT_TEMPO_UID = "grafanacloud-traces"
 DEFAULT_MIMIR_UID = "grafanacloud-prom"
 # Default project .env path — matches ``app.cli.wizard.config.PROJECT_ENV_PATH``.
-_DEFAULT_PROJECT_ENV_PATH = Path(__file__).resolve().parents[2] / ".env"
+_DEFAULT_PROJECT_ENV_PATH = (Path(__file__).resolve().parents[2] / ".env").resolve()
 
 
 def _get_env(key: str, default: str = "") -> str:
@@ -28,13 +28,13 @@ def _env_file_paths(env_path: Path | str | None) -> tuple[Path, ...]:
     """Return ordered, deduplicated .env paths (explicit > package default > cwd)."""
     if env_path is not None:
         return (Path(env_path),)
-    explicit = os.getenv("OPENSRE_PROJECT_ENV_PATH", "").strip()
+    explicit = (os.getenv("OPENSRE_PROJECT_ENV_PATH") or "").strip()
     if explicit:
         # When the project env path is explicit, do not merge in the package or cwd
         # .env files — onboard and CLI subprocess tests rely on that file alone.
         return (Path(explicit),)
     paths: list[Path] = [_DEFAULT_PROJECT_ENV_PATH]
-    cwd_env = Path.cwd() / ".env"
+    cwd_env = (Path.cwd() / ".env").resolve()
     if cwd_env not in paths:
         paths.append(cwd_env)
     return tuple(paths)

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -51,6 +51,7 @@ _CLEARED_ENV_KEYS = (
     "NVIDIA_API_KEY",
     "OPENAI_API_KEY",
     "OPENROUTER_API_KEY",
+    "LLM_PROVIDER",
     "OPENCLAW_MCP_ARGS",
     "OPENCLAW_MCP_AUTH_TOKEN",
     "OPENCLAW_MCP_COMMAND",
@@ -206,10 +207,11 @@ def _is_python_script(path: Path) -> bool:
 
 def _cli_env(home: Path, project_env_path: Path) -> dict[str, str]:
     env = os.environ.copy()
-    # Blank values block ``load_dotenv(override=False)`` from re-importing the repo
-    # ``.env`` when subprocesses run with ``cwd=REPO_ROOT``.
+    # Drop host env keys so subprocesses don't inherit developer credentials or
+    # stale provider settings. Unset keys (not empty strings) allow onboarded
+    # project.env values to apply via load_env().
     for key in _CLEARED_ENV_KEYS:
-        env[key] = ""
+        env.pop(key, None)
 
     existing_pythonpath = env.get("PYTHONPATH", "")
     pythonpath_parts = [str(REPO_ROOT)]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,23 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from app.config import LLMSettings, has_credentials_for_active_llm_provider, resolve_llm_settings
+from app.config import (
+    LLMSettings,
+    get_configured_llm_provider,
+    has_credentials_for_active_llm_provider,
+    resolve_llm_settings,
+)
+
+
+def test_get_configured_llm_provider_reads_openai_when_shell_llm_provider_blank(
+    monkeypatch, tmp_path
+) -> None:
+    env_file = tmp_path / "project.env"
+    env_file.write_text("LLM_PROVIDER=openai\n", encoding="utf-8")
+    monkeypatch.setenv("LLM_PROVIDER", "")
+    monkeypatch.setenv("OPENSRE_PROJECT_ENV_PATH", str(env_file))
+
+    assert get_configured_llm_provider() == "openai"
 
 
 def test_llm_settings_reject_provider_typos_with_suggestion() -> None:
@@ -196,6 +212,7 @@ def test_resolve_llm_settings_falls_back_to_openai_when_default_anthropic_key_mi
 ) -> None:
     monkeypatch.delenv("LLM_PROVIDER", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("GRAFANA_CONFIG_SKIP_ENV_FILE", "1")
     monkeypatch.setattr(
         "app.config.resolve_llm_api_key",
         lambda env_var: "sk-openai" if env_var == "OPENAI_API_KEY" else "",

--- a/tests/utils/test_cfg_helpers.py
+++ b/tests/utils/test_cfg_helpers.py
@@ -111,6 +111,14 @@ def test_resolve_llm_provider_defaults_to_anthropic(monkeypatch) -> None:
         None.
     """
     monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.setenv("GRAFANA_CONFIG_SKIP_ENV_FILE", "1")
+
+    assert CfgHelpers.resolve_llm_provider() == "anthropic"
+
+
+def test_resolve_llm_provider_defaults_to_anthropic_when_blank(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "")
+    monkeypatch.setenv("GRAFANA_CONFIG_SKIP_ENV_FILE", "1")
 
     assert CfgHelpers.resolve_llm_provider() == "anthropic"
 

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -1,11 +1,13 @@
 import os
 from contextlib import contextmanager
+from pathlib import Path
 
 import pytest
 
 from app.utils.config import (
     apply_otel_env_defaults,
     configure_grafana_cloud,
+    load_env,
     validate_grafana_cloud_config,
 )
 
@@ -91,3 +93,36 @@ def test_validate_grafana_cloud_config_passes_when_present():
         }
     ):
         assert validate_grafana_cloud_config() is True
+
+
+def test_load_env_overrides_blank_shell_value_from_file(monkeypatch, tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("LLM_PROVIDER=openai\n", encoding="utf-8")
+    monkeypatch.setenv("LLM_PROVIDER", "")
+
+    load_env(env_file, override=False)
+
+    assert os.environ["LLM_PROVIDER"] == "openai"
+
+
+def test_load_env_does_not_override_non_blank_shell_value(monkeypatch, tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("LLM_PROVIDER=openai\n", encoding="utf-8")
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+
+    load_env(env_file, override=False)
+
+    assert os.environ["LLM_PROVIDER"] == "anthropic"
+
+
+def test_load_env_uses_opensre_project_env_path_when_unqualified(
+    monkeypatch, tmp_path: Path
+) -> None:
+    project_env = tmp_path / "project.env"
+    project_env.write_text("LLM_PROVIDER=openai\n", encoding="utf-8")
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.setenv("OPENSRE_PROJECT_ENV_PATH", str(project_env))
+
+    load_env(override=False)
+
+    assert os.environ["LLM_PROVIDER"] == "openai"

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -126,3 +126,21 @@ def test_load_env_uses_opensre_project_env_path_when_unqualified(
     load_env(override=False)
 
     assert os.environ["LLM_PROVIDER"] == "openai"
+
+
+def test_env_file_paths_deduplicates_symlinked_cwd_env(monkeypatch, tmp_path: Path) -> None:
+    from app.utils.config import _env_file_paths
+
+    package_env = tmp_path / "project" / ".env"
+    package_env.parent.mkdir(parents=True)
+    package_env.write_text("LLM_PROVIDER=openai\n", encoding="utf-8")
+
+    link_dir = tmp_path / "link"
+    link_dir.symlink_to(package_env.parent)
+    monkeypatch.chdir(link_dir)
+    monkeypatch.setattr(
+        "app.utils.config._DEFAULT_PROJECT_ENV_PATH",
+        package_env.resolve(),
+    )
+
+    assert _env_file_paths(None) == (package_env.resolve(),)


### PR DESCRIPTION
/fix #2113 

After onboarding with OpenAI, the interactive agent could still resolve the active LLM provider as anthropic and fail with ANTHROPIC_API_KEY missing — even though onboarding had written LLM_PROVIDER=openai to the project .env.

Root cause: blank or stale shell values (e.g. LLM_PROVIDER="", common on Windows) blocked .env reload because both load_dotenv(override=False) and load_env(override=False) treat empty strings as “already set.” Runtime then fell back to the anthropic default.

Changes
load_env() — treat blank shell env values as unset so onboarded .env values apply; align default load paths with onboarding (OPENSRE_PROJECT_ENV_PATH → package .env → cwd/.env); when OPENSRE_PROJECT_ENV_PATH is explicit, load only that file
CLI startup — replace load_dotenv() with load_env() so startup uses the same logic
Provider resolution — normalize blank LLM_PROVIDER before defaulting to anthropic in get_configured_llm_provider() and CfgHelpers.resolve_llm_provider()
Smoke tests — subprocess env isolation updated (unset keys instead of ""; clear LLM_PROVIDER from host env)
<img width="740" height="103" alt="Screenshot 2026-06-05 at 10 08 46 AM" src="https://github.com/user-attachments/assets/5eaa556e-a730-4cbc-b04c-ec4048a74d2f" />

<img width="740" height="103" alt="Screenshot 2026-06-05 at 10 19 39 AM" src="https://github.com/user-attachments/assets/c2eca80c-2632-4cb7-a40e-9ed1f3797d3e" />
