### PR TITLE
fix(bench, CI): calling real EKS during bench running

### DIFF
--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -104,6 +104,24 @@ class ConnectedInvestigationAgent:
         """
         return True, None
 
+    def _filter_tools(
+        self,
+        tools: list[RegisteredTool],
+    ) -> list[RegisteredTool]:
+        """Hook: narrow the tool list the agent will see.
+
+        Called once at the start of ``run`` after the registry has produced
+        the candidate set for the resolved integrations. Default returns the
+        input unchanged — production agents expose every available tool.
+
+        Bench subclasses override this to restrict the agent to tools whose
+        results are deterministic in the bench environment (e.g. replay-backed
+        tools), preventing real-world integration tools (production EKS API
+        calls, Hermes log tailing, etc.) from being chosen and burning calls
+        on AccessDenied / network errors.
+        """
+        return tools
+
     def run(
         self,
         state: dict[str, Any],
@@ -137,7 +155,7 @@ class ConnectedInvestigationAgent:
             _emit("tool_end", _tool_event_payload(tc, output=output))
 
         resolved = state.get("resolved_integrations") or {}
-        tools = _get_available_tools(resolved)
+        tools = self._filter_tools(_get_available_tools(resolved))
         tool_context = _build_connected_tool_context(resolved, tools)
         state["available_sources"] = tool_context["available_sources"]
         state["available_action_names"] = tool_context["available_action_names"]

--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -111,14 +111,14 @@ class ConnectedInvestigationAgent:
         """Hook: narrow the tool list the agent will see.
 
         Called once at the start of ``run`` after the registry has produced
-        the candidate set for the resolved integrations. Default returns the
-        input unchanged — production agents expose every available tool.
+        the candidate set for the resolved integrations and before
+        ``_build_connected_tool_context`` derives ``state["available_sources"]``
+        and ``state["available_action_names"]`` — anything dropped here is
+        also dropped from those state fields.
 
-        Bench subclasses override this to restrict the agent to tools whose
-        results are deterministic in the bench environment (e.g. replay-backed
-        tools), preventing real-world integration tools (production EKS API
-        calls, Hermes log tailing, etc.) from being chosen and burning calls
-        on AccessDenied / network errors.
+        Default returns the input unchanged. Subclasses can override to
+        implement any policy that restricts tool availability per agent
+        instance (e.g. enforce an allowlist for an isolated execution mode).
         """
         return tools
 

--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -26,12 +26,11 @@ _SKIP_MODULE_NAMES = {
     "utils",
 }
 
-# Extension point: callers outside ``app.tools.*`` (e.g. test suites,
-# external benchmark harnesses, downstream integrators) can register
-# additional tool packages by calling
-# :func:`register_external_tool_package`. Registered packages are walked
-# the same way as :mod:`app.tools` — each top-level submodule is imported
-# and any ``@tool``-decorated callables are picked up.
+# Extension point: callers outside ``app.tools.*`` can register additional
+# tool packages by calling :func:`register_external_tool_package`.
+# Registered packages are walked the same way as :mod:`app.tools` — each
+# top-level submodule is imported and any ``@tool``-decorated callables
+# are picked up.
 #
 # Production stays clean: with no external registrations, the registry
 # discovers only ``app.tools.*``. The list is *not* persisted across
@@ -49,13 +48,13 @@ def register_external_tool_package(package: ModuleType) -> None:
 
     Idempotent and thread-safe: concurrent callers registering the same
     package (e.g. multiple workers in a ``ThreadPoolExecutor`` each
-    importing a bench package) won't add duplicate entries that would
-    otherwise produce noisy ``Duplicate tool name`` warnings on every
-    subsequent registry walk.
+    importing the same extension on first use) won't add duplicate
+    entries that would otherwise produce noisy ``Duplicate tool name``
+    warnings on every subsequent registry walk.
 
-    Production code does NOT call this — it's a hook for test suites
-    and external integrators that ship their own tools but want them
-    routed through opensre's agent loop.
+    Production code does NOT call this — it's an extension point for
+    callers outside ``app.tools.*`` that ship their own tools but want
+    them routed through opensre's agent loop.
     """
     with _external_registration_lock:
         if package in _external_tool_packages:

--- a/tests/benchmarks/cloudopsbench/bench_agent.py
+++ b/tests/benchmarks/cloudopsbench/bench_agent.py
@@ -26,7 +26,17 @@ case, so a stubborn model can't infinite-loop.
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 from app.agent.investigation import ConnectedInvestigationAgent
+from app.tools.registered_tool import RegisteredTool
+
+# Tools available to the bench agent are exactly those registered by the
+# bench-specific package. Production opensre tools (real EKS API calls,
+# Hermes log tailing, etc.) would hit live infrastructure that the bench
+# task role intentionally cannot reach — burning calls on AccessDenied
+# instead of returning deterministic replay data.
+_BENCH_TOOL_MODULE_PREFIX = "tests.benchmarks.cloudopsbench.tools."
 
 
 class BenchInvestigationAgent(ConnectedInvestigationAgent):
@@ -39,6 +49,7 @@ class BenchInvestigationAgent(ConnectedInvestigationAgent):
     """
 
     MIN_TOOL_CALLS = 8
+    ALLOWED_TOOL_MODULE_PREFIXES: ClassVar[tuple[str, ...]] = (_BENCH_TOOL_MODULE_PREFIX,)
 
     def _should_accept_conclusion(
         self,
@@ -55,3 +66,16 @@ class BenchInvestigationAgent(ConnectedInvestigationAgent):
             f"you haven't queried, or evidence that would support OR "
             f"contradict your current hypothesis."
         )
+
+    def _filter_tools(
+        self,
+        tools: list[RegisteredTool],
+    ) -> list[RegisteredTool]:
+        """Restrict to bench-package tools by origin module.
+
+        Filtering by ``origin_module`` instead of an explicit name list means
+        a new bench tool added under ``tests/benchmarks/cloudopsbench/tools/``
+        is picked up automatically — no risk of the whitelist drifting out
+        of sync with the tool registry.
+        """
+        return [t for t in tools if t.origin_module.startswith(self.ALLOWED_TOOL_MODULE_PREFIXES)]

--- a/tests/benchmarks/cloudopsbench/bench_agent.py
+++ b/tests/benchmarks/cloudopsbench/bench_agent.py
@@ -26,16 +26,27 @@ case, so a stubborn model can't infinite-loop.
 
 from __future__ import annotations
 
+import logging
 from typing import ClassVar
 
 from app.agent.investigation import ConnectedInvestigationAgent
 from app.tools.registered_tool import RegisteredTool
+
+logger = logging.getLogger(__name__)
 
 # Tools available to the bench agent are exactly those registered by the
 # bench-specific package. Production opensre tools (real EKS API calls,
 # Hermes log tailing, etc.) would hit live infrastructure that the bench
 # task role intentionally cannot reach — burning calls on AccessDenied
 # instead of returning deterministic replay data.
+#
+# Trailing dot is deliberate: it matches anything UNDER the package, not
+# the package root itself. The registry only auto-discovers submodules
+# (via ``pkgutil.iter_modules``), so a tool whose ``origin_module`` is
+# exactly the root is theoretical — but if you register a single-file
+# bench tool module directly via :func:`register_external_tool_package`,
+# its ``origin_module`` will be the root and it'll be dropped here. Use
+# a submodule (e.g. ``tools/k8s/__init__.py``) instead.
 _BENCH_TOOL_MODULE_PREFIX = "tests.benchmarks.cloudopsbench.tools."
 
 
@@ -77,5 +88,34 @@ class BenchInvestigationAgent(ConnectedInvestigationAgent):
         a new bench tool added under ``tests/benchmarks/cloudopsbench/tools/``
         is picked up automatically — no risk of the whitelist drifting out
         of sync with the tool registry.
+
+        Silent-exclusion edge cases to know about (rare today, but possible
+        if someone adds a tool in an unconventional way):
+          - A tool whose ``origin_module`` is exactly the prefix root (no
+            trailing submodule) is dropped — see the comment on
+            ``_BENCH_TOOL_MODULE_PREFIX``.
+          - A tool whose ``origin_module`` defaults to the empty string
+            (e.g. directly-constructed ``RegisteredTool(...)`` without
+            ``origin_module=`` set) is also dropped, and logged at
+            WARNING so the registry bug surfaces in the run log instead
+            of silently shrinking the bench tool set.
         """
-        return [t for t in tools if t.origin_module.startswith(self.ALLOWED_TOOL_MODULE_PREFIXES)]
+        kept: list[RegisteredTool] = []
+        dropped: list[str] = []
+        for tool in tools:
+            if not tool.origin_module:
+                logger.warning(
+                    "Bench filter dropping tool %r with empty origin_module — "
+                    "registry bug: tool was constructed without origin_module=. "
+                    "Set it explicitly so the bench can keep it.",
+                    tool.name,
+                )
+                dropped.append(f"{tool.name} (no origin_module)")
+                continue
+            if tool.origin_module.startswith(self.ALLOWED_TOOL_MODULE_PREFIXES):
+                kept.append(tool)
+            else:
+                dropped.append(f"{tool.name} ({tool.origin_module})")
+        if dropped:
+            logger.debug("Bench filter dropped %d tool(s): %s", len(dropped), ", ".join(dropped))
+        return kept

--- a/tests/benchmarks/cloudopsbench/test_bench_agent.py
+++ b/tests/benchmarks/cloudopsbench/test_bench_agent.py
@@ -139,3 +139,39 @@ def test_bench_agent_allowed_prefixes_is_class_attribute_for_override() -> None:
     prod_hermes = _make_registered_tool("HermesLogs", "app.tools.HermesLogsTool")
     filtered = _MixedBench()._filter_tools([bench_tool, prod_eks, prod_hermes])
     assert filtered == [bench_tool, prod_eks]
+
+
+def test_bench_agent_filter_drops_tool_at_prefix_root_without_submodule() -> None:
+    """Trailing-dot guard: a tool whose origin_module equals the prefix
+    ROOT (no submodule) is dropped, matching the comment on
+    ``_BENCH_TOOL_MODULE_PREFIX``. The registry's pkgutil walk never
+    produces this state for auto-discovered tools, but a direct
+    ``register_external_tool_package`` against a single-file module would —
+    the test pins the documented behavior so future contributors who hit
+    it can find this commit."""
+    at_root = _make_registered_tool(
+        "AtRoot",
+        "tests.benchmarks.cloudopsbench.tools",  # no trailing submodule
+    )
+    bench_submodule = _make_registered_tool(
+        "GetResources", "tests.benchmarks.cloudopsbench.tools.k8s"
+    )
+    filtered = BenchInvestigationAgent()._filter_tools([at_root, bench_submodule])
+    assert filtered == [bench_submodule]
+
+
+def test_bench_agent_filter_warns_on_empty_origin_module(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``origin_module`` defaults to "" on directly-constructed RegisteredTool.
+    Such a tool is dropped silently if we don't surface it — the bench
+    would quietly run with fewer tools and the user would never know.
+    We warn at WARNING so the registry bug shows up in the run log."""
+    no_origin = _make_registered_tool("Orphan", "")
+    bench_tool = _make_registered_tool("GetResources", "tests.benchmarks.cloudopsbench.tools.k8s")
+    with caplog.at_level("WARNING"):
+        filtered = BenchInvestigationAgent()._filter_tools([no_origin, bench_tool])
+    assert filtered == [bench_tool]
+    # The warning must name the offending tool so an operator can find it
+    # in the registry.
+    assert any("Orphan" in r.message and "empty origin_module" in r.message for r in caplog.records)

--- a/tests/benchmarks/cloudopsbench/test_bench_agent.py
+++ b/tests/benchmarks/cloudopsbench/test_bench_agent.py
@@ -5,7 +5,24 @@ from __future__ import annotations
 import pytest
 
 from app.agent.investigation import ConnectedInvestigationAgent
+from app.tools.registered_tool import RegisteredTool
 from tests.benchmarks.cloudopsbench.bench_agent import BenchInvestigationAgent
+
+
+def _make_registered_tool(name: str, origin_module: str) -> RegisteredTool:
+    """Build a minimal RegisteredTool stub for tool-filter tests.
+
+    We don't exercise the tool — only the registry metadata used by
+    ``_filter_tools`` — so the schema/run callable can be no-op placeholders.
+    """
+    return RegisteredTool(
+        name=name,
+        description=f"Stub tool {name}",
+        input_schema={"type": "object"},
+        source="eks",
+        run=lambda **_: None,
+        origin_module=origin_module,
+    )
 
 
 def test_bench_agent_is_subclass_of_production_agent() -> None:
@@ -69,3 +86,56 @@ def test_bench_agent_threshold_is_class_attribute_for_easy_override() -> None:
     agent = _RelaxedBench()
     accept, _ = agent._should_accept_conclusion(evidence_count=3, iteration=2)
     assert accept is True
+
+
+def test_production_agent_filter_tools_is_identity() -> None:
+    """Default ``_filter_tools`` must return the input unchanged so production
+    investigations continue to see every available tool. Regressing this
+    silently disables tools across the entire product."""
+    tools = [
+        _make_registered_tool("EKSListClusters", "app.tools.EKSListClustersTool"),
+        _make_registered_tool("HermesLogs", "app.tools.HermesLogsTool"),
+    ]
+    assert ConnectedInvestigationAgent()._filter_tools(tools) == tools
+
+
+def test_bench_agent_filter_keeps_only_bench_package_tools() -> None:
+    """The bench agent must hide production opensre tools that would hit
+    real AWS / Hermes endpoints the bench task role cannot reach. Whitelist
+    is by origin_module prefix so a new bench tool added under
+    ``tests/benchmarks/cloudopsbench/tools/`` is picked up automatically."""
+    bench_tool = _make_registered_tool("GetResources", "tests.benchmarks.cloudopsbench.tools.k8s")
+    prod_eks = _make_registered_tool("EKSListClusters", "app.tools.EKSListClustersTool")
+    prod_hermes = _make_registered_tool("HermesLogs", "app.tools.HermesLogsTool")
+    filtered = BenchInvestigationAgent()._filter_tools([bench_tool, prod_eks, prod_hermes])
+    assert filtered == [bench_tool]
+
+
+def test_bench_agent_filter_drops_everything_when_no_bench_tools_registered() -> None:
+    """Defensive: if the bench package failed to register (import error,
+    missing module) and only production tools are visible, the bench agent
+    should return an empty list rather than fall back to production tools.
+    The ``run`` loop already logs a warning when no tools are available."""
+    only_prod = [
+        _make_registered_tool("EKSListClusters", "app.tools.EKSListClustersTool"),
+        _make_registered_tool("HermesLogs", "app.tools.HermesLogsTool"),
+    ]
+    assert BenchInvestigationAgent()._filter_tools(only_prod) == []
+
+
+def test_bench_agent_allowed_prefixes_is_class_attribute_for_override() -> None:
+    """Mirrors the MIN_TOOL_CALLS convention — a one-off experiment can
+    widen or narrow the prefix tuple without rebuilding the instance or
+    duplicating the hook method."""
+
+    class _MixedBench(BenchInvestigationAgent):
+        ALLOWED_TOOL_MODULE_PREFIXES = (
+            "tests.benchmarks.cloudopsbench.tools.",
+            "app.tools.EKSListClustersTool",  # add a single production tool
+        )
+
+    bench_tool = _make_registered_tool("GetResources", "tests.benchmarks.cloudopsbench.tools.k8s")
+    prod_eks = _make_registered_tool("EKSListClusters", "app.tools.EKSListClustersTool")
+    prod_hermes = _make_registered_tool("HermesLogs", "app.tools.HermesLogsTool")
+    filtered = _MixedBench()._filter_tools([bench_tool, prod_eks, prod_hermes])
+    assert filtered == [bench_tool, prod_eks]


### PR DESCRIPTION
Fixes #2074 (fixing calling real EKS during bench running)

#### Describe the changes you have made in this PR -

Issues: still call real EKS during bench running:

```
June 5, 2026, 09:49 | Tool get_eks_events failed: AccessDeniedException: An error occurred (AccessDeniedException) when calling the DescribeCluster operation: User: arn:aws:sts::395261708130:assumed-role/opensre-bench-task/76e3713611064ea0b1ea69ab0f09ba0b is not authorized to perform: eks:DescribeCluster on resource: arn:aws:eks:us-east-1:395261708130:cluster/train-ticket because no identity-based policy allows the eks:DescribeCluster action
```

```
Tool get_eks_events failed: AccessDeniedException: An error occurred (AccessDeniedException) when calling the DescribeCluster operation: User: arn:aws:sts::395261708130:assumed-role/opensre-bench-task/76e3713611064ea0b1ea69ab0f09ba0b is not authorized to perform: eks:DescribeCluster on resource: arn:aws:eks:us-east-1:395261708130:cluster/cloudopsbench because no identity-based policy allows the eks:DescribeCluster action
```

```
June 5, 2026, 10:00 | botocore.errorfactory.AccessDeniedException: An error occurred (AccessDeniedException) when calling the DescribeCluster operation: User: arn:aws:sts::395261708130:assumed-role/opensre-bench-task/76e3713611064ea0b1ea69ab0f09ba0b is not authorized to perform: eks:DescribeCluster on resource: arn:aws:eks:us-east-1:395261708130:cluster/train-ticket because no identity-based policy allows the eks:DescribeCluster action
```

```
June 5, 2026, 10:07 | Tool get_eks_events failed: ClientError: An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:sts::395261708130:assumed-role/opensre-bench-task/76e3713611064ea0b1ea69ab0f09ba0b is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::account:role

```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Root cause.** The CloudOpsBench investigation agent was reaching into PRODUCTION opensre tools (`app/tools/EKSEventsTool/`, `app/tools/HermesLogsTool/`, etc.) that hit live AWS / Hermes endpoints. The bench Fargate task role intentionally cannot reach those — bench cases are supposed to run against deterministic State-Snapshot replay data per the Cloud-OpsBench paper protocol. Both production tools and bench-package tools were visible to the agent because the registry merges them and the agent's `tool_schemas` payload included everything.

*Fix.** One generic hook on the production agent, one override on the bench subclass:

| File | Change |
|---|---|
| `app/agent/investigation.py` | New `_filter_tools(self, tools)` hook on `ConnectedInvestigationAgent`. Default returns input unchanged. Wired into `run()` between `_get_available_tools(resolved)` and `_build_connected_tool_context(resolved, tools)`. Filtered tools also disappear from `state["available_sources"]` / `state["available_action_names"]` — agent is not told sources exist that it can't reach. Zero behavior change for production. |
| `tests/benchmarks/cloudopsbench/bench_agent.py` | `BenchInvestigationAgent` overrides `_filter_tools` to keep only tools whose `origin_module` starts with `tests.benchmarks.cloudopsbench.tools.`. Whitelist is a `ClassVar[tuple[str, ...]]` (`ALLOWED_TOOL_MODULE_PREFIXES`) so a one-off experiment can override without rebuilding the agent — same convention as `MIN_TOOL_CALLS`. |
| `tests/benchmarks/cloudopsbench/test_bench_agent.py` | 4 new tests: production default is identity, bench keeps only bench-package tools, bench returns empty when no bench tools registered (defensive), `ALLOWED_TOOL_MODULE_PREFIXES` is overridable. |

**Separation-of-concerns hygiene** in the same PR (same conceptual change — production code should not know about benchmarking):

| File | Change |
|---|---|
| `app/agent/investigation.py` (`_filter_tools` docstring) | Describes WHAT the hook does (filter tools, runs before state derivation) and WHEN to override it (allowlist policies). No mention of bench / replay / EKS / Hermes. |
| `app/tools/registry.py` (`register_external_tool_package` comment + docstring) | Removed "external benchmark harnesses" and "importing a bench package" examples. The mechanism is generic — production should not name a specific consumer when describing it. |



---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
