### PR TITLE
fix(tests): update correlation patch path after refactor

### DIFF
--- a/tests/pipeline/test_runners_agent_class.py
+++ b/tests/pipeline/test_runners_agent_class.py
@@ -60,7 +60,7 @@ def test_run_connected_investigation_uses_agent_class_when_provided() -> None:
     with (
         patch("app.agent.context.resolve_integrations", return_value={}),
         patch("app.agent.extract.extract_alert", return_value={"is_noise": False}),
-        patch("app.correlation.node.node_correlate_upstream", return_value={}),
+        patch("app.agent.correlation.node.node_correlate_upstream", return_value={}),
         patch("app.delivery.deliver", return_value={}),
     ):
         run_connected_investigation(state, agent_class=_SentinelAgent)
@@ -83,7 +83,7 @@ def test_run_connected_investigation_uses_default_agent_when_class_omitted() -> 
         patch(
             "app.agent.investigation.ConnectedInvestigationAgent.run", return_value={}
         ) as mock_run,
-        patch("app.correlation.node.node_correlate_upstream", return_value={}),
+        patch("app.agent.correlation.node.node_correlate_upstream", return_value={}),
         patch("app.delivery.deliver", return_value={}),
     ):
         run_connected_investigation(state)  # no agent_class kwarg
@@ -105,7 +105,7 @@ def test_run_investigation_forwards_agent_class_to_pipeline() -> None:
     with (
         patch("app.agent.context.resolve_integrations", return_value={}),
         patch("app.agent.extract.extract_alert", return_value={"is_noise": False}),
-        patch("app.correlation.node.node_correlate_upstream", return_value={}),
+        patch("app.agent.correlation.node.node_correlate_upstream", return_value={}),
         patch("app.delivery.deliver", return_value={}),
     ):
         run_investigation(raw_alert={"alert": "test"}, agent_class=_SentinelAgent)


### PR DESCRIPTION
Fixes failing pipeline tests after the correlation package move from `app.correlation` to `app.agent.correlation`.

The tests in `tests/pipeline/test_runners_agent_class.py` were still patching the old `node_correlate_upstream` import path, which caused:

`AttributeError: module 'app' has no attribute 'correlation'`

This PR updates the patch targets to match the new package location introduced by the correlation refactor.

Tested locally:

`pytest tests/pipeline/test_runners_agent_class.py -v`

<img width="1506" height="625" alt="Ekran görüntüsü 2026-06-05 163227" src="https://github.com/user-attachments/assets/b684b2dd-776c-4045-a276-635a4fd66c2b" />
