### PR TITLE
fix(deps): update YAML import statements and add types-PyYAML to dev …

### DIFF
--- a/app/cli/commands/config.py
+++ b/app/cli/commands/config.py
@@ -85,7 +85,7 @@ def _load_config() -> dict[str, Any]:
         return {}
 
     try:
-        import yaml  # type: ignore[import-untyped]
+        import yaml
 
         data = yaml.safe_load(path.read_text(encoding="utf-8"))
     except Exception as exc:  # noqa: BLE001
@@ -102,7 +102,7 @@ def _load_config() -> dict[str, Any]:
 
 
 def _save_config(data: dict[str, Any]) -> None:
-    import yaml  # type: ignore[import-untyped]
+    import yaml
 
     path = _config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -164,7 +164,7 @@ def config_show() -> None:
         click.echo(json.dumps(payload))
         return
 
-    import yaml  # type: ignore[import-untyped]
+    import yaml
 
     path = _config_path()
     click.echo(f"# {path} (on-disk values; environment variables do not override this output)")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,4 +179,5 @@ dev = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
     "types-psutil>=7.2.2.20260408",
+    "types-PyYAML>=6.0.12",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2009,6 +2009,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "types-psutil" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -2088,6 +2089,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "types-psutil", specifier = ">=7.2.2.20260408" },
+    { name = "types-pyyaml", specifier = ">=6.0.12" },
 ]
 
 [[package]]


### PR DESCRIPTION
…dependencies

Fixes #
chore(deps): add types-PyYAML stubs and remove yaml type ignores (#2590)

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
Added types-PyYAML>=6.0.12 to the [dependency-groups] dev list in pyproject.toml and removed three # type: ignore[import-untyped] comments from import yaml lines in app/cli/commands/config.py. With the stubs installed, mypy can now fully type-check all yaml usage without suppressions

### Demo/Screenshot for feature changes and bug fixes - 
<img width="1215" height="184" alt="Screenshot 2026-06-05 214611" src="https://github.com/user-attachments/assets/1086b6e4-83c6-422a-8277-54d9de3107b8" />
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->
What problem does your code solve?
The project uses import yaml in three places (app/cli/commands/config.py), but PyYAML doesn't ship inline type annotations. This required # type: ignore[import-untyped] on every import, suppressing mypy checks and weakening type coverage. Any misuses of the yaml API (wrong arguments, wrong return types) would go undetected

What alternative approaches did you consider?
1. Inline type stubs — writing a local yaml.pyi stub. This would need maintenance as PyYAML evolves.
2. Keeping the ignores — status quo, but leaves the type hole open.
3. Using a typed wrapper — wrapping yaml.safe_load/yaml.safe_dump in typed helper functions. Over-engineered for the problem

Why did you choose this specific implementation?
The types-PyYAML package from typeshed is the canonical solution — it's the same approach already used for types-psutil. It requires zero new code, zero behavioral changes, and is maintained by the community alongside CPython releases. Adding it to [dependency-groups] dev keeps it scoped to development (not runtime). The type: ignore comments were then removable in one clean sweep

What are the key functions/components and what do they do?
- pyproject.toml [dependency-groups] dev — declares types-PyYAML>=6.0.12 as a dev-only dependency, installed by uv sync --extra dev.
- app/cli/commands/config.py lines 88, 105, 167 — three import yaml statements. Removing the # type: ignore[import-untyped] lets mypy resolve yaml.safe_load, yaml.safe_dump etc. against the stubs and catch real type errors.
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
