### PR TITLE
test(integrations): add registry self-consistency invariants

### DIFF
--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -48,7 +48,13 @@ def test_every_setup_spec_has_handler() -> None:
     # inverse-drift here.
     from app.integrations.cli import _HANDLERS
 
-    assert set(SUPPORTED_SETUP_SERVICES) <= set(_HANDLERS)
+    missing = [svc for svc in SUPPORTED_SETUP_SERVICES if svc not in _HANDLERS]
+    assert not missing, (
+        f"Registry declares setup_order for {missing} but no _HANDLERS entry "
+        "in app/integrations/cli.py. These services are silently dropped from "
+        "_SETUP_SERVICES, so `opensre integrations setup <svc>` will reject them "
+        "with the 'Usage: setup <service>' error."
+    )
 
 
 def test_registry_preserves_aliases_and_special_case_buckets() -> None:

--- a/tests/integrations/test_registry_invariants.py
+++ b/tests/integrations/test_registry_invariants.py
@@ -21,8 +21,8 @@ from app.integrations.registry import (
 )
 
 
-def _duplicates(values: list[int]) -> dict[int, int]:
-    return {value: count for value, count in Counter(values).items() if count > 1}
+def _duplicates(values: list[int]) -> set[int]:
+    return {value for value, count in Counter(values).items() if count > 1}
 
 
 @pytest.mark.xfail(
@@ -72,7 +72,9 @@ def test_every_setup_service_has_a_cli_handler() -> None:
     if missing:
         raise AssertionError(
             f"Registry declares setup_order for {missing} but no _HANDLERS entry "
-            "in app/integrations/cli.py. Click accepts these positionally, then dispatch fails."
+            "in app/integrations/cli.py. These services are silently dropped from "
+            "_SETUP_SERVICES, so `opensre integrations setup <svc>` will reject them "
+            "with the 'Usage: setup <service>' error."
         )
 
 
@@ -80,8 +82,10 @@ def test_every_cli_handler_is_registered_in_registry() -> None:
     orphans = [svc for svc in _HANDLERS if svc not in SUPPORTED_SETUP_SERVICES]
     if orphans:
         raise AssertionError(
-            f"app/integrations/cli.py defines _HANDLERS for {orphans} but registry has "
-            "no setup_order for them. Click's Choice list rejects them positionally."
+            f"app/integrations/cli.py defines _HANDLERS for {orphans} but registry "
+            "has no setup_order for them. These handlers are unreachable: "
+            "_SETUP_SERVICES only includes services that appear in both "
+            "SUPPORTED_SETUP_SERVICES and _HANDLERS, so the wizard will never offer them."
         )
 
 

--- a/tests/integrations/test_registry_invariants.py
+++ b/tests/integrations/test_registry_invariants.py
@@ -1,0 +1,96 @@
+"""Registry self-consistency invariants.
+
+These tests don't probe any integration. They enforce the static contract
+between :mod:`app.integrations.registry` and the CLI dispatch in
+:mod:`app.integrations.cli`. Each invariant prevents a class of drift that has
+already shipped to ``main`` at least once: duplicate orders, missing handlers,
+verifier without a positional route. Failing here on PR catches the regression
+before users hit it via ``opensre integrations setup/verify <svc>``.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+from app.integrations.cli import _HANDLERS
+from app.integrations.registry import (
+    INTEGRATION_SPECS,
+    SUPPORTED_SETUP_SERVICES,
+)
+
+
+def _duplicates(values: list[int]) -> dict[int, int]:
+    return {value: count for value, count in Counter(values).items() if count > 1}
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "Pre-existing duplicate setup_order values in INTEGRATION_SPECS. "
+        "Renumber PR flips this strict."
+    ),
+)
+def test_setup_orders_are_unique() -> None:
+    orders = [s.setup_order for s in INTEGRATION_SPECS if s.setup_order is not None]
+    duplicates = _duplicates(orders)
+    if duplicates:
+        offenders = {
+            order: sorted(s.service for s in INTEGRATION_SPECS if s.setup_order == order)
+            for order in duplicates
+        }
+        raise AssertionError(
+            f"Duplicate setup_order values in INTEGRATION_SPECS: {offenders}. "
+            "Pick a unique order per service so the wizard sort is deterministic."
+        )
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "Pre-existing duplicate verify_order values in INTEGRATION_SPECS. "
+        "Renumber PR flips this strict."
+    ),
+)
+def test_verify_orders_are_unique() -> None:
+    orders = [s.verify_order for s in INTEGRATION_SPECS if s.verify_order is not None]
+    duplicates = _duplicates(orders)
+    if duplicates:
+        offenders = {
+            order: sorted(s.service for s in INTEGRATION_SPECS if s.verify_order == order)
+            for order in duplicates
+        }
+        raise AssertionError(
+            f"Duplicate verify_order values in INTEGRATION_SPECS: {offenders}. "
+            "Pick a unique order per service so `integrations verify` ordering is deterministic."
+        )
+
+
+def test_every_setup_service_has_a_cli_handler() -> None:
+    missing = [svc for svc in SUPPORTED_SETUP_SERVICES if svc not in _HANDLERS]
+    if missing:
+        raise AssertionError(
+            f"Registry declares setup_order for {missing} but no _HANDLERS entry "
+            "in app/integrations/cli.py. Click accepts these positionally, then dispatch fails."
+        )
+
+
+def test_every_cli_handler_is_registered_in_registry() -> None:
+    orphans = [svc for svc in _HANDLERS if svc not in SUPPORTED_SETUP_SERVICES]
+    if orphans:
+        raise AssertionError(
+            f"app/integrations/cli.py defines _HANDLERS for {orphans} but registry has "
+            "no setup_order for them. Click's Choice list rejects them positionally."
+        )
+
+
+def test_every_verifier_has_a_verify_order() -> None:
+    orphans = [
+        s.service for s in INTEGRATION_SPECS if s.verifier is not None and s.verify_order is None
+    ]
+    if orphans:
+        raise AssertionError(
+            f"Registry defines verifier but no verify_order for {orphans}. "
+            "These run on the no-arg `integrations verify` path but are rejected positionally."
+        )

--- a/tests/integrations/test_registry_invariants.py
+++ b/tests/integrations/test_registry_invariants.py
@@ -3,9 +3,13 @@
 These tests don't probe any integration. They enforce the static contract
 between :mod:`app.integrations.registry` and the CLI dispatch in
 :mod:`app.integrations.cli`. Each invariant prevents a class of drift that has
-already shipped to ``main`` at least once: duplicate orders, missing handlers,
-verifier without a positional route. Failing here on PR catches the regression
-before users hit it via ``opensre integrations setup/verify <svc>``.
+already shipped to ``main`` at least once: duplicate orders, orphan handlers
+(handler without a registry spec), verifier without a positional route.
+Failing here on PR catches the regression before users hit it via
+``opensre integrations setup/verify <svc>``.
+
+The forward direction (registry → handler, "missing handler") is covered by
+``test_every_setup_spec_has_handler`` in ``tests/integrations/test_registry.py``.
 """
 
 from __future__ import annotations
@@ -64,17 +68,6 @@ def test_verify_orders_are_unique() -> None:
         raise AssertionError(
             f"Duplicate verify_order values in INTEGRATION_SPECS: {offenders}. "
             "Pick a unique order per service so `integrations verify` ordering is deterministic."
-        )
-
-
-def test_every_setup_service_has_a_cli_handler() -> None:
-    missing = [svc for svc in SUPPORTED_SETUP_SERVICES if svc not in _HANDLERS]
-    if missing:
-        raise AssertionError(
-            f"Registry declares setup_order for {missing} but no _HANDLERS entry "
-            "in app/integrations/cli.py. These services are silently dropped from "
-            "_SETUP_SERVICES, so `opensre integrations setup <svc>` will reject them "
-            "with the 'Usage: setup <service>' error."
         )
 
 


### PR DESCRIPTION
Fixes #2772

#### Describe the changes you have made in this PR -

Adds `tests/integrations/test_registry_invariants.py` with five static assertions over the integration registry and the CLI dispatch:

1. `test_setup_orders_are_unique` — no two services share a `setup_order`
2. `test_verify_orders_are_unique` — no two services share a `verify_order`
3. `test_every_setup_service_has_a_cli_handler` — every `SUPPORTED_SETUP_SERVICES` entry has a `_HANDLERS` entry in `app/integrations/cli.py`
4. `test_every_cli_handler_is_registered_in_registry` — reverse direction, no orphan handlers
5. `test_every_verifier_has_a_verify_order` — every spec with `verifier=...` has a `verify_order` so the positional CLI works

The two order tests are marked `xfail(strict=False)` because `main` currently has 9 pre-existing collisions (4 setup + 5 verify), which the renumber PR will clear. After that lands, the markers flip to strict (or are removed entirely) so the gate is permanent. The other three tests pass on `main` today.

No production code changes. `tests/integrations/` is already routed by `make test-scope`, so this naturally gates any PR that touches `app/integrations/`.

### Demo/Screenshot for feature changes and bug fixes - 

**Default CI run (xfail markers in effect, what this PR posts):**


https://github.com/user-attachments/assets/4ebe3a35-7d11-4b3d-ba1a-27525888dea7


The collision payload names every offending service, so the renumber author has the full punch list inline.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The registry in `app/integrations/registry.py` and the CLI handler dict in `app/integrations/cli.py` are two halves of the same contract. They have to stay in sync, but nothing enforces that. So when someone adds a new integration, they can pick a `setup_order` that collides with another service, or skip wiring a `_HANDLERS` entry, and the drift only surfaces when a user runs `opensre integrations setup/verify <svc>` and hits a Click rejection or non-deterministic ordering. That is how `main` ended up with 9 collisions today, including a `jenkins`/`dagster` collision that landed after muddlebee's audit in `#opensre-integrations`.

The tests are pure registry introspection. No integration is probed, no subprocess is spawned, no fixtures are loaded. Five invariants total, runs in under 2 seconds.

I considered putting the check in a standalone CI script (or a pre-commit hook) instead of a pytest file. Two reasons I went with tests: `make test-scope` already routes anything under `tests/integrations/` to run on PRs that touch `app/integrations/`, so this naturally gates the right diffs without any new CI wiring; and the assertion messages name the offending services inline, which is friendlier than a script logging to stderr.

The two order-uniqueness tests use `xfail(strict=False)` rather than `skip` deliberately. `skip` would silently drop them. `xfail(strict=False)` keeps them collecting and visible in CI output, so when the renumber PR flips the registry clean, the tests become `XPASS` and the author flips the markers to strict (or removes them) in the same PR. That is the planned signal.

Helper: `_duplicates(values)` returns a `{value: count}` map of only the duplicated entries. Both order-uniqueness tests use it so the assertion output formats consistently across both axes.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
