### PR TITLE
fix(bench): seed ANTHROPIC_API_KEY in llm_alone dispatch acceptance test

### DIFF
--- a/tests/benchmarks/_framework/tests/test_runner_llm_alone_dispatch.py
+++ b/tests/benchmarks/_framework/tests/test_runner_llm_alone_dispatch.py
@@ -162,11 +162,14 @@ def test_run_inner_refuses_llm_alone_when_adapter_has_no_baseline(tmp_path: Path
     assert "no-baseline" in str(exc_info.value)
 
 
-def test_run_inner_accepts_llm_alone_when_adapter_provides_baseline(tmp_path: Path) -> None:
+def test_run_inner_accepts_llm_alone_when_adapter_provides_baseline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The flip side: same config but an adapter that DOES return a
     baseline_agent_class must proceed past the pre-flight gate. We patch
     run_investigation so the test doesn't depend on the production
     investigation pipeline."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
     runner = BenchmarkRunner(
         config=_config(tmp_path, modes=["llm_alone"]),
         adapter=_AdapterWithBaseline(),


### PR DESCRIPTION
Fixes #2774

#### Describe the changes you have made in this PR -

`test_run_inner_accepts_llm_alone_when_adapter_provides_baseline` was failing on every PR opened from a fork. The test calls `runner.run_without_integrity()`, which activates the LLM via `LLMDispatcher.activate()` in `tests/benchmarks/_framework/llm_dispatch.py:173-180`. That activation raises `MissingAPIKey` if `ANTHROPIC_API_KEY` is unset. CI on main passes because the secret is injected via `.github/workflows/ci.yml:168,370`, but GitHub Actions strips repository secrets from fork-PR workflows, so every external contributor's PR hits the same red.

Change: add `monkeypatch: pytest.MonkeyPatch` to the test and call `monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")` before constructing the runner. Same pattern `tests/benchmarks/_framework/test_llm_dispatch.py` already uses in 5+ places.

The other 6 tests in the file are unaffected: they call `_run_one_cell` directly with an explicit `spec=LLM_SPECS["claude-4-sonnet"]` and never trigger `activate()`.

### Demo/Screenshot for feature changes and bug fixes - 

**Before** (no key — reproduces the fork-PR CI failure):

<img width="1032" height="769" alt="image" src="https://github.com/user-attachments/assets/63d3978e-d8b7-4303-a0e7-7474d59bc16c" />
<img width="1032" height="769" alt="image" src="https://github.com/user-attachments/assets/cdd2f9e0-ff2b-4189-ae94-70cfae7f1e35" />




**After** (no key, same command):

<img width="1038" height="640" alt="image" src="https://github.com/user-attachments/assets/9787d341-a7f7-4990-93de-81c38bbacc2b" />


Also verified hermetic with a stub key (`ANTHROPIC_API_KEY=fake-key` set): 7 passed. The test is now green whether the env var is set or unset.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The test is verifying that the runner's pre-flight gate accepts an adapter that returns a non-None `baseline_agent_class`. The downstream investigation pipeline is patched out via `patch("app.pipeline.runners.run_investigation", ...)`, but the dispatcher's environment-variable check fires before the patch is ever reached. So the test was broken by an upstream concern (env presence) that has nothing to do with what it's actually asserting.

I considered three approaches:

1. `pytest.mark.skipif(not os.getenv("ANTHROPIC_API_KEY"))`. Would skip the test on fork PRs but also silently drop it on any local dev run without a key. The point of the test is to gate the runner's pre-flight, and that gate should be exercised on every PR, not just ones where someone happens to have a key.
2. Add `ANTHROPIC_API_KEY` to the workflow's `env:` block unconditionally with a fake value. Too invasive: changes CI for every job, and the dummy key value would show up in workflow logs.
3. `monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")` inside the test. Hermetic, scoped to the one test that needs it, automatically reverted after the test by pytest's monkeypatch fixture. Already the established pattern in `tests/benchmarks/_framework/test_llm_dispatch.py` (5+ uses).

I went with option 3. The dispatcher only checks env-var presence, not key validity, so a dummy `"test-key"` value is enough. With `run_investigation` already patched, no real Anthropic API call ever happens, so a fake key is safe.

One thing I deliberately did not change: the dispatcher's `MissingAPIKey` exception itself. It is correct behavior for production runs (you want to fail loud if the key is missing). The bug was that one specific test was indirectly exercising that production check without the test setup it needed.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
