### PR TITLE
fix(bench): fixed vocabulary and prepared config for next experiment

### DIFF
--- a/tests/benchmarks/cloudopsbench/configs/cloudopsbench_definitive_trimmed_prompt_openai.yml
+++ b/tests/benchmarks/cloudopsbench/configs/cloudopsbench_definitive_trimmed_prompt_openai.yml
@@ -62,6 +62,7 @@ benchmark: cloudopsbench
 
 modes:
   - opensre+llm
+  - llm_alone
   - llm_alone_pure
 
 llms:

--- a/tests/benchmarks/cloudopsbench/predictor/vocabulary.py
+++ b/tests/benchmarks/cloudopsbench/predictor/vocabulary.py
@@ -107,7 +107,12 @@ _FAULT_OBJECT_SERVICES: tuple[str, ...] = (
     "recommendationservice",
     "redis-cart",
     "shippingservice",
-    # train-ticket
+    # train-ticket — full enumeration of the dataset's service mesh + DB.
+    # The 2026-06-09 trimmed-prompt loss diagnostic showed 33.7% of cells had
+    # a GT fault_object missing from this list, capping A@1 below the paper
+    # baseline on Runtime / Performance / Startup. ``tsdb-mysql`` alone was
+    # 90 cells locked at A@1=0.00 because the LLM consistently substituted
+    # the nearest in-vocab service (most often ``ts-inside-payment-service``).
     "ts-gateway-service",
     "ts-order-service",
     "ts-payment-service",
@@ -116,6 +121,30 @@ _FAULT_OBJECT_SERVICES: tuple[str, ...] = (
     "ts-auth-service",
     "ts-route-service",
     "ts-ticket-office-service",
+    "ts-assurance-service",
+    "ts-basic-service",
+    "ts-cancel-service",
+    "ts-config-service",
+    "ts-consign-service",
+    "ts-contacts-service",
+    "ts-delivery-service",
+    "ts-food-delivery-service",
+    "ts-food-service",
+    "ts-inside-payment-service",
+    "ts-notification-service",
+    "ts-order-other-service",
+    "ts-preserve-service",
+    "ts-price-service",
+    "ts-seat-service",
+    "ts-security-service",
+    "ts-station-food-service",
+    "ts-station-service",
+    "ts-train-food-service",
+    "ts-train-service",
+    "ts-travel2-service",
+    "ts-voucher-service",
+    "ts-wait-order-service",
+    "tsdb-mysql",
 )
 
 _FAULT_OBJECT_NODES: tuple[str, ...] = ("master", "worker-01", "worker-02", "worker-03")


### PR DESCRIPTION
Fixes #2074 

- Fix predictor vocabulary completeness bug capping A@1 on 33.7% of cells (Runtime/Performance/Startup strata)
- Fix two greptile P1 findings: `CaseFilters.seed` silent drop + silent `ImportError` in adapter registry
- Add missing `llm_alone` arm to the trimmed-prompt definitive config
- Land the framework split + predictor package refactor that surfaced the registry / `seed` bugs during review


#### Describe the changes you have made in this PR -

## Root cause — vocabulary completeness

Loss-mode triage on the n=2118 case-level results from `dev-2026-06-09T10-09-04Z_cloudopsbench` (full N, trimmed prompt) found that **62% of opensre+llm Runtime losses are `OBJECT_MISS`** (wrong service entirely). Drilling in: GT=`app/tsdb-mysql` accounts for 90 cells at A@1=0.00 — the predictor was substituting the nearest in-vocab service (`ts-inside-payment-service`) every time.

`_FAULT_OBJECT_SERVICES` listed 19 services. The dataset has 41 distinct `fault_object` values. The system prompt declares those 19 as *"service is one of: ..."* so the LLM treats it as a closed set. 714 of 2118 cells (33.7%) had a GT not in the vocab.

| Stratum | Cells with GT not in vocab | % affected |
|---|---|---|
| Admission | 0 | 0.0% |
| Performance | 180 | 44.1% |
| Runtime | 426 | 50.4% |
| Startup | 108 | 20.9% |
---

## Predicted impact

| Metric | Current | Predicted post-fix |
|---|---|---|
| opensre+llm aggregate A@1 | 0.65 | 0.70-0.73 |
| llm_alone_pure aggregate A@1 | 0.62 | 0.67-0.70 |
| opensre+llm Runtime A@1 | 0.43 | 0.55-0.65 |
| Δ(opensre+llm − llm_alone_pure) | +0.03 (ns) | ~+0.03 (both arms gain equally) |

The vocab fix is a **scoring-artifact correction**, not an opensre-side improvement. Both arms gain equally. The structural opensre-vs-LLM-alone question remains for the Tier 1 experiments scoped in the prior issue comment.


## Code Understanding and AI Usage


**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
