### PR TITLE
Update CLI commands and documentation for remote service registration

### DIFF
--- a/app/cli/support/layout.py
+++ b/app/cli/support/layout.py
@@ -18,7 +18,7 @@ _LANDING_EXAMPLES: tuple[tuple[str, str], ...] = (
     ),
     ("opensre onboard", "Configure LLM provider and integrations"),
     ("opensre investigate -i alert.json", "Run RCA against an alert payload"),
-    ("opensre deploy ec2", "Deploy investigation server on AWS EC2"),
+    ("opensre investigate --service <name>", "Run RCA on a deployed remote service"),
     ("opensre remote --url <ip> health", "Check a remote deployed agent"),
     ("opensre remote ops status", "Inspect hosted service status (Railway)"),
     ("opensre tests", "Browse and run inventoried tests"),

--- a/app/remote/runtime_alert.py
+++ b/app/remote/runtime_alert.py
@@ -90,7 +90,7 @@ def build_runtime_alert_payload(
             f"No remote named '{name}' is configured.",
             suggestion=(
                 f"Configured remotes: {available}. "
-                f"Deploy with 'opensre deploy' or add one with 'opensre remote'."
+                "Register one with 'opensre remote --url <url> health' or run 'opensre remote'."
             ),
         )
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -87,11 +87,13 @@ export ANTHROPIC_API_KEY=...
 
 Ensure the Railway project has Postgres and Redis and that the OpenSRE service has **`DATABASE_URI`** and **`REDIS_URI`** wired to them before deploying.
 
-```bash
-opensre deploy railway --project <project> --service <service> --yes
-```
+Deploy the service using your Railway project workflow (see [deployment.mdx](deployment.mdx)).
 
-If the service never becomes healthy, confirm both URIs are set on the service.
+If the service never becomes healthy, confirm both URIs are set on the service, then register it:
+
+```bash
+opensre remote --url https://<your-service>.up.railway.app health
+```
 
 ### Remote hosted ops (Railway)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -89,11 +89,13 @@ Ensure the Railway project has Postgres and Redis and that the OpenSRE service h
 
 Deploy the service using your Railway project workflow (see [deployment.mdx](deployment.mdx)).
 
-If the service never becomes healthy, confirm both URIs are set on the service, then register it:
+After deploy, register the remote agent:
 
 ```bash
 opensre remote --url https://<your-service>.up.railway.app health
 ```
+
+If the service never becomes healthy, confirm both `DATABASE_URI` and `REDIS_URI` are set on the service.
 
 ### Remote hosted ops (Railway)
 

--- a/docs/remote-runtime-investigation.mdx
+++ b/docs/remote-runtime-investigation.mdx
@@ -9,13 +9,14 @@ description: 'Start an RCA investigation for a deployed service by name'
 
 ## Prerequisites
 
-You must have deployed a service via `opensre deploy` (or registered a named remote) and configured a remote ops provider.
+You must have deployed an OpenSRE service (see [Deployment](/deployment)), registered a named remote, and configured a remote ops provider.
 
-1. **Deploy or register a named remote:**
+1. **Deploy and register a named remote:**
    ```bash
-   opensre deploy ec2        # creates a named remote "ec2"
-   # or register manually:
-   opensre remote health https://my-service.up.railway.app
+   # Deploy via your hosting provider, then register the agent URL:
+   opensre remote --url https://my-service.up.railway.app health
+   # or use the interactive wizard:
+   opensre remote
    ```
 
 2. **Configure the remote ops provider (once):**


### PR DESCRIPTION
# Stale `opensre deploy` references after deploy command removal

## Issue

The CLI landing page and documentation still advertised `opensre deploy ec2`, but the `deploy` command was removed from the CLI. There is no `app/cli/commands/deploy.py` anymore — only commands like `remote`, `investigate`, `onboard`, etc. are registered under `app/cli/commands/`.

Users who followed the landing page or docs would hit:

```text
Error: No such command 'deploy'.
```

### Affected locations

| Location | Stale content |
|----------|---------------|
| `app/cli/support/layout.py` | Landing page quick-start: `opensre deploy ec2` |
| `docs/remote-runtime-investigation.mdx` | Prerequisites and setup steps referencing `opensre deploy` |
| `docs/DEVELOPMENT.md` | `opensre deploy railway --project ... --service ...` |
| `app/remote/runtime_alert.py` | Error suggestion: `Deploy with 'opensre deploy'` |

### Root cause

Docs and UI examples were not updated when the `deploy` CLI command was removed. Deployment is now done through the hosting provider (Railway, EC2, Dockerfile, etc.), and remotes are registered via `opensre remote`.

---

## Fix

Replace all stale `opensre deploy` references with the current workflow:

1. **Deploy** the OpenSRE service using your hosting provider (see [Deployment](docs/deployment.mdx)).
2. **Register** the remote agent with `opensre remote --url <url> health` or the interactive `opensre remote` wizard.
3. **Investigate** deployed services with `opensre investigate --service <name>`.

### Changes

| File | Change |
|------|--------|
| `app/cli/support/layout.py` | Replaced `opensre deploy ec2` with `opensre investigate --service <name>` on the landing page |
| `docs/remote-runtime-investigation.mdx` | Updated prerequisites and setup to use `remote --url` and link to Deployment docs |
| `app/remote/runtime_alert.py` | Updated missing-remote error to suggest `opensre remote --url <url> health` |
| `docs/DEVELOPMENT.md` | Replaced `opensre deploy railway` with Railway's normal deploy flow plus remote health registration |

Historical changelog entries in `docs/daily-updates/` were left unchanged (they document past releases).

### Verification

```bash
uv run python -m pytest tests/cli/test_layout.py tests/remote/test_runtime_alert.py -q
```

---

