### PR TITLE
fix(repl): propagate delegated CLI subprocess failures to session state

### DIFF
--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -43,6 +43,7 @@ def run_cli_command(
     *,
     subprocess_timeout: float | None = None,
     capture_output: bool = False,
+    session: ReplSession | None = None,
 ) -> bool:
     """Helper to delegate complex or interactive Click commands to a child process.
 
@@ -59,6 +60,14 @@ def run_cli_command(
     must leave this ``False`` so the child's prompts stay attached to the real
     TTY. Capture is also enabled automatically whenever a timeout is set.
 
+    Returns ``True`` when the child exits zero. On failure (non-zero exit,
+    timeout, spawn error, or Ctrl+C), returns ``False`` and, when ``session`` is
+    provided, marks the latest slash turn as failed via
+    :meth:`~ReplSession.mark_latest`.
+
+    Slash handlers must still return ``True`` to keep the REPL running; only
+    ``/exit`` and ``/quit`` return ``False``.
+
     Ctrl+C sends :exc:`KeyboardInterrupt`, which subclasses :exc:`BaseException`
     rather than :exc:`Exception`; it is handled here so the REPL survives and the
     child process exits on SIGINT alongside the interrupted ``run`` call.
@@ -66,6 +75,7 @@ def run_cli_command(
     console.print()
     cmd = [sys.executable, "-m", "app.cli", *args]
     should_capture = capture_output or subprocess_timeout is not None
+    ok = True
     try:
         if should_capture:
             captured_result = subprocess.run(
@@ -83,35 +93,44 @@ def run_cli_command(
                 console.print(
                     f"[{ERROR}]CLI command exited with non-zero code {captured_result.returncode}[/]"
                 )
+                ok = False
         else:
             interactive_result = subprocess.run(cmd, check=False)
             if interactive_result.returncode != 0:
                 console.print(
                     f"[{ERROR}]CLI command exited with non-zero code {interactive_result.returncode}[/]"
                 )
+                ok = False
     except subprocess.TimeoutExpired as exc:
         print_command_output(console, _decode_subprocess_stream(exc.stdout))
         print_command_output(console, _decode_subprocess_stream(exc.stderr), style=ERROR)
         console.print(f"[{ERROR}]error:[/] CLI command timed out")
+        ok = False
     except KeyboardInterrupt:
         console.print(f"[{DIM}]CLI command cancelled (Ctrl+C).[/]")
+        ok = False
     except Exception as exc:
         console.print(f"[{ERROR}]error running CLI command:[/] {exc}")
+        ok = False
     console.print()
-    return True
+    if session is not None and not ok:
+        session.mark_latest(ok=False, kind="slash")
+    return ok
 
 
-def _cmd_onboard(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_onboard(session: ReplSession, console: Console, args: list[str]) -> bool:
     # The REPL loop adds ``/onboard`` to ``_WAIT_FOR_COMPLETION_COMMANDS``
     # (dispatch.py) so the prompt_toolkit Application is torn down before
     # this handler runs — the wizard subprocess therefore gets exclusive
     # stdin and can drive its own interactive prompts without conflicting
     # with the shell's UI.
-    return run_cli_command(console, ["onboard", *args])
+    run_cli_command(console, ["onboard", *args], session=session)
+    return True
 
 
-def _cmd_remote(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(console, ["remote", *args])
+def _cmd_remote(session: ReplSession, console: Console, args: list[str]) -> bool:
+    run_cli_command(console, ["remote", *args], session=session)
+    return True
 
 
 def _catalog_task_kind(command: list[str]) -> TaskKind:
@@ -165,6 +184,7 @@ def _run_test_picker_for_background(session: ReplSession, console: Console) -> b
         if result.returncode != 0:
             console.print(f"[{ERROR}]CLI command exited with non-zero code {result.returncode}[/]")
             console.print()
+            session.mark_latest(ok=False, kind="slash")
             return True
         if not selection_path.stat().st_size:
             console.print()
@@ -210,7 +230,8 @@ def _cmd_tests(session: ReplSession, console: Console, args: list[str]) -> bool:
         return True
 
     if subcommand.startswith("-"):
-        return run_cli_command(console, ["tests", *args], capture_output=True)
+        run_cli_command(console, ["tests", *args], capture_output=True, session=session)
+        return True
 
     if subcommand not in _TEST_SUBCOMMANDS:
         suggestion = closest_choice(subcommand, _TEST_SUBCOMMANDS)
@@ -228,53 +249,64 @@ def _cmd_tests(session: ReplSession, console: Console, args: list[str]) -> bool:
         session.mark_latest(ok=False, kind="slash")
         return True
 
-    return run_cli_command(console, ["tests", *args], capture_output=True)
+    run_cli_command(console, ["tests", *args], capture_output=True, session=session)
+    return True
 
 
-def _cmd_guardrails(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_guardrails(session: ReplSession, console: Console, args: list[str]) -> bool:
     # ``opensre guardrails`` and its subcommands are all non-interactive printers
     # (init/test/audit/rules just ``click.echo``). Capture so the output — and
     # Click's usage block when no subcommand is given — reaches the REPL buffer
     # instead of bypassing ``console.print`` via the child's inherited stdout FD.
-    return run_cli_command(console, ["guardrails", *args], capture_output=True)
+    run_cli_command(console, ["guardrails", *args], capture_output=True, session=session)
+    return True
 
 
-def _cmd_update(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(
+def _cmd_update(session: ReplSession, console: Console, args: list[str]) -> bool:
+    run_cli_command(
         console,
         ["update", *args],
         subprocess_timeout=_UPDATE_SUBPROCESS_TIMEOUT_SECONDS,
+        session=session,
     )
+    return True
 
 
-def _cmd_uninstall(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(console, ["uninstall", *args])
+def _cmd_uninstall(session: ReplSession, console: Console, args: list[str]) -> bool:
+    run_cli_command(console, ["uninstall", *args], session=session)
+    return True
 
 
-def _cmd_config(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_config(session: ReplSession, console: Console, args: list[str]) -> bool:
     # Non-interactive click.echo only; capture so output reaches the REPL buffer
     # instead of the child's inherited stdout while prompt_toolkit redraws.
-    return run_cli_command(console, ["config", *args], capture_output=True)
+    run_cli_command(console, ["config", *args], capture_output=True, session=session)
+    return True
 
 
-def _cmd_messaging(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(console, ["messaging", *args])
+def _cmd_messaging(session: ReplSession, console: Console, args: list[str]) -> bool:
+    run_cli_command(console, ["messaging", *args], session=session)
+    return True
 
 
-def _cmd_hermes(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(console, ["hermes", *args])
+def _cmd_hermes(session: ReplSession, console: Console, args: list[str]) -> bool:
+    run_cli_command(console, ["hermes", *args], session=session)
+    return True
 
 
-def _cmd_cron(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(console, ["cron", *args])
+def _cmd_cron(session: ReplSession, console: Console, args: list[str]) -> bool:
+    run_cli_command(console, ["cron", *args], session=session)
+    return True
 
 
-def _cmd_watchdog(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(console, ["watchdog", *args])
+def _cmd_watchdog(session: ReplSession, console: Console, args: list[str]) -> bool:
+    run_cli_command(console, ["watchdog", *args], session=session)
+    return True
 
 
-def _cmd_debug(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(console, ["debug", *args])
+def _cmd_debug(session: ReplSession, console: Console, args: list[str]) -> bool:
+    run_cli_command(console, ["debug", *args], session=session)
+    return True
 
 
 COMMANDS: list[SlashCommand] = [

--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -197,6 +197,7 @@ def _run_test_picker_for_background(session: ReplSession, console: Console) -> b
     if not isinstance(payload, list):
         console.print(f"[{ERROR}]test picker returned an invalid selection[/]")
         console.print()
+        session.mark_latest(ok=False, kind="slash")
         return True
 
     for item in payload:

--- a/app/cli/interactive_shell/command_registry/integrations.py
+++ b/app/cli/interactive_shell/command_registry/integrations.py
@@ -255,6 +255,7 @@ def _cmd_mcp(session: ReplSession, console: Console, args: list[str]) -> bool:
         f"[{ERROR}]unknown subcommand:[/] {escape(sub)}  "
         "(try [bold]/mcp list[/bold], [bold]/mcp connect[/bold], or [bold]/mcp disconnect[/bold])"
     )
+    session.mark_latest(ok=False, kind="slash")
     return True
 
 

--- a/app/cli/interactive_shell/command_registry/integrations.py
+++ b/app/cli/interactive_shell/command_registry/integrations.py
@@ -149,10 +149,12 @@ def _cmd_integrations(session: ReplSession, console: Console, args: list[str]) -
         return True
 
     if sub == "setup":
-        return run_cli_command(console, ["integrations", "setup", *args[1:]])
+        run_cli_command(console, ["integrations", "setup", *args[1:]], session=session)
+        return True
 
     if sub == "remove":
-        return run_cli_command(console, ["integrations", "remove", *args[1:]])
+        run_cli_command(console, ["integrations", "remove", *args[1:]], session=session)
+        return True
 
     if sub == "show":
         if len(args) < 2:
@@ -242,10 +244,12 @@ def _cmd_mcp(session: ReplSession, console: Console, args: list[str]) -> bool:
         return True
 
     if sub == "connect":
-        return run_cli_command(console, ["integrations", "setup", *args[1:]])
+        run_cli_command(console, ["integrations", "setup", *args[1:]], session=session)
+        return True
 
     if sub == "disconnect":
-        return run_cli_command(console, ["integrations", "remove", *args[1:]])
+        run_cli_command(console, ["integrations", "remove", *args[1:]], session=session)
+        return True
 
     console.print(
         f"[{ERROR}]unknown subcommand:[/] {escape(sub)}  "

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -535,7 +535,7 @@ class TestIntegrationsCommand:
         monkeypatch.setattr(
             m,
             "run_cli_command",
-            lambda _, args, **kwargs: (captured.append(args), True)[1],
+            lambda _, args, **_kwargs: (captured.append(args), True)[1],
         )
         dispatch_slash("/integrations setup", ReplSession(), Console())
         assert captured == [["integrations", "setup"]]
@@ -547,7 +547,7 @@ class TestIntegrationsCommand:
         monkeypatch.setattr(
             m,
             "run_cli_command",
-            lambda _, args, **kwargs: (captured.append(args), True)[1],
+            lambda _, args, **_kwargs: (captured.append(args), True)[1],
         )
         dispatch_slash("/integrations remove slack", ReplSession(), Console())
         assert captured == [["integrations", "remove", "slack"]]
@@ -585,7 +585,7 @@ class TestMcpCommand:
         monkeypatch.setattr(
             m,
             "run_cli_command",
-            lambda _, args, **kwargs: (captured.append(args), True)[1],
+            lambda _, args, **_kwargs: (captured.append(args), True)[1],
         )
         dispatch_slash("/mcp connect", ReplSession(), Console())
         assert captured == [["integrations", "setup"]]
@@ -597,7 +597,7 @@ class TestMcpCommand:
         monkeypatch.setattr(
             m,
             "run_cli_command",
-            lambda _, args, **kwargs: (captured.append(args), True)[1],
+            lambda _, args, **_kwargs: (captured.append(args), True)[1],
         )
         dispatch_slash("/mcp disconnect github", ReplSession(), Console())
         assert captured == [["integrations", "remove", "github"]]
@@ -2264,6 +2264,46 @@ class TestCliDelegatedCommands:
 
         assert started == ["opensre tests synthetic"]
         assert not selection_path.exists()
+
+    def test_tests_picker_invalid_payload_marks_slash_turn_failed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        selection_path = tmp_path / "selection.json"
+
+        class _SelectionFile:
+            name = str(selection_path)
+            closed = False
+
+            def __init__(self) -> None:
+                selection_path.touch()
+
+            def close(self) -> None:
+                self.closed = True
+
+        handle = _SelectionFile()
+
+        def _fake_run(_command: list[str], **kwargs: object) -> object:
+            del kwargs
+            selection_path.write_text('{"not": "a list"}', encoding="utf-8")
+
+            class _Result:
+                returncode = 0
+
+            return _Result()
+
+        monkeypatch.setattr(m.tempfile, "NamedTemporaryFile", lambda **_kwargs: handle)
+        monkeypatch.setattr(m.subprocess, "run", _fake_run)
+
+        session = ReplSession()
+        console, buf = _capture()
+        dispatch_slash("/tests", session, console)
+
+        assert "invalid selection" in buf.getvalue()
+        assert session.history[-1]["ok"] is False
 
     def test_tests_flag_first_invocation_delegates_to_cli(self, monkeypatch: object) -> None:
         from app.cli.interactive_shell.command_registry import cli_parity as m

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1969,9 +1969,61 @@ class TestRunCliCommand:
         monkeypatch.setattr(m.subprocess, "run", _fake_run)
 
         console, buf = _capture()
-        assert m.run_cli_command(console, ["update"], subprocess_timeout=30.0) is True
+        assert m.run_cli_command(console, ["update"], subprocess_timeout=30.0) is False
         assert replayed == [("partial stdout\n", None), ("partial stderr\n", m.ERROR)]
         assert "timed out" in buf.getvalue()
+
+    def test_non_zero_exit_returns_false_and_marks_slash_turn(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        def _fake_run(
+            cmd: list[str],
+            *,
+            check: bool,
+            timeout: float | None,
+            capture_output: bool,
+            text: bool,
+            encoding: str,
+            errors: str,
+        ) -> subprocess.CompletedProcess[str]:
+            del check, timeout, text, encoding, errors
+            assert capture_output is True
+            return subprocess.CompletedProcess(cmd, 2, stdout="", stderr="boom\n")
+
+        monkeypatch.setattr(m.subprocess, "run", _fake_run)
+        session = ReplSession()
+        session.record("slash", "/remote health", ok=True)
+        console, buf = _capture()
+
+        assert (
+            m.run_cli_command(console, ["remote", "health"], capture_output=True, session=session)
+            is False
+        )
+        assert "non-zero code 2" in buf.getvalue()
+        assert session.history[-1]["ok"] is False
+
+    def test_delegated_slash_handler_keeps_repl_running_on_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        def _fake_run_cli_command(_console: Console, _args: list[str], **kwargs: object) -> bool:
+            session = kwargs.get("session")
+            if isinstance(session, ReplSession):
+                session.mark_latest(ok=False, kind="slash")
+            return False
+
+        monkeypatch.setattr(m, "run_cli_command", _fake_run_cli_command)
+        session = ReplSession()
+        session.record("slash", "/remote health", ok=True)
+        console, _buf = _capture()
+
+        assert m._cmd_remote(session, console, ["health"]) is True
+        assert session.history[-1]["ok"] is False
 
 
 class TestCliDelegatedCommands:

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -205,7 +205,8 @@ class TestDispatchSlash:
 
         calls: list[list[str]] = []
 
-        def _fake_run_cli_command(_console: Console, args: list[str]) -> bool:
+        def _fake_run_cli_command(_console: Console, args: list[str], **kwargs: object) -> bool:
+            del kwargs
             calls.append(args)
             return True
 
@@ -520,15 +521,22 @@ class TestIntegrationsCommand:
 
     def test_unknown_subcommand_prints_hint(self, monkeypatch: object) -> None:
         self._patch(monkeypatch)
+        session = ReplSession()
+        session.record("slash", "/integrations bogus", ok=True)
         console, buf = _capture()
-        dispatch_slash("/integrations bogus", ReplSession(), console)
+        dispatch_slash("/integrations bogus", session, console)
         assert "unknown subcommand" in buf.getvalue()
+        assert session.history[-1]["ok"] is False
 
     def test_setup_delegates_to_cli(self, monkeypatch: object) -> None:
         from app.cli.interactive_shell.command_registry import integrations as m
 
         captured = []
-        monkeypatch.setattr(m, "run_cli_command", lambda _, args: (captured.append(args), True)[1])
+        monkeypatch.setattr(
+            m,
+            "run_cli_command",
+            lambda _, args, **kwargs: (captured.append(args), True)[1],
+        )
         dispatch_slash("/integrations setup", ReplSession(), Console())
         assert captured == [["integrations", "setup"]]
 
@@ -536,7 +544,11 @@ class TestIntegrationsCommand:
         from app.cli.interactive_shell.command_registry import integrations as m
 
         captured = []
-        monkeypatch.setattr(m, "run_cli_command", lambda _, args: (captured.append(args), True)[1])
+        monkeypatch.setattr(
+            m,
+            "run_cli_command",
+            lambda _, args, **kwargs: (captured.append(args), True)[1],
+        )
         dispatch_slash("/integrations remove slack", ReplSession(), Console())
         assert captured == [["integrations", "remove", "slack"]]
 
@@ -570,7 +582,11 @@ class TestMcpCommand:
         from app.cli.interactive_shell.command_registry import integrations as m
 
         captured = []
-        monkeypatch.setattr(m, "run_cli_command", lambda _, args: (captured.append(args), True)[1])
+        monkeypatch.setattr(
+            m,
+            "run_cli_command",
+            lambda _, args, **kwargs: (captured.append(args), True)[1],
+        )
         dispatch_slash("/mcp connect", ReplSession(), Console())
         assert captured == [["integrations", "setup"]]
 
@@ -578,15 +594,22 @@ class TestMcpCommand:
         from app.cli.interactive_shell.command_registry import integrations as m
 
         captured = []
-        monkeypatch.setattr(m, "run_cli_command", lambda _, args: (captured.append(args), True)[1])
+        monkeypatch.setattr(
+            m,
+            "run_cli_command",
+            lambda _, args, **kwargs: (captured.append(args), True)[1],
+        )
         dispatch_slash("/mcp disconnect github", ReplSession(), Console())
         assert captured == [["integrations", "remove", "github"]]
 
     def test_unknown_subcommand(self, monkeypatch: object) -> None:
         self._patch(monkeypatch)
+        session = ReplSession()
+        session.record("slash", "/mcp bogus", ok=True)
         console, buf = _capture()
-        dispatch_slash("/mcp bogus", ReplSession(), console)
+        dispatch_slash("/mcp bogus", session, console)
         assert "unknown subcommand" in buf.getvalue()
+        assert session.history[-1]["ok"] is False
 
 
 class TestModelCommand:
@@ -2098,9 +2121,12 @@ class TestCliDelegatedCommands:
             return True
 
         monkeypatch.setattr(m, "run_cli_command", _fake_run_cli_command)
-        dispatch_slash(slash_input, ReplSession(), Console())
+        session = ReplSession()
+        dispatch_slash(slash_input, session, Console())
 
-        assert captured_kwargs == [{"capture_output": True}]
+        assert len(captured_kwargs) == 1
+        assert captured_kwargs[0]["capture_output"] is True
+        assert captured_kwargs[0]["session"] is session
 
     @pytest.mark.parametrize(
         "slash_input",
@@ -2124,9 +2150,12 @@ class TestCliDelegatedCommands:
             return True
 
         monkeypatch.setattr(m, "run_cli_command", _fake_run_cli_command)
-        dispatch_slash(slash_input, ReplSession(), Console())
+        session = ReplSession()
+        dispatch_slash(slash_input, session, Console())
 
-        assert captured_kwargs == [{"capture_output": True}]
+        assert len(captured_kwargs) == 1
+        assert captured_kwargs[0]["capture_output"] is True
+        assert captured_kwargs[0]["session"] is session
 
     def test_slash_onboard_with_args_forwards_them_to_subprocess(self, monkeypatch: object) -> None:
         """Args passed to ``/onboard`` must be forwarded to the subprocess."""


### PR DESCRIPTION
## Summary

- `run_cli_command()` now returns `False` when a delegated subprocess fails (non-zero exit, timeout, Ctrl+C, or spawn error) instead of always returning `True`
- Failed slash turns are marked `ok=False` in session history via `session.mark_latest()`, so `/remote`, `/config`, `/onboard`, and other CLI-parity commands no longer look successful after a failed run
- Slash handlers still return `True` so a failed delegated command does not exit the REPL (only `/exit` and `/quit` should do that)

## Problem

`dispatch_slash()` records slash turns as `ok=True` before the handler runs. `run_cli_command()` printed an error line on failure but always returned `True` and never updated session state, so failed delegated commands appeared successful in session history and downstream routing/oracle logic.

## Changes

- `app/cli/interactive_shell/command_registry/cli_parity.py`
  - Track subprocess success/failure in `run_cli_command()`
  - Optional `session` param to mark the latest slash turn failed
  - Update all CLI-parity handlers to pass `session` and always `return True`
  - Mark test picker failures in `_run_test_picker_for_background()`
- `app/cli/interactive_shell/command_registry/integrations.py`
  - Same pattern for `/integrations setup|remove` and `/mcp connect|disconnect`
- `tests/cli/interactive_shell/test_commands.py`
  - Regression tests for non-zero exit, timeout return value, and REPL continuation on failure

