### PR TITLE
feat(cli): enhance prompt handling and synthetic task follow-up

### DIFF
--- a/app/cli/interactive_shell/prompting/prompt_surface.py
+++ b/app/cli/interactive_shell/prompting/prompt_surface.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Iterable
+from typing import Any
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.application.current import get_app
@@ -328,7 +330,47 @@ def _build_prompt_style() -> Style:
     )
 
 
-_PLACEHOLDER_ANSI = ANSI(f"{ANSI_DIM}Type a message, /command, or paste an alert{ANSI_RESET}")
+_DEFAULT_PLACEHOLDER_TEXT = "Type a message, /command, or paste an alert"
+_DEFAULT_PLACEHOLDER_ANSI = ANSI(f"{ANSI_DIM}{_DEFAULT_PLACEHOLDER_TEXT}{ANSI_RESET}")
+
+
+def resolve_prompt_placeholder(session: ReplSession) -> ANSI:
+    """Contextual ghost text when the input buffer is empty."""
+    parts: list[str] = []
+    if session.trust_mode:
+        parts.append("trust on")
+    running = session.task_registry.running_count()
+    if running:
+        parts.append(f"{running} task{'s' if running != 1 else ''} running")
+    if session.resumed_from_name:
+        parts.append(f"resumed: {_short_meta(session.resumed_from_name, max_len=32)}")
+    if parts:
+        return ANSI(f"{ANSI_DIM}{' · '.join(parts)}{ANSI_RESET}")
+    return _DEFAULT_PLACEHOLDER_ANSI
+
+
+def wire_prompt_refresh(
+    session: ReplSession,
+    pt_app: Any,
+    loop: asyncio.AbstractEventLoop,
+) -> Callable[[], None]:
+    """Register session hook to prefill pending text and redraw the active prompt."""
+
+    def invalidate_prompt() -> None:
+        loop.call_soon_threadsafe(pt_app.invalidate)
+
+    def refresh_active_prompt() -> None:
+        def _apply() -> None:
+            pending = session.pending_prompt_default
+            if pending and pt_app.is_running and not pt_app.current_buffer.text:
+                session.pending_prompt_default = None
+                pt_app.current_buffer.text = pending
+            invalidate_prompt()
+
+        loop.call_soon_threadsafe(_apply)
+
+    session.prompt_refresh_fn = refresh_active_prompt
+    return invalidate_prompt
 
 # Commands where bare invocation opens an inline picker in TTY mode.
 _INLINE_PICKER_COMMANDS: frozenset[str] = frozenset(
@@ -364,7 +406,7 @@ def _build_prompt_session(_session: ReplSession | None = None) -> PromptSession[
             key_bindings=_build_prompt_key_bindings(),
             style=_build_prompt_style(),
             erase_when_done=True,
-            placeholder=_PLACEHOLDER_ANSI,
+            placeholder=_DEFAULT_PLACEHOLDER_ANSI,
         )
     )
 
@@ -382,4 +424,6 @@ __all__ = [
     "ReplInputLexer",
     "ShellCompleter",
     "render_submitted_prompt",
+    "resolve_prompt_placeholder",
+    "wire_prompt_refresh",
 ]

--- a/app/cli/interactive_shell/prompting/prompt_surface.py
+++ b/app/cli/interactive_shell/prompting/prompt_surface.py
@@ -372,6 +372,7 @@ def wire_prompt_refresh(
     session.prompt_refresh_fn = refresh_active_prompt
     return invalidate_prompt
 
+
 # Commands where bare invocation opens an inline picker in TTY mode.
 _INLINE_PICKER_COMMANDS: frozenset[str] = frozenset(
     {
@@ -394,7 +395,12 @@ def _suppress_empty_arg_completions_for_inline_picker(cmd_name: str, raw_arg: st
     return repl_tty_interactive() and not raw_arg and cmd_name in _INLINE_PICKER_COMMANDS
 
 
-def _build_prompt_session(_session: ReplSession | None = None) -> PromptSession[str]:
+def _build_prompt_session(session: ReplSession | None = None) -> PromptSession[str]:
+    placeholder = (
+        (lambda: resolve_prompt_placeholder(session))
+        if session is not None
+        else _DEFAULT_PLACEHOLDER_ANSI
+    )
     return _install_prompt_frame(
         PromptSession(
             completer=ShellCompleter(),
@@ -406,7 +412,7 @@ def _build_prompt_session(_session: ReplSession | None = None) -> PromptSession[
             key_bindings=_build_prompt_key_bindings(),
             style=_build_prompt_style(),
             erase_when_done=True,
-            placeholder=_DEFAULT_PLACEHOLDER_ANSI,
+            placeholder=placeholder,
         )
     )
 

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/__init__.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/__init__.py
@@ -55,8 +55,6 @@ from .opensre_cli_runner import (
 )
 from .shell_runner import run_cd_command, run_pwd_command, run_shell_command
 from .synthetic_tasks import (
-    _scenario_id_from_synthetic_suite_name,
-    _try_bind_synthetic_observation,
     run_synthetic_test,
     watch_synthetic_subprocess,
 )
@@ -112,12 +110,10 @@ __all__ = [
     "_pump_task_stream",
     "_run_opensre_foreground",
     "_run_opensre_foreground_streaming",
-    "_scenario_id_from_synthetic_suite_name",
     "_should_run_opensre_in_foreground",
     "_should_use_pty",
     "_start_task_output_streams",
     "_subprocess_env_with_aligned_width",
-    "_try_bind_synthetic_observation",
     "execute_shell_command",
     "os",
     "print_interactive_wizard_handoff",

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/background_tasks.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/background_tasks.py
@@ -122,6 +122,8 @@ def start_background_cli_task(
         output_thread.start()
         output_threads = [output_thread]
 
+    history_gen_when_watch_started = session.history_generation
+
     def _watch() -> None:
         terminated_by_watcher = False
         timed_out = False
@@ -148,7 +150,6 @@ def start_background_cli_task(
                 task.mark_cancelled()
                 return
 
-            _join_task_output_streams(output_threads)
             code = proc.returncode
             if code == 0:
                 task.mark_completed()
@@ -168,9 +169,10 @@ def start_background_cli_task(
             if stdout_buf is not None:
                 stdout_buf.close()
             stderr_buf.close()
-            if suggest_follow_up:
+            if suggest_follow_up and session.history_generation == history_gen_when_watch_started:
                 session.suggest_synthetic_failure_follow_up(label=display_command)
-            session.notify_prompt_changed()
+            else:
+                session.notify_prompt_changed()
 
     thread = threading.Thread(target=_watch, daemon=True)
     thread.start()

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/background_tasks.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/background_tasks.py
@@ -150,6 +150,7 @@ def start_background_cli_task(
                 task.mark_cancelled()
                 return
 
+            _join_task_output_streams(output_threads)
             code = proc.returncode
             if code == 0:
                 task.mark_completed()

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/background_tasks.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/background_tasks.py
@@ -125,6 +125,7 @@ def start_background_cli_task(
     def _watch() -> None:
         terminated_by_watcher = False
         timed_out = False
+        suggest_follow_up = False
         while proc.poll() is None:
             if time.monotonic() - started_at > timeout_seconds:
                 timed_out = True
@@ -141,6 +142,7 @@ def start_background_cli_task(
         try:
             if timed_out:
                 task.mark_failed(f"timed out after {timeout_seconds}s")
+                suggest_follow_up = kind is TaskKind.SYNTHETIC_TEST
                 return
             if terminated_by_watcher and task.cancel_requested.is_set():
                 task.mark_cancelled()
@@ -155,15 +157,20 @@ def start_background_cli_task(
                 error_msg = f"exit code {code}" + (f": {diag}" if diag else "")
                 task.mark_failed(error_msg)
                 console.print(f"[{ERROR}]command failed (exit {code}):[/]")
+                suggest_follow_up = kind is TaskKind.SYNTHETIC_TEST
         except Exception as exc:  # noqa: BLE001
             task.mark_failed(str(exc))
             report_exception(exc, context="interactive_shell.background_cli_task.watch")
             console.print(f"[{ERROR}]error:[/] {escape(str(exc))}")
+            suggest_follow_up = kind is TaskKind.SYNTHETIC_TEST
         finally:
             _join_task_output_streams(output_threads)
             if stdout_buf is not None:
                 stdout_buf.close()
             stderr_buf.close()
+            if suggest_follow_up:
+                session.suggest_synthetic_failure_follow_up(label=display_command)
+            session.notify_prompt_changed()
 
     thread = threading.Thread(target=_watch, daemon=True)
     thread.start()

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/synthetic_tasks.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/synthetic_tasks.py
@@ -24,9 +24,6 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.s
     list_rds_postgres_scenarios,
 )
 from app.cli.interactive_shell.runtime import ReplSession, TaskKind, TaskRecord
-from app.cli.interactive_shell.runtime.session import (
-    SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST,
-)
 from app.cli.interactive_shell.ui import DIM, ERROR, HIGHLIGHT
 from app.cli.support.exception_reporting import report_exception
 
@@ -44,31 +41,6 @@ from .task_streaming import (
 _SYNTHETIC_SCENARIO_ID_RE = re.compile(r"^\d{3}-[a-z0-9][a-z0-9-]*$")
 
 
-def _scenario_id_from_synthetic_suite_name(suite_name: str) -> str:
-    if ":" not in suite_name:
-        return ""
-    return suite_name.split(":", 1)[1].strip()
-
-
-def _try_bind_synthetic_observation(session: ReplSession, suite_name: str) -> None:
-    """Point session at ``_observations/<scenario>/latest.json`` after a failed run."""
-    scenario_id = _scenario_id_from_synthetic_suite_name(suite_name)
-    if not scenario_id:
-        return
-    try:
-        from app.cli.tests.discover import SYNTHETIC_SCENARIOS_DIR
-    except Exception:
-        session.last_synthetic_observation_path = None
-        return
-    latest = SYNTHETIC_SCENARIOS_DIR / "_observations" / scenario_id / "latest.json"
-    for _ in range(8):
-        if latest.is_file():
-            session.last_synthetic_observation_path = str(latest.resolve())
-            return
-        time.sleep(0.06)
-    session.last_synthetic_observation_path = None
-
-
 def watch_synthetic_subprocess(
     task: TaskRecord,
     proc: subprocess.Popen[Any],
@@ -82,12 +54,6 @@ def watch_synthetic_subprocess(
 
     history_gen_when_watch_started = session.history_generation
 
-    def _suggest_follow_up_on_failure() -> None:
-        if session.history_generation != history_gen_when_watch_started:
-            return
-        session.pending_prompt_default = SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST
-        _try_bind_synthetic_observation(session, suite_name)
-
     def _record_synthetic_if_current_session(ok: bool) -> None:
         if session.history_generation != history_gen_when_watch_started:
             return
@@ -95,6 +61,7 @@ def watch_synthetic_subprocess(
 
     def _run() -> None:
         output_threads: list[threading.Thread] = []
+        suggest_follow_up = False
         try:
             output_threads = (
                 _start_task_output_streams(
@@ -128,7 +95,7 @@ def watch_synthetic_subprocess(
             if timed_out:
                 task.mark_failed(f"timed out after {SYNTHETIC_TEST_TIMEOUT_SECONDS}s")
                 _record_synthetic_if_current_session(ok=False)
-                _suggest_follow_up_on_failure()
+                suggest_follow_up = True
                 return
 
             _join_task_output_streams(output_threads)
@@ -136,7 +103,7 @@ def watch_synthetic_subprocess(
             if code is None:
                 task.mark_failed("subprocess did not report exit code")
                 _record_synthetic_if_current_session(ok=False)
-                _suggest_follow_up_on_failure()
+                suggest_follow_up = True
                 return
 
             # Honour the real exit code when the process exited on its own.
@@ -155,17 +122,20 @@ def watch_synthetic_subprocess(
                 error_msg = f"exit code {code}" + (f": {diag}" if diag else "")
                 task.mark_failed(error_msg)
                 _record_synthetic_if_current_session(ok=False)
-                _suggest_follow_up_on_failure()
+                suggest_follow_up = True
         except Exception as exc:  # noqa: BLE001
             task.mark_failed(str(exc))
             report_exception(exc, context="interactive_shell.synthetic_test.watch")
             _record_synthetic_if_current_session(ok=False)
-            _suggest_follow_up_on_failure()
+            suggest_follow_up = True
             if console is not None:
                 console.print(f"[{ERROR}]synthetic watcher failed:[/] {escape(str(exc))}")
         finally:
             _join_task_output_streams(output_threads)
             stderr_buf.close()
+            if suggest_follow_up and session.history_generation == history_gen_when_watch_started:
+                session.suggest_synthetic_failure_follow_up(label=suite_name)
+            session.notify_prompt_changed()
 
     threading.Thread(target=_run, daemon=True, name=f"synthetic-{task.task_id}").start()
 

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/synthetic_tasks.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/synthetic_tasks.py
@@ -135,7 +135,8 @@ def watch_synthetic_subprocess(
             stderr_buf.close()
             if suggest_follow_up and session.history_generation == history_gen_when_watch_started:
                 session.suggest_synthetic_failure_follow_up(label=suite_name)
-            session.notify_prompt_changed()
+            else:
+                session.notify_prompt_changed()
 
     threading.Thread(target=_run, daemon=True, name=f"synthetic-{task.task_id}").start()
 

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -174,8 +174,7 @@ async def run_interactive(
     main_loop = asyncio.get_running_loop()
     state.bind_loop(main_loop)
 
-    def _invalidate_prompt() -> None:
-        main_loop.call_soon_threadsafe(pt_app.invalidate)
+    _invalidate_prompt = _prompt_surface.wire_prompt_refresh(session, pt_app, main_loop)
 
     def _request_exit() -> None:
         state.request_exit()
@@ -338,10 +337,13 @@ async def run_interactive(
                 await asyncio.sleep(0.05)
                 _drain_stale_cpr_bytes()
                 try:
+                    prefilled = session.take_pending_prompt_default()
                     text = await pt_session.prompt_async(
                         message=_message_with_spinner,
                         bottom_toolbar=spinner.toolbar_ansi,
                         refresh_interval=PROMPT_REFRESH_INTERVAL_S,
+                        placeholder=lambda: _prompt_surface.resolve_prompt_placeholder(session),
+                        default=prefilled,
                     )
                 except EOFError:
                     if state.is_dispatch_running():

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -161,7 +161,7 @@ async def run_interactive(
     inbox: _alert_inbox.AlertInbox | None = None,
 ) -> None:
     if pt_session is None:
-        pt_session = _prompt_surface._build_prompt_session()
+        pt_session = _prompt_surface._build_prompt_session(session)
         session.prompt_history_backend = pt_session.history
     spinner = SpinnerState()
     state = ReplState()

--- a/app/cli/interactive_shell/runtime/session.py
+++ b/app/cli/interactive_shell/runtime/session.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import re
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -20,6 +22,18 @@ InterventionKind = Literal["ctrl_c", "correction"]
 # Prefilled into the next prompt after a background synthetic test exits non-zero,
 # so the user can ask the CLI assistant for a quick RCA explanation.
 SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST = "why did it fail?"
+
+_SCENARIO_FLAG_RE = re.compile(r"--scenario\s+(\S+)")
+
+
+def _scenario_id_from_synthetic_label(label: str) -> str:
+    """Extract a scenario id from a synthetic command or ``suite:scenario`` label."""
+    match = _SCENARIO_FLAG_RE.search(label)
+    if match is not None:
+        return match.group(1).strip()
+    if ":" in label:
+        return label.rsplit(":", 1)[-1].strip()
+    return ""
 
 
 @dataclass
@@ -124,6 +138,9 @@ class ReplSession:
     pending_prompt_default: str | None = None
     """When set, the next interactive prompt is pre-filled with this string (then cleared)."""
 
+    prompt_refresh_fn: Callable[[], None] | None = field(default=None, repr=False)
+    """Loop-owned hook to apply pending prefill and redraw the active prompt."""
+
     last_synthetic_observation_path: str | None = None
     """Absolute path to ``latest.json`` for the last finished synthetic run (set on failure)."""
 
@@ -148,6 +165,33 @@ class ReplSession:
         value = self.pending_prompt_default
         self.pending_prompt_default = None
         return value or ""
+
+    def notify_prompt_changed(self) -> None:
+        """Redraw the active prompt (placeholder state and pending prefill)."""
+        if self.prompt_refresh_fn is not None:
+            self.prompt_refresh_fn()
+
+    def suggest_synthetic_failure_follow_up(self, *, label: str = "") -> None:
+        """Queue RCA prefill after a failed synthetic run; call ``notify_prompt_changed()`` after."""
+        self.pending_prompt_default = SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST
+        self._bind_last_synthetic_observation(_scenario_id_from_synthetic_label(label))
+
+    def _bind_last_synthetic_observation(self, scenario_id: str) -> None:
+        if not scenario_id:
+            self.last_synthetic_observation_path = None
+            return
+        try:
+            from app.cli.tests.discover import SYNTHETIC_SCENARIOS_DIR
+        except Exception:
+            self.last_synthetic_observation_path = None
+            return
+        latest = SYNTHETIC_SCENARIOS_DIR / "_observations" / scenario_id / "latest.json"
+        for _ in range(8):
+            if latest.is_file():
+                self.last_synthetic_observation_path = str(latest.resolve())
+                return
+            time.sleep(0.06)
+        self.last_synthetic_observation_path = None
 
     def record(self, kind: str, text: str, *, ok: bool = True) -> None:
         """Append an entry to the session history.

--- a/app/cli/interactive_shell/runtime/session.py
+++ b/app/cli/interactive_shell/runtime/session.py
@@ -24,15 +24,18 @@ InterventionKind = Literal["ctrl_c", "correction"]
 SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST = "why did it fail?"
 
 _SCENARIO_FLAG_RE = re.compile(r"--scenario\s+(\S+)")
+_SYNTHETIC_SCENARIO_ID_RE = re.compile(r"^\d{3}-[a-z0-9][a-z0-9-]*$")
 
 
 def _scenario_id_from_synthetic_label(label: str) -> str:
     """Extract a scenario id from a synthetic command or ``suite:scenario`` label."""
     match = _SCENARIO_FLAG_RE.search(label)
     if match is not None:
-        return match.group(1).strip()
+        candidate = match.group(1).strip()
+        return candidate if _SYNTHETIC_SCENARIO_ID_RE.fullmatch(candidate) else ""
     if ":" in label:
-        return label.rsplit(":", 1)[-1].strip()
+        candidate = label.rsplit(":", 1)[-1].strip()
+        return candidate if _SYNTHETIC_SCENARIO_ID_RE.fullmatch(candidate) else ""
     return ""
 
 
@@ -172,9 +175,11 @@ class ReplSession:
             self.prompt_refresh_fn()
 
     def suggest_synthetic_failure_follow_up(self, *, label: str = "") -> None:
-        """Queue RCA prefill after a failed synthetic run; call ``notify_prompt_changed()`` after."""
+        """Queue RCA prefill after a failed synthetic run and refresh the active prompt."""
         self.pending_prompt_default = SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST
+        self.notify_prompt_changed()
         self._bind_last_synthetic_observation(_scenario_id_from_synthetic_label(label))
+        self.notify_prompt_changed()
 
     def _bind_last_synthetic_observation(self, scenario_id: str) -> None:
         if not scenario_id:

--- a/app/cli/interactive_shell/runtime/tasks.py
+++ b/app/cli/interactive_shell/runtime/tasks.py
@@ -350,6 +350,11 @@ class TaskRegistry:
             return None
         return matches[0]
 
+    def running_count(self) -> int:
+        """Count in-memory running tasks (no disk merge — safe for hot prompt refresh)."""
+        with self._lock:
+            return sum(1 for task in self._tasks if task.status == TaskStatus.RUNNING)
+
     def list_recent(self, n: int = 20) -> list[TaskRecord]:
         """Return up to ``n`` tasks, newer tasks first.
 

--- a/tests/cli/interactive_shell/orchestration/test_action_executor.py
+++ b/tests/cli/interactive_shell/orchestration/test_action_executor.py
@@ -793,6 +793,69 @@ def test_start_background_cli_task_reports_watcher_failure(
     assert isinstance(captured_errors[0], RuntimeError)
 
 
+def test_start_background_cli_task_skips_follow_up_after_session_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeProcess:
+        stdout = None
+        stderr = None
+        returncode = 1
+
+        def poll(self) -> int:
+            return 1
+
+    class _DeferredThread:
+        pending: list[object] = []
+
+        def __init__(
+            self,
+            group: object = None,
+            target: object = None,
+            name: object = None,
+            args: tuple[object, ...] = (),
+            kwargs: dict[str, object] | None = None,
+            *,
+            daemon: object = None,
+        ) -> None:
+            del group, name, daemon, args, kwargs
+            if callable(target):
+                _DeferredThread.pending.append(target)
+
+        def start(self) -> None:
+            return
+
+    def _fake_popen(_command: list[str], **_kwargs: object) -> _FakeProcess:
+        return _FakeProcess()
+
+    _DeferredThread.pending.clear()
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.action_executor.threading.Thread",
+        _DeferredThread,
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.action_executor.subprocess.Popen",
+        _fake_popen,
+    )
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    task = start_background_cli_task(
+        display_command="opensre tests synthetic --scenario 001-replication-lag",
+        argv_list=["python", "-m", "app.cli", "tests", "synthetic"],
+        session=session,
+        console=console,
+        kind=TaskKind.SYNTHETIC_TEST,
+    )
+    assert task is not None
+    assert len(_DeferredThread.pending) == 1
+    session.clear()
+    _DeferredThread.pending[0]()  # type: ignore[operator]
+    assert session.pending_prompt_default is None
+    _DeferredThread.pending.clear()
+
+
 def test_watch_synthetic_subprocess_reports_daemon_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/cli/interactive_shell/prompting/test_prompt_surface.py
+++ b/tests/cli/interactive_shell/prompting/test_prompt_surface.py
@@ -1,0 +1,55 @@
+"""Tests for prompt placeholder and prefill behavior."""
+
+from __future__ import annotations
+
+from app.cli.interactive_shell.prompting.prompt_surface import (
+    _DEFAULT_PLACEHOLDER_TEXT,
+    resolve_prompt_placeholder,
+)
+from app.cli.interactive_shell.runtime.session import ReplSession
+from app.cli.interactive_shell.runtime.tasks import TaskKind
+
+
+def _placeholder_text(session: ReplSession) -> str:
+    return resolve_prompt_placeholder(session).value
+
+
+class TestResolvePromptPlaceholder:
+    def test_default_when_no_session_context(self) -> None:
+        session = ReplSession()
+        assert _DEFAULT_PLACEHOLDER_TEXT in _placeholder_text(session)
+
+    def test_shows_trust_mode(self) -> None:
+        session = ReplSession()
+        session.trust_mode = True
+        text = _placeholder_text(session)
+        assert "trust on" in text
+        assert _DEFAULT_PLACEHOLDER_TEXT not in text
+
+    def test_shows_running_task_count(self) -> None:
+        session = ReplSession()
+        task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
+        task.mark_running()
+        assert "1 task running" in _placeholder_text(session)
+
+        second = session.task_registry.create(TaskKind.INVESTIGATION)
+        second.mark_running()
+        assert "2 tasks running" in _placeholder_text(session)
+
+    def test_shows_resumed_session_name(self) -> None:
+        session = ReplSession()
+        session.resumed_from_name = "redis-incident"
+        text = _placeholder_text(session)
+        assert "resumed: redis-incident" in text
+
+    def test_combines_multiple_state_segments(self) -> None:
+        session = ReplSession()
+        session.trust_mode = True
+        session.resumed_from_name = "redis-incident"
+        task = session.task_registry.create(TaskKind.WATCHDOG)
+        task.mark_running()
+        text = _placeholder_text(session)
+        assert "trust on" in text
+        assert "1 task running" in text
+        assert "resumed: redis-incident" in text
+        assert " · " in text

--- a/tests/cli/interactive_shell/runtime/test_session.py
+++ b/tests/cli/interactive_shell/runtime/test_session.py
@@ -7,7 +7,11 @@ from pathlib import Path
 import pytest
 
 import app.constants as const_module
-from app.cli.interactive_shell.runtime.session import ReplSession
+from app.cli.interactive_shell.runtime.session import (
+    SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST,
+    ReplSession,
+    _scenario_id_from_synthetic_label,
+)
 from app.cli.interactive_shell.runtime.tasks import TaskKind, TaskRegistry
 
 
@@ -38,6 +42,24 @@ class TestReplSession:
         session.pending_prompt_default = "why did it fail?"
         session.clear()
         assert session.pending_prompt_default is None
+
+    def test_scenario_id_from_synthetic_label(self) -> None:
+        assert (
+            _scenario_id_from_synthetic_label(
+                "opensre tests synthetic --scenario 001-replication-lag"
+            )
+            == "001-replication-lag"
+        )
+        assert _scenario_id_from_synthetic_label("rds_postgres:001-replication-lag") == (
+            "001-replication-lag"
+        )
+
+    def test_suggest_synthetic_failure_follow_up_sets_pending(self) -> None:
+        session = ReplSession()
+        session.suggest_synthetic_failure_follow_up(
+            label="opensre tests synthetic --scenario 001-replication-lag",
+        )
+        assert session.pending_prompt_default == SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST
 
     def test_record_appends_entry(self) -> None:
         session = ReplSession()

--- a/tests/cli/interactive_shell/runtime/test_session.py
+++ b/tests/cli/interactive_shell/runtime/test_session.py
@@ -53,6 +53,8 @@ class TestReplSession:
         assert _scenario_id_from_synthetic_label("rds_postgres:001-replication-lag") == (
             "001-replication-lag"
         )
+        assert _scenario_id_from_synthetic_label("opensre tests synthetic --scenario ./evil") == ""
+        assert _scenario_id_from_synthetic_label("rds_postgres:not-a-scenario") == ""
 
     def test_suggest_synthetic_failure_follow_up_sets_pending(self) -> None:
         session = ReplSession()


### PR DESCRIPTION
This pull request introduces significant improvements to how the interactive CLI prompt behaves, especially in terms of contextual placeholder text, prompt prefill after synthetic test failures, and overall session state management. The changes enhance user experience by making the prompt more informative and responsive to session events, and by consolidating logic related to synthetic test follow-ups. Additionally, several code paths are refactored for clarity, and new tests are added to ensure correct behavior.

**Prompt placeholder and refresh improvements:**

* Added `resolve_prompt_placeholder` to generate dynamic placeholder text based on session state (e.g., trust mode, running tasks, resumed session), replacing the previous static placeholder. [[1]](diffhunk://#diff-050274405abce8f3fe98421bbd72464b1d6035106b814b542e3503286cbc3c83L331-R373) [[2]](diffhunk://#diff-050274405abce8f3fe98421bbd72464b1d6035106b814b542e3503286cbc3c83L367-R409)
* Introduced `wire_prompt_refresh`, allowing the prompt to be programmatically refreshed/redrawn when session state changes. [[1]](diffhunk://#diff-050274405abce8f3fe98421bbd72464b1d6035106b814b542e3503286cbc3c83L331-R373) [[2]](diffhunk://#diff-16609ace41886c81d9921f6fd5ac6aa8d203d9a4523fd97889d59e3901d2a3b6L177-R177)
* The prompt now uses a callable for the placeholder, ensuring it always reflects the latest session state.

**Synthetic test failure follow-up and session state management:**

* Moved and refactored logic for suggesting a follow-up prompt and binding the last synthetic observation after a failed synthetic test into new `ReplSession` methods: `suggest_synthetic_failure_follow_up` and `_bind_last_synthetic_observation`. This replaces the previous scattered logic and improves maintainability. [[1]](diffhunk://#diff-ea6e8b3eb308fa7e9870605ef630ad2ab16878c39072fd78eab217d04fb9870dR169-R195) [[2]](diffhunk://#diff-21a1b3e3d62fe25b48bebf6c92550cd333c396af46fb37fef596fbdfc649565bL47-L71) [[3]](diffhunk://#diff-21a1b3e3d62fe25b48bebf6c92550cd333c396af46fb37fef596fbdfc649565bL85-R64) [[4]](diffhunk://#diff-21a1b3e3d62fe25b48bebf6c92550cd333c396af46fb37fef596fbdfc649565bL131-R106) [[5]](diffhunk://#diff-21a1b3e3d62fe25b48bebf6c92550cd333c396af46fb37fef596fbdfc649565bL158-R138)
* The session now notifies the prompt to refresh whenever a synthetic test fails, ensuring the user sees the suggested follow-up immediately. [[1]](diffhunk://#diff-a9fecab000351b6bcb419a0986c9c9759d23cb19ee449082633fd8bfb872d615R160-R173) [[2]](diffhunk://#diff-21a1b3e3d62fe25b48bebf6c92550cd333c396af46fb37fef596fbdfc649565bL158-R138)

**Task registry and session enhancements:**

* Added a `running_count` method to `TaskRegistry` to efficiently count currently running tasks, supporting the new dynamic placeholder.
* The session tracks a `prompt_refresh_fn` callback, which is invoked to update the prompt when needed.

**Code cleanup and refactoring:**

* Removed now-unnecessary utility functions (`_scenario_id_from_synthetic_suite_name`, `_try_bind_synthetic_observation`) from `synthetic_tasks.py` and cleaned up related imports and exports. [[1]](diffhunk://#diff-588016d623164b6c8c0f4e668d29a94703845ae4d85237788a800ffaaf46e34dL58-L59) [[2]](diffhunk://#diff-588016d623164b6c8c0f4e668d29a94703845ae4d85237788a800ffaaf46e34dL115-L120) [[3]](diffhunk://#diff-21a1b3e3d62fe25b48bebf6c92550cd333c396af46fb37fef596fbdfc649565bL47-L71)
* Improved scenario ID extraction by introducing `_scenario_id_from_synthetic_label`, which handles both flag and label formats.

**Testing improvements:**

* Added comprehensive tests for the new prompt placeholder logic, covering various session states and combinations.
* Updated session tests to cover the new scenario ID extraction and synthetic follow-up logic.
<img width="1049" height="757" alt="Screenshot 2026-06-11 at 10 39 05 AM" src="https://github.com/user-attachments/assets/f3b10e0a-04bd-4dce-a9d6-d41376116b19" />
<img width="1049" height="446" alt="Screenshot 2026-06-11 at 10 39 41 AM" src="https://github.com/user-attachments/assets/b23aa19a-bf18-4e64-bf7c-b3f74d9d559f" />
<img width="1049" height="822" alt="Screenshot 2026-06-11 at 10 43 32 AM" src="https://github.com/user-attachments/assets/695e6fcd-e6d1-4b82-b967-f1f832ab7627" />
<img width="1049" height="219" alt="Screenshot 2026-06-11 at 10 44 12 AM" src="https://github.com/user-attachments/assets/02701c63-14e7-48df-af11-24f7a6976a2d" />
<img width="1049" height="498" alt="Screenshot 2026-06-11 at 10 44 36 AM" src="https://github.com/user-attachments/assets/c485021c-d5d8-4095-ae8e-30045e4efbb0" />
<img width="1049" height="785" alt="Screenshot 2026-06-11 at 11 06 59 AM" src="https://github.com/user-attachments/assets/90324522-c70a-45aa-bbc2-4d322f6d28a0" />







