### PR TITLE
feat(bench): investigation_a1 + translation_loss metrics

### DIFF
--- a/tests/benchmarks/_framework/runner.py
+++ b/tests/benchmarks/_framework/runner.py
@@ -497,9 +497,11 @@ class BenchmarkRunner:
             encoding="utf-8",
         )
 
+        inv_a1 = score.metrics.get("investigation_a1")
+        inv_suffix = f" inv_a1={inv_a1:.2f}" if inv_a1 is not None else ""
         print(
             f"  {case.case_id} [{mode} · {llm} · run {run_index}] "
-            f"a1={score.metrics.get('a1', 0):.2f} "
+            f"a1={score.metrics.get('a1', 0):.2f}{inv_suffix} "
             f"steps={score.metrics.get('steps', 0):.0f} "
             f"{latency_ms}ms"
         )

--- a/tests/benchmarks/cloudopsbench/adapter.py
+++ b/tests/benchmarks/cloudopsbench/adapter.py
@@ -87,7 +87,19 @@ BENCHMARK_NAME = "cloudopsbench"
 # --------------------------------------------------------------------------- #
 
 _PAPER_METRIC_SCHEMA = MetricSchema(
-    outcome_metrics=["a1", "a3", "partial_a1", "partial_a3", "object_a1", "object_a3", "tcr"],
+    outcome_metrics=[
+        "a1",
+        "a3",
+        "partial_a1",
+        "partial_a3",
+        "object_a1",
+        "object_a3",
+        "investigation_a1",
+        "investigation_partial_a1",
+        "investigation_object_a1",
+        "translation_loss",
+        "tcr",
+    ],
     process_metrics=["exact", "in_order", "any_order", "rel", "cov"],
     efficiency_metrics=["steps", "mtti"],
     robustness_metrics=["iac", "rar", "ztdr"],
@@ -106,6 +118,10 @@ _PAPER_METRIC_SCHEMA = MetricSchema(
         "partial_a3": True,
         "object_a1": True,
         "object_a3": True,
+        "investigation_a1": True,
+        "investigation_partial_a1": True,
+        "investigation_object_a1": True,
+        "translation_loss": False,
         "tcr": True,
         # Process — trajectory alignment + tool usage (higher better)
         "exact": True,

--- a/tests/benchmarks/cloudopsbench/analyze_validation.py
+++ b/tests/benchmarks/cloudopsbench/analyze_validation.py
@@ -184,7 +184,10 @@ def analyze(run_dir: Path) -> int:
     if "opensre+llm" in arms and control_arm in arms:
         for metric_label, hit_fn in (
             ("a1 (predictor rank-1)", _cell_a1),
-            ("investigation_a1 (opensre prose)", lambda r: _investigation_a1_hit(r, _gt(r["case"]))),
+            (
+                "investigation_a1 (opensre prose)",
+                lambda r: _investigation_a1_hit(r, _gt(r["case"])),
+            ),
         ):
             print(f"=== paired {metric_label}: (opensre+llm) − ({control_arm}) ===")
             for seen in (True, False, None):

--- a/tests/benchmarks/cloudopsbench/analyze_validation.py
+++ b/tests/benchmarks/cloudopsbench/analyze_validation.py
@@ -295,16 +295,37 @@ def _cell_a1(row: dict) -> int:
 
 
 def _investigation_a1_hit(row: dict, gt: tuple[str, str, str]) -> int:
-    """1 when opensre's investigation names the GT triple (L0 metric)."""
+    """1 when opensre's investigation names the GT triple (L0 metric).
+
+    Primary path: read ``investigation_a1`` from the cell's recorded metrics.
+    This is the source of truth — it's what the scorer wrote at run time
+    using the full ``case_data`` dict.
+
+    Fallback (legacy artifacts that pre-date this metric): rebuild a
+    pseudo-``case_data`` from ``final_diagnosis`` fields and re-run the
+    keyword parser. The fallback is **best-effort** and may undercount the
+    scorer's value when ``causal_chain`` / ``validated_claims`` were
+    captured at a path the synthesized dict doesn't probe — e.g. directly
+    on ``run`` rather than nested inside ``final_diagnosis``. We try both
+    locations here to cover the most common artifact shapes, but for
+    authoritative L0 numbers on legacy data, re-score the run rather than
+    rely on this fallback.
+    """
     scored = _metric(row, "investigation_a1")
     if scored is not None:
         return 1 if scored >= 1.0 else 0
     run = row.get("run", {})
     diag = run.get("final_diagnosis") or {}
+    # ``final_state`` may live nested in ``final_diagnosis`` (current shape)
+    # or directly on ``run`` (older artifacts). Prefer the nested form when
+    # both are present — that's what the scorer would have read first.
+    final_state = diag.get("final_state")
+    if not isinstance(final_state, dict):
+        final_state = run.get("final_state")
     case_data = {
         "root_cause": diag.get("root_cause"),
         "report": diag.get("report"),
-        "final_state": diag.get("final_state"),
+        "final_state": final_state if isinstance(final_state, dict) else None,
     }
     payload = infer_final_answer_from_opensre_text(case_data, include_predictor_output=False)
     if not payload:

--- a/tests/benchmarks/cloudopsbench/analyze_validation.py
+++ b/tests/benchmarks/cloudopsbench/analyze_validation.py
@@ -1,15 +1,15 @@
-"""Analyze a Fix-A + vocab-fix validation run (read-only over cases/*.json).
+"""Analyze a CloudOpsBench validation run (read-only over cases/*.json).
 
-Compares the ``opensre+llm`` and ``llm_alone`` arms per shape stratum and
-reports the metrics that the 2026-06-07 fixes target:
+Compares bench arms per shape stratum and reports:
 
   - per-stratum a1 / object_a1 / false-healthy rate per arm
-  - the paired ``opensre+llm − llm_alone`` a1 contrast (scenario-clustered
-    bootstrap CI) — the headline number Fix A should move positive on
-    seen-shape
-  - translation-loss proxy: among opensre+llm failures, how often opensre's
-    report NAMED the correct fault_object but the predictor's top-3 dropped it
-    (this is the 15.2%-vs-5.7% leak Fix A closes)
+  - L0 vs L1 panel: ``investigation_a1`` (opensre prose) vs ``a1`` (predictor
+    rank-1) and translation-loss rate
+  - paired ``opensre+llm − control`` contrasts on **a1** and **investigation_a1**
+    (scenario-clustered bootstrap CI) — use investigation_a1 to answer whether
+    opensre's investigation improved, not just the LLM formalizer
+  - translation-loss proxy: among failures, how often opensre's report NAMED
+    the correct fault_object but the predictor's top-3 dropped it
 
 Usage:
     uv run python -m tests.benchmarks.cloudopsbench.analyze_validation \
@@ -25,9 +25,14 @@ import glob
 import json
 import random
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
-_ARMS = ("opensre+llm", "llm_alone")
+from tests.benchmarks.cloudopsbench.scoring import (
+    infer_final_answer_from_opensre_text,
+)
+
+_DEFAULT_ARMS = ("opensre+llm", "llm_alone", "llm_alone_pure")
 
 # Minimum service-name length for the seen-shape translation-loss substring
 # proxy. All seen-shape ground-truth objects are ``app/<service>`` with
@@ -84,11 +89,31 @@ def _bootstrap_ci(deltas: list[float], iters: int = 2000) -> tuple[float, float,
     return pt, boots[int(0.025 * len(boots))], boots[int(0.975 * len(boots))]
 
 
+def _arms_in_run(rows: list[dict]) -> tuple[str, ...]:
+    seen = sorted({str(r["run"]["mode"]) for r in rows if r.get("run")})
+    # Prefer canonical order; append any extra modes present in the run.
+    ordered = [a for a in _DEFAULT_ARMS if a in seen]
+    extras = [a for a in seen if a not in ordered]
+    return tuple(ordered + extras)
+
+
+def _metric(row: dict, name: str) -> float | None:
+    """Read a scored metric from the cell artifact when the runner recorded it."""
+    score = row.get("score") or {}
+    metrics = score.get("metrics") if isinstance(score, dict) else None
+    if isinstance(metrics, dict) and name in metrics:
+        return float(metrics[name])
+    return None
+
+
 def analyze(run_dir: Path) -> int:
     rows = _load(run_dir)
     if not rows:
         print(f"No case files found under {run_dir}/cases/")
         return 1
+
+    arms = _arms_in_run(rows)
+    control_arm = "llm_alone_pure" if "llm_alone_pure" in arms else "llm_alone"
 
     print(f"Validation analysis: {run_dir.name}  ({len(rows)} cells)\n")
 
@@ -97,7 +122,7 @@ def analyze(run_dir: Path) -> int:
         label = "SEEN-shape" if seen else "UNSEEN-shape"
         print(f"=== {label} ===")
         print(f"{'arm':<14}{'n':>5}{'a1':>8}{'object_a1':>11}{'healthy%':>10}")
-        for arm in _ARMS:
+        for arm in arms:
             cells = [
                 r for r in rows if r["run"]["mode"] == arm and r["case"].get("seen_shape") is seen
             ]
@@ -118,40 +143,88 @@ def analyze(run_dir: Path) -> int:
             print(f"{arm:<14}{n:>5}{a1 / n:>8.3f}{obj / n:>11.3f}{100 * healthy / n:>9.1f}%")
         print()
 
-    # Paired contrast (opensre+llm − llm_alone) per stratum, scenario-clustered.
-    print("=== paired a1 contrast: (opensre+llm) − (llm_alone) ===")
-    for seen in (True, False, None):
-        label = {True: "seen", False: "unseen", None: "all"}[seen]
-
-        def scen_a1(arm: str, seen: bool | None = seen) -> dict[str, float]:
-            by: dict[str, list[int]] = {}
-            for r in rows:
-                if r["run"]["mode"] != arm:
-                    continue
-                if seen is not None and r["case"].get("seen_shape") is not seen:
-                    continue
-                preds = _top(r["run"])
-                hit = 1 if (preds and _is_a1(preds[0], _gt(r["case"]))) else 0
-                by.setdefault(r["case"]["case_id"], []).append(hit)
-            return {k: sum(v) / len(v) for k, v in by.items()}
-
-        a = scen_a1("opensre+llm")
-        b = scen_a1("llm_alone")
-        shared = sorted(set(a) & set(b))
-        deltas = [a[k] - b[k] for k in shared]
-        pt, lo, hi = _bootstrap_ci(deltas)
-        verdict = (
-            "ns (incl 0)" if (lo <= 0 <= hi) else ("opensre+ SIG" if pt > 0 else "control+ SIG")
-        )
-        print(
-            f"  {label:<7} d={pt:+.4f}  95%CI[{lo:+.4f},{hi:+.4f}]  n_scen={len(shared):>3}  {verdict}"
-        )
+    # L0 (investigation) vs L1 (predictor) side-by-side per arm.
+    #
+    # This is the "are we benchmarking opensre or the LLM wrapping its text?"
+    # panel. ``investigation_a1`` rebuilds a paper triple from opensre's
+    # prose using the same keyword parser the legacy bridge uses (with
+    # ``include_predictor_output=False`` so the predictor's structured JSON
+    # doesn't feed back through). The gap a1 − investigation_a1 is the
+    # predictor's contribution; ``translation_loss`` is the wrong-direction
+    # half (opensre right, predictor wrong).
+    #
+    # Read the panel as:
+    #   - inv_a1 column = opensre's own ability, conservative lower bound
+    #   - a1 column = full pipeline (investigate → predictor → rank-1)
+    #   - tl% column = how often the predictor LOST what opensre named
+    print("=== L0 (investigation) vs L1 (predictor) ===")
+    print("    inv_a1 = opensre prose alone (lower bound on investigation quality)")
+    print("    a1     = top_3_predictions[0] (paper-compatible headline)")
+    print("    tl%    = translation loss: inv_a1 right but a1 wrong")
+    print(f"{'arm':<14}{'n':>5}{'inv_a1':>9}{'a1':>8}{'gap':>8}{'tl%':>7}")
+    for arm in arms:
+        cells = [r for r in rows if r["run"]["mode"] == arm]
+        if not cells:
+            continue
+        n = len(cells)
+        inv_a1 = a1 = tl = 0
+        for r in cells:
+            gt = _gt(r["case"])
+            inv_hit = _investigation_a1_hit(r, gt)
+            a1_hit = _cell_a1(r)
+            inv_a1 += inv_hit
+            a1 += a1_hit
+            if inv_hit and not a1_hit:
+                tl += 1
+        gap = (a1 - inv_a1) / n
+        print(f"{arm:<14}{n:>5}{inv_a1 / n:>9.3f}{a1 / n:>8.3f}{gap:>+8.3f}{100 * tl / n:>6.1f}%")
     print()
+
+    # Paired contrasts per stratum — L1 (a1) and L0 (investigation_a1).
+    if "opensre+llm" in arms and control_arm in arms:
+        for metric_label, hit_fn in (
+            ("a1 (predictor rank-1)", _cell_a1),
+            ("investigation_a1 (opensre prose)", lambda r: _investigation_a1_hit(r, _gt(r["case"]))),
+        ):
+            print(f"=== paired {metric_label}: (opensre+llm) − ({control_arm}) ===")
+            for seen in (True, False, None):
+                label = {True: "seen", False: "unseen", None: "all"}[seen]
+
+                def scen_hit(
+                    arm: str,
+                    seen: bool | None = seen,
+                    hit_fn: Callable[[dict], int] = hit_fn,
+                ) -> dict[str, float]:
+                    by: dict[str, list[int]] = {}
+                    for r in rows:
+                        if r["run"]["mode"] != arm:
+                            continue
+                        if seen is not None and r["case"].get("seen_shape") is not seen:
+                            continue
+                        hit = hit_fn(r)
+                        by.setdefault(r["case"]["case_id"], []).append(hit)
+                    return {k: sum(v) / len(v) for k, v in by.items()}
+
+                a = scen_hit("opensre+llm")
+                b = scen_hit(control_arm)
+                shared = sorted(set(a) & set(b))
+                deltas = [a[k] - b[k] for k in shared]
+                pt, lo, hi = _bootstrap_ci(deltas)
+                verdict = (
+                    "ns (incl 0)"
+                    if (lo <= 0 <= hi)
+                    else ("opensre+ SIG" if pt > 0 else "control+ SIG")
+                )
+                print(
+                    f"  {label:<7} d={pt:+.4f}  95%CI[{lo:+.4f},{hi:+.4f}]  "
+                    f"n_scen={len(shared):>3}  {verdict}"
+                )
+            print()
 
     # Translation-loss proxy (seen-shape, the Fix-A target).
     print("=== translation-loss proxy (seen-shape failures) ===")
     print("    report NAMED correct fault_object but predictor dropped it from top-3")
-    for arm in _ARMS:
+    for arm in arms:
         fails = dropped = 0
         for r in rows:
             if r["run"]["mode"] != arm or not r["case"].get("seen_shape"):
@@ -179,7 +252,7 @@ def analyze(run_dir: Path) -> int:
     print("=== B2 false-healthy guard activations ===")
     print("    cells where the guard downgraded a false-healthy conclusion")
     any_fired = False
-    for arm in _ARMS:
+    for arm in arms:
         cells = [r for r in rows if r["run"]["mode"] == arm]
         if not cells:
             continue
@@ -216,6 +289,25 @@ def _b2_fired(row: dict) -> bool:
 def _cell_a1(row: dict) -> int:
     preds = _top(row["run"])
     return 1 if preds and _is_a1(preds[0], _gt(row["case"])) else 0
+
+
+def _investigation_a1_hit(row: dict, gt: tuple[str, str, str]) -> int:
+    """1 when opensre's investigation names the GT triple (L0 metric)."""
+    scored = _metric(row, "investigation_a1")
+    if scored is not None:
+        return 1 if scored >= 1.0 else 0
+    run = row.get("run", {})
+    diag = run.get("final_diagnosis") or {}
+    case_data = {
+        "root_cause": diag.get("root_cause"),
+        "report": diag.get("report"),
+        "final_state": diag.get("final_state"),
+    }
+    payload = infer_final_answer_from_opensre_text(case_data, include_predictor_output=False)
+    if not payload:
+        return 0
+    preds = payload.get("top_3_predictions") or []
+    return 1 if preds and _is_a1(preds[0], gt) else 0
 
 
 def main() -> int:

--- a/tests/benchmarks/cloudopsbench/configs/cloudopsbench_db_pod_logs_smoke_openai.yml
+++ b/tests/benchmarks/cloudopsbench/configs/cloudopsbench_db_pod_logs_smoke_openai.yml
@@ -79,10 +79,17 @@
 # bump).
 # Wall time: ~30-45 min Fargate at workers=1.
 #
+# Post-run analysis (read L0 vs L1):
+#   uv run python -m tests.benchmarks.cloudopsbench.analyze_validation \
+#     .bench-results/cloudopsbench_db_pod_logs_smoke_openai/<run-id>
+#   The analyzer prints investigation_a1 (opensre prose) beside a1 (predictor
+#   rank-1) and paired Δ on BOTH — use investigation_a1 to judge opensre;
+#   use a1 for the paper-compatible pipeline.
+#
 # Smoke gate (advance to full-N):
 #   ALL of:
-#   (a) opensre+llm aggregate A@1 ≥ baseline + 0.02 (point estimate; smoke
-#       CI need not exclude 0). Joint mechanism lift.
+#   (a) opensre+llm aggregate investigation_a1 ≥ control + 0.02 (PRIMARY —
+#       opensre investigation quality). Pipeline a1 lift is secondary.
 #   (b1) Planner rule fired: opensre's evidence_entries on DB-backed cases
 #        SHOULD contain at least one GetErrorLogs::tsdb-mysql / nacosdb-
 #        mysql / redis-cart on ≥30% of opensre+llm cells where GT

--- a/tests/benchmarks/cloudopsbench/scoring.py
+++ b/tests/benchmarks/cloudopsbench/scoring.py
@@ -264,6 +264,15 @@ def _infer_fault_object(text: str) -> str:
 
     Longest names first so ``ts-order-other-service`` wins over ``ts-order-service``.
     Kept in sync with ``predictor.vocabulary._FAULT_OBJECT_*``.
+
+    Namespace match REQUIRES the literal word ``namespace`` to appear in the
+    text as a precision guard. Without it, prose like "boutique system has
+    memory pressure" would incorrectly return ``namespace/boutique`` whenever
+    the cluster name is mentioned in passing — overriding the empty-string
+    "no localization" result and producing a spurious wrong-shape match on
+    cases whose GT is a ``namespace/<X>`` fault. Original guard preserved
+    here after a 2026-06 refactor (commit 8dac68c7) dropped it; the
+    regression is fixed without losing the vocab-import simplification.
     """
     from tests.benchmarks.cloudopsbench.predictor.vocabulary import (
         _FAULT_OBJECT_NAMESPACES,
@@ -277,9 +286,10 @@ def _infer_fault_object(text: str) -> str:
     for node_name in _FAULT_OBJECT_NODES:
         if node_name in text:
             return f"node/{node_name}"
-    for ns_name in _FAULT_OBJECT_NAMESPACES:
-        if ns_name in text:
-            return f"namespace/{ns_name}"
+    if "namespace" in text:
+        for ns_name in _FAULT_OBJECT_NAMESPACES:
+            if ns_name in text:
+                return f"namespace/{ns_name}"
     return ""
 
 

--- a/tests/benchmarks/cloudopsbench/scoring.py
+++ b/tests/benchmarks/cloudopsbench/scoring.py
@@ -6,7 +6,19 @@ from dataclasses import asdict, dataclass
 from typing import Any
 
 from tests.benchmarks.cloudopsbench.case_loader import CloudOpsCase
+from tests.benchmarks.cloudopsbench.predictor.vocabulary import (
+    _FAULT_OBJECT_NAMESPACES,
+    _FAULT_OBJECT_NODES,
+    _FAULT_OBJECT_SERVICES,
+)
 from tests.benchmarks.cloudopsbench.replay_backend import normalize_resource_type
+
+# Longest service names first so ``ts-order-other-service`` shadows
+# ``ts-order-service`` on substring match. Computed once at module load —
+# the underlying vocabulary tuple is stable for the process lifetime.
+_FAULT_OBJECT_SERVICES_BY_LENGTH: tuple[str, ...] = tuple(
+    sorted(_FAULT_OBJECT_SERVICES, key=len, reverse=True)
+)
 
 TOOL_KEY_PARAMS: dict[str, list[str]] = {
     "GetResources": ["resource_type"],
@@ -262,25 +274,20 @@ def _infer_root_cause(text: str) -> str:
 def _infer_fault_object(text: str) -> str:
     """Substring match against the predictor's closed service vocabulary.
 
-    Longest names first so ``ts-order-other-service`` wins over ``ts-order-service``.
-    Kept in sync with ``predictor.vocabulary._FAULT_OBJECT_*``.
+    Longest names first (precomputed in ``_FAULT_OBJECT_SERVICES_BY_LENGTH``)
+    so ``ts-order-other-service`` wins over ``ts-order-service``. Kept in
+    sync with ``predictor.vocabulary._FAULT_OBJECT_*``.
 
-    Namespace match REQUIRES the literal word ``namespace`` to appear in the
-    text as a precision guard. Without it, prose like "boutique system has
-    memory pressure" would incorrectly return ``namespace/boutique`` whenever
-    the cluster name is mentioned in passing — overriding the empty-string
-    "no localization" result and producing a spurious wrong-shape match on
-    cases whose GT is a ``namespace/<X>`` fault. Original guard preserved
-    here after a 2026-06 refactor (commit 8dac68c7) dropped it; the
-    regression is fixed without losing the vocab-import simplification.
+    Namespace match REQUIRES the literal word ``namespace`` to appear in
+    the text as a precision guard. Without it, prose like "boutique system
+    has memory pressure" would incorrectly return ``namespace/boutique``
+    whenever the cluster name is mentioned in passing — overriding the
+    empty-string "no localization" result and producing a spurious
+    wrong-shape match on cases whose GT is a ``namespace/<X>`` fault. The
+    original guard was preserved here after a 2026-06 refactor (commit
+    8dac68c7) dropped it.
     """
-    from tests.benchmarks.cloudopsbench.predictor.vocabulary import (
-        _FAULT_OBJECT_NAMESPACES,
-        _FAULT_OBJECT_NODES,
-        _FAULT_OBJECT_SERVICES,
-    )
-
-    for service_name in sorted(_FAULT_OBJECT_SERVICES, key=len, reverse=True):
+    for service_name in _FAULT_OBJECT_SERVICES_BY_LENGTH:
         if service_name in text:
             return f"app/{service_name}"
     for node_name in _FAULT_OBJECT_NODES:

--- a/tests/benchmarks/cloudopsbench/scoring.py
+++ b/tests/benchmarks/cloudopsbench/scoring.py
@@ -48,6 +48,25 @@ class CloudOpsMetrics:
     # object correct; object_a3 = correct object anywhere in the top-3.
     object_a1: float
     object_a3: float
+    # Investigation-native scoring: rebuild a single triple from opensre's
+    # prose (report + root_cause + causal_chain + validated_claims) using the
+    # deterministic keyword parser ``infer_final_answer_from_opensre_text``,
+    # then score it the same way. This isolates opensre's investigation
+    # quality from the LLM predictor that formalizes the prose into
+    # ``top_3_predictions``: a lift on ``a1`` could come from a better
+    # investigation OR a better predictor — ``investigation_a1`` only moves
+    # when the investigation itself names the correct triple.
+    #
+    # ``investigation_a1`` is a CONSERVATIVE lower bound on investigation
+    # quality: the keyword parser misses synonyms and freer phrasings.
+    # ``translation_loss`` flips on cases where investigation_a1 is right but
+    # ``a1`` is wrong — the formalization step lost what opensre found.
+    # Read together they answer "is opensre getting better, or just the
+    # wrapper around it?"
+    investigation_a1: float
+    investigation_partial_a1: float
+    investigation_object_a1: float
+    translation_loss: float
     tcr: float
     exact: float
     in_order: float
@@ -154,13 +173,27 @@ def extract_final_answer_payload(case_data: dict[str, Any]) -> tuple[dict[str, A
     return None, "unparsed"
 
 
-def infer_final_answer_from_opensre_text(case_data: dict[str, Any]) -> dict[str, Any] | None:
+def infer_final_answer_from_opensre_text(
+    case_data: dict[str, Any],
+    *,
+    include_predictor_output: bool = True,
+) -> dict[str, Any] | None:
+    """Parse opensre's free-text RCA into a single-prediction paper triple.
+
+    Set ``include_predictor_output=False`` for investigation-native scoring:
+    by default this function also reads ``case_data["final_answer"]`` (the
+    structured-predictor JSON, stringified) which would feed predictor
+    signal back through the keyword parser and defeat the purpose of an
+    "is opensre alone right?" metric. Existing callers (legacy fallback in
+    ``extract_final_answer_payload``) keep the default behavior.
+    """
     final_state = case_data.get("final_state")
     texts = [
         case_data.get("root_cause"),
         case_data.get("report"),
-        case_data.get("final_answer"),
     ]
+    if include_predictor_output:
+        texts.append(case_data.get("final_answer"))
     if isinstance(final_state, dict):
         texts.extend(
             [
@@ -227,37 +260,26 @@ def _infer_root_cause(text: str) -> str:
 
 
 def _infer_fault_object(text: str) -> str:
-    service_names = [
-        "adservice",
-        "cartservice",
-        "checkoutservice",
-        "currencyservice",
-        "emailservice",
-        "frontend",
-        "paymentservice",
-        "productcatalogservice",
-        "recommendationservice",
-        "redis-cart",
-        "shippingservice",
-        "ts-gateway-service",
-        "ts-order-service",
-        "ts-payment-service",
-        "ts-travel-service",
-        "ts-user-service",
-        "ts-auth-service",
-        "ts-route-service",
-        "ts-ticket-office-service",
-    ]
-    for service_name in service_names:
+    """Substring match against the predictor's closed service vocabulary.
+
+    Longest names first so ``ts-order-other-service`` wins over ``ts-order-service``.
+    Kept in sync with ``predictor.vocabulary._FAULT_OBJECT_*``.
+    """
+    from tests.benchmarks.cloudopsbench.predictor.vocabulary import (
+        _FAULT_OBJECT_NAMESPACES,
+        _FAULT_OBJECT_NODES,
+        _FAULT_OBJECT_SERVICES,
+    )
+
+    for service_name in sorted(_FAULT_OBJECT_SERVICES, key=len, reverse=True):
         if service_name in text:
             return f"app/{service_name}"
-    for node_name in ("master", "worker-01", "worker-02", "worker-03"):
+    for node_name in _FAULT_OBJECT_NODES:
         if node_name in text:
             return f"node/{node_name}"
-    if "namespace" in text and "boutique" in text:
-        return "namespace/boutique"
-    if "namespace" in text and "train-ticket" in text:
-        return "namespace/train-ticket"
+    for ns_name in _FAULT_OBJECT_NAMESPACES:
+        if ns_name in text:
+            return f"namespace/{ns_name}"
     return ""
 
 
@@ -581,6 +603,34 @@ def calculate_total_latency(case_data: dict[str, Any]) -> float:
     return total
 
 
+def _score_investigation_native(
+    case_data: dict[str, Any],
+    ground_truth: dict[str, Any],
+) -> dict[str, float]:
+    """Score opensre's investigation prose directly, bypassing the predictor.
+
+    Builds a single-prediction triple from opensre's text via the
+    deterministic keyword parser ``infer_final_answer_from_opensre_text``,
+    then runs it through ``score_predictions`` against ground truth. Returns
+    the same key shape as ``score_predictions`` so the call site can mirror
+    its handling. Returns all zeros when the parser cannot extract a triple
+    (empty text or unmatched root_cause / fault_object), which is the honest
+    floor — we have no evidence the investigation named the right answer.
+    """
+    inferred = infer_final_answer_from_opensre_text(case_data, include_predictor_output=False)
+    if not inferred:
+        return {"a1": 0.0, "partial_a1": 0.0, "object_a1": 0.0}
+    predictions = inferred.get("top_3_predictions", []) or []
+    if not isinstance(predictions, list) or not predictions:
+        return {"a1": 0.0, "partial_a1": 0.0, "object_a1": 0.0}
+    scored = score_predictions(predictions, ground_truth)
+    return {
+        "a1": scored["a1"],
+        "partial_a1": scored["partial_a1"],
+        "object_a1": scored["object_a1"],
+    }
+
+
 def score_case(case: CloudOpsCase, case_data: dict[str, Any]) -> CloudOpsCaseScore:
     ground_truth = {
         "fault_taxonomy": case.result.fault_taxonomy,
@@ -605,6 +655,11 @@ def score_case(case: CloudOpsCase, case_data: dict[str, Any]) -> CloudOpsCaseSco
         }
     )
 
+    investigation_scores = _score_investigation_native(case_data, ground_truth)
+    translation_loss = (
+        1.0 if investigation_scores["a1"] >= 1.0 and outcome_scores["a1"] < 1.0 else 0.0
+    )
+
     agent_steps, invalid_count, invalid_reasons = standardize_agent_steps(case_data)
     best_path = choose_best_path(agent_steps, case.process)
     steps = len(agent_steps)
@@ -616,6 +671,10 @@ def score_case(case: CloudOpsCase, case_data: dict[str, Any]) -> CloudOpsCaseSco
         partial_a3=outcome_scores["partial_a3"],
         object_a1=outcome_scores["object_a1"],
         object_a3=outcome_scores["object_a3"],
+        investigation_a1=investigation_scores["a1"],
+        investigation_partial_a1=investigation_scores["partial_a1"],
+        investigation_object_a1=investigation_scores["object_a1"],
+        translation_loss=translation_loss,
         tcr=1.0 if predictions else 0.0,
         exact=best_path["exact"],
         in_order=best_path["in_order"],
@@ -651,6 +710,10 @@ def summarize_scores(scores: list[CloudOpsCaseScore]) -> dict[str, Any]:
         "partial_a3",
         "object_a1",
         "object_a3",
+        "investigation_a1",
+        "investigation_partial_a1",
+        "investigation_object_a1",
+        "translation_loss",
         "tcr",
         "exact",
         "in_order",
@@ -686,6 +749,10 @@ def summarize_scores(scores: list[CloudOpsCaseScore]) -> dict[str, Any]:
             "Partial Accuracy @3": averages["partial_a3"],
             "Object Accuracy @1": averages["object_a1"],
             "Object Accuracy @3": averages["object_a3"],
+            "Investigation Accuracy @1": averages["investigation_a1"],
+            "Investigation Partial Accuracy @1": averages["investigation_partial_a1"],
+            "Investigation Object Accuracy @1": averages["investigation_object_a1"],
+            "Translation Loss Rate": averages["translation_loss"],
             "Task Completion Rate": averages["tcr"],
             "ExactMatch": averages["exact"],
             "InOrder": averages["in_order"],

--- a/tests/benchmarks/cloudopsbench/tests/test_scoring_investigation.py
+++ b/tests/benchmarks/cloudopsbench/tests/test_scoring_investigation.py
@@ -141,6 +141,31 @@ def test_infer_fault_object_uses_full_train_ticket_vocabulary() -> None:
     assert _infer_fault_object(text) == "app/ts-order-other-service"
 
 
+def test_infer_fault_object_namespace_requires_anchor_word() -> None:
+    """Precision guard: namespace match requires the literal word ``namespace``
+    in the text. Without it, prose like "boutique system has memory pressure"
+    would falsely return ``namespace/boutique`` and inflate investigation_a1
+    on the small fraction of cases whose GT is actually a ``namespace/<X>``
+    fault, while shifting investigation outputs on every case whose GT is a
+    service or node. Regression guard for the 2026-06 vocab-import refactor
+    that dropped this anchor."""
+    # Casual cluster-name mention WITHOUT the word "namespace" → empty.
+    # No service / node match → must NOT fall through to namespace match.
+    assert _infer_fault_object("boutique system has memory pressure") == ""
+    assert _infer_fault_object("train-ticket cluster was slow today") == ""
+    # Explicit namespace localization DOES match — the guard is the literal
+    # word "namespace", not a stricter grammar.
+    assert _infer_fault_object("issue localized to the boutique namespace") == "namespace/boutique"
+    assert (
+        _infer_fault_object("the train-ticket namespace was quota-throttled")
+        == "namespace/train-ticket"
+    )
+    # Service match still wins even when both "namespace" + cluster name
+    # appear — the service loop runs first.
+    text = "cartservice failure in the boutique namespace"
+    assert _infer_fault_object(text) == "app/cartservice"
+
+
 def test_investigation_a1_zero_when_root_cause_phrasing_does_not_match() -> None:
     """Parser sees the service name but the root cause phrasing doesn't match
     any keyword set → all zeros, because ``infer_final_answer_from_opensre_text``

--- a/tests/benchmarks/cloudopsbench/tests/test_scoring_investigation.py
+++ b/tests/benchmarks/cloudopsbench/tests/test_scoring_investigation.py
@@ -1,0 +1,155 @@
+"""Tests for investigation-native scoring + translation-loss metric.
+
+These metrics answer "is opensre's INVESTIGATION getting better, or just
+the LLM predictor that wraps its prose?" The headline ``a1`` score is
+computed on ``top_3_predictions[0]`` — that's a second LLM call's
+output. A lift on ``a1`` could come from opensre, the predictor, or the
+handoff layer (B1/snap/rerank). Without a separate score on opensre's
+text we can't tell.
+
+``investigation_a1`` scores the keyword-parsed triple from opensre's
+prose alone (``report`` + ``root_cause`` + ``final_state`` evidence —
+deliberately NOT the predictor's ``final_answer`` field, which is the
+predictor's output and would contaminate the metric).
+
+``translation_loss`` flags cases where investigation_a1 is right but
+``a1`` is wrong — opensre named the answer, the predictor lost it.
+
+The keyword parser is conservative (misses synonyms), so
+``investigation_a1`` is a lower bound on investigation quality, not the
+truth. Read it as "≥X% of cases opensre's text named the GT triple."
+"""
+
+from __future__ import annotations
+
+from tests.benchmarks.cloudopsbench.scoring import (
+    _infer_fault_object,
+    _score_investigation_native,
+    infer_final_answer_from_opensre_text,
+)
+
+# Use service_dns_resolution_failure — the keyword parser needs only
+# ("dns", "resolution", "no such host") + a known service name, which is
+# achievable in realistic prose. The cartservice + env_var_address_mismatch
+# rule requires SIX tokens at once and is hard to hit cleanly in tests.
+_GT = {
+    "fault_taxonomy": "Service_Routing_Fault",
+    "fault_object": "app/frontend",
+    "root_cause": "service_dns_resolution_failure",
+}
+
+
+def _case_data(
+    *,
+    report: str = "",
+    root_cause: str = "",
+    final_answer: object = None,
+) -> dict:
+    """Minimal case_data shape: only what the scorer reads."""
+    data: dict = {}
+    if report:
+        data["report"] = report
+    if root_cause:
+        data["root_cause"] = root_cause
+    if final_answer is not None:
+        data["final_answer"] = final_answer
+    return data
+
+
+def test_investigation_a1_fires_when_opensre_prose_names_gt_triple() -> None:
+    """opensre's report names the GT service + root cause → investigation_a1 = 1."""
+    case_data = _case_data(
+        report=(
+            "Identified component: frontend.\n"
+            "Investigation conclusion (root cause): frontend has a DNS "
+            "resolution failure — no such host when calling upstream services."
+        )
+    )
+    scores = _score_investigation_native(case_data, _GT)
+    assert scores["a1"] == 1.0
+    assert scores["object_a1"] == 1.0
+    assert scores["partial_a1"] == 1.0
+
+
+def test_investigation_a1_zero_when_prose_empty() -> None:
+    """No opensre text → no signal → zero, not crash."""
+    scores = _score_investigation_native({}, _GT)
+    assert scores == {"a1": 0.0, "partial_a1": 0.0, "object_a1": 0.0}
+
+
+def test_investigation_a1_does_not_read_predictor_final_answer() -> None:
+    """Critical contamination guard: ``case_data["final_answer"]`` is the
+    predictor's structured JSON. Stringifying it back through the keyword
+    parser would feed predictor signal into the investigation metric and
+    defeat the separation. The scorer MUST ignore that field.
+
+    To make the test meaningful (rather than passing accidentally because
+    the predictor dict happens to lack required tokens), use a rich-text
+    ``final_answer`` that DOES contain all the keyword tokens — proving
+    the contamination guard, not just the parser's natural ceiling."""
+    case_data = _case_data(
+        report="Could not determine a clear root cause.",
+        # Rich text masquerading as predictor output: contains every token
+        # needed to match service_dns_resolution_failure on the frontend.
+        # If the scorer reads this, investigation_a1 incorrectly fires.
+        final_answer=(
+            "frontend has a DNS resolution failure — no such host found "
+            "for upstream services. Localized to frontend."
+        ),
+    )
+    scores = _score_investigation_native(case_data, _GT)
+    assert scores["a1"] == 0.0
+    assert scores["object_a1"] == 0.0
+
+
+def test_infer_final_answer_default_reads_final_answer_text() -> None:
+    """Backward-compat: existing callers (legacy keyword fallback in
+    ``extract_final_answer_payload``) rely on the default behavior reading
+    ``final_answer``. The flag must default to True. We use rich-text
+    ``final_answer`` (matches the legacy pre-JSON-predictor era when the
+    field carried free-form English) so the parser has actual tokens to
+    match — proving the field IS read, not bypassed."""
+    case_data = _case_data(
+        final_answer=(
+            "frontend has a DNS resolution failure — no such host found for upstream services."
+        )
+    )
+    payload = infer_final_answer_from_opensre_text(case_data)
+    assert payload is not None
+    assert payload["top_3_predictions"][0]["fault_object"] == "app/frontend"
+
+
+def test_infer_final_answer_excludes_final_answer_when_flag_off() -> None:
+    """Flag off → ``final_answer`` field is NOT read into the parser text.
+    Mirror of the contamination guard at the parser level. With the same
+    rich-text final_answer as the default-behavior test, flag=False must
+    flip the result from "extracted triple" to None."""
+    case_data = _case_data(
+        final_answer=(
+            "frontend has a DNS resolution failure — no such host found for upstream services."
+        )
+    )
+    payload = infer_final_answer_from_opensre_text(case_data, include_predictor_output=False)
+    assert payload is None
+
+
+def test_infer_fault_object_uses_full_train_ticket_vocabulary() -> None:
+    """investigation_a1 depends on substring service match — tsdb-mysql must resolve."""
+    assert _infer_fault_object("logs from tsdb-mysql show access denied") == "app/tsdb-mysql"
+    # Longest-name-first: order-other beats order
+    text = "fault localized to ts-order-other-service not ts-order-service"
+    assert _infer_fault_object(text) == "app/ts-order-other-service"
+
+
+def test_investigation_a1_zero_when_root_cause_phrasing_does_not_match() -> None:
+    """Parser sees the service name but the root cause phrasing doesn't match
+    any keyword set → all zeros, because ``infer_final_answer_from_opensre_text``
+    requires BOTH a root_cause AND a fault_object to emit a triple. Pins the
+    conservative-floor contract: investigation_a1 will undercount opensre's
+    real quality, and we report it as a lower bound."""
+    case_data = _case_data(
+        report=("frontend was experiencing some configuration issue but I'm not sure exactly what.")
+    )
+    scores = _score_investigation_native(case_data, _GT)
+    assert scores["a1"] == 0.0
+    assert scores["object_a1"] == 0.0

--- a/tests/benchmarks/cloudopsbench/tests/test_suite.py
+++ b/tests/benchmarks/cloudopsbench/tests/test_suite.py
@@ -93,3 +93,69 @@ def test_scoring_matches_reference_semantics_for_canned_trace() -> None:
     assert score.metrics.any_order == 1.0
     assert score.metrics.cov == 1.0
     assert summary["metrics"]["Accuracy @1"] == 1.0
+
+
+def test_translation_loss_fires_when_investigation_correct_predictor_wrong() -> None:
+    """End-to-end: opensre's prose names the GT triple (investigation_a1=1)
+    but the predictor's top-3 misses it (a1=0). ``translation_loss`` must
+    flag this — it's the signal that the LLM wrapping opensre's output
+    dropped what opensre found.
+    """
+    case = load_case("boutique", "service", "1")
+    case_data = {
+        # opensre prose: names cartservice + the GT root cause
+        "report": (
+            "Identified component: cartservice.\n"
+            "Investigation conclusion (root cause): cartservice has an "
+            "invalid environment variable for the redis-cart-invalid "
+            "address (wrong hostname)."
+        ),
+        # predictor output: wrong triple
+        "final_answer": {
+            "top_3_predictions": [
+                {
+                    "rank": 1,
+                    "fault_taxonomy": "Runtime_Fault",
+                    "fault_object": "app/frontend",
+                    "root_cause": "oom_killed",
+                }
+            ]
+        },
+        "steps": [],
+    }
+
+    score = score_case(case, case_data)
+
+    assert score.metrics.investigation_a1 == 1.0
+    assert score.metrics.a1 == 0.0
+    assert score.metrics.translation_loss == 1.0
+
+
+def test_translation_loss_zero_when_both_correct() -> None:
+    """When both layers get it right, translation_loss must NOT fire."""
+    case = load_case("boutique", "service", "1")
+    case_data = {
+        "report": (
+            "Identified component: cartservice.\n"
+            "Investigation conclusion (root cause): cartservice has an "
+            "invalid environment variable for the redis-cart-invalid "
+            "address (wrong hostname)."
+        ),
+        "final_answer": {
+            "top_3_predictions": [
+                {
+                    "rank": 1,
+                    "fault_taxonomy": "Service_Routing_Fault",
+                    "fault_object": "app/cartservice",
+                    "root_cause": "service_env_var_address_mismatch",
+                }
+            ]
+        },
+        "steps": [],
+    }
+
+    score = score_case(case, case_data)
+
+    assert score.metrics.investigation_a1 == 1.0
+    assert score.metrics.a1 == 1.0
+    assert score.metrics.translation_loss == 0.0


### PR DESCRIPTION
Fixes #2074

#### Describe the changes you have made in this PR -

Adds metrics that separate opensre's investigation quality from the LLM predictor that wraps its prose into `top_3_predictions`. Today's headline `a1` measures the whole pipeline; a lift on `a1` can't tell us whether opensre or the predictor got better.


- **`investigation_a1`** — single triple parsed directly from opensre's  prose (`report` + `root_cause` + `final_state`) via the keyword bridge.  Uses `include_predictor_output=False` (new flag on  `infer_final_answer_from_opensre_text`) so the predictor's structured  JSON cannot feed back through and contaminate the metric.
- **`investigation_partial_a1`** / **`investigation_object_a1`** —  partial + object-only variants on the same path.
- **`translation_loss`** — fires when `investigation_a1 == 1` AND  `a1 == 0`. The predictor lost what opensre named.

`analyze_validation.py` gets a new "L0 vs L1" panel: per arm shows
`inv_a1`, `a1`, the gap, and translation-loss rate.

The experiment chain to date is predictor-mediated; this
PR is what makes future experiments answer "is opensre getting better?"
honestly:

| Pattern | What it means |
|---|---|
| both metrics up | opensre got better (real win) |
| only `a1` up | LLM predictor got better, not opensre |
| only `investigation_a1` up | opensre got better, predictor dropping it |
| translation_loss up | predictor bleeding investigation gains |


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
