### PR TITLE
refactor(bench): _framework decoupling Phase 1 + 2 — capability flags

### DIFF
--- a/tests/benchmarks/_framework/adapter_base.py
+++ b/tests/benchmarks/_framework/adapter_base.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from pydantic import BaseModel, ConfigDict
 
 from tests.benchmarks._framework.types import (
     AlertPayload,
@@ -37,6 +39,55 @@ if TYPE_CHECKING:
     # constraint at runtime while still letting type-checkers validate
     # that adapter overrides return an investigation-agent subclass.
     from app.agent.investigation import ConnectedInvestigationAgent
+
+
+# --------------------------------------------------------------------------- #
+# Capability flags                                                            #
+# --------------------------------------------------------------------------- #
+
+
+class AdapterCapabilities(BaseModel):
+    """Boolean feature flags an adapter declares to the framework.
+
+    Replaces hardcoded ``if config.benchmark != "cloudopsbench"`` checks
+    in the framework. Each capability flag describes a framework-level
+    feature the adapter explicitly opts into. The framework then enables
+    or refuses the matching config knob based on the adapter's
+    declaration — no name-based dispatch.
+
+    Default is ``False`` for every capability so a new adapter is locked
+    down to the minimum surface until it opts in deliberately. Adding a
+    new capability extends this model with another default-``False``
+    field; existing adapters keep working without changes.
+
+    Adapters declare capabilities as a class attribute:
+
+        class MyAdapter(BenchmarkAdapter):
+            capabilities = AdapterCapabilities(
+                supports_agent_variant=True,
+            )
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    supports_agent_variant: bool = False
+    """The adapter honors the ``agent_variant`` config field.
+
+    When False, a config with ``agent_variant != "default"`` is refused
+    at validation time so the run does not silently exercise the wrong
+    agent. CloudOpsBench currently honors this via its
+    ``BenchInvestigationAgentTrimmedPrompt`` variant; other adapters
+    have no equivalent and should leave this False until they do.
+    """
+
+    supports_predictor_variant: bool = False
+    """The adapter has a predictor stage and honors ``predictor_variant``.
+
+    When False, a config setting ``predictor_variant != "default"`` is
+    refused. CloudOpsBench has a predictor stage (paper-format triple
+    emission); adapters without one (pure investigation benchmarks,
+    tool-call benchmarks) keep this False.
+    """
 
 
 # --------------------------------------------------------------------------- #
@@ -63,6 +114,12 @@ class BenchmarkAdapter(ABC):
 
     name: str  # e.g. "cloudopsbench"
     version: str  # adapter version, separate from corpus version
+    capabilities: ClassVar[AdapterCapabilities] = AdapterCapabilities()
+    """Framework features this adapter opts into.
+
+    Default is the all-False instance: a new adapter is locked down to
+    the minimum surface until it explicitly declares each capability.
+    See :class:`AdapterCapabilities` for the available flags."""
 
     def apply_config_overrides(self, config: Any) -> None:  # noqa: ARG002 — default no-op
         """Optional: apply adapter-specific config-driven runtime setup.

--- a/tests/benchmarks/_framework/adapters.py
+++ b/tests/benchmarks/_framework/adapters.py
@@ -19,9 +19,10 @@ directly.
 
 from __future__ import annotations
 
-from tests.benchmarks._framework.adapter_base import BenchmarkAdapter
+from tests.benchmarks._framework.adapter_base import AdapterCapabilities, BenchmarkAdapter
 from tests.benchmarks._framework.registry import (
     build_adapter,
+    capabilities_for,
     ensure_known_adapters_registered,
     known_adapters,
     register_adapter,
@@ -38,6 +39,7 @@ from tests.benchmarks._framework.types import (
 )
 
 __all__ = [
+    "AdapterCapabilities",
     "AlertPayload",
     "BenchmarkAdapter",
     "BenchmarkCase",
@@ -48,6 +50,7 @@ __all__ = [
     "RunContext",
     "RunResult",
     "build_adapter",
+    "capabilities_for",
     "ensure_known_adapters_registered",
     "known_adapters",
     "register_adapter",

--- a/tests/benchmarks/_framework/config.py
+++ b/tests/benchmarks/_framework/config.py
@@ -22,7 +22,11 @@ from typing import Literal
 import yaml
 from pydantic import BaseModel, Field, model_validator
 
-from tests.benchmarks._framework.adapters import AdapterCapabilities, Mode
+from tests.benchmarks._framework.adapters import (
+    AdapterCapabilities,
+    Mode,
+    capabilities_for,
+)
 
 
 def _default_report_formats() -> list[Literal["json", "markdown", "html"]]:
@@ -41,10 +45,6 @@ def _capabilities_for_lint(benchmark_name: str) -> AdapterCapabilities:
     gated knob, plus the underlying unknown-benchmark error when the
     runner subsequently tries to build the adapter via ``build_adapter``.
     """
-    # Late import — registry imports adapter_base; importing it at module
-    # load time would create a cycle through this file's own re-exports.
-    from tests.benchmarks._framework.registry import capabilities_for
-
     try:
         return capabilities_for(benchmark_name)
     except (KeyError, ImportError):

--- a/tests/benchmarks/_framework/config.py
+++ b/tests/benchmarks/_framework/config.py
@@ -22,12 +22,33 @@ from typing import Literal
 import yaml
 from pydantic import BaseModel, Field, model_validator
 
-from tests.benchmarks._framework.adapters import Mode
+from tests.benchmarks._framework.adapters import AdapterCapabilities, Mode
 
 
 def _default_report_formats() -> list[Literal["json", "markdown", "html"]]:
     """Module-level factory keeps mypy happy with the Literal element type."""
     return ["json", "markdown"]
+
+
+def _capabilities_for_lint(benchmark_name: str) -> AdapterCapabilities:
+    """Look up an adapter's capabilities for use during config lint.
+
+    Unknown adapters return the all-False default — every gated feature
+    is refused. This is intentional: a typo in ``config.benchmark`` (e.g.
+    ``cloudopsbnech``) must NOT silently bypass capability-based guards
+    just because the adapter cannot be looked up. The user gets a clear
+    "this feature requires the adapter to declare X" error for each
+    gated knob, plus the underlying unknown-benchmark error when the
+    runner subsequently tries to build the adapter via ``build_adapter``.
+    """
+    # Late import — registry imports adapter_base; importing it at module
+    # load time would create a cycle through this file's own re-exports.
+    from tests.benchmarks._framework.registry import capabilities_for
+
+    try:
+        return capabilities_for(benchmark_name)
+    except (KeyError, ImportError):
+        return AdapterCapabilities()
 
 
 # --------------------------------------------------------------------------- #
@@ -215,27 +236,39 @@ class BenchmarkConfig(BaseModel):
             )
 
         # Cross-field guard: agent_variant is silently ignored by adapters
-        # other than CloudOpsBench. Setting it on a non-cloudopsbench config
-        # would run the wrong agent without warning — refuse the config so
-        # the intent is explicit. ``"default"`` is always allowed.
-        if self.agent_variant != "default" and self.benchmark != "cloudopsbench":
+        # that don't declare ``supports_agent_variant=True`` in their
+        # ``AdapterCapabilities``. Setting it on such a config would run
+        # the wrong agent without warning — refuse the config so the
+        # intent is explicit. ``"default"`` is always allowed.
+        #
+        # Looking up capabilities by adapter (not by hardcoded
+        # ``benchmark == "cloudopsbench"``) means a new adapter that opts
+        # in to ``supports_agent_variant=True`` is automatically accepted
+        # by the framework without changes here.
+        adapter_caps = _capabilities_for_lint(self.benchmark)
+        if self.agent_variant != "default" and not adapter_caps.supports_agent_variant:
             errors.append(
-                f"agent_variant={self.agent_variant!r} is honored only by the "
-                f"cloudopsbench adapter, but benchmark={self.benchmark!r}. The "
-                "field would be silently ignored, producing an experiment "
-                "that measures the default agent. Set agent_variant: default "
-                "or run against the cloudopsbench adapter."
+                f"agent_variant={self.agent_variant!r} requires the "
+                f"benchmark adapter to declare "
+                f"``supports_agent_variant=True`` in its "
+                f"``AdapterCapabilities``, but benchmark={self.benchmark!r} "
+                f"does not. The field would be silently ignored, producing "
+                f"an experiment that measures the default agent. Set "
+                f"agent_variant: default or use an adapter that supports it."
             )
 
-        # Cross-field guard: predictor_variant="structured" requires the
-        # cloudopsbench adapter (only adapter with a predictor stage) AND
-        # an OpenAI-compatible LLM (structured outputs is OpenAI-only).
+        # Cross-field guard: predictor_variant="structured" requires an
+        # adapter that declares a predictor stage AND an OpenAI-compatible
+        # LLM (structured outputs is OpenAI-only on the predictor side).
         if self.predictor_variant == "structured":
-            if self.benchmark != "cloudopsbench":
+            if not adapter_caps.supports_predictor_variant:
                 errors.append(
-                    f"predictor_variant=structured is honored only by the "
-                    f"cloudopsbench adapter, but benchmark={self.benchmark!r}. "
-                    "Set predictor_variant: default or run against cloudopsbench."
+                    f"predictor_variant=structured requires the benchmark "
+                    f"adapter to declare ``supports_predictor_variant=True`` "
+                    f"in its ``AdapterCapabilities``, but "
+                    f"benchmark={self.benchmark!r} does not. "
+                    f"Set predictor_variant: default or use an adapter "
+                    f"that has a predictor stage."
                 )
             # Prefixes for OpenAI models that support structured outputs.
             # Includes the o-series (o1, o3, o4-mini) and gpt-series. Other

--- a/tests/benchmarks/_framework/registry.py
+++ b/tests/benchmarks/_framework/registry.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 
-from tests.benchmarks._framework.adapter_base import BenchmarkAdapter
+from tests.benchmarks._framework.adapter_base import AdapterCapabilities, BenchmarkAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +89,24 @@ def build_adapter(name: str) -> BenchmarkAdapter:
             f"known adapters: {known_adapters() or '<none registered>'}"
         )
     return _ADAPTER_FACTORIES[name]()
+
+
+def capabilities_for(name: str) -> AdapterCapabilities:
+    """Return the registered adapter's declared capability flags.
+
+    Used by config validation (and any future framework-level
+    capability gating) to avoid hardcoded ``if benchmark == "cloudopsbench"``
+    branches. The flags are a class attribute on the adapter, so the
+    one-time factory invocation here costs only as much as the adapter's
+    ``__init__`` — typically free, since most adapter init work is
+    deferred to ``load_cases`` / ``score_case``.
+
+    Raises ``KeyError`` with the same "known adapters" hint as
+    ``build_adapter`` when ``name`` is not registered. A typo in
+    ``config.benchmark`` surfaces with a useful message rather than
+    silently bypassing capability checks.
+    """
+    return build_adapter(name).capabilities
 
 
 def known_adapters() -> list[str]:

--- a/tests/benchmarks/_framework/registry.py
+++ b/tests/benchmarks/_framework/registry.py
@@ -96,17 +96,33 @@ def capabilities_for(name: str) -> AdapterCapabilities:
 
     Used by config validation (and any future framework-level
     capability gating) to avoid hardcoded ``if benchmark == "cloudopsbench"``
-    branches. The flags are a class attribute on the adapter, so the
-    one-time factory invocation here costs only as much as the adapter's
-    ``__init__`` — typically free, since most adapter init work is
-    deferred to ``load_cases`` / ``score_case``.
+    branches.
+
+    Capabilities live as a class attribute on the adapter
+    (``ClassVar[AdapterCapabilities]``), so when the registered factory
+    IS the adapter class — the common pattern, e.g.
+    ``register_adapter("cloudopsbench", CloudOpsBenchAdapter)`` — we
+    read the attribute off the class directly. No instantiation, no
+    adapter-specific side effects (HF dataset load, replay backend
+    setup). The fallback covers the less common closure-factory pattern.
 
     Raises ``KeyError`` with the same "known adapters" hint as
     ``build_adapter`` when ``name`` is not registered. A typo in
     ``config.benchmark`` surfaces with a useful message rather than
     silently bypassing capability checks.
     """
-    return build_adapter(name).capabilities
+    ensure_known_adapters_registered()
+    if name not in _ADAPTER_FACTORIES:
+        raise KeyError(
+            f"no adapter registered as {name!r}. "
+            f"known adapters: {known_adapters() or '<none registered>'}"
+        )
+    factory = _ADAPTER_FACTORIES[name]
+    if isinstance(factory, type) and issubclass(factory, BenchmarkAdapter):
+        return factory.capabilities
+    # Closure / lambda factory — fall back to instantiation. Uncommon
+    # but supported; the registry accepts any zero-arg callable.
+    return factory().capabilities
 
 
 def known_adapters() -> list[str]:

--- a/tests/benchmarks/_framework/tests/test_adapter_capabilities.py
+++ b/tests/benchmarks/_framework/tests/test_adapter_capabilities.py
@@ -109,3 +109,70 @@ def test_capabilities_for_raises_keyerror_for_unknown_adapter() -> None:
     lists the registered adapters — same UX contract as ``build_adapter``."""
     with pytest.raises(KeyError, match="known adapters"):
         capabilities_for("not-a-real-benchmark")
+
+
+def test_capabilities_for_does_not_instantiate_class_factory() -> None:
+    """Performance + no-side-effect contract: when the registered factory
+    is the adapter class itself (the common pattern, e.g.
+    ``register_adapter("X", XAdapter)``), ``capabilities_for`` must read
+    the ClassVar directly without calling ``__init__``. Adapter __init__
+    can do real work (HF dataset loads, replay backend setup); running
+    that during config lint would be wasted work at best, surprising
+    side effects at worst."""
+    from tests.benchmarks._framework.adapter_base import (
+        AdapterCapabilities,
+        BenchmarkAdapter,
+    )
+    from tests.benchmarks._framework.registry import (
+        capabilities_for,
+        register_adapter,
+    )
+
+    init_calls: list[int] = []
+
+    class _NoInitAdapter(BenchmarkAdapter):
+        """Adapter whose __init__ records every invocation. The
+        capability lookup must NEVER append to this list."""
+
+        name = "test-no-init-adapter"
+        version = "0.0.0"
+        capabilities = AdapterCapabilities(supports_agent_variant=True)
+
+        def __init__(self) -> None:
+            init_calls.append(1)
+
+        # The abstract surface — stubs are fine for this contract test;
+        # capabilities_for must never reach them. The unused-arg noqa
+        # comments document the intent: these are deliberate trip-wires,
+        # not signatures the test exercises.
+        def load_cases(self, filters):  # type: ignore[no-untyped-def]  # noqa: ARG002
+            raise AssertionError("load_cases reached")
+
+        def build_alert(self, case):  # type: ignore[no-untyped-def]  # noqa: ARG002
+            raise AssertionError("build_alert reached")
+
+        def build_opensre_integrations(self, case):  # type: ignore[no-untyped-def]  # noqa: ARG002
+            raise AssertionError("build_opensre_integrations reached")
+
+        def build_baseline_tools(self, case):  # type: ignore[no-untyped-def]  # noqa: ARG002
+            raise AssertionError("build_baseline_tools reached")
+
+        def score_case(self, case, run, context):  # type: ignore[no-untyped-def]  # noqa: ARG002
+            raise AssertionError("score_case reached")
+
+        def metric_schema(self):  # type: ignore[no-untyped-def]
+            raise AssertionError("metric_schema reached")
+
+    register_adapter(_NoInitAdapter.name, _NoInitAdapter)
+    try:
+        caps = capabilities_for(_NoInitAdapter.name)
+        assert caps.supports_agent_variant is True
+        assert init_calls == [], (
+            f"capabilities_for unexpectedly instantiated the adapter "
+            f"({len(init_calls)} __init__ call(s))"
+        )
+    finally:
+        # Clean up the test-only registration so other tests see a clean slate.
+        from tests.benchmarks._framework.registry import _ADAPTER_FACTORIES
+
+        _ADAPTER_FACTORIES.pop(_NoInitAdapter.name, None)

--- a/tests/benchmarks/_framework/tests/test_adapter_capabilities.py
+++ b/tests/benchmarks/_framework/tests/test_adapter_capabilities.py
@@ -1,0 +1,111 @@
+"""Tests for the AdapterCapabilities flag layer.
+
+These tests pin two behaviors that replace the previous hardcoded
+``if config.benchmark != "cloudopsbench"`` guards in ``config.py``:
+
+  1. Adapters declare what framework features they support via a
+     ``capabilities: ClassVar[AdapterCapabilities]`` class attribute.
+     Default is all-False so a new adapter is locked down until it opts
+     in deliberately.
+
+  2. The framework consults the adapter's capabilities — not the
+     adapter's name — to decide whether config knobs like
+     ``agent_variant`` and ``predictor_variant`` are accepted.
+
+The pattern unblocks adding new adapters (OpenRCA, ToolCallBench, etc.)
+without touching framework validation code.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.benchmarks._framework.adapter_base import (
+    AdapterCapabilities,
+    BenchmarkAdapter,
+)
+from tests.benchmarks._framework.registry import capabilities_for
+
+# --------------------------------------------------------------------------- #
+# AdapterCapabilities model contract                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_default_capabilities_lock_down_all_features() -> None:
+    """A new adapter that doesn't override ``capabilities`` gets the
+    all-False default — every gated feature is refused until opted in.
+    This is the safe default; it prevents a new adapter from silently
+    inheriting framework features it doesn't actually implement."""
+    caps = AdapterCapabilities()
+    assert caps.supports_agent_variant is False
+    assert caps.supports_predictor_variant is False
+
+
+def test_capabilities_model_is_frozen() -> None:
+    """An adapter's declared capabilities must be immutable for the
+    lifetime of the process. Mutating capabilities at runtime would
+    let a misbehaving adapter (or a test) toggle a feature mid-run
+    and bypass config validation. ``frozen=True`` forbids field
+    assignment after construction."""
+    caps = AdapterCapabilities(supports_agent_variant=True)
+    with pytest.raises((TypeError, ValueError)):
+        caps.supports_agent_variant = False  # type: ignore[misc]
+
+
+def test_capabilities_model_forbids_extra_fields() -> None:
+    """A typo in a capability name (``support_agent_variant`` missing the
+    plural ``s``) must error at construction time rather than silently
+    create an inert flag. ``extra='forbid'`` makes the schema closed."""
+    with pytest.raises(ValueError, match="Extra inputs are not permitted"):
+        AdapterCapabilities(support_agent_variant=True)  # type: ignore[call-arg]
+
+
+# --------------------------------------------------------------------------- #
+# BenchmarkAdapter integration                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_benchmarkadapter_default_capabilities_are_all_false() -> None:
+    """Adapter subclasses that don't override ``capabilities`` inherit
+    the all-False default from the ABC. Pin so a future ABC refactor
+    doesn't accidentally enable features by default."""
+    # We can't instantiate the abstract class directly, so read the
+    # class attribute. ``ClassVar`` makes this the source of truth.
+    caps = BenchmarkAdapter.capabilities
+    assert caps.supports_agent_variant is False
+    assert caps.supports_predictor_variant is False
+
+
+def test_cloudopsbench_adapter_declares_both_capabilities() -> None:
+    """CloudOpsBench's adapter is the bench's current truth source for
+    ``agent_variant`` + ``predictor_variant``. Pin both flags so a
+    refactor that mistakenly drops the capability declaration would
+    immediately fail this test (and the cross-field config guards
+    would start refusing valid CloudOpsBench configs)."""
+    from tests.benchmarks.cloudopsbench.adapter import CloudOpsBenchAdapter
+
+    caps = CloudOpsBenchAdapter.capabilities
+    assert caps.supports_agent_variant is True
+    assert caps.supports_predictor_variant is True
+
+
+# --------------------------------------------------------------------------- #
+# Registry helper                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_capabilities_for_returns_cloudopsbench_capabilities() -> None:
+    """``capabilities_for("cloudopsbench")`` returns the same capability
+    object the adapter class declares, so framework code can read flags
+    from the registry instead of importing the adapter directly."""
+    from tests.benchmarks.cloudopsbench.adapter import CloudOpsBenchAdapter
+
+    caps = capabilities_for("cloudopsbench")
+    assert caps == CloudOpsBenchAdapter.capabilities
+
+
+def test_capabilities_for_raises_keyerror_for_unknown_adapter() -> None:
+    """An unknown benchmark name surfaces with a helpful KeyError that
+    lists the registered adapters — same UX contract as ``build_adapter``."""
+    with pytest.raises(KeyError, match="known adapters"):
+        capabilities_for("not-a-real-benchmark")

--- a/tests/benchmarks/_framework/tests/test_config.py
+++ b/tests/benchmarks/_framework/tests/test_config.py
@@ -152,28 +152,76 @@ def test_agent_variant_rejects_unknown_value(tmp_path: Path) -> None:
         BenchmarkConfig.model_validate(raw)
 
 
-def test_agent_variant_non_default_rejected_for_non_cloudopsbench(
+def test_agent_variant_non_default_rejected_for_adapter_without_capability(
     tmp_path: Path,
 ) -> None:
-    """Cross-field guard: agent_variant is honored only by the cloudopsbench
-    adapter. A config that sets agent_variant=trimmed_prompt on a different
-    benchmark would silently run the default agent. The lint gate must
-    reject so the intent is explicit."""
+    """Cross-field guard: ``agent_variant`` is honored only by adapters
+    that declare ``supports_agent_variant=True`` in their
+    ``AdapterCapabilities``. A config that sets agent_variant on an
+    adapter without that flag (or on an unknown adapter — the lint path
+    treats unknown as all-False to surface typos) would silently run
+    the default agent. The lint gate must reject so the intent is
+    explicit. The error message names ``supports_agent_variant`` so
+    operators see exactly what to fix in the adapter declaration."""
     raw = _minimal_raw(tmp_path, benchmark="some_other_bench", agent_variant="trimmed_prompt")
     config = BenchmarkConfig.model_validate(raw)
     errors = config.lint()
-    assert any("agent_variant" in e and "cloudopsbench" in e for e in errors), (
-        f"Expected an agent_variant cross-field error; got: {errors}"
+    assert any("agent_variant" in e and "supports_agent_variant" in e for e in errors), (
+        f"Expected a capability-based agent_variant error; got: {errors}"
     )
 
 
 def test_agent_variant_default_passes_lint_for_any_benchmark(tmp_path: Path) -> None:
-    """The default value must not block non-cloudopsbench benchmarks —
+    """The default value must not block adapters without the capability —
     only non-default values trigger the cross-field guard."""
     raw = _minimal_raw(tmp_path, benchmark="some_other_bench")
     config = BenchmarkConfig.model_validate(raw)
     errors = config.lint()
     assert not any("agent_variant" in e for e in errors)
+
+
+def test_agent_variant_non_default_passes_lint_for_capable_adapter(tmp_path: Path) -> None:
+    """The lint guard must accept ``agent_variant`` on adapters that
+    declare ``supports_agent_variant=True``. CloudOpsBench is the
+    current truth source. Pin so a future capability regression on the
+    CloudOpsBench adapter immediately surfaces here rather than later
+    when bench configs start failing in CI."""
+    raw = _minimal_raw(tmp_path, benchmark="cloudopsbench", agent_variant="trimmed_prompt")
+    config = BenchmarkConfig.model_validate(raw)
+    errors = config.lint()
+    assert not any("agent_variant" in e for e in errors), errors
+
+
+def test_predictor_variant_structured_rejected_for_adapter_without_capability(
+    tmp_path: Path,
+) -> None:
+    """Cross-field guard: ``predictor_variant=structured`` requires the
+    adapter to declare ``supports_predictor_variant=True``. An adapter
+    without a predictor stage (or an unknown one) is refused."""
+    raw = _minimal_raw(tmp_path, benchmark="some_other_bench", predictor_variant="structured")
+    config = BenchmarkConfig.model_validate(raw)
+    errors = config.lint()
+    assert any("predictor_variant" in e and "supports_predictor_variant" in e for e in errors), (
+        f"Expected a capability-based predictor_variant error; got: {errors}"
+    )
+
+
+def test_predictor_variant_structured_passes_lint_for_capable_adapter(
+    tmp_path: Path,
+) -> None:
+    """The lint guard must accept ``predictor_variant=structured`` on
+    adapters that declare ``supports_predictor_variant=True`` AND use
+    an OpenAI-compatible LLM (the second guard is independent and lives
+    next to the capability check). Pin both at once."""
+    raw = _minimal_raw(tmp_path, benchmark="cloudopsbench", predictor_variant="structured")
+    config = BenchmarkConfig.model_validate(raw)
+    errors = config.lint()
+    # The OpenAI-LLM guard still fires on its own merits if the LLM list
+    # is non-OpenAI, but the capability guard must NOT fire when the
+    # adapter declares it.
+    assert not any(
+        "predictor_variant" in e and "supports_predictor_variant" in e for e in errors
+    ), errors
 
 
 def test_report_formats_must_be_non_empty(tmp_path: Path) -> None:

--- a/tests/benchmarks/cloudopsbench/adapter.py
+++ b/tests/benchmarks/cloudopsbench/adapter.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any
 
 from tests.benchmarks._framework.adapters import (
+    AdapterCapabilities,
     AlertPayload,
     BenchmarkAdapter,
     BenchmarkCase,
@@ -164,6 +165,15 @@ class CloudOpsBenchAdapter(BenchmarkAdapter):
 
     name = BENCHMARK_NAME
     version = "1.0.0"
+    # Framework features this adapter opts into. Replaces the hardcoded
+    # ``if config.benchmark != "cloudopsbench"`` guards that previously
+    # lived in ``_framework/config.py``. The framework now validates
+    # config knobs against this declaration; a new adapter that wants to
+    # use ``agent_variant`` or ``predictor_variant`` opts in the same way.
+    capabilities = AdapterCapabilities(
+        supports_agent_variant=True,
+        supports_predictor_variant=True,
+    )
 
     # M7 (IntegrityGuard.pre_flight) — a documented data-contamination review
     # has been performed: Cloud-OpsBench was published 2026-02 and every model


### PR DESCRIPTION
Fixes #2074 

#### Describe the changes you have made in this PR -

First two of five planned phases to decouple `_framework/` from
CloudOpsBench-specific assumptions. Today the framework hardcodes
``if config.benchmark != "cloudopsbench"`` in multiple places — any new
adapter (OpenRCA, ToolCallBench) needs framework changes to opt in to
features it actually supports. This PR replaces name-based dispatch
with a capability flag layer.

##### Phase 1 — `AdapterCapabilities` model + ABC integration

- New `AdapterCapabilities` pydantic model in `_framework/adapter_base.py`.
  Frozen, `extra="forbid"`. Two flags to start: `supports_agent_variant`,
  `supports_predictor_variant`. Default all-False so a new adapter is
  locked down to the minimum surface until it opts in deliberately.
- `BenchmarkAdapter` ABC gets `capabilities: ClassVar[AdapterCapabilities]`
  with all-False default.
- `CloudOpsBenchAdapter` declares
  `capabilities = AdapterCapabilities(supports_agent_variant=True,
  supports_predictor_variant=True)` — exactly what the previous
  hardcoded check let through.

##### Phase 2 — Config validation goes capability-aware

- New `capabilities_for(name)` helper in `_framework/registry.py` —
  returns the registered adapter's flags without forcing the caller to
  instantiate one.
- `_framework/config.py` replaces both `if benchmark != "cloudopsbench"`
  guards with `if not adapter_caps.supports_<feature>`. Unknown
  adapter → all-False default → guard refuses the gated knob (a typo
  in `config.benchmark` surfaces with a clear error for each gated
  knob, plus the underlying unknown-benchmark error at runner build
  time).

#### Backward compat

- Existing CloudOpsBench configs (every `*.yml` in the repo) continue
  to validate cleanly — the capability declaration on the adapter
  matches the previous hardcoded behavior bit-for-bit.
- The shim at `_framework/adapters.py` re-exports `AdapterCapabilities`
  + `capabilities_for` so external imports use the same path as before.
- Pydantic `extra="forbid"` catches capability-name typos at adapter
  declaration time, not at run time.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
