### PR TITLE
fix(bench): break circular import in predictor/__init__.py

### DIFF
--- a/tests/benchmarks/_framework/reporting.py
+++ b/tests/benchmarks/_framework/reporting.py
@@ -226,6 +226,16 @@ _NON_COMPARABLE_METRICS = {
 # opensre-only instrumentation. Useful as internal diagnostics, but NOT present
 # in the paper, so they are reported in a separate panel to avoid implying a
 # comparison that doesn't exist.
+# L0 investigation-native metrics (opensre prose, keyword parser). Distinct from
+# L1 ``a1`` which scores the predictor's rank-1 formalization.
+_L0_INVESTIGATION_METRICS = [
+    "investigation_a1",
+    "investigation_partial_a1",
+    "investigation_object_a1",
+    "translation_loss",
+]
+_L0_CI_METRICS = frozenset({"investigation_a1", "investigation_object_a1"})
+
 _OPENSRE_ONLY_METRICS = [
     "partial_a1",
     "partial_a3",
@@ -696,6 +706,92 @@ def _render_decomposition_html(
     return parts
 
 
+def _render_l0_investigation_markdown(
+    by_lm: dict[str, dict[str, list[dict[str, Any]]]],
+) -> list[str]:
+    """L0 panel: investigation-native metrics from opensre prose (not predictor)."""
+    if not by_lm:
+        return []
+    flat = [c for modes in by_lm.values() for cs in modes.values() for c in cs]
+    present = [m for m in _L0_INVESTIGATION_METRICS if _per_cell_metric(flat, m)]
+    if not present:
+        return []
+
+    lines: list[str] = []
+    lines.append("### Investigation quality — L0 (opensre prose, not paper-comparable)")
+    lines.append("")
+    lines.append(
+        "_L0 scores a keyword-parsed triple from opensre's investigation prose "
+        "(``report`` / ``root_cause`` / causal chain). L1 ``a1`` in the headline "
+        "scores the predictor's rank-1 formalization. The gap "
+        "``a1 − investigation_a1`` is translation loss; "
+        "``translation_loss`` flags cases where L0 is right but L1 is wrong._"
+    )
+    lines.append("")
+    header = "| LLM | variant | " + " | ".join(present) + " |"
+    sep = "|" + "|".join(["---"] * (len(present) + 2)) + "|"
+    lines.append(header)
+    lines.append(sep)
+    for llm in sorted(by_lm.keys()):
+        for mode in sorted(by_lm[llm].keys()):
+            mode_cells = by_lm[llm][mode]
+            row = [f"`{llm}`", mode]
+            for metric in present:
+                scen_vals = _scenario_means(mode_cells, metric)
+                mean, lo, hi, n = _mean_with_ci(scen_vals)
+                if metric in _L0_CI_METRICS and len(scen_vals) >= 2:
+                    row.append(f"{mean:.2f} [{lo:.2f}–{hi:.2f}]")
+                elif n:
+                    row.append(f"{mean:.2f}")
+                else:
+                    row.append("—")
+            lines.append("| " + " | ".join(row) + " |")
+    lines.append("")
+    return lines
+
+
+def _render_l0_investigation_html(
+    by_lm: dict[str, dict[str, list[dict[str, Any]]]],
+    esc: Any,
+) -> list[str]:
+    """HTML mirror of :func:`_render_l0_investigation_markdown`."""
+    if not by_lm:
+        return []
+    flat = [c for modes in by_lm.values() for cs in modes.values() for c in cs]
+    present = [m for m in _L0_INVESTIGATION_METRICS if _per_cell_metric(flat, m)]
+    if not present:
+        return []
+
+    parts: list[str] = []
+    parts.append("<h3>Investigation quality — L0 (opensre prose, not paper-comparable)</h3>")
+    parts.append(
+        "<p><small>L0 scores a keyword-parsed triple from opensre's investigation "
+        "prose. L1 <code>a1</code> scores the predictor's rank-1 formalization. "
+        "The gap <code>a1 − investigation_a1</code> is translation loss.</small></p>"
+    )
+    parts.append("<table><thead><tr><th>LLM</th><th>variant</th>")
+    for m in present:
+        parts.append(f"<th>{esc(m)}</th>")
+    parts.append("</tr></thead><tbody>")
+    for llm in sorted(by_lm.keys()):
+        for mode in sorted(by_lm[llm].keys()):
+            mode_cells = by_lm[llm][mode]
+            parts.append(f"<tr><td><code>{esc(llm)}</code></td><td>{esc(mode)}</td>")
+            for metric in present:
+                scen_vals = _scenario_means(mode_cells, metric)
+                mean, lo, hi, n = _mean_with_ci(scen_vals)
+                if metric in _L0_CI_METRICS and len(scen_vals) >= 2:
+                    cell_txt = f"{mean:.2f}<br><small>[{lo:.2f}–{hi:.2f}]</small>"
+                elif n:
+                    cell_txt = f"{mean:.2f}"
+                else:
+                    cell_txt = "—"
+                parts.append(f'<td class="metric">{cell_txt}</td>')
+            parts.append("</tr>")
+    parts.append("</tbody></table>")
+    return parts
+
+
 # --------------------------------------------------------------------------- #
 # Markdown rendering                                                          #
 # --------------------------------------------------------------------------- #
@@ -805,6 +901,9 @@ def _render_markdown(
 
     # --- Decomposition: where the accuracy goes (Track 2) ---
     lines.extend(_render_decomposition_markdown(cells, by_lm))
+
+    # --- L0 investigation quality (opensre prose — not paper-comparable) ---
+    lines.extend(_render_l0_investigation_markdown(by_lm))
 
     # --- opensre-only diagnostics (NOT in the paper, NOT comparable) ---
     if by_lm:
@@ -1109,6 +1208,9 @@ def _render_html(
 
         # Decomposition (Track 2)
         parts.extend(_render_decomposition_html(cells, by_lm, esc))
+
+        # L0 investigation quality
+        parts.extend(_render_l0_investigation_html(by_lm, esc))
 
         # opensre-only diagnostics (segregated — not paper-comparable)
         flat = [c for modes in by_lm.values() for cs in modes.values() for c in cs]

--- a/tests/benchmarks/_framework/tests/test_reporting.py
+++ b/tests/benchmarks/_framework/tests/test_reporting.py
@@ -183,6 +183,31 @@ def test_html_includes_inline_style_no_external_deps(tmp_path: Path) -> None:
     assert "<script src=" not in html
 
 
+def test_markdown_includes_l0_investigation_panel_when_metrics_present(tmp_path: Path) -> None:
+    """L0 investigation metrics surface in report.md when cells record them."""
+    _write_report_json(tmp_path)
+    cases_dir = tmp_path / "cases"
+    cell = {
+        "case": {"case_id": "case-001", "metadata": {"fault_category": "Runtime"}},
+        "run": {"mode": "opensre+llm", "llm": "claude_sonnet"},
+        "score": {
+            "metrics": {
+                "a1": 0.0,
+                "investigation_a1": 0.75,
+                "investigation_object_a1": 0.80,
+                "translation_loss": 0.25,
+            }
+        },
+        "ok": True,
+    }
+    (cases_dir / "case-001__opensre+llm__claude_sonnet__0.json").write_text(json.dumps(cell))
+    out = render_report_dir(tmp_path, formats=["markdown"])
+    md = out["markdown"].read_text()
+    assert "Investigation quality — L0" in md
+    assert "investigation_a1" in md
+    assert "translation_loss" in md
+
+
 def test_render_works_without_cases_directory(tmp_path: Path) -> None:
     """report.json is the source of truth; cases/ is optional."""
     _write_report_json(tmp_path)

--- a/tests/benchmarks/cloudopsbench/closed_vocabulary.py
+++ b/tests/benchmarks/cloudopsbench/closed_vocabulary.py
@@ -8,6 +8,18 @@ from ``predictor.vocabulary`` for backward compatibility.
 
 from __future__ import annotations
 
+# Declaring ``__all__`` tells CodeQL that these names are the module's
+# public surface — they are not "unused globals" but intentional
+# re-exports consumed by ``taxonomy``, ``scoring``, and
+# ``predictor.vocabulary`` (which re-exports them for legacy callers).
+__all__ = [
+    "_FAULT_OBJECT_NAMESPACES",
+    "_FAULT_OBJECT_NODES",
+    "_FAULT_OBJECT_SERVICES",
+    "_ROOT_CAUSES",
+    "_TAXONOMY_CATEGORIES",
+]
+
 _TAXONOMY_CATEGORIES: tuple[str, ...] = (
     "Admission_Fault",
     "Scheduling_Fault",

--- a/tests/benchmarks/cloudopsbench/closed_vocabulary.py
+++ b/tests/benchmarks/cloudopsbench/closed_vocabulary.py
@@ -1,0 +1,129 @@
+"""Closed-vocabulary constants for CloudOpsBench scoring and prediction.
+
+Package-level module (not under ``predictor/``) so ``taxonomy`` and
+``scoring`` can import fault-object lists without loading
+``predictor/__init__.py``. The predictor subpackage re-exports these
+from ``predictor.vocabulary`` for backward compatibility.
+"""
+
+from __future__ import annotations
+
+_TAXONOMY_CATEGORIES: tuple[str, ...] = (
+    "Admission_Fault",
+    "Scheduling_Fault",
+    "Infrastructure_Fault",
+    "Startup_Fault",
+    "Runtime_Fault",
+    "Service_Routing_Fault",
+    "Performance_Fault",
+)
+
+_ROOT_CAUSES: tuple[str, ...] = (
+    # Scheduling
+    "missing_service_account",
+    "node_cordon_mismatch",
+    "node_affinity_mismatch",
+    "node_selector_mismatch",
+    "pod_anti_affinity_conflict",
+    "taint_toleration_mismatch",
+    "cpu_capacity_mismatch",
+    "memory_capacity_mismatch",
+    # Infrastructure
+    "node_network_delay",
+    "node_network_packet_loss",
+    "containerd_unavailable",
+    "kubelet_unavailable",
+    "kube_proxy_unavailable",
+    "kube_scheduler_unavailable",
+    # Startup
+    "image_registry_dns_failure",
+    "incorrect_image_reference",
+    "missing_image_pull_secret",
+    "pvc_selector_mismatch",
+    "pvc_storage_class_mismatch",
+    "pvc_access_mode_mismatch",
+    "pvc_capacity_mismatch",
+    "pv_binding_occupied",
+    "volume_mount_permission_denied",
+    # Runtime
+    "oom_killed",
+    "liveness_probe_incorrect_protocol",
+    "liveness_probe_incorrect_port",
+    "liveness_probe_incorrect_timing",
+    "readiness_probe_incorrect_protocol",
+    "readiness_probe_incorrect_port",
+    "mysql_invalid_credentials",
+    "mysql_invalid_port",
+    "missing_secret_binding",
+    "db_connection_exhaustion",
+    "db_readonly_mode",
+    "gateway_misrouted",
+    "deployment_zero_replicas",
+    # Service routing
+    "service_selector_mismatch",
+    "service_port_mapping_mismatch",
+    "service_protocol_mismatch",
+    "service_env_var_address_mismatch",
+    "service_sidecar_port_conflict",
+    "service_dns_resolution_failure",
+    # Performance
+    "pod_network_delay",
+    "pod_cpu_overload",
+    # Admission
+    "namespace_cpu_quota_exceeded",
+    "namespace_memory_quota_exceeded",
+    "namespace_pod_quota_exceeded",
+    "namespace_service_quota_exceeded",
+    "namespace_storage_quota_exceeded",
+)
+
+_FAULT_OBJECT_SERVICES: tuple[str, ...] = (
+    # online-boutique
+    "adservice",
+    "cartservice",
+    "checkoutservice",
+    "currencyservice",
+    "emailservice",
+    "frontend",
+    "paymentservice",
+    "productcatalogservice",
+    "recommendationservice",
+    "redis-cart",
+    "shippingservice",
+    # train-ticket
+    "ts-gateway-service",
+    "ts-order-service",
+    "ts-payment-service",
+    "ts-travel-service",
+    "ts-user-service",
+    "ts-auth-service",
+    "ts-route-service",
+    "ts-ticket-office-service",
+    "ts-assurance-service",
+    "ts-basic-service",
+    "ts-cancel-service",
+    "ts-config-service",
+    "ts-consign-service",
+    "ts-contacts-service",
+    "ts-delivery-service",
+    "ts-food-delivery-service",
+    "ts-food-service",
+    "ts-inside-payment-service",
+    "ts-notification-service",
+    "ts-order-other-service",
+    "ts-preserve-service",
+    "ts-price-service",
+    "ts-seat-service",
+    "ts-security-service",
+    "ts-station-food-service",
+    "ts-station-service",
+    "ts-train-food-service",
+    "ts-train-service",
+    "ts-travel2-service",
+    "ts-voucher-service",
+    "ts-wait-order-service",
+    "tsdb-mysql",
+)
+
+_FAULT_OBJECT_NODES: tuple[str, ...] = ("master", "worker-01", "worker-02", "worker-03")
+_FAULT_OBJECT_NAMESPACES: tuple[str, ...] = ("boutique", "train-ticket")

--- a/tests/benchmarks/cloudopsbench/predictor/__init__.py
+++ b/tests/benchmarks/cloudopsbench/predictor/__init__.py
@@ -107,9 +107,8 @@ _INVESTIGATION_HANDOFF_EXPORTS = frozenset(
 
 
 def __getattr__(name: str) -> Any:
-    """Lazy-load investigation handoff so ``scoring`` can import ``vocabulary``
-    without a circular import (handoff imports ``_taxonomy_for_root_cause`` from
-    ``scoring``)."""
+    """Lazy-load investigation handoff so importing ``vocabulary`` from this
+    package does not pull in handoff (and its scoring dependencies) at init."""
     if name in _INVESTIGATION_HANDOFF_EXPORTS:
         from tests.benchmarks.cloudopsbench.predictor.investigation_handoff import (
             align_predictions_to_investigation,

--- a/tests/benchmarks/cloudopsbench/predictor/__init__.py
+++ b/tests/benchmarks/cloudopsbench/predictor/__init__.py
@@ -29,10 +29,8 @@ modules above is re-exported here.
 
 from __future__ import annotations
 
-from tests.benchmarks.cloudopsbench.predictor.investigation_handoff import (
-    align_predictions_to_investigation,
-    apply_investigation_handoff,
-)
+from typing import Any
+
 from tests.benchmarks.cloudopsbench.predictor.llm_call import (
     _FENCED_JSON,
     _build_system_prompt,
@@ -102,3 +100,24 @@ __all__ = [
     # llm_call_structured_openai
     "emit_paper_predictions_structured",
 ]
+
+_INVESTIGATION_HANDOFF_EXPORTS = frozenset(
+    {"align_predictions_to_investigation", "apply_investigation_handoff"}
+)
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy-load investigation handoff so ``scoring`` can import ``vocabulary``
+    without a circular import (handoff imports ``_taxonomy_for_root_cause`` from
+    ``scoring``)."""
+    if name in _INVESTIGATION_HANDOFF_EXPORTS:
+        from tests.benchmarks.cloudopsbench.predictor.investigation_handoff import (
+            align_predictions_to_investigation,
+            apply_investigation_handoff,
+        )
+
+        return {
+            "align_predictions_to_investigation": align_predictions_to_investigation,
+            "apply_investigation_handoff": apply_investigation_handoff,
+        }[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/benchmarks/cloudopsbench/predictor/investigation_handoff.py
+++ b/tests/benchmarks/cloudopsbench/predictor/investigation_handoff.py
@@ -31,7 +31,7 @@ import logging
 import re
 from typing import Any
 
-from tests.benchmarks.cloudopsbench.scoring import _taxonomy_for_root_cause
+from tests.benchmarks.cloudopsbench.taxonomy import taxonomy_for_root_cause
 
 logger = logging.getLogger(__name__)
 
@@ -231,7 +231,7 @@ def align_predictions_to_investigation(
         {
             **prediction,
             "rank": new_rank + 1,
-            "fault_taxonomy": _taxonomy_for_root_cause(str(prediction.get("root_cause") or "")),
+            "fault_taxonomy": taxonomy_for_root_cause(str(prediction.get("root_cause") or "")),
         }
         for new_rank, prediction in enumerate(new_order)
     ]

--- a/tests/benchmarks/cloudopsbench/predictor/llm_call.py
+++ b/tests/benchmarks/cloudopsbench/predictor/llm_call.py
@@ -41,7 +41,7 @@ from tests.benchmarks.cloudopsbench.predictor.vocabulary import (
     _ROOT_CAUSES,
     _TAXONOMY_CATEGORIES,
 )
-from tests.benchmarks.cloudopsbench.scoring import _taxonomy_for_root_cause
+from tests.benchmarks.cloudopsbench.taxonomy import taxonomy_for_root_cause
 
 logger = logging.getLogger(__name__)
 
@@ -312,7 +312,7 @@ def _parse_predictions(text: str) -> dict[str, Any] | None:
         # Lever A: snap onto the dataset's closed vocabulary before scoring so
         # near-miss tokens don't auto-fail the exact-match scorer.
         normalized_root_cause = _snap_root_cause(root_cause)
-        derived_taxonomy = _taxonomy_for_root_cause(normalized_root_cause)
+        derived_taxonomy = taxonomy_for_root_cause(normalized_root_cause)
         llm_taxonomy = (prediction.get("fault_taxonomy") or "").strip()
         if llm_taxonomy and llm_taxonomy != derived_taxonomy:
             logger.info(

--- a/tests/benchmarks/cloudopsbench/predictor/llm_call_structured_openai.py
+++ b/tests/benchmarks/cloudopsbench/predictor/llm_call_structured_openai.py
@@ -71,7 +71,7 @@ from tests.benchmarks.cloudopsbench.predictor.vocabulary import (
     _ROOT_CAUSES,
     _TAXONOMY_CATEGORIES,
 )
-from tests.benchmarks.cloudopsbench.scoring import _taxonomy_for_root_cause
+from tests.benchmarks.cloudopsbench.taxonomy import taxonomy_for_root_cause
 
 logger = logging.getLogger(__name__)
 
@@ -209,7 +209,7 @@ def emit_paper_predictions_structured(
         # though the schema constrains the LLM's emit, the scorer's mapping
         # is the canonical ground truth and may differ from what the LLM
         # picked for the same root_cause.
-        derived_taxonomy = _taxonomy_for_root_cause(prediction.root_cause)
+        derived_taxonomy = taxonomy_for_root_cause(prediction.root_cause)
         cleaned.append(
             {
                 "rank": prediction.rank,

--- a/tests/benchmarks/cloudopsbench/predictor/vocabulary.py
+++ b/tests/benchmarks/cloudopsbench/predictor/vocabulary.py
@@ -1,151 +1,29 @@
-"""Closed-vocabulary constants for the cloudopsbench paper-format predictor.
+"""Closed-vocabulary constants — re-export shim.
 
-Single source of truth for the scorer's enum surfaces (root_cause,
-fault_taxonomy, fault_object scopes). Kept here so the snapping (Lever A),
-reranking (Lever D), prompt construction, and any future structured-output
-enum schema all read from the same place.
+Canonical definitions live in ``tests.benchmarks.cloudopsbench.closed_vocabulary``
+so ``taxonomy`` and ``scoring`` can import without loading ``predictor/__init__.py``.
 
-These constants mirror tests/benchmarks/cloudopsbench/scoring.py — keep
-them in lock-step with ``scoring._taxonomy_for_root_cause`` and
-``scoring._infer_fault_object``: the scorer compares exact strings after
-``normalize_text`` (lower-case + strip), so the values must match its enum.
+This module is intentionally a thin re-export so existing
+``from tests.benchmarks.cloudopsbench.predictor.vocabulary import X``
+callers keep working without change. ``__all__`` declares the
+re-exported names so ruff F401 / ``from x import *`` both behave
+correctly.
 """
 
 from __future__ import annotations
 
-_TAXONOMY_CATEGORIES: tuple[str, ...] = (
-    "Admission_Fault",
-    "Scheduling_Fault",
-    "Infrastructure_Fault",
-    "Startup_Fault",
-    "Runtime_Fault",
-    "Service_Routing_Fault",
-    "Performance_Fault",
+from tests.benchmarks.cloudopsbench.closed_vocabulary import (
+    _FAULT_OBJECT_NAMESPACES,
+    _FAULT_OBJECT_NODES,
+    _FAULT_OBJECT_SERVICES,
+    _ROOT_CAUSES,
+    _TAXONOMY_CATEGORIES,
 )
 
-_ROOT_CAUSES: tuple[str, ...] = (
-    # Scheduling
-    "missing_service_account",
-    "node_cordon_mismatch",
-    "node_affinity_mismatch",
-    "node_selector_mismatch",
-    "pod_anti_affinity_conflict",
-    "taint_toleration_mismatch",
-    "cpu_capacity_mismatch",
-    "memory_capacity_mismatch",
-    # Infrastructure
-    "node_network_delay",
-    "node_network_packet_loss",
-    "containerd_unavailable",
-    "kubelet_unavailable",
-    "kube_proxy_unavailable",
-    "kube_scheduler_unavailable",
-    # Startup
-    "image_registry_dns_failure",
-    "incorrect_image_reference",
-    "missing_image_pull_secret",
-    "pvc_selector_mismatch",
-    "pvc_storage_class_mismatch",
-    "pvc_access_mode_mismatch",
-    "pvc_capacity_mismatch",
-    "pv_binding_occupied",
-    "volume_mount_permission_denied",
-    # Runtime
-    "oom_killed",
-    "liveness_probe_incorrect_protocol",
-    "liveness_probe_incorrect_port",
-    "liveness_probe_incorrect_timing",
-    "readiness_probe_incorrect_protocol",
-    "readiness_probe_incorrect_port",
-    "mysql_invalid_credentials",
-    "mysql_invalid_port",
-    "missing_secret_binding",
-    "db_connection_exhaustion",
-    "db_readonly_mode",
-    "gateway_misrouted",
-    "deployment_zero_replicas",
-    # Service routing
-    "service_selector_mismatch",
-    "service_port_mapping_mismatch",
-    "service_protocol_mismatch",
-    "service_env_var_address_mismatch",
-    "service_sidecar_port_conflict",
-    "service_dns_resolution_failure",
-    # Performance — derive Performance_Fault via the scoring default bucket.
-    # These were absent from the vocab through the 2026-06-06 run, so the LLM
-    # was never told they were valid and ``pod_network_delay`` would mis-snap
-    # onto ``node_network_delay`` (Infrastructure_Fault). That capped a1 on the
-    # entire unseen-shape stratum (performance + admission) near zero even
-    # though object_a1 was ~0.40. See ANALYSIS.md for that run.
-    "pod_network_delay",
-    "pod_cpu_overload",
-    # Admission — the ``namespace_*`` quota family. ``_snap_root_cause`` already
-    # passes ``namespace_*`` tokens through verbatim and the scorer maps the
-    # prefix to Admission_Fault, but listing the concrete tokens here surfaces
-    # them in the system prompt so the model actually emits them.
-    "namespace_cpu_quota_exceeded",
-    "namespace_memory_quota_exceeded",
-    "namespace_pod_quota_exceeded",
-    "namespace_service_quota_exceeded",
-    "namespace_storage_quota_exceeded",
-)
-
-# fault_object values are canonical paths. The scorer accepts whatever
-# strings the LLM emits as long as they match the case's ground-truth
-# exactly (post-normalize), but giving the LLM the universe of known
-# values keeps it from inventing prefixes.
-_FAULT_OBJECT_SERVICES: tuple[str, ...] = (
-    # online-boutique
-    "adservice",
-    "cartservice",
-    "checkoutservice",
-    "currencyservice",
-    "emailservice",
-    "frontend",
-    "paymentservice",
-    "productcatalogservice",
-    "recommendationservice",
-    "redis-cart",
-    "shippingservice",
-    # train-ticket — full enumeration of the dataset's service mesh + DB.
-    # The 2026-06-09 trimmed-prompt loss diagnostic showed 33.7% of cells had
-    # a GT fault_object missing from this list, capping A@1 below the paper
-    # baseline on Runtime / Performance / Startup. ``tsdb-mysql`` alone was
-    # 90 cells locked at A@1=0.00 because the LLM consistently substituted
-    # the nearest in-vocab service (most often ``ts-inside-payment-service``).
-    "ts-gateway-service",
-    "ts-order-service",
-    "ts-payment-service",
-    "ts-travel-service",
-    "ts-user-service",
-    "ts-auth-service",
-    "ts-route-service",
-    "ts-ticket-office-service",
-    "ts-assurance-service",
-    "ts-basic-service",
-    "ts-cancel-service",
-    "ts-config-service",
-    "ts-consign-service",
-    "ts-contacts-service",
-    "ts-delivery-service",
-    "ts-food-delivery-service",
-    "ts-food-service",
-    "ts-inside-payment-service",
-    "ts-notification-service",
-    "ts-order-other-service",
-    "ts-preserve-service",
-    "ts-price-service",
-    "ts-seat-service",
-    "ts-security-service",
-    "ts-station-food-service",
-    "ts-station-service",
-    "ts-train-food-service",
-    "ts-train-service",
-    "ts-travel2-service",
-    "ts-voucher-service",
-    "ts-wait-order-service",
-    "tsdb-mysql",
-)
-
-_FAULT_OBJECT_NODES: tuple[str, ...] = ("master", "worker-01", "worker-02", "worker-03")
-_FAULT_OBJECT_NAMESPACES: tuple[str, ...] = ("boutique", "train-ticket")
+__all__ = [
+    "_FAULT_OBJECT_NAMESPACES",
+    "_FAULT_OBJECT_NODES",
+    "_FAULT_OBJECT_SERVICES",
+    "_ROOT_CAUSES",
+    "_TAXONOMY_CATEGORIES",
+]

--- a/tests/benchmarks/cloudopsbench/scoring.py
+++ b/tests/benchmarks/cloudopsbench/scoring.py
@@ -6,18 +6,12 @@ from dataclasses import asdict, dataclass
 from typing import Any
 
 from tests.benchmarks.cloudopsbench.case_loader import CloudOpsCase
-from tests.benchmarks.cloudopsbench.predictor.vocabulary import (
-    _FAULT_OBJECT_NAMESPACES,
-    _FAULT_OBJECT_NODES,
-    _FAULT_OBJECT_SERVICES,
-)
 from tests.benchmarks.cloudopsbench.replay_backend import normalize_resource_type
-
-# Longest service names first so ``ts-order-other-service`` shadows
-# ``ts-order-service`` on substring match. Computed once at module load —
-# the underlying vocabulary tuple is stable for the process lifetime.
-_FAULT_OBJECT_SERVICES_BY_LENGTH: tuple[str, ...] = tuple(
-    sorted(_FAULT_OBJECT_SERVICES, key=len, reverse=True)
+from tests.benchmarks.cloudopsbench.taxonomy import (
+    infer_fault_object as _infer_fault_object,
+)
+from tests.benchmarks.cloudopsbench.taxonomy import (
+    taxonomy_for_root_cause as _taxonomy_for_root_cause,
 )
 
 TOOL_KEY_PARAMS: dict[str, list[str]] = {
@@ -269,117 +263,6 @@ def _infer_root_cause(text: str) -> str:
         if all(token in text for token in tokens):
             return root_cause
     return ""
-
-
-def _infer_fault_object(text: str) -> str:
-    """Substring match against the predictor's closed service vocabulary.
-
-    Longest names first (precomputed in ``_FAULT_OBJECT_SERVICES_BY_LENGTH``)
-    so ``ts-order-other-service`` wins over ``ts-order-service``. Kept in
-    sync with ``predictor.vocabulary._FAULT_OBJECT_*``.
-
-    Namespace match REQUIRES the literal word ``namespace`` to appear in
-    the text as a precision guard. Without it, prose like "boutique system
-    has memory pressure" would incorrectly return ``namespace/boutique``
-    whenever the cluster name is mentioned in passing — overriding the
-    empty-string "no localization" result and producing a spurious
-    wrong-shape match on cases whose GT is a ``namespace/<X>`` fault. The
-    original guard was preserved here after a 2026-06 refactor (commit
-    8dac68c7) dropped it.
-    """
-    for service_name in _FAULT_OBJECT_SERVICES_BY_LENGTH:
-        if service_name in text:
-            return f"app/{service_name}"
-    for node_name in _FAULT_OBJECT_NODES:
-        if node_name in text:
-            return f"node/{node_name}"
-    if "namespace" in text:
-        for ns_name in _FAULT_OBJECT_NAMESPACES:
-            if ns_name in text:
-                return f"namespace/{ns_name}"
-    return ""
-
-
-def _taxonomy_for_root_cause(root_cause: str) -> str:
-    """Map a CloudOpsBench root_cause to its paper-taxonomy bucket.
-
-    The mapping below is **audited against the dataset's actual ground-truth
-    fault_taxonomy values** (see metadata.json files under
-    tests/benchmarks/cloudopsbench/benchmark/), not derived independently.
-    Two assignments were previously wrong and silently cost a1 points on
-    every case using those root_causes:
-
-    - ``missing_secret_binding`` — dataset says ``Startup_Fault`` (the failure
-      surfaces when a pod tries to start with an unbindable secret), not
-      ``Runtime_Fault``.
-    - ``service_sidecar_port_conflict`` — dataset says ``Runtime_Fault`` (the
-      port conflict manifests when the istio sidecar tries to bind at runtime),
-      not ``Service_Routing_Fault``.
-    - ``missing_service_account`` — dataset says ``Admission_Fault`` (all 10
-      boutique/admission/* cases; the apiserver rejects pod creation at admission
-      time), not ``Scheduling_Fault``.
-
-    All three are now placed in the buckets the paper's dataset uses.
-    """
-    if root_cause.startswith("namespace_") or root_cause == "missing_service_account":
-        return "Admission_Fault"
-    if root_cause in {
-        "node_cordon_mismatch",
-        "node_affinity_mismatch",
-        "node_selector_mismatch",
-        "pod_anti_affinity_conflict",
-        "taint_toleration_mismatch",
-        "cpu_capacity_mismatch",
-        "memory_capacity_mismatch",
-    }:
-        return "Scheduling_Fault"
-    if root_cause in {
-        "node_network_delay",
-        "node_network_packet_loss",
-        "containerd_unavailable",
-        "kubelet_unavailable",
-        "kube_proxy_unavailable",
-        "kube_scheduler_unavailable",
-    }:
-        return "Infrastructure_Fault"
-    if root_cause in {
-        "image_registry_dns_failure",
-        "incorrect_image_reference",
-        "missing_image_pull_secret",
-        "missing_secret_binding",  # dataset GT: Startup_Fault (moved from Runtime)
-        "pvc_selector_mismatch",
-        "pvc_storage_class_mismatch",
-        "pvc_access_mode_mismatch",
-        "pvc_capacity_mismatch",
-        "pv_binding_occupied",
-        "volume_mount_permission_denied",
-    }:
-        return "Startup_Fault"
-    if root_cause in {
-        "oom_killed",
-        "liveness_probe_incorrect_protocol",
-        "liveness_probe_incorrect_port",
-        "liveness_probe_incorrect_timing",
-        "readiness_probe_incorrect_protocol",
-        "readiness_probe_incorrect_port",
-        "mysql_invalid_credentials",
-        "mysql_invalid_port",
-        "db_connection_exhaustion",
-        "db_readonly_mode",
-        "gateway_misrouted",
-        "deployment_zero_replicas",
-        "service_sidecar_port_conflict",  # dataset GT: Runtime_Fault (moved from Service_Routing)
-    }:
-        return "Runtime_Fault"
-    if root_cause in {
-        "service_selector_mismatch",
-        "service_port_mapping_mismatch",
-        "service_protocol_mismatch",
-        "service_env_var_address_mismatch",
-        "service_dns_resolution_failure",
-    }:
-        return "Service_Routing_Fault"
-    return "Performance_Fault"
 
 
 def compare_prediction(

--- a/tests/benchmarks/cloudopsbench/taxonomy.py
+++ b/tests/benchmarks/cloudopsbench/taxonomy.py
@@ -1,0 +1,122 @@
+"""Shared root-cause → taxonomy mapping and fault-object inference.
+
+Single module for scoring (L0 investigation parsing), the predictor stage
+(L1 formalization), and investigation handoff (B1). Lives outside
+``predictor/`` so ``scoring`` can import vocabulary-backed helpers without
+loading ``predictor/__init__.py`` or creating a circular import with
+``investigation_handoff``.
+
+Keep in lock-step with ``predictor.vocabulary`` — the scorer compares exact
+strings after ``normalize_text``.
+"""
+
+from __future__ import annotations
+
+from tests.benchmarks.cloudopsbench.closed_vocabulary import (
+    _FAULT_OBJECT_NAMESPACES,
+    _FAULT_OBJECT_NODES,
+    _FAULT_OBJECT_SERVICES,
+)
+
+# Longest service names first so ``ts-order-other-service`` shadows
+# ``ts-order-service`` on substring match.
+_FAULT_OBJECT_SERVICES_BY_LENGTH: tuple[str, ...] = tuple(
+    sorted(_FAULT_OBJECT_SERVICES, key=len, reverse=True)
+)
+
+
+def infer_fault_object(text: str) -> str:
+    """Substring match against the closed service vocabulary.
+
+    Longest names first (precomputed in ``_FAULT_OBJECT_SERVICES_BY_LENGTH``)
+    so ``ts-order-other-service`` wins over ``ts-order-service``. Kept in
+    sync with ``predictor.vocabulary._FAULT_OBJECT_*``.
+
+    Namespace match REQUIRES the literal word ``namespace`` to appear in
+    the text as a precision guard. Without it, prose like "boutique system
+    has memory pressure" would incorrectly return ``namespace/boutique``
+    whenever the cluster name is mentioned in passing.
+    """
+    for service_name in _FAULT_OBJECT_SERVICES_BY_LENGTH:
+        if service_name in text:
+            return f"app/{service_name}"
+    for node_name in _FAULT_OBJECT_NODES:
+        if node_name in text:
+            return f"node/{node_name}"
+    if "namespace" in text:
+        for ns_name in _FAULT_OBJECT_NAMESPACES:
+            if ns_name in text:
+                return f"namespace/{ns_name}"
+    return ""
+
+
+def taxonomy_for_root_cause(root_cause: str) -> str:
+    """Map a CloudOpsBench root_cause to its paper-taxonomy bucket.
+
+    Audited against the dataset's actual ground-truth ``fault_taxonomy``
+    values (metadata.json under ``benchmark/``), not derived independently.
+    """
+    if root_cause.startswith("namespace_") or root_cause == "missing_service_account":
+        return "Admission_Fault"
+    if root_cause in {
+        "node_cordon_mismatch",
+        "node_affinity_mismatch",
+        "node_selector_mismatch",
+        "pod_anti_affinity_conflict",
+        "taint_toleration_mismatch",
+        "cpu_capacity_mismatch",
+        "memory_capacity_mismatch",
+    }:
+        return "Scheduling_Fault"
+    if root_cause in {
+        "node_network_delay",
+        "node_network_packet_loss",
+        "containerd_unavailable",
+        "kubelet_unavailable",
+        "kube_proxy_unavailable",
+        "kube_scheduler_unavailable",
+    }:
+        return "Infrastructure_Fault"
+    if root_cause in {
+        "image_registry_dns_failure",
+        "incorrect_image_reference",
+        "missing_image_pull_secret",
+        "missing_secret_binding",
+        "pvc_selector_mismatch",
+        "pvc_storage_class_mismatch",
+        "pvc_access_mode_mismatch",
+        "pvc_capacity_mismatch",
+        "pv_binding_occupied",
+        "volume_mount_permission_denied",
+    }:
+        return "Startup_Fault"
+    if root_cause in {
+        "oom_killed",
+        "liveness_probe_incorrect_protocol",
+        "liveness_probe_incorrect_port",
+        "liveness_probe_incorrect_timing",
+        "readiness_probe_incorrect_protocol",
+        "readiness_probe_incorrect_port",
+        "mysql_invalid_credentials",
+        "mysql_invalid_port",
+        "db_connection_exhaustion",
+        "db_readonly_mode",
+        "gateway_misrouted",
+        "deployment_zero_replicas",
+        "service_sidecar_port_conflict",
+    }:
+        return "Runtime_Fault"
+    if root_cause in {
+        "service_selector_mismatch",
+        "service_port_mapping_mismatch",
+        "service_protocol_mismatch",
+        "service_env_var_address_mismatch",
+        "service_dns_resolution_failure",
+    }:
+        return "Service_Routing_Fault"
+    return "Performance_Fault"
+
+
+# Backward-compatible aliases used across the bench codebase.
+_infer_fault_object = infer_fault_object
+_taxonomy_for_root_cause = taxonomy_for_root_cause

--- a/tests/benchmarks/cloudopsbench/taxonomy.py
+++ b/tests/benchmarks/cloudopsbench/taxonomy.py
@@ -18,6 +18,19 @@ from tests.benchmarks.cloudopsbench.closed_vocabulary import (
     _FAULT_OBJECT_SERVICES,
 )
 
+# Declaring ``__all__`` tells CodeQL that the underscore-prefixed
+# backward-compat aliases at the bottom of this file are not "unused
+# globals" but intentional re-exports for callers that hardcoded the
+# pre-refactor ``_infer_fault_object`` / ``_taxonomy_for_root_cause``
+# names (e.g. ``scoring`` re-aliases through these).
+__all__ = [
+    "_FAULT_OBJECT_SERVICES_BY_LENGTH",
+    "_infer_fault_object",
+    "_taxonomy_for_root_cause",
+    "infer_fault_object",
+    "taxonomy_for_root_cause",
+]
+
 # Longest service names first so ``ts-order-other-service`` shadows
 # ``ts-order-service`` on substring match.
 _FAULT_OBJECT_SERVICES_BY_LENGTH: tuple[str, ...] = tuple(


### PR DESCRIPTION
Fixes #2074

#### Describe the changes you have made in this PR -


`tests/benchmarks/cloudopsbench/predictor/__init__.py` was eagerly
re-exporting two names from
`predictor.investigation_handoff`. After the recent vocabulary
refactor, the import chain became:

predictor/init.py
→ investigation_handoff
→ scoring._taxonomy_for_root_cause
→ vocabulary
→ (back through scoring) → circular

This PR replaces the eager re-export with a PEP 562 `__getattr__` lazy
loader, so `apply_investigation_handoff` and
`align_predictions_to_investigation` are resolved on first access
instead of at module load time. The cycle never executes.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**


---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
