### PR TITLE
feat(integrations): add Temporal Integration (#2572)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -255,6 +255,14 @@ TEMPO_USERNAME=
 TEMPO_PASSWORD=
 TEMPO_ORG_ID=
 
+# Temporal (self-hosted only — talks to the Temporal HTTP API, not gRPC or Cloud)
+# Point TEMPORAL_API_URL at the frontend HTTP port (default 7243), not the gRPC
+# port (7233) or Web UI (8233). TEMPORAL_NAMESPACE defaults to "default".
+# TEMPORAL_API_KEY is optional — leave empty for unauthenticated self-hosted clusters.
+TEMPORAL_API_URL=
+TEMPORAL_NAMESPACE=default
+TEMPORAL_API_KEY=
+
 # AWS
 AWS_REGION=us-east-1
 AWS_ROLE_ARN=

--- a/app/agent/utils/alert_source.py
+++ b/app/agent/utils/alert_source.py
@@ -41,6 +41,7 @@ ALERT_SOURCE_TO_TOOL_SOURCES: dict[str, tuple[str, ...]] = {
     "signoz": ("signoz",),
     "jenkins": ("jenkins",),
     "tempo": ("tempo",),
+    "temporal": ("temporal",),
 }
 
 # Auto-called before the LLM loop starts. Keep this narrower than
@@ -75,6 +76,7 @@ ALERT_SOURCE_TO_SEED_TOOL_SOURCES: dict[str, tuple[str, ...]] = {
     "signoz": ("signoz",),
     "jenkins": ("jenkins",),
     "tempo": ("tempo",),
+    "temporal": ("temporal",),
 }
 
 # Generic fallback sources: useful, but never primary when incident-specific
@@ -116,6 +118,7 @@ SOURCE_ALIASES: dict[str, tuple[str, ...]] = {
     "signoz": ("signoz",),
     "jenkins": ("jenkins",),
     "tempo": ("tempo",),
+    "temporal": ("temporal", "temporal workflow", "task queue"),
 }
 
 

--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -111,6 +111,7 @@ from app.integrations.vercel import classify as _classify_vercel
 from app.integrations.victoria_logs import classify as _classify_victoria_logs
 from app.integrations.whatsapp import classify as _classify_whatsapp
 from app.llm_credentials import resolve_env_credential
+from app.services.temporal import TemporalConfig
 from app.services.vercel import VercelConfig
 from app.utils.coercion import safe_int
 from app.utils.errors import report_exception
@@ -1410,6 +1411,27 @@ def load_env_integrations() -> list[dict[str, Any]]:
             )
     except Exception:
         logger.debug("Failed to load Tempo config from env", exc_info=True)
+
+    temporal_url = os.getenv("TEMPORAL_API_URL", "").strip()
+    temporal_namespace = os.getenv("TEMPORAL_NAMESPACE", "default").strip()
+    if temporal_url and temporal_namespace:
+        try:
+            temporal_config = TemporalConfig.model_validate(
+                {
+                    "base_url": temporal_url,
+                    "api_key": os.getenv("TEMPORAL_API_KEY", "").strip(),
+                    "namespace": temporal_namespace,
+                }
+            )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="temporal")
+        else:
+            integrations.append(
+                _active_env_record(
+                    "temporal",
+                    temporal_config.model_dump(),
+                )
+            )
 
     return integrations
 

--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -106,6 +106,7 @@ from app.integrations.supabase import classify as _classify_supabase
 from app.integrations.telegram import classify as _classify_telegram
 from app.integrations.tempo import classify as _classify_tempo
 from app.integrations.tempo import tempo_config_from_env
+from app.integrations.temporal import classify as _classify_temporal
 from app.integrations.twilio import classify as _classify_twilio
 from app.integrations.vercel import classify as _classify_vercel
 from app.integrations.victoria_logs import classify as _classify_victoria_logs
@@ -275,6 +276,7 @@ _CLASSIFIERS: dict[str, _ClassifyFn] = {
     "supabase": _classify_supabase,
     "signoz": _classify_signoz,
     "tempo": _classify_tempo,
+    "temporal": _classify_temporal,
     "smtp": _classify_smtp,
 }
 

--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -60,6 +60,7 @@ from app.services.incident_io import IncidentIoClient
 from app.services.opsgenie import OpsGenieClient, OpsGenieConfig
 from app.services.pagerduty import PagerDutyClient, PagerDutyConfig
 from app.services.splunk import SplunkClient, SplunkConfig
+from app.services.temporal import TemporalClient, TemporalConfig
 from app.services.tracer_client.client import TracerClient
 from app.services.vercel.client import VercelClient, VercelConfig
 from app.services.victoria_logs import VictoriaLogsClient, VictoriaLogsConfig
@@ -737,6 +738,11 @@ _verify_victoria_logs = build_probe_verifier(
     build_config=VictoriaLogsConfig.model_validate,
     client_factory=VictoriaLogsClient,
 )
+_verify_temporal = build_probe_verifier(
+    "temporal",
+    build_config=TemporalConfig.model_validate,
+    client_factory=TemporalClient,
+)
 
 
 def _verify_slack_without_test(source: str, config: dict[str, Any]) -> dict[str, str]:
@@ -805,6 +811,7 @@ __all__ = [
     "_verify_vercel",
     "_verify_victoria_logs",
     "_verify_whatsapp",
+    "_verify_temporal",
     "build_probe_verifier",
     "build_validation_verifier",
     "result",

--- a/app/integrations/cli.py
+++ b/app/integrations/cli.py
@@ -1242,10 +1242,7 @@ _HANDLERS["dagster"] = _setup_dagster
 
 
 def _setup_temporal() -> None:
-    base_url = _p(
-        "Temporal HTTP API base URL "
-        "(e.g. http://localhost:7243)"
-    )
+    base_url = _p("Temporal HTTP API base URL (e.g. http://localhost:7243)")
     if not base_url:
         _die("base_url is required.")
     namespace = _p("Temporal namespace", default="default")

--- a/app/integrations/cli.py
+++ b/app/integrations/cli.py
@@ -1241,6 +1241,33 @@ def _setup_dagster() -> None:
 _HANDLERS["dagster"] = _setup_dagster
 
 
+def _setup_temporal() -> None:
+    base_url = _p(
+        "Temporal HTTP API base URL "
+        "(e.g. http://localhost:7243)"
+    )
+    if not base_url:
+        _die("base_url is required.")
+    namespace = _p("Temporal namespace", default="default")
+    api_key = _p(
+        "Temporal API key (leave empty for unauthenticated self-hosted clusters)",
+        secret=True,
+    )
+    upsert_integration(
+        "temporal",
+        {
+            "credentials": {
+                "base_url": base_url,
+                "namespace": namespace or "default",
+                "api_key": api_key,
+            }
+        },
+    )
+
+
+_HANDLERS["temporal"] = _setup_temporal
+
+
 def _setup_azure_sql() -> None:
     server = _p("Server (e.g. myserver.database.windows.net)")
     database = _p("Database name")

--- a/app/integrations/config_models.py
+++ b/app/integrations/config_models.py
@@ -1164,3 +1164,24 @@ class PrefectIntegrationConfig(StrictConfigModel):
     _normalize_strs = field_validator("api_key", "account_id", "workspace_id", mode="before")(
         normalize_str()
     )
+
+
+class TemporalIntegrationConfig(StrictConfigModel):
+    base_url: str = ""
+    namespace: str = "default"
+    api_key: str = ""
+
+    _normalize_base_url = field_validator("base_url", mode="before")(normalize_url(""))
+    _normalize_strs = field_validator("api_key", "namespace", mode="before")(normalize_str())
+
+    @property
+    def headers(self) -> dict[str, str]:
+
+        headers = {
+            "Content-Type": "application/json",
+        }
+
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        return headers

--- a/app/integrations/config_models.py
+++ b/app/integrations/config_models.py
@@ -1170,6 +1170,7 @@ class TemporalIntegrationConfig(StrictConfigModel):
     base_url: str = ""
     namespace: str = "default"
     api_key: str = ""
+    integration_id: str = ""
 
     _normalize_base_url = field_validator("base_url", mode="before")(normalize_url(""))
     _normalize_strs = field_validator("api_key", "namespace", mode="before")(normalize_str())

--- a/app/integrations/effective_models.py
+++ b/app/integrations/effective_models.py
@@ -108,3 +108,4 @@ class EffectiveIntegrations(StrictConfigModel):
     signoz: EffectiveIntegrationEntry | None = None
     jenkins: EffectiveIntegrationEntry | None = None
     tempo: EffectiveIntegrationEntry | None = None
+    temporal: EffectiveIntegrationEntry | None = None

--- a/app/integrations/registry.py
+++ b/app/integrations/registry.py
@@ -440,8 +440,8 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
         service="temporal",
         verifier=_verify_temporal,
         direct_effective=True,
-        setup_order=35,
-        verify_order=46,
+        setup_order=36,
+        verify_order=47,
     ),
 )
 

--- a/app/integrations/registry.py
+++ b/app/integrations/registry.py
@@ -440,8 +440,8 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
         service="temporal",
         verifier=_verify_temporal,
         direct_effective=True,
-        setup_order=31,
-        verify_order=42,
+        setup_order=35,
+        verify_order=46,
     ),
 )
 

--- a/app/integrations/registry.py
+++ b/app/integrations/registry.py
@@ -440,8 +440,8 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
         service="temporal",
         verifier=_verify_temporal,
         direct_effective=True,
-        setup_order=36,
-        verify_order=47,
+        setup_order=37,
+        verify_order=48,
     ),
 )
 

--- a/app/integrations/registry.py
+++ b/app/integrations/registry.py
@@ -51,6 +51,7 @@ from app.integrations._verification_adapters import (
     _verify_supabase,
     _verify_telegram,
     _verify_tempo,
+    _verify_temporal,
     _verify_tracer,
     _verify_twilio,
     _verify_vercel,
@@ -431,6 +432,13 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
     IntegrationSpec(
         service="pagerduty",
         verifier=_verify_pagerduty,
+        direct_effective=True,
+        setup_order=31,
+        verify_order=42,
+    ),
+    IntegrationSpec(
+        service="temporal",
+        verifier=_verify_temporal,
         direct_effective=True,
         setup_order=31,
         verify_order=42,

--- a/app/integrations/temporal.py
+++ b/app/integrations/temporal.py
@@ -1,0 +1,45 @@
+"""Temporal integration classification helpers.
+
+The Temporal connection config itself lives in
+``app.integrations.config_models.TemporalIntegrationConfig`` (re-exported as
+``TemporalConfig`` from ``app.services.temporal``). This module provides the
+``classify`` entry point the catalog uses to turn a stored/remote integration
+record into a flat, typed config the Temporal tools can consume.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.integrations._validation_helpers import report_classify_failure
+from app.services.temporal import TemporalConfig
+
+logger = logging.getLogger(__name__)
+
+
+def classify(
+    credentials: dict[str, Any], record_id: str
+) -> tuple[TemporalConfig | None, str | None]:
+    """Build a typed TemporalConfig from a raw integration record.
+
+    Returns ``(config, "temporal")`` when the record carries the minimum
+    connection fields (base_url + namespace), else ``(None, None)`` so the
+    catalog skips the instance. Mirrors the ``classify`` contract used by the
+    other integrations (e.g. tempo, signoz).
+    """
+    try:
+        cfg = TemporalConfig.model_validate(
+            {
+                "base_url": credentials.get("base_url", ""),
+                "api_key": credentials.get("api_key", ""),
+                "namespace": credentials.get("namespace", "default"),
+                "integration_id": record_id,
+            }
+        )
+    except Exception as exc:
+        report_classify_failure(exc, logger=logger, integration="temporal", record_id=record_id)
+        return None, None
+    if cfg.base_url and cfg.namespace:
+        return cfg, "temporal"
+    return None, None

--- a/app/integrations/verify.py
+++ b/app/integrations/verify.py
@@ -57,6 +57,7 @@ _verify_telegram = _adapters._verify_telegram
 _verify_tracer = _adapters._verify_tracer
 _verify_whatsapp = _adapters._verify_whatsapp
 _verify_vercel = _adapters._verify_vercel
+_verify_temporal = _adapters._verify_temporal
 
 _result = _adapters.result
 
@@ -209,6 +210,7 @@ __all__ = [
     "_verify_tracer",
     "_verify_vercel",
     "_verify_whatsapp",
+    "_verify_temporal",
     "format_verification_results",
     "resolve_effective_integrations",
     "verification_exit_code",

--- a/app/services/temporal/__init__.py
+++ b/app/services/temporal/__init__.py
@@ -1,0 +1,3 @@
+from app.services.temporal.client import TemporalClient, TemporalConfig
+
+__all__ = ["TemporalClient", "TemporalConfig"]

--- a/app/services/temporal/client.py
+++ b/app/services/temporal/client.py
@@ -243,7 +243,8 @@ class TemporalClient:
                 method="probe_access",
             )
             return ProbeResult.failed(
-                f"Failed to connect to Temporal: {exc.response.status_code}: {exc.response.text[:200]}.")
+                f"Failed to connect to Temporal: {exc.response.status_code}: {exc.response.text[:200]}."
+            )
         except Exception as exc:
             capture_service_error(
                 exc,

--- a/app/services/temporal/client.py
+++ b/app/services/temporal/client.py
@@ -19,7 +19,7 @@ TemporalConfig = TemporalIntegrationConfig
 class TemporalClient:
     def __init__(self, config: TemporalConfig):
         self.config = config
-        self._client = httpx.Client(
+        self._client: httpx.Client = httpx.Client(
             base_url=self.config.base_url,
             headers=self.config.headers,
             timeout=_DEFAULT_TIMEOUT,
@@ -35,7 +35,7 @@ class TemporalClient:
         Returns paginated workflow executions for the configured namespace.
         Each execution includes workflowId, type, status, taskQueue, and timing info.
         """
-        params = {
+        params: dict[str, str | int | bool] = {
             "pageSize": _DEFAULT_PAGE_SIZE,
         }
         if next_page_token is not None:
@@ -85,7 +85,7 @@ class TemporalClient:
         activity failed, workflow failed, etc.) that tells the story of what
         happened during the execution. Essential for diagnosing why a workflow failed.
         """
-        params = {
+        params: dict[str, str | int | bool] = {
             "pageSize": _DEFAULT_PAGE_SIZE,
         }
         if next_page_token is not None:
@@ -141,7 +141,9 @@ class TemporalClient:
         Use the taskQueue field from list_workflow_executions() results to
         identify which queues to inspect.
         """
-        params = {"reportStats": True, "taskQueueType": "TASK_QUEUE_TYPE_WORKFLOW"}
+        params: dict[str, str | int | bool] = {
+            "reportStats": True, "taskQueueType": "TASK_QUEUE_TYPE_WORKFLOW",
+        }
         try:
             r = self._client.get(
                 f"/api/v1/namespaces/{self.config.namespace}/task-queues/{task_queue_name}",
@@ -255,9 +257,7 @@ class TemporalClient:
             return ProbeResult.failed(f"Failed to connect to Temporal: {str(exc)}.")
 
     def close(self) -> None:
-        if self._client is not None:
             self._client.close()
-            self._client = None
 
     def __enter__(self) -> TemporalClient:
         return self

--- a/app/services/temporal/client.py
+++ b/app/services/temporal/client.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from app.integrations.config_models import TemporalIntegrationConfig
+from app.services._error_helpers import capture_service_error
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT = 30
+_DEFAULT_PAGE_SIZE = 10
+TemporalConfig = TemporalIntegrationConfig
+
+
+class TemporalClient:
+    def __init__(self, config: TemporalConfig):
+        self.config = config
+        self._client = httpx.Client(
+            base_url=self.config.base_url,
+            headers=self.config.headers,
+            timeout=_DEFAULT_TIMEOUT,
+        )
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.config.base_url) and bool(self.config.namespace)
+
+    def list_workflow_executions(self, next_page_token: str | None = None) -> dict[str, Any]:
+        """List recent workflow executions with status and failure reason.
+
+        Returns paginated workflow executions for the configured namespace.
+        Each execution includes workflowId, type, status, taskQueue, and timing info.
+        """
+        params = {
+            "pageSize": _DEFAULT_PAGE_SIZE,
+        }
+        if next_page_token is not None:
+            params["nextPageToken"] = next_page_token
+
+        try:
+            r = self._client.get(
+                f"/api/v1/namespaces/{self.config.namespace}/workflows", params=params
+            )
+            r.raise_for_status()
+            data = r.json()
+
+            return {
+                "success": True,
+                "executions": data["executions"],
+                "next_page_token": data["nextPageToken"],
+                "total": len(data["executions"]),
+            }
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="temporal",
+                method="list_workflow_executions",
+                extras={"query": params},
+            )
+            return {
+                "success": False,
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
+            }
+        except Exception as exc:
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="temporal",
+                method="list_workflow_executions",
+                extras={"query": params},
+            )
+            return {"success": False, "error": str(exc)}
+
+    def get_workflow_history(
+        self, workflow_id: str, run_id: str | None = None, next_page_token: str | None = None
+    ) -> dict[str, Any]:
+        """Fetch the event history for a specific workflow execution.
+
+        Returns the ordered sequence of events (started, activity scheduled,
+        activity failed, workflow failed, etc.) that tells the story of what
+        happened during the execution. Essential for diagnosing why a workflow failed.
+        """
+        params = {
+            "pageSize": _DEFAULT_PAGE_SIZE,
+        }
+        if next_page_token is not None:
+            params["nextPageToken"] = next_page_token
+        if run_id is not None:
+            params["execution.runId"] = run_id
+        try:
+            r = self._client.get(
+                f"/api/v1/namespaces/{self.config.namespace}/workflows/{workflow_id}/history",
+                params=params,
+            )
+            r.raise_for_status()
+            data = r.json()
+            history = data["history"]
+            return {
+                "success": True,
+                "events": history["events"],
+                "next_page_token": data["nextPageToken"],
+                "archived": data["archived"],
+                "total": len(history["events"]),
+            }
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="temporal",
+                method="get_workflow_history",
+                extras={"query": params},
+            )
+            return {
+                "success": False,
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
+            }
+        except Exception as exc:
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="temporal",
+                method="get_workflow_history",
+                extras={"query": params},
+            )
+            return {"success": False, "error": str(exc)}
+
+    def describe_task_queue(self, task_queue_name: str) -> dict[str, Any]:
+        """Describe a task queue's pollers and backlog stats.
+
+        The Temporal HTTP API does not expose a "list all task queues" endpoint.
+        Instead, task queue names are discovered from workflow executions (each
+        execution reports which task queue it ran on). This method describes a
+        single queue by name — returning active pollers (workers) and backlog
+        metrics (approximate count, age, add/dispatch rates).
+
+        Use the taskQueue field from list_workflow_executions() results to
+        identify which queues to inspect.
+        """
+        params = {"reportStats": True, "taskQueueType": "TASK_QUEUE_TYPE_WORKFLOW"}
+        try:
+            r = self._client.get(
+                f"/api/v1/namespaces/{self.config.namespace}/task-queues/{task_queue_name}",
+                params=params,
+            )
+            r.raise_for_status()
+            data = r.json()
+
+            return {
+                "success": True,
+                "pollers": data["pollers"],
+                "stats": data.get("stats", {}),
+                "total": len(data["pollers"]),
+            }
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="temporal",
+                method="describe_task_queue",
+                extras={"query": params},
+            )
+            return {
+                "success": False,
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
+            }
+        except Exception as exc:
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="temporal",
+                method="describe_task_queue",
+                extras={"query": params},
+            )
+            return {"success": False, "error": str(exc)}
+
+    def get_namespace_info(self) -> dict[str, Any]:
+        """Fetch namespace state and workflow counts grouped by execution status.
+
+        Combines DescribeNamespace (state, config) with CountWorkflowExecutions
+        (grouped by ExecutionStatus) to provide namespace-level health metrics.
+        """
+        try:
+            ns_resp = self._client.get(
+                f"/api/v1/namespaces/{self.config.namespace}",
+            )
+            ns_resp.raise_for_status()
+            ns_data = ns_resp.json()
+
+            count_resp = self._client.get(
+                f"/api/v1/namespaces/{self.config.namespace}/workflow-count",
+                params={"query": "GROUP BY ExecutionStatus"},
+            )
+            count_resp.raise_for_status()
+            count_data = count_resp.json()
+
+            namespace_info = ns_data.get("namespaceInfo", {})
+            return {
+                "success": True,
+                "name": namespace_info.get("name", ""),
+                "state": namespace_info.get("state", ""),
+                "workflow_count": count_data.get("count", "0"),
+                "groups": count_data.get("groups", []),
+            }
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="temporal",
+                method="get_namespace_info",
+            )
+            return {
+                "success": False,
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
+            }
+        except Exception as exc:
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="temporal",
+                method="get_namespace_info",
+            )
+            return {"success": False, "error": str(exc)}
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self) -> TemporalClient:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()

--- a/app/services/temporal/client.py
+++ b/app/services/temporal/client.py
@@ -5,6 +5,7 @@ import binascii
 import json
 import logging
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -98,7 +99,8 @@ class TemporalClient:
             params["execution.runId"] = run_id
         try:
             r = self._client.get(
-                f"/api/v1/namespaces/{self.config.namespace}/workflows/{workflow_id}/history",
+                f"/api/v1/namespaces/{self.config.namespace}"
+                f"/workflows/{quote(workflow_id, safe='')}/history",
                 params=params,
             )
             r.raise_for_status()
@@ -151,7 +153,8 @@ class TemporalClient:
         }
         try:
             r = self._client.get(
-                f"/api/v1/namespaces/{self.config.namespace}/task-queues/{task_queue_name}",
+                f"/api/v1/namespaces/{self.config.namespace}"
+                f"/task-queues/{quote(task_queue_name, safe='')}",
                 params=params,
             )
             r.raise_for_status()

--- a/app/services/temporal/client.py
+++ b/app/services/temporal/client.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import base64
+import binascii
+import json
 import logging
 from typing import Any
 
@@ -48,11 +51,12 @@ class TemporalClient:
             r.raise_for_status()
             data = r.json()
 
+            executions = data.get("executions", [])
             return {
                 "success": True,
-                "executions": data["executions"],
-                "next_page_token": data["nextPageToken"],
-                "total": len(data["executions"]),
+                "executions": executions,
+                "next_page_token": data.get("nextPageToken", ""),
+                "total": len(executions),
             }
         except httpx.HTTPStatusError as exc:
             capture_service_error(
@@ -99,13 +103,13 @@ class TemporalClient:
             )
             r.raise_for_status()
             data = r.json()
-            history = data["history"]
+            events = (data.get("history") or {}).get("events", [])
             return {
                 "success": True,
-                "events": history["events"],
-                "next_page_token": data["nextPageToken"],
-                "archived": data["archived"],
-                "total": len(history["events"]),
+                "events": events,
+                "next_page_token": data.get("nextPageToken", ""),
+                "archived": data.get("archived", False),
+                "total": len(events),
             }
         except httpx.HTTPStatusError as exc:
             capture_service_error(
@@ -142,7 +146,8 @@ class TemporalClient:
         identify which queues to inspect.
         """
         params: dict[str, str | int | bool] = {
-            "reportStats": True, "taskQueueType": "TASK_QUEUE_TYPE_WORKFLOW",
+            "reportStats": True,
+            "taskQueueType": "TASK_QUEUE_TYPE_WORKFLOW",
         }
         try:
             r = self._client.get(
@@ -152,11 +157,12 @@ class TemporalClient:
             r.raise_for_status()
             data = r.json()
 
+            pollers = data.get("pollers", [])
             return {
                 "success": True,
-                "pollers": data["pollers"],
+                "pollers": pollers,
                 "stats": data.get("stats", {}),
-                "total": len(data["pollers"]),
+                "total": len(pollers),
             }
         except httpx.HTTPStatusError as exc:
             capture_service_error(
@@ -206,7 +212,7 @@ class TemporalClient:
                 "name": namespace_info.get("name", ""),
                 "state": namespace_info.get("state", ""),
                 "workflow_count": count_data.get("count", "0"),
-                "groups": count_data.get("groups", []),
+                "groups": self._flatten_status_groups(count_data.get("groups", [])),
             }
         except httpx.HTTPStatusError as exc:
             capture_service_error(
@@ -227,6 +233,42 @@ class TemporalClient:
                 method="get_namespace_info",
             )
             return {"success": False, "error": str(exc)}
+
+    def _flatten_status_groups(self, groups: list[dict[str, Any]]) -> list[dict[str, str]]:
+        """Flatten CountWorkflowExecutions GROUP BY results into [{status, count}].
+
+        The raw response nests each bucket as
+        ``{"groupValues": [{"data": "<base64 Payload>"}], "count": "1"}``.
+        The status name is a base64-encoded Temporal Payload, so we decode it
+        and drop the metadata/encoding noise the LLM does not need.
+        """
+        flattened: list[dict[str, str]] = []
+        for group in groups:
+            values = group.get("groupValues") or []
+            decoded = [str(self._decode_payload_data(v.get("data", ""))) for v in values]
+            flattened.append(
+                {
+                    "status": ", ".join(decoded),
+                    "count": str(group.get("count", "0")),
+                }
+            )
+        return flattened
+
+    @staticmethod
+    def _decode_payload_data(data: str) -> Any:
+        """Decode a Temporal HTTP API Payload ``data`` field.
+
+        The JSON/HTTP API base64-encodes every Payload value (e.g. the status
+        name ``"Failed"`` arrives as ``"IkZhaWxlZCI="``). Decode the base64 then
+        JSON-parse it. Fall back to the raw string if it is not a standard
+        base64/JSON payload, so a format change never crashes the caller.
+        """
+        if not data:
+            return data
+        try:
+            return json.loads(base64.b64decode(data))
+        except (binascii.Error, ValueError, UnicodeDecodeError):
+            return data
 
     def probe_access(self) -> ProbeResult:
         if not self.is_configured:
@@ -257,7 +299,7 @@ class TemporalClient:
             return ProbeResult.failed(f"Failed to connect to Temporal: {str(exc)}.")
 
     def close(self) -> None:
-            self._client.close()
+        self._client.close()
 
     def __enter__(self) -> TemporalClient:
         return self

--- a/app/services/temporal/client.py
+++ b/app/services/temporal/client.py
@@ -6,6 +6,7 @@ from typing import Any
 import httpx
 
 from app.integrations.config_models import TemporalIntegrationConfig
+from app.integrations.probes import ProbeResult
 from app.services._error_helpers import capture_service_error
 
 logger = logging.getLogger(__name__)
@@ -224,6 +225,33 @@ class TemporalClient:
                 method="get_namespace_info",
             )
             return {"success": False, "error": str(exc)}
+
+    def probe_access(self) -> ProbeResult:
+        if not self.is_configured:
+            return ProbeResult.failed("Temporal Client is not configured.")
+
+        try:
+            r = self._client.get(f"/api/v1/namespaces/{self.config.namespace}")
+            r.raise_for_status()
+
+            return ProbeResult.passed("Successfully connected to Temporal.")
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="temporal",
+                method="probe_access",
+            )
+            return ProbeResult.failed(
+                f"Failed to connect to Temporal: {exc.response.status_code}: {exc.response.text[:200]}.")
+        except Exception as exc:
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="temporal",
+                method="probe_access",
+            )
+            return ProbeResult.failed(f"Failed to connect to Temporal: {str(exc)}.")
 
     def close(self) -> None:
         if self._client is not None:

--- a/app/tools/TemporalNamespaceInfoTool/__init__.py
+++ b/app/tools/TemporalNamespaceInfoTool/__init__.py
@@ -1,0 +1,112 @@
+"""Temporal namespace health overview tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.temporal import TemporalClient, TemporalConfig
+from app.tools.base import BaseTool
+
+
+class TemporalNamespaceInfoTool(BaseTool):
+    """Fetch namespace state and workflow counts grouped by execution status.
+
+    This is the first tool to call when investigating Temporal-related incidents.
+    It provides a high-level health snapshot: is the namespace active, and how
+    many workflows are running vs failed vs timed out. Use this to determine
+    whether something is wrong before drilling into specific workflows.
+    """
+
+    name = "temporal_namespace_info"
+    source = "temporal"
+    description = (
+        "Fetch Temporal namespace health overview: namespace state and workflow "
+        "execution counts grouped by status (Running, Failed, TimedOut, etc.). "
+        "Use as the first investigation step to assess overall namespace health."
+    )
+    use_cases = [
+        "Getting a high-level health snapshot of a Temporal namespace",
+        "Checking if a namespace is active or deprecated/deleted",
+        "Counting how many workflows are currently running, failed, or timed out",
+        "Determining whether a Temporal incident is widespread or isolated",
+        "Initial triage before drilling into specific workflow failures",
+    ]
+    requires = ["base_url", "namespace"]
+    injected_params = ["base_url", "api_key", "namespace"]
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "base_url": {
+                "type": "string",
+                "description": "Temporal server base URL.",
+            },
+            "api_key": {
+                "type": "string",
+                "default": "",
+                "description": "Temporal API key. Empty for unauthenticated self-hosted clusters.",
+            },
+            "namespace": {
+                "type": "string",
+                "default": "default",
+                "description": "Temporal namespace to inspect.",
+            },
+        },
+        "required": ["base_url", "namespace"],
+    }
+    outputs = {
+        "name": "Namespace name",
+        "state": "Namespace state (REGISTERED, DEPRECATED, DELETED)",
+        "workflow_count": "Total workflow executions across all statuses",
+        "groups": "Breakdown of workflow counts by execution status",
+    }
+
+    def is_available(self, sources: dict[str, Any]) -> bool:
+        temporal = sources.get("temporal", {})
+        return bool(temporal.get("base_url"))
+
+    def extract_params(self, sources: dict[str, Any]) -> dict[str, Any]:
+        temporal = sources.get("temporal", {})
+        return {
+            "base_url": temporal.get("base_url", ""),
+            "api_key": temporal.get("api_key", ""),
+            "namespace": temporal.get("namespace", "default"),
+        }
+
+    def run(
+        self,
+        base_url: str,
+        api_key: str = "",
+        namespace: str = "default",
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        if not base_url:
+            return {
+                "source": "temporal",
+                "available": False,
+                "error": "base_url is required to connect to Temporal.",
+            }
+
+        config = TemporalConfig(base_url=base_url, api_key=api_key, namespace=namespace)
+        client = TemporalClient(config)
+
+        try:
+            result = client.get_namespace_info()
+            if not result.get("success"):
+                return {
+                    "source": "temporal",
+                    "available": False,
+                    "error": result.get("error", "Unknown error fetching namespace info."),
+                }
+            return {
+                "source": "temporal",
+                "available": True,
+                "name": result["name"],
+                "state": result["state"],
+                "workflow_count": result["workflow_count"],
+                "groups": result["groups"],
+            }
+        finally:
+            client.close()
+
+
+temporal_namespace_info = TemporalNamespaceInfoTool()

--- a/app/tools/TemporalNamespaceInfoTool/__init__.py
+++ b/app/tools/TemporalNamespaceInfoTool/__init__.py
@@ -87,9 +87,7 @@ class TemporalNamespaceInfoTool(BaseTool):
             }
 
         config = TemporalConfig(base_url=base_url, api_key=api_key, namespace=namespace)
-        client = TemporalClient(config)
-
-        try:
+        with TemporalClient(config) as client:
             result = client.get_namespace_info()
             if not result.get("success"):
                 return {
@@ -105,8 +103,6 @@ class TemporalNamespaceInfoTool(BaseTool):
                 "workflow_count": result["workflow_count"],
                 "groups": result["groups"],
             }
-        finally:
-            client.close()
 
 
 temporal_namespace_info = TemporalNamespaceInfoTool()

--- a/app/tools/TemporalTaskQueueTool/__init__.py
+++ b/app/tools/TemporalTaskQueueTool/__init__.py
@@ -109,9 +109,7 @@ class TemporalTaskQueueTool(BaseTool):
             }
 
         config = TemporalConfig(base_url=base_url, api_key=api_key, namespace=namespace)
-        client = TemporalClient(config)
-
-        try:
+        with TemporalClient(config) as client:
             result = client.describe_task_queue(task_queue_name=task_queue_name)
             if not result.get("success"):
                 return {
@@ -128,8 +126,6 @@ class TemporalTaskQueueTool(BaseTool):
                 "stats": result["stats"],
                 "total": result["total"],
             }
-        finally:
-            client.close()
 
 
 temporal_task_queue = TemporalTaskQueueTool()

--- a/app/tools/TemporalTaskQueueTool/__init__.py
+++ b/app/tools/TemporalTaskQueueTool/__init__.py
@@ -1,0 +1,135 @@
+"""Temporal task queue description tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.temporal import TemporalClient, TemporalConfig
+from app.tools.base import BaseTool
+
+
+class TemporalTaskQueueTool(BaseTool):
+    """Describe a task queue's pollers and backlog stats.
+
+    After identifying failed workflows and the task queues they ran on, use this
+    tool to check worker health. Empty pollers mean workers are down. A growing
+    backlog (high approximateBacklogCount, tasksAddRate > tasksDispatchRate)
+    means workers can't keep up. Stale lastAccessTime on pollers indicates
+    workers have stopped heartbeating.
+
+    Task queue names are discovered from workflow executions — each execution
+    reports which task queue it ran on. The Temporal API does not expose a
+    "list all task queues" endpoint.
+    """
+
+    name = "temporal_task_queue"
+    source = "temporal"
+    description = (
+        "Describe a Temporal task queue: active worker pollers and backlog stats "
+        "(approximate count, age, add/dispatch rates). Use after identifying failed "
+        "workflows to check if workers are down or overwhelmed on that queue."
+    )
+    use_cases = [
+        "Checking if workers are polling a task queue (are they alive?)",
+        "Detecting worker outages (empty pollers list = no workers connected)",
+        "Identifying backlog buildup (tasks queued faster than dispatched)",
+        "Correlating workflow timeouts with stale worker heartbeats",
+        "Verifying worker capacity after a deployment or scaling event",
+    ]
+    requires = ["base_url", "namespace"]
+    injected_params = ["base_url", "api_key", "namespace"]
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "base_url": {
+                "type": "string",
+                "description": "Temporal server base URL.",
+            },
+            "api_key": {
+                "type": "string",
+                "default": "",
+                "description": "Temporal API key. Empty for unauthenticated self-hosted clusters.",
+            },
+            "namespace": {
+                "type": "string",
+                "default": "default",
+                "description": "Temporal namespace.",
+            },
+            "task_queue_name": {
+                "type": "string",
+                "description": (
+                    "Name of the task queue to inspect. Obtain this from the taskQueue "
+                    "field in workflow execution results."
+                ),
+            },
+        },
+        "required": ["base_url", "namespace", "task_queue_name"],
+    }
+    outputs = {
+        "pollers": "List of active worker pollers with identity, lastAccessTime, and ratePerSecond",
+        "stats": "Backlog metrics: approximateBacklogCount, approximateBacklogAge, tasksAddRate, tasksDispatchRate",
+        "total": "Number of active pollers on this queue",
+    }
+
+    def is_available(self, sources: dict[str, Any]) -> bool:
+        temporal = sources.get("temporal", {})
+        return bool(temporal.get("base_url"))
+
+    def extract_params(self, sources: dict[str, Any]) -> dict[str, Any]:
+        temporal = sources.get("temporal", {})
+        return {
+            "base_url": temporal.get("base_url", ""),
+            "api_key": temporal.get("api_key", ""),
+            "namespace": temporal.get("namespace", "default"),
+        }
+
+    def run(
+        self,
+        base_url: str,
+        task_queue_name: str,
+        api_key: str = "",
+        namespace: str = "default",
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        if not base_url:
+            return {
+                "source": "temporal",
+                "available": False,
+                "error": "base_url is required to connect to Temporal.",
+                "pollers": [],
+                "stats": {},
+            }
+        if not task_queue_name:
+            return {
+                "source": "temporal",
+                "available": True,
+                "error": "task_queue_name is required. Get it from the taskQueue field in workflow execution results.",
+                "pollers": [],
+                "stats": {},
+            }
+
+        config = TemporalConfig(base_url=base_url, api_key=api_key, namespace=namespace)
+        client = TemporalClient(config)
+
+        try:
+            result = client.describe_task_queue(task_queue_name=task_queue_name)
+            if not result.get("success"):
+                return {
+                    "source": "temporal",
+                    "available": False,
+                    "error": result.get("error", "Unknown error describing task queue."),
+                    "pollers": [],
+                    "stats": {},
+                }
+            return {
+                "source": "temporal",
+                "available": True,
+                "pollers": result["pollers"],
+                "stats": result["stats"],
+                "total": result["total"],
+            }
+        finally:
+            client.close()
+
+
+temporal_task_queue = TemporalTaskQueueTool()

--- a/app/tools/TemporalWorkflowHistoryTool/__init__.py
+++ b/app/tools/TemporalWorkflowHistoryTool/__init__.py
@@ -116,9 +116,7 @@ class TemporalWorkflowHistoryTool(BaseTool):
             }
 
         config = TemporalConfig(base_url=base_url, api_key=api_key, namespace=namespace)
-        client = TemporalClient(config)
-
-        try:
+        with TemporalClient(config) as client:
             result = client.get_workflow_history(
                 workflow_id=workflow_id,
                 run_id=run_id if run_id else None,
@@ -139,8 +137,6 @@ class TemporalWorkflowHistoryTool(BaseTool):
                 "next_page_token": result["next_page_token"],
                 "archived": result["archived"],
             }
-        finally:
-            client.close()
 
 
 temporal_workflow_history = TemporalWorkflowHistoryTool()

--- a/app/tools/TemporalWorkflowHistoryTool/__init__.py
+++ b/app/tools/TemporalWorkflowHistoryTool/__init__.py
@@ -1,0 +1,146 @@
+"""Temporal workflow execution history tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.temporal import TemporalClient, TemporalConfig
+from app.tools.base import BaseTool
+
+
+class TemporalWorkflowHistoryTool(BaseTool):
+    """Fetch the event history for a specific workflow execution.
+
+    After identifying a failed workflow via the workflows tool, use this to see
+    the ordered sequence of events that tells the story of what happened:
+    workflow started, activity scheduled, activity failed, workflow failed, etc.
+    This is essential for diagnosing root cause — e.g. "the payment activity
+    timed out after 3 retries" or "the child workflow was terminated externally."
+    """
+
+    name = "temporal_workflow_history"
+    source = "temporal"
+    description = (
+        "Fetch the event history for a specific Temporal workflow execution. "
+        "Shows the ordered sequence of events (started, activity scheduled, "
+        "activity failed, workflow failed, etc.) to diagnose why a workflow failed."
+    )
+    use_cases = [
+        "Diagnosing why a specific workflow execution failed",
+        "Identifying which activity within a workflow timed out or errored",
+        "Tracing the sequence of events leading to workflow failure",
+        "Checking if a workflow was terminated externally or failed internally",
+        "Finding retry patterns that indicate transient vs persistent failures",
+    ]
+    requires = ["base_url", "namespace"]
+    injected_params = ["base_url", "api_key", "namespace"]
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "base_url": {
+                "type": "string",
+                "description": "Temporal server base URL.",
+            },
+            "api_key": {
+                "type": "string",
+                "default": "",
+                "description": "Temporal API key. Empty for unauthenticated self-hosted clusters.",
+            },
+            "namespace": {
+                "type": "string",
+                "default": "default",
+                "description": "Temporal namespace.",
+            },
+            "workflow_id": {
+                "type": "string",
+                "description": "The workflow ID to fetch history for.",
+            },
+            "run_id": {
+                "type": "string",
+                "default": "",
+                "description": (
+                    "Specific run ID. If omitted, returns history for the latest run "
+                    "of the given workflow ID."
+                ),
+            },
+            "next_page_token": {
+                "type": "string",
+                "default": "",
+                "description": "Pagination token from a previous response to fetch the next page.",
+            },
+        },
+        "required": ["base_url", "namespace", "workflow_id"],
+    }
+    outputs = {
+        "events": "Ordered list of history events with eventId, eventTime, and eventType",
+        "total": "Number of events returned in this page",
+        "next_page_token": "Token for fetching the next page of events",
+        "archived": "Whether the history was retrieved from archival storage",
+    }
+
+    def is_available(self, sources: dict[str, Any]) -> bool:
+        temporal = sources.get("temporal", {})
+        return bool(temporal.get("base_url"))
+
+    def extract_params(self, sources: dict[str, Any]) -> dict[str, Any]:
+        temporal = sources.get("temporal", {})
+        return {
+            "base_url": temporal.get("base_url", ""),
+            "api_key": temporal.get("api_key", ""),
+            "namespace": temporal.get("namespace", "default"),
+        }
+
+    def run(
+        self,
+        base_url: str,
+        workflow_id: str,
+        api_key: str = "",
+        namespace: str = "default",
+        run_id: str = "",
+        next_page_token: str = "",
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        if not base_url:
+            return {
+                "source": "temporal",
+                "available": False,
+                "error": "base_url is required to connect to Temporal.",
+                "events": [],
+            }
+        if not workflow_id:
+            return {
+                "source": "temporal",
+                "available": True,
+                "error": "workflow_id is required to fetch execution history.",
+                "events": [],
+            }
+
+        config = TemporalConfig(base_url=base_url, api_key=api_key, namespace=namespace)
+        client = TemporalClient(config)
+
+        try:
+            result = client.get_workflow_history(
+                workflow_id=workflow_id,
+                run_id=run_id if run_id else None,
+                next_page_token=next_page_token if next_page_token else None,
+            )
+            if not result.get("success"):
+                return {
+                    "source": "temporal",
+                    "available": False,
+                    "error": result.get("error", "Unknown error fetching workflow history."),
+                    "events": [],
+                }
+            return {
+                "source": "temporal",
+                "available": True,
+                "events": result["events"],
+                "total": result["total"],
+                "next_page_token": result["next_page_token"],
+                "archived": result["archived"],
+            }
+        finally:
+            client.close()
+
+
+temporal_workflow_history = TemporalWorkflowHistoryTool()

--- a/app/tools/TemporalWorkflowsTool/__init__.py
+++ b/app/tools/TemporalWorkflowsTool/__init__.py
@@ -1,0 +1,119 @@
+"""Temporal workflow executions listing tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.temporal import TemporalClient, TemporalConfig
+from app.tools.base import BaseTool
+
+
+class TemporalWorkflowsTool(BaseTool):
+    """List recent workflow executions with status and failure reason.
+
+    After identifying a problem via namespace info (e.g. "8 workflows failed"),
+    use this tool to see which specific workflows failed, when they started and
+    closed, what type they are, and which task queue they ran on. The task queue
+    name from these results feeds into the task queue tool for worker health checks.
+    """
+
+    name = "temporal_workflows"
+    source = "temporal"
+    description = (
+        "List recent Temporal workflow executions showing workflowId, type, status, "
+        "taskQueue, and timing. Use after namespace info reveals failures, to identify "
+        "which specific workflows failed and on which task queues."
+    )
+    use_cases = [
+        "Listing recent workflow executions to find failures",
+        "Identifying which workflow types are failing",
+        "Discovering which task queues are involved in failures",
+        "Getting workflowId and runId for detailed history inspection",
+        "Correlating workflow failures with infrastructure alerts",
+    ]
+    requires = ["base_url", "namespace"]
+    injected_params = ["base_url", "api_key", "namespace"]
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "base_url": {
+                "type": "string",
+                "description": "Temporal server base URL.",
+            },
+            "api_key": {
+                "type": "string",
+                "default": "",
+                "description": "Temporal API key. Empty for unauthenticated self-hosted clusters.",
+            },
+            "namespace": {
+                "type": "string",
+                "default": "default",
+                "description": "Temporal namespace to query.",
+            },
+            "next_page_token": {
+                "type": "string",
+                "default": "",
+                "description": "Pagination token from a previous response to fetch the next page.",
+            },
+        },
+        "required": ["base_url", "namespace"],
+    }
+    outputs = {
+        "executions": "List of workflow executions with workflowId, type, status, taskQueue, and timing",
+        "total": "Number of executions returned in this page",
+        "next_page_token": "Token for fetching the next page of results",
+    }
+
+    def is_available(self, sources: dict[str, Any]) -> bool:
+        temporal = sources.get("temporal", {})
+        return bool(temporal.get("base_url"))
+
+    def extract_params(self, sources: dict[str, Any]) -> dict[str, Any]:
+        temporal = sources.get("temporal", {})
+        return {
+            "base_url": temporal.get("base_url", ""),
+            "api_key": temporal.get("api_key", ""),
+            "namespace": temporal.get("namespace", "default"),
+        }
+
+    def run(
+        self,
+        base_url: str,
+        api_key: str = "",
+        namespace: str = "default",
+        next_page_token: str = "",
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        if not base_url:
+            return {
+                "source": "temporal",
+                "available": False,
+                "error": "base_url is required to connect to Temporal.",
+                "executions": [],
+            }
+
+        config = TemporalConfig(base_url=base_url, api_key=api_key, namespace=namespace)
+        client = TemporalClient(config)
+
+        try:
+            token = next_page_token if next_page_token else None
+            result = client.list_workflow_executions(next_page_token=token)
+            if not result.get("success"):
+                return {
+                    "source": "temporal",
+                    "available": False,
+                    "error": result.get("error", "Unknown error listing workflow executions."),
+                    "executions": [],
+                }
+            return {
+                "source": "temporal",
+                "available": True,
+                "executions": result["executions"],
+                "total": result["total"],
+                "next_page_token": result["next_page_token"],
+            }
+        finally:
+            client.close()
+
+
+temporal_workflows = TemporalWorkflowsTool()

--- a/app/tools/TemporalWorkflowsTool/__init__.py
+++ b/app/tools/TemporalWorkflowsTool/__init__.py
@@ -93,9 +93,7 @@ class TemporalWorkflowsTool(BaseTool):
             }
 
         config = TemporalConfig(base_url=base_url, api_key=api_key, namespace=namespace)
-        client = TemporalClient(config)
-
-        try:
+        with TemporalClient(config) as client:
             token = next_page_token if next_page_token else None
             result = client.list_workflow_executions(next_page_token=token)
             if not result.get("success"):
@@ -112,8 +110,6 @@ class TemporalWorkflowsTool(BaseTool):
                 "total": result["total"],
                 "next_page_token": result["next_page_token"],
             }
-        finally:
-            client.close()
 
 
 temporal_workflows = TemporalWorkflowsTool()

--- a/app/types/evidence.py
+++ b/app/types/evidence.py
@@ -63,4 +63,5 @@ EvidenceSource = Literal[
     "hermes",
     "twilio",
     "redis",
+    "temporal",
 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -193,7 +193,9 @@
               "rds",
               "snowflake",
               "supabase",
-              "redis"
+              "redis",
+              "rds",
+              "temporal"
             ]
           }
         ]

--- a/docs/integrations-overview.mdx
+++ b/docs/integrations-overview.mdx
@@ -39,7 +39,7 @@ Inside the interactive shell you can also run `/integrations list`, `/integratio
 | **Cloud and infrastructure** | [AWS](/aws), [Argo CD](/argocd), [Helm](/helm), [Jenkins](/jenkins), [Vercel](/vercel) |
 | **Databases and data platforms** | [Azure SQL](/azure-sql), [ClickHouse](/clickhouse), [Kafka](/kafka), [MariaDB](/mariadb), [MongoDB](/mongodb), [MongoDB Atlas](/mongodb-atlas), [MySQL](/mysql), [OpenSearch](/opensearch), [PostgreSQL](/postgresql), [RabbitMQ](/rabbitmq), [RDS](/rds), [Snowflake](/snowflake), [Supabase](/supabase) |
 | **Source control and collaboration** | [Bitbucket](/bitbucket), [GitHub](/github), [GitHub Actions](/integrations/github-actions), [GitLab](/gitlab), [Google Docs](/google-docs), [Jira](/jira), [Trello](/integrations/trello) |
-| **Workflow orchestration** | [Airflow](/airflow), [Dagster](/dagster), [Prefect](/prefect) |
+| **Workflow orchestration** | [Airflow](/airflow), [Dagster](/dagster), [Prefect](/prefect), [Temporal](/temporal) |
 | **Messaging** | [Slack](/messaging/slack), [Discord](/messaging/discord), [Telegram](/messaging/telegram), [WhatsApp](/messaging/whatsapp), [Twilio SMS](/messaging/twilio-sms) |
 | **AI coding assistants** | [OpenClaw](/openclaw) |
 

--- a/docs/temporal.mdx
+++ b/docs/temporal.mdx
@@ -3,21 +3,39 @@ title: "Temporal"
 description: "Connect Temporal so OpenSRE can inspect workflow executions, event history, and worker health during investigations"
 ---
 
-OpenSRE queries Temporal's HTTP Visibility API to retrieve workflow executions, event history, task queue health, and namespace-level metrics — helping diagnose workflow failures, activity retries, and worker outages.
+OpenSRE queries Temporal's HTTP API to retrieve workflow executions, event history, task queue health, and namespace-level metrics — helping diagnose workflow failures, activity retries, and worker outages.
+
+<Note>
+OpenSRE connects to Temporal's **HTTP API** (the `/api/v1/...` REST interface served
+by the frontend service). This is a **self-hosted** server feature, enabled with the
+`--http-port` flag (dev server) or `frontend.httpPort` config.
+
+**Temporal Cloud is not currently supported**: Cloud exposes only gRPC/mTLS endpoints
+for workflow data and an HTTP *Ops API* for control-plane management — neither is the
+frontend HTTP API this integration uses. Point OpenSRE at a self-hosted Temporal
+deployment.
+</Note>
 
 ## Prerequisites
 
-- Temporal Cloud account or self-hosted Temporal Server (v1.21+ with HTTP API enabled)
-- API key (Temporal Cloud) or accessible HTTP API URL (self-hosted)
+- A self-hosted Temporal Server with the HTTP API enabled
+- The HTTP API base URL (and an API key only if your deployment requires bearer auth)
+
+<Warning>
+Port `7233` is the **gRPC** frontend port and will **not** work as `base_url` — the
+HTTP API listens on a **separate** port. On the dev server it is set with
+`--http-port` (it otherwise defaults to a random free port). The examples below use
+`7243`.
+</Warning>
 
 ## Setup
 
 ### Option 1: Environment variables
 
 ```bash
-export TEMPORAL_API_URL="https://your-namespace.tmprl.cloud:7233"
-export TEMPORAL_NAMESPACE="your-namespace"
-export TEMPORAL_API_KEY="your-temporal-api-key"
+export TEMPORAL_API_URL="http://localhost:7243"
+export TEMPORAL_NAMESPACE="default"
+export TEMPORAL_API_KEY=""   # only if your deployment requires bearer auth
 ```
 
 ### Option 2: Persistent store
@@ -33,9 +51,9 @@ Add to `~/.opensre/integrations.json`:
       "service": "temporal",
       "status": "active",
       "credentials": {
-        "base_url": "https://your-namespace.tmprl.cloud:7233",
-        "namespace": "your-namespace",
-        "api_key": "your-temporal-api-key"
+        "base_url": "http://temporal-frontend:7243",
+        "namespace": "default",
+        "api_key": ""
       }
     }
   ]
@@ -44,29 +62,51 @@ Add to `~/.opensre/integrations.json`:
 
 | Field | Default | Description |
 | --- | --- | --- |
-| `base_url` | — | Temporal HTTP API base URL |
+| `base_url` | — | Temporal **HTTP API** base URL (the `--http-port` listener, not the gRPC `7233` port) |
 | `namespace` | `default` | Temporal namespace to query |
-| `api_key` | — | API key for Temporal Cloud (omit for unauthenticated self-hosted) |
-
-## Temporal Cloud setup
-
-1. In Temporal Cloud, go to **Settings** → **API Keys**
-2. Create a new API key with read access to your namespace
-3. Your base URL follows the pattern: `https://<namespace>.<account>.tmprl.cloud:7233`
+| `api_key` | — | Bearer token, sent as `Authorization: Bearer <key>`. Leave empty for unauthenticated clusters |
 
 ## Self-hosted Temporal Server
 
-For self-hosted Temporal Server with the HTTP API enabled, set `base_url` to your server's HTTP endpoint (no API key required if unauthenticated):
+Set `base_url` to the frontend's HTTP API endpoint. Ensure the HTTP API is enabled —
+it is a distinct listener from the gRPC frontend (`frontend.httpPort` in static config,
+or `--http-port` on the dev server).
 
-```json
-{
-  "base_url": "http://temporal-frontend:7233",
-  "namespace": "default",
-  "api_key": ""
-}
+### Quick local test with Docker
+
+The `temporalio/temporal` image bundles the CLI and an embedded dev server. Pin the
+HTTP port explicitly (it is random by default) and bind to all interfaces so it is
+reachable from the host:
+
+```bash
+docker run --rm \
+  --name temporal-dev \
+  -p 7233:7233 \
+  -p 8233:8233 \
+  -p 7243:7243 \
+  temporalio/temporal:latest \
+  server start-dev \
+    --ip 0.0.0.0 \
+    --http-port 7243
 ```
 
-Ensure the HTTP API is enabled in your Temporal Server configuration (`frontend.httpPort`).
+| Port | Purpose |
+| --- | --- |
+| `7233` | gRPC frontend (SDKs, `temporal` CLI) |
+| `8233` | Web UI (`http://localhost:8233`) |
+| `7243` | **HTTP API** — set this as `base_url` |
+
+Confirm the HTTP API is answering before configuring the integration:
+
+```bash
+curl -s http://localhost:7243/api/v1/namespaces/default
+```
+
+Then verify the integration end to end:
+
+```bash
+opensre integrations verify temporal
+```
 
 ## Investigation tools
 
@@ -90,14 +130,15 @@ When OpenSRE investigates a Temporal-related alert, four diagnostic tools are av
 
 | Symptom | Fix |
 | --- | --- |
-| **401 Unauthorized** | Check your API key — Temporal Cloud requires a valid key with namespace read access |
-| **Connection refused** | Verify `base_url` is reachable and the HTTP API port is open |
+| **Connection refused / protocol errors** | You may be pointing at the gRPC port. Use the HTTP API port (`--http-port`, e.g. `7243`), not `7233` |
+| **404 on `/api/v1/...`** | The HTTP API may not be enabled — confirm `--http-port` (dev) or `frontend.httpPort` (static config) is set |
+| **401 Unauthorized** | The cluster requires auth — set `api_key` to a valid bearer token |
 | **404 Namespace not found** | Confirm the `namespace` value matches exactly (case-sensitive) |
 | **Empty workflow list** | Workflows may have passed retention — check namespace retention settings |
 | **No pollers on task queue** | Workers may be down — check worker deployment health |
 
 ## Security best practices
 
-- Use a **read-only API key** — OpenSRE never writes to Temporal.
-- For self-hosted, restrict network access to the HTTP API to trusted IPs.
+- Use a **read-only API key** where your deployment supports scoped auth — OpenSRE never writes to Temporal.
+- Restrict network access to the HTTP API to trusted IPs.
 - Store credentials in `~/.opensre/integrations.json` or environment variables, not in source code.

--- a/docs/temporal.mdx
+++ b/docs/temporal.mdx
@@ -1,0 +1,103 @@
+---
+title: "Temporal"
+description: "Connect Temporal so OpenSRE can inspect workflow executions, event history, and worker health during investigations"
+---
+
+OpenSRE queries Temporal's HTTP Visibility API to retrieve workflow executions, event history, task queue health, and namespace-level metrics — helping diagnose workflow failures, activity retries, and worker outages.
+
+## Prerequisites
+
+- Temporal Cloud account or self-hosted Temporal Server (v1.21+ with HTTP API enabled)
+- API key (Temporal Cloud) or accessible HTTP API URL (self-hosted)
+
+## Setup
+
+### Option 1: Environment variables
+
+```bash
+export TEMPORAL_API_URL="https://your-namespace.tmprl.cloud:7233"
+export TEMPORAL_NAMESPACE="your-namespace"
+export TEMPORAL_API_KEY="your-temporal-api-key"
+```
+
+### Option 2: Persistent store
+
+Add to `~/.opensre/integrations.json`:
+
+```json
+{
+  "version": 1,
+  "integrations": [
+    {
+      "id": "temporal-prod",
+      "service": "temporal",
+      "status": "active",
+      "credentials": {
+        "base_url": "https://your-namespace.tmprl.cloud:7233",
+        "namespace": "your-namespace",
+        "api_key": "your-temporal-api-key"
+      }
+    }
+  ]
+}
+```
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `base_url` | — | Temporal HTTP API base URL |
+| `namespace` | `default` | Temporal namespace to query |
+| `api_key` | — | API key for Temporal Cloud (omit for unauthenticated self-hosted) |
+
+## Temporal Cloud setup
+
+1. In Temporal Cloud, go to **Settings** → **API Keys**
+2. Create a new API key with read access to your namespace
+3. Your base URL follows the pattern: `https://<namespace>.<account>.tmprl.cloud:7233`
+
+## Self-hosted Temporal Server
+
+For self-hosted Temporal Server with the HTTP API enabled, set `base_url` to your server's HTTP endpoint (no API key required if unauthenticated):
+
+```json
+{
+  "base_url": "http://temporal-frontend:7233",
+  "namespace": "default",
+  "api_key": ""
+}
+```
+
+Ensure the HTTP API is enabled in your Temporal Server configuration (`frontend.httpPort`).
+
+## Investigation tools
+
+When OpenSRE investigates a Temporal-related alert, four diagnostic tools are available:
+
+| Tool | What it does |
+| --- | --- |
+| **Namespace info** | Retrieves namespace state and workflow execution counts grouped by status (Running, Failed, TimedOut) |
+| **Workflows** | Lists recent workflow executions with status, type, task queue, and timing |
+| **Workflow history** | Fetches the event history for a specific execution — shows the sequence of started, failed, and completed events |
+| **Task queue** | Describes a task queue's active pollers and backlog stats (queue depth, add/dispatch rates) |
+
+### Typical investigation flow
+
+1. **Namespace info** — get a high-level picture: how many workflows are running vs failed?
+2. **Workflows** — filter to failed/timed-out executions, identify the affected workflow type and task queue
+3. **Workflow history** — drill into a specific execution to find which activity failed and why
+4. **Task queue** — check if workers are polling and whether the queue has a growing backlog
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| **401 Unauthorized** | Check your API key — Temporal Cloud requires a valid key with namespace read access |
+| **Connection refused** | Verify `base_url` is reachable and the HTTP API port is open |
+| **404 Namespace not found** | Confirm the `namespace` value matches exactly (case-sensitive) |
+| **Empty workflow list** | Workflows may have passed retention — check namespace retention settings |
+| **No pollers on task queue** | Workers may be down — check worker deployment health |
+
+## Security best practices
+
+- Use a **read-only API key** — OpenSRE never writes to Temporal.
+- For self-hosted, restrict network access to the HTTP API to trusted IPs.
+- Store credentials in `~/.opensre/integrations.json` or environment variables, not in source code.

--- a/tests/integrations/test_temporal_catalog.py
+++ b/tests/integrations/test_temporal_catalog.py
@@ -1,0 +1,81 @@
+"""Catalog wiring for the Temporal integration.
+
+Regression coverage for the classifier path: a stored/remote Temporal record
+must be flattened into a typed config whose fields the Temporal tools can read.
+Before the classifier existed, a missing ``_CLASSIFIERS["temporal"]`` entry meant
+records fell through the generic passthrough, leaving ``base_url`` nested under
+``credentials`` so ``is_available``/``extract_params`` silently saw nothing.
+"""
+
+from __future__ import annotations
+
+from app.agent.stages.investigate.tools import availability_view
+from app.integrations.catalog import classify_integrations
+from app.integrations.temporal import classify
+from app.services.temporal import TemporalConfig
+from app.tools.TemporalWorkflowsTool import TemporalWorkflowsTool
+
+
+class TestClassify:
+    def test_returns_typed_config_with_required_fields(self) -> None:
+        cfg, key = classify(
+            {"base_url": "http://localhost:7243", "namespace": "production"},
+            record_id="rec-1",
+        )
+        assert key == "temporal"
+        assert isinstance(cfg, TemporalConfig)
+        assert cfg.base_url == "http://localhost:7243"
+        assert cfg.namespace == "production"
+        assert cfg.integration_id == "rec-1"
+
+    def test_defaults_namespace_when_absent(self) -> None:
+        cfg, key = classify({"base_url": "http://localhost:7243"}, record_id="rec-1")
+        assert key == "temporal"
+        assert cfg is not None
+        assert cfg.namespace == "default"
+
+    def test_skips_record_without_base_url(self) -> None:
+        cfg, key = classify({"namespace": "production"}, record_id="rec-1")
+        assert cfg is None
+        assert key is None
+
+
+class TestCatalogEndToEnd:
+    """The real wiring tools depend on: store record -> resolved -> tool params."""
+
+    def test_stored_record_reaches_tool_flattened(self) -> None:
+        resolved = classify_integrations(
+            [
+                {
+                    "service": "temporal",
+                    "id": "tmprl-1",
+                    "status": "active",
+                    "credentials": {
+                        "base_url": "http://localhost:7243",
+                        "namespace": "production",
+                        "api_key": "",
+                    },
+                }
+            ]
+        )
+        view = availability_view(resolved)
+        tool = TemporalWorkflowsTool()
+
+        assert tool.is_available(view) is True
+        params = tool.extract_params(view)
+        assert params["base_url"] == "http://localhost:7243"
+        assert params["namespace"] == "production"
+
+    def test_unconfigured_record_is_not_advertised(self) -> None:
+        resolved = classify_integrations(
+            [
+                {
+                    "service": "temporal",
+                    "id": "tmprl-1",
+                    "status": "active",
+                    "credentials": {"namespace": "default"},
+                }
+            ]
+        )
+        assert resolved.get("temporal") is None
+        assert TemporalWorkflowsTool().is_available(availability_view(resolved)) is False

--- a/tests/services/temporal/test_client.py
+++ b/tests/services/temporal/test_client.py
@@ -1,0 +1,320 @@
+from typing import Any
+
+from app.services.temporal.client import TemporalClient, TemporalConfig
+
+
+class _FakeResponse:
+    def __init__(self, payload: Any, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self.text = str(payload)[:200]
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            import httpx
+
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=None,  # type: ignore[arg-type]
+                response=self,  # type: ignore[arg-type]
+            )
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def _client() -> TemporalClient:
+    return TemporalClient(TemporalConfig(base_url="http://localhost:7233"))
+
+
+def error_payload() -> dict[str, Any]:
+    return {"code": 5, "message": "Namespace not-a-real-namespace is not found.", "details": []}
+
+
+def test_temporal_client_is_configured():
+    assert _client().is_configured is True
+
+
+def test_temporal_client_is_not_configured():
+    assert TemporalClient(TemporalConfig(base_url="")).is_configured is False
+    assert (
+        TemporalClient(TemporalConfig(base_url="http://localhost:7233", namespace="")).is_configured
+        is False
+    )
+
+
+def test_list_workflow_executions_success(monkeypatch):
+    fake_payload = {
+        "executions": [
+            {
+                "execution": {"workflowId": "wf-1", "runId": "run-1"},
+                "type": {"name": "MyWorkflowType"},
+                "startTime": "2024-01-01T00:00:00Z",
+                "closeTime": "2024-01-01T00:05:00Z",
+                "status": "WORKFLOW_EXECUTION_STATUS_FAILED",
+                "taskQueue": "my-queue",
+                "historyLength": "150",
+                "historySizeBytes": "8192",
+            }
+        ],
+        "nextPageToken": "",
+    }
+    temporal = _client()
+
+    captured = []
+
+    def fake_get(url, **kwargs):
+        captured.append({"url": url, "params": kwargs.get("params")})
+        return _FakeResponse(fake_payload)
+
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+
+    response = temporal.list_workflow_executions()
+    assert response["success"] is True
+
+    executions = response["executions"]
+
+    # Verify the right endpoint was hit
+    assert captured[0]["url"] == "/api/v1/namespaces/default/workflows"
+    assert captured[0]["params"]["pageSize"] == 10
+
+    # verify the response
+    assert response["total"] == 1
+    assert response["next_page_token"] == ""
+    assert executions[0]["type"]["name"] == "MyWorkflowType"
+    assert executions[0]["status"] == "WORKFLOW_EXECUTION_STATUS_FAILED"
+
+
+def test_list_workflow_executions_failure(monkeypatch):
+    temporal = _client()
+
+    def fake_get(_url, **_kwargs):
+        return _FakeResponse(error_payload(), 404)
+
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+    response = temporal.list_workflow_executions()
+
+    assert response["success"] is False
+
+
+def test_list_workflow_executions_exception(monkeypatch):
+    temporal = _client()
+
+    def fake_get(_url, **_kwargs):
+        raise Exception("unexpected exception")
+
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+    response = temporal.list_workflow_executions()
+
+    assert response["success"] is False
+    assert response["error"] == "unexpected exception"
+
+
+def test_get_workflow_history_success(monkeypatch):
+    fake_payload = {
+        "history": {
+            "events": [
+                {
+                    "eventId": "1",
+                    "eventTime": "2024-01-15T10:00:00Z",
+                    "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+                    "taskId": "1048576",
+                    "workerMayIgnore": False,
+                },
+                {
+                    "eventId": "2",
+                    "eventTime": "2024-01-15T10:00:01Z",
+                    "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+                    "taskId": "1048577",
+                    "workerMayIgnore": False,
+                },
+            ]
+        },
+        "nextPageToken": "",
+        "archived": False,
+    }
+
+    captured = []
+
+    def fake_get(url, **kwargs) -> _FakeResponse:
+        captured.append({"url": url, "params": kwargs.get("params")})
+        return _FakeResponse(fake_payload)
+
+    temporal = _client()
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+
+    response = temporal.get_workflow_history("wf-1", "run-1")
+    assert response["success"] is True
+
+    # Verify the right endpoint was hit
+    assert captured[0]["url"] == "/api/v1/namespaces/default/workflows/wf-1/history"
+    assert captured[0]["params"]["pageSize"] == 10
+    assert captured[0]["params"]["execution.runId"] == "run-1"
+
+    # verify the response
+    assert response["total"] == 2
+    assert response["next_page_token"] == ""
+    assert response["archived"] is False
+
+
+def test_get_workflow_history_failure(monkeypatch):
+    temporal = _client()
+
+    def fake_get(_url, **_kwargs):
+        return _FakeResponse(error_payload(), 404)
+
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+    response = temporal.get_workflow_history("wf-1", "run-1")
+
+    assert response["success"] is False
+
+
+def test_get_workflow_history_exception(monkeypatch):
+    temporal = _client()
+
+    def fake_get(_url, **_kwargs):
+        raise Exception("unexpected exception")
+
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+    response = temporal.get_workflow_history("wf-1", "run-1")
+
+    assert response["success"] is False
+    assert response["error"] == "unexpected exception"
+
+
+def test_describe_task_queue_success(monkeypatch):
+    fake_payload = {
+        "pollers": [
+            {
+                "lastAccessTime": "2024-01-15T10:05:00Z",
+                "identity": "worker-1@host-abc",
+                "ratePerSecond": 100.0,
+            },
+            {
+                "lastAccessTime": "2024-01-15T10:04:55Z",
+                "identity": "worker-2@host-def",
+                "ratePerSecond": 100.0,
+            },
+        ],
+        "stats": {
+            "approximateBacklogCount": "42",
+            "approximateBacklogAge": "30.5s",
+            "tasksAddRate": 5.2,
+            "tasksDispatchRate": 4.8,
+        },
+    }
+    captured = []
+
+    def fake_get(url, **kwargs) -> _FakeResponse:
+        captured.append({"url": url, "params": kwargs.get("params")})
+        return _FakeResponse(fake_payload)
+
+    temporal = _client()
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+
+    response = temporal.describe_task_queue("my-queue")
+    assert response["success"] is True
+    assert response["stats"]["approximateBacklogCount"] == "42"
+    assert response["total"] == 2
+
+    # Verify the right endpoint was hit
+    assert captured[0]["url"] == "/api/v1/namespaces/default/task-queues/my-queue"
+    assert captured[0]["params"]["reportStats"] is True
+    assert captured[0]["params"]["taskQueueType"] == "TASK_QUEUE_TYPE_WORKFLOW"
+
+
+def test_describe_task_queue_failure(monkeypatch):
+    temporal = _client()
+
+    def fake_get(_url, **_kwargs):
+        return _FakeResponse(error_payload(), 404)
+
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+    response = temporal.describe_task_queue("my-queue")
+
+    assert response["success"] is False
+
+
+def test_describe_task_queue_exception(monkeypatch):
+    temporal = _client()
+
+    def fake_get(_url, **_kwargs):
+        raise Exception("unexpected exception")
+
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+    response = temporal.describe_task_queue("my-queue")
+
+    assert response["success"] is False
+    assert response["error"] == "unexpected exception"
+
+
+def test_get_namespace_info_success(monkeypatch):
+    ns_payload = {
+        "namespaceInfo": {
+            "name": "default",
+            "state": "NAMESPACE_STATE_REGISTERED",
+            "description": "Default namespace",
+            "ownerEmail": "team@example.com",
+            "id": "ns-id-123",
+        },
+        "config": {},
+        "isGlobalNamespace": False,
+    }
+    count_payload = {
+        "count": "58",
+        "groups": [
+            {"groupValues": [{"data": "Running"}], "count": "45"},
+            {"groupValues": [{"data": "Failed"}], "count": "8"},
+            {"groupValues": [{"data": "TimedOut"}], "count": "5"},
+        ],
+    }
+
+    captured = []
+
+    def fake_get(url, **kwargs):
+        captured.append({"url": url, "params": kwargs.get("params")})
+        if "workflow-count" in url:
+            return _FakeResponse(count_payload)
+        return _FakeResponse(ns_payload)
+
+    temporal = _client()
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+
+    response = temporal.get_namespace_info()
+    assert response["success"] is True
+
+    # Verify correct endpoints were hit
+    assert captured[0]["url"] == "/api/v1/namespaces/default"
+    assert captured[1]["url"] == "/api/v1/namespaces/default/workflow-count"
+    assert captured[1]["params"]["query"] == "GROUP BY ExecutionStatus"
+
+    # Verify response shape
+    assert response["name"] == "default"
+    assert response["state"] == "NAMESPACE_STATE_REGISTERED"
+    assert response["workflow_count"] == "58"
+    assert len(response["groups"]) == 3
+
+
+def test_get_namespace_info_failure(monkeypatch):
+    temporal = _client()
+
+    def fake_get(_url, **_kwargs):
+        return _FakeResponse(error_payload(), 404)
+
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+    response = temporal.get_namespace_info()
+
+    assert response["success"] is False
+
+
+def test_get_namespace_info_exception(monkeypatch):
+    temporal = _client()
+
+    def fake_get(_url, **_kwargs):
+        raise Exception("connection refused")
+
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+    response = temporal.get_namespace_info()
+
+    assert response["success"] is False
+    assert response["error"] == "connection refused"

--- a/tests/services/temporal/test_client.py
+++ b/tests/services/temporal/test_client.py
@@ -1,6 +1,14 @@
+import base64
+import json
 from typing import Any
 
 from app.services.temporal.client import TemporalClient, TemporalConfig
+
+
+def _encode_status_payload(status: str) -> str:
+    """Encode a status name the way Temporal's HTTP API does: the value is a
+    JSON-encoded string, base64-encoded (e.g. "Failed" -> "IkZhaWxlZCI=")."""
+    return base64.b64encode(json.dumps(status).encode()).decode()
 
 
 class _FakeResponse:
@@ -85,6 +93,28 @@ def test_list_workflow_executions_success(monkeypatch):
     assert executions[0]["status"] == "WORKFLOW_EXECUTION_STATUS_FAILED"
 
 
+def test_list_workflow_executions_omits_next_page_token(monkeypatch):
+    """The live HTTP API omits nextPageToken when there are no more pages.
+    The client must not KeyError — it should default to an empty token."""
+    fake_payload = {
+        "executions": [
+            {
+                "execution": {"workflowId": "wf-1", "runId": "run-1"},
+                "type": {"name": "MyWorkflowType"},
+                "status": "WORKFLOW_EXECUTION_STATUS_FAILED",
+            }
+        ],
+        # nextPageToken intentionally absent — matches a real single-page response.
+    }
+    temporal = _client()
+    monkeypatch.setattr(temporal._client, "get", lambda _url, **_k: _FakeResponse(fake_payload))
+
+    response = temporal.list_workflow_executions()
+    assert response["success"] is True
+    assert response["total"] == 1
+    assert response["next_page_token"] == ""
+
+
 def test_list_workflow_executions_failure(monkeypatch):
     temporal = _client()
 
@@ -157,6 +187,27 @@ def test_get_workflow_history_success(monkeypatch):
     assert response["archived"] is False
 
 
+def test_get_workflow_history_omits_archived_and_token(monkeypatch):
+    """A single-page, non-archived history omits both nextPageToken and
+    archived on the wire. The client must default them instead of KeyError-ing."""
+    fake_payload = {
+        "history": {
+            "events": [
+                {"eventId": "1", "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED"},
+            ]
+        },
+        # nextPageToken and archived intentionally absent.
+    }
+    temporal = _client()
+    monkeypatch.setattr(temporal._client, "get", lambda _url, **_k: _FakeResponse(fake_payload))
+
+    response = temporal.get_workflow_history("wf-1", "run-1")
+    assert response["success"] is True
+    assert response["total"] == 1
+    assert response["next_page_token"] == ""
+    assert response["archived"] is False
+
+
 def test_get_workflow_history_failure(monkeypatch):
     temporal = _client()
 
@@ -223,6 +274,22 @@ def test_describe_task_queue_success(monkeypatch):
     assert captured[0]["params"]["taskQueueType"] == "TASK_QUEUE_TYPE_WORKFLOW"
 
 
+def test_describe_task_queue_omits_pollers(monkeypatch):
+    """When no worker is polling, the live API omits the pollers array entirely.
+    The client must default to [] (total 0) rather than KeyError."""
+    fake_payload = {
+        "stats": {"approximateBacklogAge": "0s"},
+        # pollers intentionally absent — no active workers right now.
+    }
+    temporal = _client()
+    monkeypatch.setattr(temporal._client, "get", lambda _url, **_k: _FakeResponse(fake_payload))
+
+    response = temporal.describe_task_queue("idle-queue")
+    assert response["success"] is True
+    assert response["pollers"] == []
+    assert response["total"] == 0
+
+
 def test_describe_task_queue_failure(monkeypatch):
     temporal = _client()
 
@@ -260,12 +327,13 @@ def test_get_namespace_info_success(monkeypatch):
         "config": {},
         "isGlobalNamespace": False,
     }
+    # The real HTTP API base64-encodes each status name as a Temporal Payload.
     count_payload = {
         "count": "58",
         "groups": [
-            {"groupValues": [{"data": "Running"}], "count": "45"},
-            {"groupValues": [{"data": "Failed"}], "count": "8"},
-            {"groupValues": [{"data": "TimedOut"}], "count": "5"},
+            {"groupValues": [{"data": _encode_status_payload("Running")}], "count": "45"},
+            {"groupValues": [{"data": _encode_status_payload("Failed")}], "count": "8"},
+            {"groupValues": [{"data": _encode_status_payload("TimedOut")}], "count": "5"},
         ],
     }
 
@@ -288,11 +356,16 @@ def test_get_namespace_info_success(monkeypatch):
     assert captured[1]["url"] == "/api/v1/namespaces/default/workflow-count"
     assert captured[1]["params"]["query"] == "GROUP BY ExecutionStatus"
 
-    # Verify response shape
+    # Verify response shape: groups are decoded from base64 and flattened to
+    # [{"status", "count"}] — the LLM never sees raw Payload encoding.
     assert response["name"] == "default"
     assert response["state"] == "NAMESPACE_STATE_REGISTERED"
     assert response["workflow_count"] == "58"
-    assert len(response["groups"]) == 3
+    assert response["groups"] == [
+        {"status": "Running", "count": "45"},
+        {"status": "Failed", "count": "8"},
+        {"status": "TimedOut", "count": "5"},
+    ]
 
 
 def test_get_namespace_info_failure(monkeypatch):

--- a/tests/services/temporal/test_client.py
+++ b/tests/services/temporal/test_client.py
@@ -318,3 +318,45 @@ def test_get_namespace_info_exception(monkeypatch):
 
     assert response["success"] is False
     assert response["error"] == "connection refused"
+
+
+def test_probe_access_success(monkeypatch):
+    payload = {
+        "namespaceInfo": {
+            "name": "default",
+            "state": "NAMESPACE_STATE_REGISTERED",
+            "description": "Default namespace",
+            "ownerEmail": "team@example.com",
+            "id": "ns-id-123",
+        },
+        "config": {},
+        "isGlobalNamespace": False,
+    }
+
+    def fake_get(_url, **_kwargs):
+        return _FakeResponse(payload)
+
+    temporal = _client()
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+
+    result = temporal.probe_access()
+
+    assert result.ok is True
+
+
+def test_probe_access_failure(monkeypatch):
+    temporal = _client()
+
+    def fake_get(_url, **_kwargs):
+        return _FakeResponse(error_payload(), 404)
+
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+    result = temporal.probe_access()
+
+    assert result.ok is False
+
+
+def test_probe_access_on_unconfigured_client(monkeypatch):
+    temporal = TemporalClient(TemporalConfig(base_url="", namespace=""))
+    result = temporal.probe_access()
+    assert result.ok is False

--- a/tests/services/temporal/test_client.py
+++ b/tests/services/temporal/test_client.py
@@ -208,6 +208,23 @@ def test_get_workflow_history_omits_archived_and_token(monkeypatch):
     assert response["archived"] is False
 
 
+def test_get_workflow_history_encodes_workflow_id_with_slashes(monkeypatch):
+    """Workflow IDs may contain '/' (e.g. 'order-service/order-123'). The client
+    must percent-encode it into a single path segment, or the Temporal frontend
+    parses the extra segment as a different route and returns 404."""
+    captured = []
+
+    def fake_get(url, **_kwargs):
+        captured.append(url)
+        return _FakeResponse({"history": {"events": []}})
+
+    temporal = _client()
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+
+    temporal.get_workflow_history("order-service/order-123", "run-1")
+    assert captured[0] == "/api/v1/namespaces/default/workflows/order-service%2Forder-123/history"
+
+
 def test_get_workflow_history_failure(monkeypatch):
     temporal = _client()
 
@@ -288,6 +305,22 @@ def test_describe_task_queue_omits_pollers(monkeypatch):
     assert response["success"] is True
     assert response["pollers"] == []
     assert response["total"] == 0
+
+
+def test_describe_task_queue_encodes_name_with_slashes(monkeypatch):
+    """Task queue names are free-form strings and may contain '/'. Encode them
+    into a single path segment so the request hits the right route."""
+    captured = []
+
+    def fake_get(url, **_kwargs):
+        captured.append(url)
+        return _FakeResponse({"stats": {}})
+
+    temporal = _client()
+    monkeypatch.setattr(temporal._client, "get", fake_get)
+
+    temporal.describe_task_queue("payments/charge-queue")
+    assert captured[0] == "/api/v1/namespaces/default/task-queues/payments%2Fcharge-queue"
 
 
 def test_describe_task_queue_failure(monkeypatch):

--- a/tests/synthetic/test_temporal_scenario.py
+++ b/tests/synthetic/test_temporal_scenario.py
@@ -27,8 +27,8 @@ from typing import Any
 import httpx
 import pytest
 
-from app.agent.investigation import _ALERT_SOURCE_TO_TOOL_SOURCES as _SEEDING_MAP
-from app.agent.prompt import _ALERT_SOURCE_TO_TOOL_SOURCES as _PROMPT_MAP
+from app.agent.stages.investigate.prompt import _ALERT_SOURCE_TO_TOOL_SOURCES as _PROMPT_MAP
+from app.agent.utils.alert_source import ALERT_SOURCE_TO_SEED_TOOL_SOURCES as _SEEDING_MAP
 from app.services.temporal import TemporalClient, TemporalConfig
 from app.tools.TemporalNamespaceInfoTool import TemporalNamespaceInfoTool
 from app.tools.TemporalTaskQueueTool import TemporalTaskQueueTool
@@ -270,7 +270,7 @@ def patched_temporal_client(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_temporal_alert_source_seeds_temporal_tools() -> None:
     """A temporal-sourced alert pre-seeds temporal tools before the ReAct loop."""
     assert "temporal" in _SEEDING_MAP
-    assert _SEEDING_MAP["temporal"] == ["temporal"]
+    assert _SEEDING_MAP["temporal"] == ("temporal",)
 
 
 def test_temporal_alert_source_appears_in_prompt_map() -> None:

--- a/tests/synthetic/test_temporal_scenario.py
+++ b/tests/synthetic/test_temporal_scenario.py
@@ -1,0 +1,394 @@
+"""Synthetic RCA scenario using Temporal as the evidence source.
+
+Validates that the full tool → client → HTTP stack surfaces realistic
+Temporal API responses for a workflow failure investigation scenario.
+
+Scenario: A payment processing workflow has failed because its
+ChargePaymentMethod activity hit a non-retryable PaymentGatewayError
+(HTTP 401 from the charge service). The agent uses namespace info to see
+elevated failure counts, lists failed workflows, drills into the event
+history to find the failed activity and its nested failure cause, and checks
+the task queue for worker health.
+
+The fixtures mirror the *real* Temporal HTTP API wire shapes captured from a
+live self-hosted dev server: status names arrive base64-encoded,
+and falsy fields like nextPageToken / archived / pollers are omitted entirely.
+
+The fixture Temporal instance is implemented as an httpx.MockTransport
+returning canned JSON for each API path.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from app.agent.investigation import _ALERT_SOURCE_TO_TOOL_SOURCES as _SEEDING_MAP
+from app.agent.prompt import _ALERT_SOURCE_TO_TOOL_SOURCES as _PROMPT_MAP
+from app.services.temporal import TemporalClient, TemporalConfig
+from app.tools.TemporalNamespaceInfoTool import TemporalNamespaceInfoTool
+from app.tools.TemporalTaskQueueTool import TemporalTaskQueueTool
+from app.tools.TemporalWorkflowHistoryTool import TemporalWorkflowHistoryTool
+from app.tools.TemporalWorkflowsTool import TemporalWorkflowsTool
+
+pytestmark = pytest.mark.synthetic
+
+
+# --- fixture Temporal instance ------------------------------------------------
+
+_NAMESPACE = "production"
+_FAILED_WORKFLOW_ID = "payment-proc-abc123"
+_FAILED_RUN_ID = "run-def456"
+_TASK_QUEUE = "payment-queue"
+
+
+def _encode_status_payload(status: str) -> str:
+    """Encode a status name as Temporal's HTTP API does: JSON-encoded string,
+    base64-encoded (e.g. "Failed" -> "IkZhaWxlZCI=")."""
+    return base64.b64encode(json.dumps(status).encode()).decode()
+
+
+# DescribeNamespace response
+_FIXTURE_DESCRIBE_NAMESPACE = {
+    "namespaceInfo": {
+        "name": _NAMESPACE,
+        "state": "NAMESPACE_STATE_REGISTERED",
+        "description": "Production payment workflows",
+    },
+    "config": {
+        "workflowExecutionRetentionTtl": "259200s",
+    },
+    "replicationConfig": {
+        "activeClusterName": "us-east-1",
+    },
+}
+
+# CountWorkflowExecutions with GROUP BY ExecutionStatus.
+# Status names arrive base64-encoded as Temporal Payloads (real wire shape).
+_FIXTURE_COUNT_WORKFLOWS = {
+    "count": "142",
+    "groups": [
+        {"groupValues": [{"data": _encode_status_payload("Running")}], "count": "95"},
+        {"groupValues": [{"data": _encode_status_payload("Failed")}], "count": "38"},
+        {"groupValues": [{"data": _encode_status_payload("TimedOut")}], "count": "9"},
+    ],
+}
+
+# ListWorkflowExecutions response — includes the failed payment workflow
+_FIXTURE_LIST_WORKFLOWS = {
+    "executions": [
+        {
+            "execution": {
+                "workflowId": _FAILED_WORKFLOW_ID,
+                "runId": _FAILED_RUN_ID,
+            },
+            "type": {"name": "PaymentProcessingWorkflow"},
+            "startTime": "2024-01-15T10:00:00Z",
+            "closeTime": "2024-01-15T10:02:30Z",
+            "status": "WORKFLOW_EXECUTION_STATUS_FAILED",
+            "taskQueue": _TASK_QUEUE,
+            "historyLength": "12",
+            "historySizeBytes": "4096",
+        },
+        {
+            "execution": {
+                "workflowId": "order-fulfill-xyz789",
+                "runId": "run-ghi012",
+            },
+            "type": {"name": "OrderFulfillmentWorkflow"},
+            "startTime": "2024-01-15T09:55:00Z",
+            "closeTime": "2024-01-15T10:01:00Z",
+            "status": "WORKFLOW_EXECUTION_STATUS_TIMED_OUT",
+            "taskQueue": _TASK_QUEUE,
+            "historyLength": "8",
+            "historySizeBytes": "2048",
+        },
+    ],
+    # nextPageToken omitted — matches a real single-page response.
+}
+
+# GetWorkflowHistory for the failed payment workflow.
+# Mirrors the real wire shape: a non-retryable activity failure surfaces as a
+# nested failure.cause chain (Go SDK), terminating in WORKFLOW_EXECUTION_FAILED.
+# There is no ACTIVITY_TASK_TIMED_OUT event — a non-retryable error fails fast.
+_FIXTURE_WORKFLOW_HISTORY = {
+    "history": {
+        "events": [
+            {
+                "eventId": "1",
+                "eventTime": "2024-01-15T10:00:00Z",
+                "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+                "taskId": "1048576",
+                "workerMayIgnore": False,
+                "workflowExecutionStartedEventAttributes": {
+                    "workflowType": {"name": "PaymentProcessingWorkflow"},
+                    "taskQueue": {"name": _TASK_QUEUE},
+                },
+            },
+            {
+                "eventId": "5",
+                "eventTime": "2024-01-15T10:00:01Z",
+                "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+                "taskId": "1048580",
+                "workerMayIgnore": False,
+                "activityTaskScheduledEventAttributes": {
+                    "activityType": {"name": "ChargePaymentMethod"},
+                    "taskQueue": {"name": _TASK_QUEUE},
+                },
+            },
+            {
+                "eventId": "11",
+                "eventTime": "2024-01-15T10:00:02Z",
+                "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_FAILED",
+                "taskId": "1048590",
+                "workerMayIgnore": False,
+                "workflowExecutionFailedEventAttributes": {
+                    "failure": {
+                        "message": "activity error",
+                        "source": "GoSDK",
+                        "cause": {
+                            "message": (
+                                "payment gateway rejected charge: downstream credentials invalid"
+                            ),
+                            "source": "GoSDK",
+                            "cause": {
+                                "message": "HTTP 401 from charge-service",
+                                "source": "GoSDK",
+                                "applicationFailureInfo": {},
+                            },
+                            "applicationFailureInfo": {
+                                "type": "PaymentGatewayError",
+                                "nonRetryable": True,
+                            },
+                        },
+                        "activityFailureInfo": {
+                            "scheduledEventId": "5",
+                            "startedEventId": "6",
+                            "activityType": {"name": "ChargePaymentMethod"},
+                            "activityId": "5",
+                            "retryState": "RETRY_STATE_NON_RETRYABLE_FAILURE",
+                        },
+                    },
+                    "retryState": "RETRY_STATE_RETRY_POLICY_NOT_SET",
+                    "workflowTaskCompletedEventId": "10",
+                },
+            },
+        ]
+    },
+    # nextPageToken and archived omitted — matches a real single-page history.
+}
+
+# DescribeTaskQueue — workers are polling but backlog is growing
+_FIXTURE_DESCRIBE_TASK_QUEUE = {
+    "pollers": [
+        {
+            "lastAccessTime": "2024-01-15T10:05:00Z",
+            "identity": "worker-1@payment-host-a",
+            "ratePerSecond": 50.0,
+        },
+    ],
+    "stats": {
+        "approximateBacklogCount": "156",
+        "approximateBacklogAge": "120.5s",
+        "tasksAddRate": 12.3,
+        "tasksDispatchRate": 4.1,
+    },
+}
+
+
+def _make_mock_temporal_transport() -> httpx.MockTransport:
+    """Build an httpx.MockTransport that routes Temporal HTTP API requests
+    to the correct canned response based on URL path."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+
+        # CountWorkflowExecutions (checked before DescribeNamespace since it is
+        # a more specific path under the same namespace prefix)
+        if path == f"/api/v1/namespaces/{_NAMESPACE}/workflow-count":
+            return httpx.Response(200, json=_FIXTURE_COUNT_WORKFLOWS)
+
+        # DescribeNamespace
+        if path == f"/api/v1/namespaces/{_NAMESPACE}":
+            return httpx.Response(200, json=_FIXTURE_DESCRIBE_NAMESPACE)
+
+        # GetWorkflowHistory (more specific than ListWorkflowExecutions)
+        if f"/workflows/{_FAILED_WORKFLOW_ID}/history" in path:
+            return httpx.Response(200, json=_FIXTURE_WORKFLOW_HISTORY)
+
+        # ListWorkflowExecutions
+        if path == f"/api/v1/namespaces/{_NAMESPACE}/workflows":
+            return httpx.Response(200, json=_FIXTURE_LIST_WORKFLOWS)
+
+        # DescribeTaskQueue
+        if f"/task-queues/{_TASK_QUEUE}" in path:
+            return httpx.Response(200, json=_FIXTURE_DESCRIBE_TASK_QUEUE)
+
+        return httpx.Response(404, json={"message": f"no fixture for path: {path}"})
+
+    return httpx.MockTransport(_handler)
+
+
+@pytest.fixture
+def patched_temporal_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch TemporalClient at each tool's import location so tool.run()
+    exercises the full stack through a fixture HTTP transport."""
+    mock_transport = _make_mock_temporal_transport()
+
+    def _make_patched_client(_config: Any) -> TemporalClient:
+        """Create a TemporalClient with a mocked httpx transport."""
+        config = TemporalConfig(
+            base_url="http://temporal.example.com:7233",
+            namespace=_NAMESPACE,
+            api_key="test-key",
+        )
+        client = TemporalClient(config)
+        # Replace the internal httpx.Client with one using our mock transport
+        client._client = httpx.Client(
+            base_url="http://temporal.example.com:7233",
+            headers={"Authorization": "Bearer test-key"},
+            timeout=10.0,
+            transport=mock_transport,
+        )
+        return client
+
+    monkeypatch.setattr("app.tools.TemporalNamespaceInfoTool.TemporalClient", _make_patched_client)
+    monkeypatch.setattr("app.tools.TemporalWorkflowsTool.TemporalClient", _make_patched_client)
+    monkeypatch.setattr(
+        "app.tools.TemporalWorkflowHistoryTool.TemporalClient", _make_patched_client
+    )
+    monkeypatch.setattr("app.tools.TemporalTaskQueueTool.TemporalClient", _make_patched_client)
+
+
+# --- alert source mapping -----------------------------------------------------
+
+
+def test_temporal_alert_source_seeds_temporal_tools() -> None:
+    """A temporal-sourced alert pre-seeds temporal tools before the ReAct loop."""
+    assert "temporal" in _SEEDING_MAP
+    assert _SEEDING_MAP["temporal"] == ["temporal"]
+
+
+def test_temporal_alert_source_appears_in_prompt_map() -> None:
+    """A temporal-sourced alert is treated as a primary temporal-tool source in the prompt."""
+    assert "temporal" in _PROMPT_MAP
+    assert _PROMPT_MAP["temporal"] == ["temporal"]
+
+
+# --- synthetic investigation scenario ----------------------------------------
+
+
+def test_namespace_info_shows_elevated_failures(
+    patched_temporal_client: None,
+) -> None:
+    """Namespace info surfaces workflow counts grouped by status,
+    revealing elevated Failed and TimedOut counts."""
+    tool = TemporalNamespaceInfoTool()
+    result = tool.run(
+        base_url="http://temporal.example.com:7233",
+        namespace=_NAMESPACE,
+    )
+    assert result["available"] is True
+    assert result["name"] == _NAMESPACE
+    assert result["state"] == "NAMESPACE_STATE_REGISTERED"
+
+    # Verify the agent can see failure breakdown — groups are decoded from
+    # base64 and flattened to {status, count} by the client.
+    groups = result["groups"]
+    failed_groups = [g for g in groups if g["status"] == "Failed"]
+    assert len(failed_groups) == 1
+    assert failed_groups[0]["count"] == "38"
+
+
+def test_list_workflows_surfaces_failed_executions(
+    patched_temporal_client: None,
+) -> None:
+    """Listing workflows reveals the failed PaymentProcessingWorkflow
+    with its task queue for further investigation."""
+    tool = TemporalWorkflowsTool()
+    result = tool.run(
+        base_url="http://temporal.example.com:7233",
+        namespace=_NAMESPACE,
+    )
+    assert result["available"] is True
+    assert result["total"] == 2
+
+    executions = result["executions"]
+    failed = [e for e in executions if "FAILED" in e.get("status", "")]
+    assert len(failed) == 1
+    assert failed[0]["execution"]["workflowId"] == _FAILED_WORKFLOW_ID
+    assert failed[0]["type"]["name"] == "PaymentProcessingWorkflow"
+    assert failed[0]["taskQueue"] == _TASK_QUEUE
+
+
+def test_workflow_history_reveals_nonretryable_payment_failure(
+    patched_temporal_client: None,
+) -> None:
+    """Event history for the failed workflow shows the ChargePaymentMethod
+    activity failed with a non-retryable PaymentGatewayError, and the nested
+    failure cause chain pins the root cause to an HTTP 401 from charge-service."""
+    tool = TemporalWorkflowHistoryTool()
+    result = tool.run(
+        base_url="http://temporal.example.com:7233",
+        workflow_id=_FAILED_WORKFLOW_ID,
+        run_id=_FAILED_RUN_ID,
+        namespace=_NAMESPACE,
+    )
+    assert result["available"] is True
+    assert result["total"] >= 3
+
+    events = result["events"]
+
+    # The activity that failed is identified on the schedule event.
+    scheduled = [e for e in events if e["eventType"] == "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED"]
+    assert len(scheduled) == 1
+    assert (
+        scheduled[0]["activityTaskScheduledEventAttributes"]["activityType"]["name"]
+        == "ChargePaymentMethod"
+    )
+
+    # The workflow failure carries the nested cause chain (Go SDK shape):
+    #   "activity error" -> gateway rejection -> HTTP 401 root cause.
+    wf_failed = [e for e in events if e["eventType"] == "EVENT_TYPE_WORKFLOW_EXECUTION_FAILED"]
+    assert len(wf_failed) == 1
+    failure = wf_failed[0]["workflowExecutionFailedEventAttributes"]["failure"]
+
+    # The failing activity is named on activityFailureInfo.
+    assert failure["activityFailureInfo"]["activityType"]["name"] == "ChargePaymentMethod"
+    assert failure["activityFailureInfo"]["retryState"] == "RETRY_STATE_NON_RETRYABLE_FAILURE"
+
+    # First-level cause: the application error and its non-retryable type.
+    cause = failure["cause"]
+    assert "payment gateway rejected charge" in cause["message"]
+    assert cause["applicationFailureInfo"]["type"] == "PaymentGatewayError"
+    assert cause["applicationFailureInfo"]["nonRetryable"] is True
+
+    # Root cause: the underlying HTTP 401 from the downstream charge service.
+    assert "HTTP 401 from charge-service" in cause["cause"]["message"]
+
+
+def test_task_queue_shows_growing_backlog(
+    patched_temporal_client: None,
+) -> None:
+    """Task queue inspection reveals workers are active but the backlog
+    is growing — add rate (12.3/s) far exceeds dispatch rate (4.1/s)."""
+    tool = TemporalTaskQueueTool()
+    result = tool.run(
+        base_url="http://temporal.example.com:7233",
+        task_queue_name=_TASK_QUEUE,
+        namespace=_NAMESPACE,
+    )
+    assert result["available"] is True
+
+    # Workers are polling (not dead)
+    assert result["total"] >= 1
+    assert result["pollers"][0]["identity"] == "worker-1@payment-host-a"
+
+    # But backlog is growing — evidence of throughput problem
+    stats = result["stats"]
+    assert int(stats["approximateBacklogCount"]) > 100
+    assert float(stats["tasksAddRate"]) > float(stats["tasksDispatchRate"])

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -171,6 +171,11 @@ def mock_agent_state(overrides: dict | None = None) -> dict[str, Any]:
             "default_query": 'index=main "NullPointerException" | head 50',
             "time_range_minutes": 60,
         },
+        "temporal": {
+            "base_url": "http://localhost:7233",
+            "api_key": "",
+            "namespace": "default",
+        },
     }
     if overrides:
         for key, value in overrides.items():

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -1133,6 +1133,13 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         "search_github_code",
         "search_github_issues",
         "search_sentry_issues",
+        # Temporal tools use try/finally only (to close the client); the client
+        # returns structured error dicts for handled HTTP failures, and any
+        # unexpected exception escapes to the #1476 global wrapper.
+        "temporal_namespace_info",
+        "temporal_task_queue",
+        "temporal_workflow_history",
+        "temporal_workflows",
         "twilio_notify",
         "vercel_deployment_logs",
         "vercel_deployment_status",

--- a/tests/tools/test_temporal_namespace_info_tool.py
+++ b/tests/tools/test_temporal_namespace_info_tool.py
@@ -1,0 +1,86 @@
+"""Tests for TemporalNamespaceInfoTool."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.tools.TemporalNamespaceInfoTool import TemporalNamespaceInfoTool
+from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+class TestTemporalNamespaceInfoToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return TemporalNamespaceInfoTool()
+
+
+def test_is_available_when_configured() -> None:
+    tool = TemporalNamespaceInfoTool()
+    assert tool.is_available({"temporal": {"base_url": "http://localhost:7233"}}) is True
+
+
+def test_is_available_when_not_configured() -> None:
+    tool = TemporalNamespaceInfoTool()
+    assert tool.is_available({"temporal": {}}) is False
+    assert tool.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    tool = TemporalNamespaceInfoTool()
+    sources = mock_agent_state()
+    params = tool.extract_params(sources)
+    assert params["base_url"] == "http://localhost:7233"
+    assert params["namespace"] == "default"
+    assert params["api_key"] == ""
+
+
+def test_run_returns_unavailable_when_no_base_url() -> None:
+    tool = TemporalNamespaceInfoTool()
+    result = tool.run(base_url="")
+    assert result["available"] is False
+    assert "base_url is required" in result["error"]
+
+
+def test_run_happy_path(monkeypatch) -> None:
+    tool = TemporalNamespaceInfoTool()
+    mock_client = MagicMock()
+    mock_client.get_namespace_info.return_value = {
+        "success": True,
+        "name": "default",
+        "state": "NAMESPACE_STATE_REGISTERED",
+        "workflow_count": "58",
+        "groups": [
+            {"groupValues": [{"data": "Running"}], "count": "45"},
+            {"groupValues": [{"data": "Failed"}], "count": "8"},
+            {"groupValues": [{"data": "TimedOut"}], "count": "5"},
+        ],
+    }
+
+    monkeypatch.setattr(
+        "app.tools.TemporalNamespaceInfoTool.TemporalClient",
+        lambda _config: mock_client,
+    )
+
+    result = tool.run(base_url="http://localhost:7233", namespace="default")
+    assert result["available"] is True
+    assert result["name"] == "default"
+    assert result["state"] == "NAMESPACE_STATE_REGISTERED"
+    assert result["workflow_count"] == "58"
+    assert len(result["groups"]) == 3
+
+
+def test_run_returns_error_on_failure(monkeypatch) -> None:
+    tool = TemporalNamespaceInfoTool()
+    mock_client = MagicMock()
+    mock_client.get_namespace_info.return_value = {
+        "success": False,
+        "error": "HTTP 404: Namespace not found.",
+    }
+
+    monkeypatch.setattr(
+        "app.tools.TemporalNamespaceInfoTool.TemporalClient",
+        lambda _config: mock_client,
+    )
+
+    result = tool.run(base_url="http://localhost:7233", namespace="bad-ns")
+    assert result["available"] is False
+    assert "404" in result["error"]

--- a/tests/tools/test_temporal_namespace_info_tool.py
+++ b/tests/tools/test_temporal_namespace_info_tool.py
@@ -48,10 +48,12 @@ def test_run_happy_path(monkeypatch) -> None:
         "name": "default",
         "state": "NAMESPACE_STATE_REGISTERED",
         "workflow_count": "58",
+        # The client flattens + base64-decodes the raw groupValues into
+        # [{"status", "count"}] before returning (see TemporalClient).
         "groups": [
-            {"groupValues": [{"data": "Running"}], "count": "45"},
-            {"groupValues": [{"data": "Failed"}], "count": "8"},
-            {"groupValues": [{"data": "TimedOut"}], "count": "5"},
+            {"status": "Running", "count": "45"},
+            {"status": "Failed", "count": "8"},
+            {"status": "TimedOut", "count": "5"},
         ],
     }
 
@@ -65,7 +67,11 @@ def test_run_happy_path(monkeypatch) -> None:
     assert result["name"] == "default"
     assert result["state"] == "NAMESPACE_STATE_REGISTERED"
     assert result["workflow_count"] == "58"
-    assert len(result["groups"]) == 3
+    assert result["groups"] == [
+        {"status": "Running", "count": "45"},
+        {"status": "Failed", "count": "8"},
+        {"status": "TimedOut", "count": "5"},
+    ]
 
 
 def test_run_returns_error_on_failure(monkeypatch) -> None:

--- a/tests/tools/test_temporal_namespace_info_tool.py
+++ b/tests/tools/test_temporal_namespace_info_tool.py
@@ -43,6 +43,7 @@ def test_run_returns_unavailable_when_no_base_url() -> None:
 def test_run_happy_path(monkeypatch) -> None:
     tool = TemporalNamespaceInfoTool()
     mock_client = MagicMock()
+    mock_client.__enter__.return_value = mock_client
     mock_client.get_namespace_info.return_value = {
         "success": True,
         "name": "default",
@@ -77,6 +78,7 @@ def test_run_happy_path(monkeypatch) -> None:
 def test_run_returns_error_on_failure(monkeypatch) -> None:
     tool = TemporalNamespaceInfoTool()
     mock_client = MagicMock()
+    mock_client.__enter__.return_value = mock_client
     mock_client.get_namespace_info.return_value = {
         "success": False,
         "error": "HTTP 404: Namespace not found.",

--- a/tests/tools/test_temporal_task_queue_tool.py
+++ b/tests/tools/test_temporal_task_queue_tool.py
@@ -1,0 +1,119 @@
+"""Tests for TemporalTaskQueueTool."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.tools.TemporalTaskQueueTool import TemporalTaskQueueTool
+from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+class TestTemporalTaskQueueToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return TemporalTaskQueueTool()
+
+
+def test_is_available_when_configured() -> None:
+    tool = TemporalTaskQueueTool()
+    assert tool.is_available({"temporal": {"base_url": "http://localhost:7233"}}) is True
+
+
+def test_is_available_when_not_configured() -> None:
+    tool = TemporalTaskQueueTool()
+    assert tool.is_available({"temporal": {}}) is False
+    assert tool.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    tool = TemporalTaskQueueTool()
+    sources = mock_agent_state()
+    params = tool.extract_params(sources)
+    assert params["base_url"] == "http://localhost:7233"
+    assert params["namespace"] == "default"
+    assert params["api_key"] == ""
+
+
+def test_run_returns_unavailable_when_no_base_url() -> None:
+    tool = TemporalTaskQueueTool()
+    result = tool.run(base_url="", task_queue_name="my-queue")
+    assert result["available"] is False
+    assert "base_url is required" in result["error"]
+    assert result["pollers"] == []
+    assert result["stats"] == {}
+
+
+def test_run_returns_error_when_no_task_queue_name() -> None:
+    tool = TemporalTaskQueueTool()
+    result = tool.run(base_url="http://localhost:7233", task_queue_name="")
+    assert result["available"] is True
+    assert "task_queue_name is required" in result["error"]
+    assert result["pollers"] == []
+
+
+def test_run_happy_path(monkeypatch) -> None:
+    tool = TemporalTaskQueueTool()
+    mock_client = MagicMock()
+    mock_client.describe_task_queue.return_value = {
+        "success": True,
+        "pollers": [
+            {
+                "lastAccessTime": "2024-01-15T10:05:00Z",
+                "identity": "worker-1@host-abc",
+                "ratePerSecond": 100.0,
+            },
+            {
+                "lastAccessTime": "2024-01-15T10:04:55Z",
+                "identity": "worker-2@host-def",
+                "ratePerSecond": 100.0,
+            },
+        ],
+        "stats": {
+            "approximateBacklogCount": "42",
+            "approximateBacklogAge": "30.5s",
+            "tasksAddRate": 5.2,
+            "tasksDispatchRate": 4.8,
+        },
+        "total": 2,
+    }
+
+    monkeypatch.setattr(
+        "app.tools.TemporalTaskQueueTool.TemporalClient",
+        lambda _config: mock_client,
+    )
+
+    result = tool.run(
+        base_url="http://localhost:7233",
+        task_queue_name="payment-queue",
+        namespace="default",
+    )
+    assert result["available"] is True
+    assert result["total"] == 2
+    assert result["pollers"][0]["identity"] == "worker-1@host-abc"
+    assert result["stats"]["approximateBacklogCount"] == "42"
+    assert result["stats"]["tasksAddRate"] == 5.2
+
+    mock_client.describe_task_queue.assert_called_once_with(task_queue_name="payment-queue")
+
+
+def test_run_returns_error_on_failure(monkeypatch) -> None:
+    tool = TemporalTaskQueueTool()
+    mock_client = MagicMock()
+    mock_client.describe_task_queue.return_value = {
+        "success": False,
+        "error": "HTTP 404: Task queue not found.",
+    }
+
+    monkeypatch.setattr(
+        "app.tools.TemporalTaskQueueTool.TemporalClient",
+        lambda _config: mock_client,
+    )
+
+    result = tool.run(
+        base_url="http://localhost:7233",
+        task_queue_name="nonexistent-queue",
+        namespace="default",
+    )
+    assert result["available"] is False
+    assert "404" in result["error"]
+    assert result["pollers"] == []
+    assert result["stats"] == {}

--- a/tests/tools/test_temporal_task_queue_tool.py
+++ b/tests/tools/test_temporal_task_queue_tool.py
@@ -53,6 +53,7 @@ def test_run_returns_error_when_no_task_queue_name() -> None:
 def test_run_happy_path(monkeypatch) -> None:
     tool = TemporalTaskQueueTool()
     mock_client = MagicMock()
+    mock_client.__enter__.return_value = mock_client
     mock_client.describe_task_queue.return_value = {
         "success": True,
         "pollers": [
@@ -98,6 +99,7 @@ def test_run_happy_path(monkeypatch) -> None:
 def test_run_returns_error_on_failure(monkeypatch) -> None:
     tool = TemporalTaskQueueTool()
     mock_client = MagicMock()
+    mock_client.__enter__.return_value = mock_client
     mock_client.describe_task_queue.return_value = {
         "success": False,
         "error": "HTTP 404: Task queue not found.",

--- a/tests/tools/test_temporal_workflow_history_tool.py
+++ b/tests/tools/test_temporal_workflow_history_tool.py
@@ -1,0 +1,131 @@
+"""Tests for TemporalWorkflowHistoryTool."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.tools.TemporalWorkflowHistoryTool import TemporalWorkflowHistoryTool
+from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+class TestTemporalWorkflowHistoryToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return TemporalWorkflowHistoryTool()
+
+
+def test_is_available_when_configured() -> None:
+    tool = TemporalWorkflowHistoryTool()
+    assert tool.is_available({"temporal": {"base_url": "http://localhost:7233"}}) is True
+
+
+def test_is_available_when_not_configured() -> None:
+    tool = TemporalWorkflowHistoryTool()
+    assert tool.is_available({"temporal": {}}) is False
+    assert tool.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    tool = TemporalWorkflowHistoryTool()
+    sources = mock_agent_state()
+    params = tool.extract_params(sources)
+    assert params["base_url"] == "http://localhost:7233"
+    assert params["namespace"] == "default"
+    assert params["api_key"] == ""
+
+
+def test_run_returns_unavailable_when_no_base_url() -> None:
+    tool = TemporalWorkflowHistoryTool()
+    result = tool.run(base_url="", workflow_id="wf-1")
+    assert result["available"] is False
+    assert "base_url is required" in result["error"]
+    assert result["events"] == []
+
+
+def test_run_returns_error_when_no_workflow_id() -> None:
+    tool = TemporalWorkflowHistoryTool()
+    result = tool.run(base_url="http://localhost:7233", workflow_id="")
+    assert result["available"] is True
+    assert "workflow_id is required" in result["error"]
+    assert result["events"] == []
+
+
+def test_run_happy_path(monkeypatch) -> None:
+    tool = TemporalWorkflowHistoryTool()
+    mock_client = MagicMock()
+    mock_client.get_workflow_history.return_value = {
+        "success": True,
+        "events": [
+            {
+                "eventId": "1",
+                "eventTime": "2024-01-15T10:00:00Z",
+                "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+                "taskId": "1048576",
+                "workerMayIgnore": False,
+            },
+            {
+                "eventId": "2",
+                "eventTime": "2024-01-15T10:00:05Z",
+                "eventType": "EVENT_TYPE_ACTIVITY_TASK_FAILED",
+                "taskId": "1048580",
+                "workerMayIgnore": False,
+            },
+            {
+                "eventId": "3",
+                "eventTime": "2024-01-15T10:00:05Z",
+                "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_FAILED",
+                "taskId": "1048581",
+                "workerMayIgnore": False,
+            },
+        ],
+        "next_page_token": "",
+        "archived": False,
+        "total": 3,
+    }
+
+    monkeypatch.setattr(
+        "app.tools.TemporalWorkflowHistoryTool.TemporalClient",
+        lambda _config: mock_client,
+    )
+
+    result = tool.run(
+        base_url="http://localhost:7233",
+        workflow_id="wf-1",
+        run_id="run-1",
+        namespace="default",
+    )
+    assert result["available"] is True
+    assert result["total"] == 3
+    assert result["events"][0]["eventType"] == "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED"
+    assert result["events"][1]["eventType"] == "EVENT_TYPE_ACTIVITY_TASK_FAILED"
+    assert result["events"][2]["eventType"] == "EVENT_TYPE_WORKFLOW_EXECUTION_FAILED"
+    assert result["archived"] is False
+    assert result["next_page_token"] == ""
+
+    mock_client.get_workflow_history.assert_called_once_with(
+        workflow_id="wf-1",
+        run_id="run-1",
+        next_page_token=None,
+    )
+
+
+def test_run_returns_error_on_failure(monkeypatch) -> None:
+    tool = TemporalWorkflowHistoryTool()
+    mock_client = MagicMock()
+    mock_client.get_workflow_history.return_value = {
+        "success": False,
+        "error": "HTTP 404: Workflow not found.",
+    }
+
+    monkeypatch.setattr(
+        "app.tools.TemporalWorkflowHistoryTool.TemporalClient",
+        lambda _config: mock_client,
+    )
+
+    result = tool.run(
+        base_url="http://localhost:7233",
+        workflow_id="nonexistent-wf",
+        namespace="default",
+    )
+    assert result["available"] is False
+    assert "404" in result["error"]
+    assert result["events"] == []

--- a/tests/tools/test_temporal_workflow_history_tool.py
+++ b/tests/tools/test_temporal_workflow_history_tool.py
@@ -52,6 +52,7 @@ def test_run_returns_error_when_no_workflow_id() -> None:
 def test_run_happy_path(monkeypatch) -> None:
     tool = TemporalWorkflowHistoryTool()
     mock_client = MagicMock()
+    mock_client.__enter__.return_value = mock_client
     mock_client.get_workflow_history.return_value = {
         "success": True,
         "events": [
@@ -111,6 +112,7 @@ def test_run_happy_path(monkeypatch) -> None:
 def test_run_returns_error_on_failure(monkeypatch) -> None:
     tool = TemporalWorkflowHistoryTool()
     mock_client = MagicMock()
+    mock_client.__enter__.return_value = mock_client
     mock_client.get_workflow_history.return_value = {
         "success": False,
         "error": "HTTP 404: Workflow not found.",

--- a/tests/tools/test_temporal_workflows_tool.py
+++ b/tests/tools/test_temporal_workflows_tool.py
@@ -44,6 +44,7 @@ def test_run_returns_unavailable_when_no_base_url() -> None:
 def test_run_happy_path(monkeypatch) -> None:
     tool = TemporalWorkflowsTool()
     mock_client = MagicMock()
+    mock_client.__enter__.return_value = mock_client
     mock_client.list_workflow_executions.return_value = {
         "success": True,
         "executions": [
@@ -78,6 +79,7 @@ def test_run_happy_path(monkeypatch) -> None:
 def test_run_returns_error_on_failure(monkeypatch) -> None:
     tool = TemporalWorkflowsTool()
     mock_client = MagicMock()
+    mock_client.__enter__.return_value = mock_client
     mock_client.list_workflow_executions.return_value = {
         "success": False,
         "error": "HTTP 401: Unauthorized",
@@ -97,6 +99,7 @@ def test_run_returns_error_on_failure(monkeypatch) -> None:
 def test_run_passes_pagination_token(monkeypatch) -> None:
     tool = TemporalWorkflowsTool()
     mock_client = MagicMock()
+    mock_client.__enter__.return_value = mock_client
     mock_client.list_workflow_executions.return_value = {
         "success": True,
         "executions": [],

--- a/tests/tools/test_temporal_workflows_tool.py
+++ b/tests/tools/test_temporal_workflows_tool.py
@@ -1,0 +1,113 @@
+"""Tests for TemporalWorkflowsTool."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.tools.TemporalWorkflowsTool import TemporalWorkflowsTool
+from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+class TestTemporalWorkflowsToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return TemporalWorkflowsTool()
+
+
+def test_is_available_when_configured() -> None:
+    tool = TemporalWorkflowsTool()
+    assert tool.is_available({"temporal": {"base_url": "http://localhost:7233"}}) is True
+
+
+def test_is_available_when_not_configured() -> None:
+    tool = TemporalWorkflowsTool()
+    assert tool.is_available({"temporal": {}}) is False
+    assert tool.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    tool = TemporalWorkflowsTool()
+    sources = mock_agent_state()
+    params = tool.extract_params(sources)
+    assert params["base_url"] == "http://localhost:7233"
+    assert params["namespace"] == "default"
+    assert params["api_key"] == ""
+
+
+def test_run_returns_unavailable_when_no_base_url() -> None:
+    tool = TemporalWorkflowsTool()
+    result = tool.run(base_url="")
+    assert result["available"] is False
+    assert "base_url is required" in result["error"]
+    assert result["executions"] == []
+
+
+def test_run_happy_path(monkeypatch) -> None:
+    tool = TemporalWorkflowsTool()
+    mock_client = MagicMock()
+    mock_client.list_workflow_executions.return_value = {
+        "success": True,
+        "executions": [
+            {
+                "execution": {"workflowId": "wf-1", "runId": "run-1"},
+                "type": {"name": "PaymentWorkflow"},
+                "startTime": "2024-01-15T10:00:00Z",
+                "closeTime": "2024-01-15T10:05:00Z",
+                "status": "WORKFLOW_EXECUTION_STATUS_FAILED",
+                "taskQueue": "payment-queue",
+                "historyLength": "42",
+                "historySizeBytes": "8192",
+            }
+        ],
+        "next_page_token": "",
+        "total": 1,
+    }
+
+    monkeypatch.setattr(
+        "app.tools.TemporalWorkflowsTool.TemporalClient",
+        lambda _config: mock_client,
+    )
+
+    result = tool.run(base_url="http://localhost:7233", namespace="default")
+    assert result["available"] is True
+    assert result["total"] == 1
+    assert result["executions"][0]["status"] == "WORKFLOW_EXECUTION_STATUS_FAILED"
+    assert result["executions"][0]["taskQueue"] == "payment-queue"
+    assert result["next_page_token"] == ""
+
+
+def test_run_returns_error_on_failure(monkeypatch) -> None:
+    tool = TemporalWorkflowsTool()
+    mock_client = MagicMock()
+    mock_client.list_workflow_executions.return_value = {
+        "success": False,
+        "error": "HTTP 401: Unauthorized",
+    }
+
+    monkeypatch.setattr(
+        "app.tools.TemporalWorkflowsTool.TemporalClient",
+        lambda _config: mock_client,
+    )
+
+    result = tool.run(base_url="http://localhost:7233", namespace="default")
+    assert result["available"] is False
+    assert "401" in result["error"]
+    assert result["executions"] == []
+
+
+def test_run_passes_pagination_token(monkeypatch) -> None:
+    tool = TemporalWorkflowsTool()
+    mock_client = MagicMock()
+    mock_client.list_workflow_executions.return_value = {
+        "success": True,
+        "executions": [],
+        "next_page_token": "",
+        "total": 0,
+    }
+
+    monkeypatch.setattr(
+        "app.tools.TemporalWorkflowsTool.TemporalClient",
+        lambda _config: mock_client,
+    )
+
+    tool.run(base_url="http://localhost:7233", namespace="default", next_page_token="abc123")
+    mock_client.list_workflow_executions.assert_called_once_with(next_page_token="abc123")


### PR DESCRIPTION
Fixes #2572 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR

Adds a Temporal workflow-orchestration integration for incident investigation (issue #2572):

  - Service client (app/services/temporal/client.py) — a thin HTTP client over Temporal's frontend REST API (/api/v1/namespaces/{ns}/...), with probe_access() for
  verification.
  - 4 investigation tools — TemporalNamespaceInfoTool, TemporalWorkflowsTool, TemporalWorkflowHistoryTool, TemporalTaskQueueTool. These compose into a natural triage
  drill-down: namespace health → which workflows failed → why (event history) → worker/queue health.
  - Integration wiring — registry spec, setup handler (integrations setup temporal), and verification adapter.
  - Docs (docs/temporal.mdx) + tests — client unit tests, per-tool suites, and a synthetic RCA scenario.

Scope: self-hosted Temporal only (not Temporal Cloud).

This integration uses Temporal's frontend HTTP API `/api/v1/namespaces/{ns}/...`, served on the server's --http-port, e.g. 7243. This HTTP gateway is a self-hosted feature. Temporal Cloud does not expose it — Cloud's data plane is gRPC/mTLS-only (port 7233), and its only HTTP surface is the control-plane Cloud Ops API, which "does not allow interaction with individual Workflows or Activities via HTTP." Cloud support would require a separate gRPC client and is intentionally out of scope for this PR. Verified end-to-end against a local Docker dev server.
 
 

### Demo/Screenshot for feature changes and bug fixes
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

Temporal HTTP API  - Self hosted (docker)

verification

https://github.com/user-attachments/assets/19ae7767-0561-477b-a0f4-91182d1b16cd


Setup

https://github.com/user-attachments/assets/fa85e41f-f4a5-49bf-aff5-c02a3c0706e1

Investigation

https://github.com/user-attachments/assets/22e6cbc5-174c-4205-b1d6-2fbd244bf057

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->
**Problem.** When a Temporal workflow fails, the cause (a failed activity, a downstream error, dead workers, a backed-up task queue) is buried in workflow event history that's tedious to dig through manually. This integration lets the agent pull that evidence directly during an investigation.

**Why HTTP, and why self-hosted only.** Temporal has two interfaces: the native gRPC data-plane API (port 7233, what SDKs use) and a frontend HTTP/JSON gateway `(/api/v1/..., served on --http-port, e.g. 7243)`. I chose HTTP because it's a dependency-light client (httpx, no Temporal SDK/protobuf toolchain) that fits the existing tool pattern. The trade-off, which I verified against Temporal's docs: Temporal Cloud does not expose the frontend HTTP API — Cloud's data plane is gRPC/mTLS-only, and its sole HTTP surface (the Cloud Ops API) is control-plane only and "does not allow interaction with individual Workflows via HTTP." So this client physically cannot reach Cloud. That's a deliberate, documented MVP boundary; Cloud support would need a separate gRPC/mTLS client.

**Key components.** The client exposes one method per tool (get_namespace_info, list_workflow_executions, get_workflow_history, describe_task_queue), each returning a structured dict `({"success": ..., ...} or an error dict)` so tools never raise into the pipeline. Two non-obvious bits live in the client because they're wire-format concerns, not tool logic: `_decode_payload_data` (the HTTP API base64-encodes Payload values — e.g. a status name comes back as IkZhaWxlZCI=) and `_flatten_status_groups` (reshapes nested groupValues into flat `[{status, count}]` so the LLM sees `Failed: 8`, not raw Payload encoding).

**What live verification changed.** Mocks alone weren't enough — running against a real Docker dev server exposed that the HTTP API omits falsy fields `(nextPageToken, archived, pollers)` rather than returning empty values, which caused KeyError crashes. The client now defaults these defensively, and the tests were realigned to the real wire shapes. This is why the PR targets a verified self-hosted server rather than assumed schemas.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
