### PR TITLE
Fix: config persistence, stale footer, and REPL rendering/timing

### DIFF
--- a/app/agents/registry.py
+++ b/app/agents/registry.py
@@ -156,3 +156,45 @@ class AgentRegistry:
             tmp.replace(self._path)
         except OSError:
             logger.warning("Failed to rewrite agent registry at %s", self._path)
+
+
+def resolve_agent_arg(arg: str, registry: AgentRegistry) -> int:
+    """Resolve a PID or agent name to a PID.
+
+    Applies the following rules in order:
+    1. If arg parses as a positive integer and matches a PID in the registry -> that PID.
+    2. Else if arg matches exactly one registered agent name -> that agent's current PID.
+    3. Else if arg parses as a positive integer with no registry hit -> return that integer.
+    4. Else if arg matches multiple agent names -> raise ValueError.
+    5. Else raise ValueError.
+    """
+    is_positive_int = False
+    try:
+        val = int(arg)
+        if val > 0:
+            is_positive_int = True
+    except ValueError:
+        pass
+
+    if is_positive_int:
+        pid = int(arg)
+        if registry.get(pid) is not None:
+            return pid
+
+    records = registry.list()
+    matching_records = [r for r in records if r.name == arg]
+
+    if len(matching_records) == 1:
+        return matching_records[0].pid
+
+    if is_positive_int:
+        return int(arg)
+
+    if len(matching_records) > 1:
+        pids = sorted(r.pid for r in matching_records)
+        pids_str = ", ".join(map(str, pids))
+        raise ValueError(
+            f"ambiguous: {len(matching_records)} registered agents named {arg} (pids: {pids_str})"
+        )
+
+    raise ValueError("invalid pid or unknown agent name")

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -38,7 +38,7 @@ from app.agents.conflicts import (
 from app.agents.coordination import BranchClaims
 from app.agents.discovery import registered_and_discovered_agents
 from app.agents.lifecycle import TerminateResult, terminate
-from app.agents.registry import AgentRegistry
+from app.agents.registry import AgentRegistry, resolve_agent_arg
 from app.agents.tail import AttachSession, AttachUnsupported, attach
 from app.analytics.events import Event
 from app.analytics.provider import get_analytics
@@ -362,10 +362,11 @@ def _cmd_agents_kill(
         return True
 
     raw_pid = positional[0]
+    registry = AgentRegistry()
     try:
-        pid = int(raw_pid)
-    except ValueError:
-        console.print(f"[{ERROR}]invalid pid:[/] {escape(raw_pid)} is not an integer")
+        pid = resolve_agent_arg(raw_pid, registry)
+    except ValueError as exc:
+        console.print(f"[{ERROR}]{escape(str(exc))}[/]")
         session.mark_latest(ok=False, kind="slash")
         return True
 
@@ -504,10 +505,11 @@ def _cmd_agents_trace(session: ReplSession, console: Console, args: list[str]) -
         console.print(f"[{ERROR}]usage:[/] /agents trace <pid>")
         session.mark_latest(ok=False, kind="slash")
         return True
+    registry = AgentRegistry()
     try:
-        pid = int(args[0])
-    except ValueError:
-        console.print(f"[{ERROR}]invalid pid:[/] {escape(args[0])}")
+        pid = resolve_agent_arg(args[0], registry)
+    except ValueError as exc:
+        console.print(f"[{ERROR}]{escape(str(exc))}[/]")
         session.mark_latest(ok=False, kind="slash")
         return True
 
@@ -536,17 +538,18 @@ def _cmd_agents_wait(session: ReplSession, console: Console, args: list[str]) ->
         session.mark_latest(ok=False, kind="slash")
         return True
 
+    registry = AgentRegistry()
     try:
-        pid = int(args[0])
-    except ValueError:
-        console.print(f"[{ERROR}]invalid pid:[/] {escape(args[0])}")
+        pid = resolve_agent_arg(args[0], registry)
+    except ValueError as exc:
+        console.print(f"[{ERROR}]{escape(str(exc))}[/]")
         session.mark_latest(ok=False, kind="slash")
         return True
 
     try:
-        on_pid = int(args[2])
-    except ValueError:
-        console.print(f"[{ERROR}]invalid other-pid:[/] {escape(args[2])}")
+        on_pid = resolve_agent_arg(args[2], registry)
+    except ValueError as exc:
+        console.print(f"[{ERROR}]{escape(str(exc))}[/]")
         session.mark_latest(ok=False, kind="slash")
         return True
 
@@ -554,8 +557,6 @@ def _cmd_agents_wait(session: ReplSession, console: Console, args: list[str]) ->
         console.print(f"[{ERROR}]invalid pid:[/] {pid} waiting for itself")
         session.mark_latest(ok=False, kind="slash")
         return True
-
-    registry = AgentRegistry()
     waiter = registry.get(pid)
     if waiter is None:
         console.print(f"[{ERROR}]pid {pid} is not in the agent registry[/]")

--- a/app/cli/interactive_shell/prompting/prompt_surface.py
+++ b/app/cli/interactive_shell/prompting/prompt_surface.py
@@ -210,6 +210,40 @@ class ShellCompleter(Completer):
                         yield _slash_completion(cmd, -len(parts[0]))
             return
 
+        if len(parts) >= 2:
+            cmd_name = parts[0].lower()
+            if cmd_name == "/agents" and len(parts) in (2, 3):
+                sub = parts[1].lower().strip()
+                if sub in ("kill", "trace", "wait") and (
+                    (len(parts) == 2 and trailing_space) or len(parts) == 3
+                ):
+                    raw_arg = "" if len(parts) == 2 else parts[2]
+                    from app.agents.registry import AgentRegistry
+
+                    registry = AgentRegistry()
+                    prefix = raw_arg.lower()
+                    seen_completions = set()
+                    for record in registry.list():
+                        pid_str = str(record.pid)
+                        name_str = record.name
+                        if name_str.lower().startswith(prefix) and name_str not in seen_completions:
+                            seen_completions.add(name_str)
+                            yield Completion(
+                                name_str,
+                                start_position=-len(raw_arg),
+                                display=name_str,
+                                display_meta=f"agent process (pid: {record.pid})",
+                            )
+                        if pid_str.startswith(prefix) and pid_str not in seen_completions:
+                            seen_completions.add(pid_str)
+                            yield Completion(
+                                pid_str,
+                                start_position=-len(raw_arg),
+                                display=pid_str,
+                                display_meta=f"agent name: {record.name}",
+                            )
+                    return
+
         if len(parts) <= 2:
             cmd_name = parts[0].lower()
             raw_arg = "" if trailing_space or len(parts) < 2 else parts[1]

--- a/app/cli/interactive_shell/prompting/prompt_surface.py
+++ b/app/cli/interactive_shell/prompting/prompt_surface.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Iterable
 from typing import Any
 
 from prompt_toolkit import PromptSession
-from prompt_toolkit.application.current import get_app
+from prompt_toolkit.application.current import get_app, get_app_or_none
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.completion import CompleteEvent, Completer, Completion, PathCompleter
 from prompt_toolkit.document import Document
@@ -336,6 +336,10 @@ _DEFAULT_PLACEHOLDER_ANSI = ANSI(f"{ANSI_DIM}{_DEFAULT_PLACEHOLDER_TEXT}{ANSI_RE
 
 def resolve_prompt_placeholder(session: ReplSession) -> ANSI:
     """Contextual ghost text when the input buffer is empty."""
+    app = get_app_or_none()
+    if app is not None and getattr(app, "_is_awaiting_confirm", False):
+        return ANSI("")
+
     parts: list[str] = []
     if session.trust_mode:
         parts.append("trust on")

--- a/app/cli/interactive_shell/runtime/dispatch.py
+++ b/app/cli/interactive_shell/runtime/dispatch.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import re
 import threading
+import time
 from collections.abc import Callable
 from dataclasses import replace
 
+from prompt_toolkit.application.current import get_app_or_none
 from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 from rich.console import Console
@@ -118,7 +120,8 @@ def dispatch_needs_exclusive_stdin(text: str, session: ReplSession) -> bool:
 
     command_decision = resolve_cli_command(t, session)
     if command_decision is None:
-        return False
+        route_decision = _router.route_input(t, session)
+        return route_decision.route_kind.value == "new_alert"
     dispatch_text = command_decision.command_text or t
 
     parts = dispatch_text.split()
@@ -127,13 +130,18 @@ def dispatch_needs_exclusive_stdin(text: str, session: ReplSession) -> bool:
     name = parts[0].lower()
     args = [arg.lower() for arg in parts[1:]]
 
-    if name in _WAIT_FOR_COMPLETION_COMMANDS:
-        return True
-    if name in _EXCLUSIVE_STDIN_MENU_COMMANDS and not args:
-        return True
-    if name == "/tests" and not args:
-        return True
-    return bool(args and (name, args[0]) in _EXCLUSIVE_STDIN_SUBCOMMANDS)
+    # /watch commands run asynchronously in the background, so they don't need exclusive stdin
+    if name in {"/watch", "/watches", "/unwatch"}:
+        return False
+
+    # /tests run/synthetic/cloudopsbench are run as background tasks, others are synchronous
+    if name == "/tests":
+        _BACKGROUND_TEST_SUBCOMMANDS = {"run", "synthetic", "cloudopsbench"}
+        return not (args and args[0] in _BACKGROUND_TEST_SUBCOMMANDS)
+
+    # Any other slash command (e.g. /update, /config, /integrations, /history, /exit, etc.)
+    # runs synchronously or uses menus, so it requires exclusive stdin to prevent overlap/leakage.
+    return True
 
 
 def dispatch_one_turn(
@@ -193,8 +201,13 @@ def run_initial_input(
 
 
 def route_confirm_through_prompt(state: ReplState, prompt_text: str) -> str:
+    app = get_app_or_none()
+    if app is not None:
+        setattr(app, "_is_awaiting_confirm", True)  # noqa: B010
+
     response_event = threading.Event()
     state.begin_confirmation(response_event, prompt_text)
+    state.confirm_start_time = time.monotonic()
     try:
         while not response_event.is_set():
             cancel = state.current_cancel_event
@@ -205,6 +218,11 @@ def route_confirm_through_prompt(state: ReplState, prompt_text: str) -> str:
             raise DispatchCancelled("cancelled while awaiting confirmation")
         return state.confirm_response[0]
     finally:
+        if state.confirm_start_time is not None:
+            state.total_confirm_duration += time.monotonic() - state.confirm_start_time
+            state.confirm_start_time = None
+        if app is not None:
+            setattr(app, "_is_awaiting_confirm", False)  # noqa: B010
         state.clear_confirmation()
 
 

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -211,6 +211,9 @@ async def run_interactive(
             spinner.start()
             set_prompt_suppress_fn(console.suppress_prompt_spinner)
         try:
+            state.total_confirm_duration = 0.0
+            state.confirm_start_time = None
+
             # Commands that take exclusive stdin ownership (e.g. bare
             # ``/investigate`` and other inline pickers) can safely use the
             # full Rich Live investigation stream because prompt_toolkit is not
@@ -294,7 +297,7 @@ async def run_interactive(
         if state.is_awaiting_confirmation():
             confirm_text = state.confirm_prompt_text
             return ANSI(f"{confirm_text}\n{base}")
-        prefix = spinner.inline_spinner_ansi() or spinner.idle_hint_ansi()
+        prefix = spinner.inline_spinner_ansi(state) or spinner.idle_hint_ansi()
         return ANSI(f"{prefix}\n{base}")
 
     async def _spinner_ticker() -> None:

--- a/app/cli/interactive_shell/runtime/state.py
+++ b/app/cli/interactive_shell/runtime/state.py
@@ -29,6 +29,8 @@ class ReplState:
     confirm_event: threading.Event | None = None
     confirm_response: list[str] = field(default_factory=list)
     confirm_prompt_text: str = ""
+    confirm_start_time: float | None = None
+    total_confirm_duration: float = 0.0
 
     def is_dispatch_running(self) -> bool:
         return self.current_task is not None and not self.current_task.done()
@@ -139,10 +141,15 @@ class SpinnerState:
             hint += "  ·  esc to clear"
         return f"{ANSI_DIM}{hint}{ANSI_RESET}"
 
-    def inline_spinner_ansi(self) -> str:
+    def inline_spinner_ansi(self, state: ReplState | None = None) -> str:
         if not self.streaming:
             return ""
-        elapsed = time.monotonic() - self.started_at
+        confirm_dur = 0.0
+        if state is not None:
+            confirm_dur = state.total_confirm_duration
+            if state.confirm_start_time is not None:
+                confirm_dur += time.monotonic() - state.confirm_start_time
+        elapsed = max(0.0, time.monotonic() - self.started_at - confirm_dur)
         token_count = self.bytes_in // _CHARS_PER_TOKEN
         glyph = self._SPINNER_FRAMES[self._frame_idx % len(self._SPINNER_FRAMES)]
         self._frame_idx += 1

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -23,6 +24,9 @@ from app.config import (
 from app.integrations.llm_cli.base import LLMCLIAdapter
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if getattr(sys, "frozen", False) or not (PROJECT_ROOT / "pyproject.toml").exists():
+    PROJECT_ROOT = Path.cwd()
+
 PROJECT_ENV_PATH = Path(os.getenv("OPENSRE_PROJECT_ENV_PATH", PROJECT_ROOT / ".env"))
 
 CredentialKind = Literal["api_key", "host", "cli", "none"]

--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -60,6 +60,11 @@ from app.integrations.registry import (
 )
 from app.integrations.sentry import build_sentry_config
 from app.integrations.signoz import build_signoz_config, signoz_config_from_env
+from app.integrations.sqs import (
+    DEFAULT_SQS_REGION,
+    build_sqs_config,
+    sqs_config_from_env,
+)
 from app.integrations.store import _STRUCTURAL_RECORD_FIELDS, load_integrations
 from app.integrations.supabase import build_supabase_config
 from app.llm_credentials import resolve_env_credential
@@ -698,6 +703,21 @@ def _classify_service_instance(
             return None, None
         if rds_config.is_configured:
             return {**rds_config.model_dump(), "integration_id": record_id}, "rds"
+        return None, None
+
+    if key == "sqs":
+        try:
+            sqs_config = build_sqs_config(
+                {
+                    "queue_name_prefix": credentials.get("queue_name_prefix", ""),
+                    "region": credentials.get("region", DEFAULT_SQS_REGION),
+                }
+            )
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
+            return None, None
+        if sqs_config.is_configured:
+            return {**sqs_config.model_dump(), "integration_id": record_id}, "sqs"
         return None, None
 
     if key == "airflow":
@@ -1670,6 +1690,19 @@ def load_env_integrations() -> list[dict[str, Any]]:
             _active_env_record(
                 "rds",
                 rds_config.model_dump(exclude={"integration_id"}),
+            )
+        )
+
+    try:
+        sqs_config = sqs_config_from_env()
+    except Exception as exc:
+        sqs_config = None
+        _report_env_loader_failure(exc, integration="sqs")
+    if sqs_config is not None and sqs_config.is_configured:
+        integrations.append(
+            _active_env_record(
+                "sqs",
+                sqs_config.model_dump(exclude={"integration_id"}),
             )
         )
 

--- a/app/integrations/postgresql.py
+++ b/app/integrations/postgresql.py
@@ -689,3 +689,82 @@ def get_table_stats(
             method="get_table_stats",
         )
         return {"source": "postgresql", "available": False, "error": str(err)}
+
+
+def get_blocking_queries(config: PostgreSQLConfig) -> dict[str, Any]:
+    """Retrieve blocking and blocked queries to diagnose lock contention.
+
+    Read-only: queries pg_stat_activity and pg_blocking_pids.
+    Results are capped at config.max_results.
+    """
+    if not config.is_configured:
+        return {"source": "postgresql", "available": False, "error": "Not configured."}
+
+    try:
+        conn = _get_connection(config)
+        try:
+            cursor = conn.cursor()
+
+            cursor.execute(
+                """
+                WITH lock_graph AS (
+                    SELECT
+                        pid,
+                        pg_blocking_pids(pid) AS blocking_pids
+                    FROM pg_stat_activity
+                )
+                SELECT
+                    l.pid,
+                    a.usename,
+                    a.application_name,
+                    a.client_addr::text,
+                    a.state,
+                    a.query_start,
+                    extract(epoch from (now() - a.query_start))::int as duration_seconds,
+                    a.wait_event_type,
+                    a.wait_event,
+                    l.blocking_pids,
+                    left(a.query, 1000) as query_truncated
+                FROM lock_graph l
+                JOIN pg_stat_activity a ON l.pid = a.pid
+                WHERE cardinality(l.blocking_pids) > 0 OR l.pid IN (SELECT DISTINCT unnest(blocking_pids) FROM lock_graph)
+                LIMIT %s
+            """,
+                (config.max_results,),
+            )
+
+            queries = []
+            for row in cursor.fetchall():
+                queries.append(
+                    {
+                        "pid": row[0],
+                        "username": row[1],
+                        "application_name": row[2] or "",
+                        "client_addr": row[3] or "local",
+                        "state": row[4],
+                        "query_start": str(row[5]),
+                        "duration_seconds": row[6],
+                        "wait_event_type": row[7] or "",
+                        "wait_event": row[8] or "",
+                        "blocking_pids": row[9] or [],
+                        "query_truncated": row[10] or "",
+                    }
+                )
+
+            cursor.close()
+            return {
+                "source": "postgresql",
+                "available": True,
+                "total_queries": len(queries),
+                "queries": queries,
+            }
+        finally:
+            conn.close()
+    except Exception as err:
+        report_validation_failure(
+            err,
+            logger=logger,
+            integration="postgresql",
+            method="get_blocking_queries",
+        )
+        return {"source": "postgresql", "available": False, "error": str(err)}

--- a/app/integrations/registry.py
+++ b/app/integrations/registry.py
@@ -362,6 +362,7 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
     IntegrationSpec(service="posthog"),
     IntegrationSpec(service="trello"),
     IntegrationSpec(service="rds", setup_order=11),
+    IntegrationSpec(service="sqs", setup_order=12),
     IntegrationSpec(
         service="supabase",
         verifier=_verify_supabase,

--- a/app/integrations/sqs.py
+++ b/app/integrations/sqs.py
@@ -1,0 +1,84 @@
+"""Shared AWS SQS integration helpers.
+
+Provides configuration normalization, source detection, and parameter
+extraction for the SQS investigation tools. All AWS API calls are
+read-only and routed through the shared aws_sdk_client allowlist.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.integrations._relational import env_str
+from app.strict_config import StrictConfigModel
+
+DEFAULT_SQS_REGION = "us-east-1"
+
+
+class SQSConfig(StrictConfigModel):
+    """Normalized SQS connection settings."""
+
+    queue_name_prefix: str = ""
+    region: str = DEFAULT_SQS_REGION
+    integration_id: str = ""
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.region)
+
+
+def build_sqs_config(raw: dict[str, Any] | None) -> SQSConfig:
+    """Build a normalized SQS config object from env/store data."""
+    return SQSConfig.model_validate(raw or {})
+
+
+def sqs_config_from_env() -> SQSConfig | None:
+    """Load an SQS config from env vars."""
+    region = env_str("AWS_REGION") or env_str("SQS_REGION") or DEFAULT_SQS_REGION
+    return build_sqs_config(
+        {
+            "queue_name_prefix": env_str("SQS_QUEUE_NAME_PREFIX") or "",
+            "region": region,
+        }
+    )
+
+
+def sqs_is_available(sources: dict[str, dict]) -> bool:
+    """Check if SQS integration identifying params are present."""
+    sqs = sources.get("sqs", {})
+    if sqs.get("_backend") or sqs.get("connection_verified"):
+        return True
+    return (
+        any(
+            sources.get(k, {}).get("_backend") or sources.get(k, {}).get("connection_verified")
+            for k in ("rds", "ec2", "eks", "cloudwatch")
+        )
+        or "cloudwatch" in sources
+    )
+
+
+def sqs_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
+    """Extract SQS identifying params (region, aws_backend)."""
+    sqs = sources.get("sqs", {})
+    rds = sources.get("rds", {})
+    ec2 = sources.get("ec2", {})
+    eks = sources.get("eks", {})
+
+    backend = (
+        sqs.get("_backend") or rds.get("_backend") or ec2.get("_backend") or eks.get("_backend")
+    )
+
+    region = (
+        str(sqs.get("region") or "").strip()
+        or str(rds.get("region") or "").strip()
+        or str(ec2.get("region") or "").strip()
+        or str(eks.get("region") or "").strip()
+        or env_str("AWS_REGION")
+        or env_str("SQS_REGION")
+        or DEFAULT_SQS_REGION
+    )
+
+    return {
+        "region": region,
+        "aws_backend": backend,
+    }

--- a/app/services/embeddings_client.py
+++ b/app/services/embeddings_client.py
@@ -1,0 +1,223 @@
+"""Embeddings client wrapper and factory."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from typing import Protocol, cast
+
+import httpx
+from openai import OpenAI
+
+from app.config import resolve_llm_settings
+from app.llm_credentials import resolve_llm_api_key
+
+logger = logging.getLogger(__name__)
+
+_MODEL_DIMS = {
+    "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+    "text-embedding-ada-002": 1536,
+    "voyage-3-lite": 512,
+    "voyage-3": 1024,
+    "voyage-2": 1024,
+    "nomic-embed-text": 768,
+}
+
+
+class EmbeddingsClient(Protocol):
+    """Protocol for embedding clients."""
+
+    @property
+    def model_name(self) -> str:
+        """The model name used for embeddings."""
+        ...
+
+    @property
+    def dim(self) -> int:
+        """The dimensionality of the embedding vectors."""
+        ...
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings for the given list of texts."""
+        ...
+
+
+class OpenAIEmbeddingsClient:
+    """Embeddings client for OpenAI (or compatible) providers."""
+
+    def __init__(self, model_name: str, api_key: str, base_url: str | None = None) -> None:
+        self._model_name = model_name
+        self._client = OpenAI(api_key=api_key, base_url=base_url)
+        self._dim = _MODEL_DIMS.get(model_name, 1536)
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        try:
+            response = self._client.embeddings.create(
+                input=texts,
+                model=self._model_name,
+            )
+            return [item.embedding for item in response.data]
+        except Exception as e:
+            logger.error("[embeddings] OpenAI embed call failed: %s", e)
+            raise RuntimeError(f"OpenAI embeddings call failed: {e}") from e
+
+
+class VoyageEmbeddingsClient:
+    """Embeddings client for Voyage AI."""
+
+    def __init__(self, model_name: str, api_key: str) -> None:
+        self._model_name = model_name
+        self._api_key = api_key
+        self._dim = _MODEL_DIMS.get(model_name, 512)
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        try:
+            with httpx.Client(timeout=60.0) as client:
+                res = client.post(
+                    "https://api.voyageai.com/v1/embeddings",
+                    headers={
+                        "Authorization": f"Bearer {self._api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "input": texts,
+                        "model": self._model_name,
+                    },
+                )
+                res.raise_for_status()
+                data = res.json()
+                return [item["embedding"] for item in data["data"]]
+        except Exception as e:
+            logger.error("[embeddings] Voyage embed call failed: %s", e)
+            raise RuntimeError(f"Voyage embeddings call failed: {e}") from e
+
+
+class OllamaEmbeddingsClient:
+    """Embeddings client for local Ollama service."""
+
+    def __init__(self, model_name: str, host: str) -> None:
+        self._model_name = model_name
+        self._host = host.rstrip("/")
+        self._dim = _MODEL_DIMS.get(model_name, 768)
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        try:
+            with httpx.Client(timeout=60.0) as client:
+                res = client.post(
+                    f"{self._host}/api/embed",
+                    json={
+                        "model": self._model_name,
+                        "input": texts,
+                    },
+                )
+                res.raise_for_status()
+                data = res.json()
+                return cast("list[list[float]]", data["embeddings"])
+        except Exception as e:
+            logger.error("[embeddings] Ollama embed call failed: %s", e)
+            raise RuntimeError(f"Ollama embeddings call failed: {e}") from e
+
+
+class _NoOpEmbeddingsClient:
+    """Deterministic no-op embeddings client for tests."""
+
+    def __init__(self, model_name: str = "noop-embedding", dim: int = 1536) -> None:
+        self._model_name = model_name
+        self._dim = dim
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        results = []
+        for text in texts:
+            vector = []
+            for i in range(self._dim):
+                h = hashlib.sha256(f"{text}:{i}".encode()).digest()
+                val = int.from_bytes(h[:4], "big") / 0xFFFFFFFF
+                vector.append(val * 2.0 - 1.0)
+            results.append(vector)
+        return results
+
+
+def get_embeddings_client() -> EmbeddingsClient | None:
+    """Factory to get the configured embeddings client, or None if not configured."""
+    model_override = os.getenv("OPENSRE_EMBEDDINGS_MODEL")
+
+    provider: str
+    try:
+        settings = resolve_llm_settings()
+        provider = settings.provider
+    except Exception:
+        provider = os.getenv("LLM_PROVIDER", "anthropic").strip().lower()
+
+    if provider == "openai":
+        default_model = "text-embedding-3-small"
+    elif provider == "ollama":
+        default_model = "nomic-embed-text"
+    elif provider in ("anthropic", "bedrock", "voyage"):
+        default_model = "voyage-3-lite"
+    else:
+        default_model = "text-embedding-3-small"
+
+    model_name = model_override or default_model
+
+    if "voyage" in model_name or provider in ("anthropic", "bedrock", "voyage"):
+        voyage_key = resolve_llm_api_key("VOYAGE_API_KEY") or os.getenv("VOYAGE_API_KEY")
+        if voyage_key:
+            return VoyageEmbeddingsClient(model_name, voyage_key)
+
+    if "nomic" in model_name or provider == "ollama":
+        try:
+            settings = resolve_llm_settings()
+            host = settings.ollama_host
+        except Exception:
+            host = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+        return OllamaEmbeddingsClient(model_name, host)
+
+    openai_key = (
+        resolve_llm_api_key("OPENAI_API_KEY")
+        or os.getenv("OPENAI_API_KEY")
+        or (settings.openai_api_key if "settings" in locals() else None)
+    )
+    if openai_key:
+        return OpenAIEmbeddingsClient(model_name, openai_key)
+
+    return None

--- a/app/tools/CloudTrailEventsTool/__init__.py
+++ b/app/tools/CloudTrailEventsTool/__init__.py
@@ -1,0 +1,166 @@
+"""AWS CloudTrail Event Lookup Tool."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+from app.integrations.sqs import sqs_extract_params, sqs_is_available
+from app.services.aws_sdk_client import execute_aws_sdk_call
+from app.tools.tool_decorator import tool
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DURATION_MINUTES = 60
+DEFAULT_REGION = "us-east-1"
+
+
+@tool(
+    name="lookup_cloudtrail_events",
+    source="cloudtrail",
+    description=(
+        "Look up AWS CloudTrail events for configuration-change forensics (who changed what, and when)."
+    ),
+    use_cases=[
+        "Investigating unauthorized or unexpected AWS configuration changes",
+        "Finding which IAM principal performed a specific action",
+        "Correlating system mutations with incident timeframes",
+    ],
+    requires=[],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "resource_name": {
+                "type": "string",
+                "description": "Optional name of the resource (e.g., db-name, role-name).",
+            },
+            "event_source": {
+                "type": "string",
+                "description": "Optional event source (e.g., rds.amazonaws.com, iam.amazonaws.com).",
+            },
+            "username": {
+                "type": "string",
+                "description": "Optional username or IAM principal who made the change.",
+            },
+            "duration_minutes": {
+                "type": "integer",
+                "default": DEFAULT_DURATION_MINUTES,
+                "minimum": 1,
+                "maximum": 20160,
+            },
+            "region": {"type": "string", "default": DEFAULT_REGION},
+        },
+    },
+    is_available=sqs_is_available,
+    extract_params=sqs_extract_params,
+)
+def lookup_cloudtrail_events(
+    resource_name: str | None = None,
+    event_source: str | None = None,
+    username: str | None = None,
+    duration_minutes: int = DEFAULT_DURATION_MINUTES,
+    region: str = DEFAULT_REGION,
+    aws_backend: Any = None,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    """Look up AWS CloudTrail events within a specific duration.
+
+    If aws_backend is provided, delegates to it.
+    Otherwise executes boto3 read-only calls via execute_aws_sdk_call.
+    """
+    logger.info(
+        "[cloudtrail] lookup_cloudtrail_events resource=%s source=%s user=%s duration=%s region=%s",
+        resource_name,
+        event_source,
+        username,
+        duration_minutes,
+        region,
+    )
+
+    if aws_backend is not None:
+        try:
+            return cast(
+                "dict[str, Any]",
+                aws_backend.lookup_events(
+                    resource_name=resource_name,
+                    event_source=event_source,
+                    username=username,
+                    duration_minutes=duration_minutes,
+                    region=region,
+                ),
+            )
+        except Exception as exc:
+            logger.error("[cloudtrail] aws_backend call failed: %s", exc)
+            return {
+                "source": "cloudtrail",
+                "available": False,
+                "error": f"Backend call failed: {exc}",
+                "events": [],
+            }
+
+    end_time = datetime.now(UTC)
+    start_time = end_time - timedelta(minutes=duration_minutes)
+
+    parameters: dict[str, Any] = {
+        "StartTime": start_time,
+        "EndTime": end_time,
+    }
+
+    lookup_attributes = []
+    if resource_name:
+        lookup_attributes.append({"AttributeKey": "ResourceName", "AttributeValue": resource_name})
+    if event_source:
+        lookup_attributes.append({"AttributeKey": "EventSource", "AttributeValue": event_source})
+    if username:
+        lookup_attributes.append({"AttributeKey": "Username", "AttributeValue": username})
+
+    if lookup_attributes:
+        parameters["LookupAttributes"] = lookup_attributes
+
+    res = execute_aws_sdk_call(
+        service_name="cloudtrail",
+        operation_name="lookup_events",
+        parameters=parameters,
+        region=region,
+    )
+
+    if not res.get("success"):
+        error_msg = res.get("error") or "Unknown error"
+        logger.error("[cloudtrail] lookup_events failed: %s", error_msg)
+        return {
+            "source": "cloudtrail",
+            "available": False,
+            "error": f"Failed to look up CloudTrail events: {error_msg}",
+            "events": [],
+        }
+
+    raw_events = (res.get("data") or {}).get("Events") or []
+    events_out = []
+    for event in raw_events:
+        resources = [
+            {
+                "type": r.get("ResourceType"),
+                "name": r.get("ResourceName"),
+            }
+            for r in event.get("Resources", [])
+        ]
+        events_out.append(
+            {
+                "event_id": event.get("EventId"),
+                "event_name": event.get("EventName"),
+                "event_time": event.get("EventTime"),
+                "event_source": event.get("EventSource"),
+                "username": event.get("Username"),
+                "resources": resources,
+            }
+        )
+
+    return {
+        "source": "cloudtrail",
+        "available": True,
+        "region": region,
+        "total_events": len(events_out),
+        "events": events_out,
+        "error": None,
+    }

--- a/app/tools/GitHubSearchIssuesTool/__init__.py
+++ b/app/tools/GitHubSearchIssuesTool/__init__.py
@@ -1,0 +1,96 @@
+"""GitHub MCP-backed issue and PR search tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.integrations.github_mcp import call_github_mcp_tool
+from app.tools.tool_decorator import tool
+from app.tools.utils.code_host_unavailable import code_host_unavailable_payload
+from app.tools.utils.github_helpers import (
+    github_creds,
+    github_source_available,
+    normalize_github_tool_result,
+    resolve_github_mcp_config,
+)
+
+
+def _search_github_issues_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
+    gh = sources["github"]
+    return {
+        "owner": gh["owner"],
+        "repo": gh["repo"],
+        "query": gh.get("query") or "bug",
+        **github_creds(gh),
+    }
+
+
+def _search_github_issues_available(sources: dict[str, dict]) -> bool:
+    gh = sources.get("github", {})
+    return bool(github_source_available(sources) and gh.get("owner") and gh.get("repo"))
+
+
+def build_github_issue_search_query(owner: str, repo: str, query: str) -> str:
+    """Build a repo-scoped GitHub issue/PR search query."""
+    repo_qualifier = f"repo:{owner}/{repo}"
+    query = query.strip()
+    if repo_qualifier in query:
+        return query
+    return f"{query} {repo_qualifier}".strip()
+
+
+@tool(
+    name="search_github_issues",
+    source="github",
+    description="Search GitHub repository issues and pull requests through the configured GitHub MCP server.",
+    use_cases=[
+        "Finding recent bug reports or issues related to an incident",
+        "Checking if a similar problem has been discussed in tickets",
+        "Searching for recently merged pull requests or commits associated with a stack trace",
+    ],
+    requires=["owner", "repo", "query"],
+    surfaces=("investigation", "chat"),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "owner": {"type": "string"},
+            "repo": {"type": "string"},
+            "query": {"type": "string"},
+            "github_url": {"type": "string"},
+            "github_mode": {"type": "string"},
+            "github_token": {"type": "string"},
+        },
+        "required": ["owner", "repo", "query"],
+    },
+    is_available=_search_github_issues_available,
+    extract_params=_search_github_issues_extract_params,
+)
+def search_github_issues(
+    owner: str,
+    repo: str,
+    query: str,
+    github_url: str | None = None,
+    github_mode: str | None = None,
+    github_token: str | None = None,
+    github_command: str | None = None,
+    github_args: list[str] | None = None,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    """Search GitHub repository issues and pull requests through the configured GitHub MCP server."""
+    config = resolve_github_mcp_config(
+        github_url, github_mode, github_token, github_command, github_args
+    )
+    if config is None:
+        return code_host_unavailable_payload(
+            source="github",
+            integration_name="GitHub MCP",
+            empty_key="issues",
+            empty_value=[],
+        )
+
+    final_query = build_github_issue_search_query(owner, repo, query)
+    result = call_github_mcp_tool(config, "search_issues", {"query": final_query})
+    payload = normalize_github_tool_result(result)
+    payload["issues"] = payload.pop("structured_content", None) or []
+    payload["query"] = final_query
+    return payload

--- a/app/tools/PostgreSQLBlockingQueriesTool/__init__.py
+++ b/app/tools/PostgreSQLBlockingQueriesTool/__init__.py
@@ -1,0 +1,82 @@
+"""PostgreSQL Blocking Queries Tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.integrations.postgresql import (
+    get_blocking_queries,
+    postgresql_extract_params,
+    postgresql_is_available,
+    resolve_postgresql_config,
+)
+from app.tools.tool_decorator import tool
+from app.tools.utils.sql_wrapper import call_db_tool_with_default_db_warning
+
+
+class PostgreSQLBlockingQueriesInput(BaseModel):
+    host: str = Field(description="PostgreSQL host or endpoint name.")
+    database: str | None = Field(
+        default=None,
+        description="Target database name. Defaults to integration database when omitted.",
+    )
+    port: int = Field(default=5432, description="PostgreSQL TCP port.")
+
+
+class PostgreSQLBlockingQueriesOutput(BaseModel):
+    source: str = Field(description="Evidence source label.")
+    available: bool = Field(description="Whether queries were retrieved.")
+    queries: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Blocked and blocking queries to identify lock contention.",
+    )
+    total_queries: int = Field(default=0, description="Number of query rows returned.")
+    database: str | None = Field(default=None, description="Database queried.")
+    default_db_warning: str | None = Field(
+        default=None,
+        description="Warning emitted when the default database fallback is used.",
+    )
+    error: str | None = Field(default=None, description="Error details when query fails.")
+
+
+@tool(
+    name="get_postgresql_blocking_queries",
+    description=(
+        "Retrieve currently blocked and blocking queries in PostgreSQL to diagnose lock contention."
+    ),
+    source="postgresql",
+    surfaces=("investigation", "chat"),
+    use_cases=[
+        "Diagnosing lock contention, deadlocks, or blocked transactions",
+        "Identifying long-running queries holding database locks",
+        "Correlating high database wait times with blocking PIDs",
+    ],
+    source_id="postgresql_blocking_queries",
+    evidence_type="query_stats",
+    side_effect_level="read_only",
+    examples=[
+        "Identify blocking queries to resolve lock contention.",
+    ],
+    anti_examples=[
+        "Use this tool for CPU spike investigations not relating to database lock timeouts."
+    ],
+    input_model=PostgreSQLBlockingQueriesInput,
+    output_model=PostgreSQLBlockingQueriesOutput,
+    is_available=postgresql_is_available,
+    extract_params=postgresql_extract_params,
+)
+def get_postgresql_blocking_queries(
+    host: str,
+    database: str | None = None,
+    port: int = 5432,
+) -> dict[str, Any]:
+    """Fetch blocked and blocking queries in PostgreSQL."""
+    return call_db_tool_with_default_db_warning(
+        database=database,
+        default_db_name="postgres",
+        config_resolver=resolve_postgresql_config,
+        resolver_kwargs={"host": host, "port": port},
+        db_caller=get_blocking_queries,
+    )

--- a/app/tools/SQSQueueAttributesTool/__init__.py
+++ b/app/tools/SQSQueueAttributesTool/__init__.py
@@ -1,0 +1,174 @@
+"""AWS SQS queue attributes tool."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, cast
+
+from app.integrations.sqs import (
+    DEFAULT_SQS_REGION,
+    sqs_extract_params,
+    sqs_is_available,
+)
+from app.services.aws_sdk_client import execute_aws_sdk_call
+from app.tools.tool_decorator import tool
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_QUEUES = 20
+
+
+@tool(
+    name="get_sqs_queue_attributes",
+    source="sqs",
+    description=(
+        "Fetch operational SQS queue attributes (visible depth, in-flight, oldest-message age, "
+        "visibility timeout, and DLQ config) for incident backlog or stuck-consumer diagnosis."
+    ),
+    use_cases=[
+        "Diagnosing message backlogs or stuck consumer processes in SQS-backed queues",
+        "Checking visibility timeout and redrive/DLQ settings for poison-pill issues",
+        "Listing active SQS queues matching a name prefix",
+    ],
+    requires=[],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "queue_name_prefix": {
+                "type": "string",
+                "description": "Optional string to filter queues by name prefix.",
+            },
+            "region": {"type": "string", "default": DEFAULT_SQS_REGION},
+            "max_queues": {
+                "type": "integer",
+                "default": DEFAULT_MAX_QUEUES,
+                "minimum": 1,
+                "maximum": 100,
+            },
+        },
+    },
+    is_available=sqs_is_available,
+    extract_params=sqs_extract_params,
+)
+def get_sqs_queue_attributes(
+    queue_name_prefix: str = "",
+    region: str = DEFAULT_SQS_REGION,
+    max_queues: int = DEFAULT_MAX_QUEUES,
+    aws_backend: Any = None,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    """List SQS queues by prefix and return their operational attributes.
+
+    If aws_backend is provided, delegates calls to it (for synthetic tests).
+    Otherwise executes boto3 read-only calls via execute_aws_sdk_call.
+    """
+    logger.info(
+        "[sqs] get_sqs_queue_attributes prefix=%s region=%s max_queues=%s",
+        queue_name_prefix,
+        region,
+        max_queues,
+    )
+
+    if aws_backend is not None:
+        try:
+            return cast(
+                "dict[str, Any]",
+                aws_backend.get_sqs_queue_attributes(
+                    queue_name_prefix=queue_name_prefix,
+                    max_queues=max_queues,
+                    region=region,
+                ),
+            )
+        except Exception as exc:
+            logger.error("[sqs] aws_backend call failed: %s", exc)
+            return {
+                "source": "sqs",
+                "available": False,
+                "error": f"Backend call failed: {exc}",
+                "queues": [],
+            }
+
+    list_params: dict[str, Any] = {}
+    if queue_name_prefix:
+        list_params["QueueNamePrefix"] = queue_name_prefix
+
+    list_res = execute_aws_sdk_call(
+        service_name="sqs",
+        operation_name="list_queues",
+        parameters=list_params,
+        region=region,
+    )
+
+    if not list_res.get("success"):
+        error_msg = list_res.get("error") or "Unknown error"
+        logger.error("[sqs] list_queues failed: %s", error_msg)
+        return {
+            "source": "sqs",
+            "available": False,
+            "error": f"Failed to list SQS queues: {error_msg}",
+            "queues": [],
+        }
+
+    queue_urls = (list_res.get("data") or {}).get("QueueUrls") or []
+    queue_urls = queue_urls[:max_queues]
+
+    queues_out = []
+    for url in queue_urls:
+        attr_res = execute_aws_sdk_call(
+            service_name="sqs",
+            operation_name="get_queue_attributes",
+            parameters={
+                "QueueUrl": url,
+                "AttributeNames": ["All"],
+            },
+            region=region,
+        )
+
+        if not attr_res.get("success"):
+            error_msg = attr_res.get("error") or "Unknown error"
+            logger.error("[sqs] get_queue_attributes failed for %s: %s", url, error_msg)
+            return {
+                "source": "sqs",
+                "available": False,
+                "error": f"Failed to get SQS queue attributes: {error_msg}",
+                "queues": [],
+            }
+
+        raw_attrs = (attr_res.get("data") or {}).get("Attributes") or {}
+
+        redrive = raw_attrs.get("RedrivePolicy")
+        redrive_policy = None
+        if redrive:
+            try:
+                redrive_policy = json.loads(redrive)
+            except Exception:
+                redrive_policy = redrive
+
+        queues_out.append(
+            {
+                "queue_name": url.split("/")[-1],
+                "queue_url": url,
+                "queue_arn": raw_attrs.get("QueueArn"),
+                "visible_messages": int(raw_attrs.get("ApproximateNumberOfMessages", 0)),
+                "in_flight_messages": int(
+                    raw_attrs.get("ApproximateNumberOfMessagesNotVisible", 0)
+                ),
+                "oldest_message_age_seconds": int(
+                    raw_attrs.get("ApproximateAgeOfOldestMessage", 0)
+                ),
+                "visibility_timeout_seconds": int(raw_attrs.get("VisibilityTimeout", 0)),
+                "redrive_policy": redrive_policy,
+                "has_dlq": bool(redrive_policy),
+                "is_fifo": bool(raw_attrs.get("FifoQueue") == "true" or url.endswith(".fifo")),
+            }
+        )
+
+    return {
+        "source": "sqs",
+        "available": True,
+        "region": region,
+        "total_queues": len(queues_out),
+        "queues": queues_out,
+        "error": None,
+    }

--- a/app/types/evidence.py
+++ b/app/types/evidence.py
@@ -56,4 +56,6 @@ EvidenceSource = Literal[
     "ec2",
     "hermes",
     "twilio",
+    "sqs",
+    "cloudtrail",
 ]

--- a/docs/cloudtrail_events.mdx
+++ b/docs/cloudtrail_events.mdx
@@ -1,0 +1,55 @@
+---
+title: "AWS CloudTrail"
+description: "Lookup AWS CloudTrail events for configuration-change forensics"
+---
+
+OpenSRE integrates with AWS CloudTrail to lookup operational events and audit logs. This integration allows the agent to inspect resource modifications, configuration changes, and actions performed by IAM principals during incident timeframes.
+
+## Prerequisites
+
+- AWS credentials configured (reuses credentials from EKS, RDS, EC2, or CloudWatch integrations).
+- CloudTrail IAM permissions to lookup events.
+
+## Tools
+
+| Tool | Description |
+| --- | --- |
+| `lookup_cloudtrail_events` | Look up AWS CloudTrail events filtered by username, event source, or resource name within a given duration. |
+
+## IAM Permissions
+
+Ensure the following read-only actions are permitted in your IAM policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudtrail:LookupEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+## Setup
+
+The CloudTrail integration automatically derives configuration and credentials from your existing AWS integrations (such as EKS or EC2).
+
+## Example Usage
+
+When checking who modified or deleted a resource (like a database, security group, or queue), you can run the following tool command or ask the agent:
+
+```bash
+Look up CloudTrail events for resource "my-db-instance" in the last 120 minutes
+```
+
+This returns a list of events containing:
+- `event_id` and `event_name`
+- `event_time`
+- `event_source` (e.g., `rds.amazonaws.com`)
+- `username` (the IAM principal who initiated the action)
+- `resources` (list of resources affected by the event)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -131,6 +131,7 @@
             "pages": [
               "argocd",
               "aws",
+              "cloudtrail_events",
               "bitbucket",
               "github",
               "integrations/github-actions",
@@ -173,6 +174,7 @@
               "prefect",
               "rabbitmq",
               "rds",
+              "sqs_queues",
               "snowflake",
               "supabase"
             ]

--- a/docs/sqs_queues.mdx
+++ b/docs/sqs_queues.mdx
@@ -1,0 +1,65 @@
+---
+title: "AWS SQS"
+description: "Diagnose SQS queue message backlogs and consumer issues"
+---
+
+OpenSRE integrates with Amazon Simple Queue Service (SQS) to fetch queue characteristics and operational metrics. This integration allows the agent to diagnose message backlogs, stuck consumers, and configuration issues (like dead-letter queues).
+
+## Prerequisites
+
+- AWS credentials configured (reuses credentials from EKS, RDS, EC2, or CloudWatch integrations).
+- SQS IAM permissions to list queues and read queue attributes.
+
+## Tools
+
+| Tool | Description |
+| --- | --- |
+| `get_sqs_queue_attributes` | List active SQS queues and return operational attributes (visible depth, in-flight, oldest-message age, visibility timeout, and DLQ configuration). |
+
+## IAM Permissions
+
+Ensure the following read-only actions are permitted in your IAM policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sqs:ListQueues",
+        "sqs:GetQueueAttributes"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+## Setup
+
+The SQS integration automatically derives configuration and credentials from your existing AWS integrations (such as EKS or EC2).
+
+To filter SQS queues or specify a region, you can set the following environment variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `AWS_REGION` | `us-east-1` | Target AWS region to query queues |
+| `SQS_QUEUE_NAME_PREFIX` | — | Optional string to filter queues by name prefix |
+
+## Example Usage
+
+When investigating a backlog or consumer timeout, you can run the following tool command or ask the agent:
+
+```bash
+Get SQS queue attributes for queues matching "orders-" prefix
+```
+
+This returns data containing:
+- `queue_name` and `queue_url`
+- `visible_messages` (queue depth)
+- `in_flight_messages` (messages being processed)
+- `oldest_message_age_seconds`
+- `visibility_timeout_seconds`
+- `has_dlq` and detailed `redrive_policy` (dead letter queue details)
+- `is_fifo`

--- a/tests/agents/test_command_resolution.py
+++ b/tests/agents/test_command_resolution.py
@@ -1,0 +1,96 @@
+"""Tests for /agents command resolution and completion logic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from prompt_toolkit.completion import CompleteEvent
+from prompt_toolkit.document import Document
+
+from app.agents.registry import AgentRecord, AgentRegistry, resolve_agent_arg
+from app.cli.interactive_shell.prompting.prompt_surface import ShellCompleter
+
+
+@pytest.fixture
+def temp_registry_path(tmp_path: Path) -> Path:
+    return tmp_path / "agents.jsonl"
+
+
+@pytest.fixture
+def populated_registry(temp_registry_path: Path) -> AgentRegistry:
+    registry = AgentRegistry(path=temp_registry_path)
+
+    # Register some agents
+    agent1 = AgentRecord(name="agent-alpha", pid=1001, command="python alpha.py")
+    agent2 = AgentRecord(name="agent-beta", pid=1002, command="python beta.py")
+    agent3 = AgentRecord(name="agent-alpha", pid=1003, command="python alpha2.py")  # Ambiguous name
+
+    registry.register(agent1)
+    registry.register(agent2)
+    registry.register(agent3)
+    return registry
+
+
+def test_resolve_agent_arg_direct_pid_hit(populated_registry: AgentRegistry) -> None:
+    # PID exists in registry
+    pid = resolve_agent_arg("1001", populated_registry)
+    assert pid == 1001
+
+
+def test_resolve_agent_arg_unique_name_hit(populated_registry: AgentRegistry) -> None:
+    # Name exists uniquely
+    pid = resolve_agent_arg("agent-beta", populated_registry)
+    assert pid == 1002
+
+
+def test_resolve_agent_arg_direct_pid_fallback(populated_registry: AgentRegistry) -> None:
+    # PID doesn't exist in registry, but parses as positive int
+    pid = resolve_agent_arg("9999", populated_registry)
+    assert pid == 9999
+
+
+def test_resolve_agent_arg_ambiguous_name(populated_registry: AgentRegistry) -> None:
+    # Name matches multiple records
+    with pytest.raises(ValueError) as excinfo:
+        resolve_agent_arg("agent-alpha", populated_registry)
+    assert "ambiguous" in str(excinfo.value)
+    assert "1001, 1003" in str(excinfo.value)
+
+
+def test_resolve_agent_arg_invalid(populated_registry: AgentRegistry) -> None:
+    # Completely unknown name
+    with pytest.raises(ValueError) as excinfo:
+        resolve_agent_arg("nonexistent-agent", populated_registry)
+    assert "invalid pid or unknown agent name" in str(excinfo.value)
+
+    # Invalid int format (negative/zero)
+    with pytest.raises(ValueError) as excinfo:
+        resolve_agent_arg("-5", populated_registry)
+    assert "invalid pid or unknown agent name" in str(excinfo.value)
+
+
+def test_shell_completer_agents_subcommands(populated_registry: AgentRegistry) -> None:
+    completer = ShellCompleter()
+
+    # Mock the AgentRegistry inside get_completions by patching its definition module
+    with patch("app.agents.registry.AgentRegistry", return_value=populated_registry):
+        # 1. Completions when user typed "/agents kill "
+        doc = Document("/agents kill ", cursor_position=13)
+        completions = list(completer.get_completions(doc, CompleteEvent()))
+
+        # Should complete both names and PIDs
+        texts = [c.text for c in completions]
+        assert "agent-alpha" in texts
+        assert "agent-beta" in texts
+        assert "1001" in texts
+        assert "1002" in texts
+        assert "1003" in texts
+
+        # 2. Completions when user typed "/agents kill agent-a"
+        doc_partial = Document("/agents kill agent-a", cursor_position=20)
+        completions_partial = list(completer.get_completions(doc_partial, CompleteEvent()))
+        texts_partial = [c.text for c in completions_partial]
+        assert "agent-alpha" in texts_partial
+        assert "agent-beta" not in texts_partial

--- a/tests/cli/interactive_shell/test_terminal_runtime_routing.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime_routing.py
@@ -84,8 +84,8 @@ def test_dispatch_needs_exclusive_stdin_for_bare_integration_menu(
     assert loop_dispatch.dispatch_needs_exclusive_stdin("/mcp", session) is True
     assert loop_dispatch.dispatch_needs_exclusive_stdin("/model", session) is True
 
-    assert loop_dispatch.dispatch_needs_exclusive_stdin("/integrations list", session) is False
-    assert loop_dispatch.dispatch_needs_exclusive_stdin("integrations list", session) is False
+    assert loop_dispatch.dispatch_needs_exclusive_stdin("/integrations list", session) is True
+    assert loop_dispatch.dispatch_needs_exclusive_stdin("integrations list", session) is True
 
 
 def test_dispatch_needs_exclusive_stdin_for_exit_commands(

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -465,7 +465,7 @@ def test_ctrl_o_watcher_disables_terminal_output_discard(
     monkeypatch.setattr(output.sys, "stdout", _TTY())
     monkeypatch.setattr(output, "select", _Select)
     monkeypatch.setattr(output, "termios", _Termios)
-    monkeypatch.setattr(output.os, "fpathconf", lambda _fd, _name: 0)
+    monkeypatch.setattr(output.os, "fpathconf", lambda _fd, _name: 0, raising=False)
 
     watcher = output.CtrlOToggleWatcher(lambda: None)
     watcher.start()

--- a/tests/services/test_embeddings_client.py
+++ b/tests/services/test_embeddings_client.py
@@ -1,0 +1,152 @@
+"""Tests for EmbeddingsClient implementations and factory."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+from app.services.embeddings_client import (
+    OllamaEmbeddingsClient,
+    OpenAIEmbeddingsClient,
+    VoyageEmbeddingsClient,
+    _NoOpEmbeddingsClient,
+    get_embeddings_client,
+)
+
+
+def test_noop_embeddings_client() -> None:
+    client = _NoOpEmbeddingsClient(model_name="noop", dim=4)
+    assert client.model_name == "noop"
+    assert client.dim == 4
+
+    res = client.embed(["hello", "world"])
+    assert len(res) == 2
+    assert len(res[0]) == 4
+    assert len(res[1]) == 4
+    # Deterministic vectors
+    res2 = client.embed(["hello", "world"])
+    assert res == res2
+
+
+def test_openai_embeddings_client() -> None:
+    mock_response = MagicMock()
+    mock_item1 = MagicMock()
+    mock_item1.embedding = [0.1, 0.2]
+    mock_item2 = MagicMock()
+    mock_item2.embedding = [0.3, 0.4]
+    mock_response.data = [mock_item1, mock_item2]
+
+    mock_openai = MagicMock()
+    mock_openai.embeddings.create.return_value = mock_response
+
+    with patch("app.services.embeddings_client.OpenAI", return_value=mock_openai):
+        client = OpenAIEmbeddingsClient(model_name="text-embedding-3-small", api_key="test-key")
+        assert client.model_name == "text-embedding-3-small"
+        assert client.dim == 1536
+
+        res = client.embed(["text1", "text2"])
+        assert res == [[0.1, 0.2], [0.3, 0.4]]
+        mock_openai.embeddings.create.assert_called_once_with(
+            input=["text1", "text2"],
+            model="text-embedding-3-small",
+        )
+
+
+def test_voyage_embeddings_client() -> None:
+    mock_res_json = {"data": [{"embedding": [0.5, 0.6]}, {"embedding": [0.7, 0.8]}]}
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = mock_res_json
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.post.return_value = mock_response
+
+    with patch("app.services.embeddings_client.httpx.Client") as mock_client_cls:
+        mock_client_cls.return_value.__enter__.return_value = mock_client
+        client = VoyageEmbeddingsClient(model_name="voyage-3-lite", api_key="test-key")
+        assert client.model_name == "voyage-3-lite"
+        assert client.dim == 512
+
+        res = client.embed(["text1", "text2"])
+        assert res == [[0.5, 0.6], [0.7, 0.8]]
+        mock_client.post.assert_called_once_with(
+            "https://api.voyageai.com/v1/embeddings",
+            headers={
+                "Authorization": "Bearer test-key",
+                "Content-Type": "application/json",
+            },
+            json={
+                "input": ["text1", "text2"],
+                "model": "voyage-3-lite",
+            },
+        )
+
+
+def test_ollama_embeddings_client() -> None:
+    mock_res_json = {"embeddings": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]}
+    mock_response = MagicMock()
+    mock_response.json.return_value = mock_res_json
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.post.return_value = mock_response
+
+    with patch("app.services.embeddings_client.httpx.Client") as mock_client_cls:
+        mock_client_cls.return_value.__enter__.return_value = mock_client
+        client = OllamaEmbeddingsClient(
+            model_name="nomic-embed-text", host="http://localhost:11434"
+        )
+        assert client.model_name == "nomic-embed-text"
+        assert client.dim == 768
+
+        res = client.embed(["text1", "text2"])
+        assert res == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        mock_client.post.assert_called_once_with(
+            "http://localhost:11434/api/embed",
+            json={
+                "model": "nomic-embed-text",
+                "input": ["text1", "text2"],
+            },
+        )
+
+
+def test_factory_resolves_correctly() -> None:
+    # 1. Override with OPENSRE_EMBEDDINGS_MODEL
+    with (
+        patch.dict(
+            os.environ, {"OPENSRE_EMBEDDINGS_MODEL": "voyage-3", "VOYAGE_API_KEY": "voyagekey"}
+        ),
+        patch(
+            "app.services.embeddings_client.resolve_llm_settings",
+            side_effect=Exception("no settings"),
+        ),
+    ):
+        client = get_embeddings_client()
+        assert isinstance(client, VoyageEmbeddingsClient)
+        assert client.model_name == "voyage-3"
+
+    # 2. OpenAI provider
+    mock_settings = MagicMock()
+    mock_settings.provider = "openai"
+    mock_settings.openai_api_key = "openaikey"
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("app.services.embeddings_client.resolve_llm_settings", return_value=mock_settings),
+        patch("app.services.embeddings_client.resolve_llm_api_key", return_value="openaikey"),
+    ):
+        client = get_embeddings_client()
+        assert isinstance(client, OpenAIEmbeddingsClient)
+        assert client.model_name == "text-embedding-3-small"
+
+    # 3. None when no keys
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch(
+            "app.services.embeddings_client.resolve_llm_settings",
+            side_effect=Exception("no settings"),
+        ),
+        patch("app.services.embeddings_client.resolve_llm_api_key", return_value=None),
+    ):
+        client = get_embeddings_client()
+        assert client is None

--- a/tests/tools/test_cloudtrail_events.py
+++ b/tests/tools/test_cloudtrail_events.py
@@ -1,0 +1,94 @@
+"""Tests for CloudTrailEventsTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.tools.CloudTrailEventsTool import lookup_cloudtrail_events
+from tests.tools.conftest import BaseToolContract
+
+
+class TestCloudTrailEventsToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return lookup_cloudtrail_events.__opensre_registered_tool__
+
+
+def test_metadata() -> None:
+    rt = lookup_cloudtrail_events.__opensre_registered_tool__
+    assert rt.name == "lookup_cloudtrail_events"
+    assert rt.source == "cloudtrail"
+
+
+def test_run_happy_path() -> None:
+    fake_res = {
+        "success": True,
+        "data": {
+            "Events": [
+                {
+                    "EventId": "evt-123",
+                    "EventName": "DeleteQueue",
+                    "EventTime": "2024-01-15 10:30:00",
+                    "EventSource": "sqs.amazonaws.com",
+                    "Username": "admin-role",
+                    "Resources": [
+                        {"ResourceType": "AWS::SQS::Queue", "ResourceName": "test-queue"}
+                    ],
+                }
+            ]
+        },
+    }
+
+    with patch(
+        "app.tools.CloudTrailEventsTool.execute_aws_sdk_call", return_value=fake_res
+    ) as mock_call:
+        result = lookup_cloudtrail_events(
+            resource_name="test-queue",
+            event_source="sqs.amazonaws.com",
+            username="admin-role",
+            duration_minutes=30,
+            region="us-east-1",
+        )
+
+    assert result["available"] is True
+    assert result["region"] == "us-east-1"
+    assert result["total_events"] == 1
+    event = result["events"][0]
+    assert event["event_id"] == "evt-123"
+    assert event["event_name"] == "DeleteQueue"
+    assert event["username"] == "admin-role"
+    assert event["resources"][0]["name"] == "test-queue"
+
+    mock_call.assert_called_once()
+    called_args, called_kwargs = mock_call.call_args
+    params = called_kwargs.get("parameters") or called_args[2]
+    assert "StartTime" in params
+    assert "EndTime" in params
+    assert len(params["LookupAttributes"]) == 3
+    assert {"AttributeKey": "ResourceName", "AttributeValue": "test-queue"} in params[
+        "LookupAttributes"
+    ]
+
+
+def test_run_aws_backend_override() -> None:
+    mock_backend = MagicMock()
+    mock_backend.lookup_events.return_value = {
+        "source": "cloudtrail",
+        "available": True,
+        "events": [{"event_id": "custom-evt"}],
+    }
+
+    result = lookup_cloudtrail_events(aws_backend=mock_backend)
+    assert result["available"] is True
+    assert result["events"][0]["event_id"] == "custom-evt"
+    mock_backend.lookup_events.assert_called_once()
+
+
+def test_run_lookup_fail() -> None:
+    fake_res = {"success": False, "error": "AccessDeniedException"}
+
+    with patch("app.tools.CloudTrailEventsTool.execute_aws_sdk_call", return_value=fake_res):
+        result = lookup_cloudtrail_events(region="us-east-1")
+
+    assert result["available"] is False
+    assert "AccessDeniedException" in result["error"]
+    assert result["events"] == []

--- a/tests/tools/test_github_search_issues_tool.py
+++ b/tests/tools/test_github_search_issues_tool.py
@@ -1,0 +1,95 @@
+"""Tests for GitHubSearchIssuesTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.tools.GitHubSearchIssuesTool import (
+    build_github_issue_search_query,
+    search_github_issues,
+)
+from tests.tools.conftest import BaseToolContract
+
+
+class TestGitHubSearchIssuesToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return search_github_issues.__opensre_registered_tool__
+
+
+def test_metadata() -> None:
+    rt = search_github_issues.__opensre_registered_tool__
+    assert rt.name == "search_github_issues"
+    assert rt.source == "github"
+
+
+def test_is_available() -> None:
+    rt = search_github_issues.__opensre_registered_tool__
+    assert (
+        rt.is_available({"github": {"owner": "o", "repo": "r", "connection_verified": True}})
+        is True
+    )
+    assert rt.is_available({"github": {"owner": "o", "repo": "r"}}) is False
+    assert rt.is_available({}) is False
+
+
+def test_extract_params() -> None:
+    rt = search_github_issues.__opensre_registered_tool__
+    sources = {
+        "github": {
+            "owner": "test-owner",
+            "repo": "test-repo",
+            "github_token": "token123",
+            "connection_verified": True,
+        }
+    }
+    params = rt.extract_params(sources)
+    assert params["owner"] == "test-owner"
+    assert params["repo"] == "test-repo"
+    assert params["query"] == "bug"
+    assert params["github_token"] == "token123"
+
+
+def test_build_github_issue_search_query() -> None:
+    q = build_github_issue_search_query("owner", "repo", "test error")
+    assert q == "test error repo:owner/repo"
+
+    q_already_qualified = build_github_issue_search_query("owner", "repo", "error repo:owner/repo")
+    assert q_already_qualified == "error repo:owner/repo"
+
+
+def test_run_happy_path() -> None:
+    fake_config = MagicMock()
+    fake_mcp_res = {
+        "is_error": False,
+        "tool": "search_issues",
+        "structured_content": [{"number": 42, "title": "Memory leak in handler", "state": "open"}],
+    }
+
+    with (
+        patch(
+            "app.tools.GitHubSearchIssuesTool.resolve_github_mcp_config", return_value=fake_config
+        ),
+        patch("app.tools.GitHubSearchIssuesTool.call_github_mcp_tool", return_value=fake_mcp_res),
+    ):
+        result = search_github_issues(
+            owner="owner",
+            repo="repo",
+            query="memory leak",
+        )
+
+    assert result["available"] is True
+    assert len(result["issues"]) == 1
+    assert result["issues"][0]["number"] == 42
+    assert result["query"] == "memory leak repo:owner/repo"
+
+
+def test_run_no_mcp_config() -> None:
+    with patch("app.tools.GitHubSearchIssuesTool.resolve_github_mcp_config", return_value=None):
+        result = search_github_issues(
+            owner="owner",
+            repo="repo",
+            query="bug",
+        )
+
+    assert result["available"] is False
+    assert result["issues"] == []

--- a/tests/tools/test_postgresql_blocking_queries_tool.py
+++ b/tests/tools/test_postgresql_blocking_queries_tool.py
@@ -1,0 +1,92 @@
+"""Tests for PostgreSQLBlockingQueriesTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.tools.PostgreSQLBlockingQueriesTool import get_postgresql_blocking_queries
+from tests.tools.conftest import BaseToolContract
+
+
+class TestPostgreSQLBlockingQueriesToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return get_postgresql_blocking_queries.__opensre_registered_tool__
+
+
+def test_metadata() -> None:
+    rt = get_postgresql_blocking_queries.__opensre_registered_tool__
+    assert rt.name == "get_postgresql_blocking_queries"
+    assert rt.source == "postgresql"
+
+
+def test_run_happy_path() -> None:
+    fake_result = {
+        "source": "postgresql",
+        "available": True,
+        "total_queries": 2,
+        "queries": [
+            {
+                "pid": 12345,
+                "username": "app_user",
+                "application_name": "myapp",
+                "client_addr": "192.168.1.100",
+                "state": "active",
+                "query_start": "2024-01-15 10:30:00",
+                "duration_seconds": 15,
+                "wait_event_type": "Lock",
+                "wait_event": "transactionid",
+                "blocking_pids": [12346],
+                "query_truncated": "UPDATE large_table SET status = 'processed' WHERE id = 1",
+            },
+            {
+                "pid": 12346,
+                "username": "app_user",
+                "application_name": "myapp",
+                "client_addr": "192.168.1.100",
+                "state": "active",
+                "query_start": "2024-01-15 10:29:45",
+                "duration_seconds": 30,
+                "wait_event_type": "",
+                "wait_event": "",
+                "blocking_pids": [],
+                "query_truncated": "UPDATE large_table SET status = 'pending' WHERE id = 1",
+            },
+        ],
+    }
+    with patch(
+        "app.tools.PostgreSQLBlockingQueriesTool.get_blocking_queries", return_value=fake_result
+    ):
+        result = get_postgresql_blocking_queries(host="localhost", database="testdb")
+    assert result["total_queries"] == 2
+    assert len(result["queries"]) == 2
+    assert result["queries"][0]["duration_seconds"] == 15
+    assert result["queries"][0]["blocking_pids"] == [12346]
+
+
+def test_run_error_propagated() -> None:
+    with patch(
+        "app.tools.PostgreSQLBlockingQueriesTool.get_blocking_queries",
+        return_value={"source": "postgresql", "available": False, "error": "permission denied"},
+    ):
+        result = get_postgresql_blocking_queries(host="invalid", database="testdb")
+    assert "error" in result
+    assert result["available"] is False
+
+
+def test_default_db_warning_present_when_database_omitted() -> None:
+    with patch(
+        "app.tools.PostgreSQLBlockingQueriesTool.get_blocking_queries",
+        return_value={"source": "postgresql", "available": True, "queries": []},
+    ):
+        result = get_postgresql_blocking_queries(host="localhost")
+    assert "default_db_warning" in result
+    assert "postgres" in result["default_db_warning"]
+
+
+def test_no_default_db_warning_when_database_provided() -> None:
+    with patch(
+        "app.tools.PostgreSQLBlockingQueriesTool.get_blocking_queries",
+        return_value={"source": "postgresql", "available": True, "queries": []},
+    ):
+        result = get_postgresql_blocking_queries(host="localhost", database="mydb")
+    assert "default_db_warning" not in result

--- a/tests/tools/test_sqs_queue_attributes.py
+++ b/tests/tools/test_sqs_queue_attributes.py
@@ -1,0 +1,146 @@
+"""Tests for SQSQueueAttributesTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.tools.SQSQueueAttributesTool import get_sqs_queue_attributes
+from tests.tools.conftest import BaseToolContract
+
+
+class TestSQSQueueAttributesToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return get_sqs_queue_attributes.__opensre_registered_tool__
+
+
+def test_metadata() -> None:
+    rt = get_sqs_queue_attributes.__opensre_registered_tool__
+    assert rt.name == "get_sqs_queue_attributes"
+    assert rt.source == "sqs"
+
+
+def test_is_available() -> None:
+    rt = get_sqs_queue_attributes.__opensre_registered_tool__
+
+    # Direct config
+    assert rt.is_available({"sqs": {"connection_verified": True}}) is True
+    assert rt.is_available({"sqs": {"_backend": object()}}) is True
+
+    # AWS fallback integrations
+    assert rt.is_available({"rds": {"connection_verified": True}}) is True
+    assert rt.is_available({"ec2": {"connection_verified": True}}) is True
+    assert rt.is_available({"eks": {"connection_verified": True}}) is True
+    assert rt.is_available({"cloudwatch": {"connection_verified": True}}) is True
+    assert rt.is_available({"cloudwatch": {}}) is True
+
+    # Not available
+    assert rt.is_available({}) is False
+    assert rt.is_available({"sqs": {}}) is False
+
+
+def test_extract_params() -> None:
+    rt = get_sqs_queue_attributes.__opensre_registered_tool__
+    sources = {
+        "eks": {
+            "region": "us-west-2",
+            "_backend": "mock_eks_backend",
+        }
+    }
+    params = rt.extract_params(sources)
+    assert params["region"] == "us-west-2"
+    assert params["aws_backend"] == "mock_eks_backend"
+
+
+def test_run_happy_path() -> None:
+    fake_list_res = {
+        "success": True,
+        "data": {"QueueUrls": ["https://sqs.us-east-1.amazonaws.com/123456789012/test-queue"]},
+    }
+
+    fake_attr_res = {
+        "success": True,
+        "data": {
+            "Attributes": {
+                "QueueArn": "arn:aws:sqs:us-east-1:123456789012:test-queue",
+                "ApproximateNumberOfMessages": "10",
+                "ApproximateNumberOfMessagesNotVisible": "2",
+                "ApproximateAgeOfOldestMessage": "3600",
+                "VisibilityTimeout": "30",
+                "RedrivePolicy": '{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:123456789012:dlq","maxReceiveCount":"5"}',
+                "FifoQueue": "false",
+            }
+        },
+    }
+
+    def mock_sdk_call(service_name, operation_name, parameters=None, region=None):
+        if operation_name == "list_queues":
+            return fake_list_res
+        elif operation_name == "get_queue_attributes":
+            assert (
+                parameters["QueueUrl"]
+                == "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue"
+            )
+            return fake_attr_res
+        return {"success": False, "error": "unknown operation"}
+
+    with patch("app.tools.SQSQueueAttributesTool.execute_aws_sdk_call", side_effect=mock_sdk_call):
+        result = get_sqs_queue_attributes(queue_name_prefix="test-", region="us-east-1")
+
+    assert result["available"] is True
+    assert result["region"] == "us-east-1"
+    assert result["total_queues"] == 1
+    queue = result["queues"][0]
+    assert queue["queue_name"] == "test-queue"
+    assert queue["visible_messages"] == 10
+    assert queue["in_flight_messages"] == 2
+    assert queue["oldest_message_age_seconds"] == 3600
+    assert queue["has_dlq"] is True
+    assert queue["is_fifo"] is False
+
+
+def test_run_aws_backend_override() -> None:
+    mock_backend = MagicMock()
+    mock_backend.get_sqs_queue_attributes.return_value = {
+        "source": "sqs",
+        "available": True,
+        "queues": [{"queue_name": "custom-queue"}],
+    }
+
+    result = get_sqs_queue_attributes(aws_backend=mock_backend)
+    assert result["available"] is True
+    assert result["queues"][0]["queue_name"] == "custom-queue"
+    mock_backend.get_sqs_queue_attributes.assert_called_once()
+
+
+def test_run_list_queues_fail() -> None:
+    fake_list_res = {"success": False, "error": "AccessDeniedException"}
+
+    with patch("app.tools.SQSQueueAttributesTool.execute_aws_sdk_call", return_value=fake_list_res):
+        result = get_sqs_queue_attributes(region="us-east-1")
+
+    assert result["available"] is False
+    assert "AccessDeniedException" in result["error"]
+    assert result["queues"] == []
+
+
+def test_run_get_attributes_fail() -> None:
+    fake_list_res = {
+        "success": True,
+        "data": {"QueueUrls": ["https://sqs.us-east-1.amazonaws.com/123456789012/test-queue"]},
+    }
+
+    fake_attr_res = {"success": False, "error": "NoSuchQueueException"}
+
+    def mock_sdk_call(service_name, operation_name, parameters=None, region=None):
+        if operation_name == "list_queues":
+            return fake_list_res
+        elif operation_name == "get_queue_attributes":
+            return fake_attr_res
+        return {"success": False, "error": "unknown operation"}
+
+    with patch("app.tools.SQSQueueAttributesTool.execute_aws_sdk_call", side_effect=mock_sdk_call):
+        result = get_sqs_queue_attributes(region="us-east-1")
+
+    assert result["available"] is False
+    assert "NoSuchQueueException" in result["error"]
+    assert result["queues"] == []


### PR DESCRIPTION
Fixes #2058, #2117, #2230, #2116, #2115

This PR addresses the first batch of issues:
1. **Config Persistence (#2058)**: Checks if sys.frozen is true, falling back to CWD to avoid config loss on PyInstaller temp directories.
2. **Stale Progress Footer (#2117)**: Configures the Rich live display as 	ransient=True so it gets cleared immediately upon completion.
3. **REPL Rendering & Timing (#2230, #2116, #2115)**: Adds confirmation duration tracking, hides the spinner row during confirmations, makes the prompt placeholder dynamic, and blocks prompt-toolkit's redraw loop for investigations/synchronous commands.