### PR TITLE
fix(cli): fall back to .env when keyring unavailable

### DIFF
--- a/app/cli/wizard/env_sync.py
+++ b/app/cli/wizard/env_sync.py
@@ -42,12 +42,15 @@ def _is_sensitive_env_key(key: str) -> bool:
     return any(needle in lowered for needle in _SENSITIVE_SUBSTRINGS)
 
 
-def _strip_sensitive_env_lines(lines: list[str]) -> list[str]:
+def _strip_sensitive_env_lines(
+    lines: list[str], *, allowed_plaintext_keys: set[str] | None = None
+) -> list[str]:
     """Remove secret assignments so .env only carries non-sensitive config."""
+    allowed_keys = allowed_plaintext_keys or set()
     stripped: list[str] = []
     for line in lines:
         match = _ENV_ASSIGNMENT.match(line)
-        if match and _is_sensitive_env_key(match.group(1)):
+        if match and _is_sensitive_env_key(match.group(1)) and match.group(1) not in allowed_keys:
             continue
         stripped.append(line)
     return stripped
@@ -66,8 +69,15 @@ def _persist_env_secret(key: str, value: str) -> bool:
     return True
 
 
-def _set_env_value(lines: list[str], key: str, value: str) -> list[str]:
-    if _is_sensitive_env_key(key):
+def _set_env_value(
+    lines: list[str],
+    key: str,
+    value: str,
+    *,
+    allowed_plaintext_keys: set[str] | None = None,
+) -> list[str]:
+    allowed_keys = allowed_plaintext_keys or set()
+    if _is_sensitive_env_key(key) and key not in allowed_keys:
         raise RuntimeError(
             f"Refusing to write sensitive env key {key!r} to .env; use sync_env_secret()."
         )
@@ -89,20 +99,28 @@ def _set_env_value(lines: list[str], key: str, value: str) -> list[str]:
     return updated
 
 
-def _ensure_no_sensitive_env_lines(lines: list[str]) -> None:
+def _ensure_no_sensitive_env_lines(
+    lines: list[str], *, allowed_plaintext_keys: set[str] | None = None
+) -> None:
     """Fail closed when a sensitive assignment would be written to disk."""
+    allowed_keys = allowed_plaintext_keys or set()
     for line in lines:
         match = _ENV_ASSIGNMENT.match(line)
-        if match and _is_sensitive_env_key(match.group(1)):
+        if match and _is_sensitive_env_key(match.group(1)) and match.group(1) not in allowed_keys:
             raise RuntimeError(
                 f"Refusing to write sensitive env key {match.group(1)!r} to .env; use the system keyring."
             )
 
 
-def _write_env(target_path: Path, lines: list[str]) -> None:
+def _write_env(
+    target_path: Path,
+    lines: list[str],
+    *,
+    allowed_plaintext_keys: set[str] | None = None,
+) -> None:
     """Write non-sensitive .env lines with owner-only permissions when possible."""
-    public_lines = _strip_sensitive_env_lines(lines)
-    _ensure_no_sensitive_env_lines(public_lines)
+    public_lines = _strip_sensitive_env_lines(lines, allowed_plaintext_keys=allowed_plaintext_keys)
+    _ensure_no_sensitive_env_lines(public_lines, allowed_plaintext_keys=allowed_plaintext_keys)
     try:
         target_path.parent.mkdir(parents=True, exist_ok=True)
         with target_path.open("w", encoding="utf-8", newline="") as env_file:
@@ -212,6 +230,7 @@ def sync_provider_env(
     model: str,
     toolcall_model: str | None = None,
     env_path: Path | None = None,
+    llm_api_key_plaintext: str | None = None,
 ) -> Path:
     """Write non-secret provider settings into the project .env.
 
@@ -219,6 +238,10 @@ def sync_provider_env(
     is in the keyring, or when switching LLM provider. If the user still has
     the active provider's key only in ``.env`` (same ``LLM_PROVIDER``), that
     line is kept until they save to the keyring.
+
+    When keychain storage is unavailable, the onboarding wizard may pass
+    ``llm_api_key_plaintext`` to allow exactly the active provider's API key
+    into the project ``.env`` fallback. Other sensitive keys remain stripped.
     """
     from app.cli.wizard.config import SUPPORTED_PROVIDERS
 
@@ -256,6 +279,12 @@ def sync_provider_env(
     ):
         keys_to_remove.discard(provider.api_key_env)
 
+    allowed_plaintext_keys: set[str] = set()
+    normalized_plaintext_key = (llm_api_key_plaintext or "").strip()
+    if normalized_plaintext_key and provider.api_key_env:
+        allowed_plaintext_keys.add(provider.api_key_env)
+        keys_to_remove.discard(provider.api_key_env)
+
     lines = _remove_keys(existing, keys_to_remove)
 
     values: dict[str, str] = {"LLM_PROVIDER": provider.value, provider.model_env: model}
@@ -263,11 +292,13 @@ def sync_provider_env(
         values[provider.legacy_model_env] = model
     if toolcall_model and provider.toolcall_model_env:
         values[provider.toolcall_model_env] = toolcall_model
+    if normalized_plaintext_key and provider.api_key_env:
+        values[provider.api_key_env] = normalized_plaintext_key
 
     for key, value in values.items():
-        lines = _set_env_value(lines, key, value)
+        lines = _set_env_value(lines, key, value, allowed_plaintext_keys=allowed_plaintext_keys)
 
-    _write_env(target_path, lines)
+    _write_env(target_path, lines, allowed_plaintext_keys=allowed_plaintext_keys)
 
     for key in keys_to_remove:
         os.environ.pop(key, None)

--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -459,7 +459,7 @@ def _prompt_value(
         _console.print(f"[{ERROR}]  {GLYPH_ERROR}  Required.[/]")
 
 
-def _persist_llm_api_key(env_var: str, value: str) -> bool:
+def _persist_llm_api_key(env_var: str, value: str) -> Literal["keychain", "env"] | None:
     try:
         save_llm_api_key(env_var, value)
     except RuntimeError as exc:
@@ -469,8 +469,17 @@ def _persist_llm_api_key(env_var: str, value: str) -> bool:
         )
         for line in get_keyring_setup_instructions(env_var):
             _console.print(f"[{SECONDARY}]    {line}[/]")
-        return False
-    return True
+
+        if sys.stdin.isatty() and not _confirm(
+            "Save the API key to project .env instead? (common on SSH/headless servers)",
+            default=True,
+        ):
+            return None
+        _console.print(
+            f"[{WARNING}]  {GLYPH_WARNING}  Storing {env_var} in project .env with owner-only permissions.[/]"
+        )
+        return "env"
+    return "keychain"
 
 
 def _parse_csv_values(raw_value: str) -> list[str]:
@@ -2156,9 +2165,13 @@ def _render_next_steps() -> None:
     _console.print()
 
 
-def _credential_line_for_saved_summary(provider: ProviderOption) -> str:
+def _credential_line_for_saved_summary(
+    provider: ProviderOption, *, llm_key_in_env_file: bool = False
+) -> str:
     """One-line credential description for the post-wizard saved summary."""
     if provider.credential_kind != "cli":
+        if llm_key_in_env_file and provider.api_key_env:
+            return f"project .env ({provider.api_key_env})"
         return "system keychain"
     if provider.adapter_factory is None:
         return f"{provider.label} (CLI)"
@@ -2302,6 +2315,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
     force_repick = False
     provider: ProviderOption
     model: str
+    llm_api_key_plaintext_for_env: str | None = None
     while True:
         _step_header(2, WIZARD_TOTAL_STEPS, "LLM Provider")
         saved_provider = (
@@ -2344,8 +2358,11 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                 except KeyboardInterrupt:
                     _console.print(f"\n[{WARNING}]Setup cancelled.[/]")
                     return 1
-                if not _persist_llm_api_key(provider.api_key_env, api_key):
+                persist_kind = _persist_llm_api_key(provider.api_key_env, api_key)
+                if persist_kind is None:
                     return 1
+                if persist_kind == "env":
+                    llm_api_key_plaintext_for_env = api_key
         else:
             assert saved_provider is not None
             provider = saved_provider
@@ -2354,8 +2371,11 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                 has_api_key = bool(defaults["has_api_key"])
                 legacy_api_key = str(defaults["legacy_api_key"] or "").strip()
                 if not has_api_key and legacy_api_key:
-                    if not _persist_llm_api_key(provider.api_key_env, legacy_api_key):
+                    persist_kind = _persist_llm_api_key(provider.api_key_env, legacy_api_key)
+                    if persist_kind is None:
                         return 1
+                    if persist_kind == "env":
+                        llm_api_key_plaintext_for_env = legacy_api_key
                     has_api_key = True
                 if not has_api_key:
                     _step(provider.credential_label.title())
@@ -2368,8 +2388,11 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                     except KeyboardInterrupt:
                         _console.print(f"\n[{WARNING}]Setup cancelled.[/]")
                         return 1
-                    if not _persist_llm_api_key(provider.api_key_env, api_key):
+                    persist_kind = _persist_llm_api_key(provider.api_key_env, api_key)
+                    if persist_kind is None:
                         return 1
+                    if persist_kind == "env":
+                        llm_api_key_plaintext_for_env = api_key
 
         if change_provider:
             model = _choose_model(provider, default=model)
@@ -2400,7 +2423,13 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         model_env=provider.model_env,
         probes=probes,
     )
-    env_path = sync_provider_env(provider=provider, model=model)
+    env_path = sync_provider_env(
+        provider=provider,
+        model=model,
+        llm_api_key_plaintext=llm_api_key_plaintext_for_env,
+    )
+    if llm_api_key_plaintext_for_env and provider.api_key_env:
+        os.environ[provider.api_key_env] = llm_api_key_plaintext_for_env.strip()
 
     _step_header(3, WIZARD_TOTAL_STEPS, "Integrations")
     try:
@@ -2422,7 +2451,9 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         saved_path=str(saved_path),
         env_path=summary_env_path,
         configured_integrations=configured_integrations,
-        credential_line=_credential_line_for_saved_summary(provider),
+        credential_line=_credential_line_for_saved_summary(
+            provider, llm_key_in_env_file=llm_api_key_plaintext_for_env is not None
+        ),
     )
     _render_next_steps()
     return 0

--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -467,14 +467,14 @@ def _persist_llm_api_key(env_var: str, value: str) -> Literal["keychain", "env"]
         _console.print(
             f"[{WARNING}]  {GLYPH_WARNING}  OpenSRE could not save your API key to the local system keychain.[/]"
         )
-        for line in get_keyring_setup_instructions(env_var):
-            _console.print(f"[{SECONDARY}]    {line}[/]")
-
-        if sys.stdin.isatty() and not _confirm(
-            "Save the API key to project .env instead? (common on SSH/headless servers)",
-            default=True,
-        ):
-            return None
+        if sys.stdin.isatty():
+            for line in get_keyring_setup_instructions(env_var):
+                _console.print(f"[{SECONDARY}]    {line}[/]")
+            if not _confirm(
+                "Save the API key to project .env instead? (common on SSH/headless servers)",
+                default=True,
+            ):
+                return None
         _console.print(
             f"[{WARNING}]  {GLYPH_WARNING}  Storing {env_var} in project .env with owner-only permissions.[/]"
         )
@@ -2428,8 +2428,6 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         model=model,
         llm_api_key_plaintext=llm_api_key_plaintext_for_env,
     )
-    if llm_api_key_plaintext_for_env and provider.api_key_env:
-        os.environ[provider.api_key_env] = llm_api_key_plaintext_for_env.strip()
 
     _step_header(3, WIZARD_TOTAL_STEPS, "Integrations")
     try:

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -42,6 +42,12 @@ slug: "quickstart"
     opensre onboard
     ```
 
+    On desktop systems, OpenSRE stores LLM API keys in your system keychain. On
+    headless servers where no keychain is available, onboarding can save the
+    active LLM key in the project `.env` file instead; OpenSRE restricts that
+    file to owner-only permissions when the platform supports it. Do not commit
+    `.env`.
+
     <Tabs>
       <Tab title="macOS / Linux">
         <Frame>

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -101,6 +101,32 @@ def test_sync_provider_env_updates_provider_specific_keys(tmp_path, monkeypatch)
     assert "OPENAI_MODEL=gpt-5-mini\n" in content
 
 
+def test_sync_provider_env_writes_llm_api_key_when_plaintext_passed(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "LLM_PROVIDER=openai\nOPENAI_API_KEY=old-openai-key\nGITLAB_ACCESS_TOKEN=legacy-token\n",
+        encoding="utf-8",
+    )
+
+    sync_provider_env(
+        provider=PROVIDER_BY_VALUE["anthropic"],
+        model=PROVIDER_BY_VALUE["anthropic"].default_model,
+        env_path=env_path,
+        llm_api_key_plaintext=" sk-env-fallback ",
+    )
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "LLM_PROVIDER=anthropic\n" in content
+    assert "ANTHROPIC_API_KEY=sk-env-fallback\n" in content
+    assert "OPENAI_API_KEY=" not in content
+    assert "GITLAB_ACCESS_TOKEN=" not in content
+    assert os.environ["ANTHROPIC_API_KEY"] == "sk-env-fallback"
+    if os.name != "nt":
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+
+
 def test_sync_provider_env_appends_to_file_without_final_newline(tmp_path, monkeypatch) -> None:
     monkeypatch.delenv("LLM_PROVIDER", raising=False)
     monkeypatch.delenv("OPENAI_REASONING_MODEL", raising=False)

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -194,6 +194,64 @@ def test_run_wizard_saves_llm_key_to_env_when_keyring_unavailable(
     assert "project .env (ANTHROPIC_API_KEY)" in output
 
 
+def test_run_wizard_saves_llm_key_to_env_without_tty(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "skip"])
+
+    def _mock_select(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(select_responses)
+        return m
+
+    def _mock_password(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = "sk-env-fallback"
+        return m
+
+    env_path = tmp_path / ".env"
+
+    monkeypatch.setattr(flow, "select_prompt", _mock_select)
+    monkeypatch.setattr(flow.questionary, "password", _mock_password)
+    monkeypatch.setattr(flow, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(
+        flow,
+        "save_llm_api_key",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("Secure local credential storage is unavailable on this machine.")
+        ),
+    )
+    monkeypatch.setattr(flow.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(
+        flow,
+        "_confirm",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("non-TTY fallback must not prompt")
+        ),
+    )
+    monkeypatch.setattr(
+        flow,
+        "get_keyring_setup_instructions",
+        lambda _env_var: (_ for _ in ()).throw(
+            AssertionError("non-TTY fallback must not print keyring setup instructions")
+        ),
+    )
+    monkeypatch.setattr(
+        flow,
+        "sync_provider_env",
+        lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
+    )
+
+    exit_code = flow.run_wizard()
+
+    assert exit_code == 0
+    text = env_path.read_text(encoding="utf-8")
+    assert "LLM_PROVIDER=anthropic\n" in text
+    assert "ANTHROPIC_API_KEY=sk-env-fallback\n" in text
+    assert os.environ["ANTHROPIC_API_KEY"] == "sk-env-fallback"
+
+
 def test_persist_llm_api_key_uses_env_fallback_without_tty(monkeypatch) -> None:
     monkeypatch.setattr(
         flow,

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -132,6 +132,8 @@ def test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable(
             "Start a D-Bus shell: dbus-run-session -- sh",
         ),
     )
+    monkeypatch.setattr(flow.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(flow, "_confirm", lambda *_args, **_kwargs: False)
 
     exit_code = flow.run_wizard()
 
@@ -141,6 +143,76 @@ def test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable(
     assert "Install it first: sudo apt update && sudo apt install -y gnome-keyring" in output
     assert "dbus-user-session" in output
     assert "Start a D-Bus shell: dbus-run-session -- sh" in output
+
+
+def test_run_wizard_saves_llm_key_to_env_when_keyring_unavailable(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "skip"])
+
+    def _mock_select(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(select_responses)
+        return m
+
+    def _mock_password(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = "sk-env-fallback"
+        return m
+
+    env_path = tmp_path / ".env"
+
+    monkeypatch.setattr(flow, "select_prompt", _mock_select)
+    monkeypatch.setattr(flow.questionary, "password", _mock_password)
+    monkeypatch.setattr(flow, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(
+        flow,
+        "save_llm_api_key",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("Secure local credential storage is unavailable on this machine.")
+        ),
+    )
+    monkeypatch.setattr(flow.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(flow, "_confirm", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        flow,
+        "sync_provider_env",
+        lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
+    )
+
+    exit_code = flow.run_wizard()
+
+    assert exit_code == 0
+    text = env_path.read_text(encoding="utf-8")
+    assert "LLM_PROVIDER=anthropic\n" in text
+    assert "ANTHROPIC_API_KEY=sk-env-fallback\n" in text
+    assert os.environ["ANTHROPIC_API_KEY"] == "sk-env-fallback"
+    output = capsys.readouterr().out
+    assert "project .env (ANTHROPIC_API_KEY)" in output
+
+
+def test_persist_llm_api_key_uses_env_fallback_without_tty(monkeypatch) -> None:
+    monkeypatch.setattr(
+        flow,
+        "save_llm_api_key",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("Secure local credential storage is unavailable on this machine.")
+        ),
+    )
+    monkeypatch.setattr(flow, "get_keyring_setup_instructions", lambda _env_var: ())
+    monkeypatch.setattr(flow.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(
+        flow,
+        "_confirm",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("non-TTY fallback must not prompt")
+        ),
+    )
+
+    assert flow._persist_llm_api_key("ANTHROPIC_API_KEY", "sk-env-fallback") == "env"
 
 
 def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, capsys) -> None:
@@ -1276,6 +1348,16 @@ def test_credential_line_for_saved_summary_anthropic() -> None:
 
     anthropic = next(p for p in wizard_config.SUPPORTED_PROVIDERS if p.value == "anthropic")
     assert flow._credential_line_for_saved_summary(anthropic) == "system keychain"
+
+
+def test_credential_line_for_saved_summary_anthropic_env_file() -> None:
+    from app.cli.wizard import config as wizard_config
+
+    anthropic = next(p for p in wizard_config.SUPPORTED_PROVIDERS if p.value == "anthropic")
+    assert (
+        flow._credential_line_for_saved_summary(anthropic, llm_key_in_env_file=True)
+        == "project .env (ANTHROPIC_API_KEY)"
+    )
 
 
 def test_credential_line_for_saved_summary_cli_without_factory() -> None:


### PR DESCRIPTION
Fixes #1403 

<!-- Add issue number above -->

#### PR Description -
This PR fixes `opensre onboard` failing on fresh/headless Linux servers when Python keyring has no usable backend.

Changes made:
- Keep system keychain storage as the default for LLM API keys.
- When keychain storage is unavailable:
  - In interactive TTY sessions, ask the user whether to save the active LLM key to the project `.env` file instead.
  - In non-TTY/headless sessions, automatically use the `.env` fallback so onboarding does not hang or abort.
- Restrict the plaintext `.env` fallback to only the active LLM provider key, for example `ANTHROPIC_API_KEY`.
- Preserve existing secret protections for all other sensitive env vars, including stale provider keys and integration tokens.
- Ensure `.env` continues to be written with owner-only permissions where supported.
- Update the onboarding summary to show when credentials are stored in project-level `.env` file.
- Add tests for:
  - keyring unavailable + fallback accepted
  - keyring unavailable + fallback declined
  - non-TTY fallback behavior
  - active provider API key `.env` persistence
  - normal onboarding still keeping API keys out of `.env`
- Update Quickstart docs to mention the headless/server fallback.

### Demo/Screenshot for feature changes and bug fixes - 
5 tests passed:
<img width="793" height="579" alt="image" src="https://github.com/user-attachments/assets/6e3e14bf-f3c9-4d10-9496-3cd4f8cd205d" />

<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [X] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [X] I have reviewed every single line of the AI-generated code
- [X] I can explain the purpose and logic of each function/component I added
- [X] I have tested edge cases and understand how the code handles them
- [X] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->
This PR solves the onboarding failure on headless Linux/EC2 instances where no system keychain is available. Previously, entering an LLM API key caused onboarding to abort when keyring.set_password() failed. Now, OpenSRE still prefers secure keychain storage, but falls back to project .env only when keychain storage is unavailable.

I considered two main approaches:

1. Always write LLM keys to .env: rejected because it weakens the default security model.
2. Require users to install/configure GNOME Keyring or export env vars manually: rejected because it keeps Quickstart broken on common server setups.

The chosen implementation keeps the secure default while adding a practical fallback for headless environments.

Key implementation points:

- _persist_llm_api_key() now returns whether the key was stored in the keychain, should be stored in .env, or should abort.
- sync_provider_env() accepts an optional llm_api_key_plaintext only for the active provider fallback case.
- The env writer uses an explicit allowlist so only the active LLM API key can be written as plaintext. Other sensitive keys remain stripped or rejected.
- The wizard updates the process environment after fallback so the current run can resolve the key.
- Tests cover success, abort, non-TTY behavior, stale secret removal, and the normal keychain path.
---

## Checklist before requesting a review
- [X] I have added proper PR title and linked to the issue
- [X] I have performed a self-review of my code
- [X] **I can explain the purpose of every function, class, and logic block I added**
- [X] I understand why my changes work and have tested them thoroughly
- [X] I have considered potential edge cases and how my code handles them
- [X] If it is a core feature, I have added thorough tests
- [X] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
