### PR TITLE
Add minimal embeddings client service

### DIFF
--- a/app/services/embeddings_client.py
+++ b/app/services/embeddings_client.py
@@ -1,0 +1,280 @@
+"""Provider-backed embeddings clients for retrieval-style features."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from collections.abc import Callable
+from typing import Any, Protocol
+
+import httpx
+from openai import OpenAI
+
+from app.config import DEFAULT_OLLAMA_HOST, get_configured_llm_provider, load_env
+from app.llm_credentials import resolve_llm_api_key
+
+logger = logging.getLogger(__name__)
+
+EMBEDDINGS_PROVIDER_ENV = "OPENSRE_EMBEDDINGS_PROVIDER"
+EMBEDDINGS_MODEL_ENV = "OPENSRE_EMBEDDINGS_MODEL"
+OPENAI_EMBEDDINGS_MODEL = "text-embedding-3-small"
+OPENAI_EMBEDDINGS_DIM = 1536
+OLLAMA_EMBEDDINGS_MODEL = "nomic-embed-text"
+OLLAMA_EMBEDDINGS_DIM = 768
+VOYAGE_EMBEDDINGS_MODEL = "voyage-3-lite"
+VOYAGE_EMBEDDINGS_DIM = 512
+
+
+class EmbeddingsClient(Protocol):
+    """Minimal synchronous embeddings interface used by retrieval callers."""
+
+    @property
+    def model_name(self) -> str:
+        """Embedding model identifier used by this client."""
+        ...
+
+    @property
+    def dim(self) -> int:
+        """Embedding vector dimension, or the last observed dimension."""
+        ...
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of input strings in input order."""
+        ...
+
+
+class _NoOpEmbeddingsClient:
+    """Deterministic local embeddings for tests and offline fallback paths."""
+
+    def __init__(self, *, dim: int = 16, model_name: str = "noop-hash-embedding") -> None:
+        if dim <= 0:
+            raise ValueError("dim must be greater than zero")
+        self._dim = dim
+        self._model_name = model_name
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [_hash_embedding(text, self._dim) for text in texts]
+
+
+def _hash_embedding(text: str, dim: int) -> list[float]:
+    values: list[float] = []
+    counter = 0
+    payload = text.encode("utf-8")
+    while len(values) < dim:
+        digest = hashlib.sha256(counter.to_bytes(4, "big") + payload).digest()
+        values.extend((byte / 127.5) - 1.0 for byte in digest)
+        counter += 1
+    return values[:dim]
+
+
+NoOpEmbeddingsClient = _NoOpEmbeddingsClient
+
+
+OpenAIClientFactory = Callable[[str, str | None], Any]
+
+
+class OpenAIEmbeddingsClient:
+    """Embeddings client for OpenAI and OpenAI-compatible APIs."""
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        api_key_env: str = "OPENAI_API_KEY",
+        api_key_default: str = "",
+        base_url: str | None = None,
+        dim: int = 0,
+        client_factory: OpenAIClientFactory | None = None,
+    ) -> None:
+        self._model_name = model
+        self._api_key_env = api_key_env
+        self._api_key_default = api_key_default
+        self._base_url = base_url
+        self._dim = dim
+        self._client_factory = client_factory or _build_openai_client
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        api_key = resolve_llm_api_key(self._api_key_env) or self._api_key_default
+        if not api_key:
+            raise RuntimeError(
+                f"Missing {self._api_key_env}. Set it in your environment, .env, "
+                "or secure local keychain before running embeddings steps."
+            )
+
+        client: Any | None = None
+        vectors: list[list[float]]
+        try:
+            client = self._client_factory(api_key, self._base_url)
+            response = client.embeddings.create(model=self._model_name, input=texts)
+            vectors = [list(item.embedding) for item in response.data]
+        except Exception as exc:
+            logger.exception("OpenAI-compatible embeddings request failed.")
+            raise RuntimeError(
+                f"Embeddings request failed for model {self._model_name!r}."
+            ) from exc
+        finally:
+            _close_client(client)
+
+        self._record_dim(vectors, expected_count=len(texts))
+        return vectors
+
+    def _record_dim(self, vectors: list[list[float]], *, expected_count: int) -> None:
+        _ensure_vector_count(vectors, expected_count=expected_count)
+        if vectors:
+            self._dim = len(vectors[0])
+
+
+def _build_openai_client(api_key: str, base_url: str | None) -> OpenAI:
+    return OpenAI(api_key=api_key, base_url=base_url, timeout=30.0)
+
+
+def _close_client(client: Any | None) -> None:
+    close = getattr(client, "close", None)
+    if callable(close):
+        close()
+
+
+HttpClientFactory = Callable[[], Any]
+
+
+class VoyageEmbeddingsClient:
+    """Embeddings client for Voyage AI's HTTP API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str,
+        api_key_env: str = "VOYAGE_API_KEY",
+        dim: int = VOYAGE_EMBEDDINGS_DIM,
+        http_client_factory: HttpClientFactory | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._api_key_env = api_key_env
+        self._model_name = model
+        self._dim = dim
+        self._http_client_factory = http_client_factory or _build_http_client
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        api_key = resolve_llm_api_key(self._api_key_env) or self._api_key
+        if not api_key:
+            raise RuntimeError(
+                f"Missing {self._api_key_env}. Set it in your environment, .env, "
+                "or secure local keychain before running embeddings steps."
+            )
+
+        client: Any | None = None
+        vectors: list[list[float]]
+        try:
+            client = self._http_client_factory()
+            response = client.post(
+                "https://api.voyageai.com/v1/embeddings",
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={"model": self._model_name, "input": texts},
+            )
+            response.raise_for_status()
+            payload = response.json()
+            vectors = [list(item["embedding"]) for item in payload.get("data", [])]
+        except Exception as exc:
+            logger.exception("Voyage embeddings request failed.")
+            raise RuntimeError(
+                f"Embeddings request failed for model {self._model_name!r}."
+            ) from exc
+        finally:
+            _close_client(client)
+
+        _ensure_vector_count(vectors, expected_count=len(texts))
+        if vectors:
+            self._dim = len(vectors[0])
+        return vectors
+
+
+def _build_http_client() -> httpx.Client:
+    return httpx.Client(timeout=30.0)
+
+
+def _ensure_vector_count(vectors: list[list[float]], *, expected_count: int) -> None:
+    if len(vectors) != expected_count:
+        raise RuntimeError(
+            f"Embeddings response returned {len(vectors)} vectors for {expected_count} input texts."
+        )
+
+
+def get_embeddings_client() -> EmbeddingsClient | None:
+    """Return an embeddings client for the active provider, or ``None`` when unavailable."""
+
+    provider = _get_configured_embeddings_provider()
+    model_override = os.getenv(EMBEDDINGS_MODEL_ENV, "").strip()
+    if provider == "openai":
+        if not resolve_llm_api_key("OPENAI_API_KEY"):
+            logger.info("OpenAI embeddings disabled because OPENAI_API_KEY is not configured.")
+            return None
+        return OpenAIEmbeddingsClient(
+            model=model_override or OPENAI_EMBEDDINGS_MODEL,
+            dim=OPENAI_EMBEDDINGS_DIM,
+        )
+    if provider == "voyage":
+        api_key = resolve_llm_api_key("VOYAGE_API_KEY")
+        if not api_key:
+            logger.info("Voyage embeddings disabled because VOYAGE_API_KEY is not configured.")
+            return None
+        return VoyageEmbeddingsClient(
+            api_key=api_key,
+            model=model_override or VOYAGE_EMBEDDINGS_MODEL,
+            dim=VOYAGE_EMBEDDINGS_DIM,
+        )
+    if provider == "ollama":
+        host = os.getenv("OLLAMA_HOST", DEFAULT_OLLAMA_HOST).strip() or DEFAULT_OLLAMA_HOST
+        return OpenAIEmbeddingsClient(
+            model=model_override or OLLAMA_EMBEDDINGS_MODEL,
+            api_key_env="OLLAMA_API_KEY",
+            api_key_default="ollama",
+            base_url=f"{host.rstrip('/')}/v1",
+            dim=OLLAMA_EMBEDDINGS_DIM,
+        )
+    logger.info("No embeddings client is available for embeddings provider %s.", provider)
+    return None
+
+
+def _get_configured_embeddings_provider() -> str:
+    load_env(override=False)
+    provider = os.getenv(EMBEDDINGS_PROVIDER_ENV, "").strip().lower()
+    return provider or get_configured_llm_provider()
+
+
+__all__ = [
+    "EmbeddingsClient",
+    "NoOpEmbeddingsClient",
+    "OpenAIEmbeddingsClient",
+    "VoyageEmbeddingsClient",
+    "get_embeddings_client",
+]

--- a/app/services/embeddings_client.py
+++ b/app/services/embeddings_client.py
@@ -185,7 +185,7 @@ class VoyageEmbeddingsClient:
     def embed(self, texts: list[str]) -> list[list[float]]:
         if not texts:
             return []
-        api_key = resolve_llm_api_key(self._api_key_env) or self._api_key
+        api_key = self._api_key or resolve_llm_api_key(self._api_key_env)
         if not api_key:
             raise RuntimeError(
                 f"Missing {self._api_key_env}. Set it in your environment, .env, "
@@ -261,7 +261,7 @@ def get_embeddings_client() -> EmbeddingsClient | None:
             base_url=f"{host.rstrip('/')}/v1",
             dim=OLLAMA_EMBEDDINGS_DIM,
         )
-    logger.info("No embeddings client is available for embeddings provider %s.", provider)
+    logger.debug("No embeddings client is available for embeddings provider %s.", provider)
     return None
 
 

--- a/tests/services/test_embeddings_client.py
+++ b/tests/services/test_embeddings_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from typing import Any
 
@@ -27,6 +28,10 @@ class _FakeOpenAIEmbeddings:
 class _FakeOpenAIClient:
     def __init__(self, vectors: list[list[float]]) -> None:
         self.embeddings = _FakeOpenAIEmbeddings(vectors)
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class _FakeVoyageResponse:
@@ -61,6 +66,12 @@ def test_noop_embeddings_are_deterministic_and_batched() -> None:
     assert first[0] != first[1]
     assert len(first) == 3
     assert all(len(vector) == client.dim for vector in first)
+
+
+@pytest.mark.parametrize("dim", [0, -1])
+def test_noop_embeddings_reject_non_positive_dim(dim: int) -> None:
+    with pytest.raises(ValueError, match="dim must be greater than zero"):
+        NoOpEmbeddingsClient(dim=dim)
 
 
 def test_factory_returns_none_for_missing_openai_credentials(
@@ -125,6 +136,18 @@ def test_factory_selects_ollama_without_credentials(monkeypatch: pytest.MonkeyPa
     assert client.dim == 768
 
 
+def test_factory_logs_unsupported_provider_at_debug(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.delenv("OPENSRE_EMBEDDINGS_PROVIDER", raising=False)
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+    caplog.set_level(logging.INFO, logger="app.services.embeddings_client")
+
+    assert get_embeddings_client() is None
+    assert "No embeddings client is available" not in caplog.text
+
+
 def test_openai_embed_sends_batch_and_tracks_response_dim(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -142,9 +165,45 @@ def test_openai_embed_sends_batch_and_tracks_response_dim(
 
     assert vectors == [[0.1, 0.2], [0.3, 0.4]]
     assert client.dim == 2
+    assert fake_client.closed is True
     assert fake_client.embeddings.calls == [
         {"model": "custom-embedding", "input": ["alpha", "beta"]},
     ]
+
+
+def test_embedding_clients_return_empty_batch_without_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.services.embeddings_client.resolve_llm_api_key", lambda _env: "")
+
+    openai_client = OpenAIEmbeddingsClient(
+        model="custom-embedding",
+        client_factory=lambda _api_key, _base_url: pytest.fail("client should not be built"),
+    )
+    voyage_client = VoyageEmbeddingsClient(
+        api_key="",
+        model="voyage-test",
+        http_client_factory=lambda: pytest.fail("client should not be built"),
+    )
+
+    assert openai_client.embed([]) == []
+    assert voyage_client.embed([]) == []
+
+
+def test_openai_embed_rejects_mismatched_vector_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_client = _FakeOpenAIClient([[0.1, 0.2]])
+    monkeypatch.setattr(
+        "app.services.embeddings_client.resolve_llm_api_key", lambda _env: "sk-test"
+    )
+    client = OpenAIEmbeddingsClient(
+        model="custom-embedding",
+        client_factory=lambda _api_key, _base_url: fake_client,
+    )
+
+    with pytest.raises(RuntimeError, match="returned 1 vectors for 2 input texts"):
+        client.embed(["alpha", "beta"])
 
 
 def test_voyage_embed_sends_batch_and_tracks_response_dim(
@@ -171,3 +230,20 @@ def test_voyage_embed_sends_batch_and_tracks_response_dim(
             "json": {"model": "voyage-test", "input": ["alpha", "beta"]},
         }
     ]
+
+
+def test_voyage_embed_prefers_constructor_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_http = _FakeHttpClient([[0.1]])
+    monkeypatch.setattr(
+        "app.services.embeddings_client.resolve_llm_api_key", lambda _env: "env-key"
+    )
+    client = VoyageEmbeddingsClient(
+        api_key="explicit-key",
+        model="voyage-test",
+        http_client_factory=lambda: fake_http,
+    )
+
+    assert client.embed(["alpha"]) == [[0.1]]
+    assert fake_http.calls[0]["headers"] == {"Authorization": "Bearer explicit-key"}

--- a/tests/services/test_embeddings_client.py
+++ b/tests/services/test_embeddings_client.py
@@ -49,10 +49,21 @@ class _FakeHttpClient:
     def __init__(self, vectors: list[list[float]]) -> None:
         self._response = _FakeVoyageResponse(vectors)
         self.calls: list[dict[str, Any]] = []
+        self.closed = False
 
     def post(self, url: str, **kwargs: Any) -> _FakeVoyageResponse:
         self.calls.append({"url": url, **kwargs})
         return self._response
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _skip_env_load(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _load_env(*, override: bool) -> None:
+        assert override is False
+
+    monkeypatch.setattr("app.services.embeddings_client.load_env", _load_env)
 
 
 def test_noop_embeddings_are_deterministic_and_batched() -> None:
@@ -77,6 +88,8 @@ def test_noop_embeddings_reject_non_positive_dim(dim: int) -> None:
 def test_factory_returns_none_for_missing_openai_credentials(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _skip_env_load(monkeypatch)
+    monkeypatch.delenv("OPENSRE_EMBEDDINGS_PROVIDER", raising=False)
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setattr("app.services.embeddings_client.resolve_llm_api_key", lambda _env: "")
@@ -85,6 +98,8 @@ def test_factory_returns_none_for_missing_openai_credentials(
 
 
 def test_factory_selects_openai_with_model_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    _skip_env_load(monkeypatch)
+    monkeypatch.delenv("OPENSRE_EMBEDDINGS_PROVIDER", raising=False)
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.setenv("OPENSRE_EMBEDDINGS_MODEL", "text-embedding-test")
     monkeypatch.setattr(
@@ -124,6 +139,8 @@ def test_factory_loads_env_and_selects_voyage_override(
 
 
 def test_factory_selects_ollama_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    _skip_env_load(monkeypatch)
+    monkeypatch.delenv("OPENSRE_EMBEDDINGS_PROVIDER", raising=False)
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
     monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
     monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
@@ -140,6 +157,7 @@ def test_factory_logs_unsupported_provider_at_debug(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    _skip_env_load(monkeypatch)
     monkeypatch.delenv("OPENSRE_EMBEDDINGS_PROVIDER", raising=False)
     monkeypatch.setenv("LLM_PROVIDER", "anthropic")
     caplog.set_level(logging.INFO, logger="app.services.embeddings_client")
@@ -223,6 +241,7 @@ def test_voyage_embed_sends_batch_and_tracks_response_dim(
 
     assert vectors == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
     assert client.dim == 3
+    assert fake_http.closed is True
     assert fake_http.calls == [
         {
             "url": "https://api.voyageai.com/v1/embeddings",

--- a/tests/services/test_embeddings_client.py
+++ b/tests/services/test_embeddings_client.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.services.embeddings_client import (
+    EmbeddingsClient,
+    NoOpEmbeddingsClient,
+    OpenAIEmbeddingsClient,
+    VoyageEmbeddingsClient,
+    get_embeddings_client,
+)
+
+
+class _FakeOpenAIEmbeddings:
+    def __init__(self, vectors: list[list[float]]) -> None:
+        self._vectors = vectors
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return SimpleNamespace(data=[SimpleNamespace(embedding=vector) for vector in self._vectors])
+
+
+class _FakeOpenAIClient:
+    def __init__(self, vectors: list[list[float]]) -> None:
+        self.embeddings = _FakeOpenAIEmbeddings(vectors)
+
+
+class _FakeVoyageResponse:
+    def __init__(self, vectors: list[list[float]]) -> None:
+        self._vectors = vectors
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return {"data": [{"embedding": vector} for vector in self._vectors]}
+
+
+class _FakeHttpClient:
+    def __init__(self, vectors: list[list[float]]) -> None:
+        self._response = _FakeVoyageResponse(vectors)
+        self.calls: list[dict[str, Any]] = []
+
+    def post(self, url: str, **kwargs: Any) -> _FakeVoyageResponse:
+        self.calls.append({"url": url, **kwargs})
+        return self._response
+
+
+def test_noop_embeddings_are_deterministic_and_batched() -> None:
+    client: EmbeddingsClient = NoOpEmbeddingsClient(dim=6)
+
+    first = client.embed(["same", "different", "same"])
+    second = client.embed(["same", "different", "same"])
+
+    assert first == second
+    assert first[0] == first[2]
+    assert first[0] != first[1]
+    assert len(first) == 3
+    assert all(len(vector) == client.dim for vector in first)
+
+
+def test_factory_returns_none_for_missing_openai_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr("app.services.embeddings_client.resolve_llm_api_key", lambda _env: "")
+
+    assert get_embeddings_client() is None
+
+
+def test_factory_selects_openai_with_model_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("OPENSRE_EMBEDDINGS_MODEL", "text-embedding-test")
+    monkeypatch.setattr(
+        "app.services.embeddings_client.resolve_llm_api_key", lambda _env: "sk-test"
+    )
+
+    client = get_embeddings_client()
+
+    assert isinstance(client, OpenAIEmbeddingsClient)
+    assert client.model_name == "text-embedding-test"
+    assert client.dim == 1536
+
+
+def test_factory_loads_env_and_selects_voyage_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.delenv("OPENSRE_EMBEDDINGS_PROVIDER", raising=False)
+    monkeypatch.delenv("OPENSRE_EMBEDDINGS_MODEL", raising=False)
+
+    def _load_env(*, override: bool) -> None:
+        assert override is False
+        monkeypatch.setenv("OPENSRE_EMBEDDINGS_PROVIDER", "voyage")
+        monkeypatch.setenv("OPENSRE_EMBEDDINGS_MODEL", "voyage-env-model")
+
+    monkeypatch.setattr("app.services.embeddings_client.load_env", _load_env)
+    monkeypatch.setattr(
+        "app.services.embeddings_client.resolve_llm_api_key",
+        lambda env: "pa-test" if env == "VOYAGE_API_KEY" else "sk-test",
+    )
+
+    client = get_embeddings_client()
+
+    assert isinstance(client, VoyageEmbeddingsClient)
+    assert client.model_name == "voyage-env-model"
+    assert client.dim == 512
+
+
+def test_factory_selects_ollama_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+    monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
+    monkeypatch.setattr("app.services.embeddings_client.resolve_llm_api_key", lambda _env: "")
+
+    client = get_embeddings_client()
+
+    assert isinstance(client, OpenAIEmbeddingsClient)
+    assert client.model_name == "nomic-embed-text"
+    assert client.dim == 768
+
+
+def test_openai_embed_sends_batch_and_tracks_response_dim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_client = _FakeOpenAIClient([[0.1, 0.2], [0.3, 0.4]])
+    monkeypatch.setattr(
+        "app.services.embeddings_client.resolve_llm_api_key", lambda _env: "sk-test"
+    )
+
+    client = OpenAIEmbeddingsClient(
+        model="custom-embedding",
+        client_factory=lambda _api_key, _base_url: fake_client,
+    )
+
+    vectors = client.embed(["alpha", "beta"])
+
+    assert vectors == [[0.1, 0.2], [0.3, 0.4]]
+    assert client.dim == 2
+    assert fake_client.embeddings.calls == [
+        {"model": "custom-embedding", "input": ["alpha", "beta"]},
+    ]
+
+
+def test_voyage_embed_sends_batch_and_tracks_response_dim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_http = _FakeHttpClient([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+    monkeypatch.setattr(
+        "app.services.embeddings_client.resolve_llm_api_key", lambda _env: "pa-test"
+    )
+    client = VoyageEmbeddingsClient(
+        api_key="pa-test",
+        model="voyage-test",
+        http_client_factory=lambda: fake_http,
+    )
+
+    vectors = client.embed(["alpha", "beta"])
+
+    assert vectors == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+    assert client.dim == 3
+    assert fake_http.calls == [
+        {
+            "url": "https://api.voyageai.com/v1/embeddings",
+            "headers": {"Authorization": "Bearer pa-test"},
+            "json": {"model": "voyage-test", "input": ["alpha", "beta"]},
+        }
+    ]


### PR DESCRIPTION
## Summary
- Add `app/services/embeddings_client.py` with a minimal `EmbeddingsClient` protocol, deterministic `NoOpEmbeddingsClient`, and provider-backed clients for OpenAI-compatible APIs and Voyage.
- Add `get_embeddings_client()` provider selection for OpenAI, Voyage, and Ollama using existing `httpx` / `openai` dependencies.
- Support `OPENSRE_EMBEDDINGS_PROVIDER` and `OPENSRE_EMBEDDINGS_MODEL` overrides while falling back to the existing LLM provider config.

## Scope
- No runtime consumer wiring.
- No new dependencies.
- No docs changes because the new service has no user-facing command or integration path yet.

Closes #1444.

## Review response
- Lower unsupported-provider fallback logging from `info` to `debug`.
- Prefer the explicit Voyage constructor API key over ambient env/keyring credentials.
- Add focused tests for those behaviors plus the existing cleanup, empty-input, vector-count, and no-op dimension paths flagged in review.
- Verify Voyage HTTP-client cleanup and isolate factory tests from ambient `OPENSRE_EMBEDDINGS_PROVIDER` / `.env` provider state.

## Tests
Local Windows shell does not have `make`, so I ran the Makefile-equivalent `uv run` commands:

- `uv run python -m pytest tests/services/test_embeddings_client.py -q` - 13 passed
- `$env:OPENSRE_EMBEDDINGS_PROVIDER='voyage'; uv run python -m pytest tests/services/test_embeddings_client.py::test_factory_selects_openai_with_model_override tests/services/test_embeddings_client.py::test_factory_selects_ollama_without_credentials -q` - 2 passed
- `uv run python -m ruff check app/ tests/`
- `uv run python -m ruff format --check app/ tests/`
- `uv run python -m mypy app/`
- `uv run python infra/ci/run_test_scope.py --base main` - 2554 passed