### PR TITLE
refactor(cli): integrate token accounting into session management

### DIFF
--- a/app/cli/interactive_shell/chat/cli_agent.py
+++ b/app/cli/interactive_shell/chat/cli_agent.py
@@ -32,6 +32,7 @@ from app.cli.interactive_shell.runtime import ReplSession
 from app.cli.interactive_shell.runtime.session import (
     SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST,
 )
+from app.cli.interactive_shell.token_accounting import build_llm_run_info
 from app.cli.interactive_shell.ui import (
     BOLD_BRAND,
     DIM,
@@ -484,11 +485,12 @@ def answer_cli_agent(
             chunks=iter((deterministic_response,)),
         )
         _record_cli_agent_turn(session, message, deterministic_response)
-        return LlmRunInfo(
+        return build_llm_run_info(
+            session=session,
+            prompt=message,
+            response_text=deterministic_response,
             model="deterministic_command_selection",
             provider="local",
-            latency_ms=0,
-            response_text=deterministic_response,
         )
 
     try:
@@ -560,11 +562,12 @@ def answer_cli_agent(
         console.print(f"[{ERROR}]assistant failed:[/] {escape(str(exc))}")
         return None
 
-    run_info = LlmRunInfo(
-        model=_resolve_model_name(client),
-        provider=_resolve_provider_name(client),
-        latency_ms=int((time.monotonic() - started) * 1000),
+    run_info = build_llm_run_info(
+        session=session,
+        prompt=prompt,
         response_text=text_str,
+        started=started,
+        client=client,
     )
 
     actions = _parse_action_plan(text_str)
@@ -590,27 +593,6 @@ def answer_cli_agent(
             console.print(Markdown(text_str, code_theme="ansi_dark"))
         console.print()
     return run_info
-
-
-def _resolve_model_name(client: object) -> str | None:
-    value = getattr(client, "_model", None)
-    return value if isinstance(value, str) and value else None
-
-
-def _resolve_provider_name(client: object) -> str | None:
-    provider_label = getattr(client, "_provider_label", None)
-    if isinstance(provider_label, str) and provider_label:
-        return provider_label.strip().lower().replace(" ", "_")
-    name = type(client).__name__.lower()
-    if "openai" in name:
-        return "openai"
-    if "bedrock" in name:
-        return "bedrock"
-    if "cli" in name:
-        return "cli"
-    if "anthropic" in name or "llmclient" in name:
-        return "anthropic"
-    return None
 
 
 __all__ = ["answer_cli_agent"]

--- a/app/cli/interactive_shell/chat/cli_agent.py
+++ b/app/cli/interactive_shell/chat/cli_agent.py
@@ -485,12 +485,11 @@ def answer_cli_agent(
             chunks=iter((deterministic_response,)),
         )
         _record_cli_agent_turn(session, message, deterministic_response)
-        return build_llm_run_info(
-            session=session,
-            prompt=message,
-            response_text=deterministic_response,
+        return LlmRunInfo(
             model="deterministic_command_selection",
             provider="local",
+            latency_ms=0,
+            response_text=deterministic_response,
         )
 
     try:

--- a/app/cli/interactive_shell/chat/cli_help.py
+++ b/app/cli/interactive_shell/chat/cli_help.py
@@ -28,6 +28,7 @@ from app.cli.interactive_shell.references.grounding_diagnostics import (
     log_grounding_cache_diagnostics,
 )
 from app.cli.interactive_shell.runtime import ReplSession
+from app.cli.interactive_shell.token_accounting import build_llm_run_info
 from app.cli.interactive_shell.ui import DIM, ERROR, STREAM_LABEL_ASSISTANT, stream_to_console
 from app.cli.support.exception_reporting import report_exception
 
@@ -81,7 +82,7 @@ def _build_grounded_prompt(question: str, cli_reference: str, docs_reference: st
 
 def answer_cli_help(
     question: str,
-    _session: ReplSession,
+    session: ReplSession,
     console: Console,
 ) -> LlmRunInfo | None:
     """Run one turn of the documentation-aware procedural assistant.
@@ -92,8 +93,8 @@ def answer_cli_help(
     history (stateless across turns) so it never interferes with follow-up
     routing on a prior investigation.
 
-    ``_session`` is accepted for API symmetry with :func:`answer_cli_agent` and
-    input routing; this path does not read session state today.
+    ``session`` is accepted for API symmetry with :func:`answer_cli_agent` and
+    input routing; this path records estimated token usage on the session.
     """
     try:
         from app.services.llm_client import get_llm_for_reasoning
@@ -122,33 +123,13 @@ def answer_cli_help(
         report_exception(exc, context="interactive_shell.cli_help.stream")
         console.print(f"[{ERROR}]assistant failed:[/] {escape(str(exc))}")
         return None
-    return LlmRunInfo(
-        model=_resolve_model_name(client),
-        provider=_resolve_provider_name(client),
-        latency_ms=int((time.monotonic() - started) * 1000),
+    return build_llm_run_info(
+        session=session,
+        prompt=prompt,
         response_text=response_text,
+        started=started,
+        client=client,
     )
-
-
-def _resolve_model_name(client: object) -> str | None:
-    value = getattr(client, "_model", None)
-    return value if isinstance(value, str) and value else None
-
-
-def _resolve_provider_name(client: object) -> str | None:
-    provider_label = getattr(client, "_provider_label", None)
-    if isinstance(provider_label, str) and provider_label:
-        return provider_label.strip().lower().replace(" ", "_")
-    name = type(client).__name__.lower()
-    if "openai" in name:
-        return "openai"
-    if "bedrock" in name:
-        return "bedrock"
-    if "cli" in name:
-        return "cli"
-    if "anthropic" in name or "llmclient" in name:
-        return "anthropic"
-    return None
 
 
 __all__ = ["answer_cli_help"]

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -15,6 +15,7 @@ from app.cli.interactive_shell.command_registry.types import (
     SlashCommand,
 )
 from app.cli.interactive_shell.runtime import ReplSession
+from app.cli.interactive_shell.token_accounting import format_token_total
 from app.cli.interactive_shell.ui import (
     BOLD_BRAND,
     DIM,
@@ -138,18 +139,22 @@ def _cmd_status(session: ReplSession, console: Console, _args: list[str]) -> boo
 
 
 def _cmd_cost(session: ReplSession, console: Console, _args: list[str]) -> bool:
-    table = repl_table(title="Session cost\n", title_style=BOLD_BRAND, show_header=False)
+    title = "Session cost"
+    if session.token_usage_has_estimates:
+        title = "Session cost (includes estimates)"
+    table = repl_table(title=f"{title}\n", title_style=BOLD_BRAND, show_header=False)
     table.add_column("key", style="bold")
     table.add_column("value")
-    table.add_row("interactions", str(len(session.history)))
+    table.add_row("history entries", str(len(session.history)))
+    if session.llm_call_count:
+        table.add_row("llm calls", str(session.llm_call_count))
 
     if session.token_usage:
-        inp = session.token_usage.get("input", 0)
-        out = session.token_usage.get("output", 0)
-        table.add_row("input tokens", f"{inp:,}")
-        table.add_row("output tokens", f"{out:,}")
+        for direction in ("input", "output"):
+            label, value = format_token_total(session, direction=direction)
+            table.add_row(label, value)
     else:
-        table.add_row("token usage", f"[{DIM}]not available (not wired yet)[/]")
+        table.add_row("token usage", f"[{DIM}]no LLM usage recorded yet[/]")
 
     print_repl_table(console, table)
     return True

--- a/app/cli/interactive_shell/prompting/follow_up.py
+++ b/app/cli/interactive_shell/prompting/follow_up.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.markup import escape
 
 from app.cli.interactive_shell.prompt_logging import LlmRunInfo
+from app.cli.interactive_shell.token_accounting import build_llm_run_info
 from app.cli.interactive_shell.ui import DIM, ERROR, STREAM_LABEL_ANSWER, WARNING, stream_to_console
 from app.cli.support.exception_reporting import report_exception
 
@@ -121,33 +122,13 @@ def answer_follow_up(
         report_exception(exc, context="interactive_shell.follow_up.stream")
         console.print(f"[{ERROR}]follow-up failed:[/] {escape(str(exc))}")
         return None
-    return LlmRunInfo(
-        model=_resolve_model_name(client),
-        provider=_resolve_provider_name(client),
-        latency_ms=int((time.monotonic() - started) * 1000),
+    return build_llm_run_info(
+        session=session,
+        prompt=prompt,
         response_text=response_text,
+        started=started,
+        client=client,
     )
-
-
-def _resolve_model_name(client: object) -> str | None:
-    value = getattr(client, "_model", None)
-    return value if isinstance(value, str) and value else None
-
-
-def _resolve_provider_name(client: object) -> str | None:
-    provider_label = getattr(client, "_provider_label", None)
-    if isinstance(provider_label, str) and provider_label:
-        return provider_label.strip().lower().replace(" ", "_")
-    name = type(client).__name__.lower()
-    if "openai" in name:
-        return "openai"
-    if "bedrock" in name:
-        return "bedrock"
-    if "cli" in name:
-        return "cli"
-    if "anthropic" in name or "llmclient" in name:
-        return "anthropic"
-    return None
 
 
 __all__ = ["answer_follow_up"]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/llm_client.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/llm_client.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from app.cli.interactive_shell.token_accounting import record_invoke_response
+
 from .constants import _OPENAI_STYLE_PROVIDERS, _USER_TEMPLATE
 from .prompting import _system_prompt
 
@@ -50,7 +52,7 @@ def _call_llm(sanitised_text: str, session: Any) -> str | None:
     try:
         client = get_llm_for_classification().bind_tools(_tool_specs_for_provider(session))
         response = client.invoke(prompt)
-        return response.content.strip()
+        return record_invoke_response(session, prompt=prompt, response=response)
     except Exception as exc:
         logger.debug(
             "llm_action_planner: LLM call failed (%s): %s",

--- a/app/cli/interactive_shell/runtime/session.py
+++ b/app/cli/interactive_shell/runtime/session.py
@@ -105,7 +105,14 @@ class ReplSession:
     """Session-scoped reasoning effort preference for REPL-driven LLM calls."""
 
     token_usage: dict[str, int] = field(default_factory=dict)
-    """Accumulated token counts: {"input": N, "output": N}. Populated when available."""
+    """Accumulated token counts.
+
+    Totals: ``input``, ``output``. Breakdown: ``input_measured``,
+    ``output_measured``, ``input_estimated``, ``output_estimated``.
+    """
+
+    llm_call_count: int = 0
+    """Number of LLM calls accumulated into ``token_usage`` (for ``/cost``)."""
 
     cli_agent_messages: list[tuple[str, str]] = field(default_factory=list)
     """Assistant conversation history: alternating (\"user\"|\"assistant\", text)."""
@@ -198,6 +205,30 @@ class ReplSession:
             time.sleep(0.06)
         self.last_synthetic_observation_path = None
 
+    @property
+    def token_usage_has_estimates(self) -> bool:
+        usage = self.token_usage
+        return bool(usage.get("input_estimated") or usage.get("output_estimated"))
+
+    def record_token_usage(
+        self,
+        *,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        estimated: bool = False,
+    ) -> None:
+        """Accumulate token counts for ``/cost`` (input/output keys)."""
+        if not input_tokens and not output_tokens:
+            return
+        suffix = "estimated" if estimated else "measured"
+        for direction, count in (("input", input_tokens), ("output", output_tokens)):
+            if not count:
+                continue
+            self.token_usage[direction] = self.token_usage.get(direction, 0) + count
+            bucket = f"{direction}_{suffix}"
+            self.token_usage[bucket] = self.token_usage.get(bucket, 0) + count
+        self.llm_call_count += 1
+
     def record(self, kind: str, text: str, *, ok: bool = True) -> None:
         """Append an entry to the session history.
 
@@ -265,6 +296,7 @@ class ReplSession:
         self.available_capabilities.clear()
         self.accumulated_context.clear()
         self.token_usage.clear()
+        self.llm_call_count = 0
         self.cli_agent_messages.clear()
         self.incoming_alerts.clear()
         # Keep persisted cross-session task history on disk intact.

--- a/app/cli/interactive_shell/token_accounting.py
+++ b/app/cli/interactive_shell/token_accounting.py
@@ -1,0 +1,132 @@
+"""Session-scoped token accounting and LLM run metadata for the interactive shell."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from app.cli.interactive_shell.prompt_logging import LlmRunInfo
+from app.cli.interactive_shell.ui.streaming import _CHARS_PER_TOKEN
+
+if TYPE_CHECKING:
+    from app.cli.interactive_shell.runtime.session import ReplSession
+    from app.services.llm_client import LLMResponse
+
+
+def estimate_tokens(text: str) -> int:
+    """Approximate token count from character length (matches streaming UI)."""
+    return len(text) // _CHARS_PER_TOKEN
+
+
+def resolve_model_name(client: object) -> str | None:
+    value = getattr(client, "_model", None)
+    return value if isinstance(value, str) and value else None
+
+
+def resolve_provider_name(client: object) -> str | None:
+    provider_label = getattr(client, "_provider_label", None)
+    if isinstance(provider_label, str) and provider_label:
+        return provider_label.strip().lower().replace(" ", "_")
+    name = type(client).__name__.lower()
+    if "openai" in name:
+        return "openai"
+    if "bedrock" in name:
+        return "bedrock"
+    if "cli" in name:
+        return "cli"
+    if "anthropic" in name or "llmclient" in name:
+        return "anthropic"
+    return None
+
+
+def record_llm_turn(
+    session: ReplSession,
+    *,
+    prompt: str,
+    response: str,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+) -> tuple[int, int, bool]:
+    """Accumulate one LLM call on ``session.token_usage``.
+
+    Returns ``(input_tokens, output_tokens, estimated)``. Provider counts are
+    used when both are supplied; otherwise chars÷4 estimates are recorded.
+    """
+    if input_tokens is not None and output_tokens is not None:
+        inp, out, estimated = input_tokens, output_tokens, False
+    else:
+        inp = estimate_tokens(prompt)
+        out = estimate_tokens(response)
+        estimated = True
+    session.record_token_usage(input_tokens=inp, output_tokens=out, estimated=estimated)
+    return inp, out, estimated
+
+
+def record_invoke_response(
+    session: ReplSession | None,
+    *,
+    prompt: str,
+    response: LLMResponse,
+) -> str:
+    """Record an ``invoke()`` turn and return stripped response content."""
+    content = response.content.strip()
+    if session is not None:
+        record_llm_turn(
+            session,
+            prompt=prompt,
+            response=content,
+            input_tokens=response.input_tokens,
+            output_tokens=response.output_tokens,
+        )
+    return content
+
+
+def build_llm_run_info(
+    *,
+    session: ReplSession,
+    prompt: str,
+    response_text: str,
+    started: float | None = None,
+    client: object | None = None,
+    model: str | None = None,
+    provider: str | None = None,
+) -> LlmRunInfo:
+    """Record token usage and assemble metadata for prompt logging."""
+    inp, out, _estimated = record_llm_turn(session, prompt=prompt, response=response_text)
+    latency_ms = 0 if started is None else int((time.monotonic() - started) * 1000)
+    return LlmRunInfo(
+        model=model or (resolve_model_name(client) if client is not None else None),
+        provider=provider or (resolve_provider_name(client) if client is not None else None),
+        latency_ms=latency_ms,
+        input_tokens=inp,
+        output_tokens=out,
+        response_text=response_text,
+    )
+
+
+def format_token_total(session: ReplSession, *, direction: str) -> tuple[str, str]:
+    """Return ``(row_label, formatted_value)`` for input or output tokens."""
+    usage = session.token_usage
+    measured = usage.get(f"{direction}_measured", 0)
+    estimated = usage.get(f"{direction}_estimated", 0)
+    total = usage.get(direction, 0)
+    label = f"{direction} tokens"
+    if estimated and measured:
+        return (
+            label,
+            f"{total:,} ({measured:,} provider + {estimated:,} est.)",
+        )
+    if estimated:
+        return (f"{label} (est.)", f"{total:,}")
+    return (label, f"{total:,}")
+
+
+__all__ = [
+    "build_llm_run_info",
+    "estimate_tokens",
+    "format_token_total",
+    "record_invoke_response",
+    "record_llm_turn",
+    "resolve_model_name",
+    "resolve_provider_name",
+]

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -155,8 +155,8 @@ def _coerce_usage_tokens(
     else:
         raw_in = getattr(usage, input_key, None)
         raw_out = getattr(usage, output_key, None)
-    inp = int(raw_in) if isinstance(raw_in, int) else None
-    out = int(raw_out) if isinstance(raw_out, int) else None
+    inp = int(raw_in) if isinstance(raw_in, (int, float)) else None
+    out = int(raw_out) if isinstance(raw_out, (int, float)) else None
     return inp, out
 
 

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -141,6 +141,38 @@ def _emit_usage(model: str, tokens_in: int | None, tokens_out: int | None) -> No
     hook(model, int(tokens_in or 0), int(tokens_out or 0))
 
 
+def _coerce_usage_tokens(
+    usage: Any,
+    *,
+    input_key: str,
+    output_key: str,
+) -> tuple[int | None, int | None]:
+    if usage is None:
+        return None, None
+    if isinstance(usage, dict):
+        raw_in = usage.get(input_key)
+        raw_out = usage.get(output_key)
+    else:
+        raw_in = getattr(usage, input_key, None)
+        raw_out = getattr(usage, output_key, None)
+    inp = int(raw_in) if isinstance(raw_in, int) else None
+    out = int(raw_out) if isinstance(raw_out, int) else None
+    return inp, out
+
+
+def _llm_response_with_usage(
+    content: str,
+    model: str,
+    usage: Any,
+    *,
+    input_key: str,
+    output_key: str,
+) -> LLMResponse:
+    inp, out = _coerce_usage_tokens(usage, input_key=input_key, output_key=output_key)
+    _emit_usage(model, inp, out)
+    return LLMResponse(content=content, input_tokens=inp, output_tokens=out)
+
+
 @dataclass(frozen=True)
 class RootCauseResult:
     root_cause: str
@@ -154,6 +186,8 @@ class RootCauseResult:
 @dataclass(frozen=True)
 class LLMResponse:
     content: str
+    input_tokens: int | None = None
+    output_tokens: int | None = None
 
 
 class LLMClient:
@@ -275,12 +309,13 @@ class LLMClient:
         else:
             content = _extract_text(response)
         usage = getattr(response, "usage", None)
-        _emit_usage(
+        return _llm_response_with_usage(
+            content,
             self._model,
-            getattr(usage, "input_tokens", None) if usage else None,
-            getattr(usage, "output_tokens", None) if usage else None,
+            usage,
+            input_key="input_tokens",
+            output_key="output_tokens",
         )
-        return LLMResponse(content=content)
 
     def invoke_stream(self, prompt_or_messages: Any) -> Iterator[str]:
         """Yield text chunks as the model emits them.
@@ -492,12 +527,13 @@ class BedrockLLMClient:
         else:
             content = _extract_text(response)
         usage = getattr(response, "usage", None)
-        _emit_usage(
+        return _llm_response_with_usage(
+            content,
             self._model,
-            getattr(usage, "input_tokens", None) if usage else None,
-            getattr(usage, "output_tokens", None) if usage else None,
+            usage,
+            input_key="input_tokens",
+            output_key="output_tokens",
         )
-        return LLMResponse(content=content)
 
     def _invoke_converse(self, prompt_or_messages: Any) -> LLMResponse:
         """Invoke via boto3 converse API (works with all Bedrock models)."""
@@ -614,13 +650,13 @@ class BedrockLLMClient:
                 f"Bedrock converse returned no text content (stopReason={stop_reason!r})"
             )
         usage_dict = response.get("usage") if isinstance(response, dict) else None
-        if isinstance(usage_dict, dict):
-            _emit_usage(
-                self._model,
-                usage_dict.get("inputTokens"),
-                usage_dict.get("outputTokens"),
-            )
-        return LLMResponse(content=content)
+        return _llm_response_with_usage(
+            content,
+            self._model,
+            usage_dict,
+            input_key="inputTokens",
+            output_key="outputTokens",
+        )
 
     def invoke(self, prompt_or_messages: Any) -> LLMResponse:
         if self._use_anthropic:
@@ -971,12 +1007,13 @@ class OpenAILLMClient:
         else:
             content = message.content or ""
         usage = getattr(response, "usage", None)
-        _emit_usage(
+        return _llm_response_with_usage(
+            content.strip(),
             self._model,
-            getattr(usage, "prompt_tokens", None) if usage else None,
-            getattr(usage, "completion_tokens", None) if usage else None,
+            usage,
+            input_key="prompt_tokens",
+            output_key="completion_tokens",
         )
-        return LLMResponse(content=content.strip())
 
     def invoke_stream(self, prompt_or_messages: Any) -> Iterator[str]:
         """Yield text chunks as the model emits them.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -40,6 +40,7 @@
             "pages": [
               "quickstart",
               "investigation-overview",
+              "interactive-shell-commands",
               "deployment",
               "faq"
             ]

--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -1,0 +1,85 @@
+---
+title: 'Interactive Shell Commands'
+description: 'Quick reference for common slash commands in the opensre REPL — session cost, status, help, and more'
+---
+
+Start the interactive shell with `opensre` (TTY required). Type a slash command at the prompt, or describe what you want in plain language and the planner can map intent to the right command.
+
+Run `/help` anytime for the full, up-to-date command list grouped by category.
+
+## Quick reference
+
+| Command | What it does |
+| --- | --- |
+| `/help` | List commands or show help for one command (`/help /model`, `/help tasks`) |
+| `/status` | Session summary — interactions, alerts, provider, reasoning effort, trust mode |
+| `/cost` | Token usage and LLM call count for the current session |
+| `/effort` | Set or show reasoning effort (`low`, `medium`, `high`, `xhigh`, `max`) |
+| `/clear` | Clear the screen and re-render the banner |
+| `/exit` | Leave the interactive shell (`/quit` is an alias) |
+| `/health` | Integration and agent health |
+| `/investigate` | Run an investigation from the REPL |
+| `/integrations` | List, verify, or manage integrations |
+| `/model` | Show or switch LLM provider and models |
+| `/sessions` | List recent REPL sessions |
+| `/resume <id>` | Restore a past session's conversation context |
+
+For session persistence in depth, see [Session History](/sessions). For `/history` and `/privacy`, see [Interactive Shell Privacy](/interactive-shell-privacy).
+
+---
+
+## Session cost — `/cost`
+
+Show how much LLM usage the **current REPL session** has accumulated:
+
+```
+/cost
+```
+
+Typical output includes:
+
+| Field | Meaning |
+| --- | --- |
+| `history entries` | Lines recorded in this session's history |
+| `llm calls` | Number of LLM turns counted this session |
+| `input tokens` / `output tokens` | Totals for prompt and completion usage |
+
+When the provider returns usage metadata (for example on planner `invoke` calls), those counts are **measured**. Streaming chat and help paths **estimate** tokens from text length (roughly four characters per token). If any estimates are included, the table title notes `(includes estimates)` and measured vs estimated splits appear on the token rows.
+
+Token totals reset when you start a new session (`/new`) or clear session state; `/cost` does not show billing from your cloud provider — only what OpenSRE tracked locally for this shell session.
+
+---
+
+## Session status — `/status`
+
+```
+/status
+```
+
+Shows interaction count, incoming alerts, last investigation, trust mode, reasoning effort, active provider, and any accumulated infra context keys.
+
+---
+
+## Reasoning effort — `/effort`
+
+For OpenAI and Codex providers, set how much reasoning the model applies in this REPL session:
+
+```
+/effort high
+/effort
+```
+
+Bare `/effort` prints the current level and usage. `/status` includes the same field. Other providers ignore this setting. You can also set `OPENSRE_REASONING_EFFORT` in the environment for non-interactive defaults. See [LLM providers](/llm-providers).
+
+---
+
+## Help — `/help`
+
+```
+/help
+/help /model
+/help investigation
+/help all
+```
+
+In a TTY, bare `/help` opens an interactive picker. Use `/help <command>` or `/help <category>` for details on one topic.

--- a/docs/investigation-overview.mdx
+++ b/docs/investigation-overview.mdx
@@ -20,7 +20,7 @@ From a terminal with stdin and stdout attached (`opensre` detects a TTY), run:
 opensre
 ```
 
-Then describe the incident or paste alert context at the prompt. Use `/help` for slash commands and `/exit` when finished.
+Then describe the incident or paste alert context at the prompt. Use `/help` for slash commands and `/exit` when finished. See [Interactive Shell Commands](/interactive-shell-commands) for a quick reference (`/cost`, `/status`, `/effort`, and more).
 
 When `LLM_PROVIDER` is `openai` or `codex`, `/effort` sets how much reasoning the model applies for that REPL session (`low`, `medium`, `high`, `xhigh`, or `max`). Run `/effort` with no arguments to print the current level and usage; `/status` includes the same field. Other providers ignore this setting (the shell prints a hint). You can also set `OPENSRE_REASONING_EFFORT` to `low`, `medium`, `high`, or `xhigh` in the environment for non-interactive defaults.
 

--- a/tests/cli/interactive_shell/chat/test_cli_agent.py
+++ b/tests/cli/interactive_shell/chat/test_cli_agent.py
@@ -285,6 +285,8 @@ class TestAssistantOutputRendering:
                 "If you want a full command list, run `opensre --help`.",
             ),
         ]
+        assert session.token_usage == {}
+        assert session.llm_call_count == 0
 
     def test_structured_content_blocks_are_rendered(self, monkeypatch: Any) -> None:
         class _Block:

--- a/tests/cli/interactive_shell/chat/test_cli_agent.py
+++ b/tests/cli/interactive_shell/chat/test_cli_agent.py
@@ -238,6 +238,7 @@ class TestAssistantOutputRendering:
         assert "**world**" not in output
         assert "world" in output
         assert "Hello" in output
+        assert session.token_usage.get("output", 0) > 0
 
     def test_table_markdown_is_rendered_as_table(self, monkeypatch: Any) -> None:
         markdown = (

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1668,16 +1668,37 @@ class TestCostCommand:
     def test_no_token_data_shows_placeholder(self) -> None:
         console, buf = _capture()
         dispatch_slash("/cost", ReplSession(), console)
-        assert "not available" in buf.getvalue()
+        assert "no LLM usage recorded yet" in buf.getvalue()
 
     def test_shows_token_counts_when_available(self) -> None:
         session = ReplSession()
         session.token_usage = {"input": 1000, "output": 500}
+        session.llm_call_count = 2
         console, buf = _capture()
         dispatch_slash("/cost", session, console)
         output = buf.getvalue()
         assert "1,000" in output
         assert "500" in output
+        assert "llm calls" in output
+        assert "2" in output
+
+    def test_shows_estimate_labels_when_mixed(self) -> None:
+        session = ReplSession()
+        session.token_usage = {
+            "input": 400,
+            "output": 60,
+            "input_measured": 300,
+            "output_measured": 40,
+            "input_estimated": 100,
+            "output_estimated": 20,
+        }
+        session.llm_call_count = 2
+        console, buf = _capture()
+        dispatch_slash("/cost", session, console)
+        output = buf.getvalue()
+        assert "provider + 100 est." in output
+        assert "provider + 20 est." in output
+        assert "includes estimates" in output
 
 
 class TestVerboseCommand:

--- a/tests/cli/interactive_shell/test_token_accounting.py
+++ b/tests/cli/interactive_shell/test_token_accounting.py
@@ -109,6 +109,16 @@ def test_build_llm_run_info_records_tokens_and_metadata() -> None:
     assert run.latency_ms is not None and run.latency_ms >= 0
 
 
+def test_coerce_usage_tokens_accepts_float_counts() -> None:
+    from app.services.llm_client import _coerce_usage_tokens
+
+    assert _coerce_usage_tokens(
+        {"input_tokens": 512.0, "output_tokens": 64.0},
+        input_key="input_tokens",
+        output_key="output_tokens",
+    ) == (512, 64)
+
+
 def test_record_token_usage_skips_zero_counts() -> None:
     session = ReplSession()
     session.record_token_usage()
@@ -126,11 +136,15 @@ class _FakeLLMClient:
         yield self._content
 
 
+_PLANNER_LLM_CLIENT = (
+    "app.cli.interactive_shell.routing.handle_message_with_agent"
+    ".orchestration.llm_action_planner.llm_client"
+)
+
+
 def test_answer_cli_agent_records_session_token_usage(monkeypatch: Any) -> None:
     client = _FakeLLMClient("assistant reply")
-    import app.services.llm_client as llm_module
-
-    monkeypatch.setattr(llm_module, "get_llm_for_reasoning", lambda: client)
+    monkeypatch.setattr("app.services.llm_client.get_llm_for_reasoning", lambda: client)
     session = ReplSession()
     console = Console(file=io.StringIO(), force_terminal=False)
     answer_cli_agent("hello", session, console)
@@ -157,9 +171,9 @@ def test_planner_call_llm_records_provider_token_usage() -> None:
                 output_tokens=42,
             )
 
-    with patch(
-        "app.services.llm_client.get_llm_for_classification",
-        return_value=_FakeClient(),
+    with (
+        patch("app.services.llm_client.get_llm_for_classification", return_value=_FakeClient()),
+        patch(f"{_PLANNER_LLM_CLIENT}._tool_specs_for_provider", return_value=[]),
     ):
         result = _call_llm("check cpu", session)
 
@@ -185,12 +199,12 @@ def test_planner_call_llm_falls_back_to_estimates_without_provider_usage() -> No
         def bind_tools(self, _tools: object) -> _FakeClient:
             return self
 
-        def invoke(self, prompt: str) -> LLMResponse:
+        def invoke(self, _prompt: str) -> LLMResponse:
             return LLMResponse(content='{"tool_calls": []}')
 
-    with patch(
-        "app.services.llm_client.get_llm_for_classification",
-        return_value=_FakeClient(),
+    with (
+        patch("app.services.llm_client.get_llm_for_classification", return_value=_FakeClient()),
+        patch(f"{_PLANNER_LLM_CLIENT}._tool_specs_for_provider", return_value=[]),
     ):
         _call_llm("check cpu", session)
 

--- a/tests/cli/interactive_shell/test_token_accounting.py
+++ b/tests/cli/interactive_shell/test_token_accounting.py
@@ -1,0 +1,199 @@
+"""Tests for interactive-shell session token accounting."""
+
+from __future__ import annotations
+
+import io
+import time
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+from rich.console import Console
+
+from app.cli.interactive_shell.chat.cli_agent import answer_cli_agent
+from app.cli.interactive_shell.runtime.session import ReplSession
+from app.cli.interactive_shell.token_accounting import (
+    build_llm_run_info,
+    estimate_tokens,
+    format_token_total,
+    record_llm_turn,
+)
+from app.cli.interactive_shell.ui.streaming import _CHARS_PER_TOKEN
+from app.services.llm_client import LLMResponse
+
+
+def test_estimate_tokens_uses_chars_per_token_ratio() -> None:
+    text = "x" * (8 * _CHARS_PER_TOKEN)
+    assert estimate_tokens(text) == 8
+
+
+def test_record_token_usage_accumulates_on_session() -> None:
+    session = ReplSession()
+    record_llm_turn(session, prompt="a" * 40, response="b" * 20)
+    assert session.token_usage == {
+        "input": 10,
+        "output": 5,
+        "input_estimated": 10,
+        "output_estimated": 5,
+    }
+    assert session.llm_call_count == 1
+    assert session.token_usage_has_estimates is True
+    record_llm_turn(session, prompt="c" * 8, response="d" * 4)
+    assert session.token_usage == {
+        "input": 12,
+        "output": 6,
+        "input_estimated": 12,
+        "output_estimated": 6,
+    }
+    assert session.llm_call_count == 2
+
+
+def test_record_llm_turn_uses_provider_counts_when_present() -> None:
+    session = ReplSession()
+    inp, out, estimated = record_llm_turn(
+        session,
+        prompt="ignored when counts supplied",
+        response="also ignored",
+        input_tokens=1200,
+        output_tokens=80,
+    )
+    assert (inp, out, estimated) == (1200, 80, False)
+    assert session.token_usage == {
+        "input": 1200,
+        "output": 80,
+        "input_measured": 1200,
+        "output_measured": 80,
+    }
+    assert session.token_usage_has_estimates is False
+
+
+def test_format_token_total_shows_mixed_breakdown() -> None:
+    session = ReplSession()
+    record_llm_turn(
+        session,
+        prompt="x",
+        response="y",
+        input_tokens=300,
+        output_tokens=40,
+    )
+    record_llm_turn(session, prompt="a" * 400, response="b" * 80)
+    assert format_token_total(session, direction="input") == (
+        "input tokens",
+        "400 (300 provider + 100 est.)",
+    )
+    assert format_token_total(session, direction="output") == (
+        "output tokens",
+        "60 (40 provider + 20 est.)",
+    )
+
+
+def test_build_llm_run_info_records_tokens_and_metadata() -> None:
+    session = ReplSession()
+
+    class _Client:
+        _model = "claude-test"
+        _provider_label = "Anthropic"
+
+    run = build_llm_run_info(
+        session=session,
+        prompt="a" * 40,
+        response_text="b" * 20,
+        client=_Client(),
+        started=time.monotonic() - 0.05,
+    )
+    assert run.model == "claude-test"
+    assert run.provider == "anthropic"
+    assert run.input_tokens == 10
+    assert run.output_tokens == 5
+    assert run.response_text == "b" * 20
+    assert run.latency_ms is not None and run.latency_ms >= 0
+
+
+def test_record_token_usage_skips_zero_counts() -> None:
+    session = ReplSession()
+    session.record_token_usage()
+    assert session.token_usage == {}
+    assert session.llm_call_count == 0
+
+
+class _FakeLLMClient:
+    def __init__(self, content: str) -> None:
+        self._content = content
+        self.last_prompt: str | None = None
+
+    def invoke_stream(self, prompt: str) -> Iterator[str]:
+        self.last_prompt = prompt
+        yield self._content
+
+
+def test_answer_cli_agent_records_session_token_usage(monkeypatch: Any) -> None:
+    client = _FakeLLMClient("assistant reply")
+    import app.services.llm_client as llm_module
+
+    monkeypatch.setattr(llm_module, "get_llm_for_reasoning", lambda: client)
+    session = ReplSession()
+    console = Console(file=io.StringIO(), force_terminal=False)
+    answer_cli_agent("hello", session, console)
+    assert session.token_usage["input"] > 0
+    assert session.token_usage["output"] == estimate_tokens("assistant reply")
+    assert session.token_usage_has_estimates is True
+
+
+def test_planner_call_llm_records_provider_token_usage() -> None:
+    from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.llm_action_planner.llm_client import (
+        _call_llm,
+    )
+
+    session = ReplSession()
+
+    class _FakeClient:
+        def bind_tools(self, _tools: object) -> _FakeClient:
+            return self
+
+        def invoke(self, _prompt: str) -> LLMResponse:
+            return LLMResponse(
+                content='{"tool_calls": []}',
+                input_tokens=321,
+                output_tokens=42,
+            )
+
+    with patch(
+        "app.services.llm_client.get_llm_for_classification",
+        return_value=_FakeClient(),
+    ):
+        result = _call_llm("check cpu", session)
+
+    assert result == '{"tool_calls": []}'
+    assert session.token_usage == {
+        "input": 321,
+        "output": 42,
+        "input_measured": 321,
+        "output_measured": 42,
+    }
+    assert session.token_usage_has_estimates is False
+    assert session.llm_call_count == 1
+
+
+def test_planner_call_llm_falls_back_to_estimates_without_provider_usage() -> None:
+    from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.llm_action_planner.llm_client import (
+        _call_llm,
+    )
+
+    session = ReplSession()
+
+    class _FakeClient:
+        def bind_tools(self, _tools: object) -> _FakeClient:
+            return self
+
+        def invoke(self, prompt: str) -> LLMResponse:
+            return LLMResponse(content='{"tool_calls": []}')
+
+    with patch(
+        "app.services.llm_client.get_llm_for_classification",
+        return_value=_FakeClient(),
+    ):
+        _call_llm("check cpu", session)
+
+    assert session.token_usage["input"] > 0
+    assert session.token_usage["output"] > 0
+    assert session.token_usage_has_estimates is True


### PR DESCRIPTION
/fix #2817 
This pull request introduces comprehensive session-scoped token accounting and improved LLM call metadata tracking for the interactive shell. The main changes unify and centralize token counting, provide more accurate and detailed session cost reporting, and refactor code to use new utilities for LLM run info and token usage. It also updates the LLM client to propagate token counts from providers and to return richer response objects.

**Session Token Accounting and Reporting**

* Added a new module `token_accounting.py` that centralizes token estimation, recording, and reporting logic, including helpers like `build_llm_run_info`, `record_llm_turn`, and `format_token_total`. This replaces scattered logic and duplicated provider/model resolution code.
* Enhanced the `ReplSession` class to track detailed token usage (measured vs estimated), total LLM call count, and provide methods for recording and resetting token usage. [[1]](diffhunk://#diff-ea6e8b3eb308fa7e9870605ef630ad2ab16878c39072fd78eab217d04fb9870dL108-R115) [[2]](diffhunk://#diff-ea6e8b3eb308fa7e9870605ef630ad2ab16878c39072fd78eab217d04fb9870dR208-R231) [[3]](diffhunk://#diff-ea6e8b3eb308fa7e9870605ef630ad2ab16878c39072fd78eab217d04fb9870dR299)
* Updated the `/cost` command to display more granular session cost information, including estimates and call counts, using the new accounting utilities.

**LLM Client Response and Usage Tracking**

* Refactored the LLM client to return a new `LLMResponse` dataclass that includes both the response content and input/output token counts, and to emit usage metrics consistently for all providers. [[1]](diffhunk://#diff-fd5e3fb40267eadcd4df1976f7d7e2896b6078d2a2d445619897240116d1ccd3R189-R190) [[2]](diffhunk://#diff-fd5e3fb40267eadcd4df1976f7d7e2896b6078d2a2d445619897240116d1ccd3L278-L283) [[3]](diffhunk://#diff-fd5e3fb40267eadcd4df1976f7d7e2896b6078d2a2d445619897240116d1ccd3L495-L500) [[4]](diffhunk://#diff-fd5e3fb40267eadcd4df1976f7d7e2896b6078d2a2d445619897240116d1ccd3L617-L623) [[5]](diffhunk://#diff-fd5e3fb40267eadcd4df1976f7d7e2896b6078d2a2d445619897240116d1ccd3R144-R175)
* Added utility functions to coerce and extract token usage from various provider response formats, ensuring consistent accounting.

**Prompt Handling and Logging Refactor**

* Updated all prompt-handling entry points (`cli_agent`, `cli_help`, `follow_up`, etc.) to use `build_llm_run_info` for logging and session accounting, removing duplicated model/provider resolution logic. [[1]](diffhunk://#diff-5e4464ef9348f22735d5f2f8a2bdec66172e17639ad1cb99d87d427b4d43b635R35) [[2]](diffhunk://#diff-5e4464ef9348f22735d5f2f8a2bdec66172e17639ad1cb99d87d427b4d43b635L563-R569) [[3]](diffhunk://#diff-5e4464ef9348f22735d5f2f8a2bdec66172e17639ad1cb99d87d427b4d43b635L595-L615) [[4]](diffhunk://#diff-25378eb202930ec8e5d3b2710801abf15cdce89f13b7baf671ceda646929fb00R31) [[5]](diffhunk://#diff-25378eb202930ec8e5d3b2710801abf15cdce89f13b7baf671ceda646929fb00L84-R85) [[6]](diffhunk://#diff-25378eb202930ec8e5d3b2710801abf15cdce89f13b7baf671ceda646929fb00L95-R97) [[7]](diffhunk://#diff-25378eb202930ec8e5d3b2710801abf15cdce89f13b7baf671ceda646929fb00L125-L153) [[8]](diffhunk://#diff-ac815007614505a4cc12da8d763335cd1bf769b0184f9c139e510fb23de8940fR14) [[9]](diffhunk://#diff-ac815007614505a4cc12da8d763335cd1bf769b0184f9c139e510fb23de8940fL124-L152)
* Updated the action planner LLM orchestration to record responses and token usage via the new accounting utilities. [[1]](diffhunk://#diff-431496fab1d75d1a0b79fb9afa6082bf1fd74d88b0eff31b55018e2a907f83eeR8-R9) [[2]](diffhunk://#diff-431496fab1d75d1a0b79fb9afa6082bf1fd74d88b0eff31b55018e2a907f83eeL53-R55)

These changes improve the accuracy and transparency of LLM usage tracking, simplify code maintenance, and lay the groundwork for better cost reporting and optimization.
before 
<img width="773" height="480" alt="Screenshot 2026-06-15 at 3 11 18 PM" src="https://github.com/user-attachments/assets/e32f5f5e-a5f8-4fb6-91c7-dbb1f461a588" />
after
<img width="773" height="480" alt="Screenshot 2026-06-15 at 3 16 37 PM" src="https://github.com/user-attachments/assets/10917dac-8713-48fa-9b2d-55b89ad0bf3a" />
