### PR TITLE
feat(spinner): introduce spinner phase management for improved user feedback

### DIFF
--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/agent_actions.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/agent_actions.py
@@ -27,6 +27,10 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.t
     ToolContext,
 )
 from app.cli.interactive_shell.runtime import ReplSession
+from app.cli.interactive_shell.runtime.spinner_phases import (
+    set_spinner_phase,
+    spinner_phase_for_action,
+)
 from app.cli.interactive_shell.ui import DIM, print_planned_actions
 from app.cli.interactive_shell.ui.streaming import render_response_header
 
@@ -239,6 +243,10 @@ def _execute_planned_actions(
         if getattr(console, "cancel_requested", False):
             console.print(f"[{DIM}](remaining actions cancelled)[/]")
             break
+        set_spinner_phase(
+            console,
+            spinner_phase_for_action(kind=action.kind, content=action.content),
+        )
         console.print()
         tool_name = ACTION_KIND_TO_TOOL.get(action.kind)
         if tool_name is None:

--- a/app/cli/interactive_shell/runtime/execution.py
+++ b/app/cli/interactive_shell/runtime/execution.py
@@ -19,6 +19,10 @@ from app.cli.interactive_shell.prompt_logging import PromptRecorder
 from app.cli.interactive_shell.prompting import follow_up as _follow_up
 from app.cli.interactive_shell.routing.types import RouteDecision
 from app.cli.interactive_shell.runtime.session import ReplSession
+from app.cli.interactive_shell.runtime.spinner_phases import (
+    SPINNER_PHASE_RUNNING_INVESTIGATION,
+    set_spinner_phase,
+)
 from app.cli.interactive_shell.ui import DIM, ERROR, WARNING
 from app.cli.support.errors import OpenSREError
 from app.cli.support.exception_reporting import report_exception
@@ -88,6 +92,7 @@ def run_new_alert(
 
     task = session.task_registry.create(TaskKind.INVESTIGATION, command="free-text investigation")
     task.mark_running()
+    set_spinner_phase(console, SPINNER_PHASE_RUNNING_INVESTIGATION)
     try:
         with (
             track_investigation(

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -114,6 +114,9 @@ class StreamingConsole(Console):
     def update_streaming_progress(self, bytes_received: int) -> None:
         self._spinner.bytes_in = bytes_received
 
+    def set_spinner_phase(self, phase: str) -> None:
+        self._spinner.set_phase(phase)
+
     @property
     def cancel_requested(self) -> bool:
         return self._cancel_event.is_set()

--- a/app/cli/interactive_shell/runtime/spinner_phases.py
+++ b/app/cli/interactive_shell/runtime/spinner_phases.py
@@ -1,0 +1,71 @@
+"""REPL inline-spinner phase labels (decoupled from UI imports)."""
+
+from __future__ import annotations
+
+SPINNER_PHASE_PLANNING = "planning"
+SPINNER_PHASE_STREAMING_ANSWER = "streaming answer"
+SPINNER_PHASE_RUNNING_INVESTIGATION = "running investigation"
+
+_STATIC_RUNNING_PHASES: dict[str, str] = {
+    "shell": "running shell command",
+    "investigation": SPINNER_PHASE_RUNNING_INVESTIGATION,
+    "synthetic_test": "running synthetic test",
+    "sample_alert": "running sample alert",
+    "implementation": "running implementation task",
+    "task_cancel": "running /cancel",
+}
+
+
+def running_phase(target: str, *, fallback: str = "action") -> str:
+    """Format a ``running …`` spinner label for a command or target name."""
+    label = target.strip()
+    return f"running {label}" if label else f"running {fallback}"
+
+
+def slash_command_phase(content: str, *, fallback: str = "/command") -> str:
+    """Format ``running /command`` for a slash-command action payload."""
+    command = content.split(maxsplit=1)[0] if content else fallback
+    if not command.startswith("/"):
+        command = f"/{command}"
+    return running_phase(command)
+
+
+def spinner_phase_for_action(*, kind: str, content: str) -> str:
+    """Map a planned action to a concrete REPL spinner phase label."""
+    stripped = content.strip()
+    match kind:
+        case "slash":
+            return slash_command_phase(stripped)
+        case "cli_command":
+            head = stripped.split(maxsplit=1)[0] if stripped else ""
+            return running_phase(head, fallback="cli command")
+        case "llm_provider":
+            if stripped.startswith("/"):
+                return running_phase(stripped.split(maxsplit=1)[0])
+            token = stripped.split(maxsplit=1)
+            return running_phase(f"/model {token[0]}") if token else running_phase("/model")
+        case static if static in _STATIC_RUNNING_PHASES:
+            return _STATIC_RUNNING_PHASES[static]
+        case _:
+            return running_phase("", fallback="action")
+
+
+def set_spinner_phase(console: object, phase: str) -> None:
+    """Update the REPL inline spinner label when the console exposes the hook."""
+    label = phase.strip()
+    if not label:
+        return
+    hook = getattr(console, "set_spinner_phase", None)
+    if callable(hook):
+        hook(label)
+
+
+__all__ = [
+    "SPINNER_PHASE_PLANNING",
+    "SPINNER_PHASE_RUNNING_INVESTIGATION",
+    "SPINNER_PHASE_STREAMING_ANSWER",
+    "running_phase",
+    "set_spinner_phase",
+    "slash_command_phase",
+    "spinner_phase_for_action",
+]

--- a/app/cli/interactive_shell/runtime/state.py
+++ b/app/cli/interactive_shell/runtime/state.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import random
 import threading
 import time
 from dataclasses import dataclass, field
 
 from prompt_toolkit.application.current import get_app_or_none
 
+from app.cli.interactive_shell.runtime.spinner_phases import SPINNER_PHASE_PLANNING
 from app.cli.interactive_shell.ui import ANSI_DIM, ANSI_RESET, PROMPT_ACCENT_ANSI
 from app.cli.interactive_shell.ui.streaming import _CHARS_PER_TOKEN, format_token_count_short
 
@@ -87,33 +87,24 @@ class SpinnerState:
     """Mutable state read by prompt callbacks for toolbar + inline spinner."""
 
     _SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
-    _THINKING_VERBS = (
-        "thinking",
-        "pondering",
-        "exploring",
-        "reasoning",
-        "considering",
-        "analysing",
-        "investigating",
-        "deliberating",
-        "ruminating",
-        "deducing",
-        "noodling",
-    )
 
     def __init__(self) -> None:
         self.streaming: bool = False
         self.started_at: float = 0.0
         self.bytes_in: int = 0
         self._frame_idx: int = 0
-        self._verb: str = self._THINKING_VERBS[0]
+        self._phase: str = SPINNER_PHASE_PLANNING
 
     def start(self) -> None:
         self.streaming = True
         self.started_at = time.monotonic()
         self.bytes_in = 0
         self._frame_idx = 0
-        self._verb = random.choice(self._THINKING_VERBS)
+        self._phase = SPINNER_PHASE_PLANNING
+
+    def set_phase(self, phase: str) -> None:
+        if phase.strip():
+            self._phase = phase.strip()
 
     def stop(self) -> None:
         self.streaming = False
@@ -152,7 +143,7 @@ class SpinnerState:
         else:
             suffix = f" ({elapsed:.0f}s)"
         return (
-            f"{PROMPT_ACCENT_ANSI}{glyph} {self._verb}…{ANSI_RESET}"
+            f"{PROMPT_ACCENT_ANSI}{glyph} {self._phase}…{ANSI_RESET}"
             f"{ANSI_DIM}{suffix}  esc to cancel{ANSI_RESET}"
         )
 

--- a/app/cli/interactive_shell/ui/streaming.py
+++ b/app/cli/interactive_shell/ui/streaming.py
@@ -32,6 +32,10 @@ from collections.abc import Iterator
 from rich.console import Console
 from rich.markdown import Markdown
 
+from app.cli.interactive_shell.runtime.spinner_phases import (
+    SPINNER_PHASE_STREAMING_ANSWER,
+    set_spinner_phase,
+)
 from app.cli.interactive_shell.ui.theme import BOLD_BRAND, DIM, MARKDOWN_THEME
 
 # Approximate characters per token. Single source of truth for the
@@ -76,7 +80,7 @@ def format_token_count_short(token_count: int) -> str:
 
     Shared with :class:`app.cli.interactive_shell.runtime.state.SpinnerState` so
     the streaming footer (``· 9.5s · ↓ 1.2k tokens``) and the live
-    spinner (``⠋ thinking… (5s · ↓ 1.2k tokens)``) format identically.
+    spinner (``⠋ streaming answer… (5s · ↓ 1.2k tokens)``) format identically.
     """
     if token_count >= 1000:
         return f"{token_count / 1000:.1f}k"
@@ -152,9 +156,10 @@ def stream_to_console(
     # Markdown via ``console.print(Markdown(...))``. Visible "streaming"
     # is per-paragraph rather than per-chunk — a true live re-render
     # would need cursor manipulation that fights ``patch_stdout``. The
-    # spinner (``⠋ thinking… (Ns · ↓ X tokens)``) ticks during long
+    # spinner (``⠋ streaming answer… (Ns · ↓ X tokens)``) ticks during long
     # paragraphs to confirm chunks are still arriving, and code blocks
     # are kept whole (we never split on ``\n\n`` while a fence is open).
+    set_spinner_phase(console, SPINNER_PHASE_STREAMING_ANSWER)
     buffer: list[str] = list(peeked)
     para_buffer: list[str] = list(peeked)
     started = time.monotonic()

--- a/tests/cli/interactive_shell/test_spinner_phases.py
+++ b/tests/cli/interactive_shell/test_spinner_phases.py
@@ -1,0 +1,31 @@
+"""Unit tests for REPL spinner phase labels."""
+
+from __future__ import annotations
+
+from app.cli.interactive_shell.runtime.spinner_phases import (
+    SPINNER_PHASE_RUNNING_INVESTIGATION,
+    slash_command_phase,
+    spinner_phase_for_action,
+)
+
+
+def test_slash_command_phase_normalizes_missing_slash_prefix() -> None:
+    assert slash_command_phase("health") == "running /health"
+    assert slash_command_phase("/integrations list") == "running /integrations"
+
+
+def test_spinner_phase_for_action_covers_common_kinds() -> None:
+    assert spinner_phase_for_action(kind="slash", content="/health") == "running /health"
+    assert (
+        spinner_phase_for_action(kind="cli_command", content="integrations list")
+        == "running integrations"
+    )
+    assert (
+        spinner_phase_for_action(kind="investigation", content="CPU spike on orders-api")
+        == SPINNER_PHASE_RUNNING_INVESTIGATION
+    )
+    assert (
+        spinner_phase_for_action(kind="llm_provider", content="anthropic")
+        == "running /model anthropic"
+    )
+    assert spinner_phase_for_action(kind="unknown_kind", content="") == "running action"

--- a/tests/cli/interactive_shell/test_terminal_runtime.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime.py
@@ -821,9 +821,7 @@ class TestSpinnerState:
         spinner.start()
         spinner.bytes_in = 1234 * _CHARS_PER_TOKEN  # = 1234 tokens
         rendered = _strip_ansi(spinner.inline_spinner_ansi())
-        # The verb is randomly picked from ``_THINKING_VERBS`` per turn —
-        # any of them followed by ``…`` is acceptable.
-        assert any(f"{verb}…" in rendered for verb in spinner._THINKING_VERBS)
+        assert "planning…" in rendered
         # 1234 tokens → "1.2k" via format_token_count_short.
         assert "1.2k tokens" in rendered
         # Spinner glyph from the brail palette.
@@ -853,19 +851,24 @@ class TestSpinnerState:
         rendered = _strip_ansi(spinner.inline_spinner_ansi())
         assert "tokens" in rendered
 
-    def test_streaming_inline_spinner_verb_stays_constant_across_calls(self) -> None:
-        """A turn's verb is fixed at ``start()`` so the indicator
-        doesn't flicker between words mid-stream."""
+    def test_streaming_inline_spinner_phase_stays_constant_across_calls(self) -> None:
+        """A turn's phase is fixed until ``set_phase`` so the indicator
+        doesn't flicker between labels mid-stream."""
         spinner = loop_state.SpinnerState()
         spinner.start()
-        verbs_seen: set[str] = set()
+        phases_seen: set[str] = set()
         for _ in range(20):
             rendered = _strip_ansi(spinner.inline_spinner_ansi())
-            for verb in spinner._THINKING_VERBS:
-                if f"{verb}…" in rendered:
-                    verbs_seen.add(verb)
-                    break
-        assert len(verbs_seen) == 1, f"verb changed mid-turn — saw {verbs_seen}"
+            if "planning…" in rendered:
+                phases_seen.add("planning")
+        assert phases_seen == {"planning"}, f"phase changed mid-turn — saw {phases_seen}"
+
+    def test_set_phase_updates_inline_spinner_label(self) -> None:
+        spinner = loop_state.SpinnerState()
+        spinner.start()
+        spinner.set_phase("running /health")
+        rendered = _strip_ansi(spinner.inline_spinner_ansi())
+        assert "running /health…" in rendered
 
     def test_inline_spinner_glyph_animates_across_calls(self) -> None:
         """Each render advances the frame index — animation in place."""
@@ -1005,6 +1008,22 @@ class TestStreamingConsole:
         )
         console.update_streaming_progress(4096)
         assert spinner.bytes_in == 4096
+
+    def test_set_spinner_phase_writes_to_spinner_state(self) -> None:
+        import threading as _threading
+
+        spinner = loop_state.SpinnerState()
+        spinner.start()
+        console = loop_module.StreamingConsole(
+            spinner,
+            _threading.Event(),
+            highlight=False,
+            force_terminal=True,
+            color_system=None,
+        )
+        console.set_spinner_phase("streaming answer")
+        rendered = _strip_ansi(spinner.inline_spinner_ansi())
+        assert "streaming answer…" in rendered
 
     def test_cancel_requested_reflects_event_state(self) -> None:
         import threading as _threading


### PR DESCRIPTION
This pull request introduces a new, unified mechanism for controlling the phase label shown in the REPL inline spinner, replacing the previous random verb-based approach with deterministic, context-aware labels. The spinner phase now reflects the current operation (e.g., "planning", "running /health", "streaming answer") and can be updated by the runtime and UI layers. The change improves clarity for users, makes the UI more predictable, and decouples phase labeling from UI imports. Comprehensive unit tests are added to verify the new behavior.

**Spinner phase system and runtime integration:**

* Added a new module, `spinner_phases.py`, which defines standard spinner phase labels (e.g., `SPINNER_PHASE_PLANNING`, `SPINNER_PHASE_STREAMING_ANSWER`, `SPINNER_PHASE_RUNNING_INVESTIGATION`) and utility functions for formatting and setting spinner phases, including mapping planned actions to concrete labels.
* Updated the spinner state in `state.py` to use a `_phase` string instead of a randomly chosen verb, with a new `set_phase` method to update the spinner label; removed the `_THINKING_VERBS` list and all random verb logic. [[1]](diffhunk://#diff-41acc3ce2598179628458139f8976d742881e440dd8fe81f7b00862777837c95L90-R107) [[2]](diffhunk://#diff-41acc3ce2598179628458139f8976d742881e440dd8fe81f7b00862777837c95L155-R146)
* Modified the streaming console (`loop.py`) to expose a `set_spinner_phase` method, which delegates to the spinner state.

**Wiring spinner phase updates throughout the REPL:**

* Inserted calls to `set_spinner_phase` with appropriate phase labels during planned action execution, investigation runs, and streaming answer rendering, so the spinner always reflects the current operation. [[1]](diffhunk://#diff-338609179ed58f6d83b2c5c391093ca9c93a7cf7bdee0b31b52d2196ee67842fR246-R249) [[2]](diffhunk://#diff-f679fde99ace4ee7b19f3a7707323f40e2c4d96ef067b0d2e96ca7c002f05506R95) [[3]](diffhunk://#diff-6220c7bf40341eb6d48a9e00cb083dd3acddf63ac4f7ff3e9dfe6569e79f647aL155-R162)

**Testing and validation:**

* Added a new test suite for spinner phase label logic (`test_spinner_phases.py`), verifying correct label generation for different action kinds and slash commands.
* Updated and expanded terminal runtime tests to check that spinner labels are set and rendered as expected, and that the phase remains stable unless explicitly changed. [[1]](diffhunk://#diff-bcd5cf1666a3dfc303ab169d92d0206dfe72cdd0def4177b4720f7cea29cf885L824-R824) [[2]](diffhunk://#diff-bcd5cf1666a3dfc303ab169d92d0206dfe72cdd0def4177b4720f7cea29cf885L856-R871) [[3]](diffhunk://#diff-bcd5cf1666a3dfc303ab169d92d0206dfe72cdd0def4177b4720f7cea29cf885R1012-R1027)

These changes ensure the REPL spinner provides clear, consistent feedback about the current operation, improving user experience and maintainability.