### PR TITLE
fix(prompt-log): default to redacting LLM prompt/response content

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -273,8 +273,9 @@ OPENSRE_SENTRY_LOGGING_DISABLED=0
 OPENSRE_PROMPT_LOG_DISABLED=0
 # Disable only local JSONL prompt log file.
 OPENSRE_PROMPT_LOG_LOCAL_DISABLED=0
-# Force prompt/response redaction before local or PostHog sinks.
-OPENSRE_PROMPT_LOG_REDACT=0
+# Redact prompt/response content (known token shapes) before local or PostHog
+# sinks. On by default — set to 0 to log/send raw, unredacted content.
+OPENSRE_PROMPT_LOG_REDACT=1
 # Optional override for local prompt log path (default ~/.config/opensre/prompt_log.jsonl).
 # OPENSRE_PROMPT_LOG_PATH=
 

--- a/app/cli/interactive_shell/prompt_logging/config.py
+++ b/app/cli/interactive_shell/prompt_logging/config.py
@@ -36,7 +36,7 @@ class PromptLogConfig:
     enabled: bool = True
     local_enabled: bool = True
     posthog_enabled: bool = True
-    redact: bool = False
+    redact: bool = True
     max_chars: int = _DEFAULT_MAX_CHARS
     log_path: Path = _DEFAULT_LOG_PATH
 
@@ -51,8 +51,12 @@ class PromptLogConfig:
         enabled = not _coerce_bool(disabled, default=False)
         local_enabled = not _coerce_bool(local_disabled, default=False)
         posthog_enabled = _coerce_bool(file_conf.get("posthog_enabled"), default=True)
+        # Default on, matching HistoryPolicy.redact — prompt/response content can
+        # carry the same token shapes as typed history and additionally leaves the
+        # machine via the PostHog sink, so it should not be less guarded by default
+        # than command history is. See docs/interactive-shell-privacy.mdx.
         redact = _coerce_bool(
-            redact_env, default=_coerce_bool(file_conf.get("redact"), default=False)
+            redact_env, default=_coerce_bool(file_conf.get("redact"), default=True)
         )
         max_chars = _coerce_int(file_conf.get("max_chars"), default=_DEFAULT_MAX_CHARS)
 

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -140,14 +140,14 @@ All configuration options for OpenSRE can be set via environment variables. This
 
 | Variable | Default | Description | Module |
 |----------|---------|-------------|--------|
-| `OPENSRE_NO_TELEMETRY` | `0` | Disable all telemetry | `utils/sentry_sdk` |
+| `OPENSRE_NO_TELEMETRY` | `0` | Disable all telemetry, including Sentry and PostHog (covers `$ai_generation` prompt/response events) | `utils/sentry_sdk` |
 | `OPENSRE_SENTRY_DISABLED` | `0` | Disable Sentry error reporting | `utils/sentry_sdk` |
 | `OPENSRE_SENTRY_DSN` | | Override Sentry DSN | `utils/sentry_sdk` |
 | `OPENSRE_SENTRY_LOGGING_DISABLED` | `0` | Disable Sentry log integration | `.env.example` |
 | `OPENSRE_DEPLOYMENT_METHOD` | `local` | Deployment method tag for Sentry (`railway`, `ec2`, `vercel`, `local`) | `.env.example` |
 | `OPENSRE_PROMPT_LOG_DISABLED` | `0` | Disable prompt logging entirely | `.env.example` |
 | `OPENSRE_PROMPT_LOG_LOCAL_DISABLED` | `0` | Disable local prompt log file | `.env.example` |
-| `OPENSRE_PROMPT_LOG_REDACT` | `0` | Redact prompts before logging | `.env.example` |
+| `OPENSRE_PROMPT_LOG_REDACT` | `1` | Redact known token shapes from prompts/responses before local or PostHog logging | `.env.example` |
 | `OPENSRE_PROMPT_LOG_PATH` | `~/.config/opensre/prompt_log.jsonl` | Path to local prompt log file | `.env.example` |
 | `DO_NOT_TRACK` | `0` | Honor global do-not-track preference | `utils/sentry_sdk` |
 | `SENTRY_TRACES_SAMPLE_RATE` | `1.0` | Trace sampling rate for Sentry | `.env.example` |

--- a/docs/interactive-shell-privacy.mdx
+++ b/docs/interactive-shell-privacy.mdx
@@ -1,18 +1,18 @@
 ---
 title: 'Interactive Shell Privacy'
-description: 'How OpenSRE redacts secrets from your command history, and the controls you have over persistence'
+description: 'How OpenSRE redacts secrets from your command history and LLM prompt/response logs, and the controls you have over persistence and cloud telemetry'
 ---
 
 ## Overview
 
-The OpenSRE interactive shell persists every line you type to a history file so up-arrow recall and `/history` work across sessions. Incident prompts can include sensitive identifiers and tokens, so the shell:
+The OpenSRE interactive shell persists every line you type to a history file so up-arrow recall and `/history` work across sessions, and separately records each LLM prompt/response turn for local debugging and `/resume`. Incident prompts can include sensitive identifiers and tokens, so the shell:
 
 - redacts known token shapes before each entry is written to disk
 - supports disabling persistence entirely (memory-only mode)
 - caps how many entries are kept (oldest pruned)
 - offers a one-shot `/history clear` to wipe the file on demand
 
-The history file lives at `~/.opensre/interactive_history`.
+The history file lives at `~/.opensre/interactive_history`. See [Prompt and response logging](#prompt-and-response-logging) below for the separate LLM turn log and its PostHog forwarding behavior.
 
 ## Defaults
 
@@ -79,6 +79,46 @@ interactive:
     max_entries: 5000
 ```
 
+## Prompt and response logging
+
+Separately from typed-command history, the interactive shell records each LLM turn — the full prompt sent and the full response received — for chat and follow-up routes. This log is richer than command history (it includes model output, not just what you typed) and is used for two purposes:
+
+1. **Local debugging / `/resume`**: appended as JSON Lines to `~/.opensre/prompt_log.jsonl`, and folded into the session file so `/resume` can restore conversation context.
+2. **Product analytics**: forwarded to PostHog as an `$ai_generation` event (model, provider, latency, token counts, and the prompt/response text) so we can track usage and quality of the AI features.
+
+### Defaults
+
+| Setting | Default | Effect |
+| --- | --- | --- |
+| Logging | **on** | Each LLM turn is recorded. |
+| Local JSONL file | **on** | Turns are appended to `~/.opensre/prompt_log.jsonl`. |
+| PostHog forwarding | **on** | Turns are also sent as a PostHog `$ai_generation` event. |
+| Redaction | **on** | Known token shapes (same patterns as command history) are stripped from the prompt and response before either sink. |
+
+### Environment variables
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `OPENSRE_PROMPT_LOG_DISABLED` | `0` | Set to `1` to disable prompt/response logging entirely (both local file and PostHog). |
+| `OPENSRE_PROMPT_LOG_LOCAL_DISABLED` | `0` | Set to `1` to skip the local JSONL file while leaving PostHog forwarding (if enabled) unaffected. |
+| `OPENSRE_PROMPT_LOG_REDACT` | `1` | Set to `0` to log/send raw, unredacted prompt and response text. |
+| `OPENSRE_PROMPT_LOG_PATH` | `~/.opensre/prompt_log.jsonl` | Override the local JSONL file path. |
+
+PostHog forwarding for this event additionally honors the global telemetry opt-outs: set **`OPENSRE_NO_TELEMETRY=1`**, `OPENSRE_ANALYTICS_DISABLED=1`, or `DO_NOT_TRACK=1` to stop all PostHog traffic (including `$ai_generation`) without touching the local JSONL file. See [Environment Variables](/configuration/environment-variables#telemetry-monitoring).
+
+### Config file
+
+```yaml
+interactive:
+  prompt_log:
+    posthog_enabled: true
+    redact: true
+    max_chars: 32000
+    path: ~/.opensre/prompt_log.jsonl
+```
+
+Redaction here uses the same built-in pattern set as command history (see [Redaction patterns](#redaction-patterns) above) — it catches known secret shapes, not arbitrary sensitive content. Raw incident details, hostnames, or business context in a prompt are not redacted; only credential-shaped substrings are.
+
 ## Threat model
 
 The history file is **plain text on local disk** at `~/.opensre/interactive_history`, with the user's default file permissions. Built-in redaction targets common token shapes only — it is not a substitute for proper secret handling. Treat the file as confidential and be aware:
@@ -87,4 +127,6 @@ The history file is **plain text on local disk** at `~/.opensre/interactive_hist
 - Redaction cannot detect tokens that look like normal text (for example a natural-language password). Don't paste secrets you wouldn't be comfortable seeing in a system log.
 - Custom redaction patterns are not yet supported in v1. If you need to redact internal token shapes, use `/history off` for that session and run `/history clear` afterwards.
 
-For the strongest posture: set `OPENSRE_HISTORY_ENABLED=0`, accept the loss of cross-session up-arrow recall, and rely on the in-memory ring instead.
+The prompt/response log carries the same caveat, plus one more: with PostHog forwarding on (the default), redacted prompt/response text leaves your machine. If you discuss confidential systems or data in the interactive shell, set `OPENSRE_NO_TELEMETRY=1` (or `OPENSRE_PROMPT_LOG_DISABLED=1` to also stop the local file) rather than relying on redaction alone.
+
+For the strongest posture: set `OPENSRE_HISTORY_ENABLED=0` and `OPENSRE_NO_TELEMETRY=1`, accept the loss of cross-session up-arrow recall and `/resume` context, and rely on the in-memory ring instead.

--- a/docs/sessions.mdx
+++ b/docs/sessions.mdx
@@ -136,7 +136,7 @@ Sessions are stored as files under `~/.opensre/sessions/`. Each file is plain te
 
 ## Privacy and what is NOT saved
 
-- **Secrets or credentials** — session text is stored as typed; enable prompt log redaction if needed
+- **Secrets or credentials** — known token shapes are redacted from the prompt log by default (set `OPENSRE_PROMPT_LOG_REDACT=0` to store raw text instead)
 - **Full investigation results** — stored separately under `~/.opensre/investigations/`
 - **Token usage** — tracked in `~/.opensre/prompt_log.jsonl` when prompt logging is enabled
 
@@ -146,5 +146,5 @@ See [Interactive Shell Privacy](/interactive-shell-privacy) for redaction contro
 
 ## Related
 
-- [Interactive Shell Privacy](/interactive-shell-privacy) — command history and redaction settings
+- [Interactive Shell Privacy](/interactive-shell-privacy) — command history, prompt/response logging, and redaction settings
 - [Prompt Logging](/configuration/environment-variables) — full prompt/response logging configuration

--- a/tests/cli/interactive_shell/prompt_logging/test_config.py
+++ b/tests/cli/interactive_shell/prompt_logging/test_config.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from app.cli.interactive_shell.prompt_logging.config import PromptLogConfig
+
+
+def _no_file_settings(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.prompt_logging.config.read_prompt_log_settings",
+        lambda: {},
+    )
+
+
+def test_load_defaults_to_redact_on(monkeypatch) -> None:
+    """Redaction must default on, matching HistoryPolicy — see issue #2804.
+
+    Prompt/response content can carry the same token shapes as typed command
+    history and additionally leaves the machine via the PostHog sink, so it
+    must not ship less guarded than history by default.
+    """
+    _no_file_settings(monkeypatch)
+    for var in (
+        "OPENSRE_PROMPT_LOG_DISABLED",
+        "OPENSRE_PROMPT_LOG_LOCAL_DISABLED",
+        "OPENSRE_PROMPT_LOG_REDACT",
+        "OPENSRE_PROMPT_LOG_PATH",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    config = PromptLogConfig.load()
+
+    assert config.redact is True
+    assert config.posthog_enabled is True
+
+
+def test_load_respects_env_opt_out_of_redaction(monkeypatch) -> None:
+    _no_file_settings(monkeypatch)
+    monkeypatch.setenv("OPENSRE_PROMPT_LOG_REDACT", "0")
+
+    config = PromptLogConfig.load()
+
+    assert config.redact is False
+
+
+def test_load_respects_file_opt_out_of_redaction(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.prompt_logging.config.read_prompt_log_settings",
+        lambda: {"redact": False},
+    )
+    monkeypatch.delenv("OPENSRE_PROMPT_LOG_REDACT", raising=False)
+
+    config = PromptLogConfig.load()
+
+    assert config.redact is False
+
+
+def test_env_redact_overrides_file_setting(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.prompt_logging.config.read_prompt_log_settings",
+        lambda: {"redact": False},
+    )
+    monkeypatch.setenv("OPENSRE_PROMPT_LOG_REDACT", "1")
+
+    config = PromptLogConfig.load()
+
+    assert config.redact is True
+
+
+def test_dataclass_default_redact_is_on() -> None:
+    """Direct construction (e.g. in other tests/callers) should also default-redact."""
+    assert PromptLogConfig().redact is True


### PR DESCRIPTION
## Summary

Fixes #2804.

`PromptLogConfig.redact` defaulted to `False`, so on a fresh install with no env vars set, the interactive shell forwarded **raw, unredacted** LLM prompt/response text to:

- PostHog (`$ai_generation` event), and
- the local `~/.opensre/prompt_log.jsonl` file.

This was inconsistent with `HistoryPolicy.redact` (typed command history), which already defaults redaction **on**, and with the documented "no raw content by design" posture. The issue reporter found connection strings/tokens flowing into the default PostHog payload as a result.

## What changed

- **`app/cli/interactive_shell/prompt_logging/config.py`**: flip `PromptLogConfig.redact` default to `True` (dataclass field + the `.load()` fallback), matching `HistoryPolicy`. Existing `OPENSRE_PROMPT_LOG_REDACT=0` / config-file `redact: false` still let users opt back into raw logging.
- **`.env.example`** / **`docs/configuration/environment-variables.mdx`**: updated to reflect the new default.
- **`docs/interactive-shell-privacy.mdx`**: added a "Prompt and response logging" section — this page previously only documented command history, not the separate LLM prompt/response log or its PostHog forwarding (the doc gap the issue also flagged). Documents defaults, env vars, config file shape, and the threat model (redaction only catches known token shapes, not arbitrary sensitive content — `OPENSRE_NO_TELEMETRY=1` is the way to stop all PostHog traffic).
- **`docs/sessions.mdx`**: updated the privacy bullet to reflect redaction-by-default.
- **`tests/cli/interactive_shell/prompt_logging/test_config.py`** (new): covers the new default and env/file override precedence.

## What didn't need to change

`OPENSRE_NO_TELEMETRY=1` already disables the PostHog `$ai_generation` forwarding — `capture_ai_generation()` routes through the same `Analytics.capture()` singleton as every other event, which short-circuits on `_is_opted_out()` (`OPENSRE_NO_TELEMETRY` / `OPENSRE_ANALYTICS_DISABLED` / `DO_NOT_TRACK`). So the gap was the **default redaction behavior**, not a missing opt-out — this PR fixes the default rather than adding a new flag.

## Testing

- `make lint`, `make format-check`, `make typecheck` — all pass.
- `make test-scope` (scoped to the `cli` area for this diff) — 1742 passed, 1 pre-existing unrelated failure (`tests/cli/test_doctor.py::test_check_llm_provider_not_set`, environment-dependent on this machine's installed LLM provider CLI; reproduces identically on an unmodified `main` checkout, unrelated to `doctor.py`/`config.py` vs. the file touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)