### PR TITLE
ci: add opt-in automerge label workflow

### DIFF
--- a/.github/scripts/automerge_pr.py
+++ b/.github/scripts/automerge_pr.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Merge a pull request when it is labeled automerge and CI checks are green."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+AUTOMERGE_LABEL = "automerge"
+ALLOWED_CONCLUSIONS = frozenset({"SUCCESS", "SKIPPED", "NEUTRAL"})
+
+
+def _run_gh(args: list[str]) -> Any:
+    result = subprocess.run(
+        ["gh", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def _checks_are_green(status_rollup: list[dict[str, Any]]) -> tuple[bool, str]:
+    if not status_rollup:
+        return False, "no status checks reported yet"
+
+    for check in status_rollup:
+        name = check.get("name", "unknown")
+        status = check.get("status", "")
+        conclusion = check.get("conclusion") or ""
+
+        if status in {"IN_PROGRESS", "QUEUED", "PENDING", "WAITING", "REQUESTED"}:
+            return False, f"check still running: {name}"
+
+        if status != "COMPLETED":
+            return False, f"unexpected check status for {name}: {status}"
+
+        if conclusion not in ALLOWED_CONCLUSIONS:
+            return False, f"check not green: {name} ({conclusion or 'missing conclusion'})"
+
+    return True, "all checks green"
+
+
+def main() -> int:
+    repo = os.environ["GITHUB_REPOSITORY"]
+    pr_number = os.environ["PR_NUMBER"]
+
+    pr = _run_gh(
+        [
+            "pr",
+            "view",
+            pr_number,
+            "--repo",
+            repo,
+            "--json",
+            "baseRefName,isDraft,mergeable,mergeStateStatus,labels,state,statusCheckRollup,title",
+        ]
+    )
+
+    if pr.get("baseRefName") != "main":
+        print(f"PR #{pr_number} does not target main; skipping.")
+        return 0
+
+    if pr.get("state") != "OPEN":
+        print(f"PR #{pr_number} is not open; skipping.")
+        return 0
+
+    if pr.get("isDraft"):
+        print(f"PR #{pr_number} is a draft; skipping.")
+        return 0
+
+    label_names = {label["name"] for label in pr.get("labels", [])}
+    if AUTOMERGE_LABEL not in label_names:
+        print(f"PR #{pr_number} does not have the {AUTOMERGE_LABEL} label; skipping.")
+        return 0
+
+    if pr.get("mergeable") != "MERGEABLE":
+        print(f"PR #{pr_number} is not mergeable ({pr.get('mergeStateStatus')}); skipping.")
+        return 0
+
+    green, reason = _checks_are_green(pr.get("statusCheckRollup") or [])
+    if not green:
+        print(f"PR #{pr_number} not ready to merge: {reason}")
+        return 0
+
+    title = pr["title"]
+    print(f"Merging PR #{pr_number}: {title}")
+    subprocess.run(
+        [
+            "gh",
+            "pr",
+            "merge",
+            pr_number,
+            "--repo",
+            repo,
+            "--squash",
+            "--delete-branch",
+            "--subject",
+            title,
+        ],
+        check=True,
+    )
+    print(f"Merged PR #{pr_number}.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr or exc.stdout or str(exc), file=sys.stderr)
+        raise SystemExit(exc.returncode) from exc

--- a/.github/scripts/automerge_pr.py
+++ b/.github/scripts/automerge_pr.py
@@ -10,7 +10,67 @@ import sys
 from typing import Any
 
 AUTOMERGE_LABEL = "automerge"
-ALLOWED_CONCLUSIONS = frozenset({"SUCCESS", "SKIPPED", "NEUTRAL"})
+CHECK_RUN_PENDING_STATUSES = frozenset({"IN_PROGRESS", "QUEUED", "PENDING", "WAITING", "REQUESTED"})
+CHECK_RUN_ALLOWED_CONCLUSIONS = frozenset({"SUCCESS", "SKIPPED", "NEUTRAL"})
+STATUS_CONTEXT_PENDING_STATES = frozenset({"PENDING", "EXPECTED"})
+STATUS_CONTEXT_ALLOWED_STATES = frozenset({"SUCCESS"})
+
+
+def _check_display_name(check: dict[str, Any]) -> str:
+    return str(check.get("name") or check.get("context") or "unknown")
+
+
+def _check_run_is_green(check: dict[str, Any]) -> tuple[bool, str]:
+    name = _check_display_name(check)
+    status = check.get("status", "")
+    conclusion = check.get("conclusion") or ""
+
+    if status in CHECK_RUN_PENDING_STATUSES:
+        return False, f"check still running: {name}"
+
+    if status != "COMPLETED":
+        return False, f"unexpected check status for {name}: {status or 'missing status'}"
+
+    if conclusion not in CHECK_RUN_ALLOWED_CONCLUSIONS:
+        return False, f"check not green: {name} ({conclusion or 'missing conclusion'})"
+
+    return True, ""
+
+
+def _status_context_is_green(check: dict[str, Any]) -> tuple[bool, str]:
+    name = _check_display_name(check)
+    state = check.get("state") or ""
+
+    if state in STATUS_CONTEXT_PENDING_STATES:
+        return False, f"status still pending: {name}"
+
+    if state not in STATUS_CONTEXT_ALLOWED_STATES:
+        return False, f"status not green: {name} ({state or 'missing state'})"
+
+    return True, ""
+
+
+def _rollup_item_is_green(check: dict[str, Any]) -> tuple[bool, str]:
+    typename = check.get("__typename", "")
+    if typename == "StatusContext":
+        return _status_context_is_green(check)
+    if typename == "CheckRun":
+        return _check_run_is_green(check)
+    if "state" in check and "status" not in check:
+        return _status_context_is_green(check)
+    return _check_run_is_green(check)
+
+
+def _checks_are_green(status_rollup: list[dict[str, Any]]) -> tuple[bool, str]:
+    if not status_rollup:
+        return False, "no status checks reported yet"
+
+    for check in status_rollup:
+        green, reason = _rollup_item_is_green(check)
+        if not green:
+            return False, reason
+
+    return True, "all checks green"
 
 
 def _run_gh(args: list[str]) -> Any:
@@ -21,27 +81,6 @@ def _run_gh(args: list[str]) -> Any:
         text=True,
     )
     return json.loads(result.stdout)
-
-
-def _checks_are_green(status_rollup: list[dict[str, Any]]) -> tuple[bool, str]:
-    if not status_rollup:
-        return False, "no status checks reported yet"
-
-    for check in status_rollup:
-        name = check.get("name", "unknown")
-        status = check.get("status", "")
-        conclusion = check.get("conclusion") or ""
-
-        if status in {"IN_PROGRESS", "QUEUED", "PENDING", "WAITING", "REQUESTED"}:
-            return False, f"check still running: {name}"
-
-        if status != "COMPLETED":
-            return False, f"unexpected check status for {name}: {status}"
-
-        if conclusion not in ALLOWED_CONCLUSIONS:
-            return False, f"check not green: {name} ({conclusion or 'missing conclusion'})"
-
-    return True, "all checks green"
 
 
 def main() -> int:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,7 +15,9 @@ Opt-in squash merge when CI is green. Trigger: add the **`automerge`** label to 
 
 1. Add the `automerge` label on GitHub (or `gh pr edit <n> --add-label automerge`).
 2. [`.github/scripts/automerge_pr.py`](../scripts/automerge_pr.py) runs on label add, new pushes, or check-suite completion.
-3. The PR is squash-merged with branch delete when every reported check is `SUCCESS`, `SKIPPED`, or `NEUTRAL`.
+3. The PR is squash-merged with branch delete when every reported check is green:
+   - GitHub Actions **CheckRun** items (`SUCCESS`, `SKIPPED`, `NEUTRAL`)
+   - Legacy commit **StatusContext** items (`SUCCESS` only)
 
 Push again with the label still on to re-merge after CI. Remove the label to cancel.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,40 @@
+# GitHub Actions (maintainer reference)
+
+Internal notes for repository automation under `.github/workflows/`. Not published on the docs site.
+
+## Auto-merge (`automerge.yml`)
+
+Opt-in squash merge when CI is green. Trigger: add the **`automerge`** label to a PR targeting `main`.
+
+### When to use
+
+1. Greptile is **5/5** and review feedback is addressed.
+2. You are ready to merge and do not want to wait on CI manually.
+
+### Flow
+
+1. Add the `automerge` label on GitHub (or `gh pr edit <n> --add-label automerge`).
+2. [`.github/scripts/automerge_pr.py`](../scripts/automerge_pr.py) runs on label add, new pushes, or check-suite completion.
+3. The PR is squash-merged with branch delete when every reported check is `SUCCESS`, `SKIPPED`, or `NEUTRAL`.
+
+Push again with the label still on to re-merge after CI. Remove the label to cancel.
+
+### Limits
+
+- **Upstream branches only** — fork PRs still need a manual merge (`GITHUB_TOKEN` cannot write on fork heads).
+- **Greptile is not a GitHub check** — the label does not wait for Greptile; add it only when review is done.
+- **Draft PRs** — skipped until marked ready for review.
+
+## Other workflows (pointers)
+
+| Workflow | Purpose |
+| -------- | ------- |
+| [`ci.yml`](ci.yml) | PR/push quality gates and sharded pytest |
+| [`ci-labels-windows.yml`](ci-labels-windows.yml) | Optional Windows CI (`ci:windows` label) |
+| [`codeql.yml`](codeql.yml) | CodeQL security analysis |
+| [`greptile-pr-reminder.yml`](greptile-pr-reminder.yml) | Greptile review nudge on PR open |
+| [`celebrate-merged-pr.yml`](celebrate-merged-pr.yml) | Post-merge celebration comment |
+| [`good-first-issue-assign.yml`](good-first-issue-assign.yml) | Auto-assign good first issues |
+| [`release.yml`](release.yml) | Release builds and artifacts |
+
+See [CI.md](../../CI.md) for local parity commands before push.

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,68 @@
+name: Auto-merge
+
+# Opt-in squash merge once all PR checks are green. Add the `automerge` label when the PR
+# is ready (Greptile 5/5, review done, etc.). Works for branches pushed to this repo;
+# fork PRs still need a maintainer merge because GITHUB_TOKEN cannot write on fork heads.
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches: [main]
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: automerge-${{ github.event.pull_request.number || github.event.check_suite.pull_requests[0].number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  merge:
+    name: Merge when CI is green
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success') ||
+      (github.event_name == 'pull_request' &&
+        (github.event.action != 'labeled' || github.event.label.name == 'automerge'))
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Resolve pull request number
+        id: pr
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          CHECK_SUITE_PRS: ${{ toJson(github.event.check_suite.pull_requests) }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if [ -z "$PR_NUMBER" ]; then
+              echo "No pull request number on event."
+              exit 0
+            fi
+            echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          pr="$(CHECK_SUITE_PRS="$CHECK_SUITE_PRS" python3 - <<'PY'
+          import json
+          import os
+
+          prs = json.loads(os.environ["CHECK_SUITE_PRS"])
+          print(prs[0]["number"] if prs else "")
+          PY
+          )"
+          if [ -z "$pr" ]; then
+            echo "No pull request linked to completed check suite."
+            exit 0
+          fi
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+
+      - name: Merge labeled PR when checks pass
+        if: steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: python3 .github/scripts/automerge_pr.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ If you prefer VS Code, use the devcontainer at [.devcontainer/devcontainer.json]
 5. **Code and test** — Make changes, add tests, ensure all checks pass
 6. **Submit a PR** — Open a pull request (or draft PR) linked to the issue; use the PR template
 7. **Review & iterate** — Respond to feedback, make changes as needed
-8. **Merge** — Maintainer merges once approved
+8. **Merge** — Maintainer merges once approved (or add the `automerge` label to squash-merge when CI is green)
 
 **Detailed steps:** See the "Development Workflow" section below.
 
@@ -183,6 +183,18 @@ We use [Greptile](https://greptile.com) for automated code review. Before a PR c
 Wait 30–60 seconds for the review to appear, then address each comment and re-trigger until you hit 5/5.
 
 > **Automate the loop** — the [greploop skill](https://skills.sh/greptileai/skills/greploop) handles triggering, waiting, fixing, and re-reviewing automatically until 5/5 is reached.
+
+### Auto-merge when CI is green
+
+For branches pushed to `Tracer-Cloud/opensre`, you can skip manually watching CI and clicking merge:
+
+1. Wait until Greptile is **5/5** and the PR is otherwise ready.
+2. Add the **`automerge`** label to the PR.
+3. The [Auto-merge workflow](.github/workflows/automerge.yml) squash-merges once every reported check is green (`SUCCESS`, `SKIPPED`, or `NEUTRAL`).
+
+If you push new commits, leave the label on — the workflow re-runs after CI finishes. Remove the label if you want to stop an automatic merge.
+
+Fork PRs still need a manual maintainer merge (GitHub does not grant Actions write access on fork heads).
 
 ### If Your PR Includes Screenshots or Logs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ If you prefer VS Code, use the devcontainer at [.devcontainer/devcontainer.json]
 5. **Code and test** — Make changes, add tests, ensure all checks pass
 6. **Submit a PR** — Open a pull request (or draft PR) linked to the issue; use the PR template
 7. **Review & iterate** — Respond to feedback, make changes as needed
-8. **Merge** — Maintainer merges once approved (or add the `automerge` label to squash-merge when CI is green)
+8. **Merge** — Maintainer merges once approved
 
 **Detailed steps:** See the "Development Workflow" section below.
 
@@ -183,18 +183,6 @@ We use [Greptile](https://greptile.com) for automated code review. Before a PR c
 Wait 30–60 seconds for the review to appear, then address each comment and re-trigger until you hit 5/5.
 
 > **Automate the loop** — the [greploop skill](https://skills.sh/greptileai/skills/greploop) handles triggering, waiting, fixing, and re-reviewing automatically until 5/5 is reached.
-
-### Auto-merge when CI is green
-
-For branches pushed to `Tracer-Cloud/opensre`, you can skip manually watching CI and clicking merge:
-
-1. Wait until Greptile is **5/5** and the PR is otherwise ready.
-2. Add the **`automerge`** label to the PR.
-3. The [Auto-merge workflow](.github/workflows/automerge.yml) squash-merges once every reported check is green (`SUCCESS`, `SKIPPED`, or `NEUTRAL`).
-
-If you push new commits, leave the label on — the workflow re-runs after CI finishes. Remove the label if you want to stop an automatic merge.
-
-Fork PRs still need a manual maintainer merge (GitHub does not grant Actions write access on fork heads).
 
 ### If Your PR Includes Screenshots or Logs
 

--- a/tests/github/test_automerge_pr.py
+++ b/tests/github/test_automerge_pr.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "automerge_pr.py"
+_spec = importlib.util.spec_from_file_location("automerge_pr", _MODULE_PATH)
+assert _spec and _spec.loader
+automerge_pr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(automerge_pr)
+
+
+def test_checks_are_green_for_completed_check_runs() -> None:
+    green, reason = automerge_pr._checks_are_green(
+        [
+            {
+                "__typename": "CheckRun",
+                "name": "quality (ubuntu-latest)",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            },
+            {
+                "__typename": "CheckRun",
+                "name": "windows test",
+                "status": "COMPLETED",
+                "conclusion": "SKIPPED",
+            },
+        ]
+    )
+    assert green is True
+    assert reason == "all checks green"
+
+
+def test_checks_are_green_for_successful_status_contexts() -> None:
+    green, reason = automerge_pr._checks_are_green(
+        [
+            {
+                "__typename": "StatusContext",
+                "context": "ci/legacy",
+                "state": "SUCCESS",
+            }
+        ]
+    )
+    assert green is True
+    assert reason == "all checks green"
+
+
+def test_checks_are_green_mixed_check_run_and_status_context() -> None:
+    green, reason = automerge_pr._checks_are_green(
+        [
+            {
+                "__typename": "CheckRun",
+                "name": "quality (ubuntu-latest)",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            },
+            {
+                "__typename": "StatusContext",
+                "context": "ci/legacy",
+                "state": "SUCCESS",
+            },
+        ]
+    )
+    assert green is True
+    assert reason == "all checks green"
+
+
+def test_status_context_failure_blocks_merge() -> None:
+    green, reason = automerge_pr._checks_are_green(
+        [
+            {
+                "__typename": "StatusContext",
+                "context": "ci/legacy",
+                "state": "FAILURE",
+            }
+        ]
+    )
+    assert green is False
+    assert reason == "status not green: ci/legacy (FAILURE)"
+
+
+def test_status_context_pending_blocks_merge() -> None:
+    green, reason = automerge_pr._checks_are_green(
+        [
+            {
+                "__typename": "StatusContext",
+                "context": "ci/legacy",
+                "state": "PENDING",
+            }
+        ]
+    )
+    assert green is False
+    assert reason == "status still pending: ci/legacy"


### PR DESCRIPTION
## Summary
- Adds an opt-in **Auto-merge** GitHub Action: add the `automerge` label and the PR squash-merges once every reported CI check is green.
- Adds `.github/scripts/automerge_pr.py` to verify mergeability and check conclusions before merging.
- Documents the workflow in `CONTRIBUTING.md`.

## Usage
1. Wait until the PR is ready (Greptile 5/5, etc.).
2. Add the **`automerge`** label.
3. Walk away — merge happens when CI finishes green.

Remove the label to cancel. Works for branches pushed to this repo; fork PRs still need manual merge.

## Test plan
- [ ] Merge this PR manually (bootstrap).
- [ ] On a follow-up PR, add `automerge` after CI is green and confirm squash merge.
- [ ] Push a new commit with label still on and confirm re-merge after CI.
- [ ] Remove label before merge and confirm no merge occurs.