### PR TITLE
docs: expand interactive shell commands documentation

### DIFF
--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -1,85 +1,745 @@
 ---
 title: 'Interactive Shell Commands'
-description: 'Quick reference for common slash commands in the opensre REPL — session cost, status, help, and more'
+description: 'Complete reference for every slash command in the OpenSRE REPL — session control, investigations, integrations, tasks, watchdogs, and more'
 ---
 
-Start the interactive shell with `opensre` (TTY required). Type a slash command at the prompt, or describe what you want in plain language and the planner can map intent to the right command.
+Start the interactive shell with `opensre` (TTY required). Type a slash command at the prompt, or describe what you want in plain language — the action planner can route intent to the right command.
 
-Run `/help` anytime for the full, up-to-date command list grouped by category.
+Run `/help` anytime for the live command list grouped by category. In a TTY, bare `/help` opens an interactive picker; selecting a command runs it directly.
+
+<Info>
+  Commands marked **elevated** may prompt for confirmation unless [trust mode](#trust-mode) is on. Non-TTY sessions fail closed on elevated actions.
+</Info>
 
 ## Quick reference
 
+### Help and exit
+
 | Command | What it does |
 | --- | --- |
-| `/help` | List commands or show help for one command (`/help /model`, `/help tasks`) |
-| `/status` | Session summary — interactions, alerts, provider, reasoning effort, trust mode |
-| `/cost` | Token usage and LLM call count for the current session |
-| `/effort` | Set or show reasoning effort (`low`, `medium`, `high`, `xhigh`, `max`) |
-| `/clear` | Clear the screen and re-render the banner |
-| `/exit` | Leave the interactive shell (`/quit` is an alias) |
-| `/health` | Integration and agent health |
-| `/investigate` | Run an investigation from the REPL |
-| `/integrations` | List, verify, or manage integrations |
-| `/model` | Show or switch LLM provider and models |
-| `/sessions` | List recent REPL sessions |
-| `/resume <id>` | Restore a past session's conversation context |
+| `/help` | List commands or show help for one command or category |
+| `/?` | Shortcut for `/help` |
+| `/exit` | Leave the interactive shell |
+| `/quit` | Alias for `/exit` |
 
-For session persistence in depth, see [Session History](/sessions). For `/history` and `/privacy`, see [Interactive Shell Privacy](/interactive-shell-privacy).
+### Session
 
----
-
-## Session cost — `/cost`
-
-Show how much LLM usage the **current REPL session** has accumulated:
-
-```
-/cost
-```
-
-Typical output includes:
-
-| Field | Meaning |
+| Command | What it does |
 | --- | --- |
-| `history entries` | Lines recorded in this session's history |
-| `llm calls` | Number of LLM turns counted this session |
-| `input tokens` / `output tokens` | Totals for prompt and completion usage |
+| `/status` | Session summary — interactions, alerts, provider, effort, trust mode |
+| `/cost` | Token usage and LLM call count for the current session |
+| `/context` | Infra metadata accumulated during the session |
+| `/effort` | Set or show reasoning effort (`low` … `max`) |
+| `/trust` | Enable or disable trust mode (skip confirmation prompts) |
+| `/verbose` | Toggle verbose logging |
+| `/clear` | Clear the screen and re-render the banner |
+| `/compact` | Trim in-memory session history to the last 20 entries |
+| `/sessions` | List recent REPL sessions on disk |
+| `/resume <id>` | Restore a past session's conversation context |
+| `/new` | Start a new session file while keeping LLM context |
 
-When the provider returns usage metadata (for example on planner `invoke` calls), those counts are **measured**. Streaming chat and help paths **estimate** tokens from text length (roughly four characters per token). If any estimates are included, the table title notes `(includes estimates)` and measured vs estimated splits appear on the token rows.
+### Investigation
 
-Token totals reset when you start a new session (`/new`) or clear session state; `/cost` does not show billing from your cloud provider — only what OpenSRE tracked locally for this shell session.
+| Command | What it does |
+| --- | --- |
+| `/investigate` | Run an RCA from a file path or sample template |
+| `/template` | Print a starter alert JSON template |
+| `/last` | Reprint the most recent investigation report |
+| `/save <path>` | Export the last investigation to a file **elevated** |
+
+### Integrations, models, and tools
+
+| Command | What it does |
+| --- | --- |
+| `/health` | Integration and agent health check |
+| `/integrations` | List, verify, show, setup, or remove integrations |
+| `/mcp` | List, connect, or disconnect MCP servers |
+| `/model` | Show or switch LLM provider and models |
+| `/tools` | List registered investigation and chat tools |
+
+### Privacy and history
+
+| Command | What it does |
+| --- | --- |
+| `/history` | Show or manage persisted command history |
+| `/privacy` | History persistence, redaction status, and threat model |
+
+### Tasks and background work
+
+| Command | What it does |
+| --- | --- |
+| `/tasks` | List recent and in-flight background tasks |
+| `/cancel <id>` | Cancel a running task by id **elevated** |
+| `/stop` | Guidance for stopping investigations and background work |
+
+### Watchdog
+
+| Command | What it does |
+| --- | --- |
+| `/watch` | Watch a process and send Telegram threshold alarms **elevated** |
+| `/watches` | List active watchdog tasks with latest samples |
+| `/unwatch <id>` | Stop a watchdog task by id **elevated** |
+| `/watchdog` | CLI-parity wrapper for the watchdog monitor |
+
+### Agents and alerts
+
+| Command | What it does |
+| --- | --- |
+| `/agents` | View and manage the local AI agent fleet |
+| `/alerts` | Alert listener inbox status |
+
+### CLI parity
+
+These commands delegate to the same Click CLI you would run outside the REPL.
+
+| Command | What it does |
+| --- | --- |
+| `/onboard` | Interactive onboarding wizard |
+| `/remote` | Connect to and operate remote deployed agents |
+| `/config` | Show or edit `~/.opensre/config.yml` |
+| `/cron` | Manage scheduled delivery jobs |
+| `/messaging` | Telegram pairing and allowlist |
+| `/hermes` | Hermes log tailing and incident routing |
+| `/guardrails` | Sensitive-information guardrail rules |
+| `/tests` | Browse and run inventoried tests |
+| `/update` | Check for updates and upgrade OpenSRE |
+| `/debug` | Targeted runtime diagnostics |
+| `/uninstall` | Remove OpenSRE and local data **elevated** |
+
+### System
+
+| Command | What it does |
+| --- | --- |
+| `/doctor` | Full local environment diagnostic |
+| `/version` | OpenSRE, Python, and OS versions |
 
 ---
 
-## Session status — `/status`
+## Using `/help`
+
+```
+/help
+/help /model
+/help investigation
+/help tasks
+/help all
+```
+
+| Form | Result |
+| --- | --- |
+| `/help` | Interactive picker in a TTY; category index otherwise |
+| `/help <command>` | Detailed usage for one command (e.g. `/help /watch`) |
+| `/help <category>` | All commands in a section (`investigation`, `session`, `tasks`, …) |
+| `/help all` | Full command index |
+
+Help categories mirror the REPL grouping: Quick Access, Session, Integrations/Models/Tools, Investigation, Privacy, Tasks, Agents, Alerts, CLI parity, and System.
+
+---
+
+## Session commands
+
+### `/status`
+
+Shows interaction count, incoming alerts (with age of the most recent), whether an investigation ran this session, trust mode, reasoning effort, active LLM provider, grounding cache stats, and any accumulated infra context keys.
 
 ```
 /status
 ```
 
-Shows interaction count, incoming alerts, last investigation, trust mode, reasoning effort, active provider, and any accumulated infra context keys.
+### `/cost`
 
----
+Shows LLM usage tracked **locally** for the current REPL session. This is not cloud-provider billing.
 
-## Reasoning effort — `/effort`
+```
+/cost
+```
 
-For OpenAI and Codex providers, set how much reasoning the model applies in this REPL session:
+| Field | Meaning |
+| --- | --- |
+| `history entries` | Lines recorded in this session's history |
+| `llm calls` | Number of LLM turns counted this session |
+| `input tokens` / `output tokens` | Prompt and completion totals |
+
+When the provider returns usage metadata (planner `invoke` calls), counts are **measured**. Streaming chat paths **estimate** tokens from text length (~four characters per token). If estimates are included, the title notes `(includes estimates)` and rows show measured vs estimated splits.
+
+Token totals reset on `/new` or when session state is cleared. See [Session History](/sessions) for persistence across sessions.
+
+### `/context`
+
+Displays key/value infra metadata collected during investigations and chat (service name, cluster, region, and similar fields).
+
+```
+/context
+```
+
+### `/effort`
+
+Set reasoning depth for OpenAI and Codex providers in this REPL session.
 
 ```
 /effort high
 /effort
 ```
 
-Bare `/effort` prints the current level and usage. `/status` includes the same field. Other providers ignore this setting. You can also set `OPENSRE_REASONING_EFFORT` in the environment for non-interactive defaults. See [LLM providers](/llm-providers).
+| Level | Notes |
+| --- | --- |
+| `low` | Favor speed and lower cost |
+| `medium` | Balanced (default for many setups) |
+| `high` | More thorough reasoning |
+| `xhigh`, `max` | Deepest supported reasoning; best with newer GPT-5 or Codex models |
+
+Bare `/effort` prints the current level and provider default. Other providers ignore this setting. You can also set `OPENSRE_REASONING_EFFORT` in the environment. See [LLM providers](/llm-providers).
+
+### `/trust`
+
+Trust mode skips execution confirmation prompts for elevated commands.
+
+```
+/trust on
+/trust off
+/trust
+```
+
+In a TTY, bare `/trust` opens an interactive on/off menu. Use with care during incidents — confirmations exist for destructive or networked actions.
+
+### `/verbose`
+
+Toggle `TRACER_VERBOSE` logging for the REPL process.
+
+```
+/verbose on
+/verbose off
+/verbose
+```
+
+### `/clear`
+
+Clears the terminal and re-renders the OpenSRE banner. Does **not** reset session state, token usage, or conversation context.
+
+```
+/clear
+```
+
+### `/compact`
+
+Trims in-memory session history to the last 20 entries to reduce memory use. Does not affect persisted session files or LLM conversation context.
+
+```
+/compact
+```
+
+### `/sessions`, `/resume`, `/new`
+
+Session persistence is documented in depth on [Session History](/sessions). Summary:
+
+```
+/sessions
+/resume 9b2e4f7a
+/resume redis
+/resume
+/new
+```
+
+| Command | Behavior |
+| --- | --- |
+| `/sessions` | Up to 20 recent sessions with ID, name, duration, turns, investigation count |
+| `/resume <prefix>` | Restore LLM messages and infra context; bare `/resume` opens a picker in a TTY |
+| `/new` | Rotate session ID and reset counters while **keeping** conversation context — use after `/resume` to continue in a fresh session file |
+
+On exit, OpenSRE prints a `/resume <id>` hint so you can pick up later.
 
 ---
 
-## Help — `/help`
+## Investigation commands
+
+You can also paste alert text or describe an incident in plain language — the planner routes that to an investigation without a slash command. Use slash commands when you want explicit control.
+
+### `/investigate`
+
+Run root-cause analysis from a local alert file or a built-in sample template.
 
 ```
-/help
-/help /model
-/help investigation
-/help all
+/investigate alert.json
+/investigate generic
+/investigate ./alerts/checkout-502.json
+/investigate
 ```
 
-In a TTY, bare `/help` opens an interactive picker. Use `/help <command>` or `/help <category>` for details on one topic.
+| Target | Behavior |
+| --- | --- |
+| `alert.json` | Bundled demo alert file |
+| `generic`, `datadog`, `grafana`, `honeycomb`, `coralogix`, `splunk` | Built-in sample templates |
+| File path | Read alert text from disk (`.json`, `.md`, `.txt`) |
+| Bare `/investigate` | Interactive picker in a TTY |
+
+Template names take precedence over same-named files in the working directory. Force file mode with an explicit path (e.g. `/investigate ./generic`).
+
+Press **Ctrl+C** during a streaming investigation to cancel. Use `/tasks` and `/cancel` for background task control.
+
+### `/template`
+
+Print starter alert JSON you can edit and feed back into `/investigate`.
+
+```
+/template generic
+/template datadog
+/template
+```
+
+Choices: `generic`, `datadog`, `grafana`, `honeycomb`, `coralogix`, `splunk`.
+
+### `/last`
+
+Reprint the root cause and report from the most recent investigation in this session.
+
+```
+/last
+```
+
+### `/save`
+
+Write the last investigation to disk. Requires confirmation unless trust mode is on.
+
+```
+/save report.md
+/save out.json
+```
+
+| Extension | Output |
+| --- | --- |
+| `.json` | Full investigation state as JSON |
+| Other | Markdown with Root Cause and Report sections |
+
+---
+
+## Integrations, models, and tools
+
+### `/health`
+
+Read-only health check: local OpenSRE agent, LLM connectivity, and each configured integration with pass/fail per component.
+
+```
+/health
+```
+
+For environment-wide checks (Python, credentials, paths), use `/doctor` instead.
+
+### `/integrations`
+
+Manage integrations stored in your local integration store.
+
+```
+/integrations
+/integrations list
+/integrations verify
+/integrations show datadog
+/integrations setup datadog
+/integrations remove datadog
+```
+
+| Subcommand | Behavior |
+| --- | --- |
+| `list` (default) | Verify and list all configured integrations |
+| `verify` | Same as list; prints a summary if any integration failed |
+| `show <service>` | Verify and print details for one integration |
+| `setup <service>` | Run the integration setup wizard (CLI parity) |
+| `remove <service>` | Remove an integration **elevated** |
+
+Bare `/integrations` opens an interactive menu in a TTY.
+
+### `/mcp`
+
+Manage MCP server connections (subset of integrations that expose MCP).
+
+```
+/mcp list
+/mcp connect <server>
+/mcp disconnect <server>
+```
+
+`connect` and `disconnect` map to `opensre integrations setup` and `remove` for MCP-capable services.
+
+### `/model`
+
+Show or change the active LLM provider and models. Changes are written to your env file and take effect on the next LLM call.
+
+```
+/model show
+/model set openai gpt-4.1
+/model set anthropic --toolcall-model claude-sonnet-4-20250514
+/model restore
+/model toolcall set gpt-4.1-mini
+/model
+```
+
+| Subcommand | Behavior |
+| --- | --- |
+| `show` (default) | Current provider, reasoning model, toolcall model |
+| `set <provider> [model] [--toolcall-model <m>]` | Switch provider; optional model overrides |
+| `restore [provider]` | Reset to provider default reasoning model |
+| `toolcall set <model>` | Set toolcall model for the active provider |
+
+Bare `/model` opens an interactive menu in a TTY. Provider switches require credentials for the target provider — run `/onboard` if a key is missing. See [LLM providers](/llm-providers).
+
+Shorthand: `/model set claude-sonnet-4-20250514` (no provider) updates the reasoning model for the **current** provider.
+
+### `/tools`
+
+List tools registered in this OpenSRE build for investigation and chat surfaces.
+
+```
+/tools
+/tools list
+```
+
+---
+
+## Privacy and history
+
+Full privacy controls, redaction patterns, and environment variables are on [Interactive Shell Privacy](/interactive-shell-privacy).
+
+### `/history`
+
+```
+/history
+/history clear
+/history off
+/history on
+/history retention 1000
+```
+
+| Subcommand | Behavior |
+| --- | --- |
+| (none) | Show persisted command history entries |
+| `clear` | Delete the history file; up-arrow recall resets on next launch |
+| `off` | Pause persistence for this session |
+| `on` | Resume persistence |
+| `retention <N>` | Cap entries on disk (requires redacting history backend) |
+
+Bare `/history` opens an interactive menu in a TTY.
+
+### `/privacy`
+
+Shows persistence on/off, redaction status, retention cap, history file path, and built-in pattern count, plus a short threat-model reminder.
+
+```
+/privacy
+```
+
+---
+
+## Tasks and background work
+
+### `/tasks`
+
+List up to 50 recent tasks in the current session: investigations, CLI commands, synthetic tests, watchdogs, and similar background work.
+
+```
+/tasks
+```
+
+Columns include task id, kind, status, start time, duration, and a detail line (progress, result, or error).
+
+### `/cancel`
+
+Cancel a **running** background task by id prefix.
+
+```
+/cancel abc12
+```
+
+Use `/tasks` to find ids. Ambiguous prefixes require more characters. For streaming investigations, also press **Ctrl+C** if output is still flowing.
+
+### `/stop`
+
+Prints guidance — not a hard stop:
+
+```
+/stop
+```
+
+- **Streaming investigation:** press **Ctrl+C**
+- **Background task:** `/tasks` then `/cancel <id>`
+
+---
+
+## Watchdog commands
+
+Watchdog tasks monitor a process and send Telegram alarms when thresholds are exceeded. Configure Telegram delivery before use.
+
+### `/watch`
+
+```
+/watch 12345 --max-cpu 80 --max-rss 512M --max-runtime 30m --cooldown 5m --interval 2s --once
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `<pid>` | Process to watch (required, first argument) |
+| `--max-cpu` | CPU percent threshold |
+| `--max-rss` | Memory cap (`512M`, `1G`, etc.) |
+| `--max-runtime` | Max wall time (`30s`, `5m`, `1h`) |
+| `--cooldown` | Minimum time between alarms (default 5m) |
+| `--interval` | Sample interval (default 2s) |
+| `--once` | Fire at most one alarm per threshold |
+
+Returns a task id for `/watches` and `/unwatch`.
+
+### `/watches`
+
+List watchdog tasks in this session with pid, status, thresholds, and the latest resource sample.
+
+```
+/watches
+```
+
+### `/unwatch`
+
+Cancel a running watchdog by task id (not pid).
+
+```
+/unwatch abc12
+```
+
+### `/watchdog`
+
+CLI-parity entry point with flag-style arguments:
+
+```
+/watchdog --pid 12345 --max-rss 1G --max-cpu 80
+```
+
+Prefer `/watch` inside the REPL for integrated task tracking.
+
+---
+
+## Agents and alerts
+
+Agent fleet management is also covered on [Agents](/agents).
+
+### `/agents`
+
+```
+/agents
+/agents budget
+/agents budget my-agent 5.00
+/agents bus
+/agents claim feature-x cursor-agent
+/agents release feature-x
+/agents conflicts
+/agents kill 12345
+/agents trace 12345
+/agents wait 12345 --on 67890
+/agents graph
+```
+
+| Subcommand | Behavior |
+| --- | --- |
+| (none) | Registered plus discovered local agents (Cursor, Claude Code, Codex, Aider, …) |
+| `budget` | View hourly budgets; `budget <agent> <usd>` to set |
+| `bus` | Live-tail the cross-agent context bus until Ctrl+C |
+| `claim <branch> <agent>` | Claim a git branch for an agent |
+| `release <branch>` | Release a branch claim |
+| `conflicts` | Show file-write conflicts between agents |
+| `kill <pid> [--force]` | SIGTERM then SIGKILL **elevated** |
+| `trace <pid>` | Live-tail an agent's stdout |
+| `wait <pid> --on <other-pid>` | Record a wait dependency |
+| `graph` | Render the wait-on dependency graph |
+
+### `/alerts`
+
+Shows whether the local alert listener is active, queue depth, dropped count, and up to five recent ingested alerts.
+
+```
+/alerts
+```
+
+Post alerts to the listener endpoint configured during setup; the REPL surfaces them in `/status` and can route them into investigations.
+
+---
+
+## CLI parity commands
+
+These spawn `opensre …` subprocesses. Interactive wizards (e.g. `/onboard`) need a TTY.
+
+### `/onboard`
+
+```
+/onboard
+/onboard local_llm
+```
+
+Launches the setup wizard for LLM keys, integrations, and related config.
+
+### `/remote`
+
+Operate remote deployed OpenSRE instances.
+
+```
+/remote health
+/remote investigate
+/remote ops
+/remote pull
+/remote trigger
+```
+
+See [Remote runtime investigation](/remote-runtime-investigation).
+
+### `/config`
+
+```
+/config show
+/config set <key> <value>
+```
+
+Read or write `~/.opensre/config.yml`.
+
+### `/cron`
+
+```
+/cron list
+/cron add
+/cron remove <id>
+/cron run <id>
+/cron logs <id>
+```
+
+See [Cron](/cron) for scheduled delivery setup.
+
+### `/messaging`
+
+```
+/messaging pair
+/messaging allow
+/messaging revoke
+/messaging status
+```
+
+Telegram pairing and allowlist management.
+
+### `/hermes`
+
+```
+/hermes watch
+```
+
+Live-tail Hermes logs and route detected incidents. See [Hermes](/hermes).
+
+### `/guardrails`
+
+```
+/guardrails audit
+/guardrails init
+/guardrails rules
+/guardrails test
+```
+
+Manage sensitive-information masking rules.
+
+### `/tests`
+
+```
+/tests
+/tests list
+/tests run <test_id>
+/tests synthetic
+/tests cloudopsbench
+```
+
+Bare `/tests` opens an interactive test picker. `run`, `synthetic`, and `cloudopsbench` start background tasks — track them with `/tasks`.
+
+### `/update`
+
+Check PyPI for a newer OpenSRE version and upgrade if available (bounded network timeout).
+
+```
+/update
+```
+
+### `/debug`
+
+```
+/debug sentry
+```
+
+Run targeted diagnostics (subcommands match `opensre debug`).
+
+### `/uninstall`
+
+Remove OpenSRE and all local data from this machine. Destructive — requires confirmation **elevated**.
+
+```
+/uninstall
+```
+
+---
+
+## System commands
+
+### `/doctor`
+
+Runs the full local environment diagnostic suite (Python, paths, credentials, Docker, and related checks) with pass/warn/fail per check.
+
+```
+/doctor
+```
+
+### `/version`
+
+```
+/version
+```
+
+Prints OpenSRE version, Python version, and OS/architecture.
+
+### `/exit` and `/quit`
+
+Leave the REPL. On exit, OpenSRE prints a `/resume <session-id>` hint when a session file was active.
+
+```
+/exit
+/quit
+```
+
+---
+
+## Trust mode and confirmations
+
+Many commands are classified by execution tier:
+
+| Tier | Examples | Confirmation |
+| --- | --- | --- |
+| Exempt | `/help`, `/exit`, `/trust` | Never prompts |
+| Safe | `/status`, `/health`, `/investigate` | Read-only or low-risk |
+| Elevated | `/save`, `/watch`, `/cancel`, `/uninstall` | Prompts unless trust mode is on |
+
+Enable trust mode only when you accept auto-approval:
+
+```
+/trust on
+```
+
+---
+
+## Natural language routing
+
+You do not need to memorize every slash command. Describe intent in plain language and the planner selects an action:
+
+- "verify datadog" → `/integrations verify` or show flow
+- "what's my token usage" → `/cost`
+- "run the generic sample alert" → `/investigate generic`
+- "list my past sessions" → `/sessions`
+
+When the planner is uncertain, it falls back to help or asks for clarification rather than running a destructive command silently.
+
+---
+
+## Related docs
+
+- [Session History](/sessions) — `/sessions`, `/resume`, `/new` in depth
+- [Interactive Shell Privacy](/interactive-shell-privacy) — `/history`, `/privacy`, redaction
+- [Investigation overview](/investigation-overview) — RCA workflow and alert formats
+- [LLM providers](/llm-providers) — `/model` and `/effort`
+- [Agents](/agents) — `/agents` fleet coordination
+- [Cron](/cron) — `/cron` scheduled deliveries
+- [Hermes](/hermes) — `/hermes watch`

--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -157,7 +157,7 @@ Bare invocation opens a picker or submenu:
 
 ## Using `/help`
 
-```
+```text
 /help
 /help /model
 /help investigation
@@ -184,7 +184,7 @@ Help categories mirror the REPL grouping: Quick Access, Session, Integrations/Mo
 
 Shows a snapshot of the **current** REPL session:
 
-```
+```text
 /status
 ```
 
@@ -207,13 +207,13 @@ Use `/status` for **session** state. Use `/health` for **integration connectivit
 
 Shows LLM usage tracked **locally** for the current REPL session. This is not cloud-provider billing and does not read your vendor invoice.
 
-```
+```text
 /cost
 ```
 
 Example output (measured + estimated mix):
 
-```
+```text
   Session cost (includes estimates)
 
   history entries     12
@@ -245,7 +245,7 @@ Token totals reset on `/new` or when session identity is rotated. They do **not*
 
 Displays key/value infra metadata collected during investigations and chat — typically `service`, `cluster`, `region`, or similar fields extracted from alert text and investigation state.
 
-```
+```text
 /context
 ```
 
@@ -255,7 +255,7 @@ Context is **inherited** across investigations in the same session (and restored
 
 Set reasoning depth for **OpenAI and Codex** providers in this REPL session only.
 
-```
+```text
 /effort high
 /effort
 ```
@@ -275,7 +275,7 @@ Other providers (Anthropic, Ollama, etc.) ignore `/effort`; the shell prints a h
 
 Trust mode skips execution confirmation prompts for **elevated** commands (`/save`, `/watch`, `/cancel`, `/uninstall`, integration remove, etc.).
 
-```
+```text
 /trust on
 /trust off
 /trust
@@ -291,7 +291,7 @@ In a TTY, bare `/trust` opens an interactive on/off menu. Trust mode is a **sess
 
 Toggle `TRACER_VERBOSE` logging for the REPL process (deeper internal logs to stderr).
 
-```
+```text
 /verbose on
 /verbose off
 /verbose
@@ -301,7 +301,7 @@ Toggle `TRACER_VERBOSE` logging for the REPL process (deeper internal logs to st
 
 Clears the terminal and re-renders the OpenSRE banner. Does **not** reset session state, token usage, LLM conversation context, or accumulated infra context.
 
-```
+```text
 /clear
 ```
 
@@ -309,7 +309,7 @@ Clears the terminal and re-renders the OpenSRE banner. Does **not** reset sessio
 
 Trims **in-memory** session history to the last 20 entries. Does not affect persisted session files under `~/.opensre/sessions/`, up-arrow recall file, or `cli_agent_messages`.
 
-```
+```text
 /compact
 ```
 
@@ -319,11 +319,11 @@ If you already have ≤20 entries, the command reports nothing to compact.
 
 List up to **20** recent sessions stored on disk, newest first:
 
-```
+```text
 /sessions
 ```
 
-```
+```text
   Recent sessions
 
    #  Session ID  Name                           Started            Duration  Turns  Investigations
@@ -345,7 +345,7 @@ The current row updates **duration** live. Sessions with no name show `(current)
 
 Restore LLM conversation context and accumulated infra context from a previous session.
 
-```
+```text
 /resume 9b2e4f7a
 /resume redis
 /resume
@@ -382,11 +382,11 @@ If turn-detail records were never written (prompt logging disabled), history rep
 
 Rotate to a **new session file** while keeping the current LLM conversation thread and accumulated context.
 
-```
+```text
 /new
 ```
 
-```
+```text
 new session started — conversation context carried forward.
   14 messages in context · type to continue
 ```
@@ -403,7 +403,7 @@ Use `/new` after a long `/resume` so `/sessions` stays tidy without losing your 
 
 `/exit`, `/quit`, double **Ctrl+C**, or **Ctrl+D** (empty prompt) all print:
 
-```
+```text
 Resume this session with:
 /resume 3f8a1c2d
 goodbye.
@@ -425,7 +425,7 @@ Investigations inherit [accumulated context](#context) from earlier runs in the 
 
 ### `/investigate`
 
-```
+```text
 /investigate alert.json
 /investigate generic
 /investigate sample:datadog
@@ -459,7 +459,7 @@ Investigations inherit [accumulated context](#context) from earlier runs in the 
 
 Print starter alert JSON to stdout — copy, edit, save, then `/investigate your-file.json`.
 
-```
+```text
 /template generic
 /template datadog
 /template
@@ -478,7 +478,7 @@ Print starter alert JSON to stdout — copy, edit, save, then `/investigate your
 
 Reprint the root cause and report sections from the most recent successful investigation in **this session**.
 
-```
+```text
 /last
 ```
 
@@ -488,7 +488,7 @@ Sections rendered when present: **Root Cause**, **Report** (from `problem_md` or
 
 Write the last investigation to disk. Requires confirmation unless trust mode is on.
 
-```
+```text
 /save report.md
 /save out.json
 /save ./rca/checkout-502.json
@@ -518,7 +518,7 @@ Parent directories must exist or be creatable; write failures print the underlyi
 
 Read-only pass/fail report for the local OpenSRE agent, LLM connectivity, and each configured integration.
 
-```
+```text
 /health
 ```
 
@@ -526,7 +526,7 @@ Runs live verification against the integration store. Use before incidents to co
 
 ### `/integrations`
 
-```
+```text
 /integrations
 /integrations list
 /integrations verify
@@ -549,7 +549,7 @@ Bare `/integrations` opens an interactive menu in a TTY with service pickers for
 
 MCP-capable integrations only (subset of the full integration catalog).
 
-```
+```text
 /mcp list
 /mcp connect github
 /mcp disconnect github
@@ -565,7 +565,7 @@ MCP-capable integrations only (subset of the full integration catalog).
 
 Show or change LLM provider and models. Updates `~/.opensre/.env` (or your configured env path) and resets in-process LLM caches.
 
-```
+```text
 /model show
 /model set openai gpt-4.1
 /model set anthropic claude-sonnet-4-20250514 --toolcall-model claude-sonnet-4-20250514
@@ -596,7 +596,7 @@ See [LLM providers](/llm-providers).
 
 List tools available to investigation and chat surfaces in this build (name, source, surfaces).
 
-```
+```text
 /tools
 /tools list
 ```
@@ -611,7 +611,7 @@ Command **history** (up-arrow recall) is separate from **session** history (`/se
 
 ### `/history`
 
-```
+```text
 /history
 /history clear
 /history off
@@ -635,7 +635,7 @@ Bare `/history` opens an interactive menu in a TTY (presets: 100, 500, 1000, 500
 
 ### `/privacy`
 
-```
+```text
 /privacy
 ```
 
@@ -669,13 +669,13 @@ Long-running work is tracked in a per-session task registry surfaced by `/tasks`
 
 ### `/tasks`
 
-```
+```text
 /tasks
 ```
 
 Example:
 
-```
+```text
   Tasks
 
   id      kind           status     started (UTC)     duration  detail
@@ -687,7 +687,7 @@ Shows up to **50** recent tasks, newest first. Use the **id** column (short pref
 
 ### `/cancel`
 
-```
+```text
 /cancel abc12
 ```
 
@@ -700,7 +700,7 @@ Shows up to **50** recent tasks, newest first. Use the **id** column (short pref
 
 Prints guidance only — does not kill processes:
 
-```
+```text
 /stop
 ```
 
@@ -718,7 +718,7 @@ Monitor a local process and send **Telegram** alarms when CPU, memory, or runtim
 
 ### `/watch`
 
-```
+```text
 /watch 12345 --max-cpu 80 --max-rss 512M --max-runtime 30m --cooldown 5m --interval 2s --once
 ```
 
@@ -734,13 +734,13 @@ Monitor a local process and send **Telegram** alarms when CPU, memory, or runtim
 
 On start:
 
-```
+```text
 task abc12 started.
 ```
 
 When a threshold fires (Telegram configured):
 
-```
+```text
 [task abc12] alarm fired: max_cpu … (telegram delivered)
 ```
 
@@ -755,7 +755,7 @@ Quoted values are supported: `/watch 12345 --max-cpu "80"`.
 
 ### `/watches`
 
-```
+```text
 /watches
 ```
 
@@ -763,7 +763,7 @@ Watchdog-only view with columns: id, pid, status, started, thresholds (from comm
 
 ### `/unwatch`
 
-```
+```text
 /unwatch abc12
 ```
 
@@ -773,7 +773,7 @@ Cancels a **watchdog** task by task id. Using `/cancel` also works; `/unwatch` v
 
 CLI-parity syntax (subprocess to `opensre watchdog`):
 
-```
+```text
 /watchdog --pid 12345 --max-rss 1G --max-cpu 80
 ```
 
@@ -787,7 +787,7 @@ Fleet coordination is documented further on [Agents](/agents). Register discover
 
 ### `/agents`
 
-```
+```text
 /agents
 /agents budget
 /agents budget cursor-agent 5.00
@@ -820,7 +820,7 @@ Fleet coordination is documented further on [Agents](/agents). Register discover
 
 ### `/alerts`
 
-```
+```text
 /alerts
 ```
 
@@ -843,7 +843,7 @@ These spawn `opensre …` subprocesses. Output is captured into the REPL buffer 
 
 ### `/onboard`
 
-```
+```text
 /onboard
 /onboard local_llm
 ```
@@ -852,7 +852,7 @@ First-run setup: LLM keys, integrations, Telegram, alert listener. Requires excl
 
 ### `/remote`
 
-```
+```text
 /remote health
 /remote investigate
 /remote ops
@@ -864,7 +864,7 @@ Operate remote deployed OpenSRE agents (EC2, Nitro, hosted runtime). See [Remote
 
 ### `/config`
 
-```
+```text
 /config show
 /config set interactive.history.max_entries 1000
 ```
@@ -873,7 +873,7 @@ Read/write `~/.opensre/config.yml`. Prefer env vars for secrets; use config for 
 
 ### `/cron`
 
-```
+```text
 /cron list
 /cron add
 /cron remove <id>
@@ -885,7 +885,7 @@ Scheduled investigation or report delivery. See [Cron](/cron).
 
 ### `/messaging`
 
-```
+```text
 /messaging pair
 /messaging allow
 /messaging revoke
@@ -896,7 +896,7 @@ Telegram bot pairing and sender allowlist — required for `/watch` alarms and s
 
 ### `/hermes`
 
-```
+```text
 /hermes watch
 ```
 
@@ -904,7 +904,7 @@ Tail Hermes logs and route classified incidents. See [Hermes](/hermes) and [Herm
 
 ### `/guardrails`
 
-```
+```text
 /guardrails audit
 /guardrails init
 /guardrails rules
@@ -922,7 +922,7 @@ Related: [Masking](/masking).
 
 ### `/tests`
 
-```
+```text
 /tests
 /tests list
 /tests run <test_id>
@@ -942,7 +942,7 @@ Synthetic tests can run for a long time; default timeout is generous — use `/c
 
 ### `/update`
 
-```
+```text
 /update
 ```
 
@@ -950,7 +950,7 @@ Checks PyPI and upgrades OpenSRE in-place (5-minute network timeout). Non-zero e
 
 ### `/debug`
 
-```
+```text
 /debug sentry
 ```
 
@@ -958,7 +958,7 @@ Targeted smoke tests (Sentry, etc.) — subcommands match `opensre debug --help`
 
 ### `/uninstall`
 
-```
+```text
 /uninstall
 ```
 
@@ -972,7 +972,7 @@ Removes OpenSRE and local data. **Destructive** — confirmation required unless
 
 Environment diagnostic distinct from `/health`:
 
-```
+```text
 /doctor
 ```
 
@@ -982,7 +982,7 @@ Use **`/doctor`** before first install debugging; use **`/health`** before an in
 
 ### `/version`
 
-```
+```text
 /version
 ```
 
@@ -994,7 +994,7 @@ Use **`/doctor`** before first install debugging; use **`/health`** before an in
 
 ### `/exit` and `/quit`
 
-```
+```text
 /exit
 /quit
 ```
@@ -1013,7 +1013,7 @@ Clean shutdown with `/resume` hint. Prefer over killing the terminal so session 
 
 Non-TTY: elevated commands **fail closed** (error message, no side effect).
 
-```
+```text
 /trust on   # skip prompts for this session
 /trust off  # restore prompts
 ```
@@ -1057,7 +1057,7 @@ Compound requests ("health then integrations") execute as an ordered sequence of
 
 ### First-time setup
 
-```
+```text
 /onboard
 /health
 /integrations verify
@@ -1066,7 +1066,7 @@ Compound requests ("health then integrations") execute as an ordered sequence of
 
 ### Incident triage (local)
 
-```
+```text
 /status
 /alerts
 /health
@@ -1074,7 +1074,7 @@ Compound requests ("health then integrations") execute as an ordered sequence of
 
 Paste alert text or:
 
-```
+```text
 /investigate ./alerts/prod-502.json
 /last
 /save ./rca/prod-502.md
@@ -1082,20 +1082,20 @@ Paste alert text or:
 
 ### Pick up yesterday's thread
 
-```
+```text
 /sessions
 /resume 9b2e4f7a
 ```
 
 Continue chatting, then optionally:
 
-```
+```text
 /new
 ```
 
 ### Switch model mid-session
 
-```
+```text
 /model set anthropic claude-sonnet-4-20250514
 /effort high
 /cost
@@ -1103,7 +1103,7 @@ Continue chatting, then optionally:
 
 ### Monitor a runaway process
 
-```
+```text
 /watch <pid> --max-cpu 90 --max-rss 2G --cooldown 10m
 /watches
 /unwatch <task_id>
@@ -1111,7 +1111,7 @@ Continue chatting, then optionally:
 
 ### Debug integration failures
 
-```
+```text
 /integrations show datadog
 /doctor
 /verbose on

--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -8,8 +8,32 @@ Start the interactive shell with `opensre` (TTY required). Type a slash command 
 Run `/help` anytime for the live command list grouped by category. In a TTY, bare `/help` opens an interactive picker; selecting a command runs it directly.
 
 <Info>
-  Commands marked **elevated** may prompt for confirmation unless [trust mode](#trust-mode) is on. Non-TTY sessions fail closed on elevated actions.
+  Commands marked **elevated** may prompt for confirmation unless [trust mode](#trust-mode-and-confirmations) is on. Non-TTY sessions fail closed on elevated actions.
 </Info>
+
+## How the REPL works
+
+| Input type | What happens |
+| --- | --- |
+| Slash command (`/status`) | Parsed and dispatched immediately — fastest path for known actions |
+| Plain language (`verify datadog`) | Routed by the action planner to slash commands, investigations, or doc-grounded answers |
+| Pasted alert JSON/text | Often starts an investigation without a slash command |
+| Shell one-liner (`kubectl get pods`) | Executed through shell policy when the planner selects a shell action |
+
+**TTY vs non-TTY:** The full experience (interactive menus, confirmations, onboarding wizards) requires a real terminal. Piping input or running in CI sets non-interactive mode — elevated commands are rejected unless trust mode was enabled in a prior interactive session (prefer explicit CLI commands outside the REPL for automation).
+
+**Unknown commands:** Typos suggest the closest registered command (`Did you mean /integrations?`). Run `/help` for the authoritative list — it always matches your installed OpenSRE version.
+
+**Keyboard shortcuts:**
+
+| Key | Effect |
+| --- | --- |
+| **Up/Down** | Recall persisted command history (when enabled) |
+| **Ctrl+C** once | Cancel in-flight streaming work or interrupt the current prompt |
+| **Ctrl+C** twice within 2s | Exit the REPL (prints `/resume` hint) |
+| **Ctrl+D** | Exit when the prompt is empty (same resume hint as `/exit`) |
+
+---
 
 ## Quick reference
 
@@ -113,6 +137,22 @@ These commands delegate to the same Click CLI you would run outside the REPL.
 | `/doctor` | Full local environment diagnostic |
 | `/version` | OpenSRE, Python, and OS versions |
 
+### Commands with interactive menus (TTY)
+
+Bare invocation opens a picker or submenu:
+
+| Command | Menu behavior |
+| --- | --- |
+| `/help` | Browse categories; Enter runs the selected command |
+| `/integrations` | list / verify / show / setup / remove |
+| `/mcp` | list / connect / disconnect |
+| `/model` | show / set / restore / toolcall |
+| `/investigate` | Demo alerts, templates, custom file path |
+| `/template` | Template type picker |
+| `/trust`, `/verbose` | on / off |
+| `/history` | show / clear / off / on / retention |
+| `/resume` | Numbered list of recent sessions |
+
 ---
 
 ## Using `/help`
@@ -134,65 +174,106 @@ These commands delegate to the same Click CLI you would run outside the REPL.
 
 Help categories mirror the REPL grouping: Quick Access, Session, Integrations/Models/Tools, Investigation, Privacy, Tasks, Agents, Alerts, CLI parity, and System.
 
+**Quick Access** duplicates frequently used commands (`/investigate`, `/integrations`, `/model`, `/health`, `/watch`, `/status`, `/help`) for faster discovery in the picker.
+
 ---
 
 ## Session commands
 
 ### `/status`
 
-Shows interaction count, incoming alerts (with age of the most recent), whether an investigation ran this session, trust mode, reasoning effort, active LLM provider, grounding cache stats, and any accumulated infra context keys.
+Shows a snapshot of the **current** REPL session:
 
 ```
 /status
 ```
 
+Typical fields:
+
+| Field | Meaning |
+| --- | --- |
+| `interactions` | Count of recorded turns (chat, slash, alerts) |
+| `incoming alerts` | Alerts received by the local listener this session, plus age of the latest |
+| `last investigation` | `yes` if `/investigate` or a streamed investigation completed |
+| `trust mode` | `on` / `off` |
+| `reasoning effort` | Current `/effort` level (OpenAI/Codex only) |
+| `provider` | Active `LLM_PROVIDER` |
+| `grounding … cache` | Doc/source cache stats used for help answers |
+| `accumulated context` | Comma-separated keys from prior investigations (e.g. `service`, `cluster`) |
+
+Use `/status` for **session** state. Use `/health` for **integration connectivity**.
+
 ### `/cost`
 
-Shows LLM usage tracked **locally** for the current REPL session. This is not cloud-provider billing.
+Shows LLM usage tracked **locally** for the current REPL session. This is not cloud-provider billing and does not read your vendor invoice.
 
 ```
 /cost
 ```
 
+Example output (measured + estimated mix):
+
+```
+  Session cost (includes estimates)
+
+  history entries     12
+  llm calls           8
+  input tokens        4,210 (measured: 1,200 · estimated: 3,010)
+  output tokens       890 (estimated: 890)
+```
+
 | Field | Meaning |
 | --- | --- |
-| `history entries` | Lines recorded in this session's history |
-| `llm calls` | Number of LLM turns counted this session |
-| `input tokens` / `output tokens` | Prompt and completion totals |
+| `history entries` | Lines recorded in this session's in-memory history |
+| `llm calls` | LLM turns counted (planner + chat + help + follow-up) |
+| `input tokens` / `output tokens` | Running totals for prompt and completion usage |
 
-When the provider returns usage metadata (planner `invoke` calls), counts are **measured**. Streaming chat paths **estimate** tokens from text length (~four characters per token). If estimates are included, the title notes `(includes estimates)` and rows show measured vs estimated splits.
+**Measured vs estimated:**
 
-Token totals reset on `/new` or when session state is cleared. See [Session History](/sessions) for persistence across sessions.
+| Code path | Token source |
+| --- | --- |
+| Planner `invoke()` (action selection) | Provider usage metadata when the API returns it |
+| Streaming chat, help, follow-up | Estimated from character length (~4 characters per token) |
+
+When any estimate is included, the table title notes `(includes estimates)` and rows show measured vs estimated splits.
+
+**What increments the counter:** Normal LLM chat turns. **What does not:** Deterministic slash routing that never calls the API (e.g. some direct command mappings).
+
+Token totals reset on `/new` or when session identity is rotated. They do **not** carry across `/resume`. See [Session History](/sessions).
 
 ### `/context`
 
-Displays key/value infra metadata collected during investigations and chat (service name, cluster, region, and similar fields).
+Displays key/value infra metadata collected during investigations and chat — typically `service`, `cluster`, `region`, or similar fields extracted from alert text and investigation state.
 
 ```
 /context
 ```
 
+Context is **inherited** across investigations in the same session (and restored by `/resume`). It is passed as overrides to subsequent `/investigate` runs so the pipeline does not re-ask for environment details you already established.
+
 ### `/effort`
 
-Set reasoning depth for OpenAI and Codex providers in this REPL session.
+Set reasoning depth for **OpenAI and Codex** providers in this REPL session only.
 
 ```
 /effort high
 /effort
 ```
 
-| Level | Notes |
+| Level | When to use |
 | --- | --- |
-| `low` | Favor speed and lower cost |
-| `medium` | Balanced (default for many setups) |
-| `high` | More thorough reasoning |
-| `xhigh`, `max` | Deepest supported reasoning; best with newer GPT-5 or Codex models |
+| `low` | Fast triage, simple lookups, lower token cost |
+| `medium` | Default balance for most incident work |
+| `high` | Deeper RCA when latency is acceptable |
+| `xhigh`, `max` | Maximum reasoning; best with newer GPT-5 or Codex models — older models may reject these levels |
 
-Bare `/effort` prints the current level and provider default. Other providers ignore this setting. You can also set `OPENSRE_REASONING_EFFORT` in the environment. See [LLM providers](/llm-providers).
+Bare `/effort` prints the current level, the config default for your provider/model, and supported choices. `/status` includes the same field.
+
+Other providers (Anthropic, Ollama, etc.) ignore `/effort`; the shell prints a hint suggesting `/model set openai` or `/model set codex`. Set `OPENSRE_REASONING_EFFORT` in the environment for non-interactive defaults. See [LLM providers](/llm-providers).
 
 ### `/trust`
 
-Trust mode skips execution confirmation prompts for elevated commands.
+Trust mode skips execution confirmation prompts for **elevated** commands (`/save`, `/watch`, `/cancel`, `/uninstall`, integration remove, etc.).
 
 ```
 /trust on
@@ -200,11 +281,15 @@ Trust mode skips execution confirmation prompts for elevated commands.
 /trust
 ```
 
-In a TTY, bare `/trust` opens an interactive on/off menu. Use with care during incidents — confirmations exist for destructive or networked actions.
+In a TTY, bare `/trust` opens an interactive on/off menu. Trust mode is a **session preference** — it is not restored by `/resume`.
+
+<Tip>
+  During watchdog demos or repeated `/save` exports, `/trust on` avoids confirmation fatigue. Turn it off before running destructive commands you might mistype.
+</Tip>
 
 ### `/verbose`
 
-Toggle `TRACER_VERBOSE` logging for the REPL process.
+Toggle `TRACER_VERBOSE` logging for the REPL process (deeper internal logs to stderr).
 
 ```
 /verbose on
@@ -214,7 +299,7 @@ Toggle `TRACER_VERBOSE` logging for the REPL process.
 
 ### `/clear`
 
-Clears the terminal and re-renders the OpenSRE banner. Does **not** reset session state, token usage, or conversation context.
+Clears the terminal and re-renders the OpenSRE banner. Does **not** reset session state, token usage, LLM conversation context, or accumulated infra context.
 
 ```
 /clear
@@ -222,63 +307,157 @@ Clears the terminal and re-renders the OpenSRE banner. Does **not** reset sessio
 
 ### `/compact`
 
-Trims in-memory session history to the last 20 entries to reduce memory use. Does not affect persisted session files or LLM conversation context.
+Trims **in-memory** session history to the last 20 entries. Does not affect persisted session files under `~/.opensre/sessions/`, up-arrow recall file, or `cli_agent_messages`.
 
 ```
 /compact
 ```
 
-### `/sessions`, `/resume`, `/new`
+If you already have ≤20 entries, the command reports nothing to compact.
 
-Session persistence is documented in depth on [Session History](/sessions). Summary:
+### `/sessions`
+
+List up to **20** recent sessions stored on disk, newest first:
 
 ```
 /sessions
+```
+
+```
+  Recent sessions
+
+   #  Session ID  Name                           Started            Duration  Turns  Investigations
+   ─────────────────────────────────────────────────────────────────────────────────────────────
+   1  3f8a1c2d    (current)                      Jun 17 10:00       42m       8      2
+   2  9b2e4f7a    why is CPU spiking on prod-api Jun 16 14:30       1h 5m    15     4
+```
+
+| Column | Meaning |
+| --- | --- |
+| `Session ID` | First 8 characters of the UUID (enough for `/resume`) |
+| `Name` | Derived from the first user message or resumed session label |
+| `Turns` | Total chat + slash + alert turns recorded |
+| `Investigations` | Count of investigation turns |
+
+The current row updates **duration** live. Sessions with no name show `(current)` or `↩ <resumed-from>` when applicable.
+
+### `/resume`
+
+Restore LLM conversation context and accumulated infra context from a previous session.
+
+```
 /resume 9b2e4f7a
 /resume redis
 /resume
+```
+
+| Form | Behavior |
+| --- | --- |
+| ID prefix | Match session UUID by prefix (must be unique) |
+| Name substring | Match when ≥3 characters and exactly one session matches (e.g. `/resume redis`) |
+| Bare `/resume` | Interactive numbered picker of recent sessions (TTY) |
+
+On success, OpenSRE:
+
+1. Switches the active session file to the target session (or reopens it if resuming into the same ID)
+2. Restores `cli_agent_messages` so the assistant remembers prior turns
+3. Restores `accumulated_context` keys
+4. Reprints conversation history (user prompts, assistant replies, slash commands)
+
+**Restored vs not restored:**
+
+| | `/resume` |
+| --- | --- |
+| Conversation context | Yes |
+| Infra context keys | Yes |
+| Trust mode, reasoning effort | No — per-session preferences |
+| Token usage / `/cost` counters | No — fresh counters for the resumed session identity |
+| In-memory history count | Yes — turn stubs from the saved session |
+
+**Warnings:** Resuming replaces the current session's LLM context if messages already exist. Resuming the **active** session ID is a no-op with a hint to pick another from `/sessions`.
+
+If turn-detail records were never written (prompt logging disabled), history replay may show prompts without assistant responses — enable prompt logging for richer resume display. See [Session History](/sessions).
+
+### `/new`
+
+Rotate to a **new session file** while keeping the current LLM conversation thread and accumulated context.
+
+```
 /new
 ```
 
-| Command | Behavior |
-| --- | --- |
-| `/sessions` | Up to 20 recent sessions with ID, name, duration, turns, investigation count |
-| `/resume <prefix>` | Restore LLM messages and infra context; bare `/resume` opens a picker in a TTY |
-| `/new` | Rotate session ID and reset counters while **keeping** conversation context — use after `/resume` to continue in a fresh session file |
+```
+new session started — conversation context carried forward.
+  14 messages in context · type to continue
+```
 
-On exit, OpenSRE prints a `/resume <id>` hint so you can pick up later.
+| Command | Session file | LLM context | Token counters |
+| --- | --- | --- | --- |
+| `/clear` | Same | Kept | Kept |
+| `/new` | New UUID | Kept | Reset |
+| `/resume` | Target session | Replaced with target | Reset for that session |
+
+Use `/new` after a long `/resume` so `/sessions` stays tidy without losing your place in the conversation.
+
+### Exit paths
+
+`/exit`, `/quit`, double **Ctrl+C**, or **Ctrl+D** (empty prompt) all print:
+
+```
+Resume this session with:
+/resume 3f8a1c2d
+goodbye.
+```
 
 ---
 
 ## Investigation commands
 
-You can also paste alert text or describe an incident in plain language — the planner routes that to an investigation without a slash command. Use slash commands when you want explicit control.
+Three ways to start RCA from the REPL:
+
+| Method | Example | Best for |
+| --- | --- | --- |
+| Plain language | `checkout returns 502 on prod` | Quick starts, pasted context |
+| Slash + file/template | `/investigate alert.json` | Repeatable runs, CI fixtures |
+| Slash + interactive picker | `/investigate` → choose template | Demos, first-time users |
+
+Investigations inherit [accumulated context](#context) from earlier runs in the same session.
 
 ### `/investigate`
-
-Run root-cause analysis from a local alert file or a built-in sample template.
 
 ```
 /investigate alert.json
 /investigate generic
+/investigate sample:datadog
 /investigate ./alerts/checkout-502.json
 /investigate
 ```
 
 | Target | Behavior |
 | --- | --- |
-| `alert.json` | Bundled demo alert file |
-| `generic`, `datadog`, `grafana`, `honeycomb`, `coralogix`, `splunk` | Built-in sample templates |
+| `alert.json` | Bundled demo alert file shipped with OpenSRE |
+| `generic`, `datadog`, `grafana`, `honeycomb`, `coralogix`, `splunk` | Built-in sample templates (runs immediately) |
+| `sample:<name>` or `template:<name>` | Explicit template prefix |
 | File path | Read alert text from disk (`.json`, `.md`, `.txt`) |
 | Bare `/investigate` | Interactive picker in a TTY |
 
-Template names take precedence over same-named files in the working directory. Force file mode with an explicit path (e.g. `/investigate ./generic`).
+<Tip>
+  Template names win over same-named files in the working directory. Force file mode: `/investigate ./generic`
+</Tip>
 
-Press **Ctrl+C** during a streaming investigation to cancel. Use `/tasks` and `/cancel` for background task control.
+**During a run:**
+
+- Output streams to the terminal like chat
+- **Ctrl+C** cancels and marks the task cancelled
+- `/tasks` shows the investigation task id and status
+- On completion, `last_state` is updated for `/last` and `/save`
+- Infra fields from the result merge into accumulated context
+
+**Errors:** Missing files, unreadable paths, and pipeline failures print actionable messages; failed runs do not update `last_state`.
 
 ### `/template`
 
-Print starter alert JSON you can edit and feed back into `/investigate`.
+Print starter alert JSON to stdout — copy, edit, save, then `/investigate your-file.json`.
 
 ```
 /template generic
@@ -286,15 +465,24 @@ Print starter alert JSON you can edit and feed back into `/investigate`.
 /template
 ```
 
-Choices: `generic`, `datadog`, `grafana`, `honeycomb`, `coralogix`, `splunk`.
+| Template | Typical use |
+| --- | --- |
+| `generic` | Minimal portable alert shape |
+| `datadog` | Datadog monitor-style payload |
+| `grafana` | Grafana alerting format |
+| `honeycomb` | Honeycomb trigger shape |
+| `coralogix` | Coralogix alert JSON |
+| `splunk` | Splunk notable-event style |
 
 ### `/last`
 
-Reprint the root cause and report from the most recent investigation in this session.
+Reprint the root cause and report sections from the most recent successful investigation in **this session**.
 
 ```
 /last
 ```
+
+Sections rendered when present: **Root Cause**, **Report** (from `problem_md` or `slack_message`). If no investigation ran yet, prints a dim empty-state message.
 
 ### `/save`
 
@@ -303,30 +491,40 @@ Write the last investigation to disk. Requires confirmation unless trust mode is
 ```
 /save report.md
 /save out.json
+/save ./rca/checkout-502.json
 ```
 
 | Extension | Output |
 | --- | --- |
-| `.json` | Full investigation state as JSON |
-| Other | Markdown with Root Cause and Report sections |
+| `.json` | Full investigation state object (machine-readable) |
+| Other (`.md`, `.txt`, …) | Markdown with `## Root Cause` and `## Report` sections |
+
+Parent directories must exist or be creatable; write failures print the underlying error.
 
 ---
 
 ## Integrations, models, and tools
 
+### Choosing the right diagnostic command
+
+| Question | Command |
+| --- | --- |
+| Are my integrations configured and reachable? | `/health` or `/integrations verify` |
+| Show one integration's credentials/endpoints? | `/integrations show datadog` |
+| Is Python/Docker/venv OK on this machine? | `/doctor` |
+| What integrations exist in OpenSRE generally? | Ask in plain language (docs answer) — not `/integrations list` |
+
 ### `/health`
 
-Read-only health check: local OpenSRE agent, LLM connectivity, and each configured integration with pass/fail per component.
+Read-only pass/fail report for the local OpenSRE agent, LLM connectivity, and each configured integration.
 
 ```
 /health
 ```
 
-For environment-wide checks (Python, credentials, paths), use `/doctor` instead.
+Runs live verification against the integration store. Use before incidents to confirm Datadog/Grafana/K8s credentials still work.
 
 ### `/integrations`
-
-Manage integrations stored in your local integration store.
 
 ```
 /integrations
@@ -339,64 +537,77 @@ Manage integrations stored in your local integration store.
 
 | Subcommand | Behavior |
 | --- | --- |
-| `list` (default) | Verify and list all configured integrations |
-| `verify` | Same as list; prints a summary if any integration failed |
-| `show <service>` | Verify and print details for one integration |
-| `setup <service>` | Run the integration setup wizard (CLI parity) |
-| `remove <service>` | Remove an integration **elevated** |
+| `list` (default) | Verify all configured integrations and render status table |
+| `verify` | Same verification; prints `all integrations ok` or `N integration(s) need attention` |
+| `show <service>` | Verify one service and print key/value config (masked secrets) |
+| `setup <service>` | Launch setup wizard via CLI subprocess |
+| `remove <service>` | Remove from local store **elevated** |
 
-Bare `/integrations` opens an interactive menu in a TTY.
+Bare `/integrations` opens an interactive menu in a TTY with service pickers for show/remove.
 
 ### `/mcp`
 
-Manage MCP server connections (subset of integrations that expose MCP).
+MCP-capable integrations only (subset of the full integration catalog).
 
 ```
 /mcp list
-/mcp connect <server>
-/mcp disconnect <server>
+/mcp connect github
+/mcp disconnect github
 ```
 
-`connect` and `disconnect` map to `opensre integrations setup` and `remove` for MCP-capable services.
+| Subcommand | Maps to |
+| --- | --- |
+| `list` | Table of MCP servers from verified integrations |
+| `connect <server>` | `opensre integrations setup <server>` |
+| `disconnect <server>` | `opensre integrations remove <server>` |
 
 ### `/model`
 
-Show or change the active LLM provider and models. Changes are written to your env file and take effect on the next LLM call.
+Show or change LLM provider and models. Updates `~/.opensre/.env` (or your configured env path) and resets in-process LLM caches.
 
 ```
 /model show
 /model set openai gpt-4.1
-/model set anthropic --toolcall-model claude-sonnet-4-20250514
+/model set anthropic claude-sonnet-4-20250514 --toolcall-model claude-sonnet-4-20250514
+/model set claude-sonnet-4-20250514
 /model restore
+/model restore anthropic
 /model toolcall set gpt-4.1-mini
 /model
 ```
 
 | Subcommand | Behavior |
 | --- | --- |
-| `show` (default) | Current provider, reasoning model, toolcall model |
-| `set <provider> [model] [--toolcall-model <m>]` | Switch provider; optional model overrides |
-| `restore [provider]` | Reset to provider default reasoning model |
-| `toolcall set <model>` | Set toolcall model for the active provider |
+| `show` (default) | Provider, reasoning model env var, toolcall model env var |
+| `set <provider> [model] [--toolcall-model <m>]` | Switch provider; optional per-slot models |
+| `set <model>` (no provider) | Update reasoning model for **current** provider only |
+| `restore [provider]` | Reset to provider's default reasoning model |
+| `toolcall set <model>` | Set investigation tool-call model for active provider |
 
-Bare `/model` opens an interactive menu in a TTY. Provider switches require credentials for the target provider — run `/onboard` if a key is missing. See [LLM providers](/llm-providers).
+**Credential guard:** Switching to a provider without an API key (or keyring entry) fails fast with setup instructions — run `/onboard` or export the key before switching.
 
-Shorthand: `/model set claude-sonnet-4-20250514` (no provider) updates the reasoning model for the **current** provider.
+**Reasoning vs toolcall model:** Reasoning model drives chat and planning; toolcall model drives investigation tool invocation when the provider exposes a separate slot (common on Anthropic/OpenAI).
+
+Interactive `/model` menu flow: pick provider → reasoning model (or default) → optional toolcall model (`keep`, `match-reasoning`, or explicit).
+
+See [LLM providers](/llm-providers).
 
 ### `/tools`
 
-List tools registered in this OpenSRE build for investigation and chat surfaces.
+List tools available to investigation and chat surfaces in this build (name, source, surfaces).
 
 ```
 /tools
 /tools list
 ```
 
+There is no global `/list` command — use domain-specific list commands (see [Natural language routing](#natural-language-routing)).
+
 ---
 
 ## Privacy and history
 
-Full privacy controls, redaction patterns, and environment variables are on [Interactive Shell Privacy](/interactive-shell-privacy).
+Command **history** (up-arrow recall) is separate from **session** history (`/sessions`). Full redaction patterns and env vars: [Interactive Shell Privacy](/interactive-shell-privacy).
 
 ### `/history`
 
@@ -410,62 +621,100 @@ Full privacy controls, redaction patterns, and environment variables are on [Int
 
 | Subcommand | Behavior |
 | --- | --- |
-| (none) | Show persisted command history entries |
-| `clear` | Delete the history file; up-arrow recall resets on next launch |
-| `off` | Pause persistence for this session |
+| (none) | Numbered list of persisted prompt lines |
+| `clear` | Delete `~/.opensre/interactive_history`; up-arrow recall empty on next launch |
+| `off` | Pause disk writes for this session (in-memory recall still works) |
 | `on` | Resume persistence |
-| `retention <N>` | Cap entries on disk (requires redacting history backend) |
+| `retention <N>` | Cap file entries; prunes immediately (requires redacting backend) |
 
-Bare `/history` opens an interactive menu in a TTY.
+Bare `/history` opens an interactive menu in a TTY (presets: 100, 500, 1000, 5000 for retention).
+
+<Warning>
+  Redaction applies to the **history file**, not necessarily to what is sent to the LLM. Treat shared machines accordingly — run `/history clear` after sensitive sessions.
+</Warning>
 
 ### `/privacy`
-
-Shows persistence on/off, redaction status, retention cap, history file path, and built-in pattern count, plus a short threat-model reminder.
 
 ```
 /privacy
 ```
 
+Shows persistence on/off, redaction on/off, retention cap, history file path, built-in pattern count, and a short threat-model reminder (unencrypted local disk).
+
 ---
 
 ## Tasks and background work
 
-### `/tasks`
+Long-running work is tracked in a per-session task registry surfaced by `/tasks`.
 
-List up to 50 recent tasks in the current session: investigations, CLI commands, synthetic tests, watchdogs, and similar background work.
+### Task kinds
+
+| Kind | Source |
+| --- | --- |
+| `investigation` | `/investigate`, streamed free-text investigations |
+| `watchdog` | `/watch` |
+| `synthetic_test` | `/tests synthetic`, CloudOpsBench |
+| `cli_command` | Other `/tests` runs, delegated CLI subprocesses |
+| `code_agent` | Code-agent integrations (when used) |
+
+### Task statuses
+
+| Status | Meaning |
+| --- | --- |
+| `running` | In progress; `/cancel` eligible |
+| `completed` | Finished successfully |
+| `cancelled` | User or `/cancel` stopped it |
+| `failed` | Non-zero exit or pipeline error |
+| `pending` | Created but not yet started |
+
+### `/tasks`
 
 ```
 /tasks
 ```
 
-Columns include task id, kind, status, start time, duration, and a detail line (progress, result, or error).
+Example:
+
+```
+  Tasks
+
+  id      kind           status     started (UTC)     duration  detail
+  abc12   investigation  running    2026-06-17 10:01  45.2s     streaming…
+  def34   watchdog       completed  2026-06-17 09:55  120.0s    pid=12345 max_cpu=80%
+```
+
+Shows up to **50** recent tasks, newest first. Use the **id** column (short prefix) with `/cancel` or `/unwatch`.
 
 ### `/cancel`
-
-Cancel a **running** background task by id prefix.
 
 ```
 /cancel abc12
 ```
 
-Use `/tasks` to find ids. Ambiguous prefixes require more characters. For streaming investigations, also press **Ctrl+C** if output is still flowing.
+- Matches task id by **prefix** (must be unique among active/recent tasks)
+- Only **running** tasks accept cancellation
+- Investigations: signals cancel; press **Ctrl+C** if streaming continues
+- Watchdogs: prefer `/unwatch` for watchdog-specific messaging
 
 ### `/stop`
 
-Prints guidance — not a hard stop:
+Prints guidance only — does not kill processes:
 
 ```
 /stop
 ```
 
-- **Streaming investigation:** press **Ctrl+C**
-- **Background task:** `/tasks` then `/cancel <id>`
+| Situation | Action |
+| --- | --- |
+| Streaming investigation | **Ctrl+C** |
+| Background test or CLI task | `/tasks` → `/cancel <id>` |
+| Watchdog | `/unwatch <id>` or `/cancel <id>` |
 
 ---
 
 ## Watchdog commands
 
-Watchdog tasks monitor a process and send Telegram alarms when thresholds are exceeded. Configure Telegram delivery before use.
+Monitor a local process and send **Telegram** alarms when CPU, memory, or runtime thresholds breach. Configure Telegram credentials before use (via `/onboard` or env — see messaging docs).
 
 ### `/watch`
 
@@ -473,61 +722,81 @@ Watchdog tasks monitor a process and send Telegram alarms when thresholds are ex
 /watch 12345 --max-cpu 80 --max-rss 512M --max-runtime 30m --cooldown 5m --interval 2s --once
 ```
 
-| Flag | Meaning |
-| --- | --- |
-| `<pid>` | Process to watch (required, first argument) |
-| `--max-cpu` | CPU percent threshold |
-| `--max-rss` | Memory cap (`512M`, `1G`, etc.) |
-| `--max-runtime` | Max wall time (`30s`, `5m`, `1h`) |
-| `--cooldown` | Minimum time between alarms (default 5m) |
-| `--interval` | Sample interval (default 2s) |
-| `--once` | Fire at most one alarm per threshold |
+| Flag | Meaning | Default |
+| --- | --- | --- |
+| `<pid>` | Process to watch (required first arg) | — |
+| `--max-cpu` | CPU percent threshold (max ≈ `100 × cpu_count`) | none |
+| `--max-rss` | Resident memory cap (`512M`, `1G`, `1.5Gib`) | none |
+| `--max-runtime` | Wall-clock limit (`30s`, `5m`, `1h`) | none |
+| `--cooldown` | Min seconds between repeat alarms | `300` (5m) |
+| `--interval` | Sample period | `2s` |
+| `--once` | At most one alarm per threshold type | off |
 
-Returns a task id for `/watches` and `/unwatch`.
+On start:
+
+```
+task abc12 started.
+```
+
+When a threshold fires (Telegram configured):
+
+```
+[task abc12] alarm fired: max_cpu … (telegram delivered)
+```
+
+**Typical demo workflow:**
+
+1. `/trust on` (optional — skips `/watch` confirmation)
+2. `/watch <pid> --max-cpu 80` — use a real PID (e.g. the REPL's Python process)
+3. `/watches` — confirm `running` status and threshold string
+4. `/unwatch abc12` — request stop; `/watches` should show `cancelled`
+
+Quoted values are supported: `/watch 12345 --max-cpu "80"`.
 
 ### `/watches`
-
-List watchdog tasks in this session with pid, status, thresholds, and the latest resource sample.
 
 ```
 /watches
 ```
 
-### `/unwatch`
+Watchdog-only view with columns: id, pid, status, started, thresholds (from command summary), **last sample** (live CPU/RSS from progress line).
 
-Cancel a running watchdog by task id (not pid).
+### `/unwatch`
 
 ```
 /unwatch abc12
 ```
 
+Cancels a **watchdog** task by task id. Using `/cancel` also works; `/unwatch` validates the task kind.
+
 ### `/watchdog`
 
-CLI-parity entry point with flag-style arguments:
+CLI-parity syntax (subprocess to `opensre watchdog`):
 
 ```
 /watchdog --pid 12345 --max-rss 1G --max-cpu 80
 ```
 
-Prefer `/watch` inside the REPL for integrated task tracking.
+Prefer `/watch` inside the REPL — it registers tasks for `/watches` and `/tasks` automatically.
 
 ---
 
 ## Agents and alerts
 
-Agent fleet management is also covered on [Agents](/agents).
+Fleet coordination is documented further on [Agents](/agents). Register discovered agents with `opensre agents scan --register` before `/agents trace` targets them.
 
 ### `/agents`
 
 ```
 /agents
 /agents budget
-/agents budget my-agent 5.00
+/agents budget cursor-agent 5.00
 /agents bus
-/agents claim feature-x cursor-agent
+/agents claim feature-x my-agent
 /agents release feature-x
 /agents conflicts
 /agents kill 12345
+/agents kill 12345 --force
 /agents trace 12345
 /agents wait 12345 --on 67890
 /agents graph
@@ -535,32 +804,42 @@ Agent fleet management is also covered on [Agents](/agents).
 
 | Subcommand | Behavior |
 | --- | --- |
-| (none) | Registered plus discovered local agents (Cursor, Claude Code, Codex, Aider, …) |
-| `budget` | View hourly budgets; `budget <agent> <usd>` to set |
-| `bus` | Live-tail the cross-agent context bus until Ctrl+C |
-| `claim <branch> <agent>` | Claim a git branch for an agent |
-| `release <branch>` | Release a branch claim |
-| `conflicts` | Show file-write conflicts between agents |
-| `kill <pid> [--force]` | SIGTERM then SIGKILL **elevated** |
-| `trace <pid>` | Live-tail an agent's stdout |
-| `wait <pid> --on <other-pid>` | Record a wait dependency |
-| `graph` | Render the wait-on dependency graph |
+| (none) | Dashboard: registered + discovered agents (Cursor, Claude Code, Codex, Aider, …) with pid, uptime, CPU, tokens/min, $/hr, status |
+| `budget` | View hourly budgets from `~/.opensre/agents.yaml` |
+| `budget <agent> <usd>` | Set `hourly_budget_usd` for one agent |
+| `bus` | Live-tail cross-agent context bus until Ctrl+C |
+| `claim <branch> <agent>` | Exclusive branch claim (agent must be in registry) |
+| `release <branch>` | Release a claim |
+| `conflicts` | File-write conflict report between agents |
+| `kill <pid> [--force]` | SIGTERM → wait → SIGKILL **elevated**; refuses self-PID |
+| `trace <pid>` | Live stdout tail of agent process |
+| `wait <pid> --on <other-pid>` | Record wait dependency for graph |
+| `graph` | Tree of wait-on relationships |
+
+**Kill confirmation:** Without `--force`, prompts `[y/N]`. `--force` skips prompt (still elevated tier unless trust mode).
 
 ### `/alerts`
-
-Shows whether the local alert listener is active, queue depth, dropped count, and up to five recent ingested alerts.
 
 ```
 /alerts
 ```
 
-Post alerts to the listener endpoint configured during setup; the REPL surfaces them in `/status` and can route them into investigations.
+When the alert listener is active:
+
+| Field | Meaning |
+| --- | --- |
+| `status` | `listening` |
+| `queue depth` | Alerts waiting for REPL consumption |
+| `dropped` | Alerts dropped when queue was full |
+| `recent` | Up to 5 latest alert names/snippets |
+
+If the listener is inactive, prints a warning. Incoming alerts also appear in `/status` as `incoming alerts`. Post alerts to your configured webhook/listener URL during setup; the REPL can route them into investigations from plain language.
 
 ---
 
 ## CLI parity commands
 
-These spawn `opensre …` subprocesses. Interactive wizards (e.g. `/onboard`) need a TTY.
+These spawn `opensre …` subprocesses. Output is captured into the REPL buffer for non-interactive subcommands; wizards attach to the real TTY.
 
 ### `/onboard`
 
@@ -569,11 +848,9 @@ These spawn `opensre …` subprocesses. Interactive wizards (e.g. `/onboard`) ne
 /onboard local_llm
 ```
 
-Launches the setup wizard for LLM keys, integrations, and related config.
+First-run setup: LLM keys, integrations, Telegram, alert listener. Requires exclusive stdin — the REPL tears down prompt_toolkit before the wizard runs.
 
 ### `/remote`
-
-Operate remote deployed OpenSRE instances.
 
 ```
 /remote health
@@ -583,16 +860,16 @@ Operate remote deployed OpenSRE instances.
 /remote trigger
 ```
 
-See [Remote runtime investigation](/remote-runtime-investigation).
+Operate remote deployed OpenSRE agents (EC2, Nitro, hosted runtime). See [Remote runtime investigation](/remote-runtime-investigation).
 
 ### `/config`
 
 ```
 /config show
-/config set <key> <value>
+/config set interactive.history.max_entries 1000
 ```
 
-Read or write `~/.opensre/config.yml`.
+Read/write `~/.opensre/config.yml`. Prefer env vars for secrets; use config for structured interactive-shell settings.
 
 ### `/cron`
 
@@ -604,7 +881,7 @@ Read or write `~/.opensre/config.yml`.
 /cron logs <id>
 ```
 
-See [Cron](/cron) for scheduled delivery setup.
+Scheduled investigation or report delivery. See [Cron](/cron).
 
 ### `/messaging`
 
@@ -615,7 +892,7 @@ See [Cron](/cron) for scheduled delivery setup.
 /messaging status
 ```
 
-Telegram pairing and allowlist management.
+Telegram bot pairing and sender allowlist — required for `/watch` alarms and some delivery features.
 
 ### `/hermes`
 
@@ -623,7 +900,7 @@ Telegram pairing and allowlist management.
 /hermes watch
 ```
 
-Live-tail Hermes logs and route detected incidents. See [Hermes](/hermes).
+Tail Hermes logs and route classified incidents. See [Hermes](/hermes) and [Hermes runbook](/hermes_runbook).
 
 ### `/guardrails`
 
@@ -634,7 +911,14 @@ Live-tail Hermes logs and route detected incidents. See [Hermes](/hermes).
 /guardrails test
 ```
 
-Manage sensitive-information masking rules.
+| Subcommand | Purpose |
+| --- | --- |
+| `init` | Scaffold local guardrail config |
+| `rules` | List active masking rules |
+| `test` | Run sample text through rules |
+| `audit` | Scan recent content for sensitive patterns |
+
+Related: [Masking](/masking).
 
 ### `/tests`
 
@@ -644,17 +928,25 @@ Manage sensitive-information masking rules.
 /tests run <test_id>
 /tests synthetic
 /tests cloudopsbench
+/tests synthetic --scenario <name>
 ```
 
-Bare `/tests` opens an interactive test picker. `run`, `synthetic`, and `cloudopsbench` start background tasks — track them with `/tasks`.
+| Form | Behavior |
+| --- | --- |
+| Bare `/tests` | Interactive multi-select picker; chosen tests run in background |
+| `list` | Print inventoried tests (captured output) |
+| `run`, `synthetic`, `cloudopsbench` | Background task — monitor with `/tasks` |
+| Flags after subcommand | Passed through to CLI |
+
+Synthetic tests can run for a long time; default timeout is generous — use `/cancel` to stop.
 
 ### `/update`
-
-Check PyPI for a newer OpenSRE version and upgrade if available (bounded network timeout).
 
 ```
 /update
 ```
+
+Checks PyPI and upgrades OpenSRE in-place (5-minute network timeout). Non-zero exit prints CLI error code.
 
 ### `/debug`
 
@@ -662,15 +954,15 @@ Check PyPI for a newer OpenSRE version and upgrade if available (bounded network
 /debug sentry
 ```
 
-Run targeted diagnostics (subcommands match `opensre debug`).
+Targeted smoke tests (Sentry, etc.) — subcommands match `opensre debug --help`.
 
 ### `/uninstall`
-
-Remove OpenSRE and all local data from this machine. Destructive — requires confirmation **elevated**.
 
 ```
 /uninstall
 ```
+
+Removes OpenSRE and local data. **Destructive** — confirmation required unless trust mode. Delegates to interactive CLI uninstall flow.
 
 ---
 
@@ -678,11 +970,15 @@ Remove OpenSRE and all local data from this machine. Destructive — requires co
 
 ### `/doctor`
 
-Runs the full local environment diagnostic suite (Python, paths, credentials, Docker, and related checks) with pass/warn/fail per check.
+Environment diagnostic distinct from `/health`:
 
 ```
 /doctor
 ```
+
+Checks Python version, venv, config paths, Docker availability, credential presence, and related local prerequisites. Each row: `ok`, `warn`, or `error` with detail text.
+
+Use **`/doctor`** before first install debugging; use **`/health`** before an incident to verify integrations.
 
 ### `/version`
 
@@ -690,56 +986,163 @@ Runs the full local environment diagnostic suite (Python, paths, credentials, Do
 /version
 ```
 
-Prints OpenSRE version, Python version, and OS/architecture.
+| Field | Example |
+| --- | --- |
+| `opensre` | Package version from install |
+| `python` | `3.12.x` |
+| `os` | `darwin (arm64)` |
 
 ### `/exit` and `/quit`
-
-Leave the REPL. On exit, OpenSRE prints a `/resume <session-id>` hint when a session file was active.
 
 ```
 /exit
 /quit
 ```
 
+Clean shutdown with `/resume` hint. Prefer over killing the terminal so session files flush cleanly.
+
 ---
 
 ## Trust mode and confirmations
 
-Many commands are classified by execution tier:
-
 | Tier | Examples | Confirmation |
 | --- | --- | --- |
 | Exempt | `/help`, `/exit`, `/trust` | Never prompts |
-| Safe | `/status`, `/health`, `/investigate` | Read-only or low-risk |
-| Elevated | `/save`, `/watch`, `/cancel`, `/uninstall` | Prompts unless trust mode is on |
+| Safe | `/status`, `/health`, `/investigate`, `/integrations list` | Read-only or standard risk |
+| Elevated | `/save`, `/watch`, `/cancel`, `/integrations remove`, `/agents kill`, `/uninstall` | Prompt `[y/N]` unless trust on |
 
-Enable trust mode only when you accept auto-approval:
+Non-TTY: elevated commands **fail closed** (error message, no side effect).
 
 ```
-/trust on
+/trust on   # skip prompts for this session
+/trust off  # restore prompts
 ```
 
 ---
 
 ## Natural language routing
 
-You do not need to memorize every slash command. Describe intent in plain language and the planner selects an action:
+You do not need to memorize every slash command. Examples:
 
-- "verify datadog" → `/integrations verify` or show flow
-- "what's my token usage" → `/cost`
-- "run the generic sample alert" → `/investigate generic`
-- "list my past sessions" → `/sessions`
+| You type | Typical routing |
+| --- | --- |
+| "what's my token usage?" | `/cost` |
+| "verify datadog" | `/integrations verify` |
+| "show datadog config" | `/integrations show datadog` |
+| "switch to openai gpt-4.1" | `/model set openai gpt-4.1` |
+| "run the generic sample alert" | `/investigate generic` |
+| "list my past sessions" | `/sessions` |
+| "check health then list integrations" | `/health` then `/integrations list` |
+| "how do I configure Datadog?" | Doc-grounded answer (no mutating command) |
 
-When the planner is uncertain, it falls back to help or asks for clarification rather than running a destructive command silently.
+**List intents** — there is no global `/list`:
+
+| Intent | Command |
+| --- | --- |
+| Connected integrations | `/integrations list` |
+| Tools | `/tools` |
+| Background tasks | `/tasks` |
+| MCP servers | `/mcp list` |
+| Cron jobs | `/cron list` |
+| Past REPL sessions | `/sessions` |
+| Watchdog tasks | `/watches` |
+
+When the planner is uncertain, it asks for clarification or falls back to help — it does not silently run elevated commands.
+
+Compound requests ("health then integrations") execute as an ordered sequence of slash actions.
+
+---
+
+## Common workflows
+
+### First-time setup
+
+```
+/onboard
+/health
+/integrations verify
+/model show
+```
+
+### Incident triage (local)
+
+```
+/status
+/alerts
+/health
+```
+
+Paste alert text or:
+
+```
+/investigate ./alerts/prod-502.json
+/last
+/save ./rca/prod-502.md
+```
+
+### Pick up yesterday's thread
+
+```
+/sessions
+/resume 9b2e4f7a
+```
+
+Continue chatting, then optionally:
+
+```
+/new
+```
+
+### Switch model mid-session
+
+```
+/model set anthropic claude-sonnet-4-20250514
+/effort high
+/cost
+```
+
+### Monitor a runaway process
+
+```
+/watch <pid> --max-cpu 90 --max-rss 2G --cooldown 10m
+/watches
+/unwatch <task_id>
+```
+
+### Debug integration failures
+
+```
+/integrations show datadog
+/doctor
+/verbose on
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Try |
+| --- | --- |
+| `unknown command` | `/help`; check spelling; use suggested correction |
+| Elevated command blocked in CI | Use CLI equivalent (`opensre investigate …`) or run interactively |
+| `/cost` shows zero | No LLM turns yet this session; chat once and retry |
+| `/resume` not found | Run `/sessions`; use longer ID prefix |
+| `/resume` ambiguous prefix | Add more characters from Session ID column |
+| `/model set` missing credential | `/onboard` or export `ANTHROPIC_API_KEY` / etc. |
+| `/watch` Telegram error | Configure messaging via `/messaging status` |
+| `/integrations show` not found | Run `/integrations list` for exact service slug |
+| History pause not working | Requires redacting backend — see `/privacy` |
+| Garbage in next prompt after table | Known TTY issue — upgrade OpenSRE; report if persistent |
 
 ---
 
 ## Related docs
 
-- [Session History](/sessions) — `/sessions`, `/resume`, `/new` in depth
-- [Interactive Shell Privacy](/interactive-shell-privacy) — `/history`, `/privacy`, redaction
-- [Investigation overview](/investigation-overview) — RCA workflow and alert formats
+- [Session History](/sessions) — persistence format, privacy, `/new` vs `/clear`
+- [Interactive Shell Privacy](/interactive-shell-privacy) — redaction, env vars, threat model
+- [Investigation overview](/investigation-overview) — RCA workflow, plain-language routing, CLI investigate
 - [LLM providers](/llm-providers) — `/model` and `/effort`
-- [Agents](/agents) — `/agents` fleet coordination
+- [Agents](/agents) — fleet dashboard, bus, trace, budgets
 - [Cron](/cron) — `/cron` scheduled deliveries
 - [Hermes](/hermes) — `/hermes watch`
+- [Remote runtime investigation](/remote-runtime-investigation) — `/remote`

--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -357,9 +357,11 @@ Restore LLM conversation context and accumulated infra context from a previous s
 | Name substring | Match when ≥3 characters and exactly one session matches (e.g. `/resume redis`) |
 | Bare `/resume` | Interactive numbered picker of recent sessions (TTY) |
 
-On success, OpenSRE:
+**Current session:** If the ID prefix matches the session you are already in, `/resume` is a no-op — OpenSRE prints a hint to pick a previous session from `/sessions`.
 
-1. Switches the active session file to the target session (or reopens it if resuming into the same ID)
+When you resume a **different** session, OpenSRE:
+
+1. Switches the active session file to the target session
 2. Restores `cli_agent_messages` so the assistant remembers prior turns
 3. Restores `accumulated_context` keys
 4. Reprints conversation history (user prompts, assistant replies, slash commands)
@@ -374,7 +376,7 @@ On success, OpenSRE:
 | Token usage / `/cost` counters | No — fresh counters for the resumed session identity |
 | In-memory history count | Yes — turn stubs from the saved session |
 
-**Warnings:** Resuming replaces the current session's LLM context if messages already exist. Resuming the **active** session ID is a no-op with a hint to pick another from `/sessions`.
+**Warning:** Resuming a different session replaces the current session's LLM context if messages already exist.
 
 If turn-detail records were never written (prompt logging disabled), history replay may show prompts without assistant responses — enable prompt logging for richer resume display. See [Session History](/sessions).
 

--- a/docs/investigation-overview.mdx
+++ b/docs/investigation-overview.mdx
@@ -20,7 +20,7 @@ From a terminal with stdin and stdout attached (`opensre` detects a TTY), run:
 opensre
 ```
 
-Then describe the incident or paste alert context at the prompt. Use `/help` for slash commands and `/exit` when finished. See [Interactive Shell Commands](/interactive-shell-commands) for a quick reference (`/cost`, `/status`, `/effort`, and more).
+Then describe the incident or paste alert context at the prompt. Use `/help` for slash commands and `/exit` when finished. See [Interactive Shell Commands](/interactive-shell-commands) for the full slash-command reference (`/cost`, `/status`, `/investigate`, and every other REPL command).
 
 When `LLM_PROVIDER` is `openai` or `codex`, `/effort` sets how much reasoning the model applies for that REPL session (`low`, `medium`, `high`, `xhigh`, or `max`). Run `/effort` with no arguments to print the current level and usage; `/status` includes the same field. Other providers ignore this setting (the shell prints a hint). You can also set `OPENSRE_REASONING_EFFORT` to `low`, `medium`, `high`, or `xhigh` in the environment for non-interactive defaults.
 


### PR DESCRIPTION
/fix #2839 
This pull request updates the documentation for the interactive shell commands in `docs/investigation-overview.mdx` to clarify that the linked reference contains the full list of slash commands, including `/investigate` and all other REPL commands.

Documentation improvements:

* Updated the description of the [Interactive Shell Commands] link to specify it provides the full slash-command reference, including `/investigate` and every other REPL command, instead of just a quick reference.