### PR TITLE
fix(bench): seen_shape filter dropped 22% of corpus + add shape constants

### DIFF
--- a/tests/benchmarks/_framework/adapter_base.py
+++ b/tests/benchmarks/_framework/adapter_base.py
@@ -47,20 +47,20 @@ if TYPE_CHECKING:
 
 
 class AdapterCapabilities(BaseModel):
-    """Boolean feature flags an adapter declares to the framework.
+    """True / False flags the adapter sets so the framework knows what
+    it supports.
 
-    Replaces hardcoded ``if config.benchmark != "cloudopsbench"`` checks
-    in the framework. Each capability flag describes a framework-level
-    feature the adapter explicitly opts into. The framework then enables
-    or refuses the matching config knob based on the adapter's
-    declaration — no name-based dispatch.
+    The framework used to check the adapter's name (``if benchmark ==
+    "cloudopsbench"``) before allowing config fields like
+    ``agent_variant``. That meant adding a new benchmark required
+    editing framework code. Now the adapter declares which features it
+    supports and the framework reads that declaration.
 
-    Default is ``False`` for every capability so a new adapter is locked
-    down to the minimum surface until it opts in deliberately. Adding a
-    new capability extends this model with another default-``False``
-    field; existing adapters keep working without changes.
+    Every flag defaults to ``False`` so a new adapter is safe by
+    default: nothing is enabled until the adapter says it is. Adding a
+    new feature in the future just means adding another field here.
 
-    Adapters declare capabilities as a class attribute:
+    Adapters set their flags as a class attribute:
 
         class MyAdapter(BenchmarkAdapter):
             capabilities = AdapterCapabilities(
@@ -71,22 +71,24 @@ class AdapterCapabilities(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     supports_agent_variant: bool = False
-    """The adapter honors the ``agent_variant`` config field.
+    """The adapter knows what to do with the ``agent_variant`` config
+    field.
 
-    When False, a config with ``agent_variant != "default"`` is refused
-    at validation time so the run does not silently exercise the wrong
-    agent. CloudOpsBench currently honors this via its
-    ``BenchInvestigationAgentTrimmedPrompt`` variant; other adapters
-    have no equivalent and should leave this False until they do.
+    When this is ``False`` and a config sets ``agent_variant`` to
+    anything other than ``"default"``, the framework rejects the config
+    instead of running the default agent quietly. CloudOpsBench uses
+    this flag to enable its trimmed-prompt agent variant. Adapters that
+    only have one kind of agent leave this off.
     """
 
     supports_predictor_variant: bool = False
-    """The adapter has a predictor stage and honors ``predictor_variant``.
+    """The adapter has a predictor step and reads ``predictor_variant``.
 
-    When False, a config setting ``predictor_variant != "default"`` is
-    refused. CloudOpsBench has a predictor stage (paper-format triple
-    emission); adapters without one (pure investigation benchmarks,
-    tool-call benchmarks) keep this False.
+    When this is ``False``, a config setting ``predictor_variant`` to
+    anything other than ``"default"`` is rejected. CloudOpsBench has a
+    predictor step (it produces the paper's three-part answer format).
+    Other benchmark types (pure investigation, tool-call) do not, so
+    they leave this off.
     """
 
 
@@ -96,39 +98,35 @@ class AdapterCapabilities(BaseModel):
 
 
 class OverfitDimensions(BaseModel):
-    """Metadata keys that overfit guards use to extract case attributes.
+    """Key names the overfit guards use to read fields from a case.
 
-    The framework's overfit module (``_framework/overfit.py``) runs
-    five guards that attribute lift across (a) the corpus's "system"
-    dimension, (b) the corpus's "stratum" / fault-category dimension,
-    and (c) per-case ground-truth objects. Different adapters emit
-    cells with different metadata layouts — CloudOpsBench uses
-    ``metadata["system"]`` / ``metadata["fault_category"]`` /
-    ``metadata["ground_truth"]["fault_object"]``; another adapter may
-    use different key names.
+    The overfit guards check whether opensre's wins are spread across
+    the corpus or piled up in one place. To do that they need to read
+    three fields off each case: which system the case came from, which
+    category of fault it is, and what the ground-truth target object is.
 
-    This model lets each adapter declare its key names without
-    requiring the framework to know about them. The defaults match
-    CloudOpsBench's schema so existing call sites continue to work;
-    other adapters override ``BenchmarkAdapter.overfit_dimensions``
-    to point at their own keys.
+    Different benchmarks store these under different key names. The
+    defaults below match how CloudOpsBench stores them. A new benchmark
+    that stores them differently overrides this model to point at its
+    own keys.
 
-    Phase 3 of the framework decoupling: the previous overfit guards
-    hardcoded ``c["case"]["metadata"]["system"]`` etc. inline, which
-    silently coupled the framework to CloudOpsBench's metadata shape.
+    Before this hook existed, the guard code looked at hard-coded keys
+    like ``metadata["system"]`` directly. That made the framework only
+    work for CloudOpsBench-shaped data.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     system_key: str = "system"
-    """``case.metadata[<key>]`` — the corpus's "system" attribute."""
+    """Which key in ``case.metadata`` holds the system name."""
 
     stratum_key: str = "fault_category"
-    """``case.metadata[<key>]`` — the corpus's stratum / category attribute."""
+    """Which key in ``case.metadata`` holds the category / stratum."""
 
     gt_object_key: str = "fault_object"
-    """``case.metadata["ground_truth"][<key>]`` — the GT object name used
-    by Guard C's cluster fingerprinting."""
+    """Which key inside ``case.metadata["ground_truth"]`` holds the
+    target object name. Used by the cluster-concentration guard to
+    group similar cases together."""
 
 
 # --------------------------------------------------------------------------- #
@@ -163,59 +161,55 @@ class BenchmarkAdapter(ABC):
     See :class:`AdapterCapabilities` for the available flags."""
 
     def apply_config_overrides(self, config: Any) -> None:  # noqa: ARG002 — default no-op
-        """Optional: apply adapter-specific config-driven runtime setup.
+        """Optional hook for the adapter to read its own config fields.
 
-        Called once by the CLI after the adapter is built and BEFORE the
-        runner instantiates any agent. Adapters use this hook to honor
-        adapter-specific config knobs (e.g. ``min_tool_calls``,
-        ``agent_variant``) by patching their own class attributes / agent
-        factory methods. Default is no-op so adapters that don't expose
-        knobs don't need to implement it.
+        Called once after the framework builds the adapter and before
+        any agent runs. Use this when the config has fields that only
+        your adapter understands (CloudOpsBench uses this for
+        ``min_tool_calls`` and ``agent_variant``). Each adapter handles
+        its own settings here so the framework does not need to know
+        about them.
 
-        Strategy-pattern design: the framework doesn't need to know which
-        config fields any specific adapter honors. Each adapter owns its
-        own knob-handling, keeping framework/adapter coupling minimal.
+        Default does nothing. If your adapter has no extra settings,
+        leave this alone.
         """
         return None
 
     def overfit_dimensions(self) -> OverfitDimensions:
-        """Metadata keys the overfit guards should consult for this adapter.
+        """Tell the overfit guards which metadata keys hold "system",
+        "category", and "ground-truth object" for this adapter.
 
-        Default returns ``OverfitDimensions()`` which matches the
-        CloudOpsBench schema (``system``, ``fault_category``,
-        ``ground_truth.fault_object``). Adapters with a different
-        metadata layout override this to point the guards at their own
-        keys.
+        The default returns the CloudOpsBench layout. Override this if
+        your benchmark stores those values under different key names.
 
-        Phase 3 of the framework decoupling: previously
-        ``_framework/overfit.py`` indexed into these keys inline,
-        coupling the framework to one adapter's metadata shape. This
-        hook moves the schema declaration to the adapter that owns it.
+        Before this hook existed, the guard code reached into hard-coded
+        keys like ``metadata["system"]``. That broke as soon as a second
+        benchmark used different key names.
         """
         return OverfitDimensions()
 
     def extend_provenance(self, provenance: dict[str, Any]) -> dict[str, Any]:
-        """Optional: inject adapter-specific fields into the provenance dict.
+        """Optional hook to add adapter-specific entries to provenance.
 
-        Called by ``_framework/provenance.py::capture_provenance`` after
-        the framework finishes assembling its standard sections
-        (``code``, ``config``, ``pre_registration``, ``models``,
-        ``environment``, ``dataset``, ``run_inputs``). Adapters can:
-          - add a new top-level key (e.g. an adapter-specific run note)
-          - extend an existing section (e.g. add ``min_tool_calls`` to
-            ``run_inputs``)
-          - return the dict unchanged
+        The framework builds a standard provenance bundle (code SHA,
+        config, model versions, environment, etc.) then calls this hook
+        to let the adapter add or change anything that is specific to
+        its benchmark. Adapters can:
 
-        Default is identity. The hook exists so the framework's
-        provenance module stays adapter-agnostic — it does NOT import or
-        reach into any adapter's internals to build the artifact. Before
-        Phase 4 the framework imported ``cloudopsbench.bench_agent``
-        directly to read ``min_tool_calls``; that import is gone and
-        CloudOpsBench now overrides this hook instead.
+          - add a brand-new top-level key, or
+          - add a key inside an existing section, or
+          - return the dict unchanged.
 
-        Implementations should mutate-and-return for performance, or
-        return a fresh dict if a non-destructive transform is needed —
-        the framework respects the return value either way.
+        The default does nothing. The point of the hook is to keep the
+        framework's provenance code free of adapter-specific imports.
+        For example, CloudOpsBench uses this hook to add the
+        ``min_tool_calls`` value into ``run_inputs``. Before the hook
+        existed, the framework imported from CloudOpsBench directly to
+        get that value, which broke the decoupling.
+
+        Implementations can either mutate ``provenance`` in place and
+        return it, or return a fresh dict. The framework respects
+        whatever the hook returns.
         """
         return provenance
 

--- a/tests/benchmarks/_framework/adapter_base.py
+++ b/tests/benchmarks/_framework/adapter_base.py
@@ -47,49 +47,30 @@ if TYPE_CHECKING:
 
 
 class AdapterCapabilities(BaseModel):
-    """True / False flags the adapter sets so the framework knows what
-    it supports.
+    """Feature flags an adapter declares to the framework.
 
-    The framework used to check the adapter's name (``if benchmark ==
-    "cloudopsbench"``) before allowing config fields like
-    ``agent_variant``. That meant adding a new benchmark required
-    editing framework code. Now the adapter declares which features it
-    supports and the framework reads that declaration.
+    The framework uses these to validate config knobs without
+    dispatching on adapter name. Every flag defaults to ``False``: a
+    new adapter is locked down to the minimum surface until it opts in.
 
-    Every flag defaults to ``False`` so a new adapter is safe by
-    default: nothing is enabled until the adapter says it is. Adding a
-    new feature in the future just means adding another field here.
-
-    Adapters set their flags as a class attribute:
+    Declare as a class attribute:
 
         class MyAdapter(BenchmarkAdapter):
-            capabilities = AdapterCapabilities(
-                supports_agent_variant=True,
-            )
+            capabilities = AdapterCapabilities(supports_agent_variant=True)
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     supports_agent_variant: bool = False
-    """The adapter knows what to do with the ``agent_variant`` config
-    field.
-
-    When this is ``False`` and a config sets ``agent_variant`` to
-    anything other than ``"default"``, the framework rejects the config
-    instead of running the default agent quietly. CloudOpsBench uses
-    this flag to enable its trimmed-prompt agent variant. Adapters that
-    only have one kind of agent leave this off.
-    """
+    """Adapter honors ``config.agent_variant``. If False, the framework
+    rejects any config with ``agent_variant != "default"`` instead of
+    silently running the default agent."""
 
     supports_predictor_variant: bool = False
-    """The adapter has a predictor step and reads ``predictor_variant``.
-
-    When this is ``False``, a config setting ``predictor_variant`` to
-    anything other than ``"default"`` is rejected. CloudOpsBench has a
-    predictor step (it produces the paper's three-part answer format).
-    Other benchmark types (pure investigation, tool-call) do not, so
-    they leave this off.
-    """
+    """Adapter has a predictor stage and honors
+    ``config.predictor_variant``. If False, any non-default value is
+    rejected. CloudOpsBench has one (paper-format triple emission);
+    most other benchmark types don't."""
 
 
 # --------------------------------------------------------------------------- #
@@ -98,35 +79,26 @@ class AdapterCapabilities(BaseModel):
 
 
 class OverfitDimensions(BaseModel):
-    """Key names the overfit guards use to read fields from a case.
+    """Metadata key names the overfit guards read from each case.
 
-    The overfit guards check whether opensre's wins are spread across
-    the corpus or piled up in one place. To do that they need to read
-    three fields off each case: which system the case came from, which
-    category of fault it is, and what the ground-truth target object is.
-
-    Different benchmarks store these under different key names. The
-    defaults below match how CloudOpsBench stores them. A new benchmark
-    that stores them differently overrides this model to point at its
-    own keys.
-
-    Before this hook existed, the guard code looked at hard-coded keys
-    like ``metadata["system"]`` directly. That made the framework only
-    work for CloudOpsBench-shaped data.
+    The guards group results by three axes — system, stratum, GT
+    object — to detect concentration. Adapters override this if their
+    cases store those values under different keys. Defaults match the
+    CloudOpsBench schema.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     system_key: str = "system"
-    """Which key in ``case.metadata`` holds the system name."""
+    """``case.metadata[<key>]`` — system / cluster name."""
 
     stratum_key: str = "fault_category"
-    """Which key in ``case.metadata`` holds the category / stratum."""
+    """``case.metadata[<key>]`` — category / stratum for per-stratum
+    uniformity checks."""
 
     gt_object_key: str = "fault_object"
-    """Which key inside ``case.metadata["ground_truth"]`` holds the
-    target object name. Used by the cluster-concentration guard to
-    group similar cases together."""
+    """``case.metadata["ground_truth"][<key>]`` — GT target object,
+    used by the cluster-concentration guard to fingerprint scenarios."""
 
 
 # --------------------------------------------------------------------------- #
@@ -161,55 +133,38 @@ class BenchmarkAdapter(ABC):
     See :class:`AdapterCapabilities` for the available flags."""
 
     def apply_config_overrides(self, config: Any) -> None:  # noqa: ARG002 — default no-op
-        """Optional hook for the adapter to read its own config fields.
+        """Read adapter-specific config fields before any agent runs.
 
-        Called once after the framework builds the adapter and before
-        any agent runs. Use this when the config has fields that only
-        your adapter understands (CloudOpsBench uses this for
-        ``min_tool_calls`` and ``agent_variant``). Each adapter handles
-        its own settings here so the framework does not need to know
-        about them.
-
-        Default does nothing. If your adapter has no extra settings,
-        leave this alone.
+        Called once by the CLI after the adapter is built. Use for
+        config knobs only your adapter understands (CloudOpsBench reads
+        ``min_tool_calls`` and ``agent_variant`` here). Default is
+        no-op.
         """
         return None
 
     def overfit_dimensions(self) -> OverfitDimensions:
-        """Tell the overfit guards which metadata keys hold "system",
-        "category", and "ground-truth object" for this adapter.
+        """Metadata keys the overfit guards consult for this adapter.
 
-        The default returns the CloudOpsBench layout. Override this if
-        your benchmark stores those values under different key names.
-
-        Before this hook existed, the guard code reached into hard-coded
-        keys like ``metadata["system"]``. That broke as soon as a second
-        benchmark used different key names.
+        Override if your case metadata uses different key names than
+        the CloudOpsBench defaults.
         """
         return OverfitDimensions()
 
     def extend_provenance(self, provenance: dict[str, Any]) -> dict[str, Any]:
-        """Optional hook to add adapter-specific entries to provenance.
+        """Add adapter-specific entries to the provenance bundle.
 
-        The framework builds a standard provenance bundle (code SHA,
-        config, model versions, environment, etc.) then calls this hook
-        to let the adapter add or change anything that is specific to
-        its benchmark. Adapters can:
+        Called by ``capture_provenance`` after the framework assembles
+        its standard sections (code, config, models, environment,
+        run_inputs). Adapters may add top-level keys, extend existing
+        sections, or return the dict unchanged.
 
-          - add a brand-new top-level key, or
-          - add a key inside an existing section, or
-          - return the dict unchanged.
+        Default is identity. The hook exists so
+        ``_framework/provenance.py`` does not need to import any
+        specific adapter to capture adapter-specific run inputs (e.g.
+        CloudOpsBench's ``min_tool_calls``).
 
-        The default does nothing. The point of the hook is to keep the
-        framework's provenance code free of adapter-specific imports.
-        For example, CloudOpsBench uses this hook to add the
-        ``min_tool_calls`` value into ``run_inputs``. Before the hook
-        existed, the framework imported from CloudOpsBench directly to
-        get that value, which broke the decoupling.
-
-        Implementations can either mutate ``provenance`` in place and
-        return it, or return a fresh dict. The framework respects
-        whatever the hook returns.
+        Mutate-and-return is fine; the framework uses whatever the
+        hook returns.
         """
         return provenance
 

--- a/tests/benchmarks/_framework/registry.py
+++ b/tests/benchmarks/_framework/registry.py
@@ -1,29 +1,21 @@
 """Benchmark adapter registry.
 
-Each adapter declares its name and a zero-arg factory. The framework
-dispatches on ``config.benchmark`` via this registry rather than an
-if/elif chain.
+Maps ``config.benchmark`` → adapter factory so the framework can build
+adapters without an if/elif chain on the benchmark name.
 
-Adding a new benchmark adapter:
-  (1) Create ``tests/benchmarks/<name>/adapter.py``.
-  (2) At module load time the adapter file calls
-      ``register_adapter(NAME, FactoryClass)``.
+Adding a new adapter:
+  1. Create ``tests/benchmarks/<name>/adapter.py``.
+  2. At module load, the file calls ``register_adapter(NAME, FactoryClass)``.
 
-That's it. Phase 5 of the framework decoupling removed the previous
-hardcoded ``_KNOWN_ADAPTER_MODULES`` tuple in favour of filesystem
-auto-discovery: the bootstrap walks ``tests/benchmarks/*/adapter.py``
-and imports each, so the registry knows about every adapter without
-manual list-maintenance. The discovery rule is deliberately strict —
-a subdirectory of ``tests/benchmarks/`` is recognised as an adapter
-ONLY if it contains an ``adapter.py`` file, so helper packages like
-``_framework/`` and stub directories without an adapter file
-(e.g. ``interactive_shell/``) are skipped automatically.
+Discovery is automatic. Bootstrap walks ``tests/benchmarks/*/adapter.py``
+on first registry use. Directories with names starting with ``_`` or
+``.``, or without an ``adapter.py``, are skipped (``_framework/`` and
+``interactive_shell/`` are the current examples).
 
-Lazy registration is the right policy: each adapter module pulls in its
-own transitive dependencies (HF dataset loaders, replay backends, etc.)
-that the framework should NOT need at import time. Callers do NOT have to
-remember to bootstrap — ``build_adapter`` and ``known_adapters`` do it
-on first use via the ``_bootstrapped`` sentinel.
+Bootstrap is lazy because adapter modules pull in heavy transitive
+deps (HF dataset loaders, replay backends). Importing them at framework
+load time is wrong — only do it when a caller actually needs an
+adapter.
 """
 
 from __future__ import annotations
@@ -40,38 +32,22 @@ AdapterFactory = Callable[[], BenchmarkAdapter]
 
 _ADAPTER_FACTORIES: dict[str, AdapterFactory] = {}
 
-# Has ``ensure_known_adapters_registered`` been called this process? Kept
-# separate from ``bool(_ADAPTER_FACTORIES)`` because tests (and any future
-# code path) can pre-register mock adapters; the canonical bootstrap must
-# still run regardless of what's already in the dict.
-#
-# Stored as a single-key dict (not a bare ``bool``) so the flag can be
-# mutated from within a function without the ``global`` keyword — module
-# scope name *rebinding* needs ``global``, but in-place mutation of a
-# mutable object reached via its existing name does not. Same registry
-# mutation pattern as ``_ADAPTER_FACTORIES`` itself.
+# Bootstrap-once flag. Kept separate from ``bool(_ADAPTER_FACTORIES)``
+# because tests can pre-register mocks; the canonical bootstrap must
+# still run independent of dict contents. Stored in a dict (not a bare
+# bool) so we can mutate it without ``global`` rebinding.
 _REGISTRY_STATE: dict[str, bool] = {"bootstrapped": False}
 
 
 def _discover_adapter_modules() -> tuple[str, ...]:
-    """Find every ``tests/benchmarks/<name>/adapter.py`` on disk.
+    """Walk ``tests/benchmarks/`` and return adapter module paths.
 
-    Returns the importable module paths (``tests.benchmarks.<name>.adapter``)
-    in sorted order so the bootstrap is deterministic.
+    Rules:
+      - Immediate subdirectories only.
+      - Skip names starting with ``_`` or ``.``.
+      - Require an ``adapter.py`` inside the subdirectory.
 
-    Discovery rules:
-      - Iterate immediate subdirectories of ``tests/benchmarks/``.
-      - Skip directories whose name starts with ``_`` (e.g. ``_framework``)
-        or ``.`` (hidden dirs). Adapter packages are user-facing and never
-        start with a leading underscore.
-      - Require an ``adapter.py`` file inside the subdirectory. Stub
-        directories without an adapter (e.g. ``interactive_shell/``)
-        are skipped automatically — they may be reused for non-adapter
-        utilities without polluting the registry.
-
-    Phase 5 of the framework decoupling replaced a hardcoded module
-    list with this walk. Adding a new adapter under
-    ``tests/benchmarks/`` now requires zero framework changes.
+    Output is sorted for deterministic bootstrap order.
     """
     benchmarks_dir = Path(__file__).resolve().parent.parent
     discovered: list[str] = []
@@ -124,24 +100,16 @@ def build_adapter(name: str) -> BenchmarkAdapter:
 
 
 def capabilities_for(name: str) -> AdapterCapabilities:
-    """Return the registered adapter's declared capability flags.
+    """Return the adapter's capability flags without instantiating it.
 
-    Used by config validation (and any future framework-level
-    capability gating) to avoid hardcoded ``if benchmark == "cloudopsbench"``
-    branches.
-
-    Capabilities live as a class attribute on the adapter
-    (``ClassVar[AdapterCapabilities]``), so when the registered factory
-    IS the adapter class — the common pattern, e.g.
-    ``register_adapter("cloudopsbench", CloudOpsBenchAdapter)`` — we
-    read the attribute off the class directly. No instantiation, no
-    adapter-specific side effects (HF dataset load, replay backend
-    setup). The fallback covers the less common closure-factory pattern.
+    When the registered factory is the adapter class itself (the common
+    case: ``register_adapter("cloudopsbench", CloudOpsBenchAdapter)``),
+    we read ``capabilities`` directly off the class — no ``__init__``
+    runs, no side effects. Falls back to instantiating closure
+    factories.
 
     Raises ``KeyError`` with the same "known adapters" hint as
-    ``build_adapter`` when ``name`` is not registered. A typo in
-    ``config.benchmark`` surfaces with a useful message rather than
-    silently bypassing capability checks.
+    ``build_adapter`` for unregistered names.
     """
     ensure_known_adapters_registered()
     if name not in _ADAPTER_FACTORIES:
@@ -169,20 +137,18 @@ def known_adapters() -> list[str]:
 
 
 def ensure_known_adapters_registered() -> None:
-    """Bootstrap: import every adapter module so each module-level
+    """Import every discovered adapter module so its
     ``register_adapter()`` call runs.
 
-    Idempotent via the ``_REGISTRY_STATE["bootstrapped"]`` sentinel. The
-    sentinel is set BEFORE the import loop so a partial failure (one
-    adapter ImportErrors, another succeeds) doesn't trigger a retry on
-    the next call — bootstrap happens exactly once per process. Operators
-    who fix a broken adapter module restart the process.
+    Idempotent: runs once per process (guarded by
+    ``_REGISTRY_STATE["bootstrapped"]``). The flag is set BEFORE the
+    import loop so a single failing adapter doesn't trigger retries on
+    subsequent calls. Fix the adapter and restart the process.
 
-    ImportError is logged then suppressed so a single missing optional
-    dependency doesn't crash the framework, while typos / refactor breakage
-    still surface as a visible warning — silent suppression would leave the
-    registry empty and force every downstream "unknown adapter" diagnosis
-    to start from scratch.
+    ImportError is logged-and-suppressed so one missing optional dep
+    doesn't crash the framework. The warning surfaces typos and
+    refactor breakage; silent suppression would leave the registry
+    empty and obscure the root cause.
     """
     if _REGISTRY_STATE["bootstrapped"]:
         return

--- a/tests/benchmarks/cloudopsbench/adapter.py
+++ b/tests/benchmarks/cloudopsbench/adapter.py
@@ -337,25 +337,18 @@ class CloudOpsBenchAdapter(BenchmarkAdapter):
             rng = random.Random(filters.seed)
             rng.shuffle(legacy_cases)
 
-        # Apply the shape filter BEFORE the limit. That way ``limit=N``
-        # means "N matching cases", not "N candidates, some of which
-        # match."
+        # Shape filter runs BEFORE the limit so ``limit=N`` means
+        # "N matching cases", not "N candidates, some of which match."
         #
-        # ``seen_shape_for`` returns one of three named tags:
-        # ``SHAPE_SEEN``, ``SHAPE_UNSEEN``, or ``SHAPE_MID``.
+        # ``seen_shape_for`` is tri-valued: SHAPE_SEEN / SHAPE_UNSEEN /
+        # SHAPE_MID. A naive ``tag in {SHAPE_SEEN, SHAPE_UNSEEN}`` check
+        # drops every SHAPE_MID case (scheduling, service, infra — 22%
+        # of the corpus). The ``ALL_LABELED_SHAPES`` short-circuit
+        # treats ``[SHAPE_SEEN, SHAPE_UNSEEN]`` (the standard "give me
+        # everything" config) as "no filter" so SHAPE_MID also passes.
         #
-        # When the operator asks for both labels (``SHAPE_SEEN`` plus
-        # ``SHAPE_UNSEEN`` — the common "give me everything tagged"
-        # config: ``seen_shape: [true, false]``), we skip the filter
-        # entirely so mid-shape cases also pass through. The old
-        # behavior dropped every mid-shape case quietly: scheduling,
-        # service routing, and infrastructure never reached the runner.
-        # That capped every full run at 78% of the corpus and we did
-        # not notice for weeks.
-        #
-        # Operators who really want only one bucket can set
-        # ``seen_shape: [true]`` (seen only) or ``seen_shape: [false]``
-        # (unseen only).
+        # Single-bucket filters (``[SHAPE_SEEN]`` only or ``[SHAPE_UNSEEN]``
+        # only) still narrow the result as expected.
         wanted_seen_shape: set[bool] | None = (
             set(filters.seen_shape) if filters.seen_shape else None
         )

--- a/tests/benchmarks/cloudopsbench/adapter.py
+++ b/tests/benchmarks/cloudopsbench/adapter.py
@@ -352,7 +352,7 @@ class CloudOpsBenchAdapter(BenchmarkAdapter):
         wanted_seen_shape: set[bool] | None = (
             set(filters.seen_shape) if filters.seen_shape else None
         )
-        if wanted_seen_shape is not None and wanted_seen_shape == set(ALL_LABELED_SHAPES):
+        if wanted_seen_shape is not None and wanted_seen_shape == ALL_LABELED_SHAPES:
             wanted_seen_shape = None
         if wanted_seen_shape is not None:
             legacy_cases = [

--- a/tests/benchmarks/cloudopsbench/adapter.py
+++ b/tests/benchmarks/cloudopsbench/adapter.py
@@ -65,7 +65,7 @@ from tests.benchmarks.cloudopsbench.predictor import (
 )
 from tests.benchmarks.cloudopsbench.replay_backend import CloudOpsBenchReplayBackend
 from tests.benchmarks.cloudopsbench.scoring import score_case as _legacy_score_case
-from tests.benchmarks.cloudopsbench.tags import seen_shape_for
+from tests.benchmarks.cloudopsbench.tags import ALL_LABELED_SHAPES, seen_shape_for
 from tests.benchmarks.cloudopsbench.validity_scoring import (
     compute_citation_grounding,
     compute_entity_existence,
@@ -337,11 +337,30 @@ class CloudOpsBenchAdapter(BenchmarkAdapter):
             rng = random.Random(filters.seed)
             rng.shuffle(legacy_cases)
 
-        # Apply seen/unseen filter BEFORE limit so `limit=N` means
-        # "N matching cases", not "N candidates, some of which match"
+        # Apply the shape filter BEFORE the limit. That way ``limit=N``
+        # means "N matching cases", not "N candidates, some of which
+        # match."
+        #
+        # ``seen_shape_for`` returns one of three named tags:
+        # ``SHAPE_SEEN``, ``SHAPE_UNSEEN``, or ``SHAPE_MID``.
+        #
+        # When the operator asks for both labels (``SHAPE_SEEN`` plus
+        # ``SHAPE_UNSEEN`` — the common "give me everything tagged"
+        # config: ``seen_shape: [true, false]``), we skip the filter
+        # entirely so mid-shape cases also pass through. The old
+        # behavior dropped every mid-shape case quietly: scheduling,
+        # service routing, and infrastructure never reached the runner.
+        # That capped every full run at 78% of the corpus and we did
+        # not notice for weeks.
+        #
+        # Operators who really want only one bucket can set
+        # ``seen_shape: [true]`` (seen only) or ``seen_shape: [false]``
+        # (unseen only).
         wanted_seen_shape: set[bool] | None = (
             set(filters.seen_shape) if filters.seen_shape else None
         )
+        if wanted_seen_shape is not None and wanted_seen_shape == set(ALL_LABELED_SHAPES):
+            wanted_seen_shape = None
         if wanted_seen_shape is not None:
             legacy_cases = [
                 c for c in legacy_cases if seen_shape_for(c.fault_category) in wanted_seen_shape

--- a/tests/benchmarks/cloudopsbench/tags.py
+++ b/tests/benchmarks/cloudopsbench/tags.py
@@ -27,6 +27,51 @@ unseen-shape vs seen-shape becomes the empirical anti-overfit gate
 from __future__ import annotations
 
 # --------------------------------------------------------------------------- #
+# Shape tag constants                                                         #
+# --------------------------------------------------------------------------- #
+#
+# We sort every fault category into one of three buckets that say how
+# hard the category is for the LLM alone:
+#
+#   SHAPE_SEEN   -> easy categories (startup, runtime)
+#   SHAPE_UNSEEN -> hard categories (admission, performance)
+#   SHAPE_MID    -> middle categories (scheduling, service routing,
+#                                      infrastructure)
+#
+# We give these buckets named constants instead of using ``True``,
+# ``False``, and ``None`` directly in the code. The reason: in June 2026
+# the case loader had a filter that asked "is the tag True or False?"
+# A reader could easily think that covers everything tagged. It does
+# not. Cases tagged ``None`` (mid-shape) silently fell out. Three whole
+# fault categories never reached the runner. Spelling each tag out
+# makes the three-way nature of the tag impossible to miss.
+#
+# We keep the underlying values as ``bool | None`` so the cell files
+# already saved to S3 (3,177 per full corpus run) still read correctly.
+# These constants are clearer names for the same values, not a new
+# type.
+
+SHAPE_SEEN: bool = True
+"""Easy categories the LLM already handles well: startup, runtime."""
+
+SHAPE_UNSEEN: bool = False
+"""Hard categories where the LLM struggles most: admission, performance.
+This is where opensre adds the most value."""
+
+SHAPE_MID: None = None
+"""Middle categories: scheduling, service routing, infrastructure.
+Show up in the ``all`` aggregate but not in the seen-vs-unseen
+comparison."""
+
+# The case loader uses this set to spot when an operator says "I want
+# both labels" (the most common intent: give me everything tagged).
+# When the filter matches this set, the loader skips the filter
+# entirely so mid-shape cases also pass through. Without this rule the
+# filter dropped every mid-shape case and capped the corpus at 78%.
+ALL_LABELED_SHAPES: frozenset[bool] = frozenset({SHAPE_SEEN, SHAPE_UNSEEN})
+
+
+# --------------------------------------------------------------------------- #
 # Mapping                                                                     #
 # --------------------------------------------------------------------------- #
 
@@ -70,34 +115,33 @@ def _normalize(fault_category: str) -> str:
 
 
 def seen_shape_for(fault_category: str) -> bool | None:
-    """Map a fault category to its seen/unseen tag.
+    """Map a fault category to its shape tag.
 
-    Returns:
-        True   — seen-shape (Easy faults; explicit signals)
-        False  — unseen-shape (Hard faults; symptoms decoupled from root cause)
-        None   — mid-shape (Medium faults; not classified — appears in `all`
-                 stratum but not in seen/unseen aggregates)
+    Returns one of the three constants defined at the top of this module:
+        ``SHAPE_SEEN``   — Easy faults; explicit signals.
+        ``SHAPE_UNSEEN`` — Hard faults; symptoms decoupled from cause.
+        ``SHAPE_MID``    — Medium faults; not in seen/unseen aggregates.
     """
     key = _normalize(fault_category)
     if key in _SEEN_SHAPE_CATEGORIES:
-        return True
+        return SHAPE_SEEN
     if key in _UNSEEN_SHAPE_CATEGORIES:
-        return False
+        return SHAPE_UNSEEN
     if key in _MID_SHAPE_CATEGORIES:
-        return None
-    # Unknown category — treat as mid-shape (None) to avoid silently
+        return SHAPE_MID
+    # Unknown category — treat as mid-shape to avoid silently
     # mis-stratifying. Surfaced through the framework's reporting layer
     # which will list `all` only for unrecognized categories.
-    return None
+    return SHAPE_MID
 
 
 def known_categories() -> dict[str, bool | None]:
     """For introspection and CLI display: every category we recognize."""
     out: dict[str, bool | None] = {}
     for cat in _SEEN_SHAPE_CATEGORIES:
-        out[cat] = True
+        out[cat] = SHAPE_SEEN
     for cat in _UNSEEN_SHAPE_CATEGORIES:
-        out[cat] = False
+        out[cat] = SHAPE_UNSEEN
     for cat in _MID_SHAPE_CATEGORIES:
-        out[cat] = None
+        out[cat] = SHAPE_MID
     return out

--- a/tests/benchmarks/cloudopsbench/tags.py
+++ b/tests/benchmarks/cloudopsbench/tags.py
@@ -30,45 +30,35 @@ from __future__ import annotations
 # Shape tag constants                                                         #
 # --------------------------------------------------------------------------- #
 #
-# We sort every fault category into one of three buckets that say how
-# hard the category is for the LLM alone:
+# Each fault category gets one of three tags based on LLM-alone
+# baseline difficulty:
 #
-#   SHAPE_SEEN   -> easy categories (startup, runtime)
-#   SHAPE_UNSEEN -> hard categories (admission, performance)
-#   SHAPE_MID    -> middle categories (scheduling, service routing,
-#                                      infrastructure)
+#   SHAPE_SEEN   (True)  — easy categories: startup, runtime
+#   SHAPE_UNSEEN (False) — hard categories: admission, performance
+#   SHAPE_MID    (None)  — mid categories: scheduling, service, infra
 #
-# We give these buckets named constants instead of using ``True``,
-# ``False``, and ``None`` directly in the code. The reason: in June 2026
-# the case loader had a filter that asked "is the tag True or False?"
-# A reader could easily think that covers everything tagged. It does
-# not. Cases tagged ``None`` (mid-shape) silently fell out. Three whole
-# fault categories never reached the runner. Spelling each tag out
-# makes the three-way nature of the tag impossible to miss.
-#
-# We keep the underlying values as ``bool | None`` so the cell files
-# already saved to S3 (3,177 per full corpus run) still read correctly.
-# These constants are clearer names for the same values, not a new
-# type.
+# Underlying values stay ``bool | None`` so existing cell artifacts on
+# S3 still parse. The constants exist to make the three-way nature
+# visible at call sites; bare ``True``/``False`` in a filter expression
+# reads as "all tagged" but actually drops every ``None``-tagged case.
 
 SHAPE_SEEN: bool = True
-"""Easy categories the LLM already handles well: startup, runtime."""
+"""Easy categories: startup, runtime."""
 
 SHAPE_UNSEEN: bool = False
-"""Hard categories where the LLM struggles most: admission, performance.
-This is where opensre adds the most value."""
+"""Hard categories: admission, performance. Where opensre's lift
+concentrates."""
 
 SHAPE_MID: None = None
-"""Middle categories: scheduling, service routing, infrastructure.
-Show up in the ``all`` aggregate but not in the seen-vs-unseen
-comparison."""
+"""Mid categories: scheduling, service routing, infrastructure.
+Excluded from the seen-vs-unseen contrast but counted in the ``all``
+aggregate."""
 
-# The case loader uses this set to spot when an operator says "I want
-# both labels" (the most common intent: give me everything tagged).
-# When the filter matches this set, the loader skips the filter
-# entirely so mid-shape cases also pass through. Without this rule the
-# filter dropped every mid-shape case and capped the corpus at 78%.
 ALL_LABELED_SHAPES: frozenset[bool] = frozenset({SHAPE_SEEN, SHAPE_UNSEEN})
+"""Filter sentinel: when ``filters.seen_shape`` matches this set, the
+adapter treats it as "no shape filter" so ``SHAPE_MID`` cases also pass
+through. Otherwise ``[SHAPE_SEEN, SHAPE_UNSEEN]`` would silently drop
+~22% of the corpus (the three mid-shape categories)."""
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/benchmarks/cloudopsbench/tags.py
+++ b/tests/benchmarks/cloudopsbench/tags.py
@@ -26,6 +26,8 @@ unseen-shape vs seen-shape becomes the empirical anti-overfit gate
 
 from __future__ import annotations
 
+from typing import Literal
+
 # --------------------------------------------------------------------------- #
 # Shape tag constants                                                         #
 # --------------------------------------------------------------------------- #
@@ -49,7 +51,7 @@ SHAPE_UNSEEN: bool = False
 """Hard categories: admission, performance. Where opensre's lift
 concentrates."""
 
-SHAPE_MID: None = None
+SHAPE_MID: Literal[None] = None
 """Mid categories: scheduling, service routing, infrastructure.
 Excluded from the seen-vs-unseen contrast but counted in the ``all``
 aggregate."""

--- a/tests/benchmarks/cloudopsbench/tests/test_seen_shape_filter.py
+++ b/tests/benchmarks/cloudopsbench/tests/test_seen_shape_filter.py
@@ -1,22 +1,15 @@
-"""Tests for the shape filter on the CloudOpsBench case loader.
+"""Tests for the shape filter on ``CloudOpsBenchAdapter.load_cases``.
 
-What these tests cover:
+Pin the contract for the four ways operators set ``filters.seen_shape``:
 
-The case loader takes a list called ``seen_shape``. Each entry in that
-list says "I want cases of this shape." There are three shapes: seen,
-unseen, and mid. The full corpus has all three.
+  [SHAPE_SEEN, SHAPE_UNSEEN]  -> all cases (mid-shape included)
+  [SHAPE_SEEN]                -> only startup + runtime
+  [SHAPE_UNSEEN]              -> only admission + performance
+  []                          -> all cases (no filter)
 
-Before the fix, asking for ``[seen, unseen]`` quietly threw away every
-mid-shape case. The benchmark dropped 99 of 452 cases — three whole
-fault categories (scheduling, service routing, infrastructure) — and
-nothing told you. The run looked clean and the report said "78% of the
-corpus" without mentioning the dropped categories.
-
-These tests pin the four ways someone can use the filter:
-  1. Both labels (seen + unseen)  -> all cases, including mid (the fix)
-  2. Only seen                    -> only startup + runtime
-  3. Only unseen                  -> only admission + performance
-  4. Empty list                   -> all cases (no filter)
+The first case is the regression guard. A previous implementation
+checked ``tag in {True, False}``, which excluded ``None``-tagged
+(SHAPE_MID) cases and silently dropped 99/452 of the corpus.
 """
 
 from __future__ import annotations

--- a/tests/benchmarks/cloudopsbench/tests/test_seen_shape_filter.py
+++ b/tests/benchmarks/cloudopsbench/tests/test_seen_shape_filter.py
@@ -1,0 +1,112 @@
+"""Tests for the shape filter on the CloudOpsBench case loader.
+
+What these tests cover:
+
+The case loader takes a list called ``seen_shape``. Each entry in that
+list says "I want cases of this shape." There are three shapes: seen,
+unseen, and mid. The full corpus has all three.
+
+Before the fix, asking for ``[seen, unseen]`` quietly threw away every
+mid-shape case. The benchmark dropped 99 of 452 cases — three whole
+fault categories (scheduling, service routing, infrastructure) — and
+nothing told you. The run looked clean and the report said "78% of the
+corpus" without mentioning the dropped categories.
+
+These tests pin the four ways someone can use the filter:
+  1. Both labels (seen + unseen)  -> all cases, including mid (the fix)
+  2. Only seen                    -> only startup + runtime
+  3. Only unseen                  -> only admission + performance
+  4. Empty list                   -> all cases (no filter)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.benchmarks._framework.types import CaseFilters
+from tests.benchmarks.cloudopsbench.adapter import CloudOpsBenchAdapter
+from tests.benchmarks.cloudopsbench.case_loader import BENCHMARK_DIR
+from tests.benchmarks.cloudopsbench.tags import SHAPE_SEEN, SHAPE_UNSEEN
+
+pytestmark = [
+    pytest.mark.cloudopsbench,
+    pytest.mark.skipif(
+        not BENCHMARK_DIR.is_dir(),
+        reason="CloudOpsBench benchmark data is not downloaded; run "
+        "`make download-cloudopsbench-hf` first.",
+    ),
+]
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _load(seen_shape: list[bool] | None) -> tuple[int, set[str]]:
+    """Run the adapter's load_cases and return (count, distinct fault categories)."""
+    adapter = CloudOpsBenchAdapter()
+    filters = CaseFilters(seen_shape=seen_shape if seen_shape is not None else [], seed=42)
+    cases = list(adapter.load_cases(filters))
+    categories = {(c.metadata.get("fault_category") or "?").lower() for c in cases}
+    return len(cases), categories
+
+
+# --------------------------------------------------------------------------- #
+# Tests                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_both_labels_returns_all_categories() -> None:
+    """Asking for both labels means "give me everything."
+
+    Before the fix this dropped every mid-shape case quietly. After the
+    fix it returns all seven fault categories the corpus has."""
+    count, categories = _load([SHAPE_SEEN, SHAPE_UNSEEN])
+    # Every shape bucket must appear at least once.
+    seen_buckets = {"startup", "runtime"}
+    unseen_buckets = {"admission", "performance"}
+    mid_buckets = {"scheduling", "service", "service_routing", "infrastructure", "infra"}
+    assert categories & seen_buckets, f"seen categories missing: {categories}"
+    assert categories & unseen_buckets, f"unseen categories missing: {categories}"
+    assert categories & mid_buckets, (
+        f"mid-shape categories were dropped — that is the bug we just fixed: {categories}"
+    )
+    # The old bug capped the count at 353. The fix must exceed that.
+    assert count > 353, f"loader returned {count} — expected mid-shape cases too"
+
+
+def test_only_seen_returns_only_seen_categories() -> None:
+    """``seen_shape=[SHAPE_SEEN]`` means "only the easy categories."
+
+    Mid-shape and unseen-shape cases must not appear in the result."""
+    _, categories = _load([SHAPE_SEEN])
+    assert categories <= {"startup", "runtime"}, (
+        f"seen-only filter let other categories through: {categories}"
+    )
+    assert "startup" in categories
+    assert "runtime" in categories
+
+
+def test_only_unseen_returns_only_unseen_categories() -> None:
+    """``seen_shape=[SHAPE_UNSEEN]`` means "only the hard categories."
+
+    Mid-shape and seen-shape cases must not appear in the result."""
+    _, categories = _load([SHAPE_UNSEEN])
+    assert categories <= {"admission", "performance"}, (
+        f"unseen-only filter let other categories through: {categories}"
+    )
+    assert "admission" in categories
+    assert "performance" in categories
+
+
+def test_empty_filter_returns_all_categories() -> None:
+    """No filter set means "no filter applied" — return every category.
+
+    This is what happens when a config does not list ``seen_shape`` at all."""
+    count, categories = _load([])
+    # Same answer as asking for both labels: every bucket present.
+    assert categories & {"startup", "runtime"}
+    assert categories & {"admission", "performance"}
+    assert categories & {"scheduling", "service", "service_routing", "infrastructure", "infra"}
+    assert count > 353

--- a/tests/benchmarks/cloudopsbench/tests/test_seen_shape_filter.py
+++ b/tests/benchmarks/cloudopsbench/tests/test_seen_shape_filter.py
@@ -55,8 +55,10 @@ def test_both_labels_returns_all_categories() -> None:
 
     Before the fix this dropped every mid-shape case quietly. After the
     fix it returns all seven fault categories the corpus has."""
-    count, categories = _load([SHAPE_SEEN, SHAPE_UNSEEN])
-    # Every shape bucket must appear at least once.
+    _, categories = _load([SHAPE_SEEN, SHAPE_UNSEEN])
+    # Every shape bucket must appear at least once. The presence of
+    # mid-shape categories is the structural proof that the bug is fixed:
+    # the prior implementation excluded every None-tagged case.
     seen_buckets = {"startup", "runtime"}
     unseen_buckets = {"admission", "performance"}
     mid_buckets = {"scheduling", "service", "service_routing", "infrastructure", "infra"}
@@ -65,8 +67,6 @@ def test_both_labels_returns_all_categories() -> None:
     assert categories & mid_buckets, (
         f"mid-shape categories were dropped — that is the bug we just fixed: {categories}"
     )
-    # The old bug capped the count at 353. The fix must exceed that.
-    assert count > 353, f"loader returned {count} — expected mid-shape cases too"
 
 
 def test_only_seen_returns_only_seen_categories() -> None:
@@ -97,9 +97,8 @@ def test_empty_filter_returns_all_categories() -> None:
     """No filter set means "no filter applied" — return every category.
 
     This is what happens when a config does not list ``seen_shape`` at all."""
-    count, categories = _load([])
+    _, categories = _load([])
     # Same answer as asking for both labels: every bucket present.
     assert categories & {"startup", "runtime"}
     assert categories & {"admission", "performance"}
     assert categories & {"scheduling", "service", "service_routing", "infrastructure", "infra"}
-    assert count > 353


### PR DESCRIPTION
Fixes #2074

#### Describe the changes you have made in this PR -

`CloudOpsBenchAdapter.load_cases` silently dropped 99 of 452 cases (~22% of the corpus) from every full-N run. Three entire fault categories — scheduling, service routing, infrastructure — never reached the runner. Every "full corpus" benchmark we shipped was actually a 4-of-7 categories subset, and nothing surfaced that.

Root cause: `seen_shape_for()` returns `True / False / None` (seen / unseen / mid). The filter checked `tag in {True, False}`, which is True only for the labelled values. `None`-tagged cases (every scheduling / service / infra case) silently failed the check.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
