### PR TITLE
fix(watchdog): resolve Telegram creds from integration store, env, or…

### DIFF
--- a/app/watch_dog/alarms.py
+++ b/app/watch_dog/alarms.py
@@ -26,35 +26,89 @@ class AlarmCredentials:
     chat_id: str = field()
 
 
+def _telegram_store_config() -> dict[str, object]:
+    """Return the Telegram integration's effective config, or ``{}``.
+
+    Reads the merged integration store + environment view used everywhere else
+    (investigation pipeline, scheduler). Returns an empty mapping when the store
+    is unavailable or has no Telegram integration so callers fall back to the
+    environment / keyring. Resolution is wrapped defensively: a malformed or
+    locked store must never crash the watchdog at startup.
+    """
+    try:
+        from app.integrations.catalog import resolve_effective_integrations
+
+        entry = resolve_effective_integrations().get("telegram", {})
+        config = entry.get("config", {}) if isinstance(entry, dict) else {}
+        return config if isinstance(config, dict) else {}
+    except Exception:
+        logger.debug("Failed to resolve Telegram credentials from the store", exc_info=True)
+        return {}
+
+
+def _resolve_bot_token(store_config: dict[str, object]) -> str:
+    """Resolve the bot token: store first, then ``TELEGRAM_BOT_TOKEN`` env, then keyring."""
+    store_token = str(store_config.get("bot_token") or "").strip()
+    if store_token:
+        return store_token
+    # resolve_env_credential checks the environment first, then the system
+    # keyring — so guided setup (which stores the token in the keyring) works.
+    from app.llm_credentials import resolve_env_credential
+
+    return resolve_env_credential("TELEGRAM_BOT_TOKEN").strip()
+
+
+def _resolve_chat_id(store_config: dict[str, object], chat_id_override: str | None) -> str:
+    """Resolve the chat id: ``--chat-id`` override, then store, then env."""
+    # Strip first so a whitespace-only override falls back consistently with an
+    # empty-string override, instead of raising a misleading "pass --chat-id"
+    # error after the caller already passed one.
+    stripped_override = chat_id_override.strip() if chat_id_override else ""
+    if stripped_override:
+        return stripped_override
+    store_chat_id = str(store_config.get("default_chat_id") or "").strip()
+    if store_chat_id:
+        return store_chat_id
+    return os.getenv("TELEGRAM_DEFAULT_CHAT_ID", "").strip()
+
+
 def load_credentials_from_env(
     *,
     chat_id_override: str | None = None,
 ) -> AlarmCredentials:
-    """Read TELEGRAM_BOT_TOKEN and TELEGRAM_DEFAULT_CHAT_ID; raise on missing."""
-    bot_token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+    """Resolve Telegram credentials from the integration store, env, or keyring.
+
+    Resolution order (matching the scheduler):
+
+    * **bot token** — integration store → ``TELEGRAM_BOT_TOKEN`` env → system keyring
+    * **chat id** — ``--chat-id`` override → store ``default_chat_id`` →
+      ``TELEGRAM_DEFAULT_CHAT_ID`` env
+
+    The name is retained for backward compatibility; resolution is no longer
+    env-only, so credentials saved by ``opensre onboard`` /
+    ``opensre integrations setup telegram`` work for the watchdog and Hermes
+    instead of raising ``TELEGRAM_BOT_TOKEN is not set``.
+    """
+    store_config = _telegram_store_config()
+
+    bot_token = _resolve_bot_token(store_config)
     if not bot_token:
         raise OpenSREError(
             "TELEGRAM_BOT_TOKEN is not set.",
             suggestion=(
-                "Export TELEGRAM_BOT_TOKEN=<your-bot-token> in your environment "
-                "and retry. Get a token from @BotFather on Telegram."
+                "Configure Telegram with `opensre integrations setup telegram` "
+                "(or `opensre onboard`), or export TELEGRAM_BOT_TOKEN=<your-bot-token>. "
+                "Get a token from @BotFather on Telegram."
             ),
         )
 
-    # Strip first so a whitespace-only override falls back to env consistently
-    # with an empty-string override, instead of raising a misleading
-    # "pass --chat-id" error after the caller already passed one.
-    stripped_override = chat_id_override.strip() if chat_id_override else ""
-    if stripped_override:
-        chat_id = stripped_override
-    else:
-        chat_id = os.getenv("TELEGRAM_DEFAULT_CHAT_ID", "").strip()
+    chat_id = _resolve_chat_id(store_config, chat_id_override)
     if not chat_id:
         raise OpenSREError(
             "Telegram chat id is not set.",
             suggestion=(
-                "Export TELEGRAM_DEFAULT_CHAT_ID=<chat-id> in your environment "
-                "or pass --chat-id to the watchdog command and retry."
+                "Set a default chat id during `opensre integrations setup telegram`, "
+                "export TELEGRAM_DEFAULT_CHAT_ID=<chat-id>, or pass --chat-id and retry."
             ),
         )
 

--- a/docs/hermes.mdx
+++ b/docs/hermes.mdx
@@ -8,7 +8,7 @@ OpenSRE can **watch the log file written by a [Hermes](https://github.com/NousRe
 Developer workflow: the **Hermes synthetic suite** under `tests/synthetic/hermes/` runs **offline** classifier checks (no LLM, no live infra); you can run that first, then **watch** a bundled scenario `errors.log` with `opensre hermes watch` as a small local demo. **Optional:** enable **`--investigate`** to attach the full OpenSRE RCA pipeline for **HIGH** / **CRITICAL** incidents ([quickstart](/quickstart)).
 
 <Note>
-Telegram delivery uses the same credential model as the rest of OpenSRE. For **`hermes watch`**, set `TELEGRAM_BOT_TOKEN` and `TELEGRAM_DEFAULT_CHAT_ID` (or pass `--chat-id`). See [Telegram](/messaging/telegram).
+Telegram delivery uses the same credential model as the rest of OpenSRE. Configure it once with `opensre integrations setup telegram` (or `opensre onboard`) — `hermes watch` resolves the token from the integration store, environment, or keyring. You can also set `TELEGRAM_BOT_TOKEN` / `TELEGRAM_DEFAULT_CHAT_ID` directly, or pass `--chat-id`. See [Telegram](/messaging/telegram).
 </Note>
 
 ---
@@ -105,7 +105,7 @@ Correlator **dedup** can also reduce multiple Telegram sends for the same finger
 
 | Variable | Role |
 |----------|------|
-| `TELEGRAM_BOT_TOKEN` | Required for delivery (see [Telegram](/messaging/telegram)) |
+| `TELEGRAM_BOT_TOKEN` | Bot token, unless already configured via `opensre integrations setup telegram` / `onboard` (see [Telegram](/messaging/telegram)) |
 | `TELEGRAM_DEFAULT_CHAT_ID` | Default destination when `--chat-id` is omitted |
 | `HERMES_LOG_PATH` | Default log path when `--log-path` is omitted |
 | `OPENSRE_HERMES_INVESTIGATE` | If set to `1` / `true` / `yes` / `on`, enables investigation when the CLI does not pass `--investigate` / `--no-investigate` |

--- a/docs/messaging/telegram.mdx
+++ b/docs/messaging/telegram.mdx
@@ -119,6 +119,16 @@ TELEGRAM_DEFAULT_CHAT_ID=<chat-id>
 
 OpenSRE picks these up at startup and registers Telegram as an active integration.
 
+<Note>
+**Credential resolution.** Every Telegram delivery surface — investigations, the
+scheduler, `opensre watchdog`, `opensre hermes watch`, and the `/watch` REPL
+command — resolves the bot token in the same order: integration store →
+`TELEGRAM_BOT_TOKEN` env → system keyring; and the chat id as `--chat-id` →
+store `default_chat_id` → `TELEGRAM_DEFAULT_CHAT_ID` env. Either setup option
+above works for all of them — you do not need to export the token separately for
+the watchdog or Hermes.
+</Note>
+
 ---
 
 ## Step 5: Verify

--- a/tests/watch_dog/test_alarms.py
+++ b/tests/watch_dog/test_alarms.py
@@ -55,6 +55,31 @@ def _patch_clock(monkeypatch: pytest.MonkeyPatch, ticks: list[float]) -> None:
     monkeypatch.setattr(AlarmDispatcher, "_now", staticmethod(_now))
 
 
+@pytest.fixture(autouse=True)
+def _isolate_credential_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make credential resolution hermetic.
+
+    By default the integration store is empty and the keyring is disabled, so
+    credential tests resolve purely from environment variables unless they opt
+    into the store (by patching ``resolve_effective_integrations``) or the
+    keyring. Without this, the new store-first resolution would read the real
+    ``~/.opensre`` store and make tests depend on local machine state.
+    """
+    monkeypatch.setattr(
+        "app.integrations.catalog.resolve_effective_integrations",
+        lambda: {},
+    )
+    monkeypatch.setenv("OPENSRE_DISABLE_KEYRING", "1")
+
+
+def _patch_store(monkeypatch: pytest.MonkeyPatch, config: dict[str, Any]) -> None:
+    """Point the store-backed Telegram config at *config*."""
+    monkeypatch.setattr(
+        "app.integrations.catalog.resolve_effective_integrations",
+        lambda: {"telegram": {"source": "local store", "config": config}},
+    )
+
+
 def test_alarm_credentials_repr_does_not_leak_bot_token() -> None:
     # Auto-generated dataclass __repr__ surfaces in pytest assertion output,
     # tracebacks, and structured log capture. The token must stay out of it.
@@ -149,6 +174,94 @@ def test_load_credentials_whitespace_override_falls_back_to_env(
     creds = load_credentials_from_env(chat_id_override="   ")
 
     assert creds.chat_id == "chat-from-env"
+
+
+def test_load_credentials_from_store_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Guided setup (`opensre integrations setup telegram` / `onboard`) saves the
+    # token to the store, not the environment. The watchdog must find it there.
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("TELEGRAM_DEFAULT_CHAT_ID", raising=False)
+    _patch_store(monkeypatch, {"bot_token": "store-tok", "default_chat_id": "store-chat"})
+
+    creds = load_credentials_from_env()
+
+    assert creds == AlarmCredentials(bot_token="store-tok", chat_id="store-chat")
+
+
+def test_load_credentials_chat_id_from_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TELEGRAM_DEFAULT_CHAT_ID", raising=False)
+    _patch_store(monkeypatch, {"bot_token": "store-tok", "default_chat_id": "store-chat"})
+
+    creds = load_credentials_from_env()
+
+    assert creds.chat_id == "store-chat"
+
+
+def test_load_credentials_store_bot_token_beats_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Store wins over env, matching the scheduler's precedence.
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "env-tok")
+    monkeypatch.setenv("TELEGRAM_DEFAULT_CHAT_ID", "chat-1")
+    _patch_store(monkeypatch, {"bot_token": "store-tok"})
+
+    creds = load_credentials_from_env()
+
+    assert creds.bot_token == "store-tok"
+
+
+def test_load_credentials_store_chat_id_beats_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok")
+    monkeypatch.setenv("TELEGRAM_DEFAULT_CHAT_ID", "env-chat")
+    _patch_store(monkeypatch, {"bot_token": "tok", "default_chat_id": "store-chat"})
+
+    creds = load_credentials_from_env()
+
+    assert creds.chat_id == "store-chat"
+
+
+def test_load_credentials_override_beats_store_chat_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_store(monkeypatch, {"bot_token": "tok", "default_chat_id": "store-chat"})
+
+    creds = load_credentials_from_env(chat_id_override="arg-chat")
+
+    assert creds.chat_id == "arg-chat"
+
+
+def test_load_credentials_from_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No store, no env — the token lives only in the system keyring (as the
+    # onboarding wizard writes it via sync_env_secret).
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.setenv("TELEGRAM_DEFAULT_CHAT_ID", "chat-1")
+    monkeypatch.setattr(
+        "app.llm_credentials.resolve_llm_api_key",
+        lambda env_var: "keyring-tok" if env_var == "TELEGRAM_BOT_TOKEN" else "",
+    )
+
+    creds = load_credentials_from_env()
+
+    assert creds.bot_token == "keyring-tok"
+
+
+def test_load_credentials_store_failure_falls_back_to_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A broken/locked store must not crash the watchdog; resolution falls back
+    # to the environment.
+    def _boom(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("store is locked")
+
+    monkeypatch.setattr("app.integrations.catalog.resolve_effective_integrations", _boom)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "env-tok")
+    monkeypatch.setenv("TELEGRAM_DEFAULT_CHAT_ID", "env-chat")
+
+    creds = load_credentials_from_env()
+
+    assert creds == AlarmCredentials(bot_token="env-tok", chat_id="env-chat")
 
 
 def test_first_dispatch_calls_telegram(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
… keyring

Fixes #2534  GAP - 1

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

opensre watchdog, opensre hermes watch, and the /watch REPL command shared a credential loader (load_credentials_from_env) that only read environment variables. But guided setup (opensre integrations setup telegram / opensre onboard) saves the bot token to the integration store and system keyring and never to .env, so after completing setup these surfaces still failed with TELEGRAM_BOT_TOKEN is not set. This PR rewrites the loader to resolve credentials in the same order the investigation scheduler already uses (integration store → TELEGRAM_BOT_TOKEN env → keyring for the token; --chat-id → store default_chat_id → TELEGRAM_DEFAULT_CHAT_ID for the chat id), with the store read wrapped defensively so a locked store never crashes the watchdog. Adds 8 hermetic unit tests and updates the Telegram and Hermes docs to reflect the unified resolution.

### Demo/Screenshot for feature changes and bug fixes - 

https://github.com/user-attachments/assets/b1f4bb0f-31ac-430d-bc4c-961be87ba6fd

<img width="1582" height="992" alt="image" src="https://github.com/user-attachments/assets/95bbacb1-2ad5-4700-bced-8a942d6d72b7" />

<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I changed only the shared load_credentials_from_env helper rather than each call site, so the watchdog, Hermes, and /watch REPL all get the fix for free without touching their wiring. The token now resolves via resolve_effective_integrations() (the same store-first path the scheduler already uses) before falling back to env and keyring, keeping behavior consistent across every Telegram surface. The store lookup is wrapped in a defensive try/except so a missing or locked store degrades to env/keyring instead of crashing, and the new unit tests are made hermetic with an autouse fixture that stubs the store empty and disables the keyring, so they never depend on local machine state.

<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---


Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
