### PR TITLE
fix(rabbitmq): treat null queue message counts as zero in backlog

### DIFF
--- a/app/integrations/rabbitmq.py
+++ b/app/integrations/rabbitmq.py
@@ -234,17 +234,24 @@ def rabbitmq_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
 
 def _summarize_queue(queue: dict[str, Any]) -> dict[str, Any]:
     stats = queue.get("message_stats") or {}
+    # The Management API returns these count fields as an explicit JSON ``null``
+    # (not just absent) for queues without live stats — e.g. a queue whose home
+    # node is down, or right after a broker restart before the stats DB is
+    # populated. ``dict.get(key, 0)`` only substitutes the default when the key
+    # is missing, so ``null`` would flow through as ``None`` and crash the
+    # backlog sort below (``None + None``). Coerce with ``or 0``, mirroring the
+    # ``message_stats or {}`` guard above.
     return {
         "name": queue.get("name", ""),
         "vhost": queue.get("vhost", ""),
         "state": queue.get("state", "unknown"),
-        "messages_ready": queue.get("messages_ready", 0),
-        "messages_unacknowledged": queue.get("messages_unacknowledged", 0),
-        "messages_total": queue.get("messages", 0),
-        "messages_persistent": queue.get("messages_persistent", 0),
-        "consumers": queue.get("consumers", 0),
+        "messages_ready": queue.get("messages_ready") or 0,
+        "messages_unacknowledged": queue.get("messages_unacknowledged") or 0,
+        "messages_total": queue.get("messages") or 0,
+        "messages_persistent": queue.get("messages_persistent") or 0,
+        "consumers": queue.get("consumers") or 0,
         "consumer_utilisation": queue.get("consumer_utilisation"),
-        "memory_bytes": queue.get("memory", 0),
+        "memory_bytes": queue.get("memory") or 0,
         "publish_rate": (stats.get("publish_details") or {}).get("rate", 0.0),
         "deliver_rate": (stats.get("deliver_get_details") or {}).get("rate", 0.0),
         "ack_rate": (stats.get("ack_details") or {}).get("rate", 0.0),

--- a/tests/integrations/test_rabbitmq.py
+++ b/tests/integrations/test_rabbitmq.py
@@ -323,6 +323,52 @@ class TestGetQueueBacklog:
         assert result["queues"][0]["name"] == "huge-q"
         assert result["queues"][1]["name"] == "small-q"
 
+    def test_null_message_counts_do_not_crash_sort(self, patched_client: Any) -> None:
+        """A queue on a down node reports null counts; backlog must still work.
+
+        The Management API returns ``messages_ready`` / ``messages_unacknowledged``
+        as an explicit JSON ``null`` for queues without live stats (e.g. a queue
+        whose home node is down). Those must be treated as 0, not crash the
+        ``None + None`` backlog sort and turn the whole tool into ``available: False``.
+        """
+        patched_client(
+            {
+                "/api/queues//": [
+                    {
+                        "name": "down-q",
+                        "vhost": "/",
+                        "state": "down",
+                        "messages_ready": None,
+                        "messages_unacknowledged": None,
+                        "messages": None,
+                        "consumers": None,
+                        "memory": None,
+                    },
+                    {
+                        "name": "ok-q",
+                        "vhost": "/",
+                        "state": "running",
+                        "messages_ready": 5,
+                        "messages_unacknowledged": 2,
+                        "messages": 7,
+                        "consumers": 1,
+                    },
+                ]
+            }
+        )
+        result = get_queue_backlog(CONFIGURED)
+        assert result["available"] is True
+        assert result["total_queues"] == 2
+        # ok-q (backlog 7) ranks above the null-count down-q (treated as 0).
+        assert result["queues"][0]["name"] == "ok-q"
+        down_q = result["queues"][1]
+        assert down_q["name"] == "down-q"
+        assert down_q["messages_ready"] == 0
+        assert down_q["messages_unacknowledged"] == 0
+        assert down_q["messages_total"] == 0
+        assert down_q["consumers"] == 0
+        assert down_q["memory_bytes"] == 0
+
     def test_error_path_returns_available_false(self, patched_client: Any) -> None:
         patched_client({"/api/queues//": httpx.Response(500, text="fail")})
         result = get_queue_backlog(CONFIGURED)


### PR DESCRIPTION
<!-- No linked issue: self-reported bug fix. Per CONTRIBUTING Path 1 — "Bugs & small fixes -> Open a PR." -->

#### Describe the changes you have made in this PR -

`get_rabbitmq_queue_backlog` crashes and reports the broker as unavailable whenever a queue is returned without live message stats.

The RabbitMQ Management API (`GET /api/queues/<vhost>`) returns the count fields (`messages_ready`, `messages_unacknowledged`, `messages`, …) as an explicit JSON `null` — not just absent — for queues that have no live statistics: a queue whose home node is **down**, or right after a broker restart before the stats DB is repopulated.

`_summarize_queue` reads them with `dict.get(key, 0)`, but the default only applies when the key is **missing**; a present `null` flows through as `None`. The backlog ranking then does:

```python
summarized.sort(key=lambda q: q["messages_ready"] + q["messages_unacknowledged"], reverse=True)
```

`None + None` raises `TypeError`, the broad `except Exception` swallows it, and the whole tool returns `{"available": False, "error": "unsupported operand type(s) for +: 'NoneType' and 'NoneType'"}` — precisely during the down-node / backlog incident the tool exists to diagnose.

**Fix:** coerce the integer count fields with `or 0`, mirroring the existing `stats = queue.get("message_stats") or {}` guard already present in the same function. `consumer_utilisation` is left nullable (it is legitimately `null` when a queue has no consumers) and the rate fields were already null-safe.

### Demo/Screenshot for feature changes and bug fixes -

Minimal repro against a mocked Management API where a down-node queue reports `null` counts next to a healthy queue.

**Before (on `main`):**
```
{'source': 'rabbitmq', 'available': False, 'error': "unsupported operand type(s) for +: 'NoneType' and 'NoneType'"}
```

**After:**
```
available     : True
total_queues  : 2
order         : ['ok-q', 'down-q']
down-q counts : {'messages_ready': 0, 'messages_unacknowledged': 0, 'messages_total': 0, 'messages_persistent': 0}
```

Regression test `TestGetQueueBacklog::test_null_message_counts_do_not_crash_sort` is **red on `main`** (TypeError → `available: False`) and **green** with the fix.

Local checks per `CI.md`: `ruff check app/ tests/` ✓ · `ruff format --check app/ tests/` ✓ · `mypy app/` ✓ (740 files) · `pytest tests/integrations/test_rabbitmq.py` ✓ (40 passed).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- **What problem does this solve?** A single queue without live stats (down home node, or a broker that just restarted) returns `null` message counts, which crashed the backlog sort and took the *entire* `get_rabbitmq_queue_backlog` tool offline — exactly when an SRE is triaging a backlog/down-node incident.
- **Alternatives considered:** (1) guarding only the sort key with `or 0` — rejected, because `messages_total`/`messages_persistent` would still surface as `null` in the output; (2) filtering out null-count queues — rejected, because a down queue is the most relevant row to show. Coercing at the summary boundary keeps every downstream consumer null-safe and reports a sane `0`.
- **Why this implementation:** `or 0` at `_summarize_queue` matches the pattern the function already uses for `message_stats` (`… or {}`), so the null-safety convention stays consistent and local.
- **Key change:** `_summarize_queue` now coerces the integer count fields (`messages_ready`, `messages_unacknowledged`, `messages`, `messages_persistent`, `consumers`, `memory`) with `or 0`; non-count fields (`consumer_utilisation`, rates) are unchanged.

---

## Checklist before requesting a review
- [x] I have added proper PR title (no issue linked — self-reported bug, per CONTRIBUTING Path 1)
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] I have added a regression test for the fix
- [x] My code follows the project's style guidelines and conventions
