### PR TITLE
fix(security): resolve open CodeQL code-scanning alerts

### DIFF
--- a/app/cli/interactive_shell/ui/__init__.py
+++ b/app/cli/interactive_shell/ui/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from app.cli.interactive_shell.ui.banner import (
     render_banner,
@@ -49,6 +49,17 @@ from app.cli.interactive_shell.ui.theme import (
     TEXT,
     WARNING,
 )
+
+if TYPE_CHECKING:
+    # ``_build_agents_table`` and ``render_agents_table`` are PEP 562 lazy module
+    # attributes resolved by ``__getattr__`` below (loaded from ``agents_view`` only
+    # on first access so collectors don't pull in Rich). Declaring them here makes
+    # them visible to static analyzers that can't follow ``__getattr__`` (CodeQL
+    # ``py/undefined-export``, ruff F822) without eagerly importing the module.
+    from app.cli.interactive_shell.ui.agents_view import (
+        _build_agents_table,
+        render_agents_table,
+    )
 
 
 def __getattr__(name: str) -> Any:

--- a/tests/benchmarks/cloudopsbench/predictor/__init__.py
+++ b/tests/benchmarks/cloudopsbench/predictor/__init__.py
@@ -29,7 +29,7 @@ modules above is re-exported here.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from tests.benchmarks.cloudopsbench.predictor.llm_call import (
     _FENCED_JSON,
@@ -65,6 +65,17 @@ from tests.benchmarks.cloudopsbench.predictor.vocabulary import (
     _ROOT_CAUSES,
     _TAXONOMY_CATEGORIES,
 )
+
+if TYPE_CHECKING:
+    # ``align_predictions_to_investigation`` and ``apply_investigation_handoff`` are
+    # PEP 562 lazy module attributes resolved by ``__getattr__`` below (see the
+    # docstring there). Declaring them here makes them visible to static analyzers
+    # that can't follow ``__getattr__`` (CodeQL ``py/undefined-export``, ruff F822)
+    # without eagerly importing ``investigation_handoff`` and its scoring deps.
+    from tests.benchmarks.cloudopsbench.predictor.investigation_handoff import (
+        align_predictions_to_investigation,
+        apply_investigation_handoff,
+    )
 
 __all__ = [
     # vocabulary

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -606,11 +606,14 @@ class TestReplHintAnimation:
         display._start_animation("analyzing results")
         assert display._anim_thread is not None
 
-        with pytest.raises(RuntimeError, match="synthesis failed"):
+        def _synthesis_then_stop() -> None:
             try:
                 raise RuntimeError("synthesis failed")
             finally:
                 display._stop_animation()
+
+        with pytest.raises(RuntimeError, match="synthesis failed"):
+            _synthesis_then_stop()
 
         assert display._anim_thread is None
 

--- a/tests/services/pagerduty/test_client.py
+++ b/tests/services/pagerduty/test_client.py
@@ -434,11 +434,15 @@ def test_context_manager_closes_on_exit() -> None:
     assert c._client is None
 
 
+def _raise_value_error() -> None:
+    raise ValueError("test error")
+
+
 def test_context_manager_closes_on_exception() -> None:
     c = _client()
     _ = c._get_client()
     with pytest.raises(ValueError), c:
-        raise ValueError("test error")
+        _raise_value_error()
     assert c._client is None
 
 


### PR DESCRIPTION
## Summary

Clears all six open CodeQL code-scanning alerts on `main`.

| Alert | Rule | Location | Fix |
| --- | --- | --- | --- |
| #1218, #1219 | `py/undefined-export` | `app/cli/interactive_shell/ui/__init__.py` | `_build_agents_table` / `render_agents_table` are PEP 562 `__getattr__` lazy exports; declared under `TYPE_CHECKING` so static analyzers see them without eager import |
| #1204, #1205 | `py/undefined-export` | `tests/benchmarks/cloudopsbench/predictor/__init__.py` | `align_predictions_to_investigation` / `apply_investigation_handoff` lazy exports declared under `TYPE_CHECKING` |
| #1217 | `py/unreachable-statement` | `tests/cli/test_output.py` | Extracted the in-block `raise` into a nested helper so the post-`with` assertion is no longer flagged unreachable |
| #1162 | `py/unreachable-statement` | `tests/services/pagerduty/test_client.py` | Extracted `raise` into `_raise_value_error()` helper (matches prior fix in #588) |

The `TYPE_CHECKING` approach matches the existing `app/cli/support/constants.py` convention and leaves runtime PEP 562 lazy resolution unchanged. Test behavior is unchanged.

## Test plan

- [x] `ruff check` + `ruff format --check` on all edited files
- [x] `mypy` on the edited `app/` module
- [x] Edited tests pass (`test_exception_during_synthesis_stops_animation_via_finally`, `test_context_manager_closes_on_exception`)
- [x] Runtime sanity: `import *` and lazy `__getattr__` attrs still resolve for both packages

Made with [Cursor](https://cursor.com)