### PR TITLE
fix(prompt-log): capture background CLI task errors in prompt logging

### DIFF
--- a/app/cli/interactive_shell/prompt_logging/recorder.py
+++ b/app/cli/interactive_shell/prompt_logging/recorder.py
@@ -16,7 +16,7 @@ from app.cli.interactive_shell.prompt_logging.sinks.posthog_ai import capture_ai
 from app.version import get_version
 
 _SUPPORTED_ROUTE_KINDS = frozenset(
-    {"handle_message_with_agent", "cli_help", "follow_up", "new_alert"}
+    {"handle_message_with_agent", "cli_help", "follow_up", "new_alert", "background_task"}
 )
 
 # Maps PromptRecorder route_kind → session turn kind stored in turn_detail records.
@@ -25,6 +25,7 @@ _ROUTE_TO_SESSION_KIND: dict[str, str] = {
     "cli_help": "chat",
     "follow_up": "follow_up",
     "new_alert": "alert",
+    "background_task": "cli_command",
 }
 
 
@@ -88,6 +89,35 @@ class PromptRecorder:
             session_id=_session_id(session),
             turn_id=str(uuid.uuid4()),
             prompt=_sanitize_text(text, config=config),
+        )
+
+    @classmethod
+    def for_background_task(
+        cls,
+        *,
+        session: Any,
+        command: str,
+        task_id: str,
+    ) -> PromptRecorder | None:
+        """Create a recorder for an async background task.
+
+        Background CLI tasks (e.g. ``opensre investigate``) finish long after
+        the originating turn has flushed, so their stdout/stderr/exit outcome is
+        not available to the turn-level recorder. This recorder is created at
+        task launch — so its latency clock spans the full task duration — and is
+        flushed by the task watcher once the outcome (including any error text)
+        is known. ``turn_id`` is set to ``task_id`` so the prompt-log event
+        correlates with the task surfaced by ``/tasks``.
+        """
+        config = PromptLogConfig.load()
+        if not config.enabled:
+            return None
+        return cls(
+            config=config,
+            route_kind="background_task",
+            session_id=_session_id(session),
+            turn_id=task_id or str(uuid.uuid4()),
+            prompt=_sanitize_text(command, config=config),
         )
 
     def set_response(self, text: str, run: LlmRunInfo | None = None) -> None:

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/__init__.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/__init__.py
@@ -77,6 +77,7 @@ from .task_streaming import (
     _start_task_output_streams,
     _subprocess_env_with_aligned_width,
     read_diag,
+    read_task_output,
     terminate_child_process,
 )
 
@@ -118,6 +119,7 @@ __all__ = [
     "os",
     "print_interactive_wizard_handoff",
     "read_diag",
+    "read_task_output",
     "run_claude_code_implementation",
     "run_cd_command",
     "run_opensre_cli_command",

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/background_tasks.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/background_tasks.py
@@ -13,6 +13,7 @@ from typing import Any
 from rich.console import Console
 from rich.markup import escape
 
+from app.cli.interactive_shell.prompt_logging import PromptRecorder
 from app.cli.interactive_shell.runtime import ReplSession, TaskKind, TaskRecord
 from app.cli.interactive_shell.ui import DIM, ERROR, HIGHLIGHT
 from app.cli.support.exception_reporting import report_exception
@@ -29,8 +30,31 @@ from .task_streaming import (
     _start_task_output_streams,
     _subprocess_env_with_aligned_width,
     read_diag,
+    read_task_output,
     terminate_child_process,
 )
+
+
+def _compose_task_log_response(
+    *,
+    headline: str,
+    stdout_buf: tempfile.SpooledTemporaryFile[bytes] | None,  # type: ignore[type-arg]
+    stderr_buf: tempfile.SpooledTemporaryFile[bytes],  # type: ignore[type-arg]
+) -> str:
+    """Build the prompt-log response text for a finished background task.
+
+    Combines a status headline with the captured stdout and stderr so the
+    flushed ``background_task`` event carries the real command output (the
+    error text the user sees in the terminal), not an empty assistant reply.
+    """
+    parts = [headline]
+    stdout_text = read_task_output(stdout_buf, limit=_MAX_COMMAND_OUTPUT_CHARS)
+    stderr_text = read_task_output(stderr_buf, limit=_MAX_COMMAND_OUTPUT_CHARS)
+    if stdout_text:
+        parts.append(stdout_text)
+    if stderr_text:
+        parts.append(stderr_text)
+    return "\n".join(parts)
 
 
 def start_background_cli_task(
@@ -47,6 +71,12 @@ def start_background_cli_task(
     console.print(f"[bold]$ {display_command}[/bold]")
     task = session.task_registry.create(kind, command=display_command)
     task.mark_running()
+    # Created at launch so the flushed prompt-log latency spans the full task
+    # duration; the watcher sets the response and flushes once the outcome
+    # (including any error text) is known. See for_background_task() docstring.
+    recorder = PromptRecorder.for_background_task(
+        session=session, command=display_command, task_id=task.task_id
+    )
     stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg]
         max_size=_SYNTHETIC_DIAG_CHARS * 2
     )
@@ -91,10 +121,20 @@ def start_background_cli_task(
             for fd in pty_fds:
                 with contextlib.suppress(OSError):
                     os.close(fd)
+        task.mark_failed(str(exc))
+        if recorder is not None:
+            with contextlib.suppress(Exception):
+                recorder.set_response(
+                    _compose_task_log_response(
+                        headline=f"command failed to start: {exc}",
+                        stdout_buf=stdout_buf,
+                        stderr_buf=stderr_buf,
+                    )
+                )
+                recorder.flush()
         if stdout_buf is not None:
             stdout_buf.close()
         stderr_buf.close()
-        task.mark_failed(str(exc))
         report_exception(exc, context="interactive_shell.background_cli_task.start")
         console.print(f"[{ERROR}]failed to start:[/] {escape(str(exc))}")
         return None
@@ -128,6 +168,7 @@ def start_background_cli_task(
         terminated_by_watcher = False
         timed_out = False
         suggest_follow_up = False
+        outcome_headline = "command completed (exit 0)"
         while proc.poll() is None:
             if time.monotonic() - started_at > timeout_seconds:
                 timed_out = True
@@ -143,10 +184,12 @@ def start_background_cli_task(
 
         try:
             if timed_out:
+                outcome_headline = f"command timed out after {timeout_seconds} seconds"
                 task.mark_failed(f"timed out after {timeout_seconds}s")
                 suggest_follow_up = kind is TaskKind.SYNTHETIC_TEST
                 return
             if terminated_by_watcher and task.cancel_requested.is_set():
+                outcome_headline = "command cancelled"
                 task.mark_cancelled()
                 return
 
@@ -157,16 +200,30 @@ def start_background_cli_task(
             else:
                 diag = _ae_resolve("read_diag", read_diag)(stderr_buf)
                 error_msg = f"exit code {code}" + (f": {diag}" if diag else "")
+                outcome_headline = f"command failed (exit {code})"
                 task.mark_failed(error_msg)
                 console.print(f"[{ERROR}]command failed (exit {code}):[/]")
                 suggest_follow_up = kind is TaskKind.SYNTHETIC_TEST
         except Exception as exc:  # noqa: BLE001
+            outcome_headline = f"command error: {exc}"
             task.mark_failed(str(exc))
             report_exception(exc, context="interactive_shell.background_cli_task.watch")
             console.print(f"[{ERROR}]error:[/] {escape(str(exc))}")
             suggest_follow_up = kind is TaskKind.SYNTHETIC_TEST
         finally:
             _join_task_output_streams(output_threads)
+            # Flush the prompt-log/PostHog event with the real outcome (stdout,
+            # stderr, exit/timeout/cancel) before the capture buffers are closed.
+            if recorder is not None:
+                with contextlib.suppress(Exception):
+                    recorder.set_response(
+                        _compose_task_log_response(
+                            headline=outcome_headline,
+                            stdout_buf=stdout_buf,
+                            stderr_buf=stderr_buf,
+                        )
+                    )
+                    recorder.flush()
             if stdout_buf is not None:
                 stdout_buf.close()
             stderr_buf.close()

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/task_streaming.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/task_streaming.py
@@ -77,11 +77,30 @@ def terminate_child_process(proc: subprocess.Popen[Any]) -> None:
             proc.wait(timeout=5)
 
 
+def read_task_output(
+    buf: tempfile.SpooledTemporaryFile[bytes] | None,  # type: ignore[type-arg]
+    *,
+    limit: int,
+) -> str:
+    """Read up to ``limit`` bytes from a captured output buffer, ANSI-stripped.
+
+    Tolerates a ``None`` buffer (e.g. the PTY path has no separate stdout
+    capture) and a closed/failed buffer, returning an empty string instead of
+    raising so callers in cleanup paths stay safe.
+    """
+    if buf is None:
+        return ""
+    try:
+        buf.seek(0)
+        raw = buf.read(limit).decode("utf-8", errors="replace").strip()
+    except (OSError, ValueError):
+        return ""
+    return _ANSI_ESCAPE.sub("", raw)
+
+
 def read_diag(buf: tempfile.SpooledTemporaryFile[bytes]) -> str:  # type: ignore[type-arg]
     """Read up to ``_SYNTHETIC_DIAG_CHARS`` bytes from a captured stderr buffer."""
-    buf.seek(0)
-    raw = buf.read(_SYNTHETIC_DIAG_CHARS).decode("utf-8", errors="replace").strip()
-    return _ANSI_ESCAPE.sub("", raw)
+    return read_task_output(buf, limit=_SYNTHETIC_DIAG_CHARS)
 
 
 def _print_task_output_line(
@@ -237,6 +256,7 @@ __all__ = [
     "_TASK_OUTPUT_JOIN_TIMEOUT_SECONDS",
     "terminate_child_process",
     "read_diag",
+    "read_task_output",
     "_print_task_output_line",
     "_subprocess_env_with_aligned_width",
     "_pump_task_stream",

--- a/tests/cli/interactive_shell/orchestration/test_action_executor.py
+++ b/tests/cli/interactive_shell/orchestration/test_action_executor.py
@@ -19,6 +19,7 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.a
     _pump_task_pty,
     _pump_task_stream,
     read_diag,
+    read_task_output,
     run_cd_command,
     run_claude_code_implementation,
     run_opensre_cli_command,
@@ -72,6 +73,24 @@ def test_read_diag_respects_byte_cap() -> None:
         buf.write(b"z" * 5_000)
         text = read_diag(buf)
     assert len(text) == 2_000
+
+
+def test_read_task_output_handles_none_buffer() -> None:
+    assert read_task_output(None, limit=100) == ""
+
+
+def test_read_task_output_strips_ansi_and_caps() -> None:
+    with tempfile.SpooledTemporaryFile() as buf:  # type: ignore[type-arg]
+        buf.write(b"\x1b[31merror\x1b[0m line\n")
+        text = read_task_output(buf, limit=1_000)
+    assert text == "error line"
+
+
+def test_read_task_output_returns_empty_for_closed_buffer() -> None:
+    with tempfile.SpooledTemporaryFile() as buf:  # type: ignore[type-arg]
+        buf.write(b"data")
+    # Buffer is closed once the ``with`` block exits.
+    assert read_task_output(buf, limit=100) == ""
 
 
 def test_run_pwd_command_prints_cwd(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -647,6 +666,117 @@ def test_start_background_cli_task_falls_back_to_pipes_when_pty_unavailable(
     assert popen_kwargs[0]["stderr"] is subprocess.PIPE
     assert popen_kwargs[0]["text"] is True
     assert "pipe progress" in buf.getvalue()
+
+
+def test_start_background_cli_task_logs_failure_outcome_to_posthog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A background CLI task that fails asynchronously must still send its real
+    stderr/exit outcome to the prompt-log/PostHog sink. This is the regression
+    for ``opensre investigate`` errors arriving after the turn recorder flushed.
+    """
+    captured: list[dict[str, object]] = []
+
+    monkeypatch.setenv("OPENSRE_PROMPT_LOG_REDACT", "0")
+    monkeypatch.setenv("OPENSRE_PROMPT_LOG_LOCAL_DISABLED", "1")
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.prompt_logging.recorder.capture_ai_generation",
+        lambda properties: captured.append(properties),
+    )
+
+    class _FakeProcess:
+        returncode = 1
+        stdout = io.StringIO("")
+        stderr = io.StringIO("No remote named 'myportfolio' is configured.\n")
+
+        def poll(self) -> int:
+            return 1
+
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.action_executor.subprocess.Popen",
+        lambda _command, **_kwargs: _FakeProcess(),
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.action_executor.threading.Thread",
+        _ImmediateThread,
+    )
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    task = start_background_cli_task(
+        display_command="opensre investigate --service myportfolio",
+        argv_list=["python", "-m", "app.cli", "investigate", "--service", "myportfolio"],
+        session=session,
+        console=console,
+        kind=TaskKind.CLI_COMMAND,
+    )
+
+    assert task is not None
+    assert task.status == TaskStatus.FAILED
+    assert len(captured) == 1
+    props = captured[0]
+    assert props["cli_route_kind"] == "background_task"
+    assert props["$ai_trace_id"] == task.task_id
+    ai_input = props["$ai_input"]
+    assert isinstance(ai_input, list)
+    assert ai_input[0]["content"] == "opensre investigate --service myportfolio"
+    choices = props["$ai_output_choices"]
+    assert isinstance(choices, list)
+    content = choices[0]["content"]
+    assert "command failed (exit 1)" in content
+    assert "No remote named 'myportfolio' is configured." in content
+
+
+def test_start_background_cli_task_logs_success_outcome_to_posthog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful background task logs its stdout outcome, not an empty reply."""
+    captured: list[dict[str, object]] = []
+
+    monkeypatch.setenv("OPENSRE_PROMPT_LOG_REDACT", "0")
+    monkeypatch.setenv("OPENSRE_PROMPT_LOG_LOCAL_DISABLED", "1")
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.prompt_logging.recorder.capture_ai_generation",
+        lambda properties: captured.append(properties),
+    )
+
+    class _FakeProcess:
+        returncode = 0
+        stdout = io.StringIO("investigation complete: root cause identified\n")
+        stderr = io.StringIO("")
+
+        def poll(self) -> int:
+            return 0
+
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.action_executor.subprocess.Popen",
+        lambda _command, **_kwargs: _FakeProcess(),
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.action_executor.threading.Thread",
+        _ImmediateThread,
+    )
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    task = start_background_cli_task(
+        display_command="opensre investigate --service checkout",
+        argv_list=["python", "-m", "app.cli", "investigate", "--service", "checkout"],
+        session=session,
+        console=console,
+        kind=TaskKind.CLI_COMMAND,
+    )
+
+    assert task is not None
+    assert task.status == TaskStatus.COMPLETED
+    assert len(captured) == 1
+    content = captured[0]["$ai_output_choices"][0]["content"]
+    assert "command completed (exit 0)" in content
+    assert "investigation complete: root cause identified" in content
 
 
 def test_task_output_stream_reports_unexpected_failure(

--- a/tests/cli/interactive_shell/prompt_logging/test_recorder.py
+++ b/tests/cli/interactive_shell/prompt_logging/test_recorder.py
@@ -24,6 +24,48 @@ def test_prompt_recorder_start_respects_supported_routes(monkeypatch, tmp_path: 
     assert PromptRecorder.start(session=session, text="hello", route_kind="cli_help") is not None
 
 
+def test_prompt_recorder_for_background_task_uses_task_id_as_trace(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: list[dict[str, object]] = []
+    cfg = PromptLogConfig(
+        enabled=True,
+        local_enabled=False,
+        posthog_enabled=True,
+        redact=False,
+        max_chars=1000,
+        log_path=tmp_path / "prompt_log.jsonl",
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.prompt_logging.recorder.PromptLogConfig.load", lambda: cfg
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.prompt_logging.recorder.capture_ai_generation",
+        lambda payload: captured.append(payload),
+    )
+    session = ReplSession()
+    recorder = PromptRecorder.for_background_task(
+        session=session, command="opensre investigate --service api", task_id="ab247135"
+    )
+    assert recorder is not None
+    recorder.set_response("command failed (exit 1)\nboom")
+    recorder.flush()
+    assert captured
+    assert captured[0]["cli_route_kind"] == "background_task"
+    assert captured[0]["$ai_trace_id"] == "ab247135"
+    assert captured[0]["$ai_input"][0]["content"] == "opensre investigate --service api"
+    assert captured[0]["$ai_output_choices"][0]["content"] == "command failed (exit 1)\nboom"
+
+
+def test_prompt_recorder_for_background_task_disabled_returns_none(monkeypatch) -> None:
+    cfg = PromptLogConfig(enabled=False)
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.prompt_logging.recorder.PromptLogConfig.load", lambda: cfg
+    )
+    session = ReplSession()
+    assert PromptRecorder.for_background_task(session=session, command="x", task_id="t") is None
+
+
 def test_prompt_recorder_flush_writes_and_redacts(monkeypatch, tmp_path: Path) -> None:
     log_path = tmp_path / "prompt_log.jsonl"
     cfg = PromptLogConfig(


### PR DESCRIPTION
Summary
This is a follow-up to PR #2847. Errors from background CLI commands, such as opensre investigate --service , were still not reaching the prompt-log or PostHog sinks. This caused the ai_output_choices field to come through empty.

Root cause
The opensre investigate command runs as a background process. It launches a subprocess in a daemon thread via start_background_cli_task and returns immediately. Because of this, the turn-level PromptRecorder flushes right away, only capturing the launch phase (showing a short ai_latency of around 1.8 seconds). The actual error, such as "No remote named myportfolio is configured," arrives seconds later in the _watch thread. That thread only updated the in-memory task record long after the recorder had already flushed. PR #2847 only added response_text capture to synchronous paths like shell, cd, pwd, and denied actions, which this background path never hits.

Fix
The background task watcher now manages a dedicated background_task prompt-log event.
A PromptRecorder is created when the task launches so latency spans the full duration of the task. The watcher then flushes it once the final outcome is known, covering completion, failure, timeout, cancellation, and spawn failure. The flushed response combines a status headline (such as command failed exit 1, completed, timed out, or cancelled) with the captured stdout and stderr. This ensures the actual error text lands in ai_output_choices. The task ID is also used as the ai_trace_id and ai_span_id so the event connects properly with /tasks.

Changes
- prompt_logging/recorder.py: Added the background_task route kind and the PromptRecorder.for_background_task function.
- action_executor/task_streaming.py: Extracted a reusable read_task_output function that strips ANSI codes and handles closed or missing buffers, then updated read_diag to use it.
- action_executor/background_tasks.py: Configured the watcher and spawn-failure paths to assemble and flush the final task outcome.

Test plan
- Verified that ruff check, ruff format --check, and mypy pass on all modified files.
- Added new tests to ensure background failure and success outcomes reach the PostHog sink with real output, alongside unit tests for for_background_task and read_task_output.
- Verified that the orchestration, prompt_logging, test_commands, and runtime test suites pass. The only failures were pre-existing live-LLM planner tests that require network access and are unrelated to this change.