### PR TITLE
Fix code-scanning notes in interactive-shell tests

### DIFF
--- a/tests/cli/interactive_shell/chat/test_tool_gathering.py
+++ b/tests/cli/interactive_shell/chat/test_tool_gathering.py
@@ -14,10 +14,11 @@ from typing import Any
 
 from rich.console import Console
 
-from app.agent.tool_loop import ToolLoopResult
+import app.agent.investigation as investigation
+import app.agent.tool_loop as tool_loop
+import app.services.agent_llm_client as agent_llm_client
 from app.cli.interactive_shell.chat.tool_gathering import gather_tool_evidence
 from app.cli.interactive_shell.runtime.session import ReplSession
-from app.services.agent_llm_client import ToolCall
 
 
 def _console() -> Console:
@@ -33,8 +34,6 @@ def test_no_tools_available_returns_none(monkeypatch: Any) -> None:
     session = ReplSession()
     session.resolved_integrations_cache = {}
 
-    import app.agent.investigation as investigation
-
     monkeypatch.setattr(investigation, "_get_available_tools", lambda _resolved: [])
 
     assert gather_tool_evidence("any question", session, _console()) is None
@@ -44,26 +43,24 @@ def test_executed_results_return_formatted_observation(monkeypatch: Any) -> None
     session = ReplSession()
     session.resolved_integrations_cache = {}
 
-    import app.agent.investigation as investigation
-    import app.agent.tool_loop as tool_loop
-    import app.services.agent_llm_client as agent_llm_client
-
     monkeypatch.setattr(
         investigation,
         "_get_available_tools",
         lambda _resolved: [_DummyTool("search_github_issues")],
     )
-    monkeypatch.setattr(agent_llm_client, "get_agent_llm", lambda: object())
+    monkeypatch.setattr(agent_llm_client, "get_agent_llm", object)
 
     executed = [
         (
-            ToolCall(id="t1", name="search_github_issues", input={"owner": "o", "repo": "r"}),
+            agent_llm_client.ToolCall(
+                id="t1", name="search_github_issues", input={"owner": "o", "repo": "r"}
+            ),
             {"issues": ["#1", "#2"]},
         )
     ]
 
-    def _fake_loop(**_kwargs: Any) -> ToolLoopResult:
-        return ToolLoopResult(messages=[], final_text="", executed=executed)
+    def _fake_loop(**_kwargs: Any) -> tool_loop.ToolLoopResult:
+        return tool_loop.ToolLoopResult(messages=[], final_text="", executed=executed)
 
     monkeypatch.setattr(tool_loop, "run_tool_calling_loop", _fake_loop)
 
@@ -79,19 +76,15 @@ def test_no_executed_returns_none(monkeypatch: Any) -> None:
     session = ReplSession()
     session.resolved_integrations_cache = {}
 
-    import app.agent.investigation as investigation
-    import app.agent.tool_loop as tool_loop
-    import app.services.agent_llm_client as agent_llm_client
-
     monkeypatch.setattr(
         investigation,
         "_get_available_tools",
         lambda _resolved: [_DummyTool("search_github_issues")],
     )
-    monkeypatch.setattr(agent_llm_client, "get_agent_llm", lambda: object())
+    monkeypatch.setattr(agent_llm_client, "get_agent_llm", object)
 
-    def _fake_loop(**_kwargs: Any) -> ToolLoopResult:
-        return ToolLoopResult(messages=[], final_text="nothing to do", executed=[])
+    def _fake_loop(**_kwargs: Any) -> tool_loop.ToolLoopResult:
+        return tool_loop.ToolLoopResult(messages=[], final_text="nothing to do", executed=[])
 
     monkeypatch.setattr(tool_loop, "run_tool_calling_loop", _fake_loop)
 
@@ -101,9 +94,6 @@ def test_no_executed_returns_none(monkeypatch: Any) -> None:
 def test_exception_path_returns_none(monkeypatch: Any) -> None:
     session = ReplSession()
     session.resolved_integrations_cache = {}
-
-    import app.agent.investigation as investigation
-    import app.services.agent_llm_client as agent_llm_client
 
     monkeypatch.setattr(
         investigation,

--- a/tests/cli/interactive_shell/runtime/test_answer_with_tools.py
+++ b/tests/cli/interactive_shell/runtime/test_answer_with_tools.py
@@ -15,7 +15,6 @@ from typing import Any
 from rich.console import Console
 
 import app.cli.interactive_shell.runtime.execution as execution
-from app.cli.interactive_shell.runtime.execution import _answer_cli_agent_with_tools
 from app.cli.interactive_shell.runtime.session import ReplSession
 
 
@@ -40,7 +39,7 @@ def test_gather_string_threads_offscreen_observation(monkeypatch: Any) -> None:
         execution, "gather_tool_evidence", lambda *_a, **_k: "Tool: x\nArguments: {}\nResult: y"
     )
 
-    _answer_cli_agent_with_tools("question", ReplSession(), _console())
+    execution._answer_cli_agent_with_tools("question", ReplSession(), _console())
 
     assert len(calls) == 1
     assert calls[0]["tool_observation"] == "Tool: x\nArguments: {}\nResult: y"
@@ -51,7 +50,7 @@ def test_gather_none_passes_through_without_observation(monkeypatch: Any) -> Non
     calls = _record_answer(monkeypatch)
     monkeypatch.setattr(execution, "gather_tool_evidence", lambda *_a, **_k: None)
 
-    _answer_cli_agent_with_tools("question", ReplSession(), _console())
+    execution._answer_cli_agent_with_tools("question", ReplSession(), _console())
 
     assert len(calls) == 1
     assert calls[0]["tool_observation"] is None
@@ -66,7 +65,7 @@ def test_existing_observation_skips_gather(monkeypatch: Any) -> None:
 
     monkeypatch.setattr(execution, "gather_tool_evidence", _should_not_run)
 
-    _answer_cli_agent_with_tools(
+    execution._answer_cli_agent_with_tools(
         "question", ReplSession(), _console(), tool_observation="already gathered"
     )
 


### PR DESCRIPTION
## Summary
Resolves the 8 open GitHub code-scanning alerts (all `note` severity) flagged on two interactive-shell test modules:

- **`py/import-and-import-from`** (6 alerts): `app.agent.tool_loop`, `app.services.agent_llm_client`, `app.agent.investigation`, and `runtime.execution` were each imported both with `import ... as` (inline) and `from ... import`. Consolidated to top-level `import ... as` aliases and reference members via the alias (`tool_loop.ToolLoopResult`, `agent_llm_client.ToolCall`, `execution._answer_cli_agent_with_tools`).
- **`py/unnecessary-lambda`** (2 alerts): replaced `lambda: object()` stubs with `object` directly.

## Test plan
- [x] `ruff check` passes on both files
- [x] `ruff format --check` clean
- [x] `pytest` on both modules — 7 passed

Made with [Cursor](https://cursor.com)