### PR TITLE
refactor(integrations): drop MCP transport prompt, fix to recommended mode

### DIFF
--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -1118,16 +1118,10 @@ def _github_wizard_auth_token(mode: str, credentials: Mapping[str, object]) -> s
 
 def _configure_github_mcp() -> tuple[str, str]:
     _, credentials = _integration_defaults("github")
-    default_mode = _string_value(credentials.get("mode"), DEFAULT_GITHUB_MCP_MODE)
-    mode = _choose(
-        "Choose the GitHub MCP transport:",
-        [
-            Choice(value="sse", label="SSE"),
-            Choice(value="streamable-http", label="Streamable HTTP"),
-            Choice(value="stdio", label="stdio"),
-        ],
-        default=default_mode,
-    )
+    # Transport is fixed to Streamable HTTP — the only mode anyone selects in practice,
+    # and SSE/stdio are deprecated for the hosted GitHub MCP server. The transport
+    # prompt was removed on purpose — do NOT reintroduce a transport selection here.
+    mode = DEFAULT_GITHUB_MCP_MODE
 
     while True:
         url = ""
@@ -1249,22 +1243,11 @@ def _configure_openclaw() -> tuple[str, str]:
         stored_command == "openclaw-mcp"
         and not _joined_values(stored_args, separator=" ", fallback="")
     )
-    default_mode = (
-        DEFAULT_OPENCLAW_MCP_MODE
-        if use_stdio_defaults
-        else _string_value(credentials.get("mode"), DEFAULT_OPENCLAW_MCP_MODE)
-    )
-
     while True:
-        mode = _choose(
-            "Choose the OpenClaw bridge transport:",
-            [
-                Choice(value="stdio", label="stdio (recommended)"),
-                Choice(value="streamable-http", label="Streamable HTTP"),
-                Choice(value="sse", label="SSE"),
-            ],
-            default=default_mode,
-        )
+        # Transport is fixed to stdio (the local OpenClaw bridge). In practice it is
+        # the only mode anyone selects, so the transport prompt was removed on purpose
+        # — do NOT reintroduce a transport selection or a remote branch here.
+        mode = DEFAULT_OPENCLAW_MCP_MODE
 
         url = ""
         command = ""
@@ -1352,24 +1335,17 @@ def _configure_openclaw() -> tuple[str, str]:
                 f"[{SECONDARY}]Accurate RCA:[/] [bold]also configure Grafana/Datadog and GitHub[/]"
             )
             return "OpenClaw", str(env_path)
-        default_mode = mode
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
 
 def _configure_posthog_mcp() -> tuple[str, str]:
     _, credentials = _integration_defaults("posthog_mcp")
-    default_mode = _string_value(credentials.get("mode"), DEFAULT_POSTHOG_MCP_MODE)
 
     while True:
-        mode = _choose(
-            "Choose the PostHog MCP transport:",
-            [
-                Choice(value="streamable-http", label="Streamable HTTP (recommended)"),
-                Choice(value="sse", label="SSE"),
-                Choice(value="stdio", label="stdio (local server)"),
-            ],
-            default=default_mode,
-        )
+        # Transport is fixed to Streamable HTTP (the hosted PostHog MCP server). In
+        # practice it is the only mode anyone selects, so the transport prompt was
+        # removed on purpose — do NOT reintroduce a transport selection here.
+        mode = DEFAULT_POSTHOG_MCP_MODE
 
         url = ""
         command = ""
@@ -1454,24 +1430,17 @@ def _configure_posthog_mcp() -> tuple[str, str]:
                 f"[{SECONDARY}]Verify:[/] [bold]uv run opensre integrations verify posthog_mcp[/]"
             )
             return "PostHog MCP", str(env_path)
-        default_mode = mode
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
 
 def _configure_sentry_mcp() -> tuple[str, str]:
     _, credentials = _integration_defaults("sentry_mcp")
-    default_mode = _string_value(credentials.get("mode"), DEFAULT_SENTRY_MCP_MODE)
 
     while True:
-        mode = _choose(
-            "Choose the Sentry MCP transport:",
-            [
-                Choice(value="streamable-http", label="Streamable HTTP (recommended)"),
-                Choice(value="sse", label="SSE"),
-                Choice(value="stdio", label="stdio (local server)"),
-            ],
-            default=default_mode,
-        )
+        # Transport is fixed to Streamable HTTP (the hosted Sentry MCP server). In
+        # practice it is the only mode anyone selects, so the transport prompt was
+        # removed on purpose — do NOT reintroduce a transport selection here.
+        mode = DEFAULT_SENTRY_MCP_MODE
 
         url = ""
         command = ""
@@ -1549,7 +1518,6 @@ def _configure_sentry_mcp() -> tuple[str, str]:
                 f"[{SECONDARY}]Verify:[/] [bold]uv run opensre integrations verify sentry_mcp[/]"
             )
             return "Sentry MCP", str(env_path)
-        default_mode = mode
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
 

--- a/app/integrations/cli.py
+++ b/app/integrations/cli.py
@@ -449,22 +449,16 @@ def _github_advanced_setup(credentials: dict[str, Any]) -> tuple[str, str]:
         DEFAULT_GITHUB_MCP_URL,
     )
 
-    print("  1) SSE  2) Streamable HTTP  3) stdio")
-    choice = _p("Choice", default="2")
-    mode = {"1": "sse", "2": "streamable-http", "3": "stdio"}.get(choice, "streamable-http")
+    # Transport is fixed to Streamable HTTP. In practice it is the only mode anyone
+    # selects, and SSE/stdio are deprecated for the hosted GitHub MCP server. The
+    # transport prompt was removed on purpose — do NOT reintroduce a transport
+    # selection or a stdio branch here.
+    mode = "streamable-http"
     credentials["mode"] = mode
-    if mode == "stdio":
-        command = _p("Command", default="github-mcp-server")
-        args = _p("Args", default="stdio --toolsets repos,issues,pull_requests,actions")
-        if not command:
-            _die("command is required for stdio mode.")
-        credentials["command"] = command
-        credentials["args"] = [part for part in args.split() if part]
-    else:
-        url = _p("MCP URL", default=DEFAULT_GITHUB_MCP_URL)
-        if not url:
-            _die("url is required for remote MCP modes.")
-        credentials["url"] = url
+    url = _p("MCP URL", default=DEFAULT_GITHUB_MCP_URL)
+    if not url:
+        _die("url is required for remote MCP modes.")
+    credentials["url"] = url
     credentials["auth_token"] = _setup_github_auth_token(mode)
     toolsets = _p("Toolsets", default=",".join(DEFAULT_GITHUB_MCP_TOOLSETS))
     credentials["toolsets"] = [part.strip() for part in toolsets.split(",") if part.strip()]
@@ -799,28 +793,19 @@ def _setup_twilio() -> None:
 
 
 def _setup_openclaw() -> None:
-    print("  1) stdio (recommended)  2) Streamable HTTP  3) SSE")
-    choice = _p("Choice", default="1")
-    mode = {"1": "stdio", "2": "streamable-http", "3": "sse"}.get(choice, "stdio")
-
+    # Transport is fixed to stdio (the local OpenClaw bridge). In practice it is the
+    # only mode anyone selects, so the transport prompt was removed on purpose — do
+    # NOT reintroduce a transport selection or a remote streamable-http/SSE branch.
+    mode = "stdio"
     credentials: dict[str, Any] = {"mode": mode}
-    if mode == "stdio":
-        command = _p("OpenClaw bridge command", default="openclaw")
-        args = _p("OpenClaw bridge args", default="mcp serve")
-        if not command:
-            _die("command is required for stdio mode.")
-        credentials["command"] = command
-        credentials["args"] = [part for part in args.split() if part]
-        credentials["url"] = ""
-        credentials["auth_token"] = ""
-    else:
-        url = _p("OpenClaw bridge URL")
-        if not url:
-            _die("url is required for remote MCP modes.")
-        credentials["url"] = url
-        credentials["command"] = ""
-        credentials["args"] = []
-        credentials["auth_token"] = _p("OpenClaw auth token (optional)", secret=True)
+    command = _p("OpenClaw bridge command", default="openclaw")
+    args = _p("OpenClaw bridge args", default="mcp serve")
+    if not command:
+        _die("command is required for stdio mode.")
+    credentials["command"] = command
+    credentials["args"] = [part for part in args.split() if part]
+    credentials["url"] = ""
+    credentials["auth_token"] = ""
 
     print("\n  Validating OpenClaw bridge...")
     config = build_openclaw_config(credentials)
@@ -837,29 +822,20 @@ def _setup_openclaw() -> None:
 
 
 def _setup_posthog_mcp() -> None:
-    print("  1) Streamable HTTP (recommended)  2) SSE  3) stdio (local server)")
-    choice = _p("Choice", default="1")
-    mode = {"1": "streamable-http", "2": "sse", "3": "stdio"}.get(choice, "streamable-http")
-
+    # Transport is fixed to Streamable HTTP (the hosted PostHog MCP server). In
+    # practice it is the only mode anyone selects, so the transport prompt was removed
+    # on purpose — do NOT reintroduce a transport selection or a stdio branch here.
+    mode = "streamable-http"
     credentials: dict[str, Any] = {"mode": mode, "read_only": True}
-    if mode == "stdio":
-        command = _p("PostHog MCP command", default="npx")
-        args = _p("PostHog MCP args", default="-y @posthog/mcp-server@latest")
-        if not command:
-            _die("command is required for stdio mode.")
-        credentials["command"] = command
-        credentials["args"] = [part for part in args.split() if part]
-        credentials["url"] = ""
-    else:
-        url = _p("PostHog MCP URL", default=DEFAULT_POSTHOG_MCP_URL)
-        if not url:
-            _die("url is required for remote MCP modes.")
-        credentials["url"] = url
-        credentials["command"] = ""
-        credentials["args"] = []
+    url = _p("PostHog MCP URL", default=DEFAULT_POSTHOG_MCP_URL)
+    if not url:
+        _die("url is required for remote MCP modes.")
+    credentials["url"] = url
+    credentials["command"] = ""
+    credentials["args"] = []
 
     credentials["auth_token"] = _p("PostHog personal API key (MCP Server preset)", secret=True)
-    if mode != "stdio" and not credentials["auth_token"]:
+    if not credentials["auth_token"]:
         _die("a personal API key is required for the hosted PostHog MCP server.")
     credentials["project_id"] = _p("PostHog project ID (optional)", default="")
 
@@ -876,29 +852,20 @@ def _setup_posthog_mcp() -> None:
 
 
 def _setup_sentry_mcp() -> None:
-    print("  1) Streamable HTTP (recommended)  2) SSE  3) stdio (local server)")
-    choice = _p("Choice", default="1")
-    mode = {"1": "streamable-http", "2": "sse", "3": "stdio"}.get(choice, "streamable-http")
-
+    # Transport is fixed to Streamable HTTP (the hosted Sentry MCP server). In
+    # practice it is the only mode anyone selects, so the transport prompt was removed
+    # on purpose — do NOT reintroduce a transport selection or a stdio branch here.
+    mode = "streamable-http"
     credentials: dict[str, Any] = {"mode": mode}
-    if mode == "stdio":
-        command = _p("Sentry MCP command", default="npx")
-        args = _p("Sentry MCP args", default="@sentry/mcp-server@latest")
-        if not command:
-            _die("command is required for stdio mode.")
-        credentials["command"] = command
-        credentials["args"] = [part for part in args.split() if part]
-        credentials["url"] = ""
-    else:
-        url = _p("Sentry MCP URL", default=DEFAULT_SENTRY_MCP_URL)
-        if not url:
-            _die("url is required for remote MCP modes.")
-        credentials["url"] = url
-        credentials["command"] = ""
-        credentials["args"] = []
+    url = _p("Sentry MCP URL", default=DEFAULT_SENTRY_MCP_URL)
+    if not url:
+        _die("url is required for remote MCP modes.")
+    credentials["url"] = url
+    credentials["command"] = ""
+    credentials["args"] = []
 
     credentials["auth_token"] = _p("Sentry user auth token", secret=True)
-    if mode != "stdio" and not credentials["auth_token"]:
+    if not credentials["auth_token"]:
         _die("a user auth token is required for the hosted Sentry MCP server.")
     credentials["host"] = _p("Self-hosted Sentry host (optional)", default="")
 

--- a/docs/posthog-mcp.mdx
+++ b/docs/posthog-mcp.mdx
@@ -33,7 +33,7 @@ OpenSRE defaults to **read-only** access (`x-posthog-read-only: true`) so invest
 opensre integrations setup
 ```
 
-Select **PostHog (MCP)** when prompted, then paste your personal API key. Keep the default Streamable HTTP transport and URL unless you have a reason to change them.
+Select **PostHog (MCP)** when prompted, then paste your personal API key. The setup uses the hosted Streamable HTTP transport; keep the default URL unless you have a reason to change it. To run a local server instead, set `POSTHOG_MCP_MODE=stdio` via environment variables (see below).
 
 To skip the menu, name the service directly. The canonical name is `posthog_mcp`, and `posthog` is accepted as a convenience alias:
 

--- a/docs/sentry-mcp.mdx
+++ b/docs/sentry-mcp.mdx
@@ -31,7 +31,7 @@ The agent typically calls `list_sentry_tools` first to discover what is availabl
 opensre integrations setup
 ```
 
-Select **Sentry (MCP)** when prompted, then paste your user auth token. Keep the default Streamable HTTP transport and URL unless you run self-hosted Sentry.
+Select **Sentry (MCP)** when prompted, then paste your user auth token. The setup uses the hosted Streamable HTTP transport; keep the default URL unless you run self-hosted Sentry. To run a local server instead, set `SENTRY_MCP_MODE=stdio` via environment variables (see below).
 
 ### Option 2: Environment variables
 

--- a/tests/cli/test_integrations.py
+++ b/tests/cli/test_integrations.py
@@ -112,7 +112,7 @@ def test_setup_vercel_saves_credentials(monkeypatch) -> None:
 
 
 def test_setup_openclaw_saves_credentials(monkeypatch) -> None:
-    answers = iter(["1", "openclaw", "mcp serve"])
+    answers = iter(["openclaw", "mcp serve"])
 
     def fake_p(_label: str, default: str = "", secret: bool = False) -> str:
         return next(answers)

--- a/tests/cli/test_integrations_setup_github.py
+++ b/tests/cli/test_integrations_setup_github.py
@@ -30,7 +30,7 @@ def test_setup_github_prints_connected_and_saves_on_validation_success(
 ) -> None:
     """_setup_github validates before saving and prints identity + detail on success."""
 
-    answers = iter(["2", "https://api.githubcopilot.com/mcp/", "repos,issues"])
+    answers = iter(["https://api.githubcopilot.com/mcp/", "repos,issues"])
 
     def fake_p(_label: str, default: str = "", secret: bool = False) -> str:
         return next(answers)
@@ -153,7 +153,7 @@ def test_setup_github_exits_without_save_on_validation_failure(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    answers = iter(["2", "https://api.githubcopilot.com/mcp/", "repos"])
+    answers = iter(["https://api.githubcopilot.com/mcp/", "repos"])
 
     def fake_p(_label: str, default: str = "", secret: bool = False) -> str:
         return next(answers)
@@ -191,7 +191,7 @@ def test_cmd_setup_github_skips_saved_line_on_validation_failure(
 ) -> None:
     """cmd_setup must not print success/saved after a failed GitHub validation."""
 
-    answers = iter(["2", "https://api.githubcopilot.com/mcp/", "repos"])
+    answers = iter(["https://api.githubcopilot.com/mcp/", "repos"])
 
     def fake_p(_label: str, default: str = "", secret: bool = False) -> str:
         return next(answers)
@@ -227,7 +227,7 @@ def test_cmd_setup_github_prints_saved_after_success(
 ) -> None:
     """Full cmd_setup('github') prints validation, Saved line, and does not duplicate handlers."""
 
-    answers = iter(["2", "https://api.githubcopilot.com/mcp/", "repos"])
+    answers = iter(["https://api.githubcopilot.com/mcp/", "repos"])
 
     def fake_p(_label: str, default: str = "", secret: bool = False) -> str:
         return next(answers)


### PR DESCRIPTION
## Summary
- Everyone selects the recommended transport during integration setup, so the `Streamable HTTP / SSE / stdio` prompt added friction without value.
- Hardcodes each MCP integration to its recommended transport in both the legacy `integrations setup` flow (`app/integrations/cli.py`) and the onboarding wizard (`app/cli/wizard/flow.py`):
  - GitHub / PostHog / Sentry -> `streamable-http`
  - OpenClaw -> `stdio`
- Leaves comments at each site documenting that the prompt must **not** be reintroduced.
- Env-var overrides (e.g. `POSTHOG_MCP_MODE=stdio`) still work for advanced users; docs lightly updated to reflect this.

## Test plan
- [x] `uv run python -m pytest tests/cli/test_integrations_setup_github.py tests/cli/test_integrations.py tests/cli/wizard/test_flow.py` (61 passed)
- [x] `uv run python -m pytest tests/integrations/test_posthog_mcp.py tests/integrations/test_sentry_mcp.py tests/integrations/test_verify.py tests/test_openclaw_integration.py tests/cli/wizard/test_integration_health.py` (160 passed)
- [x] `ruff check`, `ruff format --check`, `mypy` on edited files

Made with [Cursor](https://cursor.com)