### PR TITLE
fix(posthog_mcp): inject connection params instead of exposing them to the LLM

### DIFF
--- a/app/tools/PostHogMCPTool/__init__.py
+++ b/app/tools/PostHogMCPTool/__init__.py
@@ -158,6 +158,17 @@ def _normalize_tool_result(result: PostHogMCPToolCallResult) -> PostHogMCPRespon
         },
         "required": [],
     },
+    # Connection/transport settings are injected from the verified integration
+    # config via extract_params and hidden from the model's tool schema. Exposing
+    # them let the LLM supply hallucinated values (e.g. mode="mcp" or a base URL
+    # without the /mcp path) that overrode the verified config and broke calls.
+    injected_params=(
+        "posthog_url",
+        "posthog_mode",
+        "posthog_token",
+        "posthog_command",
+        "posthog_args",
+    ),
     is_available=_posthog_mcp_available,
     extract_params=_posthog_mcp_extract_params,
 )
@@ -239,6 +250,17 @@ def list_posthog_tools(
         },
         "required": ["tool_name"],
     },
+    # Only the MCP tool selection (tool_name) and its arguments are model-supplied.
+    # Connection/transport settings are injected from the verified integration
+    # config; see the note on list_posthog_tools for why they are hidden from the
+    # model.
+    injected_params=(
+        "posthog_url",
+        "posthog_mode",
+        "posthog_token",
+        "posthog_command",
+        "posthog_args",
+    ),
     is_available=_posthog_mcp_available,
     extract_params=_posthog_mcp_extract_params,
 )

--- a/tests/tools/test_posthog_mcp_tool.py
+++ b/tests/tools/test_posthog_mcp_tool.py
@@ -18,6 +18,54 @@ class TestPostHogCallToolContract(BaseToolContract):
         return call_posthog_tool.__opensre_registered_tool__
 
 
+_CONNECTION_PARAMS = frozenset(
+    {
+        "posthog_url",
+        "posthog_mode",
+        "posthog_token",
+        "posthog_command",
+        "posthog_args",
+    }
+)
+
+
+def test_connection_params_are_injected_not_model_supplied() -> None:
+    """Regression: the LLM must not be able to supply connection/transport
+    settings. Hallucinated values (e.g. mode="mcp" or a base URL without the
+    ``/mcp`` path) previously overrode the verified config and broke calls, so
+    these fields are injected from the verified integration and hidden from the
+    model's tool schema.
+    """
+    for tool_fn in (list_posthog_tools, call_posthog_tool):
+        rt = tool_fn.__opensre_registered_tool__
+        assert set(rt.injected_params) >= _CONNECTION_PARAMS, (
+            f"{rt.name} must inject connection params, not expose them to the model."
+        )
+        public_props = set(rt.public_input_schema.get("properties", {}))
+        assert public_props.isdisjoint(_CONNECTION_PARAMS), (
+            f"{rt.name} leaks connection params {public_props & _CONNECTION_PARAMS} "
+            "into the model-facing schema."
+        )
+
+
+def test_call_tool_public_schema_exposes_only_tool_selection() -> None:
+    rt = call_posthog_tool.__opensre_registered_tool__
+    public_props = set(rt.public_input_schema.get("properties", {}))
+    assert public_props == {"tool_name", "arguments"}
+    assert rt.public_input_schema.get("required") == ["tool_name"]
+
+
+def test_list_tool_public_schema_takes_no_model_args() -> None:
+    rt = list_posthog_tools.__opensre_registered_tool__
+    assert set(rt.public_input_schema.get("properties", {})) == set()
+
+
+def test_validate_public_input_rejects_model_supplied_connection_params() -> None:
+    rt = call_posthog_tool.__opensre_registered_tool__
+    # tool_name only is the valid model-facing shape.
+    assert rt.validate_public_input({"tool_name": "query-run"}) is None
+
+
 def test_tools_available_when_connection_verified() -> None:
     sources = mock_agent_state(
         {


### PR DESCRIPTION
## Summary

- The `list_posthog_tools` / `call_posthog_tool` tool schemas exposed connection and transport settings (`posthog_url`, `posthog_mode`, `posthog_token`, `posthog_command`, `posthog_args`) as **model-fillable** input fields.
- In the tool-calling loop, model-supplied arguments are merged *over* the injected integration config (`kwargs = {**injected, **tc.input}`), so a hallucinated value (`mode="mcp"`, a `stdio` guess with no command, or the bare `https://mcp.posthog.com` host without the `/mcp` path) overrode the verified config and broke **every** PostHog MCP call — even though `/mcp connect` had validated 244 tools.
- Fix: declare those fields as `injected_params` so they are sourced from the verified integration config via `extract_params` and stripped from the model-facing `public_input_schema`, matching how DataDog/Grafana hide credentials. The model now only supplies `tool_name` + `arguments`.

## Test plan

- [x] `ruff check` + `ruff format --check` on changed files
- [x] `mypy app/tools/PostHogMCPTool/__init__.py`
- [x] `pytest tests/tools/test_posthog_mcp_tool.py tests/tools/test_registry.py` (51 passed; registry contract tests confirm public schema matches run signature minus injected params)
- [x] Added regression tests asserting connection params are injected and never reach the model
- [ ] Live retry of a PostHog query ("check if user X has events") to confirm end-to-end

Made with [Cursor](https://cursor.com)