### PR TITLE
feat(llm): make provider fallback observable with accurate errors

### DIFF
--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -106,6 +106,29 @@ def _cmd_trust(session: ReplSession, console: Console, args: list[str]) -> bool:
     return True
 
 
+def _status_provider_display() -> str:
+    """Render the active LLM provider, flagging a fallback away from configured.
+
+    Showing the *resolved* provider (not just ``LLM_PROVIDER``) prevents the
+    trap where ``/status`` reports the configured provider while calls silently
+    go to a fallback because the configured provider's key is missing.
+    """
+    from app.config import get_configured_llm_provider, resolve_llm_settings_verbose
+
+    try:
+        resolution = resolve_llm_settings_verbose()
+    except Exception:
+        return get_configured_llm_provider()
+
+    if not resolution.fell_back:
+        return resolution.resolved_provider
+
+    note = f"fallback from '{resolution.configured_provider}'"
+    if resolution.missing_key_env:
+        note += f": {resolution.missing_key_env} not set"
+    return f"{resolution.resolved_provider} [{WARNING}]({note})[/]"
+
+
 def _cmd_status(session: ReplSession, console: Console, _args: list[str]) -> bool:
     # The cli/docs grounding sources self-register on import, which may not have
     # happened yet if /status runs before the first grounding turn. Import them
@@ -132,7 +155,7 @@ def _cmd_status(session: ReplSession, console: Console, _args: list[str]) -> boo
     table.add_row("last investigation", "yes" if session.last_state else "none")
     table.add_row("trust mode", "on" if session.trust_mode else "off")
     table.add_row("reasoning effort", display_reasoning_effort(session.reasoning_effort))
-    table.add_row("provider", os.getenv("LLM_PROVIDER", "anthropic"))
+    table.add_row("provider", _status_provider_display())
     for source in iter_grounding_sources():
         stats = source.stats_fn()
         table.add_row(f"grounding {source.name} cache", source.format_fn(stats))

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/llm_client.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/llm_client.py
@@ -69,5 +69,12 @@ def _call_llm(sanitised_text: str, session: Any) -> str | None:
         from app.cli.interactive_shell.routing.handle_message_with_agent.errors import (
             PlannerLLMError,
         )
+        from app.config import llm_provider_error_context
 
-        raise PlannerLLMError(str(exc)) from exc
+        # Prefix the raw provider error with which provider actually served the
+        # request (and whether it was a fallback). This turns a confusing
+        # "Anthropic credit balance too low" into an actionable message when the
+        # user configured OpenAI but its key was missing.
+        context = llm_provider_error_context()
+        message = f"{context} {exc}".strip() if context else str(exc)
+        raise PlannerLLMError(message) from exc

--- a/app/config.py
+++ b/app/config.py
@@ -4,8 +4,10 @@ Clerk JWT configuration for both development and production environments.
 These are public endpoints and issuer URLs, not secrets.
 """
 
+import logging
 import os
 from collections.abc import Sequence
+from dataclasses import dataclass
 from difflib import get_close_matches
 from enum import Enum
 from typing import Literal
@@ -15,6 +17,8 @@ from pydantic import Field, ValidationError, field_validator, model_validator
 from app.llm_credentials import resolve_llm_api_key
 from app.strict_config import StrictConfigModel
 from app.utils.config import load_env
+
+logger = logging.getLogger(__name__)
 
 
 class LLMModelConfig(StrictConfigModel):
@@ -501,6 +505,125 @@ def _is_only_missing_llm_api_key_validation(exc: ValidationError) -> bool:
     return "LLM provider" in msg and "requires" in msg and "API_KEY" in msg and "to be set" in msg
 
 
+@dataclass(frozen=True)
+class LLMResolution:
+    """Outcome of resolving usable LLM settings, with fallback diagnostics.
+
+    :func:`resolve_llm_settings` can silently switch away from the configured
+    provider when that provider is missing credentials. This record makes the
+    decision observable: callers can see whether a fallback happened, which
+    provider is actually being used, and why the configured one was skipped.
+    Without it, a missing ``OPENAI_API_KEY`` surfaces only as a confusing
+    "Anthropic credit balance too low" error even though the user configured
+    OpenAI.
+    """
+
+    settings: LLMSettings
+    configured_provider: str
+    resolved_provider: str
+    attempted_providers: tuple[str, ...]
+    missing_key_env: str | None
+
+    @property
+    def fell_back(self) -> bool:
+        """True when the active provider differs from the configured one."""
+        return self.resolved_provider != self.configured_provider
+
+    def summary(self) -> str:
+        """One-line, user-facing description of the active provider decision."""
+        if not self.fell_back:
+            return f"Using configured LLM provider '{self.resolved_provider}'."
+        reason = (
+            f"{self.missing_key_env} is not set" if self.missing_key_env else "it is unavailable"
+        )
+        hint = (
+            f" Set {self.missing_key_env} or change LLM_PROVIDER to use it."
+            if self.missing_key_env
+            else ""
+        )
+        return (
+            f"Configured LLM provider '{self.configured_provider}' is unusable "
+            f"({reason}); falling back to '{self.resolved_provider}'.{hint}"
+        )
+
+
+# Deduplicates fallback warnings so the operational breadcrumb is logged once
+# per distinct fallback condition instead of on every client creation.
+_LLM_FALLBACK_WARNING_CACHE: set[tuple[str, str, str | None]] = set()
+
+
+def reset_llm_fallback_warning_cache() -> None:
+    """Clear the fallback-warning dedup cache (test/diagnostic helper)."""
+    _LLM_FALLBACK_WARNING_CACHE.clear()
+
+
+def _warn_on_llm_fallback(resolution: LLMResolution) -> None:
+    if not resolution.fell_back:
+        return
+    signature = (
+        resolution.configured_provider,
+        resolution.resolved_provider,
+        resolution.missing_key_env,
+    )
+    if signature in _LLM_FALLBACK_WARNING_CACHE:
+        return
+    _LLM_FALLBACK_WARNING_CACHE.add(signature)
+    logger.warning("%s", resolution.summary())
+
+
+def resolve_llm_settings_verbose(
+    fallback_providers: Sequence[str] = DEFAULT_LLM_RESOLUTION_FALLBACK_PROVIDERS,
+) -> LLMResolution:
+    """Resolve usable LLM settings and report any provider fallback.
+
+    Behaves exactly like :func:`resolve_llm_settings` but returns an
+    :class:`LLMResolution` describing whether the configured provider was used
+    or a fallback was chosen (and why). Emits a deduplicated warning when a
+    fallback occurs so operators can see, in logs, that calls are going to a
+    different provider than the one they configured.
+    """
+    load_env(override=False)
+    configured_provider = get_configured_llm_provider()
+    attempted = _candidate_llm_providers(configured_provider, fallback_providers)
+    configured_missing_key_error: ValidationError | None = None
+
+    for provider in attempted:
+        try:
+            settings = LLMSettings.model_validate(_llm_settings_env_payload(provider))
+        except ValidationError as exc:
+            if not _is_only_missing_llm_api_key_validation(exc):
+                raise
+            if provider == configured_provider:
+                configured_missing_key_error = exc
+            continue
+        resolution = LLMResolution(
+            settings=settings,
+            configured_provider=configured_provider,
+            resolved_provider=settings.provider,
+            attempted_providers=attempted,
+            missing_key_env=(
+                get_llm_provider_api_key_env(configured_provider)
+                if settings.provider != configured_provider
+                else None
+            ),
+        )
+        _warn_on_llm_fallback(resolution)
+        return resolution
+
+    if configured_missing_key_error is not None:
+        raise configured_missing_key_error
+    # Defensive parity with the strict path: no candidate validated for a
+    # non-key reason. Re-raise the strict error semantics.
+    settings = LLMSettings.from_env()
+    return LLMResolution(
+        settings=settings,
+        configured_provider=configured_provider,
+        resolved_provider=settings.provider,
+        attempted_providers=attempted,
+        missing_key_env=None,
+    )
+
+
 def resolve_llm_settings(
     fallback_providers: Sequence[str] = DEFAULT_LLM_RESOLUTION_FALLBACK_PROVIDERS,
 ) -> LLMSettings:
@@ -509,24 +632,73 @@ def resolve_llm_settings(
     ``LLMSettings.from_env`` remains strict: it validates the configured provider
     exactly. This resolver is for runtime and live-test paths that can safely use
     another hosted provider when the configured/default provider lacks credentials
-    but an equivalent provider, such as OpenAI, is configured.
+    but an equivalent provider, such as OpenAI, is configured. Use
+    :func:`resolve_llm_settings_verbose` when you need to know whether a fallback
+    occurred.
     """
-    load_env(override=False)
-    configured_provider = get_configured_llm_provider()
-    configured_missing_key_error: ValidationError | None = None
+    return resolve_llm_settings_verbose(fallback_providers).settings
 
-    for provider in _candidate_llm_providers(configured_provider, fallback_providers):
-        try:
-            return LLMSettings.model_validate(_llm_settings_env_payload(provider))
-        except ValidationError as exc:
-            if not _is_only_missing_llm_api_key_validation(exc):
-                raise
-            if provider == configured_provider:
-                configured_missing_key_error = exc
 
-    if configured_missing_key_error is not None:
-        raise configured_missing_key_error
-    return LLMSettings.from_env()
+def describe_llm_resolution(
+    fallback_providers: Sequence[str] = DEFAULT_LLM_RESOLUTION_FALLBACK_PROVIDERS,
+) -> str:
+    """Return a human-readable LLM provider resolution report for diagnostics.
+
+    Safe to call even when no provider has usable credentials: instead of
+    raising it reports the missing-credentials condition. Intended for
+    ``/status``, doctor commands, and CI diagnostics so operators no longer need
+    ad-hoc inline probes to see which provider is actually in use.
+    """
+    configured = get_configured_llm_provider()
+    try:
+        resolution = resolve_llm_settings_verbose(fallback_providers)
+    except ValidationError as exc:
+        env_var = get_llm_provider_api_key_env(configured)
+        detail = exc.errors()[0].get("msg", str(exc)) if exc.errors() else str(exc)
+        lines = [
+            f"configured provider : {configured}",
+            "resolved provider   : <none — no usable provider credentials>",
+        ]
+        if env_var:
+            lines.append(f"required key        : {env_var}")
+        lines.append(f"detail              : {detail}")
+        return "\n".join(lines)
+
+    lines = [
+        f"configured provider : {resolution.configured_provider}",
+        f"resolved provider   : {resolution.resolved_provider}",
+        f"fell back           : {'yes' if resolution.fell_back else 'no'}",
+        f"providers attempted : {', '.join(resolution.attempted_providers)}",
+    ]
+    if resolution.fell_back and resolution.missing_key_env:
+        lines.append(f"missing key         : {resolution.missing_key_env}")
+    return "\n".join(lines)
+
+
+def llm_provider_error_context(
+    fallback_providers: Sequence[str] = DEFAULT_LLM_RESOLUTION_FALLBACK_PROVIDERS,
+) -> str:
+    """Return a short bracketed provider context for prefixing error messages.
+
+    Never raises — diagnostics must not mask the original error. Returns an
+    empty string when resolution itself fails so callers can fall back to the
+    raw provider error untouched.
+    """
+    try:
+        resolution = resolve_llm_settings_verbose(fallback_providers)
+    except Exception:
+        return ""
+    if resolution.fell_back:
+        reason = (
+            f"{resolution.missing_key_env} not set"
+            if resolution.missing_key_env
+            else "configured provider unavailable"
+        )
+        return (
+            f"[LLM provider: {resolution.resolved_provider} — fell back from "
+            f"configured '{resolution.configured_provider}' ({reason})]"
+        )
+    return f"[LLM provider: {resolution.resolved_provider}]"
 
 
 def has_credentials_for_active_llm_provider() -> bool:

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -324,6 +324,34 @@ export OPENSRE_REASONING_EFFORT=high   # low | medium | high | xhigh
 
 Session `/effort` overrides this for interactive runs. Implementation: [`app/llm_reasoning_effort.py`](https://github.com/Tracer-Cloud/opensre/blob/main/app/llm_reasoning_effort.py).
 
+## Provider fallback and diagnostics
+
+If the provider you set in `LLM_PROVIDER` is missing its API key, OpenSRE does **not** fail outright — it falls back to the next configured provider (by default it tries `openai`, then `anthropic`) so a partially configured machine still works. The trade-off is that calls can quietly go to a different provider than you intended, and you would otherwise only find out via a confusing error naming the *fallback* provider (for example "Anthropic credit balance too low" when you actually configured OpenAI).
+
+To make this visible:
+
+- **A warning is logged** the first time a fallback happens, naming the configured provider, the missing key, and the provider actually used:
+
+  ```
+  Configured LLM provider 'openai' is unusable (OPENAI_API_KEY is not set);
+  falling back to 'anthropic'. Set OPENAI_API_KEY or change LLM_PROVIDER to use it.
+  ```
+
+- **`/status`** (in the interactive shell) shows the **resolved** provider and flags a fallback inline, instead of just echoing `LLM_PROVIDER`:
+
+  ```
+  provider   anthropic (fallback from 'openai': OPENAI_API_KEY not set)
+  ```
+
+- **Provider errors in the interactive shell** are prefixed with which provider served the request and whether it was a fallback, so the message is actionable:
+
+  ```
+  [LLM provider: anthropic — fell back from configured 'openai' (OPENAI_API_KEY not set)]
+  Anthropic request rejected (HTTP 400): Your credit balance is too low ...
+  ```
+
+To remove a fallback, either set the missing key for your configured provider or change `LLM_PROVIDER` to a provider you have credentials for.
+
 ## Switching providers at runtime
 
 OpenSRE caches LLM clients on first use. To switch providers within a single process (tests, benchmarks), call `reset_llm_singletons()` from `app.services.llm_client` after updating the env vars; otherwise a fresh process picks up the new `LLM_PROVIDER` automatically.

--- a/tests/cli/interactive_shell/orchestration/test_llm_action_planner.py
+++ b/tests/cli/interactive_shell/orchestration/test_llm_action_planner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from typing import TypedDict
 
@@ -26,7 +27,7 @@ from app.config import (
     DEFAULT_LLM_RESOLUTION_FALLBACK_PROVIDERS,
     get_configured_llm_provider,
     get_llm_provider_api_key_env,
-    resolve_llm_settings,
+    resolve_llm_settings_verbose,
 )
 
 PROJECT_ROOT = Path(__file__).resolve().parents[4]
@@ -93,8 +94,13 @@ def _load_live_cases() -> list[PlannerLiveCase]:
 
 @pytest.fixture(autouse=True)
 def _require_default_llm_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Capture the explicit pin (if any) BEFORE resolution so we can tell apart
+    # "intentionally testing the default-resolution chain" from "CI pinned a
+    # provider but its key is missing/broken".
+    explicit_pin = os.environ.get("LLM_PROVIDER", "").strip().lower()
+
     try:
-        settings = resolve_llm_settings()
+        resolution = resolve_llm_settings_verbose()
     except ValidationError as exc:
         provider = get_configured_llm_provider()
         env_var = get_llm_provider_api_key_env(provider)
@@ -110,9 +116,24 @@ def _require_default_llm_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
             f"Skipping live LLM planner tests; missing usable LLM configuration:{hint}. {msg}"
         )
 
+    # Anti-masking guard: when a provider is explicitly pinned (e.g. CI sets
+    # LLM_PROVIDER=openai) but resolution falls back to a different provider, the
+    # pinned provider's credentials are missing/broken. Silently validating the
+    # contract on the fallback provider — then skipping on *its* billing error —
+    # is exactly how the OPENAI_API_KEY leak hid 24 unrun cases. Fail loudly with
+    # an actionable message instead.
+    if explicit_pin and resolution.fell_back:
+        pytest.fail(
+            f"LLM_PROVIDER={explicit_pin!r} is pinned but provider resolution fell back to "
+            f"{resolution.resolved_provider!r}. The pinned provider is unusable "
+            f"({resolution.missing_key_env or 'credentials missing'}); live planner contracts "
+            "would silently validate the wrong provider. Fix the pinned provider's credentials "
+            "or unset LLM_PROVIDER to opt into default resolution."
+        )
+
     from app.services.llm_client import reset_llm_singletons
 
-    monkeypatch.setenv("LLM_PROVIDER", settings.provider)
+    monkeypatch.setenv("LLM_PROVIDER", resolution.resolved_provider)
     reset_llm_singletons()
 
 

--- a/tests/cli/interactive_shell/orchestration/test_llm_action_planner_fallback.py
+++ b/tests/cli/interactive_shell/orchestration/test_llm_action_planner_fallback.py
@@ -119,3 +119,81 @@ def test_plan_actions_with_llm_result_re_raises_timeout_too_long_errors() -> Non
         pytest.raises(PlannerLLMError, match="too long"),
     ):
         plan_actions_with_llm_result("check cpu usage")
+
+
+class _RaisingClient:
+    """Stand-in classification client whose invoke always fails."""
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    def bind_tools(self, _specs: object) -> _RaisingClient:
+        return self
+
+    def invoke(self, _prompt: object) -> object:
+        raise self._error
+
+
+def _patch_planner_llm(monkeypatch, error: Exception) -> None:
+    from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration import (
+        llm_action_planner,
+    )
+
+    monkeypatch.setattr(
+        llm_action_planner.llm_client,
+        "_tool_specs_for_provider",
+        lambda _session: [],
+    )
+    monkeypatch.setattr(
+        "app.services.llm_client.get_llm_for_classification",
+        lambda: _RaisingClient(error),
+    )
+
+
+def test_call_llm_prefixes_fallback_provider_context(monkeypatch) -> None:
+    # Configured openai but only anthropic has a key: the user-visible planner
+    # error must say the call fell back to anthropic, instead of an opaque
+    # "Anthropic credit balance too low" that contradicts their config.
+    from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.llm_action_planner.llm_client import (  # noqa: E501
+        _call_llm,
+    )
+    from app.cli.interactive_shell.runtime.session import ReplSession
+
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr(
+        "app.config.resolve_llm_api_key",
+        lambda env_var: "sk-present" if env_var == "ANTHROPIC_API_KEY" else "",
+    )
+    _patch_planner_llm(
+        monkeypatch,
+        RuntimeError("Anthropic request rejected (HTTP 400): Your credit balance is too low"),
+    )
+
+    with pytest.raises(PlannerLLMError) as excinfo:
+        _call_llm("show me the logs", ReplSession())
+
+    message = str(excinfo.value)
+    assert message.startswith("[LLM provider: anthropic — fell back from configured 'openai'")
+    assert "OPENAI_API_KEY not set" in message
+    assert "credit balance is too low" in message
+
+
+def test_call_llm_prefixes_active_provider_context_without_fallback(monkeypatch) -> None:
+    from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.llm_action_planner.llm_client import (  # noqa: E501
+        _call_llm,
+    )
+    from app.cli.interactive_shell.runtime.session import ReplSession
+
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr(
+        "app.config.resolve_llm_api_key",
+        lambda env_var: "sk-present" if env_var == "OPENAI_API_KEY" else "",
+    )
+    _patch_planner_llm(monkeypatch, RuntimeError("OpenAI billing quota exceeded."))
+
+    with pytest.raises(PlannerLLMError) as excinfo:
+        _call_llm("show me the logs", ReplSession())
+
+    message = str(excinfo.value)
+    assert message.startswith("[LLM provider: openai]")
+    assert "billing quota exceeded" in message

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
+import logging
+
 import pytest
 from pydantic import ValidationError
 
-from app.config import LLMSettings, has_credentials_for_active_llm_provider, resolve_llm_settings
+from app.config import (
+    LLMSettings,
+    describe_llm_resolution,
+    has_credentials_for_active_llm_provider,
+    llm_provider_error_context,
+    reset_llm_fallback_warning_cache,
+    resolve_llm_settings,
+    resolve_llm_settings_verbose,
+)
 
 
 def test_llm_settings_reject_provider_typos_with_suggestion() -> None:
@@ -253,3 +263,115 @@ def test_has_credentials_for_active_llm_provider_re_raises_invalid_provider(monk
 
     with pytest.raises(ValidationError, match="Unsupported LLM provider"):
         has_credentials_for_active_llm_provider()
+
+
+def _only_key(present_env: str):
+    """Return a resolve_llm_api_key stub where only *present_env* has a value."""
+    return lambda env_var: "sk-present" if env_var == present_env else ""
+
+
+def test_resolve_llm_settings_verbose_reports_no_fallback_when_configured_key_present(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", _only_key("OPENAI_API_KEY"))
+
+    resolution = resolve_llm_settings_verbose()
+
+    assert resolution.resolved_provider == "openai"
+    assert resolution.configured_provider == "openai"
+    assert resolution.fell_back is False
+    assert resolution.missing_key_env is None
+
+
+def test_resolve_llm_settings_verbose_reports_fallback_and_missing_key(monkeypatch) -> None:
+    # Configured openai, but only the anthropic key is present: this is exactly
+    # the incident where a stripped OPENAI_API_KEY silently routed to anthropic.
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", _only_key("ANTHROPIC_API_KEY"))
+
+    resolution = resolve_llm_settings_verbose()
+
+    assert resolution.configured_provider == "openai"
+    assert resolution.resolved_provider == "anthropic"
+    assert resolution.fell_back is True
+    assert resolution.missing_key_env == "OPENAI_API_KEY"
+    assert "openai" in resolution.summary()
+    assert "OPENAI_API_KEY" in resolution.summary()
+
+
+def test_resolve_llm_settings_verbose_warns_once_on_fallback(monkeypatch, caplog) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", _only_key("ANTHROPIC_API_KEY"))
+    reset_llm_fallback_warning_cache()
+
+    with caplog.at_level(logging.WARNING, logger="app.config"):
+        resolve_llm_settings_verbose()
+        resolve_llm_settings_verbose()
+
+    fallback_warnings = [
+        record
+        for record in caplog.records
+        if record.name == "app.config" and "falling back to 'anthropic'" in record.getMessage()
+    ]
+    assert len(fallback_warnings) == 1
+
+
+def test_resolve_llm_settings_verbose_does_not_warn_without_fallback(monkeypatch, caplog) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", _only_key("OPENAI_API_KEY"))
+    reset_llm_fallback_warning_cache()
+
+    with caplog.at_level(logging.WARNING, logger="app.config"):
+        resolve_llm_settings_verbose()
+
+    assert not [r for r in caplog.records if "falling back" in r.getMessage()]
+
+
+def test_describe_llm_resolution_reports_fallback(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", _only_key("ANTHROPIC_API_KEY"))
+
+    report = describe_llm_resolution()
+
+    assert "configured provider : openai" in report
+    assert "resolved provider   : anthropic" in report
+    assert "fell back           : yes" in report
+    assert "missing key         : OPENAI_API_KEY" in report
+
+
+def test_describe_llm_resolution_reports_no_usable_credentials(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
+
+    report = describe_llm_resolution()
+
+    assert "no usable provider credentials" in report
+    assert "OPENAI_API_KEY" in report
+
+
+def test_llm_provider_error_context_includes_fallback(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", _only_key("ANTHROPIC_API_KEY"))
+
+    context = llm_provider_error_context()
+
+    assert context.startswith("[LLM provider: anthropic")
+    assert "fell back from configured 'openai'" in context
+    assert "OPENAI_API_KEY not set" in context
+
+
+def test_llm_provider_error_context_no_fallback(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", _only_key("OPENAI_API_KEY"))
+
+    assert llm_provider_error_context() == "[LLM provider: openai]"
+
+
+def test_llm_provider_error_context_never_raises(monkeypatch) -> None:
+    # No usable credentials anywhere: the helper must degrade to an empty string
+    # so the caller surfaces the raw provider error untouched.
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
+
+    assert llm_provider_error_context() == ""


### PR DESCRIPTION
## Why

The recent `OPENAI_API_KEY` leak incident was hard to diagnose because of an architectural blind spot: when the configured LLM provider is missing its API key, `resolve_llm_settings()` **silently falls back** to another provider with zero observability. That turned a simple "OpenAI key got stripped" into:

- A user-facing error naming the *fallback* provider ("Anthropic credit balance too low") even though **OpenAI** was configured.
- 24 live planner contract cases **silently skipping** (the suite "passed" while validating nothing).
- `/status` reporting the configured provider while calls went elsewhere.

This PR makes the fallback a first-class, observable decision and produces accurate, actionable error messages.

## What

- **`app/config.py`**
  - New `LLMResolution` dataclass + `resolve_llm_settings_verbose()` reporting `configured_provider`, `resolved_provider`, `fell_back`, `missing_key_env`, and `attempted_providers`.
  - **Deduplicated warning** logged on fallback (once per distinct condition).
  - `describe_llm_resolution()` — human-readable diagnostics (replaces ad-hoc inline CI probes).
  - `llm_provider_error_context()` — a never-raising error prefix.
  - `resolve_llm_settings()` keeps its signature and delegates to the verbose path.
- **Planner (`llm_action_planner/llm_client.py`)**: prefixes planner LLM errors with the active provider and fallback context.
- **`/status`**: shows the **resolved** provider and flags a fallback inline.
- **Live planner suite**: fails loudly when a pinned `LLM_PROVIDER` falls back, instead of silently validating the wrong provider and skipping on its billing error (the exact masking that hid the incident).
- **Docs**: `docs/llm-providers.mdx` gains a "Provider fallback and diagnostics" section.

### Before / after (interactive shell error)

Before:
```
Anthropic request rejected (HTTP 400): Your credit balance is too low ...
```
After:
```
[LLM provider: anthropic — fell back from configured 'openai' (OPENAI_API_KEY not set)]
Anthropic request rejected (HTTP 400): Your credit balance is too low ...
```

## Test plan
- [x] `make lint`, `make format-check`, `make typecheck` (mypy: 735 files) all pass.
- [x] New unit tests in `tests/test_config.py` (resolution reporting, dedup warning, diagnostics, error-context) and `test_llm_action_planner_fallback.py` (error-context prefix, fallback + non-fallback).
- [x] 345 non-live tests pass across affected dirs; live planner suite collects 27 cases cleanly.
- [ ] CI green.

Made with [Cursor](https://cursor.com)