### PR TITLE
feat(repl): summarize sample alert before investigation

### DIFF
--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/investigation_runner.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/investigation_runner.py
@@ -17,6 +17,26 @@ from app.cli.support.errors import OpenSREError
 from app.cli.support.exception_reporting import report_exception
 
 
+def _print_sample_alert_summary(template_name: str, console: Console) -> None:
+    """Show a compact summary of the sample alert before the investigation runs.
+
+    The announcement only prints the template name, so without this the
+    operator has no view of the incident being investigated. Failures here are
+    purely cosmetic, so an unknown/invalid template never blocks the run.
+    """
+    from app.cli.interactive_shell.ui import print_alert_summary
+    from app.cli.investigation.alert_templates import (
+        build_alert_template,
+        summarize_alert_template,
+    )
+
+    try:
+        pairs = summarize_alert_template(build_alert_template(template_name))
+    except Exception:
+        return
+    print_alert_summary(console, pairs)
+
+
 def run_sample_alert(
     template_name: str,
     session: ReplSession,
@@ -42,6 +62,7 @@ def run_sample_alert(
         return
 
     console.print(f"[bold]sample alert:[/bold] {escape(template_name)}")
+    _print_sample_alert_summary(template_name, console)
     task = session.task_registry.create(
         TaskKind.INVESTIGATION, command=f"sample alert:{template_name}"
     )

--- a/app/cli/interactive_shell/ui/__init__.py
+++ b/app/cli/interactive_shell/ui/__init__.py
@@ -16,6 +16,7 @@ from app.cli.interactive_shell.ui.choice_menu import (
 from app.cli.interactive_shell.ui.rendering import (
     MCP_INTEGRATION_SERVICES,
     ColumnDef,
+    print_alert_summary,
     print_command_output,
     print_planned_actions,
     print_repl_json,
@@ -95,6 +96,7 @@ __all__ = [
     "WARNING",
     "_build_agents_table",
     "print_valid_choice_list",
+    "print_alert_summary",
     "print_command_output",
     "print_planned_actions",
     "print_repl_json",

--- a/app/cli/interactive_shell/ui/rendering.py
+++ b/app/cli/interactive_shell/ui/rendering.py
@@ -343,6 +343,20 @@ def print_command_output(console: Console, output: str, *, style: str | None = N
     repl_print(console, Text(text) if style is None else Text(text, style=style))
 
 
+def print_alert_summary(console: Console, pairs: list[tuple[str, str]]) -> None:
+    """Print a compact label/value summary of an alert payload.
+
+    Used to surface what alert is being read before an investigation runs
+    (e.g. for the built-in sample alert). Labels are dim and padded so values
+    align in a clean column, matching the rest of the REPL's quiet styling.
+    """
+    if not pairs:
+        return
+    label_width = max(len(label) for label, _ in pairs)
+    for label, value in pairs:
+        console.print(f"  [{DIM}]{escape(label.ljust(label_width))}[/]  {escape(value)}")
+
+
 def print_planned_actions(console: Console, actions: list[PlannedAction]) -> None:
     console.print(f"[{DIM}]Requested actions:[/]")
     for index, action in enumerate(actions, start=1):
@@ -365,6 +379,7 @@ __all__ = [
     "ColumnDef",
     "MCP_INTEGRATION_SERVICES",
     "_repl_table_width",
+    "print_alert_summary",
     "print_command_output",
     "print_planned_actions",
     "print_repl_json",

--- a/app/cli/investigation/alert_templates.py
+++ b/app/cli/investigation/alert_templates.py
@@ -2,7 +2,48 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
+
+
+def summarize_alert_template(alert: Mapping[str, Any]) -> list[tuple[str, str]]:
+    """Return ordered ``(label, value)`` pairs summarizing a sample alert payload.
+
+    The interactive shell announces a sample-alert run with only the template
+    name (``sample alert: generic``), which gives no insight into the incident
+    that is about to be investigated. This produces a compact, human-readable
+    summary so the operator can see what alert is being read before any tools
+    run. Only present fields are included, and the extraction tolerates the
+    differing key shapes across templates (``alert_name``/``title``,
+    ``pipeline_name``/``service_name``/``application_name``,
+    ``message``/``commonAnnotations.summary``/``text``).
+    """
+    annotations = alert.get("commonAnnotations") or alert.get("common_annotations") or {}
+    if not isinstance(annotations, Mapping):
+        annotations = {}
+
+    def _first(*candidates: object) -> str:
+        for candidate in candidates:
+            text = str(candidate or "").strip()
+            if text:
+                return text
+        return ""
+
+    candidate_pairs = (
+        ("Alert", _first(alert.get("alert_name"), alert.get("title"))),
+        (
+            "Pipeline",
+            _first(
+                alert.get("pipeline_name"),
+                alert.get("service_name"),
+                alert.get("application_name"),
+            ),
+        ),
+        ("Severity", _first(alert.get("severity"))),
+        ("Source", _first(alert.get("alert_source"))),
+        ("Summary", _first(alert.get("message"), annotations.get("summary"), alert.get("text"))),
+    )
+    return [(label, value) for label, value in candidate_pairs if value]
 
 
 def build_alert_template(template_name: str) -> dict[str, Any]:

--- a/docs/investigation-overview.mdx
+++ b/docs/investigation-overview.mdx
@@ -37,6 +37,8 @@ Examples:
 | "run the sample alert investigation" | `/investigate` with a built-in template |
 | "connect to my remote EC2 instance and send it hello world" | `/remote` subcommands, then a remote investigation |
 
+When you run a built-in sample alert, the shell prints a short summary of the alert (name, pipeline, severity, and a one-line description) before the investigation starts, so you can see exactly what incident is being read.
+
 List-style questions route to **per-domain** commands (there is no global `/list`):
 
 | Intent | Command |

--- a/tests/cli/interactive_shell/orchestration/test_agent_actions.py
+++ b/tests/cli/interactive_shell/orchestration/test_agent_actions.py
@@ -685,6 +685,11 @@ def test_execute_cli_actions_runs_sample_alert(monkeypatch: object) -> None:
     output = buf.getvalue()
     assert "sample alert" in output
     assert "generic" in output
+    # The alert summary is rendered before the investigation runs so the
+    # operator can see what incident is being read.
+    assert "High error rate in payments ETL" in output
+    assert "payments_etl" in output
+    assert "critical" in output
 
 
 def test_execute_cli_actions_sample_alert_opensre_error_marks_task_failed(

--- a/tests/cli/test_alert_templates.py
+++ b/tests/cli/test_alert_templates.py
@@ -1,0 +1,65 @@
+"""Tests for sample-alert templates and their human-readable summary."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.cli.investigation.alert_templates import (
+    build_alert_template,
+    summarize_alert_template,
+)
+
+
+def test_summarize_generic_template_includes_core_fields() -> None:
+    pairs = summarize_alert_template(build_alert_template("generic"))
+    summary = dict(pairs)
+
+    assert summary["Alert"] == "High error rate in payments ETL"
+    assert summary["Pipeline"] == "payments_etl"
+    assert summary["Severity"] == "critical"
+    assert summary["Source"] == "generic"
+    assert "database connection errors" in summary["Summary"]
+    # Labels stay in a stable, predictable order for rendering.
+    assert [label for label, _ in pairs] == [
+        "Alert",
+        "Pipeline",
+        "Severity",
+        "Source",
+        "Summary",
+    ]
+
+
+@pytest.mark.parametrize(
+    "template_name",
+    ["generic", "datadog", "grafana", "honeycomb", "coralogix", "splunk"],
+)
+def test_summarize_every_template_yields_named_alert(template_name: str) -> None:
+    pairs = summarize_alert_template(build_alert_template(template_name))
+    summary = dict(pairs)
+
+    # Every template should at least identify the alert, a subject, and severity.
+    assert summary.get("Alert")
+    assert summary.get("Pipeline")
+    assert summary.get("Severity") == "critical"
+    # Only non-empty fields are emitted.
+    assert all(value for _, value in pairs)
+
+
+def test_summarize_falls_back_to_title_and_annotation_summary() -> None:
+    pairs = summarize_alert_template(
+        {
+            "title": "[FIRING] checkout latency",
+            "service_name": "checkout-api",
+            "commonAnnotations": {"summary": "spans timing out"},
+        }
+    )
+    summary = dict(pairs)
+
+    assert summary["Alert"] == "[FIRING] checkout latency"
+    assert summary["Pipeline"] == "checkout-api"
+    assert summary["Summary"] == "spans timing out"
+    assert "Severity" not in summary
+
+
+def test_summarize_empty_payload_returns_no_pairs() -> None:
+    assert summarize_alert_template({}) == []


### PR DESCRIPTION
## Summary
- When running a built-in sample alert, the interactive shell only printed `sample alert: generic` — the operator had no view of the incident about to be investigated (see the reported terminal flow where the alert content was a mystery at announcement time).
- This prints a compact, aligned summary (alert name, pipeline, severity, source, and a one-line description) immediately after the announcement, before any tools run.
- Adds a tolerant `summarize_alert_template` helper (handles every template shape: `generic`, `datadog`, `grafana`, `honeycomb`, `coralogix`, `splunk`) and a `print_alert_summary` REPL renderer using existing theme tokens.

## Example
```
sample alert: generic
  Alert     High error rate in payments ETL
  Pipeline  payments_etl
  Severity  critical
  Source    generic
  Summary   payments_etl is failing with repeated database connection errors
```

## Changes
- `app/cli/investigation/alert_templates.py` — add `summarize_alert_template`.
- `app/cli/interactive_shell/ui/rendering.py` (+ `ui/__init__.py`) — add `print_alert_summary`.
- `.../action_executor/investigation_runner.py` — render the summary in `run_sample_alert` (failures are cosmetic and never block the run).
- `docs/investigation-overview.mdx` — note the new summary behavior.

## Test plan
- [x] `tests/cli/test_alert_templates.py` — new unit tests for the summary across all templates, fallbacks, and empty payloads.
- [x] `tests/cli/interactive_shell/orchestration/test_agent_actions.py::test_execute_cli_actions_runs_sample_alert` — asserts the summary renders before the investigation.
- [x] `ruff check`, `ruff format --check`, and `mypy` pass on changed files.

> Note: based on top of `feature/fix-prompting-tests` (the branch that contains the interactive-shell `run_sample_alert` flow); PR targets that branch.

Made with [Cursor](https://cursor.com)