### PR TITLE
feat(routing): dispatch investigations for integration-backed diagnostic prompts

### DIFF
--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/constants.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/constants.py
@@ -44,25 +44,43 @@ question.
 If this appears as one clause in a compound request, still emit alert_sample
 for that clause in sequence.
 
-Alert payloads and incident descriptions vs. explicit investigations — decide
-carefully, this is a common error. The deciding factor is whether the user gave
-an explicit instruction to act, NOT whether alert/JSON content is present:
-- EXPLICIT investigate instruction → investigation_start. If the user tells you
-  to investigate, analyze, diagnose, root-cause, or RCA something — even when
-  the message also contains a pasted alert payload — emit investigation_start
-  with the alert text/payload as alert_text. Examples: 'investigate "<text>"',
-  'investigate this alert: {"alertname": "HighCPU"}', "RCA this", "why did the
-  orders job fail?". The presence of a JSON/alert blob does NOT downgrade an
-  explicit investigate instruction to a handoff.
-- NO explicit instruction → assistant_handoff. A message that is JUST an alert
-  or incident with no instruction — a pasted alert payload (JSON, YAML, or
-  key-value blob) on its own, or a bare incident description such as "CPU is
-  spiking to 99% on orders-api" or "checkout is returning 502s" — is NOT an
-  instruction to act. Emit assistant_handoff, even when it reads urgent or
-  "critical". Do NOT start an investigation for it.
-- When unsure whether a BARE alert/incident (no explicit instruction) should be
-  investigated or handed off, choose assistant_handoff. The user can always
-  follow up with an explicit "investigate this".
+Alert payloads, incident descriptions, and diagnostic questions vs. explicit
+investigations — decide carefully, this is a common error. A CONNECTED
+INTEGRATIONS line is provided below this prompt listing the integrations
+connected right now (or "none" / "unknown"). Apply these rules in order:
+- EXPLICIT investigate instruction → investigation_start, ALWAYS (regardless of
+  which integrations are connected). If the user tells you to investigate,
+  analyze, diagnose, root-cause, or RCA something — even when the message also
+  contains a pasted alert payload — emit investigation_start with the alert
+  text/payload as alert_text. Examples: 'investigate "<text>"', 'investigate
+  this alert: {"alertname": "HighCPU"}', "RCA this", "diagnose the orders
+  outage". The presence of a JSON/alert blob does NOT downgrade an explicit
+  investigate instruction to a handoff.
+- DIAGNOSTIC QUESTION asking you to FIND, EXPLAIN, or TRACK DOWN the cause of a
+  failure, crash, error, outage, or incident — WITHOUT an explicit investigate
+  verb — is an investigation request WHEN there is data to investigate with.
+  This includes "figure out why X is crashing", "why is X failing/broken?",
+  "what's causing the 502s?", "why did the orders job fail?", and questions that
+  name sources to look at ("check sentry, github, and posthog to find why the
+  agent crashes on Windows"). Gate it on the CONNECTED INTEGRATIONS line:
+  * At least ONE integration connected → emit investigation_start with alert_text
+    synthesized from the request (state the failure plus any named sources). Do
+    NOT hand off — run the investigation.
+  * "none" or "unknown" → emit assistant_handoff instead; with no connected data
+    source a root-cause run would be empty, so let the assistant answer and
+    suggest connecting an integration.
+- NEITHER an instruction NOR a diagnostic question → assistant_handoff. A message
+  that is JUST an alert or incident — a pasted alert payload (JSON, YAML, or
+  key-value blob) on its own, or a bare incident statement such as "CPU is
+  spiking to 99% on orders-api" or "checkout is returning 502s" — states a fact
+  but does not ask you to find a cause. Emit assistant_handoff, even when it
+  reads urgent or "critical". Do NOT start an investigation for it.
+- A diagnostic question that is a FOLLOW-UP about a result you already produced
+  (see RECENT CONVERSATION) — e.g. "why did it fail?" / "what caused the spike?"
+  after a completed investigation — is answered from that prior context: emit
+  assistant_handoff, do NOT start a new investigation.
+- When unsure, choose assistant_handoff. The user can always follow up with an
+  explicit "investigate this".
 
 Quoted directives are actionable, never chatty. When an action verb (investigate,
 run, analyze, diagnose, RCA, root-cause, start) takes quotation-marked text as its
@@ -168,18 +186,17 @@ never a discovery command (listing configured integrations would not answer
 
 If the entire request is informational or conversational — a how-to/docs question
 (including "what is supported?" / "what can I add?"), a greeting like
-"hi"/"hello"/"hey", an alert blob pasted as JSON or free text, an incident
-description, a follow-up like "why did it fail?" / "what caused the spike?", or
-a vague operational question like "why is the database slow?" — ALWAYS call the
-assistant_handoff tool with a concise handoff content. The ONLY exception is a
-factual question about the current state that a read-only discovery command would
-answer (handled in the discovery rule above): emit that discovery action instead.
-A pasted alert blob or incident description is NOT a discovery question — hand it
-off; do not start an investigation unless the user explicitly asks to investigate
-it. When you hand the whole request off this way, emit ONLY the assistant_handoff
-call. An informational, diagnostic, troubleshooting, or investigation question
-(including "figure out why X" or "query sentry/github/posthog to find the cause")
-is FULLY handled by that single handoff. The planner only forwards actions emitted
-through tool calls, so always emit assistant_handoff rather than relying on
-plain-text output.
+"hi"/"hello"/"hey", or a pasted alert blob / bare incident statement with no
+instruction and no diagnostic question — ALWAYS call the assistant_handoff tool
+with a concise handoff content. Two exceptions take precedence over this handoff:
+1. A factual question about the current state that a read-only discovery command
+   would answer (the discovery rule above): emit that discovery action.
+2. A diagnostic question asking to find or explain the cause of a failure / crash
+   / error / incident (the investigation rule above): when at least one
+   integration is connected, emit investigation_start; hand off only when no
+   integration is connected. A pasted alert blob or bare incident statement is
+   NOT such a question — hand it off.
+When you do hand the whole request off, emit ONLY the assistant_handoff call. The
+planner only forwards actions emitted through tool calls, so always emit a tool
+call rather than relying on plain-text output.
 """

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/llm_client.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/llm_client.py
@@ -8,7 +8,7 @@ from typing import Any
 from app.cli.interactive_shell.token_accounting import record_invoke_response
 
 from .constants import _OPENAI_STYLE_PROVIDERS, _USER_TEMPLATE
-from .prompting import _recent_conversation_block, _system_prompt
+from .prompting import _connected_integrations_block, _recent_conversation_block, _system_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +51,7 @@ def _call_llm(sanitised_text: str, session: Any) -> str | None:
     prompt = (
         _system_prompt()
         + "\n\n"
+        + _connected_integrations_block(session)
         + _recent_conversation_block(session)
         + _USER_TEMPLATE.format(text=sanitised_text)
     )

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/prompting.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/prompting.py
@@ -14,6 +14,25 @@ def _system_prompt() -> str:
     return _SYSTEM_PROMPT_BASE
 
 
+def _connected_integrations_block(session: Any | None) -> str:
+    """Render which integrations are connected for THIS turn.
+
+    The planner gates *implicit* diagnostic questions (no explicit "investigate"
+    verb) on this line: it may dispatch an investigation only when at least one
+    integration is connected; with "none" or "unknown" it hands off instead.
+    Explicit investigate instructions are NOT gated and dispatch regardless.
+    """
+    known = bool(getattr(session, "configured_integrations_known", False))
+    configured = tuple(getattr(session, "configured_integrations", ()) or ())
+    if known and configured:
+        listing = ", ".join(sorted(str(name) for name in configured))
+    elif known:
+        listing = "none"
+    else:
+        listing = "unknown"
+    return f"CONNECTED INTEGRATIONS (this install, right now): {listing}\n\n"
+
+
 def _recent_conversation_block(session: Any | None) -> str:
     """Render the shared recent-conversation context for the planner prompt.
 

--- a/app/cli/interactive_shell/routing/tests/_oracle_runtime.py
+++ b/app/cli/interactive_shell/routing/tests/_oracle_runtime.py
@@ -19,7 +19,10 @@ from app.cli.interactive_shell.routing.tests._oracle_normalize import (
     normalize_response_text,
     oracle_action_matches,
 )
-from app.cli.interactive_shell.routing.tests.scenario_loader import ScenarioCase
+from app.cli.interactive_shell.routing.tests.scenario_loader import (
+    GatheredToolsContract,
+    ScenarioCase,
+)
 from app.cli.interactive_shell.runtime.execution import execute_routed_turn
 from app.cli.interactive_shell.runtime.session import ReplSession
 
@@ -35,6 +38,7 @@ def fresh_session(
     with_prior_state: bool,
     configured_integrations: tuple[str, ...] = (),
     available_capabilities: dict[str, tuple[str, ...]] | None = None,
+    resolved_integrations_override: dict[str, Any] | None = None,
 ) -> ReplSession:
     session = ReplSession()
     if with_prior_state:
@@ -42,6 +46,12 @@ def fresh_session(
     session.configured_integrations = configured_integrations
     session.configured_integrations_known = True
     session.available_capabilities = available_capabilities or {}
+    # When a scenario pins resolved_integrations, seed the gather-loop cache so
+    # the conversational data-gathering pass sees a deterministic, fixture-owned
+    # integration set instead of resolving the developer's real ~/.opensre store.
+    # An explicit empty mapping ({}) deliberately forces a no-integration world.
+    if resolved_integrations_override is not None:
+        session.resolved_integrations_cache = resolved_integrations_override
     return session
 
 
@@ -94,6 +104,28 @@ def history_matches(actual: list[dict[str, Any]], expected: list[dict[str, Any]]
             return False
         remaining.pop(match_index)
     return True
+
+
+def _gathered_contract_failures(
+    contract: GatheredToolsContract | None,
+    gathered_tool_calls: list[str],
+) -> list[str]:
+    """Return the names of any violated gathered-tools contract dimensions.
+
+    A tool counts as "called" when it fired during the gather loop, regardless
+    of whether the call succeeded or returned an error.
+    """
+    if contract is None:
+        return []
+    failures: list[str] = []
+    called = set(gathered_tool_calls)
+    if contract.must_call_any and not (called & set(contract.must_call_any)):
+        failures.append("must_call_any")
+    if any(name not in called for name in contract.must_call_all):
+        failures.append("must_call_all")
+    if any(name in called for name in contract.must_not_call):
+        failures.append("must_not_call")
+    return failures
 
 
 def patch_execution_boundary(
@@ -179,9 +211,26 @@ def run_oracle_once(case: ScenarioCase, monkeypatch: pytest.MonkeyPatch) -> Orac
             "cli_commands": case.scenario.available_capabilities.cli_commands,
             "synthetic_suites": case.scenario.available_capabilities.synthetic_suites,
         },
+        resolved_integrations_override=case.scenario.session.resolved_integrations,
     )
     executed: list[dict[str, Any]] = []
     patch_execution_boundary(monkeypatch, executed)
+
+    # Record which registered tools fire during the conversational
+    # gather_tool_evidence pass. gather_tool_evidence imports
+    # run_tool_calling_loop lazily from app.agent.tool_loop, so patch the name on
+    # that source module (the local import re-binds from there at call time).
+    import app.agent.tool_loop as _tool_loop_mod
+
+    gathered_tool_calls: list[str] = []
+    _original_tool_loop = _tool_loop_mod.run_tool_calling_loop
+
+    def _recording_tool_loop(*args: Any, **kwargs: Any) -> Any:
+        result = _original_tool_loop(*args, **kwargs)
+        gathered_tool_calls.extend(tc.name for tc, _ in result.executed)
+        return result
+
+    monkeypatch.setattr(_tool_loop_mod, "run_tool_calling_loop", _recording_tool_loop)
 
     console_buffer = io.StringIO()
     console = Console(file=console_buffer, force_terminal=False, highlight=False, width=100)
@@ -224,6 +273,10 @@ def run_oracle_once(case: ScenarioCase, monkeypatch: pytest.MonkeyPatch) -> Orac
         action["kind"] for action in executed if action.get("kind") in forbidden_action_kinds
     ]
 
+    gathered_contract_failures = _gathered_contract_failures(
+        answer.gathered_tools_contract, gathered_tool_calls
+    )
+
     passed = True
     if decision.route_kind.value != answer.route.expected_kind:
         passed = False
@@ -250,6 +303,8 @@ def run_oracle_once(case: ScenarioCase, monkeypatch: pytest.MonkeyPatch) -> Orac
         passed = False
     if not history_match:
         passed = False
+    if gathered_contract_failures:
+        passed = False
 
     return OracleRunResult(
         passed=passed,
@@ -265,6 +320,8 @@ def run_oracle_once(case: ScenarioCase, monkeypatch: pytest.MonkeyPatch) -> Orac
             "response_contract": answer.response_contract,
             "forbidden_tokens_matched": forbidden_tokens,
             "forbidden_executed_kinds": forbidden_executed,
+            "gathered_tool_calls": gathered_tool_calls,
+            "gathered_contract_failures": gathered_contract_failures,
             "last_assistant_intent": session.last_assistant_intent,
         },
     )

--- a/app/cli/interactive_shell/routing/tests/scenario_loader.py
+++ b/app/cli/interactive_shell/routing/tests/scenario_loader.py
@@ -76,6 +76,7 @@ class ScenarioSession:
     has_prior_state: bool
     remote_connected: bool
     configured_integrations: tuple[str, ...]
+    resolved_integrations: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -127,6 +128,28 @@ class AnswerPolicy:
 
 
 @dataclass(frozen=True)
+class GatheredToolsContract:
+    """Assertions on which registered tools fire during the conversational
+    ``gather_tool_evidence`` loop for a turn.
+
+    A turn's conversational data-gathering pass runs the same registered tools
+    the investigation uses. This contract lets a scenario assert that the right
+    tools were (or were not) invoked when grounding a chat answer:
+
+    * ``must_call_any`` — at least one of these tool names must be invoked.
+    * ``must_call_all`` — every one of these tool names must be invoked.
+    * ``must_not_call`` — none of these tool names may be invoked.
+
+    A tool counts as "called" when it appears in ``ToolLoopResult.executed``,
+    regardless of whether the call succeeded or returned an error.
+    """
+
+    must_call_any: tuple[str, ...]
+    must_call_all: tuple[str, ...]
+    must_not_call: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class Answer:
     """Expected behavior for one routing scenario.
 
@@ -156,6 +179,7 @@ class Answer:
     history_expected: tuple[dict[str, Any], ...]
     tier: str
     runs: int
+    gathered_tools_contract: GatheredToolsContract | None = None
 
 
 @dataclass(frozen=True)
@@ -169,6 +193,44 @@ def _require_mapping(raw: object, *, label: str) -> dict[str, Any]:
         msg = f"{label} must be a mapping, got {type(raw).__name__}."
         raise ValueError(msg)
     return cast(dict[str, Any], raw)
+
+
+def _optional_mapping(raw: object, *, label: str) -> dict[str, Any] | None:
+    """Parse an optional mapping field.
+
+    Returns ``None`` when the key is absent or explicitly null (preserving the
+    "use the real resolved store" default), and the mapping itself when present
+    (including an explicit empty ``{}`` that forces an isolated, empty store).
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        msg = f"{label} must be a mapping, got {type(raw).__name__}."
+        raise ValueError(msg)
+    return cast(dict[str, Any], raw)
+
+
+def _parse_gathered_tools_contract(raw: object, *, label: str) -> GatheredToolsContract | None:
+    """Parse the optional ``gathered_tools_contract`` block.
+
+    Returns ``None`` when absent. Each of ``must_call_any``, ``must_call_all``,
+    and ``must_not_call`` is an optional list of non-empty tool-name strings.
+    Registry membership of those names is enforced separately by
+    ``test_routing_fixture_integrity`` so the loader stays free of a heavy tool
+    registry import.
+    """
+    if raw is None:
+        return None
+    mapping = _require_mapping(raw, label=label)
+    contract = GatheredToolsContract(
+        must_call_any=_string_list(mapping.get("must_call_any"), label=f"{label}.must_call_any"),
+        must_call_all=_string_list(mapping.get("must_call_all"), label=f"{label}.must_call_all"),
+        must_not_call=_string_list(mapping.get("must_not_call"), label=f"{label}.must_not_call"),
+    )
+    if not (contract.must_call_any or contract.must_call_all or contract.must_not_call):
+        msg = f"{label} must define at least one of must_call_any/must_call_all/must_not_call."
+        raise ValueError(msg)
+    return contract
 
 
 def _string_list(raw: object, *, label: str) -> tuple[str, ...]:
@@ -361,6 +423,10 @@ def _parse_scenario_yaml(
                 session_raw.get("configured_integrations"),
                 label=f"{scenario_path} session.configured_integrations",
             ),
+            resolved_integrations=_optional_mapping(
+                session_raw.get("resolved_integrations"),
+                label=f"{scenario_path} session.resolved_integrations",
+            ),
         ),
         available_capabilities=ScenarioCapabilities(
             slash_commands=_string_list(
@@ -495,6 +561,11 @@ def _parse_answer_yaml(answer_path: Path, *, scenario_id: str) -> Answer:
         else None
     )
 
+    gathered_tools_contract = _parse_gathered_tools_contract(
+        data.get("gathered_tools_contract"),
+        label=f"{answer_path} gathered_tools_contract",
+    )
+
     return Answer(
         route=AnswerRoute(
             expected_kind=expected_kind,
@@ -514,6 +585,7 @@ def _parse_answer_yaml(answer_path: Path, *, scenario_id: str) -> Answer:
         history_expected=history_expected,
         tier=tier,
         runs=runs,
+        gathered_tools_contract=gathered_tools_contract,
     )
 
 
@@ -595,6 +667,7 @@ __all__ = [
     "Answer",
     "AnswerPolicy",
     "AnswerRoute",
+    "GatheredToolsContract",
     "SCENARIOS_DIR",
     "Scenario",
     "ScenarioCapabilities",

--- a/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/313-github-issues-windows-crashes.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/313-github-issues-windows-crashes.yml
@@ -9,14 +9,18 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Force an empty resolved store in every environment so the gather loop has no
+  # tools available regardless of the developer's local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
   synthetic_suites: []
 notes:
-- "Covers the assistant gathering live data from a connected integration when\
-  \ answering a free-form question. With no GitHub integration configured the\
-  \ assistant answers from text only and must not shell out or start an RCA run."
+- "Covers the no-integration handoff path (Option A negative control): with no\
+  \ integrations connected, the planner must NOT dispatch a sourceless RCA, so it\
+  \ hands off and the assistant answers from text only -- no shell, no\
+  \ investigation. The dispatch counterpart (integrations connected) is 314."
 route:
   expected_kind: handle_message_with_agent
   expected_command_text: null
@@ -35,6 +39,12 @@ response_contract:
   forbidden_actions:
   - shell
   - investigation
+gathered_tools_contract:
+  # No integrations are resolved, so no remote-integration tool may fire.
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/314-windows-crash-multisource-query.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/314-windows-crash-multisource-query.yml
@@ -1,5 +1,5 @@
 id: 314-windows-crash-multisource-query
-title: Windows crash epic asks the agent to query Sentry, GitHub issues, and PostHog
+title: Windows crash epic dispatches an investigation across Sentry, GitHub, and PostHog
 intent_class: complex_shell_prompts
 risk_level: medium
 input:
@@ -13,47 +13,69 @@ session:
   configured_integrations:
   - sentry
   - github
-  - posthog
+  - posthog_mcp
+  # Pin fixture-owned integration configs so the planner sees >=1 connected
+  # integration and dispatches an investigation (the Option A gate). Tokens are
+  # fake; no real investigation runs because the oracle stubs the dispatch
+  # boundary (REGISTRY.dispatch), so the call is recorded without remote I/O.
+  resolved_integrations:
+    sentry:
+      connection_verified: true
+      organization_slug: fixture-org
+      project_slug: fixture-project
+      auth_token: fixture-token
+      base_url: https://sentry.io
+    github:
+      connection_verified: true
+      owner: tracer-cloud
+      repo: opensre
+      mode: streamable-http
+      url: https://api.githubcopilot.com/mcp/
+      auth_token: fixture-token
+    posthog_mcp:
+      connection_verified: true
+      mode: streamable-http
+      url: https://mcp.posthog.com/mcp
+      auth_token: fixture-token
 available_capabilities:
   slash_commands: []
   cli_commands: []
   synthetic_suites: []
 notes:
-- "Multi-source investigation epic with Sentry, GitHub, and PostHog all configured.\
-  \ The agent must engage with the request and commit to checking the named\
-  \ sources for the Windows crashes rather than deflecting with a generic 'paste\
-  \ an alert and run opensre investigate' reply."
-- "The agent must not shell out or auto-start an RCA run; this is the\
-  \ conversational/tool-gathering surface, so it answers directly and references\
-  \ all three configured sources."
+- "Multi-source investigation request with Sentry, GitHub, and PostHog connected.\
+  \ Because at least one integration is connected, the planner DISPATCHES an\
+  \ investigation (investigation_start) with synthesized alert_text instead of\
+  \ handing off. This is the dispatch counterpart to 313 (no integrations ->\
+  \ handoff)."
+- "The investigation alert_text is synthesized from the prompt and varies per\
+  \ run, so planned_actions leaves content empty: the planning test asserts an\
+  \ investigation with non-empty alert_text rather than an exact string."
 route:
   expected_kind: handle_message_with_agent
   expected_command_text: null
 policy:
-  executes_terminal_action: false
-planned_actions: []
-executed_actions: []
+  executes_terminal_action: true
+planned_actions:
+- kind: investigation
+  source: llm
+  target_surface: investigation
+executed_actions:
+- kind: investigation
 response_contract:
-  must_contain_all:
-  - Sentry
-  - GitHub
-  - PostHog
   must_contain_any:
+  - investigat
+  - rca
   - Windows
   - crash
   must_not_contain:
   - $ /
-  # The agent must commit to checking the connected sources, not deflect the
-  # user back to pasting an alert / running a separate investigation command.
-  - opensre investigate
-  - paste the alert
-  - paste one of
   forbidden_actions:
   - shell
-  - investigation
 history:
   expected:
   - type: cli_agent
+    ok: true
+  - type: alert
     ok: true
 tier: full
 runs: 5

--- a/app/cli/interactive_shell/routing/tests/test_routing_fixture_integrity.py
+++ b/app/cli/interactive_shell/routing/tests/test_routing_fixture_integrity.py
@@ -156,6 +156,30 @@ def test_executes_terminal_action_invariants() -> None:
     assert not violations, "policy invariant violations:\n" + "\n".join(violations)
 
 
+def test_gathered_tools_contract_names_are_registered() -> None:
+    from app.tools.registry import clear_tool_registry_cache, get_registered_tools
+
+    clear_tool_registry_cache()
+    registered = {tool.name for tool in get_registered_tools()}
+
+    missing: list[str] = []
+    for case in load_all_scenarios():
+        contract = case.answer.gathered_tools_contract
+        if contract is None:
+            continue
+        names = (
+            *contract.must_call_any,
+            *contract.must_call_all,
+            *contract.must_not_call,
+        )
+        for name in names:
+            if name not in registered:
+                missing.append(f"{case.scenario.id}: gathered_tools_contract names {name!r}")
+    assert not missing, "gathered_tools_contract references unregistered tool names:\n" + "\n".join(
+        missing
+    )
+
+
 def test_routing_test_modules_do_not_use_mock_patterns() -> None:
     violations: list[str] = []
     for test_path in (ROUTING_SCENARIOS_TEST, ORACLE_RUNTIME):

--- a/app/cli/interactive_shell/routing/tests/test_routing_scenarios.py
+++ b/app/cli/interactive_shell/routing/tests/test_routing_scenarios.py
@@ -103,15 +103,26 @@ def _assert_planned_actions_match(
     assert len(actual_actions) == len(expected_actions)
     for index, expected in enumerate(expected_actions):
         actual = actual_actions[index]
-        if str(expected.get("kind", "")) != "assistant_handoff":
-            assert _action_match_view(actual) == _action_match_view(expected)
+        expected_kind = str(expected.get("kind", ""))
+        if expected_kind == "assistant_handoff":
+            assert actual.get("kind") == "assistant_handoff"
+            expected_source = str(expected.get("source", "")).strip()
+            if expected_source:
+                assert actual.get("source") == expected_source
+            content = str(actual.get("content", "")).strip()
+            assert content, f"assistant_handoff action {index} must include text content."
             continue
-        assert actual.get("kind") == "assistant_handoff"
-        expected_source = str(expected.get("source", "")).strip()
-        if expected_source:
-            assert actual.get("source") == expected_source
-        content = str(actual.get("content", "")).strip()
-        assert content, f"assistant_handoff action {index} must include text content."
+        # A synthesized investigation (no pasted/quoted payload) carries freeform
+        # alert_text that varies per live run. When the fixture leaves content
+        # empty, assert kind + non-empty alert_text rather than exact equality;
+        # fixtures that pin a verbatim payload (e.g. a pasted alert) keep the
+        # strict match below.
+        if expected_kind == "investigation" and not str(expected.get("content", "")).strip():
+            assert actual.get("kind") == "investigation"
+            content = str(actual.get("content", "")).strip()
+            assert content, f"investigation action {index} must include synthesized alert_text."
+            continue
+        assert _action_match_view(actual) == _action_match_view(expected)
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:

--- a/app/integrations/posthog_mcp.py
+++ b/app/integrations/posthog_mcp.py
@@ -108,8 +108,11 @@ class PostHogMCPConfig(StrictConfigModel):
     def _normalize_mode(cls, value: object) -> str:
         normalized = str(value or DEFAULT_POSTHOG_MCP_MODE).strip().lower()
         normalized = normalized or DEFAULT_POSTHOG_MCP_MODE
-        # "mcp" is a generic alias — map it to the default HTTP transport.
-        if normalized == "mcp":
+        # Generic aliases that callers (env, store, or the planner) may emit
+        # all map to the default hosted HTTP transport rather than tripping the
+        # Literal validation. "default" is what the planner tends to guess when
+        # it has no explicit transport to pass.
+        if normalized in {"mcp", "default", "http", "https", "streamable_http"}:
             return DEFAULT_POSTHOG_MCP_MODE
         return normalized
 

--- a/app/tools/PostHogMCPTool/__init__.py
+++ b/app/tools/PostHogMCPTool/__init__.py
@@ -72,6 +72,9 @@ def _unavailable_response(
     return payload
 
 
+_KNOWN_POSTHOG_MCP_MODES = frozenset({"stdio", "sse", "streamable-http"})
+
+
 def _resolve_config(
     posthog_url: str | None,
     posthog_mode: str | None,
@@ -81,17 +84,31 @@ def _resolve_config(
 ) -> PostHogMCPConfig | None:
     env_config = posthog_mcp_config_from_env()
     if any((posthog_url, posthog_mode, posthog_token, posthog_command, posthog_args)):
+        url = posthog_url or (env_config.url if env_config else "")
+        command = posthog_command or (env_config.command if env_config else "")
+
+        # The planner fills these connection params from a loose schema and often
+        # guesses an invalid transport (e.g. "default") or asks for "stdio"
+        # without a command. Drop anything we can't honor so we fall back to
+        # inferring the transport from the configured command/url rather than
+        # building a config that fails PostHogMCPConfig validation.
+        requested_mode = (posthog_mode or "").strip().lower()
+        if requested_mode not in _KNOWN_POSTHOG_MCP_MODES:
+            requested_mode = ""
+        if requested_mode == "stdio" and not command:
+            requested_mode = ""
+
         inferred_mode = (
-            posthog_mode
-            or ("stdio" if posthog_command else "")
-            or ("streamable-http" if posthog_url else "")
+            requested_mode
+            or ("stdio" if command else "")
+            or ("streamable-http" if url else "")
             or (env_config.mode if env_config else "")
         )
         raw_config: PostHogMCPParams = {
-            "url": posthog_url or (env_config.url if env_config else ""),
+            "url": url,
             "mode": inferred_mode,
             "auth_token": posthog_token or (env_config.auth_token if env_config else ""),
-            "command": posthog_command or (env_config.command if env_config else ""),
+            "command": command,
             "args": posthog_args or (list(env_config.args) if env_config else []),
             "headers": env_config.headers if env_config else {},
             "organization_id": env_config.organization_id if env_config else "",

--- a/docs/routing-scenario-test-gap.md
+++ b/docs/routing-scenario-test-gap.md
@@ -1,0 +1,343 @@
+# Memorandum: Routing Scenario Test Infrastructure Gap
+
+**Date:** 2026-06-18  
+**Concerns:** `complex_shell_prompts` scenario class; oracle coverage of conversational tool-gathering  
+**Status:** Active gap — CI gives false green on integration behaviour
+
+---
+
+## Summary
+
+The routing scenario oracle (`_oracle_runtime.py`) does not observe, assert on,
+or control the conversational tool-gathering path (`gather_tool_evidence` →
+`run_tool_calling_loop`). Every `complex_shell_prompts` scenario passes in CI
+even when zero integrations are queried and the response is entirely hallucinated
+text. The test infrastructure provides confidence that does not exist.
+
+---
+
+## 1. The Two Execution Paths — Only One Is Tested
+
+When a REPL turn routes to `handle_message_with_agent`, two independent paths
+can fire:
+
+| Path | What it does | Oracle coverage |
+|---|---|---|
+| **Planner → `REGISTRY.dispatch`** | LLM proposes a terminal action (slash, investigation, shell, etc.); the oracle intercepts every call through `patch_execution_boundary` | **Fully observed and asserted** |
+| **`gather_tool_evidence` → `run_tool_calling_loop`** | A bounded ReAct loop queries registered tools (Sentry, GitHub, PostHog, etc.) to ground a conversational answer | **Completely unobserved** |
+
+The oracle patches `REGISTRY.dispatch`. It does not patch `gather_tool_evidence`,
+`run_tool_calling_loop`, `_run_parallel`, or `_resolve_session_integrations`.
+Tool calls made during the gather pass are invisible to the test.
+
+---
+
+## 2. `configured_integrations` in Fixtures Does Not Isolate the Store
+
+`fresh_session` applies the fixture's `configured_integrations` list to
+`session.configured_integrations`. This field controls the LLM system-prompt
+copy and the REPL status bar. It does not control which integrations are
+**actually loaded** for the gather loop.
+
+`_resolve_session_integrations` ignores `session.configured_integrations`
+entirely:
+
+```python
+# app/cli/interactive_shell/chat/tool_gathering.py
+def _resolve_session_integrations(session: ReplSession) -> dict[str, Any]:
+    if session.resolved_integrations_cache is not None:
+        return session.resolved_integrations_cache
+    resolved = resolve_integrations({})  # hits the real env and ~/.opensre/integrations.json
+    session.resolved_integrations_cache = resolved
+    return resolved
+```
+
+`resolve_integrations({})` reads the developer's live `~/.opensre/integrations.json`
+and environment variables. This produces three distinct, silent behaviours across
+environments:
+
+| Environment | What `resolve_integrations` returns | Tool-gathering outcome |
+|---|---|---|
+| CI (no store, no env keys) | `{}` — no tools available | Gathering is a no-op; text-only answer |
+| Developer machine, no keys | `{}` | Same no-op |
+| Developer machine with real integrations | Real configs (PostHog, GitHub, Sentry, …) | Real tool calls fire with the developer's live credentials |
+
+A scenario that declares `configured_integrations: [sentry, github, posthog]`
+in CI runs exactly the same code path as one that declares
+`configured_integrations: []`. The field is decoration, not isolation.
+
+---
+
+## 3. Response Contracts Are Satisfiable by Hallucination Alone
+
+Because the gather loop is a no-op in CI, the response evaluated against the
+contract is produced by the LLM from its training data, not from any live
+integration. The contracts for the two `complex_shell_prompts` scenarios are:
+
+**313** (`configured_integrations: []`)
+```yaml
+must_contain_any: [GitHub, issues, Windows, crash]
+```
+Any response that mentions "GitHub" passes. The LLM always mentions GitHub when
+asked about GitHub issues.
+
+**314** (`configured_integrations: [sentry, github, posthog]`)
+```yaml
+must_contain_all: [Sentry, GitHub, PostHog]
+must_contain_any: [Windows, crash]
+```
+Any response that mentions all three names passes — including a response that
+says "I cannot access Sentry, GitHub, or PostHog right now." The scenario
+explicitly notes the agent "must commit to checking the connected sources," but
+the contract cannot verify this because it cannot observe whether any source
+was actually checked.
+
+---
+
+## 4. The Behaviour Proven by Current Tests
+
+Across all 54 routing scenarios, what passes in CI is:
+
+- **Routing correctness** — `route_input` returns the right `route_kind`. This
+  is genuine and valuable.
+- **Deterministic command dispatch** — slash commands and aliases resolve
+  correctly. This is genuine and valuable.
+- **Planned terminal action shape** — when a planner action fires (slash, shell,
+  investigation), the oracle records and asserts it correctly. This is genuine
+  and valuable.
+- **Hallucination-satisfiable text contracts** — for all conversational turns,
+  the contract is met by the LLM generating plausible text that mentions the
+  right words. **This is not a meaningful signal.**
+
+What is not proven:
+
+- Whether the gather loop fires at all.
+- Whether any specific tool was called.
+- Whether any integration returned data.
+- Whether the response is grounded in integration data vs. generated from
+  training knowledge.
+- Whether a broken integration (validation error, auth failure, timeout)
+  prevents the response from being useful.
+
+---
+
+## 5. Why This Is a Large Correctness Risk
+
+The `complex_shell_prompts` class exists specifically to cover the integration
+data-gathering surface — the tests are named and described as covering exactly
+what they do not cover. This creates three concrete risks:
+
+**Risk 1: Broken tool extraction goes undetected.**  
+If `_posthog_mcp_extract_params` starts returning bad config fields (as
+happened: live PostHog calls received `posthog_mode="mcp"` from the LLM), the
+scenario passes. The broken extraction is only discovered when a user exercises
+the feature interactively.
+
+**Risk 2: Integration registration silently drops.**  
+If a tool's `is_available` check starts returning `False` for all sessions, or
+if the tool is accidentally deregistered, every `complex_shell_prompts` scenario
+still passes. A regression that stops the agent from ever querying GitHub or
+PostHog cannot be caught by the current test suite.
+
+**Risk 3: The no-mocks policy blocks the obvious fix.**  
+`AGENTS.md` and `test_routing_fixture_integrity.py` enforce a hard no-mocks
+rule on the routing oracle:
+
+> "Do not use `unittest.mock`, `patch`, `MagicMock`, or equivalent mocking
+> primitives in routing tests."
+
+The intent of this rule is correct — it prevents tests from faking the LLM and
+making routing assertions against synthetic planner output. But it accidentally
+also blocks injecting a controlled integration config into the gather loop,
+which does not involve the LLM at all. The rule currently prevents the fix.
+
+---
+
+## 6. Root Cause: Architectural Seam Is Missing
+
+The docstring in `scenario_loader.py` acknowledges the gap explicitly:
+
+```python
+# Answer docstring, path 2:
+# "Deeper 'did it actually query the integration?' assertions belong in
+# execution-layer tests, not these routing fixtures."
+```
+
+That execution-layer test does not exist. `tests/cli/interactive_shell/runtime/
+test_answer_with_tools.py` patches both `gather_tool_evidence` and
+`answer_cli_agent` entirely, so it tests the wiring between them (gather output
+flows to answer), not whether the gather loop calls the right tools with the
+right config. The gap noted in the docstring has never been closed.
+
+---
+
+## 7. Proposed Remediation
+
+Three changes are required, in dependency order.
+
+### 7.1 — Add a stable test seam for integration injection
+
+Add `resolved_integrations_override` support to `fresh_session` in the oracle.
+When set, `_resolve_session_integrations` returns the override instead of
+hitting the real store. This does not mock the LLM, does not mock any tool, and
+does not violate the spirit of the no-mocks rule — it controls the integration
+config the tool is called with, which is fixture input, not LLM output.
+
+```python
+# _oracle_runtime.py
+def fresh_session(
+    *,
+    with_prior_state: bool,
+    configured_integrations: tuple[str, ...] = (),
+    available_capabilities: dict[str, tuple[str, ...]] | None = None,
+    resolved_integrations_override: dict[str, Any] | None = None,
+) -> ReplSession:
+    session = ReplSession()
+    ...
+    if resolved_integrations_override is not None:
+        session.resolved_integrations_cache = resolved_integrations_override
+    return session
+```
+
+`run_oracle_once` reads this from `case.scenario.session.resolved_integrations`
+when present, and uses `{}` (no-op gather) otherwise. CI remains fast because
+no fixture currently sets this field.
+
+### 7.2 — Track gather-loop tool calls in the oracle
+
+Wrap `run_tool_calling_loop` (or `_run_parallel`) with a thin recorder inside
+`run_oracle_once` so tool calls made during gathering are captured alongside
+planned terminal actions. This does not mock the tools themselves; it records
+which ones fired.
+
+```python
+# _oracle_runtime.py
+gathered_calls: list[str] = []
+
+original_loop = tool_loop.run_tool_calling_loop
+
+def _recording_loop(*args, **kwargs):
+    result = original_loop(*args, **kwargs)
+    for tc, _ in result.executed:
+        gathered_calls.append(tc.name)
+    return result
+
+monkeypatch.setattr(tool_loop, "run_tool_calling_loop", _recording_loop)
+```
+
+The oracle result gains `gathered_tool_calls: list[str]` and the OracleRunResult
+exposes this for contract assertions.
+
+### 7.3 — Add `gathered_tools_contract` to the scenario schema
+
+Extend the YAML schema with an optional section that the scenario loader
+validates and the oracle asserts:
+
+```yaml
+gathered_tools_contract:
+  must_call_any:         # at least one of these tool names must appear
+  - list_github_issues
+  - search_github_issues
+  must_not_call:         # none of these must appear
+  - run_investigation
+  - execute_shell_command
+```
+
+Updated `314-windows-crash-multisource-query.yml`:
+
+```yaml
+session:
+  configured_integrations: [sentry, github, posthog_mcp]
+  resolved_integrations:   # injected into session cache; tool calls run for real
+    sentry:
+      connection_verified: true
+      auth_token: "test-token"
+      ...
+    github:
+      connection_verified: true
+      ...
+    posthog_mcp:
+      connection_verified: true
+      mode: streamable-http
+      ...
+
+gathered_tools_contract:
+  must_call_any:
+  - search_sentry_issues
+  - list_sentry_issues
+  - search_github_issues
+  - list_github_issues
+  - list_posthog_tools
+```
+
+With the override in the session cache, the tools run with the fixture config
+(no live credentials needed). With the gather recorder active, the contract is
+asserted. A broken `is_available` check or bad `extract_params` now fails the
+test immediately.
+
+### 7.4 — Update the no-mocks rule scope
+
+Amend the "no mocks" policy in `AGENTS.md` and `test_routing_fixture_integrity.py`
+to distinguish between two separate things:
+
+- **Mocking the LLM** — prohibited. Routing oracle must exercise the real LLM.
+- **Injecting fixture integration configs** — permitted. This is equivalent to
+  providing test credentials and does not involve the LLM.
+
+Add an AST check that specifically permits `monkeypatch.setattr` on
+`tool_gathering._resolve_session_integrations` and
+`tool_loop.run_tool_calling_loop` while continuing to prohibit `patch`,
+`MagicMock`, and LLM client stubs.
+
+### 7.5 — Rename or reclassify misleading existing scenarios
+
+**313** (`configured_integrations: []`) does not test complex shell prompts
+with live data — it tests the text-only fallback when no integration is
+configured. It should either be moved to `docs_no_execute` or its notes updated
+to reflect that it covers the no-integration fallback path only, not the
+data-gathering path.
+
+---
+
+## 8. Migration Path and Priority
+
+| Step | Effort | Risk | Priority |
+|---|---|---|---|
+| 7.1 — `resolved_integrations_override` seam | Small (20 lines) | Low | **P0** — unblocks everything else |
+| 7.2 — gather-loop tool call recorder | Small (30 lines) | Low | **P0** — required for assertions |
+| 7.3 — `gathered_tools_contract` schema + assertions | Medium (100 lines) | Low | **P1** — makes contracts meaningful |
+| 7.4 — Update no-mocks rule scope | Trivial | None | **P1** — prevents the fix from being reverted |
+| 7.5 — Reclassify 313 | Trivial | None | **P2** — clarity, not correctness |
+| Write new `complex_shell_prompts` scenarios with fixture configs | Medium | Low | **P1** — actual test coverage |
+
+Items 7.1 and 7.2 can land in one PR. Items 7.3 and 7.4 land together. New
+scenario fixtures follow.
+
+---
+
+## 9. What Does Not Change
+
+- The no-mocks policy on the LLM path. The planner, classifier, and
+  conversational assistant all continue to hit the real LLM in routing tests.
+- The routing oracle structure (`route_input` → `execute_routed_turn`).
+- Any existing passing scenario. The `resolved_integrations_override` is opt-in;
+  existing scenarios without it keep the current no-op gather behaviour and
+  continue to pass.
+- CI runtime budget. Fixture-injected integration configs do not make live
+  network calls (tools check `is_available` against the resolved dict, not a
+  live endpoint), so test time stays flat.
+
+---
+
+## 10. Acceptance Criteria for "Fixed"
+
+1. A scenario in `complex_shell_prompts` with `resolved_integrations` injected
+   and `gathered_tools_contract` defined **fails** when the named tools do not
+   fire.
+2. The same scenario **passes** when the tools fire and return data.
+3. Introducing a bug in `_posthog_mcp_extract_params` (e.g. passing
+   `mode="mcp"`) causes the affected scenario to **fail** in CI.
+4. A tool whose `is_available` is patched to always return `False` causes the
+   scenario to **fail** if it is in `gathered_tools_contract.must_call_any`.
+5. No existing scenario changes its pass/fail status.
+6. CI runtime increases by less than 10 seconds per shard.

--- a/tests/cli/interactive_shell/orchestration/test_llm_action_planner_fallback.py
+++ b/tests/cli/interactive_shell/orchestration/test_llm_action_planner_fallback.py
@@ -47,6 +47,29 @@ def test_system_prompt_permits_read_only_discovery_for_factual_questions() -> No
     assert "may emit that read-only discovery action" in prompt
 
 
+def test_system_prompt_gates_diagnostic_dispatch_on_connected_integrations() -> None:
+    """Investigation-intent diagnostic questions dispatch only when integrations are
+    connected; explicit investigate instructions dispatch regardless.
+
+    This encodes the Option A behavior change: the planner must read the
+    CONNECTED INTEGRATIONS line and dispatch investigation_start for diagnostic
+    questions only when at least one integration is connected.
+    """
+    import re
+
+    prompt = re.sub(r"\s+", " ", _system_prompt().lower())
+    # The gate line the planner reads.
+    assert "connected integrations" in prompt
+    # Diagnostic questions are an investigation request gated on integrations.
+    assert "diagnostic question" in prompt
+    assert "investigation_start" in prompt
+    # Explicit investigate instructions are NOT gated.
+    assert "regardless of" in prompt
+    # The figure-out / query-sources phrasing is now a dispatch candidate, not a
+    # hardcoded handoff.
+    assert "figure out why x is crashing" in prompt
+
+
 @pytest.mark.parametrize(
     ("message", "expected"),
     [

--- a/tests/cli/interactive_shell/orchestration/test_llm_action_planner_history.py
+++ b/tests/cli/interactive_shell/orchestration/test_llm_action_planner_history.py
@@ -13,6 +13,7 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.l
     _SYSTEM_PROMPT_BASE,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.llm_action_planner.prompting import (
+    _connected_integrations_block,
     _recent_conversation_block,
 )
 
@@ -20,6 +21,8 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.l
 @dataclass
 class _FakeSession:
     cli_agent_messages: list[tuple[str, str]] = field(default_factory=list)
+    configured_integrations: tuple[str, ...] = ()
+    configured_integrations_known: bool = False
 
 
 def test_block_contains_history_lines() -> None:
@@ -79,3 +82,52 @@ def test_call_llm_prompt_includes_recent_conversation(monkeypatch: Any) -> None:
     assert "RECENT CONVERSATION" in prompt
     assert "User: how can I remove github integration" in prompt
     assert "USER MESSAGE (literal): <<<do both for me>>>" in prompt
+
+
+def test_connected_integrations_block_renders_state() -> None:
+    """The block surfaces the integration set the planner gates dispatch on."""
+    # Unknown: no session / not yet resolved → planner must NOT dispatch implicit
+    # diagnostic questions.
+    assert "unknown" in _connected_integrations_block(None)
+    assert "unknown" in _connected_integrations_block(_FakeSession())
+    # Known-but-empty → "none" (no-integration handoff path, e.g. scenario 313).
+    none_block = _connected_integrations_block(
+        _FakeSession(configured_integrations=(), configured_integrations_known=True)
+    )
+    assert "none" in none_block
+    # Known with integrations → sorted listing the planner can gate on.
+    listed = _connected_integrations_block(
+        _FakeSession(
+            configured_integrations=("sentry", "github", "posthog_mcp"),
+            configured_integrations_known=True,
+        )
+    )
+    assert "github, posthog_mcp, sentry" in listed
+
+
+def test_call_llm_prompt_includes_connected_integrations(monkeypatch: Any) -> None:
+    """The planner prompt must carry the CONNECTED INTEGRATIONS gate line."""
+    captured: dict[str, str] = {}
+
+    class _FakeClient:
+        def bind_tools(self, _specs: object) -> _FakeClient:
+            return self
+
+        def invoke(self, prompt: str) -> str:
+            captured["prompt"] = prompt
+            return "ok"
+
+    monkeypatch.setattr(llm_client, "_tool_specs_for_provider", lambda _session: [])
+    monkeypatch.setattr(llm_client, "record_invoke_response", lambda *_a, **_k: "ok")
+    monkeypatch.setattr(
+        "app.services.llm_client.get_llm_for_classification",
+        lambda: _FakeClient(),
+    )
+
+    session = _FakeSession(
+        configured_integrations=("github", "sentry"),
+        configured_integrations_known=True,
+    )
+    llm_client._call_llm("figure out why the agent crashes on windows", session)
+
+    assert "CONNECTED INTEGRATIONS (this install, right now): github, sentry" in captured["prompt"]

--- a/tests/integrations/test_posthog_mcp.py
+++ b/tests/integrations/test_posthog_mcp.py
@@ -47,6 +47,11 @@ class TestPostHogMCPConfig:
         config = PostHogMCPConfig(mode="mcp")
         assert config.mode == "streamable-http"
 
+    @pytest.mark.parametrize("alias", ["default", "http", "https", "streamable_http"])
+    def test_mode_generic_aliases_map_to_streamable_http(self, alias: str) -> None:
+        config = PostHogMCPConfig(mode=alias)
+        assert config.mode == "streamable-http"
+
     def test_bearer_prefix_stripped_from_token(self) -> None:
         config = PostHogMCPConfig(auth_token="Bearer phx_secret")
         assert config.auth_token == "phx_secret"

--- a/tests/tools/test_posthog_mcp_tool.py
+++ b/tests/tools/test_posthog_mcp_tool.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from app.tools.PostHogMCPTool import call_posthog_tool, list_posthog_tools
+import pytest
+
+from app.tools.PostHogMCPTool import _resolve_config, call_posthog_tool, list_posthog_tools
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
@@ -171,6 +173,44 @@ def test_call_tool_surfaces_mcp_error() -> None:
         )
     assert result["available"] is False
     assert "permission denied" in str(result["error"])
+
+
+@pytest.mark.parametrize("guessed_mode", ["default", "mcp", "http", "bogus", ""])
+def test_resolve_config_recovers_from_guessed_mode(guessed_mode: str) -> None:
+    """The planner often guesses an invalid transport; fall back to HTTP."""
+    config = _resolve_config(
+        posthog_url="https://mcp.posthog.com/mcp",
+        posthog_mode=guessed_mode,
+        posthog_token="phx_secret",
+    )
+    assert config is not None
+    assert config.mode == "streamable-http"
+    assert config.url == "https://mcp.posthog.com/mcp"
+
+
+def test_resolve_config_stdio_without_command_falls_back_to_http() -> None:
+    """A 'stdio' request with only a URL must not build a broken stdio config."""
+    config = _resolve_config(
+        posthog_url="https://mcp.posthog.com/mcp",
+        posthog_mode="stdio",
+        posthog_token="phx_secret",
+        posthog_command="",
+    )
+    assert config is not None
+    assert config.mode == "streamable-http"
+
+
+def test_resolve_config_keeps_explicit_stdio_with_command() -> None:
+    config = _resolve_config(
+        posthog_url="",
+        posthog_mode="stdio",
+        posthog_token="",
+        posthog_command="npx",
+        posthog_args=["-y", "@posthog/mcp-server"],
+    )
+    assert config is not None
+    assert config.mode == "stdio"
+    assert config.command == "npx"
 
 
 def test_list_tools_returns_discovered_tools() -> None:


### PR DESCRIPTION
## Summary

Two related changes, motivated by the routing-scenario test gap write-up in `docs/routing-scenario-test-gap.md`:

1. **Planner dispatches investigations for integration-backed diagnostic prompts.** The LLM action planner now emits `investigation_start` (with synthesized `alert_text`) for "figure out why X is broken" / "query sentry/github/posthog to find the cause" prompts **when at least one integration is connected** (the "Option A" gate). Explicit "investigate this" instructions still dispatch regardless of integrations; with **no** integration connected, diagnostic questions stay a handoff so we never start a sourceless RCA. A new `CONNECTED INTEGRATIONS` line in the planner prompt surfaces the session's integration set so the model can apply the gate.

2. **Closes the routing-scenario-oracle gap** that let live-execution failures pass silently. The oracle now seeds `resolved_integrations` and records gather-loop tool calls; scenario fixtures gain `resolved_integrations` and `gathered_tools_contract`; `313`/`314` are rewritten as the no-integration **handoff control** and the integration-backed **dispatch** case respectively.

Also folds in `fix(posthog-mcp)`: harden `_resolve_config` against planner-supplied transports (normalize more `mode` aliases, drop un-honorable transports) so the original `PostHogMCPConfig mode input_value='mcp'` validation error can't recur.

## Behavior-change note

This is an intentional product-behavior change that overrides the prior "handoff for freeform" design for the specific case of *diagnostic questions with connected integrations*. Implemented by correcting planner behavior (not by forcing deterministic routing), per `live-routing-tests.mdc`. Blast-radius audit: the only existing scenario with connected integrations + investigation intent is `314`; all other integration-backed scenarios are discovery/docs/slash, and all no-integration freeform scenarios stay handoff.

## Test plan

- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] PostHog MCP unit tests, planner unit tests, fixture-integrity, deterministic routing (107 passed)
- [x] Live routing subset `-k "313 or 314"` (planning + oracle, runs:5) green: `313` hands off, `314` dispatches an investigation
- [ ] CI green

Made with [Cursor](https://cursor.com)