### PR TITLE
fix(agent): stop investigation loop from re-running identical tool calls

### DIFF
--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 from collections.abc import Callable
 from typing import Any
@@ -65,6 +66,60 @@ _ALERT_SOURCE_TO_TOOL_SOURCES: dict[str, list[str]] = {
     "jenkins": ["jenkins"],
     "tempo": ["tempo"],
 }
+
+# Consecutive iterations made up ENTIRELY of duplicate (already-seen) tool calls
+# that we tolerate before forcing the agent to conclude. Re-running a tool with
+# identical arguments returns the same data, so a model that loops on duplicates
+# makes no progress yet still burns the whole MAX_INVESTIGATION_LOOPS budget. The
+# failure mode is made worse by context trimming (app/agent/tool_loop.py), which
+# drops the oldest tool exchanges to fit the window and can erase the very
+# history that would otherwise remind the model it already has the result.
+_MAX_STAGNANT_ITERATIONS = 2
+
+# Injected as a user turn once the agent starts repeating itself, steering it to
+# stop gathering and write the diagnosis from what it already has.
+_STAGNATION_NUDGE = (
+    "You are repeating tool calls you already made, so they return no new "
+    "information and the investigation is not progressing. Stop calling tools and "
+    "write your final diagnosis from the evidence already gathered: root cause, "
+    "root cause category, supporting evidence, validated and non-validated claims, "
+    "remediation steps, and a validity score. If the evidence is insufficient to "
+    "determine a root cause, say so explicitly and use a low validity score."
+)
+
+
+def _tool_call_signature(tool_call: ToolCall) -> str:
+    """Stable identity for a tool call: ``name`` + canonicalised arguments.
+
+    Two calls to the same tool with the same arguments (regardless of key order)
+    produce the same signature. Used to detect when the model re-requests a query
+    it has already run so the runtime can refuse to re-execute it.
+    """
+    try:
+        args = json.dumps(tool_call.input, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        args = repr(tool_call.input)
+    return f"{tool_call.name}::{args}"
+
+
+def _duplicate_call_result(tool_call: ToolCall) -> dict[str, Any]:
+    """Synthetic result returned in place of re-running an already-seen call.
+
+    Keeps the provider tool_use/tool_result contract valid (every requested call
+    still gets a result) while telling the model, in the result itself, that the
+    repeat was skipped and what to do instead.
+    """
+    return {
+        "suppressed_duplicate": True,
+        "tool": tool_call.name,
+        "note": (
+            f"Skipped: '{tool_call.name}' was already called earlier in this "
+            "investigation with identical arguments, so re-running it would return "
+            "the same data. Do not call it again. Either call a DIFFERENT tool (or "
+            "the same tool with DIFFERENT arguments) to gather new evidence, or "
+            "write your final diagnosis."
+        ),
+    }
 
 
 class ConnectedInvestigationAgent:
@@ -183,6 +238,10 @@ class ConnectedInvestigationAgent:
         evidence: dict[str, Any] = {}
         evidence_entries: list[EvidenceEntry] = []
         executed_hypotheses: list[dict[str, Any]] = []
+        # Tool-call signatures already executed. Tracked in Python (not in the
+        # message history) so it survives context trimming and reliably catches
+        # repeats even after the conversation is trimmed to fit the window.
+        seen_signatures: set[str] = set()
 
         _emit(
             "agent_start",
@@ -200,6 +259,7 @@ class ConnectedInvestigationAgent:
         if seed_calls:
             logger.debug("[agent] seeding %d primary tool calls before LLM loop", len(seed_calls))
             for tc in seed_calls:
+                seen_signatures.add(_tool_call_signature(tc))
                 _record_tool_start(tc)
             executed_hypotheses.append(
                 {
@@ -235,14 +295,20 @@ class ConnectedInvestigationAgent:
         # ceiling overflows smaller-window models (e.g. gpt-4o at 128k) because
         # trimming "down to" an Anthropic-sized ceiling still exceeds their cap.
         context_ceiling = _context_budget_ceiling_for_model(getattr(llm, "_model", None))
+        # Consecutive iterations that produced no fresh (non-duplicate) tool call.
+        stagnant_iterations = 0
+        # Once set, the next invoke offers no tools so the model is forced to emit
+        # a textual diagnosis instead of looping on repeats.
+        force_conclusion = False
         for iteration in range(MAX_INVESTIGATION_LOOPS):
             logger.debug("[agent] iteration=%d", iteration)
             _emit("llm_start", {"iteration": iteration})
+            active_tool_schemas: list[dict[str, Any]] = [] if force_conclusion else tool_schemas
             _enforce_context_budget(
-                messages, system=system, tools=tool_schemas, ceiling=context_ceiling
+                messages, system=system, tools=active_tool_schemas, ceiling=context_ceiling
             )
             try:
-                response = llm.invoke(messages, system=system, tools=tool_schemas)
+                response = llm.invoke(messages, system=system, tools=active_tool_schemas)
 
             except Exception as err:
                 failure = classify_llm_invoke_failure(err)
@@ -287,23 +353,41 @@ class ConnectedInvestigationAgent:
                 messages.append({"role": "user", "content": nudge})
                 continue
 
-            # Emit tool_start for each pending call before executing
-            for tc in response.tool_calls:
+            # Split requested calls into fresh ones (not seen before) and repeats.
+            # Repeats are NOT re-executed — they get a synthetic "already ran this"
+            # result so the provider's tool_use/tool_result contract stays valid
+            # while steering the model off the loop.
+            duplicate_flags = [
+                _tool_call_signature(tc) in seen_signatures for tc in response.tool_calls
+            ]
+            fresh_calls = [
+                tc for tc, is_dup in zip(response.tool_calls, duplicate_flags) if not is_dup
+            ]
+            for tc in fresh_calls:
+                seen_signatures.add(_tool_call_signature(tc))
                 _record_tool_start(tc)
+
             executed_hypotheses.append(
                 {
                     "hypothesis": f"Agent iteration {iteration}",
-                    "actions": [tc.name for tc in response.tool_calls],
+                    "actions": [tc.name for tc in fresh_calls],
                     "loop_iteration": iteration,
                 }
             )
 
-            results = _run_parallel(response.tool_calls, tools, resolved)
+            fresh_results = iter(_run_parallel(fresh_calls, tools, resolved) if fresh_calls else [])
+            results = [
+                _duplicate_call_result(tc) if is_dup else next(fresh_results)
+                for tc, is_dup in zip(response.tool_calls, duplicate_flags)
+            ]
 
             tool_result_messages = _build_tool_result_messages(llm, response.tool_calls, results)
             messages.extend(tool_result_messages)
 
-            for tc, output in zip(response.tool_calls, results):
+            for tc, output, is_dup in zip(response.tool_calls, results, duplicate_flags):
+                if is_dup:
+                    debug_print(f"[{tc.name}] → duplicate call suppressed")
+                    continue
                 _merge_tool_evidence(evidence, tc.name, output, tc.input)
                 evidence_entries.append(
                     EvidenceEntry(
@@ -317,6 +401,22 @@ class ConnectedInvestigationAgent:
                 )
                 _record_tool_end(tc, output)
                 debug_print(f"[{tc.name}] → {_summarise(output)}")
+
+            # Stagnation breaker: an iteration with no fresh calls gathered no new
+            # evidence. Tolerate a couple (the nudge often unsticks the model) then
+            # force a tool-free conclusion rather than spinning to the loop cap.
+            if fresh_calls:
+                stagnant_iterations = 0
+            else:
+                stagnant_iterations += 1
+                messages.append({"role": "user", "content": _STAGNATION_NUDGE})
+                if stagnant_iterations >= _MAX_STAGNANT_ITERATIONS:
+                    logger.warning(
+                        "[agent] %d consecutive duplicate-only iterations — forcing "
+                        "tool-free conclusion before MAX_INVESTIGATION_LOOPS",
+                        stagnant_iterations,
+                    )
+                    force_conclusion = True
         else:
             logger.warning(
                 "[agent] hit MAX_INVESTIGATION_LOOPS=%d without finishing",

--- a/app/agent/prompt.py
+++ b/app/agent/prompt.py
@@ -25,6 +25,10 @@ Your task: investigate the alert below and produce a clear, evidence-backed root
 - If all evidence points to healthy service, say so clearly (root_cause_category = healthy).
 - Be specific: include error messages, timestamps, service names, namespaces, run IDs.
 - **Only call tools listed under "Available tools".** Do not fabricate tool calls for integrations not listed.
+- **Never call the same tool with the same arguments twice.** You already have that result — re-running it returns nothing new and wastes the investigation. Re-running is only useful with *different* arguments (e.g. a different service, time window, or query).
+- **Discovery or listing tools (those that just enumerate other tools or resources) are useful at most once.** Call such a tool a single time, then act on what it returned — do not keep re-listing.
+- **Prefer tools relevant to the alert.** Do not fan out to integrations unrelated to the alert's service or symptoms just because they are available.
+- **If your recent tool calls stopped producing new evidence, stop investigating and write your diagnosis** with whatever you have, rather than repeating calls.
 
 ## What to produce at the end
 

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sys
 import types
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,7 +11,10 @@ import pytest
 from app.agent.investigation import (
     ConnectedInvestigationAgent,
     _availability_view,
+    _duplicate_call_result,
+    _tool_call_signature,
 )
+from app.agent.result import InvestigationResult
 from app.agent.tool_loop import (
     _build_synthetic_assistant_tool_call_msg,
     _context_budget_ceiling_for_model,
@@ -761,6 +765,164 @@ def test_enforce_context_budget_returns_when_only_untruncatable_overhead() -> No
     _enforce_context_budget(messages, tools=tools, ceiling=ceiling)
 
     assert messages == [{"role": "user", "content": "tiny"}]
+
+
+# --------------------------------------------------------------------------- #
+# Duplicate-call guard + stagnation breaker. The 2026-06-18 report showed a    #
+# generic alert spinning to MAX_INVESTIGATION_LOOPS while re-running           #
+# list_posthog_tools x15 / get_sre_guidance x14 — identical calls that return  #
+# no new evidence. Context trimming erases the history that would remind the   #
+# model it already ran them, so the dedup ledger is tracked in Python instead. #
+# --------------------------------------------------------------------------- #
+
+
+def test_tool_call_signature_is_argument_order_independent() -> None:
+    a = ToolCall(id="1", name="query", input={"service": "x", "window": "1h"})
+    b = ToolCall(id="2", name="query", input={"window": "1h", "service": "x"})
+    c = ToolCall(id="3", name="query", input={"service": "y", "window": "1h"})
+
+    assert _tool_call_signature(a) == _tool_call_signature(b)
+    assert _tool_call_signature(a) != _tool_call_signature(c)
+
+
+def test_duplicate_call_result_marks_suppression() -> None:
+    result = _duplicate_call_result(ToolCall(id="1", name="list_posthog_tools", input={}))
+    assert result["suppressed_duplicate"] is True
+    assert result["tool"] == "list_posthog_tools"
+    assert "already" in result["note"].lower()
+
+
+def _fake_tool(name: str, *, source: str = "posthog_mcp") -> MagicMock:
+    tool = MagicMock()
+    tool.name = name
+    tool.source = source
+    tool.validate_public_input.return_value = None
+    tool.extract_params.return_value = {}
+    tool.run.return_value = {"ok": True, "tool": name}
+    return tool
+
+
+def _tool_call_response(tool_calls: list[ToolCall]) -> MagicMock:
+    response = MagicMock()
+    response.tool_calls = tool_calls
+    response.has_tool_calls = True
+    response.content = ""
+    response.raw_content = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": tc.id,
+                "type": "function",
+                "function": {"name": tc.name, "arguments": json.dumps(tc.input)},
+            }
+            for tc in tool_calls
+        ],
+    }
+    return response
+
+
+def _text_response(text: str) -> MagicMock:
+    response = MagicMock()
+    response.tool_calls = []
+    response.has_tool_calls = False
+    response.content = text
+    response.raw_content = {"role": "assistant", "content": text}
+    return response
+
+
+def _run_agent_with_scripted_llm(
+    *,
+    invoke: Any,
+    tools: list[MagicMock],
+) -> tuple[dict[str, Any], MagicMock]:
+    mock_llm = MagicMock()
+    mock_llm._model = "gpt-4o"
+    mock_llm.tool_schemas.return_value = [{"name": t.name} for t in tools]
+    mock_llm.invoke.side_effect = invoke
+    mock_llm.build_tool_result_message.side_effect = lambda _calls, results: {
+        "role": "user",
+        "content": json.dumps(results, default=str),
+    }
+
+    state = {
+        "alert_name": "Test alert",
+        "pipeline_name": "test-pipeline",
+        "severity": "critical",
+        "resolved_integrations": {},
+    }
+
+    with (
+        patch("app.agent.investigation.get_agent_llm", return_value=mock_llm),
+        patch("app.agent.investigation.get_tracker", return_value=MagicMock()),
+        patch("app.agent.investigation._get_available_tools", return_value=tools),
+        patch(
+            "app.agent.investigation.parse_diagnosis",
+            return_value=InvestigationResult(root_cause="done", root_cause_category="unknown"),
+        ),
+    ):
+        result = ConnectedInvestigationAgent().run(state)
+    return result, mock_llm
+
+
+def test_run_suppresses_duplicate_tool_calls() -> None:
+    """A tool re-requested with identical arguments is NOT executed again."""
+    tool = _fake_tool("list_posthog_tools")
+    responses = [
+        _tool_call_response([ToolCall(id="c1", name="list_posthog_tools", input={})]),
+        # identical call — must be suppressed, not re-run
+        _tool_call_response([ToolCall(id="c2", name="list_posthog_tools", input={})]),
+        _text_response("Final diagnosis."),
+    ]
+
+    result, mock_llm = _run_agent_with_scripted_llm(invoke=responses, tools=[tool])
+
+    # Executed exactly once despite being requested twice.
+    assert tool.run.call_count == 1
+    # The duplicate got a synthetic suppression result fed back to the model.
+    assert any(
+        isinstance(m.get("content"), str) and "suppressed_duplicate" in m["content"]
+        for m in result["agent_messages"]
+    )
+    assert mock_llm.invoke.call_count == 3
+
+
+def test_run_does_not_suppress_calls_with_different_args() -> None:
+    """Same tool, different arguments is legitimate and must still execute."""
+    tool = _fake_tool("query_logs")
+    responses = [
+        _tool_call_response([ToolCall(id="c1", name="query_logs", input={"svc": "a"})]),
+        _tool_call_response([ToolCall(id="c2", name="query_logs", input={"svc": "b"})]),
+        _text_response("Final diagnosis."),
+    ]
+
+    tool_run = _run_agent_with_scripted_llm(invoke=responses, tools=[tool])[0]
+    assert tool.run.call_count == 2
+    assert tool_run["root_cause"] == "done"
+
+
+def test_run_forces_conclusion_when_stuck_repeating() -> None:
+    """A model that loops on the same call is forced to conclude well before
+    MAX_INVESTIGATION_LOOPS=20. When the runtime offers no tools (the forced
+    conclusion turn), the model must produce its diagnosis."""
+    tool = _fake_tool("get_sre_guidance", source="knowledge")
+
+    def invoke(messages: Any, system: Any, tools: Any) -> MagicMock:  # noqa: ARG001
+        # No tools offered → forced conclusion turn → return text.
+        if not tools:
+            return _text_response("Final diagnosis: insufficient evidence.")
+        # Stubborn model: always re-requests the same call.
+        return _tool_call_response([ToolCall(id="c", name="get_sre_guidance", input={})])
+
+    result, mock_llm = _run_agent_with_scripted_llm(invoke=invoke, tools=[tool])
+
+    # Ran the real tool exactly once (first, fresh); every repeat was suppressed.
+    assert tool.run.call_count == 1
+    # Converged far below the 20-iteration cap instead of spinning.
+    assert mock_llm.invoke.call_count < 6
+    # The final forced turn was invoked with NO tools.
+    assert mock_llm.invoke.call_args_list[-1].kwargs["tools"] == []
+    assert result["root_cause"] == "done"
 
 
 def test_truncate_content_distributes_across_multiple_blocks() -> None:


### PR DESCRIPTION
## Summary

From a default/generic sample alert, the core agentic investigation loop spun to `MAX_INVESTIGATION_LOOPS=20` while repeatedly calling the same tools (e.g. `list posthog tools` x15, `SRE runbook` x14), picking tools unrelated to the alert and producing no usable diagnosis.

Root cause: the ReAct loop in `app/agent/investigation.py` had **no guard against the model re-requesting the same tool with the same arguments**, and `_run_parallel` blindly re-executed every requested call. Context trimming (`app/agent/tool_loop.py`) made this worse — to fit the model window it drops the oldest tool exchanges (the registry's 100+ tool schemas consume a large fixed budget at the 112k ceiling), so the model literally lost the history that would have reminded it those calls were already made, and re-issued them.

## What changed (core investigation workflow only)

- **Duplicate-call guard.** Track executed tool-call signatures (`name` + canonicalised args) in Python so the ledger survives context trimming. A call already seen is **not** re-executed; it gets a synthetic `suppressed_duplicate` result fed back to the model (keeping the provider `tool_use`/`tool_result` contract valid) telling it to do something different or conclude.
- **Stagnation breaker.** After `_MAX_STAGNANT_ITERATIONS` consecutive duplicate-only iterations, inject a "stop and conclude" nudge and force the next turn with **no tools offered**, so the model must emit a textual diagnosis instead of burning the full loop budget.
- **Prompt hardening** (`app/agent/prompt.py`): explicit rules to never repeat a tool with identical args, call discovery/listing tools at most once, prefer alert-relevant tools, and stop when calls stop producing new evidence.

No tools or interactive-shell code were modified, per request.

## Test plan

- [x] `tests/agent/test_investigation.py` — new tests: signature equality is arg-order-independent; duplicate calls suppressed (executed once); different-arg calls still execute; stuck/repeating model is forced to conclude in <6 iterations with a tool-free final turn.
- [x] `make`-equivalent checks on edited files: `ruff check`, `ruff format --check`, `mypy` all clean.
- [x] `pytest tests/agent/ tests/pipeline/` — 73 passed.

Made with [Cursor](https://cursor.com)