### PR TITLE
fix(posthog-mcp): return a bounded, filterable tool listing

### DIFF
--- a/app/tools/PostHogMCPTool/__init__.py
+++ b/app/tools/PostHogMCPTool/__init__.py
@@ -9,6 +9,8 @@ or renames individual MCP-side tools.
 
 from __future__ import annotations
 
+import re
+
 from app.integrations.posthog_mcp import (
     PostHogMCPConfig,
     PostHogMCPToolCallResult,
@@ -30,6 +32,110 @@ PostHogMCPParams = dict[str, object]
 PostHogMCPResponse = dict[str, object]
 
 _COMPONENT = "app.tools.PostHogMCPTool"
+
+# The hosted PostHog MCP server exposes 240+ tools, each carrying a full JSON
+# input schema. Returning every tool with its schema produces a payload that is
+# multiple times larger than any model's context window (~580k estimated tokens
+# observed against the live server), so the agent's context-budget enforcer
+# trims the result away before the model ever sees a single tool name. The
+# model then loops re-calling this tool and guesses tool names that don't exist.
+# To stay well under the budget we return a compact, bounded listing by default
+# (names + truncated descriptions, no schemas) and let the caller narrow with a
+# filter or pull the full schema for a small, specific set of tools.
+_MAX_DESCRIPTION_CHARS = 160
+_MAX_TOOLS_RETURNED = 80
+_MAX_SCHEMAS_RETURNED = 15
+
+
+def _truncate_description(description: str) -> str:
+    cleaned = " ".join(description.split())
+    if len(cleaned) <= _MAX_DESCRIPTION_CHARS:
+        return cleaned
+    return cleaned[: _MAX_DESCRIPTION_CHARS - 1].rstrip() + "\u2026"
+
+
+def _filter_tools(
+    tools: list[dict[str, object]],
+    name_filter: str,
+) -> list[dict[str, object]]:
+    """Keep tools whose name or description matches any whitespace/comma term."""
+    terms = [term for term in re.split(r"[,\s]+", name_filter.lower()) if term]
+    if not terms:
+        return tools
+    matched: list[dict[str, object]] = []
+    for descriptor in tools:
+        haystack = f"{descriptor.get('name', '')} {descriptor.get('description', '')}".lower()
+        if any(term in haystack for term in terms):
+            matched.append(descriptor)
+    return matched
+
+
+def _summarize_tool(
+    descriptor: dict[str, object],
+    *,
+    include_schema: bool,
+) -> dict[str, object]:
+    summary: dict[str, object] = {
+        "name": str(descriptor.get("name", "")).strip(),
+        "description": _truncate_description(str(descriptor.get("description", "") or "")),
+    }
+    schema = descriptor.get("input_schema")
+    if include_schema and schema is not None:
+        summary["input_schema"] = schema
+    return summary
+
+
+def _build_tool_listing(
+    tools: list[dict[str, object]],
+    *,
+    name_filter: str | None,
+    include_schema: bool,
+) -> dict[str, object]:
+    """Render a bounded, model-safe view of the discovered MCP tools."""
+    total = len(tools)
+    filtered = _filter_tools(tools, name_filter) if name_filter else list(tools)
+    returned = filtered[:_MAX_TOOLS_RETURNED]
+    # Only attach full schemas when the result set is small enough that doing so
+    # keeps the payload bounded. Otherwise schemas would reintroduce the very
+    # context blow-up this listing exists to prevent.
+    attach_schema = include_schema and len(returned) <= _MAX_SCHEMAS_RETURNED
+
+    summaries = [
+        _summarize_tool(descriptor, include_schema=attach_schema) for descriptor in returned
+    ]
+    notes: list[str] = []
+    if len(filtered) > len(returned):
+        notes.append(
+            f"Showing {len(returned)} of {len(filtered)} matching tools; "
+            "pass name_filter to narrow the list."
+        )
+    elif total > len(returned):
+        notes.append(
+            f"Showing {len(returned)} of {total} tools; pass name_filter "
+            "(e.g. 'events query sql') to narrow the list."
+        )
+    if include_schema and not attach_schema:
+        notes.append(
+            "input_schema omitted because too many tools matched; narrow to "
+            f"{_MAX_SCHEMAS_RETURNED} or fewer tools with name_filter to include schemas."
+        )
+    if not include_schema:
+        notes.append(
+            "Schemas omitted to save context; call again with include_schema=true and a "
+            "name_filter once you know which tool you need."
+        )
+
+    listing: dict[str, object] = {
+        "total_tools": total,
+        "matched_tools": len(filtered),
+        "returned_tools": len(summaries),
+        "tools": summaries,
+    }
+    if name_filter:
+        listing["name_filter"] = name_filter
+    if notes:
+        listing["notes"] = " ".join(notes)
+    return listing
 
 
 def _string_list(value: object) -> list[str]:
@@ -158,15 +264,37 @@ def _normalize_tool_result(result: PostHogMCPToolCallResult) -> PostHogMCPRespon
 @tool(
     name="list_posthog_tools",
     source="posthog_mcp",
-    description="List the tools exposed by the configured PostHog MCP server.",
+    description=(
+        "List the tools exposed by the configured PostHog MCP server. The server "
+        "exposes 240+ tools, so this returns a compact, bounded listing (names + "
+        "short descriptions, no schemas). Pass name_filter (e.g. 'events query sql') "
+        "to narrow the list, and include_schema=true on a narrowed list to fetch the "
+        "input schema of the specific tool you intend to call. To query events, call "
+        "call_posthog_tool with tool_name='execute-sql' and a HogQL query."
+    ),
     use_cases=[
         "Discovering which PostHog MCP tools are available before calling one",
-        "Confirming whether analytics, feature-flag, or error-tracking tools are exposed",
+        "Finding the right tool for a task by passing a name_filter (e.g. 'events query sql')",
+        "Fetching the input schema of a specific tool with include_schema before calling it",
     ],
     surfaces=("investigation", "chat"),
     input_schema={
         "type": "object",
         "properties": {
+            "name_filter": {
+                "type": "string",
+                "description": (
+                    "Optional space- or comma-separated terms; tools whose name or "
+                    "description contains any term are returned (e.g. 'events query sql')."
+                ),
+            },
+            "include_schema": {
+                "type": "boolean",
+                "description": (
+                    "Include each tool's full input_schema. Only honored when the "
+                    "(filtered) result set is small; narrow with name_filter first."
+                ),
+            },
             "posthog_url": {"type": "string"},
             "posthog_mode": {"type": "string"},
             "posthog_token": {"type": "string"},
@@ -190,6 +318,8 @@ def _normalize_tool_result(result: PostHogMCPToolCallResult) -> PostHogMCPRespon
     extract_params=_posthog_mcp_extract_params,
 )
 def list_posthog_tools(
+    name_filter: str | None = None,
+    include_schema: bool = False,
     posthog_url: str | None = None,
     posthog_mode: str | None = None,
     posthog_token: str | None = None,
@@ -197,7 +327,12 @@ def list_posthog_tools(
     posthog_args: list[str] | None = None,
     **_kwargs: object,
 ) -> PostHogMCPResponse:
-    """List tools available from the configured PostHog MCP server."""
+    """List tools available from the configured PostHog MCP server.
+
+    Returns a compact, bounded view by default so the listing never overflows the
+    agent's context budget (the live server's full schema dump is ~580k estimated
+    tokens, multiples of any model's context window).
+    """
     config = _resolve_config(
         posthog_url,
         posthog_mode,
@@ -231,12 +366,17 @@ def list_posthog_tools(
         payload["tools"] = []
         return payload
 
+    listing = _build_tool_listing(
+        [dict(descriptor) for descriptor in tools],
+        name_filter=(name_filter or "").strip() or None,
+        include_schema=bool(include_schema),
+    )
     return {
         "source": "posthog_mcp",
         "available": True,
         "transport": config.mode,
         "endpoint": config.command if config.mode == "stdio" else config.url,
-        "tools": tools,
+        **listing,
     }
 
 

--- a/docs/posthog-mcp.mdx
+++ b/docs/posthog-mcp.mdx
@@ -11,10 +11,17 @@ This is distinct from the PostHog bounce-rate integration, which is a narrow RES
 
 | Tool | What it does |
 | --- | --- |
-| `list_posthog_tools` | List the tools the connected PostHog MCP server exposes |
+| `list_posthog_tools` | List the tools the connected PostHog MCP server exposes (compact, filterable) |
 | `call_posthog_tool` | Call a named PostHog MCP tool (e.g. run a HogQL query, list feature flags, inspect an error) |
 
 The agent typically calls `list_posthog_tools` first to discover what is available for your project, then `call_posthog_tool` with the chosen tool name and arguments.
+
+The hosted PostHog MCP server exposes 240+ tools, each with a full input schema. Returning all of them at once is far larger than any model's context window, so `list_posthog_tools` returns a **compact, bounded listing** — tool names plus short descriptions, without schemas. To work with it efficiently:
+
+- Pass `name_filter` (space- or comma-separated terms, e.g. `"events query sql"`) to narrow the list to relevant tools.
+- Pass `include_schema=true` on a narrowed list to fetch the full input schema for the specific tool you intend to call.
+
+To query events for a person or across a project, call `call_posthog_tool` with `tool_name="execute-sql"` and a HogQL query (e.g. `SELECT event, count() FROM events WHERE ... GROUP BY event`). There is no `search_events` tool.
 
 ## Prerequisites
 

--- a/tests/tools/test_posthog_mcp_tool.py
+++ b/tests/tools/test_posthog_mcp_tool.py
@@ -57,9 +57,14 @@ def test_call_tool_public_schema_exposes_only_tool_selection() -> None:
     assert rt.public_input_schema.get("required") == ["tool_name"]
 
 
-def test_list_tool_public_schema_takes_no_model_args() -> None:
+def test_list_tool_public_schema_exposes_only_filter_controls() -> None:
+    """The model may steer discovery (filter + schema toggle) but must never see
+    connection/transport params — those are injected from the verified config.
+    """
     rt = list_posthog_tools.__opensre_registered_tool__
-    assert set(rt.public_input_schema.get("properties", {})) == set()
+    public_props = set(rt.public_input_schema.get("properties", {}))
+    assert public_props == {"name_filter", "include_schema"}
+    assert public_props.isdisjoint(_CONNECTION_PARAMS)
 
 
 def test_validate_public_input_rejects_model_supplied_connection_params() -> None:
@@ -213,9 +218,12 @@ def test_resolve_config_keeps_explicit_stdio_with_command() -> None:
     assert config.command == "npx"
 
 
-def test_list_tools_returns_discovered_tools() -> None:
+def test_list_tools_returns_compact_summaries_without_schema() -> None:
+    """Default listing drops input_schema and truncates descriptions so the
+    payload cannot overflow the agent's context budget.
+    """
     fake_tools = [
-        {"name": "query-run", "description": "Run HogQL", "input_schema": {}},
+        {"name": "execute-sql", "description": "Run HogQL", "input_schema": {"a": 1}},
     ]
     with patch(
         "app.tools.PostHogMCPTool.list_posthog_mcp_server_tools",
@@ -227,5 +235,100 @@ def test_list_tools_returns_discovered_tools() -> None:
             posthog_token="phx_secret",
         )
     assert result["available"] is True
-    assert result["tools"] == fake_tools
     assert result["transport"] == "streamable-http"
+    assert result["total_tools"] == 1
+    assert result["returned_tools"] == 1
+    assert result["tools"] == [{"name": "execute-sql", "description": "Run HogQL"}]
+    assert "input_schema" not in result["tools"][0]
+
+
+def _many_fake_tools(count: int) -> list[dict[str, object]]:
+    return [
+        {"name": f"tool-{i:03d}", "description": f"desc {i}", "input_schema": {"i": i}}
+        for i in range(count)
+    ]
+
+
+def test_list_tools_caps_large_listing_and_notes_truncation() -> None:
+    with patch(
+        "app.tools.PostHogMCPTool.list_posthog_mcp_server_tools",
+        return_value=_many_fake_tools(244),
+    ):
+        result = list_posthog_tools(
+            posthog_url="https://mcp.posthog.com/mcp",
+            posthog_token="phx_secret",
+        )
+    assert result["total_tools"] == 244
+    # Bounded well under the full set to keep the payload small.
+    assert result["returned_tools"] <= 80
+    assert len(result["tools"]) == result["returned_tools"]
+    assert "name_filter" in str(result.get("notes", ""))
+
+
+def test_list_tools_filters_by_name_or_description() -> None:
+    fake_tools = [
+        {"name": "execute-sql", "description": "Run HogQL", "input_schema": {}},
+        {"name": "feature-flag-get-all", "description": "List flags", "input_schema": {}},
+        {"name": "query-trends", "description": "Trend query over events", "input_schema": {}},
+    ]
+    with patch(
+        "app.tools.PostHogMCPTool.list_posthog_mcp_server_tools",
+        return_value=fake_tools,
+    ):
+        result = list_posthog_tools(
+            name_filter="events query sql",
+            posthog_url="https://mcp.posthog.com/mcp",
+            posthog_token="phx_secret",
+        )
+    names = {t["name"] for t in result["tools"]}
+    assert names == {"execute-sql", "query-trends"}
+    assert result["matched_tools"] == 2
+    assert result["name_filter"] == "events query sql"
+
+
+def test_list_tools_includes_schema_only_for_narrow_results() -> None:
+    fake_tools = [
+        {"name": "execute-sql", "description": "Run HogQL", "input_schema": {"q": "str"}},
+        {"name": "query-trends", "description": "Trends", "input_schema": {"t": "str"}},
+    ]
+    with patch(
+        "app.tools.PostHogMCPTool.list_posthog_mcp_server_tools",
+        return_value=fake_tools,
+    ):
+        result = list_posthog_tools(
+            name_filter="execute-sql",
+            include_schema=True,
+            posthog_url="https://mcp.posthog.com/mcp",
+            posthog_token="phx_secret",
+        )
+    assert result["returned_tools"] == 1
+    assert result["tools"][0]["input_schema"] == {"q": "str"}
+
+
+def test_list_tools_omits_schema_when_too_many_match() -> None:
+    with patch(
+        "app.tools.PostHogMCPTool.list_posthog_mcp_server_tools",
+        return_value=_many_fake_tools(50),
+    ):
+        result = list_posthog_tools(
+            include_schema=True,
+            posthog_url="https://mcp.posthog.com/mcp",
+            posthog_token="phx_secret",
+        )
+    assert all("input_schema" not in t for t in result["tools"])
+    assert "input_schema omitted" in str(result.get("notes", ""))
+
+
+def test_list_tools_truncates_long_descriptions() -> None:
+    long_desc = "x" * 500
+    with patch(
+        "app.tools.PostHogMCPTool.list_posthog_mcp_server_tools",
+        return_value=[{"name": "execute-sql", "description": long_desc, "input_schema": {}}],
+    ):
+        result = list_posthog_tools(
+            posthog_url="https://mcp.posthog.com/mcp",
+            posthog_token="phx_secret",
+        )
+    description = result["tools"][0]["description"]
+    assert len(description) <= 160
+    assert description.endswith("\u2026")


### PR DESCRIPTION
## Summary

**Is PostHog MCP working from the interactive shell?** Yes — the connection is fine and it returns real data. I validated live against `https://mcp.posthog.com/mcp` (244 tools discovered) and ran a real `execute-sql` HogQL query that returned event data (`install_detected`, `$autocapture`, `$pageview`, …).

**So why did the session in the bug report fail?** The agent kept emitting `· gathering data via list_posthog_tools…` + `[agent] trimmed oldest tool pair to fit context budget (ceiling=112000)` in a loop, then guessed a non-existent tool `search_events` ("Tool search_events not found").

### Root cause

`list_posthog_tools` returned **all 244 tools with their full JSON input schemas**. Measured against the live server, that payload is **~1,162,708 chars ≈ 581k estimated tokens** — over **5x** any model's context window (ceiling ~112k). The agent's context-budget enforcer (`app/agent/tool_loop.py`) trims/truncates the largest message, so the giant tool-list result was discarded *before the model ever saw a single tool name*. With no usable tool list, the model:
- re-called `list_posthog_tools` repeatedly (the "trimmed oldest tool pair" spam), and
- guessed tool names that don't exist (`search_events`; the real one is `execute-sql`).

Even a name+description-only compaction (~131k tokens) still exceeds the ceiling, so simply dropping schemas isn't enough — the result must be capped.

### Fix

`list_posthog_tools` now returns a **compact, bounded listing**:
- Names + truncated (≤160 char) descriptions, **no schemas by default**.
- Capped at 80 tools, with `total_tools` / `matched_tools` / `returned_tools` counts and a `notes` hint.
- New `name_filter` (space/comma-separated terms matched against name + description, e.g. `"events query sql"`).
- New `include_schema` to pull full schemas, honored only when the (filtered) result set is ≤15 tools so the payload stays bounded.
- Description/use-cases now tell the model that events are queried via `call_posthog_tool(tool_name="execute-sql", ...)` with HogQL.

Connection/transport params remain injected from the verified config and hidden from the model (unchanged).

### Live impact (measured against the real server)

| Call | Est. tokens |
| --- | --- |
| Before (all tools + schemas) | ~581,000 |
| After, default | ~8,500 |
| After, `name_filter="events query sql"` | ~9,000 |
| After, `name_filter="execute-sql"` + `include_schema=true` (7 tools) | ~13,500 |

~68x smaller by default, comfortably under the budget, and discovery is still usable.

## Test plan

- [x] `tests/tools/test_posthog_mcp_tool.py` — 36 passed (updated public-schema test for the new `name_filter`/`include_schema` controls; added coverage for compaction, capping, filtering, schema-on-narrow, schema-omission-when-broad, and description truncation).
- [x] `ruff check` + `ruff format --check` + `mypy` clean on changed files.
- [x] Live validation: bounded payloads confirmed against `mcp.posthog.com`; `execute-sql` returns real events.

Made with [Cursor](https://cursor.com)