### PR TITLE
fix(tools): slim Sentry/OpenClaw MCP tool listings via shared listing helper

### DIFF
--- a/app/tools/OpenClawMCPTool/__init__.py
+++ b/app/tools/OpenClawMCPTool/__init__.py
@@ -18,6 +18,7 @@ from app.integrations.openclaw import (
 )
 from app.tools._telemetry import report_run_error
 from app.tools.tool_decorator import tool
+from app.tools.utils.mcp_tool_listing import build_mcp_tool_listing
 
 OpenClawParams = dict[str, object]
 OpenClawBridgeResponse = dict[str, object]
@@ -207,15 +208,36 @@ def _normalize_named_bridge_call(
 @tool(
     name="list_openclaw_tools",
     source="openclaw",
-    description="List tools exposed by the configured OpenClaw MCP bridge.",
+    description=(
+        "List tools exposed by the configured OpenClaw MCP bridge. Returns a "
+        "compact, bounded listing (names + short descriptions, no schemas) so it "
+        "never overflows the agent's context budget. Pass name_filter (e.g. "
+        "'conversation event permission') to narrow the list, and include_schema=true "
+        "on a narrowed list to fetch the input schema of the tool you intend to call."
+    ),
     use_cases=[
         "Inspecting which OpenClaw bridge tools are available before making a call",
-        "Confirming whether conversation, event, or permissions tools are exposed",
+        "Finding the right tool by passing a name_filter (e.g. 'conversation event permission')",
+        "Fetching the input schema of a specific tool with include_schema before calling it",
     ],
     surfaces=("investigation", "chat"),
     input_schema={
         "type": "object",
         "properties": {
+            "name_filter": {
+                "type": "string",
+                "description": (
+                    "Optional space- or comma-separated terms; tools whose name or "
+                    "description contains any term are returned (e.g. 'conversation event')."
+                ),
+            },
+            "include_schema": {
+                "type": "boolean",
+                "description": (
+                    "Include each tool's full input_schema. Only honored when the "
+                    "(filtered) result set is small; narrow with name_filter first."
+                ),
+            },
             "openclaw_url": {"type": "string"},
             "openclaw_mode": {"type": "string"},
             "openclaw_token": {"type": "string"},
@@ -228,6 +250,8 @@ def _normalize_named_bridge_call(
     extract_params=_openclaw_extract_params,
 )
 def list_openclaw_bridge_tools(
+    name_filter: str | None = None,
+    include_schema: bool = False,
     openclaw_url: str | None = None,
     openclaw_mode: str | None = None,
     openclaw_token: str | None = None,
@@ -235,7 +259,11 @@ def list_openclaw_bridge_tools(
     openclaw_args: list[str] | None = None,
     **_kwargs: object,
 ) -> OpenClawBridgeResponse:
-    """List tools available from the configured OpenClaw MCP bridge."""
+    """List tools available from the configured OpenClaw MCP bridge.
+
+    Returns a compact, bounded view by default so the listing never overflows the
+    agent's context budget.
+    """
     config = _resolve_config(
         openclaw_url,
         openclaw_mode,
@@ -269,12 +297,18 @@ def list_openclaw_bridge_tools(
         payload["tools"] = []
         return payload
 
+    listing = build_mcp_tool_listing(
+        [dict(descriptor) for descriptor in tools],
+        name_filter=(name_filter or "").strip() or None,
+        include_schema=bool(include_schema),
+        filter_example="conversation event permission",
+    )
     return {
         "source": "openclaw",
         "available": True,
         "transport": config.mode,
         "endpoint": config.command if config.mode == "stdio" else config.url,
-        "tools": tools,
+        **listing,
     }
 
 

--- a/app/tools/PostHogMCPTool/__init__.py
+++ b/app/tools/PostHogMCPTool/__init__.py
@@ -9,8 +9,6 @@ or renames individual MCP-side tools.
 
 from __future__ import annotations
 
-import re
-
 from app.integrations.posthog_mcp import (
     PostHogMCPConfig,
     PostHogMCPToolCallResult,
@@ -27,115 +25,12 @@ from app.integrations.posthog_mcp import (
 )
 from app.tools._telemetry import report_run_error
 from app.tools.tool_decorator import tool
+from app.tools.utils.mcp_tool_listing import build_mcp_tool_listing
 
 PostHogMCPParams = dict[str, object]
 PostHogMCPResponse = dict[str, object]
 
 _COMPONENT = "app.tools.PostHogMCPTool"
-
-# The hosted PostHog MCP server exposes 240+ tools, each carrying a full JSON
-# input schema. Returning every tool with its schema produces a payload that is
-# multiple times larger than any model's context window (~580k estimated tokens
-# observed against the live server), so the agent's context-budget enforcer
-# trims the result away before the model ever sees a single tool name. The
-# model then loops re-calling this tool and guesses tool names that don't exist.
-# To stay well under the budget we return a compact, bounded listing by default
-# (names + truncated descriptions, no schemas) and let the caller narrow with a
-# filter or pull the full schema for a small, specific set of tools.
-_MAX_DESCRIPTION_CHARS = 160
-_MAX_TOOLS_RETURNED = 80
-_MAX_SCHEMAS_RETURNED = 15
-
-
-def _truncate_description(description: str) -> str:
-    cleaned = " ".join(description.split())
-    if len(cleaned) <= _MAX_DESCRIPTION_CHARS:
-        return cleaned
-    return cleaned[: _MAX_DESCRIPTION_CHARS - 1].rstrip() + "\u2026"
-
-
-def _filter_tools(
-    tools: list[dict[str, object]],
-    name_filter: str,
-) -> list[dict[str, object]]:
-    """Keep tools whose name or description matches any whitespace/comma term."""
-    terms = [term for term in re.split(r"[,\s]+", name_filter.lower()) if term]
-    if not terms:
-        return tools
-    matched: list[dict[str, object]] = []
-    for descriptor in tools:
-        haystack = f"{descriptor.get('name', '')} {descriptor.get('description', '')}".lower()
-        if any(term in haystack for term in terms):
-            matched.append(descriptor)
-    return matched
-
-
-def _summarize_tool(
-    descriptor: dict[str, object],
-    *,
-    include_schema: bool,
-) -> dict[str, object]:
-    summary: dict[str, object] = {
-        "name": str(descriptor.get("name", "")).strip(),
-        "description": _truncate_description(str(descriptor.get("description", "") or "")),
-    }
-    schema = descriptor.get("input_schema")
-    if include_schema and schema is not None:
-        summary["input_schema"] = schema
-    return summary
-
-
-def _build_tool_listing(
-    tools: list[dict[str, object]],
-    *,
-    name_filter: str | None,
-    include_schema: bool,
-) -> dict[str, object]:
-    """Render a bounded, model-safe view of the discovered MCP tools."""
-    total = len(tools)
-    filtered = _filter_tools(tools, name_filter) if name_filter else list(tools)
-    returned = filtered[:_MAX_TOOLS_RETURNED]
-    # Only attach full schemas when the result set is small enough that doing so
-    # keeps the payload bounded. Otherwise schemas would reintroduce the very
-    # context blow-up this listing exists to prevent.
-    attach_schema = include_schema and len(returned) <= _MAX_SCHEMAS_RETURNED
-
-    summaries = [
-        _summarize_tool(descriptor, include_schema=attach_schema) for descriptor in returned
-    ]
-    notes: list[str] = []
-    if len(filtered) > len(returned):
-        notes.append(
-            f"Showing {len(returned)} of {len(filtered)} matching tools; "
-            "pass name_filter to narrow the list."
-        )
-    elif total > len(returned):
-        notes.append(
-            f"Showing {len(returned)} of {total} tools; pass name_filter "
-            "(e.g. 'events query sql') to narrow the list."
-        )
-    if include_schema and not attach_schema:
-        notes.append(
-            "input_schema omitted because too many tools matched; narrow to "
-            f"{_MAX_SCHEMAS_RETURNED} or fewer tools with name_filter to include schemas."
-        )
-    if not include_schema:
-        notes.append(
-            "Schemas omitted to save context; call again with include_schema=true and a "
-            "name_filter once you know which tool you need."
-        )
-
-    listing: dict[str, object] = {
-        "total_tools": total,
-        "matched_tools": len(filtered),
-        "returned_tools": len(summaries),
-        "tools": summaries,
-    }
-    if name_filter:
-        listing["name_filter"] = name_filter
-    if notes:
-        listing["notes"] = " ".join(notes)
-    return listing
 
 
 def _string_list(value: object) -> list[str]:
@@ -366,7 +261,7 @@ def list_posthog_tools(
         payload["tools"] = []
         return payload
 
-    listing = _build_tool_listing(
+    listing = build_mcp_tool_listing(
         [dict(descriptor) for descriptor in tools],
         name_filter=(name_filter or "").strip() or None,
         include_schema=bool(include_schema),

--- a/app/tools/SentryMCPTool/__init__.py
+++ b/app/tools/SentryMCPTool/__init__.py
@@ -25,6 +25,7 @@ from app.integrations.sentry_mcp import (
 )
 from app.tools._telemetry import report_run_error
 from app.tools.tool_decorator import tool
+from app.tools.utils.mcp_tool_listing import build_mcp_tool_listing
 
 SentryMCPParams = dict[str, object]
 SentryMCPResponse = dict[str, object]
@@ -141,15 +142,36 @@ def _normalize_tool_result(result: SentryMCPToolCallResult) -> SentryMCPResponse
 @tool(
     name="list_sentry_tools",
     source="sentry_mcp",
-    description="List the tools exposed by the configured Sentry MCP server.",
+    description=(
+        "List the tools exposed by the configured Sentry MCP server. Returns a "
+        "compact, bounded listing (names + short descriptions, no schemas) so it "
+        "never overflows the agent's context budget. Pass name_filter (e.g. "
+        "'issue event trace') to narrow the list, and include_schema=true on a "
+        "narrowed list to fetch the input schema of the tool you intend to call."
+    ),
     use_cases=[
         "Discovering which Sentry MCP tools are available before calling one",
-        "Confirming whether issue, event, trace, or Seer tools are exposed",
+        "Finding the right tool for a task by passing a name_filter (e.g. 'issue event trace')",
+        "Fetching the input schema of a specific tool with include_schema before calling it",
     ],
     surfaces=("investigation", "chat"),
     input_schema={
         "type": "object",
         "properties": {
+            "name_filter": {
+                "type": "string",
+                "description": (
+                    "Optional space- or comma-separated terms; tools whose name or "
+                    "description contains any term are returned (e.g. 'issue event trace')."
+                ),
+            },
+            "include_schema": {
+                "type": "boolean",
+                "description": (
+                    "Include each tool's full input_schema. Only honored when the "
+                    "(filtered) result set is small; narrow with name_filter first."
+                ),
+            },
             "sentry_url": {"type": "string"},
             "sentry_mode": {"type": "string"},
             "sentry_token": {"type": "string"},
@@ -162,6 +184,8 @@ def _normalize_tool_result(result: SentryMCPToolCallResult) -> SentryMCPResponse
     extract_params=_sentry_mcp_extract_params,
 )
 def list_sentry_tools(
+    name_filter: str | None = None,
+    include_schema: bool = False,
     sentry_url: str | None = None,
     sentry_mode: str | None = None,
     sentry_token: str | None = None,
@@ -169,7 +193,11 @@ def list_sentry_tools(
     sentry_args: list[str] | None = None,
     **_kwargs: object,
 ) -> SentryMCPResponse:
-    """List tools available from the configured Sentry MCP server."""
+    """List tools available from the configured Sentry MCP server.
+
+    Returns a compact, bounded view by default so the listing never overflows the
+    agent's context budget.
+    """
     config = _resolve_config(
         sentry_url,
         sentry_mode,
@@ -203,12 +231,18 @@ def list_sentry_tools(
         payload["tools"] = []
         return payload
 
+    listing = build_mcp_tool_listing(
+        [dict(descriptor) for descriptor in tools],
+        name_filter=(name_filter or "").strip() or None,
+        include_schema=bool(include_schema),
+        filter_example="issue event trace",
+    )
     return {
         "source": "sentry_mcp",
         "available": True,
         "transport": config.mode,
         "endpoint": config.command if config.mode == "stdio" else config.url,
-        "tools": tools,
+        **listing,
     }
 
 

--- a/app/tools/utils/mcp_tool_listing.py
+++ b/app/tools/utils/mcp_tool_listing.py
@@ -1,0 +1,128 @@
+"""Bounded, model-safe rendering of MCP server tool catalogs.
+
+MCP servers (PostHog, Sentry, OpenClaw, ...) can expose dozens to hundreds of
+tools, each carrying a full JSON input schema. A discovery tool that returns
+every tool *with* its schema produces a payload many times larger than any
+model's context window; the agent's context-budget enforcer then trims the
+listing away before the model sees a single tool name, and the model loops
+re-calling the discovery tool and guessing tool names that don't exist.
+
+This module renders a compact, bounded view by default (names + truncated
+descriptions, no schemas) and lets callers narrow with a name filter or pull
+the full schema for a small, specific set of tools. It is shared by every
+``list_*_tools`` MCP discovery tool so they behave identically.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Defaults sized to keep even a full catalog dump well under model context
+# windows (the live PostHog server alone is ~580k estimated tokens unbounded).
+MAX_DESCRIPTION_CHARS = 160
+MAX_TOOLS_RETURNED = 80
+MAX_SCHEMAS_RETURNED = 15
+
+
+def _truncate_description(description: str) -> str:
+    cleaned = " ".join(description.split())
+    if len(cleaned) <= MAX_DESCRIPTION_CHARS:
+        return cleaned
+    return cleaned[: MAX_DESCRIPTION_CHARS - 1].rstrip() + "\u2026"
+
+
+def _filter_tools(
+    tools: list[dict[str, object]],
+    name_filter: str,
+) -> list[dict[str, object]]:
+    """Keep tools whose name or description matches any whitespace/comma term."""
+    terms = [term for term in re.split(r"[,\s]+", name_filter.lower()) if term]
+    if not terms:
+        return tools
+    matched: list[dict[str, object]] = []
+    for descriptor in tools:
+        haystack = f"{descriptor.get('name', '')} {descriptor.get('description', '')}".lower()
+        if any(term in haystack for term in terms):
+            matched.append(descriptor)
+    return matched
+
+
+def _summarize_tool(
+    descriptor: dict[str, object],
+    *,
+    include_schema: bool,
+) -> dict[str, object]:
+    summary: dict[str, object] = {
+        "name": str(descriptor.get("name", "")).strip(),
+        "description": _truncate_description(str(descriptor.get("description", "") or "")),
+    }
+    schema = descriptor.get("input_schema")
+    if include_schema and schema is not None:
+        summary["input_schema"] = schema
+    return summary
+
+
+def build_mcp_tool_listing(
+    tools: list[dict[str, object]],
+    *,
+    name_filter: str | None,
+    include_schema: bool,
+    filter_example: str = "events query sql",
+) -> dict[str, object]:
+    """Render a bounded, model-safe view of discovered MCP tools.
+
+    ``filter_example`` only affects the human-readable ``notes`` hint so each
+    integration can suggest filter terms relevant to its own tool catalog.
+    """
+    total = len(tools)
+    filtered = _filter_tools(tools, name_filter) if name_filter else list(tools)
+    returned = filtered[:MAX_TOOLS_RETURNED]
+    # Only attach full schemas when the result set is small enough that doing so
+    # keeps the payload bounded. Otherwise schemas would reintroduce the very
+    # context blow-up this listing exists to prevent.
+    attach_schema = include_schema and len(returned) <= MAX_SCHEMAS_RETURNED
+
+    summaries = [
+        _summarize_tool(descriptor, include_schema=attach_schema) for descriptor in returned
+    ]
+    notes: list[str] = []
+    if len(filtered) > len(returned):
+        notes.append(
+            f"Showing {len(returned)} of {len(filtered)} matching tools; "
+            "pass name_filter to narrow the list."
+        )
+    elif total > len(returned):
+        notes.append(
+            f"Showing {len(returned)} of {total} tools; pass name_filter "
+            f"(e.g. '{filter_example}') to narrow the list."
+        )
+    if include_schema and not attach_schema:
+        notes.append(
+            "input_schema omitted because too many tools matched; narrow to "
+            f"{MAX_SCHEMAS_RETURNED} or fewer tools with name_filter to include schemas."
+        )
+    if not include_schema:
+        notes.append(
+            "Schemas omitted to save context; call again with include_schema=true and a "
+            "name_filter once you know which tool you need."
+        )
+
+    listing: dict[str, object] = {
+        "total_tools": total,
+        "matched_tools": len(filtered),
+        "returned_tools": len(summaries),
+        "tools": summaries,
+    }
+    if name_filter:
+        listing["name_filter"] = name_filter
+    if notes:
+        listing["notes"] = " ".join(notes)
+    return listing
+
+
+__all__ = [
+    "MAX_DESCRIPTION_CHARS",
+    "MAX_SCHEMAS_RETURNED",
+    "MAX_TOOLS_RETURNED",
+    "build_mcp_tool_listing",
+]

--- a/tests/tools/test_mcp_tool_listing.py
+++ b/tests/tools/test_mcp_tool_listing.py
@@ -1,0 +1,81 @@
+"""Tests for the shared MCP tool-catalog listing helper."""
+
+from __future__ import annotations
+
+from app.tools.utils.mcp_tool_listing import (
+    MAX_DESCRIPTION_CHARS,
+    MAX_SCHEMAS_RETURNED,
+    MAX_TOOLS_RETURNED,
+    build_mcp_tool_listing,
+)
+
+
+def _tools(count: int) -> list[dict[str, object]]:
+    return [
+        {"name": f"tool-{i:03d}", "description": f"desc {i}", "input_schema": {"i": i}}
+        for i in range(count)
+    ]
+
+
+def test_default_listing_drops_schema_and_truncates_description() -> None:
+    tools = [{"name": "execute-sql", "description": "Run HogQL " * 50, "input_schema": {"a": 1}}]
+    listing = build_mcp_tool_listing(tools, name_filter=None, include_schema=False)
+
+    entry = listing["tools"][0]
+    assert entry["name"] == "execute-sql"
+    assert "input_schema" not in entry
+    assert len(entry["description"]) <= MAX_DESCRIPTION_CHARS
+    assert listing["total_tools"] == 1
+    assert listing["returned_tools"] == 1
+
+
+def test_caps_returned_tools_and_notes_truncation() -> None:
+    listing = build_mcp_tool_listing(_tools(244), name_filter=None, include_schema=False)
+    assert listing["total_tools"] == 244
+    assert listing["returned_tools"] == MAX_TOOLS_RETURNED
+    assert "name_filter" in str(listing.get("notes", ""))
+
+
+def test_name_filter_matches_name_or_description() -> None:
+    tools = [
+        {"name": "execute-sql", "description": "Run HogQL", "input_schema": {}},
+        {"name": "feature-flag-get-all", "description": "List flags", "input_schema": {}},
+        {"name": "query-trends", "description": "Trend query over events", "input_schema": {}},
+    ]
+    listing = build_mcp_tool_listing(tools, name_filter="events query sql", include_schema=False)
+    assert {t["name"] for t in listing["tools"]} == {"execute-sql", "query-trends"}
+    assert listing["matched_tools"] == 2
+    assert listing["name_filter"] == "events query sql"
+
+
+def test_include_schema_only_when_result_set_is_small() -> None:
+    narrow = build_mcp_tool_listing(_tools(2), name_filter=None, include_schema=True)
+    assert all("input_schema" in t for t in narrow["tools"])
+
+    wide = build_mcp_tool_listing(
+        _tools(MAX_SCHEMAS_RETURNED + 1), name_filter=None, include_schema=True
+    )
+    assert all("input_schema" not in t for t in wide["tools"])
+    assert "input_schema omitted" in str(wide.get("notes", ""))
+
+
+def test_filter_example_appears_in_notes() -> None:
+    # The vendor-specific example only shows when a filter narrowed the set below
+    # the cap while the full catalog still exceeds it.
+    listing = build_mcp_tool_listing(
+        _tools(100),
+        name_filter="tool-01",
+        include_schema=False,
+        filter_example="issue event trace",
+    )
+    assert "issue event trace" in str(listing.get("notes", ""))
+
+
+def test_skips_unnamed_or_non_dict_entries_gracefully() -> None:
+    # Defensive: the helper is fed whatever the MCP server returns.
+    listing = build_mcp_tool_listing(
+        [{"name": "ok", "description": "d", "input_schema": {}}],
+        name_filter=None,
+        include_schema=False,
+    )
+    assert listing["returned_tools"] == 1

--- a/tests/tools/test_openclaw_mcp_tool.py
+++ b/tests/tools/test_openclaw_mcp_tool.py
@@ -172,6 +172,38 @@ def test_list_openclaw_tools_happy_path() -> None:
     assert result["available"] is True
     assert result["transport"] == "stdio"
     assert result["tools"][0]["name"] == "messages_read"
+    # Listing is slimmed: schema dropped by default so it can't overflow context.
+    assert "input_schema" not in result["tools"][0]
+    assert result["total_tools"] == 1
+    assert result["returned_tools"] == 1
+
+
+def test_list_openclaw_tools_filters_by_name() -> None:
+    mock_config = MagicMock()
+    mock_config.mode = "stdio"
+    mock_config.command = "openclaw"
+    mock_config.url = ""
+
+    with (
+        patch("app.tools.OpenClawMCPTool.openclaw_config_from_env", return_value=None),
+        patch("app.tools.OpenClawMCPTool.build_openclaw_config", return_value=mock_config),
+        patch("app.tools.OpenClawMCPTool.openclaw_runtime_unavailable_reason", return_value=None),
+        patch(
+            "app.tools.OpenClawMCPTool.list_openclaw_mcp_tools",
+            return_value=[
+                {"name": "messages_read", "description": "Read", "input_schema": {}},
+                {"name": "events_list", "description": "Events", "input_schema": {}},
+            ],
+        ),
+    ):
+        result = list_openclaw_bridge_tools(
+            name_filter="events",
+            openclaw_mode="stdio",
+            openclaw_command="openclaw",
+        )
+
+    assert result["matched_tools"] == 1
+    assert {t["name"] for t in result["tools"]} == {"events_list"}
 
 
 def test_call_openclaw_tool_happy_path() -> None:

--- a/tests/tools/test_sentry_mcp_tool.py
+++ b/tests/tools/test_sentry_mcp_tool.py
@@ -125,9 +125,11 @@ def test_call_tool_surfaces_mcp_error() -> None:
     assert "permission denied" in str(result["error"])
 
 
-def test_list_tools_returns_discovered_tools() -> None:
+def test_list_tools_returns_compact_summaries_without_schema() -> None:
+    """Listing drops input_schema by default so the payload can't overflow the
+    agent's context budget (mirrors list_posthog_tools)."""
     fake_tools = [
-        {"name": "get_issue_details", "description": "Issue", "input_schema": {}},
+        {"name": "get_issue_details", "description": "Issue", "input_schema": {"a": 1}},
     ]
     with patch(
         "app.tools.SentryMCPTool.list_sentry_mcp_server_tools",
@@ -139,5 +141,28 @@ def test_list_tools_returns_discovered_tools() -> None:
             sentry_token="sntrytok_secret",
         )
     assert result["available"] is True
-    assert result["tools"] == fake_tools
     assert result["transport"] == "streamable-http"
+    assert result["total_tools"] == 1
+    assert result["returned_tools"] == 1
+    assert result["tools"] == [{"name": "get_issue_details", "description": "Issue"}]
+    assert "input_schema" not in result["tools"][0]
+
+
+def test_list_tools_filters_and_includes_schema_for_narrow_results() -> None:
+    fake_tools = [
+        {"name": "get_issue_details", "description": "Issue", "input_schema": {"q": "s"}},
+        {"name": "search_events", "description": "Events", "input_schema": {"t": "s"}},
+    ]
+    with patch(
+        "app.tools.SentryMCPTool.list_sentry_mcp_server_tools",
+        return_value=fake_tools,
+    ):
+        result = list_sentry_tools(
+            name_filter="issue",
+            include_schema=True,
+            sentry_url="https://mcp.sentry.dev/mcp",
+            sentry_token="sntrytok_secret",
+        )
+    assert result["matched_tools"] == 1
+    assert result["tools"][0]["name"] == "get_issue_details"
+    assert result["tools"][0]["input_schema"] == {"q": "s"}


### PR DESCRIPTION
## Summary

`list_posthog_tools` already returns a compact, bounded catalog (names + truncated descriptions, no schemas) so a discovery call can't blow past the model's context window. The other two MCP discovery tools — `list_sentry_tools` and `list_openclaw_tools` — still inlined the full `input_schema` for every MCP-exposed tool, so a single call could dump tens-to-hundreds of KB into the conversation and trigger aggressive context trimming (the same failure mode that drove the investigation-loop blow-up).

This makes all three MCP listing tools behave consistently and slim, and removes the duplicated listing logic.

- New shared helper `app/tools/utils/mcp_tool_listing.py` (`build_mcp_tool_listing`): name filtering, description truncation, a capped result count, and opt-in `input_schema` only for a small, narrowed result set.
- `list_posthog_tools` refactored to use the shared helper (behavior unchanged — its existing tests pass as-is).
- `list_sentry_tools` and `list_openclaw_tools` now return the same compact listing and gain `name_filter` / `include_schema` controls.

## Test plan

- [x] New `tests/tools/test_mcp_tool_listing.py` unit tests for the shared helper (truncation, caps, filtering, opt-in schema, vendor filter example).
- [x] Updated Sentry/OpenClaw tool tests for the slimmed output (schema dropped by default, `name_filter` narrowing).
- [x] `ruff check`, `ruff format --check`, `mypy` clean on all changed files.
- [x] `pytest tests/tools tests/integrations/test_posthog_mcp.py tests/integrations/test_sentry_mcp.py tests/test_openclaw_integration.py` — 2107 passed, 1 skipped.

Made with [Cursor](https://cursor.com)