### PR TITLE
test(routing): isolate integration state and align Phase 2 scenario fixtures

### DIFF
--- a/app/cli/interactive_shell/routing/tests/scenarios/compound/405-slash-then-sample-alert-success.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/compound/405-slash-then-sample-alert-success.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store for environment isolation so the planned/executed
+  # action sequence does not depend on the developer's local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /health

--- a/app/cli/interactive_shell/routing/tests/scenarios/compound/406-slash-then-investigate-sample-alert.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/compound/406-slash-then-investigate-sample-alert.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store for environment isolation so the planned/executed
+  # action sequence does not depend on the developer's local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /health

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/000-slash-help-prefix.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/000-slash-help-prefix.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /help

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/001-slash-status-trim.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/001-slash-status-trim.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /status

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/002-slash-investigate-args.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/002-slash-investigate-args.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /investigate

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/003-slash-opensre-wrapped.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/003-slash-opensre-wrapped.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /onboard

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/004-slash-unknown-passthrough.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/004-slash-unknown-passthrough.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /definitely-not-a-command

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/010-alias-help.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/010-alias-help.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /help

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/011-alias-help-symbol.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/011-alias-help-symbol.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /help

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/012-alias-help-casefolded.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/012-alias-help-casefolded.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /help

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/013-alias-help-typo.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/013-alias-help-typo.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /help

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/014-alias-quit.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/014-alias-quit.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /quit

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/015-alias-status.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/015-alias-status.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /status

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/016-alias-integrations-list.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/016-alias-integrations-list.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /integrations

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/017-alias-integration-verify.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/017-alias-integration-verify.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /integrations

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/018-alias-int-show-datadog.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/018-alias-int-show-datadog.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /integrations

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/019-alias-mcp-list.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/019-alias-mcp-list.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /mcp

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/020-alias-remote-deploy.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/020-alias-remote-deploy.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /remote

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/021-alias-welcome-hi.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/021-alias-welcome-hi.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /welcome

--- a/app/cli/interactive_shell/routing/tests/scenarios/deterministic/022-opensre-investigate-alert-json.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/deterministic/022-opensre-investigate-alert-json.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /investigate

--- a/app/cli/interactive_shell/routing/tests/scenarios/docs_no_execute/100-docs-run-investigation.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/docs_no_execute/100-docs-run-investigation.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -34,6 +35,11 @@ response_contract:
   - paste
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/docs_no_execute/101-docs-datadog-setup.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/docs_no_execute/101-docs-datadog-setup.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -29,6 +30,11 @@ response_contract:
   - datadog
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/docs_no_execute/102-docs-supported-integrations.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/docs_no_execute/102-docs-supported-integrations.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -29,6 +30,11 @@ response_contract:
   - integrations
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/docs_no_execute/103-docs-railway-deploy.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/docs_no_execute/103-docs-railway-deploy.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -29,6 +30,11 @@ response_contract:
   - railway
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/docs_no_execute/104-docs-command-question.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/docs_no_execute/104-docs-command-question.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -37,6 +38,11 @@ response_contract:
   - common ones
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/docs_no_execute/105-docs-verify-dry-run-no-execute.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/docs_no_execute/105-docs-verify-dry-run-no-execute.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -28,6 +29,11 @@ response_contract:
   - --help
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/docs_no_execute/106-docs-latency-measurement.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/docs_no_execute/106-docs-latency-measurement.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -29,6 +30,11 @@ response_contract:
   - latency
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/follow_up/600-follow-up-why-failed.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/follow_up/600-follow-up-why-failed.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: true
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store so the follow-up is answered from prior context
+  # only -- the gather loop has no tools regardless of local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -32,6 +35,12 @@ response_contract:
   - alert text
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  # No integrations are resolved, so no remote-integration tool may fire.
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/follow_up/601-follow-up-spike-cause.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/follow_up/601-follow-up-spike-cause.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: true
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store so the follow-up is answered from prior context
+  # only -- the gather loop has no tools regardless of local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -32,6 +35,12 @@ response_contract:
   - alert text or json
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  # No integrations are resolved, so no remote-integration tool may fire.
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/follow_up/602-follow-up-what-happened.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/follow_up/602-follow-up-what-happened.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: true
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store so the follow-up is answered from prior context
+  # only -- the gather loop has no tools regardless of local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -32,6 +35,12 @@ response_contract:
   - happened
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  # No integrations are resolved, so no remote-integration tool may fire.
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/follow_up/603-follow-up-last-investigation-wording.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/follow_up/603-follow-up-last-investigation-wording.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: true
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store so the follow-up is answered from prior context
+  # only -- the gather loop has no tools regardless of local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -32,6 +35,12 @@ response_contract:
   - alert text
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  # No integrations are resolved, so no remote-integration tool may fire.
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/investigations/300-sample-alert-run.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/investigations/300-sample-alert-run.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store so this scenario is isolated from the developer's
+  # local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []

--- a/app/cli/interactive_shell/routing/tests/scenarios/investigations/301-sample-alert-paraphrase.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/investigations/301-sample-alert-paraphrase.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store so this scenario is isolated from the developer's
+  # local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []

--- a/app/cli/interactive_shell/routing/tests/scenarios/investigations/302-sample-alert-investigate-phrasing.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/investigations/302-sample-alert-investigate-phrasing.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store so this scenario is isolated from the developer's
+  # local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []

--- a/app/cli/interactive_shell/routing/tests/scenarios/investigations/302-synthetic-connection-exhaustion.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/investigations/302-synthetic-connection-exhaustion.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store so this scenario is isolated from the developer's
+  # local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []

--- a/app/cli/interactive_shell/routing/tests/scenarios/investigations/303-synthetic-storage-full.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/investigations/303-synthetic-storage-full.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store so this scenario is isolated from the developer's
+  # local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []

--- a/app/cli/interactive_shell/routing/tests/scenarios/investigations/304-synthetic-bare-numeric-id.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/investigations/304-synthetic-bare-numeric-id.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store so this scenario is isolated from the developer's
+  # local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []

--- a/app/cli/interactive_shell/routing/tests/scenarios/investigations/305-synthetic-cpu-saturation.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/investigations/305-synthetic-cpu-saturation.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store so this scenario is isolated from the developer's
+  # local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []

--- a/app/cli/interactive_shell/routing/tests/scenarios/investigations/306-pasted-alert-json-payload.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/investigations/306-pasted-alert-json-payload.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store so this scenario is isolated from the developer's
+  # local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []

--- a/app/cli/interactive_shell/routing/tests/scenarios/investigations/307-new-alert-checkout-502.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/investigations/307-new-alert-checkout-502.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Force an empty resolved store so the gather loop has no tools regardless of
+  # the developer's local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -30,6 +33,12 @@ response_contract:
   - incident
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  # No integrations are resolved, so no remote-integration tool may fire.
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/investigations/309-freeform-database-slow.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/investigations/309-freeform-database-slow.yml
@@ -8,7 +8,20 @@ input:
 session:
   has_prior_state: false
   remote_connected: false
-  configured_integrations: []
+  configured_integrations:
+  - datadog
+  # Pin a fixture-owned Datadog config so the planner sees >=1 connected
+  # integration and DISPATCHES an investigation for this diagnostic question
+  # (the connected-integration gate). Tokens are fake; no real investigation
+  # runs because the oracle stubs the dispatch boundary (REGISTRY.dispatch), so
+  # the call is recorded without remote I/O.
+  resolved_integrations:
+    datadog:
+      connection_verified: true
+      api_key: fixture-api-key
+      app_key: fixture-app-key
+      site: datadoghq.com
+      base_url: https://api.datadoghq.com
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -18,38 +31,30 @@ route:
   expected_kind: handle_message_with_agent
   expected_command_text: null
 policy:
-  executes_terminal_action: false
+  executes_terminal_action: true
 planned_actions:
-- kind: assistant_handoff
-  content: diagnostic_question:database_slow
+# Diagnostic question ("why is the database slow?") with Datadog connected, so
+# the planner dispatches an investigation with synthesized alert_text. The
+# alert_text varies per run, so content is omitted: the planning test asserts an
+# investigation with non-empty alert_text rather than an exact string.
+- kind: investigation
   source: llm
-executed_actions: []
+  target_surface: investigation
+executed_actions:
+- kind: investigation
 response_contract:
-  # The intended behavior for a vague ops question (no pasted alert) is to ask
-  # for the target system/service or alert context (see the cli_agent system
-  # prompt). Accept any phrasing that does that rather than one literal string,
-  # so the contract tracks behavior instead of exact wording.
   must_contain_any:
-  - why is the database slow
-  - vague operational question
-  - specific system
-  - don't have any alert or context yet
-  - which database
-  - what database
-  - which environment
-  - paste
-  - more context
-  - which service
-  - what service
-  - service name
-  - what context
-  - paste the alert
-  - opensre investigate
+  - investigat
+  - rca
+  - database
+  - slow
   must_not_contain:
   - $ /
 history:
   expected:
   - type: cli_agent
+    ok: true
+  - type: alert
     ok: true
 tier: full
 runs: 3

--- a/app/cli/interactive_shell/routing/tests/scenarios/investigations/310-low-signal-greeting.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/investigations/310-low-signal-greeting.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Force an empty resolved store so the gather loop has no tools regardless of
+  # the developer's local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -29,6 +32,12 @@ response_contract:
   - OpenSRE
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  # No integrations are resolved, so no remote-integration tool may fire.
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/investigations/311-freeform-checkout-500-rich-context.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/investigations/311-freeform-checkout-500-rich-context.yml
@@ -14,6 +14,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Force an empty resolved store so the gather loop has no tools regardless of
+  # the developer's local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -39,6 +42,12 @@ response_contract:
   must_contain_any: []
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  # No integrations are resolved, so no remote-integration tool may fire.
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/local_execution/200-show-connected-integrations.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/local_execution/200-show-connected-integrations.yml
@@ -11,6 +11,7 @@ session:
   configured_integrations:
   - datadog
   - sentry
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /integrations

--- a/app/cli/interactive_shell/routing/tests/scenarios/local_execution/201-show-connected-services.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/local_execution/201-show-connected-services.yml
@@ -11,6 +11,7 @@ session:
   configured_integrations:
   - datadog
   - sentry
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /integrations

--- a/app/cli/interactive_shell/routing/tests/scenarios/local_execution/202-health-then-connected-services.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/local_execution/202-health-then-connected-services.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /health

--- a/app/cli/interactive_shell/routing/tests/scenarios/local_execution/203-cli-verify-dry-run.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/local_execution/203-cli-verify-dry-run.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands:

--- a/app/cli/interactive_shell/routing/tests/scenarios/local_execution/204-integration-show-unconfigured-fail-closed.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/local_execution/204-integration-show-unconfigured-fail-closed.yml
@@ -9,6 +9,7 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []

--- a/app/cli/interactive_shell/routing/tests/scenarios/non_actionable/700-pasted-self-improvement-offer.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/non_actionable/700-pasted-self-improvement-offer.yml
@@ -11,6 +11,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store so the pasted blob hands off and the gather loop
+  # has no tools regardless of the developer's local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -29,6 +32,12 @@ response_contract:
   must_contain_any: []
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  # No integrations are resolved, so no remote-integration tool may fire.
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/remote/500-connect-local-llama-fail-closed.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/remote/500-connect-local-llama-fail-closed.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store so the vague provider request hands off and the
+  # gather loop has no tools regardless of the developer's local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -30,6 +33,12 @@ response_contract:
   - local-model connection tool
   must_not_contain:
   - $ /
+gathered_tools_contract:
+  # No integrations are resolved, so no remote-integration tool may fire.
+  must_not_call:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
 history:
   expected:
   - type: cli_agent

--- a/app/cli/interactive_shell/routing/tests/scenarios/remote/501-nitro-connect-then-investigate.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/remote/501-nitro-connect-then-investigate.yml
@@ -9,6 +9,9 @@ session:
   has_prior_state: false
   remote_connected: false
   configured_integrations: []
+  # Pin an empty resolved store for environment isolation so the planned/executed
+  # action sequence does not depend on the developer's local ~/.opensre integrations.
+  resolved_integrations: {}
 available_capabilities:
   slash_commands:
   - /remote


### PR DESCRIPTION
## Summary

Pins `session.resolved_integrations` on every routing scenario fixture so tests no longer leak ambient integration state into the planner, and aligns each scenario class with the Phase 1 dispatch pivot.

- **investigations/**: isolate sample/synthetic/explicit dispatch fixtures; flip `309` ("why is the database slow?") to investigation dispatch with a fixture-owned Datadog config; keep `307`/`310`/`311` as handoff controls.
- **deterministic/**: isolation only (`resolved_integrations: {}`).
- **docs_no_execute/ + local_execution/**: handoff + `must_not_call` locks (`search_sentry_issues` / `search_github_issues` / `list_posthog_tools`); CLI/local isolation.
- **follow_up/ + compound/ + remote/ + non_actionable/**: dispatch/handoff per intent + isolation.

## Test plan

- [x] All scenarios live-verified by class
- [x] Fixture integrity + deterministic suite green (28 passed)
- [ ] CI live routing suite passes

## Notes

`315-quoted-directive-investigation` is intentionally left unmodified: the live planner unreliably downgrades the explicit-investigate directive to handoff with no integration connected, independent of the isolation edit.

Made with [Cursor](https://cursor.com)