### PR TITLE
fix(routing): route data lookups to handoff; log gathered tool calls to session

### DIFF
--- a/app/cli/interactive_shell/chat/tool_gathering.py
+++ b/app/cli/interactive_shell/chat/tool_gathering.py
@@ -21,6 +21,7 @@ Design notes:
 
 from __future__ import annotations
 
+import contextlib
 import json
 from typing import Any
 
@@ -70,6 +71,37 @@ def _format_observation(executed: list[tuple[Any, Any]]) -> str:
             f"Tool: {tc.name}\nArguments: {args}\nResult: {_truncate(body, _MAX_PER_TOOL_CHARS)}"
         )
     return _truncate("\n\n".join(blocks), _MAX_OBSERVATION_CHARS)
+
+
+def _persist_tool_calls(session: ReplSession, executed: list[tuple[Any, Any]]) -> None:
+    """Record each gathered tool-call result into the session log.
+
+    Closes the observability gap where a turn's actual integration/API evidence
+    was never persisted (only the final prose answer was). Arguments and results
+    are redacted and bounded before writing; failures are swallowed so logging
+    never breaks the turn.
+    """
+    from app.cli.interactive_shell.sessions.store import SessionStore
+    from app.utils.tool_trace import redact_sensitive
+
+    for tc, output in executed:
+        with contextlib.suppress(Exception):
+            ok = not (isinstance(output, dict) and "error" in output)
+            body = (
+                output
+                if isinstance(output, str)
+                else json.dumps(redact_sensitive(output), default=str)
+            )
+            arguments = (
+                redact_sensitive(tc.input) if isinstance(tc.input, dict) else {"value": tc.input}
+            )
+            SessionStore.append_tool_call(
+                session.session_id,
+                tool=str(tc.name),
+                arguments=arguments,
+                result=_truncate(body, _MAX_PER_TOOL_CHARS),
+                ok=ok,
+            )
 
 
 def _build_gather_system_prompt(session: ReplSession) -> str:
@@ -152,6 +184,7 @@ def gather_tool_evidence(
 
     if not result.executed:
         return None
+    _persist_tool_calls(session, result.executed)
     return _format_observation(result.executed)
 
 

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/constants.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/constants.py
@@ -69,6 +69,23 @@ connected right now (or "none" / "unknown"). Apply these rules in order:
   * "none" or "unknown" → emit assistant_handoff instead; with no connected data
     source a root-cause run would be empty, so let the assistant answer and
     suggest connecting an integration.
+- DATA-RETRIEVAL / ANALYTICS LOOKUP is NOT an investigation. A request to fetch,
+  list, show, query, count, search, or look up specific records — events,
+  metrics, logs, sessions, traces, persons/users, issues, feature flags,
+  dashboards, insights — for a named entity, user, filter, or time window is a
+  plain data query. Emit assistant_handoff: the assistant gathers the data live
+  via the same integration tools and answers. This holds EVEN WHEN the request
+  names an observability source (PostHog, Datadog, Sentry, Grafana, etc.) and
+  EVEN WHEN integrations are connected. The investigation rule applies ONLY when
+  the request asks for the CAUSE of a failure, crash, error, outage, or incident;
+  a lookup with no failure being diagnosed is never investigation_start.
+  Examples that are HANDOFFS (data lookups), NOT investigations:
+  * "events for the person whose github_username is davincios in posthog"
+  * "show me the latest sessions for user X"
+  * "how many $pageview events did we get yesterday?"
+  * "list the open sentry issues for checkout"
+  Contrast: "why is checkout crashing — check sentry and posthog" names a
+  FAILURE to root-cause, so it IS investigation_start (per the rule above).
 - NEITHER an instruction NOR a diagnostic question → assistant_handoff. A message
   that is JUST an alert or incident — a pasted alert payload (JSON, YAML, or
   key-value blob) on its own, or a bare incident statement such as "CPU is

--- a/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/315-posthog-events-person-lookup-handoff.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/315-posthog-events-person-lookup-handoff.yml
@@ -1,0 +1,65 @@
+id: 315-posthog-events-person-lookup-handoff
+title: PostHog person data lookup hands off and gathers data (not an investigation)
+intent_class: complex_shell_prompts
+risk_level: low
+input:
+  prompt: >-
+    events for the person whose github_username is davincios in posthog mcp
+  surface: interactive_cli
+session:
+  has_prior_state: false
+  remote_connected: false
+  configured_integrations:
+  - posthog_mcp
+  # PostHog is connected so the gather loop has a real tool to call. This is the
+  # crux of the regression: even WITH an observability source connected, a plain
+  # data-retrieval query ("events for person X") is NOT an incident
+  # root-cause, so the planner must HAND OFF (no investigation_start) and let the
+  # conversational gather loop query PostHog. Token is fake; the oracle records
+  # the tool call without real remote I/O.
+  resolved_integrations:
+    posthog_mcp:
+      connection_verified: true
+      mode: streamable-http
+      url: https://mcp.posthog.com/mcp
+      auth_token: fixture-token
+available_capabilities:
+  slash_commands: []
+  cli_commands: []
+  synthetic_suites: []
+notes:
+- "Data-retrieval / analytics lookup, NOT an investigation. The prompt asks to\
+  \ fetch events for a named person in PostHog -- it names no failure, crash,\
+  \ error, outage, or incident to root-cause. The planner must NOT emit\
+  \ investigation_start (regression guard): it hands off and the conversational\
+  \ gather loop queries PostHog to ground the answer. Contrast with 314, where\
+  \ 'crashing on Windows' names a failure and DOES dispatch an investigation."
+route:
+  expected_kind: handle_message_with_agent
+  expected_command_text: null
+policy:
+  executes_terminal_action: false
+planned_actions: []
+executed_actions: []
+response_contract:
+  must_contain_any:
+  - posthog
+  - event
+  - davincios
+  must_not_contain:
+  - $ /
+  forbidden_actions:
+  - investigation
+  - shell
+gathered_tools_contract:
+  # A data lookup with PostHog connected should drive the gather loop to query
+  # PostHog, not start an investigation.
+  must_call_any:
+  - list_posthog_tools
+  - call_posthog_tool
+history:
+  expected:
+  - type: cli_agent
+    ok: true
+tier: full
+runs: 3

--- a/app/cli/interactive_shell/sessions/store.py
+++ b/app/cli/interactive_shell/sessions/store.py
@@ -176,6 +176,43 @@ class SessionStore:
                 fh.write(json.dumps(record, ensure_ascii=False) + "\n")
 
     @staticmethod
+    def append_tool_call(
+        session_id: str,
+        *,
+        tool: str,
+        arguments: dict[str, Any],
+        result: str,
+        ok: bool,
+        source: str | None = None,
+    ) -> None:
+        """Append one integration/API tool-call result to the session file.
+
+        Written by the conversational data-gathering loop after each tool runs,
+        so a session file carries the actual evidence each turn fetched (tool
+        name, arguments, and a bounded result snippet) rather than only the
+        final prose answer. Callers MUST pass already-redacted, already-truncated
+        values: this writer stays a dumb sink and pulls in no agent/tool imports.
+        No-ops silently if the session file does not exist.
+        """
+        with contextlib.suppress(Exception):
+            path = _session_path(session_id)
+            if not path.exists():
+                return
+            SessionStore._ensure_session_open(session_id)
+            record: dict[str, Any] = {
+                "type": "tool_call",
+                "ts": datetime.now(UTC).isoformat(),
+                "tool": tool,
+                "arguments": arguments,
+                "ok": ok,
+                "result": result,
+            }
+            if source is not None:
+                record["source"] = source
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+
+    @staticmethod
     def flush(session: SessionPersistenceSource) -> None:
         """Write conversation_snapshot + session_end and close the session file.
 

--- a/tests/cli/interactive_shell/sessions/test_store.py
+++ b/tests/cli/interactive_shell/sessions/test_store.py
@@ -8,8 +8,10 @@ import uuid
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from app.cli.interactive_shell.runtime.session import ReplSession
-from app.cli.interactive_shell.sessions.store import SessionStore
+from app.cli.interactive_shell.sessions.store import SessionStore, _sessions_dir
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -24,6 +26,18 @@ def _read_lines(path: Path) -> list[dict]:
 
 def _patch_dir(tmp_path: Path):
     return patch("app.cli.interactive_shell.sessions.store._sessions_dir", return_value=tmp_path)
+
+
+@pytest.fixture
+def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect OpenSRE's home to a real temp dir so SessionStore reads/writes real files.
+
+    No mocking: ``_sessions_dir()`` resolves the real ``OPENSRE_HOME_DIR`` constant
+    on every call, so pointing it at a temp directory exercises the genuine
+    filesystem path end to end.
+    """
+    monkeypatch.setattr("app.constants.OPENSRE_HOME_DIR", tmp_path)
+    return tmp_path
 
 
 # ── open_session ──────────────────────────────────────────────────────────────
@@ -140,6 +154,67 @@ def test_append_turn_detail_noop_when_file_missing(tmp_path: Path) -> None:
     with _patch_dir(tmp_path):
         SessionStore.append_turn_detail("nonexistent-id", "chat", "hi")
     assert not list(tmp_path.glob("*.jsonl"))
+
+
+# ── append_tool_call ──────────────────────────────────────────────────────────
+
+
+def test_append_tool_call_writes_record(tmp_home: Path) -> None:
+    session = _make_session()
+    SessionStore.open_session(session)
+    SessionStore.append_tool_call(
+        session.session_id,
+        tool="call_posthog_tool",
+        arguments={"tool": "execute-sql", "args": {"query": "select 1"}},
+        result='{"rows": []}',
+        ok=True,
+        source="posthog_mcp",
+    )
+
+    records = _read_lines(_sessions_dir() / f"{session.session_id}.jsonl")
+    call = next(r for r in records if r["type"] == "tool_call")
+    assert call["tool"] == "call_posthog_tool"
+    assert call["arguments"] == {"tool": "execute-sql", "args": {"query": "select 1"}}
+    assert call["result"] == '{"rows": []}'
+    assert call["ok"] is True
+    assert call["source"] == "posthog_mcp"
+    assert "ts" in call
+
+
+def test_append_tool_call_omits_source_when_none(tmp_home: Path) -> None:
+    session = _make_session()
+    SessionStore.open_session(session)
+    SessionStore.append_tool_call(
+        session.session_id,
+        tool="list_posthog_tools",
+        arguments={},
+        result="error: boom",
+        ok=False,
+    )
+
+    records = _read_lines(_sessions_dir() / f"{session.session_id}.jsonl")
+    call = next(r for r in records if r["type"] == "tool_call")
+    assert call["ok"] is False
+    assert "source" not in call
+
+
+def test_append_tool_call_noop_when_file_missing(tmp_home: Path) -> None:
+    SessionStore.append_tool_call("nonexistent-id", tool="t", arguments={}, result="r", ok=True)
+    assert not list(_sessions_dir().glob("*.jsonl"))
+
+
+def test_append_tool_call_reopens_finalized_session(tmp_home: Path) -> None:
+    session = _make_session()
+    SessionStore.open_session(session)
+    SessionStore.append_turn(session, "cli_agent", "events for davincios in posthog")
+    SessionStore.flush(session)
+    # A late tool-call write (e.g. background gather) must reopen the file.
+    SessionStore.append_tool_call(
+        session.session_id, tool="call_posthog_tool", arguments={}, result="{}", ok=True
+    )
+
+    records = _read_lines(_sessions_dir() / f"{session.session_id}.jsonl")
+    assert any(r["type"] == "tool_call" for r in records)
 
 
 # ── flush ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Routing fix:** the action planner classified plain PostHog *data lookups* (e.g. `events for the person whose github_username is davincios in posthog`) as incident investigations and triggered the full investigation pipeline. Root cause: the planner prompt's "diagnostic question that names a source" rule didn't distinguish data-retrieval/analytics queries from failure root-cause. Added a `DATA-RETRIEVAL / ANALYTICS LOOKUP` carve-out so these hand off to the conversational gather path; failure/crash/error questions still investigate.
- **Regression guard:** new routing scenario `315-posthog-events-person-lookup-handoff` (PostHog connected → must hand off + gather, must **not** investigate). Validated live; `313`/`314` still pass.
- **Observability gap:** persist each gathered tool-call result (tool, redacted arguments, bounded result, `ok`) into the session JSONL via `SessionStore.append_tool_call`, written from the gather loop — previously only the final prose answer was stored.
- **Tests:** real-usage (no-mock) tests for the new session persistence.

## Test plan
- [x] `ruff check` + `ruff format --check` on changed files
- [x] `mypy` on changed app modules
- [x] `pytest` SessionStore tests (incl. 4 new) + routing fixture integrity — 62 passed
- [x] Live routing scenarios `313`/`314`/`315` (handoff vs investigation) validated

Made with [Cursor](https://cursor.com)