### PR TITLE
test(routing): solidify PostHog person-lookup handoff scenario (315)

### DIFF
--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/constants.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/constants.py
@@ -69,6 +69,23 @@ connected right now (or "none" / "unknown"). Apply these rules in order:
   * "none" or "unknown" → emit assistant_handoff instead; with no connected data
     source a root-cause run would be empty, so let the assistant answer and
     suggest connecting an integration.
+- DATA-RETRIEVAL / ANALYTICS LOOKUP is NOT an investigation. A request to fetch,
+  list, show, query, count, search, or look up specific records — events,
+  metrics, logs, sessions, traces, persons/users, issues, feature flags,
+  dashboards, insights — for a named entity, user, filter, or time window is a
+  plain data query. Emit assistant_handoff: the assistant gathers the data live
+  via the same integration tools and answers. This holds EVEN WHEN the request
+  names an observability source (PostHog, Datadog, Sentry, Grafana, etc.) and
+  EVEN WHEN integrations are connected. The investigation rule applies ONLY when
+  the request asks for the CAUSE of a failure, crash, error, outage, or incident;
+  a lookup with no failure being diagnosed is never investigation_start.
+  Examples that are HANDOFFS (data lookups), NOT investigations:
+  * "events for the person whose github_username is davincios in posthog"
+  * "show me the latest sessions for user X"
+  * "how many $pageview events did we get yesterday?"
+  * "list the open sentry issues for checkout"
+  Contrast: "why is checkout crashing — check sentry and posthog" names a
+  FAILURE to root-cause, so it IS investigation_start (per the rule above).
 - NEITHER an instruction NOR a diagnostic question → assistant_handoff. A message
   that is JUST an alert or incident — a pasted alert payload (JSON, YAML, or
   key-value blob) on its own, or a bare incident statement such as "CPU is

--- a/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/315-posthog-events-person-lookup-handoff.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/315-posthog-events-person-lookup-handoff.yml
@@ -1,0 +1,91 @@
+id: 315-posthog-events-person-lookup-handoff
+title: PostHog person-events lookup hands off and grounds the answer via PostHog (not an investigation)
+intent_class: complex_shell_prompts
+risk_level: low
+input:
+  prompt: >-
+    events for the person whose github_username is davincios in posthog mcp
+  surface: interactive_cli
+session:
+  has_prior_state: false
+  remote_connected: false
+  configured_integrations:
+  - posthog_mcp
+  # PostHog is the ONLY connected source, so the gather loop has exactly one real
+  # integration to call. This is the crux of the regression: even WITH an
+  # observability source connected, a plain data-retrieval query ("events for
+  # person X") is NOT an incident root-cause, so the planner must HAND OFF (no
+  # investigation_start) and let the conversational gather loop query PostHog.
+  # The token is fake, so list_posthog_tools reaches the live endpoint and 401s;
+  # the oracle records the tool as "called" regardless of the auth error, which
+  # is the deterministic, credential-independent signal the contract asserts.
+  resolved_integrations:
+    posthog_mcp:
+      connection_verified: true
+      mode: streamable-http
+      url: https://mcp.posthog.com/mcp
+      auth_token: fixture-token
+available_capabilities:
+  slash_commands: []
+  cli_commands: []
+  synthetic_suites: []
+notes:
+- "Data-retrieval / analytics lookup, NOT an investigation. The prompt asks to\
+  \ fetch events for a named person in PostHog -- it names no failure, crash,\
+  \ error, outage, or incident to root-cause. The planner must NOT emit\
+  \ investigation_start (regression guard for the DATA-RETRIEVAL rule in the\
+  \ action-planner prompt): it hands off and the conversational gather loop\
+  \ queries PostHog to ground the answer. Contrast with 314, where 'crashing on\
+  \ Windows' names a failure and DOES dispatch an investigation."
+- "Grounded against the live PostHog MCP (project 'Tracer Cloud Production',\
+  \ id 196678) on 2026-06-18. The person whose github_username is 'davincios'\
+  \ exists (person id bed2a68f-ce46-5d68-9835-537389f3e317, distinct_id\
+  \ fb70eccb-ba6d-46a3-b9ba-7cf67dbc9d9a, $lib opensre-cli). They carry two\
+  \ $identify events (17:05:49Z and 17:25:05Z) plus a rich history (~21 event\
+  \ types incl. interactive_shell_route_decision, $ai_generation, cli_invoked),\
+  \ so this is a legitimate, reproducible lookup -- not a contrived prompt."
+- "Solidity contract: because PostHog is the only resolved integration, the\
+  \ gather loop MUST engage the PostHog tool surface on every run --\
+  \ list_posthog_tools is asserted via must_call_all (strictly stronger than\
+  \ must_call_any), so a silently-dropped PostHog tool registration, a broken\
+  \ is_available check, or the planner wrongly starting an investigation instead\
+  \ of handing off all fail this scenario instead of passing on hallucinated\
+  \ text. call_posthog_tool is intentionally NOT required: it only fires after\
+  \ list_posthog_tools authenticates against the live endpoint, which the fake\
+  \ fixture token cannot do (it 401s), so requiring it would make the fixture\
+  \ fail in every credential-less environment (CI included). list_posthog_tools\
+  \ firing is the deterministic, auth-independent proof that the gather loop\
+  \ routed this lookup to PostHog."
+route:
+  expected_kind: handle_message_with_agent
+  expected_command_text: null
+policy:
+  executes_terminal_action: false
+planned_actions: []
+executed_actions: []
+response_contract:
+  must_contain_any:
+  - posthog
+  - event
+  - davincios
+  must_not_contain:
+  - $ /
+  forbidden_actions:
+  - investigation
+  - shell
+gathered_tools_contract:
+  # A PostHog data lookup with ONLY PostHog connected must drive the gather loop
+  # to engage the PostHog tool surface -- list_posthog_tools is the entry tool
+  # the loop always hits when PostHog is the resolved integration. must_call_all
+  # (not must_call_any) makes this the strong, grounded signal: it fails if the
+  # assistant answers from training data without querying PostHog, if the tool
+  # is deregistered, or if the planner wrongly dispatches an investigation. The
+  # investigation action is guarded separately via response_contract.forbidden_actions.
+  must_call_all:
+  - list_posthog_tools
+history:
+  expected:
+  - type: cli_agent
+    ok: true
+tier: full
+runs: 3


### PR DESCRIPTION
## Summary

- Adds a **DATA-RETRIEVAL / analytics-lookup** rule to the action-planner prompt (`llm_action_planner/constants.py`): a plain "fetch/list/show events for person X in PostHog" query is a data lookup, not an incident root-cause, so the planner **hands off** to the conversational gather loop instead of dispatching `investigation_start` — even when an observability source is connected. Investigation remains reserved for prompts that name a *failure* to diagnose (contrast scenario 314).
- **Strengthens the 315 regression fixture** (`complex_shell_prompts/315-posthog-events-person-lookup-handoff.yml`) and grounds it against the **live PostHog MCP** so it is a faithful, reproducible scenario rather than a contrived one.

## What changed in the fixture (why it's "more solid")

- `gathered_tools_contract` now uses **`must_call_all: [list_posthog_tools]`** instead of `must_call_any`. Because PostHog is the only resolved integration, the gather loop must engage the PostHog tool surface on **every** run. This fails the scenario if:
  - the planner wrongly dispatches an investigation instead of handing off,
  - the PostHog MCP tool is deregistered / its `is_available` check breaks, or
  - the assistant answers from training data without querying PostHog.
- `call_posthog_tool` is **intentionally not required**: it only fires after `list_posthog_tools` authenticates against the live endpoint, which the fake fixture token cannot do (it 401s). Requiring it would make the fixture fail in every credential-less environment (CI included). `list_posthog_tools` firing is the deterministic, auth-independent proof that the lookup routed to PostHog.
- `runs` set to 3 (majority 2/3) to bound the cost of the live gather loop's real network round-trips.
- Notes rewritten to document the routing intent, the validated real-data grounding, and the contract rationale.

## Validated against live PostHog MCP

Queried the active project **"Tracer Cloud Production"** (id `196678`) via the PostHog MCP:
- The person with `github_username = davincios` exists — person id `bed2a68f-…`, distinct_id `fb70eccb-…`, `$lib = opensre-cli`.
- They carry the two `$identify` events at `17:05:49Z` / `17:25:05Z` shown in the original terminal session, **plus** a rich history (~21 event types incl. `interactive_shell_route_decision`, `$ai_generation`, `cli_invoked`). So the lookup is legitimate and reproducible.

## Test plan

- [x] `test_routing_fixture_integrity.py` — 10/10 pass (schema + `gathered_tools_contract` registered-name checks).
- [x] `test_deterministic_routing` — pass.
- [x] Live `test_live_action_planning[315-…]` — planner emits `assistant_handoff`, **not** investigation.
- [x] Live `test_live_turn_execution_oracle[315-…]` — 3/3 pass; `list_posthog_tools` fires every run, no investigation/shell executed.
- [x] `ruff check` + `ruff format --check` on `constants.py` — clean.

> Note: the live oracle for this scenario makes real round-trips to `mcp.posthog.com` via the gather loop (the fixture token 401s, which is recorded as "called"). This runs in the post-merge sharded live suite, not PR CI.

Made with [Cursor](https://cursor.com)