### PR TITLE
fix(routing): disable natural-language investigation loop in interactive shell

### DIFF
--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/feature_flags.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/feature_flags.py
@@ -1,0 +1,36 @@
+"""Runtime feature flags for interactive-shell action orchestration.
+
+These flags gate optional behavior at the planner/orchestration boundary. Keep
+them dependency-light: this module must stay importable without pulling in the
+LLM, tool runners, or the investigation pipeline.
+"""
+
+from __future__ import annotations
+
+# Temporary kill-switch for the natural-language investigation loop in the
+# interactive shell. When ``False`` the planner is NOT offered the
+# ``investigation_start`` tool, so diagnostic / incident-style prompts can no
+# longer trigger the heavyweight RCA pipeline from the REPL -- they fall through
+# to the conversational assistant instead.
+#
+# Scope: this gates ONLY the planner's natural-language path. The
+# ``/sample-alert`` command and the local alert listener still run
+# investigations; they do not go through ``investigation_start``.
+#
+# Flip to ``True`` to restore natural-language investigation routing (which also
+# re-enables the investigation routing scenarios that skip while this is False).
+INTERACTIVE_SHELL_INVESTIGATION_ENABLED = False
+
+
+def investigation_loop_enabled() -> bool:
+    """Return whether the planner may select the natural-language investigation tool.
+
+    Reads the module-level flag at call time so tests can monkeypatch it.
+    """
+    return INTERACTIVE_SHELL_INVESTIGATION_ENABLED
+
+
+__all__ = [
+    "INTERACTIVE_SHELL_INVESTIGATION_ENABLED",
+    "investigation_loop_enabled",
+]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tool_contracts.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tool_contracts.py
@@ -38,7 +38,13 @@ class ToolEntry:
     input_schema: dict[str, Any]
     execution_tier: ExecutionTier
     execute: ToolExecutor
+    # ``is_available`` gates BOTH planner offering and runtime dispatch.
+    # ``is_planner_selectable`` additionally hides a tool from the planner's
+    # tool specs WITHOUT blocking direct/programmatic dispatch, so a feature can
+    # be removed from natural-language selection while staying reachable for
+    # explicit, tested code paths.
     is_available: ToolAvailability = _tool_is_available
+    is_planner_selectable: ToolAvailability = _tool_is_available
 
 
 def string_property(

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tool_registry.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tool_registry.py
@@ -32,7 +32,7 @@ class ActionToolRegistry:
         specs: list[dict[str, Any]] = []
         for name in self.names():
             entry = self._tools[name]
-            if not entry.is_available(session):
+            if not entry.is_available(session) or not entry.is_planner_selectable(session):
                 continue
             specs.append(
                 {

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/investigation_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/investigation_tool.py
@@ -10,12 +10,25 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.a
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
     ExecutionTier,
 )
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.feature_flags import (
+    investigation_loop_enabled,
+)
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolContext,
     ToolEntry,
     object_schema,
     string_property,
 )
+from app.cli.interactive_shell.runtime.session import ReplSession
+
+
+def _investigation_planner_selectable(_session: ReplSession) -> bool:
+    """Hide ``investigation_start`` from the planner when the loop is disabled.
+
+    Direct dispatch (e.g. explicit/programmatic ``investigation`` actions) stays
+    available; only natural-language planner selection is gated here.
+    """
+    return investigation_loop_enabled()
 
 
 def execute_investigation_action(args: dict[str, Any], ctx: ToolContext) -> bool:
@@ -47,6 +60,7 @@ TOOL_ENTRY = ToolEntry(
     ),
     execution_tier=ExecutionTier.ELEVATED,
     execute=execute_investigation_action,
+    is_planner_selectable=_investigation_planner_selectable,
 )
 
 

--- a/app/cli/interactive_shell/routing/tests/test_routing_scenarios.py
+++ b/app/cli/interactive_shell/routing/tests/test_routing_scenarios.py
@@ -12,6 +12,9 @@ from app.cli.interactive_shell.commands import SLASH_COMMANDS
 from app.cli.interactive_shell.routing.handle_message_with_agent.command_dispatch import (
     deterministic_command_text,
 )
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.feature_flags import (
+    investigation_loop_enabled,
+)
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.interaction_models import (
     PlannedAction,
 )
@@ -57,6 +60,29 @@ _LIVE_CASES = iter_scenarios_for_shard(
 
 def _slash_content(command: str, args: list[str]) -> str:
     return " ".join([command, *args]) if args else command
+
+
+def _expects_investigation(case: ScenarioCase) -> bool:
+    """True when a scenario expects the planner to dispatch a natural-language
+    investigation (``investigation_start``).
+
+    The investigation loop can be disabled in the interactive shell via
+    ``feature_flags.INTERACTIVE_SHELL_INVESTIGATION_ENABLED``. When it is off the
+    planner is not offered ``investigation_start``, so these scenarios no longer
+    apply and are skipped rather than asserted against the old behavior. Sample
+    alerts and synthetic runs are unaffected.
+    """
+    actions = (*case.answer.planned_actions, *case.answer.executed_actions)
+    return any(str(action.get("kind", "")).strip() == "investigation" for action in actions)
+
+
+def _skip_if_investigation_disabled(case: ScenarioCase) -> None:
+    if not investigation_loop_enabled() and _expects_investigation(case):
+        pytest.skip(
+            "Natural-language investigation loop is disabled in the interactive shell "
+            "(feature_flags.INTERACTIVE_SHELL_INVESTIGATION_ENABLED is False); "
+            "this investigation scenario does not apply. Re-enable the flag to run it."
+        )
 
 
 def _build_actual_action(action: PlannedAction) -> ExpectedAction:
@@ -184,6 +210,7 @@ def test_help_route_decision_has_structured_shape() -> None:
 @pytest.mark.integration
 @pytest.mark.live_llm
 def test_live_action_planning(live_planning_case: ScenarioCase) -> None:
+    _skip_if_investigation_disabled(live_planning_case)
     session = fresh_session(
         with_prior_state=live_planning_case.scenario.session.has_prior_state,
         configured_integrations=live_planning_case.scenario.session.configured_integrations,
@@ -247,6 +274,7 @@ def test_live_turn_execution_oracle(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
+    _skip_if_investigation_disabled(live_oracle_case)
     runs = max(1, live_oracle_case.answer.runs)
     run_results: list[OracleRunResult] = []
     passed_count = 0

--- a/app/cli/interactive_shell/routing/tests/test_tool_registry.py
+++ b/app/cli/interactive_shell/routing/tests/test_tool_registry.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import re
 
+import pytest
 from rich.console import Console
 
 from app.cli.interactive_shell.commands import SLASH_COMMANDS
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration import (
+    feature_flags,
+)
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolContext,
 )
@@ -140,3 +144,39 @@ def test_registry_dispatch_blocks_unavailable_tool() -> None:
         ctx=ctx,
     )
     assert ok is False
+
+
+def test_investigation_hidden_from_planner_when_loop_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the natural-language investigation loop disabled (the default), the
+    planner must not be offered ``investigation_start`` -- so diagnostic prompts
+    fall through to the assistant instead of triggering the RCA pipeline."""
+    monkeypatch.setattr(feature_flags, "INTERACTIVE_SHELL_INVESTIGATION_ENABLED", False)
+    names = {spec["name"] for spec in REGISTRY.tool_specs_for_llm(ReplSession())}
+    assert "investigation_start" not in names
+    # Unrelated tools stay offered.
+    assert "alert_sample" in names
+    assert "assistant_handoff" in names
+
+
+def test_investigation_offered_to_planner_when_loop_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(feature_flags, "INTERACTIVE_SHELL_INVESTIGATION_ENABLED", True)
+    names = {spec["name"] for spec in REGISTRY.tool_specs_for_llm(ReplSession())}
+    assert "investigation_start" in names
+
+
+def test_investigation_dispatch_not_gated_by_planner_selectability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hiding the tool from the planner must NOT block direct/programmatic
+    dispatch: ``is_available`` stays True while ``is_planner_selectable`` is the
+    only thing the disable flag flips."""
+    monkeypatch.setattr(feature_flags, "INTERACTIVE_SHELL_INVESTIGATION_ENABLED", False)
+    entry = REGISTRY.get("investigation_start")
+    assert entry is not None
+    session = ReplSession()
+    assert entry.is_available(session) is True
+    assert entry.is_planner_selectable(session) is False


### PR DESCRIPTION
## Summary
- Disables the natural-language investigation loop in the interactive shell so a plain data/diagnostic prompt can no longer kick off the heavyweight RCA pipeline (root cause of the recent "Interactive session" auto-investigation).
- Adds a single feature flag `INTERACTIVE_SHELL_INVESTIGATION_ENABLED` (default `False`) as the kill-switch, plus a new `ToolEntry.is_planner_selectable` hook that hides a tool from the planner's tool specs **without** blocking direct/programmatic dispatch.
- The planner is no longer offered `investigation_start`, so diagnostic/incident prompts fall through to the conversational assistant.

## Scope
- Only the **natural-language planner path** is gated. `/sample-alert` and the local alert listener still run investigations (they don't go through `investigation_start`).
- Routing scenario fixtures that expect an investigation skip while the flag is off, and re-enable automatically when it is flipped back to `True`.

## Test plan
- [x] `test_tool_registry.py` (incl. new gating tests: hidden-from-planner, dispatch-not-gated)
- [x] `test_routing_fixture_integrity.py`
- [x] `test_routing_scenarios.py::test_deterministic_routing`
- [x] `test_terminal_runtime_routing.py` (nitro dispatch still works)
- [x] Full live routing suite locally: investigation scenarios skip, all others pass (one unrelated pre-existing live flake: `700-pasted-self-improvement-offer`)
- [x] ruff + mypy clean

## Notes
- Reversible: flip `INTERACTIVE_SHELL_INVESTIGATION_ENABLED` to `True` to restore NL investigation routing and its scenarios. Planner prompt intentionally left unchanged.

Made with [Cursor](https://cursor.com)