### PR TITLE
test(routing): make 315-quoted satisfy the integration-backed investigation gate

### DIFF
--- a/app/cli/interactive_shell/routing/tests/scenarios/investigations/315-quoted-directive-investigation.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/investigations/315-quoted-directive-investigation.yml
@@ -8,7 +8,20 @@ input:
 session:
   has_prior_state: false
   remote_connected: false
-  configured_integrations: []
+  configured_integrations:
+  - sentry
+  # Pin a fixture-owned Sentry config so the planner sees >=1 connected
+  # integration and the integration-backed investigation gate is satisfied. The
+  # token is fake; no real investigation runs because the oracle stubs the
+  # dispatch boundary (REGISTRY.dispatch), so the call is recorded without
+  # remote I/O.
+  resolved_integrations:
+    sentry:
+      connection_verified: true
+      organization_slug: fixture-org
+      project_slug: fixture-project
+      auth_token: fixture-token
+      base_url: https://sentry.io
 available_capabilities:
   slash_commands: []
   cli_commands: []
@@ -16,8 +29,13 @@ available_capabilities:
 notes:
 - "Regression for quoted directives. An explicit action verb (investigate) whose\
   \ object is quotation-marked text must treat the quoted text as the investigation\
-  \ payload and emit investigation_start. Quoted content must never be downgraded to\
-  \ a chatty statement or rhetorical question and handed off to the assistant."
+  \ payload and emit investigation_start with alert_text set to the quoted text\
+  \ verbatim. Quoted content must never be downgraded to a chatty statement or\
+  \ rhetorical question and handed off to the assistant."
+- "Sentry is connected so the integration-backed investigation gate (>=1 connected\
+  \ integration, added in #2871) is satisfied. With a data source connected, the\
+  \ explicit quoted directive dispatches an investigation instead of handing off to\
+  \ suggest connecting one. Contrast with 313 (incident, no integrations -> handoff)."
 route:
   expected_kind: handle_message_with_agent
   expected_command_text: null


### PR DESCRIPTION
## Context: forward-fix, not an active main-CI fix

The Routing Live failure this scenario caused on `main` is **already neutralized
by #2880**, which set `INTERACTIVE_SHELL_INVESTIGATION_ENABLED = False` (a
temporary kill-switch). While that flag is off, the harness skips
investigation-expecting scenarios (`_skip_if_investigation_disabled`), so
`315-quoted-directive-investigation` no longer runs and `main` is green.

This PR makes that scenario **correct again for when the kill-switch is flipped
back to `True`** — its own docstring notes that re-enabling "also re-enables the
investigation routing scenarios that skip while this is False". Without this
change, re-enabling the investigation loop would immediately re-break the live
routing suite on the same assertion.

## Underlying bug

`6fad6987` (#2871) gated investigation dispatch on having >=1 connected
integration (otherwise hand off and suggest connecting a data source).
`315-quoted-directive-investigation` declared `configured_integrations: []` but
still expected an `investigation`, so with the loop enabled the live planner now
hands off instead:

```
expected: {'kind': 'investigation',     'content': 'checkout is returning 502s for EU customers'}
actual:   {'kind': 'assistant_handoff', 'content': "I can't start a real investigation ... no integrations are connected ..."}
```

## Fix

- Connect a fixture-owned **Sentry** integration to `315-quoted` (mirroring the proven `314` setup) so the integration-backed gate is satisfied.
- Preserves the scenario's unique intent: a **quoted directive's payload is extracted verbatim** into `investigation_start`, never downgraded to a chatty handoff (`content: checkout is returning 502s for EU customers` retained — `314` leaves content synthesized, so this assertion is unique to `315-quoted`).
- Per the live-routing policy this is an intentional fixture update for an approved behavior change; no live planner decision is bypassed.

## Test plan

- [x] Live `test_live_action_planning[315-quoted...]` + oracle pass with the investigation loop enabled (`LLM_PROVIDER=openai`)
- [x] Live planning reruns: 5/5 (no flakiness)
- [x] No-LLM routing gate `-m "not live_llm"`: 60 passed
- [x] `ruff check`, `ruff format --check`, `mypy app/` clean
- [x] PR CI green (routing-live shards correctly skip `315-quoted` while the loop is disabled on the base branch)
