### PR TITLE
fix(cli): normalize whitespace in model ids on the planner tool path

### DIFF
--- a/app/cli/interactive_shell/command_registry/model.py
+++ b/app/cli/interactive_shell/command_registry/model.py
@@ -28,6 +28,19 @@ def _format_supported_models(provider_models: tuple[object, ...]) -> str:
     return ", ".join(visible) if visible else "provider default"
 
 
+def _normalize_model_id(model: str) -> str:
+    """Collapse internal whitespace in a model id to single hyphens.
+
+    A model id is a single token, so a value like ``"gpt 5.5"`` is a mis-parsed
+    ``"gpt-5.5"``. The CLI path (``/model set gpt 5.5``) already rebuilds the id as
+    ``gpt-5.5``; normalizing here keeps the planner/tool path
+    (``llm_set_provider`` -> ``switch_reasoning_model``) consistent so a custom-model
+    provider (e.g. openai) can't persist a whitespace-bearing slug that later fails
+    availability checks and silently falls back.
+    """
+    return "-".join(model.split())
+
+
 def _is_model_supported(
     _provider_value: str, model: str, provider_models: tuple[object, ...]
 ) -> bool:
@@ -105,7 +118,7 @@ def switch_llm_provider(
         )
         return False
 
-    selected_model = model.strip() if model else provider.default_model
+    selected_model = _normalize_model_id(model) if model else provider.default_model
     if selected_model and not _is_model_allowed(provider, selected_model):
         console.print(f"[{ERROR}]unknown model for {provider.value}:[/] {escape(selected_model)}")
         console.print(
@@ -121,7 +134,7 @@ def switch_llm_provider(
                 "toolcall model[/] — toolcall override ignored."
             )
         else:
-            selected_toolcall = toolcall_model.strip()
+            selected_toolcall = _normalize_model_id(toolcall_model)
             if selected_toolcall and not _is_model_allowed(provider, selected_toolcall):
                 console.print(
                     f"[{ERROR}]unknown model for {provider.value}:[/] {escape(selected_toolcall)}"
@@ -182,7 +195,7 @@ def switch_toolcall_model(
             "toolcall model[/] — nothing to set."
         )
         return False
-    new_model = toolcall_model.strip()
+    new_model = _normalize_model_id(toolcall_model)
     if not new_model:
         console.print(f"[{ERROR}]toolcall model cannot be empty[/]")
         return False
@@ -223,7 +236,7 @@ def switch_reasoning_model(
         )
         return False
 
-    new_model = reasoning_model.strip()
+    new_model = _normalize_model_id(reasoning_model)
     if not new_model:
         console.print(f"[{ERROR}]reasoning model cannot be empty[/]")
         return False

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -853,6 +853,36 @@ class TestModelCommand:
         assert "OPENAI_REASONING_MODEL=gpt-5.5" in contents
         assert "OPENAI_MODEL=gpt-5.5" in contents
 
+    def test_switch_reasoning_model_normalizes_whitespace_slug(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Regression: the planner ``llm_set_provider`` tool dispatches the raw
+        target straight to ``switch_reasoning_model`` (no CLI arg-splitting), so a
+        spoken "set model to gpt 5.5" arrived as the single token ``"gpt 5.5"``.
+        Because openai allows custom models, that malformed slug used to be
+        persisted verbatim and then silently fail availability checks. It must be
+        normalized to ``gpt-5.5`` instead."""
+        self._patch_llm(monkeypatch)
+        import app.cli.wizard.env_sync as env_sync
+        from app.cli.interactive_shell.commands import switch_reasoning_model
+
+        env_path = tmp_path / ".env"
+        monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setenv("LLM_PROVIDER", "openai")
+
+        console, buf = _capture()
+        ok = switch_reasoning_model("gpt 5.5", console)
+
+        assert ok is True
+        assert "gpt-5.5" in buf.getvalue()
+        assert "gpt 5.5" not in buf.getvalue()
+        contents = env_path.read_text(encoding="utf-8")
+        assert "OPENAI_REASONING_MODEL=gpt-5.5" in contents
+        assert "OPENAI_MODEL=gpt-5.5" in contents
+        assert "gpt 5.5" not in contents
+
     def test_set_unknown_toolcall_model_is_rejected(
         self,
         monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- The interactive-shell `llm_set_provider` planner tool sends its raw target straight to `switch_reasoning_model` (no CLI arg-splitting), so a spoken **"set model to gpt 5.5"** reached the setter as the single token `"gpt 5.5"`.
- Providers like `openai` set `allow_custom_models=True`, so `_is_model_allowed` accepted the malformed slug; it was written to `.env` verbatim and then failed the provider availability check at request time, silently falling back to the toolcall model.
- Fix: normalize internal whitespace to single hyphens in `switch_reasoning_model`, `switch_toolcall_model`, and `switch_llm_provider`, so the tool path matches the CLI path (which already rebuilds `gpt 5.5` -> `gpt-5.5`).

## Test plan
- [x] `pytest tests/cli/interactive_shell/test_commands.py::TestModelCommand` (23 passed, incl. new `test_switch_reasoning_model_normalizes_whitespace_slug`)
- [x] `ruff check` + `ruff format --check` on changed files
- [x] `mypy app/cli/interactive_shell/command_registry/model.py`

Made with [Cursor](https://cursor.com)