### PR TITLE
fix(analytics): stamp github_username on all events after login

### DIFF
--- a/app/analytics/cli.py
+++ b/app/analytics/cli.py
@@ -457,15 +457,26 @@ def capture_integration_verified(service: str) -> None:
 
 
 def identify_github_username(username: str) -> None:
-    """Attach the authenticated GitHub username as a PostHog person property.
+    """Attach the authenticated GitHub username to PostHog.
+
+    Calls :meth:`~app.analytics.provider.Analytics.identify` to persist
+    ``github_username`` on the person profile AND
+    :meth:`~app.analytics.provider.Analytics.set_persistent_property` so the
+    property is stamped directly on every subsequent event.  Both are needed:
+    the ``$identify`` call keeps the person profile up-to-date for cohort
+    queries, while the persistent property makes ``github_username`` queryable
+    as a plain ``properties.github_username`` filter on any event without
+    requiring a person-profile join.
 
     No-op for an empty username. Best-effort: telemetry kill-switches make the
-    underlying call a no-op, and any unexpected error is swallowed to Sentry.
+    underlying calls no-ops, and any unexpected error is swallowed to Sentry.
     """
     if not username:
         return
     try:
-        get_analytics().identify({"github_username": username})
+        analytics = get_analytics()
+        analytics.identify({"github_username": username})
+        analytics.set_persistent_property("github_username", username)
     except Exception as exc:
         capture_exception(exc)
 

--- a/app/analytics/provider.py
+++ b/app/analytics/provider.py
@@ -671,6 +671,7 @@ class Analytics:
         self._worker: threading.Thread | None = None
         self._shutdown = False
         self._worker_alive = not self._disabled
+        self._persistent_properties: Properties = {}
 
         if not self._disabled:
             atexit.register(self.shutdown)
@@ -682,9 +683,24 @@ class Analytics:
             return
         envelope = _Envelope(
             event=event.value,
-            properties=_BASE_PROPERTIES | _coerce_properties(event.value, properties),
+            properties=_BASE_PROPERTIES
+            | self._persistent_properties
+            | _coerce_properties(event.value, properties),
         )
         self._enqueue(envelope)
+
+    def set_persistent_property(self, key: str, value: JsonScalar) -> None:
+        """Store a property merged into every subsequent :meth:`capture` call.
+
+        Use for user-scoped attributes discovered after the ``Analytics``
+        instance is created (e.g. ``github_username`` after OAuth login) so
+        they appear on all future events as direct event properties and are
+        trivially queryable without a person-profile join. No-ops when
+        telemetry is disabled.
+        """
+        if self._disabled:
+            return
+        self._persistent_properties[key] = value
 
     def identify(self, set_properties: Properties) -> None:
         """Attach person properties to the anonymous distinct id via a ``$identify`` event.

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -28,12 +28,16 @@ class _StubAnalytics:
     def __init__(self) -> None:
         self.events: list[tuple[Event, dict[str, object] | None]] = []
         self.identified: list[dict[str, object]] = []
+        self.persistent_properties: dict[str, object] = {}
 
     def capture(self, event: Event, properties: dict[str, object] | None = None) -> None:
         self.events.append((event, properties))
 
     def identify(self, set_properties: dict[str, object]) -> None:
         self.identified.append(set_properties)
+
+    def set_persistent_property(self, key: str, value: object) -> None:
+        self.persistent_properties[key] = value
 
 
 def test_capture_cli_invoked_uses_safe_capture(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -71,6 +75,7 @@ def test_identify_github_username_sets_person_property(monkeypatch: pytest.Monke
     cli.identify_github_username("octocat")
 
     assert stub.identified == [{"github_username": "octocat"}]
+    assert stub.persistent_properties == {"github_username": "octocat"}
 
 
 def test_identify_github_username_noop_on_empty(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -282,6 +282,47 @@ def test_analytics_events_from_same_instance_share_exact_distinct_id(
     assert f'distinct_id="{analytics._anonymous_id}"' in log_lines[0]
 
 
+def test_set_persistent_property_merges_into_subsequent_captures(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("OPENSRE_ANALYTICS_DISABLED", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+    monkeypatch.setattr(provider.atexit, "register", lambda _func: None)
+    posted_payloads = _stub_httpx_client(monkeypatch)
+
+    analytics = provider.Analytics()
+    analytics.capture(Event.CLI_INVOKED)
+    analytics.set_persistent_property("github_username", "octocat")
+    analytics.capture(Event.ONBOARD_STARTED, {"entrypoint": "cli"})
+    analytics.capture(Event.INTERACTIVE_SHELL_ROUTE_DECISION, {"route": "agent"})
+    analytics.shutdown(flush=True)
+
+    assert len(posted_payloads) == 3
+    props_before = posted_payloads[0]["json"]["properties"]
+    props_after_1 = posted_payloads[1]["json"]["properties"]
+    props_after_2 = posted_payloads[2]["json"]["properties"]
+
+    assert "github_username" not in props_before
+    assert props_after_1["github_username"] == "octocat"
+    assert props_after_2["github_username"] == "octocat"
+    assert props_after_2["route"] == "agent"
+
+
+def test_set_persistent_property_noop_when_telemetry_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OPENSRE_NO_TELEMETRY", "1")
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+
+    analytics = provider.Analytics()
+    analytics.set_persistent_property("github_username", "octocat")
+
+    assert analytics._persistent_properties == {}
+
+
 def test_existing_install_missing_anonymous_id_captures_posthog_error(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

- Adds `set_persistent_property(key, value)` to `Analytics` in `provider.py` — stores a property merged into every subsequent `capture()` call without affecting `_BASE_PROPERTIES`
- `identify_github_username()` now calls both `identify()` (person profile) **and** `set_persistent_property("github_username", ...)` so the username appears as a direct event property on all subsequent events
- Previously `github_username` was only queryable via a person-profile join (event-time person properties mode returned `None` for events before `$identify`); now it's available as `properties.github_username` on every event after login

## Test plan

- `test_set_persistent_property_merges_into_subsequent_captures`: verifies the property is absent before the call and present on every event after
- `test_set_persistent_property_noop_when_telemetry_disabled`: verifies no mutation when opted out
- `test_identify_github_username_sets_person_property`: extended to also assert `persistent_properties` was updated
- All 76 analytics tests pass; `make lint` and `make typecheck` clean

Made with [Cursor](https://cursor.com)