### PR TITLE
fix(tools): inject integration credentials so the assistant can call tools

### DIFF
--- a/app/tools/AlertmanagerAlertsTool/__init__.py
+++ b/app/tools/AlertmanagerAlertsTool/__init__.py
@@ -33,6 +33,7 @@ class AlertmanagerAlertsTool(BaseTool):
         "Determining the blast radius of an infrastructure change via active alert labels",
     ]
     requires = ["base_url"]
+    injected_params = ["base_url", "password", "username"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/app/tools/AlertmanagerSilencesTool/__init__.py
+++ b/app/tools/AlertmanagerSilencesTool/__init__.py
@@ -28,6 +28,7 @@ class AlertmanagerSilencesTool(BaseTool):
         "Determining if an alert is suppressed by an ongoing maintenance window",
     ]
     requires = ["base_url"]
+    injected_params = ["base_url", "password", "username"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/app/tools/ArgoCDApplicationDiffTool/__init__.py
+++ b/app/tools/ArgoCDApplicationDiffTool/__init__.py
@@ -23,6 +23,7 @@ class ArgoCDApplicationDiffTool(BaseTool):
         "Correlating deployment drift with application health degradation",
     ]
     requires = ["base_url", "application_name"]
+    injected_params = ["base_url", "password", "username"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/app/tools/ArgoCDApplicationStatusTool/__init__.py
+++ b/app/tools/ArgoCDApplicationStatusTool/__init__.py
@@ -23,6 +23,7 @@ class ArgoCDApplicationStatusTool(BaseTool):
         "Listing visible Argo CD applications when an alert omits the application name",
     ]
     requires = ["base_url"]
+    injected_params = ["base_url", "password", "username"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/app/tools/AzureMonitorLogsTool/__init__.py
+++ b/app/tools/AzureMonitorLogsTool/__init__.py
@@ -71,6 +71,7 @@ def _ensure_take_clause(query: str, limit: int) -> str:
         "required": ["workspace_id", "access_token"],
     },
     is_available=_azure_available,
+    injected_params=("access_token", "workspace_id"),
     extract_params=_azure_extract_params,
 )
 def query_azure_monitor_logs(

--- a/app/tools/AzureSQLCurrentQueriesTool/__init__.py
+++ b/app/tools/AzureSQLCurrentQueriesTool/__init__.py
@@ -26,6 +26,7 @@ from app.tools.utils.sql_wrapper import call_db_tool_with_default_db_warning
         "Finding queries consuming excessive CPU or IO",
     ],
     is_available=azure_sql_is_available,
+    injected_params=("server",),
     extract_params=azure_sql_extract_params,
 )
 def get_azure_sql_current_queries(

--- a/app/tools/AzureSQLResourceStatsTool/__init__.py
+++ b/app/tools/AzureSQLResourceStatsTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Reviewing historical resource trends to determine if tier upgrade is needed",
     ],
     is_available=azure_sql_is_available,
+    injected_params=("server",),
     extract_params=azure_sql_extract_params,
 )
 def get_azure_sql_resource_stats(

--- a/app/tools/AzureSQLServerStatusTool/__init__.py
+++ b/app/tools/AzureSQLServerStatusTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Reviewing service tier and connection saturation",
     ],
     is_available=azure_sql_is_available,
+    injected_params=("server",),
     extract_params=azure_sql_extract_params,
 )
 def get_azure_sql_server_status(

--- a/app/tools/AzureSQLSlowQueriesTool/__init__.py
+++ b/app/tools/AzureSQLSlowQueriesTool/__init__.py
@@ -26,6 +26,7 @@ from app.tools.utils.sql_wrapper import call_db_tool_with_default_db_warning
         "Reviewing query performance trends for capacity planning",
     ],
     is_available=azure_sql_is_available,
+    injected_params=("server",),
     extract_params=azure_sql_extract_params,
 )
 def get_azure_sql_slow_queries(

--- a/app/tools/AzureSQLWaitStatsTool/__init__.py
+++ b/app/tools/AzureSQLWaitStatsTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Understanding resource governance limits on Azure SQL",
     ],
     is_available=azure_sql_is_available,
+    injected_params=("server",),
     extract_params=azure_sql_extract_params,
 )
 def get_azure_sql_wait_stats(

--- a/app/tools/BetterStackLogsTool/__init__.py
+++ b/app/tools/BetterStackLogsTool/__init__.py
@@ -31,6 +31,7 @@ from app.tools.tool_decorator import tool
         "Scanning a specific source (e.g. t123456_myapp) for recent and archived activity",
     ],
     is_available=betterstack_is_available,
+    injected_params=("password", "query_endpoint", "username"),
     extract_params=betterstack_extract_params,
 )
 def query_betterstack_logs(

--- a/app/tools/ClickHouseQueryActivityTool/__init__.py
+++ b/app/tools/ClickHouseQueryActivityTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Reviewing query activity after an alert fires",
     ],
     is_available=clickhouse_is_available,
+    injected_params=("host",),
     extract_params=clickhouse_extract_params,
 )
 def get_clickhouse_query_activity(

--- a/app/tools/ClickHouseSystemHealthTool/__init__.py
+++ b/app/tools/ClickHouseSystemHealthTool/__init__.py
@@ -23,6 +23,7 @@ from app.tools.tool_decorator import tool
         "Reviewing connection and query counts for capacity issues",
     ],
     is_available=clickhouse_is_available,
+    injected_params=("host",),
     extract_params=clickhouse_extract_params,
 )
 def get_clickhouse_system_health(

--- a/app/tools/DagsterAssetsTool/__init__.py
+++ b/app/tools/DagsterAssetsTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="dagster",
     surfaces=("investigation", "chat"),
     is_available=dagster_is_available,
+    injected_params=("api_token", "endpoint"),
     extract_params=dagster_extract_params,
 )
 def list_dagster_assets(

--- a/app/tools/DagsterRunLogsTool/__init__.py
+++ b/app/tools/DagsterRunLogsTool/__init__.py
@@ -33,6 +33,7 @@ from app.tools.tool_decorator import tool
     source="dagster",
     surfaces=("investigation", "chat"),
     is_available=dagster_is_available,
+    injected_params=("api_token", "endpoint"),
     extract_params=dagster_extract_params,
 )
 def get_dagster_run_logs(

--- a/app/tools/DagsterRunsTool/__init__.py
+++ b/app/tools/DagsterRunsTool/__init__.py
@@ -27,6 +27,7 @@ from app.tools.tool_decorator import tool
     source="dagster",
     surfaces=("investigation", "chat"),
     is_available=dagster_is_available,
+    injected_params=("api_token", "endpoint"),
     extract_params=dagster_extract_params,
 )
 def list_dagster_runs(

--- a/app/tools/DagsterSchedulesTool/__init__.py
+++ b/app/tools/DagsterSchedulesTool/__init__.py
@@ -21,6 +21,7 @@ from app.tools.tool_decorator import tool
     source="dagster",
     surfaces=("investigation", "chat"),
     is_available=dagster_is_available,
+    injected_params=("api_token", "endpoint"),
     extract_params=dagster_extract_params,
 )
 def list_dagster_schedule_ticks(

--- a/app/tools/DagsterSensorsTool/__init__.py
+++ b/app/tools/DagsterSensorsTool/__init__.py
@@ -21,6 +21,7 @@ from app.tools.tool_decorator import tool
     source="dagster",
     surfaces=("investigation", "chat"),
     is_available=dagster_is_available,
+    injected_params=("api_token", "endpoint"),
     extract_params=dagster_extract_params,
 )
 def list_dagster_sensor_ticks(

--- a/app/tools/EKSDeploymentStatusTool/__init__.py
+++ b/app/tools/EKSDeploymentStatusTool/__init__.py
@@ -49,6 +49,7 @@ def _deployment_status_extract_params(sources: dict[str, dict]) -> dict[str, Any
         "required": ["cluster_name", "namespace", "deployment_name", "role_arn"],
     },
     is_available=_deployment_status_is_available,
+    injected_params=("credentials", "external_id", "role_arn"),
     extract_params=_deployment_status_extract_params,
 )
 def get_eks_deployment_status(

--- a/app/tools/EKSDescribeAddonTool/__init__.py
+++ b/app/tools/EKSDescribeAddonTool/__init__.py
@@ -44,6 +44,7 @@ def _addon_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         "required": ["cluster_name", "role_arn"],
     },
     is_available=_addon_is_available,
+    injected_params=("credentials", "external_id", "role_arn"),
     extract_params=_addon_extract_params,
 )
 def describe_eks_addon(

--- a/app/tools/EKSDescribeClusterTool/__init__.py
+++ b/app/tools/EKSDescribeClusterTool/__init__.py
@@ -46,6 +46,7 @@ def _describe_cluster_extract_params(sources: dict[str, dict]) -> dict[str, Any]
         "required": ["cluster_name", "role_arn"],
     },
     is_available=_describe_cluster_is_available,
+    injected_params=("credentials", "external_id", "role_arn"),
     extract_params=_describe_cluster_extract_params,
 )
 def describe_eks_cluster(

--- a/app/tools/EKSEventsTool/__init__.py
+++ b/app/tools/EKSEventsTool/__init__.py
@@ -50,6 +50,7 @@ def _events_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         "required": ["cluster_name", "namespace", "role_arn"],
     },
     is_available=_events_is_available,
+    injected_params=("credentials", "external_id", "role_arn"),
     extract_params=_events_extract_params,
 )
 def get_eks_events(

--- a/app/tools/EKSListClustersTool/__init__.py
+++ b/app/tools/EKSListClustersTool/__init__.py
@@ -49,6 +49,7 @@ def _eks_creds(eks: dict) -> dict:
         "required": ["role_arn"],
     },
     is_available=_eks_available,
+    injected_params=("credentials", "external_id", "role_arn"),
     extract_params=extract_cluster_params,
 )
 def list_eks_clusters(

--- a/app/tools/EKSListDeploymentsTool/__init__.py
+++ b/app/tools/EKSListDeploymentsTool/__init__.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
         "required": ["cluster_name", "namespace", "role_arn"],
     },
     is_available=eks_available_or_backend,
+    injected_params=("credentials", "external_id", "role_arn"),
     extract_params=extract_workload_params,
 )
 def list_eks_deployments(

--- a/app/tools/EKSListNamespacesTool/__init__.py
+++ b/app/tools/EKSListNamespacesTool/__init__.py
@@ -43,6 +43,7 @@ def _list_ns_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         "required": ["cluster_name", "role_arn"],
     },
     is_available=_list_ns_is_available,
+    injected_params=("credentials", "external_id", "role_arn"),
     extract_params=_list_ns_extract_params,
 )
 def list_eks_namespaces(

--- a/app/tools/EKSNodeHealthTool/__init__.py
+++ b/app/tools/EKSNodeHealthTool/__init__.py
@@ -48,6 +48,7 @@ def _node_health_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         "required": ["cluster_name", "role_arn"],
     },
     is_available=_node_health_is_available,
+    injected_params=("credentials", "external_id", "role_arn"),
     extract_params=_node_health_extract_params,
 )
 def get_eks_node_health(

--- a/app/tools/EKSNodegroupHealthTool/__init__.py
+++ b/app/tools/EKSNodegroupHealthTool/__init__.py
@@ -44,6 +44,7 @@ def _nodegroup_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         "required": ["cluster_name", "role_arn"],
     },
     is_available=_nodegroup_is_available,
+    injected_params=("credentials", "external_id", "role_arn"),
     extract_params=_nodegroup_extract_params,
 )
 def get_eks_nodegroup_health(

--- a/app/tools/EKSPodLogsTool/__init__.py
+++ b/app/tools/EKSPodLogsTool/__init__.py
@@ -53,6 +53,7 @@ def _pod_logs_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         "required": ["cluster_name", "namespace", "pod_name", "role_arn"],
     },
     is_available=_pod_logs_is_available,
+    injected_params=("credentials", "external_id", "role_arn"),
     extract_params=_pod_logs_extract_params,
 )
 def get_eks_pod_logs(

--- a/app/tools/GoogleDocsCreateReportTool/__init__.py
+++ b/app/tools/GoogleDocsCreateReportTool/__init__.py
@@ -116,6 +116,7 @@ def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         ],
     },
     is_available=_is_available,
+    injected_params=("credentials_file",),
     extract_params=_extract_params,
 )
 def create_google_docs_incident_report(

--- a/app/tools/JiraAddCommentTool/__init__.py
+++ b/app/tools/JiraAddCommentTool/__init__.py
@@ -24,6 +24,7 @@ class JiraAddCommentTool(BaseTool):
         "Documenting resolution steps on the tracking ticket",
     ]
     requires = ["base_url", "email", "api_token", "issue_key", "body"]
+    injected_params = ["api_token", "base_url", "email"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/app/tools/JiraCreateIssueTool/__init__.py
+++ b/app/tools/JiraCreateIssueTool/__init__.py
@@ -24,6 +24,7 @@ class JiraCreateIssueTool(BaseTool):
         "Documenting a new issue with evidence from the investigation",
     ]
     requires = ["base_url", "email", "api_token", "summary", "description"]
+    injected_params = ["api_token", "base_url", "email"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/app/tools/JiraIssueDetailTool/__init__.py
+++ b/app/tools/JiraIssueDetailTool/__init__.py
@@ -24,6 +24,7 @@ class JiraIssueDetailTool(BaseTool):
         "Pulling assignee and label information for an existing ticket",
     ]
     requires = ["base_url", "email", "api_token", "issue_key"]
+    injected_params = ["api_token", "base_url", "email"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/app/tools/JiraSearchIssuesTool/__init__.py
+++ b/app/tools/JiraSearchIssuesTool/__init__.py
@@ -24,6 +24,7 @@ class JiraSearchIssuesTool(BaseTool):
         "Listing high-priority issues updated recently in a project",
     ]
     requires = ["base_url", "email", "api_token"]
+    injected_params = ["api_token", "base_url", "email"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/app/tools/KafkaConsumerGroupTool/__init__.py
+++ b/app/tools/KafkaConsumerGroupTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Checking consumer group health after a deployment",
     ],
     is_available=kafka_is_available,
+    injected_params=("bootstrap_servers",),
     extract_params=kafka_extract_params,
 )
 def get_kafka_consumer_group_lag(

--- a/app/tools/KafkaTopicHealthTool/__init__.py
+++ b/app/tools/KafkaTopicHealthTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Reviewing topic metadata for capacity planning",
     ],
     is_available=kafka_is_available,
+    injected_params=("bootstrap_servers",),
     extract_params=kafka_extract_params,
 )
 def get_kafka_topic_health(

--- a/app/tools/MariaDBInnoDBStatusTool/__init__.py
+++ b/app/tools/MariaDBInnoDBStatusTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="mariadb",
     surfaces=("investigation", "chat"),
     is_available=mariadb_is_available,
+    injected_params=("host", "password", "username"),
     extract_params=mariadb_extract_params,
 )
 def get_mariadb_innodb_status(

--- a/app/tools/MariaDBProcessListTool/__init__.py
+++ b/app/tools/MariaDBProcessListTool/__init__.py
@@ -21,6 +21,7 @@ from app.tools.utils.sql_wrapper import call_db_tool_with_default_db_warning
     source="mariadb",
     surfaces=("investigation", "chat"),
     is_available=mariadb_is_available,
+    injected_params=("host", "password", "username"),
     extract_params=mariadb_extract_params,
 )
 def get_mariadb_process_list(

--- a/app/tools/MariaDBReplicationTool/__init__.py
+++ b/app/tools/MariaDBReplicationTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="mariadb",
     surfaces=("investigation", "chat"),
     is_available=mariadb_is_available,
+    injected_params=("host", "password", "username"),
     extract_params=mariadb_extract_params,
 )
 def get_mariadb_replication_status(

--- a/app/tools/MariaDBSlowQueriesTool/__init__.py
+++ b/app/tools/MariaDBSlowQueriesTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="mariadb",
     surfaces=("investigation", "chat"),
     is_available=mariadb_is_available,
+    injected_params=("host", "password", "username"),
     extract_params=mariadb_extract_params,
 )
 def get_mariadb_slow_queries(

--- a/app/tools/MariaDBStatusTool/__init__.py
+++ b/app/tools/MariaDBStatusTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="mariadb",
     surfaces=("investigation", "chat"),
     is_available=mariadb_is_available,
+    injected_params=("host", "password", "username"),
     extract_params=mariadb_extract_params,
 )
 def get_mariadb_global_status(

--- a/app/tools/MongoDBAtlasAlertsTool/__init__.py
+++ b/app/tools/MongoDBAtlasAlertsTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="mongodb_atlas",
     surfaces=("investigation", "chat"),
     is_available=atlas_is_available,
+    injected_params=("api_private_key", "api_public_key", "base_url"),
     extract_params=atlas_extract_params,
 )
 def get_mongodb_atlas_alerts(

--- a/app/tools/MongoDBAtlasClustersTool/__init__.py
+++ b/app/tools/MongoDBAtlasClustersTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="mongodb_atlas",
     surfaces=("investigation", "chat"),
     is_available=atlas_is_available,
+    injected_params=("api_private_key", "api_public_key", "base_url"),
     extract_params=atlas_extract_params,
 )
 def get_mongodb_atlas_clusters(

--- a/app/tools/MongoDBAtlasEventsTool/__init__.py
+++ b/app/tools/MongoDBAtlasEventsTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="mongodb_atlas",
     surfaces=("investigation", "chat"),
     is_available=atlas_is_available,
+    injected_params=("api_private_key", "api_public_key", "base_url"),
     extract_params=atlas_extract_params,
 )
 def get_mongodb_atlas_cluster_events(

--- a/app/tools/MongoDBAtlasMetricsTool/__init__.py
+++ b/app/tools/MongoDBAtlasMetricsTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="mongodb_atlas",
     surfaces=("investigation", "chat"),
     is_available=atlas_is_available,
+    injected_params=("api_private_key", "api_public_key", "base_url"),
     extract_params=atlas_extract_params,
 )
 def get_mongodb_atlas_cluster_metrics(

--- a/app/tools/MongoDBAtlasPerformanceAdvisorTool/__init__.py
+++ b/app/tools/MongoDBAtlasPerformanceAdvisorTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="mongodb_atlas",
     surfaces=("investigation", "chat"),
     is_available=atlas_is_available,
+    injected_params=("api_private_key", "api_public_key", "base_url"),
     extract_params=atlas_extract_params,
 )
 def get_mongodb_atlas_performance_advisor(

--- a/app/tools/MongoDBCollectionStatsTool/__init__.py
+++ b/app/tools/MongoDBCollectionStatsTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="mongodb",
     surfaces=("investigation", "chat"),
     is_available=mongodb_database_is_available,
+    injected_params=("connection_string",),
     extract_params=mongodb_extract_params,
 )
 def get_mongodb_collection_stats(

--- a/app/tools/MongoDBCurrentOpsTool/__init__.py
+++ b/app/tools/MongoDBCurrentOpsTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="mongodb",
     surfaces=("investigation", "chat"),
     is_available=mongodb_is_available,
+    injected_params=("connection_string",),
     extract_params=mongodb_extract_params,
 )
 def get_mongodb_current_ops(

--- a/app/tools/MongoDBProfilerTool/__init__.py
+++ b/app/tools/MongoDBProfilerTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="mongodb",
     surfaces=("investigation", "chat"),
     is_available=mongodb_database_is_available,
+    injected_params=("connection_string",),
     extract_params=mongodb_extract_params,
 )
 def get_mongodb_profiler_data(

--- a/app/tools/MongoDBReplicaStatusTool/__init__.py
+++ b/app/tools/MongoDBReplicaStatusTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="mongodb",
     surfaces=("investigation", "chat"),
     is_available=mongodb_is_available,
+    injected_params=("connection_string",),
     extract_params=mongodb_extract_params,
 )
 def get_mongodb_replica_status(

--- a/app/tools/MongoDBServerStatusTool/__init__.py
+++ b/app/tools/MongoDBServerStatusTool/__init__.py
@@ -17,6 +17,7 @@ from app.tools.tool_decorator import tool
     source="mongodb",
     surfaces=("investigation", "chat"),
     is_available=mongodb_is_available,
+    injected_params=("connection_string",),
     extract_params=mongodb_extract_params,
 )
 def get_mongodb_server_status(

--- a/app/tools/MySQLCurrentProcessesTool/__init__.py
+++ b/app/tools/MySQLCurrentProcessesTool/__init__.py
@@ -26,6 +26,7 @@ from app.tools.utils.sql_wrapper import call_db_tool_with_default_db_warning
         "Spotting runaway queries during an incident",
     ],
     is_available=mysql_is_available,
+    injected_params=("host",),
     extract_params=mysql_extract_params,
 )
 def get_mysql_current_processes(

--- a/app/tools/MySQLReplicationStatusTool/__init__.py
+++ b/app/tools/MySQLReplicationStatusTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Diagnosing replication errors and identifying last error details",
     ],
     is_available=mysql_is_available,
+    injected_params=("host",),
     extract_params=mysql_extract_params,
 )
 def get_mysql_replication_status(

--- a/app/tools/MySQLServerStatusTool/__init__.py
+++ b/app/tools/MySQLServerStatusTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Reviewing InnoDB buffer pool hit ratio and deadlock counts",
     ],
     is_available=mysql_is_available,
+    injected_params=("host",),
     extract_params=mysql_extract_params,
 )
 def get_mysql_server_status(

--- a/app/tools/MySQLSlowQueriesTool/__init__.py
+++ b/app/tools/MySQLSlowQueriesTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Finding poorly optimized queries with high execution times or full-table scans",
     ],
     is_available=mysql_is_available,
+    injected_params=("host",),
     extract_params=mysql_extract_params,
 )
 def get_mysql_slow_queries(

--- a/app/tools/MySQLTableStatsTool/__init__.py
+++ b/app/tools/MySQLTableStatsTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Finding tables with unexpectedly high row counts or index overhead",
     ],
     is_available=mysql_is_available,
+    injected_params=("host",),
     extract_params=mysql_extract_params,
 )
 def get_mysql_table_stats(

--- a/app/tools/OpenObserveLogsTool/__init__.py
+++ b/app/tools/OpenObserveLogsTool/__init__.py
@@ -103,6 +103,7 @@ def _extract_records(body: dict[str, Any]) -> list[dict[str, Any]]:
         "required": ["base_url"],
     },
     is_available=_openobserve_available,
+    injected_params=("base_url",),
     extract_params=_openobserve_extract_params,
 )
 def query_openobserve_logs(

--- a/app/tools/OpenSearchAnalyticsTool/__init__.py
+++ b/app/tools/OpenSearchAnalyticsTool/__init__.py
@@ -60,6 +60,7 @@ def _opensearch_extract_params(sources: dict[str, dict[str, Any]]) -> dict[str, 
         "required": ["url"],
     },
     is_available=_opensearch_available,
+    injected_params=("url",),
     extract_params=_opensearch_extract_params,
 )
 def query_opensearch_analytics(

--- a/app/tools/OpsGenieAlertDetailTool/__init__.py
+++ b/app/tools/OpsGenieAlertDetailTool/__init__.py
@@ -24,6 +24,7 @@ class OpsGenieAlertDetailTool(BaseTool):
         "Reading alert details (custom fields, tags, entity) for RCA context",
     ]
     requires = ["api_key", "alert_id"]
+    injected_params = ["api_key"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/app/tools/OpsGenieAlertsTool/__init__.py
+++ b/app/tools/OpsGenieAlertsTool/__init__.py
@@ -26,6 +26,7 @@ class OpsGenieAlertsTool(BaseTool):
         "Checking recent alert history for a service or tag",
     ]
     requires = ["api_key"]
+    injected_params = ["api_key"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/app/tools/PostgreSQLCurrentQueriesTool/__init__.py
+++ b/app/tools/PostgreSQLCurrentQueriesTool/__init__.py
@@ -25,6 +25,7 @@ from app.tools.utils.sql_wrapper import call_db_tool_with_default_db_warning
         "Finding resource-intensive queries correlating with alert timeframes",
     ],
     is_available=postgresql_is_available,
+    injected_params=("host",),
     extract_params=postgresql_extract_params,
 )
 def get_postgresql_current_queries(

--- a/app/tools/PostgreSQLReplicationStatusTool/__init__.py
+++ b/app/tools/PostgreSQLReplicationStatusTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Monitoring WAL streaming and replica connectivity problems",
     ],
     is_available=postgresql_is_available,
+    injected_params=("host",),
     extract_params=postgresql_extract_params,
 )
 def get_postgresql_replication_status(

--- a/app/tools/PostgreSQLServerStatusTool/__init__.py
+++ b/app/tools/PostgreSQLServerStatusTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Reviewing transaction rates and cache efficiency metrics",
     ],
     is_available=postgresql_is_available,
+    injected_params=("host",),
     extract_params=postgresql_extract_params,
 )
 def get_postgresql_server_status(

--- a/app/tools/PostgreSQLSlowQueriesTool/__init__.py
+++ b/app/tools/PostgreSQLSlowQueriesTool/__init__.py
@@ -70,6 +70,7 @@ class PostgreSQLSlowQueriesOutput(BaseModel):
     input_model=PostgreSQLSlowQueriesInput,
     output_model=PostgreSQLSlowQueriesOutput,
     is_available=postgresql_is_available,
+    injected_params=("host",),
     extract_params=postgresql_extract_params,
 )
 def get_postgresql_slow_queries(

--- a/app/tools/PostgreSQLTableStatsTool/__init__.py
+++ b/app/tools/PostgreSQLTableStatsTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Checking table maintenance status like vacuum and analyze operations",
     ],
     is_available=postgresql_is_available,
+    injected_params=("host",),
     extract_params=postgresql_extract_params,
 )
 def get_postgresql_table_stats(

--- a/app/tools/PrefectFlowRunsTool/__init__.py
+++ b/app/tools/PrefectFlowRunsTool/__init__.py
@@ -28,6 +28,7 @@ class PrefectFlowRunsTool(BaseTool):
         "Identifying recurring flow failures across deployments",
     ]
     requires = ["api_url"]
+    injected_params = ["api_key", "api_url", "workspace_id"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/app/tools/PrefectWorkerHealthTool/__init__.py
+++ b/app/tools/PrefectWorkerHealthTool/__init__.py
@@ -28,6 +28,7 @@ class PrefectWorkerHealthTool(BaseTool):
         "Auditing work pool concurrency limits during incident investigation",
     ]
     requires = ["api_url"]
+    injected_params = ["api_key", "api_url", "workspace_id"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/app/tools/RabbitMQBrokerOverviewTool/__init__.py
+++ b/app/tools/RabbitMQBrokerOverviewTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Comparing publish vs deliver rates to detect throughput imbalances",
     ],
     is_available=rabbitmq_is_available,
+    injected_params=("host", "password", "username"),
     extract_params=rabbitmq_extract_params,
 )
 def get_rabbitmq_broker_overview(

--- a/app/tools/RabbitMQConnectionStatsTool/__init__.py
+++ b/app/tools/RabbitMQConnectionStatsTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Checking if slow consumers are holding open idle connections",
     ],
     is_available=rabbitmq_is_available,
+    injected_params=("host", "password", "username"),
     extract_params=rabbitmq_extract_params,
 )
 def get_rabbitmq_connection_stats(

--- a/app/tools/RabbitMQConsumerHealthTool/__init__.py
+++ b/app/tools/RabbitMQConsumerHealthTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Identifying stalled or inactive consumers on a specific queue",
     ],
     is_available=rabbitmq_is_available,
+    injected_params=("host", "password", "username"),
     extract_params=rabbitmq_extract_params,
 )
 def get_rabbitmq_consumer_health(

--- a/app/tools/RabbitMQNodeHealthTool/__init__.py
+++ b/app/tools/RabbitMQNodeHealthTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Investigating file descriptor or socket exhaustion on a broker node",
     ],
     is_available=rabbitmq_is_available,
+    injected_params=("host", "password", "username"),
     extract_params=rabbitmq_extract_params,
 )
 def get_rabbitmq_node_health(

--- a/app/tools/RabbitMQQueueBacklogTool/__init__.py
+++ b/app/tools/RabbitMQQueueBacklogTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Finding queues with zero consumers that are silently accumulating messages",
     ],
     is_available=rabbitmq_is_available,
+    injected_params=("host", "password", "username"),
     extract_params=rabbitmq_extract_params,
 )
 def get_rabbitmq_queue_backlog(

--- a/app/tools/RedisKeyScanTool/__init__.py
+++ b/app/tools/RedisKeyScanTool/__init__.py
@@ -30,6 +30,7 @@ from app.tools.tool_decorator import tool
         "samples": "Per-key samples: key, ttl_seconds (-1 none, -2 missing), and type.",
     },
     is_available=redis_is_available,
+    injected_params=("host",),
     extract_params=redis_extract_params,
 )
 def scan_redis_keys(

--- a/app/tools/RedisReplicationTool/__init__.py
+++ b/app/tools/RedisReplicationTool/__init__.py
@@ -30,6 +30,7 @@ from app.tools.tool_decorator import tool
         "replicas": "For masters: per-replica address, state, offset, and lag_bytes.",
     },
     is_available=redis_is_available,
+    injected_params=("host",),
     extract_params=redis_extract_params,
 )
 def get_redis_replication(

--- a/app/tools/RedisServerInfoTool/__init__.py
+++ b/app/tools/RedisServerInfoTool/__init__.py
@@ -31,6 +31,7 @@ from app.tools.tool_decorator import tool
         "keyspace": "Per-database key counts, expires, and average TTL.",
     },
     is_available=redis_is_available,
+    injected_params=("host",),
     extract_params=redis_extract_params,
 )
 def get_redis_server_info(

--- a/app/tools/RedisSlowlogTool/__init__.py
+++ b/app/tools/RedisSlowlogTool/__init__.py
@@ -28,6 +28,7 @@ from app.tools.tool_decorator import tool
         "entries": "Slow log records: id, start_time, duration_microseconds, command, and client.",
     },
     is_available=redis_is_available,
+    injected_params=("host",),
     extract_params=redis_extract_params,
 )
 def get_redis_slowlog(

--- a/app/tools/SentryIssueDetailsTool/__init__.py
+++ b/app/tools/SentryIssueDetailsTool/__init__.py
@@ -46,6 +46,7 @@ def _issue_details_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         },
         "required": ["organization_slug", "sentry_token", "issue_id"],
     },
+    injected_params=("organization_slug", "sentry_token", "sentry_url"),
     is_available=_issue_details_available,
     extract_params=_issue_details_extract_params,
     surfaces=("investigation", "chat"),

--- a/app/tools/SentryIssueEventsTool/__init__.py
+++ b/app/tools/SentryIssueEventsTool/__init__.py
@@ -48,6 +48,7 @@ def _issue_events_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         },
         "required": ["organization_slug", "sentry_token", "issue_id"],
     },
+    injected_params=("organization_slug", "sentry_token", "sentry_url"),
     is_available=_issue_events_available,
     extract_params=_issue_events_extract_params,
     surfaces=("investigation", "chat"),

--- a/app/tools/SentrySearchIssuesTool/__init__.py
+++ b/app/tools/SentrySearchIssuesTool/__init__.py
@@ -86,6 +86,7 @@ def _search_issues_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         },
         "required": ["organization_slug", "sentry_token"],
     },
+    injected_params=("organization_slug", "sentry_token", "sentry_url"),
     is_available=_sentry_available,
     extract_params=_search_issues_extract_params,
     surfaces=("investigation", "chat"),

--- a/app/tools/SnowflakeQueryHistoryTool/__init__.py
+++ b/app/tools/SnowflakeQueryHistoryTool/__init__.py
@@ -117,6 +117,7 @@ def _normalize_rows(response_payload: dict[str, Any]) -> list[dict[str, Any]]:
         "required": ["account_identifier"],
     },
     is_available=_snowflake_available,
+    injected_params=("account_identifier",),
     extract_params=_snowflake_extract_params,
 )
 def query_snowflake_history(

--- a/app/tools/SupabaseHealthTool/__init__.py
+++ b/app/tools/SupabaseHealthTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Triaging intermittent 503 or 401 errors from a Supabase-backed application",
     ],
     is_available=supabase_is_available,
+    injected_params=("project_url",),
     extract_params=supabase_extract_params,
 )
 def get_supabase_service_health(

--- a/app/tools/SupabaseStorageTool/__init__.py
+++ b/app/tools/SupabaseStorageTool/__init__.py
@@ -22,6 +22,7 @@ from app.tools.tool_decorator import tool
         "Listing all buckets to identify orphaned or misconfigured storage resources",
     ],
     is_available=supabase_is_available,
+    injected_params=("project_url",),
     extract_params=supabase_extract_params,
 )
 def get_supabase_storage_buckets(

--- a/app/tools/VercelDeploymentStatusTool/__init__.py
+++ b/app/tools/VercelDeploymentStatusTool/__init__.py
@@ -26,6 +26,7 @@ class VercelDeploymentStatusTool(BaseTool):
         "Listing recent deployment history for a Vercel project",
     ]
     requires = ["api_token"]
+    injected_params = ["api_token"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/app/tools/VercelLogsTool/__init__.py
+++ b/app/tools/VercelLogsTool/__init__.py
@@ -26,6 +26,7 @@ class VercelLogsTool(BaseTool):
         "Inspecting build output for dependency or compilation errors",
     ]
     requires = ["api_token", "deployment_id"]
+    injected_params = ["api_token"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/app/tools/VictoriaLogsTool/__init__.py
+++ b/app/tools/VictoriaLogsTool/__init__.py
@@ -40,6 +40,7 @@ class VictoriaLogsTool(BaseTool):
     # follow-up. Mirrors SplunkSearchTool, the closest log-query analog.
     surfaces = ("investigation", "chat")
     requires = ["base_url"]
+    injected_params = ["base_url"]
     input_schema = {
         "type": "object",
         "properties": {

--- a/tests/tools/test_tool_selection_contracts.py
+++ b/tests/tools/test_tool_selection_contracts.py
@@ -1,6 +1,131 @@
 from __future__ import annotations
 
-from app.tools.registry import get_registered_tool_map
+import pytest
+
+from app.tools.registry import get_registered_tool_map, get_registered_tools
+
+# Parameter names that are supplied from resolved integration config (auth
+# secrets and connection/account identities) and that the model can NEVER
+# legitimately provide. Such a param MUST be declared in a tool's
+# ``injected_params`` so it is stripped from the model-facing schema and
+# auto-injected at run time. If one stays in the model-facing ``required`` list,
+# the LLM is asked for a value it cannot know, so it silently never calls the
+# tool — the conversational assistant then answers from prose instead of live
+# data. See ``app/tools/SentrySearchIssuesTool`` and the chat tool-gathering
+# loop in ``app/cli/interactive_shell/chat/tool_gathering.py``.
+CREDENTIAL_PARAM_NAMES = frozenset(
+    {
+        # auth secrets
+        "api_key",
+        "app_key",
+        "api_token",
+        "auth_token",
+        "sentry_token",
+        "access_token",
+        "api_private_key",
+        "api_public_key",
+        "password",
+        "secret",
+        "secret_key",
+        "client_secret",
+        "connection_string",
+        "grafana_api_key",
+        "grafana_password",
+        "token",
+        # connection / account identity (config-only)
+        "base_url",
+        "site",
+        "host",
+        "server",
+        "endpoint",
+        "url",
+        "api_url",
+        "project_url",
+        "workspace_id",
+        "account_identifier",
+        "bootstrap_servers",
+        "query_endpoint",
+        "organization_slug",
+        "role_arn",
+        "credentials_file",
+        "grafana_endpoint",
+        "grafana_username",
+        "username",
+        "email",
+        "credentials",
+        "external_id",
+    }
+)
+
+# (tool_name, param) pairs where a credential-NAMED parameter is genuinely a
+# model-supplied target, not a credential, and is intentionally exposed. Keep
+# this list tiny and justified; each entry is a deliberate exception.
+MODEL_SUPPLIED_CREDENTIAL_PARAMS = frozenset(
+    {
+        # CloudTrail filters events by an IAM principal name; ``username`` here is
+        # the forensic search target, not an auth credential.
+        ("lookup_cloudtrail_events", "username"),
+    }
+)
+
+
+def _all_registered_tools() -> dict[str, object]:
+    tools: dict[str, object] = {}
+    for surface in ("investigation", "chat"):
+        for tool in get_registered_tools(surface):
+            tools[tool.name] = tool
+    return tools
+
+
+def test_no_tool_requires_a_credential_in_its_model_facing_schema() -> None:
+    """Credentials must be injected from config, never required of the model.
+
+    Regression guard for the whole tool registry: a tool whose model-facing
+    ``required`` list contains an auth secret or connection identity can never be
+    invoked by the planner/assistant, because the model cannot supply that value.
+    The fix is always to add the param to the tool's ``injected_params``.
+    """
+    offenders: dict[str, list[str]] = {}
+    for name, tool in sorted(_all_registered_tools().items()):
+        schema = tool.public_input_schema  # type: ignore[attr-defined]
+        required = set(schema.get("required", []) or [])
+        leaked = sorted(
+            param
+            for param in (required & CREDENTIAL_PARAM_NAMES)
+            if (name, param) not in MODEL_SUPPLIED_CREDENTIAL_PARAMS
+        )
+        if leaked:
+            offenders[name] = leaked
+
+    assert not offenders, (
+        "These tools require a config-injected credential in their model-facing "
+        "schema; add each listed param to the tool's injected_params:\n"
+        + "\n".join(f"  - {name}: {params}" for name, params in offenders.items())
+    )
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "search_sentry_issues",
+        "jira_search_issues",
+        "get_mysql_server_status",
+        "alertmanager_alerts",
+        "query_azure_monitor_logs",
+        "describe_eks_cluster",
+    ],
+)
+def test_representative_tools_hide_credentials_but_keep_targets(tool_name: str) -> None:
+    """Spot-check that fixed tools strip credentials yet keep model-facing args."""
+    tool = _all_registered_tools()[tool_name]
+    props = set(tool.public_input_schema.get("properties", {}).keys())  # type: ignore[attr-defined]
+    required = set(tool.public_input_schema.get("required", []))  # type: ignore[attr-defined]
+    assert CREDENTIAL_PARAM_NAMES.isdisjoint(required)
+    # The injected credentials are also gone from the visible properties.
+    assert (
+        set(tool.injected_params) & CREDENTIAL_PARAM_NAMES
+    )  # declares some creds  # type: ignore[attr-defined]
+    assert set(tool.injected_params).isdisjoint(props)  # type: ignore[attr-defined]
 
 
 def test_rds_performance_family_uses_rds_and_postgresql_contracts() -> None:
@@ -13,7 +138,13 @@ def test_rds_performance_family_uses_rds_and_postgresql_contracts() -> None:
     assert "db_instance_identifier" in set(rds_tool.public_input_schema.get("required", []))
 
     assert pg_tool.source == "postgresql"
-    assert {"host", "threshold_ms"} <= set(pg_tool.public_input_schema.get("properties", {}).keys())
+    pg_props = set(pg_tool.public_input_schema.get("properties", {}).keys())
+    # ``threshold_ms`` is a real model-supplied parameter and stays visible.
+    assert "threshold_ms" in pg_props
+    # ``host`` is a config-injected connection identity and must NOT be exposed
+    # to the model (it is supplied from the resolved integration, not the LLM).
+    assert "host" not in pg_props
+    assert "host" not in set(pg_tool.public_input_schema.get("required", []))
 
 
 def test_kubernetes_contract_requires_cluster_and_namespace_filters() -> None:


### PR DESCRIPTION
## Summary

- The interactive-shell chat assistant gathers live data by exposing investigation tools to the LLM via each tool's **model-facing schema** (`public_input_schema`). Tools that listed auth secrets / connection identities (`sentry_token`, `organization_slug`, `host`, `base_url`, `api_token`, …) as **required** were never callable — the model can't know a secret, so it silently skipped the tool and the assistant answered from prose instead of real data. This is exactly why asking the REPL to query Sentry for recent Windows issues only ever produced a *suggested query*, never results.
- Declare these config-supplied params in each tool's `injected_params` so they're stripped from the model-facing schema and auto-injected from the resolved integration at run time (the pattern DataDog/Grafana already used). **84 tools** fixed across Sentry, Jira, EKS, Azure, the SQL/NoSQL families, Kafka, Redis, Dagster, Prefect, Vercel, Opsgenie, and more.
- Add a **registry-wide regression test** asserting no tool requires a credential-named parameter in its model-facing schema, with a small documented allowlist for genuine model-supplied targets (CloudTrail's `username` forensic filter).

## Why this is the right fix

`extract_params` already injects each tool's credentials from resolved config at run time; the bug was purely that those same params were *also* advertised to the model as required. Each tool now authoritatively declares its own injected credentials, so there's no global heuristic that can misfire (e.g. CloudTrail's `username` filter is preserved because that tool simply never lists it as injected).

## Test plan

- [x] Registry audit: 0 tools leak a credential into the model-facing required schema (was 84).
- [x] `tests/tools/test_tool_selection_contracts.py` — new regression guard + spot checks pass.
- [x] `make`-equivalent: `ruff check`, `ruff format --check`, `mypy app/tools/` all clean.
- [x] `tests/tools/`, `tests/agent/test_tool_loop.py`, `tests/cli/interactive_shell/` green (3208 passed).
- [ ] Manual REPL check: ask the shell to query Sentry for recent Windows issues and confirm it returns live issues.

Made with [Cursor](https://cursor.com)