### PR TITLE
test(routing): ground Sentry lookup (316) on valid live data

### DIFF
--- a/.github/workflows/routing-live.yml
+++ b/.github/workflows/routing-live.yml
@@ -99,6 +99,15 @@ jobs:
       ROUTING_SHARD_TOTAL: "8"
       ROUTING_SHARD_INDEX: ${{ matrix.shard_index }}
       PYTHONUTF8: "1"
+      # Live-data routing scenarios (e.g. 316) resolve a real Sentry integration
+      # from these env vars and assert the gather loop returns valid data. Only
+      # the token is a secret; org/project/url are non-sensitive. When the secret
+      # is absent (e.g. fork PRs) the scenario SKIPS rather than fails, so this is
+      # additive and never breaks the suite.
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG_SLUG: tracer-30
+      SENTRY_PROJECT_SLUG: python
+      SENTRY_URL: https://sentry.io
 
     steps:
       - uses: actions/checkout@v5

--- a/app/cli/interactive_shell/routing/tests/_oracle_runtime.py
+++ b/app/cli/interactive_shell/routing/tests/_oracle_runtime.py
@@ -27,11 +27,69 @@ from app.cli.interactive_shell.routing.tests.scenario_loader import (
 from app.cli.interactive_shell.runtime.execution import execute_routed_turn
 from app.cli.interactive_shell.runtime.session import ReplSession
 
+# Sentinel a fixture's ``resolved_integrations`` uses to request the REAL,
+# live-resolved config for a service instead of a pinned fake one. The oracle
+# replaces ``<service>: "@live"`` with the integration resolved from the local
+# store / env (real credentials) and forces ``connection_verified: true`` so the
+# tool is available. Scenarios that use it pair it with
+# ``gathered_tools_contract.must_return_valid_data`` to assert the tool reached
+# the live integration and returned valid data (not a 401). When the credential
+# cannot be resolved the scenario is skipped, never failed (env gap, not bug).
+LIVE_INTEGRATION_SENTINEL = "@live"
+
 
 @dataclass
 class OracleRunResult:
     passed: bool
     details: dict[str, Any]
+
+
+def resolve_live_integrations(
+    override: dict[str, Any] | None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    """Expand any ``<service>: "@live"`` sentinel into a real resolved config.
+
+    A fixture marks a service ``"@live"`` to opt into a real, credentialed call
+    during the gather loop (see :data:`LIVE_INTEGRATION_SENTINEL`). For each such
+    service this resolves the integration from the developer's local store / env
+    (via the production ``resolve_integrations`` path) and forces
+    ``connection_verified: true`` so the tool's ``is_available`` check passes —
+    the local store omits that flag, but the live REPL sets it during startup, so
+    the test mirrors the REPL rather than the bare classifier.
+
+    Returns ``(expanded_override, unavailable_services)``. ``unavailable_services``
+    lists services whose credentials could not be resolved; callers skip those
+    scenarios rather than failing them (a missing credential is an environment
+    gap, not a routing regression). Non-sentinel entries pass through untouched.
+    """
+    if not override:
+        return override, []
+
+    live_services = [
+        service for service, config in override.items() if config == LIVE_INTEGRATION_SENTINEL
+    ]
+    if not live_services:
+        return override, []
+
+    from app.agent.context import resolve_integrations
+
+    resolved = resolve_integrations({})  # type: ignore[arg-type]  # real store/env resolution
+    expanded: dict[str, Any] = {}
+    unavailable: list[str] = []
+    for service, config in override.items():
+        if config != LIVE_INTEGRATION_SENTINEL:
+            expanded[service] = config
+            continue
+        live_config = resolved.get(service)
+        # A usable integration must carry at least one credential token; the bare
+        # classifier returns an empty shell for unconfigured services.
+        if not isinstance(live_config, dict) or not any(
+            live_config.get(field) for field in ("auth_token", "api_key", "api_token", "token")
+        ):
+            unavailable.append(service)
+            continue
+        expanded[service] = {**live_config, "connection_verified": True}
+    return expanded, unavailable
 
 
 def session_capabilities(capabilities: ScenarioCapabilities) -> dict[str, tuple[str, ...]]:
@@ -251,11 +309,14 @@ def patch_execution_boundary(
 
 
 def run_oracle_once(case: ScenarioCase, monkeypatch: pytest.MonkeyPatch) -> OracleRunResult:
+    resolved_override, _unavailable = resolve_live_integrations(
+        case.scenario.session.resolved_integrations
+    )
     session = fresh_session(
         with_prior_state=case.scenario.session.has_prior_state,
         configured_integrations=case.scenario.session.configured_integrations,
         available_capabilities=session_capabilities(case.scenario.available_capabilities),
-        resolved_integrations_override=case.scenario.session.resolved_integrations,
+        resolved_integrations_override=resolved_override,
     )
     executed: list[dict[str, Any]] = []
     patch_execution_boundary(monkeypatch, executed)

--- a/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/316-sentry-recent-issues-windows-handoff.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/316-sentry-recent-issues-windows-handoff.yml
@@ -1,5 +1,5 @@
 id: 316-sentry-recent-issues-windows-handoff
-title: Sentry recent-issues lookup hands off and grounds the answer via Sentry (not an investigation)
+title: Sentry recent-issues lookup hands off and grounds the answer on valid live Sentry data
 intent_class: complex_shell_prompts
 input:
   prompt: >-
@@ -8,24 +8,15 @@ session:
   has_prior_state: false
   configured_integrations:
   - sentry
-  # Sentry is the ONLY connected source, so the gather loop has exactly one real
-  # integration to call. This is the Sentry counterpart to 315 (PostHog): even
-  # WITH an observability source connected, a plain data-retrieval query ("are
-  # there recent issues on windows?") is NOT an incident root-cause, so the
-  # planner must HAND OFF (no investigation_start) and let the conversational
-  # gather loop query Sentry. The token is fake, so search_sentry_issues reaches
-  # the live endpoint and fails auth; the oracle records the tool as "called"
-  # regardless of the error, which is the deterministic, credential-independent
-  # signal the contract asserts. issue_id is intentionally omitted so the only
-  # available Sentry tool is search_sentry_issues -- get_sentry_issue_details and
-  # list_sentry_issue_events both gate is_available on a known issue_id.
+  # Use the REAL, live-resolved Sentry integration (NOT a fake token). The "@live"
+  # sentinel tells the oracle to resolve Sentry from the local store / env (or CI
+  # secrets) and force connection_verified, so the gather loop makes an
+  # AUTHENTICATED call and gets a real 200 response back. The token never lives in
+  # the repo, and the scenario SKIPS (never fails) when no Sentry credential is
+  # available -- that is an environment gap, not a routing regression. CI provides
+  # SENTRY_AUTH_TOKEN / SENTRY_ORG_SLUG / SENTRY_PROJECT_SLUG as secrets.
   resolved_integrations:
-    sentry:
-      connection_verified: true
-      organization_slug: fixture-org
-      project_slug: fixture-project
-      auth_token: fixture-token
-      base_url: https://sentry.io
+    sentry: "@live"
 notes:
 - "Data-retrieval / analytics lookup, NOT an investigation. The prompt asks to\
   \ search Sentry for recent issues on Windows -- it names no failure, crash,\
@@ -36,24 +27,20 @@ notes:
   \ off and the conversational gather loop queries Sentry to ground the answer.\
   \ Contrast with 314, where 'crashing on Windows' names a failure and DOES\
   \ dispatch an investigation."
-- "This reproduces a real interactive-shell turn ('can you query sentry if there\
-  \ are recent issue on windows?') that routed to the gather loop and called\
-  \ search_sentry_issues live. Before this fixture, no scenario locked in the\
-  \ Sentry data-gathering path: 315 covers PostHog, 314 covers multi-source\
-  \ investigation dispatch, 313 covers the no-integration negative control. A\
-  \ broken Sentry is_available/extract_params (e.g. a bad injected_params change),\
-  \ a silently-dropped search_sentry_issues registration, or the planner wrongly\
-  \ starting an investigation would all have passed CI undetected."
-- "Solidity contract: because Sentry is the only resolved integration, the gather\
-  \ loop MUST engage the Sentry tool surface on every run -- search_sentry_issues\
-  \ is asserted via must_call_all (strictly stronger than must_call_any), so a\
-  \ silently-dropped Sentry tool registration, a broken is_available check, or\
-  \ the planner wrongly starting an investigation instead of handing off all fail\
-  \ this scenario instead of passing on hallucinated text. search_sentry_issues\
-  \ is the only chat-surface Sentry tool available without a pre-known issue_id,\
-  \ so it is the deterministic, auth-independent proof that the gather loop routed\
-  \ this lookup to Sentry; it 401s on the fake fixture token but still counts as\
-  \ called."
+- "Reproduces a real interactive-shell turn ('can you query sentry if there are\
+  \ recent issue on windows?') that routed to the gather loop and called\
+  \ search_sentry_issues. The earlier draft pinned a FAKE token, so the call\
+  \ 401'd yet still counted as 'called' (must_call_all) -- a hollow signal. This\
+  \ version resolves the REAL Sentry integration and asserts the tool returned\
+  \ VALID data via must_return_valid_data, so a credential 401, a malformed-param\
+  \ 400, a broken injected_params change, or the planner wrongly starting an\
+  \ investigation all fail instead of passing on hallucinated text."
+- "must_return_valid_data is satisfied by a successful, authenticated 200 response\
+  \ (available=true, no error) -- it does NOT require a non-empty issue list. A\
+  \ valid empty result ('no Windows issues in the window') still proves the\
+  \ integration path works end to end (resolution -> injected credentials -> live\
+  \ API -> parsed payload); the failure mode it catches is a broken/unauthenticated\
+  \ call, which is exactly the 401 the fake-token draft masked."
 route:
   expected_kind: handle_message_with_agent
   expected_command_text: null
@@ -72,15 +59,12 @@ response_contract:
   - investigation
   - shell
 gathered_tools_contract:
-  # A Sentry data lookup with ONLY Sentry connected must drive the gather loop to
-  # engage the Sentry tool surface -- search_sentry_issues is the entry tool the
-  # loop hits when Sentry is the resolved integration and no issue_id is known.
-  # must_call_all (not must_call_any) makes this the strong, grounded signal: it
-  # fails if the assistant answers from training data without querying Sentry, if
-  # the tool is deregistered, or if the planner wrongly dispatches an
-  # investigation. The investigation action is guarded separately via
-  # response_contract.forbidden_actions.
-  must_call_all:
+  # Sentry is the only connected source and issue_id is unknown, so
+  # search_sentry_issues is the single Sentry tool the gather loop can engage.
+  # must_return_valid_data is strictly stronger than must_call_all: the tool must
+  # be invoked AND return a successful integration response (not a 401/400/error),
+  # proving the lookup reached live Sentry and produced valid data.
+  must_return_valid_data:
   - search_sentry_issues
 history:
   expected:

--- a/app/cli/interactive_shell/routing/tests/test_routing_scenarios.py
+++ b/app/cli/interactive_shell/routing/tests/test_routing_scenarios.py
@@ -25,6 +25,7 @@ from app.cli.interactive_shell.routing.router import RouteKind, route_input
 from app.cli.interactive_shell.routing.tests._oracle_runtime import (
     OracleRunResult,
     fresh_session,
+    resolve_live_integrations,
     run_oracle_once,
     session_capabilities,
 )
@@ -83,6 +84,27 @@ def _skip_if_investigation_disabled(case: ScenarioCase) -> None:
             "Natural-language investigation loop is disabled in the interactive shell "
             "(feature_flags.INTERACTIVE_SHELL_INVESTIGATION_ENABLED is False); "
             "this investigation scenario does not apply. Re-enable the flag to run it."
+        )
+
+
+def _skip_if_live_integrations_unavailable(case: ScenarioCase) -> None:
+    """Skip scenarios that need a real credentialed integration we can't resolve.
+
+    Scenarios that pin ``<service>: "@live"`` in ``resolved_integrations`` (paired
+    with ``gathered_tools_contract.must_return_valid_data``) make a real call to
+    that integration during the gather loop. That only works when the integration
+    is configured locally (store/env) or via CI secrets. When the credential is
+    absent the scenario is skipped — it is an environment gap, not a regression —
+    rather than failing every credential-less run.
+    """
+    _expanded, unavailable = resolve_live_integrations(case.scenario.session.resolved_integrations)
+    if unavailable:
+        pytest.skip(
+            "Live integration credentials unavailable for: "
+            + ", ".join(sorted(unavailable))
+            + ". Configure the integration in the local store/env or provide CI "
+            "secrets (e.g. SENTRY_AUTH_TOKEN, SENTRY_ORG_SLUG, SENTRY_PROJECT_SLUG) "
+            "to run this scenario."
         )
 
 
@@ -274,6 +296,7 @@ def test_live_turn_execution_oracle(
     tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
     _skip_if_investigation_disabled(live_oracle_case)
+    _skip_if_live_integrations_unavailable(live_oracle_case)
     runs = max(1, live_oracle_case.answer.runs)
     run_results: list[OracleRunResult] = []
     passed_count = 0


### PR DESCRIPTION
## Summary

- Scenario **316** (Sentry-only data-retrieval lookup) now asserts the gather loop reaches **real Sentry** and gets a **successful authenticated response** back — not a 401. The earlier draft pinned a fake token, so the call 401'd yet still counted as "called" (`must_call_all`), a hollow signal.
- Adds a `"@live"` `resolved_integrations` sentinel: the oracle resolves the real Sentry config from the local store / env (or CI secrets), forces `connection_verified`, and **skips** the scenario (never fails) when no credential is available — an environment gap, not a routing regression.
- 316 uses `"@live"` together with the existing `must_return_valid_data` gathered-tools contract (already on `main`), so a `401` / `400` / errored call fails instead of passing on hallucinated text. The contract is satisfied by a successful 200 (`available: true`, no `error`); an empty-but-successful result still proves the end-to-end path.
- Wires `SENTRY_*` into the `routing-live` workflow: token as a secret (`SENTRY_AUTH_TOKEN`), org/project/url inline. The token is **never committed**.

## Validation

- `routing-checks` (no-LLM) suite: green locally.
- Live: `test_live_action_planning[316]` and `test_live_turn_execution_oracle[316]` pass with real Sentry credentials — the gather loop calls `search_sentry_issues` and it returns a valid 200 response.
- `ruff` / `ruff format --check` / `mypy` clean on changed files.

## Notes for reviewers / ops

- Add `SENTRY_AUTH_TOKEN` as a repo secret so the live shard runs 316 with valid data. Until then 316 **skips** gracefully (no failure). `SENTRY_ORG_SLUG=tracer-30` / `SENTRY_PROJECT_SLUG=python` are set inline in the workflow.

## Test plan

- [ ] `routing-checks` job green on this PR
- [ ] `routing-live` shard containing 316 runs (with `SENTRY_AUTH_TOKEN` secret) and passes — or skips with a clear reason if the secret is not yet set

Made with [Cursor](https://cursor.com)