### PR TITLE
fix(wizard): persist Slack webhook to integration store after guided …

### DIFF
--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -946,6 +946,11 @@ def _configure_slack() -> tuple[str, str]:
             result = validate_slack_webhook(webhook_url=webhook_url)
         _render_integration_result("Slack", result)
         if result.ok:
+            # Persist the webhook to the store like every other integration
+            # (and like the CLI `_setup_slack`). Without this the wizard would
+            # validate the webhook, report "Slack" in the success summary, then
+            # silently discard it — leaving no readable credential anywhere.
+            upsert_integration("slack", {"credentials": {"webhook_url": webhook_url}})
             env_path = sync_env_values({})
             return "Slack", str(env_path)
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")

--- a/docs/messaging/slack.mdx
+++ b/docs/messaging/slack.mdx
@@ -55,11 +55,7 @@ You have two equivalent paths:
     ```bash
     opensre onboard
     ```
-    Select **Slack** and paste your webhook URL. The wizard validates the URL via a probe request.
-
-    <Note>
-    The wizard's Slack step currently validates the URL but does not persist it. After the wizard completes, run `opensre integrations setup slack` (or set `SLACK_WEBHOOK_URL` in `.env`) so the credentials are saved.
-    </Note>
+    Select **Slack** and paste your webhook URL. The wizard validates the URL via a probe request, then persists it to `~/.opensre/integrations.json` — the same store the direct setup command writes to. No extra step is needed.
   </Tab>
 </Tabs>
 

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -498,6 +498,75 @@ def test_run_wizard_configures_dagster_oss_skips_secret(monkeypatch, tmp_path) -
     assert synced_secrets == []  # OSS path: no token
 
 
+def test_run_wizard_configures_slack_persists_webhook(monkeypatch, tmp_path) -> None:
+    """Regression: the wizard must upsert the Slack webhook to the store.
+
+    Previously `_configure_slack` validated the webhook and reported "Slack" in
+    the success summary but never called `upsert_integration`, silently
+    discarding the webhook (the catalog reads Slack store-first, so nothing was
+    readable afterwards). The webhook is a secret, so it belongs in the store,
+    not `.env` — `sync_env_values` is called with an empty mapping.
+    """
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "slack"])
+    # webhook_url is prompted with secret=True, so it comes from the password mock.
+    password_responses = iter(["llm-secret", "https://hooks.slack.com/services/T0/B0/XXXXX"])
+    saved_integrations: list[tuple[str, dict]] = []
+    synced_env_values: list[dict[str, str]] = []
+
+    def _mock_select(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(select_responses)
+        return m
+
+    def _mock_password(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(password_responses)
+        return m
+
+    def _mock_text(*_args, **_kwargs):
+        # Slack has no plain-text prompt; guard against an unexpected one.
+        m = MagicMock()
+        m.ask.return_value = ""
+        return m
+
+    monkeypatch.setattr(flow, "select_prompt", _mock_select)
+    monkeypatch.setattr(flow.questionary, "password", _mock_password)
+    monkeypatch.setattr(flow.questionary, "text", _mock_text)
+    monkeypatch.setattr(flow, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(
+        flow,
+        "validate_slack_webhook",
+        lambda **_kwargs: flow.IntegrationHealthResult(ok=True, detail="Slack ok"),
+    )
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
+    monkeypatch.setattr(flow, "save_llm_api_key", lambda *_args, **_kwargs: None)
+
+    def _sync_env_values(values: dict[str, str], **_kwargs):
+        synced_env_values.append(values)
+        return tmp_path / ".env"
+
+    monkeypatch.setattr(flow, "sync_env_values", _sync_env_values)
+    monkeypatch.setattr(
+        flow,
+        "upsert_integration",
+        lambda service, payload: saved_integrations.append((service, payload)),
+    )
+
+    exit_code = flow.run_wizard()
+
+    assert exit_code == 0
+    assert saved_integrations == [
+        (
+            "slack",
+            {"credentials": {"webhook_url": "https://hooks.slack.com/services/T0/B0/XXXXX"}},
+        )
+    ]
+    # Webhook is a secret: it goes to the store, not `.env`.
+    assert synced_env_values == [{}]
+
+
 def test_run_wizard_dagster_retries_on_validation_failure(monkeypatch, tmp_path) -> None:
     """Two consecutive Dagster validation failures, then success.
 


### PR DESCRIPTION
…setup

Fixes #2534 GAP - 2

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

The onboarding wizard's Slack step validated the webhook url and reported "Slack" in the success summary but never called upsert_integration, silently discarding the credential. Every other integration in the same wizard (Dagster, Vercel, Telegram, etc.) and the CLI opensre integrations setup slack both call upsert_integration on success, Slack was the only exception. This PR adds the missing upsert_integration("slack", {"credentials": {"webhook_url": webhook_url}}) call so the webhook is persisted to ~/.opensre/integrations.json (where the catalog reads it store-first), adds a regression test asserting the webhook lands in the store and not in .env, and removes the stale <Note> in docs/messaging/slack.mdx that documented the bug as a known limitation.

### Demo/Screenshot for feature changes and bug fixes - 


https://github.com/user-attachments/assets/7d8af796-940b-48e5-87f3-651f6681c343



<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The fix is a single upsert_integration call inserted before sync_env_values({}) in _configure_slack, matching the pattern every other wizard integration already follows. The webhook is a secret so it goes to the store (not .env), which is why sync_env_values is called with an empty mapping so no change needed there. A unit test (test_run_wizard_configures_slack_persists_webhook) was added to prevent the bug from silently coming back, and verified end-to-end with a real Slack webhook, opensre integrations show slack confirmed the credential landed in the store after opensre onboard.

<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---


Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
