### PR TITLE
chore(docs): disable Changelog navigation and update related documentation

### DIFF
--- a/app/integrations/daily_update.py
+++ b/app/integrations/daily_update.py
@@ -729,7 +729,8 @@ def write_daily_archive(update: DailyUpdate, *, output_dir: Path | None = None) 
     archive_path = target_dir / f"{update.window.london_date.isoformat()}.mdx"
     archive_path.write_text(render_markdown(update), encoding="utf-8")
     regenerate_overview(target_dir)
-    update_docs_navigation(target_dir)
+    # Changelog nav disabled — re-enable the Changelog tab in docs/docs.json and uncomment below.
+    # update_docs_navigation(target_dir)
     return archive_path
 
 

--- a/app/integrations/daily_update.py
+++ b/app/integrations/daily_update.py
@@ -728,8 +728,9 @@ def write_daily_archive(update: DailyUpdate, *, output_dir: Path | None = None) 
     target_dir.mkdir(parents=True, exist_ok=True)
     archive_path = target_dir / f"{update.window.london_date.isoformat()}.mdx"
     archive_path.write_text(render_markdown(update), encoding="utf-8")
-    regenerate_overview(target_dir)
-    # Changelog nav disabled — re-enable the Changelog tab in docs/docs.json and uncomment below.
+    # Changelog disabled — to re-enable: restore the Changelog tab in docs/docs.json,
+    # uncomment the Daily updates Card in docs/index.mdx, and uncomment both calls below.
+    # regenerate_overview(target_dir)
     # update_docs_navigation(target_dir)
     return archive_path
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -312,18 +312,6 @@
             ]
           }
         ]
-      },
-      {
-        "tab": "Changelog",
-        "icon": "clock",
-        "groups": [
-          {
-            "group": "Daily updates",
-            "pages": [
-              "daily-updates/overview"
-            ]
-          }
-        ]
       }
     ]
   },

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -35,9 +35,12 @@ OpenSRE is agentic alert investigation for production systems. It connects to yo
   <Card title="Platform" icon="layers-group" href="/technology/end-to-end">
     OpenSRE architecture, product capabilities, deployment targets, and comparisons.
   </Card>
+  {/* Changelog disabled — daily-update workflow removed (PR #1409). To re-enable, restore the
+      Changelog tab in docs/docs.json and uncomment below.
   <Card title="Daily updates" icon="newspaper" href="/daily-updates/overview">
     Follow product progress and recent documentation changes.
   </Card>
+  */}
 </CardGroup>
 
 ## What it does


### PR DESCRIPTION
/fix #2897 
Comment out the Changelog navigation update in daily_update.py and remove the Changelog tab from docs.json. Update index.mdx to reflect the disabled Changelog feature, providing instructions for re-enabling it in the future.