### PR TITLE
fix(docs): disable changelog tab and daily updates workflow (#2897)

### DIFF
--- a/app/integrations/daily_update.py
+++ b/app/integrations/daily_update.py
@@ -728,8 +728,8 @@ def write_daily_archive(update: DailyUpdate, *, output_dir: Path | None = None) 
     target_dir.mkdir(parents=True, exist_ok=True)
     archive_path = target_dir / f"{update.window.london_date.isoformat()}.mdx"
     archive_path.write_text(render_markdown(update), encoding="utf-8")
-    regenerate_overview(target_dir)
-    update_docs_navigation(target_dir)
+    # regenerate_overview(target_dir)
+    # update_docs_navigation(target_dir)
     return archive_path
 
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -312,18 +312,6 @@
             ]
           }
         ]
-      },
-      {
-        "tab": "Changelog",
-        "icon": "clock",
-        "groups": [
-          {
-            "group": "Daily updates",
-            "pages": [
-              "daily-updates/overview"
-            ]
-          }
-        ]
       }
     ]
   },

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -35,9 +35,9 @@ OpenSRE is agentic alert investigation for production systems. It connects to yo
   <Card title="Platform" icon="layers-group" href="/technology/end-to-end">
     OpenSRE architecture, product capabilities, deployment targets, and comparisons.
   </Card>
-  <Card title="Daily updates" icon="newspaper" href="/daily-updates/overview">
+  {/* <Card title="Daily updates" icon="newspaper" href="/daily-updates/overview">
     Follow product progress and recent documentation changes.
-  </Card>
+  </Card> */}
 </CardGroup>
 
 ## What it does


### PR DESCRIPTION
Disables the changelog tab on the docs site and comments out the daily updates card until the daily-update workflow is restored.