### PR TITLE
fix(routing): improve router prompt to classify synthetic alerts reliably (#656)

### DIFF
--- a/app/constants/prompts.py
+++ b/app/constants/prompts.py
@@ -24,9 +24,20 @@ for concrete details they can share (alert text, error snippets, timelines) or u
 
 Always respond in clear markdown."""
 
-ROUTER_PROMPT = """Classify the user message:
+ROUTER_PROMPT = """You are a router that classifies the user's message.
+Classify the message as either "tracer_data" or "general":
 
-- "tracer_data" if the user is asking to investigate an alert/incident or requesting analysis that likely requires querying data (e.g., logs, metrics, traces, failed runs/tasks/jobs, error messages, service health, Sentry issues, GitHub code/history).
-- "general" for general questions, greetings, or best practices
+- "tracer_data": The message indicates a specific system error, outage, incident, alert, or requires investigating real or simulated environment metrics, logs, traces, or database/container stats. Examples:
+  * Pasted JSON alert payload or alert summaries (e.g., RDS latency spike, OOMKilled pod, CrashLoopBackOff, PostgreSQL connection exhaustion, CPU/Memory alerts).
+  * Error logs, stack traces, specific database lock warnings, replication errors.
+  * Requests to analyze or investigate a specific host, database, service, or queue (e.g., "check the orders queue", "investigate the rds instance").
+  * Requests querying current/slow SQL queries, replication status, or container statuses.
+
+- "general": The message is a conceptual question, a greeting, or asking for general best practices, definitions, how-to explanations, or general system design. Examples:
+  * "How do I configure SQS in AWS?"
+  * "What causes PostgreSQL lock contention?"
+  * "Explain CrashLoopBackOff."
+  * "Hello, how are you?"
+  * "What are best practices for database indexes?"
 
 Respond with ONLY: tracer_data or general"""

--- a/app/constants/prompts.py
+++ b/app/constants/prompts.py
@@ -28,7 +28,7 @@ ROUTER_PROMPT = """You are a router that classifies the user's message.
 Classify the message as either "tracer_data" or "general":
 
 - "tracer_data": The message indicates a specific system error, outage, incident, alert, or requires investigating real or simulated environment metrics, logs, traces, or database/container stats. Examples:
-  * Pasted JSON alert payload or alert summaries (e.g., RDS latency spike, OOMKilled pod, CrashLoopBackOff, PostgreSQL connection exhaustion, CPU/Memory alerts).
+  * Pasted JSON alert payload or alert summaries (e.g., RDS latency spike, OOMKilled pod, CrashLoopBackOff pod status, PostgreSQL connection exhaustion, CPU/Memory alerts).
   * Error logs, stack traces, specific database lock warnings, replication errors.
   * Requests to analyze or investigate a specific host, database, service, or queue (e.g., "check the orders queue", "investigate the rds instance").
   * Requests querying current/slow SQL queries, replication status, or container statuses.
@@ -36,7 +36,7 @@ Classify the message as either "tracer_data" or "general":
 - "general": The message is a conceptual question, a greeting, or asking for general best practices, definitions, how-to explanations, or general system design. Examples:
   * "How do I configure SQS in AWS?"
   * "What causes PostgreSQL lock contention?"
-  * "Explain CrashLoopBackOff."
+  * "Explain what CrashLoopBackOff means."
   * "Hello, how are you?"
   * "What are best practices for database indexes?"
 

--- a/tests/agent/test_chat.py
+++ b/tests/agent/test_chat.py
@@ -48,3 +48,41 @@ def test_tracer_data_chat_executes_tool_calls_and_finishes(monkeypatch: Any) -> 
     assert result["messages"][1]["role"] == "tool"
     assert result["messages"][2]["content"] == "The API incident has supporting tool evidence."
     assert any(message["role"] == "tool" for message in fake_llm.invocations[1])
+
+
+def test_route_classification(monkeypatch: Any) -> None:
+    from app.agent.chat import _route
+
+    class FakeRouteLLM:
+        def __init__(self, content: str) -> None:
+            self.content = content
+            self.invocations: list[Any] = []
+
+        def invoke(self, messages: list[dict[str, Any]]) -> Any:
+            self.invocations.append(messages)
+
+            class FakeResponse:
+                def __init__(self, content: str) -> None:
+                    self.content = content
+
+            return FakeResponse(self.content)
+
+    # Test routing to tracer_data
+    fake_llm_tracer = FakeRouteLLM("tracer_data")
+    monkeypatch.setattr("app.agent.chat.get_llm_for_tools", lambda: fake_llm_tracer)
+    state = cast(AgentState, {"messages": [{"role": "user", "content": "RDS latency spike"}]})
+    assert _route(state) == "tracer_data"
+    assert len(fake_llm_tracer.invocations) == 1
+    assert "tracer_data" in fake_llm_tracer.invocations[0][0]["content"]
+
+    # Test routing to general
+    fake_llm_general = FakeRouteLLM("general")
+    monkeypatch.setattr("app.agent.chat.get_llm_for_tools", lambda: fake_llm_general)
+    state = cast(AgentState, {"messages": [{"role": "user", "content": "Explain RDS"}]})
+    assert _route(state) == "general"
+
+    # Test routing with invalid LLM response defaults to general
+    fake_llm_invalid = FakeRouteLLM("something_else")
+    monkeypatch.setattr("app.agent.chat.get_llm_for_tools", lambda: fake_llm_invalid)
+    state = cast(AgentState, {"messages": [{"role": "user", "content": "Explain RDS"}]})
+    assert _route(state) == "general"

--- a/tests/agent/test_prompt.py
+++ b/tests/agent/test_prompt.py
@@ -173,4 +173,3 @@ def test_router_prompt_contains_expected_keywords() -> None:
     assert "general" in ROUTER_PROMPT.lower()
     assert "crashloopbackoff" in ROUTER_PROMPT.lower()
     assert "rds" in ROUTER_PROMPT.lower()
-

--- a/tests/agent/test_prompt.py
+++ b/tests/agent/test_prompt.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.agent.prompt import _relevant_sources, build_system_prompt, format_alert_context
+from app.constants.prompts import ROUTER_PROMPT
 
 
 def test_build_system_prompt_non_hermes_uses_generic_category_instruction() -> None:
@@ -164,3 +165,12 @@ def test_alert_context_surfaces_v2_contract_hints_for_tool_selection() -> None:
     assert "source_id=aws_rds" in context
     assert "evidence=deployment_metadata" in context
     assert "avoid=Use this tool to inspect SQL query text or Postgres locks." in context
+
+
+def test_router_prompt_contains_expected_keywords() -> None:
+    # Verify ROUTER_PROMPT contains the new classification examples
+    assert "tracer_data" in ROUTER_PROMPT.lower()
+    assert "general" in ROUTER_PROMPT.lower()
+    assert "crashloopbackoff" in ROUTER_PROMPT.lower()
+    assert "rds" in ROUTER_PROMPT.lower()
+


### PR DESCRIPTION
Improves the router prompt to ensure that synthetic incident reports, error logs, and metrics alerts are classified as tracer_data instead of general.