### PR TITLE
fix(agent): improve chat prompts to prevent speculative RCA (#657, #658)

### DIFF
--- a/app/constants/prompts.py
+++ b/app/constants/prompts.py
@@ -27,7 +27,7 @@ IMPORTANT: You are currently in general chat mode, meaning you DO NOT have acces
 Your behavior guidelines:
 1. If the user's request is an investigation, a root cause analysis request, or contains a system alert/error summary (such as a database outage, pod failure, or latency spike):
    - You MUST explicitly state that you are in general mode without tools or live/fixture evidence and cannot perform an actual investigation.
-   - DO NOT guess or speculate on the root cause of the incident. Reject speculative root-cause claims.
+   - DO NOT guess or speculate on the root cause of the incident. Reject making speculative root-cause claims yourself.
    - Direct the user to provide concrete logs, metrics, alert JSON, or switch to a tool-backed investigation workflow to query their systems.
 2. If the user asks conceptual questions (e.g. general SRE best practices, definitions of terms, explanations of how components work):
    - Answer directly and helpfully from general knowledge and SRE practice.

--- a/app/constants/prompts.py
+++ b/app/constants/prompts.py
@@ -5,22 +5,32 @@ SYSTEM_PROMPT = """You are Tracer, an AI SRE assistant for incident investigatio
 Your job is to help users triage production alerts, investigate service degradation/outages, and produce evidence-backed conclusions.
 You can query connected systems (e.g., Tracer run/task data, logs, metrics, failed jobs/tools) and developer tooling (e.g., GitHub and Sentry) using available tools.
 
-When you need specific evidence (exact errors, timelines, run IDs, traces, metric values), use tools instead of guessing.
-When the user is asking conceptual questions (SRE best practices, incident process, how-to explanations) answer directly without tools.
+Investigation guidelines:
+1. Clearly separate observations (facts gathered from tools) from inferences (hypotheses or conclusions).
+2. Avoid premature root-cause claims. Do not state a root cause unless sufficient evidence has been gathered to support it.
+3. When evidence is mixed, identify and explicitly rule out or discuss alternative failure modes instead of focusing on a single explanation.
+4. When you need specific evidence (exact errors, timelines, run IDs, traces, metric values), use tools instead of guessing.
+5. When the user is asking conceptual questions (SRE best practices, incident process, how-to explanations), answer directly without tools.
 
 Be explicit about:
-- what you observed (with relevant identifiers like run_id, task_name, job_id, host, service)
-- what you think is happening and why
-- what you recommend doing next (incremental steps)
+- what you observed (with relevant identifiers like run_id, task_name, job_id, host, service, or query)
+- what you think is happening (inference) vs what the evidence proves (observation)
+- what alternative hypotheses you considered and ruled out
+- what you recommend doing next (incremental, logical steps)
 
 Always respond in clear markdown."""
 
-GENERAL_SYSTEM_PROMPT = """You are Tracer, an AI SRE assistant for incident investigation, production operations,
-and root cause thinking.
+GENERAL_SYSTEM_PROMPT = """You are Tracer, an AI SRE assistant.
 
-You are in general chat mode: you do not have access to tools or live data (Tracer runs, logs, metrics, GitHub, Sentry).
-Answer from SRE practice and general knowledge. If the user needs data-backed investigation, say so briefly and ask
-for concrete details they can share (alert text, error snippets, timelines) or use a workflow that queries their systems.
+IMPORTANT: You are currently in general chat mode, meaning you DO NOT have access to tools or live/fixture-backed evidence (such as Tracer runs, logs, metrics, databases, GitHub, or Sentry).
+
+Your behavior guidelines:
+1. If the user's request is an investigation, a root cause analysis request, or contains a system alert/error summary (such as a database outage, pod failure, or latency spike):
+   - You MUST explicitly state that you are in general mode without tools or live/fixture evidence and cannot perform an actual investigation.
+   - DO NOT guess or speculate on the root cause of the incident. Reject speculative root-cause claims.
+   - Direct the user to provide concrete logs, metrics, alert JSON, or switch to a tool-backed investigation workflow to query their systems.
+2. If the user asks conceptual questions (e.g. general SRE best practices, definitions of terms, explanations of how components work):
+   - Answer directly and helpfully from general knowledge and SRE practice.
 
 Always respond in clear markdown."""
 

--- a/tests/agent/test_chat.py
+++ b/tests/agent/test_chat.py
@@ -48,3 +48,41 @@ def test_tracer_data_chat_executes_tool_calls_and_finishes(monkeypatch: Any) -> 
     assert result["messages"][1]["role"] == "tool"
     assert result["messages"][2]["content"] == "The API incident has supporting tool evidence."
     assert any(message["role"] == "tool" for message in fake_llm.invocations[1])
+
+
+def test_route_classification(monkeypatch: Any) -> None:
+    from app.agent.chat import _route
+
+    class FakeRouteLLM:
+        def __init__(self, content: str) -> None:
+            self.content = content
+            self.invocations: list[Any] = []
+
+        def invoke(self, messages: list[dict[str, Any]]) -> Any:
+            self.invocations.append(messages)
+
+            class FakeResponse:
+                def __init__(self, content: str) -> None:
+                    self.content = content
+
+            return FakeResponse(self.content)
+
+    # Test routing to tracer_data
+    fake_llm_tracer = FakeRouteLLM("tracer_data")
+    monkeypatch.setattr("app.agent.chat.get_llm_for_tools", lambda: fake_llm_tracer)
+    state = cast(AgentState, {"messages": [{"role": "user", "content": "RDS latency spike"}]})
+    assert _route(state) == "tracer_data"
+    assert len(fake_llm_tracer.invocations) == 1
+    assert "tracer_data" in fake_llm_tracer.invocations[0][0]["content"]
+
+    # Test routing to general
+    fake_llm_general = FakeRouteLLM("general")
+    monkeypatch.setattr("app.agent.chat.get_llm_for_tools", lambda: fake_llm_general)
+    state = cast(AgentState, {"messages": [{"role": "user", "content": "Explain RDS"}]})
+    assert _route(state) == "general"
+
+    # Test routing with invalid LLM response defaults to general
+    fake_llm_invalid = FakeRouteLLM("something_else")
+    monkeypatch.setattr("app.agent.chat.get_llm_for_tools", lambda: fake_llm_invalid)
+    state = cast(AgentState, {"messages": [{"role": "user", "content": "Explain RDS"}]})
+    assert _route(state) == "general"

--- a/tests/agent/test_prompt.py
+++ b/tests/agent/test_prompt.py
@@ -176,3 +176,7 @@ def test_system_and_general_prompts_contain_key_guidelines() -> None:
     # Verify GENERAL_SYSTEM_PROMPT guidelines
     assert "general chat mode" in GENERAL_SYSTEM_PROMPT.lower()
     assert "do not guess or speculate" in GENERAL_SYSTEM_PROMPT.lower()
+    assert (
+        "direct the user to" in GENERAL_SYSTEM_PROMPT.lower()
+        or "tool-backed" in GENERAL_SYSTEM_PROMPT.lower()
+    )

--- a/tests/agent/test_prompt.py
+++ b/tests/agent/test_prompt.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.agent.prompt import _relevant_sources, build_system_prompt, format_alert_context
+from app.constants.prompts import GENERAL_SYSTEM_PROMPT, SYSTEM_PROMPT
 
 
 def test_build_system_prompt_non_hermes_uses_generic_category_instruction() -> None:
@@ -164,3 +165,15 @@ def test_alert_context_surfaces_v2_contract_hints_for_tool_selection() -> None:
     assert "source_id=aws_rds" in context
     assert "evidence=deployment_metadata" in context
     assert "avoid=Use this tool to inspect SQL query text or Postgres locks." in context
+
+
+def test_system_and_general_prompts_contain_key_guidelines() -> None:
+    # Verify SYSTEM_PROMPT guidelines
+    assert "clearly separate observations" in SYSTEM_PROMPT.lower()
+    assert "premature root-cause claims" in SYSTEM_PROMPT.lower()
+    assert "alternative failure modes" in SYSTEM_PROMPT.lower()
+
+    # Verify GENERAL_SYSTEM_PROMPT guidelines
+    assert "general chat mode" in GENERAL_SYSTEM_PROMPT.lower()
+    assert "do not guess or speculate" in GENERAL_SYSTEM_PROMPT.lower()
+

--- a/tests/agent/test_prompt.py
+++ b/tests/agent/test_prompt.py
@@ -176,4 +176,3 @@ def test_system_and_general_prompts_contain_key_guidelines() -> None:
     # Verify GENERAL_SYSTEM_PROMPT guidelines
     assert "general chat mode" in GENERAL_SYSTEM_PROMPT.lower()
     assert "do not guess or speculate" in GENERAL_SYSTEM_PROMPT.lower()
-


### PR DESCRIPTION
Improves the tool-backed chat system prompt to enforce strict separation of observations and inferences and rejects speculative root cause claims in general mode, fallback/guidelines included.