### PR TITLE
fix(repl): scrub leaked CPR cursor replies from the prompt during streaming (#2888)

### DIFF
--- a/app/cli/interactive_shell/AGENTS.md
+++ b/app/cli/interactive_shell/AGENTS.md
@@ -110,6 +110,14 @@ owning area rather than adding more logic to the caller.
   - **How to check:** after adding a command, run it in the REPL and type a few
     characters in the next prompt. If no `^[[…R` garbage appears, the registration
     is correct.
+  - **Mid-prompt leaks during streaming:** while an investigation streams, the
+    spinner ticker invalidates the prompt ~10x/s, and CPR replies can arrive
+    *while* the input reader is active (not just at teardown), so they appear as
+    fragmented garbage like `[34;1R57R38;57R` in the field. The between-prompt
+    drain cannot catch those; `_install_cpr_buffer_scrubber` in `runtime/loop.py`
+    hooks the buffer's `on_text_changed` and strips CPR runs in place. CPR runs
+    are identified as runs over `[`, digits, `;`, `R` that pair a digit with an
+    `R`, so ordinary words (`Restart`) and `[1]`-style text are left intact.
   - **Agent-planned (LLM) interactive commands:** `_EXCLUSIVE_STDIN_MENU_COMMANDS`
     only reserves stdin for *deterministically-typed* commands
     (`deterministic_command_text` returns the slash). When free text like

--- a/app/cli/interactive_shell/AGENTS.md
+++ b/app/cli/interactive_shell/AGENTS.md
@@ -115,9 +115,13 @@ owning area rather than adding more logic to the caller.
     *while* the input reader is active (not just at teardown), so they appear as
     fragmented garbage like `[34;1R57R38;57R` in the field. The between-prompt
     drain cannot catch those; `_install_cpr_buffer_scrubber` in `runtime/loop.py`
-    hooks the buffer's `on_text_changed` and strips CPR runs in place. CPR runs
-    are identified as runs over `[`, digits, `;`, `R` that pair a digit with an
-    `R`, so ordinary words (`Restart`) and `[1]`-style text are left intact.
+    hooks the buffer's `on_text_changed` (only while a turn is dispatching) and
+    strips CPR runs in place. A CPR run is `digits;digits` terminated by `R`, so
+    the matcher requires the digit(s) to come *before* the `R` (`34;1R`, `57R`).
+    That deliberately leaves text where `R` precedes the digit untouched — most
+    importantly AWS R-series instance names (`R5`, `R6g`, `r5.xlarge`) that SREs
+    type during an investigation, exactly when the scrubber is live — as well as
+    ordinary words (`Restart`) and `[1]`-style text.
   - **Agent-planned (LLM) interactive commands:** `_EXCLUSIVE_STDIN_MENU_COMMANDS`
     only reserves stdin for *deterministically-typed* commands
     (`deterministic_command_text` returns the slash). When free text like

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -112,7 +112,10 @@ def _contains_cpr_sequence(text: str | None) -> bool:
     return bool(text) and _strip_cpr_sequences(text) != text
 
 
-def _install_cpr_buffer_scrubber(pt_session: PromptSession[str]) -> None:
+def _install_cpr_buffer_scrubber(
+    pt_session: PromptSession[str],
+    is_active: Callable[[], bool] | None = None,
+) -> None:
     """Strip leaked CPR replies out of the live input buffer as they arrive.
 
     During a streaming dispatch the spinner ticker invalidates the prompt ~10x/s.
@@ -123,6 +126,12 @@ def _install_cpr_buffer_scrubber(pt_session: PromptSession[str]) -> None:
     the submit-time strip only fires on Enter, so the garbage is visible in the
     field while the investigation runs. This removes it in place the moment it
     appears, preserving the cursor position relative to the user's real text.
+
+    ``is_active`` scopes the scrubber to exactly the window where the flood can
+    happen (a turn is dispatching). Outside that window the handler is a strict
+    no-op, so it never rewrites the buffer document at the idle prompt — the
+    between-prompt drain owns that case. When omitted, the scrubber is always
+    active (used by tests).
     """
     buffer = pt_session.default_buffer
     scrubbing = False
@@ -130,6 +139,8 @@ def _install_cpr_buffer_scrubber(pt_session: PromptSession[str]) -> None:
     def _scrub(_buffer: Buffer) -> None:
         nonlocal scrubbing
         if scrubbing:
+            return
+        if is_active is not None and not is_active():
             return
         text = buffer.text
         if not _contains_cpr_sequence(text):
@@ -219,7 +230,7 @@ async def run_interactive(
 
     cancel_kb = build_cancel_key_bindings(state)
     install_session_key_bindings(pt_session, cancel_kb)
-    _install_cpr_buffer_scrubber(pt_session)
+    _install_cpr_buffer_scrubber(pt_session, is_active=state.is_dispatch_running)
 
     pt_app = pt_session.app
     main_loop = asyncio.get_running_loop()

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -50,24 +50,15 @@ from app.fleet_monitoring.sampler import start_sampler
 
 log = logging.getLogger(__name__)
 
-# A leaked CPR reply is a maximal run drawn only from the CPR alphabet:
-# an optional ESC/CSI introducer, then digits, ';', '[' and 'R'. Matching the
-# whole run (rather than one well-formed reply) lets us also clear the
-# fragmented bursts that high-frequency streaming redraws produce, where the
-# ESC is dropped and partial 'row;colR' pieces and collapsed 'RRRR' runs
-# concatenate, e.g. '[34;1R57R38;57R'.
-_CPR_RUN_RE = re.compile(r"(?:\x1b|\x9b)?[\[0-9;R]+")
-
-
-def _looks_like_cpr_run(run: str) -> bool:
-    """Whether a CPR-alphabet run is a real cursor reply rather than user text.
-
-    Every CPR reply and every fragment of one pairs at least one digit with the
-    terminating ``R``. Requiring both lets us strip leaked replies while leaving
-    ordinary words that merely contain ``R`` (``Restart``) or a digit (``[1]``)
-    untouched.
-    """
-    return "R" in run and any(ch.isdigit() for ch in run)
+# A leaked CPR reply (and every fragment of one) is ``digits ; digits`` terminated
+# by ``R`` — the digits always come *before* the ``R``: ``ESC[34;1R``, ``[34;1R``,
+# ``38;57R``, the bare tail ``57R``, and collapsed ``...57RRRR`` runs.  Requiring at
+# least one digit immediately before the terminating ``R+`` (with an optional ESC/CSI
+# introducer and ``[``) lets us clear the fragmented streaming bursts while leaving
+# real input untouched.  Critically, this does NOT match tokens where ``R`` precedes
+# the digit — e.g. AWS R-series instance names (``R5``, ``R6g``, ``r5.xlarge``) that
+# SREs type during an active investigation, exactly when the scrubber is live.
+_CPR_RUN_RE = re.compile(r"(?:\x1b|\x9b)?\[?[0-9;]*[0-9]R+")
 
 
 def _drain_stale_cpr_bytes() -> None:
@@ -105,7 +96,7 @@ def _strip_cpr_sequences(text: str | None) -> str:
     streaming redraw produces (``[34;1R57R38;57R``)."""
     if not text:
         return ""
-    return _CPR_RUN_RE.sub(lambda m: "" if _looks_like_cpr_run(m.group(0)) else m.group(0), text)
+    return _CPR_RUN_RE.sub("", text)
 
 
 def _contains_cpr_sequence(text: str | None) -> bool:
@@ -133,10 +124,9 @@ def _install_cpr_buffer_scrubber(
     between-prompt drain owns that case. When omitted, the scrubber is always
     active (used by tests).
     """
-    buffer = pt_session.default_buffer
     scrubbing = False
 
-    def _scrub(_buffer: Buffer) -> None:
+    def _scrub(buffer: Buffer) -> None:
         nonlocal scrubbing
         if scrubbing:
             return
@@ -145,15 +135,20 @@ def _install_cpr_buffer_scrubber(
         text = buffer.text
         if not _contains_cpr_sequence(text):
             return
-        cleaned_before = _strip_cpr_sequences(text[: buffer.cursor_position])
         cleaned_text = _strip_cpr_sequences(text)
+        # Keep the cursor where the user's text is. When the cursor sits inside a
+        # half-typed run, the prefix may strip to a different length than the full
+        # text, so clamp to avoid overshooting cleaned_text (which prompt_toolkit
+        # would otherwise silently pull back to the end).
+        cleaned_before = _strip_cpr_sequences(text[: buffer.cursor_position])
+        cursor = min(len(cleaned_before), len(cleaned_text))
         scrubbing = True
         try:
-            buffer.document = Document(cleaned_text, cursor_position=len(cleaned_before))
+            buffer.document = Document(cleaned_text, cursor_position=cursor)
         finally:
             scrubbing = False
 
-    buffer.on_text_changed += _scrub
+    pt_session.default_buffer.on_text_changed += _scrub
 
 
 class StreamingConsole(Console):

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -14,6 +14,8 @@ from collections.abc import Callable
 from typing import Any
 
 from prompt_toolkit import PromptSession
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.document import Document
 from prompt_toolkit.formatted_text import ANSI
 from prompt_toolkit.patch_stdout import patch_stdout
 from rich.console import Console
@@ -48,12 +50,24 @@ from app.fleet_monitoring.sampler import start_sampler
 
 log = logging.getLogger(__name__)
 
-_CPR_SEQUENCE_RE = re.compile(
-    r"(?:\x1b\[|\x9b)\d{1,4};\d{1,4}R"  # ESC [ row ; col R
-    r"|\[\d{1,4};\d{1,4}R"  # [row;colR without ESC (leaked into input)
-    r"|\d{1,4};\d{1,4}R"  # row;colR without ESC or [
-    r"|\d{1,4}R(?=[\[\d])"  # trailing rowR before another CPR fragment
-)
+# A leaked CPR reply is a maximal run drawn only from the CPR alphabet:
+# an optional ESC/CSI introducer, then digits, ';', '[' and 'R'. Matching the
+# whole run (rather than one well-formed reply) lets us also clear the
+# fragmented bursts that high-frequency streaming redraws produce, where the
+# ESC is dropped and partial 'row;colR' pieces and collapsed 'RRRR' runs
+# concatenate, e.g. '[34;1R57R38;57R'.
+_CPR_RUN_RE = re.compile(r"(?:\x1b|\x9b)?[\[0-9;R]+")
+
+
+def _looks_like_cpr_run(run: str) -> bool:
+    """Whether a CPR-alphabet run is a real cursor reply rather than user text.
+
+    Every CPR reply and every fragment of one pairs at least one digit with the
+    terminating ``R``. Requiring both lets us strip leaked replies while leaving
+    ordinary words that merely contain ``R`` (``Restart``) or a digit (``[1]``)
+    untouched.
+    """
+    return "R" in run and any(ch.isdigit() for ch in run)
 
 
 def _drain_stale_cpr_bytes() -> None:
@@ -85,14 +99,50 @@ def _drain_stale_cpr_bytes() -> None:
 
 
 def _strip_cpr_sequences(text: str | None) -> str:
-    """Remove terminal cursor-position replies that leaked into submitted text."""
+    """Remove terminal cursor-position replies that leaked into text.
+
+    Handles both intact replies (``ESC[row;colR``) and the fragmented bursts a
+    streaming redraw produces (``[34;1R57R38;57R``)."""
     if not text:
         return ""
-    return _CPR_SEQUENCE_RE.sub("", text)
+    return _CPR_RUN_RE.sub(lambda m: "" if _looks_like_cpr_run(m.group(0)) else m.group(0), text)
 
 
 def _contains_cpr_sequence(text: str | None) -> bool:
-    return bool(text and _CPR_SEQUENCE_RE.search(text))
+    return bool(text) and _strip_cpr_sequences(text) != text
+
+
+def _install_cpr_buffer_scrubber(pt_session: PromptSession[str]) -> None:
+    """Strip leaked CPR replies out of the live input buffer as they arrive.
+
+    During a streaming dispatch the spinner ticker invalidates the prompt ~10x/s.
+    Each redraw under ``patch_stdout(raw=True)`` can trigger a CPR (``ESC[6n``)
+    query whose reply lands while the prompt's input reader is active, so the
+    bytes are parsed as keystrokes and inserted into the buffer. The
+    between-prompt drain (`_drain_stale_cpr_bytes`) cannot help mid-prompt and
+    the submit-time strip only fires on Enter, so the garbage is visible in the
+    field while the investigation runs. This removes it in place the moment it
+    appears, preserving the cursor position relative to the user's real text.
+    """
+    buffer = pt_session.default_buffer
+    scrubbing = False
+
+    def _scrub(_buffer: Buffer) -> None:
+        nonlocal scrubbing
+        if scrubbing:
+            return
+        text = buffer.text
+        if not _contains_cpr_sequence(text):
+            return
+        cleaned_before = _strip_cpr_sequences(text[: buffer.cursor_position])
+        cleaned_text = _strip_cpr_sequences(text)
+        scrubbing = True
+        try:
+            buffer.document = Document(cleaned_text, cursor_position=len(cleaned_before))
+        finally:
+            scrubbing = False
+
+    buffer.on_text_changed += _scrub
 
 
 class StreamingConsole(Console):
@@ -169,6 +219,7 @@ async def run_interactive(
 
     cancel_kb = build_cancel_key_bindings(state)
     install_session_key_bindings(pt_session, cancel_kb)
+    _install_cpr_buffer_scrubber(pt_session)
 
     pt_app = pt_session.app
     main_loop = asyncio.get_running_loop()

--- a/tests/cli/interactive_shell/test_terminal_runtime.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime.py
@@ -62,6 +62,12 @@ def test_streaming_console_status_does_not_recurse(monkeypatch) -> None:
         ("before \x1b[12;80R after", "before  after"),
         ("7R[25;57R23;57R", ""),
         ("25;57R", ""),
+        # Fragmented streaming-flood burst (lost ESC, partial rows, collapsed Rs).
+        ("[34;1R57R38;57R57R8;57R[38;57R57R57R;57RR[38;57RRRRR38;57R38;57R", ""),
+        # Real text typed/queued during a turn must survive intact.
+        ("Restart the pod", "Restart the pod"),
+        ("give me 3 reasons", "give me 3 reasons"),
+        ("check error [1] in logs", "check error [1] in logs"),
     ],
 )
 def test_strip_cpr_sequences_removes_terminal_cursor_replies(
@@ -69,6 +75,28 @@ def test_strip_cpr_sequences_removes_terminal_cursor_replies(
     expected: str,
 ) -> None:
     assert loop_module._strip_cpr_sequences(text) == expected
+
+
+def test_cpr_buffer_scrubber_removes_leaked_replies_live() -> None:
+    """Leaked CPR bytes inserted mid-prompt are scrubbed from the live buffer."""
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.default_buffer = Buffer()
+
+    session = _FakeSession()
+    loop_module._install_cpr_buffer_scrubber(session)  # type: ignore[arg-type]
+    buffer = session.default_buffer
+
+    # Simulate a streaming flood landing in the field as keystrokes.
+    buffer.insert_text("[34;1R57R38;57R")
+    assert buffer.text == ""
+
+    # User's real text is preserved; trailing CPR bytes are stripped.
+    buffer.insert_text("scale up")
+    buffer.insert_text("25;57R")
+    assert buffer.text == "scale up"
+    assert buffer.cursor_position == len("scale up")
 
 
 def test_repl_input_lexer_highlights_first_slash_token() -> None:

--- a/tests/cli/interactive_shell/test_terminal_runtime.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime.py
@@ -68,6 +68,13 @@ def test_streaming_console_status_does_not_recurse(monkeypatch) -> None:
         ("Restart the pod", "Restart the pod"),
         ("give me 3 reasons", "give me 3 reasons"),
         ("check error [1] in logs", "check error [1] in logs"),
+        # AWS R-series instance names (R before the digit) must NOT be stripped —
+        # they are typed constantly during investigations, while the scrubber is live.
+        ("R3 instances", "R3 instances"),
+        ("check R5 capacity", "check R5 capacity"),
+        ("scale the R6g nodes", "scale the R6g nodes"),
+        ("use m5.large and r5.2xlarge", "use m5.large and r5.2xlarge"),
+        ("R6i", "R6i"),
     ],
 )
 def test_strip_cpr_sequences_removes_terminal_cursor_replies(
@@ -97,6 +104,30 @@ def test_cpr_buffer_scrubber_removes_leaked_replies_live() -> None:
     buffer.insert_text("25;57R")
     assert buffer.text == "scale up"
     assert buffer.cursor_position == len("scale up")
+
+
+def test_cpr_buffer_scrubber_clamps_cursor_inside_partial_run() -> None:
+    """Cursor sitting inside a half-typed CPR run must not overshoot cleaned text.
+
+    The prefix before the cursor can strip to a different length than the full
+    text (the run's terminating ``R`` may be past the cursor), so the cursor is
+    clamped to len(cleaned_text) rather than left to overshoot.
+    """
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.default_buffer = Buffer()
+
+    session = _FakeSession()
+    loop_module._install_cpr_buffer_scrubber(session)  # type: ignore[arg-type]
+    buffer = session.default_buffer
+
+    # Cursor sits inside the run ("38;|57R"): the prefix "38;" does not strip
+    # (no terminating R) while the full run strips to "", so an unclamped cursor
+    # would land at position 3 in a 0-length buffer.
+    buffer.document = Document("38;57R", cursor_position=3)
+    assert buffer.text == ""
+    assert 0 <= buffer.cursor_position <= len(buffer.text)
 
 
 def test_cpr_buffer_scrubber_is_noop_when_inactive() -> None:

--- a/tests/cli/interactive_shell/test_terminal_runtime.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime.py
@@ -99,6 +99,36 @@ def test_cpr_buffer_scrubber_removes_leaked_replies_live() -> None:
     assert buffer.cursor_position == len("scale up")
 
 
+def test_cpr_buffer_scrubber_is_noop_when_inactive() -> None:
+    """When no turn is dispatching, the scrubber must not touch the buffer.
+
+    Guarantees the idle prompt is never rewritten (no spurious redraws); leaked
+    bytes there are owned by the between-prompt drain instead.
+    """
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.default_buffer = Buffer()
+
+    session = _FakeSession()
+    active = False
+    loop_module._install_cpr_buffer_scrubber(
+        session,  # type: ignore[arg-type]
+        is_active=lambda: active,
+    )
+    buffer = session.default_buffer
+
+    # Inactive: leaked bytes are left untouched (drain handles them elsewhere).
+    buffer.insert_text("[34;1R")
+    assert buffer.text == "[34;1R"
+
+    # Active: the same flood is scrubbed in place.
+    active = True
+    buffer.reset()
+    buffer.insert_text("[34;1R")
+    assert buffer.text == ""
+
+
 def test_repl_input_lexer_highlights_first_slash_token() -> None:
     lexer = ReplInputLexer()
     get_line = lexer.lex_document(Document("/model show", len("/model")))


### PR DESCRIPTION
Fixes #2888

#### Describe the changes you have made in this PR -

Fixes the garbled terminal output (e.g. `[34;1R57R38;57R...`) that appears in the
interactive-shell prompt input line while an investigation is streaming.

That string is not random corruption — it's leaked **CPR (Cursor Position Report)**
replies. While an investigation streams, the spinner ticker (added in #2638)
invalidates the prompt ~10x/s. Each redraw under `patch_stdout(raw=True)` makes
prompt_toolkit re-locate the cursor with a CPR query (`ESC[6n`), and the reply
arrives *while the prompt's input reader is active*, so the bytes are parsed as
keystrokes and shown in the field. The existing defenses only act *between* prompts
(`_drain_stale_cpr_bytes`) or *on submit* (`_strip_cpr_sequences`), so neither
catches the mid-prompt flood.

Changes:
- Replace the rigid `\d+;\d+R` CPR regex (which left residue like `57R` on
  fragmented bursts) with a run-based matcher over the CPR alphabet
  (`[`, digits, `;`, `R`). A run is treated as CPR only when it pairs a digit with
  an `R`, so ordinary words (`Restart`) and text like `[1]` are left untouched.
- Add `_install_cpr_buffer_scrubber`, which hooks the prompt buffer's
  `on_text_changed` to strip CPR runs in place the moment they appear, preserving
  the user's real text and cursor position (recursion-guarded).
- Scope the scrubber to active dispatch only (`is_active=state.is_dispatch_running`)
  — the single window where the flood can happen. Outside it the handler is a
  strict no-op, so it never rewrites or forces a redraw of the idle prompt (that
  case stays owned by the between-prompt drain).
- Tests: extend the strip cases with the fragmented-flood and real-text inputs,
  add a live buffer-scrubber test and an inactive-no-op test.
- Document the mid-prompt layer in the interactive-shell `AGENTS.md`.

### Demo/Screenshot for feature changes and bug fixes -

The on-screen flood is terminal-emulator dependent (it reproduces on terminals
that fragment CPR replies, like the one in the issue screenshot). To demonstrate
deterministically and independent of terminal, the leaked bytes were fed through
prompt_toolkit's real input parser on each branch:

```
# main (unpatched) — leaked CPR bytes interleaved with the user typing "scale up"
live buffer (visible in prompt field): '[34;1Rscale 38;57Rup57R'
even main's strip-on-submit leaves residue: 'scale up57R'

# fix branch — during dispatch (the bug window)
live buffer: 'scale up'        # garbage removed in place

# fix branch — at the idle prompt
scrubber is a strict no-op (between-prompt drain owns that case)
```

Reproduce locally:
```
opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json
```

A live REPL investigation on the fix branch also confirms no regression: the
post-investigation prompt renders cleanly (single prompt, clean `/exit`).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: terminal cursor-position replies (CPR, `ESC[<row>;<col>R`) leak into
the prompt input line during streaming investigations and render as garbage. The
existing code already fought CPR leaks, but only between prompts and on submit —
not while the prompt is open mid-stream, which is the window the 100ms spinner
ticker (#2638) opens.

Alternatives considered:
1. Disable CPR entirely (`PROMPT_TOOLKIT_NO_CPR=1` / `enable_cpr=False`). Rejected:
   prompt_toolkit uses CPR to measure available height below the cursor during
   `patch_stdout` writes; disabling it risks prompt mis-placement during streaming —
   a worse regression than the cosmetic garbage.
2. Throttle the spinner ticker. Rejected: reduces but doesn't eliminate the leak and
   degrades the spinner animation #2638 added.
3. (chosen) Keep CPR on, scrub leaked replies out of the live buffer in real time,
   and scope it to the dispatch window. Lowest regression risk; targets the exact
   symptom without touching the renderer's legitimate CPR handling or the idle prompt.

Key pieces:
- `_CPR_RUN_RE` + `_looks_like_cpr_run`: match maximal CPR-alphabet runs and treat a
  run as CPR only if it contains both a digit and an `R` — the signature every CPR
  reply/fragment shares, which keeps real user input safe.
- `_strip_cpr_sequences` / `_contains_cpr_sequence`: reuse the matcher; used on the
  submit path and by the live scrubber.
- `_install_cpr_buffer_scrubber(..., is_active)`: registers an `on_text_changed`
  handler that rewrites the buffer with CPR runs removed, recursion-guarded and
  cursor-preserving, and only while `is_active()` is true (a turn is dispatching).

Edge cases handled/tested: intact replies (`ESC[row;colR`), ESC-less and CSI (`\x9b`)
fragments, collapsed `RRRR` runs, the literal issue-screenshot burst, real input that
merely contains `R`/digits (`Restart`, `give me 3 reasons`, `[1]`), and the inactive
no-op path.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
