### PR TITLE
fix(postgresql): use shared call_db_tool_with_default_db_warning helper in all tools

### DIFF
--- a/app/tools/PostgreSQLReplicationStatusTool/__init__.py
+++ b/app/tools/PostgreSQLReplicationStatusTool/__init__.py
@@ -9,6 +9,7 @@ from app.integrations.postgresql import (
     resolve_postgresql_config,
 )
 from app.tools.tool_decorator import tool
+from app.tools.utils.sql_wrapper import call_db_tool_with_default_db_warning
 
 
 @tool(
@@ -31,13 +32,10 @@ def get_postgresql_replication_status(
     port: int = 5432,
 ) -> dict[str, Any]:
     """Fetch replication status from a PostgreSQL primary server."""
-    _db_defaulted = database is None
-    if database is None:
-        database = "postgres"
-    config = resolve_postgresql_config(host=host, database=database, port=port)
-    result = get_replication_status(config)
-    if _db_defaulted:
-        result["default_db_warning"] = (
-            "WARNING: No database was specified; defaulted to 'postgres'. Results may not reflect application data."
-        )
-    return result
+    return call_db_tool_with_default_db_warning(
+        database=database,
+        default_db_name="postgres",
+        config_resolver=resolve_postgresql_config,
+        resolver_kwargs={"host": host, "port": port},
+        db_caller=get_replication_status,
+    )

--- a/app/tools/PostgreSQLServerStatusTool/__init__.py
+++ b/app/tools/PostgreSQLServerStatusTool/__init__.py
@@ -9,6 +9,7 @@ from app.integrations.postgresql import (
     resolve_postgresql_config,
 )
 from app.tools.tool_decorator import tool
+from app.tools.utils.sql_wrapper import call_db_tool_with_default_db_warning
 
 
 @tool(
@@ -31,13 +32,10 @@ def get_postgresql_server_status(
     port: int = 5432,
 ) -> dict[str, Any]:
     """Fetch server status metrics from a PostgreSQL instance."""
-    _db_defaulted = database is None
-    if database is None:
-        database = "postgres"
-    config = resolve_postgresql_config(host=host, database=database, port=port)
-    result = get_server_status(config)
-    if _db_defaulted:
-        result["default_db_warning"] = (
-            "WARNING: No database was specified; defaulted to 'postgres'. Results may not reflect application data."
-        )
-    return result
+    return call_db_tool_with_default_db_warning(
+        database=database,
+        default_db_name="postgres",
+        config_resolver=resolve_postgresql_config,
+        resolver_kwargs={"host": host, "port": port},
+        db_caller=get_server_status,
+    )

--- a/app/tools/PostgreSQLTableStatsTool/__init__.py
+++ b/app/tools/PostgreSQLTableStatsTool/__init__.py
@@ -9,6 +9,7 @@ from app.integrations.postgresql import (
     resolve_postgresql_config,
 )
 from app.tools.tool_decorator import tool
+from app.tools.utils.sql_wrapper import call_db_tool_with_default_db_warning
 
 
 @tool(
@@ -32,13 +33,10 @@ def get_postgresql_table_stats(
     port: int = 5432,
 ) -> dict[str, Any]:
     """Fetch table statistics for a specific schema (default 'public')."""
-    _db_defaulted = database is None
-    if database is None:
-        database = "postgres"
-    config = resolve_postgresql_config(host=host, database=database, port=port)
-    result = get_table_stats(config, schema_name=schema_name)
-    if _db_defaulted:
-        result["default_db_warning"] = (
-            "WARNING: No database was specified; defaulted to 'postgres'. Results may not reflect application data."
-        )
-    return result
+    return call_db_tool_with_default_db_warning(
+        database=database,
+        default_db_name="postgres",
+        config_resolver=resolve_postgresql_config,
+        resolver_kwargs={"host": host, "port": port},
+        db_caller=lambda config: get_table_stats(config, schema_name=schema_name),
+    )


### PR DESCRIPTION
## Summary

Three PostgreSQL tools (`PostgreSQLTableStatsTool`, `PostgreSQLServerStatusTool`, `PostgreSQLReplicationStatusTool`) were implementing the `default_db_warning` logic inline:

```python
_db_defaulted = database is None
if database is None:
    database = "postgres"
config = resolve_postgresql_config(...)
result = get_table_stats(config, ...)
if _db_defaulted:
    result["default_db_warning"] = "WARNING: No database was specified..."
return result
```

The other two tools (`PostgreSQLCurrentQueriesTool`, `PostgreSQLSlowQueriesTool`) already use the centralized helper `call_db_tool_with_default_db_warning` from `app/tools/utils/sql_wrapper.py`.

## Changes

- `PostgreSQLTableStatsTool`: refactored to use `call_db_tool_with_default_db_warning`
- `PostgreSQLServerStatusTool`: refactored to use `call_db_tool_with_default_db_warning`
- `PostgreSQLReplicationStatusTool`: refactored to use `call_db_tool_with_default_db_warning`

## Type of change

- [x] Bug fix / refactor (non-breaking change that improves code consistency)

## Testing

- All existing tests pass (`make test-cov`)
- No behavior change — same warning text, same logic, now centralized
