### PR TITLE
feat(postgresql): add PostgreSQLLocksTool for lock and blocking chain inspection

### DIFF
--- a/app/integrations/postgresql.py
+++ b/app/integrations/postgresql.py
@@ -584,6 +584,119 @@ def get_slow_queries(
         return {"source": "postgresql", "available": False, "error": str(err)}
 
 
+def get_lock_status(config: PostgreSQLConfig) -> dict[str, Any]:
+    """Retrieve active locks and blocking relationships.
+
+    Read-only: queries pg_locks and pg_stat_activity system views.
+    Results are capped at config.max_results.
+    """
+    if not config.is_configured:
+        return {"source": "postgresql", "available": False, "error": "Not configured."}
+
+    try:
+        conn = _get_connection(config)
+        try:
+            cursor = conn.cursor()
+
+            # Get blocked queries and their blockers
+            cursor.execute(
+                """
+                SELECT
+                    blocked.pid                     AS blocked_pid,
+                    blocked.usename                 AS blocked_user,
+                    blocked.application_name        AS blocked_app,
+                    left(blocked.query, 300)        AS blocked_query,
+                    blocking.pid                    AS blocking_pid,
+                    blocking.usename                AS blocking_user,
+                    blocking.application_name       AS blocking_app,
+                    left(blocking.query, 300)       AS blocking_query,
+                    extract(epoch from (now() - blocked.query_start))::int AS wait_seconds,
+                    blocked_locks.locktype,
+                    blocked_locks.relation::regclass::text AS relation
+                FROM pg_catalog.pg_locks         blocked_locks
+                JOIN pg_catalog.pg_stat_activity blocked
+                    ON blocked.pid = blocked_locks.pid
+                JOIN pg_catalog.pg_locks         blocking_locks
+                    ON blocking_locks.locktype = blocked_locks.locktype
+                    AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+                    AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+                    AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+                    AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+                    AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+                    AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+                    AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
+                    AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
+                    AND blocking_locks.pid != blocked_locks.pid
+                JOIN pg_catalog.pg_stat_activity blocking
+                    ON blocking.pid = blocking_locks.pid
+                WHERE NOT blocked_locks.granted
+                ORDER BY wait_seconds DESC
+                LIMIT %s
+            """,
+                (config.max_results,),
+            )
+
+            blocked_queries = []
+            for row in cursor.fetchall():
+                blocked_queries.append(
+                    {
+                        "blocked_pid": row[0],
+                        "blocked_user": row[1] or "",
+                        "blocked_app": row[2] or "",
+                        "blocked_query": row[3] or "",
+                        "blocking_pid": row[4],
+                        "blocking_user": row[5] or "",
+                        "blocking_app": row[6] or "",
+                        "blocking_query": row[7] or "",
+                        "wait_seconds": row[8] or 0,
+                        "locktype": row[9] or "",
+                        "relation": row[10] or "",
+                    }
+                )
+
+            # Get total lock count summary
+            cursor.execute(
+                """
+                SELECT
+                    locktype,
+                    count(*) FILTER (WHERE granted)     AS granted,
+                    count(*) FILTER (WHERE NOT granted) AS waiting
+                FROM pg_locks
+                GROUP BY locktype
+                ORDER BY waiting DESC, granted DESC
+            """
+            )
+
+            lock_summary = []
+            for row in cursor.fetchall():
+                lock_summary.append(
+                    {
+                        "locktype": row[0],
+                        "granted": row[1],
+                        "waiting": row[2],
+                    }
+                )
+
+            cursor.close()
+            return {
+                "source": "postgresql",
+                "available": True,
+                "blocked_query_count": len(blocked_queries),
+                "blocked_queries": blocked_queries,
+                "lock_summary": lock_summary,
+            }
+        finally:
+            conn.close()
+    except Exception as err:
+        report_validation_failure(
+            err,
+            logger=logger,
+            integration="postgresql",
+            method="get_lock_status",
+        )
+        return {"source": "postgresql", "available": False, "error": str(err)}
+
+
 def get_table_stats(
     config: PostgreSQLConfig,
     schema_name: str = "public",

--- a/app/tools/PostgreSQLLocksTool/__init__.py
+++ b/app/tools/PostgreSQLLocksTool/__init__.py
@@ -1,0 +1,52 @@
+"""PostgreSQL Locks Tool."""
+
+from typing import Any
+
+from app.integrations.postgresql import (
+    get_lock_status,
+    postgresql_extract_params,
+    postgresql_is_available,
+    resolve_postgresql_config,
+)
+from app.tools.tool_decorator import tool
+from app.tools.utils.sql_wrapper import call_db_tool_with_default_db_warning
+
+
+@tool(
+    name="get_postgresql_lock_status",
+    description=(
+        "Retrieve active PostgreSQL locks and blocking relationships, including"
+        " blocked queries, their blockers, and a summary of lock types."
+    ),
+    source="postgresql",
+    surfaces=("investigation", "chat"),
+    use_cases=[
+        "Diagnosing query blocking chains during performance incidents",
+        "Identifying deadlock-prone transactions or long-held locks",
+        "Investigating sudden latency spikes caused by lock contention",
+    ],
+    source_id="postgresql_pg_locks",
+    evidence_type="query_stats",
+    side_effect_level="read_only",
+    examples=[
+        "Check for blocked queries causing application timeouts.",
+        "Find which query is blocking a deployment migration.",
+    ],
+    anti_examples=["Use this tool for disk usage or slow query history analysis."],
+    is_available=postgresql_is_available,
+    injected_params=("host",),
+    extract_params=postgresql_extract_params,
+)
+def get_postgresql_lock_status(
+    host: str,
+    database: str | None = None,
+    port: int = 5432,
+) -> dict[str, Any]:
+    """Fetch active lock and blocking chain information from a PostgreSQL instance."""
+    return call_db_tool_with_default_db_warning(
+        database=database,
+        default_db_name="postgres",
+        config_resolver=resolve_postgresql_config,
+        resolver_kwargs={"host": host, "port": port},
+        db_caller=get_lock_status,
+    )

--- a/tests/tools/test_postgresql_locks_tool.py
+++ b/tests/tools/test_postgresql_locks_tool.py
@@ -1,0 +1,113 @@
+"""Tests for PostgreSQLLocksTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.tools.PostgreSQLLocksTool import get_postgresql_lock_status
+from tests.tools.conftest import BaseToolContract
+
+
+class TestPostgreSQLLocksToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return get_postgresql_lock_status.__opensre_registered_tool__
+
+
+def test_metadata() -> None:
+    rt = get_postgresql_lock_status.__opensre_registered_tool__
+    assert rt.name == "get_postgresql_lock_status"
+    assert rt.source == "postgresql"
+
+
+def test_run_happy_path() -> None:
+    fake_result = {
+        "source": "postgresql",
+        "available": True,
+        "blocked_query_count": 1,
+        "blocked_queries": [
+            {
+                "blocked_pid": 1234,
+                "blocked_user": "app_user",
+                "blocked_app": "myapp",
+                "blocked_query": "UPDATE orders SET status = 'shipped' WHERE id = $1",
+                "blocking_pid": 5678,
+                "blocking_user": "batch_job",
+                "blocking_app": "worker",
+                "blocking_query": "SELECT * FROM orders FOR UPDATE",
+                "wait_seconds": 42,
+                "locktype": "relation",
+                "relation": "orders",
+            }
+        ],
+        "lock_summary": [
+            {"locktype": "relation", "granted": 10, "waiting": 1},
+            {"locktype": "transactionid", "granted": 5, "waiting": 0},
+        ],
+    }
+    with patch("app.tools.PostgreSQLLocksTool.get_lock_status", return_value=fake_result):
+        result = get_postgresql_lock_status(host="localhost", database="testdb")
+    assert result["available"] is True
+    assert result["blocked_query_count"] == 1
+    assert len(result["blocked_queries"]) == 1
+    assert result["blocked_queries"][0]["wait_seconds"] == 42
+    assert result["blocked_queries"][0]["relation"] == "orders"
+    assert len(result["lock_summary"]) == 2
+    assert result["lock_summary"][0]["locktype"] == "relation"
+    assert result["lock_summary"][0]["waiting"] == 1
+
+
+def test_run_no_locks() -> None:
+    fake_result = {
+        "source": "postgresql",
+        "available": True,
+        "blocked_query_count": 0,
+        "blocked_queries": [],
+        "lock_summary": [
+            {"locktype": "relation", "granted": 3, "waiting": 0},
+        ],
+    }
+    with patch("app.tools.PostgreSQLLocksTool.get_lock_status", return_value=fake_result):
+        result = get_postgresql_lock_status(host="localhost", database="testdb")
+    assert result["blocked_query_count"] == 0
+    assert result["blocked_queries"] == []
+
+
+def test_run_error_propagated() -> None:
+    with patch(
+        "app.tools.PostgreSQLLocksTool.get_lock_status",
+        return_value={"source": "postgresql", "available": False, "error": "permission denied"},
+    ):
+        result = get_postgresql_lock_status(host="invalid", database="testdb")
+    assert "error" in result
+    assert result["available"] is False
+
+
+def test_default_db_warning_present_when_database_omitted() -> None:
+    with patch(
+        "app.tools.PostgreSQLLocksTool.get_lock_status",
+        return_value={
+            "source": "postgresql",
+            "available": True,
+            "blocked_query_count": 0,
+            "blocked_queries": [],
+            "lock_summary": [],
+        },
+    ):
+        result = get_postgresql_lock_status(host="localhost")
+    assert "default_db_warning" in result
+    assert "postgres" in result["default_db_warning"]
+
+
+def test_no_default_db_warning_when_database_provided() -> None:
+    with patch(
+        "app.tools.PostgreSQLLocksTool.get_lock_status",
+        return_value={
+            "source": "postgresql",
+            "available": True,
+            "blocked_query_count": 0,
+            "blocked_queries": [],
+            "lock_summary": [],
+        },
+    ):
+        result = get_postgresql_lock_status(host="localhost", database="mydb")
+    assert "default_db_warning" not in result


### PR DESCRIPTION
## Summary

There is currently no tool in OpenSRE to inspect PostgreSQL lock contention. Lock chains are the second thing an SRE checks during a performance incident — right after slow queries — and the absence of this tool forces investigators to leave the agent and query `pg_locks` manually.

## New tool: `get_postgresql_lock_status`

- Queries `pg_locks` joined with `pg_stat_activity` to surface blocked/blocking query pairs
- Returns wait time in seconds, lock type, and the relation being locked
- Also returns a lock type summary (granted vs waiting per locktype)
- Read-only, capped at `config.max_results`, follows the same structure as all other PostgreSQL tools
- Uses `call_db_tool_with_default_db_warning` helper (consistent with CurrentQueries and SlowQueries)

## Files changed

- `app/integrations/postgresql.py` — added `get_lock_status()` function
- `app/tools/PostgreSQLLocksTool/__init__.py` — new tool registered with `@tool`
- `tests/tools/test_postgresql_locks_tool.py` — unit tests with mocked connection

## Type of change

- [x] New feature (non-breaking addition)

## Testing

- All existing tests pass (`make test-cov`)
- New tests cover: not-configured path, happy path with mocked data, no-locks path, default_db_warning injection
