### PR TITLE
Port dependency-traversal prompt rule and flag root-cause category mismatches

### DIFF
--- a/app/agent/category_alignment.py
+++ b/app/agent/category_alignment.py
@@ -64,11 +64,17 @@ def detect_category_text_mismatch(root_cause: str, root_cause_category: str) -> 
         return None
 
     text = root_cause.lower()
+    # Only compare groups we have keyword signals for — avoids false positives when
+    # the category is e.g. code_and_configuration but the text describes downstream
+    # database symptoms caused by a deploy.
+    if category_group not in _GROUP_SIGNALS:
+        return None
+
     group_scores = {
         group: sum(1 for keyword in keywords if keyword in text)
         for group, keywords in _GROUP_SIGNALS.items()
     }
-    best_group = max(group_scores, key=group_scores.get)
+    best_group = max(group_scores, key=lambda group: group_scores[group])
     best_score = group_scores[best_group]
     if best_score < _MIN_GROUP_SIGNAL_HITS or best_group == category_group:
         return None
@@ -89,11 +95,11 @@ def apply_category_alignment_adjustments(
     root_cause_category: str,
     validity_score: float,
     investigation_recommendations: list[str],
-) -> tuple[float, list[str], bool]:
+) -> tuple[float, list[str], bool, str | None]:
     """Lower confidence and add a recommendation when text and category disagree."""
-    mismatch = detect_category_text_mismatch(root_cause, root_cause_category)
-    if mismatch is None:
-        return validity_score, investigation_recommendations, False
+    mismatch_reason = detect_category_text_mismatch(root_cause, root_cause_category)
+    if mismatch_reason is None:
+        return validity_score, investigation_recommendations, False, None
 
     adjusted_score = max(0.0, validity_score - _VALIDITY_PENALTY)
     recommendation = (
@@ -101,5 +107,10 @@ def apply_category_alignment_adjustments(
         "review the classification before acting on it."
     )
     if recommendation in investigation_recommendations:
-        return adjusted_score, investigation_recommendations, True
-    return adjusted_score, [*investigation_recommendations, recommendation], True
+        return adjusted_score, investigation_recommendations, True, mismatch_reason
+    return (
+        adjusted_score,
+        [*investigation_recommendations, recommendation],
+        True,
+        mismatch_reason,
+    )

--- a/app/agent/category_alignment.py
+++ b/app/agent/category_alignment.py
@@ -1,0 +1,105 @@
+"""Heuristic check that root_cause text aligns with root_cause_category."""
+
+from __future__ import annotations
+
+from app.types.root_cause_categories import (
+    GROUP_DATABASE,
+    GROUP_KUBERNETES,
+    GROUP_NETWORK,
+    categories_by_group,
+)
+
+_CATEGORY_GROUPS: dict[str, str] = {
+    entry.name: group for group, entries in categories_by_group().items() for entry in entries
+}
+
+# Strong keyword signals per taxonomy group. Require multiple hits before flagging.
+_GROUP_SIGNALS: dict[str, tuple[str, ...]] = {
+    GROUP_DATABASE: (
+        "postgres",
+        "postgresql",
+        "mysql",
+        "mariadb",
+        "redis",
+        "connection pool",
+        "max_connections",
+        "replication lag",
+        "slow query",
+        "sql database",
+    ),
+    GROUP_KUBERNETES: (
+        "oomkilled",
+        "oom killed",
+        "crashloop",
+        "crash loop",
+        "kubelet",
+        "liveness probe",
+        "readiness probe",
+        "imagepull",
+        "evicted",
+    ),
+    GROUP_NETWORK: (
+        "dns resolution",
+        "dns failure",
+        "tls certificate",
+        "security group",
+        "nat gateway",
+        "network partition",
+    ),
+}
+
+_SKIP_CATEGORIES = frozenset({"healthy", "unknown"})
+_MIN_GROUP_SIGNAL_HITS = 2
+_VALIDITY_PENALTY = 0.15
+
+
+def detect_category_text_mismatch(root_cause: str, root_cause_category: str) -> str | None:
+    """Return a mismatch reason when text strongly signals a different taxonomy group."""
+    category = root_cause_category.strip()
+    if category in _SKIP_CATEGORIES:
+        return None
+
+    category_group = _CATEGORY_GROUPS.get(category)
+    if category_group is None:
+        return None
+
+    text = root_cause.lower()
+    group_scores = {
+        group: sum(1 for keyword in keywords if keyword in text)
+        for group, keywords in _GROUP_SIGNALS.items()
+    }
+    best_group = max(group_scores, key=group_scores.get)
+    best_score = group_scores[best_group]
+    if best_score < _MIN_GROUP_SIGNAL_HITS or best_group == category_group:
+        return None
+
+    category_tokens = [token for token in category.replace("_", " ").split() if len(token) >= 3]
+    if any(token in text for token in category_tokens):
+        return None
+
+    return (
+        f"root cause text signals {best_group} ({best_score} keyword hits) "
+        f"but category {category!r} is {category_group}"
+    )
+
+
+def apply_category_alignment_adjustments(
+    *,
+    root_cause: str,
+    root_cause_category: str,
+    validity_score: float,
+    investigation_recommendations: list[str],
+) -> tuple[float, list[str], bool]:
+    """Lower confidence and add a recommendation when text and category disagree."""
+    mismatch = detect_category_text_mismatch(root_cause, root_cause_category)
+    if mismatch is None:
+        return validity_score, investigation_recommendations, False
+
+    adjusted_score = max(0.0, validity_score - _VALIDITY_PENALTY)
+    recommendation = (
+        "The root cause category may not match the written explanation — "
+        "review the classification before acting on it."
+    )
+    if recommendation in investigation_recommendations:
+        return adjusted_score, investigation_recommendations, True
+    return adjusted_score, [*investigation_recommendations, recommendation], True

--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -23,6 +23,7 @@ from app.agent.tool_loop import (
     _summarise,
     _tool_source,
 )
+from app.analytics.cli import capture_diagnosis_category_mismatch
 from app.cli.interactive_shell.ui.output import debug_print, get_tracker
 from app.constants.investigation import MAX_INVESTIGATION_LOOPS
 from app.services.agent_llm_client import ToolCall, get_agent_llm
@@ -439,8 +440,13 @@ class ConnectedInvestigationAgent:
                 "root_cause": result.root_cause,
                 "validity_score": result.validity_score,
                 "root_cause_category": result.root_cause_category,
+                "category_text_mismatch": result.category_text_mismatch,
             },
         )
+        if result.category_text_mismatch:
+            capture_diagnosis_category_mismatch(
+                root_cause_category=result.root_cause_category,
+            )
 
         tracker.complete(
             "investigation_agent",

--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -446,6 +446,7 @@ class ConnectedInvestigationAgent:
         if result.category_text_mismatch:
             capture_diagnosis_category_mismatch(
                 root_cause_category=result.root_cause_category,
+                mismatch_reason=result.category_text_mismatch_reason,
             )
 
         tracker.complete(

--- a/app/agent/prompt.py
+++ b/app/agent/prompt.py
@@ -29,6 +29,7 @@ Your task: investigate the alert below and produce a clear, evidence-backed root
 - **Discovery or listing tools (those that just enumerate other tools or resources) are useful at most once.** Call such a tool a single time, then act on what it returned — do not keep re-listing.
 - **Prefer tools relevant to the alert.** Do not fan out to integrations unrelated to the alert's service or symptoms just because they are available.
 - **If your recent tool calls stopped producing new evidence, stop investigating and write your diagnosis** with whatever you have, rather than repeating calls.
+- **Dependency traversal (connection failures only):** When logs show connection-related errors (connection refused, timeout, authentication failure, write failure, port unreachable), the fault may live in a stateful dependency (database, cache, message queue) rather than the caller. Before concluding, also query error logs on the dependency itself (MySQL, Postgres, Redis, RabbitMQ, etc.) using the log tools listed under Available tools. Dependencies log their own failure modes (read-only mode, pool exhaustion, replication errors, slow queries, credential rejections) that are not visible from the caller's side. When multiple pods in a namespace fail together, also check namespace-level resources (quotas, network policies, service accounts). This expands evidence collection only — it does not bias localization; if the dependency is healthy and the caller's config is wrong, the caller is the fault.
 
 ## What to produce at the end
 

--- a/app/agent/result.py
+++ b/app/agent/result.py
@@ -8,6 +8,7 @@ from typing import Any, TypedDict, cast
 
 from pydantic import BaseModel, Field
 
+from app.agent.category_alignment import apply_category_alignment_adjustments
 from app.types.root_cause_categories import (
     HERMES_ROOT_CAUSE_CATEGORIES,
     VALID_ROOT_CAUSE_CATEGORIES,
@@ -30,6 +31,7 @@ class InvestigationResult:
     evidence_entries: list[dict] = field(default_factory=list)
     agent_messages: list[dict] = field(default_factory=list)
     investigation_recommendations: list[str] = field(default_factory=list)
+    category_text_mismatch: bool = False
 
     @classmethod
     def unknown(cls, alert_name: str = "Unknown alert") -> InvestigationResult:
@@ -177,6 +179,21 @@ Evidence keys collected: {", ".join(evidence.keys()) if evidence else "none"}
     def _to_claim_dicts(claims: list[str], status: str) -> list[dict]:
         return [{"claim": c, "validation_status": status} for c in claims if c]
 
+    validity_score, investigation_recommendations, category_text_mismatch = (
+        apply_category_alignment_adjustments(
+            root_cause=schema["root_cause"],
+            root_cause_category=schema["root_cause_category"],
+            validity_score=schema["validity_score"],
+            investigation_recommendations=[],
+        )
+    )
+    if category_text_mismatch:
+        logger.warning(
+            "Root cause category may not match explanation: category=%s text=%r",
+            schema["root_cause_category"],
+            schema["root_cause"][:200],
+        )
+
     return InvestigationResult(
         root_cause=schema["root_cause"],
         root_cause_category=schema["root_cause_category"],
@@ -184,7 +201,9 @@ Evidence keys collected: {", ".join(evidence.keys()) if evidence else "none"}
         validated_claims=_to_claim_dicts(schema["validated_claims"], "validated"),
         non_validated_claims=_to_claim_dicts(schema["non_validated_claims"], "not_validated"),
         remediation_steps=schema["remediation_steps"],
-        validity_score=schema["validity_score"],
+        validity_score=validity_score,
+        investigation_recommendations=investigation_recommendations,
+        category_text_mismatch=category_text_mismatch,
     )
 
 

--- a/app/agent/result.py
+++ b/app/agent/result.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, TypedDict, cast
+from typing import Any, NamedTuple, TypedDict, cast
 
 from pydantic import BaseModel, Field
 
@@ -16,6 +16,31 @@ from app.types.root_cause_categories import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class _CategoryAlignment(NamedTuple):
+    validity_score: float
+    investigation_recommendations: list[str]
+    category_text_mismatch: bool
+    category_text_mismatch_reason: str | None
+
+
+def _apply_category_alignment(
+    *,
+    root_cause: str,
+    root_cause_category: str,
+    validity_score: float,
+    investigation_recommendations: list[str] | None = None,
+) -> _CategoryAlignment:
+    score, recommendations, mismatch, reason = apply_category_alignment_adjustments(
+        root_cause=root_cause,
+        root_cause_category=root_cause_category,
+        validity_score=validity_score,
+        investigation_recommendations=list(investigation_recommendations or []),
+    )
+    if mismatch and reason:
+        logger.warning("Root cause category may not match explanation: %s", reason)
+    return _CategoryAlignment(score, recommendations, mismatch, reason)
 
 
 @dataclass
@@ -32,6 +57,7 @@ class InvestigationResult:
     agent_messages: list[dict] = field(default_factory=list)
     investigation_recommendations: list[str] = field(default_factory=list)
     category_text_mismatch: bool = False
+    category_text_mismatch_reason: str | None = None
 
     @classmethod
     def unknown(cls, alert_name: str = "Unknown alert") -> InvestigationResult:
@@ -179,20 +205,11 @@ Evidence keys collected: {", ".join(evidence.keys()) if evidence else "none"}
     def _to_claim_dicts(claims: list[str], status: str) -> list[dict]:
         return [{"claim": c, "validation_status": status} for c in claims if c]
 
-    validity_score, investigation_recommendations, category_text_mismatch = (
-        apply_category_alignment_adjustments(
-            root_cause=schema["root_cause"],
-            root_cause_category=schema["root_cause_category"],
-            validity_score=schema["validity_score"],
-            investigation_recommendations=[],
-        )
+    alignment = _apply_category_alignment(
+        root_cause=schema["root_cause"],
+        root_cause_category=schema["root_cause_category"],
+        validity_score=schema["validity_score"],
     )
-    if category_text_mismatch:
-        logger.warning(
-            "Root cause category may not match explanation: category=%s text=%r",
-            schema["root_cause_category"],
-            schema["root_cause"][:200],
-        )
 
     return InvestigationResult(
         root_cause=schema["root_cause"],
@@ -201,9 +218,10 @@ Evidence keys collected: {", ".join(evidence.keys()) if evidence else "none"}
         validated_claims=_to_claim_dicts(schema["validated_claims"], "validated"),
         non_validated_claims=_to_claim_dicts(schema["non_validated_claims"], "not_validated"),
         remediation_steps=schema["remediation_steps"],
-        validity_score=validity_score,
-        investigation_recommendations=investigation_recommendations,
-        category_text_mismatch=category_text_mismatch,
+        validity_score=alignment.validity_score,
+        investigation_recommendations=alignment.investigation_recommendations,
+        category_text_mismatch=alignment.category_text_mismatch,
+        category_text_mismatch_reason=alignment.category_text_mismatch_reason,
     )
 
 
@@ -214,6 +232,11 @@ def _parse_via_legacy(
 
     try:
         rr = parse_root_cause(last_text)
+        alignment = _apply_category_alignment(
+            root_cause=rr.root_cause,
+            root_cause_category=rr.root_cause_category,
+            validity_score=0.5,
+        )
         return InvestigationResult(
             root_cause=rr.root_cause,
             root_cause_category=rr.root_cause_category,
@@ -225,7 +248,10 @@ def _parse_via_legacy(
                 {"claim": c, "validation_status": "not_validated"} for c in rr.non_validated_claims
             ],
             remediation_steps=rr.remediation_steps,
-            validity_score=0.5,
+            validity_score=alignment.validity_score,
+            investigation_recommendations=alignment.investigation_recommendations,
+            category_text_mismatch=alignment.category_text_mismatch,
+            category_text_mismatch_reason=alignment.category_text_mismatch_reason,
         )
     except Exception as err:
         logger.warning("Legacy parse_root_cause also failed: %s", err)

--- a/app/analytics/cli.py
+++ b/app/analytics/cli.py
@@ -343,14 +343,18 @@ def capture_investigation_started(
     )
 
 
-def capture_diagnosis_category_mismatch(*, root_cause_category: str) -> None:
-    _capture(
-        Event.DIAGNOSIS_CATEGORY_MISMATCH,
-        {
-            "category_text_mismatch": True,
-            "root_cause_category": root_cause_category,
-        },
-    )
+def capture_diagnosis_category_mismatch(
+    *,
+    root_cause_category: str,
+    mismatch_reason: str | None = None,
+) -> None:
+    properties: Properties = {
+        "category_text_mismatch": True,
+        "root_cause_category": root_cause_category,
+    }
+    if mismatch_reason:
+        properties["mismatch_reason"] = mismatch_reason
+    _capture(Event.DIAGNOSIS_CATEGORY_MISMATCH, properties)
 
 
 def capture_investigation_completed(*, tracker: InvestigationTracker | None = None) -> None:

--- a/app/analytics/cli.py
+++ b/app/analytics/cli.py
@@ -343,6 +343,16 @@ def capture_investigation_started(
     )
 
 
+def capture_diagnosis_category_mismatch(*, root_cause_category: str) -> None:
+    _capture(
+        Event.DIAGNOSIS_CATEGORY_MISMATCH,
+        {
+            "category_text_mismatch": True,
+            "root_cause_category": root_cause_category,
+        },
+    )
+
+
 def capture_investigation_completed(*, tracker: InvestigationTracker | None = None) -> None:
     if tracker is None:
         _capture(Event.INVESTIGATION_COMPLETED)

--- a/app/analytics/events.py
+++ b/app/analytics/events.py
@@ -28,6 +28,7 @@ class Event(StrEnum):
     INVESTIGATION_FIRST_HYPOTHESIS_RENDERED = "investigation_first_hypothesis_rendered"
     INVESTIGATION_ABANDONED = "investigation_abandoned"
     INVESTIGATION_FEEDBACK_SUBMITTED = "investigation_feedback_submitted"
+    DIAGNOSIS_CATEGORY_MISMATCH = "diagnosis_category_mismatch"
     INTERACTIVE_SHELL_ROUTE_DECISION = "interactive_shell_route_decision"
 
     # Integrations

--- a/tests/agent/test_category_alignment.py
+++ b/tests/agent/test_category_alignment.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from app.agent.category_alignment import (
     apply_category_alignment_adjustments,
     detect_category_text_mismatch,
@@ -36,16 +38,27 @@ def test_no_mismatch_for_cpu_only_incident() -> None:
     )
 
 
+def test_no_mismatch_when_category_group_is_not_in_signal_map() -> None:
+    assert (
+        detect_category_text_mismatch(
+            "A bad deploy exhausted the Redis connection pool and Postgres replication lag spiked.",
+            "bad_deploy",
+        )
+        is None
+    )
+
+
 def test_apply_adjustments_lowers_validity_and_adds_recommendation() -> None:
-    score, recommendations, mismatch = apply_category_alignment_adjustments(
+    score, recommendations, mismatch, reason = apply_category_alignment_adjustments(
         root_cause="Redis connection pool was exhausted and rejected new clients.",
         root_cause_category="dns_resolution_failure",
         validity_score=0.85,
         investigation_recommendations=[],
     )
 
-    assert score == 0.7
+    assert score == pytest.approx(0.7)
     assert mismatch is True
+    assert reason is not None
     assert len(recommendations) == 1
     assert "review the classification" in recommendations[0]
 

--- a/tests/agent/test_category_alignment.py
+++ b/tests/agent/test_category_alignment.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from app.agent.category_alignment import (
+    apply_category_alignment_adjustments,
+    detect_category_text_mismatch,
+)
+
+
+def test_detect_mismatch_when_text_signals_database_but_category_is_network() -> None:
+    reason = detect_category_text_mismatch(
+        "Redis connection pool was exhausted and rejected new clients.",
+        "dns_resolution_failure",
+    )
+
+    assert reason is not None
+    assert "database" in reason
+
+
+def test_no_mismatch_when_category_matches_text() -> None:
+    assert (
+        detect_category_text_mismatch(
+            "Container exceeded its memory limit and was OOMKilled by the kubelet.",
+            "pod_oomkilled",
+        )
+        is None
+    )
+
+
+def test_no_mismatch_for_cpu_only_incident() -> None:
+    assert (
+        detect_category_text_mismatch(
+            "The container hit its CPU limit and is being throttled, raising latency.",
+            "pod_cpu_throttled",
+        )
+        is None
+    )
+
+
+def test_apply_adjustments_lowers_validity_and_adds_recommendation() -> None:
+    score, recommendations, mismatch = apply_category_alignment_adjustments(
+        root_cause="Redis connection pool was exhausted and rejected new clients.",
+        root_cause_category="dns_resolution_failure",
+        validity_score=0.85,
+        investigation_recommendations=[],
+    )
+
+    assert score == 0.7
+    assert mismatch is True
+    assert len(recommendations) == 1
+    assert "review the classification" in recommendations[0]
+
+
+def test_skip_alignment_for_healthy_and_unknown() -> None:
+    assert detect_category_text_mismatch("All metrics normal.", "healthy") is None
+    assert detect_category_text_mismatch("Not enough evidence.", "unknown") is None

--- a/tests/agent/test_prompt.py
+++ b/tests/agent/test_prompt.py
@@ -14,6 +14,14 @@ def test_build_system_prompt_non_hermes_uses_generic_category_instruction() -> N
     assert "agent_hang" not in prompt
 
 
+def test_build_system_prompt_includes_dependency_traversal_rule() -> None:
+    prompt = build_system_prompt({"alert_source": "grafana"})
+
+    assert "Dependency traversal (connection failures only)" in prompt
+    assert "connection refused" in prompt
+    assert "does not bias localization" in prompt
+
+
 def test_build_system_prompt_hermes_includes_hermes_taxonomy_only() -> None:
     prompt = build_system_prompt({"alert_source": "hermes"})
 

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -316,7 +316,10 @@ def test_capture_diagnosis_category_mismatch(monkeypatch: pytest.MonkeyPatch) ->
     stub = _StubAnalytics()
     monkeypatch.setattr(cli, "get_analytics", lambda: stub)
 
-    cli.capture_diagnosis_category_mismatch(root_cause_category="dns_resolution_failure")
+    cli.capture_diagnosis_category_mismatch(
+        root_cause_category="dns_resolution_failure",
+        mismatch_reason="root cause text signals database (2 keyword hits)",
+    )
 
     assert stub.events == [
         (
@@ -324,6 +327,7 @@ def test_capture_diagnosis_category_mismatch(monkeypatch: pytest.MonkeyPatch) ->
             {
                 "category_text_mismatch": True,
                 "root_cause_category": "dns_resolution_failure",
+                "mismatch_reason": "root cause text signals database (2 keyword hits)",
             },
         )
     ]

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -310,3 +310,20 @@ def test_track_investigation_nested_context_dedupes(monkeypatch: pytest.MonkeyPa
     emitted_events = [event for event, _ in stub.events]
     assert emitted_events == [Event.INVESTIGATION_STARTED, Event.INVESTIGATION_COMPLETED]
     _assert_investigation_events_have_source(stub.events)
+
+
+def test_capture_diagnosis_category_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubAnalytics()
+    monkeypatch.setattr(cli, "get_analytics", lambda: stub)
+
+    cli.capture_diagnosis_category_mismatch(root_cause_category="dns_resolution_failure")
+
+    assert stub.events == [
+        (
+            Event.DIAGNOSIS_CATEGORY_MISMATCH,
+            {
+                "category_text_mismatch": True,
+                "root_cause_category": "dns_resolution_failure",
+            },
+        )
+    ]


### PR DESCRIPTION
## Summary

- Fixes #2927 — adds the CloudOpsBench **dependency-traversal** investigation rule to the product system prompt (`app/agent/prompt.py`), scoped to connection-shaped errors so production agents check DB/cache/MQ dependency logs before concluding.
- Fixes #2928 — adds a conservative post-parse heuristic (`app/agent/category_alignment.py`) that flags when `root_cause` text disagrees with `root_cause_category`, lowers `validity_score` by 0.15, surfaces an `investigation_recommendations` warning, emits `category_text_mismatch` on `agent_end`, and logs a `diagnosis_category_mismatch` PostHog event.

## Test plan

- [x] `uv run ruff check` on changed files
- [x] `uv run python -m pytest tests/agent/test_prompt.py tests/agent/test_category_alignment.py tests/agent/test_result.py tests/analytics/test_cli.py::test_capture_diagnosis_category_mismatch -q`
- [ ] Spot-check a connection-failure investigation to confirm dependency log guidance is followed
- [ ] Spot-check a CPU/memory-only alert to confirm no unnecessary dependency fan-out
