### PR TITLE
fix(ci): unblock automerge on label and fork PRs

### DIFF
--- a/.github/scripts/automerge_pr.py
+++ b/.github/scripts/automerge_pr.py
@@ -10,6 +10,8 @@ import sys
 from typing import Any
 
 AUTOMERGE_LABEL = "automerge"
+AUTOMERGE_WORKFLOW_NAME = "Auto-merge"
+AUTOMERGE_JOB_CHECK_NAME = "Merge when CI is green"
 CHECK_RUN_PENDING_STATUSES = frozenset({"IN_PROGRESS", "QUEUED", "PENDING", "WAITING", "REQUESTED"})
 CHECK_RUN_ALLOWED_CONCLUSIONS = frozenset({"SUCCESS", "SKIPPED", "NEUTRAL"})
 STATUS_CONTEXT_PENDING_STATES = frozenset({"PENDING", "EXPECTED"})
@@ -18,6 +20,12 @@ STATUS_CONTEXT_ALLOWED_STATES = frozenset({"SUCCESS"})
 
 def _check_display_name(check: dict[str, Any]) -> str:
     return str(check.get("name") or check.get("context") or "unknown")
+
+
+def _is_automerge_workflow_check(check: dict[str, Any]) -> bool:
+    if check.get("workflowName") == AUTOMERGE_WORKFLOW_NAME:
+        return True
+    return check.get("name") == AUTOMERGE_JOB_CHECK_NAME
 
 
 def _check_run_is_green(check: dict[str, Any]) -> tuple[bool, str]:
@@ -66,6 +74,8 @@ def _checks_are_green(status_rollup: list[dict[str, Any]]) -> tuple[bool, str]:
         return False, "no status checks reported yet"
 
     for check in status_rollup:
+        if _is_automerge_workflow_check(check):
+            continue
         green, reason = _rollup_item_is_green(check)
         if not green:
             return False, reason

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,8 +14,8 @@ Opt-in squash merge when CI is green. Trigger: add the **`automerge`** label to 
 ### Flow
 
 1. Add the `automerge` label on GitHub (or `gh pr edit <n> --add-label automerge`).
-2. [`.github/scripts/automerge_pr.py`](../scripts/automerge_pr.py) runs on label add, new pushes, or check-suite completion.
-3. The PR is squash-merged with branch delete when every reported check is green:
+2. [`.github/scripts/automerge_pr.py`](../scripts/automerge_pr.py) runs on label add, new pushes, or check-suite completion (excluding this workflow's own check).
+3. The PR is squash-merged with branch delete when every other reported check is green:
    - GitHub Actions **CheckRun** items (`SUCCESS`, `SKIPPED`, `NEUTRAL`)
    - Legacy commit **StatusContext** items (`SUCCESS` only)
 
@@ -23,7 +23,7 @@ Push again with the label still on to re-merge after CI. Remove the label to can
 
 ### Limits
 
-- **Upstream branches only** — fork PRs still need a manual merge (`GITHUB_TOKEN` cannot write on fork heads).
+- Uses **`pull_request_target`** so fork PRs can merge; the job only calls `gh` APIs (no PR head code execution).
 - **Greptile is not a GitHub check** — the label does not wait for Greptile; add it only when review is done.
 - **Draft PRs** — skipped until marked ready for review.
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,10 +1,10 @@
 name: Auto-merge
 
 # Opt-in squash merge once all PR checks are green. Add the `automerge` label when the PR
-# is ready (Greptile 5/5, review done, etc.). Works for branches pushed to this repo;
-# fork PRs still need a maintainer merge because GITHUB_TOKEN cannot write on fork heads.
+# is ready (Greptile 5/5, review done, etc.). Uses pull_request_target so fork PRs can merge
+# via GITHUB_TOKEN; the job only calls gh APIs and never executes PR head code.
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, synchronize, reopened]
     branches: [main]
   check_suite:
@@ -23,8 +23,10 @@ jobs:
     name: Merge when CI is green
     runs-on: ubuntu-latest
     if: >-
-      (github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success') ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'check_suite' &&
+        contains(fromJSON('["success", "neutral"]'), github.event.check_suite.conclusion) &&
+        github.event.check_suite.name != 'Auto-merge') ||
+      (github.event_name == 'pull_request_target' &&
         (github.event.action != 'labeled' || github.event.label.name == 'automerge'))
     steps:
       - uses: actions/checkout@v5
@@ -37,7 +39,7 @@ jobs:
           CHECK_SUITE_PRS: ${{ toJson(github.event.check_suite.pull_requests) }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
             if [ -z "$PR_NUMBER" ]; then
               echo "No pull request number on event."
               exit 0

--- a/tests/github/test_automerge_pr.py
+++ b/tests/github/test_automerge_pr.py
@@ -91,3 +91,25 @@ def test_status_context_pending_blocks_merge() -> None:
     )
     assert green is False
     assert reason == "status still pending: ci/legacy"
+
+
+def test_ignores_automerge_workflow_check_while_running() -> None:
+    green, reason = automerge_pr._checks_are_green(
+        [
+            {
+                "__typename": "CheckRun",
+                "name": "quality (ubuntu-latest)",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            },
+            {
+                "__typename": "CheckRun",
+                "name": "Merge when CI is green",
+                "workflowName": "Auto-merge",
+                "status": "IN_PROGRESS",
+                "conclusion": None,
+            },
+        ]
+    )
+    assert green is True
+    assert reason == "all checks green"


### PR DESCRIPTION
## Summary
- Fixes automerge blocking on its own in-progress **Merge when CI is green** check (seen on #2933).
- Switches label/push triggers to **`pull_request_target`** so fork PRs can merge via `GITHUB_TOKEN`.
- Skips self-triggered `Auto-merge` check_suite events and treats `neutral` suite conclusions as eligible.

## Root cause (#2933)
Adding `automerge` after CI was green still failed because the workflow counted itself as a pending check:
`PR #2933 not ready to merge: check still running: Merge when CI is green`

## Test plan
- [ ] Merge this PR manually (bootstrap fix).
- [ ] On #2933: remove and re-add `automerge` label; confirm squash merge when CI green.
- [ ] Confirm fork PR merge works (author branch on `ViniLF/opensre`).
- [ ] `uv run pytest tests/github/test_automerge_pr.py -q`