### PR TITLE
chore: ollama alert when local synthetic tests are run

### DIFF
--- a/tests/synthetic/eks/run_suite.py
+++ b/tests/synthetic/eks/run_suite.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
@@ -11,6 +12,10 @@ from tests.synthetic.eks.scenario_loader import (
     SUITE_DIR,
     K8sScenarioFixture,
     load_all_scenarios,
+)
+from tests.synthetic.llm_provider_preflight import (
+    UnsupportedSyntheticLLMProviderError,
+    validate_synthetic_llm_provider,
 )
 from tests.synthetic.mock_datadog_backend.backend import FixtureDatadogBackend
 from tests.synthetic.mock_eks_backend.backend import FixtureEKSBackend
@@ -453,6 +458,7 @@ def run_scenario(
 
 def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
     args = parse_args(argv)
+    validate_synthetic_llm_provider(suite_name="EKS")
     fixtures = load_all_scenarios(SUITE_DIR)
     if args.scenario:
         fixtures = [fixture for fixture in fixtures if fixture.scenario_id == args.scenario]
@@ -483,7 +489,11 @@ def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    results = run_suite(argv)
+    try:
+        results = run_suite(argv)
+    except UnsupportedSyntheticLLMProviderError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
     return 0 if all(result.passed for result in results) else 1
 
 

--- a/tests/synthetic/hermes_rca/run_suite.py
+++ b/tests/synthetic/hermes_rca/run_suite.py
@@ -16,6 +16,10 @@ from tests.synthetic.hermes_rca.scenario_loader import (
     load_all_scenarios,
     load_scenario,
 )
+from tests.synthetic.llm_provider_preflight import (
+    UnsupportedSyntheticLLMProviderError,
+    validate_synthetic_llm_provider,
+)
 from tests.synthetic.mock_hermes_backend.backend import FixtureHermesBackend
 
 HISTORY_DIR = SUITE_DIR / "benchmark_history"
@@ -212,6 +216,15 @@ def main(argv: list[str] | None = None) -> int:
         for fixture in scenarios:
             results.append(_offline_result(fixture))
     else:
+        try:
+            validate_synthetic_llm_provider(
+                suite_name="Hermes RCA",
+                offline_hint="--offline-only",
+            )
+        except UnsupportedSyntheticLLMProviderError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 1
+
         if not has_credentials_for_active_llm_provider():
             print(
                 "Skipping LLM-backed Hermes RCA run: no credentials for active provider. "

--- a/tests/synthetic/llm_provider_preflight.py
+++ b/tests/synthetic/llm_provider_preflight.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from app.config import get_configured_llm_provider
+
+UNSUPPORTED_SYNTHETIC_LLM_PROVIDERS = frozenset({"ollama"})
+
+
+class UnsupportedSyntheticLLMProviderError(RuntimeError):
+    """Raised when a synthetic suite is run with a known-unsupported LLM provider."""
+
+
+def validate_synthetic_llm_provider(
+    *,
+    suite_name: str,
+    offline_hint: str | None = None,
+) -> None:
+    """Fail fast for LLM providers that cannot reliably run scored synthetic suites."""
+    provider = get_configured_llm_provider()
+    if provider not in UNSUPPORTED_SYNTHETIC_LLM_PROVIDERS:
+        return
+
+    hint = (
+        f" Use {offline_hint} for fixture-only checks."
+        if offline_hint
+        else " Use a hosted provider such as LLM_PROVIDER=openai or LLM_PROVIDER=anthropic."
+    )
+    raise UnsupportedSyntheticLLMProviderError(
+        f"{suite_name} synthetic tests are not supported with LLM_PROVIDER={provider}. "
+        "Local Ollama models currently produce unreliable synthetic-test failures rather than "
+        f"stable benchmark signal.{hint}"
+    )

--- a/tests/synthetic/openclaw/run_suite.py
+++ b/tests/synthetic/openclaw/run_suite.py
@@ -25,6 +25,10 @@ import textwrap
 import time
 from typing import Any
 
+from tests.synthetic.llm_provider_preflight import (
+    UnsupportedSyntheticLLMProviderError,
+    validate_synthetic_llm_provider,
+)
 from tests.synthetic.mock_openclaw_backend.backend import FixtureOpenClawBackend
 from tests.synthetic.openclaw.scenario_loader import (
     OpenClawScenario,
@@ -131,6 +135,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     args, _ = parser.parse_known_args(argv)
     output_json: bool = bool(args.output_json)
+
+    try:
+        validate_synthetic_llm_provider(suite_name="OpenClaw")
+    except UnsupportedSyntheticLLMProviderError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
 
     if args.scenario:
         try:

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -11,6 +11,7 @@ import argparse
 import difflib
 import json
 import os
+import sys
 import textwrap
 import time
 from collections.abc import Callable, Iterator
@@ -32,6 +33,10 @@ from rich.progress import (
 )
 from rich.table import Table
 
+from tests.synthetic.llm_provider_preflight import (
+    UnsupportedSyntheticLLMProviderError,
+    validate_synthetic_llm_provider,
+)
 from tests.synthetic.mock_aws_backend import FixtureAWSBackend
 from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
 from tests.synthetic.mock_grafana_backend.selective_backend import SelectiveGrafanaBackend
@@ -767,6 +772,7 @@ def _run_axis2_suite(
 def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
     args = parse_args(argv)
     config = _build_run_config(args)
+    validate_synthetic_llm_provider(suite_name="RDS PostgreSQL")
 
     # --axis2 short-circuits the default per-level orchestration: every selected
     # fixture is run twice (FixtureGrafanaBackend then SelectiveGrafanaBackend)
@@ -802,7 +808,11 @@ def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    results = run_suite(argv)
+    try:
+        results = run_suite(argv)
+    except UnsupportedSyntheticLLMProviderError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
     return 0 if all(result.passed for result in results) else 1
 
 

--- a/tests/synthetic/rds_postgres/test_run_suite_axis2_cli.py
+++ b/tests/synthetic/rds_postgres/test_run_suite_axis2_cli.py
@@ -201,3 +201,29 @@ def test_axis2_with_json_emits_structured_payload_with_both_axes(
     assert len(payload["axis2"]) == 1
     assert payload["axis1"][0]["scenario_id"] == fixture.scenario_id
     assert payload["axis2"][0]["scenario_id"] == fixture.scenario_id
+
+
+def test_main_rejects_ollama_before_synthetic_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+
+    exit_code = run_suite_module.main(
+        [
+            "--scenario",
+            "001-replication-lag",
+            "--axis2",
+            "--observations-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "RDS PostgreSQL synthetic tests are not supported with LLM_PROVIDER=ollama" in (
+        captured.err
+    )
+    assert "Local Ollama models" in captured.err

--- a/tests/synthetic/test_llm_provider_preflight.py
+++ b/tests/synthetic/test_llm_provider_preflight.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.synthetic.llm_provider_preflight import (
+    UnsupportedSyntheticLLMProviderError,
+    validate_synthetic_llm_provider,
+)
+
+
+def test_preflight_allows_hosted_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+
+    validate_synthetic_llm_provider(suite_name="RDS PostgreSQL")
+
+
+def test_preflight_rejects_ollama_with_actionable_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+
+    with pytest.raises(UnsupportedSyntheticLLMProviderError) as exc_info:
+        validate_synthetic_llm_provider(
+            suite_name="Hermes RCA",
+            offline_hint="--offline-only",
+        )
+
+    message = str(exc_info.value)
+    assert "Hermes RCA synthetic tests are not supported with LLM_PROVIDER=ollama" in message
+    assert "Local Ollama models" in message
+    assert "--offline-only" in message


### PR DESCRIPTION
Adds a synthetic-suite preflight that fails fast when LLM_PROVIDER=ollama, with a clear explanation that local Ollama models produce unreliable benchmark signal. Wires the guard into the LLM-backed synthetic runners and adds coverage for the shared preflight plus the RDS CLI error path.