### PR TITLE
docs(readme): fix broken link to AGENTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ When an alert fires, OpenSRE automatically:
 5. **Posts** a summary directly to Slack or PagerDuty — no context switching needed
 
 For the current code-level agent architecture after removing the old graph and chain
-framework layers, see [AGENT_ARCHITECTURE.md](AGENT_ARCHITECTURE.md).
+framework layers, see [AGENTS.md](AGENTS.md).
 
 ---
 


### PR DESCRIPTION
Fixes #2941

#### Describe the changes you have made in this PR -
Fixed a broken documentation link in `README.md` at line 180. The text pointed to a non-existent `AGENT_ARCHITECTURE.md` file, which has been corrected to reference `AGENTS.md` (the actual developer and codebase structure reference file).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The repository maps its agent codebase and developer reference details in `AGENTS.md`. The link in `README.md` was updated from pointing to the missing `AGENT_ARCHITECTURE.md` to point to the correct `AGENTS.md` guide.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions