### PR TITLE
fix(agent) Reuse cached tool results on duplicate investigation calls

### DIFF
--- a/app/agent/stages/investigate/agent.py
+++ b/app/agent/stages/investigate/agent.py
@@ -233,7 +233,8 @@ class ConnectedInvestigationAgent:
             ]
             duplicate_flags = [cached is not None for cached in cached_entries]
             fresh_calls = [
-                tc for tc, is_dup in zip(response.tool_calls, duplicate_flags) if not is_dup
+                tc for tc, cached in zip(response.tool_calls, cached_entries, strict=True)
+                if cached is None
             ]
             for tc in fresh_calls:
                 _record_tool_start(tc)
@@ -248,11 +249,8 @@ class ConnectedInvestigationAgent:
 
             fresh_results = iter(_run_parallel(fresh_calls, tools, resolved) if fresh_calls else [])
             results: list[Any] = []
-            for tc, cached_entry, is_dup in zip(
-                response.tool_calls, cached_entries, duplicate_flags, strict=True
-            ):
-                if is_dup:
-                    assert cached_entry is not None
+            for tc, cached_entry in zip(response.tool_calls, cached_entries, strict=True):
+                if cached_entry is not None:
                     results.append(duplicate_call_result(tc, cached_entry))
                     continue
                 output = next(fresh_results)

--- a/app/agent/stages/investigate/agent.py
+++ b/app/agent/stages/investigate/agent.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any
 
 from app.agent.stages.investigate.loop import (
+    InvestigationToolCallCache,
     degraded_investigation_from_llm_failure,
     duplicate_call_result,
     tool_call_signature,
@@ -131,7 +132,7 @@ class ConnectedInvestigationAgent:
         evidence: dict[str, Any] = {}
         evidence_entries: list[EvidenceEntry] = []
         executed_hypotheses: list[dict[str, Any]] = []
-        seen_signatures: set[str] = set()
+        tool_call_cache = InvestigationToolCallCache()
 
         _emit(
             "agent_start",
@@ -146,7 +147,6 @@ class ConnectedInvestigationAgent:
         if seed_calls:
             logger.debug("[agent] seeding %d primary tool calls before LLM loop", len(seed_calls))
             for tc in seed_calls:
-                seen_signatures.add(tool_call_signature(tc))
                 _record_tool_start(tc)
             executed_hypotheses.append(
                 {
@@ -164,6 +164,7 @@ class ConnectedInvestigationAgent:
             messages.extend(seed_msgs)
 
             for tc, output in zip(seed_calls, seed_results):
+                tool_call_cache.store(tool_call_signature(tc), output, loop_iteration=-1)
                 merge_tool_evidence(evidence, tc.name, output, tc.input)
                 evidence_entries.append(
                     EvidenceEntry(
@@ -227,14 +228,14 @@ class ConnectedInvestigationAgent:
                 messages.append({"role": "user", "content": nudge})
                 continue
 
-            duplicate_flags = [
-                tool_call_signature(tc) in seen_signatures for tc in response.tool_calls
+            cached_entries = [
+                tool_call_cache.lookup(tool_call_signature(tc)) for tc in response.tool_calls
             ]
+            duplicate_flags = [cached is not None for cached in cached_entries]
             fresh_calls = [
                 tc for tc, is_dup in zip(response.tool_calls, duplicate_flags) if not is_dup
             ]
             for tc in fresh_calls:
-                seen_signatures.add(tool_call_signature(tc))
                 _record_tool_start(tc)
 
             executed_hypotheses.append(
@@ -246,10 +247,17 @@ class ConnectedInvestigationAgent:
             )
 
             fresh_results = iter(_run_parallel(fresh_calls, tools, resolved) if fresh_calls else [])
-            results = [
-                duplicate_call_result(tc) if is_dup else next(fresh_results)
-                for tc, is_dup in zip(response.tool_calls, duplicate_flags)
-            ]
+            results: list[Any] = []
+            for tc, cached_entry, is_dup in zip(
+                response.tool_calls, cached_entries, duplicate_flags, strict=True
+            ):
+                if is_dup:
+                    assert cached_entry is not None
+                    results.append(duplicate_call_result(tc, cached_entry))
+                    continue
+                output = next(fresh_results)
+                tool_call_cache.store(tool_call_signature(tc), output, loop_iteration=iteration)
+                results.append(output)
 
             tool_result_messages = _build_tool_result_messages(llm, response.tool_calls, results)
             if duplicate_flags and all(duplicate_flags):

--- a/app/agent/stages/investigate/agent.py
+++ b/app/agent/stages/investigate/agent.py
@@ -233,7 +233,8 @@ class ConnectedInvestigationAgent:
             ]
             duplicate_flags = [cached is not None for cached in cached_entries]
             fresh_calls = [
-                tc for tc, cached in zip(response.tool_calls, cached_entries, strict=True)
+                tc
+                for tc, cached in zip(response.tool_calls, cached_entries, strict=True)
                 if cached is None
             ]
             for tc in fresh_calls:

--- a/app/agent/stages/investigate/loop.py
+++ b/app/agent/stages/investigate/loop.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from app.agent.utils.llm_invoke_errors import LLMInvokeFailure
@@ -20,18 +21,45 @@ def tool_call_signature(tool_call: ToolCall) -> str:
     return f"{tool_call.name}::{args}"
 
 
-def duplicate_call_result(tool_call: ToolCall) -> dict[str, Any]:
-    """Synthetic result returned in place of re-running an already-seen call."""
+@dataclass(frozen=True)
+class CachedToolResult:
+    result: Any
+    loop_iteration: int
+
+
+class InvestigationToolCallCache:
+    """Per-investigation cache of tool results keyed by ``tool_call_signature``."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, CachedToolResult] = {}
+
+    def store(self, signature: str, result: Any, *, loop_iteration: int) -> None:
+        self._entries[signature] = CachedToolResult(result=result, loop_iteration=loop_iteration)
+
+    def lookup(self, signature: str) -> CachedToolResult | None:
+        return self._entries.get(signature)
+
+
+def duplicate_call_result(tool_call: ToolCall, cached: CachedToolResult) -> dict[str, Any]:
+    """Return a wrapped cached result instead of re-running an identical tool call."""
+    if cached.loop_iteration < 0:
+        when = "during seed evidence collection"
+    else:
+        when = f"in lap {cached.loop_iteration + 1}"
+
     return {
         "suppressed_duplicate": True,
+        "reused_cached_result": True,
         "tool": tool_call.name,
+        "first_called_at_loop": cached.loop_iteration,
         "note": (
-            f"Skipped: '{tool_call.name}' was already called earlier in this "
-            "investigation with identical arguments, so re-running it would return "
-            "the same data. Do not call it again. Either call a DIFFERENT tool (or "
-            "the same tool with DIFFERENT arguments) to gather new evidence, or "
-            "write your final diagnosis."
+            f"You already called '{tool_call.name}' with identical arguments {when}. "
+            "Reused the cached result below instead of fetching again. Do not call it "
+            "again with the same arguments — either call a DIFFERENT tool (or the same "
+            "tool with DIFFERENT arguments) to gather new evidence, or write your final "
+            "diagnosis."
         ),
+        "cached_result": cached.result,
     }
 
 

--- a/app/agent/stages/investigate/loop.py
+++ b/app/agent/stages/investigate/loop.py
@@ -10,6 +10,9 @@ from typing import Any
 from app.agent.utils.llm_invoke_errors import LLMInvokeFailure
 from app.services.agent_llm_client import ToolCall
 from app.state.evidence import EvidenceEntry
+from app.utils.truncation import truncate
+
+_MAX_CACHED_RESULT_CHARS = 8_000
 
 
 def tool_call_signature(tool_call: ToolCall) -> str:
@@ -34,10 +37,26 @@ class InvestigationToolCallCache:
         self._entries: dict[str, CachedToolResult] = {}
 
     def store(self, signature: str, result: Any, *, loop_iteration: int) -> None:
+        if signature in self._entries:
+            return
         self._entries[signature] = CachedToolResult(result=result, loop_iteration=loop_iteration)
 
     def lookup(self, signature: str) -> CachedToolResult | None:
         return self._entries.get(signature)
+
+
+def _bounded_cached_result_payload(result: Any, *, max_chars: int) -> Any:
+    """Bound duplicate replay size; the cache still stores the full first result."""
+    try:
+        serialized = json.dumps(result, default=str, ensure_ascii=False)
+    except (TypeError, ValueError):
+        serialized = repr(result)
+    if len(serialized) <= max_chars:
+        return result
+    return {
+        "_truncated_for_duplicate_replay": True,
+        "preview": truncate(serialized, max_chars),
+    }
 
 
 def duplicate_call_result(tool_call: ToolCall, cached: CachedToolResult) -> dict[str, Any]:
@@ -59,7 +78,10 @@ def duplicate_call_result(tool_call: ToolCall, cached: CachedToolResult) -> dict
             "tool with DIFFERENT arguments) to gather new evidence, or write your final "
             "diagnosis."
         ),
-        "cached_result": cached.result,
+        "cached_result": _bounded_cached_result_payload(
+            cached.result,
+            max_chars=_MAX_CACHED_RESULT_CHARS,
+        ),
     }
 
 

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -1033,6 +1033,29 @@ def test_investigation_tool_call_cache_lookup_after_store() -> None:
     assert cached.loop_iteration == 0
 
 
+def test_investigation_tool_call_cache_first_write_wins() -> None:
+    cache = InvestigationToolCallCache()
+    signature = tool_call_signature(ToolCall(id="1", name="query_logs", input={"svc": "api"}))
+
+    cache.store(signature, {"lines": 3}, loop_iteration=0)
+    cache.store(signature, {"lines": 99}, loop_iteration=1)
+
+    cached = cache.lookup(signature)
+    assert cached is not None
+    assert cached.result == {"lines": 3}
+    assert cached.loop_iteration == 0
+
+
+def test_duplicate_call_result_truncates_large_cached_payload() -> None:
+    cached = CachedToolResult(result={"logs": "x" * 20_000}, loop_iteration=0)
+    result = duplicate_call_result(ToolCall(id="1", name="query_logs", input={}), cached)
+
+    payload = result["cached_result"]
+    assert isinstance(payload, dict)
+    assert payload["_truncated_for_duplicate_replay"] is True
+    assert len(payload["preview"]) <= 8_000
+
+
 def _fake_tool(name: str, *, source: str = "posthog_mcp") -> MagicMock:
     tool = MagicMock()
     tool.name = name

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -13,6 +13,8 @@ from app.agent.stages.investigate import (
 )
 from app.agent.stages.investigate.agent import _tools_for_plan
 from app.agent.stages.investigate.loop import (
+    CachedToolResult,
+    InvestigationToolCallCache,
     duplicate_call_result,
     tool_call_signature,
 )
@@ -1008,10 +1010,27 @@ def test_tool_call_signature_is_argument_order_independent() -> None:
 
 
 def test_duplicate_call_result_marks_suppression() -> None:
-    result = duplicate_call_result(ToolCall(id="1", name="list_posthog_tools", input={}))
+    cached = CachedToolResult(result={"logs": ["error A"]}, loop_iteration=2)
+    result = duplicate_call_result(ToolCall(id="1", name="list_posthog_tools", input={}), cached)
+
     assert result["suppressed_duplicate"] is True
+    assert result["reused_cached_result"] is True
     assert result["tool"] == "list_posthog_tools"
-    assert "already" in result["note"].lower()
+    assert result["cached_result"] == {"logs": ["error A"]}
+    assert "lap 3" in result["note"]
+
+
+def test_investigation_tool_call_cache_lookup_after_store() -> None:
+    cache = InvestigationToolCallCache()
+    signature = tool_call_signature(ToolCall(id="1", name="query_logs", input={"svc": "api"}))
+
+    assert cache.lookup(signature) is None
+    cache.store(signature, {"lines": 3}, loop_iteration=0)
+
+    cached = cache.lookup(signature)
+    assert cached is not None
+    assert cached.result == {"lines": 3}
+    assert cached.loop_iteration == 0
 
 
 def _fake_tool(name: str, *, source: str = "posthog_mcp") -> MagicMock:
@@ -1097,9 +1116,12 @@ def test_run_suppresses_duplicate_tool_calls() -> None:
 
     # Executed exactly once despite being requested twice.
     assert tool.run.call_count == 1
-    # The duplicate got a synthetic suppression result fed back to the model.
+    # The duplicate got the wrapped cached result fed back to the model.
     assert any(
-        isinstance(m.get("content"), str) and "suppressed_duplicate" in m["content"]
+        isinstance(m.get("content"), str)
+        and "suppressed_duplicate" in m["content"]
+        and "cached_result" in m["content"]
+        and '"ok": true' in m["content"].lower()
         for m in result["agent_messages"]
     )
     duplicate_messages = [


### PR DESCRIPTION
## Summary

- Fixes #2905 — adds a per-investigation tool result cache and uses it as the single source of truth for duplicate detection (replacing `seen_signatures`).
- On duplicate `(tool_name, sorted_args)`, the agent no longer re-executes the tool; it returns the **full wrapped cached result** so the model sees prior output instead of a skip-only note.
- Stagnation handling (nudge + force conclusion after duplicate-only laps) is unchanged.

## Test plan

- [x] `uv run ruff check` on changed files
- [x] `uv run python -m mypy app/agent/stages/investigate/loop.py app/agent/stages/investigate/agent.py`
- [x] `uv run python -m pytest tests/agent/test_investigation.py -k "duplicate or tool_call_signature or stuck_repeating or different_args" -q`
- [ ] CloudOpsBench A/B: compare lap count and tool-call count with cache on vs prior behavior; confirm no a1 regression
