### PR TITLE
refactor(agent/correlation): extract Datadog wiring into datadog_factory

### DIFF
--- a/app/agent/correlation/__init__.py
+++ b/app/agent/correlation/__init__.py
@@ -97,6 +97,13 @@ def build_upstream_evidence_provider(state: dict[str, Any]) -> UpstreamEvidenceP
     return None
 
 
+# Note: ``build_datadog_provider`` is intentionally NOT exported here.
+# Callers must go through the vendor-agnostic
+# :func:`build_upstream_evidence_provider`; exposing the concrete
+# Datadog factory invites bypassing the abstraction. The function is
+# still importable as
+# ``from app.agent.correlation.datadog_factory import build_datadog_provider``
+# for internal use within the correlation package.
 __all__ = [
     "DatadogCorrelationAdapter",
     "DatadogCorrelationQueries",
@@ -108,7 +115,6 @@ __all__ = [
     "TopologyHint",
     "UpstreamEvidenceBundle",
     "UpstreamEvidenceProvider",
-    "build_datadog_provider",
     "build_upstream_evidence_provider",
     "candidate_services_from_state",
     "target_resource_from_state",

--- a/app/agent/correlation/__init__.py
+++ b/app/agent/correlation/__init__.py
@@ -21,23 +21,79 @@ from app.agent.correlation.upstream import (
 )
 
 
+def target_resource_from_state(state: dict[str, Any]) -> str:
+    """Pull the correlation target resource (e.g. RDS DB identifier) from a raw alert.
+
+    Vendor-neutral: any correlation source that needs an alert target
+    reads from the same keys. Defaults to ``"unknown-rds"`` when no
+    relevant field is present.
+    """
+    raw_alert = state.get("raw_alert") or {}
+    if not isinstance(raw_alert, dict):
+        return "unknown-rds"
+    return str(
+        raw_alert.get("resource")
+        or raw_alert.get("resource_name")
+        or raw_alert.get("db_instance")
+        or raw_alert.get("db_instance_identifier")
+        or "unknown-rds"
+    )
+
+
+def candidate_services_from_state(state: dict[str, Any]) -> tuple[str, ...]:
+    """Pull upstream-service candidate names from a raw alert.
+
+    Accepts a comma-separated string or a list/tuple under one of
+    ``upstream_services`` / ``candidate_services`` / ``related_services``.
+    Empty tuple when nothing relevant is present. Vendor-neutral.
+    """
+    raw_alert = state.get("raw_alert") or {}
+    if not isinstance(raw_alert, dict):
+        return ()
+
+    raw_candidates = (
+        raw_alert.get("upstream_services")
+        or raw_alert.get("candidate_services")
+        or raw_alert.get("related_services")
+    )
+    if isinstance(raw_candidates, str):
+        return tuple(item.strip() for item in raw_candidates.split(",") if item.strip())
+    if isinstance(raw_candidates, list | tuple):
+        return tuple(str(item).strip() for item in raw_candidates if str(item).strip())
+    return ()
+
+
 def build_upstream_evidence_provider(state: dict[str, Any]) -> UpstreamEvidenceProvider | None:
     """Vendor-agnostic factory: pick a correlation provider for ``state``.
 
-    Inspects the agent state's ``resolved_integrations`` and delegates to
-    the matching vendor factory. Returns ``None`` when no integration
-    can serve correlation evidence — the caller treats that as "skip
-    upstream correlation for this run".
+    Owns the agent-state shape: extracts the integration config, target
+    resource, and candidate services here, then hands clean values to
+    each vendor factory. Vendor factories don't know about state.
+
+    Returns ``None`` when no integration can serve correlation evidence
+    — the caller (typically :mod:`app.pipeline.pipeline`) treats that
+    as "skip upstream correlation for this run".
 
     Adding a new correlation source is a single new factory module
-    + an ``elif`` branch here. Callers (specifically
-    :mod:`app.pipeline.pipeline`) must not import from
+    + an ``elif`` branch here. Callers must not import from
     ``app.services.<vendor>`` directly — that's a layering violation
     enforced by ``tests/pipeline/test_layering.py``.
     """
-    provider = build_datadog_provider(state)
-    if provider is not None:
-        return provider
+    resolved = state.get("resolved_integrations") or {}
+    if not isinstance(resolved, dict):
+        return None
+    target_resource = target_resource_from_state(state)
+    candidate_services = candidate_services_from_state(state)
+
+    datadog_cfg_raw = resolved.get("datadog")
+    datadog_provider = build_datadog_provider(
+        datadog_config=datadog_cfg_raw if isinstance(datadog_cfg_raw, dict) else None,
+        target_resource=target_resource,
+        candidate_services=candidate_services,
+    )
+    if datadog_provider is not None:
+        return datadog_provider
+
     return None
 
 
@@ -54,4 +110,6 @@ __all__ = [
     "UpstreamEvidenceProvider",
     "build_datadog_provider",
     "build_upstream_evidence_provider",
+    "candidate_services_from_state",
+    "target_resource_from_state",
 ]

--- a/app/agent/correlation/__init__.py
+++ b/app/agent/correlation/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from typing import Any
+
 from app.agent.correlation.datadog_adapter import DatadogCorrelationAdapter
+from app.agent.correlation.datadog_factory import build_datadog_provider
 from app.agent.correlation.datadog_provider import (
     DatadogCorrelationQueries,
     DatadogUpstreamEvidenceProvider,
@@ -17,6 +20,27 @@ from app.agent.correlation.upstream import (
     UpstreamEvidenceProvider,
 )
 
+
+def build_upstream_evidence_provider(state: dict[str, Any]) -> UpstreamEvidenceProvider | None:
+    """Vendor-agnostic factory: pick a correlation provider for ``state``.
+
+    Inspects the agent state's ``resolved_integrations`` and delegates to
+    the matching vendor factory. Returns ``None`` when no integration
+    can serve correlation evidence — the caller treats that as "skip
+    upstream correlation for this run".
+
+    Adding a new correlation source is a single new factory module
+    + an ``elif`` branch here. Callers (specifically
+    :mod:`app.pipeline.pipeline`) must not import from
+    ``app.services.<vendor>`` directly — that's a layering violation
+    enforced by ``tests/pipeline/test_layering.py``.
+    """
+    provider = build_datadog_provider(state)
+    if provider is not None:
+        return provider
+    return None
+
+
 __all__ = [
     "DatadogCorrelationAdapter",
     "DatadogCorrelationQueries",
@@ -28,4 +52,6 @@ __all__ = [
     "TopologyHint",
     "UpstreamEvidenceBundle",
     "UpstreamEvidenceProvider",
+    "build_datadog_provider",
+    "build_upstream_evidence_provider",
 ]

--- a/app/agent/correlation/datadog_factory.py
+++ b/app/agent/correlation/datadog_factory.py
@@ -9,8 +9,11 @@ plus a registration in :mod:`app.agent.correlation.__init__`.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
+
+from pydantic import ValidationError
 
 from app.agent.correlation.datadog_adapter import DatadogCorrelationAdapter
 from app.agent.correlation.datadog_provider import (
@@ -43,68 +46,31 @@ def _datadog_avg_query(metric_name: str) -> str:
     return f"avg:{metric}{{*}}"
 
 
-def target_resource_from_state(state: dict[str, Any]) -> str:
-    """Extract the Datadog ``target_resource`` (RDS DB identifier) from an
-    investigation state's raw alert. Defaults to ``"unknown-rds"``.
-
-    Public because the same key set is exercised by tests outside this
-    module.
-    """
-    raw_alert = state.get("raw_alert") or {}
-    if not isinstance(raw_alert, dict):
-        return "unknown-rds"
-    return str(
-        raw_alert.get("resource")
-        or raw_alert.get("resource_name")
-        or raw_alert.get("db_instance")
-        or raw_alert.get("db_instance_identifier")
-        or "unknown-rds"
-    )
-
-
-def candidate_services_from_state(state: dict[str, Any]) -> tuple[str, ...]:
-    """Extract upstream-service candidate names from a raw alert.
-
-    Accepts a comma-separated string or a list/tuple under one of
-    ``upstream_services`` / ``candidate_services`` / ``related_services``.
-    Empty tuple when nothing relevant is present.
-    """
-    raw_alert = state.get("raw_alert") or {}
-    if not isinstance(raw_alert, dict):
-        return ()
-
-    raw_candidates = (
-        raw_alert.get("upstream_services")
-        or raw_alert.get("candidate_services")
-        or raw_alert.get("related_services")
-    )
-    if isinstance(raw_candidates, str):
-        return tuple(item.strip() for item in raw_candidates.split(",") if item.strip())
-    if isinstance(raw_candidates, list | tuple):
-        return tuple(str(item).strip() for item in raw_candidates if str(item).strip())
-    return ()
-
-
-def build_datadog_provider(state: dict[str, Any]) -> UpstreamEvidenceProvider | None:
+def build_datadog_provider(
+    *,
+    datadog_config: Mapping[str, Any] | None,
+    target_resource: str = "unknown-rds",
+    candidate_services: tuple[str, ...] = (),
+) -> UpstreamEvidenceProvider | None:
     """Return a Datadog-backed upstream-evidence provider, or ``None``.
 
-    Returns ``None`` when the agent state has no resolved Datadog
-    integration config (or a malformed one). Callers can treat that as
-    "no Datadog correlation available for this run" — the top-level
-    factory in :mod:`app.agent.correlation` is responsible for picking
-    a different vendor or short-circuiting.
+    Callers pass the integration config and the alert-derived knobs
+    directly; the factory does **not** know about agent state shape.
+    State extraction lives in :mod:`app.agent.correlation.__init__`.
+
+    Returns ``None`` when ``datadog_config`` is empty/missing or fails
+    Pydantic validation — both signal "no Datadog correlation available
+    for this run".
     """
     from app.integrations.config_models import DatadogIntegrationConfig
     from app.services.datadog import DatadogClient
 
-    resolved = state.get("resolved_integrations") or {}
-    datadog_cfg_raw = resolved.get("datadog")
-    if not isinstance(datadog_cfg_raw, dict) or not datadog_cfg_raw:
+    if not datadog_config:
         return None
 
     try:
-        datadog_cfg = DatadogIntegrationConfig.model_validate(datadog_cfg_raw)
-    except Exception:
+        datadog_cfg = DatadogIntegrationConfig.model_validate(datadog_config)
+    except ValidationError:
         return None
 
     client = DatadogClient(datadog_cfg)
@@ -152,7 +118,7 @@ def build_datadog_provider(state: dict[str, Any]) -> UpstreamEvidenceProvider | 
             log_query_fn=log_query,
         ),
         queries=DatadogCorrelationQueries(
-            upstream_service_names=candidate_services_from_state(state),
+            upstream_service_names=candidate_services,
         ),
-        target_resource=target_resource_from_state(state),
+        target_resource=target_resource,
     )

--- a/app/agent/correlation/datadog_factory.py
+++ b/app/agent/correlation/datadog_factory.py
@@ -37,7 +37,7 @@ def _window_minutes(start: str, end: str) -> int:
         return 60
 
 
-def _datadog_avg_query(metric_name: str) -> str:
+def datadog_avg_query(metric_name: str) -> str:
     metric = metric_name.strip()
     if metric.startswith(("avg:", "sum:", "min:", "max:", "count:")):
         return metric
@@ -80,7 +80,7 @@ def build_datadog_provider(
         end = str(window.get("to") or "")
         if not start or not end:
             return {"timestamps": [], "values": []}
-        query = _datadog_avg_query(metric_name)
+        query = datadog_avg_query(metric_name)
         result = client.query_metrics(query, start=_parse_iso8601(start), end=_parse_iso8601(end))
         if not result.get("success"):
             return {"timestamps": [], "values": []}

--- a/app/agent/correlation/datadog_factory.py
+++ b/app/agent/correlation/datadog_factory.py
@@ -1,0 +1,158 @@
+"""Datadog-backed upstream-evidence provider factory.
+
+Construction of a Datadog provider lives here, not in
+``app.pipeline.pipeline``, so the pipeline layer doesn't import from
+``app.services.datadog``. Adding a new correlation source (Grafana,
+AWS, …) follows the same shape: a sibling ``<vendor>_factory`` module
+plus a registration in :mod:`app.agent.correlation.__init__`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from app.agent.correlation.datadog_adapter import DatadogCorrelationAdapter
+from app.agent.correlation.datadog_provider import (
+    DatadogCorrelationQueries,
+    DatadogUpstreamEvidenceProvider,
+)
+
+if TYPE_CHECKING:
+    from app.agent.correlation.upstream import UpstreamEvidenceProvider
+
+
+def _parse_iso8601(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _window_minutes(start: str, end: str) -> int:
+    try:
+        delta = _parse_iso8601(end) - _parse_iso8601(start)
+        return max(1, int(delta.total_seconds() // 60))
+    except Exception:
+        return 60
+
+
+def _datadog_avg_query(metric_name: str) -> str:
+    metric = metric_name.strip()
+    if metric.startswith(("avg:", "sum:", "min:", "max:", "count:")):
+        return metric
+    if "{" in metric and "}" in metric:
+        return f"avg:{metric}"
+    return f"avg:{metric}{{*}}"
+
+
+def target_resource_from_state(state: dict[str, Any]) -> str:
+    """Extract the Datadog ``target_resource`` (RDS DB identifier) from an
+    investigation state's raw alert. Defaults to ``"unknown-rds"``.
+
+    Public because the same key set is exercised by tests outside this
+    module.
+    """
+    raw_alert = state.get("raw_alert") or {}
+    if not isinstance(raw_alert, dict):
+        return "unknown-rds"
+    return str(
+        raw_alert.get("resource")
+        or raw_alert.get("resource_name")
+        or raw_alert.get("db_instance")
+        or raw_alert.get("db_instance_identifier")
+        or "unknown-rds"
+    )
+
+
+def candidate_services_from_state(state: dict[str, Any]) -> tuple[str, ...]:
+    """Extract upstream-service candidate names from a raw alert.
+
+    Accepts a comma-separated string or a list/tuple under one of
+    ``upstream_services`` / ``candidate_services`` / ``related_services``.
+    Empty tuple when nothing relevant is present.
+    """
+    raw_alert = state.get("raw_alert") or {}
+    if not isinstance(raw_alert, dict):
+        return ()
+
+    raw_candidates = (
+        raw_alert.get("upstream_services")
+        or raw_alert.get("candidate_services")
+        or raw_alert.get("related_services")
+    )
+    if isinstance(raw_candidates, str):
+        return tuple(item.strip() for item in raw_candidates.split(",") if item.strip())
+    if isinstance(raw_candidates, list | tuple):
+        return tuple(str(item).strip() for item in raw_candidates if str(item).strip())
+    return ()
+
+
+def build_datadog_provider(state: dict[str, Any]) -> UpstreamEvidenceProvider | None:
+    """Return a Datadog-backed upstream-evidence provider, or ``None``.
+
+    Returns ``None`` when the agent state has no resolved Datadog
+    integration config (or a malformed one). Callers can treat that as
+    "no Datadog correlation available for this run" — the top-level
+    factory in :mod:`app.agent.correlation` is responsible for picking
+    a different vendor or short-circuiting.
+    """
+    from app.integrations.config_models import DatadogIntegrationConfig
+    from app.services.datadog import DatadogClient
+
+    resolved = state.get("resolved_integrations") or {}
+    datadog_cfg_raw = resolved.get("datadog")
+    if not isinstance(datadog_cfg_raw, dict) or not datadog_cfg_raw:
+        return None
+
+    try:
+        datadog_cfg = DatadogIntegrationConfig.model_validate(datadog_cfg_raw)
+    except Exception:
+        return None
+
+    client = DatadogClient(datadog_cfg)
+
+    def metric_query(metric_name: str, window: dict[str, Any]) -> dict[str, Any]:
+        start = str(window.get("from") or "")
+        end = str(window.get("to") or "")
+        if not start or not end:
+            return {"timestamps": [], "values": []}
+        query = _datadog_avg_query(metric_name)
+        result = client.query_metrics(query, start=_parse_iso8601(start), end=_parse_iso8601(end))
+        if not result.get("success"):
+            return {"timestamps": [], "values": []}
+        return {
+            "timestamps": result.get("timestamps") or [],
+            "values": result.get("values") or [],
+        }
+
+    def log_query(query: str, window: dict[str, Any]) -> dict[str, Any]:
+        start = str(window.get("from") or "")
+        end = str(window.get("to") or "")
+        start_dt = _parse_iso8601(start) if start else None
+        end_dt = _parse_iso8601(end) if end else None
+        minutes = _window_minutes(start, end)
+        result = client.search_logs(
+            query,
+            time_range_minutes=minutes,
+            limit=100,
+            start=start_dt,
+            end=end_dt,
+        )
+        logs = result.get("logs") if isinstance(result, dict) else []
+        if not isinstance(logs, list):
+            logs = []
+        return {
+            "timestamps": [
+                str(item.get("timestamp", "")) for item in logs if isinstance(item, dict)
+            ],
+            "messages": [str(item.get("message", "")) for item in logs if isinstance(item, dict)],
+        }
+
+    return DatadogUpstreamEvidenceProvider(
+        adapter=DatadogCorrelationAdapter(
+            metric_query_fn=metric_query,
+            log_query_fn=log_query,
+        ),
+        queries=DatadogCorrelationQueries(
+            upstream_service_names=candidate_services_from_state(state),
+        ),
+        target_resource=target_resource_from_state(state),
+    )

--- a/app/pipeline/pipeline.py
+++ b/app/pipeline/pipeline.py
@@ -18,13 +18,13 @@ logger = logging.getLogger(__name__)
 
 
 def _build_correlation_config(state: dict[str, Any]) -> dict[str, Any] | None:
-    """Return the LangGraph runtime config carrying the upstream-evidence provider.
+    """Return the runtime config carrying the upstream-evidence provider.
 
     The vendor-specific provider construction lives in
     :mod:`app.agent.correlation`; this function only wraps the result
     in the ``{"configurable": ...}`` shape the correlation node expects.
     Keeping the wrapping here (and not in the correlation package)
-    means correlation stays decoupled from the LangGraph runtime
+    means correlation stays decoupled from the pipeline's runtime
     contract.
     """
     provider = build_upstream_evidence_provider(state)

--- a/app/pipeline/pipeline.py
+++ b/app/pipeline/pipeline.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
+from app.agent.correlation import build_upstream_evidence_provider
 from app.state import AgentState
 
 if TYPE_CHECKING:
@@ -17,125 +17,19 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _parse_iso8601(value: str) -> datetime:
-    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
-
-
-def _window_minutes(start: str, end: str) -> int:
-    try:
-        delta = _parse_iso8601(end) - _parse_iso8601(start)
-        return max(1, int(delta.total_seconds() // 60))
-    except Exception:
-        return 60
-
-
-def _datadog_avg_query(metric_name: str) -> str:
-    metric = metric_name.strip()
-    if metric.startswith(("avg:", "sum:", "min:", "max:", "count:")):
-        return metric
-    if "{" in metric and "}" in metric:
-        return f"avg:{metric}"
-    return f"avg:{metric}{{*}}"
-
-
-def _target_resource_from_state(state: dict[str, Any]) -> str:
-    raw_alert = state.get("raw_alert") or {}
-    if not isinstance(raw_alert, dict):
-        return "unknown-rds"
-    return str(
-        raw_alert.get("resource")
-        or raw_alert.get("resource_name")
-        or raw_alert.get("db_instance")
-        or raw_alert.get("db_instance_identifier")
-        or "unknown-rds"
-    )
-
-
-def _candidate_services_from_state(state: dict[str, Any]) -> tuple[str, ...]:
-    raw_alert = state.get("raw_alert") or {}
-    if not isinstance(raw_alert, dict):
-        return ()
-
-    raw_candidates = (
-        raw_alert.get("upstream_services")
-        or raw_alert.get("candidate_services")
-        or raw_alert.get("related_services")
-    )
-    if isinstance(raw_candidates, str):
-        return tuple(item.strip() for item in raw_candidates.split(",") if item.strip())
-    if isinstance(raw_candidates, list | tuple):
-        return tuple(str(item).strip() for item in raw_candidates if str(item).strip())
-    return ()
-
-
 def _build_correlation_config(state: dict[str, Any]) -> dict[str, Any] | None:
-    from app.agent.correlation.datadog_adapter import DatadogCorrelationAdapter
-    from app.agent.correlation.datadog_provider import (
-        DatadogCorrelationQueries,
-        DatadogUpstreamEvidenceProvider,
-    )
-    from app.integrations.config_models import DatadogIntegrationConfig
-    from app.services.datadog import DatadogClient
+    """Return the LangGraph runtime config carrying the upstream-evidence provider.
 
-    resolved = state.get("resolved_integrations") or {}
-    datadog_cfg_raw = resolved.get("datadog")
-    if not isinstance(datadog_cfg_raw, dict) or not datadog_cfg_raw:
+    The vendor-specific provider construction lives in
+    :mod:`app.agent.correlation`; this function only wraps the result
+    in the ``{"configurable": ...}`` shape the correlation node expects.
+    Keeping the wrapping here (and not in the correlation package)
+    means correlation stays decoupled from the LangGraph runtime
+    contract.
+    """
+    provider = build_upstream_evidence_provider(state)
+    if provider is None:
         return None
-
-    try:
-        datadog_cfg = DatadogIntegrationConfig.model_validate(datadog_cfg_raw)
-    except Exception:
-        return None
-
-    client = DatadogClient(datadog_cfg)
-
-    def metric_query(metric_name: str, window: dict[str, Any]) -> dict[str, Any]:
-        start = str(window.get("from") or "")
-        end = str(window.get("to") or "")
-        if not start or not end:
-            return {"timestamps": [], "values": []}
-        query = _datadog_avg_query(metric_name)
-        result = client.query_metrics(query, start=_parse_iso8601(start), end=_parse_iso8601(end))
-        if not result.get("success"):
-            return {"timestamps": [], "values": []}
-        return {
-            "timestamps": result.get("timestamps") or [],
-            "values": result.get("values") or [],
-        }
-
-    def log_query(query: str, window: dict[str, Any]) -> dict[str, Any]:
-        start = str(window.get("from") or "")
-        end = str(window.get("to") or "")
-        start_dt = _parse_iso8601(start) if start else None
-        end_dt = _parse_iso8601(end) if end else None
-        minutes = _window_minutes(start, end)
-        result = client.search_logs(
-            query,
-            time_range_minutes=minutes,
-            limit=100,
-            start=start_dt,
-            end=end_dt,
-        )
-        logs = result.get("logs") if isinstance(result, dict) else []
-        if not isinstance(logs, list):
-            logs = []
-        return {
-            "timestamps": [
-                str(item.get("timestamp", "")) for item in logs if isinstance(item, dict)
-            ],
-            "messages": [str(item.get("message", "")) for item in logs if isinstance(item, dict)],
-        }
-
-    provider = DatadogUpstreamEvidenceProvider(
-        adapter=DatadogCorrelationAdapter(
-            metric_query_fn=metric_query,
-            log_query_fn=log_query,
-        ),
-        queries=DatadogCorrelationQueries(
-            upstream_service_names=_candidate_services_from_state(state),
-        ),
-        target_resource=_target_resource_from_state(state),
-    )
     return {"configurable": {"upstream_evidence_provider": provider}}
 
 

--- a/tests/pipeline/test_correlation_config.py
+++ b/tests/pipeline/test_correlation_config.py
@@ -4,11 +4,11 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import patch
 
-from app.agent.correlation.datadog_factory import (
-    _datadog_avg_query,
+from app.agent.correlation import (
     candidate_services_from_state,
     target_resource_from_state,
 )
+from app.agent.correlation.datadog_factory import _datadog_avg_query
 from app.agent.correlation.upstream import UpstreamEvidenceBundle
 from app.pipeline.pipeline import _build_correlation_config
 

--- a/tests/pipeline/test_correlation_config.py
+++ b/tests/pipeline/test_correlation_config.py
@@ -4,13 +4,13 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import patch
 
-from app.agent.correlation.upstream import UpstreamEvidenceBundle
-from app.pipeline.pipeline import (
-    _build_correlation_config,
-    _candidate_services_from_state,
+from app.agent.correlation.datadog_factory import (
     _datadog_avg_query,
-    _target_resource_from_state,
+    candidate_services_from_state,
+    target_resource_from_state,
 )
+from app.agent.correlation.upstream import UpstreamEvidenceBundle
+from app.pipeline.pipeline import _build_correlation_config
 
 
 def test_datadog_avg_query_preserves_existing_scope() -> None:
@@ -22,8 +22,8 @@ def test_datadog_avg_query_preserves_existing_scope() -> None:
 
 
 def test_correlation_config_state_helpers_use_compatible_fallbacks() -> None:
-    assert _target_resource_from_state({}) == "unknown-rds"
-    assert _candidate_services_from_state({"raw_alert": {"upstream_services": "api, worker"}}) == (
+    assert target_resource_from_state({}) == "unknown-rds"
+    assert candidate_services_from_state({"raw_alert": {"upstream_services": "api, worker"}}) == (
         "api",
         "worker",
     )

--- a/tests/pipeline/test_correlation_config.py
+++ b/tests/pipeline/test_correlation_config.py
@@ -8,17 +8,17 @@ from app.agent.correlation import (
     candidate_services_from_state,
     target_resource_from_state,
 )
-from app.agent.correlation.datadog_factory import _datadog_avg_query
+from app.agent.correlation.datadog_factory import datadog_avg_query
 from app.agent.correlation.upstream import UpstreamEvidenceBundle
 from app.pipeline.pipeline import _build_correlation_config
 
 
 def test_datadog_avg_query_preserves_existing_scope() -> None:
-    assert _datadog_avg_query("system.cpu.user{service:orders}") == (
+    assert datadog_avg_query("system.cpu.user{service:orders}") == (
         "avg:system.cpu.user{service:orders}"
     )
-    assert _datadog_avg_query("aws.rds.cpuutilization") == "avg:aws.rds.cpuutilization{*}"
-    assert _datadog_avg_query("avg:custom.metric{env:prod}") == "avg:custom.metric{env:prod}"
+    assert datadog_avg_query("aws.rds.cpuutilization") == "avg:aws.rds.cpuutilization{*}"
+    assert datadog_avg_query("avg:custom.metric{env:prod}") == "avg:custom.metric{env:prod}"
 
 
 def test_correlation_config_state_helpers_use_compatible_fallbacks() -> None:

--- a/tests/pipeline/test_layering.py
+++ b/tests/pipeline/test_layering.py
@@ -1,0 +1,60 @@
+"""Layering boundary tests for ``app/pipeline/``.
+
+The pipeline orchestrator coordinates stages; it must not import from
+vendor service modules. Vendor wiring lives behind the
+``app.agent.correlation`` factory (and similar factories for future
+correlation sources).
+
+Without this guard the dependency drift is easy:
+``app.pipeline.pipeline`` previously imported ``DatadogClient``
+directly, coupling the orchestrator to one vendor and making "add a
+second correlation source" an edit-this-file change instead of a
+new-file change. See issue #34 and the refactor that introduced
+``build_upstream_evidence_provider``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_PIPELINE_DIR = Path("app/pipeline")
+_FORBIDDEN_PREFIXES: tuple[str, ...] = ("app.services.datadog",)
+
+
+def _pipeline_modules() -> list[Path]:
+    return sorted(p for p in _PIPELINE_DIR.glob("**/*.py") if "__pycache__" not in p.parts)
+
+
+def _imported_modules(source: str) -> set[str]:
+    """Module-paths every ``import``/``from`` statement names in ``source``."""
+    tree = ast.parse(source)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:  # relative import — out of scope
+                continue
+            if node.module:
+                names.add(node.module)
+    return names
+
+
+@pytest.mark.parametrize("module_path", _pipeline_modules(), ids=lambda p: str(p))
+def test_pipeline_module_does_not_import_forbidden_layer(module_path: Path) -> None:
+    """Every module under ``app/pipeline/`` must avoid forbidden vendor imports."""
+    source = module_path.read_text(encoding="utf-8")
+    imports = _imported_modules(source)
+    leaks = {
+        imp
+        for imp in imports
+        if any(imp == prefix or imp.startswith(f"{prefix}.") for prefix in _FORBIDDEN_PREFIXES)
+    }
+    assert not leaks, (
+        f"{module_path} imports vendor service module(s) {sorted(leaks)} — route through "
+        "``app.agent.correlation.build_upstream_evidence_provider`` instead."
+    )

--- a/tests/pipeline/test_layering.py
+++ b/tests/pipeline/test_layering.py
@@ -21,7 +21,12 @@ from pathlib import Path
 import pytest
 
 _PIPELINE_DIR = Path("app/pipeline")
-_FORBIDDEN_PREFIXES: tuple[str, ...] = ("app.services.datadog",)
+# Block *all* vendor service modules, not just Datadog. The whole pattern
+# is that ``app/pipeline/`` routes vendor wiring through a factory in
+# ``app/agent/correlation/`` (or analogous), so reaching directly into
+# ``app.services.<anything>`` is a layering violation regardless of vendor.
+# This guards against future Grafana/AWS/etc. imports without manual edits.
+_FORBIDDEN_PREFIXES: tuple[str, ...] = ("app.services",)
 
 
 def _pipeline_modules() -> list[Path]:
@@ -44,7 +49,7 @@ def _imported_modules(source: str) -> set[str]:
     return names
 
 
-@pytest.mark.parametrize("module_path", _pipeline_modules(), ids=lambda p: str(p))
+@pytest.mark.parametrize("module_path", _pipeline_modules(), ids=str)
 def test_pipeline_module_does_not_import_forbidden_layer(module_path: Path) -> None:
     """Every module under ``app/pipeline/`` must avoid forbidden vendor imports."""
     source = module_path.read_text(encoding="utf-8")
@@ -56,5 +61,5 @@ def test_pipeline_module_does_not_import_forbidden_layer(module_path: Path) -> N
     }
     assert not leaks, (
         f"{module_path} imports vendor service module(s) {sorted(leaks)} — route through "
-        "``app.agent.correlation.build_upstream_evidence_provider`` instead."
+        "an abstraction (e.g. ``app.agent.correlation.build_upstream_evidence_provider``) instead."
     )


### PR DESCRIPTION
Fixes #2969 

#### Describe the changes you have made in this PR -

The investigation pipeline used to reach directly into the Datadog client to build correlation evidence. That meant the pipeline knew about a specific vendor, and adding a second correlation source (Grafana, AWS, etc.) would have required editing pipeline.py every time.

This PR moves all the Datadog-specific wiring out of pipeline.py and into the correlation package, behind a small factory that the pipeline calls. Pipeline now depends on the abstract idea of "an upstream- evidence provider" — not on Datadog. Adding a new vendor next time is a new file plus one branch in the factory; pipeline.py stays untouched.

No behavior change for existing investigations. The same DatadogClient is constructed at the same time with the same arguments — just from a different module.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- `_build_correlation_config` used to live in `app/pipeline/pipeline.py` and was 130 lines. It read the agent state, pulled out the Datadog config, built a DatadogClient, wrapped it in an adapter and provider, and returned a runtime config dict.

- After this PR, `_build_correlation_config` is 5 lines. It just calls `build_upstream_evidence_provider(state)` from `app/agent/correlation/` and wraps the result.

- All the Datadog wiring lives in a new `app/agent/correlation/datadog_factory.py`. The function there takes  the Datadog config + a couple of alert-derived values; it doesn't  know what an agent state looks like.

- A new top-level factory in `app/agent/correlation/__init__.py` (`build_upstream_evidence_provider`) is the one that reads agent state and decides which vendor factory to call. Today there's only Datadog, so it's one branch — but the seam is there.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
