### PR TITLE
refactor(observability): introduce ports and decouple core from cli.interactive_shell.ui.output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ output/
 # CLI terminal output package (must stay tracked; ``output/`` above ignores new files here)
 !app/cli/interactive_shell/ui/output/
 !app/cli/interactive_shell/ui/output/**
+app/cli/interactive_shell/ui/output/**/__pycache__/
 .cloudopsbench-results/
 .bench-results/
 tests/benchmarks/cloudopsbench/benchmark/

--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,9 @@ Temporary Items
 # Project specific
 .antigravitycli/
 output/
+# CLI terminal output package (must stay tracked; ``output/`` above ignores new files here)
+!app/cli/interactive_shell/ui/output/
+!app/cli/interactive_shell/ui/output/**
 .cloudopsbench-results/
 .bench-results/
 tests/benchmarks/cloudopsbench/benchmark/

--- a/app/agent/correlation/node.py
+++ b/app/agent/correlation/node.py
@@ -6,7 +6,7 @@ from typing import Any, Protocol, cast
 from app.agent.correlation.providers import NoopUpstreamEvidenceProvider
 from app.agent.correlation.runtime import build_runtime_correlation
 from app.agent.correlation.upstream import UpstreamEvidenceBundle
-from app.cli.interactive_shell.ui.output import get_tracker
+from app.observability import get_progress_tracker as get_tracker
 from app.state import InvestigationState
 from app.utils.tracing import traceable
 

--- a/app/agent/stages/diagnose/node.py
+++ b/app/agent/stages/diagnose/node.py
@@ -111,9 +111,9 @@ def diagnose(state: dict[str, Any]) -> dict[str, Any]:
         return {}
 
     from app.analytics.cli import capture_diagnosis_category_mismatch
-    from app.cli.interactive_shell.ui.output import get_tracker
+    from app.observability import get_progress_tracker
 
-    tracker = get_tracker()
+    tracker = get_progress_tracker()
     tracker.start("diagnose_root_cause", "Parsing investigation conclusion")
 
     messages = _list_of_dicts(state.get("agent_messages"))

--- a/app/agent/stages/extract_alert/node.py
+++ b/app/agent/stages/extract_alert/node.py
@@ -10,12 +10,12 @@ from typing import Any, cast
 
 from pydantic import BaseModel, Field
 
-from app.cli.interactive_shell.ui.output import (
+from app.incident_window import resolve_incident_window
+from app.observability import (
     debug_print,
-    get_tracker,
     render_investigation_header,
 )
-from app.incident_window import resolve_incident_window
+from app.observability import get_progress_tracker as get_tracker
 from app.services import get_llm_for_reasoning
 from app.state import InvestigationState
 

--- a/app/agent/stages/extract_alert/node.py
+++ b/app/agent/stages/extract_alert/node.py
@@ -15,7 +15,9 @@ from app.observability import (
     debug_print,
     render_investigation_header,
 )
-from app.observability import get_progress_tracker as get_tracker
+from app.observability import (
+    get_progress_tracker as get_tracker,
+)
 from app.services import get_llm_for_reasoning
 from app.state import InvestigationState
 

--- a/app/agent/stages/investigate/agent.py
+++ b/app/agent/stages/investigate/agent.py
@@ -34,8 +34,9 @@ from app.agent.tool_loop import (
     _tool_source,
 )
 from app.agent.utils.llm_invoke_errors import classify_llm_invoke_failure
-from app.cli.interactive_shell.ui.output import debug_print, get_tracker
 from app.constants.investigation import MAX_INVESTIGATION_LOOPS
+from app.observability import debug_print
+from app.observability import get_progress_tracker as get_tracker
 from app.services.agent_llm_client import ToolCall, get_agent_llm
 from app.state.evidence import EvidenceEntry
 from app.tools.registered_tool import RegisteredTool

--- a/app/agent/stages/publish_findings/renderers/terminal.py
+++ b/app/agent/stages/publish_findings/renderers/terminal.py
@@ -5,8 +5,8 @@ import re
 from rich.console import Console
 from rich.text import Text
 
-from app.cli.interactive_shell.ui.output import get_output_format
-from app.cli.interactive_shell.ui.theme import BRAND, DIM, HIGHLIGHT, WARNING
+from app.observability import get_output_format
+from app.ui_theme import BRAND, DIM, HIGHLIGHT, WARNING
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers
@@ -114,12 +114,12 @@ def _render_rich_evidence_item(console: Console, line: str) -> None:
 
 def render_report(slack_message: str) -> None:
     """Render the final RCA report to terminal."""
-    from app.cli.interactive_shell.ui.output import (
+    from app.observability import (
+        get_progress_tracker,
         render_completed_investigation_footer,
-        stop_display,
     )
 
-    stop_display()
+    get_progress_tracker().stop()
     fmt = get_output_format()
 
     if not slack_message:

--- a/app/agent/stages/resolve_integrations/node.py
+++ b/app/agent/stages/resolve_integrations/node.py
@@ -8,7 +8,6 @@ import logging
 import os
 from typing import Any
 
-from app.cli.interactive_shell.ui.output import get_tracker
 from app.integrations.catalog import (
     classify_integrations as _classify_integrations,
 )
@@ -21,6 +20,7 @@ from app.integrations.catalog import (
 from app.integrations.catalog import (
     merge_local_integrations as _merge_local_integrations,
 )
+from app.observability import get_progress_tracker as get_tracker
 from app.state import InvestigationState
 
 logger = logging.getLogger(__name__)

--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -225,6 +225,15 @@ def main(argv: list[str] | None = None) -> int:
     except ModuleNotFoundError as exc:
         if exc.name != "sentry_sdk" or not _is_update_invocation(cli_argv):
             raise
+    # Wire CLI-flavored implementations into the observability ports
+    # (ProgressTracker, debug_print) so any core code under app/agent,
+    # app/pipeline, app/utils that calls into the abstractions routes
+    # through the Rich-aware adapters during this process.
+    from app.cli.interactive_shell.ui.output.environment import (
+        install_cli_observability_adapters,
+    )
+
+    install_cli_observability_adapters()
     install_questionary_escape_cancel()
     install_questionary_ctrl_c_double_exit()
     _install_sigint_handler()

--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -229,7 +229,7 @@ def main(argv: list[str] | None = None) -> int:
     # (ProgressTracker, debug_print) so any core code under app/agent,
     # app/pipeline, app/utils that calls into the abstractions routes
     # through the Rich-aware adapters during this process.
-    from app.cli.interactive_shell.ui.output.environment import (
+    from app.cli.interactive_shell.ui.output.boundary import (
         install_cli_observability_adapters,
     )
 

--- a/app/cli/interactive_shell/ui/output/boundary.py
+++ b/app/cli/interactive_shell/ui/output/boundary.py
@@ -1,0 +1,42 @@
+"""CLI → observability port wiring (boundary module).
+
+Lives in a leaf module so ``environment`` (imported by ``renderers`` and
+``tracker`` for utility plumbing) does not import those modules back —
+that would create a static import cycle. ``__main__`` and tests call
+:func:`install_cli_observability_adapters` from here.
+"""
+
+from __future__ import annotations
+
+
+def install_cli_observability_adapters() -> None:
+    """Wire CLI implementations into the observability ports.
+
+    Call once from the CLI boundary (typically the REPL/CLI start-up).
+    Idempotent — re-registers the same callables so calling it twice
+    is a no-op.
+
+    Wires:
+    - debug_print: stderr default → Rich-aware CLI version
+    - render_investigation_header: no-op default → Rich panel
+    - progress tracker: Noop default → Rich-backed CLI singleton (lazy)
+    """
+    from app.cli.interactive_shell.ui.output.environment import debug_print
+    from app.cli.interactive_shell.ui.output.renderers import (
+        render_completed_investigation_footer,
+        render_investigation_header,
+    )
+    from app.cli.interactive_shell.ui.output.tracker import get_tracker
+    from app.observability.debug import set_debug_printer
+    from app.observability.display import (
+        set_investigation_footer_renderer,
+        set_investigation_header_renderer,
+    )
+    from app.observability.progress import set_progress_tracker_factory
+
+    set_debug_printer(debug_print)
+    set_investigation_header_renderer(render_investigation_header)
+    set_investigation_footer_renderer(render_completed_investigation_footer)
+    # Lazy: first core ``get_progress_tracker()`` call constructs the CLI
+    # tracker after REPL boot so ``_repl_progress_active()`` is accurate.
+    set_progress_tracker_factory(get_tracker)

--- a/app/cli/interactive_shell/ui/output/environment.py
+++ b/app/cli/interactive_shell/ui/output/environment.py
@@ -6,17 +6,7 @@ import sys
 
 from app.cli.interactive_shell.runtime.repl_progress import repl_safe_progress_requested
 from app.cli.interactive_shell.ui.theme import SECONDARY
-
-
-def get_output_format() -> str:
-    """Return 'rich' for interactive TTY, 'text' otherwise."""
-    if fmt := os.getenv("TRACER_OUTPUT_FORMAT"):
-        return fmt
-    if os.getenv("NO_COLOR") is not None:
-        return "text"
-    if os.getenv("SLACK_WEBHOOK_URL"):
-        return "text"
-    return "rich" if sys.stdout.isatty() else "text"
+from app.observability.output_format import get_output_format
 
 
 def _is_silent_output() -> bool:
@@ -66,3 +56,35 @@ def debug_print(message: str) -> None:
         _get_console().print(f"[{SECONDARY}]{message}[/]")
     else:
         print(f"DEBUG: {message}")
+
+
+def install_cli_observability_adapters() -> None:
+    """Wire CLI implementations into the observability ports.
+
+    Call once from the CLI boundary (typically the REPL/CLI start-up).
+    Idempotent — re-registers the same callables so calling it twice
+    is a no-op.
+
+    Wires:
+    - debug_print: stderr default → Rich-aware CLI version
+    - render_investigation_header: no-op default → Rich panel
+    - progress tracker: Noop default → Rich-backed CLI singleton
+    """
+    from app.cli.interactive_shell.ui.output.renderers import (
+        render_completed_investigation_footer,
+        render_investigation_header,
+    )
+    from app.cli.interactive_shell.ui.output.tracker import get_tracker
+    from app.observability.debug import set_debug_printer
+    from app.observability.display import (
+        set_investigation_footer_renderer,
+        set_investigation_header_renderer,
+    )
+    from app.observability.progress import set_progress_tracker_factory
+
+    set_debug_printer(debug_print)
+    set_investigation_header_renderer(render_investigation_header)
+    set_investigation_footer_renderer(render_completed_investigation_footer)
+    # Lazy: first core ``get_progress_tracker()`` call constructs the CLI
+    # tracker after REPL boot so ``_repl_progress_active()`` is accurate.
+    set_progress_tracker_factory(get_tracker)

--- a/app/cli/interactive_shell/ui/output/environment.py
+++ b/app/cli/interactive_shell/ui/output/environment.py
@@ -58,33 +58,9 @@ def debug_print(message: str) -> None:
         print(f"DEBUG: {message}")
 
 
-def install_cli_observability_adapters() -> None:
-    """Wire CLI implementations into the observability ports.
-
-    Call once from the CLI boundary (typically the REPL/CLI start-up).
-    Idempotent — re-registers the same callables so calling it twice
-    is a no-op.
-
-    Wires:
-    - debug_print: stderr default → Rich-aware CLI version
-    - render_investigation_header: no-op default → Rich panel
-    - progress tracker: Noop default → Rich-backed CLI singleton
-    """
-    from app.cli.interactive_shell.ui.output.renderers import (
-        render_completed_investigation_footer,
-        render_investigation_header,
-    )
-    from app.cli.interactive_shell.ui.output.tracker import get_tracker
-    from app.observability.debug import set_debug_printer
-    from app.observability.display import (
-        set_investigation_footer_renderer,
-        set_investigation_header_renderer,
-    )
-    from app.observability.progress import set_progress_tracker_factory
-
-    set_debug_printer(debug_print)
-    set_investigation_header_renderer(render_investigation_header)
-    set_investigation_footer_renderer(render_completed_investigation_footer)
-    # Lazy: first core ``get_progress_tracker()`` call constructs the CLI
-    # tracker after REPL boot so ``_repl_progress_active()`` is accurate.
-    set_progress_tracker_factory(get_tracker)
+# ``install_cli_observability_adapters`` lives in
+# :mod:`app.cli.interactive_shell.ui.output.boundary`, not here. Putting
+# it in this module would re-introduce a static import cycle:
+# ``renderers`` and ``tracker`` already import from this module for
+# utility plumbing, and the install function imports them back. Moving
+# the wiring into a leaf module keeps the static graph acyclic.

--- a/app/cli/interactive_shell/ui/output/live_display.py
+++ b/app/cli/interactive_shell/ui/output/live_display.py
@@ -22,7 +22,6 @@ from app.cli.interactive_shell.ui.output.labels import (
     _node_label,
     _node_phase_label,
 )
-from app.cli.interactive_shell.ui.time_format import _elapsed_hms, _fmt_timing
 from app.cli.interactive_shell.ui.theme import (
     BRAND,
     DIM,
@@ -32,6 +31,7 @@ from app.cli.interactive_shell.ui.theme import (
     TEXT,
     WARNING,
 )
+from app.cli.interactive_shell.ui.time_format import _elapsed_hms, _fmt_timing
 from app.utils.tool_trace import format_json_preview
 
 _SPINNER_FRAMES = ("·  ", "·· ", "···", "·· ")

--- a/app/cli/interactive_shell/ui/output/renderers.py
+++ b/app/cli/interactive_shell/ui/output/renderers.py
@@ -12,7 +12,6 @@ from app.cli.interactive_shell.ui.output.environment import (
     get_output_format,
 )
 from app.cli.interactive_shell.ui.output.labels import BADGE_STYLES
-from app.cli.interactive_shell.ui.time_format import _elapsed_hms
 from app.cli.interactive_shell.ui.theme import (
     BRAND,
     DIM,
@@ -22,6 +21,7 @@ from app.cli.interactive_shell.ui.theme import (
     TEXT,
     WARNING,
 )
+from app.cli.interactive_shell.ui.time_format import _elapsed_hms
 
 
 def render_divider(width: int = 80) -> None:

--- a/app/cli/interactive_shell/ui/output/repl_display.py
+++ b/app/cli/interactive_shell/ui/output/repl_display.py
@@ -19,8 +19,8 @@ from app.cli.interactive_shell.ui.output.labels import (
     _node_phase_label,
     build_progress_step_text,
 )
-from app.cli.interactive_shell.ui.time_format import _elapsed_hms
 from app.cli.interactive_shell.ui.theme import BRAND, DIM, SECONDARY
+from app.cli.interactive_shell.ui.time_format import _elapsed_hms
 
 _REPL_ANIM_FRAMES = ("·", "··", "···", "··")
 _REPL_ANIM_INTERVAL = 0.35

--- a/app/cli/interactive_shell/ui/output/tool_details.py
+++ b/app/cli/interactive_shell/ui/output/tool_details.py
@@ -4,8 +4,8 @@ from typing import Any
 
 from rich.text import Text
 
-from app.cli.interactive_shell.ui.time_format import _elapsed_hms, _fmt_timing
 from app.cli.interactive_shell.ui.theme import BRAND, DIM, HIGHLIGHT, SECONDARY, TEXT
+from app.cli.interactive_shell.ui.time_format import _elapsed_hms, _fmt_timing
 from app.tools.registry import get_registered_tool_map, resolve_tool_display_name
 from app.utils.tool_trace import format_json_preview
 

--- a/app/cli/interactive_shell/ui/output/tool_tracking.py
+++ b/app/cli/interactive_shell/ui/output/tool_tracking.py
@@ -9,7 +9,6 @@ from app.cli.interactive_shell.ui.output.environment import _safe_print
 
 if TYPE_CHECKING:
     from app.cli.interactive_shell.ui.output.events import DisplayProtocol
-from app.cli.interactive_shell.ui.time_format import _elapsed_hms, _fmt_timing
 from app.cli.interactive_shell.ui.output.repl_display import _ReplEventLogDisplay
 from app.cli.interactive_shell.ui.output.tool_details import (
     build_tool_call_line,
@@ -25,6 +24,7 @@ from app.cli.interactive_shell.ui.output.tool_details import (
 from app.cli.interactive_shell.ui.output.tool_details import (
     record_tool_summary as _record_tool_summary,
 )
+from app.cli.interactive_shell.ui.time_format import _elapsed_hms, _fmt_timing
 from app.tools.registry import resolve_tool_display_name
 
 

--- a/app/cli/interactive_shell/ui/output/tracker.py
+++ b/app/cli/interactive_shell/ui/output/tracker.py
@@ -164,12 +164,27 @@ class ProgressTracker(ToolTrackingMixin):
 _tracker: ProgressTracker | None = None
 
 
+def _register_with_observability(tracker: ProgressTracker) -> None:
+    """Tell the observability port which tracker core code should see.
+
+    The Rich tracker structurally satisfies the
+    :class:`app.observability.progress.ProgressTracker` Protocol;
+    registering it here means any module that imports
+    ``get_progress_tracker`` from core gets the same instance the CLI
+    is driving.
+    """
+    from app.observability.progress import set_progress_tracker
+
+    set_progress_tracker(tracker)
+
+
 def get_tracker(*, reset: bool = False) -> ProgressTracker:
     global _tracker
     if _tracker is None or reset:
         if reset and _tracker is not None:
             _tracker.stop()
         _tracker = ProgressTracker()
+        _register_with_observability(_tracker)
     return _tracker
 
 
@@ -197,6 +212,7 @@ def set_silent_tracker() -> None:
     _tracker._tool_summary_order = []
     _tracker._toggle_watcher = None
     _tracker._toggle_unregister = None
+    _register_with_observability(_tracker)
 
 
 def _stop_active_tracker_toggle_watcher() -> None:

--- a/app/cli/interactive_shell/ui/theme.py
+++ b/app/cli/interactive_shell/ui/theme.py
@@ -32,10 +32,7 @@ from rich.theme import Theme
 # modules (e.g. the publish_findings terminal renderer) can read the
 # same hex values without depending on the CLI layer. CLI-only tokens
 # (TEXT, SECONDARY, ERROR, BG) stay here.
-from app.ui_theme import BRAND as BRAND
-from app.ui_theme import DIM as DIM
-from app.ui_theme import HIGHLIGHT as HIGHLIGHT
-from app.ui_theme import WARNING as WARNING
+from app.ui_theme import BRAND, DIM, HIGHLIGHT, WARNING
 
 TEXT = "#E0E0E0"
 SECONDARY = "#888888"
@@ -55,6 +52,47 @@ DEVICE_CODE = BOLD_HIGHLIGHT
 
 # Distinct accent for incoming alerts (visually distinct from BOLD_BRAND used for assistant)
 INCOMING_ALERT_ACCENT = BOLD_WARNING
+
+__all__ = [
+    "ANSI_BOLD",
+    "ANSI_DIM",
+    "ANSI_RESET",
+    "BG",
+    "BOLD_BRAND",
+    "BOLD_BRAND_ANSI",
+    "BOLD_ERROR",
+    "BOLD_HIGHLIGHT",
+    "BOLD_TEXT",
+    "BOLD_WARNING",
+    "BRAND",
+    "BRAND_ANSI",
+    "DEVICE_CODE",
+    "DEVICE_CODE_ANSI",
+    "DIM",
+    "DIM_ANSI",
+    "DIM_COUNTER_ANSI",
+    "ERROR",
+    "GLYPH_ACTIVE",
+    "GLYPH_BULLET",
+    "GLYPH_ERROR",
+    "GLYPH_PROMPT",
+    "GLYPH_SUCCESS",
+    "GLYPH_WARNING",
+    "HIGHLIGHT",
+    "HIGHLIGHT_ANSI",
+    "INCOMING_ALERT_ACCENT",
+    "INPUT_SURFACE",
+    "INPUT_SURFACE_BG_ANSI",
+    "MARKDOWN_THEME",
+    "MENU_SELECTION_ROW_ANSI",
+    "PROMPT_ACCENT_ANSI",
+    "PROMPT_FRAME_ANSI",
+    "SECONDARY",
+    "SURFACE_BG_ANSI",
+    "TEXT",
+    "TEXT_ANSI",
+    "WARNING",
+]
 
 # ── Semantic glyphs ────────────────────────────────────────────────────────
 

--- a/app/cli/interactive_shell/ui/theme.py
+++ b/app/cli/interactive_shell/ui/theme.py
@@ -28,13 +28,14 @@ from __future__ import annotations
 from rich.theme import Theme
 
 # ── Semantic color tokens (the only permitted colours) ─────────────────────
+# BRAND/DIM/HIGHLIGHT/WARNING are re-exported from app.ui_theme so core
+# modules (e.g. the publish_findings terminal renderer) can read the
+# same hex values without depending on the CLI layer. CLI-only tokens
+# (TEXT, SECONDARY, ERROR, BG) stay here.
+from app.ui_theme import BRAND, DIM, HIGHLIGHT, WARNING  # noqa: F401 — re-exported
 
-HIGHLIGHT = "#B9EDAF"
-BRAND = "#66A17D"
 TEXT = "#E0E0E0"
 SECONDARY = "#888888"
-DIM = "#444444"
-WARNING = "#CEA25C"
 ERROR = "#C45B52"
 BG = "#0A0A0A"
 

--- a/app/cli/interactive_shell/ui/theme.py
+++ b/app/cli/interactive_shell/ui/theme.py
@@ -32,7 +32,10 @@ from rich.theme import Theme
 # modules (e.g. the publish_findings terminal renderer) can read the
 # same hex values without depending on the CLI layer. CLI-only tokens
 # (TEXT, SECONDARY, ERROR, BG) stay here.
-from app.ui_theme import BRAND, DIM, HIGHLIGHT, WARNING  # noqa: F401 — re-exported
+from app.ui_theme import BRAND as BRAND
+from app.ui_theme import DIM as DIM
+from app.ui_theme import HIGHLIGHT as HIGHLIGHT
+from app.ui_theme import WARNING as WARNING
 
 TEXT = "#E0E0E0"
 SECONDARY = "#888888"

--- a/app/observability/__init__.py
+++ b/app/observability/__init__.py
@@ -1,0 +1,48 @@
+"""Observability ports — abstractions core code uses to report progress,
+debug output, and check the runtime output format.
+
+Core agent/pipeline/utils code depends only on these ports. Concrete
+implementations live in adapter packages (e.g. the Rich-backed REPL
+tracker under ``app/cli/interactive_shell/ui/output/``). The boundary
+(typically the CLI entry point) registers the adapter via the
+``set_progress_tracker`` / ``set_debug_printer`` injection helpers.
+
+This is the same Ports & Adapters pattern used by
+``app/agent/correlation/`` (see :func:`build_upstream_evidence_provider`):
+high-level modules depend on abstractions, not concretions.
+"""
+
+from __future__ import annotations
+
+from app.observability.debug import debug_print, set_debug_printer
+from app.observability.display import (
+    render_completed_investigation_footer,
+    render_investigation_header,
+    set_investigation_footer_renderer,
+    set_investigation_header_renderer,
+)
+from app.observability.output_format import get_output_format
+from app.observability.progress import (
+    NoopProgressTracker,
+    ProgressTracker,
+    get_progress_tracker,
+    set_progress_tracker,
+    set_progress_tracker_factory,
+    silence_progress_tracker,
+)
+
+__all__ = [
+    "NoopProgressTracker",
+    "ProgressTracker",
+    "debug_print",
+    "get_output_format",
+    "get_progress_tracker",
+    "render_completed_investigation_footer",
+    "render_investigation_header",
+    "set_debug_printer",
+    "set_investigation_footer_renderer",
+    "set_investigation_header_renderer",
+    "set_progress_tracker",
+    "set_progress_tracker_factory",
+    "silence_progress_tracker",
+]

--- a/app/observability/debug.py
+++ b/app/observability/debug.py
@@ -1,0 +1,54 @@
+"""Debug-print port — plain default + injection for richer adapters.
+
+Core call sites do ``debug_print("...")`` unconditionally. The default
+implementation prints to stdout only when ``TRACER_VERBOSE`` is set,
+matching how the legacy CLI helper behaved in non-rich mode.
+
+The REPL boundary can register a Rich-styled adapter via
+:func:`set_debug_printer` so debug output threads through the
+persistent input frame instead of landing as raw text below it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable
+
+DebugPrinter = Callable[[str], None]
+
+
+def _verbose_env_set() -> bool:
+    """True iff ``TRACER_VERBOSE`` indicates the user wants debug output.
+
+    Kept narrow on purpose: the legacy helper also consulted the
+    interactive-shell's data-store (``is_debug``/``is_verbose``); pulling
+    that in would re-introduce the CLI dependency we're refactoring
+    out of core. Adapters that want richer gating can register their
+    own printer that checks additional state.
+    """
+    return os.getenv("TRACER_VERBOSE", "").lower() in ("1", "true", "yes")
+
+
+def _default_debug_printer(message: str) -> None:
+    if not _verbose_env_set():
+        return
+    print(f"DEBUG: {message}", file=sys.stderr)
+
+
+_printer: DebugPrinter = _default_debug_printer
+
+
+def debug_print(message: str) -> None:
+    """Emit a debug message via the registered printer."""
+    _printer(message)
+
+
+def set_debug_printer(printer: DebugPrinter) -> None:
+    """Install ``printer`` as the active debug-print implementation.
+
+    Boundary code (typically the CLI start-up) calls this to wire a
+    Rich/REPL-aware printer in place of the stderr default.
+    """
+    global _printer
+    _printer = printer

--- a/app/observability/display.py
+++ b/app/observability/display.py
@@ -1,0 +1,58 @@
+"""Investigation-display port — header render + injection.
+
+Core stages call :func:`render_investigation_header` at the start of
+an investigation to announce its alert. The default is a no-op; the
+CLI registers a Rich-panel adapter at boundary so the same call
+produces the styled banner the REPL expects.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+InvestigationHeaderRenderer = Callable[[str, str, str, str | None], None]
+InvestigationFooterRenderer = Callable[[], None]
+
+
+def _default_header_renderer(
+    alert_name: str,
+    pipeline_name: str,
+    severity: str,
+    alert_id: str | None = None,
+) -> None:
+    _ = (alert_name, pipeline_name, severity, alert_id)
+
+
+def _default_footer_renderer() -> None:
+    return None
+
+
+_header_renderer: InvestigationHeaderRenderer = _default_header_renderer
+_footer_renderer: InvestigationFooterRenderer = _default_footer_renderer
+
+
+def render_investigation_header(
+    alert_name: str,
+    pipeline_name: str,
+    severity: str,
+    alert_id: str | None = None,
+) -> None:
+    """Render the investigation start banner via the registered adapter."""
+    _header_renderer(alert_name, pipeline_name, severity, alert_id)
+
+
+def render_completed_investigation_footer() -> None:
+    """Render the post-report footer via the registered adapter."""
+    _footer_renderer()
+
+
+def set_investigation_header_renderer(renderer: InvestigationHeaderRenderer) -> None:
+    """Install ``renderer`` as the active investigation-header implementation."""
+    global _header_renderer
+    _header_renderer = renderer
+
+
+def set_investigation_footer_renderer(renderer: InvestigationFooterRenderer) -> None:
+    """Install ``renderer`` as the active investigation-footer implementation."""
+    global _footer_renderer
+    _footer_renderer = renderer

--- a/app/observability/output_format.py
+++ b/app/observability/output_format.py
@@ -1,0 +1,46 @@
+"""Output format probe — what shape should rendered output take.
+
+Pure env/TTY check. No injection needed — every caller wants the same
+answer for a given process. Returns one of :data:`OUTPUT_FORMAT_RICH`,
+:data:`OUTPUT_FORMAT_TEXT`, or :data:`OUTPUT_FORMAT_NONE` (callers
+typically compare against the named constant rather than the bare
+string).
+
+Caller is responsible for honoring the verdict.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Output-format return values. Use these constants in callers instead
+# of the bare strings so a future rename happens in one place.
+OUTPUT_FORMAT_RICH = "rich"
+OUTPUT_FORMAT_TEXT = "text"
+OUTPUT_FORMAT_NONE = "none"
+
+# Env-var keys the probe consults, in priority order. Named constants
+# match the rest of the observability surface (``HERMES_LOG_PATH`` etc.)
+# and make ``grep`` for "who reads TRACER_OUTPUT_FORMAT" trivial.
+_ENV_OUTPUT_FORMAT = "TRACER_OUTPUT_FORMAT"
+_ENV_NO_COLOR = "NO_COLOR"
+_ENV_SLACK_WEBHOOK = "SLACK_WEBHOOK_URL"
+
+
+def get_output_format() -> str:
+    """Return one of the ``OUTPUT_FORMAT_*`` constants based on env + TTY.
+
+    Priority order:
+    1. ``TRACER_OUTPUT_FORMAT`` env var — explicit override wins.
+    2. ``NO_COLOR`` set (any value) — force text.
+    3. ``SLACK_WEBHOOK_URL`` set — force text (Slack-bound output).
+    4. Default: rich if stdout is a TTY, text otherwise.
+    """
+    if fmt := os.getenv(_ENV_OUTPUT_FORMAT):
+        return fmt
+    if os.getenv(_ENV_NO_COLOR) is not None:
+        return OUTPUT_FORMAT_TEXT
+    if os.getenv(_ENV_SLACK_WEBHOOK):
+        return OUTPUT_FORMAT_TEXT
+    return OUTPUT_FORMAT_RICH if sys.stdout.isatty() else OUTPUT_FORMAT_TEXT

--- a/app/observability/progress.py
+++ b/app/observability/progress.py
@@ -1,0 +1,179 @@
+"""Progress-tracker port (Protocol) + Noop default + injection helpers.
+
+Core code (under ``app/agent/``, ``app/pipeline/``, ``app/utils/``)
+imports only from this module to report stage progress; the CLI
+surface implements the Protocol and registers its concrete tracker
+via :func:`set_progress_tracker` at boundary.
+
+The Protocol surface is intentionally narrow: the methods listed here
+are the ones core actually calls. The Rich-backed REPL tracker exposes
+many more (subtext animation, ``print_above`` etc.), but those stay in
+the adapter — they're not the core's concern.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Protocol
+
+
+class ProgressTracker(Protocol):
+    """Stage-progress reporting contract for core code.
+
+    The default in a process that hasn't registered an adapter is
+    :class:`NoopProgressTracker` — all methods are no-ops. The CLI
+    layer registers a Rich-backed implementation at startup via
+    :func:`set_progress_tracker`.
+    """
+
+    def start(self, node_name: str, message: str | None = None) -> None:
+        """Mark stage ``node_name`` as started, with an optional caption."""
+
+    def complete(
+        self,
+        node_name: str,
+        fields_updated: list[str] | None = None,
+        message: str | None = None,
+    ) -> None:
+        """Mark stage ``node_name`` as completed, optionally naming the
+        state fields it produced and a closing caption.
+        """
+
+    def error(self, node_name: str, message: str) -> None:
+        """Mark stage ``node_name`` as errored with a human-readable cause."""
+
+    def record_tool_start(
+        self,
+        tool_name: str,
+        tool_input: Any = None,
+        *,
+        event_key: str | None = None,
+    ) -> None:
+        """Record that ``tool_name`` has begun execution within the
+        current stage. ``event_key`` is the per-invocation id used by
+        the matching :meth:`record_tool_end` call.
+        """
+
+    def record_tool_end(
+        self,
+        tool_name: str,
+        output: Any = None,
+        *,
+        event_key: str | None = None,
+        tool_input: Any = None,
+    ) -> None:
+        """Record that ``tool_name`` finished, with optional output
+        + the same ``event_key`` passed to ``record_tool_start`` so
+        the adapter can pair start/end for timing.
+        """
+
+    def stop(self) -> None:
+        """Tear down any active display/animation/watchers.
+
+        Core callers invoke this when transitioning from progress
+        rendering into final-report rendering, so the live display
+        releases the terminal before plain text prints.
+        """
+
+
+class NoopProgressTracker:
+    """Drop-on-floor implementation used when no adapter is registered.
+
+    Conforms to :class:`ProgressTracker` structurally. Headless
+    contexts (tests, non-TTY runs, scripted invocations) get this by
+    default, so core code can call tracker methods unconditionally
+    without checking for ``None``.
+    """
+
+    def start(self, node_name: str, message: str | None = None) -> None:
+        _ = (node_name, message)
+
+    def complete(
+        self,
+        node_name: str,
+        fields_updated: list[str] | None = None,
+        message: str | None = None,
+    ) -> None:
+        _ = (node_name, fields_updated, message)
+
+    def error(self, node_name: str, message: str) -> None:
+        _ = (node_name, message)
+
+    def record_tool_start(
+        self,
+        tool_name: str,
+        tool_input: Any = None,
+        *,
+        event_key: str | None = None,
+    ) -> None:
+        _ = (tool_name, tool_input, event_key)
+
+    def record_tool_end(
+        self,
+        tool_name: str,
+        output: Any = None,
+        *,
+        event_key: str | None = None,
+        tool_input: Any = None,
+    ) -> None:
+        _ = (tool_name, output, event_key, tool_input)
+
+    def stop(self) -> None:
+        return None
+
+
+_tracker: ProgressTracker = NoopProgressTracker()
+_tracker_factory: Callable[[], ProgressTracker] | None = None
+_silenced: bool = False
+
+
+def get_progress_tracker() -> ProgressTracker:
+    """Return the currently-registered tracker (or the Noop default).
+
+    When a CLI factory is registered and progress has not been silenced,
+    the first call materializes the adapter lazily so ``ProgressTracker``
+    is constructed after REPL boot (when ``_repl_progress_active()`` is
+    accurate) rather than at process start-up.
+    """
+    global _tracker
+    if not _silenced and isinstance(_tracker, NoopProgressTracker) and _tracker_factory is not None:
+        set_progress_tracker(_tracker_factory())
+    return _tracker
+
+
+def set_progress_tracker_factory(factory: Callable[[], ProgressTracker] | None) -> None:
+    """Register a lazy factory for the CLI progress tracker.
+
+    Boundary code (typically ``install_cli_observability_adapters``)
+    installs ``get_tracker`` here instead of constructing the Rich
+    tracker eagerly at process start-up.
+    """
+    global _tracker_factory
+    _tracker_factory = factory
+
+
+def set_progress_tracker(tracker: ProgressTracker) -> None:
+    """Install ``tracker`` as the active implementation. Called by the
+    CLI boundary (or any other adapter) at startup so subsequent
+    ``get_progress_tracker()`` calls return the real implementation.
+    """
+    global _tracker, _silenced
+    _tracker = tracker
+    if not isinstance(tracker, NoopProgressTracker):
+        _silenced = False
+
+
+def silence_progress_tracker() -> None:
+    """Replace whatever is registered with a Noop tracker.
+
+    Used at the pipeline entry point when a run shouldn't emit progress
+    (e.g. headless investigations whose output goes only to a sink).
+    Calls ``stop()`` on the previous tracker first so any active
+    display / watcher / animation it owns gets released — silencing a
+    Rich tracker without stopping it leaks its toggle watcher and the
+    Live display keeps holding the terminal.
+    """
+    global _silenced
+    _silenced = True
+    _tracker.stop()
+    set_progress_tracker(NoopProgressTracker())

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -156,9 +156,9 @@ async def astream_investigation(
     # Silence the global ProgressTracker before starting the background thread
     # so pipeline internals (extract_alert, resolve_integrations, etc.) don't
     # open their own Rich Live display — the StreamRenderer drives it instead.
-    from app.cli.interactive_shell.ui.output import set_silent_tracker
+    from app.observability import silence_progress_tracker
 
-    set_silent_tracker()
+    silence_progress_tracker()
 
     event_queue: queue.Queue[StreamEvent | BaseException | None] = queue.Queue()
     loop = asyncio.get_running_loop()

--- a/app/ui_theme.py
+++ b/app/ui_theme.py
@@ -1,0 +1,18 @@
+"""Shared UI theme constants (color hex codes).
+
+Lives at the top of ``app/`` rather than under ``app/cli/`` because
+core modules (e.g. ``app/agent/stages/publish_findings/renderers/
+terminal.py``) need the same color values without depending on the
+CLI layer. The CLI's theme module re-exports these so existing
+``from app.cli.interactive_shell.ui.theme import BRAND, …`` imports
+keep working — the hex values stay in one place.
+"""
+
+from __future__ import annotations
+
+HIGHLIGHT = "#B9EDAF"
+BRAND = "#66A17D"
+DIM = "#444444"
+WARNING = "#CEA25C"
+
+__all__ = ["BRAND", "DIM", "HIGHLIGHT", "WARNING"]

--- a/app/utils/slack_delivery.py
+++ b/app/utils/slack_delivery.py
@@ -7,8 +7,8 @@ import os
 import re
 from typing import Any
 
-from app.cli.interactive_shell.ui.output import debug_print
 from app.config import SLACK_CHANNEL
+from app.observability import debug_print
 from app.utils.delivery_transport import post_json
 
 logger = logging.getLogger(__name__)

--- a/tests/test_core_layering.py
+++ b/tests/test_core_layering.py
@@ -1,0 +1,77 @@
+"""Layering boundary test: core packages must not import from ``app.cli``.
+
+Core (``app/agent/``, ``app/pipeline/``, ``app/utils/``) reports progress,
+prints debug output, and renders investigation headers/footers through
+the ports defined in :mod:`app.observability`. Reaching into
+``app.cli.*`` directly couples the agent/pipeline layer to the REPL's
+specific renderer and breaks headless / non-TTY callers.
+
+See issue #35 and the introduction of ``build_*_provider`` /
+``set_*`` injection helpers in ``app/observability/``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_CORE_PACKAGES: tuple[Path, ...] = (
+    Path("app/agent"),
+    Path("app/pipeline"),
+    Path("app/utils"),
+)
+# Anything imported from ``app.cli.*`` by a core module is a layering
+# violation. Inverted dependency: core defines ports, CLI implements
+# them. Exemption note: at the time of writing none of the core
+# packages legitimately need CLI internals; if a real need ever comes
+# up, prefer a new observability port over an exemption.
+_FORBIDDEN_PREFIXES: tuple[str, ...] = ("app.cli",)
+
+
+def _core_modules() -> list[Path]:
+    files: list[Path] = []
+    for root in _CORE_PACKAGES:
+        files.extend(p for p in root.glob("**/*.py") if "__pycache__" not in p.parts)
+    return sorted(files)
+
+
+def _imported_modules(source: str) -> set[str]:
+    """Module-paths every ``import``/``from`` statement names in ``source``."""
+    tree = ast.parse(source)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:  # relative import — out of scope
+                continue
+            if node.module:
+                names.add(node.module)
+    return names
+
+
+@pytest.mark.parametrize("module_path", _core_modules(), ids=str)
+def test_core_module_does_not_import_cli(module_path: Path) -> None:
+    """Every module under ``app/agent/``, ``app/pipeline/``, ``app/utils/``
+    must avoid imports from ``app.cli.*``.
+
+    If you need progress reporting, debug output, or display rendering
+    from core, use the ports under :mod:`app.observability` and let the
+    CLI layer register its concrete implementation at boundary via
+    ``install_cli_observability_adapters``.
+    """
+    source = module_path.read_text(encoding="utf-8")
+    imports = _imported_modules(source)
+    leaks = {
+        imp
+        for imp in imports
+        if any(imp == prefix or imp.startswith(f"{prefix}.") for prefix in _FORBIDDEN_PREFIXES)
+    }
+    assert not leaks, (
+        f"{module_path} imports CLI module(s) {sorted(leaks)} — route through an "
+        "observability port (``app.observability.progress`` / ``debug`` / "
+        "``display`` / ``output_format``) instead."
+    )

--- a/tests/test_observability_adapters.py
+++ b/tests/test_observability_adapters.py
@@ -1,0 +1,90 @@
+"""Integration tests for CLI → observability port wiring."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.cli.interactive_shell.ui.output import environment as output_environment
+from app.cli.interactive_shell.ui.output import tracker as output_tracker
+from app.cli.interactive_shell.ui.output.renderers import (
+    render_completed_investigation_footer,
+    render_investigation_header,
+)
+from app.cli.interactive_shell.ui.output.tracker import ProgressTracker, get_tracker
+from app.observability import NoopProgressTracker, get_progress_tracker, silence_progress_tracker
+from app.observability import debug as obs_debug
+from app.observability import display as obs_display
+from app.observability import progress as obs_progress
+from app.observability.debug import set_debug_printer
+from app.observability.display import (
+    set_investigation_footer_renderer,
+    set_investigation_header_renderer,
+)
+from app.observability.progress import (
+    set_progress_tracker,
+    set_progress_tracker_factory,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_observability_ports(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give each test a clean observability port state and tracker singleton."""
+    for name in ("TRACER_OUTPUT_FORMAT", "NO_COLOR", "SLACK_WEBHOOK_URL", "TRACER_VERBOSE"):
+        monkeypatch.delenv(name, raising=False)
+    set_progress_tracker(NoopProgressTracker())
+    set_progress_tracker_factory(None)
+    obs_progress._silenced = False
+    set_debug_printer(obs_debug._default_debug_printer)
+    set_investigation_header_renderer(obs_display._default_header_renderer)
+    set_investigation_footer_renderer(obs_display._default_footer_renderer)
+    monkeypatch.setattr(output_tracker, "_tracker", None)
+
+
+def test_ports_default_to_noop_before_cli_install() -> None:
+    assert isinstance(get_progress_tracker(), NoopProgressTracker)
+
+
+def test_install_cli_observability_adapters_wires_progress_tracker() -> None:
+    output_environment.install_cli_observability_adapters()
+
+    tracker = get_progress_tracker()
+    assert isinstance(tracker, ProgressTracker)
+    assert tracker is get_tracker()
+
+
+def test_install_cli_observability_adapters_wires_debug_and_display() -> None:
+    output_environment.install_cli_observability_adapters()
+
+    assert obs_debug._printer is output_environment.debug_print
+    assert obs_display._header_renderer is render_investigation_header
+    assert obs_display._footer_renderer is render_completed_investigation_footer
+
+
+def test_sync_pipeline_path_records_progress_after_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Core ``get_progress_tracker()`` must drive the CLI tracker in sync runs."""
+    monkeypatch.setenv("TRACER_OUTPUT_FORMAT", "text")
+    output_environment.install_cli_observability_adapters()
+
+    tracker = get_progress_tracker()
+    tracker.start("extract_alert", "Parsing alert payload")
+    tracker.complete("extract_alert", message="done")
+
+    assert len(tracker.events) == 2
+    assert tracker.events[0].node_name == "extract_alert"
+    assert tracker.events[0].status == "started"
+    assert tracker.events[1].status == "completed"
+
+
+def test_silence_progress_tracker_blocks_lazy_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TRACER_OUTPUT_FORMAT", "text")
+    output_environment.install_cli_observability_adapters()
+
+    silence_progress_tracker()
+    tracker = get_progress_tracker()
+    tracker.start("extract_alert")
+
+    assert isinstance(tracker, NoopProgressTracker)

--- a/tests/test_observability_adapters.py
+++ b/tests/test_observability_adapters.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from app.cli.interactive_shell.ui.output import environment as output_environment
+from app.cli.interactive_shell.ui.output import boundary as output_boundary
 from app.cli.interactive_shell.ui.output import tracker as output_tracker
+from app.cli.interactive_shell.ui.output.environment import debug_print
 from app.cli.interactive_shell.ui.output.renderers import (
     render_completed_investigation_footer,
     render_investigation_header,
@@ -45,7 +46,7 @@ def test_ports_default_to_noop_before_cli_install() -> None:
 
 
 def test_install_cli_observability_adapters_wires_progress_tracker() -> None:
-    output_environment.install_cli_observability_adapters()
+    output_boundary.install_cli_observability_adapters()
 
     tracker = get_progress_tracker()
     assert isinstance(tracker, ProgressTracker)
@@ -53,9 +54,9 @@ def test_install_cli_observability_adapters_wires_progress_tracker() -> None:
 
 
 def test_install_cli_observability_adapters_wires_debug_and_display() -> None:
-    output_environment.install_cli_observability_adapters()
+    output_boundary.install_cli_observability_adapters()
 
-    assert obs_debug._printer is output_environment.debug_print
+    assert obs_debug._printer is debug_print
     assert obs_display._header_renderer is render_investigation_header
     assert obs_display._footer_renderer is render_completed_investigation_footer
 
@@ -65,7 +66,7 @@ def test_sync_pipeline_path_records_progress_after_install(
 ) -> None:
     """Core ``get_progress_tracker()`` must drive the CLI tracker in sync runs."""
     monkeypatch.setenv("TRACER_OUTPUT_FORMAT", "text")
-    output_environment.install_cli_observability_adapters()
+    output_boundary.install_cli_observability_adapters()
 
     tracker = get_progress_tracker()
     tracker.start("extract_alert", "Parsing alert payload")
@@ -81,7 +82,7 @@ def test_silence_progress_tracker_blocks_lazy_factory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("TRACER_OUTPUT_FORMAT", "text")
-    output_environment.install_cli_observability_adapters()
+    output_boundary.install_cli_observability_adapters()
 
     silence_progress_tracker()
     tracker = get_progress_tracker()


### PR DESCRIPTION
Fixes #2971 

#### Describe the changes you have made in this PR -

Core packages (`app/agent/`, `app/pipeline/`, `app/utils/`) used to import directly from `app/cli/interactive_shell/ui/output/` whenever they needed to report progress, print debug output, or render a header. That's the CLI layer — the highest one in the dependency stack. Reaching into it from agent code coupled the investigation pipeline to the REPL's specific renderer and made the layering boundary fictional.

This PR introduces four ports under a new `app/observability/` package. Core code depends on the Protocol; the CLI registers Rich-backed implementations at the boundary; headless contexts get no-op defaults.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**New package — `app/observability/`** (the ports):

- `progress.py` — `ProgressTracker` Protocol, `NoopProgressTracker`
  default, `get_progress_tracker` / `set_progress_tracker` /
  `set_progress_tracker_factory` / `silence_progress_tracker`. The
  factory pattern means the Rich tracker is constructed lazily after
  REPL boot, so `_repl_progress_active()` returns the correct mode.
- `debug.py` — `debug_print` with `set_debug_printer`. Default
  prints to stderr when `TRACER_VERBOSE` is set.
- `display.py` — `render_investigation_header` and
  `render_completed_investigation_footer` with setters. Default no-op.
- `output_format.py` — `get_output_format()` plus named constants
  (`OUTPUT_FORMAT_RICH`/`TEXT`/`NONE`, `_ENV_OUTPUT_FORMAT`, etc.).
  Pure env/TTY probe; no injection needed.

**New module — `app/ui_theme.py`:**

Top-level home for the four color hex constants
(`BRAND`, `DIM`, `HIGHLIGHT`, `WARNING`) that the publish_findings
terminal renderer needs. The CLI's existing
`app/cli/interactive_shell/ui/theme.py` re-exports them so all
existing `from app.cli.interactive_shell.ui.theme import BRAND, …`
callers keep working.

**Adapter wiring at the CLI boundary:**

- `app/cli/__main__.py::main` calls `install_cli_observability_adapters()`
  after `init_sentry`, before signal handlers.
- `install_cli_observability_adapters()` (in
  `app/cli/interactive_shell/ui/output/environment.py`) registers
  the Rich debug printer + header/footer renderers + tracker
  factory. The progress tracker is created on first
  `get_progress_tracker()` call, not eagerly.

**Migrated 8 core files** to import from observability instead of
CLI:

- `app/pipeline/runners.py` — `silence_progress_tracker`
- `app/utils/slack_delivery.py` — `debug_print`
- `app/agent/stages/resolve_integrations/node.py`
- `app/agent/stages/investigate/agent.py`
- `app/agent/stages/extract_alert/node.py`
- `app/agent/stages/publish_findings/renderers/terminal.py`
- `app/agent/stages/diagnose/node.py`
- `app/agent/correlation/node.py`

**Layering regression test — `tests/test_core_layering.py`:**

Parametrized over every `.py` file under `app/agent/`,
`app/pipeline/`, `app/utils/`. Each module is parsed via `ast` and
checked against the forbidden prefix `app.cli`. Currently 86
modules covered — all clean.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
