### PR TITLE
refactor: standardise nodes between different stages

### DIFF
--- a/app/agent/stages/diagnose/__init__.py
+++ b/app/agent/stages/diagnose/__init__.py
@@ -1,4 +1,14 @@
-"""Diagnose node — parse investigation conclusions into structured RCA fields."""
+"""Diagnose node — parse investigation conclusions into structured RCA fields.
+
+Node contract:
+    Entrypoint : diagnose(state: InvestigationState) -> dict[str, Any]
+    Reads      : agent_messages, evidence, alert_name, alert_source,
+                 root_cause (idempotency guard — skips if already set)
+    Writes     : root_cause, root_cause_category, causal_chain,
+                 validated_claims, non_validated_claims, remediation_steps,
+                 validity_score, investigation_recommendations, evidence,
+                 evidence_entries, agent_messages
+"""
 
 from app.agent.stages.diagnose.node import InvestigationResult, diagnose, parse_diagnosis
 

--- a/app/agent/stages/diagnose/node.py
+++ b/app/agent/stages/diagnose/node.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 
 from app.agent.category_alignment import apply_category_alignment_adjustments
 from app.agent.utils.alert_source import resolve_alert_source
+from app.state import InvestigationState
 from app.types.root_cause_categories import (
     HERMES_ROOT_CAUSE_CATEGORIES,
     VALID_ROOT_CAUSE_CATEGORIES,
@@ -105,7 +106,7 @@ def parse_diagnosis(
         return _parse_via_legacy(last_text, evidence, alert_name)
 
 
-def diagnose(state: dict[str, Any]) -> dict[str, Any]:
+def diagnose(state: InvestigationState) -> dict[str, Any]:
     """Parse investigation output into structured RCA fields."""
     if str(state.get("root_cause") or "").strip():
         return {}
@@ -123,7 +124,7 @@ def diagnose(state: dict[str, Any]) -> dict[str, Any]:
         messages,
         evidence,
         str(state.get("alert_name") or ""),
-        alert_source=resolve_alert_source(state),
+        alert_source=resolve_alert_source(cast(dict[str, Any], state)),
     )
     result.evidence = evidence
     result.evidence_entries = _list_of_dicts(state.get("evidence_entries"))

--- a/app/agent/stages/extract_alert/__init__.py
+++ b/app/agent/stages/extract_alert/__init__.py
@@ -1,4 +1,11 @@
-"""Extract alert node — classify and parse raw alerts into structured state."""
+"""Extract alert node — classify and parse raw alerts into structured state.
+
+Node contract:
+    Entrypoint : extract_alert(state: InvestigationState) -> dict[str, Any]
+    Reads      : raw_alert, slack_context, org_id
+    Writes     : alert_name, pipeline_name, severity, problem_md,
+                 alert_source, raw_alert (enriched), is_noise
+"""
 
 from app.agent.stages.extract_alert.node import extract_alert
 

--- a/app/agent/stages/investigate/__init__.py
+++ b/app/agent/stages/investigate/__init__.py
@@ -1,4 +1,12 @@
-"""Investigate node — connected ReAct investigation agent."""
+"""Investigate node — connected ReAct investigation agent.
+
+Node contract:
+    Entrypoint : ConnectedInvestigationAgent().run(state, on_event=None) -> dict[str, Any]
+    Reads      : planned_actions, resolved_integrations, retrieval_controls,
+                 agent_messages, alert_name, raw_alert
+    Writes     : evidence, agent_messages, executed_hypotheses,
+                 investigation_started_at, investigation_loop_count
+"""
 
 from app.agent.stages.investigate.agent import ConnectedInvestigationAgent, InvestigationAgent
 

--- a/app/agent/stages/investigate/agent.py
+++ b/app/agent/stages/investigate/agent.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from typing import Any
+from typing import Any, cast
 
 from app.agent.stages.investigate.loop import (
     InvestigationToolCallCache,
@@ -38,6 +38,7 @@ from app.constants.investigation import MAX_INVESTIGATION_LOOPS
 from app.observability import debug_print
 from app.observability import get_progress_tracker as get_tracker
 from app.services.agent_llm_client import ToolCall, get_agent_llm
+from app.state import InvestigationState
 from app.state.evidence import EvidenceEntry
 from app.tools.registered_tool import RegisteredTool
 from app.utils.tool_trace import redact_sensitive
@@ -89,7 +90,7 @@ class ConnectedInvestigationAgent:
 
     def run(
         self,
-        state: dict[str, Any],
+        state: InvestigationState,
         on_event: AgentEventCallback | None = None,
     ) -> dict[str, Any]:
         """Run the full investigation. Returns a dict of state updates."""
@@ -114,11 +115,10 @@ class ConnectedInvestigationAgent:
             )
             _emit("tool_end", tool_event_payload(tc, output=output))
 
+        state_dict = cast(dict[str, Any], state)
         resolved = state.get("resolved_integrations") or {}
-        tools = _tools_for_plan(self._filter_tools(get_available_tools(resolved)), state)
+        tools = _tools_for_plan(self._filter_tools(get_available_tools(resolved)), state_dict)
         tool_context = build_connected_tool_context(resolved, tools)
-        state["available_sources"] = tool_context["available_sources"]
-        state["available_action_names"] = tool_context["available_action_names"]
 
         if not tools:
             logger.warning("No tools available for investigation")
@@ -126,8 +126,10 @@ class ConnectedInvestigationAgent:
         llm = get_agent_llm()
         tool_schemas = llm.tool_schemas(tools)
 
-        system = self._build_system_prompt(state)
-        alert_text = format_alert_context(state)
+        # Merge tool_context into a local view so the system prompt can read
+        # available_sources / available_action_names without mutating the caller's state.
+        system = self._build_system_prompt({**state_dict, **tool_context})
+        alert_text = format_alert_context(state_dict)
         messages: list[dict[str, Any]] = [{"role": "user", "content": alert_text}]
 
         evidence: dict[str, Any] = {}
@@ -144,7 +146,7 @@ class ConnectedInvestigationAgent:
             },
         )
 
-        seed_calls = build_seed_calls(state, tools, llm)
+        seed_calls = build_seed_calls(state_dict, tools, llm)
         if seed_calls:
             logger.debug("[agent] seeding %d primary tool calls before LLM loop", len(seed_calls))
             for tc in seed_calls:

--- a/app/agent/stages/plan_actions/__init__.py
+++ b/app/agent/stages/plan_actions/__init__.py
@@ -1,4 +1,12 @@
-"""Plan actions stage — prioritized investigation tool selection."""
+"""Plan actions stage — prioritized investigation tool selection.
+
+Node contract:
+    Entrypoint : plan_actions(state: InvestigationState) -> dict[str, Any]
+    Reads      : resolved_integrations, alert_name, alert_source, raw_alert,
+                 retrieval_controls, is_noise
+    Writes     : planned_actions, plan_rationale, retrieval_controls, plan_audit,
+                 connected_tool_context (for investigate stage)
+"""
 
 from app.agent.stages.plan_actions.node import plan_actions
 

--- a/app/agent/stages/plan_actions/node.py
+++ b/app/agent/stages/plan_actions/node.py
@@ -12,7 +12,7 @@ from app.agent.stages.plan_actions.selectors import (
     primary_sources_for_alert,
     relevant_sources_for_alert,
 )
-from app.state import AgentState
+from app.state import InvestigationState
 from app.tools.registered_tool import RegisteredTool
 from app.tools.registry import get_registered_tools
 from app.types.retrieval import RetrievalControlsMap, RetrievalIntent, TimeBounds
@@ -21,7 +21,7 @@ FALLBACK_TOOL_NAMES: tuple[str, ...] = ("get_sre_guidance",)
 DEFAULT_RETRIEVAL_LIMIT = 100
 
 
-def plan_actions(state: AgentState) -> dict[str, Any]:
+def plan_actions(state: InvestigationState) -> dict[str, Any]:
     """Return a prioritized investigation tool plan as partial state updates."""
     if state.get("is_noise"):
         return {}

--- a/app/agent/stages/publish_findings/__init__.py
+++ b/app/agent/stages/publish_findings/__init__.py
@@ -1,23 +1,15 @@
-"""Publish findings node — format and deliver investigation reports."""
+"""Publish findings node — format and deliver investigation reports.
 
-from __future__ import annotations
+Node contract:
+    Entrypoint : deliver(state: InvestigationState) -> dict[str, Any]
+    Reads      : root_cause, validated_claims, non_validated_claims,
+                 remediation_steps, correlation, evidence, resolved_integrations,
+                 slack_context, telegram_context, whatsapp_context,
+                 discord_context, problem_md, masking_context, opensre_evaluate
+    Writes     : slack_message, report, opensre_llm_eval (optional)
+"""
 
-from typing import Any
-
-from app.agent.stages.publish_findings.evaluation import run_optional_opensre_evaluation
-from app.agent.stages.publish_findings.node import generate_report
-from app.state import InvestigationState
-
-
-def deliver(state: InvestigationState) -> dict[str, Any]:
-    """Format and deliver the investigation report to all configured channels.
-
-    Returns state updates with slack_message and report fields.
-    """
-    state_dict = dict(state)
-    extra_updates = run_optional_opensre_evaluation(state_dict)
-    return {**generate_report(state), **extra_updates}
-
+from app.agent.stages.publish_findings.node import deliver, generate_report
 
 __all__ = [
     "deliver",

--- a/app/agent/stages/publish_findings/node.py
+++ b/app/agent/stages/publish_findings/node.py
@@ -1,9 +1,21 @@
-"""Main orchestration node for report generation and publishing."""
+"""Publish-findings node — entry points for the investigation pipeline.
+
+Node contract:
+    Entrypoint : deliver(state: InvestigationState) -> dict[str, Any]
+    Reads      : root_cause, validated_claims, non_validated_claims,
+                 remediation_steps, correlation, evidence, resolved_integrations,
+                 slack_context, telegram_context, whatsapp_context,
+                 discord_context, problem_md, masking_context, opensre_evaluate
+    Writes     : slack_message, report, opensre_llm_eval (optional)
+"""
+
+from __future__ import annotations
 
 from typing import Any
 
 from app.agent.stages.publish_findings.context import build_report_context
 from app.agent.stages.publish_findings.delivery import dispatch_report
+from app.agent.stages.publish_findings.evaluation import run_optional_opensre_evaluation
 from app.agent.stages.publish_findings.formatters.messages import (
     ReportMessages,
     build_report_messages,
@@ -13,6 +25,16 @@ from app.agent.stages.publish_findings.renderers.terminal import render_report
 from app.masking import MaskingContext
 from app.state import InvestigationState
 from app.utils.ingest_delivery import create_investigation_and_attach_url
+
+
+def deliver(state: InvestigationState) -> dict[str, Any]:
+    """Format and deliver the investigation report to all configured channels.
+
+    Returns state updates with slack_message and report fields.
+    """
+    state_dict = dict(state)
+    extra_updates = run_optional_opensre_evaluation(state_dict)
+    return {**generate_report(state), **extra_updates}
 
 
 def generate_report(

--- a/app/agent/stages/resolve_integrations/__init__.py
+++ b/app/agent/stages/resolve_integrations/__init__.py
@@ -1,4 +1,11 @@
-"""Resolve integrations node — integration discovery for investigations."""
+"""Resolve integrations node — integration discovery for investigations.
+
+Node contract:
+    Entrypoint : resolve_integrations(state: InvestigationState) -> dict[str, Any]
+    Reads      : _auth_token, org_id,
+                 resolved_integrations (idempotency guard — skips if already set)
+    Writes     : resolved_integrations
+"""
 
 from app.agent.stages.resolve_integrations.node import resolve_integrations
 

--- a/app/agent/stages/resolve_integrations/node.py
+++ b/app/agent/stages/resolve_integrations/node.py
@@ -27,7 +27,16 @@ logger = logging.getLogger(__name__)
 
 
 def resolve_integrations(state: InvestigationState) -> dict[str, Any]:
-    """Fetch and classify all available integrations. Returns resolved_integrations dict."""
+    """Discover and classify all integrations available for this investigation.
+
+    Reads  : _auth_token, org_id, resolved_integrations (idempotency guard)
+    Writes : resolved_integrations
+    """
+    return {"resolved_integrations": _resolve(state)}
+
+
+def _resolve(state: InvestigationState) -> dict[str, Any]:
+    """Return the raw integrations dict (keyed by vendor name)."""
     if state.get("resolved_integrations"):
         return dict(state["resolved_integrations"])
 

--- a/app/pipeline/pipeline.py
+++ b/app/pipeline/pipeline.py
@@ -61,7 +61,7 @@ def run_connected_investigation(
     state_any = cast(dict[str, Any], state)
 
     try:
-        _merge(state_any, {"resolved_integrations": resolve_integrations(state)})
+        _merge(state_any, resolve_integrations(state))
 
         _merge(state_any, extract_alert(state))
         if state_any.get("is_noise"):

--- a/app/pipeline/pipeline.py
+++ b/app/pipeline/pipeline.py
@@ -68,8 +68,8 @@ def run_connected_investigation(
             return cast(AgentState, state_any)
 
         _merge(state_any, plan_actions(cast(AgentState, state_any)))
-        _merge(state_any, agent_class().run(state_any))
-        _merge(state_any, diagnose(state_any))
+        _merge(state_any, agent_class().run(cast(AgentState, state_any)))
+        _merge(state_any, diagnose(cast(AgentState, state_any)))
         _merge(
             state_any,
             node_correlate_upstream(

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -225,8 +225,9 @@ async def astream_investigation(
 
             # --- resolve_integrations ---
             _put(_make_node_event("on_chain_start", "resolve_integrations", {}))
-            resolved = _traced_node("resolve_integrations", resolve_integrations, initial)
-            _merge(state_any, {"resolved_integrations": resolved})
+            resolved_updates = _traced_node("resolve_integrations", resolve_integrations, initial)
+            _merge(state_any, resolved_updates)
+            resolved = resolved_updates.get("resolved_integrations") or {}
             _put(
                 _make_node_event(
                     "on_chain_end",

--- a/tests/pipeline/test_runners_agent_class.py
+++ b/tests/pipeline/test_runners_agent_class.py
@@ -58,7 +58,10 @@ def test_run_connected_investigation_uses_agent_class_when_provided() -> None:
     # Avoid running real integration/extraction; mock them to no-ops so the
     # test focuses on the agent_class threading specifically.
     with (
-        patch("app.agent.stages.resolve_integrations.resolve_integrations", return_value={}),
+        patch(
+            "app.agent.stages.resolve_integrations.resolve_integrations",
+            return_value={"resolved_integrations": {}},
+        ),
         patch("app.agent.stages.extract_alert.extract_alert", return_value={"is_noise": False}),
         patch("app.agent.stages.plan_actions.plan_actions", return_value={}),
         patch("app.agent.correlation.node.node_correlate_upstream", return_value={}),
@@ -79,7 +82,10 @@ def test_run_connected_investigation_uses_default_agent_when_class_omitted() -> 
 
     state = make_initial_state(raw_alert="alert text")
     with (
-        patch("app.agent.stages.resolve_integrations.resolve_integrations", return_value={}),
+        patch(
+            "app.agent.stages.resolve_integrations.resolve_integrations",
+            return_value={"resolved_integrations": {}},
+        ),
         patch("app.agent.stages.extract_alert.extract_alert", return_value={"is_noise": False}),
         patch("app.agent.stages.plan_actions.plan_actions", return_value={}),
         patch(
@@ -105,7 +111,10 @@ def test_run_investigation_forwards_agent_class_to_pipeline() -> None:
     from app.pipeline.runners import run_investigation
 
     with (
-        patch("app.agent.stages.resolve_integrations.resolve_integrations", return_value={}),
+        patch(
+            "app.agent.stages.resolve_integrations.resolve_integrations",
+            return_value={"resolved_integrations": {}},
+        ),
         patch("app.agent.stages.extract_alert.extract_alert", return_value={"is_noise": False}),
         patch("app.agent.stages.plan_actions.plan_actions", return_value={}),
         patch("app.agent.correlation.node.node_correlate_upstream", return_value={}),
@@ -138,7 +147,8 @@ def test_run_connected_investigation_runs_plan_actions_before_agent() -> None:
     with (
         patch(
             "app.agent.stages.resolve_integrations.resolve_integrations",
-            side_effect=lambda _state: calls.append("resolve_integrations") or {},
+            side_effect=lambda _state: calls.append("resolve_integrations")
+            or {"resolved_integrations": {}},
         ),
         patch(
             "app.agent.stages.extract_alert.extract_alert",

--- a/tests/pipeline/test_runners_agent_class.py
+++ b/tests/pipeline/test_runners_agent_class.py
@@ -147,8 +147,9 @@ def test_run_connected_investigation_runs_plan_actions_before_agent() -> None:
     with (
         patch(
             "app.agent.stages.resolve_integrations.resolve_integrations",
-            side_effect=lambda _state: calls.append("resolve_integrations")
-            or {"resolved_integrations": {}},
+            side_effect=lambda _state: (
+                calls.append("resolve_integrations") or {"resolved_integrations": {}}
+            ),
         ),
         patch(
             "app.agent.stages.extract_alert.extract_alert",

--- a/tests/pipeline/test_streaming_plan_actions.py
+++ b/tests/pipeline/test_streaming_plan_actions.py
@@ -25,7 +25,7 @@ async def test_astream_investigation_emits_plan_actions_before_agent(
 ) -> None:
     monkeypatch.setattr(
         "app.agent.stages.resolve_integrations.resolve_integrations",
-        lambda _state: {},
+        lambda _state: {"resolved_integrations": {}},
     )
     monkeypatch.setattr(
         "app.agent.stages.extract_alert.extract_alert",

--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -858,7 +858,7 @@ async def test_investigate_stream_emits_correlation_payload(
 
     monkeypatch.setattr(
         "app.agent.stages.resolve_integrations.resolve_integrations",
-        lambda _state: {},
+        lambda _state: {"resolved_integrations": {}},
     )
 
     monkeypatch.setattr(


### PR DESCRIPTION
Uniform return shape for resolve_integrations

resolve_integrations() previously returned the raw integrations dict and the pipeline manually wrapped it: {"resolved_integrations": resolve_integrations(state)}. This was the only node that didn't return its own keyed update. Fixed by extracting the body into a private _resolve() helper and making the public function return {"resolved_integrations": _resolve(state)}. Updated both call sites in pipeline.py and runners.py.

deliver() moved into node.py

deliver() was defined inline in publish_findings/__init__.py, mixing the public API file with implementation. Moved to node.py alongside generate_report(). __init__.py is now a thin re-export only.

Consistent type annotations:

plan_actions/node.py: state: AgentState → state: InvestigationState (they are the same alias, but all other nodes used InvestigationState)
investigate/agent.py: run(state: dict[str, Any]) → run(state: InvestigationState)
diagnose/node.py: diagnose(state: dict[str, Any]) → diagnose(state: InvestigationState)
Contract docstrings on all __init__.py files

Every stage's __init__.py now documents the node's public entrypoint, the state keys it reads, and the state keys it writes — the single place a pipeline author needs to look to understand what a stage consumes and produces.

State mutation fix in investigate/agent.py
The run() method was directly mutating the caller's state dict before the loop:

# before — hard contract violation
state["available_sources"] = tool_context["available_sources"]
state["available_action_names"] = tool_context["available_action_names"]
These keys were written in so _build_system_prompt(state) could read them. Fixed by passing a merged local dict instead:

# after — no mutation of caller state
system = self._build_system_prompt({**state_dict, **tool_context})
Both keys are still returned in the final updates dict at the end of run(), so the pipeline receives them correctly.