### PR TITLE
refactor(integrations): introduce RemoteIntegrationsFetcher port and decouple resolve_integrations from services.tracer_client

### DIFF
--- a/app/agent/stages/resolve_integrations/node.py
+++ b/app/agent/stages/resolve_integrations/node.py
@@ -45,9 +45,9 @@ def resolve_integrations(state: InvestigationState) -> dict[str, Any]:
             tracker.complete("resolve_integrations", fields_updated=["resolved_integrations"])
             return {}
         try:
-            from app.services.tracer_client import get_tracer_client_for_org
+            from app.integrations.port import fetch_remote_integrations
 
-            all_integrations = get_tracer_client_for_org(org_id, auth_token).get_all_integrations()
+            all_integrations = fetch_remote_integrations(org_id=org_id, auth_token=auth_token)
         except Exception as exc:
             logger.warning("Remote integrations fetch failed: %s", exc)
             tracker.complete("resolve_integrations", fields_updated=["resolved_integrations"])
@@ -63,9 +63,9 @@ def resolve_integrations(state: InvestigationState) -> dict[str, Any]:
         if not org_id:
             return _resolve_from_local_sources(tracker)
         try:
-            from app.services.tracer_client import get_tracer_client_for_org
+            from app.integrations.port import fetch_remote_integrations
 
-            all_integrations = get_tracer_client_for_org(org_id, env_token).get_all_integrations()
+            all_integrations = fetch_remote_integrations(org_id=org_id, auth_token=env_token)
         except Exception:
             logger.debug(
                 "Remote integrations fetch failed for org %s, falling back to local",

--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -230,10 +230,10 @@ def main(argv: list[str] | None = None) -> int:
     # app/pipeline, app/utils that calls into the abstractions routes
     # through the Rich-aware adapters during this process.
     from app.cli.interactive_shell.ui.output.boundary import (
-        install_cli_observability_adapters,
+        install_product_adapters,
     )
 
-    install_cli_observability_adapters()
+    install_product_adapters()
     install_questionary_escape_cancel()
     install_questionary_ctrl_c_double_exit()
     _install_sigint_handler()

--- a/app/cli/interactive_shell/ui/output/boundary.py
+++ b/app/cli/interactive_shell/ui/output/boundary.py
@@ -1,18 +1,19 @@
-"""CLI → observability port wiring (boundary module).
+"""CLI boundary wiring — observability and integration ports.
 
 Lives in a leaf module so ``environment`` (imported by ``renderers`` and
 ``tracker`` for utility plumbing) does not import those modules back —
-that would create a static import cycle. ``__main__`` and tests call
-:func:`install_cli_observability_adapters` from here.
+that would create a static import cycle. Entry points (``__main__``,
+MCP, remote server) and tests call :func:`install_product_adapters`
+from here.
 """
 
 from __future__ import annotations
 
 
-def install_cli_observability_adapters() -> None:
-    """Wire CLI implementations into the observability ports.
+def install_product_adapters() -> None:
+    """Wire product adapters into observability and integration ports.
 
-    Call once from the CLI boundary (typically the REPL/CLI start-up).
+    Call once from each process entry point (CLI, MCP, remote server).
     Idempotent — re-registers the same callables so calling it twice
     is a no-op.
 
@@ -20,6 +21,7 @@ def install_cli_observability_adapters() -> None:
     - debug_print: stderr default → Rich-aware CLI version
     - render_investigation_header: no-op default → Rich panel
     - progress tracker: Noop default → Rich-backed CLI singleton (lazy)
+    - remote integrations fetcher: empty default → Tracer Cloud adapter
     """
     from app.cli.interactive_shell.ui.output.environment import debug_print
     from app.cli.interactive_shell.ui.output.renderers import (
@@ -27,12 +29,16 @@ def install_cli_observability_adapters() -> None:
         render_investigation_header,
     )
     from app.cli.interactive_shell.ui.output.tracker import get_tracker
+    from app.integrations.port import set_remote_integrations_fetcher
     from app.observability.debug import set_debug_printer
     from app.observability.display import (
         set_investigation_footer_renderer,
         set_investigation_header_renderer,
     )
     from app.observability.progress import set_progress_tracker_factory
+    from app.services.tracer_client.integrations_adapter import (
+        fetch_tracer_remote_integrations,
+    )
 
     set_debug_printer(debug_print)
     set_investigation_header_renderer(render_investigation_header)
@@ -40,3 +46,4 @@ def install_cli_observability_adapters() -> None:
     # Lazy: first core ``get_progress_tracker()`` call constructs the CLI
     # tracker after REPL boot so ``_repl_progress_active()`` is accurate.
     set_progress_tracker_factory(get_tracker)
+    set_remote_integrations_fetcher(fetch_tracer_remote_integrations)

--- a/app/cli/interactive_shell/ui/output/environment.py
+++ b/app/cli/interactive_shell/ui/output/environment.py
@@ -58,7 +58,7 @@ def debug_print(message: str) -> None:
         print(f"DEBUG: {message}")
 
 
-# ``install_cli_observability_adapters`` lives in
+# ``install_product_adapters`` lives in
 # :mod:`app.cli.interactive_shell.ui.output.boundary`, not here. Putting
 # it in this module would re-introduce a static import cycle:
 # ``renderers`` and ``tracker`` already import from this module for

--- a/app/entrypoints/mcp.py
+++ b/app/entrypoints/mcp.py
@@ -10,11 +10,13 @@ from pydantic import BaseModel, Field, ValidationError
 from app.analytics.cli import track_investigation
 from app.analytics.source import EntrypointSource, TriggerMode
 from app.cli.interactive_shell.error_handling.errors import OpenSREError
+from app.cli.interactive_shell.ui.output.boundary import install_product_adapters
 from app.cli.investigation import run_investigation_cli
 from app.utils.sentry_sdk import capture_exception, init_sentry
 
 load_dotenv(override=False)
 init_sentry(entrypoint="mcp")
+install_product_adapters()
 
 
 class RunRCAInput(BaseModel):

--- a/app/integrations/port.py
+++ b/app/integrations/port.py
@@ -1,0 +1,54 @@
+"""Integration provider ports — abstractions core code uses to fetch
+remote integration configuration without depending on a specific
+SaaS backend.
+
+Today the only port is :func:`fetch_remote_integrations`, called by
+:mod:`app.agent.stages.resolve_integrations.node` to pull the user's
+org-wide integrations from a remote source. The default returns an
+empty list; the CLI/SDK boundary registers a Tracer-Cloud-backed
+fetcher via :func:`set_remote_integrations_fetcher`. Headless
+contexts (tests, scripted invocations, alternate hosting) get the
+empty default and fall through to local-store integration sources.
+
+Same Ports & Adapters pattern as ``app/agent/correlation`` (see
+``build_upstream_evidence_provider``) and ``app/observability``: core
+depends on abstractions, vendor SDKs plug in as adapters at the
+boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+RemoteIntegrationsFetcher = Callable[[str, str], list[dict[str, Any]]]
+
+
+def _default_fetcher(org_id: str, auth_token: str) -> list[dict[str, Any]]:
+    """No remote source available — caller falls through to local sources."""
+    _ = (org_id, auth_token)
+    return []
+
+
+_fetcher: RemoteIntegrationsFetcher = _default_fetcher
+
+
+def fetch_remote_integrations(*, org_id: str, auth_token: str) -> list[dict[str, Any]]:
+    """Fetch the user's remote integrations via the registered fetcher.
+
+    Returns the integration list as raw dicts (same shape the local
+    store uses), or an empty list if no fetcher is registered. Empty
+    is a meaningful signal: caller should fall through to local
+    sources rather than error.
+    """
+    return _fetcher(org_id, auth_token)
+
+
+def set_remote_integrations_fetcher(fetcher: RemoteIntegrationsFetcher) -> None:
+    """Install ``fetcher`` as the active remote-integrations implementation.
+
+    Boundary code (typically the CLI start-up) calls this to wire a
+    Tracer-Cloud-backed fetcher in place of the empty default.
+    """
+    global _fetcher
+    _fetcher = fetcher

--- a/app/observability/progress.py
+++ b/app/observability/progress.py
@@ -144,7 +144,7 @@ def get_progress_tracker() -> ProgressTracker:
 def set_progress_tracker_factory(factory: Callable[[], ProgressTracker] | None) -> None:
     """Register a lazy factory for the CLI progress tracker.
 
-    Boundary code (typically ``install_cli_observability_adapters``)
+    Boundary code (typically ``install_product_adapters``)
     installs ``get_tracker`` here instead of constructing the Rich
     tracker eagerly at process start-up.
     """

--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -48,6 +48,7 @@ from app.analytics.cli import capture_investigation_failed, track_investigation
 from app.analytics.source import EntrypointSource, TriggerMode
 from app.cli.interactive_shell.error_handling.cli_error_mapping import reraise_cli_runtime_error
 from app.cli.interactive_shell.error_handling.errors import OpenSREError
+from app.cli.interactive_shell.ui.output.boundary import install_product_adapters
 from app.remote.error_reporting import report_remote_exception
 from app.remote.vercel_poller import (
     VercelInvestigationCandidate,
@@ -60,6 +61,7 @@ from app.version import get_version
 
 load_dotenv(override=False)
 init_sentry(entrypoint="remote")
+install_product_adapters()
 
 INVESTIGATIONS_DIR = Path(
     os.getenv("INVESTIGATIONS_DIR", str(Path.home() / ".opensre" / "investigations"))

--- a/app/services/tracer_client/integrations_adapter.py
+++ b/app/services/tracer_client/integrations_adapter.py
@@ -1,0 +1,27 @@
+"""Adapter: wire ``TracerClient.get_all_integrations`` into the
+:mod:`app.integrations.port` ``RemoteIntegrationsFetcher`` port.
+
+Lives in ``app/services/tracer_client/`` so the Tracer-specific
+dependency stays inside the Tracer integration package. Core code
+under ``app/agent/`` calls
+:func:`app.integrations.port.fetch_remote_integrations`; the boundary
+(``app.cli.interactive_shell.ui.output.boundary``) registers this
+adapter at startup so the call routes through ``TracerClient``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.tracer_client import get_tracer_client_for_org
+
+
+def fetch_tracer_remote_integrations(org_id: str, auth_token: str) -> list[dict[str, Any]]:
+    """Fetch a user's remote integrations from Tracer Cloud.
+
+    Matches :data:`app.integrations.port.RemoteIntegrationsFetcher`.
+    Any exception (network, auth, schema) propagates to the caller —
+    ``resolve_integrations`` already has the try/except + local
+    fall-through logic.
+    """
+    return get_tracer_client_for_org(org_id, auth_token).get_all_integrations()

--- a/tests/test_core_layering.py
+++ b/tests/test_core_layering.py
@@ -22,12 +22,23 @@ _CORE_PACKAGES: tuple[Path, ...] = (
     Path("app/pipeline"),
     Path("app/utils"),
 )
-# Anything imported from ``app.cli.*`` by a core module is a layering
-# violation. Inverted dependency: core defines ports, CLI implements
-# them. Exemption note: at the time of writing none of the core
-# packages legitimately need CLI internals; if a real need ever comes
-# up, prefer a new observability port over an exemption.
-_FORBIDDEN_PREFIXES: tuple[str, ...] = ("app.cli",)
+# Anything imported from a forbidden prefix by a core module is a
+# layering violation. Inverted dependency: core defines ports, CLI /
+# vendor service packages implement them at the boundary.
+#
+# Forbidden prefixes:
+# - ``app.cli`` — closed by #35 (observability ports). Core never
+#   needs CLI internals; if you think you do, file a new
+#   observability port instead.
+# - ``app.services.tracer_client`` — closed by #36
+#   (``app.integrations.port`` ``fetch_remote_integrations``). Other
+#   ``app.services.*`` modules (LLM client, chat SDK adapter,
+#   ``agent_llm_client``) stay allowed because they are core
+#   capability access, not vendor-coupled like ``tracer_client``.
+_FORBIDDEN_PREFIXES: tuple[str, ...] = (
+    "app.cli",
+    "app.services.tracer_client",
+)
 
 
 def _core_modules() -> list[Path]:
@@ -54,14 +65,14 @@ def _imported_modules(source: str) -> set[str]:
 
 
 @pytest.mark.parametrize("module_path", _core_modules(), ids=str)
-def test_core_module_does_not_import_cli(module_path: Path) -> None:
+def test_core_module_does_not_import_forbidden_layers(module_path: Path) -> None:
     """Every module under ``app/agent/``, ``app/pipeline/``, ``app/utils/``
-    must avoid imports from ``app.cli.*``.
+    must avoid imports from forbidden boundary packages (``app.cli.*``,
+    ``app.services.tracer_client``).
 
-    If you need progress reporting, debug output, or display rendering
-    from core, use the ports under :mod:`app.observability` and let the
-    CLI layer register its concrete implementation at boundary via
-    ``install_cli_observability_adapters``.
+    Use ports instead — ``app.observability`` for progress/debug/display,
+    ``app.integrations.port`` for remote integrations — and register
+    concrete adapters via ``install_product_adapters``.
     """
     source = module_path.read_text(encoding="utf-8")
     imports = _imported_modules(source)
@@ -71,7 +82,7 @@ def test_core_module_does_not_import_cli(module_path: Path) -> None:
         if any(imp == prefix or imp.startswith(f"{prefix}.") for prefix in _FORBIDDEN_PREFIXES)
     }
     assert not leaks, (
-        f"{module_path} imports CLI module(s) {sorted(leaks)} — route through an "
-        "observability port (``app.observability.progress`` / ``debug`` / "
-        "``display`` / ``output_format``) instead."
+        f"{module_path} imports forbidden module(s) {sorted(leaks)} — route through a "
+        "port (``app.observability.*`` or ``app.integrations.port``) and register "
+        "adapters via ``install_product_adapters``."
     )

--- a/tests/test_integrations_port_adapters.py
+++ b/tests/test_integrations_port_adapters.py
@@ -9,22 +9,50 @@ import pytest
 from app.cli.interactive_shell.ui.output import boundary as output_boundary
 from app.integrations import port as integrations_port
 from app.integrations.port import fetch_remote_integrations, set_remote_integrations_fetcher
+from app.observability import NoopProgressTracker
+from app.observability import debug as obs_debug
+from app.observability import display as obs_display
+from app.observability import progress as obs_progress
+from app.observability.debug import set_debug_printer
+from app.observability.display import (
+    set_investigation_footer_renderer,
+    set_investigation_header_renderer,
+)
+from app.observability.progress import set_progress_tracker, set_progress_tracker_factory
 from app.services.tracer_client.integrations_adapter import fetch_tracer_remote_integrations
+
+
+def _reset_all_ports() -> None:
+    """Restore every port + global to its no-op / default state.
+
+    ``install_product_adapters`` wires four observability ports in
+    addition to the integrations fetcher; resetting only the
+    integrations fetcher would leave the other four registered for
+    the rest of the pytest session. Symmetric with the helper in
+    :mod:`tests.test_observability_adapters`.
+    """
+    set_remote_integrations_fetcher(integrations_port._default_fetcher)
+    set_progress_tracker(NoopProgressTracker())
+    set_progress_tracker_factory(None)
+    obs_progress._silenced = False
+    set_debug_printer(obs_debug._default_debug_printer)
+    set_investigation_header_renderer(obs_display._default_header_renderer)
+    set_investigation_footer_renderer(obs_display._default_footer_renderer)
 
 
 @pytest.fixture(autouse=True)
 def _reset_integrations_port() -> Iterator[None]:
-    """Reset the integrations-port fetcher before AND after every test.
+    """Reset every port the boundary wires before AND after each test.
 
-    The teardown matters: without it, the final test in this file
-    leaks its registered fetcher (e.g. ``_fake_fetcher`` from
-    ``test_registered_fetcher_is_invoked``) into the rest of the
-    pytest session, polluting any later test that touches
-    ``fetch_remote_integrations``.
+    The teardown matters: without it, the final test that calls
+    ``install_product_adapters`` (e.g.
+    ``test_install_product_adapters_wires_tracer_fetcher``) leaks the
+    CLI debug printer, Rich header/footer renderers, and progress-tracker
+    factory into the rest of the pytest session.
     """
-    set_remote_integrations_fetcher(integrations_port._default_fetcher)
+    _reset_all_ports()
     yield
-    set_remote_integrations_fetcher(integrations_port._default_fetcher)
+    _reset_all_ports()
 
 
 def test_port_defaults_to_empty_before_boundary_install() -> None:

--- a/tests/test_integrations_port_adapters.py
+++ b/tests/test_integrations_port_adapters.py
@@ -1,0 +1,39 @@
+"""Integration tests for CLI → integrations port wiring."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.cli.interactive_shell.ui.output import boundary as output_boundary
+from app.integrations import port as integrations_port
+from app.integrations.port import fetch_remote_integrations, set_remote_integrations_fetcher
+from app.services.tracer_client.integrations_adapter import fetch_tracer_remote_integrations
+
+
+@pytest.fixture(autouse=True)
+def _reset_integrations_port() -> None:
+    set_remote_integrations_fetcher(integrations_port._default_fetcher)
+
+
+def test_port_defaults_to_empty_before_boundary_install() -> None:
+    assert fetch_remote_integrations(org_id="org-1", auth_token="tok") == []
+
+
+def test_install_product_adapters_wires_tracer_fetcher() -> None:
+    output_boundary.install_product_adapters()
+
+    assert integrations_port._fetcher is fetch_tracer_remote_integrations
+
+
+def test_registered_fetcher_is_invoked() -> None:
+    calls: list[tuple[str, str]] = []
+
+    def _fake_fetcher(org_id: str, auth_token: str) -> list[dict[str, object]]:
+        calls.append((org_id, auth_token))
+        return [{"service": "grafana", "config": {}}]
+
+    set_remote_integrations_fetcher(_fake_fetcher)
+    result = fetch_remote_integrations(org_id="org-42", auth_token="jwt-here")
+
+    assert calls == [("org-42", "jwt-here")]
+    assert result == [{"service": "grafana", "config": {}}]

--- a/tests/test_integrations_port_adapters.py
+++ b/tests/test_integrations_port_adapters.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 
 from app.cli.interactive_shell.ui.output import boundary as output_boundary
@@ -11,7 +13,17 @@ from app.services.tracer_client.integrations_adapter import fetch_tracer_remote_
 
 
 @pytest.fixture(autouse=True)
-def _reset_integrations_port() -> None:
+def _reset_integrations_port() -> Iterator[None]:
+    """Reset the integrations-port fetcher before AND after every test.
+
+    The teardown matters: without it, the final test in this file
+    leaks its registered fetcher (e.g. ``_fake_fetcher`` from
+    ``test_registered_fetcher_is_invoked``) into the rest of the
+    pytest session, polluting any later test that touches
+    ``fetch_remote_integrations``.
+    """
+    set_remote_integrations_fetcher(integrations_port._default_fetcher)
+    yield
     set_remote_integrations_fetcher(integrations_port._default_fetcher)
 
 

--- a/tests/test_observability_adapters.py
+++ b/tests/test_observability_adapters.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 
 from app.cli.interactive_shell.ui.output import boundary as output_boundary
@@ -12,6 +14,8 @@ from app.cli.interactive_shell.ui.output.renderers import (
     render_investigation_header,
 )
 from app.cli.interactive_shell.ui.output.tracker import ProgressTracker, get_tracker
+from app.integrations import port as integrations_port
+from app.integrations.port import set_remote_integrations_fetcher
 from app.observability import NoopProgressTracker, get_progress_tracker, silence_progress_tracker
 from app.observability import debug as obs_debug
 from app.observability import display as obs_display
@@ -27,18 +31,35 @@ from app.observability.progress import (
 )
 
 
-@pytest.fixture(autouse=True)
-def _reset_observability_ports(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Give each test a clean observability port state and tracker singleton."""
-    for name in ("TRACER_OUTPUT_FORMAT", "NO_COLOR", "SLACK_WEBHOOK_URL", "TRACER_VERBOSE"):
-        monkeypatch.delenv(name, raising=False)
+def _reset_all_ports() -> None:
+    """Restore every port + global to its no-op / default state."""
     set_progress_tracker(NoopProgressTracker())
     set_progress_tracker_factory(None)
     obs_progress._silenced = False
     set_debug_printer(obs_debug._default_debug_printer)
     set_investigation_header_renderer(obs_display._default_header_renderer)
     set_investigation_footer_renderer(obs_display._default_footer_renderer)
+    # ``install_product_adapters`` now also wires the integrations
+    # fetcher; reset it here so this file's tests don't leak the
+    # Tracer adapter into other tests in the session.
+    set_remote_integrations_fetcher(integrations_port._default_fetcher)
+
+
+@pytest.fixture(autouse=True)
+def _reset_observability_ports(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Give each test a clean port state — setup AND teardown.
+
+    The teardown matters: without it, the final test in this file
+    leaves whatever adapters ``install_product_adapters()`` registered
+    in place for the rest of the pytest session, polluting any later
+    test that touches the observability or integrations ports.
+    """
+    for name in ("TRACER_OUTPUT_FORMAT", "NO_COLOR", "SLACK_WEBHOOK_URL", "TRACER_VERBOSE"):
+        monkeypatch.delenv(name, raising=False)
+    _reset_all_ports()
     monkeypatch.setattr(output_tracker, "_tracker", None)
+    yield
+    _reset_all_ports()
 
 
 def test_ports_default_to_noop_before_cli_install() -> None:

--- a/tests/test_observability_adapters.py
+++ b/tests/test_observability_adapters.py
@@ -45,16 +45,16 @@ def test_ports_default_to_noop_before_cli_install() -> None:
     assert isinstance(get_progress_tracker(), NoopProgressTracker)
 
 
-def test_install_cli_observability_adapters_wires_progress_tracker() -> None:
-    output_boundary.install_cli_observability_adapters()
+def test_install_product_adapters_wires_progress_tracker() -> None:
+    output_boundary.install_product_adapters()
 
     tracker = get_progress_tracker()
     assert isinstance(tracker, ProgressTracker)
     assert tracker is get_tracker()
 
 
-def test_install_cli_observability_adapters_wires_debug_and_display() -> None:
-    output_boundary.install_cli_observability_adapters()
+def test_install_product_adapters_wires_debug_and_display() -> None:
+    output_boundary.install_product_adapters()
 
     assert obs_debug._printer is debug_print
     assert obs_display._header_renderer is render_investigation_header
@@ -66,7 +66,7 @@ def test_sync_pipeline_path_records_progress_after_install(
 ) -> None:
     """Core ``get_progress_tracker()`` must drive the CLI tracker in sync runs."""
     monkeypatch.setenv("TRACER_OUTPUT_FORMAT", "text")
-    output_boundary.install_cli_observability_adapters()
+    output_boundary.install_product_adapters()
 
     tracker = get_progress_tracker()
     tracker.start("extract_alert", "Parsing alert payload")
@@ -82,7 +82,7 @@ def test_silence_progress_tracker_blocks_lazy_factory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("TRACER_OUTPUT_FORMAT", "text")
-    output_boundary.install_cli_observability_adapters()
+    output_boundary.install_product_adapters()
 
     silence_progress_tracker()
     tracker = get_progress_tracker()


### PR DESCRIPTION
Fixes #2978 

#### Describe the changes you have made in this PR -

`app/agent/stages/resolve_integrations/node.py` used to import `get_tracer_client_for_org` directly from `app/services/tracer_client/`. That coupled the agent stage to a specific SaaS backend (Tracer
Cloud) and meant headless tests, alternate hosting backends, or local-only runs couldn't substitute a different remote-integrations source without monkey-patching.

This PR introduces a port — `app/integrations/port.py` — that core depends on. The Tracer-specific client wraps as an adapter at the boundary. Same Ports & Adapters pattern as `build_upstream_evidence_provider` and `set_progress_tracker_factory`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**New port — `app/integrations/port.py`:**

- `RemoteIntegrationsFetcher` Callable type
- `fetch_remote_integrations(*, org_id, auth_token)` — public entry point delegating to the registered fetcher
- `set_remote_integrations_fetcher(fn)` — boundary injection
- Default fetcher returns `[]` so `resolve_integrations` falls through to local-store sources naturally — no scaffolding needed for "is the remote source configured?"

**New adapter — `app/services/tracer_client/integrations_adapter.py`:**

One-line wrapper around `get_tracer_client_for_org(...).get_all_integrations()`. Lives in the Tracer service package, not core, so the Tracer-specific dependency stays inside the Tracer integration package.

**Boundary wiring update — `app/cli/interactive_shell/ui/output/boundary.py`:**

`install_product_adapters` (renamed from `install_cli_observability_adapters`, see below) now also registers the Tracer adapter. Called from all three entry points: CLI, MCP, remote server.

**Migrated `app/agent/stages/resolve_integrations/node.py`:**

Both `from app.services.tracer_client import get_tracer_client_for_org` function-local imports replaced with `from app.integrations.port import fetch_remote_integrations`. The `try/except` + local fallback structure is preserved.

**Extended layering test — `tests/test_core_layering.py`:**

`_FORBIDDEN_PREFIXES` now includes `app.services.tracer_client` alongside `app.cli` (from #35). 86 core modules in `app/agent/`, `app/pipeline/`, `app/utils/` — all clean of both prefixes.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
