### PR TITLE
fix(cli): distinguish repeated tool-gathering progress lines

### DIFF
--- a/app/cli/interactive_shell/chat/tool_gathering.py
+++ b/app/cli/interactive_shell/chat/tool_gathering.py
@@ -106,10 +106,11 @@ def _format_gathering_progress_line(
     call_display = f"{source} · {label}" if label else source
     if repeat_index > 1:
         call_display = f"{call_display} ({repeat_index})"
+    safe_display = escape(call_display)
     hint = _tool_input_hint(tool_input)
     if hint:
-        return f"· gathering via {call_display} — {escape(hint)}…"
-    return f"· gathering via {call_display}…"
+        return f"· gathering via {safe_display} — {escape(hint)}…"
+    return f"· gathering via {safe_display}…"
 
 
 def _resolve_session_integrations(session: ReplSession) -> dict[str, Any]:

--- a/app/cli/interactive_shell/chat/tool_gathering.py
+++ b/app/cli/interactive_shell/chat/tool_gathering.py
@@ -32,6 +32,7 @@ from app.agent.utils.alert_source import SECONDARY_TOOL_SOURCES
 from app.cli.interactive_shell.error_handling.exception_reporting import report_exception
 from app.cli.interactive_shell.runtime.session import ReplSession
 from app.cli.interactive_shell.ui import DIM
+from app.cli.interactive_shell.ui.output.tool_details import tool_short_label, tool_source_label
 
 # Keep the gathering loop short: this runs inline on a REPL turn, so it must stay
 # responsive. A handful of iterations is enough to fetch the data needed to
@@ -42,6 +43,73 @@ _MAX_GATHER_ITERATIONS = 4
 # assistant must summarize.
 _MAX_OBSERVATION_CHARS = 12_000
 _MAX_PER_TOOL_CHARS = 4_000
+
+# Keys most likely to distinguish back-to-back calls to the same tool.
+_GATHER_INPUT_HINT_KEYS: tuple[str, ...] = (
+    "metric_name",
+    "query",
+    "search",
+    "filter",
+    "expression",
+    "promql",
+    "service_name",
+    "owner",
+    "repo",
+    "log_group",
+    "monitor_id",
+    "alert_id",
+    "issue_id",
+    "trace_id",
+    "span_id",
+    "dashboard_uid",
+    "panel_id",
+    "from",
+    "to",
+    "time_range",
+)
+
+
+def _truncate_hint(text: str, *, max_len: int = 48) -> str:
+    compact = " ".join(text.split())
+    if len(compact) <= max_len:
+        return compact
+    return f"{compact[: max_len - 1]}…"
+
+
+def _tool_input_hint(tool_input: Any) -> str:
+    if not isinstance(tool_input, dict):
+        return ""
+    hints: list[str] = []
+    seen: set[str] = set()
+    for key in _GATHER_INPUT_HINT_KEYS:
+        value = tool_input.get(key)
+        if value in (None, "", [], {}):
+            continue
+        rendered = _truncate_hint(str(value))
+        if not rendered or rendered in seen:
+            continue
+        seen.add(rendered)
+        hints.append(rendered)
+        if len(hints) >= 2:
+            break
+    return " · ".join(hints)
+
+
+def _format_gathering_progress_line(
+    tool_name: str,
+    tool_input: Any,
+    *,
+    repeat_index: int,
+) -> str:
+    source = tool_source_label(tool_name)
+    label = tool_short_label(tool_name, source)
+    call_display = f"{source} · {label}" if label else source
+    if repeat_index > 1:
+        call_display = f"{call_display} ({repeat_index})"
+    hint = _tool_input_hint(tool_input)
+    if hint:
+        return f"· gathering via {call_display} — {escape(hint)}…"
+    return f"· gathering via {call_display}…"
 
 
 def _resolve_session_integrations(session: ReplSession) -> dict[str, Any]:
@@ -163,11 +231,18 @@ def gather_tool_evidence(
             report_exception(exc, context="interactive_shell.tool_gathering.client", expected=True)
             return None
 
+        tool_call_counts: dict[str, int] = {}
+
         def _on_event(kind: str, data: dict[str, Any]) -> None:
             if kind == "tool_start":
-                console.print(
-                    f"[{DIM}]· gathering data via {escape(str(data.get('name', '')))}…[/]"
+                name = str(data.get("name", "")).strip() or "tool"
+                tool_call_counts[name] = tool_call_counts.get(name, 0) + 1
+                line = _format_gathering_progress_line(
+                    name,
+                    data.get("input"),
+                    repeat_index=tool_call_counts[name],
                 )
+                console.print(f"[{DIM}]{line}[/]")
 
         result = run_tool_calling_loop(
             llm=llm,

--- a/docs/interactive-shell-assistant.mdx
+++ b/docs/interactive-shell-assistant.mdx
@@ -11,13 +11,13 @@ This happens automatically. You do not run a slash command or pick a tool — ju
 
 ```text
 > can you check the github issues for the windows crashes?
-· gathering data via search_github_issues…
+· gathering via GitHub · search issues — windows crashes…
 There are 3 open issues mentioning Windows crashes. The most recent, #482
 "App crashes on launch (Windows 11)", reports a startup segfault after the
 2.4.0 update and has 6 reactions…
 ```
 
-The dim `· gathering data via <tool>…` line shows which integration the assistant reached for while it works.
+The dim `· gathering via <source> · <tool> — <query hint>…` line shows which integration the assistant reached for while it works. When the same tool runs more than once, a `(2)`, `(3)`, … suffix and the query hint distinguish each call.
 
 More questions that trigger live gathering:
 

--- a/docs/interactive-shell-assistant.mdx
+++ b/docs/interactive-shell-assistant.mdx
@@ -3,7 +3,7 @@ title: 'Assistant with Connected Tools'
 description: 'How the interactive shell assistant pulls live data from your connected integrations to answer free-form questions'
 ---
 
-When you ask the OpenSRE interactive shell a free-form question, the assistant can pull **live data from your connected integrations** before answering — instead of replying from text alone. If a question is answerable from an integration you have configured (GitHub, Datadog, Sentry, Grafana, cloud APIs, and more), the assistant transparently calls the same tools the investigation pipeline uses, gathers the results, and answers from that real data.
+When you ask the OpenSRE interactive shell a free-form question, the assistant can pull **live data from your connected integrations** before answering — instead of replying from text alone. If a question is answerable from an integration you have configured (GitHub, Datadog, Sentry, Grafana, cloud services, and more), the assistant transparently calls the same tools the investigation pipeline uses, gathers the results, and answers from that real data.
 
 This happens automatically. You do not run a slash command or pick a tool — just describe what you want to know.
 
@@ -23,7 +23,7 @@ More questions that trigger live gathering:
 
 | You ask | The assistant gathers from |
 | --- | --- |
-| "check the github issues for the windows crashes" | GitHub issues |
+| "check the GitHub issues for the Windows crashes" | GitHub issues |
 | "what do the datadog logs say about the payment service?" | Datadog logs |
 | "are there recent Sentry errors on checkout?" | Sentry |
 | "what's the recent error rate in grafana for prod-api?" | Grafana |

--- a/tests/cli/interactive_shell/chat/test_tool_gathering.py
+++ b/tests/cli/interactive_shell/chat/test_tool_gathering.py
@@ -17,7 +17,11 @@ from rich.console import Console
 import app.agent.stages.investigate.tools as investigate_tools
 import app.agent.tool_loop as tool_loop
 import app.services.agent_llm_client as agent_llm_client
-from app.cli.interactive_shell.chat.tool_gathering import gather_tool_evidence
+from app.cli.interactive_shell.chat.tool_gathering import (
+    _format_gathering_progress_line,
+    _tool_input_hint,
+    gather_tool_evidence,
+)
 from app.cli.interactive_shell.runtime.session import ReplSession
 
 
@@ -126,3 +130,64 @@ def test_exception_path_returns_none(monkeypatch: Any) -> None:
     monkeypatch.setattr(agent_llm_client, "get_agent_llm", _boom)
 
     assert gather_tool_evidence("any question", session, _console()) is None
+
+
+def test_tool_input_hint_prefers_distinguishing_fields() -> None:
+    hint = _tool_input_hint(
+        {
+            "grafana_endpoint": "https://example.grafana.net",
+            "metric_name": "sum(rate(http_requests_total[5m]))",
+            "service_name": "checkout-api",
+        }
+    )
+    assert hint == "sum(rate(http_requests_total[5m])) · checkout-api"
+
+
+def test_format_gathering_progress_line_shows_repeat_index_and_hint() -> None:
+    line = _format_gathering_progress_line(
+        "query_grafana_metrics",
+        {"metric_name": "pipeline_runs_total"},
+        repeat_index=2,
+    )
+    assert line.startswith("· gathering via Grafana · Mimir (2) — pipeline_runs_total…")
+
+
+def test_gathering_progress_lines_print_on_tool_start(monkeypatch: Any) -> None:
+    session = ReplSession()
+    session.resolved_integrations_cache = {}
+    console = _console()
+
+    monkeypatch.setattr(
+        investigate_tools,
+        "get_available_tools",
+        lambda _resolved: [_DummyTool("query_grafana_metrics", source="grafana")],
+    )
+    monkeypatch.setattr(agent_llm_client, "get_agent_llm", object)
+
+    def _fake_loop(**kwargs: Any) -> tool_loop.ToolLoopResult:
+        on_event = kwargs.get("on_event")
+        if on_event is not None:
+            on_event(
+                "tool_start",
+                {
+                    "id": "t1",
+                    "name": "query_grafana_metrics",
+                    "input": {"metric_name": "pipeline_runs_total"},
+                },
+            )
+            on_event(
+                "tool_start",
+                {
+                    "id": "t2",
+                    "name": "query_grafana_metrics",
+                    "input": {"metric_name": "http_errors_total"},
+                },
+            )
+        return tool_loop.ToolLoopResult(messages=[], final_text="", executed=[])
+
+    monkeypatch.setattr(tool_loop, "run_tool_calling_loop", _fake_loop)
+
+    gather_tool_evidence("check metrics", session, console)
+    output = console.file.getvalue()
+    assert "Grafana · Mimir — pipeline_runs_total" in output
+    assert "Grafana · Mimir (2) — http_errors_total" in output

--- a/tests/cli/interactive_shell/chat/test_tool_gathering.py
+++ b/tests/cli/interactive_shell/chat/test_tool_gathering.py
@@ -152,6 +152,31 @@ def test_format_gathering_progress_line_shows_repeat_index_and_hint() -> None:
     assert line.startswith("· gathering via Grafana · Mimir (2) — pipeline_runs_total…")
 
 
+def test_format_gathering_progress_line_escapes_display_and_hint_markup(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.chat.tool_gathering.tool_source_label",
+        lambda _name: "Grafana [prod]",
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.chat.tool_gathering.tool_short_label",
+        lambda _name, _source: "Mimir",
+    )
+
+    line = _format_gathering_progress_line(
+        "query_grafana_metrics",
+        {"metric_name": "[critical] rate[5m]"},
+        repeat_index=1,
+    )
+    console = _console()
+    console.print(f"[dim]{line}[/]")
+
+    output = console.file.getvalue()
+    assert "Grafana [prod]" in output
+    assert "[critical] rate[5m]" in output
+
+
 def test_gathering_progress_lines_print_on_tool_start(monkeypatch: Any) -> None:
     session = ReplSession()
     session.resolved_integrations_cache = {}


### PR DESCRIPTION
## Summary
- Replace raw tool-name gathering progress lines with human-readable integration labels (e.g. `Grafana · Mimir`).
- Add query hints from distinguishing tool arguments (`metric_name`, `query`, `service_name`, etc.).
- Add a repeat index suffix when the same tool runs multiple times in one turn.

Fixes #2984

## Test plan
- [x] `uv run python -m pytest tests/cli/interactive_shell/chat/test_tool_gathering.py -q`
- [ ] In the REPL, ask a broad question that triggers multiple calls to the same integration tool and confirm each progress line is distinct.