### PR TITLE
fix(cli): show lap and prior tools in investigation progress hints

### DIFF
--- a/app/cli/ui/renderer/formatting.py
+++ b/app/cli/ui/renderer/formatting.py
@@ -4,7 +4,55 @@ from __future__ import annotations
 
 import math
 import re
+from collections.abc import Sequence
 from typing import Any
+
+from app.constants.investigation import MAX_INVESTIGATION_LOOPS
+
+
+def format_prior_tools_clause(
+    tools: Sequence[str],
+    *,
+    max_tools: int = 3,
+) -> str:
+    """Appendix naming tools gathered since the previous LLM lap."""
+    if not tools:
+        return ""
+    labels: list[str] = []
+    counts: dict[str, int] = {}
+    for label in tools:
+        stripped = label.strip()
+        if not stripped:
+            continue
+        counts[stripped] = counts.get(stripped, 0) + 1
+        if stripped not in labels:
+            labels.append(stripped)
+    if not labels:
+        return ""
+    rendered = [
+        f"{label} x{counts[label]}" if counts[label] > 1 else label for label in labels[:max_tools]
+    ]
+    suffix = ", ..." if len(labels) > max_tools else ""
+    return f" after {', '.join(rendered)}{suffix}"
+
+
+def investigation_llm_progress_hint(
+    iteration: int,
+    *,
+    max_loops: int = MAX_INVESTIGATION_LOOPS,
+    prior_tools: Sequence[str] | None = None,
+) -> str:
+    """Human-readable status for one investigation-agent LLM lap.
+
+    Each ``llm_start`` event maps to one ReAct think step: the model reads
+    accumulated alert + tool evidence and either requests more tools or stops.
+    """
+    lap = iteration + 1
+    cap = f"lap {lap}/{max_loops}"
+    tools_clause = format_prior_tools_clause(prior_tools or ())
+    if iteration == 0:
+        return f"Planning investigation ({cap}){tools_clause}"
+    return f"Reviewing evidence ({cap}){tools_clause}"
 
 
 def _clean_markdown_line(line: str) -> str:

--- a/app/cli/ui/renderer/renderer.py
+++ b/app/cli/ui/renderer/renderer.py
@@ -28,7 +28,7 @@ from app.cli.ui.renderer.constants import (
     _render_source,
 )
 from app.cli.ui.renderer.diagnose import _DiagnoseStreamRenderer
-from app.cli.ui.renderer.formatting import _validity_score_percent
+from app.cli.ui.renderer.formatting import _validity_score_percent, investigation_llm_progress_hint
 from app.cli.ui.renderer.terminal import _print_connection_banner, _print_info
 from app.cli.ui.renderer.tools import (
     _tool_event_key,
@@ -75,6 +75,7 @@ class StreamRenderer:
         self._printed_tool_detail_ids: set[int] = set()
         self._tool_summary_counts: dict[str, dict[str, int]] = {}
         self._tool_summary_order: list[tuple[str, str]] = []
+        self._prior_lap_tools: list[str] = []
         self._toggle_watcher: CtrlOToggleWatcher | None = None
         self._toggle_unregister: Callable[[], None] | None = None
 
@@ -282,8 +283,10 @@ class StreamRenderer:
                 self._mark_node_seen(canonical)
                 self._tracker.start(canonical)
                 if canonical == "investigation_agent":
+                    self._prior_lap_tools = []
                     # Prime the Live spinner subtext; hint line printed on first llm_start.
-                    self._tracker.update_subtext(canonical, "analyzing alert ·", duration=300.0)
+                    primed = investigation_llm_progress_hint(0)
+                    self._tracker.update_subtext(canonical, f"{primed} ·", duration=300.0)
             return
 
         if kind in _NODE_END_KINDS and self._is_graph_node_event(event):
@@ -340,13 +343,22 @@ class StreamRenderer:
             print_tool_call_line = getattr(self._tracker, "print_tool_call_line", None)
             if callable(print_tool_call_line):
                 print_tool_call_line(name, elapsed_ms)
+        if self._active_node == "investigation_agent":
+            self._prior_lap_tools.append(display)
 
     def _handle_llm_start(self, event: StreamEvent) -> None:
         if self._active_node != "investigation_agent":
             return
         iteration = event.data.get("iteration", 0)
+        if not isinstance(iteration, int):
+            iteration = 0
+        base = investigation_llm_progress_hint(
+            iteration,
+            prior_tools=self._prior_lap_tools,
+        )
+        self._prior_lap_tools = []
         dots = "·" * ((iteration % 3) + 1)
-        hint = f"analyzing alert {dots}" if iteration == 0 else f"analyzing results {dots}"
+        hint = f"{base} {dots}"
         self._tracker.update_subtext(self._active_node, hint, duration=300.0)
         self._tracker.print_status_hint(hint)
 

--- a/tests/cli/ui/test_renderer_formatting.py
+++ b/tests/cli/ui/test_renderer_formatting.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from app.cli.ui.renderer.formatting import (
+    format_prior_tools_clause,
+    investigation_llm_progress_hint,
+)
+
+
+def test_investigation_llm_progress_hint_first_lap() -> None:
+    assert investigation_llm_progress_hint(0, max_loops=20) == "Planning investigation (lap 1/20)"
+
+
+def test_investigation_llm_progress_hint_later_laps() -> None:
+    assert investigation_llm_progress_hint(1, max_loops=20) == "Reviewing evidence (lap 2/20)"
+    assert investigation_llm_progress_hint(4, max_loops=20) == "Reviewing evidence (lap 5/20)"
+
+
+def test_investigation_llm_progress_hint_includes_prior_tools() -> None:
+    hint = investigation_llm_progress_hint(
+        2,
+        max_loops=20,
+        prior_tools=["Datadog Logs", "Grafana Metrics"],
+    )
+    assert hint == "Reviewing evidence (lap 3/20) after Datadog Logs, Grafana Metrics"
+
+
+def test_format_prior_tools_clause_dedupes_and_counts() -> None:
+    clause = format_prior_tools_clause(
+        ["Datadog Logs", "Datadog Logs", "Grafana Metrics"],
+    )
+    assert clause == " after Datadog Logs x2, Grafana Metrics"
+
+
+def test_format_prior_tools_clause_truncates_long_lists() -> None:
+    clause = format_prior_tools_clause(
+        ["Tool A", "Tool B", "Tool C", "Tool D"],
+        max_tools=2,
+    )
+    assert clause == " after Tool A, Tool B, ..."


### PR DESCRIPTION
## Summary

- Replace vague repeated `analyzing results` INVEST progress lines with numbered ReAct laps (`Planning investigation (lap 1/20)`, `Reviewing evidence (lap 3/20)`, …).
- Append the tools gathered since the previous LLM turn (seed + agent calls), e.g. `after Datadog Logs, Grafana Metrics`.
- Track completed tool display names in `StreamRenderer` between `llm_start` events.

Fixes #2988

## Test plan

- [x] `uv run python -m pytest tests/cli/ui/test_renderer_formatting.py -q`
- [ ] Run a sample alert in the REPL and confirm each INVEST hint shows lap number and prior tools
- [ ] Run `opensre investigate --sample` on a TTY and confirm non-REPL progress subtext uses the same labels