### PR TITLE
fix(routing): drop $ / from scenario 320 oracle contract

### DIFF
--- a/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/320-priority-prompt-connected-services.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/320-priority-prompt-connected-services.yml
@@ -2,7 +2,7 @@ id: 320-priority-prompt-connected-services
 title: Priority prompt — show connected services
 intent_class: complex_shell_prompts
 input:
-  prompt: show me connected services
+  prompt: 'show me connected services'
 session:
   has_prior_state: false
   configured_integrations:

--- a/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/320-priority-prompt-connected-services.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/320-priority-prompt-connected-services.yml
@@ -43,7 +43,6 @@ response_contract:
   - services
   - ran /integrations list
   must_not_contain:
-  - $ /
   - can't help
   - cannot help
   - I can't help


### PR DESCRIPTION
## Summary
- Remove `$ /` from `must_not_contain` in routing scenario **320** (`show me connected services`).
- Scenario executes `/integrations list`, which always prints a `$ /integrations list` line; forbidding `$ /` caused live oracle false failures.
- Aligns with **201-show-connected-services**, which uses an empty `must_not_contain` for the same executing slash path.

Follow-up to #2982 / #2974 priority-prompt routing scenarios.

## Test plan
- [x] `uv run python -m pytest app/cli/interactive_shell/routing/tests/test_routing_fixture_integrity.py::test_executes_terminal_action_invariants`
- [ ] Live oracle: `uv run python -m pytest app/cli/interactive_shell/routing/tests/test_routing_scenarios.py -k 320-priority-prompt-connected-services`