### PR TITLE
fix: add OCI labels and use PORT env var in health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@
 
 FROM python:3.12-slim
 
+LABEL org.opencontainers.image.source="https://github.com/Tracer-Cloud/opensre"
+LABEL org.opencontainers.image.description="OpenSRE - Build Your Own AI SRE Agents"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
 WORKDIR /app
 
 RUN apt-get update \
@@ -25,6 +29,6 @@ ENV PORT=8000
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=5)" || exit 1
+    CMD python -c "import urllib.request, os; port = os.environ.get('PORT', '8000'); urllib.request.urlopen(f'http://127.0.0.1:{port}/health', timeout=5)" || exit 1
 
 CMD ["sh", "-c", "exec uvicorn app.webapp:app --host 0.0.0.0 --port ${PORT:-8000}"]


### PR DESCRIPTION
## Summary

Minor Dockerfile improvements:

1. **OCI labels** — Added `org.opencontainers.image.source`, `description`, and `licenses` for container metadata
2. **Health check fix** — Now reads `PORT` from the environment variable (default 8000) instead of hardcoding 8000, so it works correctly regardless of runtime port config

### Testing

Config-only change; no behavioral impact on default usage.