### PR TITLE
Refactor: slice TypedDicts and single schema source

### DIFF
--- a/app/state/__init__.py
+++ b/app/state/__init__.py
@@ -1,11 +1,23 @@
 """Agent state definitions — types, state shape, and factory functions."""
 
-from app.state.agent_state import AgentState, AgentStateModel, InvestigationState
-from app.state.factory import (
-    STATE_DEFAULTS,
-    make_agent_incident_state,
-    make_chat_state,
-    make_initial_state,
+from app.state.agent_state import (
+    AgentState,
+    AgentStateModel,
+    InvestigationState,
+    model_default_payload,
+)
+from app.state.factory import make_agent_incident_state, make_chat_state, make_initial_state
+from app.state.slices import (
+    AlertInputSlice,
+    ChatStateSlice,
+    DeliveryContextSlice,
+    DeliveryOutputSlice,
+    DiagnosisSlice,
+    EvalHarnessSlice,
+    InvestigationPlanSlice,
+    InvestigationRuntimeSlice,
+    MaskingSlice,
+    SessionContext,
 )
 from app.state.types import AgentMode, ChatMessage, ChatMessageModel
 
@@ -13,11 +25,21 @@ __all__ = [
     "AgentMode",
     "AgentState",
     "AgentStateModel",
+    "AlertInputSlice",
     "ChatMessage",
     "ChatMessageModel",
+    "ChatStateSlice",
+    "DeliveryContextSlice",
+    "DeliveryOutputSlice",
+    "DiagnosisSlice",
+    "EvalHarnessSlice",
+    "InvestigationPlanSlice",
+    "InvestigationRuntimeSlice",
     "InvestigationState",
-    "STATE_DEFAULTS",
+    "MaskingSlice",
+    "SessionContext",
     "make_agent_incident_state",
     "make_chat_state",
     "make_initial_state",
+    "model_default_payload",
 ]

--- a/app/state/agent_state.py
+++ b/app/state/agent_state.py
@@ -1,9 +1,12 @@
 """AgentState TypedDict and its Pydantic validator model.
 
-WARNING — drift risk: AgentState (TypedDict) and AgentStateModel (Pydantic) must
-stay in sync.  Whenever you add or remove a field in one, do the same in the other.
-The test in tests/app/test_agent_state_sync.py asserts that both definitions share
-the same set of keys and will fail if they diverge.
+``AgentStateModel`` is the single source of truth for field defaults and
+validation. ``AgentState`` composes slice TypedDicts from :mod:`app.state.slices`
+for documentation and stage-level typing; the runtime dict remains flat.
+
+Whenever you add or remove a field, update ``AgentStateModel`` and the
+appropriate slice in ``slices.py``. ``tests/app/test_agent_state_sync.py``
+asserts slice keys and Pydantic fields stay aligned with ``AgentState``.
 """
 
 from __future__ import annotations
@@ -11,138 +14,43 @@ from __future__ import annotations
 from typing import Any
 
 from pydantic import ConfigDict, Field
-from typing_extensions import TypedDict
 
+from app.state.slices import (
+    AlertInputSlice,
+    ChatStateSlice,
+    DeliveryContextSlice,
+    DeliveryOutputSlice,
+    DiagnosisSlice,
+    EvalHarnessSlice,
+    InvestigationPlanSlice,
+    InvestigationRuntimeSlice,
+    MaskingSlice,
+    SessionContext,
+)
 from app.state.types import AgentMode, ChatMessageModel
 from app.strict_config import StrictConfigModel
 from app.types.retrieval import RetrievalControlsMap
 
 
-class AgentState(TypedDict, total=False):
-    """Unified state for chat and investigation modes.
+class AgentState(
+    SessionContext,
+    ChatStateSlice,
+    AlertInputSlice,
+    InvestigationPlanSlice,
+    InvestigationRuntimeSlice,
+    DiagnosisSlice,
+    MaskingSlice,
+    DeliveryContextSlice,
+    DeliveryOutputSlice,
+    EvalHarnessSlice,
+    total=False,
+):
+    """Unified flat state for chat and investigation modes.
 
-    Chat mode: Uses messages for conversation with tools
-    Investigation mode: Uses alert info for automated RCA
+    Chat mode primarily uses ``ChatStateSlice`` + ``SessionContext``.
+    Investigation mode uses alert, plan, runtime, diagnosis, and delivery slices.
+    See :mod:`app.state.slices` for field groupings and stage ownership.
     """
-
-    # Mode selection
-    mode: AgentMode
-    route: str
-
-    # Auth context (from JWT)
-    org_id: str
-    user_id: str
-    user_email: str
-    user_name: str
-    organization_slug: str
-
-    # Chat mode — conversation history
-    messages: list
-
-    # Alert classification
-    is_noise: bool
-
-    # Investigation mode — alert input
-    alert_name: str
-    pipeline_name: str
-    severity: str
-    alert_source: str
-    raw_alert: str | dict[str, Any]
-    alert_json: dict[str, Any]
-
-    # Investigation planning
-    planned_actions: list[str]
-    plan_rationale: str
-    retrieval_controls: RetrievalControlsMap | None
-    available_sources: dict[str, dict]
-    available_action_names: list[str]
-
-    # Tool budget enforcement - caps the number of tools per investigation step
-    tool_budget: int  # Maximum tools to select per step (default: 10)
-
-    # Audit trail for each planning step - records rerouting and budget decisions
-    plan_audit: dict[str, Any]  # Audit data with loop, budget, reroute_reason, etc
-
-    # Resolved integrations (from resolve_integrations node)
-    resolved_integrations: dict[str, Any]
-
-    # Shared context/evidence
-    context: dict[str, Any]
-    evidence: dict[str, Any]
-    correlation: dict[str, Any]
-
-    # Investigation analysis
-    root_cause: str
-    root_cause_category: str
-    validated_claims: list[dict[str, Any]]
-    non_validated_claims: list[dict[str, Any]]
-    validity_score: float
-    investigation_recommendations: list[str]
-    remediation_steps: list[str]
-    investigation_loop_count: int
-    hypotheses: list[str]
-    executed_hypotheses: list[dict[str, Any]]
-    evidence_entries: list[dict[str, Any]]
-    hypothesis_results: list[dict[str, Any]]
-    action_to_run: str
-    investigation_started_at: float
-
-    # Resolved [since, until) time window for the current incident.
-    # Populated by extract_alert from the alert's own timestamps via
-    # ``app.incident_window.resolve_incident_window``. Time-aware tools will
-    # read from this in a follow-up PR; in this PR the field is wired through
-    # state but not yet consumed. ``None`` means extract_alert has not run yet.
-    # Shape: {"_schema_version": int, "since": iso8601, "until": iso8601,
-    #         "source": str, "confidence": float}.
-    incident_window: dict[str, Any] | None
-
-    # Append-only audit trail of windows replaced by ``adapt_window``. Each
-    # entry is the OLD window dict at the moment of replacement, plus
-    # ``replaced_at`` (ISO-8601) and ``replaced_reason`` (e.g.
-    # "expanded:empty_deploy_timeline"). Bounded by
-    # ``app.constants.investigation.MAX_EXPANSIONS`` in the adapt_window rule
-    # layer; the field itself imposes no cap.
-    # ``None`` until the first expansion. Diagnose narratives may cite
-    # this to explain "we tried 120m, found no deploys, widened to 240m".
-    incident_window_history: list[dict[str, Any]] | None
-
-    # Placeholder→original map for reversible infrastructure identifier masking
-    masking_map: dict[str, str]
-
-    # Slack context (when triggered from Slack message)
-    slack_context: dict[str, Any]
-
-    # Discord context (when triggered from Discord interaction)
-    discord_context: dict[str, Any]
-
-    # Telegram context (when triggered from Telegram message)
-    telegram_context: dict[str, Any]
-
-    # WhatsApp context (when triggered from WhatsApp message or override)
-    whatsapp_context: dict[str, Any]
-
-    # Twilio SMS context (recipient override, e.g. {"to": "+1..."})
-    twilio_sms_context: dict[str, Any]
-
-    # OpenClaw context (for write-back targeting / transport overrides)
-    openclaw_context: dict[str, Any]
-
-    # Runtime context (injected from config by inject_auth_node)
-    thread_id: str
-    run_id: str
-    _auth_token: str
-
-    # Outputs
-    slack_message: str
-    problem_md: str
-    summary: str
-    problem_report: dict[str, Any]
-    report: str
-
-    # OpenRCA offline rubric eval (``opensre investigate --evaluate``)
-    opensre_evaluate: bool
-    opensre_eval_rubric: str
-    opensre_llm_eval: dict[str, Any]
 
 
 InvestigationState = AgentState
@@ -217,3 +125,19 @@ class AgentStateModel(StrictConfigModel):
     opensre_evaluate: bool = False
     opensre_eval_rubric: str = ""
     opensre_llm_eval: dict[str, Any] = Field(default_factory=dict)
+
+
+def model_default_payload(*exclude: str) -> dict[str, Any]:
+    """Return default field values from ``AgentStateModel``, omitting ``exclude`` keys."""
+    skip = frozenset(exclude)
+    model = AgentStateModel()
+    dumped = model.model_dump(mode="python", by_alias=True, exclude_none=True)
+    return {key: value for key, value in dumped.items() if key not in skip}
+
+
+__all__ = [
+    "AgentState",
+    "AgentStateModel",
+    "InvestigationState",
+    "model_default_payload",
+]

--- a/app/state/factory.py
+++ b/app/state/factory.py
@@ -9,53 +9,9 @@ from app.integrations.opensre.hf_remote import (
     extract_openrca_scoring_points,
     strip_scoring_points_from_alert,
 )
-from app.state.agent_state import AgentState, AgentStateModel
+from app.state.agent_state import AgentState, AgentStateModel, model_default_payload
 from app.state.types import ChatMessage
 from app.utils.alert_normalization import normalize_alert_payload
-
-STATE_DEFAULTS: dict[str, Any] = {
-    "mode": "chat",
-    "route": "",
-    "is_noise": False,
-    "org_id": "",
-    "user_id": "",
-    "user_email": "",
-    "user_name": "",
-    "organization_slug": "",
-    "messages": [],
-    "planned_actions": [],
-    "plan_rationale": "",
-    "resolved_integrations": {},
-    "available_sources": {},
-    "available_action_names": [],
-    "context": {},
-    "evidence": {},
-    "correlation": {},
-    "root_cause": "",
-    "root_cause_category": "",
-    "validated_claims": [],
-    "non_validated_claims": [],
-    "validity_score": 0.0,
-    "investigation_recommendations": [],
-    "remediation_steps": [],
-    "investigation_loop_count": 0,
-    "hypotheses": [],
-    "executed_hypotheses": [],
-    "evidence_entries": [],
-    "masking_map": {},
-    "slack_context": {},
-    "discord_context": {},
-    "telegram_context": {},
-    "whatsapp_context": {},
-    "twilio_sms_context": {},
-    "openclaw_context": {},
-    "thread_id": "",
-    "run_id": "",
-    "_auth_token": "",
-    "slack_message": "",
-    "problem_md": "",
-    "report": "",
-}
 
 
 def make_initial_state(
@@ -92,6 +48,7 @@ def make_initial_state(
 
     state = AgentStateModel.model_validate(
         {
+            **model_default_payload("mode", "messages"),
             "mode": "investigation",
             "alert_name": alert_name,
             "pipeline_name": pipeline_name,
@@ -100,7 +57,6 @@ def make_initial_state(
             "investigation_started_at": time.monotonic(),
             "opensre_evaluate": opensre_evaluate,
             "opensre_eval_rubric": rubric,
-            **{k: v for k, v in STATE_DEFAULTS.items() if k not in ("mode", "messages")},
         }
     )
     return cast(AgentState, state.model_dump(mode="python", by_alias=True, exclude_none=True))
@@ -183,12 +139,12 @@ def make_agent_incident_state(
     }
     state = AgentStateModel.model_validate(
         {
+            **model_default_payload("mode", "messages", "context"),
             "mode": "agent_incident",
             "raw_alert": {},
             "context": {"agent_incident": payload},
             "investigation_started_at": time.monotonic(),
             "opensre_evaluate": opensre_evaluate,
-            **{k: v for k, v in STATE_DEFAULTS.items() if k not in ("mode", "messages", "context")},
         }
     )
     return cast(AgentState, state.model_dump(mode="python", by_alias=True, exclude_none=True))

--- a/app/state/slices.py
+++ b/app/state/slices.py
@@ -1,0 +1,148 @@
+"""Logical slices of :class:`~app.state.agent_state.AgentState`.
+
+The investigation pipeline still uses one flat runtime dict. These TypedDicts
+document which fields belong together and which stages typically own them.
+
+Stage ownership (typical read/write):
+
+- ``resolve_integrations`` → ``InvestigationRuntimeSlice.resolved_integrations``
+- ``extract_alert`` → ``AlertInputSlice``
+- ``plan_actions`` → ``InvestigationPlanSlice``
+- ``investigate`` → ``InvestigationRuntimeSlice`` (evidence, hypotheses, …)
+- ``diagnose`` → ``DiagnosisSlice``
+- ``deliver`` → ``DeliveryOutputSlice`` (+ reads diagnosis/runtime slices)
+- ``ChatAgent`` → ``ChatStateSlice``, ``SessionContext``
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import TypedDict
+
+from app.state.types import AgentMode
+from app.types.retrieval import RetrievalControlsMap
+
+
+class SessionContext(TypedDict, total=False):
+    """Mode, auth, and run identifiers injected by callers."""
+
+    mode: AgentMode
+    route: str
+    org_id: str
+    user_id: str
+    user_email: str
+    user_name: str
+    organization_slug: str
+    thread_id: str
+    run_id: str
+    _auth_token: str
+
+
+class ChatStateSlice(TypedDict, total=False):
+    """Conversation history for chat mode."""
+
+    messages: list
+
+
+class AlertInputSlice(TypedDict, total=False):
+    """Raw alert input and incident time window (``extract_alert``)."""
+
+    is_noise: bool
+    alert_name: str
+    pipeline_name: str
+    severity: str
+    alert_source: str
+    raw_alert: str | dict[str, Any]
+    alert_json: dict[str, Any]
+    incident_window: dict[str, Any] | None
+    incident_window_history: list[dict[str, Any]] | None
+
+
+class InvestigationPlanSlice(TypedDict, total=False):
+    """Tool plan produced by ``plan_actions``."""
+
+    planned_actions: list[str]
+    plan_rationale: str
+    retrieval_controls: RetrievalControlsMap | None
+    available_sources: dict[str, dict]
+    available_action_names: list[str]
+    tool_budget: int
+    plan_audit: dict[str, Any]
+
+
+class InvestigationRuntimeSlice(TypedDict, total=False):
+    """Integrations, collected evidence, and investigate-loop metadata."""
+
+    resolved_integrations: dict[str, Any]
+    context: dict[str, Any]
+    evidence: dict[str, Any]
+    correlation: dict[str, Any]
+    investigation_loop_count: int
+    hypotheses: list[str]
+    executed_hypotheses: list[dict[str, Any]]
+    evidence_entries: list[dict[str, Any]]
+    hypothesis_results: list[dict[str, Any]]
+    action_to_run: str
+    investigation_started_at: float
+
+
+class DiagnosisSlice(TypedDict, total=False):
+    """Structured RCA output from ``diagnose``."""
+
+    root_cause: str
+    root_cause_category: str
+    validated_claims: list[dict[str, Any]]
+    non_validated_claims: list[dict[str, Any]]
+    validity_score: float
+    investigation_recommendations: list[str]
+    remediation_steps: list[str]
+
+
+class MaskingSlice(TypedDict, total=False):
+    """Reversible infrastructure identifier masking."""
+
+    masking_map: dict[str, str]
+
+
+class DeliveryContextSlice(TypedDict, total=False):
+    """Channel-specific delivery metadata from the triggering surface."""
+
+    slack_context: dict[str, Any]
+    discord_context: dict[str, Any]
+    telegram_context: dict[str, Any]
+    whatsapp_context: dict[str, Any]
+    twilio_sms_context: dict[str, Any]
+    openclaw_context: dict[str, Any]
+
+
+class DeliveryOutputSlice(TypedDict, total=False):
+    """Rendered report artifacts from ``deliver``."""
+
+    slack_message: str
+    problem_md: str
+    summary: str
+    problem_report: dict[str, Any]
+    report: str
+
+
+class EvalHarnessSlice(TypedDict, total=False):
+    """OpenRCA offline evaluation harness fields."""
+
+    opensre_evaluate: bool
+    opensre_eval_rubric: str
+    opensre_llm_eval: dict[str, Any]
+
+
+__all__ = [
+    "AlertInputSlice",
+    "ChatStateSlice",
+    "DeliveryContextSlice",
+    "DeliveryOutputSlice",
+    "DiagnosisSlice",
+    "EvalHarnessSlice",
+    "InvestigationPlanSlice",
+    "InvestigationRuntimeSlice",
+    "MaskingSlice",
+    "SessionContext",
+]

--- a/tests/app/test_agent_state_sync.py
+++ b/tests/app/test_agent_state_sync.py
@@ -1,10 +1,36 @@
-"""Ensure AgentState (TypedDict) and AgentStateModel (Pydantic) stay in sync.
+"""Ensure AgentState slices and AgentStateModel stay in sync.
 
 If this test fails, a field was added/removed in one definition but not the other.
-Fix the drift by updating both classes in app/state/agent_state.py.
+Fix drift by updating ``AgentStateModel`` and the matching slice in
+``app/state/slices.py``.
 """
 
 from app.state.agent_state import AgentState, AgentStateModel
+from app.state.slices import (
+    AlertInputSlice,
+    ChatStateSlice,
+    DeliveryContextSlice,
+    DeliveryOutputSlice,
+    DiagnosisSlice,
+    EvalHarnessSlice,
+    InvestigationPlanSlice,
+    InvestigationRuntimeSlice,
+    MaskingSlice,
+    SessionContext,
+)
+
+_SLICE_TYPES: tuple[type, ...] = (
+    SessionContext,
+    ChatStateSlice,
+    AlertInputSlice,
+    InvestigationPlanSlice,
+    InvestigationRuntimeSlice,
+    DiagnosisSlice,
+    MaskingSlice,
+    DeliveryContextSlice,
+    DeliveryOutputSlice,
+    EvalHarnessSlice,
+)
 
 
 def _typed_dict_keys(td: type) -> set[str]:
@@ -24,6 +50,29 @@ def _pydantic_keys(model: type) -> set[str]:
     return keys
 
 
+def _slice_keys() -> set[str]:
+    keys: set[str] = set()
+    for slice_type in _SLICE_TYPES:
+        keys.update(_typed_dict_keys(slice_type))
+    return keys
+
+
+def test_slices_cover_agent_state_keys() -> None:
+    """Every AgentState key must be declared on exactly one slice TypedDict."""
+    agent_keys = _typed_dict_keys(AgentState)
+    slice_keys = _slice_keys()
+
+    only_in_agent = agent_keys - slice_keys
+    only_in_slices = slice_keys - agent_keys
+
+    assert not only_in_agent, (
+        f"Fields on AgentState but missing from slice TypedDicts: {sorted(only_in_agent)}"
+    )
+    assert not only_in_slices, (
+        f"Fields on slice TypedDicts but missing from AgentState: {sorted(only_in_slices)}"
+    )
+
+
 def test_agent_state_and_model_share_same_keys() -> None:
     """AgentState and AgentStateModel must declare exactly the same set of field keys."""
     typed_dict_keys = _typed_dict_keys(AgentState)
@@ -40,3 +89,17 @@ def test_agent_state_and_model_share_same_keys() -> None:
         f"Fields present in AgentStateModel (Pydantic) but missing from AgentState: "
         f"{sorted(only_in_pydantic)}"
     )
+
+
+def test_slice_types_do_not_duplicate_keys() -> None:
+    """Each field belongs to one slice — no duplicate declarations across slices."""
+    seen: dict[str, str] = {}
+    duplicates: list[str] = []
+    for slice_type in _SLICE_TYPES:
+        for key in _typed_dict_keys(slice_type):
+            if key in seen:
+                duplicates.append(f"{key!r} on {slice_type.__name__} and {seen[key]}")
+            else:
+                seen[key] = slice_type.__name__
+
+    assert not duplicates, "Duplicate slice keys: " + "; ".join(duplicates)


### PR DESCRIPTION
## Summary
- Add `app/state/slices.py` with named TypedDict slices (`SessionContext`, `AlertInputSlice`, `InvestigationPlanSlice`, etc.) documenting stage ownership
- Compose `AgentState` from slice types (runtime dict stays flat)
- Remove duplicated `STATE_DEFAULTS`; factories use `model_default_payload()` from `AgentStateModel`
- Extend sync tests to verify slices cover all keys with no duplicates

Fixes #3000

## Test plan
- [x] `uv run python -m pytest tests/app/test_agent_state_sync.py tests/test_state.py -q`
- [x] `make lint`
- [x] `make typecheck`


Made with [Cursor](https://cursor.com)