### PR TITLE
fix(repl): warm integration configs silently at startup

### DIFF
--- a/app/agent/stages/resolve_integrations/__init__.py
+++ b/app/agent/stages/resolve_integrations/__init__.py
@@ -7,6 +7,9 @@ Node contract:
     Writes     : resolved_integrations
 """
 
-from app.agent.stages.resolve_integrations.node import resolve_integrations
+from app.agent.stages.resolve_integrations.node import (
+    resolve_integrations,
+    resolve_integrations_quiet,
+)
 
-__all__ = ["resolve_integrations"]
+__all__ = ["resolve_integrations", "resolve_integrations_quiet"]

--- a/app/agent/stages/resolve_integrations/node.py
+++ b/app/agent/stages/resolve_integrations/node.py
@@ -32,16 +32,22 @@ def resolve_integrations(state: InvestigationState) -> dict[str, Any]:
     Reads  : _auth_token, org_id, resolved_integrations (idempotency guard)
     Writes : resolved_integrations
     """
-    return {"resolved_integrations": _resolve(state)}
+    return {"resolved_integrations": _resolve(state, emit_progress=True)}
 
 
-def _resolve(state: InvestigationState) -> dict[str, Any]:
+def resolve_integrations_quiet(state: InvestigationState) -> dict[str, Any]:
+    """Like :func:`resolve_integrations` but without progress-tracker UI."""
+    return _resolve(state, emit_progress=False)
+
+
+def _resolve(state: InvestigationState, *, emit_progress: bool) -> dict[str, Any]:
     """Return the raw integrations dict (keyed by vendor name)."""
     if state.get("resolved_integrations"):
         return dict(state["resolved_integrations"])
 
-    tracker = get_tracker()
-    tracker.start("resolve_integrations", "Fetching org integrations")
+    tracker = get_tracker() if emit_progress else None
+    if tracker is not None:
+        tracker.start("resolve_integrations", "Fetching org integrations")
 
     org_id = state.get("org_id", "")
     auth_token = _strip_bearer((state.get("_auth_token", "") or "").strip())
@@ -51,7 +57,11 @@ def _resolve(state: InvestigationState) -> dict[str, Any]:
             org_id = _decode_org_id_from_token(auth_token)
         if not org_id:
             logger.warning("_auth_token present but could not decode org_id")
-            tracker.complete("resolve_integrations", fields_updated=["resolved_integrations"])
+            _complete_tracker(
+                tracker,
+                "resolve_integrations",
+                fields_updated=["resolved_integrations"],
+            )
             return {}
         try:
             from app.integrations.port import fetch_remote_integrations
@@ -59,7 +69,11 @@ def _resolve(state: InvestigationState) -> dict[str, Any]:
             all_integrations = fetch_remote_integrations(org_id=org_id, auth_token=auth_token)
         except Exception as exc:
             logger.warning("Remote integrations fetch failed: %s", exc)
-            tracker.complete("resolve_integrations", fields_updated=["resolved_integrations"])
+            _complete_tracker(
+                tracker,
+                "resolve_integrations",
+                fields_updated=["resolved_integrations"],
+            )
             return {}
         resolved = _classify_integrations(all_integrations)
         _log_resolved(tracker, resolved)
@@ -87,9 +101,15 @@ def _resolve(state: InvestigationState) -> dict[str, Any]:
     return _resolve_from_local_sources(tracker)
 
 
-def _log_resolved(tracker: Any, resolved: dict[str, Any]) -> None:
+def _complete_tracker(tracker: Any | None, node_name: str, **kwargs: Any) -> None:
+    if tracker is not None:
+        tracker.complete(node_name, **kwargs)
+
+
+def _log_resolved(tracker: Any | None, resolved: dict[str, Any]) -> None:
     services = [s for s in resolved if s != "_all"]
-    tracker.complete(
+    _complete_tracker(
+        tracker,
         "resolve_integrations",
         fields_updated=["resolved_integrations"],
         message=f"Resolved integrations: {services}"
@@ -98,14 +118,15 @@ def _log_resolved(tracker: Any, resolved: dict[str, Any]) -> None:
     )
 
 
-def _resolve_from_local_sources(tracker: Any) -> dict[str, Any]:
+def _resolve_from_local_sources(tracker: Any | None) -> dict[str, Any]:
     from app.integrations.store import STORE_PATH, load_integrations
 
     store_integrations = load_integrations()
     env_integrations = _load_env_integrations() if not store_integrations else []
     integrations = _merge_local_integrations(store_integrations, env_integrations)
     if not integrations:
-        tracker.complete(
+        _complete_tracker(
+            tracker,
             "resolve_integrations",
             fields_updated=["resolved_integrations"],
             message=(
@@ -122,7 +143,8 @@ def _resolve_from_local_sources(tracker: Any) -> dict[str, Any]:
         source_labels.append("store")
     if env_integrations:
         source_labels.append("env")
-    tracker.complete(
+    _complete_tracker(
+        tracker,
         "resolve_integrations",
         fields_updated=["resolved_integrations"],
         message=(
@@ -136,7 +158,7 @@ def _resolve_from_local_sources(tracker: Any) -> dict[str, Any]:
 
 def _resolve_remote_with_local_fallback(
     remote_integrations: list[dict[str, Any]],
-    tracker: Any,
+    tracker: Any | None,
 ) -> dict[str, Any]:
     from app.integrations.store import load_integrations
 
@@ -156,7 +178,8 @@ def _resolve_remote_with_local_fallback(
     if env_integrations:
         source_labels.append("env")
 
-    tracker.complete(
+    _complete_tracker(
+        tracker,
         "resolve_integrations",
         fields_updated=["resolved_integrations"],
         message=(

--- a/app/cli/interactive_shell/chat/tool_gathering.py
+++ b/app/cli/interactive_shell/chat/tool_gathering.py
@@ -120,8 +120,10 @@ def _resolve_session_integrations(session: ReplSession) -> dict[str, Any]:
 
     from app.agent.stages.resolve_integrations import resolve_integrations
 
-    resolved = resolve_integrations({})  # type: ignore[arg-type]  # env/store resolution path
-    session.resolved_integrations_cache = resolved
+    updates = resolve_integrations({})  # type: ignore[arg-type]  # env/store resolution path
+    resolved = dict(updates.get("resolved_integrations") or {})
+    if resolved:
+        session.resolved_integrations_cache = resolved
     return resolved
 
 

--- a/app/cli/interactive_shell/runtime/entrypoint.py
+++ b/app/cli/interactive_shell/runtime/entrypoint.py
@@ -34,7 +34,6 @@ def _hydrate_configured_integrations(session: ReplSession) -> None:
     Best-effort: any failure leaves the session in its default "unknown" state.
     """
     session.hydrate_configured_integrations()
-    session.warm_resolved_integrations()
 
 
 async def repl_main(initial_input: str | None = None, _config: ReplConfig | None = None) -> int:
@@ -46,6 +45,7 @@ async def repl_main(initial_input: str | None = None, _config: ReplConfig | None
     session.prompt_history_backend = pt_session.history
 
     if initial_input:
+        session.warm_resolved_integrations()
         return run_initial_input(initial_input, session)
 
     # Open the session file now that we know this is an interactive REPL run.

--- a/app/cli/interactive_shell/runtime/entrypoint.py
+++ b/app/cli/interactive_shell/runtime/entrypoint.py
@@ -34,6 +34,7 @@ def _hydrate_configured_integrations(session: ReplSession) -> None:
     Best-effort: any failure leaves the session in its default "unknown" state.
     """
     session.hydrate_configured_integrations()
+    session.warm_resolved_integrations()
 
 
 async def repl_main(initial_input: str | None = None, _config: ReplConfig | None = None) -> int:

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -164,6 +164,7 @@ async def run_interactive(
     pt_session: PromptSession[str] | None = None,
     inbox: _alert_inbox.AlertInbox | None = None,
 ) -> None:
+    session.schedule_warm_resolved_integrations()
     if pt_session is None:
         pt_session = _prompt_surface._build_prompt_session(session)
         session.prompt_history_backend = pt_session.history

--- a/app/cli/interactive_shell/runtime/session.py
+++ b/app/cli/interactive_shell/runtime/session.py
@@ -104,6 +104,13 @@ class ReplSession:
     waiting for the first user message to trigger a visible "Loading
     integrations" pass. Cleared by ``refresh_integration_state`` when
     integrations change."""
+    _integration_warm_lock: threading.Lock = field(
+        default_factory=threading.Lock,
+        repr=False,
+        compare=False,
+    )
+    _integration_warm_generation: int = field(default=0, repr=False, compare=False)
+    _integration_warm_task: Any = field(default=None, repr=False, compare=False)
     available_capabilities: dict[str, tuple[str, ...]] = field(default_factory=dict)
     """Optional planning-time capability constraints (slash/cli/synthetic)."""
 
@@ -402,7 +409,7 @@ class ReplSession:
             # Best-effort: keep whatever state we already had (default unknown).
             pass
 
-    def warm_resolved_integrations(self) -> None:
+    def warm_resolved_integrations(self, *, generation: int | None = None) -> None:
         """Resolve full integration configs once, without progress UI.
 
         The banner already shows configured integration names from
@@ -416,22 +423,29 @@ class ReplSession:
         """
         if self.resolved_integrations_cache is not None:
             return
-        try:
-            from app.agent.stages.resolve_integrations import resolve_integrations
-            from app.cli.interactive_shell.ui.output import reset_tracker, set_silent_tracker
-        except Exception:
-            return
+        if generation is None:
+            with self._integration_warm_lock:
+                generation = self._integration_warm_generation
 
         try:
-            set_silent_tracker()
-            updates = resolve_integrations({})  # type: ignore[arg-type]
-            resolved = dict(updates.get("resolved_integrations") or {})
-            if resolved:
-                self.resolved_integrations_cache = resolved
+            from app.agent.stages.resolve_integrations import resolve_integrations_quiet
+
+            resolved = resolve_integrations_quiet({})  # type: ignore[arg-type]
         except Exception:
-            pass
-        finally:
-            reset_tracker()
+            # Best-effort warmup: leave cache unset so later turns can retry.
+            return
+
+        self._store_warm_cache(resolved, generation=generation)
+
+    def _store_warm_cache(self, resolved: dict[str, Any], *, generation: int) -> None:
+        if not resolved:
+            return
+        with self._integration_warm_lock:
+            if generation != self._integration_warm_generation:
+                return
+            if self.resolved_integrations_cache is not None:
+                return
+            self.resolved_integrations_cache = dict(resolved)
 
     def schedule_warm_resolved_integrations(self) -> None:
         """Warm integration configs off the interactive prompt critical path."""
@@ -442,7 +456,25 @@ class ReplSession:
         except RuntimeError:
             self.warm_resolved_integrations()
             return
-        loop.create_task(asyncio.to_thread(self.warm_resolved_integrations))
+
+        with self._integration_warm_lock:
+            if self._integration_warm_task is not None and not self._integration_warm_task.done():
+                return
+            generation = self._integration_warm_generation
+
+        async def _run_warm() -> None:
+            await asyncio.to_thread(self.warm_resolved_integrations, generation=generation)
+
+        task = loop.create_task(_run_warm())
+        with self._integration_warm_lock:
+            self._integration_warm_task = task
+
+        def _clear_warm_task(done_task: asyncio.Task[None]) -> None:
+            with self._integration_warm_lock:
+                if self._integration_warm_task is done_task:
+                    self._integration_warm_task = None
+
+        task.add_done_callback(_clear_warm_task)
 
     def refresh_integration_state(self) -> None:
         """Re-resolve integration state after the local store changes.
@@ -454,7 +486,13 @@ class ReplSession:
         session immediately reflects the change instead of answering from the
         boot-time snapshot.
         """
-        self.resolved_integrations_cache = None
+        with self._integration_warm_lock:
+            self._integration_warm_generation += 1
+            pending = self._integration_warm_task
+            self._integration_warm_task = None
+            self.resolved_integrations_cache = None
+        if pending is not None and not pending.done():
+            pending.cancel()
         self.hydrate_configured_integrations()
         self.warm_resolved_integrations()
 
@@ -481,7 +519,13 @@ class ReplSession:
         self.last_assistant_intent = None
         self.configured_integrations = ()
         self.configured_integrations_known = False
-        self.resolved_integrations_cache = None
+        with self._integration_warm_lock:
+            self._integration_warm_generation += 1
+            pending = self._integration_warm_task
+            self._integration_warm_task = None
+            self.resolved_integrations_cache = None
+        if pending is not None and not pending.done():
+            pending.cancel()
         self.available_capabilities.clear()
         self.accumulated_context.clear()
         self.token_usage.clear()

--- a/app/cli/interactive_shell/runtime/session.py
+++ b/app/cli/interactive_shell/runtime/session.py
@@ -433,6 +433,17 @@ class ReplSession:
         finally:
             reset_tracker()
 
+    def schedule_warm_resolved_integrations(self) -> None:
+        """Warm integration configs off the interactive prompt critical path."""
+        import asyncio
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self.warm_resolved_integrations()
+            return
+        loop.create_task(asyncio.to_thread(self.warm_resolved_integrations))
+
     def refresh_integration_state(self) -> None:
         """Re-resolve integration state after the local store changes.
 

--- a/app/cli/interactive_shell/runtime/session.py
+++ b/app/cli/interactive_shell/runtime/session.py
@@ -97,12 +97,13 @@ class ReplSession:
     configured_integrations_known: bool = False
     """Whether configured_integrations reflects known state (vs default unknown)."""
     resolved_integrations_cache: dict[str, Any] | None = None
-    """Lazily-resolved integration configs (env/store) shared across turns.
+    """Resolved integration configs (env/store) shared across turns.
 
-    Populated on first use by the tool-gathering pass so the conversational
-    assistant can call the same registered tools the investigation uses without
-    re-resolving (and re-rendering progress) every turn. Cleared by
-    ``refresh_integration_state`` when integrations change."""
+    Populated silently at REPL boot and again after integration mutations so the
+    conversational assistant and investigations can call registered tools without
+    waiting for the first user message to trigger a visible "Loading
+    integrations" pass. Cleared by ``refresh_integration_state`` when
+    integrations change."""
     available_capabilities: dict[str, tuple[str, ...]] = field(default_factory=dict)
     """Optional planning-time capability constraints (slash/cli/synthetic)."""
 
@@ -401,6 +402,30 @@ class ReplSession:
             # Best-effort: keep whatever state we already had (default unknown).
             pass
 
+    def warm_resolved_integrations(self) -> None:
+        """Resolve full integration configs once, without progress UI.
+
+        The banner already shows configured integration names from
+        :meth:`hydrate_configured_integrations`; this loads the classified configs
+        the tool-gathering pass and investigation pipeline need so the first
+        conversational turn does not pay resolve cost or emit READ progress.
+        """
+        if self.resolved_integrations_cache is not None:
+            return
+        try:
+            from app.agent.stages.resolve_integrations import resolve_integrations
+            from app.cli.interactive_shell.ui.output import reset_tracker, set_silent_tracker
+
+            set_silent_tracker()
+            try:
+                updates = resolve_integrations({})  # type: ignore[arg-type]
+                self.resolved_integrations_cache = dict(updates.get("resolved_integrations") or {})
+            finally:
+                reset_tracker()
+        except Exception:
+            # Best-effort: tool-gathering will retry on first use if needed.
+            pass
+
     def refresh_integration_state(self) -> None:
         """Re-resolve integration state after the local store changes.
 
@@ -413,6 +438,7 @@ class ReplSession:
         """
         self.resolved_integrations_cache = None
         self.hydrate_configured_integrations()
+        self.warm_resolved_integrations()
 
     def apply_investigation_result(self, state: dict[str, Any]) -> None:
         """Record a completed investigation result and reset follow-up context.

--- a/app/cli/interactive_shell/runtime/session.py
+++ b/app/cli/interactive_shell/runtime/session.py
@@ -409,22 +409,29 @@ class ReplSession:
         :meth:`hydrate_configured_integrations`; this loads the classified configs
         the tool-gathering pass and investigation pipeline need so the first
         conversational turn does not pay resolve cost or emit READ progress.
+
+        Empty resolves are not cached so a later turn can retry if boot-time
+        resolution raced store/env hydration. Failures leave the cache unset for
+        the same reason.
         """
         if self.resolved_integrations_cache is not None:
             return
         try:
             from app.agent.stages.resolve_integrations import resolve_integrations
             from app.cli.interactive_shell.ui.output import reset_tracker, set_silent_tracker
-
-            set_silent_tracker()
-            try:
-                updates = resolve_integrations({})  # type: ignore[arg-type]
-                self.resolved_integrations_cache = dict(updates.get("resolved_integrations") or {})
-            finally:
-                reset_tracker()
         except Exception:
-            # Best-effort: tool-gathering will retry on first use if needed.
+            return
+
+        try:
+            set_silent_tracker()
+            updates = resolve_integrations({})  # type: ignore[arg-type]
+            resolved = dict(updates.get("resolved_integrations") or {})
+            if resolved:
+                self.resolved_integrations_cache = resolved
+        except Exception:
             pass
+        finally:
+            reset_tracker()
 
     def refresh_integration_state(self) -> None:
         """Re-resolve integration state after the local store changes.

--- a/tests/cli/interactive_shell/command_registry/test_integrations_refresh.py
+++ b/tests/cli/interactive_shell/command_registry/test_integrations_refresh.py
@@ -32,6 +32,11 @@ def test_refresh_integration_state_rehydrates_and_clears_cache(monkeypatch: Any)
         "app.integrations.verify.resolve_effective_integrations",
         lambda: {"gitlab": {}, "sentry": {}},
     )
+    refreshed = {"gitlab": {"token": "x"}, "sentry": {"dsn": "y"}}
+    monkeypatch.setattr(
+        "app.agent.stages.resolve_integrations.resolve_integrations",
+        lambda _state: {"resolved_integrations": refreshed},
+    )
     session = ReplSession()
     # Stale boot-time snapshot + a cached resolution from an earlier turn.
     session.configured_integrations = ("gitlab",)
@@ -40,7 +45,7 @@ def test_refresh_integration_state_rehydrates_and_clears_cache(monkeypatch: Any)
 
     session.refresh_integration_state()
 
-    assert session.resolved_integrations_cache is None
+    assert session.resolved_integrations_cache == refreshed
     assert session.configured_integrations_known is True
     assert session.configured_integrations == ("gitlab", "sentry")
 

--- a/tests/cli/interactive_shell/command_registry/test_integrations_refresh.py
+++ b/tests/cli/interactive_shell/command_registry/test_integrations_refresh.py
@@ -34,8 +34,8 @@ def test_refresh_integration_state_rehydrates_and_clears_cache(monkeypatch: Any)
     )
     refreshed = {"gitlab": {"token": "x"}, "sentry": {"dsn": "y"}}
     monkeypatch.setattr(
-        "app.agent.stages.resolve_integrations.resolve_integrations",
-        lambda _state: {"resolved_integrations": refreshed},
+        "app.agent.stages.resolve_integrations.resolve_integrations_quiet",
+        lambda _state: refreshed,
     )
     session = ReplSession()
     # Stale boot-time snapshot + a cached resolution from an earlier turn.

--- a/tests/cli/interactive_shell/runtime/test_entrypoint_integrations.py
+++ b/tests/cli/interactive_shell/runtime/test_entrypoint_integrations.py
@@ -45,8 +45,8 @@ def test_hydrate_marks_known_even_when_none_configured(monkeypatch: Any) -> None
 def test_warm_resolved_integrations_populates_cache(monkeypatch: Any) -> None:
     resolved = {"datadog": {"site": "datadoghq.com"}, "grafana": {"url": "http://localhost"}}
     monkeypatch.setattr(
-        "app.agent.stages.resolve_integrations.resolve_integrations",
-        lambda _state: {"resolved_integrations": resolved},
+        "app.agent.stages.resolve_integrations.resolve_integrations_quiet",
+        lambda _state: resolved,
     )
     session = ReplSession()
     session.warm_resolved_integrations()
@@ -58,10 +58,10 @@ def test_warm_resolved_integrations_is_idempotent(monkeypatch: Any) -> None:
 
     def _resolve(_state: dict[str, Any]) -> dict[str, Any]:
         calls.append("resolve")
-        return {"resolved_integrations": {"github": {}}}
+        return {"github": {}}
 
     monkeypatch.setattr(
-        "app.agent.stages.resolve_integrations.resolve_integrations",
+        "app.agent.stages.resolve_integrations.resolve_integrations_quiet",
         _resolve,
     )
     session = ReplSession()
@@ -75,10 +75,10 @@ def test_warm_resolved_integrations_skips_empty_cache(monkeypatch: Any) -> None:
 
     def _resolve(_state: dict[str, Any]) -> dict[str, Any]:
         calls.append("resolve")
-        return {"resolved_integrations": {}}
+        return {}
 
     monkeypatch.setattr(
-        "app.agent.stages.resolve_integrations.resolve_integrations",
+        "app.agent.stages.resolve_integrations.resolve_integrations_quiet",
         _resolve,
     )
     session = ReplSession()
@@ -88,32 +88,34 @@ def test_warm_resolved_integrations_skips_empty_cache(monkeypatch: Any) -> None:
     assert calls == ["resolve", "resolve"]
 
 
-def test_warm_resolved_integrations_resets_tracker_on_resolve_failure(
-    monkeypatch: Any,
-) -> None:
-    resets: list[str] = []
-
-    def _resolve(_state: dict[str, Any]) -> dict[str, Any]:
-        raise RuntimeError("resolve failed")
+def test_warm_resolved_integrations_uses_quiet_resolve(monkeypatch: Any) -> None:
+    progress_calls: list[str] = []
+    quiet_calls: list[str] = []
 
     monkeypatch.setattr(
         "app.agent.stages.resolve_integrations.resolve_integrations",
-        _resolve,
+        lambda _state: progress_calls.append("progress") or {"resolved_integrations": {}},
     )
     monkeypatch.setattr(
-        "app.cli.interactive_shell.ui.output.set_silent_tracker",
-        lambda: None,
-    )
-    monkeypatch.setattr(
-        "app.cli.interactive_shell.ui.output.reset_tracker",
-        lambda: resets.append("reset"),
+        "app.agent.stages.resolve_integrations.resolve_integrations_quiet",
+        lambda _state: quiet_calls.append("quiet") or {"datadog": {}},
     )
 
     session = ReplSession()
     session.warm_resolved_integrations()
 
-    assert session.resolved_integrations_cache is None
-    assert resets == ["reset"]
+    assert quiet_calls == ["quiet"]
+    assert progress_calls == []
+    assert session.resolved_integrations_cache == {"datadog": {}}
+
+
+def test_stale_background_warm_does_not_overwrite_refreshed_cache() -> None:
+    session = ReplSession()
+    stale_generation = session._integration_warm_generation
+    session._integration_warm_generation += 1
+    session._store_warm_cache({"fresh": {"token": "new"}}, generation=session._integration_warm_generation)
+    session._store_warm_cache({"stale": {"token": "old"}}, generation=stale_generation)
+    assert session.resolved_integrations_cache == {"fresh": {"token": "new"}}
 
 
 def test_hydrate_entrypoint_does_not_warm_before_prompt(monkeypatch: Any) -> None:
@@ -125,10 +127,10 @@ def test_hydrate_entrypoint_does_not_warm_before_prompt(monkeypatch: Any) -> Non
 
     def _resolve(_state: dict[str, Any]) -> dict[str, Any]:
         resolve_calls.append("resolve")
-        return {"resolved_integrations": {"datadog": {"site": "datadoghq.com"}}}
+        return {"datadog": {"site": "datadoghq.com"}}
 
     monkeypatch.setattr(
-        "app.agent.stages.resolve_integrations.resolve_integrations",
+        "app.agent.stages.resolve_integrations.resolve_integrations_quiet",
         _resolve,
     )
     session = ReplSession()
@@ -145,7 +147,7 @@ def test_schedule_warm_resolved_integrations_runs_in_background(
 
     warmed = asyncio.Event()
 
-    def _warm(self: ReplSession) -> None:
+    def _warm(self: ReplSession, *, generation: int | None = None) -> None:
         warmed.set()
 
     monkeypatch.setattr(ReplSession, "warm_resolved_integrations", _warm)
@@ -154,6 +156,7 @@ def test_schedule_warm_resolved_integrations_runs_in_background(
         session = ReplSession()
         session.schedule_warm_resolved_integrations()
         await asyncio.wait_for(warmed.wait(), timeout=1.0)
+        assert warmed.is_set()
 
     asyncio.run(_run())
 

--- a/tests/cli/interactive_shell/runtime/test_entrypoint_integrations.py
+++ b/tests/cli/interactive_shell/runtime/test_entrypoint_integrations.py
@@ -70,6 +70,52 @@ def test_warm_resolved_integrations_is_idempotent(monkeypatch: Any) -> None:
     assert calls == ["resolve"]
 
 
+def test_warm_resolved_integrations_skips_empty_cache(monkeypatch: Any) -> None:
+    calls: list[str] = []
+
+    def _resolve(_state: dict[str, Any]) -> dict[str, Any]:
+        calls.append("resolve")
+        return {"resolved_integrations": {}}
+
+    monkeypatch.setattr(
+        "app.agent.stages.resolve_integrations.resolve_integrations",
+        _resolve,
+    )
+    session = ReplSession()
+    session.warm_resolved_integrations()
+    assert session.resolved_integrations_cache is None
+    session.warm_resolved_integrations()
+    assert calls == ["resolve", "resolve"]
+
+
+def test_warm_resolved_integrations_resets_tracker_on_resolve_failure(
+    monkeypatch: Any,
+) -> None:
+    resets: list[str] = []
+
+    def _resolve(_state: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("resolve failed")
+
+    monkeypatch.setattr(
+        "app.agent.stages.resolve_integrations.resolve_integrations",
+        _resolve,
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.output.set_silent_tracker",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.output.reset_tracker",
+        lambda: resets.append("reset"),
+    )
+
+    session = ReplSession()
+    session.warm_resolved_integrations()
+
+    assert session.resolved_integrations_cache is None
+    assert resets == ["reset"]
+
+
 def test_hydrate_entrypoint_also_warms_resolved_integrations(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         "app.integrations.verify.resolve_effective_integrations",

--- a/tests/cli/interactive_shell/runtime/test_entrypoint_integrations.py
+++ b/tests/cli/interactive_shell/runtime/test_entrypoint_integrations.py
@@ -42,6 +42,49 @@ def test_hydrate_marks_known_even_when_none_configured(monkeypatch: Any) -> None
     assert session.configured_integrations == ()
 
 
+def test_warm_resolved_integrations_populates_cache(monkeypatch: Any) -> None:
+    resolved = {"datadog": {"site": "datadoghq.com"}, "grafana": {"url": "http://localhost"}}
+    monkeypatch.setattr(
+        "app.agent.stages.resolve_integrations.resolve_integrations",
+        lambda _state: {"resolved_integrations": resolved},
+    )
+    session = ReplSession()
+    session.warm_resolved_integrations()
+    assert session.resolved_integrations_cache == resolved
+
+
+def test_warm_resolved_integrations_is_idempotent(monkeypatch: Any) -> None:
+    calls: list[str] = []
+
+    def _resolve(_state: dict[str, Any]) -> dict[str, Any]:
+        calls.append("resolve")
+        return {"resolved_integrations": {"github": {}}}
+
+    monkeypatch.setattr(
+        "app.agent.stages.resolve_integrations.resolve_integrations",
+        _resolve,
+    )
+    session = ReplSession()
+    session.warm_resolved_integrations()
+    session.warm_resolved_integrations()
+    assert calls == ["resolve"]
+
+
+def test_hydrate_entrypoint_also_warms_resolved_integrations(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        "app.integrations.verify.resolve_effective_integrations",
+        lambda: {"datadog": {}},
+    )
+    resolved = {"datadog": {"site": "datadoghq.com"}}
+    monkeypatch.setattr(
+        "app.agent.stages.resolve_integrations.resolve_integrations",
+        lambda _state: {"resolved_integrations": resolved},
+    )
+    session = ReplSession()
+    entrypoint._hydrate_configured_integrations(session)
+    assert session.resolved_integrations_cache == resolved
+
+
 def test_hydrate_leaves_unknown_on_failure(monkeypatch: Any) -> None:
     def _boom() -> dict[str, Any]:
         raise RuntimeError("catalog blew up")

--- a/tests/cli/interactive_shell/runtime/test_entrypoint_integrations.py
+++ b/tests/cli/interactive_shell/runtime/test_entrypoint_integrations.py
@@ -116,19 +116,46 @@ def test_warm_resolved_integrations_resets_tracker_on_resolve_failure(
     assert resets == ["reset"]
 
 
-def test_hydrate_entrypoint_also_warms_resolved_integrations(monkeypatch: Any) -> None:
+def test_hydrate_entrypoint_does_not_warm_before_prompt(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         "app.integrations.verify.resolve_effective_integrations",
         lambda: {"datadog": {}},
     )
-    resolved = {"datadog": {"site": "datadoghq.com"}}
+    resolve_calls: list[str] = []
+
+    def _resolve(_state: dict[str, Any]) -> dict[str, Any]:
+        resolve_calls.append("resolve")
+        return {"resolved_integrations": {"datadog": {"site": "datadoghq.com"}}}
+
     monkeypatch.setattr(
         "app.agent.stages.resolve_integrations.resolve_integrations",
-        lambda _state: {"resolved_integrations": resolved},
+        _resolve,
     )
     session = ReplSession()
     entrypoint._hydrate_configured_integrations(session)
-    assert session.resolved_integrations_cache == resolved
+    assert session.configured_integrations_known is True
+    assert session.resolved_integrations_cache is None
+    assert resolve_calls == []
+
+
+def test_schedule_warm_resolved_integrations_runs_in_background(
+    monkeypatch: Any,
+) -> None:
+    import asyncio
+
+    warmed = asyncio.Event()
+
+    def _warm(self: ReplSession) -> None:
+        warmed.set()
+
+    monkeypatch.setattr(ReplSession, "warm_resolved_integrations", _warm)
+
+    async def _run() -> None:
+        session = ReplSession()
+        session.schedule_warm_resolved_integrations()
+        await asyncio.wait_for(warmed.wait(), timeout=1.0)
+
+    asyncio.run(_run())
 
 
 def test_hydrate_leaves_unknown_on_failure(monkeypatch: Any) -> None:

--- a/tests/cli/interactive_shell/runtime/test_entrypoint_integrations.py
+++ b/tests/cli/interactive_shell/runtime/test_entrypoint_integrations.py
@@ -113,7 +113,9 @@ def test_stale_background_warm_does_not_overwrite_refreshed_cache() -> None:
     session = ReplSession()
     stale_generation = session._integration_warm_generation
     session._integration_warm_generation += 1
-    session._store_warm_cache({"fresh": {"token": "new"}}, generation=session._integration_warm_generation)
+    session._store_warm_cache(
+        {"fresh": {"token": "new"}}, generation=session._integration_warm_generation
+    )
     session._store_warm_cache({"stale": {"token": "old"}}, generation=stale_generation)
     assert session.resolved_integrations_cache == {"fresh": {"token": "new"}}
 

--- a/tests/cli/interactive_shell/sessions/test_resume_scenarios.py
+++ b/tests/cli/interactive_shell/sessions/test_resume_scenarios.py
@@ -310,7 +310,7 @@ class TestResumeLiveRepl:
             assert repl.contains("live9999") or repl.contains("live redis")
 
             repl.reset_output()
-            repl.send(f"/resume {target_id[:8]}", wait=4.0)
+            repl.send(f"/resume {target_id[:8]}", wait=8.0)
             assert repl.contains("resumed session")
             assert repl.contains("live redis investigation")
 

--- a/tests/cli/interactive_shell/sessions/test_resume_scenarios.py
+++ b/tests/cli/interactive_shell/sessions/test_resume_scenarios.py
@@ -310,7 +310,7 @@ class TestResumeLiveRepl:
             assert repl.contains("live9999") or repl.contains("live redis")
 
             repl.reset_output()
-            repl.send(f"/resume {target_id[:8]}", wait=8.0)
+            repl.send(f"/resume {target_id[:8]}", wait=4.0)
             assert repl.contains("resumed session")
             assert repl.contains("live redis investigation")
 


### PR DESCRIPTION
## Summary

- Add `ReplSession.warm_resolved_integrations()` to resolve full integration configs at boot using a silent progress tracker (no READ lines).
- Call it from REPL entrypoint hydration and after `/integrations` mutations via `refresh_integration_state()`.
- Cache results in `resolved_integrations_cache` so the tool-gathering pass skips redundant resolve work on the first user message.

Fixes #3005

## Test plan

- [x] `uv run python -m pytest tests/cli/interactive_shell/runtime/test_entrypoint_integrations.py tests/cli/interactive_shell/command_registry/test_integrations_refresh.py -q`
- [ ] Restart `uv run opensre`, send a casual first message (e.g. `yo`) — confirm no `Loading integrations` READ lines appear
- [ ] Run `/integrations setup` or remove an integration — confirm session still reflects changes without stale cache