### PR TITLE
feat(fleet): unify /fleet kill|trace PID|name resolution

### DIFF
--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -52,7 +52,7 @@ from app.fleet_monitoring.conflicts import (
 from app.fleet_monitoring.coordination import BranchClaims
 from app.fleet_monitoring.discovery import registered_and_discovered_agents
 from app.fleet_monitoring.lifecycle import TerminateResult, terminate
-from app.fleet_monitoring.registry import AgentRegistry
+from app.fleet_monitoring.registry import AgentRegistry, AgentResolveError, resolve_agent_arg
 from app.fleet_monitoring.tail import AttachSession, AttachUnsupported, attach
 
 _AGENTS_FIRST_ARGS: tuple[tuple[str, str], ...] = (
@@ -60,9 +60,9 @@ _AGENTS_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("bus", "live-tail the cross-agent context bus"),
     ("claim", "claim a branch for an agent"),
     ("conflicts", "show file-write conflicts between local AI agents"),
-    ("kill", "SIGTERM → SIGKILL a local agent by PID"),
+    ("kill", "SIGTERM → SIGKILL a local agent by PID or name"),
     ("release", "release a branch claim"),
-    ("trace", "live tail of an agent's stdout by pid"),
+    ("trace", "live tail of an agent's stdout by PID or name"),
     ("graph", "render the wait-on dependency graph as a tree"),
     ("wait", "mark <pid> as waiting on another pid: /fleet wait <pid> --on <other-pid>"),
 )
@@ -340,6 +340,21 @@ def _cmd_agents_budget(session: ReplSession, console: Console, args: list[str]) 
 _ConfirmFn = Callable[[str], str]
 
 
+def _resolve_fleet_target_pid(
+    session: ReplSession,
+    console: Console,
+    raw: str,
+    registry: AgentRegistry,
+) -> int | None:
+    """Resolve a kill/trace target; print and mark the turn failed on error."""
+    try:
+        return resolve_agent_arg(raw, registry)
+    except AgentResolveError as exc:
+        console.print(f"[{ERROR}]{escape(exc.message)}[/]")
+        session.mark_latest(ok=False, kind="slash")
+        return None
+
+
 def _cmd_agents_kill(
     session: ReplSession,
     console: Console,
@@ -347,7 +362,7 @@ def _cmd_agents_kill(
     *,
     confirm_fn: _ConfirmFn | None = None,
 ) -> bool:
-    """Handle ``/fleet kill <pid> [--force]``.
+    """Handle ``/fleet kill <pid|name> [--force]``.
 
     Sends SIGTERM, waits up to 5 s, then escalates to SIGKILL.
     Asks for confirmation unless ``--force`` is present.
@@ -357,16 +372,14 @@ def _cmd_agents_kill(
     positional = [a for a in args if a != "--force"]
 
     if not positional:
-        console.print(f"[{ERROR}]usage:[/] /fleet kill <pid> [--force]")
+        console.print(f"[{ERROR}]usage:[/] /fleet kill <pid|name> [--force]")
         session.mark_latest(ok=False, kind="slash")
         return True
 
     raw_pid = positional[0]
-    try:
-        pid = int(raw_pid)
-    except ValueError:
-        console.print(f"[{ERROR}]invalid pid:[/] {escape(raw_pid)} is not an integer")
-        session.mark_latest(ok=False, kind="slash")
+    registry = AgentRegistry()
+    pid = _resolve_fleet_target_pid(session, console, raw_pid, registry)
+    if pid is None:
         return True
 
     if pid == os.getpid():
@@ -375,7 +388,6 @@ def _cmd_agents_kill(
         return True
 
     # Look up agent name from registry for friendlier output.
-    registry = AgentRegistry()
     record = registry.get(pid)
     label = f"{record.name} (pid {pid})" if record else f"pid {pid}"
 
@@ -494,24 +506,23 @@ def _render_live_tail(console: Console, label: str, sess: AttachSession) -> None
 
 
 def _cmd_agents_trace(session: ReplSession, console: Console, args: list[str]) -> bool:
-    """Live-tail an agent's stdout by pid; see :func:`_render_live_tail`.
+    """Live-tail an agent's stdout by PID or name; see :func:`_render_live_tail`.
 
     Validates eagerly (``attach()`` raises :class:`AttachUnsupported`
     synchronously on bad pid / unsupported fd type / missing file) so
     we never enter the ``Live`` block on a target we cannot tail.
     """
     if len(args) != 1:
-        console.print(f"[{ERROR}]usage:[/] /fleet trace <pid>")
-        session.mark_latest(ok=False, kind="slash")
-        return True
-    try:
-        pid = int(args[0])
-    except ValueError:
-        console.print(f"[{ERROR}]invalid pid:[/] {escape(args[0])}")
+        console.print(f"[{ERROR}]usage:[/] /fleet trace <pid|name>")
         session.mark_latest(ok=False, kind="slash")
         return True
 
-    record = AgentRegistry().get(pid)
+    registry = AgentRegistry()
+    pid = _resolve_fleet_target_pid(session, console, args[0], registry)
+    if pid is None:
+        return True
+
+    record = registry.get(pid)
     label = f"{record.name} (pid {pid})" if record else f"pid {pid}"
 
     try:

--- a/app/fleet_monitoring/registry.py
+++ b/app/fleet_monitoring/registry.py
@@ -156,3 +156,51 @@ class AgentRegistry:
             tmp.replace(self._path)
         except OSError:
             logger.warning("Failed to rewrite agent registry at %s", self._path)
+
+
+class AgentResolveError(Exception):
+    """Raised when a PID or agent-name argument cannot be resolved uniquely."""
+
+    message: str
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+def resolve_agent_arg(arg: str, registry: AgentRegistry) -> int:
+    """Resolve a ``/fleet kill`` or ``/fleet trace`` target to a PID.
+
+    Resolution order:
+    1. Positive int that exists in the registry → that PID.
+    2. Exactly one registered agent name (case-sensitive) → that record's PID.
+    3. Positive int not in the registry → return the int (caller surfaces errors).
+    4. Multiple records share the name → :class:`AgentResolveError`.
+    5. Otherwise → :class:`AgentResolveError`.
+    """
+    stripped = arg.strip()
+    if not stripped:
+        raise AgentResolveError("invalid pid or unknown agent name")
+
+    parsed_pid: int | None = None
+    try:
+        candidate = int(stripped)
+        if candidate > 0:
+            parsed_pid = candidate
+    except ValueError:
+        pass
+
+    if parsed_pid is not None and registry.get(parsed_pid) is not None:
+        return parsed_pid
+
+    name_matches = [record for record in registry.list() if record.name == stripped]
+    if len(name_matches) == 1:
+        return name_matches[0].pid
+    if len(name_matches) > 1:
+        pids = ", ".join(str(record.pid) for record in name_matches)
+        raise AgentResolveError(f"ambiguous agent name '{stripped}': multiple PIDs ({pids})")
+
+    if parsed_pid is not None:
+        return parsed_pid
+
+    raise AgentResolveError("invalid pid or unknown agent name")

--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -801,7 +801,9 @@ Fleet coordination is documented further on [Agents](/fleet). Register discovere
 /fleet conflicts
 /fleet kill 12345
 /fleet kill 12345 --force
+/fleet kill claude-code
 /fleet trace 12345
+/fleet trace claude-code
 /fleet wait 12345 --on 67890
 /fleet graph
 ```
@@ -815,8 +817,8 @@ Fleet coordination is documented further on [Agents](/fleet). Register discovere
 | `claim <branch> <agent>` | Exclusive branch claim (agent must be in registry) |
 | `release <branch>` | Release a claim |
 | `conflicts` | File-write conflict report between agents |
-| `kill <pid> [--force]` | SIGTERM → wait → SIGKILL **elevated**; refuses self-PID |
-| `trace <pid>` | Live stdout tail of agent process |
+| `kill <pid\|name> [--force]` | SIGTERM → wait → SIGKILL **elevated**; refuses self-PID |
+| `trace <pid\|name>` | Live stdout tail of agent process |
 | `wait <pid> --on <other-pid>` | Record wait dependency for graph |
 | `graph` | Tree of wait-on relationships |
 

--- a/tests/cli/interactive_shell/test_agents_commands.py
+++ b/tests/cli/interactive_shell/test_agents_commands.py
@@ -19,6 +19,7 @@ from app.fleet_monitoring.conflicts import (
     FileWriteConflict,
     render_conflicts,
 )
+from app.fleet_monitoring.lifecycle import TerminateResult
 from app.fleet_monitoring.registry import AgentRecord, AgentRegistry
 from app.fleet_monitoring.tail import AttachUnsupported, TailBuffer
 
@@ -502,7 +503,7 @@ class TestAgentsTrace:
         assert dispatch_slash("/fleet trace", sess_obj, console) is True
         out = buf.getvalue().lower()
         assert "usage" in out
-        assert "<pid>" in out
+        assert "<pid|name>" in out
         assert sess_obj.history[-1]["ok"] is False
 
     def test_non_numeric_pid_rejected(self) -> None:
@@ -510,7 +511,7 @@ class TestAgentsTrace:
         console, buf = _capture()
         assert dispatch_slash("/fleet trace abc", sess_obj, console) is True
         out = buf.getvalue().lower()
-        assert "invalid pid" in out
+        assert "invalid pid or unknown agent name" in out
         assert sess_obj.history[-1]["ok"] is False
 
     def test_too_many_args_rejected(self) -> None:
@@ -561,6 +562,45 @@ class TestAgentsTrace:
         out = buf.getvalue()
         assert "claude-code" in out
         assert "8421" in out
+
+    def test_trace_by_registered_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
+        monkeypatch.setattr(agents_mod, "attach", lambda _pid: _FakeSession(chunks=[]))
+
+        sess_obj = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/fleet trace claude-code", sess_obj, console) is True
+        out = buf.getvalue()
+        assert "claude-code" in out
+        assert "8421" in out
+        assert "trace ended" in out
+
+    def test_ambiguous_name_shows_error_with_pids(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
+        registry.register(AgentRecord(name="claude-code", pid=9133, command="claude"))
+
+        sess_obj = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/fleet trace claude-code", sess_obj, console) is True
+        out = buf.getvalue()
+        assert "ambiguous agent name" in out
+        assert "8421" in out
+        assert "9133" in out
+        assert sess_obj.history[-1]["ok"] is False
+
+    def test_bogus_arg_shows_invalid_or_unknown_error(self) -> None:
+        sess_obj = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/fleet trace bogus-agent", sess_obj, console) is True
+        out = buf.getvalue().lower()
+        assert "invalid pid or unknown agent name" in out
+        assert sess_obj.history[-1]["ok"] is False
 
     def test_renders_chunks_through_live(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Two chunks then StopIteration: the handler should append them
@@ -641,6 +681,84 @@ class TestAgentsTrace:
         out = buf.getvalue()
         assert "process exited" not in out
         assert "trace ended" in out
+
+
+class TestAgentsKill:
+    def test_kill_by_pid_with_force(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        registry_path = tmp_path / "agents.jsonl"
+        _isolate_registry(monkeypatch, registry_path)
+        AgentRegistry(path=registry_path).register(
+            AgentRecord(name="claude-code", pid=8421, command="claude")
+        )
+
+        def _fake_terminate(pid: int) -> TerminateResult:
+            return TerminateResult(
+                pid=pid,
+                exited=True,
+                signal_sent="SIGTERM",
+                elapsed_seconds=0.1,
+            )
+
+        monkeypatch.setattr(agents_mod, "terminate", _fake_terminate)
+        monkeypatch.setattr(
+            agents_mod,
+            "get_analytics",
+            lambda: type("A", (), {"capture": lambda *_a, **_k: None})(),
+        )
+
+        sess_obj = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/fleet kill 8421 --force", sess_obj, console) is True
+        out = buf.getvalue()
+        assert "SIGTERM" in out
+        assert AgentRegistry(path=registry_path).get(8421) is None
+
+    def test_kill_by_registered_name(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        registry_path = tmp_path / "agents.jsonl"
+        _isolate_registry(monkeypatch, registry_path)
+        AgentRegistry(path=registry_path).register(
+            AgentRecord(name="claude-code", pid=8421, command="claude")
+        )
+
+        killed: list[int] = []
+
+        def _fake_terminate(pid: int) -> TerminateResult:
+            killed.append(pid)
+            return TerminateResult(
+                pid=pid,
+                exited=True,
+                signal_sent="SIGTERM",
+                elapsed_seconds=0.1,
+            )
+
+        monkeypatch.setattr(agents_mod, "terminate", _fake_terminate)
+        monkeypatch.setattr(
+            agents_mod,
+            "get_analytics",
+            lambda: type("A", (), {"capture": lambda *_a, **_k: None})(),
+        )
+
+        sess_obj = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/fleet kill claude-code --force", sess_obj, console) is True
+        assert killed == [8421]
+        assert AgentRegistry(path=registry_path).get(8421) is None
+
+    def test_ambiguous_name_shows_error_with_pids(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
+        registry.register(AgentRecord(name="claude-code", pid=9133, command="claude"))
+
+        sess_obj = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/fleet kill claude-code --force", sess_obj, console) is True
+        out = buf.getvalue()
+        assert "ambiguous agent name" in out
+        assert "8421" in out
+        assert "9133" in out
+        assert sess_obj.history[-1]["ok"] is False
 
 
 class TestAgentsWait:

--- a/tests/fleet_monitoring/test_registry.py
+++ b/tests/fleet_monitoring/test_registry.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 import pytest
 
-from app.fleet_monitoring.registry import AgentRecord, AgentRegistry
+from app.fleet_monitoring.registry import (
+    AgentRecord,
+    AgentRegistry,
+    AgentResolveError,
+    resolve_agent_arg,
+)
 
 
 @pytest.fixture
@@ -256,3 +261,37 @@ class TestAgentRegistry:
         rehydrated = reg2.get(7702)
         assert rehydrated is not None
         assert rehydrated.waits_on == ()
+
+
+class TestResolveAgentArg:
+    def test_pid_hit_in_registry(self, registry: AgentRegistry, sample_record: AgentRecord) -> None:
+        registry.register(sample_record)
+        assert resolve_agent_arg("8421", registry) == 8421
+
+    def test_unique_name_returns_pid(
+        self, registry: AgentRegistry, sample_record: AgentRecord
+    ) -> None:
+        registry.register(sample_record)
+        assert resolve_agent_arg("claude-code", registry) == 8421
+
+    def test_integer_not_in_registry_fallthrough(self, registry: AgentRegistry) -> None:
+        assert resolve_agent_arg("99999", registry) == 99999
+
+    def test_ambiguous_name_raises_with_pids(self, registry: AgentRegistry) -> None:
+        registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
+        registry.register(AgentRecord(name="claude-code", pid=9133, command="claude"))
+
+        with pytest.raises(AgentResolveError, match="ambiguous agent name") as exc_info:
+            resolve_agent_arg("claude-code", registry)
+
+        message = exc_info.value.message
+        assert "8421" in message
+        assert "9133" in message
+
+    def test_unknown_string_raises(self, registry: AgentRegistry) -> None:
+        with pytest.raises(AgentResolveError, match="invalid pid or unknown agent name"):
+            resolve_agent_arg("bogus-agent", registry)
+
+    def test_numeric_name_when_pid_missing_returns_name_pid(self, registry: AgentRegistry) -> None:
+        registry.register(AgentRecord(name="8421", pid=7702, command="claude"))
+        assert resolve_agent_arg("8421", registry) == 7702


### PR DESCRIPTION
Fixes #1749

#### Describe the changes you have made in this PR -

`/fleet kill` and `/fleet trace` now accept a registered agent **name** or **PID** via shared `resolve_agent_arg()` in `app/fleet_monitoring/registry.py`.

Resolution order (per issue):
1. Positive int in registry → PID
2. Unique name match → that agent's PID
3. Positive int not in registry → fall through (existing terminate/attach errors)
4. Ambiguous name → error listing all PIDs
5. Unknown input → `invalid pid or unknown agent name`

Wired through `_resolve_fleet_target_pid()` in `agents.py`. Usage strings and docs updated to `<pid|name>`. `claim` / `release` / `budget` / `wait` unchanged.

**Note:** Issue title says `/agents`; the live slash command is `/fleet`.

### Demo/Screenshot for feature changes and bug fixes -

```text
/fleet trace claude-code   # resolves registered name → live tail
/fleet kill claude-code --force
# ambiguous: ambiguous agent name 'claude-code': multiple PIDs (8421, 9133)
# unknown:  invalid pid or unknown agent name
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Crash-looping agents rotate PIDs, but registry names stay stable. Today only `/fleet claim` and `/fleet budget` accept names; kill and trace required `int(pid)`, which breaks the common flow of copying a name from the `/fleet` dashboard.

`resolve_agent_arg()` centralizes the five-rule lookup next to `AgentRegistry` so kill, trace, and future PID-targeting subcommands (e.g. inspect) share one path. Names use case-sensitive exact matches, consistent with `/fleet claim`. Integer fallthrough preserves existing `no such process` / `AttachUnsupported` behavior for unknown PIDs. `_resolve_fleet_target_pid()` deduplicates error rendering in the two slash handlers.

**Follow-up (out of scope):** Tab completion for kill/trace targets (second token) — `ShellCompleter` only completes `/fleet` subcommands today.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.