### PR TITLE
fix(integrations): add interactive setup for helm

### DIFF
--- a/app/integrations/cli.py
+++ b/app/integrations/cli.py
@@ -1128,6 +1128,35 @@ def _setup_jenkins() -> None:
     )
 
 
+def _setup_helm() -> None:
+    helm_path = _p("Helm binary path or name", default="helm")
+    if not helm_path:
+        _die("helm_path is required.")
+    kube_context = _p(
+        "Kubernetes context (optional, passed as --kube-context)",
+        default="",
+    )
+    kubeconfig = _p(
+        "Kubeconfig file path (optional, passed as --kubeconfig)",
+        default="",
+    )
+    default_namespace = _p(
+        "Default namespace when alerts do not specify one (optional)",
+        default="",
+    )
+    upsert_integration(
+        "helm",
+        {
+            "credentials": {
+                "helm_path": helm_path,
+                "kube_context": kube_context,
+                "kubeconfig": kubeconfig,
+                "default_namespace": default_namespace,
+            }
+        },
+    )
+
+
 def _setup_tempo() -> None:
     from app.integrations.tempo import build_tempo_config, validate_tempo_config
 
@@ -1186,6 +1215,7 @@ _HANDLERS: dict[str, Any] = {
     "groundcover": _setup_groundcover,
     "grafana": _setup_grafana,
     "honeycomb": _setup_honeycomb,
+    "helm": _setup_helm,
     "incident_io": _setup_incident_io,
     "mariadb": _setup_mariadb,
     "mongodb_atlas": _setup_mongodb_atlas,

--- a/app/integrations/registry.py
+++ b/app/integrations/registry.py
@@ -372,6 +372,7 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
         service="helm",
         verifier=_verify_helm,
         direct_effective=True,
+        setup_order=38,
         verify_order=34,
     ),
     IntegrationSpec(

--- a/docs/helm.mdx
+++ b/docs/helm.mdx
@@ -17,7 +17,7 @@ OpenSRE runs the **Helm 3** command-line client on the machine where the agent e
 
 ## Setup
 
-Configure Helm like other local integrations: environment variables and/or `~/.opensre/integrations.json`.
+Configure Helm like other local integrations: run `opensre integrations setup helm`, use environment variables, and/or `~/.opensre/integrations.json`.
 
 ### Option 1: Environment variables
 

--- a/tests/cli/test_integrations.py
+++ b/tests/cli/test_integrations.py
@@ -336,6 +336,27 @@ def test_integrations_verify_accepts_argocd() -> None:
     mock_capture.assert_called_once_with("argocd")
 
 
+def test_integrations_setup_accepts_helm() -> None:
+    # Regression test for #1973: helm had verify wired in the registry but no
+    # setup_order / _setup_helm handler, so Click rejected the positional arg.
+    runner = CliRunner()
+
+    with (
+        patch("app.cli.commands.integrations.capture_integration_setup_started"),
+        patch("app.cli.commands.integrations.capture_integration_setup_completed"),
+        patch("app.cli.commands.integrations.capture_integration_verified") as mock_capture,
+        patch("app.integrations.cli.cmd_setup") as mock_setup,
+        patch("app.integrations.cli.cmd_verify", return_value=0) as mock_verify,
+    ):
+        mock_setup.return_value = "helm"
+        result = runner.invoke(cli, ["integrations", "setup", "helm"])
+
+    assert result.exit_code == 0
+    mock_setup.assert_called_once_with("helm")
+    mock_verify.assert_called_once_with("helm")
+    mock_capture.assert_called_once_with("helm")
+
+
 def test_integrations_verify_accepts_helm() -> None:
     # Regression test for #1973: helm was registered in the runtime registry
     # but rejected by Click because the CLI's hardcoded VERIFY_SERVICES tuple

--- a/tests/integrations/test_helm_setup.py
+++ b/tests/integrations/test_helm_setup.py
@@ -1,0 +1,59 @@
+"""Interactive setup coverage for the Helm integration."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.integrations.cli import _setup_helm, cmd_setup
+from app.integrations.registry import SUPPORTED_SETUP_SERVICES
+
+
+def test_setup_helm_persists_credentials() -> None:
+    prompts = {
+        "Helm binary path or name": "/usr/local/bin/helm",
+        "Kubernetes context (optional, passed as --kube-context)": "prod-admin",
+        "Kubeconfig file path (optional, passed as --kubeconfig)": "~/.kube/config",
+        "Default namespace when alerts do not specify one (optional)": "production",
+    }
+
+    def fake_prompt(label: str, default: str = "", secret: bool = False) -> str:
+        del secret
+        return prompts.get(label, default)
+
+    with (
+        patch("app.integrations.cli._p", side_effect=fake_prompt),
+        patch("app.integrations.cli.upsert_integration") as mock_upsert,
+    ):
+        _setup_helm()
+
+    mock_upsert.assert_called_once_with(
+        "helm",
+        {
+            "credentials": {
+                "helm_path": "/usr/local/bin/helm",
+                "kube_context": "prod-admin",
+                "kubeconfig": "~/.kube/config",
+                "default_namespace": "production",
+            }
+        },
+    )
+
+
+def test_cmd_setup_helm_dispatches_handler() -> None:
+    calls: list[str] = []
+
+    def fake_handler() -> None:
+        calls.append("helm")
+
+    with patch.dict("app.integrations.cli._HANDLERS", {"helm": fake_handler}):
+        resolved = cmd_setup("helm")
+
+    assert resolved == "helm"
+    assert calls == ["helm"]
+
+
+def test_helm_is_registered_for_setup() -> None:
+    from app.integrations.cli import _HANDLERS
+
+    assert "helm" in SUPPORTED_SETUP_SERVICES
+    assert "helm" in _HANDLERS


### PR DESCRIPTION
Fixes #1973

#### Describe the changes you have made in this PR -

Helm had verify wired in the integration registry (#1657, #1974) but never got an interactive setup wizard. `opensre integrations setup helm` failed Click validation because `helm` had no `setup_order` and no `_setup_helm` entry in `_HANDLERS`.

Changes:
- Add `_setup_helm()` in `app/integrations/cli.py` — prompts for `helm_path`, `kube_context`, `kubeconfig`, and `default_namespace`, then persists to `~/.opensre/integrations.json`.
- Register the handler in `_HANDLERS` and add `setup_order=38` on helm's `IntegrationSpec` so it flows into `SUPPORTED_SETUP_SERVICES` / `SETUP_SERVICES`.
- Regression tests: CLI acceptance (`test_integrations_setup_accepts_helm`), handler persistence/dispatch (`tests/integrations/test_helm_setup.py`), and existing `test_every_setup_spec_has_handler` invariant.
- Document `opensre integrations setup helm` in `docs/helm.mdx`.

Scope: Helm only — argocd/victoria_logs remain verify-only.

### Demo/Screenshot for feature changes and bug fixes - 

**Before** (main):
```bash
$ uv run opensre integrations setup helm
Error: Invalid value for '[[...]]': 'helm' is not one of '...'.
```

**After** (this branch):
```bash
$ uv run opensre integrations setup --help
... [[...|temporal|helm]]

$ uv run python -c "from app.cli.interactive_shell.data_store.constants import SETUP_SERVICES; print('helm' in SETUP_SERVICES)"
True
```

Tests:
```bash
make lint && make format-check && make typecheck
uv run python -m pytest tests/cli/test_integrations.py::test_integrations_setup_accepts_helm tests/integrations/test_helm_setup.py tests/integrations/test_registry.py::test_every_setup_spec_has_handler -v
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The verify side of #1973 was fixed by syncing Click choices with `SUPPORTED_VERIFY_SERVICES`. Helm setup needed the other half: a real wizard plus `setup_order` so the registry-derived `SETUP_SERVICES` list includes `helm`, and a `_HANDLERS` entry so `_SETUP_SERVICES` (registry ∩ handlers) does not drop it silently.

`_setup_helm` mirrors the credential shape already documented in `docs/helm.mdx` and validated by `HelmIntegrationConfig`. Only `helm_path` is required; kube context/config/namespace are optional passthrough fields for `--kube-context`, `--kubeconfig`, and default namespace hints.

I considered reusing env-var setup only, but that leaves the same manual JSON editing gap reported in #1973. Adding setup_order without a handler would pass Click then fail in `cmd_setup` — the #2537 invariant test guards against that.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
