### PR TITLE
refactor(domain): move incident window, alert extraction, and diagnosis helpers

### DIFF
--- a/app/core/domain/alerts/extraction.py
+++ b/app/core/domain/alerts/extraction.py
@@ -1,0 +1,153 @@
+"""Deterministic alert normalization helpers for extract_alert."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+CANONICAL_ALERT_SOURCES = frozenset({"openrca_dataset", "opensre", "opensre_dataset"})
+
+RAW_ALERT_DETAIL_FIELDS = (
+    "kube_namespace",
+    "cloudwatch_log_group",
+    "error_message",
+    "log_query",
+    "eks_cluster",
+    "pod_name",
+    "deployment",
+)
+
+
+class AlertDetails(BaseModel):
+    is_noise: bool = Field(default=False)
+    alert_name: str = Field(default="unknown")
+    pipeline_name: str = Field(default="unknown")
+    severity: str = Field(default="unknown")
+    alert_source: str | None = Field(default=None)
+    environment: str | None = Field(default=None)
+    summary: str | None = Field(default=None)
+    kube_namespace: str | None = Field(default=None)
+    cloudwatch_log_group: str | None = Field(default=None)
+    error_message: str | None = Field(default=None)
+    log_query: str | None = Field(default=None)
+    eks_cluster: str | None = Field(default=None)
+    pod_name: str | None = Field(default=None)
+    deployment: str | None = Field(default=None)
+
+
+def format_raw_alert(raw_alert: Any) -> str:
+    if isinstance(raw_alert, str):
+        return raw_alert
+    if isinstance(raw_alert, dict):
+        if raw_alert.get("text") and not needs_full_json_prompt(raw_alert):
+            return str(raw_alert["text"])
+        return json.dumps(raw_alert, indent=2, sort_keys=True)
+    return json.dumps(raw_alert, indent=2, sort_keys=True)
+
+
+def needs_full_json_prompt(raw_alert: dict[str, Any]) -> bool:
+    src = str(raw_alert.get("alert_source", "")).lower()
+    if src in CANONICAL_ALERT_SOURCES:
+        return True
+    if (
+        raw_alert.get("commonLabels")
+        or raw_alert.get("commonAnnotations")
+        or raw_alert.get("alerts")
+    ):
+        return True
+    for key in (
+        "opensre_telemetry_relative",
+        "openrca_telemetry_relative",
+        "opensre_dataset_root",
+        "openrca_dataset_root",
+    ):
+        if raw_alert.get(key):
+            return True
+        ann = raw_alert.get("commonAnnotations")
+        if isinstance(ann, dict) and ann.get(key):
+            return True
+    meta = raw_alert.get("_meta")
+    return bool(isinstance(meta, dict) and "openrca" in str(meta.get("purpose", "")).lower())
+
+
+def fallback_details(state: Mapping[str, Any], raw_alert: Any) -> AlertDetails:
+    alert_name = state.get("alert_name", "unknown")
+    pipeline_name = state.get("pipeline_name", "unknown")
+    severity = state.get("severity", "unknown")
+
+    if isinstance(raw_alert, dict):
+        labels = dict_value(raw_alert, "commonLabels") or dict_value(raw_alert, "labels")
+        annotations = dict_value(raw_alert, "commonAnnotations") or dict_value(
+            raw_alert, "annotations"
+        )
+        canonical = dict_value(raw_alert, "canonical_alert")
+
+        alert_name = first_value(
+            raw_alert.get("alert_name"),
+            canonical.get("alert_name"),
+            labels.get("alertname"),
+            labels.get("alert_name"),
+            alert_name,
+        )
+        pipeline_name = first_value(
+            raw_alert.get("pipeline_name"),
+            canonical.get("pipeline_name"),
+            labels.get("pipeline_name"),
+            labels.get("pipeline"),
+            labels.get("service"),
+            annotations.get("pipeline_name"),
+            pipeline_name,
+        )
+        severity = first_value(
+            raw_alert.get("severity"),
+            canonical.get("severity"),
+            labels.get("severity"),
+            severity,
+        )
+
+    return AlertDetails(
+        is_noise=False,
+        alert_name=alert_name or "unknown",
+        pipeline_name=pipeline_name or "unknown",
+        severity=severity or "unknown",
+    )
+
+
+def dict_value(source: Mapping[str, Any], key: str) -> dict[str, Any]:
+    value = source.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def first_value(*values: Any) -> Any:
+    return next((value for value in values if value), None)
+
+
+def make_problem_md(details: AlertDetails) -> str:
+    parts = [
+        f"# {details.alert_name}",
+        f"Pipeline: {details.pipeline_name} | Severity: {details.severity}",
+    ]
+    if details.kube_namespace:
+        parts.append(f"Namespace: {details.kube_namespace}")
+    if details.error_message:
+        parts.append(f"\nError: {details.error_message}")
+    return "\n".join(parts)
+
+
+def enrich_raw_alert(raw_alert: Any, details: AlertDetails) -> Any:
+    if not isinstance(raw_alert, dict):
+        raw_alert = {}
+    enriched = dict(raw_alert)
+    prior_source = str(raw_alert.get("alert_source", "")).lower()
+
+    for field_name in RAW_ALERT_DETAIL_FIELDS:
+        value = getattr(details, field_name)
+        if value:
+            enriched[field_name] = value
+
+    if details.alert_source and prior_source not in CANONICAL_ALERT_SOURCES:
+        enriched["alert_source"] = details.alert_source
+    return enriched

--- a/app/core/domain/correlation/scoring.py
+++ b/app/core/domain/correlation/scoring.py
@@ -47,6 +47,11 @@ class PeriodicityScore:
 
 
 @dataclass(frozen=True)
+class OperatorHintScore:
+    score: float
+
+
+@dataclass(frozen=True)
 class CandidateCorrelationScore:
     candidate_name: str
     time_window_score: float
@@ -183,16 +188,29 @@ def score_periodic_spikes(
     )
 
 
+def score_operator_hint(
+    *,
+    metric_name: str,
+    operator_hints: tuple[str, ...],
+) -> OperatorHintScore:
+    normalized_metric_name = (
+        metric_name.lower().replace("{", " ").replace("}", " ").replace(":", " ").replace(",", " ")
+    )
+    tokens = tuple(token for token in normalized_metric_name.split() if len(token) > 2)
+    matched = any(token in hint.lower() for hint in operator_hints for token in tokens)
+    return OperatorHintScore(score=1.0 if matched else 0.0)
+
+
 def score_candidate_correlation(
     *,
     candidate_name: str,
     time_window: TimeWindowCorrelation,
     topology: TopologyCorrelation,
     periodicity: PeriodicityScore | None = None,
-    operator_hint: object | None = None,
+    operator_hint: OperatorHintScore | None = None,
 ) -> CandidateCorrelationScore:
     periodicity_score = periodicity.score if periodicity is not None else 0.0
-    operator_hint_score = getattr(operator_hint, "score", 0.0) if operator_hint is not None else 0.0
+    operator_hint_score = operator_hint.score if operator_hint is not None else 0.0
 
     final_confidence = round(
         (

--- a/app/core/domain/state/diagnosis.py
+++ b/app/core/domain/state/diagnosis.py
@@ -1,0 +1,157 @@
+"""Diagnosis result model and pure parse helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.core.domain.state.category_alignment import apply_category_alignment_adjustments
+from app.types.root_cause_categories import (
+    HERMES_ROOT_CAUSE_CATEGORIES,
+    VALID_ROOT_CAUSE_CATEGORIES,
+    render_prompt_taxonomy,
+)
+
+
+@dataclass
+class InvestigationResult:
+    root_cause: str
+    root_cause_category: str
+    causal_chain: list[str] = field(default_factory=list)
+    validated_claims: list[dict] = field(default_factory=list)
+    non_validated_claims: list[dict] = field(default_factory=list)
+    remediation_steps: list[str] = field(default_factory=list)
+    validity_score: float = 0.0
+    evidence: dict[str, Any] = field(default_factory=dict)
+    evidence_entries: list[dict] = field(default_factory=list)
+    agent_messages: list[dict] = field(default_factory=list)
+    investigation_recommendations: list[str] = field(default_factory=list)
+    category_text_mismatch: bool = False
+    category_text_mismatch_reason: str | None = None
+
+    @classmethod
+    def unknown(cls, alert_name: str = "Unknown alert") -> InvestigationResult:
+        return cls(
+            root_cause=f"{alert_name}: Unable to determine root cause — insufficient evidence.",
+            root_cause_category="unknown",
+            validity_score=0.0,
+            non_validated_claims=[
+                {
+                    "claim": "Insufficient evidence available",
+                    "validation_status": "not_validated",
+                }
+            ],
+        )
+
+
+def result_to_state(result: InvestigationResult) -> dict[str, Any]:
+    return {
+        "root_cause": result.root_cause,
+        "root_cause_category": result.root_cause_category,
+        "causal_chain": result.causal_chain,
+        "validated_claims": result.validated_claims,
+        "non_validated_claims": result.non_validated_claims,
+        "remediation_steps": result.remediation_steps,
+        "validity_score": result.validity_score,
+        "investigation_recommendations": result.investigation_recommendations,
+        "evidence": result.evidence,
+        "evidence_entries": result.evidence_entries,
+        "agent_messages": result.agent_messages,
+    }
+
+
+def extract_last_assistant_text(messages: list[dict[str, Any]]) -> str:
+    for msg in reversed(messages):
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, str) and content.strip():
+            return content.strip()
+        if isinstance(content, list):
+            parts: list[str] = []
+            for block in content:
+                if isinstance(block, str):
+                    parts.append(block)
+                    continue
+                if isinstance(block, dict):
+                    if block.get("type") == "text" and isinstance(block.get("text"), str):
+                        parts.append(block["text"])
+                    continue
+                block_type = getattr(block, "type", None)
+                block_text = getattr(block, "text", None)
+                if block_type == "text" and isinstance(block_text, str):
+                    parts.append(block_text)
+            text = " ".join(p for p in parts if p).strip()
+            if text:
+                return text
+    return ""
+
+
+def taxonomy_categories_for_alert_source(alert_source: str) -> set[str]:
+    source = alert_source.strip().lower()
+    if source == "hermes":
+        return set(HERMES_ROOT_CAUSE_CATEGORIES | {"healthy", "unknown"})
+    return set(VALID_ROOT_CAUSE_CATEGORIES - HERMES_ROOT_CAUSE_CATEGORIES)
+
+
+def build_diagnosis_schema(include_categories: set[str]) -> type[BaseModel]:
+    category_taxonomy = render_prompt_taxonomy(include_categories).strip()
+
+    class DiagnosisSchema(BaseModel):
+        root_cause: str = Field(description="Concise root cause statement (2-3 sentences max)")
+        root_cause_category: str = Field(
+            description=(f"Use exactly one category from this taxonomy:\n{category_taxonomy}")
+        )
+        causal_chain: list[str] = Field(
+            default_factory=list, description="Ordered steps leading to the failure"
+        )
+        validated_claims: list[str] = Field(
+            default_factory=list, description="Claims supported by tool evidence"
+        )
+        non_validated_claims: list[str] = Field(
+            default_factory=list, description="Claims not yet confirmed by evidence"
+        )
+        remediation_steps: list[str] = Field(
+            default_factory=list, description="Concrete remediation actions in order"
+        )
+        validity_score: float = Field(
+            default=0.0, description="0.0–1.0 confidence in the diagnosis"
+        )
+
+    return DiagnosisSchema
+
+
+def claims_to_dicts(claims: list[str], status: str) -> list[dict[str, str]]:
+    return [{"claim": c, "validation_status": status} for c in claims if c]
+
+
+def build_investigation_result(
+    *,
+    root_cause: str,
+    root_cause_category: str,
+    causal_chain: list[str],
+    validated_claims: list[str],
+    non_validated_claims: list[str],
+    remediation_steps: list[str],
+    validity_score: float,
+) -> InvestigationResult:
+    score, recommendations, mismatch, reason = apply_category_alignment_adjustments(
+        root_cause=root_cause,
+        root_cause_category=root_cause_category,
+        validity_score=validity_score,
+        investigation_recommendations=[],
+    )
+    return InvestigationResult(
+        root_cause=root_cause,
+        root_cause_category=root_cause_category,
+        causal_chain=causal_chain,
+        validated_claims=claims_to_dicts(validated_claims, "validated"),
+        non_validated_claims=claims_to_dicts(non_validated_claims, "not_validated"),
+        remediation_steps=remediation_steps,
+        validity_score=score,
+        investigation_recommendations=recommendations,
+        category_text_mismatch=mismatch,
+        category_text_mismatch_reason=reason,
+    )

--- a/app/core/domain/types/incident_window.py
+++ b/app/core/domain/types/incident_window.py
@@ -13,8 +13,8 @@ follow.
    the same incident answer questions about different windows.
 
 This module introduces a single ``IncidentWindow`` value object owned by
-``AgentState`` and populated from the alert's own timestamps in the
-``extract_alert`` step. Once tools start reading from it (deferred to a
+investigation state and populated from the alert's own timestamps in the
+``extract_alert`` orchestration step. Once tools start reading from it (deferred to a
 follow-up PR) every time-aware tool will agree on the same window.
 
 This file is pure foundation. It does not change any tool's behavior. It

--- a/app/core/orchestration/node/diagnose/__init__.py
+++ b/app/core/orchestration/node/diagnose/__init__.py
@@ -10,6 +10,7 @@ Node contract:
                  evidence_entries, agent_messages
 """
 
-from app.core.orchestration.node.diagnose.node import InvestigationResult, diagnose, parse_diagnosis
+from app.core.domain.state.diagnosis import InvestigationResult
+from app.core.orchestration.node.diagnose.node import diagnose, parse_diagnosis
 
 __all__ = ["InvestigationResult", "diagnose", "parse_diagnosis"]

--- a/app/core/orchestration/node/diagnose/node.py
+++ b/app/core/orchestration/node/diagnose/node.py
@@ -3,79 +3,22 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
-from typing import Any, NamedTuple, TypedDict, cast
+from typing import Any, TypedDict, cast
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from app.core.domain.alerts.alert_source import resolve_alert_source
-from app.core.domain.state.category_alignment import (
-    apply_category_alignment_adjustments,
+from app.core.domain.state.diagnosis import (
+    InvestigationResult,
+    build_diagnosis_schema,
+    build_investigation_result,
+    extract_last_assistant_text,
+    result_to_state,
+    taxonomy_categories_for_alert_source,
 )
 from app.state import InvestigationState
-from app.types.root_cause_categories import (
-    HERMES_ROOT_CAUSE_CATEGORIES,
-    VALID_ROOT_CAUSE_CATEGORIES,
-    render_prompt_taxonomy,
-)
 
 logger = logging.getLogger(__name__)
-
-
-class _CategoryAlignment(NamedTuple):
-    validity_score: float
-    investigation_recommendations: list[str]
-    category_text_mismatch: bool
-    category_text_mismatch_reason: str | None
-
-
-def _apply_category_alignment(
-    *,
-    root_cause: str,
-    root_cause_category: str,
-    validity_score: float,
-    investigation_recommendations: list[str] | None = None,
-) -> _CategoryAlignment:
-    score, recommendations, mismatch, reason = apply_category_alignment_adjustments(
-        root_cause=root_cause,
-        root_cause_category=root_cause_category,
-        validity_score=validity_score,
-        investigation_recommendations=list(investigation_recommendations or []),
-    )
-    if mismatch and reason:
-        logger.warning("Root cause category may not match explanation: %s", reason)
-    return _CategoryAlignment(score, recommendations, mismatch, reason)
-
-
-@dataclass
-class InvestigationResult:
-    root_cause: str
-    root_cause_category: str
-    causal_chain: list[str] = field(default_factory=list)
-    validated_claims: list[dict] = field(default_factory=list)
-    non_validated_claims: list[dict] = field(default_factory=list)
-    remediation_steps: list[str] = field(default_factory=list)
-    validity_score: float = 0.0
-    evidence: dict[str, Any] = field(default_factory=dict)
-    evidence_entries: list[dict] = field(default_factory=list)
-    agent_messages: list[dict] = field(default_factory=list)
-    investigation_recommendations: list[str] = field(default_factory=list)
-    category_text_mismatch: bool = False
-    category_text_mismatch_reason: str | None = None
-
-    @classmethod
-    def unknown(cls, alert_name: str = "Unknown alert") -> InvestigationResult:
-        return cls(
-            root_cause=f"{alert_name}: Unable to determine root cause — insufficient evidence.",
-            root_cause_category="unknown",
-            validity_score=0.0,
-            non_validated_claims=[
-                {
-                    "claim": "Insufficient evidence available",
-                    "validation_status": "not_validated",
-                }
-            ],
-        )
 
 
 def parse_diagnosis(
@@ -89,7 +32,7 @@ def parse_diagnosis(
     Uses structured output to extract root_cause, claims, remediation, etc.
     Falls back to parse_root_cause() if structured output fails.
     """
-    last_text = _extract_last_assistant_text(messages)
+    last_text = extract_last_assistant_text(messages)
     if not last_text:
         return InvestigationResult.unknown(alert_name)
 
@@ -129,6 +72,10 @@ def diagnose(state: InvestigationState) -> dict[str, Any]:
             root_cause_category=result.root_cause_category,
             mismatch_reason=result.category_text_mismatch_reason,
         )
+        logger.warning(
+            "Root cause category may not match explanation: %s",
+            result.category_text_mismatch_reason,
+        )
 
     tracker.complete(
         "diagnose_root_cause",
@@ -138,87 +85,10 @@ def diagnose(state: InvestigationState) -> dict[str, Any]:
     return result_to_state(result)
 
 
-def result_to_state(result: InvestigationResult) -> dict[str, Any]:
-    return {
-        "root_cause": result.root_cause,
-        "root_cause_category": result.root_cause_category,
-        "causal_chain": result.causal_chain,
-        "validated_claims": result.validated_claims,
-        "non_validated_claims": result.non_validated_claims,
-        "remediation_steps": result.remediation_steps,
-        "validity_score": result.validity_score,
-        "investigation_recommendations": result.investigation_recommendations,
-        "evidence": result.evidence,
-        "evidence_entries": result.evidence_entries,
-        "agent_messages": result.agent_messages,
-    }
-
-
 def _list_of_dicts(value: Any) -> list[dict[str, Any]]:
     if not isinstance(value, list):
         return []
     return [item for item in value if isinstance(item, dict)]
-
-
-def _extract_last_assistant_text(messages: list[dict[str, Any]]) -> str:
-    for msg in reversed(messages):
-        if msg.get("role") != "assistant":
-            continue
-        content = msg.get("content", "")
-        if isinstance(content, str) and content.strip():
-            return content.strip()
-        if isinstance(content, list):
-            parts: list[str] = []
-            for block in content:
-                if isinstance(block, str):
-                    parts.append(block)
-                    continue
-                if isinstance(block, dict):
-                    if block.get("type") == "text" and isinstance(block.get("text"), str):
-                        parts.append(block["text"])
-                    continue
-                block_type = getattr(block, "type", None)
-                block_text = getattr(block, "text", None)
-                if block_type == "text" and isinstance(block_text, str):
-                    parts.append(block_text)
-            text = " ".join(p for p in parts if p).strip()
-            if text:
-                return text
-    return ""
-
-
-def _taxonomy_categories_for_alert_source(alert_source: str) -> set[str]:
-    source = alert_source.strip().lower()
-    if source == "hermes":
-        return set(HERMES_ROOT_CAUSE_CATEGORIES | {"healthy", "unknown"})
-    return set(VALID_ROOT_CAUSE_CATEGORIES - HERMES_ROOT_CAUSE_CATEGORIES)
-
-
-def _build_diagnosis_schema(include_categories: set[str]) -> type[BaseModel]:
-    category_taxonomy = render_prompt_taxonomy(include_categories).strip()
-
-    class DiagnosisSchema(BaseModel):
-        root_cause: str = Field(description="Concise root cause statement (2-3 sentences max)")
-        root_cause_category: str = Field(
-            description=(f"Use exactly one category from this taxonomy:\n{category_taxonomy}")
-        )
-        causal_chain: list[str] = Field(
-            default_factory=list, description="Ordered steps leading to the failure"
-        )
-        validated_claims: list[str] = Field(
-            default_factory=list, description="Claims supported by tool evidence"
-        )
-        non_validated_claims: list[str] = Field(
-            default_factory=list, description="Claims not yet confirmed by evidence"
-        )
-        remediation_steps: list[str] = Field(
-            default_factory=list, description="Concrete remediation actions in order"
-        )
-        validity_score: float = Field(
-            default=0.0, description="0.0–1.0 confidence in the diagnosis"
-        )
-
-    return DiagnosisSchema
 
 
 def _parse_via_structured_output(
@@ -247,7 +117,7 @@ Evidence keys collected: {", ".join(evidence.keys()) if evidence else "none"}
         validity_score: float
 
     llm = get_llm_for_reasoning()
-    schema_model = _build_diagnosis_schema(_taxonomy_categories_for_alert_source(alert_source))
+    schema_model = build_diagnosis_schema(taxonomy_categories_for_alert_source(alert_source))
     raw_schema = (
         llm.with_structured_output(schema_model)
         .with_config(run_name="LLM – Parse diagnosis")
@@ -258,26 +128,14 @@ Evidence keys collected: {", ".join(evidence.keys()) if evidence else "none"}
     )
     schema = cast(_DiagnosisPayload, schema_instance.model_dump())
 
-    def _to_claim_dicts(claims: list[str], status: str) -> list[dict]:
-        return [{"claim": c, "validation_status": status} for c in claims if c]
-
-    alignment = _apply_category_alignment(
-        root_cause=schema["root_cause"],
-        root_cause_category=schema["root_cause_category"],
-        validity_score=schema["validity_score"],
-    )
-
-    return InvestigationResult(
+    return build_investigation_result(
         root_cause=schema["root_cause"],
         root_cause_category=schema["root_cause_category"],
         causal_chain=schema["causal_chain"],
-        validated_claims=_to_claim_dicts(schema["validated_claims"], "validated"),
-        non_validated_claims=_to_claim_dicts(schema["non_validated_claims"], "not_validated"),
+        validated_claims=schema["validated_claims"],
+        non_validated_claims=schema["non_validated_claims"],
         remediation_steps=schema["remediation_steps"],
-        validity_score=alignment.validity_score,
-        investigation_recommendations=alignment.investigation_recommendations,
-        category_text_mismatch=alignment.category_text_mismatch,
-        category_text_mismatch_reason=alignment.category_text_mismatch_reason,
+        validity_score=schema["validity_score"],
     )
 
 
@@ -288,26 +146,14 @@ def _parse_via_legacy(
 
     try:
         rr = parse_root_cause(last_text)
-        alignment = _apply_category_alignment(
-            root_cause=rr.root_cause,
-            root_cause_category=rr.root_cause_category,
-            validity_score=0.5,
-        )
-        return InvestigationResult(
+        return build_investigation_result(
             root_cause=rr.root_cause,
             root_cause_category=rr.root_cause_category,
             causal_chain=rr.causal_chain,
-            validated_claims=[
-                {"claim": c, "validation_status": "validated"} for c in rr.validated_claims
-            ],
-            non_validated_claims=[
-                {"claim": c, "validation_status": "not_validated"} for c in rr.non_validated_claims
-            ],
+            validated_claims=rr.validated_claims,
+            non_validated_claims=rr.non_validated_claims,
             remediation_steps=rr.remediation_steps,
-            validity_score=alignment.validity_score,
-            investigation_recommendations=alignment.investigation_recommendations,
-            category_text_mismatch=alignment.category_text_mismatch,
-            category_text_mismatch_reason=alignment.category_text_mismatch_reason,
+            validity_score=0.5,
         )
     except Exception as err:
         logger.warning("Legacy parse_root_cause also failed: %s", err)

--- a/app/core/orchestration/node/extract_alert/node.py
+++ b/app/core/orchestration/node/extract_alert/node.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import json
 import logging
 import time
-from collections.abc import Mapping
 from typing import Any, cast
 
-from pydantic import BaseModel, Field
-
-from app.incident_window import resolve_incident_window
+from app.core.domain.alerts.extraction import (
+    AlertDetails,
+    enrich_raw_alert,
+    fallback_details,
+    format_raw_alert,
+    make_problem_md,
+)
+from app.core.domain.types.incident_window import resolve_incident_window
 from app.observability import (
     debug_print,
     render_investigation_header,
@@ -23,38 +27,7 @@ from app.state import InvestigationState
 
 logger = logging.getLogger(__name__)
 
-# Alert source values that must never be overwritten by the LLM classifier.
-_CANONICAL_ALERT_SOURCES = frozenset({"openrca_dataset", "opensre", "opensre_dataset"})
-
 _EXTRACTED_STATE_FIELDS = ["alert_name", "pipeline_name", "severity", "alert_source", "problem_md"]
-
-_RAW_ALERT_DETAIL_FIELDS = (
-    "kube_namespace",
-    "cloudwatch_log_group",
-    "error_message",
-    "log_query",
-    "eks_cluster",
-    "pod_name",
-    "deployment",
-)
-
-
-class AlertDetails(BaseModel):
-    is_noise: bool = Field(default=False)
-    alert_name: str = Field(default="unknown")
-    pipeline_name: str = Field(default="unknown")
-    severity: str = Field(default="unknown")
-    alert_source: str | None = Field(default=None)
-    environment: str | None = Field(default=None)
-    summary: str | None = Field(default=None)
-    kube_namespace: str | None = Field(default=None)
-    cloudwatch_log_group: str | None = Field(default=None)
-    error_message: str | None = Field(default=None)
-    log_query: str | None = Field(default=None)
-    eks_cluster: str | None = Field(default=None)
-    pod_name: str | None = Field(default=None)
-    deployment: str | None = Field(default=None)
-
 
 _EXTRACT_PROMPT = """Classify and extract fields from this alert message.
 
@@ -165,8 +138,8 @@ def _build_alert_updates(
         "pipeline_name": details.pipeline_name,
         "severity": details.severity,
         "alert_json": details.model_dump(),
-        "raw_alert": _enrich_raw_alert(raw_alert, details),
-        "problem_md": _make_problem_md(details),
+        "raw_alert": enrich_raw_alert(raw_alert, details),
+        "problem_md": make_problem_md(details),
         "incident_window": resolve_incident_window(raw_alert).to_dict(),
     }
     if details.alert_source:
@@ -181,7 +154,7 @@ def _extract_alert_details(state: InvestigationState) -> AlertDetails:
     if raw_alert is None:
         raise RuntimeError("raw_alert is required for alert extraction")
 
-    text = _format_raw_alert(raw_alert)
+    text = format_raw_alert(raw_alert)
     prompt = _EXTRACT_PROMPT.format(text=text)
 
     llm = get_llm_for_reasoning()
@@ -199,122 +172,7 @@ def _extract_alert_details(state: InvestigationState) -> AlertDetails:
         return details
     except Exception as err:
         debug_print(f"LLM alert extraction failed, using fallback: {err}")
-        return _fallback_details(state, raw_alert)
-
-
-def _format_raw_alert(raw_alert: Any) -> str:
-    if isinstance(raw_alert, str):
-        return raw_alert
-    if isinstance(raw_alert, dict):
-        if raw_alert.get("text") and not _needs_full_json_prompt(raw_alert):
-            return str(raw_alert["text"])
-        return json.dumps(raw_alert, indent=2, sort_keys=True)
-    return json.dumps(raw_alert, indent=2, sort_keys=True)
-
-
-def _needs_full_json_prompt(raw_alert: dict[str, Any]) -> bool:
-    src = str(raw_alert.get("alert_source", "")).lower()
-    if src in _CANONICAL_ALERT_SOURCES:
-        return True
-    if (
-        raw_alert.get("commonLabels")
-        or raw_alert.get("commonAnnotations")
-        or raw_alert.get("alerts")
-    ):
-        return True
-    for key in (
-        "opensre_telemetry_relative",
-        "openrca_telemetry_relative",
-        "opensre_dataset_root",
-        "openrca_dataset_root",
-    ):
-        if raw_alert.get(key):
-            return True
-        ann = raw_alert.get("commonAnnotations")
-        if isinstance(ann, dict) and ann.get(key):
-            return True
-    meta = raw_alert.get("_meta")
-    return bool(isinstance(meta, dict) and "openrca" in str(meta.get("purpose", "")).lower())
-
-
-def _fallback_details(state: InvestigationState, raw_alert: Any) -> AlertDetails:
-    alert_name = state.get("alert_name", "unknown")
-    pipeline_name = state.get("pipeline_name", "unknown")
-    severity = state.get("severity", "unknown")
-
-    if isinstance(raw_alert, dict):
-        labels = _dict_value(raw_alert, "commonLabels") or _dict_value(raw_alert, "labels")
-        annotations = _dict_value(raw_alert, "commonAnnotations") or _dict_value(
-            raw_alert, "annotations"
-        )
-        canonical = _dict_value(raw_alert, "canonical_alert")
-
-        alert_name = _first_value(
-            raw_alert.get("alert_name"),
-            canonical.get("alert_name"),
-            labels.get("alertname"),
-            labels.get("alert_name"),
-            alert_name,
-        )
-        pipeline_name = _first_value(
-            raw_alert.get("pipeline_name"),
-            canonical.get("pipeline_name"),
-            labels.get("pipeline_name"),
-            labels.get("pipeline"),
-            labels.get("service"),
-            annotations.get("pipeline_name"),
-            pipeline_name,
-        )
-        severity = _first_value(
-            raw_alert.get("severity"),
-            canonical.get("severity"),
-            labels.get("severity"),
-            severity,
-        )
-
-    return AlertDetails(
-        is_noise=False,
-        alert_name=alert_name or "unknown",
-        pipeline_name=pipeline_name or "unknown",
-        severity=severity or "unknown",
-    )
-
-
-def _dict_value(source: Mapping[str, Any], key: str) -> dict[str, Any]:
-    value = source.get(key)
-    return value if isinstance(value, dict) else {}
-
-
-def _first_value(*values: Any) -> Any:
-    return next((value for value in values if value), None)
-
-
-def _make_problem_md(details: AlertDetails) -> str:
-    parts = [
-        f"# {details.alert_name}",
-        f"Pipeline: {details.pipeline_name} | Severity: {details.severity}",
-    ]
-    if details.kube_namespace:
-        parts.append(f"Namespace: {details.kube_namespace}")
-    if details.error_message:
-        parts.append(f"\nError: {details.error_message}")
-    return "\n".join(parts)
-
-
-def _enrich_raw_alert(raw_alert: Any, details: AlertDetails) -> Any:
-    if not isinstance(raw_alert, dict):
-        raw_alert = {}
-    enriched = dict(raw_alert)
-    prior_source = str(raw_alert.get("alert_source", "")).lower()
-
-    for field_name in _RAW_ALERT_DETAIL_FIELDS:
-        value = getattr(details, field_name)
-        if value:
-            enriched[field_name] = value
-
-    if details.alert_source and prior_source not in _CANONICAL_ALERT_SOURCES:
-        enriched["alert_source"] = details.alert_source
-    return enriched
+        return fallback_details(state, raw_alert)
 
 
 def _handle_noise_reaction(state: InvestigationState) -> None:

--- a/app/core/orchestration/node/publish_findings/upstream_correlation/runtime.py
+++ b/app/core/orchestration/node/publish_findings/upstream_correlation/runtime.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any
 
 from app.core.domain.correlation.scoring import (
@@ -8,6 +7,7 @@ from app.core.domain.correlation.scoring import (
     metric_to_time_series,
     rank_upstream_candidates,
     score_candidate_correlation,
+    score_operator_hint,
     score_periodic_spikes,
     score_time_window_correlation,
     score_topology_adjacency,
@@ -21,26 +21,6 @@ from app.core.orchestration.node.publish_findings.upstream_correlation.reporting
     build_correlation_report,
     correlation_report_to_payload,
 )
-
-
-@dataclass(frozen=True)
-class RuntimeOperatorHintScore:
-    score: float
-
-
-def _operator_hint_score(
-    *,
-    metric_name: str,
-    operator_hints: tuple[str, ...],
-) -> RuntimeOperatorHintScore:
-    normalized_metric_name = (
-        metric_name.lower().replace("{", " ").replace("}", " ").replace(":", " ").replace(",", " ")
-    )
-    tokens = tuple(token for token in normalized_metric_name.split() if len(token) > 2)
-
-    matched = any(token in hint.lower() for hint in operator_hints for token in tokens)
-
-    return RuntimeOperatorHintScore(score=1.0 if matched else 0.0)
 
 
 def _empty_correlation() -> dict[str, Any]:
@@ -91,7 +71,7 @@ def build_runtime_correlation(
             spike_threshold=75.0,
         )
 
-        operator_hint = _operator_hint_score(
+        operator_hint = score_operator_hint(
             metric_name=metric.name,
             operator_hints=evidence.operator_hints,
         )

--- a/app/tools/GitDeployTimelineTool/__init__.py
+++ b/app/tools/GitDeployTimelineTool/__init__.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from app.incident_window import IncidentWindow
+from app.core.domain.types.incident_window import IncidentWindow
 from app.integrations.github_mcp import call_github_mcp_tool
 from app.tools.tool_decorator import tool
 from app.tools.utils.github_helpers import (

--- a/tests/agent/test_result.py
+++ b/tests/agent/test_result.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from app.core.orchestration.node.diagnose.node import (
-    _build_diagnosis_schema,
-    _extract_last_assistant_text,
-    _taxonomy_categories_for_alert_source,
+from app.core.domain.state.diagnosis import (
+    build_diagnosis_schema,
+    extract_last_assistant_text,
+    taxonomy_categories_for_alert_source,
 )
 
 
@@ -32,24 +32,22 @@ def test_extract_last_assistant_text_handles_anthropic_content_blocks() -> None:
         },
     ]
 
-    assert _extract_last_assistant_text(messages) == (
-        "## Diagnosis\n Root cause: missing telemetry"
-    )
+    assert extract_last_assistant_text(messages) == ("## Diagnosis\n Root cause: missing telemetry")
 
 
 def test_non_hermes_taxonomy_excludes_hermes_categories() -> None:
-    categories = _taxonomy_categories_for_alert_source("postgresql")
+    categories = taxonomy_categories_for_alert_source("postgresql")
     assert "agent_hang" not in categories
     assert "ghost_session" not in categories
 
 
 def test_hermes_taxonomy_is_scoped_to_hermes_categories() -> None:
-    categories = _taxonomy_categories_for_alert_source("hermes")
+    categories = taxonomy_categories_for_alert_source("hermes")
     assert "agent_hang" in categories
     assert "ghost_session" in categories
     assert "connection_exhaustion" not in categories
 
-    schema = _build_diagnosis_schema(categories)
+    schema = build_diagnosis_schema(categories)
     description = str(schema.model_fields["root_cause_category"].description)
     assert "agent_hang" in description
     assert "connection_exhaustion" not in description

--- a/tests/app/test_incident_window.py
+++ b/tests/app/test_incident_window.py
@@ -1,4 +1,4 @@
-"""Tests for app.incident_window.
+"""Tests for app.core.domain.types.incident_window.
 
 Coverage strategy:
 1. ``IncidentWindow`` value object: construction validation, UTC
@@ -22,7 +22,7 @@ from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 
-from app.incident_window import (
+from app.core.domain.types.incident_window import (
     DEFAULT_LOOKBACK_MINUTES,
     MAX_LOOKBACK_MINUTES,
     SCHEMA_VERSION,

--- a/tests/app/test_incident_window_cloudwatch_depth.py
+++ b/tests/app/test_incident_window_cloudwatch_depth.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from app.incident_window import (
+from app.core.domain.types.incident_window import (
     SOURCE_ACTIVATED_AT,
     SOURCE_DEFAULT,
     resolve_incident_window,

--- a/tests/app/test_incident_window_extract_wiring.py
+++ b/tests/app/test_incident_window_extract_wiring.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 
-from app.incident_window import (
+from app.core.domain.types.incident_window import (
     SOURCE_DEFAULT,
     SOURCE_STARTS_AT,
     resolve_incident_window,

--- a/tests/core/domain/alerts/test_extraction.py
+++ b/tests/core/domain/alerts/test_extraction.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from app.core.domain.alerts.extraction import (
+    fallback_details,
+    needs_full_json_prompt,
+)
+
+
+def test_needs_full_json_prompt_for_alertmanager_shape() -> None:
+    payload = {
+        "commonLabels": {"alertname": "HighCPU"},
+        "alerts": [{"startsAt": "2026-01-01T00:00:00Z"}],
+    }
+    assert needs_full_json_prompt(payload) is True
+
+
+def test_fallback_details_reads_alertmanager_labels() -> None:
+    raw_alert = {
+        "commonLabels": {"alertname": "DiskFull", "severity": "critical", "service": "api"},
+        "commonAnnotations": {"pipeline_name": "billing"},
+    }
+    details = fallback_details({}, raw_alert)
+    assert details.alert_name == "DiskFull"
+    assert details.pipeline_name == "api"
+    assert details.severity == "critical"
+    assert details.is_noise is False

--- a/tests/core/domain/correlation/test_scoring.py
+++ b/tests/core/domain/correlation/test_scoring.py
@@ -4,6 +4,7 @@ from app.core.domain.correlation.scoring import (
     TimeSeries,
     TopologyNode,
     rank_upstream_candidates,
+    score_operator_hint,
     score_time_window_correlation,
     score_topology_adjacency,
 )
@@ -33,6 +34,14 @@ def test_score_topology_adjacency_requires_target_relationship() -> None:
     )
 
     assert score.adjacency_score == 1.0
+
+
+def test_score_operator_hint_matches_metric_tokens() -> None:
+    score = score_operator_hint(
+        metric_name="orders api latency",
+        operator_hints=("orders api slow",),
+    )
+    assert score.score == 1.0
 
 
 def test_rank_upstream_candidates_orders_by_confidence_then_name() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #3017 — moves remaining high-priority pure investigation logic into `app/core/domain/`:

- `app/incident_window.py` → `domain/types/incident_window.py`
- Deterministic alert normalization from `extract_alert/node.py` → `domain/alerts/extraction.py`
- `InvestigationResult` and diagnosis parse helpers → `domain/state/diagnosis.py`
- Operator-hint scoring from upstream runtime → `domain/correlation/scoring.py`

Orchestration nodes remain thin LLM/I/O glue.

Fixes #3018

## Test plan

- [x] `make lint`
- [x] `make format-check`
- [x] `make typecheck`
- [x] Focused domain + incident-window + diagnosis tests (177 passed)
- [x] Rebased onto `main` after #3017 merge (conflict resolved)


Made with [Cursor](https://cursor.com)