### PR TITLE
feat(cli): group onboard integrations by category

### DIFF
--- a/app/cli/wizard/_integration_configurators.py
+++ b/app/cli/wizard/_integration_configurators.py
@@ -57,6 +57,11 @@ from app.cli.wizard.integration_health import (
     validate_tempo_integration,
     validate_vercel_integration,
 )
+from app.cli.wizard.onboard_integrations import (
+    ONBOARD_INTEGRATION_CHOICES,
+    ONBOARD_INTEGRATION_GROUP_ORDER,
+    ONBOARD_SKIP_CHOICE,
+)
 from app.integrations.sentry import get_sentry_auth_recommendations
 from app.integrations.store import remove_integration, upsert_integration
 
@@ -1696,132 +1701,13 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
     _console.print(
         f"[{SECONDARY}]Pick one integration to wire up now, or skip this step and come back later.[/]"
     )
-    integration_choices = [
-        Choice(
-            value="grafana_local",
-            label="Grafana Local (Docker)",
-            hint="Starts Grafana + Loki and seeds demo alerts",
-        ),
-        Choice(
-            value="grafana",
-            label="Grafana Cloud / self-hosted",
-            hint="Connect an existing Grafana instance",
-        ),
-        Choice(value="datadog", label="Datadog", hint="Logs, monitors, and Kubernetes context"),
-        Choice(value="honeycomb", label="Honeycomb", hint="Query traces and spans from Honeycomb"),
-        Choice(value="coralogix", label="Coralogix", hint="Query logs from Coralogix DataPrime"),
-        Choice(value="slack", label="Slack", hint="Send findings to a webhook or channel"),
-        Choice(
-            value="discord",
-            label="Discord",
-            hint="Trigger investigations via slash commands and post findings to threads",
-        ),
-        Choice(
-            value="telegram",
-            label="Telegram",
-            hint="Post findings to a Telegram chat",
-        ),
-        Choice(value="aws", label="AWS", hint="Inspect CloudWatch, EKS, and account resources"),
-        Choice(
-            value="github", label="GitHub MCP", hint="Let the agent inspect repos, PRs, and issues"
-        ),
-        Choice(
-            value="sentry", label="Sentry", hint="Investigate errors, events, and issue history"
-        ),
-        Choice(value="gitlab", label="Gitlab", hint="Let the agent inspect repos, PRs, and issues"),
-        Choice(
-            value="jenkins",
-            label="Jenkins",
-            hint="Correlate failed builds and deployments with incidents",
-        ),
-        Choice(
-            value="google_docs",
-            label="Google Docs",
-            hint="Create shareable incident postmortem reports",
-        ),
-        Choice(
-            value="vercel",
-            label="Vercel",
-            hint=(
-                "Deployments, build output, and logs tools; runtime-log API can lag the dashboard"
-            ),
-        ),
-        Choice(
-            value="dagster",
-            label="Dagster",
-            hint="Pipeline runs, asset materializations, and tick history",
-        ),
-        Choice(
-            value="betterstack",
-            label="Better Stack Telemetry",
-            hint="Query logs from Better Stack (ClickHouse SQL over HTTP)",
-        ),
-        Choice(
-            value="jira",
-            label="Jira",
-            hint="File and update incident tickets automatically",
-        ),
-        Choice(
-            value="alertmanager",
-            label="Alertmanager",
-            hint="Query firing alerts and silences from Prometheus Alertmanager",
-        ),
-        Choice(
-            value="opsgenie",
-            label="OpsGenie",
-            hint="Investigate alerts and triage state from OpsGenie",
-        ),
-        Choice(
-            value="pagerduty",
-            label="PagerDuty",
-            hint="Fetch incidents, on-call schedules, and service topology from PagerDuty",
-        ),
-        Choice(
-            value="incident_io",
-            label="incident.io",
-            hint="Read incident context and updates from incident.io",
-        ),
-        Choice(
-            value="notion",
-            label="Notion",
-            hint="Post investigation reports to a Notion database",
-        ),
-        Choice(
-            value="openclaw",
-            label="OpenClaw (recommended)",
-            hint="Connect OpenSRE to OpenClaw for editor-driven RCA, setup checks, and write-back",
-        ),
-        Choice(
-            value="posthog_mcp",
-            label="PostHog (MCP)",
-            hint="Query PostHog analytics, feature flags, error tracking, and HogQL via MCP",
-        ),
-        Choice(
-            value="sentry_mcp",
-            label="Sentry (MCP)",
-            hint="Query Sentry issues, events, traces, and Seer root-cause analysis via MCP",
-        ),
-        Choice(value="splunk", label="Splunk", hint="Query logs from Splunk"),
-        Choice(
-            value="opensearch",
-            label="OpenSearch / Elasticsearch",
-            hint="Query logs and indices from OpenSearch or Elasticsearch clusters",
-        ),
-        Choice(
-            value="tempo",
-            label="Grafana Tempo",
-            hint="Query distributed traces from a standalone Tempo backend",
-        ),
-        Choice(
-            value="skip",
-            label="Skip for now",
-            hint="Finish onboarding without configuring an integration",
-        ),
-    ]
+    integration_choices = list(ONBOARD_INTEGRATION_CHOICES)
     selected_service = _choose(
         "Choose an integration to configure",
         integration_choices,
         default="grafana_local",
+        group_order=ONBOARD_INTEGRATION_GROUP_ORDER,
+        trailing_choices=[ONBOARD_SKIP_CHOICE],
     )
     if selected_service == "skip":
         return configured, last_env_path

--- a/app/cli/wizard/_ui.py
+++ b/app/cli/wizard/_ui.py
@@ -150,6 +150,39 @@ def _questionary_choice(choice: Choice) -> questionary.Choice:
     )
 
 
+def _grouped_questionary_choices(
+    choices: list[Choice],
+    *,
+    group_order: tuple[str, ...],
+    trailing_choices: list[Choice] | None = None,
+) -> list[questionary.Choice | questionary.Separator]:
+    """Render selectable choices with non-selectable category separators."""
+    grouped: dict[str, list[Choice]] = {group: [] for group in group_order}
+    ungrouped: list[Choice] = []
+
+    for choice in choices:
+        if choice.group is None or choice.group not in grouped:
+            ungrouped.append(choice)
+            continue
+        grouped[choice.group].append(choice)
+
+    rendered: list[questionary.Choice | questionary.Separator] = []
+    for group in group_order:
+        group_choices = grouped[group]
+        if not group_choices:
+            continue
+        rendered.append(questionary.Separator(group))
+        rendered.extend(_questionary_choice(choice) for choice in group_choices)
+
+    rendered.extend(_questionary_choice(choice) for choice in ungrouped)
+
+    if trailing_choices:
+        rendered.append(questionary.Separator())
+        rendered.extend(_questionary_choice(choice) for choice in trailing_choices)
+
+    return rendered
+
+
 _CUSTOM_MODEL_SENTINEL = "__custom__"
 
 
@@ -204,8 +237,25 @@ def _choose_model(provider: ProviderOption, *, default: str | None) -> str:
     )
 
 
-def _choose(prompt: str, choices: list[Choice], *, default: str | None = None) -> str:
-    q_choices = [_questionary_choice(choice) for choice in choices]
+def _choose(
+    prompt: str,
+    choices: list[Choice],
+    *,
+    default: str | None = None,
+    group_order: tuple[str, ...] | None = None,
+    trailing_choices: list[Choice] | None = None,
+) -> str:
+    if group_order is not None:
+        q_choices = _grouped_questionary_choices(
+            choices,
+            group_order=group_order,
+            trailing_choices=trailing_choices,
+        )
+    else:
+        q_choices = [_questionary_choice(choice) for choice in choices]
+        if trailing_choices:
+            q_choices.append(questionary.Separator())
+            q_choices.extend(_questionary_choice(choice) for choice in trailing_choices)
 
     result = select_prompt(
         prompt,

--- a/app/cli/wizard/_ui.py
+++ b/app/cli/wizard/_ui.py
@@ -44,12 +44,18 @@ _STYLE = questionary.Style(
         ("pointer", f"fg:{HIGHLIGHT} bold"),
         ("highlighted", f"fg:{TEXT} bg:{HIGHLIGHT} bold"),
         ("selected", f"fg:{TEXT} bg:default bold"),
+        ("group-header", f"fg:{HIGHLIGHT} bold"),
         ("separator", f"fg:{DIM}"),
         ("text", f"fg:{TEXT} bg:default"),
         ("disabled", f"fg:{SECONDARY} bg:default italic"),
         ("instruction", f"fg:{SECONDARY} italic"),
     ]
 )
+
+
+def _group_header_label(group: str) -> str:
+    """Format a category label for grouped wizard pickers."""
+    return f"── {group} ──"
 
 
 @dataclass(frozen=True)
@@ -171,7 +177,7 @@ def _grouped_questionary_choices(
         group_choices = grouped[group]
         if not group_choices:
             continue
-        rendered.append(questionary.Separator(group))
+        rendered.append(questionary.Separator(_group_header_label(group)))
         rendered.extend(_questionary_choice(choice) for choice in group_choices)
 
     rendered.extend(_questionary_choice(choice) for choice in ungrouped)

--- a/app/cli/wizard/_ui.py
+++ b/app/cli/wizard/_ui.py
@@ -180,7 +180,9 @@ def _grouped_questionary_choices(
         rendered.append(questionary.Separator(_group_header_label(group)))
         rendered.extend(_questionary_choice(choice) for choice in group_choices)
 
-    rendered.extend(_questionary_choice(choice) for choice in ungrouped)
+    if ungrouped:
+        rendered.append(questionary.Separator(_group_header_label("Other")))
+        rendered.extend(_questionary_choice(choice) for choice in ungrouped)
 
     if trailing_choices:
         rendered.append(questionary.Separator())

--- a/app/cli/wizard/onboard_integrations.py
+++ b/app/cli/wizard/onboard_integrations.py
@@ -1,0 +1,196 @@
+"""Onboard wizard integration picker taxonomy and choices."""
+
+from __future__ import annotations
+
+from app.cli.wizard._ui import Choice
+
+ONBOARD_INTEGRATION_GROUP_ORDER: tuple[str, ...] = (
+    "Observability",
+    "Infrastructure & CI",
+    "Incident & Comms",
+    "Dev & Deploy",
+    "MCP & Protocols",
+)
+
+ONBOARD_INTEGRATION_CHOICES: tuple[Choice, ...] = (
+    Choice(
+        value="grafana_local",
+        label="Grafana Local (Docker)",
+        group="Observability",
+        hint="Starts Grafana + Loki and seeds demo alerts",
+    ),
+    Choice(
+        value="grafana",
+        label="Grafana Cloud / self-hosted",
+        group="Observability",
+        hint="Connect an existing Grafana instance",
+    ),
+    Choice(
+        value="datadog",
+        label="Datadog",
+        group="Observability",
+        hint="Logs, monitors, and Kubernetes context",
+    ),
+    Choice(
+        value="honeycomb",
+        label="Honeycomb",
+        group="Observability",
+        hint="Query traces and spans from Honeycomb",
+    ),
+    Choice(
+        value="coralogix",
+        label="Coralogix",
+        group="Observability",
+        hint="Query logs from Coralogix DataPrime",
+    ),
+    Choice(
+        value="sentry",
+        label="Sentry",
+        group="Observability",
+        hint="Investigate errors, events, and issue history",
+    ),
+    Choice(
+        value="betterstack",
+        label="Better Stack Telemetry",
+        group="Observability",
+        hint="Query logs from Better Stack (ClickHouse SQL over HTTP)",
+    ),
+    Choice(
+        value="splunk",
+        label="Splunk",
+        group="Observability",
+        hint="Query logs from Splunk",
+    ),
+    Choice(
+        value="opensearch",
+        label="OpenSearch / Elasticsearch",
+        group="Observability",
+        hint="Query logs and indices from OpenSearch or Elasticsearch clusters",
+    ),
+    Choice(
+        value="tempo",
+        label="Grafana Tempo",
+        group="Observability",
+        hint="Query distributed traces from a standalone Tempo backend",
+    ),
+    Choice(
+        value="aws",
+        label="AWS",
+        group="Infrastructure & CI",
+        hint="Inspect CloudWatch, EKS, and account resources",
+    ),
+    Choice(
+        value="jenkins",
+        label="Jenkins",
+        group="Infrastructure & CI",
+        hint="Correlate failed builds and deployments with incidents",
+    ),
+    Choice(
+        value="dagster",
+        label="Dagster",
+        group="Infrastructure & CI",
+        hint="Pipeline runs, asset materializations, and tick history",
+    ),
+    Choice(
+        value="jira",
+        label="Jira",
+        group="Incident & Comms",
+        hint="File and update incident tickets automatically",
+    ),
+    Choice(
+        value="alertmanager",
+        label="Alertmanager",
+        group="Incident & Comms",
+        hint="Query firing alerts and silences from Prometheus Alertmanager",
+    ),
+    Choice(
+        value="opsgenie",
+        label="OpsGenie",
+        group="Incident & Comms",
+        hint="Investigate alerts and triage state from OpsGenie",
+    ),
+    Choice(
+        value="pagerduty",
+        label="PagerDuty",
+        group="Incident & Comms",
+        hint="Fetch incidents, on-call schedules, and service topology from PagerDuty",
+    ),
+    Choice(
+        value="incident_io",
+        label="incident.io",
+        group="Incident & Comms",
+        hint="Read incident context and updates from incident.io",
+    ),
+    Choice(
+        value="slack",
+        label="Slack",
+        group="Incident & Comms",
+        hint="Send findings to a webhook or channel",
+    ),
+    Choice(
+        value="discord",
+        label="Discord",
+        group="Incident & Comms",
+        hint="Trigger investigations via slash commands and post findings to threads",
+    ),
+    Choice(
+        value="telegram",
+        label="Telegram",
+        group="Incident & Comms",
+        hint="Post findings to a Telegram chat",
+    ),
+    Choice(
+        value="google_docs",
+        label="Google Docs",
+        group="Incident & Comms",
+        hint="Create shareable incident postmortem reports",
+    ),
+    Choice(
+        value="notion",
+        label="Notion",
+        group="Incident & Comms",
+        hint="Post investigation reports to a Notion database",
+    ),
+    Choice(
+        value="gitlab",
+        label="Gitlab",
+        group="Dev & Deploy",
+        hint="Let the agent inspect repos, PRs, and issues",
+    ),
+    Choice(
+        value="vercel",
+        label="Vercel",
+        group="Dev & Deploy",
+        hint=("Deployments, build output, and logs tools; runtime-log API can lag the dashboard"),
+    ),
+    Choice(
+        value="github",
+        label="GitHub MCP",
+        group="MCP & Protocols",
+        hint="Let the agent inspect repos, PRs, and issues",
+    ),
+    Choice(
+        value="openclaw",
+        label="OpenClaw (recommended)",
+        group="MCP & Protocols",
+        hint="Connect OpenSRE to OpenClaw for editor-driven RCA, setup checks, and write-back",
+    ),
+    Choice(
+        value="posthog_mcp",
+        label="PostHog (MCP)",
+        group="MCP & Protocols",
+        hint="Query PostHog analytics, feature flags, error tracking, and HogQL via MCP",
+    ),
+    Choice(
+        value="sentry_mcp",
+        label="Sentry (MCP)",
+        group="MCP & Protocols",
+        hint="Query Sentry issues, events, traces, and Seer root-cause analysis via MCP",
+    ),
+)
+
+ONBOARD_SKIP_CHOICE = Choice(
+    value="skip",
+    label="Skip for now",
+    hint="Finish onboarding without configuring an integration",
+)

--- a/app/cli/wizard/prompts.py
+++ b/app/cli/wizard/prompts.py
@@ -27,6 +27,107 @@ from app.cli.interactive_shell.ui.prompt_support import (
 from app.cli.interactive_shell.ui.theme import GLYPH_PROMPT
 
 
+class _SelectControl(InquirerControl):
+    """Single-select list with prominent category headers."""
+
+    def _append_separator_tokens(
+        self,
+        tokens: list[tuple[str, str]],
+        *,
+        title: str,
+        saw_group_header: bool,
+    ) -> bool:
+        label = title.strip()
+        pointer_length = len(self.pointer) if self.pointer is not None else 1
+        indent = " " * (2 + pointer_length)
+
+        if label.startswith("── ") and label.endswith(" ──"):
+            if saw_group_header:
+                tokens.append(("", "\n"))
+            tokens.append(("class:text", indent))
+            tokens.append(("class:group-header", label))
+            tokens.append(("", "\n"))
+            return True
+
+        if label:
+            tokens.append(("class:text", indent))
+            tokens.append(("class:separator", label))
+            tokens.append(("", "\n"))
+            return saw_group_header
+
+        tokens.append(("class:text", indent))
+        tokens.append(("class:separator", "─" * 36))
+        tokens.append(("", "\n"))
+        return saw_group_header
+
+    def _get_choice_tokens(self) -> list[tuple[str, str]]:  # type: ignore[override]
+        tokens: list[tuple[str, str]] = []
+        saw_group_header = False
+
+        for index, choice in enumerate(self.filtered_choices):
+            selected = choice.value in self.selected_options
+            is_pointed = index == self.pointed_at
+
+            if is_pointed:
+                if self.pointer is not None:
+                    tokens.append(("class:pointer", f" {self.pointer} "))
+                else:
+                    tokens.append(("class:text", " " * 3))
+                tokens.append(("[SetCursorPosition]", ""))
+            else:
+                pointer_length = len(self.pointer) if self.pointer is not None else 1
+                tokens.append(("class:text", " " * (2 + pointer_length)))
+
+            if isinstance(choice, Separator):
+                saw_group_header = self._append_separator_tokens(
+                    tokens,
+                    title=str(choice.title or ""),
+                    saw_group_header=saw_group_header,
+                )
+                continue
+
+            if choice.disabled:
+                disabled_class = "class:selected" if selected else "class:disabled"
+                if isinstance(choice.title, list):
+                    tokens.append((disabled_class, "- "))
+                    tokens.extend(choice.title)
+                else:
+                    tokens.append((disabled_class, f"- {choice.title}"))
+                if not isinstance(choice.disabled, bool):
+                    tokens.append((disabled_class, f" ({choice.disabled})"))
+                tokens.append(("", "\n"))
+                continue
+
+            shortcut = choice.get_shortcut_title() if self.use_shortcuts else ""
+            if selected:
+                indicator = f"{INDICATOR_SELECTED} " if self.use_indicator else ""
+                tokens.append(("class:selected", indicator))
+            else:
+                indicator = f"{INDICATOR_UNSELECTED} " if self.use_indicator else ""
+                tokens.append(("class:text", indicator))
+
+            if isinstance(choice.title, list):
+                text_class = (
+                    "class:highlighted"
+                    if is_pointed
+                    else ("class:selected" if selected else "class:text")
+                )
+                tokens.extend((text_class, text) for _style, text in choice.title)
+            elif selected:
+                tokens.append(("class:selected", f"{shortcut}{choice.title}"))
+            elif is_pointed:
+                tokens.append(("class:highlighted", f"{shortcut}{choice.title}"))
+            else:
+                tokens.append(("class:text", f"{shortcut}{choice.title}"))
+
+            tokens.append(("", "\n"))
+
+        if tokens and not (self.show_selected or self.show_description):
+            tokens.pop()
+
+        return tokens
+
+
 class _CheckboxControl(InquirerControl):
     """Render checked items neutrally unless they are the active row."""
 
@@ -192,7 +293,7 @@ def select(
     output: Any | None = None,
 ) -> Question:
     """Render a single-select prompt with navigation-only movement."""
-    ic = InquirerControl(
+    ic = _SelectControl(
         choices,
         None,
         pointer="❯",

--- a/tests/cli/wizard/test_onboard_integrations.py
+++ b/tests/cli/wizard/test_onboard_integrations.py
@@ -1,0 +1,45 @@
+"""Tests for onboard integration picker taxonomy."""
+
+from __future__ import annotations
+
+import questionary
+
+from app.cli.wizard._ui import _grouped_questionary_choices
+from app.cli.wizard.onboard_integrations import (
+    ONBOARD_INTEGRATION_CHOICES,
+    ONBOARD_INTEGRATION_GROUP_ORDER,
+    ONBOARD_SKIP_CHOICE,
+)
+
+
+def test_onboard_integration_choices_have_unique_values_and_valid_groups() -> None:
+    values = [choice.value for choice in ONBOARD_INTEGRATION_CHOICES]
+    assert len(values) == len(set(values))
+    assert ONBOARD_SKIP_CHOICE.value not in values
+
+    for choice in ONBOARD_INTEGRATION_CHOICES:
+        assert choice.group in ONBOARD_INTEGRATION_GROUP_ORDER
+
+
+def test_grouped_questionary_choices_renders_category_separators() -> None:
+    rendered = _grouped_questionary_choices(
+        list(ONBOARD_INTEGRATION_CHOICES),
+        group_order=ONBOARD_INTEGRATION_GROUP_ORDER,
+        trailing_choices=[ONBOARD_SKIP_CHOICE],
+    )
+
+    separator_titles = [item.title for item in rendered if isinstance(item, questionary.Separator)]
+    assert separator_titles[: len(ONBOARD_INTEGRATION_GROUP_ORDER)] == list(
+        ONBOARD_INTEGRATION_GROUP_ORDER
+    )
+    assert len(separator_titles) == len(ONBOARD_INTEGRATION_GROUP_ORDER) + 1
+
+    selectable_values = [
+        item.value
+        for item in rendered
+        if isinstance(item, questionary.Choice) and not isinstance(item, questionary.Separator)
+    ]
+    assert selectable_values == [
+        *[choice.value for choice in ONBOARD_INTEGRATION_CHOICES],
+        ONBOARD_SKIP_CHOICE.value,
+    ]

--- a/tests/cli/wizard/test_onboard_integrations.py
+++ b/tests/cli/wizard/test_onboard_integrations.py
@@ -4,12 +4,34 @@ from __future__ import annotations
 
 import questionary
 
-from app.cli.wizard._ui import _grouped_questionary_choices
+from app.cli.wizard._ui import _group_header_label, _grouped_questionary_choices
 from app.cli.wizard.onboard_integrations import (
     ONBOARD_INTEGRATION_CHOICES,
     ONBOARD_INTEGRATION_GROUP_ORDER,
     ONBOARD_SKIP_CHOICE,
 )
+from app.cli.wizard.prompts import _SelectControl
+
+
+def test_group_header_label_formats_category_title() -> None:
+    assert _group_header_label("Observability") == "── Observability ──"
+
+
+def test_select_control_renders_group_headers_with_highlight_style() -> None:
+    ic = _SelectControl(
+        [
+            questionary.Separator(_group_header_label("Observability")),
+            questionary.Choice("Datadog", value="datadog"),
+        ],
+        None,
+        pointer="❯",
+        initial_choice="datadog",
+        show_description=False,
+    )
+
+    rendered = "".join(text for _style, text in ic._get_choice_tokens())
+    assert "── Observability ──" in rendered
+    assert any(style == "class:group-header" for style, _text in ic._get_choice_tokens())
 
 
 def test_onboard_integration_choices_have_unique_values_and_valid_groups() -> None:
@@ -29,9 +51,9 @@ def test_grouped_questionary_choices_renders_category_separators() -> None:
     )
 
     separator_titles = [item.title for item in rendered if isinstance(item, questionary.Separator)]
-    assert separator_titles[: len(ONBOARD_INTEGRATION_GROUP_ORDER)] == list(
-        ONBOARD_INTEGRATION_GROUP_ORDER
-    )
+    assert separator_titles[: len(ONBOARD_INTEGRATION_GROUP_ORDER)] == [
+        _group_header_label(group) for group in ONBOARD_INTEGRATION_GROUP_ORDER
+    ]
     assert len(separator_titles) == len(ONBOARD_INTEGRATION_GROUP_ORDER) + 1
 
     selectable_values = [

--- a/tests/cli/wizard/test_onboard_integrations.py
+++ b/tests/cli/wizard/test_onboard_integrations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import questionary
 
-from app.cli.wizard._ui import _group_header_label, _grouped_questionary_choices
+from app.cli.wizard._ui import Choice, _group_header_label, _grouped_questionary_choices
 from app.cli.wizard.onboard_integrations import (
     ONBOARD_INTEGRATION_CHOICES,
     ONBOARD_INTEGRATION_GROUP_ORDER,
@@ -43,6 +43,26 @@ def test_onboard_integration_choices_have_unique_values_and_valid_groups() -> No
         assert choice.group in ONBOARD_INTEGRATION_GROUP_ORDER
 
 
+def _expected_grouped_choice_values(
+    choices: tuple[Choice, ...] | list[Choice],
+    *,
+    group_order: tuple[str, ...],
+    trailing_choices: list[Choice] | None = None,
+) -> list[str]:
+    """Build selectable values in the same order as ``_grouped_questionary_choices``."""
+    grouped_values: dict[str, list[str]] = {group: [] for group in group_order}
+    for choice in choices:
+        if choice.group in grouped_values:
+            grouped_values[choice.group].append(choice.value)
+
+    ordered_values: list[str] = []
+    for group in group_order:
+        ordered_values.extend(grouped_values[group])
+    if trailing_choices:
+        ordered_values.extend(choice.value for choice in trailing_choices)
+    return ordered_values
+
+
 def test_grouped_questionary_choices_renders_category_separators() -> None:
     rendered = _grouped_questionary_choices(
         list(ONBOARD_INTEGRATION_CHOICES),
@@ -61,7 +81,30 @@ def test_grouped_questionary_choices_renders_category_separators() -> None:
         for item in rendered
         if isinstance(item, questionary.Choice) and not isinstance(item, questionary.Separator)
     ]
-    assert selectable_values == [
-        *[choice.value for choice in ONBOARD_INTEGRATION_CHOICES],
-        ONBOARD_SKIP_CHOICE.value,
+    assert selectable_values == _expected_grouped_choice_values(
+        ONBOARD_INTEGRATION_CHOICES,
+        group_order=ONBOARD_INTEGRATION_GROUP_ORDER,
+        trailing_choices=[ONBOARD_SKIP_CHOICE],
+    )
+
+
+def test_grouped_questionary_choices_labels_unknown_groups_as_other() -> None:
+    rendered = _grouped_questionary_choices(
+        [
+            Choice(value="datadog", label="Datadog", group="Observability"),
+            Choice(value="custom", label="Custom", group="Unknown"),
+        ],
+        group_order=("Observability",),
+    )
+
+    separator_titles = [item.title for item in rendered if isinstance(item, questionary.Separator)]
+    assert separator_titles == [
+        _group_header_label("Observability"),
+        _group_header_label("Other"),
     ]
+    selectable_values = [
+        item.value
+        for item in rendered
+        if isinstance(item, questionary.Choice) and not isinstance(item, questionary.Separator)
+    ]
+    assert selectable_values == ["datadog", "custom"]


### PR DESCRIPTION
Fixes #3020

#### Describe the changes you have made in this PR -

- Group the `opensre onboard` integration picker into five categories with visible section headers.
- Move integration choice definitions into `app/cli/wizard/onboard_integrations.py` as the single taxonomy source.
- Extend wizard `_choose()` to render `questionary.Separator` headers when `group_order` is provided.
- Keep **Skip for now** separated at the bottom after all integration groups.

**Taxonomy (agreed simpler scheme):**

| Group | Integrations |
| --- | --- |
| **Observability** | Grafana Local, Grafana Cloud, Datadog, Honeycomb, Coralogix, Sentry, Better Stack, Splunk, OpenSearch, Tempo |
| **Infrastructure & CI** | AWS, Jenkins, Dagster |
| **Incident & Comms** | Jira, Alertmanager, OpsGenie, PagerDuty, incident.io, Slack, Discord, Telegram, Google Docs, Notion |
| **Dev & Deploy** | GitLab, Vercel |
| **MCP & Protocols** | GitHub MCP, OpenClaw, PostHog (MCP), Sentry (MCP) |

MCP integrations are grouped together so users can distinguish transport/protocol setup from native API integrations (e.g. Sentry vs Sentry MCP).

### Demo/Screenshot for feature changes and bug fixes - 
Before
<img width="943" height="580" alt="image" src="https://github.com/user-attachments/assets/241fc847-78aa-453d-8518-ac80653d00ef" />


After 
<img width="792" height="713" alt="image" src="https://github.com/user-attachments/assets/fbb89c49-f15c-4684-9330-ea51d9caf8da" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The onboard integration list was a flat inline array in `_integration_configurators.py`, which made categories impossible to scan. I extracted choices plus group metadata into `onboard_integrations.py` and taught `_choose()` to render grouped separators using the same questionary pattern already used in `remote.py`. Separators are non-selectable and navigation skips them via existing `is_selection_valid()` logic in `prompts.py`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
