### PR TITLE
fix(cli): show full root cause in feedback prompt

### DIFF
--- a/app/cli/interactive_shell/ui/feedback.py
+++ b/app/cli/interactive_shell/ui/feedback.py
@@ -155,13 +155,15 @@ def _print_context(final_state: dict[str, Any], *, console: Console | None) -> N
 
     cols = min(88, max(40, shutil.get_terminal_size((80, 24)).columns))
 
+    from rich.markup import escape
+
     from app.cli.interactive_shell.ui.theme import BRAND, DIM, SECONDARY
 
     if console is not None:
         console.print()
         console.rule(characters="─", style=DIM)
         console.print(
-            f"[{SECONDARY}]Root cause:[/] [{BRAND}]{root}[/]",
+            f"[{SECONDARY}]Root cause:[/] [{BRAND}]{escape(root)}[/]",
             soft_wrap=True,
             width=cols,
         )

--- a/app/cli/interactive_shell/ui/feedback.py
+++ b/app/cli/interactive_shell/ui/feedback.py
@@ -130,8 +130,23 @@ def _emit_analytics(record: dict[str, Any]) -> None:
 # ── context display ───────────────────────────────────────────────────────────
 
 
+def _format_root_cause_lines(root: str, *, cols: int) -> list[str]:
+    """Wrap root-cause text to terminal width with a hanging ``Root cause:`` prefix."""
+    import textwrap
+
+    prefix = "Root cause: "
+    content_width = max(20, cols - len(prefix))
+    wrapped = textwrap.wrap(root, width=content_width)
+    if not wrapped:
+        return []
+    lines = [prefix + wrapped[0]]
+    indent = " " * len(prefix)
+    lines.extend(indent + line for line in wrapped[1:])
+    return lines
+
+
 def _print_context(final_state: dict[str, Any], *, console: Console | None) -> None:
-    """Print a brief root-cause snippet above the rating prompt."""
+    """Print the root-cause summary above the rating prompt."""
     root = (final_state.get("root_cause") or "").strip()
     if not root:
         return
@@ -139,17 +154,21 @@ def _print_context(final_state: dict[str, Any], *, console: Console | None) -> N
     import shutil
 
     cols = min(88, max(40, shutil.get_terminal_size((80, 24)).columns))
-    snippet = root if len(root) <= cols - 14 else root[: cols - 17] + "…"
 
     from app.cli.interactive_shell.ui.theme import BRAND, DIM, SECONDARY
 
     if console is not None:
         console.print()
         console.rule(characters="─", style=DIM)
-        console.print(f"[{SECONDARY}]Root cause:[/] [{BRAND}]{snippet}[/]")
+        console.print(
+            f"[{SECONDARY}]Root cause:[/] [{BRAND}]{root}[/]",
+            soft_wrap=True,
+            width=cols,
+        )
     else:
         rule = "─" * cols
-        sys.stdout.write(f"\n{rule}\nRoot cause: {snippet}\n{rule}\n")
+        body = "\n".join(_format_root_cause_lines(root, cols=cols))
+        sys.stdout.write(f"\n{rule}\n{body}\n{rule}\n")
         sys.stdout.flush()
 
 

--- a/tests/cli/interactive_shell/ui/test_feedback.py
+++ b/tests/cli/interactive_shell/ui/test_feedback.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import io
 
-import pytest
 from rich.console import Console
 
 from app.cli.interactive_shell.ui.feedback import _format_root_cause_lines, _print_context
@@ -24,11 +23,7 @@ def test_format_root_cause_lines_wraps_long_text_without_truncation() -> None:
     assert " ".join(line.strip() for line in lines) == f"Root cause: {root}"
 
 
-def test_print_context_shows_full_root_cause_in_rich_path(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "shutil.get_terminal_size",
-        lambda _fallback: type("Size", (), {"columns": 60})(),
-    )
+def test_print_context_shows_full_root_cause_in_rich_path() -> None:
     root = (
         "The Kubernetes job 'etl-transform-error' for pipeline "
         "'kubernetes_etl_pipeline' failed because schema validation requires "

--- a/tests/cli/interactive_shell/ui/test_feedback.py
+++ b/tests/cli/interactive_shell/ui/test_feedback.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import io
+import os
 
+import pytest
 from rich.console import Console
 
 from app.cli.interactive_shell.ui.feedback import _format_root_cause_lines, _print_context
+
+
+def _fixed_terminal_size(*_args: object, **_kwargs: object) -> os.terminal_size:
+    return os.terminal_size((60, 24))
 
 
 def test_format_root_cause_lines_wraps_long_text_without_truncation() -> None:
@@ -37,3 +43,39 @@ def test_print_context_shows_full_root_cause_in_rich_path() -> None:
     output = buf.getvalue()
     assert root in output
     assert "…" not in output
+
+
+def test_print_context_escapes_rich_markup_in_root() -> None:
+    root = "Pod restart [1/3] failed because schema validation requires 'payment_method'."
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=80)
+
+    _print_context({"root_cause": root}, console=console)
+
+    output = buf.getvalue()
+    assert "[1/3]" in output
+    assert "…" not in output
+
+
+def test_print_context_shows_full_root_cause_in_stdout_path(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("shutil.get_terminal_size", _fixed_terminal_size)
+    root = (
+        "The Kubernetes job 'etl-transform-error' for pipeline "
+        "'kubernetes_etl_pipeline' failed because schema validation requires "
+        "'payment_method'."
+    )
+
+    _print_context({"root_cause": root}, console=None)
+
+    captured = capsys.readouterr().out
+    assert "…" not in captured
+    assert " ".join(captured.split()) == (
+        "─" * 60
+        + " Root cause: "
+        + root
+        + " "
+        + "─" * 60
+    )

--- a/tests/cli/interactive_shell/ui/test_feedback.py
+++ b/tests/cli/interactive_shell/ui/test_feedback.py
@@ -1,0 +1,44 @@
+"""Tests for post-investigation feedback UI."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from rich.console import Console
+
+from app.cli.interactive_shell.ui.feedback import _format_root_cause_lines, _print_context
+
+
+def test_format_root_cause_lines_wraps_long_text_without_truncation() -> None:
+    root = (
+        "The Kubernetes job 'etl-transform-error' for pipeline "
+        "'kubernetes_etl_pipeline' failed in namespace 'tracer-test' because "
+        "schema validation requires 'payment_method'."
+    )
+
+    lines = _format_root_cause_lines(root, cols=60)
+
+    assert len(lines) > 1
+    assert all("…" not in line for line in lines)
+    assert " ".join(line.strip() for line in lines) == f"Root cause: {root}"
+
+
+def test_print_context_shows_full_root_cause_in_rich_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "shutil.get_terminal_size",
+        lambda _fallback: type("Size", (), {"columns": 60})(),
+    )
+    root = (
+        "The Kubernetes job 'etl-transform-error' for pipeline "
+        "'kubernetes_etl_pipeline' failed because schema validation requires "
+        "'payment_method'."
+    )
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=60)
+
+    _print_context({"root_cause": root}, console=console)
+
+    output = buf.getvalue()
+    assert root in output
+    assert "…" not in output

--- a/tests/cli/interactive_shell/ui/test_feedback.py
+++ b/tests/cli/interactive_shell/ui/test_feedback.py
@@ -72,10 +72,4 @@ def test_print_context_shows_full_root_cause_in_stdout_path(
 
     captured = capsys.readouterr().out
     assert "…" not in captured
-    assert " ".join(captured.split()) == (
-        "─" * 60
-        + " Root cause: "
-        + root
-        + " "
-        + "─" * 60
-    )
+    assert " ".join(captured.split()) == ("─" * 60 + " Root cause: " + root + " " + "─" * 60)


### PR DESCRIPTION
Fixes #3024

#### Describe the changes you have made in this PR -

- Remove single-line truncation (`root[: cols - 17] + "…"`) from the post-investigation feedback context in `app/cli/interactive_shell/ui/feedback.py`.
- Wrap the full root cause to terminal width instead: Rich `soft_wrap` for the REPL path, `textwrap` with a hanging `Root cause:` prefix for the plain stdout CLI path.
- Add `_format_root_cause_lines()` helper and regression tests in `tests/cli/interactive_shell/ui/test_feedback.py`.

### Demo/Screenshot for feature changes and bug fixes - 
Before: `Root cause: The Kubernetes job 'etl-transform-error' for pipeline 'kubernetes_etl_p…`
Check #3024 

After: full root-cause sentence wraps across lines above the "Was this RCA accurate?" prompt.

<img width="1900" height="943" alt="image" src="https://github.com/user-attachments/assets/3c023eb3-4dc0-49bd-b90d-dc0120ac1996" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The feedback prompt intentionally showed a brief root-cause snippet, but truncation made long RCAs unreadable right when the user is asked to rate accuracy. Wrapping preserves the full text without changing the feedback flow. Considered removing the context line entirely, but keeping it with wrapping gives useful context for rating. Two render paths exist (Rich console vs plain stdout after streaming); each uses the appropriate wrapping mechanism already used elsewhere in the CLI.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
