### PR TITLE
fix(ci): append PR number to automerge squash subject

### DIFF
--- a/.github/scripts/automerge_pr.py
+++ b/.github/scripts/automerge_pr.py
@@ -69,6 +69,14 @@ def _rollup_item_is_green(check: dict[str, Any]) -> tuple[bool, str]:
     return _check_run_is_green(check)
 
 
+def _squash_commit_subject(title: str, pr_number: str) -> str:
+    suffix = f"(#{pr_number})"
+    stripped = title.rstrip()
+    if stripped.endswith(suffix):
+        return stripped
+    return f"{stripped} {suffix}"
+
+
 def _checks_are_green(status_rollup: list[dict[str, Any]]) -> tuple[bool, str]:
     if not status_rollup:
         return False, "no status checks reported yet"
@@ -148,7 +156,7 @@ def main() -> int:
             "--squash",
             "--delete-branch",
             "--subject",
-            title,
+            _squash_commit_subject(title, pr_number),
         ],
         check=True,
     )

--- a/tests/github/test_automerge_pr.py
+++ b/tests/github/test_automerge_pr.py
@@ -10,6 +10,20 @@ automerge_pr = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(automerge_pr)
 
 
+def test_squash_commit_subject_appends_pr_number() -> None:
+    assert (
+        automerge_pr._squash_commit_subject("fix(cli): show full root cause", "3025")
+        == "fix(cli): show full root cause (#3025)"
+    )
+
+
+def test_squash_commit_subject_avoids_duplicate_pr_number() -> None:
+    assert (
+        automerge_pr._squash_commit_subject("fix(cli): example (#3025)", "3025")
+        == "fix(cli): example (#3025)"
+    )
+
+
 def test_checks_are_green_for_completed_check_runs() -> None:
     green, reason = automerge_pr._checks_are_green(
         [


### PR DESCRIPTION
Fixes #

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Append `(#NNNN)` to the squash merge subject in `.github/scripts/automerge_pr.py` so automerge commits match GitHub’s default manual squash format (e.g. PR #3025 landed without the PR number).
- Add `_squash_commit_subject()` helper that skips duplicate suffixes when the title already ends with `(#NNNN)`.
- Add unit tests in `tests/github/test_automerge_pr.py`.

### Demo/Screenshot for feature changes and bug fixes - 
N/A — workflow script change only. Verified with `uv run python -m pytest tests/github/test_automerge_pr.py -v` (8 passed).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Automerge passes `--subject` to `gh pr merge`, which overrides GitHub’s default squash title and dropped the `(#PR)` suffix. The fix appends `(#<pr_number>)` to the PR title unless it is already present, keeping history consistent with manually merged PRs. Considered omitting `--subject` entirely, but we set it explicitly today to control the title; appending the suffix is the minimal change.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
