### PR TITLE
fix(cli): use full terminal width for RCA feedback box

### DIFF
--- a/app/cli/interactive_shell/ui/feedback.py
+++ b/app/cli/interactive_shell/ui/feedback.py
@@ -145,15 +145,24 @@ def _format_root_cause_lines(root: str, *, cols: int) -> list[str]:
     return lines
 
 
+def _root_cause_width(*, console: Console | None) -> int:
+    """Best-effort terminal width for root-cause display (matches REPL tables)."""
+    import shutil
+
+    from app.cli.interactive_shell.ui.rendering import _repl_table_width
+
+    if console is not None:
+        return _repl_table_width(console)
+    return max(40, shutil.get_terminal_size(fallback=(80, 24)).columns)
+
+
 def _print_context(final_state: dict[str, Any], *, console: Console | None) -> None:
     """Print the root-cause summary above the rating prompt."""
     root = (final_state.get("root_cause") or "").strip()
     if not root:
         return
 
-    import shutil
-
-    cols = min(88, max(40, shutil.get_terminal_size((80, 24)).columns))
+    cols = _root_cause_width(console=console)
 
     from rich.markup import escape
 

--- a/tests/cli/interactive_shell/ui/test_feedback.py
+++ b/tests/cli/interactive_shell/ui/test_feedback.py
@@ -8,11 +8,41 @@ import os
 import pytest
 from rich.console import Console
 
-from app.cli.interactive_shell.ui.feedback import _format_root_cause_lines, _print_context
+from app.cli.interactive_shell.ui.feedback import (
+    _format_root_cause_lines,
+    _print_context,
+    _root_cause_width,
+)
 
 
 def _fixed_terminal_size(*_args: object, **_kwargs: object) -> os.terminal_size:
     return os.terminal_size((60, 24))
+
+
+def _wide_terminal_size(*_args: object, **_kwargs: object) -> os.terminal_size:
+    return os.terminal_size((160, 24))
+
+
+def test_root_cause_width_uses_full_terminal_not_capped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("shutil.get_terminal_size", _wide_terminal_size)
+
+    assert _root_cause_width(console=None) == 160
+
+
+def test_print_context_stdout_uses_full_terminal_width(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("shutil.get_terminal_size", _wide_terminal_size)
+    root = "Schema validation failed because payment_method is missing."
+
+    _print_context({"root_cause": root}, console=None)
+
+    captured = capsys.readouterr().out
+    assert captured.startswith("\n" + "─" * 160 + "\n")
+    assert captured.rstrip().endswith("─" * 160)
 
 
 def test_format_root_cause_lines_wraps_long_text_without_truncation() -> None:


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

The post-investigation RCA feedback box capped display width at 88 columns, so the horizontal rules and wrapped root-cause text appeared as a narrow "half box" on wide terminals while the investigation report above used the full width.

- Remove the hard `min(88, …)` cap in `_print_context`.
- Add `_root_cause_width()` that uses full terminal width on the stdout/CLI path and `_repl_table_width()` on the Rich REPL path for parity with other REPL output.
- Add regression tests asserting 160-column terminals render 160-column rules.

### Demo/Screenshot for feature changes and bug fixes - 

Quick visual check without running a full investigation:

```bash
uv run python -c "
from app.cli.interactive_shell.ui.feedback import _print_context
root = 'Schema validation failed: Missing fields [\"payment_method\"] in record 0 in namespace tracer-test.'
_print_context({'root_cause': root}, console=None)
"
```

Rules and wrapped text should span the full terminal width.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The feedback prompt reuses the same width helper as REPL tables (`_repl_table_width`) when a Rich console is available, and falls back to `shutil.get_terminal_size()` without an artificial cap for the CLI stdout path. This keeps the root-cause box aligned with the rest of the terminal output on any screen size.

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
