### PR TITLE
fix(tools): inject Grafana creds from classified integration configs

### DIFF
--- a/app/core/orchestration/node/investigate/tools.py
+++ b/app/core/orchestration/node/investigate/tools.py
@@ -12,6 +12,7 @@ from app.core.runtime import public_tool_input
 from app.services.agent_llm_client import ToolCall
 from app.tools.registered_tool import RegisteredTool
 from app.tools.registry import get_registered_tools
+from app.tools.utils.integration_sources import availability_view
 from app.utils.tool_trace import redact_sensitive
 
 # Consecutive iterations made up ENTIRELY of duplicate (already-seen) tool calls
@@ -32,28 +33,6 @@ STAGNATION_NUDGE = (
 def get_available_tools(resolved_integrations: dict[str, Any]) -> list[RegisteredTool]:
     available_sources = availability_view(resolved_integrations)
     return [t for t in get_registered_tools("investigation") if t.is_available(available_sources)]
-
-
-def availability_view(resolved_integrations: dict[str, Any]) -> dict[str, Any]:
-    """Adapt resolved integration configs to the legacy tool availability contract."""
-    from pydantic import BaseModel
-
-    view: dict[str, Any] = {}
-    for key, value in resolved_integrations.items():
-        if key.startswith("_"):
-            view[key] = value
-            continue
-        if isinstance(value, BaseModel):
-            item = value.model_dump(exclude_none=True)
-            item.setdefault("connection_verified", True)
-            view[key] = item
-        elif isinstance(value, dict) and value:
-            item = dict(value)
-            item.setdefault("connection_verified", True)
-            view[key] = item
-        else:
-            view[key] = value
-    return view
 
 
 def build_connected_tool_context(

--- a/app/core/orchestration/node/investigate/tools.py
+++ b/app/core/orchestration/node/investigate/tools.py
@@ -107,6 +107,7 @@ def build_seed_calls(
         return []
 
     resolved = state.get("resolved_integrations") or {}
+    tool_sources = availability_view(resolved)
     seed_tools = [t for t in tools if str(t.source) in target_sources]
     if not seed_tools:
         return []
@@ -118,7 +119,7 @@ def build_seed_calls(
     calls: list[ToolCall] = []
     for tool in seed_tools:
         try:
-            injected = tool.extract_params(resolved)
+            injected = tool.extract_params(tool_sources)
         except Exception:
             injected = {}
         tool_id = new_tool_use_id() if use_converse_ids else f"seed_{tool.name}"

--- a/app/core/runtime/execution.py
+++ b/app/core/runtime/execution.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from app.services.agent_llm_client import ToolCall
 from app.tools.registered_tool import RegisteredTool
+from app.tools.utils.integration_sources import availability_view
 from app.utils.tool_trace import redact_sensitive
 
 logger = logging.getLogger(__name__)
@@ -22,8 +23,6 @@ def execute_tools(
     tools: list[RegisteredTool],
     resolved_integrations: dict[str, Any],
 ) -> list[Any]:
-    from app.core.orchestration.node.investigate.tools import availability_view
-
     tool_sources = availability_view(resolved_integrations)
     tool_map = {t.name: t for t in tools}
 

--- a/app/core/runtime/execution.py
+++ b/app/core/runtime/execution.py
@@ -22,6 +22,9 @@ def execute_tools(
     tools: list[RegisteredTool],
     resolved_integrations: dict[str, Any],
 ) -> list[Any]:
+    from app.core.orchestration.node.investigate.tools import availability_view
+
+    tool_sources = availability_view(resolved_integrations)
     tool_map = {t.name: t for t in tools}
 
     def _call(tc: ToolCall) -> Any:
@@ -32,7 +35,7 @@ def execute_tools(
             validation_error = tool.validate_public_input(tc.input)
             if validation_error:
                 return {"error": validation_error}
-            injected = tool.extract_params(resolved_integrations)
+            injected = tool.extract_params(tool_sources)
             kwargs = {**injected, **tc.input}
             return tool.run(**kwargs)
         except Exception as exc:

--- a/app/tools/GrafanaLogsTool/__init__.py
+++ b/app/tools/GrafanaLogsTool/__init__.py
@@ -41,7 +41,11 @@ def _grafana_creds(grafana: dict) -> dict:
 
 
 def _grafana_source(sources: dict) -> dict:
+    from pydantic import BaseModel
+
     grafana = sources.get("grafana") or sources.get("grafana_local") or {}
+    if isinstance(grafana, BaseModel):
+        return grafana.model_dump(exclude_none=True)
     return grafana if isinstance(grafana, dict) else {}
 
 

--- a/app/tools/GrafanaLogsTool/__init__.py
+++ b/app/tools/GrafanaLogsTool/__init__.py
@@ -45,8 +45,16 @@ def _grafana_source(sources: dict) -> dict:
 
     grafana = sources.get("grafana") or sources.get("grafana_local") or {}
     if isinstance(grafana, BaseModel):
-        return grafana.model_dump(exclude_none=True)
-    return grafana if isinstance(grafana, dict) else {}
+        item = grafana.model_dump(exclude_none=True)
+        item.setdefault("connection_verified", True)
+        return item
+    if isinstance(grafana, dict):
+        if not grafana:
+            return {}
+        item = dict(grafana)
+        item.setdefault("connection_verified", True)
+        return item
+    return {}
 
 
 def _grafana_available(sources: dict) -> bool:

--- a/app/tools/utils/integration_sources.py
+++ b/app/tools/utils/integration_sources.py
@@ -1,0 +1,27 @@
+"""Adapt resolved integration configs to the legacy tool availability contract."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+def availability_view(resolved_integrations: dict[str, Any]) -> dict[str, Any]:
+    """Convert classified integration configs into dicts tools can consume."""
+    view: dict[str, Any] = {}
+    for key, value in resolved_integrations.items():
+        if key.startswith("_"):
+            view[key] = value
+            continue
+        if isinstance(value, BaseModel):
+            item = value.model_dump(exclude_none=True)
+            item.setdefault("connection_verified", True)
+            view[key] = item
+        elif isinstance(value, dict) and value:
+            item = dict(value)
+            item.setdefault("connection_verified", True)
+            view[key] = item
+        else:
+            view[key] = value
+    return view

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -315,6 +315,39 @@ def test_run_gracefully_handles_single_tool_call_only_model() -> None:
     assert result["causal_chain"]
 
 
+def test_execute_tools_uses_availability_view_for_classified_integrations() -> None:
+    from app.integrations.config_models import GrafanaIntegrationConfig
+    from app.tools.GrafanaLogsTool import query_grafana_logs
+
+    rt = query_grafana_logs.__opensre_registered_tool__
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    mock_client.loki_datasource_uid = "loki-uid"
+    mock_client.query_loki.return_value = {"success": True, "logs": [], "total_logs": 0}
+
+    resolved = {
+        "grafana": GrafanaIntegrationConfig(
+            endpoint="https://tracerbio.grafana.net",
+            api_key="glsa_test",
+        )
+    }
+    tool_calls = [ToolCall(id="tc1", name="query_grafana_logs", input={"service_name": "checkout"})]
+
+    with patch(
+        "app.tools.GrafanaLogsTool.get_grafana_client_from_credentials",
+        return_value=mock_client,
+    ) as mock_factory:
+        results = execute_tools(tool_calls, [rt], resolved)
+
+    assert results[0]["available"] is True
+    mock_factory.assert_called_once_with(
+        endpoint="https://tracerbio.grafana.net",
+        api_key="glsa_test",
+        username="",
+        password="",
+    )
+
+
 def testexecute_tools_handles_interpreter_shutdown() -> None:
     """When pool.submit raises RuntimeError (interpreter shutdown), execute_tools
     must fall back to sequential execution and still return results for all slots."""

--- a/tests/tools/test_grafana_logs_tool.py
+++ b/tests/tools/test_grafana_logs_tool.py
@@ -47,6 +47,22 @@ def test_extract_params_accepts_catalog_grafana_shape() -> None:
     assert params["grafana_api_key"] == "glsa_test"
 
 
+def test_extract_params_accepts_classified_grafana_model() -> None:
+    from app.integrations.config_models import GrafanaIntegrationConfig
+
+    rt = query_grafana_logs.__opensre_registered_tool__
+    params = rt.extract_params(
+        {
+            "grafana": GrafanaIntegrationConfig(
+                endpoint="https://tracerbio.grafana.net",
+                api_key="glsa_test",
+            )
+        }
+    )
+    assert params["grafana_endpoint"] == "https://tracerbio.grafana.net"
+    assert params["grafana_api_key"] == "glsa_test"
+
+
 def test_run_with_backend_returns_logs() -> None:
     mock_backend = MagicMock()
     mock_backend.query_logs.return_value = {

--- a/tests/tools/test_grafana_logs_tool.py
+++ b/tests/tools/test_grafana_logs_tool.py
@@ -23,6 +23,23 @@ def test_is_available_requires_grafana_creds() -> None:
     assert rt.is_available({}) is False
 
 
+def test_is_available_accepts_classified_grafana_model() -> None:
+    from app.integrations.config_models import GrafanaIntegrationConfig
+
+    rt = query_grafana_logs.__opensre_registered_tool__
+    assert (
+        rt.is_available(
+            {
+                "grafana": GrafanaIntegrationConfig(
+                    endpoint="https://tracerbio.grafana.net",
+                    api_key="glsa_test",
+                )
+            }
+        )
+        is True
+    )
+
+
 def test_extract_params_maps_fields() -> None:
     rt = query_grafana_logs.__opensre_registered_tool__
     sources = mock_agent_state()


### PR DESCRIPTION
## Summary

- Pass `availability_view(resolved_integrations)` into `extract_params` from `execute_tools` and investigation seed calls so classified Pydantic configs become injectable dicts at runtime
- Teach `_grafana_source()` to accept `GrafanaIntegrationConfig` models as a safety net
- Add regression tests for classified-model extract and execute paths

Fixes #3033

## Context

`/integrations` verifies Grafana by calling the API directly, but REPL tool gathering reported "Grafana integration not configured" because availability and execution used different shapes of the resolved integration map.

## Test plan

- [x] `uv run python -m pytest tests/tools/test_grafana_logs_tool.py tests/agent/test_investigation.py::test_execute_tools_uses_availability_view_for_classified_integrations -q`
- [x] `make lint`
- [x] `make typecheck`