### PR TITLE
refactor(cli): REPL hygiene batch 2 (#3028)

### DIFF
--- a/app/cli/interactive_shell/command_registry/investigation.py
+++ b/app/cli/interactive_shell/command_registry/investigation.py
@@ -9,18 +9,18 @@ from rich.console import Console
 from rich.markup import escape
 
 from app.cli.interactive_shell.command_registry.types import ExecutionTier, SlashCommand
-from app.cli.interactive_shell.error_handling.errors import OpenSREError
 from app.cli.interactive_shell.error_handling.exception_reporting import report_exception
-from app.cli.interactive_shell.runtime import ReplSession, TaskKind
+from app.cli.interactive_shell.runtime import ReplSession
 from app.cli.interactive_shell.runtime.background_runner import (
     start_background_template_investigation,
     start_background_text_investigation,
 )
+from app.cli.interactive_shell.runtime.foreground_investigation import run_foreground_investigation
+from app.cli.interactive_shell.runtime.tasks import TaskRecord
 from app.cli.interactive_shell.ui import (
     DIM,
     ERROR,
     HIGHLIGHT,
-    WARNING,
     print_repl_json,
 )
 from app.cli.interactive_shell.ui.choice_menu import (
@@ -174,11 +174,8 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
             )
             session.record("alert", f"/investigate {template_name}")
             return True
-        task = session.task_registry.create(
-            TaskKind.INVESTIGATION, command=f"/investigate {template_name}"
-        )
-        task.mark_running()
-        try:
+
+        def _run_template(task: TaskRecord) -> dict[str, object]:
             with (
                 track_investigation(
                     entrypoint=EntrypointSource.CLI_REPL_FILE,
@@ -191,36 +188,24 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
                 suppress = getattr(console, "suppress_prompt_spinner", None)
                 if callable(suppress):
                     suppress()
-                final_state = run_sample_alert_for_session(
+                return run_sample_alert_for_session(
                     template_name=template_name,
                     context_overrides=session.accumulated_context or None,
                     cancel_requested=task.cancel_requested,
                 )
-        except KeyboardInterrupt:
-            task.mark_cancelled()
-            console.print(f"[{WARNING}]investigation cancelled.[/]")
-            session.record("alert", f"/investigate {template_name}", ok=False)
-            session.mark_latest(ok=False, kind="slash")
-            return True
-        except OpenSREError as exc:
-            task.mark_failed(str(exc))
-            console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
-            if exc.suggestion:
-                console.print(f"[{WARNING}]suggestion:[/] {escape(exc.suggestion)}")
-            session.record("alert", f"/investigate {template_name}", ok=False)
-            session.mark_latest(ok=False, kind="slash")
-            return True
-        except Exception as exc:
-            task.mark_failed(str(exc))
-            report_exception(exc, context="interactive_shell.investigate_template")
-            console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
+
+        final_state = run_foreground_investigation(
+            session=session,
+            console=console,
+            task_command=f"/investigate {template_name}",
+            run=_run_template,
+            exception_context="interactive_shell.investigate_template",
+        )
+        if final_state is None:
             session.record("alert", f"/investigate {template_name}", ok=False)
             session.mark_latest(ok=False, kind="slash")
             return True
 
-        root = final_state.get("root_cause")
-        task.mark_completed(result=str(root) if root is not None else "")
-        session.apply_investigation_result(final_state)
         session.record("alert", f"/investigate {template_name}")
         return True
 
@@ -248,9 +233,7 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
         session.record("alert", args[0])
         return True
 
-    task = session.task_registry.create(TaskKind.INVESTIGATION, command=f"/investigate {path}")
-    task.mark_running()
-    try:
+    def _run_file(task: TaskRecord) -> dict[str, object]:
         with (
             track_investigation(
                 entrypoint=EntrypointSource.CLI_REPL_FILE,
@@ -263,36 +246,24 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
             suppress = getattr(console, "suppress_prompt_spinner", None)
             if callable(suppress):
                 suppress()
-            final_state = run_investigation_for_session(
+            return run_investigation_for_session(
                 alert_text=text,
                 context_overrides=session.accumulated_context or None,
                 cancel_requested=task.cancel_requested,
             )
-    except KeyboardInterrupt:
-        task.mark_cancelled()
-        console.print(f"[{WARNING}]investigation cancelled.[/]")
-        session.record("alert", args[0], ok=False)
-        session.mark_latest(ok=False, kind="slash")
-        return True
-    except OpenSREError as exc:
-        task.mark_failed(str(exc))
-        console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
-        if exc.suggestion:
-            console.print(f"[{WARNING}]suggestion:[/] {escape(exc.suggestion)}")
-        session.record("alert", args[0], ok=False)
-        session.mark_latest(ok=False, kind="slash")
-        return True
-    except Exception as exc:
-        task.mark_failed(str(exc))
-        report_exception(exc, context="interactive_shell.investigate_file")
-        console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
+
+    final_state = run_foreground_investigation(
+        session=session,
+        console=console,
+        task_command=f"/investigate {path}",
+        run=_run_file,
+        exception_context="interactive_shell.investigate_file",
+    )
+    if final_state is None:
         session.record("alert", args[0], ok=False)
         session.mark_latest(ok=False, kind="slash")
         return True
 
-    root = final_state.get("root_cause")
-    task.mark_completed(result=str(root) if root is not None else "")
-    session.apply_investigation_result(final_state)
     session.record("alert", f"/investigate {raw_target}")
     return True
 

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/investigation_runner.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/investigation_runner.py
@@ -7,14 +7,13 @@ from collections.abc import Callable
 from rich.console import Console
 from rich.markup import escape
 
-from app.cli.interactive_shell.error_handling.errors import OpenSREError
-from app.cli.interactive_shell.error_handling.exception_reporting import report_exception
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_policy import (
     execution_allowed,
     plan_investigation_execution,
 )
-from app.cli.interactive_shell.runtime import ReplSession, TaskKind
-from app.cli.interactive_shell.ui import ERROR, WARNING
+from app.cli.interactive_shell.runtime import ReplSession
+from app.cli.interactive_shell.runtime.foreground_investigation import run_foreground_investigation
+from app.cli.interactive_shell.runtime.tasks import TaskRecord
 
 
 def run_sample_alert(
@@ -56,38 +55,26 @@ def run_sample_alert(
         session.record("alert", f"sample:{template_name}")
         return
 
-    task = session.task_registry.create(
-        TaskKind.INVESTIGATION, command=f"sample alert:{template_name}"
-    )
-    task.mark_running()
-    try:
-        final_state = run_sample_alert_for_session(
+    def _run(task: TaskRecord) -> dict[str, object]:
+        return run_sample_alert_for_session(
             template_name=template_name,
             context_overrides=session.accumulated_context or None,
             cancel_requested=task.cancel_requested,
         )
-    except KeyboardInterrupt:
-        task.mark_cancelled()
-        console.print(f"[{WARNING}]investigation cancelled.[/]")
-        session.record("alert", f"sample:{template_name}", ok=False)
-        return
-    except OpenSREError as exc:
-        task.mark_failed(str(exc))
-        console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
-        if exc.suggestion:
-            console.print(f"[{WARNING}]suggestion:[/] {escape(exc.suggestion)}")
-        session.record("alert", f"sample:{template_name}", ok=False)
-        return
-    except Exception as exc:
-        task.mark_failed(str(exc))
-        report_exception(exc, context="interactive_shell.sample_alert")
-        console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
+
+    if (
+        run_foreground_investigation(
+            session=session,
+            console=console,
+            task_command=f"sample alert:{template_name}",
+            run=_run,
+            exception_context="interactive_shell.sample_alert",
+        )
+        is None
+    ):
         session.record("alert", f"sample:{template_name}", ok=False)
         return
 
-    root = final_state.get("root_cause")
-    task.mark_completed(result=str(root) if root is not None else "")
-    session.apply_investigation_result(final_state)
     session.record("alert", f"sample:{template_name}")
 
 
@@ -130,34 +117,24 @@ def run_text_investigation(
         session.record("alert", alert_text)
         return
 
-    task = session.task_registry.create(TaskKind.INVESTIGATION, command=f"investigate:{alert_text}")
-    task.mark_running()
-    try:
-        final_state = run_investigation_for_session(
+    def _run(task: TaskRecord) -> dict[str, object]:
+        return run_investigation_for_session(
             alert_text=alert_text,
             context_overrides=session.accumulated_context or None,
             cancel_requested=task.cancel_requested,
         )
-    except KeyboardInterrupt:
-        task.mark_cancelled()
-        console.print(f"[{WARNING}]investigation cancelled.[/]")
-        session.record("alert", alert_text, ok=False)
-        return
-    except OpenSREError as exc:
-        task.mark_failed(str(exc))
-        console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
-        if exc.suggestion:
-            console.print(f"[{WARNING}]suggestion:[/] {escape(exc.suggestion)}")
-        session.record("alert", alert_text, ok=False)
-        return
-    except Exception as exc:
-        task.mark_failed(str(exc))
-        report_exception(exc, context="interactive_shell.text_investigation")
-        console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
+
+    if (
+        run_foreground_investigation(
+            session=session,
+            console=console,
+            task_command=f"investigate:{alert_text}",
+            run=_run,
+            exception_context="interactive_shell.text_investigation",
+        )
+        is None
+    ):
         session.record("alert", alert_text, ok=False)
         return
 
-    root = final_state.get("root_cause")
-    task.mark_completed(result=str(root) if root is not None else "")
-    session.apply_investigation_result(final_state)
     session.record("alert", alert_text)

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/terminal_actions/execution.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/terminal_actions/execution.py
@@ -13,7 +13,7 @@ from app.cli.interactive_shell.runtime import ReplSession
 from .dispatch import execute_planned_actions
 from .feedback import persist_error_turn, render_planner_llm_error
 from .models import ActionExecutionDeps, ActionPlanningDecision, TerminalActionExecutionResult
-from .planning import coerce_action_plan_decision, normalize_terminal_plan
+from .planning import normalize_terminal_plan
 
 
 def _response_text_from_history_entries(entries: list[dict[str, Any]]) -> str:
@@ -35,12 +35,13 @@ def _resolve_plan(
 ) -> ActionPlanningDecision:
     if deps is not None and deps.planner is not None:
         planned = deps.planner(message, session=session)
-        return (
-            ActionPlanningDecision((), False, ("planner_unavailable",))
-            if planned is None
-            else coerce_action_plan_decision(planned)
-        )
-    return coerce_action_plan_decision(plan_actions_fn(message, session))
+        if planned is None:
+            return ActionPlanningDecision((), False, ("planner_unavailable",))
+        if not isinstance(planned, ActionPlanningDecision):
+            msg = "deps.planner must return ActionPlanningDecision or None"
+            raise TypeError(msg)
+        return planned
+    return plan_actions_fn(message, session)
 
 
 def execute_cli_actions(

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/terminal_actions/planning.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/terminal_actions/planning.py
@@ -10,29 +10,12 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.interaction_models import (
-    PlannedAction,
-)
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.llm_action_planner import (
     plan_actions_with_llm_result,
 )
 from app.cli.interactive_shell.runtime import ReplSession
 
 from .models import ActionPlanningDecision
-
-
-def coerce_action_plan_decision(
-    raw: ActionPlanningDecision | tuple[list[PlannedAction], bool],
-) -> ActionPlanningDecision:
-    """Back-compat adapter for tests that monkeypatch planning to tuple output."""
-    if isinstance(raw, ActionPlanningDecision):
-        return raw
-    actions, has_unhandled_clause = raw
-    return ActionPlanningDecision(
-        actions=tuple(actions),
-        has_unhandled_clause=bool(has_unhandled_clause),
-        policy_trace=(),
-    )
 
 
 def normalize_terminal_plan(plan: ActionPlanningDecision) -> ActionPlanningDecision:
@@ -80,19 +63,20 @@ def plan_actions(
         actions = list(llm_plan_result.actions)
         policy_trace = llm_plan_result.policy_trace
     else:
-        # Preserve existing monkeypatch seam used by unit tests and debug harnesses.
-        llm_plan_legacy = planner(message, session=session)
-        if llm_plan_legacy is None:
+        planned = planner(message, session=session)
+        if planned is None:
             return ActionPlanningDecision((), False, ("planner_unavailable",))
-        actions, _has_unhandled_clause = llm_plan_legacy
-        policy_trace = ()
+        if not isinstance(planned, ActionPlanningDecision):
+            msg = "planner must return ActionPlanningDecision or None"
+            raise TypeError(msg)
+        actions = list(planned.actions)
+        policy_trace = planned.policy_trace
 
     executable = [action for action in actions if action.kind != "assistant_handoff"]
     return ActionPlanningDecision(tuple(executable), False, policy_trace)
 
 
 __all__ = [
-    "coerce_action_plan_decision",
     "normalize_terminal_plan",
     "plan_actions",
 ]

--- a/app/cli/interactive_shell/runtime/foreground_investigation.py
+++ b/app/cli/interactive_shell/runtime/foreground_investigation.py
@@ -1,0 +1,57 @@
+"""Shared foreground investigation task lifecycle for REPL entry points."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from rich.console import Console
+from rich.markup import escape
+
+from app.cli.interactive_shell.error_handling.errors import OpenSREError
+from app.cli.interactive_shell.error_handling.exception_reporting import report_exception
+from app.cli.interactive_shell.runtime import ReplSession, TaskKind
+from app.cli.interactive_shell.runtime.tasks import TaskRecord
+from app.cli.interactive_shell.ui import ERROR, WARNING
+
+
+def run_foreground_investigation(
+    *,
+    session: ReplSession,
+    console: Console,
+    task_command: str,
+    run: Callable[[TaskRecord], dict[str, Any]],
+    exception_context: str,
+) -> dict[str, Any] | None:
+    """Run one foreground investigation with shared task and error handling.
+
+    Returns the investigation final state on success, or ``None`` when the run
+    was cancelled or failed.
+    """
+    task = session.task_registry.create(TaskKind.INVESTIGATION, command=task_command)
+    task.mark_running()
+    try:
+        final_state = run(task)
+    except KeyboardInterrupt:
+        task.mark_cancelled()
+        console.print(f"[{WARNING}]investigation cancelled.[/]")
+        return None
+    except OpenSREError as exc:
+        task.mark_failed(str(exc))
+        console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
+        if exc.suggestion:
+            console.print(f"[{WARNING}]suggestion:[/] {escape(exc.suggestion)}")
+        return None
+    except Exception as exc:
+        task.mark_failed(str(exc))
+        report_exception(exc, context=exception_context)
+        console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
+        return None
+
+    root = final_state.get("root_cause")
+    task.mark_completed(result=str(root) if root is not None else "")
+    session.apply_investigation_result(final_state)
+    return final_state
+
+
+__all__ = ["run_foreground_investigation"]

--- a/app/cli/interactive_shell/ui/rendering.py
+++ b/app/cli/interactive_shell/ui/rendering.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import io
 import shutil
 import sys
+from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any
 
@@ -55,6 +56,37 @@ def _prepare_tty_for_rich(console: Console) -> int:
     return _repl_table_width(console)
 
 
+def _normalize_repl_line_endings(text: str) -> str:
+    """Convert Rich output to ``\\r\\n`` so each line starts at column zero."""
+    return text.replace("\r\n", "\n").replace("\n", "\r\n")
+
+
+def _write_repl_tty_buffered(
+    *,
+    width: int,
+    leading_blank: bool,
+    render_to_buffer: Callable[[Console], None],
+) -> None:
+    """Render Rich output to a buffer and write it in one TTY-safe stdout call."""
+    buf = io.StringIO()
+    buf_console = Console(
+        file=buf,
+        force_terminal=True,
+        highlight=False,
+        width=width,
+    )
+    render_to_buffer(buf_console)
+    rendered = _normalize_repl_line_endings(buf.getvalue())
+    if leading_blank:
+        rendered = "\r\n" + rendered
+    token = _REPL_OUTPUT_PREPARED.set(True)
+    try:
+        sys.stdout.write(rendered)
+        sys.stdout.flush()
+    finally:
+        _REPL_OUTPUT_PREPARED.reset(token)
+
+
 def print_repl_table(console: Console, table: Table, *, width: int | None = None) -> None:
     """Print a Rich table using REPL-safe TTY width.
 
@@ -73,31 +105,11 @@ def print_repl_table(console: Console, table: Table, *, width: int | None = None
     leading_blank = width is None
     width = width if width is not None else _prepare_tty_for_rich(console)
     if console.file is sys.stdout and sys.stdout.isatty():
-        buf = io.StringIO()
-        buf_console = Console(
-            file=buf,
-            force_terminal=True,
-            highlight=False,
+        _write_repl_tty_buffered(
             width=width,
+            leading_blank=leading_blank,
+            render_to_buffer=lambda buf_console: buf_console.print(table),
         )
-        buf_console.print(table)
-        rendered = buf.getvalue()
-        # Normalise to \r\n so each row starts at column zero even when ONLCR is
-        # disabled (raw-mode terminal under patch_stdout). Strip pre-existing \r\n
-        # first so partial Windows line-endings in cell content don't prevent the
-        # remaining bare \n chars from being converted.
-        rendered = rendered.replace("\r\n", "\n").replace("\n", "\r\n")
-        # Prepend blank line as part of the same write to avoid a separate
-        # patch_stdout proxy flush that can trigger a toolbar DSR query and
-        # leave stale CPR bytes in stdin for the next prompt.
-        if leading_blank:
-            rendered = "\r\n" + rendered
-        token = _REPL_OUTPUT_PREPARED.set(True)
-        try:
-            sys.stdout.write(rendered)
-            sys.stdout.flush()
-        finally:
-            _REPL_OUTPUT_PREPARED.reset(token)
     else:
         if leading_blank:
             _console_print_prepared(console)
@@ -117,22 +129,11 @@ def print_repl_json(console: Console, json_str: str) -> None:
     """
     width = _prepare_tty_for_rich(console)
     if console.file is sys.stdout and sys.stdout.isatty():
-        buf = io.StringIO()
-        buf_console = Console(
-            file=buf,
-            force_terminal=True,
-            highlight=False,
+        _write_repl_tty_buffered(
             width=width,
+            leading_blank=True,
+            render_to_buffer=lambda buf_console: buf_console.print_json(json_str),
         )
-        buf_console.print_json(json_str)
-        rendered = buf.getvalue().replace("\r\n", "\n").replace("\n", "\r\n")
-        rendered = "\r\n" + rendered
-        token = _REPL_OUTPUT_PREPARED.set(True)
-        try:
-            sys.stdout.write(rendered)
-            sys.stdout.flush()
-        finally:
-            _REPL_OUTPUT_PREPARED.reset(token)
     else:
         token = _REPL_OUTPUT_PREPARED.set(True)
         try:

--- a/tests/cli/interactive_shell/orchestration/test_agent_actions.py
+++ b/tests/cli/interactive_shell/orchestration/test_agent_actions.py
@@ -33,9 +33,17 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.i
     PlannedAction,
     default_target_surface,
 )
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.llm_action_planner import (
+    LlmActionPlanResult,
+)
 from app.cli.interactive_shell.runtime.session import ReplSession
 from app.cli.interactive_shell.runtime.tasks import TaskKind, TaskStatus
 from app.cli.interactive_shell.shell import execution as shell_execution
+
+_PLANNER_RESULT_PATCH = (
+    "app.cli.interactive_shell.routing.handle_message_with_agent.orchestration"
+    ".terminal_actions.planning.plan_actions_with_llm_result"
+)
 
 
 def _capture() -> tuple[Console, io.StringIO]:
@@ -170,6 +178,28 @@ _FAKE_PLANS: dict[str, tuple[list[PlannedAction], bool]] = {
 }
 
 
+def _llm_plan_result(
+    actions: list[PlannedAction],
+    *,
+    has_unhandled: bool = False,
+    policy_trace: tuple[str, ...] = ("fake_planner",),
+) -> LlmActionPlanResult:
+    return LlmActionPlanResult(
+        actions=tuple(actions),
+        has_unhandled_clause=has_unhandled,
+        policy_trace=policy_trace,
+    )
+
+
+def _fake_planner_result(
+    message: str,
+    *,
+    session: ReplSession | None = None,  # noqa: ARG001
+) -> LlmActionPlanResult:
+    actions, has_unhandled = _FAKE_PLANS.get(message, ([], False))
+    return _llm_plan_result(list(actions), has_unhandled=has_unhandled)
+
+
 @pytest.fixture(autouse=True)
 def _llm_planner_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
     """Install a deterministic fake LLM planner for execution-mechanics tests.
@@ -180,19 +210,10 @@ def _llm_planner_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
     stable fake planner that looks up explicit ``PlannedAction`` plans by the
     exact message string. Unknown phrases fall through with ``([], False)``.
 
-    Per-test ``monkeypatch.setattr(agent_actions, "plan_actions_with_llm", ...)``
-    overrides run after this autouse fixture, so those tests still win.
+    Per-test overrides of ``plan_actions_with_llm_result`` run after this
+    autouse fixture, so those tests still win.
     """
-
-    def _fake_planner(
-        message: str,
-        *,
-        session: ReplSession | None = None,  # noqa: ARG001
-    ) -> tuple[list[PlannedAction], bool]:
-        actions, has_unhandled = _FAKE_PLANS.get(message, ([], False))
-        return list(actions), has_unhandled
-
-    monkeypatch.setattr(agent_actions, "plan_actions_with_llm", _fake_planner)
+    monkeypatch.setattr(_PLANNER_RESULT_PATCH, _fake_planner_result)
 
 
 def test_execute_cli_actions_dispatches_planned_commands(monkeypatch: object) -> None:
@@ -390,9 +411,8 @@ def test_execute_cli_actions_sets_bare_model_for_active_provider(
     reasoning_models: list[str] = []
 
     monkeypatch.setattr(
-        agent_actions,
-        "plan_actions_with_llm",
-        lambda _message, *, session=None: (  # noqa: ARG005
+        _PLANNER_RESULT_PATCH,
+        lambda _message, *, session=None: _llm_plan_result(  # noqa: ARG005
             [
                 PlannedAction(
                     kind="llm_provider",
@@ -401,8 +421,7 @@ def test_execute_cli_actions_sets_bare_model_for_active_provider(
                     source="llm",
                     target_surface="slash",
                 )
-            ],
-            False,
+            ]
         ),
     )
     monkeypatch.setattr(
@@ -1274,8 +1293,7 @@ def test_execute_cli_actions_falls_through_when_llm_plan_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        agent_actions,
-        "plan_actions_with_llm",
+        _PLANNER_RESULT_PATCH,
         lambda _message, *, session=None: None,  # noqa: ARG005
     )
 
@@ -1295,11 +1313,10 @@ def test_execute_cli_actions_executes_matched_clause_ignoring_unhandled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        agent_actions,
-        "plan_actions_with_llm",
-        lambda _message, *, session=None: (  # noqa: ARG005
+        _PLANNER_RESULT_PATCH,
+        lambda _message, *, session=None: _llm_plan_result(  # noqa: ARG005
             [_action("slash", "/health")],
-            True,
+            has_unhandled=True,
         ),
     )
 
@@ -1358,7 +1375,7 @@ def test_execute_cli_actions_bang_prefix_routes_to_shell_bypassing_llm(
         llm_called.append(message)
         raise AssertionError("LLM planner must not be called for !cmd input")
 
-    monkeypatch.setattr(agent_actions, "plan_actions_with_llm", _fail_if_called)
+    monkeypatch.setattr(_PLANNER_RESULT_PATCH, _fail_if_called)
 
     calls: list[tuple[str, dict[str, object]]] = []
 
@@ -1417,17 +1434,15 @@ def test_execute_cli_actions_handoff_only_plan_falls_through_silently(
     planner reasoning that should have been invisible.
     """
     monkeypatch.setattr(
-        agent_actions,
-        "plan_actions_with_llm",
-        lambda _message, *, session=None: (  # noqa: ARG005
+        _PLANNER_RESULT_PATCH,
+        lambda _message, *, session=None: _llm_plan_result(  # noqa: ARG005
             [
                 PlannedAction(
                     kind="assistant_handoff",
                     content="informational question about current model",
                     position=0,
                 )
-            ],
-            False,
+            ]
         ),
     )
 

--- a/tests/cli/interactive_shell/orchestration/test_agent_actions_harness.py
+++ b/tests/cli/interactive_shell/orchestration/test_agent_actions_harness.py
@@ -7,13 +7,18 @@ from rich.console import Console
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.agent_actions import (
     execute_cli_actions,
 )
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.terminal_actions.models import (
+    ActionPlanningDecision,
+)
 from app.cli.interactive_shell.runtime.session import ReplSession
 
 from .routing_test_harness import FakeDispatcher, FakePlanner, RoutingHarness, planned_action
 
 
 def test_execute_with_harness_dispatches_slash_action() -> None:
-    planner = FakePlanner(result=([planned_action("slash", "/health")], False))
+    planner = FakePlanner(
+        result=ActionPlanningDecision((planned_action("slash", "/health"),), False, ())
+    )
     dispatcher = FakeDispatcher()
     harness = RoutingHarness(planner=planner, dispatcher=dispatcher)
 
@@ -31,7 +36,13 @@ def test_execute_with_harness_dispatches_slash_action() -> None:
 
 
 def test_execute_with_harness_hands_off_handoff_only_plan() -> None:
-    planner = FakePlanner(result=([planned_action("assistant_handoff", "docs:help")], True))
+    planner = FakePlanner(
+        result=ActionPlanningDecision(
+            (planned_action("assistant_handoff", "docs:help"),),
+            True,
+            (),
+        )
+    )
     dispatcher = FakeDispatcher()
     harness = RoutingHarness(planner=planner, dispatcher=dispatcher)
 

--- a/tests/cli/interactive_shell/test_terminal_runtime_routing.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime_routing.py
@@ -13,6 +13,9 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.a
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.interaction_models import (
     PlannedAction,
 )
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.llm_action_planner import (
+    LlmActionPlanResult,
+)
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tools import (
     investigation_tool as _investigation_tool,
 )
@@ -250,14 +253,15 @@ def test_dispatch_one_turn_nitro_prompt_executes_remote_then_investigation(
         call_order.append(f"investigation:{alert_text}")
 
     monkeypatch.setattr(
-        loop_execution._agent_actions,
-        "_plan_actions",
-        lambda _message, _session: (
-            [
+        "app.cli.interactive_shell.routing.handle_message_with_agent.orchestration"
+        ".terminal_actions.planning.plan_actions_with_llm_result",
+        lambda _message, *, session=None: LlmActionPlanResult(  # noqa: ARG005
+            actions=(
                 PlannedAction(kind="slash", content="/remote", position=0),
                 PlannedAction(kind="investigation", content="hello world", position=1),
-            ],
-            False,
+            ),
+            has_unhandled_clause=False,
+            policy_trace=("fake_planner",),
         ),
     )
     monkeypatch.setattr(_slash_tool, "dispatch_slash", _fake_dispatch)

--- a/tests/cli/interactive_shell/ui/test_rendering.py
+++ b/tests/cli/interactive_shell/ui/test_rendering.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import io
-import sys
 import threading
 
 import pytest

--- a/tests/cli/interactive_shell/ui/test_rendering.py
+++ b/tests/cli/interactive_shell/ui/test_rendering.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import io
+import sys
 import threading
 
 import pytest
 from rich.console import Console
 
 from app.cli.interactive_shell.runtime import loop
-from app.cli.interactive_shell.ui.rendering import repl_print, repl_table
+from app.cli.interactive_shell.ui.rendering import print_repl_json, repl_print, repl_table
 from app.cli.interactive_shell.ui.tables import (
     print_planned_actions,
     render_integrations_table,
@@ -20,6 +21,32 @@ from app.cli.interactive_shell.ui.tables import (
 def test_repl_table_minimal_box() -> None:
     t = repl_table(title="T")
     assert t.title == "T"
+
+
+def test_print_repl_json_tty_uses_single_buffered_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeStdout:
+        def __init__(self) -> None:
+            self.writes: list[str] = []
+
+        def write(self, text: str) -> int:
+            self.writes.append(text)
+            return len(text)
+
+        def flush(self) -> None:
+            return None
+
+        def isatty(self) -> bool:
+            return True
+
+    fake_stdout = _FakeStdout()
+    monkeypatch.setattr("sys.stdout", fake_stdout)
+
+    console = Console(file=fake_stdout, force_terminal=True, width=80)
+    print_repl_json(console, '{"ok": true}')
+
+    assert len(fake_stdout.writes) == 1
+    assert fake_stdout.writes[0].startswith("\r\n")
+    assert '"ok": true' in fake_stdout.writes[0]
 
 
 def test_render_integrations_table_empty_shows_hint() -> None:

--- a/tests/cli/interactive_shell/ui/test_rendering.py
+++ b/tests/cli/interactive_shell/ui/test_rendering.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import re
 import threading
 
 import pytest
@@ -44,8 +45,9 @@ def test_print_repl_json_tty_uses_single_buffered_write(monkeypatch: pytest.Monk
     print_repl_json(console, '{"ok": true}')
 
     assert len(fake_stdout.writes) == 1
-    assert fake_stdout.writes[0].startswith("\r\n")
-    assert '"ok": true' in fake_stdout.writes[0]
+    rendered = re.sub(r"\x1b\[[0-9;]*m", "", fake_stdout.writes[0])
+    assert rendered.startswith("\r\n")
+    assert '"ok": true' in rendered
 
 
 def test_render_integrations_table_empty_shows_hint() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #3029 (item 1). Incremental REPL hygiene from #3028 without touching loop/CPR behavior:

- **Item 2:** Extract `run_foreground_investigation()` shared by `/investigate` slash commands and routing `investigation_runner.py` — deduplicates task lifecycle, error handling, and result application.
- **Item 3:** DRY REPL-safe buffered TTY writes in `rendering.py` via `_write_repl_tty_buffered()` used by both `print_repl_table` and `print_repl_json`.
- **Item 6:** Remove `coerce_action_plan_decision` back-compat adapter; fix execution-mechanics tests to patch `plan_actions_with_llm_result` (the path production code actually uses) instead of the dead `agent_actions.plan_actions_with_llm` seam.

Fixes #3028 (partial — items 2, 3, 6)

## Test plan

- [x] `make lint`
- [x] `make format-check`
- [x] `make typecheck`
- [x] Focused pytest: agent_actions, agent_actions_harness, rendering, investigate commands (70 passed, `-m "not live_llm"`)
- [ ] CI routing-checks + unit suite on PR

## Out of scope (deferred)

- Item 4: CPR/queue split from `runtime/loop.py`
- Item 5: Split oversized command-registry modules
- Item 7: Relocate orchestration tests under `routing/tests/`