### PR TITLE
refactor(tools/datadog): collapse duplicated tag-parsing if/elif chains

### DIFF
--- a/app/tools/DataDogContextTool/__init__.py
+++ b/app/tools/DataDogContextTool/__init__.py
@@ -27,23 +27,45 @@ def _run_in_thread(coro: Any) -> Any:
     return asyncio.run(coro)
 
 
+# Kubernetes tag keys read out of a Datadog log's ``tags`` list.
+_POD_TAG_KEYS = frozenset(
+    {
+        "pod_name",
+        "container_name",
+        "kube_namespace",
+        "exit_code",
+        "kube_job",
+        "cluster",
+        "node_name",
+        "node_ip",
+    }
+)
+
+
+def _parse_log_tags(log: dict, keys: frozenset[str]) -> dict[str, str]:
+    """Parse a Datadog log's ``tags`` list into a ``{key: value}`` map.
+
+    Only keys in ``keys`` are kept. When a key appears more than once the last
+    occurrence wins, matching the original sequential-assignment behavior.
+    """
+    parsed: dict[str, str] = {}
+    for tag in log.get("tags", []):
+        if not isinstance(tag, str) or ":" not in tag:
+            continue
+        k, _, v = tag.partition(":")
+        if k in keys:
+            parsed[k] = v
+    return parsed
+
+
 def _extract_pod_from_logs(logs: list[dict]) -> tuple[str | None, str | None, str | None]:
     for log in logs:
         if not isinstance(log, dict):
             continue
-        pod_name = container_name = kube_namespace = None
-        for tag in log.get("tags", []):
-            if not isinstance(tag, str) or ":" not in tag:
-                continue
-            k, _, v = tag.partition(":")
-            if k == "pod_name":
-                pod_name = v
-            elif k == "container_name":
-                container_name = v
-            elif k == "kube_namespace":
-                kube_namespace = v
+        tags = _parse_log_tags(log, _POD_TAG_KEYS)
+        pod_name = tags.get("pod_name")
         if pod_name:
-            return pod_name, container_name, kube_namespace
+            return pod_name, tags.get("container_name"), tags.get("kube_namespace")
     return None, None, None
 
 
@@ -70,37 +92,17 @@ def _collect_failed_pods(logs: list[dict]) -> list[dict]:
     for log in logs:
         if not isinstance(log, dict):
             continue
-        pod_name = container_name = kube_namespace = exit_code = kube_job = cluster = None
-        node_name = node_ip = None
-        for tag in log.get("tags", []):
-            if not isinstance(tag, str) or ":" not in tag:
-                continue
-            k, _, v = tag.partition(":")
-            if k == "pod_name":
-                pod_name = v
-            elif k == "container_name":
-                container_name = v
-            elif k == "kube_namespace":
-                kube_namespace = v
-            elif k == "exit_code":
-                exit_code = v
-            elif k == "kube_job":
-                kube_job = v
-            elif k == "cluster":
-                cluster = v
-            elif k == "node_name":
-                node_name = v
-            elif k == "node_ip":
-                node_ip = v
-        pod_name = pod_name or log.get("pod_name")
-        container_name = container_name or log.get("container_name")
-        kube_namespace = kube_namespace or log.get("kube_namespace")
+        tags = _parse_log_tags(log, _POD_TAG_KEYS)
+        pod_name = tags.get("pod_name") or log.get("pod_name")
+        container_name = tags.get("container_name") or log.get("container_name")
+        kube_namespace = tags.get("kube_namespace") or log.get("kube_namespace")
+        exit_code = tags.get("exit_code")
         if exit_code is None and log.get("exit_code") is not None:
             exit_code = str(log["exit_code"])
-        kube_job = kube_job or log.get("kube_job")
-        cluster = cluster or log.get("cluster")
-        node_name = node_name or log.get("node_name")
-        node_ip = node_ip or log.get("node_ip")
+        kube_job = tags.get("kube_job") or log.get("kube_job")
+        cluster = tags.get("cluster") or log.get("cluster")
+        node_name = tags.get("node_name") or log.get("node_name")
+        node_ip = tags.get("node_ip") or log.get("node_ip")
         if pod_name and pod_name not in seen:
             seen.add(pod_name)
             entry: dict[str, Any] = {


### PR DESCRIPTION
Fixes #3042

#### Describe the changes you have made in this PR -

`_extract_pod_from_logs` and `_collect_failed_pods` in
`app/tools/DataDogContextTool/__init__.py` both hand-rolled the same
`tag.partition(":")` -> `if k == ... elif ...` dispatch over a Datadog log's
`tags` list (a 3-branch chain and a 9-branch chain). Collapsed both into one
helper `_parse_log_tags(log, keys)` plus a `_POD_TAG_KEYS` frozenset, so there
is a single place to add or rename a tag key. Removes ~20 lines of duplicated
branch boilerplate. Targets two of the refactoring-focus items: long if/elif
chains and duplicated logic.

Behavior is preserved exactly, including last-occurrence-wins when a tag key
repeats. No public API or output-shape change.

### Demo/Screenshot for feature changes and bug fixes -

Behavior-preserving refactor (no user-visible change), so the proof is the
existing suite passing unchanged plus a clean quality harness:

```
$ uv run pytest tests/tools/test_datadog_context_tool.py tests/tools/test_telemetry.py -q
43 passed in 2.37s

$ make lint            -> All checks passed!
$ make format-check    -> 1916 files already formatted
$ make typecheck       -> Success: no issues found in 864 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The two functions duplicated the same tag-parsing dispatch. I extracted a single
`_parse_log_tags` helper returning a `{key: value}` map filtered to a known key
set, and had both callers read from it. I kept last-occurrence-wins semantics
(plain `parsed[k] = v`, no first-wins guard) to match the original sequential
assignment exactly, so output is identical. I considered a per-caller key set but
used one shared frozenset since the larger caller needs all keys and the extra
parsed keys in the smaller caller are harmless.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
