### PR TITLE
Stagnation nudge can create consecutive user messages and break Anthropic investigations

### DIFF
--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -409,7 +409,14 @@ class ConnectedInvestigationAgent:
                 stagnant_iterations = 0
             else:
                 stagnant_iterations += 1
-                messages.append({"role": "user", "content": _STAGNATION_NUDGE})
+                if messages and messages[-1].get("role") == "user":
+                    last_content = messages[-1]["content"]
+                    if isinstance(last_content, list):
+                        last_content.append({"type": "text", "text": _STAGNATION_NUDGE})
+                    else:
+                        messages[-1]["content"] = f"{last_content}\n\n{_STAGNATION_NUDGE}"
+                else:
+                    messages.append({"role": "user", "content": _STAGNATION_NUDGE})
                 if stagnant_iterations >= _MAX_STAGNANT_ITERATIONS:
                     logger.warning(
                         "[agent] %d consecutive duplicate-only iterations — forcing "


### PR DESCRIPTION
The stagnation recovery path in ConnectedInvestigationAgent.run appends a
user-role _STAGNATION_NUDGE immediately after Anthropic tool_result
messages, which are also represented as user-role messages.

This creates consecutive user turns:

assistant
user (tool_result)
user (stagnation nudge)

Anthropic rejects this payload because roles must alternate.

As a result, the stagnation recovery mechanism can terminate the
investigation with a BadRequestError instead of nudging the model toward
a final conclusion.

Proposed Fix

Merge the stagnation nudge into the existing user turn when the most
recent message already has role="user" rather than appending a new user
message.

This preserves role alternation at the source and keeps responsibility
inside the investigation orchestrator.
