### PR TITLE
fix(cli): restore terminal after investigate feedback prompt

### DIFF
--- a/app/cli/interactive_shell/ui/feedback.py
+++ b/app/cli/interactive_shell/ui/feedback.py
@@ -4,22 +4,35 @@ Shown after every investigation when stdin/stdout is a TTY.
 Silently skipped when: not a TTY, the user has opted out via prefs, or any
 exception occurs — feedback must never disrupt the CLI.
 
-The CLI ``opensre investigate`` path uses a plain line prompt (``input()``)
-after restoring canonical terminal mode.  The REPL path keeps
-:func:`repl_choose_one` inside prompt_toolkit's stdout patch context.
+Why a custom select menu instead of repl_choose_one() on the CLI path:
+  Rich's Live renderer leaves the cursor at an indeterminate row.
+  choice_menu._erase_menu_block() assumes a fixed cursor position and can
+  redraw in the wrong place after streaming output ends.
+
+  The local :func:`_run_select` erases line-by-line with ``\\x1b[2K`` and is
+  robust to any cursor state.  Call :func:`restore_stdin_terminal` before
+  entering the menu so investigation progress UI (Ctrl+O watcher) does not
+  leave stdin in no-echo mode.  The REPL path keeps :func:`repl_choose_one`
+  inside prompt_toolkit's stdout patch context.
 """
 
 from __future__ import annotations
 
 import contextlib
 import json
+import os
 import sys
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from app.cli.interactive_shell.ui.key_reader import restore_stdin_terminal
+from app.cli.interactive_shell.ui.key_reader import (
+    flush_stdin_unix,
+    read_key_unix,
+    read_key_windows,
+    restore_stdin_terminal,
+)
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -33,30 +46,14 @@ _CHOICES: list[tuple[str, str]] = [
     ("never", "Never ask again"),
 ]
 
-_CLI_CHOICE_BY_TOKEN: dict[str, str] = {
-    "1": "accurate",
-    "a": "accurate",
-    "accurate": "accurate",
-    "2": "partial",
-    "p": "partial",
-    "partial": "partial",
-    "3": "inaccurate",
-    "i": "inaccurate",
-    "inaccurate": "inaccurate",
-    "4": "skip",
-    "s": "skip",
-    "skip": "skip",
-    "5": "never",
-    "n": "never",
-    "never": "never",
-}
-
 _NEVER_AGAIN_KEY = "feedback_disabled"
+_SKIP_KEYS = (b"s", b"S")
 
 # ANSI helpers (theme colours inlined to avoid import at module level)
 _H = "\x1b[1;38;2;185;237;175m"  # HIGHLIGHT bold  (#B9EDAF)
 _D = "\x1b[2m"  # dim
 _R = "\x1b[0m"  # reset
+_HINT = f"  {_D}↑↓ / j k  ·  Enter  ·  Esc / s to skip{_R}"
 
 
 # ── persistence ───────────────────────────────────────────────────────────────
@@ -186,28 +183,65 @@ def _print_context(final_state: dict[str, Any], *, console: Console | None) -> N
         sys.stdout.flush()
 
 
-# ── CLI line prompt ───────────────────────────────────────────────────────────
+# ── self-contained select (CLI path) ─────────────────────────────────────────
 
 
-def _parse_cli_choice(raw: str) -> str | None:
-    token = raw.strip().lower()
-    if not token:
-        return None
-    return _CLI_CHOICE_BY_TOKEN.get(token)
+def _run_select(choices: list[tuple[str, str]]) -> str | None:
+    """Arrow-key select menu after streaming output.
 
+    Uses per-line ``\\x1b[2K`` (erase line) instead of a block cursor-position
+    assumption.  ``restore_stdin_terminal()`` must run before this so the menu
+    starts from canonical echo mode rather than the investigation watcher state.
 
-def _pick_rating_cli() -> str | None:
-    """Ask for feedback with a normal line prompt; returns choice key or None."""
+    Returns the selected key string, or None on Esc / Ctrl-C / s.
+    """
     restore_stdin_terminal()
-    for index, (_key, label) in enumerate(_CHOICES, start=1):
-        sys.stdout.write(f"  {index}. {label}\n")
-    sys.stdout.write(
-        f"\n  {_D}Enter 1-5, a/p/i/s/n, or press Enter to skip{_R}\n{_H}Choice{_R}: "
-    )
-    sys.stdout.flush()
-    with contextlib.suppress(EOFError, KeyboardInterrupt):
-        return _parse_cli_choice(input())
-    return None
+    labels = [label for _, label in choices]
+    n = len(labels)
+    total_lines = n + 1  # n choice lines + 1 hint line
+    idx = 0
+    is_unix = os.name != "nt"
+
+    if is_unix:
+        flush_stdin_unix()
+
+    def _out(s: str) -> None:
+        sys.stdout.write(s)
+        sys.stdout.flush()
+
+    def _draw(redraw: bool) -> None:
+        if redraw:
+            _out(f"\x1b[{total_lines}A")
+        for i, label in enumerate(labels):
+            if i == idx:
+                _out(f"\r\x1b[2K{_H}  > {label}{_R}\r\n")
+            else:
+                _out(f"\r\x1b[2K{_D}    {label}{_R}\r\n")
+        _out(f"\r\x1b[2K{_HINT}\r\n")
+
+    _draw(False)
+
+    while True:
+        key = (
+            read_key_unix(also_cancel=_SKIP_KEYS)
+            if is_unix
+            else read_key_windows()
+        )
+
+        if key == "enter":
+            _out(f"\x1b[{total_lines}A\r\x1b[J")
+            return choices[idx][0]
+
+        if key in ("cancel", "eof"):
+            _out(f"\x1b[{total_lines}A\r\x1b[J")
+            return None
+
+        if key == "up":
+            idx = (idx - 1) % n
+            _draw(True)
+        elif key == "down":
+            idx = (idx + 1) % n
+            _draw(True)
 
 
 # ── note reader ───────────────────────────────────────────────────────────────
@@ -243,7 +277,7 @@ def _pick_rating(*, console: Console | None) -> str | None:
 
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         return None
-    return _pick_rating_cli()
+    return _run_select(_CHOICES)
 
 
 def _collect(final_state: dict[str, Any], *, console: Console | None) -> None:
@@ -262,7 +296,9 @@ def _collect(final_state: dict[str, Any], *, console: Console | None) -> None:
             f"[{DIM}]↑↓ · Enter · Esc or s to skip[/]"
         )
     else:
-        sys.stdout.write(f"\n{_H}Was this RCA accurate?{_R}\n")
+        sys.stdout.write(
+            f"\n{_H}Was this RCA accurate?{_R}  {_D}↑↓ · Enter · Esc to skip{_R}\n\n"
+        )
         sys.stdout.flush()
 
     rating = _pick_rating(console=console)

--- a/app/cli/interactive_shell/ui/feedback.py
+++ b/app/cli/interactive_shell/ui/feedback.py
@@ -1,39 +1,25 @@
 """Post-investigation accuracy feedback prompt.
 
 Shown after every investigation when stdin/stdout is a TTY.
-Silently skipped when: not a TTY, the user has opted out, or any exception
-occurs — feedback must never disrupt the CLI.
+Silently skipped when: not a TTY, the user has opted out via prefs, or any
+exception occurs — feedback must never disrupt the CLI.
 
-Why a custom select menu instead of repl_choose_one():
-  Rich's Live renderer (used by StreamRenderer) leaves the cursor at an
-  indeterminate row.  choice_menu._erase_menu_block() uses \x1b[{N}A to
-  move the cursor up by a fixed count, which assumes the cursor is still at
-  the bottom of the menu.  After Live ends that assumption breaks, so the
-  erase lands at the wrong row and redraws appear frozen.
-
-  The local _run_select() implementation erases line-by-line with \x1b[2K
-  (erase entire line, no cursor-position assumption) and is therefore robust
-  to any cursor state the streaming renderer leaves behind.  The REPL path
-  (console is not None) keeps repl_choose_one() which works correctly inside
-  the prompt_toolkit / patch_stdout context.
+The CLI ``opensre investigate`` path uses a plain line prompt (``input()``)
+after restoring canonical terminal mode.  The REPL path keeps
+:func:`repl_choose_one` inside prompt_toolkit's stdout patch context.
 """
 
 from __future__ import annotations
 
 import contextlib
 import json
-import os
 import sys
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from app.cli.interactive_shell.ui.key_reader import (
-    flush_stdin_unix,
-    read_key_unix,
-    read_key_windows,
-)
+from app.cli.interactive_shell.ui.key_reader import restore_stdin_terminal
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -47,13 +33,30 @@ _CHOICES: list[tuple[str, str]] = [
     ("never", "Never ask again"),
 ]
 
+_CLI_CHOICE_BY_TOKEN: dict[str, str] = {
+    "1": "accurate",
+    "a": "accurate",
+    "accurate": "accurate",
+    "2": "partial",
+    "p": "partial",
+    "partial": "partial",
+    "3": "inaccurate",
+    "i": "inaccurate",
+    "inaccurate": "inaccurate",
+    "4": "skip",
+    "s": "skip",
+    "skip": "skip",
+    "5": "never",
+    "n": "never",
+    "never": "never",
+}
+
 _NEVER_AGAIN_KEY = "feedback_disabled"
 
 # ANSI helpers (theme colours inlined to avoid import at module level)
 _H = "\x1b[1;38;2;185;237;175m"  # HIGHLIGHT bold  (#B9EDAF)
 _D = "\x1b[2m"  # dim
 _R = "\x1b[0m"  # reset
-_HINT = f"  {_D}↑↓ / j k  ·  Space/Enter  ·  Esc to skip{_R}"
 
 
 # ── persistence ───────────────────────────────────────────────────────────────
@@ -183,62 +186,28 @@ def _print_context(final_state: dict[str, Any], *, console: Console | None) -> N
         sys.stdout.flush()
 
 
-# ── self-contained select (CLI path) ─────────────────────────────────────────
+# ── CLI line prompt ───────────────────────────────────────────────────────────
 
 
-def _run_select(choices: list[tuple[str, str]]) -> str | None:
-    """Arrow-key select menu that works in any TTY context after streaming output.
+def _parse_cli_choice(raw: str) -> str | None:
+    token = raw.strip().lower()
+    if not token:
+        return None
+    return _CLI_CHOICE_BY_TOKEN.get(token)
 
-    Uses per-line \x1b[2K (erase line) instead of a block cursor-position
-    assumption, so it redraws correctly regardless of where the streaming
-    renderer left the cursor.
 
-    Returns the selected key string, or None on Esc / Ctrl-C.
-    """
-    labels = [label for _, label in choices]
-    n = len(labels)
-    total_lines = n + 1  # n choice lines + 1 hint line
-    idx = 0
-    is_unix = os.name != "nt"
-
-    if is_unix:
-        flush_stdin_unix()
-
-    def _out(s: str) -> None:
-        sys.stdout.write(s)
-        sys.stdout.flush()
-
-    def _draw(redraw: bool) -> None:
-        if redraw:
-            # Move cursor up to start of the menu block
-            _out(f"\x1b[{total_lines}A")
-        for i, label in enumerate(labels):
-            if i == idx:
-                _out(f"\r\x1b[2K{_H}  > {label}{_R}\r\n")
-            else:
-                _out(f"\r\x1b[2K{_D}    {label}{_R}\r\n")
-        _out(f"\r\x1b[2K{_HINT}\r\n")
-
-    _draw(False)
-
-    while True:
-        key = read_key_unix() if is_unix else read_key_windows()
-
-        if key == "enter":
-            _out(f"\x1b[{total_lines}A\r\x1b[J")
-            return choices[idx][0]
-
-        if key in ("cancel", "eof"):
-            _out(f"\x1b[{total_lines}A\r\x1b[J")
-            return None
-
-        if key == "up":
-            idx = (idx - 1) % n
-            _draw(True)
-        elif key == "down":
-            idx = (idx + 1) % n
-            _draw(True)
-        # "ignore" → no redraw
+def _pick_rating_cli() -> str | None:
+    """Ask for feedback with a normal line prompt; returns choice key or None."""
+    restore_stdin_terminal()
+    for index, (_key, label) in enumerate(_CHOICES, start=1):
+        sys.stdout.write(f"  {index}. {label}\n")
+    sys.stdout.write(
+        f"\n  {_D}Enter 1-5, a/p/i/s/n, or press Enter to skip{_R}\n{_H}Choice{_R}: "
+    )
+    sys.stdout.flush()
+    with contextlib.suppress(EOFError, KeyboardInterrupt):
+        return _parse_cli_choice(input())
+    return None
 
 
 # ── note reader ───────────────────────────────────────────────────────────────
@@ -247,6 +216,7 @@ def _run_select(choices: list[tuple[str, str]]) -> str | None:
 def _read_note(*, console: Console | None) -> str:
     from app.cli.interactive_shell.ui.theme import DIM, SECONDARY
 
+    restore_stdin_terminal()
     if console is not None:
         console.print(
             f"[{SECONDARY}]What was wrong or missing? [{DIM}](Enter to skip)[/]:[/] ", end=""
@@ -263,20 +233,17 @@ def _read_note(*, console: Console | None) -> str:
 
 
 def _pick_rating(*, console: Console | None) -> str | None:
-    """Show the rating select menu; returns key or None on cancel."""
+    """Show the rating prompt; returns key or None on cancel/skip."""
     if console is not None:
-        # REPL path: prompt_toolkit / patch_stdout context active.
-        # repl_choose_one() works correctly here.
         from app.cli.interactive_shell.ui.choice_menu import repl_choose_one, repl_tty_interactive
 
         if not repl_tty_interactive():
             return None
         return repl_choose_one(title="Was this RCA accurate?", choices=_CHOICES)
 
-    # CLI path: use the self-contained picker that is robust after streaming.
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         return None
-    return _run_select(_CHOICES)
+    return _pick_rating_cli()
 
 
 def _collect(final_state: dict[str, Any], *, console: Console | None) -> None:
@@ -290,9 +257,12 @@ def _collect(final_state: dict[str, Any], *, console: Console | None) -> None:
     from app.cli.interactive_shell.ui.theme import BRAND, DIM
 
     if console is not None:
-        console.print(f"\n[{BRAND}]Was this RCA accurate?[/] [{DIM}]↑↓ · Enter · Esc to skip[/]")
+        console.print(
+            f"\n[{BRAND}]Was this RCA accurate?[/] "
+            f"[{DIM}]↑↓ · Enter · Esc or s to skip[/]"
+        )
     else:
-        sys.stdout.write(f"\n{_H}Was this RCA accurate?{_R}  {_D}↑↓ · Enter · Esc to skip{_R}\n\n")
+        sys.stdout.write(f"\n{_H}Was this RCA accurate?{_R}\n")
         sys.stdout.flush()
 
     rating = _pick_rating(console=console)
@@ -356,4 +326,7 @@ def prompt_investigation_feedback(
     the hosted/JWT path).
     """
     with contextlib.suppress(Exception):
-        _collect(final_state, console=console)
+        try:
+            _collect(final_state, console=console)
+        finally:
+            restore_stdin_terminal()

--- a/app/cli/interactive_shell/ui/feedback.py
+++ b/app/cli/interactive_shell/ui/feedback.py
@@ -222,7 +222,11 @@ def _run_select(choices: list[tuple[str, str]]) -> str | None:
     _draw(False)
 
     while True:
-        key = read_key_unix(also_cancel=_SKIP_KEYS) if is_unix else read_key_windows()
+        key = (
+            read_key_unix(also_cancel=_SKIP_KEYS)
+            if is_unix
+            else read_key_windows(also_cancel=_SKIP_KEYS)
+        )
 
         if key == "enter":
             _out(f"\x1b[{total_lines}A\r\x1b[J")
@@ -291,7 +295,9 @@ def _collect(final_state: dict[str, Any], *, console: Console | None) -> None:
             f"\n[{BRAND}]Was this RCA accurate?[/] [{DIM}]↑↓ · Enter · Esc or s to skip[/]"
         )
     else:
-        sys.stdout.write(f"\n{_H}Was this RCA accurate?{_R}  {_D}↑↓ · Enter · Esc to skip{_R}\n\n")
+        sys.stdout.write(
+            f"\n{_H}Was this RCA accurate?{_R}  {_D}↑↓ · Enter · Esc or s to skip{_R}\n\n"
+        )
         sys.stdout.flush()
 
     rating = _pick_rating(console=console)

--- a/app/cli/interactive_shell/ui/feedback.py
+++ b/app/cli/interactive_shell/ui/feedback.py
@@ -222,11 +222,7 @@ def _run_select(choices: list[tuple[str, str]]) -> str | None:
     _draw(False)
 
     while True:
-        key = (
-            read_key_unix(also_cancel=_SKIP_KEYS)
-            if is_unix
-            else read_key_windows()
-        )
+        key = read_key_unix(also_cancel=_SKIP_KEYS) if is_unix else read_key_windows()
 
         if key == "enter":
             _out(f"\x1b[{total_lines}A\r\x1b[J")
@@ -292,13 +288,10 @@ def _collect(final_state: dict[str, Any], *, console: Console | None) -> None:
 
     if console is not None:
         console.print(
-            f"\n[{BRAND}]Was this RCA accurate?[/] "
-            f"[{DIM}]↑↓ · Enter · Esc or s to skip[/]"
+            f"\n[{BRAND}]Was this RCA accurate?[/] [{DIM}]↑↓ · Enter · Esc or s to skip[/]"
         )
     else:
-        sys.stdout.write(
-            f"\n{_H}Was this RCA accurate?{_R}  {_D}↑↓ · Enter · Esc to skip{_R}\n\n"
-        )
+        sys.stdout.write(f"\n{_H}Was this RCA accurate?{_R}  {_D}↑↓ · Enter · Esc to skip{_R}\n\n")
         sys.stdout.flush()
 
     rating = _pick_rating(console=console)

--- a/app/cli/interactive_shell/ui/key_reader.py
+++ b/app/cli/interactive_shell/ui/key_reader.py
@@ -99,17 +99,19 @@ def read_key_unix(*, also_cancel: tuple[bytes, ...] = ()) -> str:
         termios.tcsetattr(fd, termios.TCSADRAIN, old)  # type: ignore[attr-defined]
 
 
-def read_key_windows() -> str:
+def read_key_windows(*, also_cancel: tuple[bytes, ...] = ()) -> str:
     """Read one logical keypress on Windows; return a normalised key name.
 
     Possible return values: ``"up"``, ``"down"``, ``"enter"``,
     ``"cancel"``, ``"tab"``, ``"right"``, ``"left"``, ``"eof"``,
     ``"ignore"``.
+
+    ``also_cancel`` treats additional single-byte keys as ``"cancel"``.
     """
     import msvcrt  # type: ignore[import,attr-defined]
 
     ch = msvcrt.getch()  # type: ignore[attr-defined]
-    if ch in (b"\x03", b"\x1b"):
+    if ch in (b"\x03", b"\x1b") or ch in also_cancel:
         return "cancel"
     if ch in (b"\r", b"\n", b" "):
         return "enter"

--- a/app/cli/interactive_shell/ui/key_reader.py
+++ b/app/cli/interactive_shell/ui/key_reader.py
@@ -24,12 +24,37 @@ def flush_stdin_unix() -> None:
         termios.tcflush(sys.stdin.fileno(), termios.TCIFLUSH)  # type: ignore[attr-defined]
 
 
-def read_key_unix() -> str:
+def restore_stdin_terminal() -> None:
+    """Return stdin to canonical echo mode after Live/raw investigation UI.
+
+    Investigation progress uses a background Ctrl+O watcher that puts stdin in
+    non-canonical mode without echo. If nested watchers restore the wrong
+    snapshot, the shell prompt appears to accept input but characters are not
+    echoed. Call this after investigation UI teardown and before line prompts.
+    """
+    if os.name == "nt" or not sys.stdin.isatty():
+        return
+    import termios
+
+    with contextlib.suppress(Exception):
+        fd = sys.stdin.fileno()
+        attrs = termios.tcgetattr(fd)  # type: ignore[attr-defined]
+        attrs[3] |= termios.ICANON | termios.ECHO  # type: ignore[attr-defined]
+        if hasattr(termios, "IEXTEN"):
+            attrs[3] |= termios.IEXTEN  # type: ignore[attr-defined]
+        termios.tcsetattr(fd, termios.TCSADRAIN, attrs)  # type: ignore[attr-defined]
+        termios.tcflush(fd, termios.TCIFLUSH)  # type: ignore[attr-defined]
+
+
+def read_key_unix(*, also_cancel: tuple[bytes, ...] = ()) -> str:
     """Read one logical keypress in raw mode; return a normalised key name.
 
     Possible return values: ``"up"``, ``"down"``, ``"enter"``,
     ``"cancel"``, ``"tab"``, ``"right"``, ``"left"``, ``"eof"``,
     ``"ignore"``.
+
+    ``also_cancel`` treats additional single-byte keys as ``"cancel"`` (e.g.
+    ``(b"s", b"S")`` for an explicit skip shortcut).
     """
     import select as _sel
     import termios
@@ -43,7 +68,7 @@ def read_key_unix() -> str:
         if not ch:
             return "eof"
         b = ch[0]
-        if b in (3, 4):  # Ctrl-C / Ctrl-D
+        if b in (3, 4) or ch in also_cancel:  # Ctrl-C / Ctrl-D / caller shortcuts
             return "cancel"
         if b in (10, 13, 32):  # LF / CR / Space
             return "enter"
@@ -110,4 +135,4 @@ def read_key_windows() -> str:
     return "ignore"
 
 
-__all__ = ["flush_stdin_unix", "read_key_unix", "read_key_windows"]
+__all__ = ["flush_stdin_unix", "read_key_unix", "read_key_windows", "restore_stdin_terminal"]

--- a/app/cli/interactive_shell/ui/output/toggles.py
+++ b/app/cli/interactive_shell/ui/output/toggles.py
@@ -123,6 +123,9 @@ class CtrlOToggleWatcher:
         if self._fd is not None and self._old_attrs is not None and termios is not None:
             with contextlib.suppress(Exception):
                 termios.tcsetattr(self._fd, termios.TCSADRAIN, self._old_attrs)
+        from app.cli.interactive_shell.ui.key_reader import restore_stdin_terminal
+
+        restore_stdin_terminal()
 
     def _run(self) -> None:
         if self._fd is None or select is None:

--- a/app/cli/interactive_shell/ui/output/tracker.py
+++ b/app/cli/interactive_shell/ui/output/tracker.py
@@ -20,6 +20,7 @@ from app.cli.interactive_shell.ui.output.repl_display import _ReplEventLogDispla
 from app.cli.interactive_shell.ui.output.toggles import (
     CtrlOToggleWatcher,
     register_tool_detail_toggle,
+    toggle_active_tool_details,
 )
 from app.cli.interactive_shell.ui.output.tool_tracking import ToolTrackingMixin
 from app.cli.interactive_shell.ui.time_format import _fmt_timing
@@ -53,7 +54,7 @@ class ProgressTracker(ToolTrackingMixin):
             self._display = _make_event_log_display(t0=self._t0)
             self._toggle_unregister = register_tool_detail_toggle(self.toggle_tool_details)
             if not self._repl_append_only:
-                self._toggle_watcher = CtrlOToggleWatcher(self.toggle_tool_details)
+                self._toggle_watcher = CtrlOToggleWatcher(toggle_active_tool_details)
                 self._toggle_watcher.start()
 
     @property

--- a/app/cli/interactive_shell/ui/output/tracker.py
+++ b/app/cli/interactive_shell/ui/output/tracker.py
@@ -30,6 +30,10 @@ def _make_event_log_display(*, t0: float) -> DisplayProtocol:
     return _ReplEventLogDisplay(t0=t0) if _repl_progress_active() else _EventLogDisplay(t0=t0)
 
 
+def _invoke_registered_tool_detail_toggle() -> None:
+    toggle_active_tool_details()
+
+
 class ProgressTracker(ToolTrackingMixin):
     """Drives event-log displays from node lifecycle calls."""
 
@@ -54,7 +58,7 @@ class ProgressTracker(ToolTrackingMixin):
             self._display = _make_event_log_display(t0=self._t0)
             self._toggle_unregister = register_tool_detail_toggle(self.toggle_tool_details)
             if not self._repl_append_only:
-                self._toggle_watcher = CtrlOToggleWatcher(toggle_active_tool_details)
+                self._toggle_watcher = CtrlOToggleWatcher(_invoke_registered_tool_detail_toggle)
                 self._toggle_watcher.start()
 
     @property

--- a/app/cli/investigation/investigate.py
+++ b/app/cli/investigation/investigate.py
@@ -270,7 +270,9 @@ def run_investigation_cli_streaming(
         raise
 
     from app.cli.interactive_shell.ui.feedback import prompt_investigation_feedback
+    from app.cli.interactive_shell.ui.key_reader import restore_stdin_terminal
 
+    restore_stdin_terminal()
     prompt_investigation_feedback(final_state)
     return {
         "report": final_state.get("slack_message", final_state.get("report", "")),

--- a/app/cli/ui/renderer/renderer.py
+++ b/app/cli/ui/renderer/renderer.py
@@ -12,7 +12,6 @@ from rich.text import Text
 from app.analytics.events import Event
 from app.analytics.provider import get_analytics
 from app.cli.interactive_shell.ui.output import (
-    CtrlOToggleWatcher,
     ProgressTracker,
     _fmt_timing,
     _repl_progress_active,
@@ -76,7 +75,6 @@ class StreamRenderer:
         self._tool_summary_counts: dict[str, dict[str, int]] = {}
         self._tool_summary_order: list[tuple[str, str]] = []
         self._prior_lap_tools: list[str] = []
-        self._toggle_watcher: CtrlOToggleWatcher | None = None
         self._toggle_unregister: Callable[[], None] | None = None
 
     def _print_above_renderable(self, renderable: Any) -> None:
@@ -111,14 +109,11 @@ class StreamRenderer:
     def _start_toggle_watcher(self) -> None:
         if get_output_format() != "rich" or _repl_progress_active():
             return
+        # ProgressTracker already owns the single Ctrl+O stdin watcher.
+        # Register our handler so toggle_active_tool_details() routes here.
         self._toggle_unregister = register_tool_detail_toggle(self._toggle_tool_details)
-        self._toggle_watcher = CtrlOToggleWatcher(self._toggle_tool_details)
-        self._toggle_watcher.start()
 
     def _stop_toggle_watcher(self) -> None:
-        if self._toggle_watcher is not None:
-            self._toggle_watcher.stop()
-            self._toggle_watcher = None
         if self._toggle_unregister is not None:
             self._toggle_unregister()
             self._toggle_unregister = None

--- a/tests/cli/interactive_shell/ui/test_feedback.py
+++ b/tests/cli/interactive_shell/ui/test_feedback.py
@@ -10,6 +10,7 @@ from rich.console import Console
 
 from app.cli.interactive_shell.ui.feedback import (
     _format_root_cause_lines,
+    _parse_cli_choice,
     _print_context,
     _root_cause_width,
 )
@@ -103,3 +104,34 @@ def test_print_context_shows_full_root_cause_in_stdout_path(
     captured = capsys.readouterr().out
     assert "…" not in captured
     assert " ".join(captured.split()) == ("─" * 60 + " Root cause: " + root + " " + "─" * 60)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("", None),
+        ("1", "accurate"),
+        ("a", "accurate"),
+        ("3", "inaccurate"),
+        ("s", "skip"),
+        ("n", "never"),
+        ("bogus", None),
+    ],
+)
+def test_parse_cli_choice(raw: str, expected: str | None) -> None:
+    assert _parse_cli_choice(raw) == expected
+
+
+def test_pick_rating_cli_uses_line_input(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda: "2")
+    from app.cli.interactive_shell.ui.feedback import _pick_rating_cli
+
+    assert _pick_rating_cli() == "partial"
+    captured = capsys.readouterr().out
+    assert "Choice" in captured
+    assert "Partially accurate" in captured

--- a/tests/cli/interactive_shell/ui/test_feedback.py
+++ b/tests/cli/interactive_shell/ui/test_feedback.py
@@ -9,10 +9,11 @@ import pytest
 from rich.console import Console
 
 from app.cli.interactive_shell.ui.feedback import (
+    _CHOICES,
     _format_root_cause_lines,
-    _parse_cli_choice,
     _print_context,
     _root_cause_width,
+    _run_select,
 )
 
 
@@ -106,32 +107,29 @@ def test_print_context_shows_full_root_cause_in_stdout_path(
     assert " ".join(captured.split()) == ("─" * 60 + " Root cause: " + root + " " + "─" * 60)
 
 
-@pytest.mark.parametrize(
-    ("raw", "expected"),
-    [
-        ("", None),
-        ("1", "accurate"),
-        ("a", "accurate"),
-        ("3", "inaccurate"),
-        ("s", "skip"),
-        ("n", "never"),
-        ("bogus", None),
-    ],
-)
-def test_parse_cli_choice(raw: str, expected: str | None) -> None:
-    assert _parse_cli_choice(raw) == expected
-
-
-def test_pick_rating_cli_uses_line_input(
+def test_run_select_returns_highlighted_choice_on_enter(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
-    monkeypatch.setattr("builtins.input", lambda: "2")
-    from app.cli.interactive_shell.ui.feedback import _pick_rating_cli
+    calls = {"n": 0}
 
-    assert _pick_rating_cli() == "partial"
+    def read_then_enter(**_kwargs: object) -> str:
+        calls["n"] += 1
+        return "enter" if calls["n"] > 1 else "down"
+
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.feedback.read_key_unix",
+        read_then_enter,
+    )
+    monkeypatch.setattr("app.cli.interactive_shell.ui.feedback.flush_stdin_unix", lambda: None)
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.feedback.restore_stdin_terminal",
+        lambda: None,
+    )
+
+    assert _run_select(_CHOICES) == "partial"
     captured = capsys.readouterr().out
-    assert "Choice" in captured
     assert "Partially accurate" in captured
+    assert "↑↓" in captured

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -486,6 +486,66 @@ def test_ctrl_o_watcher_disables_terminal_output_discard(
     assert attrs[6][_Termios.VDISCARD] == b"\x00"
 
 
+def test_ctrl_o_watcher_stop_restores_canonical_echo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _TTY:
+        def isatty(self) -> bool:
+            return True
+
+        def fileno(self) -> int:
+            return 0
+
+    class _Termios:
+        ICANON = 0x0002
+        ECHO = 0x0008
+        IEXTEN = 0x0400
+        VMIN = 6
+        VTIME = 5
+        VDISCARD = 13
+        TCSADRAIN = 1
+        TCIFLUSH = 0
+        final_attrs: list[int] | None = None
+
+        @classmethod
+        def tcgetattr(cls, _fd: int) -> list[Any]:
+            lflags = cls.ICANON | cls.ECHO | cls.IEXTEN
+            if cls.final_attrs is not None:
+                lflags = cls.final_attrs[3]
+            return [0, 0, 0, lflags, 0, 0, [0] * 20]
+
+        @classmethod
+        def tcsetattr(cls, _fd: int, _when: int, attrs: list[Any]) -> None:
+            cls.final_attrs = attrs[3]
+
+        @classmethod
+        def tcflush(cls, _fd: int, _queue: int) -> None:
+            return None
+
+    class _Select:
+        @staticmethod
+        def select(*_args: Any, **_kwargs: Any) -> tuple[list[int], list[int], list[int]]:
+            return [], [], []
+
+    from app.cli.interactive_shell.ui import key_reader
+
+    monkeypatch.setattr(output_toggles.sys, "stdin", _TTY())
+    monkeypatch.setattr(output_toggles.sys, "stdout", _TTY())
+    monkeypatch.setattr(output_toggles, "select", _Select)
+    monkeypatch.setattr(output_toggles, "termios", _Termios)
+    monkeypatch.setattr(output_toggles.os, "fpathconf", lambda _fd, _name: 0)
+    monkeypatch.setattr(key_reader, "termios", _Termios, raising=False)
+    monkeypatch.setattr(key_reader.sys, "stdin", _TTY())
+
+    watcher = output.CtrlOToggleWatcher(lambda: None)
+    watcher.start()
+    watcher.stop()
+
+    assert _Termios.final_attrs is not None
+    assert _Termios.final_attrs & _Termios.ICANON
+    assert _Termios.final_attrs & _Termios.ECHO
+
+
 def test_suppressed_stdin_watchers_do_not_touch_terminal_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/remote/test_renderer.py
+++ b/tests/remote/test_renderer.py
@@ -483,6 +483,27 @@ class TestStreamRendererCleanupOnException:
         assert renderer.final_state.get("alert_name") == "interrupted-alert"
 
 
+class TestStreamRendererStdinWatcher:
+    @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "rich"})
+    def test_starts_only_one_stdin_watcher(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.cli.interactive_shell.ui.output import toggles as toggles_module
+
+        starts = 0
+        original_start = toggles_module.CtrlOToggleWatcher.start
+
+        def counting_start(self: toggles_module.CtrlOToggleWatcher) -> None:
+            nonlocal starts
+            starts += 1
+            original_start(self)
+
+        monkeypatch.setattr(toggles_module.CtrlOToggleWatcher, "start", counting_start)
+
+        renderer = StreamRenderer(local=True)
+        renderer.render_stream(_investigation_events())
+
+        assert starts == 1
+
+
 def _diagnose_streaming_events() -> Iterator[StreamEvent]:
     """Simulate the diagnose node emitting token deltas before chain end."""
     yield _make_event("metadata", data={"run_id": "r-d"})
@@ -563,7 +584,7 @@ class TestStreamRendererDiagnoseStreaming:
         renderer.render_stream(_diagnose_streaming_events())
 
         assert renderer._diagnose._live is None
-        assert renderer._toggle_watcher is None
+        assert renderer._toggle_unregister is None
 
     @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "text"})
     def test_diagnose_text_mode_replays_buffer_at_finish(self, capfd) -> None:


### PR DESCRIPTION
Fixes #3053

#### Describe the changes you have made in this PR -

Fixes the post-`opensre investigate` terminal hang where the shell appeared frozen after the RCA feedback prompt.

- **Root cause:** `StreamRenderer` and `ProgressTracker` each started a `CtrlOToggleWatcher`, corrupting termios restoration (stdin left in non-canonical/no-echo mode).
- **Fix:** Only `ProgressTracker` owns the stdin watcher; `StreamRenderer` registers its Ctrl+O handler without starting a second watcher.
- **Safety net:** `restore_stdin_terminal()` forces canonical echo mode after investigation UI teardown and around the feedback prompt.
- **UX:** CLI feedback uses a normal line prompt (`Choice:` with `1-5` / `a/p/i/s/n` / Enter to skip) instead of a raw arrow-key menu that blocked normal typing.

### Demo/Screenshot for feature changes and bug fixes - 
N/A — terminal behavior fix; verified by unit tests for single watcher start, canonical echo restore, and line-input feedback parsing.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Investigation streaming puts stdin in raw/no-echo mode for the Ctrl+O tool-details watcher. Nested watchers saved/restored the wrong termios snapshot, so after investigate finished users could not type at the shell prompt. Consolidating to one watcher and explicitly restoring canonical mode fixes the hang. The feedback prompt now uses `input()` so it behaves like a normal CLI prompt instead of hijacking raw key events.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.