### PR TITLE
refactor(core): decouple orchestration from app.remote

### DIFF
--- a/app/cli/investigation/investigate.py
+++ b/app/cli/investigation/investigate.py
@@ -14,7 +14,7 @@ from app.config import resolve_llm_settings
 from app.utils.tracing import traceable
 
 if TYPE_CHECKING:
-    from app.remote.stream import StreamEvent
+    from app.core.domain.stream import StreamEvent
     from app.state import AgentState
 
 _logger = logging.getLogger(__name__)

--- a/app/cli/ui/renderer/__init__.py
+++ b/app/cli/ui/renderer/__init__.py
@@ -3,6 +3,5 @@
 from __future__ import annotations
 
 from app.cli.ui.renderer.renderer import StreamRenderer, _canonical_node_name
-from app.remote.stream import StreamEvent
 
-__all__ = ["StreamEvent", "StreamRenderer", "_canonical_node_name"]
+__all__ = ["StreamRenderer", "_canonical_node_name"]

--- a/app/cli/ui/renderer/diagnose.py
+++ b/app/cli/ui/renderer/diagnose.py
@@ -35,7 +35,7 @@ from app.cli.ui.renderer.constants import (
     _WHITE,
     _render_source,
 )
-from app.remote.stream import StreamEvent
+from app.core.domain.stream import StreamEvent
 
 
 class _DiagnoseStreamRenderer:

--- a/app/cli/ui/renderer/renderer.py
+++ b/app/cli/ui/renderer/renderer.py
@@ -37,8 +37,8 @@ from app.cli.ui.renderer.tools import (
     _tool_short_label,
     _tool_source_label,
 )
+from app.core.domain.stream import StreamEvent
 from app.remote.reasoning import reasoning_text
-from app.remote.stream import StreamEvent
 from app.tools.registry import resolve_tool_display_name
 from app.utils.tool_trace import format_json_preview
 

--- a/app/core/domain/stream.py
+++ b/app/core/domain/stream.py
@@ -1,0 +1,44 @@
+"""Domain envelope for pipeline streaming events.
+
+``StreamEvent`` is the inter-layer event shape produced by the
+orchestration pipeline (node updates + fine-grained chain/tool/LLM
+callbacks) and consumed by the CLI renderer, the remote runner, and
+any future surface that observes pipeline progress.
+
+It deliberately lives in ``app.core.domain`` so that the orchestration
+core does not need to import from ``app.remote`` (a transport-layer
+package). The SSE parser that materializes ``StreamEvent``s from a
+remote HTTP response stays in ``app.remote.stream``; the event shape
+itself is domain.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class StreamEvent:
+    """A parsed event from the pipeline stream.
+
+    Attributes:
+        event_type: The SSE event type (e.g. "events", "metadata", "end",
+            or legacy "updates").
+        node_name: The pipeline node that produced this event, if applicable.
+        data: The parsed JSON payload.
+        timestamp: Monotonic timestamp when this event was received.
+        kind: For ``events`` mode — the callback kind
+            (e.g. "on_tool_start", "on_chat_model_stream").
+        run_id: Run ID from event metadata.
+        tags: Tags attached to the event payload.
+    """
+
+    event_type: str
+    data: dict[str, Any] = field(default_factory=dict)
+    node_name: str = ""
+    timestamp: float = field(default_factory=time.monotonic)
+    kind: str = ""
+    run_id: str = ""
+    tags: list[str] = field(default_factory=list)

--- a/app/core/orchestration/entrypoints.py
+++ b/app/core/orchestration/entrypoints.py
@@ -10,8 +10,8 @@ import threading
 from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any, cast
 
+from app.core.domain.stream import StreamEvent
 from app.core.orchestration.stream_payloads import resolved_integrations_stream_payload
-from app.remote.stream import StreamEvent
 from app.state import AgentState, make_initial_state
 from app.utils.errors import report_and_reraise
 from app.utils.sentry_sdk import init_sentry

--- a/app/remote/__init__.py
+++ b/app/remote/__init__.py
@@ -3,6 +3,5 @@
 from __future__ import annotations
 
 from app.remote.client import RemoteAgentClient, RemoteRunResult
-from app.remote.stream import StreamEvent
 
-__all__ = ["RemoteAgentClient", "RemoteRunResult", "StreamEvent"]
+__all__ = ["RemoteAgentClient", "RemoteRunResult"]

--- a/app/remote/client.py
+++ b/app/remote/client.py
@@ -10,8 +10,9 @@ from typing import Any
 
 import httpx
 
+from app.core.domain.stream import StreamEvent
 from app.remote.error_reporting import report_remote_exception
-from app.remote.stream import StreamEvent, parse_sse_stream
+from app.remote.stream import parse_sse_stream
 
 logger = logging.getLogger(__name__)
 

--- a/app/remote/stream.py
+++ b/app/remote/stream.py
@@ -2,42 +2,21 @@
 
 Supports both ``stream_mode: ["updates"]`` (node-level) and
 ``stream_mode: ["events"]`` (fine-grained tool/LLM/chain events).
+
+The event envelope itself (:class:`StreamEvent`) lives in
+``app.core.domain.stream`` so the orchestration core can produce
+events without importing from this transport-layer module.
 """
 
 from __future__ import annotations
 
 import json
-import time
 from collections.abc import Iterator
-from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
 
-
-@dataclass
-class StreamEvent:
-    """A parsed event from an SSE stream.
-
-    Attributes:
-        event_type: The SSE event type (e.g. "events", "metadata", "end",
-            or legacy "updates").
-        node_name: The pipeline node that produced this event, if applicable.
-        data: The parsed JSON payload.
-        timestamp: Monotonic timestamp when this event was received.
-        kind: For ``events`` mode — the callback kind
-            (e.g. "on_tool_start", "on_chat_model_stream").
-        run_id: Run ID from event metadata.
-        tags: Tags attached to the event payload.
-    """
-
-    event_type: str
-    data: dict[str, Any] = field(default_factory=dict)
-    node_name: str = ""
-    timestamp: float = field(default_factory=time.monotonic)
-    kind: str = ""
-    run_id: str = ""
-    tags: list[str] = field(default_factory=list)
+from app.core.domain.stream import StreamEvent
 
 
 def parse_sse_stream(response: httpx.Response) -> Iterator[StreamEvent]:
@@ -125,3 +104,6 @@ def _extract_event_details(event_type: str, data: dict[str, Any]) -> tuple[str, 
     raw_tags = data.get("tags", [])
     tags: list[str] = list(raw_tags) if isinstance(raw_tags, list) else []
     return kind, run_id, tags
+
+
+__all__ = ["parse_sse_stream"]

--- a/tests/cli/test_investigate.py
+++ b/tests/cli/test_investigate.py
@@ -11,8 +11,8 @@ from app.cli.investigation import (
     run_investigation_cli,
     stream_investigation_cli,
 )
+from app.core.domain.stream import StreamEvent
 from app.integrations.llm_cli.errors import CLIAuthenticationRequired
-from app.remote.stream import StreamEvent
 
 
 def test_resolve_investigation_context_prefers_cli_overrides() -> None:

--- a/tests/cli/test_remote.py
+++ b/tests/cli/test_remote.py
@@ -7,8 +7,8 @@ import httpx
 from click.testing import CliRunner
 
 from app.cli.__main__ import cli
+from app.core.domain.stream import StreamEvent
 from app.remote.ops import RemoteOpsError, RestartResult, ServiceStatus
-from app.remote.stream import StreamEvent
 
 
 class _AnsweredPrompt:

--- a/tests/core/orchestration/test_layering.py
+++ b/tests/core/orchestration/test_layering.py
@@ -31,7 +31,12 @@ _ORCHESTRATION_PIPELINE_FILES: tuple[Path, ...] = (
 # factory, so reaching directly into ``app.services.<anything>`` is a
 # layering violation regardless of vendor.
 # This guards against future Grafana/AWS/etc. imports without manual edits.
-_FORBIDDEN_PREFIXES: tuple[str, ...] = ("app.services",)
+#
+# ``app.remote`` is a transport-layer package (HTTP client, SSE parser). The
+# orchestration core must not depend on it — domain types it shares with
+# the remote runner live in ``app.core.domain`` (see ``StreamEvent``).
+# ``app.cli`` is the presentation layer; same rule.
+_FORBIDDEN_PREFIXES: tuple[str, ...] = ("app.services", "app.remote", "app.cli")
 
 
 def _orchestration_pipeline_modules() -> list[Path]:

--- a/tests/remote/test_client.py
+++ b/tests/remote/test_client.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
+from app.core.domain.stream import StreamEvent
 from app.remote.client import (
     DEFAULT_PORT,
     PreflightResult,
@@ -14,7 +15,6 @@ from app.remote.client import (
     _build_synthetic_payload,
     normalize_url,
 )
-from app.remote.stream import StreamEvent
 
 
 class TestNormalizeUrl:

--- a/tests/remote/test_renderer.py
+++ b/tests/remote/test_renderer.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from app.cli.ui.renderer import StreamRenderer, _canonical_node_name
-from app.remote.stream import StreamEvent
+from app.core.domain.stream import StreamEvent
 
 
 def _make_event(
@@ -1270,7 +1270,8 @@ class TestStreamRendererPrintAboveRenderable:
 
     def test_merge_chain_start_input_eagerly_updates_metadata(self) -> None:
         """_merge_chain_start_input should pull 'input' payload from data into _final_state."""
-        from app.cli.ui.renderer import StreamEvent, StreamRenderer
+        from app.cli.ui.renderer import StreamRenderer
+        from app.core.domain.stream import StreamEvent
 
         renderer = StreamRenderer()
         assert "alert_name" not in renderer._final_state

--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -16,6 +16,7 @@ _DiskUsage = collections.namedtuple("usage", ["total", "used", "free"])
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
+from app.core.domain.stream import StreamEvent
 from app.remote import server as remote_server
 from app.remote.server import (
     DeepHealthCheck,
@@ -29,7 +30,6 @@ from app.remote.server import (
     investigate,
     investigate_stream,
 )
-from app.remote.stream import StreamEvent
 from app.remote.vercel_poller import VercelResolutionError
 
 


### PR DESCRIPTION
Fixes #3052 

#### Describe the changes you have made in this PR -

Moves the `StreamEvent` dataclass from `app/remote/stream.py` into `app/core/domain/stream.py` and extends the orchestration layering test to block any future imports from `app.remote.*` or `app.cli.*`.

## Why

`app/core/orchestration/entrypoints.py` was importing `StreamEvent` from `app.remote.stream` — a transport-layer module. That's the wrong direction: orchestration core should not depend on remote. The existing layering regression test (`tests/core/orchestration/test_layering.py`) already enforced this rule for `app.services.*`, but `app.remote.*` and `app.cli.*` were silently allowed.

`StreamEvent` is a pure dataclass — no SSE, no httpx, no transport concerns. It belongs alongside the other domain envelopes in `app/core/domain/`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

## What changed

- **New**: `app/core/domain/stream.py` holds the `StreamEvent` dataclass and nothing else.
- **Shrunk**: `app/remote/stream.py` is now the SSE parser only (`parse_sse_stream` plus its `_build_event` / `_extract_*` helpers). It imports `StreamEvent` from the new domain location.
- **Flipped import**: `app/core/orchestration/entrypoints.py` now imports `StreamEvent` from `app.core.domain.stream`. The  forbidden-direction edge is gone.
- **Migrated consumers** (canonical path everywhere):
  `app/remote/client.py`, `app/cli/investigation/investigate.py`,
  `app/cli/ui/renderer/__init__.py`, `app/cli/ui/renderer/diagnose.py`,
  `app/cli/ui/renderer/renderer.py`, and six test files.
- **Dropped cross-layer re-exports**: `app/remote/__init__.py` no longer re-exports `StreamEvent`; same for `app/cli/ui/renderer/__init__.py`. Per the repo's "no  compatibility-only forwarding modules after refactors" rule (AGENTS.md). Both re-exports had zero consumers in the codebase.
- **Layering test extended**:
  `tests/core/orchestration/test_layering.py` now blocks
  `app.services`, `app.remote`, AND `app.cli` imports from the four orchestration runtime modules. A future drift in any  direction fails this test on CI.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
