### PR TITLE
fix(repl): align /investigate RCA output with CLI

### DIFF
--- a/app/cli/interactive_shell/command_registry/investigation.py
+++ b/app/cli/interactive_shell/command_registry/investigation.py
@@ -74,7 +74,8 @@ def _interactive_investigate_menu(session: ReplSession, console: Console) -> boo
                 continue
             target = custom_path
         _cmd_investigate_file(session, console, [target])
-        repl_section_break(console)
+        # One picker selection → one investigation, then return to the REPL prompt.
+        return True
 
 
 def _prompt_investigate_path(console: Console) -> str | None:

--- a/app/cli/interactive_shell/runtime/foreground_investigation.py
+++ b/app/cli/interactive_shell/runtime/foreground_investigation.py
@@ -51,6 +51,13 @@ def run_foreground_investigation(
     root = final_state.get("root_cause")
     task.mark_completed(result=str(root) if root is not None else "")
     session.apply_investigation_result(final_state)
+
+    from app.cli.interactive_shell.ui.feedback import prompt_investigation_feedback
+    from app.cli.interactive_shell.ui.key_reader import restore_stdin_terminal
+
+    restore_stdin_terminal()
+    prompt_investigation_feedback(final_state, console=console, post_stream=True)
+
     return final_state
 
 

--- a/app/cli/interactive_shell/ui/feedback.py
+++ b/app/cli/interactive_shell/ui/feedback.py
@@ -266,31 +266,53 @@ def _read_note(*, console: Console | None) -> str:
 # ── core ──────────────────────────────────────────────────────────────────────
 
 
-def _pick_rating(*, console: Console | None) -> str | None:
+def _report_already_rendered(final_state: dict[str, Any]) -> bool:
+    report = final_state.get("slack_message") or final_state.get("report") or ""
+    return bool(str(report).strip())
+
+
+def _pick_rating(*, console: Console | None, post_stream: bool) -> str | None:
     """Show the rating prompt; returns key or None on cancel/skip."""
-    if console is not None:
-        from app.cli.interactive_shell.ui.choice_menu import repl_choose_one, repl_tty_interactive
-
-        if not repl_tty_interactive():
+    if post_stream or console is None:
+        if not (sys.stdin.isatty() and sys.stdout.isatty()):
             return None
-        return repl_choose_one(title="Was this RCA accurate?", choices=_CHOICES)
+        return _run_select(_CHOICES)
 
-    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+    from app.cli.interactive_shell.ui.choice_menu import repl_choose_one, repl_tty_interactive
+
+    if not repl_tty_interactive():
         return None
-    return _run_select(_CHOICES)
+    return repl_choose_one(title="Was this RCA accurate?", choices=_CHOICES)
 
 
-def _collect(final_state: dict[str, Any], *, console: Console | None) -> None:
+def _collect(
+    final_state: dict[str, Any],
+    *,
+    console: Console | None,
+    post_stream: bool = False,
+) -> None:
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         return
     if _is_disabled():
         return
 
-    _print_context(final_state, console=console)
+    if not _report_already_rendered(final_state):
+        _print_context(final_state, console=console)
 
     from app.cli.interactive_shell.ui.theme import BRAND, DIM
 
-    if console is not None:
+    if post_stream or console is None:
+        from app.cli.interactive_shell.ui.choice_menu import prepare_repl_output_line
+
+        prepare_repl_output_line()
+        if console is not None:
+            console.print(f"\n[{BRAND}]Was this RCA accurate?[/]")
+        else:
+            sys.stdout.write(
+                f"\n{_H}Was this RCA accurate?{_R}  {_D}↑↓ · Enter · Esc or s to skip{_R}\n\n"
+            )
+            sys.stdout.flush()
+    elif console is not None:
         console.print(
             f"\n[{BRAND}]Was this RCA accurate?[/] [{DIM}]↑↓ · Enter · Esc or s to skip[/]"
         )
@@ -300,7 +322,7 @@ def _collect(final_state: dict[str, Any], *, console: Console | None) -> None:
         )
         sys.stdout.flush()
 
-    rating = _pick_rating(console=console)
+    rating = _pick_rating(console=console, post_stream=post_stream)
     if not rating or rating == "skip":
         return
 
@@ -351,6 +373,7 @@ def prompt_investigation_feedback(
     final_state: dict[str, Any],
     *,
     console: Console | None = None,
+    post_stream: bool = False,
 ) -> None:
     """Prompt for RCA accuracy feedback; never raises.
 
@@ -359,9 +382,14 @@ def prompt_investigation_feedback(
     provenance (run_id, alert_name, validity_score, root_cause_category, …)
     and user context (user_id, user_email, org_id when available on
     the hosted/JWT path).
+
+    Set ``post_stream=True`` after a streaming investigation in the REPL so the
+    cursor-safe :func:`_run_select` menu is used instead of
+    :func:`repl_choose_one`, and the root-cause recap is skipped when the full
+    report was already rendered.
     """
     with contextlib.suppress(Exception):
         try:
-            _collect(final_state, console=console)
+            _collect(final_state, console=console, post_stream=post_stream)
         finally:
             restore_stdin_terminal()

--- a/app/cli/investigation/investigate.py
+++ b/app/cli/investigation/investigate.py
@@ -273,7 +273,7 @@ def run_investigation_cli_streaming(
     from app.cli.interactive_shell.ui.key_reader import restore_stdin_terminal
 
     restore_stdin_terminal()
-    prompt_investigation_feedback(final_state)
+    prompt_investigation_feedback(final_state, post_stream=True)
     return {
         "report": final_state.get("slack_message", final_state.get("report", "")),
         "problem_md": final_state.get("problem_md", ""),

--- a/app/cli/ui/renderer/renderer.py
+++ b/app/cli/ui/renderer/renderer.py
@@ -531,8 +531,11 @@ class StreamRenderer:
 
         stop_display()
 
-        slack_message = self._final_state.get("slack_message") or self._final_state.get(
-            "report", ""
+        slack_message = (
+            self._final_state.get("slack_message")
+            or self._final_state.get("report")
+            or self._final_state.get("problem_md")
+            or ""
         )
 
         if not slack_message:

--- a/app/core/orchestration/node/publish_findings/renderers/terminal.py
+++ b/app/core/orchestration/node/publish_findings/renderers/terminal.py
@@ -1,6 +1,9 @@
 """Terminal rendering for RCA reports — Claude-style output."""
 
+from __future__ import annotations
+
 import re
+import sys
 
 from rich.console import Console
 from rich.text import Text
@@ -131,18 +134,49 @@ def render_report(slack_message: str) -> None:
             print("No report generated.")
         return
 
-    if fmt == "rich":
-        _render_rich_report(slack_message)
-    else:
-        _render_plain_report(slack_message)
+    from app.cli.interactive_shell.ui.output.environment import _repl_progress_active
 
-    # Print the investigation phase footer at the absolute bottom of the
-    # RCA report (without "esc to cancel" — the investigation is complete).
+    if _repl_progress_active() and sys.stdout.isatty():
+        from app.cli.interactive_shell.ui.choice_menu import prepare_repl_output_line
+        from app.cli.interactive_shell.ui.rendering import (
+            _prepare_tty_for_rich,
+            _write_repl_tty_buffered,
+        )
+
+        prepare_repl_output_line()
+        base = Console(highlight=False, force_terminal=True, color_system="truecolor")
+        width = _prepare_tty_for_rich(base)
+        _write_repl_tty_buffered(
+            width=width,
+            leading_blank=False,
+            render_to_buffer=lambda buf: _render_report_body(slack_message, console=buf),
+        )
+        render_completed_investigation_footer()
+        return
+
+    _render_report_body(slack_message, console=None)
     render_completed_investigation_footer()
 
 
-def _render_rich_report(slack_message: str) -> None:
-    console = Console(highlight=False, force_terminal=True, color_system="truecolor")
+def _render_report_body(slack_message: str, *, console: Console | None) -> None:
+    fmt = get_output_format()
+    if fmt == "rich":
+        _render_rich_report(
+            slack_message,
+            console=console
+            or Console(highlight=False, force_terminal=True, color_system="truecolor"),
+        )
+        return
+    if console is not None:
+        console.print()
+        clean = _strip_slack_links(_strip_mrkdwn(slack_message))
+        for line in clean.splitlines():
+            console.print(line)
+        return
+    _render_plain_report(slack_message)
+
+
+def _render_rich_report(slack_message: str, *, console: Console) -> None:
     console.print()
 
     lines = slack_message.splitlines()

--- a/tests/cli/interactive_shell/runtime/test_foreground_investigation.py
+++ b/tests/cli/interactive_shell/runtime/test_foreground_investigation.py
@@ -1,0 +1,80 @@
+"""Tests for shared foreground investigation lifecycle."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+from app.cli.interactive_shell.runtime import ReplSession
+from app.cli.interactive_shell.runtime.foreground_investigation import run_foreground_investigation
+from app.cli.interactive_shell.runtime.tasks import TaskRecord
+
+
+def test_foreground_investigation_prompts_feedback_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    feedback_calls: list[dict[str, object]] = []
+
+    def _fake_feedback(final_state: dict[str, object], **kwargs: object) -> None:
+        feedback_calls.append(dict(final_state))
+
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.feedback.prompt_investigation_feedback",
+        _fake_feedback,
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.key_reader.restore_stdin_terminal",
+        lambda: None,
+    )
+
+    session = ReplSession()
+    console = Console(file=StringIO(), force_terminal=False)
+
+    def _run(_task: TaskRecord) -> dict[str, str]:
+        return {"root_cause": "db unreachable", "alert_name": "payments_etl"}
+
+    final_state = run_foreground_investigation(
+        session=session,
+        console=console,
+        task_command="/investigate generic",
+        run=_run,
+        exception_context="test.foreground_investigation",
+    )
+
+    assert final_state == {"root_cause": "db unreachable", "alert_name": "payments_etl"}
+    assert session.last_state == final_state
+    assert feedback_calls == [final_state]
+
+
+def test_foreground_investigation_skips_feedback_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    feedback_calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.feedback.prompt_investigation_feedback",
+        lambda *_a, **_k: feedback_calls.append({}),
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.key_reader.restore_stdin_terminal",
+        lambda: None,
+    )
+
+    session = ReplSession()
+    console = Console(file=StringIO(), force_terminal=False)
+
+    def _run(_task: TaskRecord) -> dict[str, str]:
+        raise RuntimeError("boom")
+
+    result = run_foreground_investigation(
+        session=session,
+        console=console,
+        task_command="/investigate generic",
+        run=_run,
+        exception_context="test.foreground_investigation",
+    )
+
+    assert result is None
+    assert feedback_calls == []

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1280,7 +1280,7 @@ class TestInvestigateFileCommand:
     ) -> None:
         from app.cli.interactive_shell.command_registry import investigation as investigation_cmd
 
-        picks = iter(["generic", "done"])
+        picks = iter(["generic"])
         captured: list[str] = []
 
         def _fake_sample(
@@ -1313,7 +1313,7 @@ class TestInvestigateFileCommand:
         alert_file = tmp_path / "custom_alert.json"
         alert_file.write_text('{"alert_name": "custom"}', encoding="utf-8")
 
-        picks = iter(["__browse__", "done"])
+        picks = iter(["__browse__"])
         captured: list[str] = []
 
         def _fake(

--- a/tests/cli/interactive_shell/ui/test_feedback.py
+++ b/tests/cli/interactive_shell/ui/test_feedback.py
@@ -10,8 +10,10 @@ from rich.console import Console
 
 from app.cli.interactive_shell.ui.feedback import (
     _CHOICES,
+    _collect,
     _format_root_cause_lines,
     _print_context,
+    _report_already_rendered,
     _root_cause_width,
     _run_select,
 )
@@ -133,3 +135,39 @@ def test_run_select_returns_highlighted_choice_on_enter(
     captured = capsys.readouterr().out
     assert "Partially accurate" in captured
     assert "↑↓" in captured
+
+
+def test_report_already_rendered_detects_slack_message() -> None:
+    assert _report_already_rendered({"slack_message": "Findings\n- item"})
+    assert not _report_already_rendered({"root_cause": "only root"})
+
+
+def test_collect_post_stream_skips_root_cause_recap_when_report_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("app.cli.interactive_shell.ui.feedback._is_disabled", lambda: False)
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.feedback._pick_rating",
+        lambda **_kwargs: "skip",
+    )
+    context_calls: list[dict[str, object]] = []
+
+    def _spy_context(final_state: dict[str, object], *, console: Console | None) -> None:
+        _ = console
+        context_calls.append(dict(final_state))
+
+    monkeypatch.setattr("app.cli.interactive_shell.ui.feedback._print_context", _spy_context)
+
+    _collect(
+        {
+            "root_cause": "db unreachable",
+            "slack_message": "## Findings\n- alert fired",
+        },
+        console=Console(file=io.StringIO(), force_terminal=False),
+        post_stream=True,
+    )
+
+    assert context_calls == []
+

--- a/tests/delivery/test_terminal_renderer_repl.py
+++ b/tests/delivery/test_terminal_renderer_repl.py
@@ -1,0 +1,54 @@
+"""Tests for REPL-safe RCA report rendering."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+class _NoopTracker:
+    def stop(self) -> None:
+        return None
+
+
+@patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "rich"})
+def test_render_report_uses_repl_buffered_write_in_repl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writes: list[str] = []
+
+    class _FakeStdout:
+        def write(self, text: str) -> int:
+            writes.append(text)
+            return len(text)
+
+        def flush(self) -> None:
+            return None
+
+        def isatty(self) -> bool:
+            return True
+
+    fake_stdout = _FakeStdout()
+    monkeypatch.setattr("sys.stdout", fake_stdout)
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.output.environment._repl_progress_active",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "app.observability.progress.get_progress_tracker",
+        lambda: _NoopTracker(),
+    )
+    monkeypatch.setattr(
+        "app.observability.render_completed_investigation_footer",
+        lambda: None,
+    )
+
+    from app.core.orchestration.node.publish_findings.renderers.terminal import render_report
+
+    render_report("## Findings\n- Database connection refused\n")
+
+    assert len(writes) == 1
+    rendered = writes[0].replace("\r\n", "\n")
+    assert "Database connection refused" in rendered


### PR DESCRIPTION
Fixes #3056

#### Describe the changes you have made in this PR -

- Render the final RCA via `render_report()` using REPL-safe buffered stdout (same formatter as `opensre investigate`).
- Call `prompt_investigation_feedback(post_stream=True)` after foreground REPL investigations.
- Use cursor-safe `_run_select` for post-stream feedback; skip duplicate root-cause recap when the full report exists.
- Exit the bare `/investigate` TTY picker after one run instead of looping.
- Add regression tests for REPL report rendering, feedback wiring, and menu behavior.

### Demo/Screenshot for feature changes and bug fixes - 
Before: REPL showed only a one-line "Root cause:" recap + static feedback hint, investigate picker reopened, full RCA missing from scrollback.

After: same formatted RCA block as CLI → blocking feedback menu → normal REPL prompt.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
REPL and CLI already share `StreamRenderer` → `render_report(slack_message)`; the gap was display plumbing and feedback wiring. Under `patch_stdout`, line-by-line Rich writes often never landed in scrollback, so users only saw the feedback helper's root-cause snippet. Buffered REPL output mirrors `print_repl_table`. Post-stream feedback now uses `_run_select` (same as CLI) instead of `repl_choose_one`, which is unstable after streaming progress. Foreground investigation is the single hook for REPL feedback so `/investigate`, file runs, and agent-triggered runs behave consistently.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.