### PR TITLE
fix(repl): align /investigate RCA output and feedback with CLI

### DIFF
--- a/app/cli/interactive_shell/command_registry/investigation.py
+++ b/app/cli/interactive_shell/command_registry/investigation.py
@@ -60,21 +60,24 @@ def _interactive_investigate_menu(session: ReplSession, console: Console) -> boo
     choices.append(("__browse__", "custom file path…"))
     choices.append(("done", "done"))
 
-    while True:
-        target = repl_choose_one(
-            title="investigate",
-            breadcrumb=root,
-            choices=choices,
-        )
-        if target is None or target == "done":
+    # Run the picker once, then return to the REPL prompt — re-opening the menu
+    # after each investigation buried the RCA report and felt like a loop the
+    # user could not escape. The standalone CLI runs a single investigation and
+    # returns; bare /investigate now matches that.
+    target = repl_choose_one(
+        title="investigate",
+        breadcrumb=root,
+        choices=choices,
+    )
+    if target is None or target == "done":
+        return True
+    if target == "__browse__":
+        custom_path = _prompt_investigate_path(console)
+        if custom_path is None:
             return True
-        if target == "__browse__":
-            custom_path = _prompt_investigate_path(console)
-            if custom_path is None:
-                continue
-            target = custom_path
-        _cmd_investigate_file(session, console, [target])
-        repl_section_break(console)
+        target = custom_path
+    _cmd_investigate_file(session, console, [target])
+    return True
 
 
 def _prompt_investigate_path(console: Console) -> str | None:

--- a/app/cli/interactive_shell/runtime/foreground_investigation.py
+++ b/app/cli/interactive_shell/runtime/foreground_investigation.py
@@ -59,6 +59,11 @@ def run_foreground_investigation(
     from app.cli.interactive_shell.ui.feedback import prompt_investigation_feedback
     from app.cli.interactive_shell.ui.key_reader import restore_stdin_terminal
 
+    # The explicit pre-call (kept identical to the CLI path) primes the terminal
+    # out of the streaming watcher's no-echo/raw mode *before* the feedback
+    # helper prints its root-cause context and header. prompt_investigation_feedback
+    # restores again in its own finally; this pre-call covers the output it emits
+    # ahead of _run_select's own restore, so it is not redundant with that teardown.
     restore_stdin_terminal()
     prompt_investigation_feedback(final_state)
     return final_state

--- a/app/cli/interactive_shell/runtime/foreground_investigation.py
+++ b/app/cli/interactive_shell/runtime/foreground_investigation.py
@@ -51,6 +51,16 @@ def run_foreground_investigation(
     root = final_state.get("root_cause")
     task.mark_completed(result=str(root) if root is not None else "")
     session.apply_investigation_result(final_state)
+
+    # Mirror the standalone CLI (run_investigation_cli_streaming): show the
+    # blocking RCA-accuracy feedback menu after the report. Pass console=None so
+    # the cursor-safe _run_select (per-line erase) is used instead of
+    # repl_choose_one, whose block-erase is unstable after Rich Live streaming.
+    from app.cli.interactive_shell.ui.feedback import prompt_investigation_feedback
+    from app.cli.interactive_shell.ui.key_reader import restore_stdin_terminal
+
+    restore_stdin_terminal()
+    prompt_investigation_feedback(final_state)
     return final_state
 
 

--- a/app/cli/ui/renderer/renderer.py
+++ b/app/cli/ui/renderer/renderer.py
@@ -540,6 +540,19 @@ class StreamRenderer:
                 _print_info("Alert classified as noise — no investigation needed.")
             elif self._events_received == 0:
                 _print_info("No events received from the remote agent.")
+            else:
+                # Stream finished but no report was published — e.g. the pipeline
+                # raised after diagnosis, or publish_findings produced no message.
+                # Never go silently blank: surface whatever root cause we captured,
+                # then a clear notice so the user knows the run ended (and the UI
+                # did not just swallow the report).
+                root_cause = (self._final_state.get("root_cause") or "").strip()
+                if root_cause:
+                    _print_info(f"Root cause: {root_cause}")
+                _print_info(
+                    "Investigation finished without a full report. "
+                    "Re-run, or check the logs if this persists."
+                )
             return
 
         from app.core.orchestration.node.publish_findings.renderers.terminal import (

--- a/app/core/orchestration/node/publish_findings/renderers/terminal.py
+++ b/app/core/orchestration/node/publish_findings/renderers/terminal.py
@@ -129,6 +129,15 @@ def _emit(rendered: str) -> None:
     interactive REPL) every line starts at column zero. Rendering line-by-line
     through a fresh Rich Console there interleaves with the proxy and the report
     body is dropped from scrollback; one normalised write avoids that.
+
+    The ``isatty()`` branch is intentional, not dead code. Under ``patch_stdout``
+    ``sys.stdout`` is prompt_toolkit's ``StdoutProxy``, whose ``isatty()``
+    delegates to the real underlying stdout — and the REPL only enables
+    ``patch_stdout`` when that is a TTY — so this returns ``True`` in the REPL.
+    In ``raw=True`` mode the proxy writes text verbatim (``write_raw``) without
+    converting bare ``\\n`` to ``\\r\\n``, so we must normalise here ourselves
+    (mirrors ``rendering._normalize_repl_line_endings``). For non-TTY stdout
+    (piped/captured/tests) the text is written as-is.
     """
     if sys.stdout.isatty():
         rendered = rendered.replace("\r\n", "\n").replace("\n", "\r\n")

--- a/app/core/orchestration/node/publish_findings/renderers/terminal.py
+++ b/app/core/orchestration/node/publish_findings/renderers/terminal.py
@@ -1,6 +1,9 @@
 """Terminal rendering for RCA reports — Claude-style output."""
 
+import io
 import re
+import shutil
+import sys
 
 from rich.console import Console
 from rich.text import Text
@@ -112,6 +115,27 @@ def _render_rich_evidence_item(console: Console, line: str) -> None:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+def _report_width() -> int:
+    """Best-effort terminal width for the buffered report render."""
+    return max(40, shutil.get_terminal_size(fallback=(80, 24)).columns)
+
+
+def _emit(rendered: str) -> None:
+    """Write a pre-rendered report in a single TTY-safe stdout call.
+
+    The report is built into one string and emitted with a single
+    ``sys.stdout.write``. When stdout is a TTY, line endings are normalised to
+    ``\\r\\n`` so that under prompt_toolkit's ``patch_stdout(raw=True)`` (the
+    interactive REPL) every line starts at column zero. Rendering line-by-line
+    through a fresh Rich Console there interleaves with the proxy and the report
+    body is dropped from scrollback; one normalised write avoids that.
+    """
+    if sys.stdout.isatty():
+        rendered = rendered.replace("\r\n", "\n").replace("\n", "\r\n")
+    sys.stdout.write(rendered)
+    sys.stdout.flush()
+
+
 def render_report(slack_message: str) -> None:
     """Render the final RCA report to terminal."""
     from app.observability import (
@@ -124,25 +148,34 @@ def render_report(slack_message: str) -> None:
 
     if not slack_message:
         if fmt == "rich":
-            Console(highlight=False, force_terminal=True).print(
+            buf = io.StringIO()
+            Console(file=buf, highlight=False, force_terminal=True, width=_report_width()).print(
                 Text.assemble(("  ● ", f"bold {WARNING}"), ("No report generated.", DIM))
             )
+            _emit(buf.getvalue())
         else:
-            print("No report generated.")
+            _emit("No report generated.\n")
         return
 
     if fmt == "rich":
-        _render_rich_report(slack_message)
+        _emit(_render_rich_report(slack_message))
     else:
-        _render_plain_report(slack_message)
+        _emit(_render_plain_report(slack_message))
 
     # Print the investigation phase footer at the absolute bottom of the
     # RCA report (without "esc to cancel" — the investigation is complete).
     render_completed_investigation_footer()
 
 
-def _render_rich_report(slack_message: str) -> None:
-    console = Console(highlight=False, force_terminal=True, color_system="truecolor")
+def _render_rich_report(slack_message: str) -> str:
+    buf = io.StringIO()
+    console = Console(
+        file=buf,
+        highlight=False,
+        force_terminal=True,
+        color_system="truecolor",
+        width=_report_width(),
+    )
     console.print()
 
     lines = slack_message.splitlines()
@@ -205,9 +238,9 @@ def _render_rich_report(slack_message: str) -> None:
         console.print(t)
 
     console.print()
+    return buf.getvalue()
 
 
-def _render_plain_report(slack_message: str) -> None:
-    print()
+def _render_plain_report(slack_message: str) -> str:
     clean = _strip_slack_links(_strip_mrkdwn(slack_message))
-    print(clean)
+    return f"\n{clean}\n"


### PR DESCRIPTION
## Problem

Running `/investigate` in the interactive shell (especially via the TTY template picker) diverged from standalone `opensre investigate`:

- Final RCA report often did not appear in scrollback (only a one-line root-cause recap from the feedback helper).
- Post-investigation feedback prompt was missing.
- Bare `/investigate` re-opened the template picker after each run instead of returning to the REPL prompt.
- When the pipeline finished without a published report (e.g. it raised after diagnosis), the UI went silently blank.

## Root cause

- The REPL session path (`run_foreground_investigation`) never called `prompt_investigation_feedback`. Feedback was only ever wired into the standalone streaming path (`run_investigation_cli_streaming`) when the feature landed (#2371).
- `render_report()` wrote line-by-line through a fresh Rich `Console`. Under the REPL's `patch_stdout(raw=True)` those writes interleave with the proxy and the report body is dropped from scrollback.
- The interactive investigate menu looped after every selection.
- `StreamRenderer._print_report` only printed a message for the *noise* and *zero-events* cases; the "events received but no report" case fell through to a bare `return`.

## Fix

- **terminal.py** — render the report into a single buffer and emit it with one `\r\n`-normalised `sys.stdout.write` so every line starts at column zero under `patch_stdout`. Standalone/non-TTY output is unchanged.
- **foreground_investigation.py** — call `prompt_investigation_feedback(final_state)` after the report (covers `/investigate` and free-text/agent-routed runs), with `console=None` so the cursor-safe `_run_select` (per-line erase) is used instead of `repl_choose_one`, whose block-erase is unstable after Rich Live streaming.
- **investigation.py** — bare `/investigate` picker now runs once and returns to the REPL prompt.
- **renderer.py** — when the stream finishes with no published report, surface the captured root cause plus a clear "Investigation finished without a full report" notice instead of going blank.

## Verification

- `make lint`, `make format-check`, `make typecheck` clean.
- Full unit suite: **9560 passed, 0 failures** (the 113 errors are live-LLM routing tests requiring `ANTHROPIC_API_KEY` — CI-only, unrelated).

Closes #3056

🤖 Generated with [Claude Code](https://claude.com/claude-code)