### PR TITLE
fix(repl): normalise RCA feedback line endings under patch_stdout

### DIFF
--- a/app/cli/interactive_shell/ui/feedback.py
+++ b/app/cli/interactive_shell/ui/feedback.py
@@ -56,6 +56,22 @@ _R = "\x1b[0m"  # reset
 _HINT = f"  {_D}↑↓ / j k  ·  Enter  ·  Esc / s to skip{_R}"
 
 
+def _write_raw(text: str) -> None:
+    """Write the console-less (CLI/REPL) feedback text in one TTY-safe call.
+
+    Normalises bare ``\\n`` to ``\\r\\n`` when stdout is a TTY so the context,
+    header, note and confirmation lines do not staircase under the REPL's
+    ``patch_stdout(raw=True)`` proxy, which passes raw-mode output through
+    verbatim. ``_run_select`` already emits ``\\r\\n`` for the menu rows; this
+    applies the same rule to the surrounding text. For non-TTY stdout
+    (piped/captured/tests) the text is written as-is.
+    """
+    if sys.stdout.isatty():
+        text = text.replace("\r\n", "\n").replace("\n", "\r\n")
+    sys.stdout.write(text)
+    sys.stdout.flush()
+
+
 # ── persistence ───────────────────────────────────────────────────────────────
 
 
@@ -179,8 +195,7 @@ def _print_context(final_state: dict[str, Any], *, console: Console | None) -> N
     else:
         rule = "─" * cols
         body = "\n".join(_format_root_cause_lines(root, cols=cols))
-        sys.stdout.write(f"\n{rule}\n{body}\n{rule}\n")
-        sys.stdout.flush()
+        _write_raw(f"\n{rule}\n{body}\n{rule}\n")
 
 
 # ── self-contained select (CLI path) ─────────────────────────────────────────
@@ -256,8 +271,7 @@ def _read_note(*, console: Console | None) -> str:
             f"[{SECONDARY}]What was wrong or missing? [{DIM}](Enter to skip)[/]:[/] ", end=""
         )
     else:
-        sys.stdout.write("\nWhat was wrong or missing? (Enter to skip): ")
-        sys.stdout.flush()
+        _write_raw("\nWhat was wrong or missing? (Enter to skip): ")
     with contextlib.suppress(EOFError, KeyboardInterrupt):
         return input().strip()
     return ""
@@ -295,10 +309,7 @@ def _collect(final_state: dict[str, Any], *, console: Console | None) -> None:
             f"\n[{BRAND}]Was this RCA accurate?[/] [{DIM}]↑↓ · Enter · Esc or s to skip[/]"
         )
     else:
-        sys.stdout.write(
-            f"\n{_H}Was this RCA accurate?{_R}  {_D}↑↓ · Enter · Esc or s to skip{_R}\n\n"
-        )
-        sys.stdout.flush()
+        _write_raw(f"\n{_H}Was this RCA accurate?{_R}  {_D}↑↓ · Enter · Esc or s to skip{_R}\n\n")
 
     rating = _pick_rating(console=console)
     if not rating or rating == "skip":
@@ -313,8 +324,7 @@ def _collect(final_state: dict[str, Any], *, console: Console | None) -> None:
         if console is not None:
             console.print(f"[{DIM}]{msg}[/]")
         else:
-            sys.stdout.write(f"\n{_D}{msg}{_R}\n")
-            sys.stdout.flush()
+            _write_raw(f"\n{_D}{msg}{_R}\n")
         return
 
     note = ""
@@ -343,8 +353,7 @@ def _collect(final_state: dict[str, Any], *, console: Console | None) -> None:
     if console is not None:
         console.print(f"[{BRAND}]✓ Feedback saved.[/] [{DIM}]{_feedback_path()}[/]")
     else:
-        sys.stdout.write(f"\n{_H}✓ Feedback saved.{_R}  {_D}{_feedback_path()}{_R}\n\n")
-        sys.stdout.flush()
+        _write_raw(f"\n{_H}✓ Feedback saved.{_R}  {_D}{_feedback_path()}{_R}\n\n")
 
 
 def prompt_investigation_feedback(


### PR DESCRIPTION
## Problem

Follow-up to #3058 (merged), which wired the post-investigation RCA-accuracy feedback prompt into the interactive shell. The `console=None` feedback path still writes bare `\n` to stdout for:

- the root-cause context block (`_print_context`),
- the "Was this RCA accurate?" header,
- the note prompt (`_read_note`), and
- the saved / "never ask again" confirmation lines.

Under the REPL's `patch_stdout(raw=True)` proxy (which passes raw-mode output through verbatim), those bare `\n` lines **staircase** — each line starts where the previous one ended instead of at column zero. This is the same class of bug #3058 fixed for the report body via `_emit`; the surrounding feedback text was the one remaining narrow path, flagged by review.

## Fix

Add a small `_write_raw` helper in `feedback.py` that normalises `\n` → `\r\n` when stdout is a TTY, and route the four `console=None` write sites through it. This mirrors:

- `_emit` in `renderers/terminal.py` (report body), and
- the `\r\n` that `_run_select` already uses for the menu rows (proven safe in both the standalone CLI and the REPL).

Non-TTY stdout (piped/captured/tests) is written as-is, so output is unchanged there.

## Verification

- `make lint`, `make format-check` clean.
- `tests/cli/interactive_shell/ui/test_feedback.py` — 7 passed (capsys is non-TTY, so assertions are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)