### PR TITLE
test(routing): add complex gather and investigate scenarios 336-340

### DIFF
--- a/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/336-explicit-investigate-no-integrations-dispatch.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/336-explicit-investigate-no-integrations-dispatch.yml
@@ -1,0 +1,63 @@
+id: 336-explicit-investigate-no-integrations-dispatch
+title: Explicit investigate verb dispatches an investigation even with zero integrations connected
+intent_class: complex_shell_prompts
+input:
+  prompt: investigate why the orders-api keeps OOM-killing its pods
+session:
+  has_prior_state: false
+  configured_integrations: []
+  resolved_integrations: {}
+notes:
+- 'Pins the EXPLICIT-INVESTIGATE rule that the diagnostic-question scenarios (313 handoff / 314 dispatch)
+  deliberately do NOT exercise. 313 and 314 use a bare diagnostic question ("figure out why X is crashing")
+  whose dispatch-vs-handoff outcome is GATED on the CONNECTED INTEGRATIONS line: no integrations -> handoff,
+  >=1 integration -> investigation_start. This scenario removes that gate: the prompt carries an explicit
+  "investigate" verb, which the planner system prompt says maps to investigation_start ALWAYS, regardless
+  of which integrations are connected ("EXPLICIT investigate instruction -> investigation_start, ALWAYS").'
+- 'Negative control on the gate itself: configured_integrations and resolved_integrations are BOTH empty,
+  so if the planner were (incorrectly) gating an explicit "investigate" on connected data sources it would
+  hand off here and the test would fail. A passing run proves the explicit verb overrides the gate -- the
+  planner dispatches investigation_start with synthesized alert_text even when a root-cause run would have
+  no live data source to read.'
+- 'The synthesized alert_text varies per run, so planned_actions leaves content empty: the planning test
+  asserts an investigation with non-empty alert_text rather than an exact string (same convention as 314).'
+route:
+  expected_kind: handle_message_with_agent
+  expected_command_text: null
+policy:
+  executes_terminal_action: true
+planned_actions:
+- kind: investigation
+  source: llm
+  target_surface: investigation
+response_contract:
+  must_contain_any:
+  - investigat
+  - rca
+  - orders
+  - oom
+  - pod
+  must_not_contain:
+  - $ /
+  - can't help
+  - cannot help
+  - I can't help
+  - I cannot help
+  forbidden_actions:
+  - shell
+history:
+  expected:
+  - type: cli_agent
+    ok: true
+  - type: alert
+    ok: true
+runs: 5
+tool_actions:
+- surface: dispatch
+  kind: investigation
+- surface: gather
+  tools:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
+  expect: not_called

--- a/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/337-datadog-monitors-lookup-live-gather.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/337-datadog-monitors-lookup-live-gather.yml
@@ -1,0 +1,69 @@
+id: 337-datadog-monitors-lookup-live-gather
+title: Datadog monitor listing is a data lookup that hands off and grounds on live Datadog (not an investigation)
+intent_class: complex_shell_prompts
+input:
+  prompt: list the datadog monitors that are currently in an alerting state
+session:
+  has_prior_state: false
+  configured_integrations:
+  - datadog
+  resolved_integrations:
+    datadog: '@live'
+notes:
+- 'Data-retrieval / analytics lookup against Datadog, NOT an investigation. The prompt asks to LIST monitors
+  in a given state -- it names no failure, crash, error, outage, or incident to root-cause. Per the
+  DATA-RETRIEVAL rule in the action-planner prompt ("list ... metrics, logs, ... for a named entity, user,
+  filter, or time window is a plain data query ... EVEN WHEN the request names an observability source like
+  Datadog"), the planner must hand off and let the conversational gather loop query Datadog. This is the
+  Datadog counterpart to the Sentry lookup in 316 and the PostHog lookup in 315, and the lookup contrast to
+  the Datadog INCIDENT gathers in 333-335 (which describe a failing service, not a record listing).'
+- 'Correct-integration routing guard: Datadog is the only resolved integration, so the gather loop MUST
+  engage a Datadog tool and MUST NOT touch Sentry/GitHub/PostHog. search_sentry_issues, search_github_issues,
+  and list_posthog_tools are asserted not_called so a gather loop that fans out to the wrong integration
+  fails here instead of passing on unrelated text.'
+- 'Resolves the REAL Datadog integration (@live) and asserts a Datadog gather tool returned VALID data via
+  valid_data_any over query_datadog_monitors/query_datadog_all (316-style): a credential 401, a malformed
+  param 400, or the planner wrongly starting an investigation all fail instead of passing on hallucinated
+  text. valid_data_any (not must_call_all on a single tool) lets the gather LLM pick whichever Datadog tool
+  fits "monitors in an alerting state" without over-pinning the exact tool. A valid empty result still
+  proves the end-to-end path; the scenario skips (never fails) when no @live Datadog credentials resolve.'
+route:
+  expected_kind: handle_message_with_agent
+  expected_command_text: null
+policy:
+  executes_terminal_action: false
+planned_actions:
+- kind: assistant_handoff
+  content: metrics_query:datadog_monitors_alerting
+  source: llm
+response_contract:
+  must_contain_any:
+  - datadog
+  - monitor
+  - alert
+  must_not_contain:
+  - $ /
+  - can't help
+  - cannot help
+  - I can't help
+  - I cannot help
+  forbidden_actions:
+  - investigation
+  - shell
+history:
+  expected:
+  - type: cli_agent
+    ok: true
+runs: 3
+tool_actions:
+- surface: gather
+  tools:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
+  expect: not_called
+- surface: gather
+  tools:
+  - query_datadog_monitors
+  - query_datadog_all
+  expect: valid_data_any

--- a/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/338-compound-sentry-github-lookup-handoff.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/338-compound-sentry-github-lookup-handoff.yml
@@ -1,0 +1,85 @@
+id: 338-compound-sentry-github-lookup-handoff
+title: Compound two-source lookup hands off and fans out across Sentry and GitHub without dispatching an investigation
+intent_class: complex_shell_prompts
+input:
+  prompt: list the open sentry issues for checkout and the latest github issues about login failures
+session:
+  has_prior_state: false
+  configured_integrations:
+  - sentry
+  - github
+  resolved_integrations:
+    sentry:
+      connection_verified: true
+      organization_slug: fixture-org
+      project_slug: fixture-project
+      auth_token: fixture-token
+      base_url: https://sentry.io
+    github:
+      connection_verified: true
+      owner: tracer-cloud
+      repo: opensre
+      mode: streamable-http
+      url: https://api.githubcopilot.com/mcp/
+      auth_token: fixture-token
+notes:
+- 'Compound DATA-RETRIEVAL lookup spanning two sources, NOT an investigation. The prompt joins two record
+  listings with "and" ("list the open sentry issues ..." + "the latest github issues ..."); neither clause
+  names a failure to root-cause. The compound rule in the action-planner prompt emits a tool call only for
+  clauses that map to an executable tool, and a data lookup maps to NO tool (it is an assistant_handoff),
+  so the whole turn collapses to a single handoff -- planned_actions is empty. This guards the regression
+  where a compound "X and Y" lookup is mis-read as two actions, or where naming sources tips the planner
+  into investigation_start. Contrast with 314, where "crashing on Windows" names a FAILURE across the same
+  Sentry/GitHub/PostHog set and DOES dispatch an investigation.'
+- 'Gather fan-out, auth-independent: both Sentry and GitHub are connected with shaped (non-live) fixture
+  configs that satisfy each tool''s is_available check, so the gather loop can route to either integration
+  on the live planner''s choice. call_any over search_sentry_issues/search_github_issues asserts the loop
+  engaged AT LEAST ONE integration tool. call_any (not valid_data) is intentional: the fixture tokens are
+  fake and 401 against the live endpoints, but "was called" is the deterministic, credential-free proof that
+  the planner handed off to integration gathering rather than answering from hallucinated text (same
+  reasoning as the list_posthog_tools assertion in 315).'
+- 'Cross-integration negative control: PostHog and Datadog are NOT configured, so list_posthog_tools and
+  query_datadog_all/query_datadog_logs must never fire. Asserting them not_called catches a gather loop that
+  reaches for an unconfigured integration.'
+route:
+  expected_kind: handle_message_with_agent
+  expected_command_text: null
+policy:
+  executes_terminal_action: false
+planned_actions:
+- kind: assistant_handoff
+  content: issues_lookup:sentry_and_github
+  source: llm
+response_contract:
+  must_contain_any:
+  - sentry
+  - github
+  - issue
+  - checkout
+  - login
+  must_not_contain:
+  - $ /
+  - can't help
+  - cannot help
+  - I can't help
+  - I cannot help
+  forbidden_actions:
+  - investigation
+  - shell
+history:
+  expected:
+  - type: cli_agent
+    ok: true
+runs: 3
+tool_actions:
+- surface: gather
+  tools:
+  - search_sentry_issues
+  - search_github_issues
+  expect: call_any
+- surface: gather
+  tools:
+  - list_posthog_tools
+  - query_datadog_all
+  - query_datadog_logs
+  expect: not_called

--- a/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/339-grafana-logs-lookup-handoff.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/339-grafana-logs-lookup-handoff.yml
@@ -1,0 +1,68 @@
+id: 339-grafana-logs-lookup-handoff
+title: Grafana logs lookup hands off and routes the gather loop to query_grafana_logs
+intent_class: complex_shell_prompts
+input:
+  prompt: show me the most recent grafana logs for the payments service
+session:
+  has_prior_state: false
+  configured_integrations:
+  - grafana
+  resolved_integrations:
+    grafana:
+      connection_verified: true
+      endpoint: https://grafana.example.com
+      api_key: fixture-token
+notes:
+- 'Data-retrieval / analytics lookup against Grafana Loki, NOT an investigation. The prompt asks to SHOW
+  recent logs for a named service -- it names no failure, crash, error, outage, or incident to root-cause --
+  so per the DATA-RETRIEVAL rule the planner hands off and the conversational gather loop queries Grafana.
+  This is the CONNECTED-Grafana counterpart to 324 (query_grafana_logs with NO integration connected, which
+  can only hand off), upgrading that negative control into a positive gather-routing assertion.'
+- 'Routing guard: Grafana is the only resolved integration, so the gather loop MUST select query_grafana_logs
+  and MUST NOT touch Sentry/GitHub/PostHog/Datadog. query_grafana_logs is asserted via must_call_all
+  (expect: called) because the prompt explicitly names "grafana logs", making it the deterministic tool the
+  loop should reach for; the unrelated integration tools are asserted not_called.'
+- 'Auth-independent by design: the fixture Grafana config is shaped (connection_verified + endpoint) so the
+  tool''s is_available check passes and the call fires, but the fake token cannot authenticate against a
+  live Loki endpoint. "Was called" is therefore the credential-free proof that the gather loop routed this
+  lookup to Grafana (same reasoning as list_posthog_tools in 315); requiring valid_data would make the
+  fixture fail in every credential-less environment, including CI.'
+route:
+  expected_kind: handle_message_with_agent
+  expected_command_text: null
+policy:
+  executes_terminal_action: false
+planned_actions:
+- kind: assistant_handoff
+  content: logs_query:grafana_payments
+  source: llm
+response_contract:
+  must_contain_any:
+  - grafana
+  - log
+  - payments
+  must_not_contain:
+  - $ /
+  - can't help
+  - cannot help
+  - I can't help
+  - I cannot help
+  forbidden_actions:
+  - investigation
+  - shell
+history:
+  expected:
+  - type: cli_agent
+    ok: true
+runs: 3
+tool_actions:
+- surface: gather
+  tool: query_grafana_logs
+  expect: called
+- surface: gather
+  tools:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
+  - query_datadog_all
+  expect: not_called

--- a/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/340-rca-verb-pasted-json-dispatch.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/complex_shell_prompts/340-rca-verb-pasted-json-dispatch.yml
@@ -1,0 +1,68 @@
+id: 340-rca-verb-pasted-json-dispatch
+title: RCA verb on a pasted JSON alert dispatches an investigation (the blob does not downgrade the explicit verb)
+intent_class: complex_shell_prompts
+input:
+  prompt: 'RCA this: {"alertname":"HighErrorRate","service":"checkout","severity":"critical","value":"7.3%"}'
+session:
+  has_prior_state: false
+  configured_integrations:
+  - datadog
+  resolved_integrations:
+    datadog:
+      connection_verified: true
+      api_key: fixture-api-key
+      app_key: fixture-app-key
+notes:
+- 'Pins the rule that an explicit investigate/RCA verb wins even when the message also carries a pasted
+  alert payload: "The presence of a JSON/alert blob does NOT downgrade an explicit investigate instruction
+  to a handoff" (action-planner prompt). The verb "RCA this" takes the JSON blob as its target, so the
+  planner emits investigation_start with the payload as alert_text. This is the explicit-verb contrast to
+  306-pasted-alert-json-payload, where a BARE JSON blob with no instruction is just a fact statement and
+  correctly hands off; here the same kind of blob is the OBJECT of an explicit RCA verb and must dispatch.'
+- 'Because this routes down the planner -> dispatch path (investigation_start), the conversational
+  gather_tool_evidence loop does not run, so no integration tool should fire. search_sentry_issues,
+  search_github_issues, list_posthog_tools, and query_datadog_all are asserted not_called as a guard that a
+  dispatched investigation never silently falls back into chat-surface gathering.'
+- 'The alert_text the planner attaches may be the verbatim JSON or a lightly normalized form, so
+  planned_actions leaves content empty: the planning test asserts an investigation with non-empty alert_text
+  rather than an exact string (same convention as 314 and 336).'
+route:
+  expected_kind: handle_message_with_agent
+  expected_command_text: null
+policy:
+  executes_terminal_action: true
+planned_actions:
+- kind: investigation
+  source: llm
+  target_surface: investigation
+response_contract:
+  must_contain_any:
+  - investigat
+  - rca
+  - checkout
+  - error
+  must_not_contain:
+  - $ /
+  - can't help
+  - cannot help
+  - I can't help
+  - I cannot help
+  forbidden_actions:
+  - shell
+history:
+  expected:
+  - type: cli_agent
+    ok: true
+  - type: alert
+    ok: true
+runs: 5
+tool_actions:
+- surface: dispatch
+  kind: investigation
+- surface: gather
+  tools:
+  - search_sentry_issues
+  - search_github_issues
+  - list_posthog_tools
+  - query_datadog_all
+  expect: not_called


### PR DESCRIPTION
## Summary

- Add five live routing scenarios (336–340) to `complex_shell_prompts/` that exercise planner and gather-loop contracts not covered by 313–316
- **336**: explicit `investigate` dispatches investigation even with zero integrations connected
- **337**: Datadog monitor listing is a data lookup → handoff + live Datadog gather with cross-integration `not_called` guards
- **338**: compound Sentry + GitHub lookup → handoff, gather fan-out (`call_any`), no investigation
- **339**: Grafana logs lookup with Grafana connected → handoff + `query_grafana_logs` (positive counterpart to 324)
- **340**: `RCA this:` + pasted JSON dispatches investigation (explicit verb is not downgraded by the blob)

Fixes #3064

## Test plan

- [x] `uv run python -m pytest app/cli/interactive_shell/routing/tests/test_routing_fixture_integrity.py`
- [x] `uv run python -m pytest app/cli/interactive_shell/routing/tests/ -m "not live_llm"`
- [ ] Routing Live CI green (336, 337, 338, 339, 340 are live LLM scenarios)