### PR TITLE
fix(security): resolve CodeQL alerts

### DIFF
--- a/cli/interactive_shell/chat/tool_gathering.py
+++ b/cli/interactive_shell/chat/tool_gathering.py
@@ -157,8 +157,8 @@ def _persist_tool_calls(session: ReplSession, executed: list[tuple[Any, Any]]) -
     from platform.observability.tool_trace import redact_sensitive
 
     for tc, output in executed:
+        ok = not (isinstance(output, dict) and "error" in output)
         with contextlib.suppress(Exception):
-            ok = not (isinstance(output, dict) and "error" in output)
             body = (
                 output
                 if isinstance(output, str)

--- a/cli/interactive_shell/ui/output/console_state.py
+++ b/cli/interactive_shell/ui/output/console_state.py
@@ -10,6 +10,7 @@ _live_console: Console | None = None
 _active_display: Any | None = None
 _completed_footer_snapshot: tuple[str, float, str, str] | None = None
 _prompt_suppress_fn: Callable[[], None] | None = None
+_tracker_toggle_stop_fn: Callable[[], None] | None = None
 
 
 def set_prompt_suppress_fn(fn: Callable[[], None] | None) -> None:
@@ -20,6 +21,12 @@ def set_prompt_suppress_fn(fn: Callable[[], None] | None) -> None:
 
 def get_prompt_suppress_fn() -> Callable[[], None] | None:
     return _prompt_suppress_fn
+
+
+def set_tracker_toggle_stop_fn(fn: Callable[[], None] | None) -> None:
+    """Register callback used to stop tracker-owned keyboard watchers."""
+    global _tracker_toggle_stop_fn
+    _tracker_toggle_stop_fn = fn
 
 
 def _capture_footer_snapshot(display: Any) -> None:
@@ -75,6 +82,6 @@ def stop_display() -> None:
     """Stop any running live display before printing final report output."""
     if _active_display is not None:
         _active_display.stop()
-    from cli.interactive_shell.ui.output.tracker import _stop_active_tracker_toggle_watcher
 
-    _stop_active_tracker_toggle_watcher()
+    if _tracker_toggle_stop_fn is not None:
+        _tracker_toggle_stop_fn()

--- a/cli/interactive_shell/ui/output/environment.py
+++ b/cli/interactive_shell/ui/output/environment.py
@@ -33,6 +33,7 @@ def _safe_print(text: str) -> None:
         with contextlib.suppress(BrokenPipeError):
             print(text.encode(enc, errors="replace").decode(enc))
     except BrokenPipeError:
+        # Downstream closed the pipe; mirror standard CLI behavior and stop writing.
         pass
 
 

--- a/cli/interactive_shell/ui/output/events.py
+++ b/cli/interactive_shell/ui/output/events.py
@@ -21,13 +21,17 @@ class DisplayProtocol(Protocol):
     ``isinstance`` branching on concrete classes.
     """
 
-    def stop(self) -> None: ...
+    def stop(self) -> None:
+        raise NotImplementedError
 
-    def step_start(self, node_name: str) -> None: ...
+    def step_start(self, node_name: str) -> None:
+        raise NotImplementedError
 
-    def step_complete(self, node_name: str, event: ProgressEvent) -> None: ...
+    def step_complete(self, node_name: str, event: ProgressEvent) -> None:
+        raise NotImplementedError
 
-    def step_subtext(self, node_name: str, text: str, duration: float = 4.0) -> None: ...
+    def step_subtext(self, node_name: str, text: str, duration: float = 4.0) -> None:
+        raise NotImplementedError
 
     def set_tool_details(
         self,
@@ -36,8 +40,11 @@ class DisplayProtocol(Protocol):
         records: list[dict[str, Any]],
         summary: str,
         clear: bool = False,
-    ) -> None: ...
+    ) -> None:
+        raise NotImplementedError
 
-    def print_above(self, text: str) -> None: ...
+    def print_above(self, text: str) -> None:
+        raise NotImplementedError
 
-    def print_above_renderable(self, renderable: Any) -> None: ...
+    def print_above_renderable(self, renderable: Any) -> None:
+        raise NotImplementedError

--- a/cli/interactive_shell/ui/output/live_display.py
+++ b/cli/interactive_shell/ui/output/live_display.py
@@ -7,13 +7,6 @@ from typing import Any
 from rich.console import Console, ConsoleOptions, RenderResult
 from rich.text import Text
 
-from cli.interactive_shell.ui.output.console_state import (
-    _capture_footer_snapshot,
-    clear_active_display,
-    set_active_display,
-    set_live_console,
-    unregister_live_console,
-)
 from cli.interactive_shell.ui.output.events import ProgressEvent
 from cli.interactive_shell.ui.output.labels import (
     BADGE_STYLES,
@@ -156,6 +149,11 @@ class _EventLogDisplay:
     def __init__(self, model: str = "", mode: str = "local", t0: float | None = None) -> None:
         from rich.live import Live
 
+        from cli.interactive_shell.ui.output.console_state import (
+            set_active_display,
+            set_live_console,
+        )
+
         self._model = model
         self._mode = mode
         self._t0 = t0 if t0 is not None else time.monotonic()
@@ -179,6 +177,12 @@ class _EventLogDisplay:
         set_active_display(self)
 
     def stop(self) -> None:
+        from cli.interactive_shell.ui.output.console_state import (
+            _capture_footer_snapshot,
+            clear_active_display,
+            unregister_live_console,
+        )
+
         _capture_footer_snapshot(self)
         if self._live.is_started:
             self._live.stop()

--- a/cli/interactive_shell/ui/output/repl_display.py
+++ b/cli/interactive_shell/ui/output/repl_display.py
@@ -10,10 +10,6 @@ from typing import Any
 from rich.console import Console
 from rich.text import Text
 
-from cli.interactive_shell.ui.output.console_state import (
-    _capture_footer_snapshot,
-    get_prompt_suppress_fn,
-)
 from cli.interactive_shell.ui.output.events import ProgressEvent
 from cli.interactive_shell.ui.output.labels import (
     _node_phase_label,
@@ -52,6 +48,8 @@ class _ReplEventLogDisplay:
         self._anim_thread: threading.Thread | None = None
 
     def stop(self) -> None:
+        from cli.interactive_shell.ui.output.console_state import _capture_footer_snapshot
+
         self._stop_animation()
         _capture_footer_snapshot(self)
 
@@ -112,6 +110,8 @@ class _ReplEventLogDisplay:
         self._start_animation(prefix)
 
     def step_start(self, node_name: str) -> None:
+        from cli.interactive_shell.ui.output.console_state import get_prompt_suppress_fn
+
         prompt_suppress_fn = get_prompt_suppress_fn()
         if not self._prompt_suppressed and prompt_suppress_fn is not None:
             self._prompt_suppressed = True

--- a/cli/interactive_shell/ui/output/tool_tracking.py
+++ b/cli/interactive_shell/ui/output/tool_tracking.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeGuard, runtime_checkable
 
 from rich.text import Text
 
@@ -9,7 +9,7 @@ from cli.interactive_shell.ui.output.environment import _safe_print
 
 if TYPE_CHECKING:
     from cli.interactive_shell.ui.output.events import DisplayProtocol
-from cli.interactive_shell.ui.output.repl_display import _ReplEventLogDisplay
+    from cli.interactive_shell.ui.output.repl_display import _ReplEventLogDisplay
 from cli.interactive_shell.ui.output.tool_details import (
     build_tool_call_line,
     build_tool_detail_text,
@@ -28,13 +28,21 @@ from cli.interactive_shell.ui.time_format import _elapsed_hms, _fmt_timing
 from tools.registry import resolve_tool_display_name
 
 
+def _is_repl_display(display: object) -> TypeGuard[_ReplEventLogDisplay]:
+    from cli.interactive_shell.ui.output.repl_display import _ReplEventLogDisplay
+
+    return isinstance(display, _ReplEventLogDisplay)
+
+
 @runtime_checkable
 class ToolTrackingSupport(Protocol):
     """Interface that concrete classes must satisfy to use :class:`ToolTrackingMixin`."""
 
-    def update_subtext(self, node_name: str, text: str, duration: float = 4.0) -> None: ...
+    def update_subtext(self, node_name: str, text: str, duration: float = 4.0) -> None:
+        raise NotImplementedError
 
-    def print_above_renderable(self, renderable: Any) -> None: ...
+    def print_above_renderable(self, renderable: Any) -> None:
+        raise NotImplementedError
 
 
 class ToolTrackingMixin:
@@ -105,7 +113,7 @@ class ToolTrackingMixin:
     def print_status_hint(self, text: str) -> None:
         if self._silent:
             return
-        if isinstance(self._display, _ReplEventLogDisplay):
+        if _is_repl_display(self._display):
             self._display.animate_hint(text)
             return
         t = Text()
@@ -118,11 +126,7 @@ class ToolTrackingMixin:
         if self._silent:
             return
         self._tool_details_visible = not self._tool_details_visible
-        if (
-            self._rich
-            and self._display is not None
-            and not isinstance(self._display, _ReplEventLogDisplay)
-        ):
+        if self._rich and self._display is not None and not _is_repl_display(self._display):
             self._sync_tool_detail_view(clear=True)
             return
         label = "shown" if self._tool_details_visible else "hidden"
@@ -131,11 +135,7 @@ class ToolTrackingMixin:
             self._flush_tool_details()
 
     def _sync_tool_detail_view(self, *, clear: bool = False) -> None:
-        if (
-            self._rich
-            and self._display is not None
-            and not isinstance(self._display, _ReplEventLogDisplay)
-        ):
+        if self._rich and self._display is not None and not _is_repl_display(self._display):
             self._display.set_tool_details(
                 visible=self._tool_details_visible,
                 records=self._tool_detail_records,
@@ -165,11 +165,7 @@ class ToolTrackingMixin:
         self._tool_detail_records.append(record)
         if not self._tool_details_visible:
             return
-        if (
-            self._rich
-            and self._display is not None
-            and not isinstance(self._display, _ReplEventLogDisplay)
-        ):
+        if self._rich and self._display is not None and not _is_repl_display(self._display):
             self._sync_tool_detail_view()
         else:
             self._print_tool_detail(record)

--- a/cli/interactive_shell/ui/output/tracker.py
+++ b/cli/interactive_shell/ui/output/tracker.py
@@ -6,7 +6,6 @@ import time
 from collections.abc import Callable
 from typing import Any
 
-from cli.interactive_shell.ui.output.console_state import _get_console
 from cli.interactive_shell.ui.output.environment import (
     _is_silent_output,
     _repl_progress_active,
@@ -15,8 +14,6 @@ from cli.interactive_shell.ui.output.environment import (
 )
 from cli.interactive_shell.ui.output.events import DisplayProtocol, ProgressEvent
 from cli.interactive_shell.ui.output.labels import _humanise_message, _node_label
-from cli.interactive_shell.ui.output.live_display import _EventLogDisplay
-from cli.interactive_shell.ui.output.repl_display import _ReplEventLogDisplay
 from cli.interactive_shell.ui.output.toggles import (
     CtrlOToggleWatcher,
     register_tool_detail_toggle,
@@ -24,6 +21,18 @@ from cli.interactive_shell.ui.output.toggles import (
 )
 from cli.interactive_shell.ui.output.tool_tracking import ToolTrackingMixin
 from cli.interactive_shell.ui.time_format import _fmt_timing
+
+
+def _EventLogDisplay(*args: Any, **kwargs: Any) -> DisplayProtocol:
+    from cli.interactive_shell.ui.output.live_display import _EventLogDisplay
+
+    return _EventLogDisplay(*args, **kwargs)
+
+
+def _ReplEventLogDisplay(*args: Any, **kwargs: Any) -> DisplayProtocol:
+    from cli.interactive_shell.ui.output.repl_display import _ReplEventLogDisplay
+
+    return _ReplEventLogDisplay(*args, **kwargs)
 
 
 def _make_event_log_display(*, t0: float) -> DisplayProtocol:
@@ -133,6 +142,8 @@ class ProgressTracker(ToolTrackingMixin):
         if self._display:
             self._display.print_above_renderable(renderable)
         else:
+            from cli.interactive_shell.ui.output.console_state import _get_console
+
             _get_console().print(renderable)
 
     def _finish(
@@ -181,6 +192,9 @@ def _register_with_observability(tracker: ProgressTracker) -> None:
     from platform.observability.progress import set_progress_tracker
 
     set_progress_tracker(tracker)
+    from cli.interactive_shell.ui.output.console_state import set_tracker_toggle_stop_fn
+
+    set_tracker_toggle_stop_fn(_stop_active_tracker_toggle_watcher)
 
 
 def get_tracker(*, reset: bool = False) -> ProgressTracker:

--- a/cli/ui/renderer/constants.py
+++ b/cli/ui/renderer/constants.py
@@ -29,6 +29,24 @@ _DIAGNOSE_SPINNER_NAME = "dots12"
 _DIAGNOSE_SPINNER_COLOR = "orange1"
 _HIDDEN_PROGRESS_NODES = frozenset({"publish_findings"})
 
+__all__ = [
+    "_BOLD",
+    "_CYAN",
+    "_DIAGNOSE_NODE",
+    "_DIAGNOSE_RENDER_INTERVAL_S",
+    "_DIAGNOSE_SPINNER_COLOR",
+    "_DIAGNOSE_SPINNER_NAME",
+    "_DIM",
+    "_GREEN",
+    "_HIDDEN_PROGRESS_NODES",
+    "_NODE_END_KINDS",
+    "_NODE_START_KINDS",
+    "_RESET",
+    "_TOKEN_STREAM_KIND",
+    "_WHITE",
+    "_render_source",
+]
+
 
 def _render_source(*, local: bool) -> str:
     return EntrypointSource.CLI_PASTE.value if local else EntrypointSource.REMOTE_HTTP.value

--- a/cli/wizard/env_sync.py
+++ b/cli/wizard/env_sync.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import re
 from contextlib import suppress
+from dataclasses import dataclass
 from pathlib import Path
 
 from cli.wizard.config import PROJECT_ENV_PATH, ProviderOption
@@ -29,6 +30,23 @@ _SENSITIVE_TERMINAL_TOKENS: frozenset[str] = frozenset(
     }
 )
 _SENSITIVE_SUBSTRINGS: tuple[str, ...] = ("connection_string",)
+
+
+@dataclass(frozen=True)
+class _PublicEnvLines:
+    """Validated `.env` content that contains no sensitive assignments."""
+
+    lines: tuple[str, ...]
+
+    @classmethod
+    def from_lines(cls, lines: list[str]) -> _PublicEnvLines:
+        public_lines = _strip_sensitive_env_lines(lines)
+        _ensure_no_sensitive_env_lines(public_lines)
+        return cls(tuple(public_lines))
+
+    def write_to(self, target_path: Path) -> None:
+        with target_path.open("w", encoding="utf-8", newline="") as env_file:
+            env_file.writelines(self.lines)
 
 
 def _is_sensitive_env_key(key: str) -> bool:
@@ -101,13 +119,10 @@ def _ensure_no_sensitive_env_lines(lines: list[str]) -> None:
 
 def _write_env(target_path: Path, lines: list[str]) -> None:
     """Write non-sensitive .env lines with owner-only permissions when possible."""
-    public_lines = _strip_sensitive_env_lines(lines)
-    _ensure_no_sensitive_env_lines(public_lines)
+    public_lines = _PublicEnvLines.from_lines(lines)
     try:
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        with target_path.open("w", encoding="utf-8", newline="") as env_file:
-            # Sensitive assignments are stripped and checked above before this sink.
-            env_file.writelines(public_lines)  # lgtm[py/clear-text-storage-sensitive-data]
+        public_lines.write_to(target_path)
     except PermissionError as exc:
         raise PermissionError(
             f"Cannot write to {target_path}: permission denied. "

--- a/cli/wizard/flow.py
+++ b/cli/wizard/flow.py
@@ -6,7 +6,7 @@ import os
 import sys
 from typing import Literal
 
-import questionary as questionary
+import questionary
 from rich.text import Text
 
 from cli.interactive_shell.ui.theme import (
@@ -17,12 +17,7 @@ from cli.interactive_shell.ui.theme import (
     TEXT,
     WARNING,
 )
-from cli.wizard._integration_configurators import (
-    DEFAULT_GITHUB_MCP_MODE as DEFAULT_GITHUB_MCP_MODE,
-)
-from cli.wizard._integration_configurators import (
-    DEFAULT_GITHUB_MCP_URL as DEFAULT_GITHUB_MCP_URL,
-)
+from cli.wizard import _integration_configurators as _integration_configurators_module
 from cli.wizard._integration_configurators import (
     _configure_selected_integrations,
 )
@@ -44,13 +39,23 @@ from cli.wizard._ui import (
 )
 from cli.wizard.config import PROVIDER_BY_VALUE, SUPPORTED_PROVIDERS, ProviderOption
 from cli.wizard.env_sync import sync_env_values, sync_provider_env
-from cli.wizard.integration_health import IntegrationHealthResult as IntegrationHealthResult
+from cli.wizard.integration_health import IntegrationHealthResult
 from cli.wizard.probes import ProbeResult, probe_local_target, probe_remote_target
 from cli.wizard.store import get_store_path, save_local_config
 from cli.wizard.validation import build_demo_action_response as _build_demo_action_response
 from integrations.llm_cli.binary_resolver import diagnose_binary_path
 
+DEFAULT_GITHUB_MCP_MODE = _integration_configurators_module.DEFAULT_GITHUB_MCP_MODE
+DEFAULT_GITHUB_MCP_URL = _integration_configurators_module.DEFAULT_GITHUB_MCP_URL
 WIZARD_TOTAL_STEPS = 4
+
+__all__ = [
+    "DEFAULT_GITHUB_MCP_MODE",
+    "DEFAULT_GITHUB_MCP_URL",
+    "IntegrationHealthResult",
+    "build_demo_action_response",
+    "questionary",
+]
 
 
 # Re-export build_demo_action_response from validation as a stable module-level

--- a/core/domain/correlation/scoring.py
+++ b/core/domain/correlation/scoring.py
@@ -59,7 +59,8 @@ class OperatorHintScore:
 
 class HintEvidenceScore(Protocol):
     @property
-    def score(self) -> float: ...
+    def score(self) -> float:
+        raise NotImplementedError
 
 
 @dataclass(frozen=True)

--- a/deployment/remote/server.py
+++ b/deployment/remote/server.py
@@ -22,7 +22,7 @@ import time
 import urllib.error
 import urllib.request
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -160,8 +160,8 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
     finally:
         if poller_task is not None:
             poller_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await poller_task
+            # Let the poller observe cancellation before FastAPI shutdown completes.
+            await asyncio.gather(poller_task, return_exceptions=True)
 
 
 app = FastAPI(

--- a/tests/services/test_llm_client_provider_registry.py
+++ b/tests/services/test_llm_client_provider_registry.py
@@ -14,11 +14,10 @@ from types import SimpleNamespace
 import pytest
 
 import services.llm_client as llm_client
-from services.llm_client import (
-    _OPENAI_COMPATIBLE_PROVIDERS,
-    OpenAILLMClient,
-    _create_llm_client,
-)
+
+_OPENAI_COMPATIBLE_PROVIDERS = llm_client._OPENAI_COMPATIBLE_PROVIDERS
+OpenAILLMClient = llm_client.OpenAILLMClient
+_create_llm_client = llm_client._create_llm_client
 
 
 def test_registry_entries_are_well_formed() -> None:


### PR DESCRIPTION
## Summary
- Route sensitive `.env` writes through validated public env lines before writing to disk.
- Remove stale imports/import styles and replace Protocol ellipses that CodeQL reports as ineffectual statements.
- Break UI output import cycles with lazy factories/callback registration while preserving renderer patch points.

## Test plan
- `make lint`
- `make typecheck`
- `uv run python -m pytest tests/cli/wizard/test_env_sync.py tests/cli/interactive_shell/ui tests/remote/test_vercel_poller.py tests/remote/test_runtime_alert.py tests/remote/test_renderer.py tests/services/test_llm_client_provider_registry.py tests/synthetic/rds_postgres/correlation -v`


Made with [Cursor](https://cursor.com)