### PR TITLE
fix: clean up post-refactor leftovers

### DIFF
--- a/.cursor/rules/graph-nodes.mdc
+++ b/.cursor/rules/graph-nodes.mdc
@@ -4,7 +4,6 @@ globs:
     - core/orchestration/**
     - core/runtime/**
     - core/domain/state/**
-    - app/agent/**
 ---
 
 # Investigation pipeline
@@ -25,7 +24,7 @@ globs:
 
 ## Conventions
 
-- Prefer `@traceable` from `utils.tracing` on externally-visible orchestration helpers.
+- Prefer `@traceable` from `platform.observability.tracing` on externally-visible orchestration helpers.
 - Stages read full state and return **partial dict** updates.
 - Use `get_tracker()` for CLI progress when appropriate.
 - Keep new persisted keys in the state `TypedDict` and any matching validators.

--- a/.github/workflows/ci-labels-windows.yml
+++ b/.github/workflows/ci-labels-windows.yml
@@ -46,13 +46,13 @@ jobs:
         run: uv sync --frozen --extra dev
 
       - name: Lint
-        run: uv run python -m ruff check app/ tests/
+        run: uv run python -m ruff check cli config core deployment integrations platform services tools tests/
 
       - name: Format check
-        run: uv run python -m ruff format --check app/ tests/
+        run: uv run python -m ruff format --check cli config core deployment integrations platform services tools tests/
 
       - name: Typecheck
-        run: uv run python -m mypy app/
+        run: uv run python -m mypy cli config core deployment integrations platform services tools
 
   windows-test:
     if: contains(github.event.pull_request.labels.*.name, 'ci:windows')
@@ -99,7 +99,7 @@ jobs:
       - name: Run full tests
         run: >-
           uv run python -m pytest -n auto -v
-          --cov=app
+          --cov=cli --cov=config --cov=core --cov=deployment --cov=integrations --cov=platform --cov=services --cov=tools
           --cov-report=term-missing
           --cov-report=html
           --ignore=tests/e2e/kubernetes_local_alert_simulation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,8 @@ Main packages one level deeper:
 - `core/domain/state/` — Shared agent runtime envelope (`AgentState`), chat slice, state factories, investigation pipeline slice contracts, `EvidenceEntry`, and diagnosis rules.
 - `tools/` — Tool registry, decorator, base classes, per-tool packages, shared utilities, and registry helpers.
 - `core/domain/types/` — Shared typed contracts for evidence, retrieval, and tool-related payloads.
-- `utils/` — Cross-cutting utility helpers used across the app and test harnesses.
-- `tools/watch_dog/` — Watchdog feature: per-threshold Telegram alarm dispatch with cooldown, sitting on top of `utils/telegram_delivery.py`.
+- `platform/` — Guardrails, masking, sandbox, analytics, auth, and cross-cutting platform services (e.g. `platform/notifications/telegram_delivery.py`).
+- `tools/watch_dog/` — Watchdog feature: per-threshold Telegram alarm dispatch with cooldown, sitting on top of `platform/notifications/telegram_delivery.py`.
 - `config/webapp.py` — Web-facing application entrypoint; the `opensre` CLI is `cli/__main__.py`.
 
 ## 2. Entry Points

--- a/CI.md
+++ b/CI.md
@@ -95,7 +95,7 @@ Rules with `always_escalate=True` map to `make test-cov`; all others list their
 
 Run `make test-cov` (instead of only targeted tests) when any of these are true:
 
-- Shared/core code changed (`utils/`, `core/domain/state/`, `core/domain/types/`, `core/orchestration/`, `app/nodes/`)
+- Shared/core code changed (`core/domain/state/`, `core/domain/types/`, `core/orchestration/`, `core/orchestration/node/`)
 - 3+ app areas changed in one diff
 - New files with unclear blast radius
 - Cross-cutting refactor

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 import sys
 import textwrap
@@ -27,6 +28,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 INSTALL_SH = Path(__file__).parents[2] / "install.sh"
+_INSTALL_SH_SHELL = shlex.quote(str(INSTALL_SH))
 _LOCAL_BIN = ".local/bin"
 
 
@@ -36,9 +38,12 @@ def _run(
     fake_home = tmp_path / "home"
     fake_home.mkdir(exist_ok=True)
     idir = install_dir if install_dir is not None else str(fake_home / _LOCAL_BIN)
+    install_sh = _INSTALL_SH_SHELL
+    idir_shell = shlex.quote(idir)
+    home_shell = shlex.quote(str(fake_home))
 
     script = textwrap.dedent(f"""\
-        __fn=$(awk 'p&&/^}}$/{{print;exit}} /^configure_path\\(\\)/{{p=1}} p{{print}}' {INSTALL_SH})
+        __fn=$(awk 'p&&/^}}$/{{print;exit}} /^configure_path\\(\\)/{{p=1}} p{{print}}' {install_sh})
         if [ -z "$__fn" ]; then
             echo "configure_path not found in install.sh" >&2
             exit 1
@@ -46,19 +51,20 @@ def _run(
         log()  {{ printf '%s\\n' "$*"; }}
         warn() {{ printf 'Warning: %s\\n' "$*" >&2; }}
         eval "$__fn"
-        INSTALL_DIR="{idir}" platform="{platform}" HOME="{fake_home}" SHELL="{shell}" configure_path
+        INSTALL_DIR={idir_shell} platform="{platform}" HOME={home_shell} SHELL="{shell}" configure_path
     """)
     return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
 
 
 def _run_logging_snippet(body: str) -> subprocess.CompletedProcess[str]:
+    install_sh = _INSTALL_SH_SHELL
     script = textwrap.dedent(f"""\
-        eval "$(awk '/^REPO=/{{exit}} {{print}}' {INSTALL_SH})"
+        eval "$(awk '/^REPO=/{{exit}} {{print}}' {install_sh})"
         eval "$(awk '
             /^[a-z_][a-z_]*\\(\\)/ {{ in_fn=1 }}
             in_fn {{ print }}
             in_fn && /^\\}}$/ {{ in_fn=0 }}
-        ' {INSTALL_SH})"
+        ' {install_sh})"
         {body}
     """)
     return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
@@ -83,13 +89,14 @@ def _run_release_metadata_step(
     install_channel: str = "release", version: str = ""
 ) -> subprocess.CompletedProcess[str]:
     block = _find_release_metadata_step_block()
+    install_sh = _INSTALL_SH_SHELL
     script = textwrap.dedent(f"""\
-        eval "$(awk '/^REPO=/{{exit}} {{print}}' {INSTALL_SH})"
+        eval "$(awk '/^REPO=/{{exit}} {{print}}' {install_sh})"
         eval "$(awk '
             /^[a-z_][a-z_]*\\(\\)/ {{ in_fn=1 }}
             in_fn {{ print }}
             in_fn && /^\\}}$/ {{ in_fn=0 }}
-        ' {INSTALL_SH})"
+        ' {install_sh})"
         INSTALL_CHANNEL="{install_channel}"
         version="{version}"
         {block}
@@ -307,6 +314,9 @@ def _run_post_install(
     path_value = f"{idir}:/usr/bin:/bin" if dir_already_on_path else "/usr/bin:/bin"
 
     start_line = _find_post_install_start_line()
+    install_sh = _INSTALL_SH_SHELL
+    idir_shell = shlex.quote(idir)
+    home_shell = shlex.quote(str(fake_home))
 
     script = textwrap.dedent(f"""\
         # 1. Load every function definition from install.sh
@@ -314,7 +324,7 @@ def _run_post_install(
             /^[a-z_][a-z_]*\\(\\)/ {{ in_fn=1 }}
             in_fn {{ print }}
             in_fn && /^\\}}$/ {{ in_fn=0 }}
-        ' {INSTALL_SH})"
+        ' {install_sh})"
 
         # 2. Stub side-effect functions — no binary or network calls
         install_binary()               {{ :; }}
@@ -324,11 +334,11 @@ def _run_post_install(
 
         # 3. Set every variable the output block reads
         BIN_NAME="opensre"
-        INSTALL_DIR="{idir}"
+        INSTALL_DIR={idir_shell}
         INSTALL_CHANNEL="{install_channel}"
         installed_version="{installed_version}"
         platform="{platform}"
-        HOME="{fake_home}"
+        HOME={home_shell}
         SHELL="{shell}"
         PATH="{path_value}"
         export HOME SHELL PATH
@@ -337,7 +347,7 @@ def _run_post_install(
         #    tail -n +{start_line} feeds everything from the version-print block
         #    to EOF, so any change to those lines in install.sh is immediately
         #    reflected here — no copy-paste tautology.
-        eval "$(tail -n +{start_line} {INSTALL_SH})"
+        eval "$(tail -n +{start_line} {install_sh})"
     """)
     return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
 

--- a/tests/fleet_monitoring/test_probe.py
+++ b/tests/fleet_monitoring/test_probe.py
@@ -22,7 +22,17 @@ from tools.fleet_monitoring.probe import (
 )
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
-_PROBE_MODULE = _REPO_ROOT / "app" / "tools" / "fleet_monitoring" / "probe.py"
+_PROBE_MODULE = _REPO_ROOT / "tools" / "fleet_monitoring" / "probe.py"
+_SOURCE_ROOTS = (
+    "cli",
+    "config",
+    "core",
+    "deployment",
+    "integrations",
+    "platform",
+    "services",
+    "tools",
+)
 
 
 @pytest.fixture
@@ -112,12 +122,15 @@ def test_process_has_open_codex_rollout_returns_false_when_inaccessible() -> Non
 def test_psutil_is_not_imported_outside_probe_module() -> None:
     """Acceptance criterion #3: ``psutil`` must stay confined to
     ``tools/fleet_monitoring/probe.py`` so the dependency surface is explicit. A
-    static scan over ``app/**/*.py`` catches future regressions
+    static scan over runtime package trees catches future regressions
     deterministically — runtime import-graph checks would be flaky
     against lazy-import patterns the codebase already uses elsewhere.
     """
     leaks: list[str] = []
-    for py_file in sorted((_REPO_ROOT / "app").rglob("*.py")):
+    py_files: list[pathlib.Path] = []
+    for root_name in _SOURCE_ROOTS:
+        py_files.extend(sorted((_REPO_ROOT / root_name).rglob("*.py")))
+    for py_file in py_files:
         if py_file == _PROBE_MODULE:
             continue
         text = py_file.read_text(encoding="utf-8")

--- a/tests/synthetic/rds_upstream/run_suite.py
+++ b/tests/synthetic/rds_upstream/run_suite.py
@@ -16,9 +16,8 @@ import sys
 from dataclasses import asdict
 from typing import Any
 
-from app.config import has_credentials_for_active_llm_provider
-from app.pipeline.runners import run_investigation
-
+from config.config import has_credentials_for_active_llm_provider
+from core.orchestration.entrypoints import run_investigation
 from tests.synthetic.mock_aws_backend import FixtureAWSBackend
 from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
 from tests.synthetic.rds_postgres.scenario_loader import ScenarioFixture


### PR DESCRIPTION
## Summary
- Fix broken `app.*` imports in `tests/synthetic/rds_upstream/run_suite.py` so the synthetic runner works again after the package refactor
- Restore the fleet monitoring `psutil` leak scan to cover top-level runtime packages instead of the deleted `app/` tree
- Align the optional Windows CI workflow with main CI lint/typecheck/coverage paths
- Quote paths in `install.sh` tests so they pass when the checkout path contains spaces
- Update stale contributor docs/rules that still referenced `app/` and old `utils/` paths

Fixes #3078
Fixes #3079
Fixes #3080
Fixes #3081
Fixes #3082

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `uv run python -m pytest tests/cli/test_install_sh_path.py tests/fleet_monitoring/test_probe.py tests/synthetic/rds_upstream/ -q`
- [x] `uv run python -m tests.synthetic.rds_upstream.run_suite --offline-only`


Made with [Cursor](https://cursor.com)