### PR TITLE
fix(repl): stop CPR escape bytes leaking into prompt after investigation

### DIFF
--- a/cli/interactive_shell/runtime/foreground_investigation.py
+++ b/cli/interactive_shell/runtime/foreground_investigation.py
@@ -56,16 +56,25 @@ def run_foreground_investigation(
     # blocking RCA-accuracy feedback menu after the report. Pass console=None so
     # the cursor-safe _run_select (per-line erase) is used instead of
     # repl_choose_one, whose block-erase is unstable after Rich Live streaming.
+    #
+    # Safety check: only read stdin when prompt_async is NOT running.
+    # When the investigation was dispatched without exclusive stdin (e.g. an
+    # LLM-agent-routed free-text message), prompt_async is already active and its
+    # Application periodically sends ESC[6n CPR queries. Those terminal responses
+    # (ESC[row;colR) arrive in stdin while read_key_unix is blocking. Even with the
+    # CSI-drain fix in read_key_unix, racing with an active Application is unsafe:
+    # skip the feedback menu and avoid the stdin conflict entirely.
     from cli.interactive_shell.ui.feedback import prompt_investigation_feedback
     from cli.interactive_shell.ui.key_reader import restore_stdin_terminal
 
-    # The explicit pre-call (kept identical to the CLI path) primes the terminal
-    # out of the streaming watcher's no-echo/raw mode *before* the feedback
-    # helper prints its root-cause context and header. prompt_investigation_feedback
-    # restores again in its own finally; this pre-call covers the output it emits
-    # ahead of _run_select's own restore, so it is not redundant with that teardown.
-    restore_stdin_terminal()
-    prompt_investigation_feedback(final_state)
+    pt_app = getattr(session, "pt_style_app", None)
+    pt_app_running = pt_app is not None and getattr(pt_app, "is_running", False)
+    if not pt_app_running:
+        # The explicit pre-call (kept identical to the CLI path) primes the terminal
+        # out of the streaming watcher's no-echo/raw mode *before* the feedback
+        # helper prints its root-cause context and header.
+        restore_stdin_terminal()
+        prompt_investigation_feedback(final_state)
     return final_state
 
 

--- a/cli/interactive_shell/ui/key_reader.py
+++ b/cli/interactive_shell/ui/key_reader.py
@@ -96,17 +96,8 @@ def read_key_unix(*, also_cancel: tuple[bytes, ...] = ()) -> str:
                     # Not an arrow key — drain the rest of the CSI sequence so
                     # bytes like "0;1R" from a CPR (ESC[row;colR) don't leak into
                     # the next read or the prompt buffer as literal characters.
-                    while arr and arr[-1:] not in (
-                        b"R",
-                        b"~",
-                        b"u",
-                        b"H",
-                        b"F",
-                        b"Z",
-                        b"P",
-                        b"Q",
-                        b"S",
-                    ):
+                    # The VT/xterm spec defines 0x40–0x7E as valid CSI final bytes.
+                    while arr and not (0x40 <= arr[0] <= 0x7E):
                         if not _sel.select([fd], [], [], 0)[0]:
                             break
                         arr = os.read(fd, 1)

--- a/cli/interactive_shell/ui/key_reader.py
+++ b/cli/interactive_shell/ui/key_reader.py
@@ -93,6 +93,23 @@ def read_key_unix(*, also_cancel: tuple[bytes, ...] = ()) -> str:
                         return "right"
                     if arr == b"D":
                         return "left"
+                    # Not an arrow key — drain the rest of the CSI sequence so
+                    # bytes like "0;1R" from a CPR (ESC[row;colR) don't leak into
+                    # the next read or the prompt buffer as literal characters.
+                    while arr and arr[-1:] not in (
+                        b"R",
+                        b"~",
+                        b"u",
+                        b"H",
+                        b"F",
+                        b"Z",
+                        b"P",
+                        b"Q",
+                        b"S",
+                    ):
+                        if not _sel.select([fd], [], [], 0)[0]:
+                            break
+                        arr = os.read(fd, 1)
             return "cancel"
         return "ignore"
     finally:


### PR DESCRIPTION
## Root cause

When an investigation runs without exclusive stdin (e.g. `/investigate <args>` or
an LLM-agent-routed free-text message), the REPL loop immediately starts the next
`prompt_async` call while the investigation + RCA feedback menu run concurrently.

The active `prompt_async` Application has a bottom toolbar with `refresh_interval`,
causing it to periodically send `ESC[6n` DSR queries. The terminal responds with
`ESC[row;colR` (cursor position report). Those bytes arrive in stdin while
`read_key_unix` is blocking inside the feedback arrow-key menu.

`read_key_unix` consumed exactly **ESC + `[` + first_row_digit** when handling the
ESC-prefix arrow-key branch, leaving `rest_of_row;colR` (e.g. `0;1R`) in the stdin
buffer. After the feedback ended and `restore_stdin_terminal()` flushed that
residue, a fresh CPR response from the still-active Application arrived between the
flush and the `drain_stale_cpr_bytes()` call. `prompt_async`'s vt100 parser received
`[60;1R` (without the ESC byte) and inserted them as literal characters into the
text buffer — the `[60;1R` garbage visible in the screenshot.

## Fix

**`cli/interactive_shell/ui/key_reader.py`** — `read_key_unix`: after reading an
unrecognised CSI byte (not A/B/C/D), drain the remaining bytes of that escape
sequence non-blockingly. This prevents partial CPR consumption from leaving `0;1R`
residue in stdin even if the concurrent path still runs.

**`cli/interactive_shell/runtime/foreground_investigation.py`** — skip the
stdin-reading RCA feedback menu when `session.pt_style_app.is_running` (the
Application is active, meaning `prompt_async` is running concurrently). Racing
`read_key_unix` against an active Application is the structural root cause; the
guard eliminates the conflict for the concurrent investigation path.

## Test plan

- [ ] Run `/investigate <alert-name>` — observe no `[60;1R` garbage in the next prompt
- [ ] Run a free-text investigation via LLM agent — no garbage, feedback menu skipped silently
- [ ] Run bare `/investigate` (exclusive stdin) — feedback menu still appears normally
- [ ] `make test-scope` — 1786 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)