### PR TITLE
security: add gitleaks secret scanning and harden issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,6 +7,8 @@ body:
   - type: markdown
     attributes:
       value: |
+        > **Security notice:** Never paste real API keys, tokens, or passwords in this form. Replace them with placeholders like `glsa_***`, `sk-***`, or `your-token-here` before submitting. Tokens posted here are publicly visible and cannot be fully deleted from GitHub's history.
+
         Thanks for the report. Please include **observed** behavior and repro steps — guesses make triage slower.
   - type: textarea
     id: summary

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12
     hooks:


### PR DESCRIPTION
## Summary

- **Immediate:** Resolved GitHub secret scanning alert #4 (Grafana token in issue #2500 body). The token was already redacted from the visible body. Alert marked as `revoked` — **the token holder must rotate it in Grafana**, as the original value is preserved in GitHub edit history and is compromised.
- **Prevention (code commits):** Added `gitleaks` v8.30.1 to `.pre-commit-config.yaml`. Every commit now runs gitleaks before ruff. Verified clean pass against the full codebase with no false positives.
- **Prevention (issue reports):** Added a prominent security notice at the top of `bug_report.yml` so reporters see the warning before filling in any fields — not buried in field descriptions.

## Why the issue template fix matters

Issue #2500 had "Redact API keys, tokens, and passwords" in small-print field descriptions. The reporter missed it. The new notice is the first thing rendered when the form loads.

## Test plan

- [x] `uv run pre-commit run gitleaks --all-files` — Passed (no false positives)
- [x] `uv run pre-commit run --all-files` — All hooks pass
- [x] `uv run pytest tests/ -x -q` — 9680 passed, 77 skipped

## Action required (outside this PR)

The Grafana service account token `glsa_5Cl...` from issue #2500 must be **revoked and rotated** in the Grafana instance it belongs to. It cannot be removed from GitHub's edit history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)