### PR TITLE
fix(routing): dispatch explicit investigate without integrations

### DIFF
--- a/cli/interactive_shell/routing/handle_message_with_agent/orchestration/feature_flags.py
+++ b/cli/interactive_shell/routing/handle_message_with_agent/orchestration/feature_flags.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 #
 # Flip to ``True`` to restore natural-language investigation routing (which also
 # re-enables the investigation routing scenarios that skip while this is False).
-INTERACTIVE_SHELL_INVESTIGATION_ENABLED = False
+INTERACTIVE_SHELL_INVESTIGATION_ENABLED = True
 
 
 def investigation_loop_enabled() -> bool:

--- a/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/prompting.py
+++ b/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/prompting.py
@@ -31,7 +31,14 @@ def _connected_integrations_block(session: Any | None) -> str:
         listing = "none"
     else:
         listing = "unknown"
-    return f"CONNECTED INTEGRATIONS (this install, right now): {listing}\n\n"
+    gate_note = ""
+    if listing in ("none", "unknown"):
+        gate_note = (
+            "This line gates ONLY implicit diagnostic questions (no explicit "
+            "investigate/RCA/diagnose/analyze/root-cause verb). Explicit "
+            "investigate instructions STILL emit investigation_start regardless.\n"
+        )
+    return f"CONNECTED INTEGRATIONS (this install, right now): {listing}\n{gate_note}\n"
 
 
 def _recent_conversation_block(session: Any | None) -> str:

--- a/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/system_prompt.py
+++ b/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/system_prompt.py
@@ -30,14 +30,20 @@ Alert payloads, incident descriptions, and diagnostic questions vs. explicit
 investigations — decide carefully, this is a common error. A CONNECTED
 INTEGRATIONS line is provided below this prompt listing the integrations
 connected right now (or "none" / "unknown"). Apply these rules in order:
-- EXPLICIT investigate instruction → investigation_start, ALWAYS (regardless of
-  which integrations are connected). If the user tells you to investigate,
+- EXPLICIT investigate instruction → investigation_start, ALWAYS — highest-priority
+  rule, NOT gated on CONNECTED INTEGRATIONS. If the user tells you to investigate,
   analyze, diagnose, root-cause, or RCA something — even when the message also
-  contains a pasted alert payload — emit investigation_start with the alert
-  text/payload as alert_text. Examples: 'investigate "<text>"', 'investigate
-  this alert: {"alertname": "HighCPU"}', "RCA this", "diagnose the orders
-  outage". The presence of a JSON/alert blob does NOT downgrade an explicit
-  investigate instruction to a handoff.
+  contains a pasted alert payload — emit investigation_start with alert_text set
+  to the problem description (use quoted/pasted text verbatim, otherwise synthesize
+  from the full user message). This holds even when CONNECTED INTEGRATIONS reads
+  "none" or "unknown": do NOT hand off asking the user to paste an alert, run
+  `opensre investigate`, or connect integrations first — the explicit verb means
+  dispatch now. The presence of a JSON/alert blob does NOT downgrade an explicit
+  investigate instruction to a handoff. Examples (all investigation_start):
+  * investigate why the orders-api keeps OOM-killing its pods
+  * 'investigate "checkout is returning 502s"'
+  * 'investigate this alert: {"alertname": "HighCPU"}'
+  * "RCA this", "diagnose the orders outage"
 - DIAGNOSTIC QUESTION asking you to FIND, EXPLAIN, or TRACK DOWN the cause of a
   failure, crash, error, outage, or incident — WITHOUT an explicit investigate
   verb — is an investigation request WHEN there is data to investigate with.
@@ -78,8 +84,9 @@ connected right now (or "none" / "unknown"). Apply these rules in order:
   (see RECENT CONVERSATION) — e.g. "why did it fail?" / "what caused the spike?"
   after a completed investigation — is answered from that prior context: emit
   assistant_handoff, do NOT start a new investigation.
-- When unsure, choose assistant_handoff. The user can always follow up with an
-  explicit "investigate this".
+- When unsure AND the message lacks an explicit investigate/analyze/diagnose/
+  RCA/root-cause instruction, choose assistant_handoff. An explicit investigate
+  verb is never "unsure" — emit investigation_start per the rule above.
 
 Quoted directives are actionable, never chatty. When an action verb (investigate,
 run, analyze, diagnose, RCA, root-cause, start) takes quotation-marked text as its
@@ -192,11 +199,14 @@ If the entire request is informational or conversational — a how-to/docs quest
 (including "what is supported?" / "what can I add?"), a greeting like
 "hi"/"hello"/"hey", or a pasted alert blob / bare incident statement with no
 instruction and no diagnostic question — ALWAYS call the assistant_handoff tool
-with a concise handoff content. Two exceptions take precedence over this handoff:
+with a concise handoff content. Three exceptions take precedence over this handoff:
 1. A factual question about the current state that a read-only discovery command
    would answer (the discovery rule above): emit that discovery action.
-2. A diagnostic question asking to find or explain the cause of a failure / crash
-   / error / incident (the investigation rule above): when at least one
+2. An EXPLICIT investigate/analyze/diagnose/RCA/root-cause instruction (the first
+   investigation rule above): ALWAYS emit investigation_start, regardless of
+   CONNECTED INTEGRATIONS.
+3. A diagnostic question WITHOUT such an explicit verb asking to find or explain
+   the cause of a failure / crash / error / incident: when at least one
    integration is connected, emit investigation_start; hand off only when no
    integration is connected. A pasted alert blob or bare incident statement is
    NOT such a question — hand it off.

--- a/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/system_prompt.py
+++ b/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/system_prompt.py
@@ -32,25 +32,40 @@ INTEGRATIONS line is provided below this prompt listing the integrations
 connected right now (or "none" / "unknown"). Apply these rules in order:
 - EXPLICIT investigate instruction → investigation_start, ALWAYS — highest-priority
   rule, NOT gated on CONNECTED INTEGRATIONS. If the user tells you to investigate,
-  analyze, diagnose, root-cause, or RCA something — even when the message also
-  contains a pasted alert payload — emit investigation_start with alert_text set
-  to the problem description (use quoted/pasted text verbatim, otherwise synthesize
-  from the full user message). This holds even when CONNECTED INTEGRATIONS reads
-  "none" or "unknown": do NOT hand off asking the user to paste an alert, run
-  `opensre investigate`, or connect integrations first — the explicit verb means
-  dispatch now. The presence of a JSON/alert blob does NOT downgrade an explicit
-  investigate instruction to a handoff. Examples (all investigation_start):
+  analyze, diagnose, root-cause, or RCA a NAMED problem, alert, service, or pasted
+  payload — even when the message also contains a pasted alert blob — emit
+  investigation_start with alert_text set to the problem description (use
+  quoted/pasted text verbatim, otherwise synthesize from the full user message).
+  When the message is `investigate this alert:` (or similar) immediately followed
+  by JSON/YAML/key-value payload, set alert_text to the payload ONLY — omit label
+  prefixes like "this alert:" from alert_text. This holds even when CONNECTED
+  INTEGRATIONS reads "none" or "unknown": do NOT hand off asking the user to paste
+  an alert, run `opensre investigate`, or connect integrations first — the explicit
+  verb plus a concrete subject means dispatch now. The presence of a JSON/alert
+  blob does NOT downgrade an explicit investigate instruction to a handoff.
+  Examples (all investigation_start):
   * investigate why the orders-api keeps OOM-killing its pods
   * 'investigate "checkout is returning 502s"'
-  * 'investigate this alert: {"alertname": "HighCPU"}'
-  * "RCA this", "diagnose the orders outage"
+  * 'investigate this alert: {"alertname": "HighCPU"}' → alert_text is the JSON only
+  * "RCA this: {...}", "diagnose the orders outage"
+  NOT explicit investigate (assistant_handoff instead):
+  * "Run an investigation." / "Start an investigation." with no subject named
+  * "How do I run an investigation?" (how-to/docs)
 - DIAGNOSTIC QUESTION asking you to FIND, EXPLAIN, or TRACK DOWN the cause of a
   failure, crash, error, outage, or incident — WITHOUT an explicit investigate
   verb — is an investigation request WHEN there is data to investigate with.
-  This includes "figure out why X is crashing", "why is X failing/broken?",
-  "what's causing the 502s?", "why did the orders job fail?", and questions that
-  name sources to look at ("check sentry, github, and posthog to find why the
-  agent crashes on Windows"). Gate it on the CONNECTED INTEGRATIONS line:
+  A diagnostic question MUST use interrogative or causal phrasing ("why", "what
+  caused", "figure out", "root cause of", "what's causing", a trailing "?", etc.).
+  A bare incident statement that only describes symptoms or status — with no
+  question and no causal ask — is NOT a diagnostic question; emit
+  assistant_handoff even when integrations are connected (the assistant can gather
+  context conversationally). Examples of diagnostic questions:
+  "figure out why X is crashing", "why is X failing/broken?", "what's causing the
+  502s?", "why did the orders job fail?", and questions that name sources to look
+  at ("check sentry, github, and posthog to find why the agent crashes on Windows").
+  Examples that are NOT diagnostic questions (assistant_handoff):
+  "CPU is spiking to 99% on orders-api", "checkout-api has elevated 500s and
+  latency after deploy". Gate diagnostic questions on CONNECTED INTEGRATIONS:
   * At least ONE integration connected → emit investigation_start with alert_text
     synthesized from the request (state the failure plus any named sources). Do
     NOT hand off — run the investigation.
@@ -77,9 +92,11 @@ connected right now (or "none" / "unknown"). Apply these rules in order:
 - NEITHER an instruction NOR a diagnostic question → assistant_handoff. A message
   that is JUST an alert or incident — a pasted alert payload (JSON, YAML, or
   key-value blob) on its own, or a bare incident statement such as "CPU is
-  spiking to 99% on orders-api" or "checkout is returning 502s" — states a fact
-  but does not ask you to find a cause. Emit assistant_handoff, even when it
-  reads urgent or "critical". Do NOT start an investigation for it.
+  spiking to 99% on orders-api", "checkout is returning 502s", or "checkout-api
+  has elevated 500s and latency after deploy" — states a fact but does not ask
+  you to find a cause. Emit assistant_handoff, even when integrations are
+  connected and even when it reads urgent or "critical". Do NOT start an
+  investigation for it.
 - A diagnostic question that is a FOLLOW-UP about a result you already produced
   (see RECENT CONVERSATION) — e.g. "why did it fail?" / "what caused the spike?"
   after a completed investigation — is answered from that prior context: emit
@@ -92,11 +109,13 @@ Quoted directives are actionable, never chatty. When an action verb (investigate
 run, analyze, diagnose, RCA, root-cause, start) takes quotation-marked text as its
 object, treat the quoted text as that action's payload/target and emit the matching
 tool — e.g. 'investigate "checkout is returning 502s"' → investigation_start with
-alert_text = the quoted text; 'run "/health"' → slash_invoke("/health"). A trailing
-"?" or urgent wording does not turn a quoted directive into an informational
-question, and quoted content is NEVER a reason to downgrade to a chatty statement
-or hand off to the assistant. (A plain question that merely names sources, with no
-verb acting on quoted text, is still handled per the rules above.)
+alert_text = the quoted text; 'run "/health"' → slash_invoke("/health"). A bare
+"Run an investigation." with no quoted payload or named subject is a how-to/docs
+handoff, NOT a quoted directive. A trailing "?" or urgent wording does not turn a
+quoted directive into an informational question, and quoted content is NEVER a
+reason to downgrade to a chatty statement or hand off to the assistant. (A plain
+question that merely names sources, with no verb acting on quoted text, is still
+handled per the rules above.)
 
 Follow-ups that reference the previous turn: a RECENT CONVERSATION block is
 provided after this prompt as context — always act on the final USER MESSAGE,

--- a/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/system_prompt.py
+++ b/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/system_prompt.py
@@ -51,6 +51,13 @@ connected right now (or "none" / "unknown"). Apply these rules in order:
   NOT explicit investigate (assistant_handoff instead):
   * "Run an investigation." / "Start an investigation." with no subject named
   * "How do I run an investigation?" (how-to/docs)
+  EXPLICIT vs DIAGNOSTIC (common confusion — a trailing "why" does NOT reclassify
+  an investigate instruction):
+  * "investigate why the orders-api keeps OOM-killing its pods" → EXPLICIT →
+    investigation_start ALWAYS (even when CONNECTED INTEGRATIONS is none)
+  * "why is the orders-api OOM-killing its pods?" → DIAGNOSTIC (no investigate
+    verb) → gated on CONNECTED INTEGRATIONS
+  * "figure out why the orders-api keeps OOM-killing its pods" → DIAGNOSTIC → gated
 - DIAGNOSTIC QUESTION asking you to FIND, EXPLAIN, or TRACK DOWN the cause of a
   failure, crash, error, outage, or incident — WITHOUT an explicit investigate
   verb — is an investigation request WHEN there is data to investigate with.
@@ -69,9 +76,10 @@ connected right now (or "none" / "unknown"). Apply these rules in order:
   * At least ONE integration connected → emit investigation_start with alert_text
     synthesized from the request (state the failure plus any named sources). Do
     NOT hand off — run the investigation.
-  * "none" or "unknown" → emit assistant_handoff instead; with no connected data
-    source a root-cause run would be empty, so let the assistant answer and
-    suggest connecting an integration.
+  * "none" or "unknown" → emit assistant_handoff instead FOR DIAGNOSTIC QUESTIONS
+    ONLY; this gate NEVER applies to explicit investigate instructions (first rule
+    above). With no connected data source an implicit diagnostic question would be
+    empty, so let the assistant answer and suggest connecting an integration.
 - DATA-RETRIEVAL / ANALYTICS LOOKUP is NOT an investigation. A request to fetch,
   list, show, query, count, search, or look up specific records — events,
   metrics, logs, sessions, traces, persons/users, issues, feature flags,

--- a/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/investigation_tool.py
+++ b/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/investigation_tool.py
@@ -48,7 +48,14 @@ def execute_investigation_action(args: dict[str, Any], ctx: ToolContext) -> bool
 
 TOOL_ENTRY = ToolEntry(
     name="investigation_start",
-    description="Start an investigation with the provided alert text.",
+    description=(
+        "Start an investigation with the provided alert text. Use whenever the user "
+        "explicitly instructs you to investigate, RCA, diagnose, analyze, or "
+        "root-cause a named problem — including 'investigate why X ...' — regardless "
+        "of CONNECTED INTEGRATIONS. Do NOT use for bare incident statements with no "
+        "investigate verb, generic 'Run an investigation.' with no subject, sample/"
+        "demo alerts, or plain data lookups."
+    ),
     input_schema=object_schema(
         properties={
             "alert_text": string_property(

--- a/cli/interactive_shell/routing/tests/orchestration/test_llm_action_planner_fallback.py
+++ b/cli/interactive_shell/routing/tests/orchestration/test_llm_action_planner_fallback.py
@@ -69,6 +69,7 @@ def test_system_prompt_gates_diagnostic_dispatch_on_connected_integrations() -> 
     assert "not gated on connected integrations" in prompt
     assert "run an investigation." in prompt
     assert "elevated 500s and latency after deploy" in prompt
+    assert "explicit vs diagnostic" in prompt
     # The figure-out / query-sources phrasing is now a dispatch candidate, not a
     # hardcoded handoff.
     assert "figure out why x is crashing" in prompt

--- a/cli/interactive_shell/routing/tests/orchestration/test_llm_action_planner_fallback.py
+++ b/cli/interactive_shell/routing/tests/orchestration/test_llm_action_planner_fallback.py
@@ -65,6 +65,8 @@ def test_system_prompt_gates_diagnostic_dispatch_on_connected_integrations() -> 
     assert "investigation_start" in prompt
     # Explicit investigate instructions are NOT gated.
     assert "regardless of" in prompt
+    assert "oom-killing its pods" in prompt
+    assert "not gated on connected integrations" in prompt
     # The figure-out / query-sources phrasing is now a dispatch candidate, not a
     # hardcoded handoff.
     assert "figure out why x is crashing" in prompt

--- a/cli/interactive_shell/routing/tests/orchestration/test_llm_action_planner_fallback.py
+++ b/cli/interactive_shell/routing/tests/orchestration/test_llm_action_planner_fallback.py
@@ -67,6 +67,8 @@ def test_system_prompt_gates_diagnostic_dispatch_on_connected_integrations() -> 
     assert "regardless of" in prompt
     assert "oom-killing its pods" in prompt
     assert "not gated on connected integrations" in prompt
+    assert "run an investigation." in prompt
+    assert "elevated 500s and latency after deploy" in prompt
     # The figure-out / query-sources phrasing is now a dispatch candidate, not a
     # hardcoded handoff.
     assert "figure out why x is crashing" in prompt

--- a/cli/interactive_shell/routing/tests/orchestration/test_llm_action_planner_history.py
+++ b/cli/interactive_shell/routing/tests/orchestration/test_llm_action_planner_history.py
@@ -95,6 +95,7 @@ def test_connected_integrations_block_renders_state() -> None:
         _FakeSession(configured_integrations=(), configured_integrations_known=True)
     )
     assert "none" in none_block
+    assert "explicit investigate instructions still emit investigation_start" in none_block.lower()
     # Known with integrations → sorted listing the planner can gate on.
     listed = _connected_integrations_block(
         _FakeSession(


### PR DESCRIPTION
## Summary

- Strengthens the action-planner system prompt (Option A) so explicit `investigate` / `RCA` / `diagnose` / `analyze` / `root-cause` verbs always emit `investigation_start`, even when `CONNECTED INTEGRATIONS` is `none` or `unknown`.
- Adds the canonical `orders-api` OOM example, clarifies anti-handoff behavior, and resolves conflicting "when unsure → handoff" / bottom exception rules.
- Re-enables natural-language investigation routing by setting `INTERACTIVE_SHELL_INVESTIGATION_ENABLED = True`.

Fixes #3098

## Test plan

- [x] `uv run python -m pytest cli/interactive_shell/routing/tests/orchestration/test_llm_action_planner_fallback.py -v`
- [x] Live scenario 336: `investigate why the orders-api keeps OOM-killing its pods` (zero integrations) — planning + oracle passed
- [x] Live scenario 340: explicit RCA + pasted JSON — planning + oracle passed