### PR TITLE
fix(build): include platform package in PyInstaller binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,6 +248,7 @@ jobs:
           --noconfirm
           --collect-data cli
           --collect-data config
+          --collect-submodules platform
 
       - name: Smoke test binary (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
The release binary fails at startup with:\r\n\r\n    FileNotFoundError: platform/__init__.py\r\n\r\nconfig/platform_bootstrap.py dynamically loads platform/\__init__.py\r\nvia importlib.util.spec_from_file_location at runtime, which\r\nPyInstaller cannot discover through static analysis.\r\n\r\nAdding `--collect-submodules platform` ensures the platform package\r\nand all its submodules are included in the frozen bundle.