### PR TITLE
ci: add deterministic synthetic test guardrail

### DIFF
--- a/.github/workflows/synthetic-deterministic.yml
+++ b/.github/workflows/synthetic-deterministic.yml
@@ -1,0 +1,86 @@
+name: Synthetic Deterministic Tests
+
+# Regression guardrail: run every offline (no-LLM) synthetic test on every
+# PR and merge so pipeline refactors can't silently break investigations.
+#
+# Tests that need a live LLM are excluded via the marker filter below.
+# Those suites live in routing-live.yml and hermes-tests.yml instead.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "cli/**"
+      - "config/**"
+      - "core/**"
+      - "integrations/**"
+      - "platform/**"
+      - "services/**"
+      - "tools/**"
+      - "tests/synthetic/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "pytest.ini"
+      - ".github/workflows/synthetic-deterministic.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "cli/**"
+      - "config/**"
+      - "core/**"
+      - "integrations/**"
+      - "platform/**"
+      - "services/**"
+      - "tools/**"
+      - "tests/synthetic/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "pytest.ini"
+      - ".github/workflows/synthetic-deterministic.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: synthetic-det-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  offline:
+    name: Synthetic offline (deterministic)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Run deterministic synthetic tests
+        # Excludes markers that require a live LLM:
+        #   synthetic  — full RCA scenario suites (EKS, RDS, Hermes, Dagster …)
+        #   axis2      — adversarial scenario suites (also call the LLM)
+        #   live_llm   — explicit live-credential gate
+        #   e2e        — requires live infrastructure
+        run: |
+          uv run pytest tests/synthetic \
+            -m "not synthetic and not live_llm and not e2e and not axis2" \
+            -q
+
+      - name: Run hermes_rca offline scenario suite
+        run: uv run python -m tests.synthetic.hermes_rca.run_suite --offline-only


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/synthetic-deterministic.yml` — a new CI workflow that runs the offline (no-LLM) subset of `tests/synthetic/` on every PR and push to main
- Previously all 285 synthetic tests were excluded from CI via `--ignore=tests/synthetic`, leaving investigation pipeline contracts completely dark; a refactor could break them silently
- The marker filter `not synthetic and not live_llm and not e2e and not axis2` selects 180 deterministic tests (EKS scenario loading, hermes_rca scoring, RDS correlation algorithms, Jenkins/SigNoz tool fixtures, mock backend contracts) and deselects the 105 that require a live LLM
- LLM-backed suites remain in their existing workflows (`routing-live.yml`, `hermes-tests.yml`)

## Test plan

- [ ] Confirm workflow appears in the Actions tab after merge
- [ ] Trigger manually via `workflow_dispatch` to verify all 180 tests pass (takes ~2s locally)
- [ ] Verify the marker filter deselects LLM-dependent tests (105 deselected in dry run)
- [ ] Make a trivial breaking change to a synthetic fixture and confirm the workflow blocks the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)