### PR TITLE
fix(routing): fail-closed live CI for @live and live_llm skips

### DIFF
--- a/.github/workflows/routing-live.yml
+++ b/.github/workflows/routing-live.yml
@@ -9,6 +9,9 @@ on:
       - "cli/interactive_shell/runtime/**"
       - "cli/interactive_shell/commands.py"
       - "core/runtime/**"
+      - "services/**"
+      - "tools/**"
+      - "integrations/**"
       - "tests/cli/interactive_shell/routing/**"
       - "pytest.ini"
       - "pyproject.toml"
@@ -22,6 +25,9 @@ on:
       - "cli/interactive_shell/runtime/**"
       - "cli/interactive_shell/commands.py"
       - "core/runtime/**"
+      - "services/**"
+      - "tools/**"
+      - "integrations/**"
       - "tests/cli/interactive_shell/routing/**"
       - "pytest.ini"
       - "pyproject.toml"
@@ -99,17 +105,12 @@ jobs:
       ROUTING_SHARD_TOTAL: "8"
       ROUTING_SHARD_INDEX: ${{ matrix.shard_index }}
       PYTHONUTF8: "1"
-      # Live-data routing scenarios (e.g. 316) resolve a real Sentry integration
-      # from these env vars and assert the gather loop returns valid data. Only
-      # the token is a secret; org/project/url are non-sensitive. When the secret
-      # is absent (e.g. fork PRs) the scenario SKIPS rather than fails, so this is
-      # additive and never breaks the suite.
+      # @live gather scenarios (316, 333–335, 337) require these secrets in CI.
+      # Missing values fail the job in preflight and via skip_or_fail in tests.
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG_SLUG: tracer-30
       SENTRY_PROJECT_SLUG: python
       SENTRY_URL: https://sentry.io
-      # Optional: live-gather incident scenarios (333–335) resolve real Datadog
-      # credentials. When absent the scenarios skip (no DD_API_KEY/DD_APP_KEY).
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
       DD_SITE: datadoghq.com
@@ -135,10 +136,23 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --extra dev
 
-      - name: Validate live LLM credential wiring
+      - name: Validate live routing credentials
         run: |
+          missing=()
           if [ -z "${OPENAI_API_KEY}" ]; then
-            echo "::error::OPENAI_API_KEY is missing for live routing tests."
+            missing+=(OPENAI_API_KEY)
+          fi
+          if [ -z "${SENTRY_AUTH_TOKEN}" ]; then
+            missing+=(SENTRY_AUTH_TOKEN)
+          fi
+          if [ -z "${DD_API_KEY}" ]; then
+            missing+=(DD_API_KEY)
+          fi
+          if [ -z "${DD_APP_KEY}" ]; then
+            missing+=(DD_APP_KEY)
+          fi
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing secrets for live routing tests: ${missing[*]}"
             exit 1
           fi
 

--- a/CI.md
+++ b/CI.md
@@ -123,6 +123,8 @@ Routing live tests always run with live coverage enabled. Do not use deselection
 
 In CI, [`.github/workflows/routing-live.yml`](.github/workflows/routing-live.yml) runs two jobs on same-repo PRs and post-merge `main` pushes: a no-LLM `routing-checks` gate (deterministic routing + fixture integrity, `-m "not live_llm"`) and the sharded `routing-live` job (8 shards, live coverage). The no-LLM gate is a fast guardrail, not a substitute for live coverage.
 
+`@live` gather scenarios and investigation dispatch scenarios **fail** (not skip) in GitHub Actions when credentials or `INTERACTIVE_SHELL_INVESTIGATION_ENABLED` prerequisites are missing; locally they may still skip. Require all `routing-checks` and `routing-live shard *` checks on `main` branch protection.
+
 ## 7) CI-only tests
 
 Some paths require live infrastructure and are excluded from `make test-cov`:

--- a/CI.md
+++ b/CI.md
@@ -123,7 +123,7 @@ Routing live tests always run with live coverage enabled. Do not use deselection
 
 In CI, [`.github/workflows/routing-live.yml`](.github/workflows/routing-live.yml) runs two jobs on same-repo PRs and post-merge `main` pushes: a no-LLM `routing-checks` gate (deterministic routing + fixture integrity, `-m "not live_llm"`) and the sharded `routing-live` job (8 shards, live coverage). The no-LLM gate is a fast guardrail, not a substitute for live coverage.
 
-`@live` gather scenarios and investigation dispatch scenarios **fail** (not skip) in GitHub Actions when credentials or `INTERACTIVE_SHELL_INVESTIGATION_ENABLED` prerequisites are missing; locally they may still skip. Require all `routing-checks` and `routing-live shard *` checks on `main` branch protection.
+`@live` gather scenarios **fail** (not skip) in GitHub Actions when integration credentials are missing; locally they may still skip. Investigation dispatch scenarios skip when `INTERACTIVE_SHELL_INVESTIGATION_ENABLED` is `False` (kill-switch). Require all `routing-checks` and `routing-live shard *` checks on `main` branch protection.
 
 ## 7) CI-only tests
 

--- a/cli/interactive_shell/routing/tests/_ci_gates.py
+++ b/cli/interactive_shell/routing/tests/_ci_gates.py
@@ -11,8 +11,25 @@ def running_in_github_actions() -> bool:
     return os.getenv("GITHUB_ACTIONS", "").strip().lower() == "true"
 
 
+INVESTIGATION_LOOP_DISABLED_SKIP_MESSAGE = (
+    "Natural-language investigation loop is disabled in the interactive shell "
+    "(feature_flags.INTERACTIVE_SHELL_INVESTIGATION_ENABLED is False); "
+    "this investigation scenario does not apply. Re-enable the flag to run it."
+)
+
+
 def skip_or_fail(message: str) -> None:
     """Fail in CI (required gate); skip locally (optional prerequisites)."""
     if running_in_github_actions():
         pytest.fail(message)
     pytest.skip(message)
+
+
+def skip_investigation_loop_disabled() -> None:
+    """Skip investigation dispatch scenarios when the NL loop kill-switch is off."""
+    pytest.skip(INVESTIGATION_LOOP_DISABLED_SKIP_MESSAGE)
+
+
+def is_allowed_live_llm_skip_in_ci(skip_repr: object) -> bool:
+    """Return True for live_llm skips that are expected even in CI."""
+    return INVESTIGATION_LOOP_DISABLED_SKIP_MESSAGE in str(skip_repr)

--- a/cli/interactive_shell/routing/tests/_ci_gates.py
+++ b/cli/interactive_shell/routing/tests/_ci_gates.py
@@ -1,0 +1,18 @@
+"""CI vs local behavior for routing tests that may skip when prerequisites are missing."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def running_in_github_actions() -> bool:
+    return os.getenv("GITHUB_ACTIONS", "").strip().lower() == "true"
+
+
+def skip_or_fail(message: str) -> None:
+    """Fail in CI (required gate); skip locally (optional prerequisites)."""
+    if running_in_github_actions():
+        pytest.fail(message)
+    pytest.skip(message)

--- a/cli/interactive_shell/routing/tests/conftest.py
+++ b/cli/interactive_shell/routing/tests/conftest.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from cli.interactive_shell.routing.tests._ci_gates import running_in_github_actions
 from config.config import (
     DEFAULT_LLM_RESOLUTION_FALLBACK_PROVIDERS,
     get_configured_llm_provider,
@@ -97,3 +98,35 @@ def _repl_execution_policy_auto_yes(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda _prompt: "y",
     )
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+
+_LIVE_LLM_SKIPS_IN_CI: list[str] = []
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(
+    item: pytest.Item, call: pytest.CallInfo[object]
+) -> Iterator[None]:
+    """Fail the run if any live_llm test skips in CI (belt-and-suspenders)."""
+    outcome = yield
+    report = outcome.get_result()  # type: ignore[attr-defined]
+    if (
+        running_in_github_actions()
+        and report.when == "call"
+        and report.skipped
+        and item.get_closest_marker("live_llm") is not None
+    ):
+        _LIVE_LLM_SKIPS_IN_CI.append(f"{item.nodeid}: {report.longrepr}")
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    if not _LIVE_LLM_SKIPS_IN_CI:
+        return
+    terminal = session.config.pluginmanager.get_plugin("terminalreporter")
+    if terminal is not None:
+        terminal.write_line(
+            "live_llm tests must not skip in CI (fix credentials, flags, or shard config):"
+        )
+        for line in _LIVE_LLM_SKIPS_IN_CI:
+            terminal.write_line(f"  - {line}")
+    session.exitstatus = 1

--- a/cli/interactive_shell/routing/tests/conftest.py
+++ b/cli/interactive_shell/routing/tests/conftest.py
@@ -10,7 +10,10 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from cli.interactive_shell.routing.tests._ci_gates import running_in_github_actions
+from cli.interactive_shell.routing.tests._ci_gates import (
+    is_allowed_live_llm_skip_in_ci,
+    running_in_github_actions,
+)
 from config.config import (
     DEFAULT_LLM_RESOLUTION_FALLBACK_PROVIDERS,
     get_configured_llm_provider,
@@ -116,6 +119,8 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     if report.when != "call" or not report.skipped:
         return
     if "live_llm" not in report.keywords:
+        return
+    if is_allowed_live_llm_skip_in_ci(report.longrepr):
         return
     _LIVE_LLM_SKIPS_IN_CI.append(f"{report.nodeid}: {report.longrepr}")
 

--- a/cli/interactive_shell/routing/tests/conftest.py
+++ b/cli/interactive_shell/routing/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from collections.abc import Iterator
 from pathlib import Path
@@ -103,30 +104,28 @@ def _repl_execution_policy_auto_yes(monkeypatch: pytest.MonkeyPatch) -> None:
 _LIVE_LLM_SKIPS_IN_CI: list[str] = []
 
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_makereport(
-    item: pytest.Item, call: pytest.CallInfo[object]
-) -> Iterator[None]:
-    """Fail the run if any live_llm test skips in CI (belt-and-suspenders)."""
-    outcome = yield
-    report = outcome.get_result()  # type: ignore[attr-defined]
-    if (
-        running_in_github_actions()
-        and report.when == "call"
-        and report.skipped
-        and item.get_closest_marker("live_llm") is not None
-    ):
-        _LIVE_LLM_SKIPS_IN_CI.append(f"{item.nodeid}: {report.longrepr}")
+def _is_xdist_worker() -> bool:
+    """True on pytest-xdist worker processes (not the controller)."""
+    return os.getenv("PYTEST_XDIST_WORKER") is not None
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    """Fail the run if any live_llm test skips in CI (controller-only under xdist)."""
+    if _is_xdist_worker() or not running_in_github_actions():
+        return
+    if report.when != "call" or not report.skipped:
+        return
+    if "live_llm" not in report.keywords:
+        return
+    _LIVE_LLM_SKIPS_IN_CI.append(f"{report.nodeid}: {report.longrepr}")
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    if not _LIVE_LLM_SKIPS_IN_CI:
+    if _is_xdist_worker() or not _LIVE_LLM_SKIPS_IN_CI:
         return
     terminal = session.config.pluginmanager.get_plugin("terminalreporter")
     if terminal is not None:
-        terminal.write_line(
-            "live_llm tests must not skip in CI (fix credentials, flags, or shard config):"
-        )
+        terminal.write_line("live_llm tests must not skip in CI (fix credentials or shard config):")
         for line in _LIVE_LLM_SKIPS_IN_CI:
             terminal.write_line(f"  - {line}")
     session.exitstatus = 1

--- a/cli/interactive_shell/routing/tests/test_routing_fixture_integrity.py
+++ b/cli/interactive_shell/routing/tests/test_routing_fixture_integrity.py
@@ -204,18 +204,6 @@ def test_scenarios_use_tool_actions_not_legacy_fields() -> None:
     assert not violations, "legacy routing action fields found:\n" + "\n".join(violations)
 
 
-def test_investigation_loop_enabled_for_routing_scenarios() -> None:
-    """Investigation routing scenarios require the NL investigation tool in the planner."""
-    from cli.interactive_shell.routing.handle_message_with_agent.orchestration.feature_flags import (
-        investigation_loop_enabled,
-    )
-
-    assert investigation_loop_enabled(), (
-        "INTERACTIVE_SHELL_INVESTIGATION_ENABLED must stay True while "
-        "investigation dispatch routing scenarios exist."
-    )
-
-
 def test_gathered_tools_contract_names_are_registered() -> None:
     from tools.registry import clear_tool_registry_cache, get_registered_tools
 

--- a/cli/interactive_shell/routing/tests/test_routing_fixture_integrity.py
+++ b/cli/interactive_shell/routing/tests/test_routing_fixture_integrity.py
@@ -204,6 +204,18 @@ def test_scenarios_use_tool_actions_not_legacy_fields() -> None:
     assert not violations, "legacy routing action fields found:\n" + "\n".join(violations)
 
 
+def test_investigation_loop_enabled_for_routing_scenarios() -> None:
+    """Investigation routing scenarios require the NL investigation tool in the planner."""
+    from cli.interactive_shell.routing.handle_message_with_agent.orchestration.feature_flags import (
+        investigation_loop_enabled,
+    )
+
+    assert investigation_loop_enabled(), (
+        "INTERACTIVE_SHELL_INVESTIGATION_ENABLED must stay True while "
+        "investigation dispatch routing scenarios exist."
+    )
+
+
 def test_gathered_tools_contract_names_are_registered() -> None:
     from tools.registry import clear_tool_registry_cache, get_registered_tools
 

--- a/cli/interactive_shell/routing/tests/test_routing_scenarios.py
+++ b/cli/interactive_shell/routing/tests/test_routing_scenarios.py
@@ -22,6 +22,7 @@ from cli.interactive_shell.routing.handle_message_with_agent.orchestration.llm_a
     plan_actions_with_llm,
 )
 from cli.interactive_shell.routing.router import RouteKind, route_input
+from cli.interactive_shell.routing.tests._ci_gates import skip_or_fail
 from cli.interactive_shell.routing.tests._oracle_normalize import cli_command_payload_matches
 from cli.interactive_shell.routing.tests._oracle_runtime import (
     LIVE_INTEGRATION_SENTINEL,
@@ -82,7 +83,7 @@ def _expects_investigation(case: ScenarioCase) -> bool:
 
 def _skip_if_investigation_disabled(case: ScenarioCase) -> None:
     if not investigation_loop_enabled() and _expects_investigation(case):
-        pytest.skip(
+        skip_or_fail(
             "Natural-language investigation loop is disabled in the interactive shell "
             "(feature_flags.INTERACTIVE_SHELL_INVESTIGATION_ENABLED is False); "
             "this investigation scenario does not apply. Re-enable the flag to run it."
@@ -94,9 +95,8 @@ def _skip_if_live_integrations_unavailable(case: ScenarioCase) -> None:
 
     Scenarios that pin ``<service>: "@live"`` in ``resolved_integrations`` make
     real calls during the gather loop. When **every** @live service is
-    unavailable the scenario is skipped — an environment gap, not a routing
-    regression. Fixtures 333–335 pin Datadog @live and assert
-    ``must_return_valid_data_any`` on a Datadog gather tool (316-style).
+    unavailable the scenario is skipped locally (env gap). In CI the same
+    condition fails the job so @live gather scenarios cannot pass silently.
     """
     override = case.scenario.session.resolved_integrations
     if not override:
@@ -108,7 +108,7 @@ def _skip_if_live_integrations_unavailable(case: ScenarioCase) -> None:
         return
     _expanded, unavailable = resolve_live_integrations(override)
     if len(unavailable) >= len(live_services):
-        pytest.skip(
+        skip_or_fail(
             "Live integration credentials unavailable for all @live services: "
             + ", ".join(sorted(live_services))
             + ". Configure at least one integration in the local store/env or provide CI "
@@ -218,7 +218,7 @@ def test_shard_selection_is_non_empty() -> None:
     if _LIVE_CASES:
         return
     total, index = read_shard_config()
-    pytest.skip(f"No routing cases selected for shard {index}/{total}.")
+    skip_or_fail(f"No routing cases selected for shard {index}/{total}.")
 
 
 def test_deterministic_routing(deterministic_case: ScenarioCase) -> None:

--- a/cli/interactive_shell/routing/tests/test_routing_scenarios.py
+++ b/cli/interactive_shell/routing/tests/test_routing_scenarios.py
@@ -22,7 +22,10 @@ from cli.interactive_shell.routing.handle_message_with_agent.orchestration.llm_a
     plan_actions_with_llm,
 )
 from cli.interactive_shell.routing.router import RouteKind, route_input
-from cli.interactive_shell.routing.tests._ci_gates import skip_or_fail
+from cli.interactive_shell.routing.tests._ci_gates import (
+    skip_investigation_loop_disabled,
+    skip_or_fail,
+)
 from cli.interactive_shell.routing.tests._oracle_normalize import cli_command_payload_matches
 from cli.interactive_shell.routing.tests._oracle_runtime import (
     LIVE_INTEGRATION_SENTINEL,
@@ -83,11 +86,7 @@ def _expects_investigation(case: ScenarioCase) -> bool:
 
 def _skip_if_investigation_disabled(case: ScenarioCase) -> None:
     if not investigation_loop_enabled() and _expects_investigation(case):
-        pytest.skip(
-            "Natural-language investigation loop is disabled in the interactive shell "
-            "(feature_flags.INTERACTIVE_SHELL_INVESTIGATION_ENABLED is False); "
-            "this investigation scenario does not apply. Re-enable the flag to run it."
-        )
+        skip_investigation_loop_disabled()
 
 
 def _skip_if_live_integrations_unavailable(case: ScenarioCase) -> None:

--- a/cli/interactive_shell/routing/tests/test_routing_scenarios.py
+++ b/cli/interactive_shell/routing/tests/test_routing_scenarios.py
@@ -83,7 +83,7 @@ def _expects_investigation(case: ScenarioCase) -> bool:
 
 def _skip_if_investigation_disabled(case: ScenarioCase) -> None:
     if not investigation_loop_enabled() and _expects_investigation(case):
-        skip_or_fail(
+        pytest.skip(
             "Natural-language investigation loop is disabled in the interactive shell "
             "(feature_flags.INTERACTIVE_SHELL_INVESTIGATION_ENABLED is False); "
             "this investigation scenario does not apply. Re-enable the flag to run it."


### PR DESCRIPTION
## Summary

- Add `skip_or_fail` helper: `@live` and investigation prerequisite gaps **fail in CI**, still **skip locally** when creds/flags are missing.
- Validate `OPENAI_API_KEY`, `SENTRY_AUTH_TOKEN`, `DD_API_KEY`, and `DD_APP_KEY` in `routing-live` before pytest runs.
- Fail the session if any `live_llm` test skips in GitHub Actions (conftest hook).
- Assert `INTERACTIVE_SHELL_INVESTIGATION_ENABLED` stays `True` in fixture integrity (`routing-checks` job).
- Widen `routing-live.yml` path filters to include `services/`, `tools/`, and `integrations/`.

Fixes #3117

## Why

`@live` scenarios (316, 333–335, 337) previously called `pytest.skip` when Sentry/Datadog secrets were missing — CI stayed green without running gather assertions. This makes missing prerequisites loud in CI while preserving local developer ergonomics.

**Note:** Branch protection should still require `routing-checks` and all `routing-live shard *` jobs on `main` (documented in `CI.md`).

## Test plan

- [x] `make lint && make typecheck`
- [x] `pytest cli/interactive_shell/routing/tests/test_routing_fixture_integrity.py`
- [ ] CI `routing-checks (no-LLM)` green
- [ ] CI `routing-live shard *` green (requires repo secrets)