### PR TITLE
docs(agents): correct repo map and paths after the app/ -> top-level refactor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,13 @@ Before any push or PR creation follow **[CI.md](CI.md)** — lint, format, typec
 
 | Path                  | What it does                                                                                       |
 | --------------------- | -------------------------------------------------------------------------------------------------- |
-| `app/`                | Core application logic, tools, integrations, services, and runtime state.                          |
+| `core/`               | Investigation orchestration, the shared runtime tool-calling loop, and domain logic (state, types, correlation rules). |
+| `cli/`                | Command-line interface, onboarding wizard, and the interactive terminal (REPL) loop.               |
+| `integrations/`       | Integration config normalization, verification, store, catalog logic, and the Hermes log pipeline. |
+| `services/`           | Reusable API clients and adapters for integrations and tools (including LLM providers).            |
+| `tools/`              | Tool registry, decorator, base classes, per-tool packages, and shared tool utilities.              |
+| `platform/`           | Cross-cutting platform services: guardrails, masking, sandbox, analytics, auth, notifications, observability. |
+| `config/`             | Shared constants, prompts, UI theme, and the web app entrypoint (`config/webapp.py`).              |
 | `infra/deployment/`         | Deployment operations, remote-hosted runtime code, and external runtime entrypoints.               |
 | `tests/`              | Unit, integration, synthetic, deployment, e2e, chaos engineering, and support tests.               |
 | `docs/`               | User-facing documentation, integration guides, and docs-site assets.                               |
@@ -152,7 +158,7 @@ Basic steps:
 - If adding or materially changing a tool/integration -> follow [TOOL_INTEGRATION_CHECKLIST.md](TOOL_INTEGRATION_CHECKLIST.md) in the same PR.
 - If an integration changes -> update `tests/integrations/` and verify with `make verify-integrations`.
 - If adding a new integration -> follow [TOOL_INTEGRATION_CHECKLIST.md](TOOL_INTEGRATION_CHECKLIST.md) before opening the PR for review.
-- If adding new tests -> always place them in `tests/`, never in `app/` (no inline tests).
+- If adding new tests -> always place them in `tests/`, never inside the source packages (no inline tests).
 - If CI-only tests are added -> mark them with the right pytest marker or place them in the appropriate e2e/synthetic/chaos folder so they do not run in the default local suite.
 - If investigation branching or loop behavior changes -> update `core/orchestration/pipeline.py` and the tests for that path.
 - If adding or changing interactive REPL behavior (slash commands, session management, display output) -> use `ReplDriver` from `tests/utils/repl_driver.py` for live verification alongside unit tests; see [TESTING.md](TESTING.md).
@@ -164,7 +170,7 @@ Test commands, routing rules, CI-only paths: **[CI.md](CI.md)**. Live REPL testi
 
 ## 5. Footguns (common mistakes to avoid)
 
-- No planning-stage fail-closed safeguard (v0.1): the interactive-shell action planner never denies a turn with "I couldn't safely decide actions". All terminal actions are read-only, so unmatched/ambiguous/chatty clauses run what they can and fall through to the assistant. Do **not** reintroduce a planner denial, the `mark_unhandled` tool, or the `UNHANDLED:` convention. Rationale and details: `cli/interactive_shell/routing/AGENTS.md` and `docs/routing-policy-architecture.md`. If mutating actions are ever added, gate them at the execution stage (`orchestration/execution_policy.py`), not the planner.
+- No planning-stage fail-closed safeguard (v0.1): the interactive-shell action planner never denies a turn with "I couldn't safely decide actions". All terminal actions are read-only, so unmatched/ambiguous/chatty clauses run what they can and fall through to the assistant. Do **not** reintroduce a planner denial, the `mark_unhandled` tool, or the `UNHANDLED:` convention. Rationale and details: `cli/interactive_shell/routing/AGENTS.md` and `docs/routing-policy-architecture.md`. If mutating actions are ever added, gate them at the execution stage (`cli/interactive_shell/routing/handle_message_with_agent/orchestration/execution_policy.py`), not the planner.
 - Vendored deps: No obvious vendored third-party dependencies are present. Python dependencies are managed in `pyproject.toml`, and the docs site has its own `docs/package.json` and `docs/pnpm-lock.yaml`. Do not vendor new libraries unless there is a strong reason.
 - Secrets: Never commit `.env` - always use `.env.example` as the template. Use read-only credentials for production integrations.
 - CI-only tests: Some e2e tests, including Kubernetes, EKS, and chaos engineering paths, require live infrastructure and are excluded from `make test-cov`. Do not expect them to pass locally without that environment.


### PR DESCRIPTION
Fixes #3121

#### Describe the changes you have made in this PR -

The `app/ -> top-level packages` refactor (#3067) moved every code package out of the old top-level `app/` directory, but `AGENTS.md` — the agent/contributor source of truth, `@`-referenced by `CLAUDE.md` — was never updated. This corrects the three stale references:

1. **Repo Map table** — replaced the `app/` row (a directory that no longer exists) with rows for the real top-level code packages: `core/`, `cli/`, `integrations/`, `services/`, `tools/`, `platform/`, `config/`. Descriptions are taken from the "Main packages one level deeper" section already in the file, so they match the documented reality.
2. **Section 3 (Rules)** — "always place them in `tests/`, never in `app/`" reworded to "never inside the source packages", dropping the dead path while keeping the intent (tests live in `tests/`).
3. **Section 5 (Footguns)** — the execution-gate reference `orchestration/execution_policy.py` corrected to its current location, `cli/interactive_shell/routing/handle_message_with_agent/orchestration/execution_policy.py`.

Docs only — no code or behavior changes.

### Demo/Screenshot for feature changes and bug fixes -

Before (on `main`) the table points at a directory that does not exist:

```
$ ls app
ls: app: No such file or directory
```

After this change, every path referenced in the edited lines resolves from the repo root:

```
$ for p in core cli integrations services tools platform config \
    config/webapp.py \
    cli/interactive_shell/routing/handle_message_with_agent/orchestration/execution_policy.py; do
    test -e "$p" && echo "OK   $p" || echo "MISS $p"
  done
OK   core
OK   cli
OK   integrations
OK   services
OK   tools
OK   platform
OK   config
OK   config/webapp.py
OK   cli/interactive_shell/routing/handle_message_with_agent/orchestration/execution_policy.py

$ grep -c '`app/' AGENTS.md
0
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is documentation drift: after #3067 deleted the top-level `app/` package, `AGENTS.md` still mapped it, and one file path (`execution_policy.py`) had moved. Because this file is the canonical map agents and contributors use to navigate the repo, the stale entries actively send readers to paths that no longer exist.

I considered the minimal fix of just deleting the `app/` row, but that would leave the Repo Map silent about where the application code now lives. Instead I replaced it with the actual top-level packages so the table stays a complete, accurate map, and I deliberately reused the wording already present in the "Main packages one level deeper" section rather than inventing new descriptions — keeping the file internally consistent and the descriptions verifiable against existing content.

Scope was kept strictly to documentation accuracy: I audited every backtick path reference in `AGENTS.md` against the working tree and only touched the three that were stale. No behavior, code, or rule semantics changed.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
