### PR TITLE
fix(make): point `make test` at cli/ after app/ removal in #3067

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ test-bedrock:
 
 # Run fast tests + Prefect cloud E2E
 test:
-	$(PYTHON) -m pytest -v app tests/utils
+	$(PYTHON) -m pytest -v cli tests/utils
 	$(PYTHON) -m tests.e2e.upstream_prefect_ecs_fargate.test_agent_e2e
 
 # Run full test suite (CI/CD)


### PR DESCRIPTION
Fixes #3122

#### Describe the changes you have made in this PR -

The `test` target in the `Makefile` ran pytest against a top-level `app/` directory:

```make
test:
	$(PYTHON) -m pytest -v app tests/utils
	$(PYTHON) -m tests.e2e.upstream_prefect_ecs_fargate.test_agent_e2e
```

#3067 ("Refactor platform packages to top-level modules") removed the `app/` package and promoted its contents to top-level packages (`cli/`, `services/`, `tools/`, `core/`, `integrations/`, …). With `app/` gone, `make test` aborts immediately with `ERROR: file or directory not found: app` and collects **0 tests**.

The colocated unit tests that survived the move now live under `cli/` (the other top-level source packages keep their tests under `tests/`). The `lint` / `format-check` / `typecheck` targets were already retargeted to the new layout via `PYTHON_SOURCE_PATHS`; the `test` target's pytest path was the one that got missed.

This one-line change points the target at the surviving location:

```diff
 test:
-	$(PYTHON) -m pytest -v app tests/utils
+	$(PYTHON) -m pytest -v cli tests/utils
 	$(PYTHON) -m tests.e2e.upstream_prefect_ecs_fargate.test_agent_e2e
```

CI was unaffected because the pipeline never invokes `make test` — it runs explicit `pytest_paths` shards plus `make lint` / `make format-check` (see `.github/workflows/ci.yml` and `CI.md`). So the breakage was invisible to CI but hit anyone running `make test` locally.

### Demo/Screenshot for feature changes and bug fixes -

Before (current `main`) — the first line of `make test`:

```
$ uv run python -m pytest -v app tests/utils --collect-only -q
collecting ... ERROR: file or directory not found: app
collected 0 items
========================= no tests collected in 0.00s ==========================
```

After (this PR):

```
$ uv run python -m pytest -v cli tests/utils --collect-only -q
...
========================= 676 tests collected in 7.54s =========================
```

And the collected tests run green, e.g.:

```
$ uv run python -m pytest cli/interactive_shell/routing/tests/test_routing_metamorphic.py -q
.........                                                                [100%]
9 passed in 0.13s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- **What problem does this solve?** `make test` is dead on `main` — it targets the `app/` directory that #3067 deleted, so it collects 0 tests and exits before running anything.
- **Alternatives considered:** (1) `pytest -v $(PYTHON_SOURCE_PATHS) tests/utils` for consistency with the lint/format/typecheck targets — rejected as broader than needed, since only `cli/` currently holds colocated tests and it would also walk dirs with none. (2) Dropping the path entirely and relying on `tests/` — rejected because it changes the target's documented intent ("fast unit tests"). The minimal, faithful fix is to repoint `app` → `cli`, preserving the original behavior (colocated unit tests + `tests/utils`).
- **Why this implementation?** It's the smallest change that restores the target's documented behavior (`make help`: "Run fast unit tests + Prefect cloud E2E") and matches where the colocated tests actually moved.
- **Verification:** `pytest -v cli tests/utils` collects 676 tests (vs 0 today), and a sample colocated module runs green.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: **Allow edits from maintainers** is enabled.