### PR TITLE
fix(repl): show turn [1] at startup and integrations in hint bar

### DIFF
--- a/cli/interactive_shell/prompting/prompt_surface.py
+++ b/cli/interactive_shell/prompting/prompt_surface.py
@@ -29,6 +29,7 @@ from cli.interactive_shell.routing.handle_message_with_agent.command_dispatch.ca
 )
 from cli.interactive_shell.runtime import ReplSession
 from cli.interactive_shell.ui import theme as ui_theme
+from cli.interactive_shell.ui.banner_state import integration_display_name
 from cli.interactive_shell.ui.choice_menu import repl_tty_interactive
 
 _PROMPT_RULE_CHAR = "─"
@@ -61,10 +62,7 @@ def _prompt_prefix_text(session: ReplSession) -> str:
 
 def _prompt_line_ansi(session: ReplSession) -> ANSI:
     counter = _prompt_counter_text(session)
-    if counter:
-        prefix = f"{ui_theme.DIM_COUNTER_ANSI}{counter}{ui_theme.ANSI_RESET}"
-    else:
-        prefix = ""
+    prefix = f"{ui_theme.DIM_COUNTER_ANSI}{counter}{ui_theme.ANSI_RESET}"
     return ANSI(f"{prefix}{ui_theme.PROMPT_ACCENT_ANSI}❯{ui_theme.ANSI_RESET} ")
 
 
@@ -81,8 +79,7 @@ def render_submitted_prompt(console: Console, session: ReplSession, text: str) -
     counter = _prompt_counter_text(session)
     # Rich's Style.parse() reads the bare str value of a _LazyRichStyle (""),
     # so resolve to a concrete string at the call site to keep palette colors.
-    if counter:
-        rendered.append(counter, style=str(ui_theme.DIM))
+    rendered.append(counter, style=str(ui_theme.DIM))
     rendered.append("❯ ", style=f"bold {ui_theme.HIGHLIGHT}")
     rendered.append(lines[0], style=str(ui_theme.TEXT))
     for line in lines[1:]:
@@ -445,13 +442,8 @@ def resolve_idle_hint_ansi(session: ReplSession) -> str:
     """Dim hint line above the prompt rule — shortcuts plus connected integrations."""
     parts = ["/ for commands", "↑↓ history"]
     if session.configured_integrations_known and session.configured_integrations:
-        from cli.interactive_shell.ui.banner_state import _SERVICE_DISPLAY_NAMES
-
         _MAX_SHOWN = 4
-        names = [
-            _SERVICE_DISPLAY_NAMES.get(name, name.replace("_", " ").title())
-            for name in sorted(session.configured_integrations)
-        ]
+        names = [integration_display_name(name) for name in sorted(session.configured_integrations)]
         shown = names[:_MAX_SHOWN]
         overflow = len(names) - len(shown)
         integration_segment = " · ".join(shown)

--- a/cli/interactive_shell/prompting/prompt_surface.py
+++ b/cli/interactive_shell/prompting/prompt_surface.py
@@ -46,8 +46,13 @@ def _prompt_rule_ansi() -> str:
     )
 
 
+def _prompt_turn_number(session: ReplSession) -> int:
+    """1-based index for the turn about to be entered or just submitted."""
+    return len(session.history) + 1
+
+
 def _prompt_counter_text(session: ReplSession) -> str:
-    return f"[{len(session.history)}] " if session.history else ""
+    return f"[{_prompt_turn_number(session)}] "
 
 
 def _prompt_prefix_text(session: ReplSession) -> str:
@@ -436,6 +441,30 @@ _DEFAULT_PLACEHOLDER_ANSI = ANSI(
 )
 
 
+def resolve_idle_hint_ansi(session: ReplSession) -> str:
+    """Dim hint line above the prompt rule — shortcuts plus connected integrations."""
+    parts = ["/ for commands", "↑↓ history"]
+    if session.configured_integrations_known and session.configured_integrations:
+        from cli.interactive_shell.ui.banner_state import _SERVICE_DISPLAY_NAMES
+
+        _MAX_SHOWN = 4
+        names = [
+            _SERVICE_DISPLAY_NAMES.get(name, name.replace("_", " ").title())
+            for name in sorted(session.configured_integrations)
+        ]
+        shown = names[:_MAX_SHOWN]
+        overflow = len(names) - len(shown)
+        integration_segment = " · ".join(shown)
+        if overflow:
+            integration_segment += f" +{overflow}"
+        parts.append(integration_segment)
+    app = get_app_or_none()
+    if app is not None and app.current_buffer.text:
+        parts.append("esc to clear")
+    hint = " · ".join(parts)
+    return f"{ui_theme.DIM_ANSI}{hint}{ui_theme.ANSI_RESET}"
+
+
 def resolve_prompt_placeholder(session: ReplSession) -> ANSI:
     """Contextual ghost text when the input buffer is empty."""
     parts: list[str] = []
@@ -571,6 +600,7 @@ __all__ = [
     "ShellCompleter",
     "completion_preview_hint_ansi",
     "render_submitted_prompt",
+    "resolve_idle_hint_ansi",
     "resolve_prompt_placeholder",
     "resolve_prompt_prefix_ansi",
     "wire_prompt_refresh",

--- a/cli/interactive_shell/runtime/loop.py
+++ b/cli/interactive_shell/runtime/loop.py
@@ -197,7 +197,7 @@ async def run_interactive(
         prefix = strip_cpr_sequences(
             _prompt_surface.resolve_prompt_prefix_ansi(
                 inline_spinner=spinner.inline_spinner_ansi(),
-                idle_hint=spinner.idle_hint_ansi(),
+                idle_hint=_prompt_surface.resolve_idle_hint_ansi(session),
             )
         )
         return ANSI(f"{prefix}\n{base}")

--- a/cli/interactive_shell/ui/banner_state.py
+++ b/cli/interactive_shell/ui/banner_state.py
@@ -49,6 +49,11 @@ _SERVICE_DISPLAY_NAMES: dict[str, str] = {
 }
 
 
+def integration_display_name(service: str) -> str:
+    """Human-readable label for an integration service slug."""
+    return _SERVICE_DISPLAY_NAMES.get(service, service.replace("_", " ").title())
+
+
 def _load_integration_health() -> list[tuple[str, str]]:
     """Return ``(display_name, status)`` for each configured integration.
 
@@ -62,7 +67,7 @@ def _load_integration_health() -> list[tuple[str, str]]:
         )
 
         return [
-            (_SERVICE_DISPLAY_NAMES.get(service, service.title()), status)
+            (integration_display_name(service), status)
             for service, status in configured_integration_health()
         ]
     except Exception:
@@ -135,6 +140,7 @@ def _build_ambient_right_column(session: object = None) -> Text:
 
 __all__ = [
     "_SERVICE_DISPLAY_NAMES",
+    "integration_display_name",
     "_build_ambient_right_column",
     "_is_alert_listener_active",
     "_load_integration_health",

--- a/tests/cli/interactive_shell/prompting/test_prompt_surface.py
+++ b/tests/cli/interactive_shell/prompting/test_prompt_surface.py
@@ -14,7 +14,6 @@ from cli.interactive_shell.prompting.prompt_surface import (
     _prompt_counter_text,
     _prompt_turn_number,
     completion_preview_hint_ansi,
-    render_submitted_prompt,
     resolve_idle_hint_ansi,
     resolve_prompt_placeholder,
     resolve_prompt_prefix_ansi,

--- a/tests/cli/interactive_shell/prompting/test_prompt_surface.py
+++ b/tests/cli/interactive_shell/prompting/test_prompt_surface.py
@@ -11,7 +11,11 @@ from prompt_toolkit.completion import Completion
 from cli.interactive_shell.prompting import prompt_surface
 from cli.interactive_shell.prompting.prompt_surface import (
     _DEFAULT_PLACEHOLDER_TEXT,
+    _prompt_counter_text,
+    _prompt_turn_number,
     completion_preview_hint_ansi,
+    render_submitted_prompt,
+    resolve_idle_hint_ansi,
     resolve_prompt_placeholder,
     resolve_prompt_prefix_ansi,
     wire_prompt_refresh,
@@ -73,6 +77,39 @@ class TestPromptRefreshAutoSubmit:
         session.notify_prompt_changed()
         assert app.current_buffer.text == "why did it fail?"
         assert app.current_buffer.submitted is False
+
+
+class TestPromptTurnCounter:
+    def test_first_turn_is_numbered_one(self) -> None:
+        session = ReplSession()
+        assert _prompt_turn_number(session) == 1
+        assert _prompt_counter_text(session) == "[1] "
+
+    def test_counter_advances_with_history(self) -> None:
+        session = ReplSession()
+        session.record("chat", "hello")
+        assert _prompt_turn_number(session) == 2
+        assert _prompt_counter_text(session) == "[2] "
+
+
+class TestResolveIdleHint:
+    def test_shows_connected_integrations_in_hint_bar(self) -> None:
+        session = ReplSession()
+        session.configured_integrations_known = True
+        session.configured_integrations = ("datadog", "github", "grafana")
+        rendered = _strip_ansi(resolve_idle_hint_ansi(session))
+        assert "/ for commands" in rendered
+        assert "Datadog" in rendered
+        assert "GitHub" in rendered
+        assert "Grafana" in rendered
+
+    def test_omits_integrations_when_none_configured(self) -> None:
+        session = ReplSession()
+        session.configured_integrations_known = True
+        session.configured_integrations = ()
+        rendered = _strip_ansi(resolve_idle_hint_ansi(session))
+        assert "Datadog" not in rendered
+        assert "/ for commands" in rendered
 
 
 class TestResolvePromptPlaceholder:


### PR DESCRIPTION
## Summary

- Fixes blank first-turn numbering: prompt counter now uses `len(session.history) + 1`, so the first prompt shows `[1] ❯` instead of an unnumbered `❯`.
- Restores connected integrations in the live idle hint bar above the prompt (`/ for commands · ↑↓ history · Datadog · GitHub · …`).
- Submitted user lines use the same upcoming-turn index, so the first message echoes as `[1] ❯ …` instead of appearing unnumbered.

Fixes #3125

## Test plan

- [x] `uv run python -m pytest tests/cli/interactive_shell/prompting/test_prompt_surface.py -q`
- [x] Restart `uv run opensre` — first prompt shows `[1] ❯` and integration names in the hint bar when configured
- [x] Send a chat message — submitted line shows `[1]`, next prompt shows `[2]`