### PR TITLE
fix(llm): normalize OpenAI tool schemas for DeepSeek API

### DIFF
--- a/services/agent_llm_client.py
+++ b/services/agent_llm_client.py
@@ -16,12 +16,12 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
-from services.bedrock_converse import normalize_tool_input_schema
 from services.llm_retry import (
     LLMCreditExhaustedError,
     extract_retry_after_seconds,
     is_credit_exhausted_error,
 )
+from services.tool_schema_normalize import normalize_openai_tool_input_schema
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +128,7 @@ def _openai_tool_schema(tool: Any) -> dict[str, Any]:
         "function": {
             "name": tool.name,
             "description": tool.description,
-            "parameters": normalize_tool_input_schema(tool.public_input_schema),
+            "parameters": normalize_openai_tool_input_schema(tool.public_input_schema),
         },
     }
 

--- a/services/agent_llm_client.py
+++ b/services/agent_llm_client.py
@@ -16,6 +16,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
+from services.bedrock_converse import normalize_tool_input_schema
 from services.llm_retry import (
     LLMCreditExhaustedError,
     extract_retry_after_seconds,
@@ -127,9 +128,14 @@ def _openai_tool_schema(tool: Any) -> dict[str, Any]:
         "function": {
             "name": tool.name,
             "description": tool.description,
-            "parameters": tool.public_input_schema,
+            "parameters": normalize_tool_input_schema(tool.public_input_schema),
         },
     }
+
+
+def build_openai_tool_specs(tools: list[Any]) -> list[dict[str, Any]]:
+    """Build OpenAI chat ``tools`` entries from registered tool objects."""
+    return [_openai_tool_schema(t) for t in tools]
 
 
 class AnthropicAgentClient:
@@ -503,7 +509,7 @@ class OpenAIAgentClient:
         self._max_tokens = max_tokens
 
     def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
-        return [_openai_tool_schema(t) for t in tools]
+        return build_openai_tool_specs(tools)
 
     def invoke(
         self,

--- a/services/bedrock_converse.py
+++ b/services/bedrock_converse.py
@@ -12,27 +12,13 @@ import os
 import secrets
 from typing import Any
 
-logger = logging.getLogger(__name__)
-
-# Keys that Converse toolSpec.inputSchema.json rejects or cannot resolve.
-_UNSUPPORTED_SCHEMA_KEYS = frozenset(
-    {
-        "title",
-        "$schema",
-        "$defs",
-        "definitions",
-        "$ref",
-        "not",
-        "nullable",  # OpenAPI nullable — Converse uses explicit types; anyOf/oneOf are flattened instead
-        # Non-Anthropic Bedrock models (Mistral, Llama, etc.) reject additionalProperties even
-        # when it carries a valid boolean value such as false.  Tool calling never relies on this
-        # constraint, so stripping it is safe and avoids HTTP 400 ValidationException errors.
-        "additionalProperties",
-    }
+from services.tool_schema_normalize import (
+    BEDROCK_UNSUPPORTED_SCHEMA_KEYS,
+    normalize_object_tool_input_schema,
+    sanitize_strict_tool_schema,
 )
 
-# Injected when a tool exposes ``type: array`` without ``items``.
-_DEFAULT_ARRAY_ITEMS: dict[str, str] = {"type": "string"}
+logger = logging.getLogger(__name__)
 
 
 def require_aws_region() -> str:
@@ -48,131 +34,9 @@ def new_tool_use_id() -> str:
     return secrets.token_hex(5)
 
 
-def _pick_non_null_schema_variant(variants: list[Any]) -> dict[str, Any] | None:
-    """Return the first ``anyOf`` / ``oneOf`` branch with a concrete non-null type."""
-    for item in variants:
-        if not isinstance(item, dict):
-            continue
-        branch_type = item.get("type")
-        if branch_type and branch_type != "null":
-            return item
-        # Accept an implicit object schema (properties present, no explicit type).
-        if "properties" in item:
-            return item
-    return None
-
-
-def _merge_all_of_subschemas(variants: list[Any]) -> dict[str, Any]:
-    """Merge ``allOf`` branches (e.g. Pydantic constrained fields) into one schema dict."""
-    merged: dict[str, Any] = {}
-    for item in variants:
-        if not isinstance(item, dict):
-            continue
-        for key, value in item.items():
-            if key == "properties" and isinstance(value, dict):
-                props = merged.setdefault("properties", {})
-                if isinstance(props, dict):
-                    props.update(value)
-                else:
-                    merged["properties"] = dict(value)
-            elif key == "required" and isinstance(value, list):
-                required = merged.setdefault("required", [])
-                if isinstance(required, list):
-                    for name in value:
-                        if name not in required:
-                            required.append(name)
-            elif key not in merged:
-                merged[key] = value
-    return merged
-
-
-def _flatten_composite_keywords(schema: dict[str, Any]) -> dict[str, Any]:
-    """Resolve ``allOf`` / ``anyOf`` / ``oneOf`` into explicit ``type`` fields."""
-    flattened = dict(schema)
-    if "allOf" in flattened:
-        variants = flattened.pop("allOf")
-        if isinstance(variants, list):
-            for key, value in _merge_all_of_subschemas(variants).items():
-                if key == "properties" and isinstance(value, dict):
-                    existing = flattened.get("properties")
-                    if isinstance(existing, dict):
-                        existing.update(value)
-                    else:
-                        flattened["properties"] = dict(value)
-                elif key not in flattened:
-                    flattened[key] = value
-    for composite in ("anyOf", "oneOf"):
-        if composite not in flattened:
-            continue
-        variants = flattened.pop(composite)
-        if not isinstance(variants, list):
-            continue
-        picked = _pick_non_null_schema_variant(variants)
-        if picked:
-            for key, value in picked.items():
-                flattened.setdefault(key, value)
-        elif "type" not in flattened:
-            flattened["type"] = "string"
-    return flattened
-
-
 def sanitize_converse_schema(schema: dict[str, Any]) -> dict[str, Any]:
     """Return a Converse-compatible copy of *schema* with required ``type`` / ``items`` filled in."""
-    cleaned: dict[str, Any] = {}
-    for key, value in _flatten_composite_keywords(schema).items():
-        if key in _UNSUPPORTED_SCHEMA_KEYS:
-            continue
-        if isinstance(value, dict):
-            cleaned[key] = sanitize_converse_schema(value)
-        elif isinstance(value, list):
-            cleaned[key] = [
-                sanitize_converse_schema(item) if isinstance(item, dict) else item for item in value
-            ]
-        else:
-            cleaned[key] = value
-
-    _ensure_schema_node(cleaned)
-    return cleaned
-
-
-def _coerce_schema_type(node: dict[str, Any]) -> str | None:
-    """Return a single Converse-compatible ``type`` string (Bedrock rejects ``type`` arrays)."""
-    schema_type = node.get("type")
-    if isinstance(schema_type, list):
-        for candidate in schema_type:
-            if isinstance(candidate, str) and candidate != "null":
-                node["type"] = candidate
-                return candidate
-        node["type"] = "string"
-        return "string"
-    if isinstance(schema_type, str):
-        return schema_type
-    return None
-
-
-def _ensure_schema_node(node: dict[str, Any]) -> None:
-    """Mutate *node* so Bedrock's strict JSON Schema validation receives explicit types."""
-    if "properties" in node and "type" not in node:
-        node["type"] = "object"
-
-    schema_type = _coerce_schema_type(node)
-    if schema_type == "object" and "properties" not in node:
-        node["properties"] = {}
-
-    if schema_type == "array":
-        items = node.get("items")
-        if items is None:
-            node["items"] = dict(_DEFAULT_ARRAY_ITEMS)
-        elif isinstance(items, dict):
-            if "type" not in items and "properties" not in items:
-                node["items"] = dict(_DEFAULT_ARRAY_ITEMS)
-            else:
-                _ensure_schema_node(items)
-        return
-
-    items = node.get("items")
-    if isinstance(items, dict):
-        _ensure_schema_node(items)
+    return sanitize_strict_tool_schema(schema, unsupported_keys=BEDROCK_UNSUPPORTED_SCHEMA_KEYS)
 
 
 def normalize_tool_input_schema(schema: dict[str, Any] | None) -> dict[str, Any]:
@@ -181,12 +45,10 @@ def normalize_tool_input_schema(schema: dict[str, Any] | None) -> dict[str, Any]
     Converse tool inputs must be JSON objects at the top level. Non-object roots are
     replaced with an empty object schema so validation stays strict but safe.
     """
-    cleaned = sanitize_converse_schema(dict(schema or {}))
-    if cleaned.get("type") != "object":
-        return {"type": "object", "properties": {}}
-    if "properties" not in cleaned:
-        cleaned["properties"] = {}
-    return cleaned
+    return normalize_object_tool_input_schema(
+        schema,
+        unsupported_keys=BEDROCK_UNSUPPORTED_SCHEMA_KEYS,
+    )
 
 
 def build_converse_tool_specs(tools: list[Any]) -> list[dict[str, Any]]:

--- a/services/chat_sdk_adapter.py
+++ b/services/chat_sdk_adapter.py
@@ -13,7 +13,7 @@ from typing import Any, Protocol, Required, TypedDict
 
 from config.config import DEFAULT_MAX_TOKENS
 from config.llm_credentials import resolve_llm_api_key
-from services.bedrock_converse import normalize_tool_input_schema
+from services.tool_schema_normalize import normalize_openai_tool_input_schema
 from tools.registered_tool import RegisteredTool
 from tools.registry import get_registered_tools
 
@@ -154,7 +154,7 @@ def _openai_tool_schema(tool: RegisteredTool) -> dict[str, Any]:
         "function": {
             "name": tool.name,
             "description": tool.description,
-            "parameters": normalize_tool_input_schema(tool.public_input_schema),
+            "parameters": normalize_openai_tool_input_schema(tool.public_input_schema),
         },
     }
 

--- a/services/chat_sdk_adapter.py
+++ b/services/chat_sdk_adapter.py
@@ -13,6 +13,7 @@ from typing import Any, Protocol, Required, TypedDict
 
 from config.config import DEFAULT_MAX_TOKENS
 from config.llm_credentials import resolve_llm_api_key
+from services.bedrock_converse import normalize_tool_input_schema
 from tools.registered_tool import RegisteredTool
 from tools.registry import get_registered_tools
 
@@ -153,7 +154,7 @@ def _openai_tool_schema(tool: RegisteredTool) -> dict[str, Any]:
         "function": {
             "name": tool.name,
             "description": tool.description,
-            "parameters": tool.public_input_schema,
+            "parameters": normalize_tool_input_schema(tool.public_input_schema),
         },
     }
 

--- a/services/tool_schema_normalize.py
+++ b/services/tool_schema_normalize.py
@@ -1,0 +1,183 @@
+"""Shared strict JSON Schema normalization for LLM tool ``parameters`` / ``inputSchema``.
+
+Provider adapters choose which keys to strip (e.g. Bedrock Converse rejects
+``additionalProperties``; OpenAI-compatible APIs should keep it for strict mode).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Keys rejected or unresolvable by strict HTTP tool-schema APIs.
+COMMON_UNSUPPORTED_SCHEMA_KEYS = frozenset(
+    {
+        "title",
+        "$schema",
+        "$defs",
+        "definitions",
+        "$ref",
+        "not",
+        "nullable",
+    }
+)
+
+# Bedrock Converse (incl. Mistral/Llama) rejects additionalProperties even when false.
+BEDROCK_UNSUPPORTED_SCHEMA_KEYS = COMMON_UNSUPPORTED_SCHEMA_KEYS | frozenset(
+    {"additionalProperties"}
+)
+
+_DEFAULT_ARRAY_ITEMS: dict[str, str] = {"type": "string"}
+
+
+def _pick_non_null_schema_variant(variants: list[Any]) -> dict[str, Any] | None:
+    """Return the first ``anyOf`` / ``oneOf`` branch with a concrete non-null type."""
+    for item in variants:
+        if not isinstance(item, dict):
+            continue
+        branch_type = item.get("type")
+        if branch_type and branch_type != "null":
+            return item
+        if "properties" in item:
+            return item
+    return None
+
+
+def _merge_all_of_subschemas(variants: list[Any]) -> dict[str, Any]:
+    """Merge ``allOf`` branches (e.g. Pydantic constrained fields) into one schema dict."""
+    merged: dict[str, Any] = {}
+    for item in variants:
+        if not isinstance(item, dict):
+            continue
+        for key, value in item.items():
+            if key == "properties" and isinstance(value, dict):
+                props = merged.setdefault("properties", {})
+                if isinstance(props, dict):
+                    props.update(value)
+                else:
+                    merged["properties"] = dict(value)
+            elif key == "required" and isinstance(value, list):
+                required = merged.setdefault("required", [])
+                if isinstance(required, list):
+                    for name in value:
+                        if name not in required:
+                            required.append(name)
+            elif key not in merged:
+                merged[key] = value
+    return merged
+
+
+def _flatten_composite_keywords(schema: dict[str, Any]) -> dict[str, Any]:
+    """Resolve ``allOf`` / ``anyOf`` / ``oneOf`` into explicit ``type`` fields."""
+    flattened = dict(schema)
+    if "allOf" in flattened:
+        variants = flattened.pop("allOf")
+        if isinstance(variants, list):
+            for key, value in _merge_all_of_subschemas(variants).items():
+                if key == "properties" and isinstance(value, dict):
+                    existing = flattened.get("properties")
+                    if isinstance(existing, dict):
+                        existing.update(value)
+                    else:
+                        flattened["properties"] = dict(value)
+                elif key not in flattened:
+                    flattened[key] = value
+    for composite in ("anyOf", "oneOf"):
+        if composite not in flattened:
+            continue
+        variants = flattened.pop(composite)
+        if not isinstance(variants, list):
+            continue
+        picked = _pick_non_null_schema_variant(variants)
+        if picked:
+            for key, value in picked.items():
+                flattened.setdefault(key, value)
+        elif "type" not in flattened:
+            flattened["type"] = "string"
+    return flattened
+
+
+def _coerce_schema_type(node: dict[str, Any]) -> str | None:
+    """Return a single ``type`` string (strict APIs reject ``type`` arrays)."""
+    schema_type = node.get("type")
+    if isinstance(schema_type, list):
+        for candidate in schema_type:
+            if isinstance(candidate, str) and candidate != "null":
+                node["type"] = candidate
+                return candidate
+        node["type"] = "string"
+        return "string"
+    if isinstance(schema_type, str):
+        return schema_type
+    return None
+
+
+def _ensure_schema_node(node: dict[str, Any]) -> None:
+    """Mutate *node* so strict JSON Schema validation receives explicit types."""
+    if "properties" in node and "type" not in node:
+        node["type"] = "object"
+
+    schema_type = _coerce_schema_type(node)
+    if schema_type == "object" and "properties" not in node:
+        node["properties"] = {}
+
+    if schema_type == "array":
+        items = node.get("items")
+        if items is None:
+            node["items"] = dict(_DEFAULT_ARRAY_ITEMS)
+        elif isinstance(items, dict):
+            if "type" not in items and "properties" not in items:
+                node["items"] = dict(_DEFAULT_ARRAY_ITEMS)
+            else:
+                _ensure_schema_node(items)
+        return
+
+    items = node.get("items")
+    if isinstance(items, dict):
+        _ensure_schema_node(items)
+
+
+def sanitize_strict_tool_schema(
+    schema: dict[str, Any],
+    *,
+    unsupported_keys: frozenset[str] = COMMON_UNSUPPORTED_SCHEMA_KEYS,
+) -> dict[str, Any]:
+    """Return a strict-API copy of *schema* with required ``type`` / ``items`` filled in."""
+    cleaned: dict[str, Any] = {}
+    for key, value in _flatten_composite_keywords(schema).items():
+        if key in unsupported_keys:
+            continue
+        if isinstance(value, dict):
+            cleaned[key] = sanitize_strict_tool_schema(value, unsupported_keys=unsupported_keys)
+        elif isinstance(value, list):
+            cleaned[key] = [
+                sanitize_strict_tool_schema(item, unsupported_keys=unsupported_keys)
+                if isinstance(item, dict)
+                else item
+                for item in value
+            ]
+        else:
+            cleaned[key] = value
+
+    _ensure_schema_node(cleaned)
+    return cleaned
+
+
+def normalize_object_tool_input_schema(
+    schema: dict[str, Any] | None,
+    *,
+    unsupported_keys: frozenset[str] = COMMON_UNSUPPORTED_SCHEMA_KEYS,
+) -> dict[str, Any]:
+    """Normalize a tool's public input schema to a top-level JSON object."""
+    cleaned = sanitize_strict_tool_schema(dict(schema or {}), unsupported_keys=unsupported_keys)
+    if cleaned.get("type") != "object":
+        return {"type": "object", "properties": {}}
+    if "properties" not in cleaned:
+        cleaned["properties"] = {}
+    return cleaned
+
+
+def normalize_openai_tool_input_schema(schema: dict[str, Any] | None) -> dict[str, Any]:
+    """Normalize tool parameters for OpenAI-compatible chat ``tools`` APIs."""
+    return normalize_object_tool_input_schema(
+        schema, unsupported_keys=COMMON_UNSUPPORTED_SCHEMA_KEYS
+    )

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -715,6 +715,31 @@ def test_unrelated_type_error_is_retried_and_wrapped(
     assert call_count == 3, "non-auth TypeError should be retried like a generic exception"
 
 
+def test_build_openai_tool_specs_normalizes_anyof_optional_parameters() -> None:
+    from services.agent_llm_client import build_openai_tool_specs
+    from tests.services.investigation_tool_schema_contract import assert_strict_tool_schema_node
+
+    tool = types.SimpleNamespace(
+        name="optional_field_tool",
+        description="tool with optional field",
+        public_input_schema={
+            "type": "object",
+            "properties": {
+                "required_field": {"type": "string"},
+                "optional_field": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+            },
+            "required": ["required_field"],
+        },
+    )
+
+    specs = build_openai_tool_specs([tool])
+    parameters = specs[0]["function"]["parameters"]
+    assert parameters["type"] == "object"
+    assert "anyOf" not in parameters["properties"]["optional_field"]
+    assert parameters["properties"]["optional_field"]["type"] == "string"
+    assert_strict_tool_schema_node(parameters, path="optional_field_tool")
+
+
 def test_get_agent_llm_routes_deepseek_to_openai_compatible_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -715,6 +715,24 @@ def test_unrelated_type_error_is_retried_and_wrapped(
     assert call_count == 3, "non-auth TypeError should be retried like a generic exception"
 
 
+def test_build_openai_tool_specs_preserves_additional_properties_false() -> None:
+    from services.agent_llm_client import build_openai_tool_specs
+
+    tool = types.SimpleNamespace(
+        name="strict_object_tool",
+        description="tool with closed object schema",
+        public_input_schema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+    )
+
+    parameters = build_openai_tool_specs([tool])[0]["function"]["parameters"]
+    assert parameters["additionalProperties"] is False
+
+
 def test_build_openai_tool_specs_normalizes_anyof_optional_parameters() -> None:
     from services.agent_llm_client import build_openai_tool_specs
     from tests.services.investigation_tool_schema_contract import assert_strict_tool_schema_node

--- a/tests/services/test_investigation_tool_schemas.py
+++ b/tests/services/test_investigation_tool_schemas.py
@@ -8,6 +8,7 @@ import pytest
 
 from services.agent_llm_client import build_openai_tool_specs
 from services.bedrock_converse import build_converse_tool_specs, normalize_tool_input_schema
+from services.tool_schema_normalize import normalize_openai_tool_input_schema
 from tests.services.investigation_tool_schema_contract import (
     assert_all_investigation_tools_satisfy_strict_adapter,
 )
@@ -37,6 +38,6 @@ def test_all_investigation_tool_schemas_satisfy_strict_adapter_invariants() -> N
 def test_all_investigation_tool_schemas_satisfy_openai_compat_adapter() -> None:
     """OpenAI-compatible providers (DeepSeek native API, etc.) require explicit ``type`` on every schema node."""
     assert_all_investigation_tools_satisfy_strict_adapter(
-        normalize_schema=normalize_tool_input_schema,
+        normalize_schema=normalize_openai_tool_input_schema,
         build_tool_specs=build_openai_tool_specs,
     )

--- a/tests/services/test_investigation_tool_schemas.py
+++ b/tests/services/test_investigation_tool_schemas.py
@@ -6,6 +6,7 @@ from collections.abc import Generator
 
 import pytest
 
+from services.agent_llm_client import build_openai_tool_specs
 from services.bedrock_converse import build_converse_tool_specs, normalize_tool_input_schema
 from tests.services.investigation_tool_schema_contract import (
     assert_all_investigation_tools_satisfy_strict_adapter,
@@ -30,4 +31,12 @@ def test_all_investigation_tool_schemas_satisfy_strict_adapter_invariants() -> N
     assert_all_investigation_tools_satisfy_strict_adapter(
         normalize_schema=normalize_tool_input_schema,
         build_tool_specs=build_converse_tool_specs,
+    )
+
+
+def test_all_investigation_tool_schemas_satisfy_openai_compat_adapter() -> None:
+    """OpenAI-compatible providers (DeepSeek native API, etc.) require explicit ``type`` on every schema node."""
+    assert_all_investigation_tools_satisfy_strict_adapter(
+        normalize_schema=normalize_tool_input_schema,
+        build_tool_specs=build_openai_tool_specs,
     )

--- a/tests/services/test_tool_schema_normalize.py
+++ b/tests/services/test_tool_schema_normalize.py
@@ -1,0 +1,41 @@
+"""Tests for shared strict tool schema normalization."""
+
+from __future__ import annotations
+
+from services.tool_schema_normalize import (
+    BEDROCK_UNSUPPORTED_SCHEMA_KEYS,
+    COMMON_UNSUPPORTED_SCHEMA_KEYS,
+    normalize_openai_tool_input_schema,
+    sanitize_strict_tool_schema,
+)
+
+
+def test_openai_normalizer_preserves_additional_properties_false() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "additionalProperties": False,
+    }
+    cleaned = normalize_openai_tool_input_schema(schema)
+    assert cleaned["additionalProperties"] is False
+
+
+def test_bedrock_normalizer_strips_additional_properties_false() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "additionalProperties": False,
+    }
+    cleaned = sanitize_strict_tool_schema(schema, unsupported_keys=BEDROCK_UNSUPPORTED_SCHEMA_KEYS)
+    assert "additionalProperties" not in cleaned
+
+
+def test_openai_and_bedrock_share_composite_flattening() -> None:
+    schema = {"anyOf": [{"type": "string"}, {"type": "null"}]}
+    openai_cleaned = sanitize_strict_tool_schema(
+        schema, unsupported_keys=COMMON_UNSUPPORTED_SCHEMA_KEYS
+    )
+    bedrock_cleaned = sanitize_strict_tool_schema(
+        schema, unsupported_keys=BEDROCK_UNSUPPORTED_SCHEMA_KEYS
+    )
+    assert openai_cleaned == bedrock_cleaned == {"type": "string"}


### PR DESCRIPTION
## Summary
- Normalize `function.parameters` in OpenAI-compatible tool specs using the existing Bedrock `normalize_tool_input_schema` helper so every nested JSON Schema node has an explicit `type`
- Apply the fix in both investigation (`agent_llm_client`) and interactive chat (`chat_sdk_adapter`) paths
- Add registry-wide contract coverage for OpenAI-compatible tool serialization plus a focused `anyOf` regression test

Fixes #3129

## Root cause
DeepSeek's native API (`api.deepseek.com`) uses a strict deserializer that rejects tool parameter schemas with nested nodes missing `type` (e.g. Pydantic `anyOf` for optional fields). OpenAI, Claude, and OpenRouter are lenient, so the raw `public_input_schema` worked there but failed on DeepSeek with HTTP 400.

## Test plan
- [x] `uv run python -m pytest tests/services/test_investigation_tool_schemas.py -q`
- [x] `uv run python -m pytest tests/services/test_agent_llm_client.py::test_build_openai_tool_specs_normalizes_anyof_optional_parameters -q`
- [x] `make lint && make format-check`