### PR TITLE
fix(analytics): re-identify saved GitHub username and tighten login gate

### DIFF
--- a/cli/first_launch_github.py
+++ b/cli/first_launch_github.py
@@ -1,13 +1,13 @@
 """First-launch mandatory GitHub login gate.
 
-On the first interactive launch of ``opensre`` on macOS or Windows (never on
-Linux, never in CI/tests), the user must sign in to GitHub via device flow. The
-sign-in runs the hosted GitHub MCP setup, persists the integration, and
-propagates the authenticated GitHub username to PostHog.
+On the first interactive launch of ``opensre`` (all platforms), the user must
+sign in to GitHub via device flow unless they are in CI/CD, a test harness, or a
+non-interactive session. The sign-in runs the hosted GitHub MCP setup, persists
+the integration, and propagates the authenticated GitHub username to PostHog.
 
 Escape hatch: ``OPENSRE_SKIP_GITHUB_LOGIN=1`` bypasses the gate so a GitHub
 outage or a disabled device flow can never permanently lock anyone out. The gate
-is also auto-bypassed on Linux and in CI/test environments.
+is also auto-bypassed in CI/test environments and when stdin is not a TTY.
 """
 
 from __future__ import annotations
@@ -17,14 +17,12 @@ import os
 from rich.console import Console
 from rich.markup import escape
 
-import platform
 from cli.interactive_shell.ui import repl_tty_interactive
 from cli.interactive_shell.ui.theme import DEVICE_CODE
-from platform.analytics.cli import capture_github_login_completed, identify_github_username
+from platform.analytics.cli import capture_github_login_completed
 from platform.analytics.source import is_test_run
 
 _SKIP_ENV_VAR = "OPENSRE_SKIP_GITHUB_LOGIN"
-_ELIGIBLE_OS = frozenset({"Darwin", "Windows"})
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
 
 
@@ -32,27 +30,15 @@ def _skip_requested() -> bool:
     return os.getenv(_SKIP_ENV_VAR, "").strip().lower() in _TRUTHY
 
 
-def _eligible_os() -> bool:
-    return platform.system() in _ELIGIBLE_OS
-
-
 def _github_already_configured() -> bool:
-    from integrations.github_mcp import github_mcp_config_from_env
-    from integrations.store import get_integration
+    from integrations.github_mcp import github_integration_is_configured
 
-    if get_integration("github") is not None:
-        return True
-    try:
-        return github_mcp_config_from_env() is not None
-    except Exception:
-        return False
+    return github_integration_is_configured()
 
 
 def should_require_github_login() -> bool:
     """Return True when the mandatory first-launch GitHub login must run now."""
     if _skip_requested():
-        return False
-    if not _eligible_os():
         return False
     if is_test_run():
         return False
@@ -69,7 +55,8 @@ def should_require_github_login() -> bool:
 def _propagate_username(username: str) -> None:
     if not username:
         return
-    identify_github_username(username)
+    # ``authenticate_and_configure_github`` already calls identify_github_username;
+    # only emit the one-time login lifecycle event here.
     capture_github_login_completed(username)
 
 

--- a/cli/interactive_shell/runtime/entrypoint.py
+++ b/cli/interactive_shell/runtime/entrypoint.py
@@ -9,7 +9,6 @@ import sys
 
 from rich.console import Console
 
-import platform
 from cli.config import ReplConfig
 from cli.interactive_shell import alert_inbox as _alert_inbox
 from cli.interactive_shell.prompting import prompt_surface as _prompt_surface
@@ -38,6 +37,9 @@ def _hydrate_configured_integrations(session: ReplSession) -> None:
 
 async def repl_main(initial_input: str | None = None, _config: ReplConfig | None = None) -> int:
     from cli.interactive_shell.ui.theme import get_active_theme_name
+    from platform.analytics.cli import identify_saved_github_username
+
+    identify_saved_github_username()
 
     cfg = _config or ReplConfig.load()
     session = ReplSession()
@@ -89,19 +91,21 @@ async def repl_main(initial_input: str | None = None, _config: ReplConfig | None
 
 
 def _github_login_explicitly_bypassed() -> bool:
-    """Cheap, dependency-free check for contexts where the GitHub gate is intentionally skipped.
+    """Cheap check for contexts where the GitHub gate is intentionally skipped.
 
     Used only as the *error* fallback for the first-launch gate. It must not import
     the gate module (that import may be exactly what failed), so it re-derives the
     documented bypasses directly:
 
     * ``OPENSRE_SKIP_GITHUB_LOGIN`` — the user-facing escape hatch.
-    * Non-eligible operating systems — the gate only runs on macOS/Windows.
-    * Non-interactive stdin — scripted / CI runs have no prompt to drive.
+    * CI/CD and test harnesses — detected via :func:`platform.analytics.source.is_test_run`.
+    * Non-interactive stdin — scripted / piped runs have no prompt to drive.
     """
     if os.getenv("OPENSRE_SKIP_GITHUB_LOGIN", "").strip().lower() in {"1", "true", "yes", "on"}:
         return True
-    if platform.system() not in {"Darwin", "Windows"}:
+    from platform.analytics.source import is_test_run
+
+    if is_test_run():
         return True
     try:
         return not sys.stdin.isatty()
@@ -119,7 +123,7 @@ def _maybe_require_github_login(console: Console) -> bool:
     On an unexpected error we deliberately do NOT fail open into the REPL: that
     would let a gate bug silently skip the mandatory sign-in. Instead we only
     allow startup when an explicit, documented bypass applies (skip env var,
-    ineligible OS, or non-TTY); otherwise we block and point the user at the
+    CI/test harness, or non-TTY); otherwise we block and point the user at the
     escape hatch so a real outage can never permanently lock them out.
     """
     try:

--- a/cli/interactive_shell/runtime/entrypoint.py
+++ b/cli/interactive_shell/runtime/entrypoint.py
@@ -98,14 +98,21 @@ def _github_login_explicitly_bypassed() -> bool:
     documented bypasses directly:
 
     * ``OPENSRE_SKIP_GITHUB_LOGIN`` — the user-facing escape hatch.
-    * CI/CD and test harnesses — detected via :func:`platform.analytics.source.is_test_run`.
+    * CI/CD and test harnesses — env vars only (no analytics import).
     * Non-interactive stdin — scripted / piped runs have no prompt to drive.
     """
     if os.getenv("OPENSRE_SKIP_GITHUB_LOGIN", "").strip().lower() in {"1", "true", "yes", "on"}:
         return True
-    from platform.analytics.source import is_test_run
-
-    if is_test_run():
+    if os.getenv("OPENSRE_INVESTIGATION_SOURCE", "").strip().lower() == "test":
+        return True
+    if os.getenv("OPENSRE_IS_TEST", "0").strip() == "1":
+        return True
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        return True
+    if os.getenv("GITHUB_ACTIONS", "").strip().lower() == "true":
+        return True
+    ci_value = os.getenv("CI", "").strip().lower()
+    if ci_value in {"1", "true", "yes"}:
         return True
     try:
         return not sys.stdin.isatty()

--- a/cli/interactive_shell/ui/banner.py
+++ b/cli/interactive_shell/ui/banner.py
@@ -182,9 +182,12 @@ def _github_username() -> str:
     Best-effort and never raises: the welcome greeting must render even when the
     integration store is unreadable or GitHub is not configured.
     """
-    from integrations.github_login import saved_github_username
+    try:
+        from integrations.github_identity import saved_github_username
 
-    return saved_github_username()
+        return saved_github_username()
+    except Exception:
+        return ""
 
 
 def _get_username() -> str:

--- a/cli/interactive_shell/ui/banner.py
+++ b/cli/interactive_shell/ui/banner.py
@@ -182,16 +182,9 @@ def _github_username() -> str:
     Best-effort and never raises: the welcome greeting must render even when the
     integration store is unreadable or GitHub is not configured.
     """
-    try:
-        from integrations.store import get_integration
+    from integrations.github_login import saved_github_username
 
-        record = get_integration("github")
-        if not record:
-            return ""
-        credentials = record.get("credentials") or {}
-        return str(credentials.get("username") or "").strip()
-    except Exception:
-        return ""
+    return saved_github_username()
 
 
 def _get_username() -> str:

--- a/cli/wizard/_integration_configurators.py
+++ b/cli/wizard/_integration_configurators.py
@@ -639,7 +639,16 @@ def _configure_github_mcp() -> tuple[str, str]:
                 "args": args,
                 "toolsets": toolsets,
             }
+            authenticated_user = ""
+            if result.github_mcp is not None:
+                authenticated_user = (result.github_mcp.authenticated_user or "").strip()
+            if authenticated_user:
+                credentials["username"] = authenticated_user
             upsert_integration("github", {"credentials": credentials})
+            if authenticated_user:
+                from platform.analytics.cli import identify_github_username
+
+                identify_github_username(authenticated_user)
             env_path = sync_env_values(
                 {
                     "GITHUB_MCP_URL": url,

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -126,11 +126,11 @@ Events are tagged with `entrypoint`, `opensre.runtime`, and `deployment_method`.
 
 A random install ID is stored under `~/.opensre/anonymous_id`. PostHog `distinct_id` is scoped to that ID. Telemetry is off in GitHub Actions and pytest.
 
-### First-launch GitHub login (macOS & Windows)
+### First-launch GitHub login
 
-On the first interactive launch on macOS or Windows (never on Linux, never in CI/tests), OpenSRE requires a GitHub device-flow sign-in before the REPL prompt. On success it sets `github_username` as a PostHog **person property** (via `$identify`/`$set`, which forces `$process_person_profile: True` for that one event — this is the only intentional PII OpenSRE sends) and emits a `github_login_completed` event. A marker at `~/.opensre/github_login_done` prevents re-prompting.
+On the first interactive launch (all platforms, except CI/CD and test harnesses), OpenSRE requires a GitHub device-flow sign-in before the REPL prompt. On success it sets `github_username` as a PostHog **person property** (via `$identify`/`$set`, which forces `$process_person_profile: True` for that one event — this is the only intentional PII OpenSRE sends) and emits a `github_login_completed` event. A configured GitHub integration suppresses re-prompting on later launches.
 
-The existing kill-switches still apply: `OPENSRE_NO_TELEMETRY` / `DO_NOT_TRACK` make the `$identify` and `github_login_completed` calls no-ops, but the login itself still runs. Set `OPENSRE_SKIP_GITHUB_LOGIN=1` to bypass the login gate entirely (also auto-bypassed on Linux and in CI/tests).
+The existing kill-switches still apply: `OPENSRE_NO_TELEMETRY` / `DO_NOT_TRACK` make the `$identify` and `github_login_completed` calls no-ops, but the login itself still runs. Set `OPENSRE_SKIP_GITHUB_LOGIN=1` to bypass the login gate entirely (also auto-bypassed in CI — `CI=true`, `GITHUB_ACTIONS=true` — and in pytest).
 
 ### Kill-switch matrix
 

--- a/integrations/cli.py
+++ b/integrations/cli.py
@@ -581,6 +581,10 @@ def _setup_github() -> str | None:
         # handle instead of the local system username.
         credentials["username"] = result.authenticated_user
     upsert_integration("github", {"credentials": credentials})
+    if result.authenticated_user:
+        from platform.analytics.cli import identify_github_username
+
+        identify_github_username(result.authenticated_user)
     return result.authenticated_user
 
 

--- a/integrations/github_identity.py
+++ b/integrations/github_identity.py
@@ -1,0 +1,25 @@
+"""Lightweight GitHub identity helpers for UI and analytics.
+
+Kept separate from :mod:`integrations.github_login` so callers like the welcome
+banner can read the saved handle without importing the heavy GitHub MCP stack.
+"""
+
+from __future__ import annotations
+
+
+def saved_github_username() -> str:
+    """Return the persisted GitHub login from the integration store, or "".
+
+    Best-effort and never raises: callers like the welcome banner and analytics
+    re-identify must work even when the store is unreadable.
+    """
+    try:
+        from integrations.store import get_integration
+
+        record = get_integration("github")
+        if not record:
+            return ""
+        credentials = record.get("credentials") or {}
+        return str(credentials.get("username") or "").strip()
+    except Exception:
+        return ""

--- a/integrations/github_login.py
+++ b/integrations/github_login.py
@@ -34,6 +34,24 @@ class GitHubLoginResult:
     detail: str = ""
 
 
+def saved_github_username() -> str:
+    """Return the persisted GitHub login from the integration store, or "".
+
+    Best-effort and never raises: callers like the welcome banner and analytics
+    re-identify must work even when the store is unreadable.
+    """
+    try:
+        from integrations.store import get_integration
+
+        record = get_integration("github")
+        if not record:
+            return ""
+        credentials = record.get("credentials") or {}
+        return str(credentials.get("username") or "").strip()
+    except Exception:
+        return ""
+
+
 def authenticate_and_configure_github(
     *,
     on_prompt: Callable[[GitHubDeviceCode], None] | None = None,
@@ -65,4 +83,9 @@ def authenticate_and_configure_github(
         # handle instead of the local system username.
         credentials["username"] = result.authenticated_user
     upsert_integration("github", {"credentials": credentials})
-    return GitHubLoginResult(ok=True, username=result.authenticated_user, detail=result.detail)
+    username = result.authenticated_user
+    if username:
+        from platform.analytics.cli import identify_github_username
+
+        identify_github_username(username)
+    return GitHubLoginResult(ok=True, username=username, detail=result.detail)

--- a/integrations/github_login.py
+++ b/integrations/github_login.py
@@ -34,24 +34,6 @@ class GitHubLoginResult:
     detail: str = ""
 
 
-def saved_github_username() -> str:
-    """Return the persisted GitHub login from the integration store, or "".
-
-    Best-effort and never raises: callers like the welcome banner and analytics
-    re-identify must work even when the store is unreadable.
-    """
-    try:
-        from integrations.store import get_integration
-
-        record = get_integration("github")
-        if not record:
-            return ""
-        credentials = record.get("credentials") or {}
-        return str(credentials.get("username") or "").strip()
-    except Exception:
-        return ""
-
-
 def authenticate_and_configure_github(
     *,
     on_prompt: Callable[[GitHubDeviceCode], None] | None = None,

--- a/integrations/github_mcp.py
+++ b/integrations/github_mcp.py
@@ -442,6 +442,34 @@ def github_mcp_config_from_env() -> GitHubMCPConfig | None:
     )
 
 
+def github_mcp_is_usably_configured(config: GitHubMCPConfig) -> bool:
+    """Return True when credentials are enough to use GitHub MCP without re-prompting.
+
+    Aligns with validation's ``not_configured`` handling: stdio needs a command;
+    the hosted Copilot endpoint needs an auth token; other HTTP endpoints need a URL.
+    """
+    if config.mode == "stdio":
+        return bool(config.command.strip())
+    if config.auth_token.strip():
+        return True
+    if _is_github_copilot_host(config.url):
+        return False
+    return bool(config.url.strip())
+
+
+def github_integration_is_configured() -> bool:
+    """Return True when GitHub MCP is configured with usable store or env credentials."""
+    from integrations.store import get_integration
+
+    record = get_integration("github")
+    if record is not None:
+        credentials = record.get("credentials") or {}
+        if github_mcp_is_usably_configured(build_github_mcp_config(credentials)):
+            return True
+    env_config = github_mcp_config_from_env()
+    return env_config is not None and github_mcp_is_usably_configured(env_config)
+
+
 @asynccontextmanager
 async def _open_github_mcp_session(config: GitHubMCPConfig) -> AsyncIterator[ClientSession]:
     stack = AsyncExitStack()

--- a/platform/analytics/cli.py
+++ b/platform/analytics/cli.py
@@ -483,6 +483,20 @@ def capture_integration_verified(service: str) -> None:
     _capture(Event.INTEGRATION_VERIFIED, _integration_lifecycle_properties(service))
 
 
+def identify_saved_github_username() -> None:
+    """Re-attach a previously saved GitHub handle to PostHog for this process.
+
+    The integration store persists ``credentials.username`` across REPL sessions
+    (used by the welcome banner), but analytics persistent properties are
+    in-memory per CLI process. Call at REPL boot so events like
+    ``$ai_generation`` include ``github_username`` without requiring a fresh
+    device-flow login each session.
+    """
+    from integrations.github_login import saved_github_username
+
+    identify_github_username(saved_github_username())
+
+
 def identify_github_username(username: str) -> None:
     """Attach the authenticated GitHub username to PostHog.
 

--- a/platform/analytics/cli.py
+++ b/platform/analytics/cli.py
@@ -492,7 +492,7 @@ def identify_saved_github_username() -> None:
     ``$ai_generation`` include ``github_username`` without requiring a fresh
     device-flow login each session.
     """
-    from integrations.github_login import saved_github_username
+    from integrations.github_identity import saved_github_username
 
     identify_github_username(saved_github_username())
 

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -87,6 +87,32 @@ def test_identify_github_username_noop_on_empty(monkeypatch: pytest.MonkeyPatch)
     assert stub.identified == []
 
 
+def test_identify_saved_github_username_reads_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubAnalytics()
+    monkeypatch.setattr(cli, "get_analytics", lambda: stub)
+    monkeypatch.setattr(
+        "integrations.github_login.saved_github_username",
+        lambda: "octocat",
+    )
+
+    cli.identify_saved_github_username()
+
+    assert stub.identified == [{"github_username": "octocat"}]
+    assert stub.persistent_properties == {"github_username": "octocat"}
+
+
+def test_identify_saved_github_username_noop_when_store_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubAnalytics()
+    monkeypatch.setattr(cli, "get_analytics", lambda: stub)
+    monkeypatch.setattr("integrations.github_login.saved_github_username", lambda: "")
+
+    cli.identify_saved_github_username()
+
+    assert stub.identified == []
+
+
 def test_identify_github_username_reports_failures_to_sentry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -91,7 +91,7 @@ def test_identify_saved_github_username_reads_store(monkeypatch: pytest.MonkeyPa
     stub = _StubAnalytics()
     monkeypatch.setattr(cli, "get_analytics", lambda: stub)
     monkeypatch.setattr(
-        "integrations.github_login.saved_github_username",
+        "integrations.github_identity.saved_github_username",
         lambda: "octocat",
     )
 
@@ -106,7 +106,7 @@ def test_identify_saved_github_username_noop_when_store_empty(
 ) -> None:
     stub = _StubAnalytics()
     monkeypatch.setattr(cli, "get_analytics", lambda: stub)
-    monkeypatch.setattr("integrations.github_login.saved_github_username", lambda: "")
+    monkeypatch.setattr("integrations.github_identity.saved_github_username", lambda: "")
 
     cli.identify_saved_github_username()
 

--- a/tests/cli/interactive_shell/runtime/test_entrypoint_integrations.py
+++ b/tests/cli/interactive_shell/runtime/test_entrypoint_integrations.py
@@ -199,12 +199,46 @@ def test_gate_error_allows_startup_with_bypass(monkeypatch: Any) -> None:
     assert entrypoint._maybe_require_github_login(_console()) is True
 
 
+def test_repl_main_identifies_saved_github_username(monkeypatch: Any) -> None:
+    identified: list[str] = []
+    monkeypatch.setattr(
+        "platform.analytics.cli.identify_saved_github_username",
+        lambda: identified.append("called"),
+    )
+    monkeypatch.setattr(entrypoint, "_hydrate_configured_integrations", lambda _session: None)
+    monkeypatch.setattr(entrypoint, "run_initial_input", lambda *_args, **_kwargs: 0)
+
+    class _Session:
+        active_theme_name = None
+
+        def warm_resolved_integrations(self) -> None:
+            return None
+
+    monkeypatch.setattr(entrypoint, "ReplSession", _Session)
+    monkeypatch.setattr(
+        entrypoint.TaskRegistry,
+        "persistent",
+        staticmethod(lambda: None),
+    )
+    monkeypatch.setattr(
+        entrypoint._prompt_surface,
+        "_build_prompt_session",
+        lambda: type("P", (), {"history": None})(),
+    )
+
+    import asyncio
+
+    asyncio.run(entrypoint.repl_main(initial_input="hello"))
+
+    assert identified == ["called"]
+
+
 def test_explicit_bypass_detects_skip_env(monkeypatch: Any) -> None:
     monkeypatch.setenv("OPENSRE_SKIP_GITHUB_LOGIN", "1")
     assert entrypoint._github_login_explicitly_bypassed() is True
 
 
-def test_explicit_bypass_detects_ineligible_os(monkeypatch: Any) -> None:
+def test_explicit_bypass_detects_ci_environment(monkeypatch: Any) -> None:
     monkeypatch.delenv("OPENSRE_SKIP_GITHUB_LOGIN", raising=False)
-    monkeypatch.setattr(entrypoint.platform, "system", lambda: "Linux")
+    monkeypatch.setenv("CI", "true")
     assert entrypoint._github_login_explicitly_bypassed() is True

--- a/tests/cli/interactive_shell/ui/test_banner.py
+++ b/tests/cli/interactive_shell/ui/test_banner.py
@@ -96,6 +96,21 @@ def test_github_username_empty_when_not_configured(monkeypatch: object) -> None:
     assert banner_module._github_username() == ""
 
 
+def test_github_username_survives_identity_import_failure(monkeypatch: object) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fail_github_identity(name: str, *args: object, **kwargs: object) -> object:
+        if name == "integrations.github_identity":
+            raise ImportError("simulated heavy import failure")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fail_github_identity)
+
+    assert banner_module._github_username() == ""
+
+
 def test_ambient_column_marks_incomplete_integration(monkeypatch: object) -> None:
     # A hosted MCP record saved without an API token is "present" but cannot
     # connect; the banner must mark it rather than imply it works.

--- a/tests/cli/test_first_launch_github.py
+++ b/tests/cli/test_first_launch_github.py
@@ -9,7 +9,9 @@ from cli import first_launch_github as flg
 from cli.interactive_shell.ui.theme import DEVICE_CODE_ANSI
 from integrations import github_login as github_login_mod
 from integrations.github_login import GitHubLoginResult
+from integrations.github_mcp import DEFAULT_GITHUB_MCP_TOOLSETS, DEFAULT_GITHUB_MCP_URL
 from integrations.github_mcp_oauth import GitHubDeviceCode
+from platform.analytics import source as analytics_source
 
 
 def _console() -> Console:
@@ -23,7 +25,6 @@ def _terminal_console(output: io.StringIO) -> Console:
 def _force_required(monkeypatch: pytest.MonkeyPatch) -> None:
     """Set every gate input so that login would be required."""
     monkeypatch.delenv("OPENSRE_SKIP_GITHUB_LOGIN", raising=False)
-    monkeypatch.setattr(flg, "_eligible_os", lambda: True)
     monkeypatch.setattr(flg, "is_test_run", lambda: False)
     monkeypatch.setattr(flg, "repl_tty_interactive", lambda: True)
     monkeypatch.setattr(flg, "_github_already_configured", lambda: False)
@@ -41,16 +42,15 @@ def test_gate_skipped_by_env(monkeypatch: pytest.MonkeyPatch, value: str) -> Non
     assert flg.should_require_github_login() is False
 
 
-def test_gate_skipped_on_ineligible_os(monkeypatch: pytest.MonkeyPatch) -> None:
-    _force_required(monkeypatch)
-    monkeypatch.setattr(flg, "_eligible_os", lambda: False)
-    assert flg.should_require_github_login() is False
-
-
 def test_gate_skipped_in_test_run(monkeypatch: pytest.MonkeyPatch) -> None:
     _force_required(monkeypatch)
     monkeypatch.setattr(flg, "is_test_run", lambda: True)
     assert flg.should_require_github_login() is False
+
+
+def test_gate_required_on_linux_when_interactive(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_required(monkeypatch)
+    assert flg.should_require_github_login() is True
 
 
 def test_gate_skipped_when_not_tty(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -75,12 +75,49 @@ def test_gate_required_when_github_not_configured(monkeypatch: pytest.MonkeyPatc
 
 
 @pytest.mark.parametrize(
-    "system,expected",
-    [("Darwin", True), ("Windows", True), ("Linux", False), ("FreeBSD", False)],
+    "ci_env",
+    [
+        ("CI", "true"),
+        ("GITHUB_ACTIONS", "true"),
+        ("OPENSRE_IS_TEST", "1"),
+    ],
 )
-def test_eligible_os(monkeypatch: pytest.MonkeyPatch, system: str, expected: bool) -> None:
-    monkeypatch.setattr(flg.platform, "system", lambda: system)
-    assert flg._eligible_os() is expected
+def test_gate_skipped_in_ci_like_environment(
+    monkeypatch: pytest.MonkeyPatch, ci_env: tuple[str, str]
+) -> None:
+    monkeypatch.delenv("OPENSRE_SKIP_GITHUB_LOGIN", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("OPENSRE_IS_TEST", raising=False)
+    monkeypatch.delenv("OPENSRE_INVESTIGATION_SOURCE", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(flg, "is_test_run", analytics_source.is_test_run)
+    monkeypatch.setattr(flg, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(flg, "_github_already_configured", lambda: False)
+    monkeypatch.setenv(ci_env[0], ci_env[1])
+    assert flg.should_require_github_login() is False
+
+
+def test_gate_required_when_stale_github_store_record_has_no_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy installs may have an abandoned github store row without credentials."""
+    _force_required(monkeypatch)
+    monkeypatch.setattr(
+        "integrations.store.get_integration",
+        lambda service: (
+            {
+                "credentials": {
+                    "mode": "streamable-http",
+                    "url": DEFAULT_GITHUB_MCP_URL,
+                    "toolsets": list(DEFAULT_GITHUB_MCP_TOOLSETS),
+                }
+            }
+            if service == "github"
+            else None
+        ),
+    )
+    assert flg.should_require_github_login() is True
 
 
 def test_device_code_prompt_highlights_user_code(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -107,15 +144,12 @@ def test_orchestrator_success_proceeds_and_propagates(monkeypatch: pytest.Monkey
         "authenticate_and_configure_github",
         lambda **_kwargs: GitHubLoginResult(ok=True, username="octocat", detail="OK"),
     )
-    identified: list[str] = []
     completed: list[str] = []
-    monkeypatch.setattr(flg, "identify_github_username", identified.append)
     monkeypatch.setattr(flg, "capture_github_login_completed", completed.append)
 
     proceed = flg.require_github_login_on_first_launch(_console())
 
     assert proceed is True
-    assert identified == ["octocat"]
     assert completed == ["octocat"]
 
 
@@ -154,7 +188,6 @@ def test_orchestrator_retries_until_success(monkeypatch: pytest.MonkeyPatch) -> 
 
     monkeypatch.setattr(github_login_mod, "authenticate_and_configure_github", _login)
     monkeypatch.setattr(flg, "_ask_retry", lambda _console: True)
-    monkeypatch.setattr(flg, "identify_github_username", lambda _username: None)
     monkeypatch.setattr(flg, "capture_github_login_completed", lambda _username: None)
 
     proceed = flg.require_github_login_on_first_launch(_console())

--- a/tests/integrations/test_github_login.py
+++ b/tests/integrations/test_github_login.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from integrations import github_login
+from integrations.github_identity import saved_github_username
 from integrations.github_login import GitHubLoginResult
 from integrations.github_mcp import GitHubMCPValidationResult
 from integrations.github_mcp_oauth import GitHubDeviceToken
@@ -86,10 +87,10 @@ def test_saved_github_username_reads_integration_store(monkeypatch: pytest.Monke
         lambda service: {"credentials": {"username": "octocat"}} if service == "github" else None,
     )
 
-    assert github_login.saved_github_username() == "octocat"
+    assert saved_github_username() == "octocat"
 
 
 def test_saved_github_username_empty_when_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("integrations.store.get_integration", lambda _service: None)
 
-    assert github_login.saved_github_username() == ""
+    assert saved_github_username() == ""

--- a/tests/integrations/test_github_login.py
+++ b/tests/integrations/test_github_login.py
@@ -27,6 +27,11 @@ def test_authenticate_and_configure_github_happy_path(monkeypatch: pytest.Monkey
         "upsert_integration",
         lambda service, entry: saved.append((service, entry)),
     )
+    identified: list[str] = []
+    monkeypatch.setattr(
+        "platform.analytics.cli.identify_github_username",
+        lambda username: identified.append(username),
+    )
 
     result = github_login.authenticate_and_configure_github()
 
@@ -42,6 +47,7 @@ def test_authenticate_and_configure_github_happy_path(monkeypatch: pytest.Monkey
     # The resolved GitHub login is persisted as a non-secret field so the
     # welcome banner can greet the user by their GitHub handle.
     assert credentials["username"] == "octocat"
+    assert identified == ["octocat"]
 
 
 def test_authenticate_and_configure_github_validation_failure_does_not_save(
@@ -72,3 +78,18 @@ def test_authenticate_and_configure_github_validation_failure_does_not_save(
     assert result.username == "octocat"
     assert result.detail == "missing tools"
     assert saved == []
+
+
+def test_saved_github_username_reads_integration_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "integrations.store.get_integration",
+        lambda service: {"credentials": {"username": "octocat"}} if service == "github" else None,
+    )
+
+    assert github_login.saved_github_username() == "octocat"
+
+
+def test_saved_github_username_empty_when_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("integrations.store.get_integration", lambda _service: None)
+
+    assert github_login.saved_github_username() == ""

--- a/tests/integrations/test_github_mcp_validation.py
+++ b/tests/integrations/test_github_mcp_validation.py
@@ -852,3 +852,68 @@ def test_print_github_mcp_validation_report_success_and_failure() -> None:
     fail_text = fail_console.export_text()
     assert "validation failed" in fail_text.lower()
     assert "connection reset" in fail_text
+
+
+def test_github_mcp_is_usably_configured_requires_token_for_hosted_copilot() -> None:
+    config = github_mcp_module.build_github_mcp_config(
+        {
+            "mode": "streamable-http",
+            "url": github_mcp_module.DEFAULT_GITHUB_MCP_URL,
+            "auth_token": "",
+        }
+    )
+    assert github_mcp_module.github_mcp_is_usably_configured(config) is False
+
+
+def test_github_mcp_is_usably_configured_accepts_hosted_copilot_with_token() -> None:
+    config = github_mcp_module.build_github_mcp_config(
+        {
+            "mode": "streamable-http",
+            "url": github_mcp_module.DEFAULT_GITHUB_MCP_URL,
+            "auth_token": "gho_test",
+        }
+    )
+    assert github_mcp_module.github_mcp_is_usably_configured(config) is True
+
+
+def test_github_integration_is_configured_ignores_stale_store_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "integrations.store.get_integration",
+        lambda service: (
+            {
+                "credentials": {
+                    "mode": "streamable-http",
+                    "url": github_mcp_module.DEFAULT_GITHUB_MCP_URL,
+                }
+            }
+            if service == "github"
+            else None
+        ),
+    )
+    monkeypatch.setattr(github_mcp_module, "github_mcp_config_from_env", lambda: None)
+
+    assert github_mcp_module.github_integration_is_configured() is False
+
+
+def test_github_integration_is_configured_true_when_store_has_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "integrations.store.get_integration",
+        lambda service: (
+            {
+                "credentials": {
+                    "mode": "streamable-http",
+                    "url": github_mcp_module.DEFAULT_GITHUB_MCP_URL,
+                    "auth_token": "gho_test",
+                }
+            }
+            if service == "github"
+            else None
+        ),
+    )
+    monkeypatch.setattr(github_mcp_module, "github_mcp_config_from_env", lambda: None)
+
+    assert github_mcp_module.github_integration_is_configured() is True


### PR DESCRIPTION
## Summary

- Remove the macOS/Windows-only exemption so interactive Linux users hit the first-launch GitHub device-flow gate; CI/CD (`CI`, `GITHUB_ACTIONS`), pytest, non-TTY, and `OPENSRE_SKIP_GITHUB_LOGIN=1` remain exempt via `is_test_run()`.
- Re-stamp `github_username` on PostHog events at REPL boot by reading the saved handle from the integration store (`identify_saved_github_username`), matching what the welcome banner already uses.
- Call `identify_github_username` after every GitHub setup path: device-flow login, `integrations setup github`, and onboarding wizard (wizard now also persists `credentials.username`).
- Tighten the first-launch GitHub gate so stale store rows without usable credentials (e.g. hosted Copilot URL but no auth token) no longer bypass sign-in — legacy installs without real GitHub config get prompted on all platforms.

Fixes #3132
Fixes #3133

## Test plan

- [x] `pytest tests/cli/test_first_launch_github.py`
- [x] `pytest tests/integrations/test_github_login.py tests/integrations/test_github_mcp_validation.py -k github_integration`
- [x] `pytest tests/analytics/test_cli.py -k github`
- [x] `make lint` and `make format-check`
- [ ] Manual: launch `opensre` on Linux without GitHub configured → confirm device-flow login gate appears
- [x] Manual: launch `opensre` with saved GitHub username → confirm `$ai_generation` events include `properties.github_username`
- [x] Manual: remove GitHub token from store row → confirm interactive REPL prompts for device-flow sign-in