### PR TITLE
fix(release): use --add-data instead of --collect-submodules for platform package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,7 +248,7 @@ jobs:
           --noconfirm
           --collect-data cli
           --collect-data config
-          --collect-submodules platform
+          --add-data "platform:platform"
 
       - name: Smoke test binary (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Problem

The merged PR #3119 added `--collect-submodules platform` to PyInstaller, but this doesn't work for `--onefile` builds. `--collect-submodules` stores modules in PYZ (in-memory bytecode), while `config/platform_bootstrap.py` uses `importlib.util.spec_from_file_location` which needs raw source files on disk.

## Fix

Replace `--collect-submodules platform` with `--add-data "platform:platform"`, which ensures the entire `platform/` directory is extracted to `_MEIPASS` at runtime as raw files.