### PR TITLE
fix(release): bundle stdlib platform.py so the binary smoke test passes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,18 @@ jobs:
         shell: bash
         run: uv sync --frozen --extra release-binary
 
+      - name: Stage stdlib platform module for bundling
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The first-party ``platform`` package shadows the stdlib ``platform``
+          # module. PyInstaller does not lay out the stdlib as loose ``.py`` files,
+          # so bundle a copy of the genuine module that platform/__init__.py can
+          # load from ``sys._MEIPASS`` at runtime (see _FROZEN_STDLIB_DIR).
+          rm -rf .stdlib_vendor
+          mkdir -p .stdlib_vendor
+          uv run python -c "import os, shutil, sysconfig; src = os.path.join(sysconfig.get_path('stdlib'), 'platform.py'); shutil.copy(src, os.path.join('.stdlib_vendor', 'platform.py')); print('Staged stdlib platform from ' + src)"
+
       - name: Build binary
         run: >-
           uv run pyinstaller cli/__main__.py
@@ -249,6 +261,7 @@ jobs:
           --collect-data cli
           --collect-data config
           --add-data "platform:platform"
+          --add-data ".stdlib_vendor:_opensre_stdlib_platform"
 
       - name: Smoke test binary (Unix)
         if: runner.os != 'Windows'

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ __pycache__/
 build/
 develop-eggs/
 dist/
+.stdlib_vendor/
+# PyInstaller generates this from CLI args during the release build.
+opensre.spec
 downloads/
 eggs/
 .eggs/

--- a/platform/__init__.py
+++ b/platform/__init__.py
@@ -9,30 +9,62 @@ such as ``platform.analytics``.
 from __future__ import annotations
 
 import importlib.util
+import os
+import sys
 import sysconfig
 from pathlib import Path
 
+# Directory (relative to ``sys._MEIPASS``) where the release build stages a copy
+# of the genuine stdlib ``platform.py``. PyInstaller does not lay out the stdlib
+# as loose ``.py`` files on disk, and this package shadows the ``platform`` name,
+# so the frozen binary cannot otherwise reach the real module. The release
+# workflow bundles it here; keep this constant in sync with that ``--add-data``
+# destination.
+_FROZEN_STDLIB_DIR = "_opensre_stdlib_platform"
+
+
+def _candidate_stdlib_platform_paths() -> list[Path]:
+    """Return the locations to probe for the genuine stdlib ``platform.py``."""
+    candidates: list[Path] = []
+
+    # Frozen builds (PyInstaller): a copy bundled into the extracted data tree.
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        candidates.append(Path(meipass) / _FROZEN_STDLIB_DIR / "platform.py")
+
+    # Regular source checkout / installed interpreter.
+    stdlib_dir = sysconfig.get_path("stdlib")
+    if stdlib_dir:
+        candidates.append(Path(stdlib_dir) / "platform.py")
+
+    # Last resort: sit next to another known stdlib module on disk.
+    os_file = getattr(os, "__file__", None)
+    if os_file:
+        candidates.append(Path(os_file).resolve().parent / "platform.py")
+
+    return candidates
+
 
 def _load_stdlib_platform():
-    """Load the stdlib ``platform`` module.
+    """Load the genuine stdlib ``platform`` module.
 
-    PyInstaller patches ``sysconfig`` in frozen builds so
-    ``sysconfig.get_path("stdlib")`` resolves correctly inside the bundled
-    Python stdlib without any special handling here.
+    This package intentionally shadows the stdlib ``platform`` name, so the real
+    module is loaded directly from its source file. In frozen builds the stdlib
+    is not available as loose ``.py`` files, so the release build bundles a copy
+    that we load from ``sys._MEIPASS`` (see ``_FROZEN_STDLIB_DIR``).
     """
-    stdlib_dir = sysconfig.get_path("stdlib")
-    if stdlib_dir is not None and (Path(stdlib_dir) / "platform.py").is_file():
-        stdlib_path = Path(stdlib_dir) / "platform.py"
+    candidates = _candidate_stdlib_platform_paths()
+    for stdlib_path in candidates:
+        if not stdlib_path.is_file():
+            continue
         spec = importlib.util.spec_from_file_location("_opensre_stdlib_platform", stdlib_path)
         if spec is not None and spec.loader is not None:
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
             return module
 
-    raise ImportError(
-        "Unable to load stdlib platform module — sysconfig path "
-        f"{stdlib_dir!r} does not contain platform.py"
-    )
+    checked = ", ".join(repr(str(path)) for path in candidates) or "<no candidate paths>"
+    raise ImportError(f"Unable to load stdlib platform module — checked: {checked}")
 
 
 _stdlib_platform = _load_stdlib_platform()

--- a/tests/packaging/test_platform_stdlib_loader.py
+++ b/tests/packaging/test_platform_stdlib_loader.py
@@ -1,0 +1,80 @@
+"""Regression tests for the frozen-binary stdlib ``platform`` loader.
+
+The first-party ``platform`` package shadows the stdlib ``platform`` module and
+re-exports its API. In a PyInstaller onefile build the stdlib is not laid out as
+loose ``.py`` files, so the release workflow bundles a copy of ``platform.py``
+that ``platform/__init__.py`` loads from ``sys._MEIPASS``. These tests guard that
+contract so the binary smoke test cannot silently regress again.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from config.platform_bootstrap import ensure_project_platform_package
+
+ensure_project_platform_package()
+
+import platform as _platform_pkg  # noqa: E402  (first-party package after bootstrap)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+_FROZEN_STDLIB_DIR = _platform_pkg._FROZEN_STDLIB_DIR
+_candidate_stdlib_platform_paths = _platform_pkg._candidate_stdlib_platform_paths
+_load_stdlib_platform = _platform_pkg._load_stdlib_platform
+
+_BUNDLED_PLATFORM_SOURCE = "OPENSRE_BUNDLED_MARKER = 'bundled'\n"
+
+
+def test_first_party_platform_is_a_package_proxying_stdlib() -> None:
+    """The shadowing package must still expose the stdlib platform API."""
+    assert hasattr(_platform_pkg, "__path__")  # it is a package
+    assert _platform_pkg.system()  # stdlib API copied in
+    assert _platform_pkg.python_version()
+
+
+def test_candidate_paths_prioritize_meipass(monkeypatch, tmp_path) -> None:
+    """Frozen builds must probe the bundled copy under ``sys._MEIPASS`` first."""
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+
+    candidates = _candidate_stdlib_platform_paths()
+
+    assert candidates[0] == tmp_path / _FROZEN_STDLIB_DIR / "platform.py"
+
+
+def test_candidate_paths_without_meipass_resolve_real_stdlib(monkeypatch) -> None:
+    """Source checkouts must still resolve the genuine stdlib ``platform.py``."""
+    monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+    candidates = _candidate_stdlib_platform_paths()
+
+    assert candidates  # at least the sysconfig location
+    assert any(path.is_file() for path in candidates)
+
+
+def test_load_stdlib_platform_uses_bundled_copy_when_frozen(monkeypatch, tmp_path) -> None:
+    """When frozen, the loader must read the bundled copy, not a system path."""
+    bundled_dir = tmp_path / _FROZEN_STDLIB_DIR
+    bundled_dir.mkdir()
+    (bundled_dir / "platform.py").write_text(_BUNDLED_PLATFORM_SOURCE, encoding="utf-8")
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+
+    module = _load_stdlib_platform()
+
+    assert getattr(module, "OPENSRE_BUNDLED_MARKER", None) == "bundled"
+
+
+def test_release_workflow_bundles_stdlib_platform() -> None:
+    """The release build must stage and bundle ``platform.py`` for the binary.
+
+    This ties the workflow's ``--add-data`` destination to ``_FROZEN_STDLIB_DIR``
+    so renaming the constant without updating the workflow fails fast instead of
+    only surfacing as a release-time binary crash.
+    """
+    workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "platform.py" in workflow  # staging step copies the stdlib module
+    assert ".stdlib_vendor" in workflow  # staged into a relative dir
+    assert _FROZEN_STDLIB_DIR in workflow  # bundled under the loader's dest dir


### PR DESCRIPTION
## Summary

The **Release** workflow has been failing on `main` (every `workflow_dispatch` run) at the **"Smoke test binary"** step on **all** platforms (macOS arm64/x64, Linux arm64, Windows). The freshly built onefile binary crashes on `opensre --version`:

```
ImportError: Unable to load stdlib platform module — sysconfig path
'.../T/_MEI.../lib/python3.13' does not contain platform.py
```

**Root cause:** the first-party `platform/` package (added in #3067) shadows the stdlib `platform` module and re-exports its API by loading the stdlib source at import time (`platform/__init__.py::_load_stdlib_platform`). That loader assumed `sysconfig.get_path("stdlib")/platform.py` exists in frozen builds — but PyInstaller does **not** lay out the stdlib as loose `.py` files, and because the first-party package wins the `platform` name during analysis, the genuine `platform.py` is bundled **nowhere** (verified via `PYZ-00.toc` + `base_library.zip`). So the lookup could never succeed and `opensre --version` aborted before doing anything.

## Fix

- **Build:** stage a copy of the genuine stdlib `platform.py` and bundle it under `_opensre_stdlib_platform/` via `--add-data` (relative path → no Windows drive-colon ambiguity).
- **Runtime:** `_load_stdlib_platform()` now probes `sys._MEIPASS/_opensre_stdlib_platform/platform.py` first in frozen builds, then falls back to the sysconfig stdlib path (source checkouts) and an `os.__file__`-relative last resort.
- **Tests:** add `tests/packaging/test_platform_stdlib_loader.py` covering loader path ordering, loading from a bundled copy, and a drift guard tying the workflow's `--add-data` destination to `_FROZEN_STDLIB_DIR`.

## Test plan

- [x] Reproduced the crash locally: built the onefile binary with the exact workflow command → `opensre --version` raised the same `ImportError`.
- [x] After the fix, rebuilt the binary → `./dist/opensre --version` prints `opensre, version 0.1` (exit 0) and `./dist/opensre -h` exits 0 (exact CI smoke-test invocations).
- [x] `make lint` — passes
- [x] `make typecheck` — passes (894 files)
- [x] `make test-cli-smoke` — 16 passed, 1 skipped
- [x] `tests/packaging/test_platform_stdlib_loader.py` — 5 passed
- [ ] Confirm green on the Release workflow's `build-binaries` matrix (all OSes) after merge / via `workflow_dispatch`.

> Note: this PR addresses the deterministic, all-platform **Release (CD)** failure. The separate, intermittent `Routing Live` flake on `shard 2` (`501-nitro-connect-then-investigate`, a live-LLM scenario) is not touched here, per the live-routing policy against forcing/disabling live scenarios.

Made with [Cursor](https://cursor.com)