### PR TITLE
fix(github): strip username metadata before MCP config validation

### DIFF
--- a/integrations/github_mcp.py
+++ b/integrations/github_mcp.py
@@ -37,6 +37,9 @@ DEFAULT_GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/"
 DEFAULT_GITHUB_MCP_MODE = "streamable-http"
 DEFAULT_GITHUB_MCP_TOOLSETS = ("repos", "issues", "pull_requests", "actions", "search")
 
+# Non-transport metadata persisted alongside MCP credentials in the integration store.
+_CREDENTIAL_METADATA_KEYS: frozenset[str] = frozenset({"username"})
+
 REQUIRED_SOURCE_INVESTIGATION_TOOLS = (
     "get_file_contents",
     "get_repository_tree",
@@ -411,8 +414,10 @@ def format_github_mcp_validation_cli_report(result: GitHubMCPValidationResult) -
 
 def build_github_mcp_config(raw: dict[str, Any] | None) -> GitHubMCPConfig:
     """Build a normalized config object from env/store data."""
-
-    return GitHubMCPConfig.model_validate(raw or {})
+    data = dict(raw or {})
+    for key in _CREDENTIAL_METADATA_KEYS:
+        data.pop(key, None)
+    return GitHubMCPConfig.model_validate(data)
 
 
 def github_mcp_config_from_env() -> GitHubMCPConfig | None:
@@ -464,9 +469,19 @@ def github_integration_is_configured() -> bool:
     record = get_integration("github")
     if record is not None:
         credentials = record.get("credentials") or {}
-        if github_mcp_is_usably_configured(build_github_mcp_config(credentials)):
-            return True
-    env_config = github_mcp_config_from_env()
+        try:
+            if github_mcp_is_usably_configured(build_github_mcp_config(credentials)):
+                return True
+        except Exception:
+            logger.warning(
+                "Ignoring invalid GitHub integration credentials in store",
+                exc_info=True,
+            )
+    try:
+        env_config = github_mcp_config_from_env()
+    except Exception:
+        logger.warning("Ignoring invalid GitHub MCP env configuration", exc_info=True)
+        return False
     return env_config is not None and github_mcp_is_usably_configured(env_config)
 
 

--- a/tests/integrations/test_github_mcp_validation.py
+++ b/tests/integrations/test_github_mcp_validation.py
@@ -876,6 +876,42 @@ def test_github_mcp_is_usably_configured_accepts_hosted_copilot_with_token() -> 
     assert github_mcp_module.github_mcp_is_usably_configured(config) is True
 
 
+def test_build_github_mcp_config_strips_persisted_username_metadata() -> None:
+    config = github_mcp_module.build_github_mcp_config(
+        {
+            "mode": "streamable-http",
+            "url": github_mcp_module.DEFAULT_GITHUB_MCP_URL,
+            "auth_token": "gho_test",
+            "username": "octocat",
+        }
+    )
+    assert config.auth_token == "gho_test"
+    assert "username" not in config.model_fields_set
+
+
+def test_github_integration_is_configured_true_when_store_has_token_and_username(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "integrations.store.get_integration",
+        lambda service: (
+            {
+                "credentials": {
+                    "mode": "streamable-http",
+                    "url": github_mcp_module.DEFAULT_GITHUB_MCP_URL,
+                    "auth_token": "gho_test",
+                    "username": "octocat",
+                }
+            }
+            if service == "github"
+            else None
+        ),
+    )
+    monkeypatch.setattr(github_mcp_module, "github_mcp_config_from_env", lambda: None)
+
+    assert github_mcp_module.github_integration_is_configured() is True
+
+
 def test_github_integration_is_configured_ignores_stale_store_record(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Strip persisted `credentials.username` before validating GitHub MCP config (`StrictConfigModel` forbids unknown fields).
- Harden `github_integration_is_configured()` so invalid store/env credentials log a warning and are treated as unconfigured instead of crashing the REPL login gate.

Fixes #3141

## Test plan

- [x] `pytest tests/integrations/test_github_mcp_validation.py -k username`
- [x] `pytest tests/cli/test_first_launch_github.py`
- [ ] Manual: launch `opensre` with saved GitHub token + `username` in `~/.opensre/integrations.json` → REPL starts without gate crash