### PR TITLE
fix(platform): handle frozen PyInstaller builds in stdlib platform loading

### DIFF
--- a/platform/__init__.py
+++ b/platform/__init__.py
@@ -9,17 +9,40 @@ such as ``platform.analytics``.
 from __future__ import annotations
 
 import importlib.util
+import sys
 import sysconfig
 from pathlib import Path
+
+
+def _is_frozen() -> bool:
+    """Check if running in a PyInstaller frozen build."""
+    return getattr(sys, "frozen", False)
 
 
 def _load_stdlib_platform():
     """Load the stdlib ``platform`` module.
 
-    PyInstaller patches ``sysconfig`` in frozen builds so
-    ``sysconfig.get_path("stdlib")`` resolves correctly inside the bundled
-    Python stdlib without any special handling here.
+    In frozen PyInstaller builds, the stdlib ``platform`` module is a
+    built-in/frozen module not available as a ``.py`` file. Handle both
+    frozen and non-frozen environments.
     """
+    # In frozen builds, try importing the stdlib platform directly by
+    # temporarily removing our package from sys.modules
+    if _is_frozen():
+        # Save and remove our platform package from sys.modules
+        our_platform = sys.modules.pop("platform", None)
+        try:
+            import platform as stdlib_platform
+
+            return stdlib_platform
+        except ImportError:
+            pass
+        finally:
+            # Restore our platform package
+            if our_platform is not None:
+                sys.modules["platform"] = our_platform
+
+    # Non-frozen: load from stdlib file path
     stdlib_dir = sysconfig.get_path("stdlib")
     if stdlib_dir is not None and (Path(stdlib_dir) / "platform.py").is_file():
         stdlib_path = Path(stdlib_dir) / "platform.py"


### PR DESCRIPTION
This pull request updates the logic for loading the standard library `platform` module to better handle both frozen (PyInstaller) and non-frozen environments. The main improvement is robust detection and loading of the stdlib `platform` module when running in a PyInstaller-built executable.

Enhancements for frozen (PyInstaller) and non-frozen environments:

* Added the `_is_frozen` helper function to detect if the application is running in a PyInstaller frozen build.
* Updated `_load_stdlib_platform` to import the stdlib `platform` module directly in frozen builds by temporarily removing the package from `sys.modules`, and to fall back to loading from the stdlib file path in non-frozen environments.