### PR TITLE
feat(interactive-shell): infer GitHub repo scope for tool gathering

### DIFF
--- a/cli/interactive_shell/chat/tool_gathering.py
+++ b/cli/interactive_shell/chat/tool_gathering.py
@@ -23,16 +23,25 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 from typing import Any
 
 from rich.console import Console
 from rich.markup import escape
 
 from cli.interactive_shell.runtime.session import ReplSession
+from cli.interactive_shell.state.conversation_history import (
+    NO_HISTORY_PLACEHOLDER,
+    format_recent_conversation,
+)
 from cli.interactive_shell.ui import DIM
 from cli.interactive_shell.ui.output.tool_details import tool_short_label, tool_source_label
 from cli.interactive_shell.utils.error_handling.exception_reporting import report_exception
 from core.domain.alerts.alert_source import SECONDARY_TOOL_SOURCES
+from tools.utils.github_repo_scope import (
+    apply_github_repo_scope,
+    infer_github_repo_scope,
+)
 
 # Keep the gathering loop short: this runs inline on a REPL turn, so it must stay
 # responsive. A handful of iterations is enough to fetch the data needed to
@@ -199,6 +208,29 @@ def _build_gather_system_prompt(session: ReplSession) -> str:
     )
 
 
+def _resolve_gather_integrations(session: ReplSession, message: str) -> dict[str, Any]:
+    """Resolve integrations for one gather turn, enriching GitHub repo scope when inferred."""
+    base = _resolve_session_integrations(session)
+    scope = infer_github_repo_scope(
+        message=message,
+        conversation_messages=session.cli_agent_messages,
+        env=os.environ,
+        cwd=os.getcwd(),
+        cached=session.github_repo_scope,
+    )
+    if scope:
+        session.github_repo_scope = scope
+        return apply_github_repo_scope(base, scope[0], scope[1])
+    return base
+
+
+def _build_gather_user_message(session: ReplSession, message: str) -> str:
+    history = format_recent_conversation(session, max_turns=3)
+    if history == NO_HISTORY_PLACEHOLDER:
+        return message
+    return f"Recent conversation:\n{history}\n\nCurrent question:\n{message}"
+
+
 def gather_tool_evidence(
     message: str,
     session: ReplSession,
@@ -218,7 +250,7 @@ def gather_tool_evidence(
         from core.runtime import run_tool_calling_loop
         from services.agent_llm_client import get_agent_llm
 
-        resolved = _resolve_session_integrations(session)
+        resolved = _resolve_gather_integrations(session, message)
         tools = get_available_tools(resolved)
         if not tools:
             return None
@@ -249,7 +281,7 @@ def gather_tool_evidence(
         result = run_tool_calling_loop(
             llm=llm,
             system=_build_gather_system_prompt(session),
-            messages=[{"role": "user", "content": message}],
+            messages=[{"role": "user", "content": _build_gather_user_message(session, message)}],
             tools=tools,
             resolved_integrations=resolved,
             max_iterations=_MAX_GATHER_ITERATIONS,

--- a/cli/interactive_shell/harness/tests/scenarios/complex_shell_prompts/341-github-issues-repo-url-gather.yml
+++ b/cli/interactive_shell/harness/tests/scenarios/complex_shell_prompts/341-github-issues-repo-url-gather.yml
@@ -1,0 +1,49 @@
+id: 341-github-issues-repo-url-gather
+title: GitHub issue lookup gathers when repo URL is supplied inline without stored owner/repo
+intent_class: complex_shell_prompts
+input:
+  prompt: check github issues for windows crashes in https://github.com/Tracer-Cloud/opensre
+session:
+  has_prior_state: false
+  configured_integrations:
+  - github
+  resolved_integrations:
+    github:
+      connection_verified: true
+      mode: streamable-http
+      url: https://api.githubcopilot.com/mcp/
+      auth_token: fixture-token
+notes:
+- GitHub MCP auth alone does not set owner/repo in the integration store. This scenario asserts
+  the gather loop infers Tracer-Cloud/opensre from the inline repo URL, enables search_github_issues,
+  and calls it. call_any (not valid_data) matches 338 — fake fixture token may 401 against live MCP,
+  but "was called" proves gather routed to GitHub instead of hallucinating issue text.
+route:
+  expected_kind: handle_message_with_agent
+  expected_command_text: null
+policy:
+  executes_terminal_action: false
+planned_actions:
+- kind: assistant_handoff
+  content: github_issues:windows_crashes
+  source: llm
+response_contract:
+  must_contain_any:
+  - github
+  - issue
+  - windows
+  - crash
+  must_not_contain:
+  - $ /
+  forbidden_actions:
+  - investigation
+  - shell
+history:
+  expected:
+  - type: cli_agent
+    ok: true
+runs: 3
+tool_actions:
+- surface: gather
+  tool: search_github_issues
+  expect: called

--- a/cli/interactive_shell/runtime/session.py
+++ b/cli/interactive_shell/runtime/session.py
@@ -104,6 +104,8 @@ class ReplSession:
     waiting for the first user message to trigger a visible "Loading
     integrations" pass. Cleared by ``refresh_integration_state`` when
     integrations change."""
+    github_repo_scope: tuple[str, str] | None = None
+    """Sticky owner/repo inferred from chat, env, or git remote for GitHub tools."""
     _integration_warm_lock: threading.Lock = field(
         default_factory=threading.Lock,
         repr=False,
@@ -510,6 +512,7 @@ class ReplSession:
             pending = self._integration_warm_task
             self._integration_warm_task = None
             self.resolved_integrations_cache = None
+            self.github_repo_scope = None
         if pending is not None and not pending.done():
             pending.cancel()
         self.hydrate_configured_integrations()
@@ -551,6 +554,7 @@ class ReplSession:
             pending = self._integration_warm_task
             self._integration_warm_task = None
             self.resolved_integrations_cache = None
+            self.github_repo_scope = None
         if pending is not None and not pending.done():
             pending.cancel()
         self.available_capabilities.clear()

--- a/docs/interactive-shell-assistant.mdx
+++ b/docs/interactive-shell-assistant.mdx
@@ -10,12 +10,14 @@ This happens automatically. You do not run a slash command or pick a tool — ju
 ## Example
 
 ```text
-> can you check the github issues for the windows crashes?
+> can you check the github issues for the windows crashes in https://github.com/Tracer-Cloud/opensre?
 · gathering via GitHub · search issues — windows crashes…
 There are 3 open issues mentioning Windows crashes. The most recent, #482
 "App crashes on launch (Windows 11)", reports a startup segfault after the
 2.4.0 update and has 6 reactions…
 ```
+
+You can name the repository inline (`… in https://github.com/org/repo`), mention it in an earlier turn, rely on `GITHUB_REPOSITORY`, or let OpenSRE infer it from the current git checkout's `origin` remote when GitHub is connected.
 
 The dim `· gathering via <source> · <tool> — <query hint>…` line shows which integration the assistant reached for while it works. When the same tool runs more than once, a `(2)`, `(3)`, … suffix and the query hint distinguish each call.
 

--- a/infra/deployment/remote/vercel_poller.py
+++ b/infra/deployment/remote/vercel_poller.py
@@ -138,11 +138,9 @@ def _int_env(name: str, default: int, *, minimum: int) -> int:
 
 
 def _split_repo_full_name(value: str) -> tuple[str, str]:
-    cleaned = value.strip().strip("/")
-    if cleaned.count("/") < 1:
-        return "", ""
-    owner, repo = cleaned.split("/", 1)
-    return owner.strip(), repo.strip().removesuffix(".git")
+    from tools.utils.github_repo_scope import split_repo_full_name
+
+    return split_repo_full_name(value)
 
 
 def _extract_meta_field(meta: dict[str, Any], *keys: str) -> str:

--- a/tests/cli/interactive_shell/chat/test_tool_gathering.py
+++ b/tests/cli/interactive_shell/chat/test_tool_gathering.py
@@ -19,6 +19,7 @@ import core.runtime as runtime_module
 import services.agent_llm_client as agent_llm_client
 from cli.interactive_shell.chat.tool_gathering import (
     _format_gathering_progress_line,
+    _resolve_gather_integrations,
     _tool_input_hint,
     gather_tool_evidence,
 )
@@ -216,3 +217,97 @@ def test_gathering_progress_lines_print_on_tool_start(monkeypatch: Any) -> None:
     output = console.file.getvalue()
     assert "Grafana · Mimir — pipeline_runs_total" in output
     assert "Grafana · Mimir (2) — http_errors_total" in output
+
+
+def test_resolve_gather_integrations_enriches_github_from_repo_url() -> None:
+    session = ReplSession()
+    session.resolved_integrations_cache = {
+        "github": {"connection_verified": True, "url": "https://api.githubcopilot.com/mcp/"}
+    }
+
+    resolved = _resolve_gather_integrations(
+        session,
+        "check github issues in https://github.com/Tracer-Cloud/opensre",
+    )
+
+    gh = resolved["github"]
+    assert gh["owner"] == "Tracer-Cloud"
+    assert gh["repo"] == "opensre"
+    assert session.github_repo_scope == ("Tracer-Cloud", "opensre")
+
+
+def test_resolve_gather_integrations_uses_session_cache_on_follow_up() -> None:
+    session = ReplSession()
+    session.resolved_integrations_cache = {
+        "github": {"connection_verified": True, "url": "https://api.githubcopilot.com/mcp/"}
+    }
+    session.github_repo_scope = ("Tracer-Cloud", "opensre")
+    session.cli_agent_messages = [
+        ("user", "https://github.com/Tracer-Cloud/opensre"),
+        ("assistant", "Got it."),
+    ]
+
+    resolved = _resolve_gather_integrations(session, "do these searches")
+
+    assert resolved["github"]["owner"] == "Tracer-Cloud"
+    assert resolved["github"]["repo"] == "opensre"
+
+
+def test_gather_enriches_github_before_selecting_tools(monkeypatch: Any) -> None:
+    session = ReplSession()
+    session.resolved_integrations_cache = {
+        "github": {"connection_verified": True, "url": "https://api.githubcopilot.com/mcp/"}
+    }
+    seen: dict[str, Any] = {}
+
+    def _capture_tools(resolved: dict[str, Any]) -> list[_DummyTool]:
+        seen["resolved"] = resolved
+        gh = resolved.get("github", {})
+        if isinstance(gh, dict) and gh.get("owner") and gh.get("repo"):
+            return [_DummyTool("search_github_issues")]
+        return []
+
+    monkeypatch.setattr(investigate_tools, "get_available_tools", _capture_tools)
+    monkeypatch.setattr(agent_llm_client, "get_agent_llm", object)
+
+    def _fake_loop(**_kwargs: Any) -> runtime_module.ToolLoopResult:
+        return runtime_module.ToolLoopResult(messages=[], final_text="", executed=[])
+
+    monkeypatch.setattr(runtime_module, "run_tool_calling_loop", _fake_loop)
+
+    gather_tool_evidence(
+        "check github issues in https://github.com/Tracer-Cloud/opensre",
+        session,
+        _console(),
+    )
+
+    gh = seen["resolved"]["github"]
+    assert gh["owner"] == "Tracer-Cloud"
+    assert gh["repo"] == "opensre"
+
+
+def test_gather_user_message_includes_recent_conversation(monkeypatch: Any) -> None:
+    session = ReplSession()
+    session.resolved_integrations_cache = {}
+    session.cli_agent_messages = [("user", "prior question"), ("assistant", "prior answer")]
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        investigate_tools,
+        "get_available_tools",
+        lambda _resolved: [_DummyTool("search_github_issues")],
+    )
+    monkeypatch.setattr(agent_llm_client, "get_agent_llm", object)
+
+    def _fake_loop(**kwargs: Any) -> runtime_module.ToolLoopResult:
+        captured["messages"] = kwargs["messages"]
+        return runtime_module.ToolLoopResult(messages=[], final_text="", executed=[])
+
+    monkeypatch.setattr(runtime_module, "run_tool_calling_loop", _fake_loop)
+
+    gather_tool_evidence("follow up", session, _console())
+
+    content = captured["messages"][0]["content"]
+    assert "Recent conversation:" in content
+    assert "prior question" in content
+    assert "Current question:\nfollow up" in content

--- a/tests/tools/test_github_repo_scope.py
+++ b/tests/tools/test_github_repo_scope.py
@@ -1,0 +1,123 @@
+"""Tests for GitHub repository scope inference helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from integrations.github_mcp import GitHubMCPConfig
+from tools.utils.github_repo_scope import (
+    apply_github_repo_scope,
+    detect_git_remote_repo_scope,
+    infer_github_repo_scope,
+    parse_github_repository_reference,
+    split_repo_full_name,
+)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("https://github.com/Tracer-Cloud/opensre", ("Tracer-Cloud", "opensre")),
+        ("https://github.com/Tracer-Cloud/opensre.git", ("Tracer-Cloud", "opensre")),
+        (
+            "https://github.com/Tracer-Cloud/opensre/issues/42",
+            ("Tracer-Cloud", "opensre"),
+        ),
+        ("github.com/org/my-repo", ("org", "my-repo")),
+        ("repo:Tracer-Cloud/opensre windows crash", ("Tracer-Cloud", "opensre")),
+        ("see Tracer-Cloud/opensre for details", ("Tracer-Cloud", "opensre")),
+    ],
+)
+def test_parse_github_repository_reference(text: str, expected: tuple[str, str]) -> None:
+    assert parse_github_repository_reference(text) == expected
+
+
+def test_parse_github_repository_reference_last_match_wins() -> None:
+    text = "https://github.com/first/a and https://github.com/second/b"
+    assert parse_github_repository_reference(text) == ("second", "b")
+
+
+def test_parse_github_repository_reference_rejects_paths() -> None:
+    assert parse_github_repository_reference("cli/interactive_shell/chat") is None
+
+
+def test_split_repo_full_name() -> None:
+    assert split_repo_full_name("Tracer-Cloud/opensre.git") == ("Tracer-Cloud", "opensre")
+    assert split_repo_full_name("owner-only") == ("", "")
+
+
+def test_infer_github_repo_scope_prefers_current_message_over_cache() -> None:
+    scope = infer_github_repo_scope(
+        message="issues in https://github.com/new-org/new-repo",
+        conversation_messages=[],
+        cached=("old-org", "old-repo"),
+    )
+    assert scope == ("new-org", "new-repo")
+
+
+def test_infer_github_repo_scope_uses_conversation_before_cache() -> None:
+    scope = infer_github_repo_scope(
+        message="do these searches",
+        conversation_messages=[
+            ("user", "https://github.com/Tracer-Cloud/opensre"),
+            ("assistant", "Got it."),
+        ],
+        cached=("other", "repo"),
+    )
+    assert scope == ("Tracer-Cloud", "opensre")
+
+
+def test_infer_github_repo_scope_uses_cache_when_no_explicit_reference() -> None:
+    scope = infer_github_repo_scope(
+        message="do these searches",
+        conversation_messages=[("user", "hello"), ("assistant", "hi")],
+        cached=("Tracer-Cloud", "opensre"),
+    )
+    assert scope == ("Tracer-Cloud", "opensre")
+
+
+def test_infer_github_repo_scope_uses_github_repository_env() -> None:
+    scope = infer_github_repo_scope(
+        message="any issues?",
+        conversation_messages=[],
+        env={"GITHUB_REPOSITORY": "Tracer-Cloud/opensre"},
+        cached=None,
+    )
+    assert scope == ("Tracer-Cloud", "opensre")
+
+
+def test_detect_git_remote_repo_scope_parses_https_remote() -> None:
+    with patch("tools.utils.github_repo_scope.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0, stdout="https://github.com/org/repo.git\n")
+        assert detect_git_remote_repo_scope("/tmp/repo") == ("org", "repo")
+    run.assert_called_once()
+
+
+def test_detect_git_remote_repo_scope_parses_ssh_remote() -> None:
+    with patch("tools.utils.github_repo_scope.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0, stdout="git@github.com:org/repo.git\n")
+        assert detect_git_remote_repo_scope() == ("org", "repo")
+
+
+def test_apply_github_repo_scope_merges_into_github_mcp_config() -> None:
+    resolved: dict[str, Any] = {
+        "github": GitHubMCPConfig(
+            url="https://api.githubcopilot.com/mcp/",
+            auth_token="tok",
+        )
+    }
+    merged = apply_github_repo_scope(resolved, "Tracer-Cloud", "opensre")
+    gh = merged["github"]
+    assert isinstance(gh, dict)
+    assert gh["owner"] == "Tracer-Cloud"
+    assert gh["repo"] == "opensre"
+    assert gh["url"] == "https://api.githubcopilot.com/mcp/"
+    assert isinstance(resolved["github"], GitHubMCPConfig)
+
+
+def test_apply_github_repo_scope_noop_without_github() -> None:
+    resolved = {"datadog": {"connection_verified": True}}
+    assert apply_github_repo_scope(resolved, "o", "r") == {"datadog": {"connection_verified": True}}

--- a/tools/utils/github_repo_scope.py
+++ b/tools/utils/github_repo_scope.py
@@ -1,0 +1,144 @@
+"""Infer GitHub repository scope (owner/repo) for repo-scoped tool calls."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+_GITHUB_HOST_RE = re.compile(
+    r"(?:https?://)?(?:www\.)?github\.com/(?P<owner>[^/\s]+)/(?P<repo>[^/\s#?]+)",
+    re.IGNORECASE,
+)
+_REPO_QUALIFIER_RE = re.compile(
+    r"\brepo:(?P<owner>[^/\s]+)/(?P<repo>[^/\s#?]+)",
+    re.IGNORECASE,
+)
+_BARE_REPO_RE = re.compile(
+    r"(?<![/\w.-])(?P<owner>[A-Za-z0-9][\w.-]*)/(?P<repo>[A-Za-z0-9][\w.-]*)(?![/\w.-])",
+)
+
+
+def split_repo_full_name(value: str) -> tuple[str, str]:
+    """Split ``owner/repo`` (optionally with trailing ``.git``) into its parts."""
+    cleaned = value.strip().strip("/")
+    if cleaned.count("/") < 1:
+        return "", ""
+    owner, repo = cleaned.split("/", 1)
+    return owner.strip(), repo.strip().removesuffix(".git")
+
+
+def parse_github_repository_reference(text: str) -> tuple[str, str] | None:
+    """Return the last owner/repo pair found in *text*, or ``None``."""
+    if not text.strip():
+        return None
+
+    matches: list[tuple[str, str]] = []
+    for pattern in (_GITHUB_HOST_RE, _REPO_QUALIFIER_RE, _BARE_REPO_RE):
+        for match in pattern.finditer(text):
+            owner = match.group("owner").strip()
+            repo = match.group("repo").strip().removesuffix(".git")
+            if owner and repo:
+                matches.append((owner, repo))
+    return matches[-1] if matches else None
+
+
+def _parse_git_remote_url(url: str) -> tuple[str, str] | None:
+    cleaned = url.strip()
+    if not cleaned:
+        return None
+    if cleaned.startswith("git@"):
+        _, _, path = cleaned.partition(":")
+        if path:
+            owner, repo = split_repo_full_name(path)
+            return (owner, repo) if owner and repo else None
+    return parse_github_repository_reference(cleaned)
+
+
+def detect_git_remote_repo_scope(cwd: str | Path | None = None) -> tuple[str, str] | None:
+    """Best-effort ``owner/repo`` from ``git remote get-url origin`` in *cwd*."""
+    work_dir = Path(cwd or os.getcwd())
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=work_dir,
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return _parse_git_remote_url(result.stdout)
+
+
+def infer_github_repo_scope(
+    *,
+    message: str,
+    conversation_messages: Sequence[tuple[str, str]] | None = None,
+    env: Mapping[str, str] | None = None,
+    cwd: str | Path | None = None,
+    cached: tuple[str, str] | None = None,
+) -> tuple[str, str] | None:
+    """Resolve GitHub owner/repo using message, history, session cache, env, and git."""
+    from_message = parse_github_repository_reference(message)
+    if from_message:
+        return from_message
+
+    if conversation_messages:
+        for _role, content in reversed(conversation_messages):
+            from_history = parse_github_repository_reference(content)
+            if from_history:
+                return from_history
+
+    if cached:
+        return cached
+
+    env_map = env if env is not None else os.environ
+    env_repo = str(env_map.get("GITHUB_REPOSITORY", "")).strip()
+    if env_repo:
+        owner, repo = split_repo_full_name(env_repo)
+        if owner and repo:
+            return owner, repo
+
+    return detect_git_remote_repo_scope(cwd)
+
+
+def apply_github_repo_scope(
+    resolved: dict[str, Any],
+    owner: str,
+    repo: str,
+) -> dict[str, Any]:
+    """Return a copy of *resolved* with ``github.owner`` and ``github.repo`` set."""
+    gh = resolved.get("github")
+    if not gh:
+        return dict(resolved)
+
+    if isinstance(gh, BaseModel):
+        gh_dict = gh.model_dump(exclude_none=True)
+    elif isinstance(gh, dict):
+        gh_dict = dict(gh)
+    else:
+        return dict(resolved)
+
+    merged = dict(resolved)
+    gh_dict["owner"] = owner
+    gh_dict["repo"] = repo
+    merged["github"] = gh_dict
+    return merged
+
+
+__all__ = [
+    "apply_github_repo_scope",
+    "detect_git_remote_repo_scope",
+    "infer_github_repo_scope",
+    "parse_github_repository_reference",
+    "split_repo_full_name",
+]


### PR DESCRIPTION
## Summary

- Add `tools/utils/github_repo_scope.py` to parse and infer `owner/repo` from chat URLs, `repo:` qualifiers, recent conversation, session cache, `GITHUB_REPOSITORY`, or `git remote origin`.
- Enrich resolved integrations in the REPL gather loop so `search_github_issues` (and other repo-scoped GitHub tools) become available when GitHub MCP is connected but no default repo is stored.
- Persist inferred scope on `ReplSession.github_repo_scope` so multi-turn flows work (e.g. paste repo URL, then ask follow-up searches).
- Pass recent conversation into the gather LLM prompt for better multi-turn query derivation.

## Test plan

- [x] `uv run python -m pytest tests/tools/test_github_repo_scope.py tests/cli/interactive_shell/chat/test_tool_gathering.py -q`
- [x] `uv run python -m pytest cli/interactive_shell/harness/tests/test_routing_scenarios.py -k 341-github-issues-repo-url-gather -q`
- [x] `make lint && make typecheck`
- [ ] Manual REPL: `check github issues for windows crashes in https://github.com/Tracer-Cloud/opensre` shows `· gathering via GitHub · search issues …`


Made with [Cursor](https://cursor.com)