### PR TITLE
[codex] move packaging scripts under infra deployment

### DIFF
--- a/infra/deployment/packaging/sync_release_version.py
+++ b/infra/deployment/packaging/sync_release_version.py
@@ -7,7 +7,7 @@ import re
 from collections.abc import Callable
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(__file__).resolve().parents[3]
 PYPROJECT_PATH = ROOT / "pyproject.toml"
 APP_CONSTANTS_OPENSRE_PATH = ROOT / "config" / "constants" / "opensre.py"
 CALENDAR_VERSION_PATTERN = re.compile(r"v?(?P<version>\d{4}\.\d{1,2}\.\d{1,2})")

--- a/tests/packaging/test_sync_release_version.py
+++ b/tests/packaging/test_sync_release_version.py
@@ -8,12 +8,18 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SPEC = importlib.util.spec_from_file_location(
     "opensre_sync_release_version",
-    _REPO_ROOT / "deployment" / "packaging" / "sync_release_version.py",
+    _REPO_ROOT / "infra" / "deployment" / "packaging" / "sync_release_version.py",
 )
 assert _SPEC is not None and _SPEC.loader is not None
 _MODULE = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_MODULE)
 _normalize_release_version = _MODULE._normalize_release_version
+
+
+def test_release_paths_resolve_from_moved_infra_location() -> None:
+    assert _MODULE.ROOT == _REPO_ROOT
+    assert _MODULE.PYPROJECT_PATH == _REPO_ROOT / "pyproject.toml"
+    assert _MODULE.APP_CONSTANTS_OPENSRE_PATH == _REPO_ROOT / "config" / "constants" / "opensre.py"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Move `deployment/packaging/sync_release_version.py` under `infra/deployment/packaging/`.
- Update the script repo-root calculation for the deeper path.
- Update packaging tests to load the new canonical path and assert release paths resolve to the repo root.

## Validation
- `make lint`
- `make format-check`
- `make typecheck`
- `SKIP_INFRA_TESTS=1 uv run python infra/ci/run_test_scope.py --base origin/main`
- `uv run python -m pytest tests/packaging/test_sync_release_version.py -v`
- `uv run python infra/deployment/packaging/sync_release_version.py --help`

Note: an initial `run_test_scope --base origin/main` without `SKIP_INFRA_TESTS=1` entered live deployment tests; the Bedrock invocation tests failed due local infrastructure/model-access conditions, so the scoped run was repeated with the repo-supported infrastructure skip flag.