### PR TITLE
[codex] fix import graph root for deployment infra

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -3,7 +3,7 @@ root_packages =
     cli
     config
     core
-    deployment
+    infra
     integrations
     platform
     services

--- a/tests/interactive_shell/shell/test_execution.py
+++ b/tests/interactive_shell/shell/test_execution.py
@@ -23,8 +23,7 @@ def test_execute_shell_command_reports_timeout_argv_mode(monkeypatch: pytest.Mon
         )
 
     monkeypatch.setattr(
-        "interactive_shell.harness.orchestration"
-        ".action_executor.shell_execution.subprocess.run",
+        "interactive_shell.harness.orchestration.action_executor.shell_execution.subprocess.run",
         _raise,
     )
 
@@ -58,8 +57,7 @@ def test_execute_shell_command_reports_timeout_shell_mode(monkeypatch: pytest.Mo
         )
 
     monkeypatch.setattr(
-        "interactive_shell.harness.orchestration"
-        ".action_executor.shell_execution.subprocess.run",
+        "interactive_shell.harness.orchestration.action_executor.shell_execution.subprocess.run",
         _raise,
     )
 


### PR DESCRIPTION
## Summary
- Update `.importlinter` to use the existing top-level `infra` package instead of the removed `deployment` package.
- Fixes the import graph failure triggered after moving deployment packaging under `infra/deployment`.
- Apply a ruff formatting wrap in `tests/interactive_shell/shell/test_execution.py` required by the current `main` baseline.

## Validation
- `uv run python infra/ci/check_imports.py`
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/interactive_shell/shell/test_execution.py -v`

Note: `run_test_scope.py --base origin/main` falls back to the full suite for this `.importlinter`-only diff; that full-suite fallback was intentionally stopped because it is not a useful scoped validation for this CI-config fix.