### PR TITLE
fix(infra): use platform-native temporary directory for hub alert output

### DIFF
--- a/infra/opensre-dataset/fetch_opensre_hub_alert.py
+++ b/infra/opensre-dataset/fetch_opensre_hub_alert.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import tempfile
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -54,7 +55,7 @@ def main() -> int:
         "--output",
         "-o",
         default="",
-        help="Write one alert JSON here (default: /tmp/opensre-hub-alert.json). Ignored if --export-dir is set.",
+        help="Write one alert JSON here (default: operating system temporary directory). Ignored if --export-dir is set.",
     )
     parser.add_argument(
         "--export-dir",
@@ -115,7 +116,8 @@ def main() -> int:
         print("No alert at this index.", file=sys.stderr)
         return 1
 
-    out = Path(args.output or "/tmp/opensre-hub-alert.json").expanduser()
+    default_output = Path(tempfile.gettempdir()) / "opensre-hub-alert.json"
+    out = Path(args.output or default_output).expanduser()
     out.write_text(json.dumps(alert, indent=2) + "\n", encoding="utf-8")
     print(out)
     return 0

--- a/infra/opensre-dataset/fetch_opensre_hub_alert.py
+++ b/infra/opensre-dataset/fetch_opensre_hub_alert.py
@@ -55,7 +55,7 @@ def main() -> int:
         "--output",
         "-o",
         default="",
-        help="Write one alert JSON here (default: operating system temporary directory). Ignored if --export-dir is set.",
+        help="Write one alert JSON here (default: <tmpdir>/opensre-hub-alert.json). Ignored if --export-dir is set.",
     )
     parser.add_argument(
         "--export-dir",


### PR DESCRIPTION
Fixes #3009

#### Describe the changes you have made in this PR -

This PR replaces the hardcoded `/tmp` fallback path in `infra/opensre-dataset/fetch_opensre_hub_alert.py` with Python's standard `tempfile.gettempdir()` API.

### Changes

* Replaced the hardcoded `/tmp/opensre-hub-alert.json` fallback with a platform-native temporary directory using `tempfile.gettempdir()`.
* Updated the `--output` CLI help text to reflect the new default behavior.

This makes the default output location more portable across Linux, macOS, and Windows while preserving the existing behavior when `--output` is explicitly provided.

### Demo/Screenshot for feature changes and bug fixes -
<img width="842" height="67" alt="image" src="https://github.com/user-attachments/assets/cd82f118-da64-400c-bde5-ac3f41d853f3" />


Verified on Windows:

```text
C:\Users\hp\AppData\Local\Temp\opensre-hub-alert.json
```

Also verified that the CLI help text now reflects the updated default output behavior.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

* [x] No, I wrote all the code myself
* [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

* [ ] I have reviewed every single line of the AI-generated code
* [ ] I can explain the purpose and logic of each function/component I added
* [ ] I have tested edge cases and understand how the code handles them
* [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The existing implementation used a hardcoded `/tmp` path as the default output location when `--output` was not provided. While this works naturally on Unix-like systems, it is not the platform-native temporary directory on Windows.

I replaced the hardcoded path with `tempfile.gettempdir()`, which returns the operating system's designated temporary directory. This keeps the behavior platform-independent while preserving the existing workflow for users who explicitly provide an output path.

I also updated the CLI help text so that it accurately describes the new default behavior.

---

## Checklist before requesting a review

* [x] I have added proper PR title and linked to the issue
* [x] I have performed a self-review of my code
* [x] I can explain the purpose of every function, class, and logic block I added
* [x] I understand why my changes work and have tested them thoroughly
* [x] I have considered potential edge cases and how my code handles them
* [ ] If it is a core feature, I have added thorough tests
* [x] My code follows the project's style guidelines and conventions
