### PR TITLE
ci(windows): use canonical PYTHON_SOURCE_PATHS in label workflow (fix missing deployment/ path)

### DIFF
--- a/.github/workflows/ci-labels-windows.yml
+++ b/.github/workflows/ci-labels-windows.yml
@@ -13,6 +13,8 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  # Keep in sync with ci.yml — single source of truth for lint/typecheck/coverage targets.
+  PYTHON_SOURCE_PATHS: "cli config core infra/deployment integrations platform tools"
 
 concurrency:
   group: ci-labels-windows-${{ github.ref }}
@@ -46,13 +48,13 @@ jobs:
         run: uv sync --frozen --extra dev
 
       - name: Lint
-        run: uv run python -m ruff check cli config core deployment integrations platform tools tests/
+        run: uv run python -m ruff check ${{ env.PYTHON_SOURCE_PATHS }} tests/
 
       - name: Format check
-        run: uv run python -m ruff format --check cli config core deployment integrations platform tools tests/
+        run: uv run python -m ruff format --check ${{ env.PYTHON_SOURCE_PATHS }} tests/
 
       - name: Typecheck
-        run: uv run python -m mypy cli config core deployment integrations platform tools
+        run: uv run python -m mypy ${{ env.PYTHON_SOURCE_PATHS }}
 
   windows-test:
     if: contains(github.event.pull_request.labels.*.name, 'ci:windows')
@@ -99,7 +101,7 @@ jobs:
       - name: Run full tests
         run: >-
           uv run python -m pytest -n auto -v
-          --cov=cli --cov=config --cov=core --cov=deployment --cov=integrations --cov=platform --cov=tools
+          --cov=cli --cov=config --cov=core --cov=infra/deployment --cov=integrations --cov=platform --cov=tools
           --cov-report=term-missing
           --cov-report=html
           --ignore=tests/e2e/kubernetes_local_alert_simulation


### PR DESCRIPTION
Fixes #3155

#### Describe the changes you have made in this PR -

`.github/workflows/ci-labels-windows.yml` (the optional `ci:windows` workflow)
hardcodes a bare `deployment` as a lint / format / typecheck / coverage target, but
there is no top-level `deployment/` package — it lives at `infra/deployment`. So the
Windows quality job fails with a missing-path error, and its source paths have
repeatedly drifted from the canonical list in `ci.yml` across the recent restructures
(#3067, #3083, #3151).

`ci.yml` already solved this by defining `PYTHON_SOURCE_PATHS` once at the workflow
level and referencing it. This change mirrors that in the Windows workflow:

- add a `PYTHON_SOURCE_PATHS` env equal to `ci.yml`'s (`cli config core
  infra/deployment integrations platform tools`)
- reference `${{ env.PYTHON_SOURCE_PATHS }}` in the lint / format-check / typecheck
  steps, so the two workflows can't drift apart again
- correct the explicit `--cov` list in the test job (`deployment` → `infra/deployment`)

> Rebased onto current main after #3151 (which collapsed `services/`+`vendors/` into
> integrations/tools). The path list now matches the post-#3151 canonical set.

### Demo/Screenshot for feature changes and bug fixes -

The path list is identical to what `ci.yml` / the Makefile already use, validated
locally:

```
$ make lint        # ruff check cli config core infra/deployment integrations platform tools tests/
All checks passed!

$ make typecheck    # mypy cli config core infra/deployment integrations platform tools
Success: no issues found
```

YAML validated with `yaml.safe_load`. The Windows `PYTHON_SOURCE_PATHS` now byte-matches
`ci.yml`'s. Before this change the Windows job ran `ruff check ... deployment ...`,
which errors because `deployment` does not exist.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The root cause is duplicated, hand-maintained path lists drifting apart — exactly what
a shared variable prevents. `ci.yml` already uses a workflow-level `PYTHON_SOURCE_PATHS`,
so I mirrored that pattern rather than re-hardcoding a corrected list. I used the
`${{ env.PYTHON_SOURCE_PATHS }}` expression form (resolved by Actions before the shell)
so it works regardless of the Windows runner shell. The coverage flags stay explicit
since `--cov=` needs per-path prefixes, but I corrected them to match. Validated the
paths with the same ruff/mypy commands the Makefile uses.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
