### PR TITLE
ci: include interactive_shell in lint/typecheck/coverage paths (200 files were skipped)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  PYTHON_SOURCE_PATHS: "cli config core infra/deployment integrations platform tools"
+  PYTHON_SOURCE_PATHS: "cli config core infra/deployment integrations interactive_shell platform tools"
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - "core/**"
       - "infra/deployment/**"
       - "integrations/**"
+      - "interactive_shell/**"
       - "platform/**"
       - "tools/**"
       - "tests/**"
@@ -30,6 +31,7 @@ on:
       - "core/**"
       - "infra/deployment/**"
       - "integrations/**"
+      - "interactive_shell/**"
       - "platform/**"
       - "tools/**"
       - "tests/**"
@@ -238,6 +240,7 @@ jobs:
           --cov=core
           --cov=infra.deployment
           --cov=integrations
+          --cov=interactive_shell
           --cov=platform
           --cov=tools
           --cov-report=

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ USER_BASE := $(shell $(PYTHON) -m site --user-base)
 USER_BIN := $(if $(filter Windows_NT,$(OS)),$(USER_BASE)/Scripts,$(USER_BASE)/bin)
 export PATH := $(if $(wildcard .venv/bin),$(CURDIR)/.venv/bin:,$(if $(wildcard .venv/Scripts),$(CURDIR)/.venv/Scripts:))$(USER_BIN):$(PATH)
 
-PYTHON_SOURCE_PATHS := cli config core infra/deployment integrations platform tools
+PYTHON_SOURCE_PATHS := cli config core infra/deployment integrations interactive_shell platform tools
 
 # Create venv and install dependencies (requires https://docs.astral.sh/uv/)
 install:

--- a/interactive_shell/chat/cli_agent.py
+++ b/interactive_shell/chat/cli_agent.py
@@ -34,13 +34,13 @@ from interactive_shell.chat.system_prompt import (
     _build_observation_block,
     _build_system_prompt,
 )
-from interactive_shell.runtime import ReplSession
-from interactive_shell.runtime.session import SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST
-from interactive_shell.runtime.token_accounting import build_llm_run_info
 from interactive_shell.harness.state.conversation_history import (
     MAX_CONVERSATION_MESSAGES,
     format_recent_conversation,
 )
+from interactive_shell.runtime import ReplSession
+from interactive_shell.runtime.session import SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST
+from interactive_shell.runtime.token_accounting import build_llm_run_info
 from interactive_shell.ui import (
     BOLD_BRAND,
     DIM,

--- a/interactive_shell/chat/tool_gathering.py
+++ b/interactive_shell/chat/tool_gathering.py
@@ -30,11 +30,11 @@ from rich.console import Console
 from rich.markup import escape
 
 from core.domain.alerts.alert_source import SECONDARY_TOOL_SOURCES
-from interactive_shell.runtime.session import ReplSession
 from interactive_shell.harness.state.conversation_history import (
     NO_HISTORY_PLACEHOLDER,
     format_recent_conversation,
 )
+from interactive_shell.runtime.session import ReplSession
 from interactive_shell.ui import DIM
 from interactive_shell.ui.output.tool_details import tool_short_label, tool_source_label
 from interactive_shell.utils.error_handling.exception_reporting import report_exception

--- a/interactive_shell/command_registry/privacy_cmds.py
+++ b/interactive_shell/command_registry/privacy_cmds.py
@@ -7,7 +7,6 @@ from rich.console import Console
 from rich.markup import escape
 
 from interactive_shell.command_registry.types import SlashCommand
-from interactive_shell.runtime import ReplSession
 from interactive_shell.harness.state.history import (
     clear_persisted_history,
     load_command_history_entries,
@@ -17,6 +16,7 @@ from interactive_shell.harness.state.history.policy import (
     DEFAULT_REDACTION_RULES,
     RedactingFileHistory,
 )
+from interactive_shell.runtime import ReplSession
 from interactive_shell.ui import (
     BOLD_BRAND,
     DIM,

--- a/interactive_shell/command_registry/rca_cmds.py
+++ b/interactive_shell/command_registry/rca_cmds.py
@@ -13,8 +13,8 @@ from interactive_shell.command_registry.investigation import (
     write_investigation_export,
 )
 from interactive_shell.command_registry.types import ExecutionTier, SlashCommand
-from interactive_shell.runtime import ReplSession
 from interactive_shell.harness.state.sessions.store import SessionStore
+from interactive_shell.runtime import ReplSession
 from interactive_shell.ui import (
     BOLD_BRAND,
     DIM,

--- a/interactive_shell/command_registry/tasks_cmds.py
+++ b/interactive_shell/command_registry/tasks_cmds.py
@@ -11,8 +11,8 @@ from interactive_shell.command_registry.types import (
     ExecutionTier,
     SlashCommand,
 )
-from interactive_shell.runtime import ReplSession, TaskKind, TaskRecord, TaskStatus
 from interactive_shell.harness.state.history import load_command_history_entries
+from interactive_shell.runtime import ReplSession, TaskKind, TaskRecord, TaskStatus
 from interactive_shell.ui import (
     BOLD_BRAND,
     DIM,

--- a/interactive_shell/harness/orchestration/terminal_actions/feedback.py
+++ b/interactive_shell/harness/orchestration/terminal_actions/feedback.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from rich.console import Console
 from rich.markup import escape
 
-from interactive_shell.runtime import ReplSession
 from interactive_shell.harness.state.conversation_history import MAX_CONVERSATION_MESSAGES
+from interactive_shell.runtime import ReplSession
 from interactive_shell.ui.streaming import render_response_header
 
 

--- a/interactive_shell/harness/pipeline.py
+++ b/interactive_shell/harness/pipeline.py
@@ -14,11 +14,11 @@ from rich.console import Console
 from rich.markup import escape
 
 from config.llm_reasoning_effort import apply_reasoning_effort
-from interactive_shell.harness.orchestration.command_dispatch import (
-    deterministic_command_text,
-)
 from interactive_shell.harness.orchestration.agent_actions import (
     TerminalActionExecutionResult,
+)
+from interactive_shell.harness.orchestration.command_dispatch import (
+    deterministic_command_text,
 )
 from interactive_shell.runtime.session import ReplSession
 from interactive_shell.ui import DIM, ERROR

--- a/interactive_shell/harness/tests/orchestration/test_agent_actions.py
+++ b/interactive_shell/harness/tests/orchestration/test_agent_actions.py
@@ -41,8 +41,7 @@ from interactive_shell.runtime.session import ReplSession
 from platform.common.task_types import TaskKind, TaskStatus
 
 _PLANNER_RESULT_PATCH = (
-    "interactive_shell.harness.orchestration"
-    ".terminal_actions.planning.plan_actions_with_llm_result"
+    "interactive_shell.harness.orchestration.terminal_actions.planning.plan_actions_with_llm_result"
 )
 
 

--- a/interactive_shell/harness/tests/orchestration/test_llm_action_planner.py
+++ b/interactive_shell/harness/tests/orchestration/test_llm_action_planner.py
@@ -17,10 +17,10 @@ from config.config import (
     get_llm_provider_api_key_env,
     resolve_llm_settings_verbose,
 )
+from interactive_shell.harness.domain.errors import PlannerLLMError
 from interactive_shell.harness.orchestration.command_dispatch import (
     deterministic_command_text,
 )
-from interactive_shell.harness.domain.errors import PlannerLLMError
 from interactive_shell.harness.orchestration.interaction_models import (
     PlannedAction,
 )

--- a/interactive_shell/runtime/entrypoint.py
+++ b/interactive_shell/runtime/entrypoint.py
@@ -11,11 +11,11 @@ from rich.console import Console
 
 from config.repl_config import ReplConfig
 from core.domain.alerts import inbox as _alert_inbox
+from interactive_shell.harness.state.sessions.store import SessionStore
 from interactive_shell.runtime.dispatch import run_initial_input
 from interactive_shell.runtime.loop import run_interactive
 from interactive_shell.runtime.session import ReplSession
 from interactive_shell.runtime.tasks import TaskRegistry
-from interactive_shell.harness.state.sessions.store import SessionStore
 from interactive_shell.ui import DIM, render_banner
 from interactive_shell.ui import prompt_surface as _prompt_surface
 from tools.fleet_monitoring.sweep import run_startup_sweep

--- a/interactive_shell/runtime/execution.py
+++ b/interactive_shell/runtime/execution.py
@@ -11,10 +11,10 @@ import interactive_shell.harness.orchestration.agent_actions as _agent_actions
 from interactive_shell.chat import cli_agent as _cli_agent
 from interactive_shell.chat.tool_gathering import gather_tool_evidence
 from interactive_shell.command_registry import dispatch_slash
+from interactive_shell.harness.domain.types import RouteDecision
 from interactive_shell.harness.pipeline import (
     handle_message_with_agent,
 )
-from interactive_shell.harness.domain.types import RouteDecision
 from interactive_shell.runtime.session import ReplSession
 from interactive_shell.utils.telemetry import LlmRunInfo, PromptRecorder
 from platform.analytics.events import Event

--- a/interactive_shell/runtime/token_accounting.py
+++ b/interactive_shell/runtime/token_accounting.py
@@ -9,8 +9,8 @@ from interactive_shell.ui.streaming import _CHARS_PER_TOKEN
 from interactive_shell.utils.telemetry import LlmRunInfo
 
 if TYPE_CHECKING:
-    from interactive_shell.runtime.session import ReplSession
     from core.runtime.llm.llm_client import LLMResponse
+    from interactive_shell.runtime.session import ReplSession
 
 
 def estimate_tokens(text: str) -> int:

--- a/interactive_shell/ui/output/boundary.py
+++ b/interactive_shell/ui/output/boundary.py
@@ -24,6 +24,9 @@ def install_product_adapters() -> None:
     - remote integrations fetcher: empty default → Tracer Cloud adapter
     """
     from integrations.port import set_remote_integrations_fetcher
+    from integrations.tracer.integrations_adapter import (
+        fetch_tracer_remote_integrations,
+    )
     from interactive_shell.ui.output.environment import debug_print
     from interactive_shell.ui.output.renderers import (
         render_completed_investigation_footer,
@@ -36,9 +39,6 @@ def install_product_adapters() -> None:
         set_investigation_header_renderer,
     )
     from platform.observability.progress import set_progress_tracker_factory
-    from integrations.tracer.integrations_adapter import (
-        fetch_tracer_remote_integrations,
-    )
 
     set_debug_printer(debug_print)
     set_investigation_header_renderer(render_investigation_header)

--- a/interactive_shell/ui/prompt_surface.py
+++ b/interactive_shell/ui/prompt_surface.py
@@ -26,8 +26,8 @@ from interactive_shell.command_registry.types import SlashCommand
 from interactive_shell.harness.orchestration.command_dispatch.catalog import (
     BARE_COMMAND_ALIASES,
 )
-from interactive_shell.runtime import ReplSession
 from interactive_shell.harness.state.history import load_prompt_history
+from interactive_shell.runtime import ReplSession
 from interactive_shell.ui.banner_state import integration_display_name
 from interactive_shell.ui.choice_menu import repl_tty_interactive
 from platform.terminal import theme as ui_theme


### PR DESCRIPTION
Fixes #3158

#### Describe the changes you have made in this PR -

`interactive_shell/` (200 `.py` files — the interactive shell, the product's primary
surface) is the only top-level source package missing from `PYTHON_SOURCE_PATHS`, so
`ruff`, `mypy`, and coverage silently skipped it on every CI run. It moved out of
`cli/interactive_shell/` (now empty) to a top-level package during the restructures
(#3067/#3151) and was never added to the quality-gate paths.

As a direct result, **13 `ruff` import-sort (`I001`) violations and one unformatted
file** had accumulated in `interactive_shell/` without CI noticing.

This PR:
- adds `interactive_shell` to `PYTHON_SOURCE_PATHS` in the **Makefile** and **ci.yml**
  (the Windows label workflow tracks its own copy — handled in #3156);
- clears the accumulated violations (`ruff check --fix` for the 13 `I001`, `ruff format`
  for the one file) so the gate passes with the package included.

The 13 import-sort changes are mechanical (import reordering only); no logic changed.

### Demo/Screenshot for feature changes and bug fixes -

Before: `ruff check interactive_shell` → `Found 13 errors`; CI never ran it.
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/1407bed1-d267-4f09-bbdc-e2e006fecd85" />

After, the full gate passes with `interactive_shell` included:

$ make lint        # ruff check ... integrations interactive_shell platform tools tests/
All checks passed!
<img width="877" height="76" alt="image" src="https://github.com/user-attachments/assets/64af5e27-61c9-4a1a-b67f-1cfacfd33c89" />
<img width="568" height="59" alt="image" src="https://github.com/user-attachments/assets/f1c163b5-ca17-40f2-bc17-aacea925fef0" />

<img width="761" height="78" alt="image" src="https://github.com/user-attachments/assets/13d33620-1750-448b-84a2-71e087dc9ea8" />

Safety of the import-sort reorder, verified:
- all 12 changed non-test modules import cleanly;
- 28 `interactive_shell`-importing tests in `tests/` pass (`tests/cli/test_investigate_service_flag.py`, `test_health_view.py`, `test_observability_adapters.py`, `test_integrations_port_adapters.py`).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I compared every tracked top-level source package against `PYTHON_SOURCE_PATHS` and
found `interactive_shell` (200 files) was the only one missing — `mypy` was clean on
it but `ruff` had 13 uncaught `I001` violations. I added it to the canonical paths
(Makefile + ci.yml) and cleared the violations with `ruff --fix`/`ruff format` so the
gate is green with the package included. I confirmed the import reordering is safe by
importing the changed modules and running the `interactive_shell`-importing tests. The
Windows label workflow keeps a separate path copy, which is already being corrected in
#3156, so I left it out of this PR to avoid overlap.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
