### PR TITLE
ci(release): name dated releases v0.1.YYYY.M.D and mark them Latest

### DIFF
--- a/.github/scripts/sync-release-version.py
+++ b/.github/scripts/sync-release-version.py
@@ -52,7 +52,7 @@ def sync_release_version(tag: str) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--tag", required=True, help="Release tag, e.g. v2026.6.26 or v0.1")
+    parser.add_argument("--tag", required=True, help="Release tag, e.g. v0.1.2026.6.26 or v0.1")
     args = parser.parse_args()
     version = sync_release_version(args.tag)
     print(f"Synced release version to {version}")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ on:
           - release
           - main
       tag:
-        description: "Optional tag to release (e.g. v2026.4.5 or v0.1). Ignored for the main channel."
+        description: "Optional tag to release (e.g. v0.1.2026.6.26 or v0.1). Ignored for the main channel."
         required: false
         type: string
 
@@ -91,7 +91,9 @@ jobs:
             year="$(date -u +%Y)"
             month="$(date -u +%-m)"
             day="$(date -u +%-d)"
-            tag_name="v${year}.${month}.${day}"
+            # Keep the v0.1 prefix so the tag makes clear the product is still
+            # v0.1, while the date stays useful (e.g. v0.1.2026.6.26).
+            tag_name="v0.1.${year}.${month}.${day}"
           fi
 
           echo "channel=release" >> "$GITHUB_OUTPUT"
@@ -377,7 +379,7 @@ jobs:
           target_sha="$(git rev-parse "origin/$default_branch")"
 
           previous_tag="$(
-            git tag --list 'v[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*' --sort=-v:refname \
+            git tag --list 'v0.1.[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*' --sort=-v:refname \
               | grep -v -x "$TAG_NAME" \
               | head -n 1 \
               || true
@@ -477,23 +479,17 @@ jobs:
           fi
 
           VERSION="${TAG_NAME#v}"
-          latest_flag="--latest=false"
-          release_title="Latest"
-          case "$TAG_NAME" in
-            v[0-9][0-9][0-9][0-9].*) ;;
-            *)
-              latest_flag="--latest"
-              release_title="OpenSRE ${VERSION}"
-              ;;
-          esac
 
+          # Every release-channel publish is the newest stable build at this
+          # point, so mark it as GitHub's Latest. The title keeps the full
+          # version (e.g. "OpenSRE 0.1.2026.6.26") so the v0.1 line is clear.
           gh release create "$TAG_NAME" \
             release-assets/* \
             --repo "${{ github.repository }}" \
             --target "$TARGET_SHA" \
-            --title "$release_title" \
+            --title "OpenSRE ${VERSION}" \
             --notes-file RELEASE_NOTES.md \
-            "$latest_flag"
+            --latest
 
           echo "created=true" >> "$GITHUB_OUTPUT"
 

--- a/infra/deployment/packaging/sync_release_version.py
+++ b/infra/deployment/packaging/sync_release_version.py
@@ -10,20 +10,26 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[3]
 PYPROJECT_PATH = ROOT / "pyproject.toml"
 APP_CONSTANTS_OPENSRE_PATH = ROOT / "config" / "constants" / "opensre.py"
+# Dated stable tags carry the v0.1 line prefix, e.g. v0.1.2026.6.26.
+PREFIXED_CALENDAR_VERSION_PATTERN = re.compile(r"v?(?P<version>\d+\.\d+\.\d{4}\.\d{1,2}\.\d{1,2})")
 CALENDAR_VERSION_PATTERN = re.compile(r"v?(?P<version>\d{4}\.\d{1,2}\.\d{1,2})")
 SEMVER_VERSION_PATTERN = re.compile(r"v?(?P<version>\d+\.\d+(?:\.\d+)?)")
 
 
 def _normalize_release_version(raw_value: str) -> str:
     value = raw_value.strip()
-    for pattern in (CALENDAR_VERSION_PATTERN, SEMVER_VERSION_PATTERN):
+    for pattern in (
+        PREFIXED_CALENDAR_VERSION_PATTERN,
+        CALENDAR_VERSION_PATTERN,
+        SEMVER_VERSION_PATTERN,
+    ):
         match = pattern.fullmatch(value)
         if match is not None:
             return match.group("version")
 
     msg = (
-        "Release tag must look like 'vYYYY.M.D', 'YYYY.M.D', 'v0.1', or '0.1.0'; "
-        f"got {raw_value!r}."
+        "Release tag must look like 'v0.1.YYYY.M.D', 'vYYYY.M.D', 'YYYY.M.D', "
+        f"'v0.1', or '0.1.0'; got {raw_value!r}."
     )
     raise ValueError(msg)
 
@@ -85,7 +91,7 @@ def main() -> None:
     parser.add_argument(
         "--tag",
         required=True,
-        help="Release tag to sync from, e.g. v2026.4.13 or v0.1.",
+        help="Release tag to sync from, e.g. v0.1.2026.6.26 or v0.1.",
     )
     args = parser.parse_args()
 

--- a/infra/deployment/packaging/sync_release_version.py
+++ b/infra/deployment/packaging/sync_release_version.py
@@ -10,8 +10,12 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[3]
 PYPROJECT_PATH = ROOT / "pyproject.toml"
 APP_CONSTANTS_OPENSRE_PATH = ROOT / "config" / "constants" / "opensre.py"
-# Dated stable tags carry the v0.1 line prefix, e.g. v0.1.2026.6.26.
-PREFIXED_CALENDAR_VERSION_PATTERN = re.compile(r"v?(?P<version>\d+\.\d+\.\d{4}\.\d{1,2}\.\d{1,2})")
+# Dated stable tags carry the v0.1 line prefix, e.g. v0.1.2026.6.26. Month and
+# day are bounded (1-12, 1-31) so a malformed dispatch tag fails here rather
+# than producing a nonsensical version string.
+PREFIXED_CALENDAR_VERSION_PATTERN = re.compile(
+    r"v?(?P<version>\d+\.\d+\.\d{4}\.(?:1[0-2]|[1-9])\.(?:3[01]|[12]\d|[1-9]))"
+)
 CALENDAR_VERSION_PATTERN = re.compile(r"v?(?P<version>\d{4}\.\d{1,2}\.\d{1,2})")
 SEMVER_VERSION_PATTERN = re.compile(r"v?(?P<version>\d+\.\d+(?:\.\d+)?)")
 

--- a/tests/packaging/test_sync_release_version.py
+++ b/tests/packaging/test_sync_release_version.py
@@ -26,6 +26,7 @@ def test_release_paths_resolve_from_moved_infra_location() -> None:
     ("raw_value", "expected"),
     [
         ("v0.1.2026.6.26", "0.1.2026.6.26"),
+        ("0.1.2026.6.26", "0.1.2026.6.26"),
         ("v2026.4.13", "2026.4.13"),
         ("2026.4.13", "2026.4.13"),
         ("v0.1", "0.1"),
@@ -39,6 +40,7 @@ def test_normalize_release_version_accepts_calendar_and_semver(
     assert _normalize_release_version(raw_value) == expected
 
 
-def test_normalize_release_version_rejects_unknown_shapes() -> None:
+@pytest.mark.parametrize("raw_value", ["not-a-version", "v0.1.2026.99.99"])
+def test_normalize_release_version_rejects_unknown_shapes(raw_value: str) -> None:
     with pytest.raises(ValueError, match="Release tag must look like"):
-        _normalize_release_version("not-a-version")
+        _normalize_release_version(raw_value)

--- a/tests/packaging/test_sync_release_version.py
+++ b/tests/packaging/test_sync_release_version.py
@@ -25,6 +25,7 @@ def test_release_paths_resolve_from_moved_infra_location() -> None:
 @pytest.mark.parametrize(
     ("raw_value", "expected"),
     [
+        ("v0.1.2026.6.26", "0.1.2026.6.26"),
         ("v2026.4.13", "2026.4.13"),
         ("2026.4.13", "2026.4.13"),
         ("v0.1", "0.1"),


### PR DESCRIPTION
## What

Dated release builds were tagged `vYYYY.M.D` and published with `--latest=false` and the title `"Latest"`. Only the hand-cut `v0.1` tag got `--latest`. So the GitHub releases sidebar and the `/releases/latest` API both pinned the stale `v0.1` (May 15), not the newest build, and `opensre update` (which reads `/releases/latest`) never saw new builds.

This switches to the scheme Vincent raised in #releases:

- Tag dated releases `v0.1.YYYY.M.D` (e.g. `v0.1.2026.6.26`) so the v0.1 line stays clear while keeping the useful date.
- Mark every release-channel publish as GitHub's actual Latest, titled `OpenSRE <version>`. The release-create branching collapses, so this is a net line removal there.

`packaging.Version` orders `0.1.2026.6.26 > 0.1.2026.6.25 > 0.1`, so update detection keeps working.

## Changes

- `.github/workflows/release.yml`: `tag_name` now `v0.1.${y}.${m}.${d}`; release-create always `--latest` with title `OpenSRE ${VERSION}`; previous-tag glob updated; dispatch help text updated.
- `.github/scripts/sync-release-version.py` and `infra/deployment/packaging/sync_release_version.py`: help text updated; the infra normalizer learns the new shape (+1 test row).

## Verified

- YAML parses; ruff clean; `tests/packaging/test_sync_release_version.py` 7/7.
- Dist tarball name, release title, release URL, and `opensre update` math all line up for `v0.1.2026.6.26`.

## One-time effect to note

The previous-tag glob is intentionally new-scheme-only. Mixing `v2026.*` and `v0.1.2026.*` breaks `--sort=-v:refname` because the `0.1` prefix sorts numerically below `2026`. The cost is a single bloated changelog on the first `v0.1.*` release, since no prior `v0.1.*` tag exists yet to diff against. Steady state is correct.

Closes #3160
