### PR TITLE
fix(ci): route interactive_shell in test-scope, drop dead app refs

### DIFF
--- a/infra/ci/check_import_cycles.py
+++ b/infra/ci/check_import_cycles.py
@@ -79,7 +79,6 @@ _SKIP_ROOT_DIRS = frozenset(
         ".ruff_cache",
         ".venv",
         "__pycache__",
-        "app",
         "docs",
         "infra",
         "opensre.egg-info",

--- a/infra/ci/test_scope_rules.py
+++ b/infra/ci/test_scope_rules.py
@@ -36,6 +36,7 @@ RULES: tuple[PathRule, ...] = (
     PathRule("integrations/", ("tests/integrations/",)),
     PathRule("tools/fleet_monitoring/", ("tests/agent/", "tests/fleet_monitoring/")),
     PathRule("cli/", ("tests/cli/",)),
+    PathRule("interactive_shell/", ("tests/interactive_shell/",)),
     PathRule("tools/watch_dog/", ("tests/watch_dog/",)),
     PathRule("tools/", ("tests/tools/",)),
     PathRule("platform/analytics/", ("tests/analytics/",)),
@@ -63,8 +64,6 @@ def _matches(path: str, prefix: str) -> bool:
 
 def _area_key(prefix: str) -> str:
     parts = prefix.split("/")
-    if len(parts) > 1 and parts[0] == "app":
-        return parts[1]
     if parts[0] == "deployment" or parts[:2] == ["infra", "deployment"]:
         return "deployment"
     return prefix
@@ -93,12 +92,8 @@ def classify(changed: list[str]) -> tuple[bool, list[str], list[str]]:
                         targets.append(target)
             break
 
-        if not matched:
-            if path.startswith("tests/"):
-                if path not in targets:
-                    targets.append(path)
-            elif path.startswith("app/"):
-                escalate = True
+        if not matched and path.startswith("tests/") and path not in targets:
+            targets.append(path)
 
     if len(areas) >= ESCALATION_AREA_THRESHOLD:
         escalate = True

--- a/tests/infra_ci/test_test_scope_rules.py
+++ b/tests/infra_ci/test_test_scope_rules.py
@@ -33,6 +33,13 @@ def test_hermes_rule_routes_to_tests_hermes_not_integrations() -> None:
     assert targets == ["tests/hermes/"]
 
 
+def test_interactive_shell_routes_to_its_own_tests() -> None:
+    rules = _rules_module()
+    escalate, targets, _ = rules.classify(["interactive_shell/runtime/session.py"])
+    assert not escalate
+    assert targets == ["tests/interactive_shell/"]
+
+
 def test_three_areas_escalates() -> None:
     rules = _rules_module()
     changed = [


### PR DESCRIPTION
Fixes #3162

#### Describe the changes you have made in this PR -

`make test-scope` (CI.md §2) maps changed paths to scoped pytest targets. The top-level
`interactive_shell/` package (200 `.py` files — the interactive shell, the product's
primary surface) had **no `PathRule`**, so an interactive-shell-only diff matched nothing
and fell through to the full-suite fallback in `run_test_scope.py` — running the entire
`make test-cov` every time instead of the fast scoped `tests/interactive_shell/` run that
`cli/`, `tools/`, and `integrations/` all get. It moved out of `cli/interactive_shell/`
to top-level during the restructures and was never wired into the routing table.

This PR:
- adds `PathRule("interactive_shell/", ("tests/interactive_shell/",))` next to its peer
  `cli/` rule;
- removes the dead `app` handling left by #3067 (which removed the top-level `app/` tree):
  the `_area_key` `app` branch and the `classify` `elif path.startswith("app/")` branch in
  `test_scope_rules.py`, plus the `"app"` entry in `check_import_cycles.py`'s skip-dirs set;
- adds a routing test mirroring the existing `cli`/`hermes` cases.

Net effect: interactive-shell changes now run the scoped suite, and the routing module is
free of references to a tree that no longer exists. No behavior change for any other path
(3-area escalation, core/shared escalation, and `tests/` passthrough are unchanged).

### Demo/Screenshot for feature changes and bug fixes -

Before:

```
$ uv run python -c "...classify(['interactive_shell/runtime/session.py'])"
(False, [], [])          # no targets → run_test_scope.py runs full make test-cov
```

After:

```
$ uv run python -c "...classify(['interactive_shell/runtime/session.py'])"
(False, ['tests/interactive_shell/'], ['interactive_shell/'])   # scoped, 64 test files

$ uv run python -m pytest tests/infra_ci/test_test_scope_rules.py tests/infra_ci/test_check_import_cycles.py -q
9 passed

$ uv run ruff check / format --check / mypy   (changed files)
All checks passed!  3 files already formatted  Success: no issues found
```

3-area escalation still trips (`classify([...3 areas...])[0] == True`), confirming the
dead-code removal preserved escalation behavior.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I compared every top-level source package against the `RULES` table and found
`interactive_shell` was the only one without a routing rule, so it always hit the
full-suite fallback. I added the rule pointing at `tests/interactive_shell/` (the package's
existing 64-file test dir), matching the `cli/` → `tests/cli/` pattern. While there I
removed the two dead `app` branches and the `"app"` skip entry that #3067 left behind, and
confirmed escalation behavior is unchanged. Verified with the routing unit tests and the
lint/format/typecheck gate.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
