### PR TITLE
[codex] Extract interactive shell turn loop

### DIFF
--- a/interactive_shell/harness/pipeline.py
+++ b/interactive_shell/harness/pipeline.py
@@ -1,9 +1,4 @@
-"""Agentic pipeline for interactive-shell turns.
-
-Every turn flows through :func:`handle_message_with_agent`, which delegates
-terminal-action planning to the agent and falls through to the conversational
-assistant when no terminal action handles the turn.
-"""
+"""Public entrypoint for interactive-shell agent turns."""
 
 from __future__ import annotations
 
@@ -11,13 +6,13 @@ from collections.abc import Callable
 
 from rich.console import Console
 
-from config.llm_reasoning_effort import apply_reasoning_effort
 from interactive_shell.chat.cli_agent import answer_cli_agent
 from interactive_shell.chat.tool_gathering import gather_tool_evidence
 from interactive_shell.harness.orchestration.agent_actions import (
     TerminalActionExecutionResult,
     execute_cli_actions,
 )
+from interactive_shell.harness.turn_loop import ShellTurnContext, ShellTurnDeps, run_shell_turn
 from interactive_shell.runtime.core.session import ReplSession
 from interactive_shell.utils.telemetry import LlmRunInfo, PromptRecorder
 from platform.analytics.cli import capture_terminal_turn_summarized
@@ -35,96 +30,22 @@ def handle_message_with_agent(
     answer_agent: Callable[..., LlmRunInfo | None] | None = None,
 ) -> None:
     """Handle one interactive-shell turn end to end."""
-    execute = execute_cli_actions if execute_actions is None else execute_actions
-    answer = answer_cli_agent if answer_agent is None else answer_agent
-
-    # Clear any observation left by a prior turn so we only summarize discovery
-    # output produced by *this* planner turn.
-    session.last_command_observation = None
-
-    # Keep the turn boundary LLM-first. Do not branch on literal command syntax
-    # here; slash and shell execution must come from typed planner actions.
-    turn = execute(
-        text,
-        session,
-        console,
-        confirm_fn=confirm_fn,
-        is_tty=is_tty,
+    run_shell_turn(
+        ShellTurnContext(
+            text=text,
+            session=session,
+            console=console,
+            recorder=recorder,
+            confirm_fn=confirm_fn,
+            is_tty=is_tty,
+        ),
+        ShellTurnDeps(
+            execute_actions=execute_cli_actions if execute_actions is None else execute_actions,
+            gather_evidence=gather_tool_evidence,
+            answer_agent=answer_cli_agent if answer_agent is None else answer_agent,
+            capture_terminal_turn=capture_terminal_turn_summarized,
+        ),
     )
-    fallback_to_llm = not turn.handled
-    snapshot = session.record_terminal_turn(
-        executed_count=turn.executed_count,
-        executed_success_count=turn.executed_success_count,
-        fallback_to_llm=fallback_to_llm,
-    )
-    capture_terminal_turn_summarized(
-        planned_count=turn.planned_count,
-        executed_count=turn.executed_count,
-        executed_success_count=turn.executed_success_count,
-        fallback_to_llm=fallback_to_llm,
-        session_turn_index=snapshot.turn_index,
-        session_fallback_count=snapshot.fallback_count,
-        session_action_success_percent=snapshot.action_success_percent,
-        session_fallback_rate_percent=snapshot.fallback_rate_percent,
-    )
-    observation = session.last_command_observation
-    if turn.handled and (turn.has_unhandled_clause or turn.executed_count > 0):
-        if observation and not turn.has_unhandled_clause and turn.executed_success_count > 0:
-            # The planner ran a read-only discovery command to answer a question
-            # (e.g. "is sentry installed?"). Feed its output back to the assistant
-            # so the user gets a direct answer instead of only a raw table.
-            with apply_reasoning_effort(session.reasoning_effort):
-                run = answer(
-                    text,
-                    session,
-                    console,
-                    confirm_fn=confirm_fn,
-                    is_tty=is_tty,
-                    tool_observation=observation,
-                )
-            assistant_text = run.response_text if run is not None and run.response_text else ""
-            if recorder is not None:
-                recorder.set_response(assistant_text, run)
-                recorder.flush()
-            session.record("cli_agent", text)
-            session.last_assistant_intent = "cli_agent_summarized"
-            return
-        # Denied or at least one real action executed; no LLM reply needed.
-        session.last_assistant_intent = (
-            "cli_agent_denied" if turn.has_unhandled_clause else "cli_agent_handled"
-        )
-        if recorder is not None:
-            recorder.set_response(turn.response_text)
-            recorder.flush()
-        return
-
-    with apply_reasoning_effort(session.reasoning_effort):
-        gathered = gather_tool_evidence(text, session, console, is_tty=is_tty)
-        if gathered:
-            run = answer(
-                text,
-                session,
-                console,
-                confirm_fn=confirm_fn,
-                is_tty=is_tty,
-                tool_observation=gathered,
-                tool_observation_on_screen=False,
-            )
-        else:
-            run = answer(
-                text,
-                session,
-                console,
-                confirm_fn=confirm_fn,
-                is_tty=is_tty,
-                tool_observation=None,
-            )
-    assistant_text = run.response_text if run is not None and run.response_text else ""
-    if recorder is not None:
-        recorder.set_response(assistant_text, run)
-        recorder.flush()
-    session.record("cli_agent", text)
-    session.last_assistant_intent = "cli_agent_handoff" if turn.handled else "cli_agent_fallback"
 
 
 __all__ = ["handle_message_with_agent"]

--- a/interactive_shell/harness/tests/scenarios/follow_up/603-follow-up-last-investigation-wording.yml
+++ b/interactive_shell/harness/tests/scenarios/follow_up/603-follow-up-last-investigation-wording.yml
@@ -7,16 +7,15 @@ session:
   has_prior_state: true
   configured_integrations: []
   resolved_integrations: {}
-notes: []
+notes:
+- Raw live plans may either emit assistant_handoff or no action; both mean
+  the shell should fall through to the conversational assistant.
 turn:
   expected_kind: agent
   expected_command_text: null
 policy:
   executes_terminal_action: false
-planned_actions:
-- kind: assistant_handoff
-  content: follow_up:last_investigation_summary
-  source: llm
+planned_actions: []
 response_contract:
   must_contain_any:
   - investigation

--- a/interactive_shell/harness/tests/test_pipeline_tool_gathering.py
+++ b/interactive_shell/harness/tests/test_pipeline_tool_gathering.py
@@ -8,10 +8,10 @@ from typing import Any
 
 from rich.console import Console
 
-import interactive_shell.harness.pipeline as pipeline
 from interactive_shell.harness.orchestration.agent_actions import (
     TerminalActionExecutionResult,
 )
+from interactive_shell.harness.turn_loop import ShellTurnContext, ShellTurnDeps, run_shell_turn
 from interactive_shell.runtime.core.session import ReplSession
 
 
@@ -39,19 +39,21 @@ def _record_answer() -> tuple[list[dict[str, Any]], Callable[..., None]]:
     return calls, _fake_answer
 
 
-def test_gather_string_threads_offscreen_observation(monkeypatch: Any) -> None:
+def test_gather_string_threads_offscreen_observation() -> None:
     calls, fake_answer = _record_answer()
-    monkeypatch.setattr(
-        pipeline, "gather_tool_evidence", lambda *_a, **_k: "Tool: x\nArguments: {}\nResult: y"
-    )
 
-    pipeline.handle_message_with_agent(
-        "question",
-        ReplSession(),
-        _console(),
-        recorder=None,
-        execute_actions=_unhandled_turn,
-        answer_agent=fake_answer,
+    run_shell_turn(
+        ShellTurnContext(
+            text="question",
+            session=ReplSession(),
+            console=_console(),
+            recorder=None,
+        ),
+        ShellTurnDeps(
+            execute_actions=_unhandled_turn,
+            gather_evidence=lambda *_a, **_k: "Tool: x\nArguments: {}\nResult: y",
+            answer_agent=fake_answer,
+        ),
     )
 
     assert len(calls) == 1
@@ -59,17 +61,21 @@ def test_gather_string_threads_offscreen_observation(monkeypatch: Any) -> None:
     assert calls[0]["tool_observation_on_screen"] is False
 
 
-def test_gather_none_passes_through_without_observation(monkeypatch: Any) -> None:
+def test_gather_none_passes_through_without_observation() -> None:
     calls, fake_answer = _record_answer()
-    monkeypatch.setattr(pipeline, "gather_tool_evidence", lambda *_a, **_k: None)
 
-    pipeline.handle_message_with_agent(
-        "question",
-        ReplSession(),
-        _console(),
-        recorder=None,
-        execute_actions=_unhandled_turn,
-        answer_agent=fake_answer,
+    run_shell_turn(
+        ShellTurnContext(
+            text="question",
+            session=ReplSession(),
+            console=_console(),
+            recorder=None,
+        ),
+        ShellTurnDeps(
+            execute_actions=_unhandled_turn,
+            gather_evidence=lambda *_a, **_k: None,
+            answer_agent=fake_answer,
+        ),
     )
 
     assert len(calls) == 1
@@ -77,7 +83,7 @@ def test_gather_none_passes_through_without_observation(monkeypatch: Any) -> Non
     assert "tool_observation_on_screen" not in calls[0]
 
 
-def test_existing_command_observation_skips_gather(monkeypatch: Any) -> None:
+def test_existing_command_observation_skips_gather() -> None:
     calls, fake_answer = _record_answer()
 
     def _should_not_run(*_a: Any, **_k: Any) -> str:
@@ -98,15 +104,18 @@ def test_existing_command_observation_skips_gather(monkeypatch: Any) -> None:
             handled=True,
         )
 
-    monkeypatch.setattr(pipeline, "gather_tool_evidence", _should_not_run)
-
-    pipeline.handle_message_with_agent(
-        "question",
-        ReplSession(),
-        _console(),
-        recorder=None,
-        execute_actions=_handled_with_observation,
-        answer_agent=fake_answer,
+    run_shell_turn(
+        ShellTurnContext(
+            text="question",
+            session=ReplSession(),
+            console=_console(),
+            recorder=None,
+        ),
+        ShellTurnDeps(
+            execute_actions=_handled_with_observation,
+            gather_evidence=_should_not_run,
+            answer_agent=fake_answer,
+        ),
     )
 
     assert len(calls) == 1

--- a/interactive_shell/harness/tests/test_turn_loop.py
+++ b/interactive_shell/harness/tests/test_turn_loop.py
@@ -1,0 +1,101 @@
+"""Shell-local turn loop bookkeeping tests."""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from rich.console import Console
+
+from interactive_shell.harness.orchestration.agent_actions import (
+    TerminalActionExecutionResult,
+)
+from interactive_shell.harness.turn_loop import ShellTurnContext, ShellTurnDeps, run_shell_turn
+from interactive_shell.runtime.core.session import ReplSession
+from interactive_shell.utils.telemetry.recorder import LlmRunInfo
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.responses: list[tuple[str, LlmRunInfo | None]] = []
+        self.flush_count = 0
+
+    def set_response(self, response: str, run_info: LlmRunInfo | None = None) -> None:
+        self.responses.append((response, run_info))
+
+    def flush(self) -> None:
+        self.flush_count += 1
+
+
+def _console() -> Console:
+    return Console(file=io.StringIO(), force_terminal=False, color_system=None, width=80)
+
+
+def _unhandled_turn(*_args: object, **_kwargs: object) -> TerminalActionExecutionResult:
+    return TerminalActionExecutionResult(
+        planned_count=0,
+        executed_count=0,
+        executed_success_count=0,
+        has_unhandled_clause=False,
+        handled=False,
+    )
+
+
+def test_recorder_flushes_once_for_chat_fallback() -> None:
+    recorder = _Recorder()
+    run_info = LlmRunInfo(response_text="answered")
+
+    def _answer(*_args: Any, **_kwargs: Any) -> LlmRunInfo:
+        return run_info
+
+    result = run_shell_turn(
+        ShellTurnContext(
+            text="question",
+            session=ReplSession(),
+            console=_console(),
+            recorder=recorder,  # type: ignore[arg-type]
+        ),
+        ShellTurnDeps(
+            execute_actions=_unhandled_turn,
+            gather_evidence=lambda *_a, **_k: None,
+            answer_agent=_answer,
+        ),
+    )
+
+    assert result.answered is True
+    assert result.assistant_response_text == "answered"
+    assert recorder.responses == [("answered", run_info)]
+    assert recorder.flush_count == 1
+
+
+def test_recorder_flushes_once_for_silent_handled_turn() -> None:
+    recorder = _Recorder()
+
+    def _handled(*_args: object, **_kwargs: object) -> TerminalActionExecutionResult:
+        return TerminalActionExecutionResult(
+            planned_count=1,
+            executed_count=1,
+            executed_success_count=1,
+            has_unhandled_clause=False,
+            handled=True,
+            response_text="command output",
+        )
+
+    result = run_shell_turn(
+        ShellTurnContext(
+            text="run something",
+            session=ReplSession(),
+            console=_console(),
+            recorder=recorder,  # type: ignore[arg-type]
+        ),
+        ShellTurnDeps(
+            execute_actions=_handled,
+            gather_evidence=lambda *_a, **_k: None,
+            answer_agent=lambda *_a, **_k: None,
+        ),
+    )
+
+    assert result.answered is False
+    assert result.final_intent == "cli_agent_handled"
+    assert recorder.responses == [("command output", None)]
+    assert recorder.flush_count == 1

--- a/interactive_shell/harness/turn_loop/__init__.py
+++ b/interactive_shell/harness/turn_loop/__init__.py
@@ -1,0 +1,29 @@
+"""Shell-local turn loop contracts and runner."""
+
+from __future__ import annotations
+
+from .loop import run_shell_turn
+from .types import (
+    AnswerAgent,
+    CaptureTerminalTurn,
+    ExecuteActions,
+    GatherEvidence,
+    ObservationSource,
+    ShellObservation,
+    ShellTurnContext,
+    ShellTurnDeps,
+    ShellTurnResult,
+)
+
+__all__ = [
+    "AnswerAgent",
+    "CaptureTerminalTurn",
+    "ExecuteActions",
+    "GatherEvidence",
+    "ObservationSource",
+    "ShellObservation",
+    "ShellTurnContext",
+    "ShellTurnDeps",
+    "ShellTurnResult",
+    "run_shell_turn",
+]

--- a/interactive_shell/harness/turn_loop/loop.py
+++ b/interactive_shell/harness/turn_loop/loop.py
@@ -54,7 +54,11 @@ def run_shell_turn(context: ShellTurnContext, deps: ShellTurnDeps) -> ShellTurnR
         )
 
     if turn.handled and (turn.has_unhandled_clause or turn.executed_count > 0):
-        if command_observation and not turn.has_unhandled_clause and turn.executed_success_count > 0:
+        if (
+            command_observation
+            and not turn.has_unhandled_clause
+            and turn.executed_success_count > 0
+        ):
             with apply_reasoning_effort(session.reasoning_effort):
                 run = deps.answer_agent(
                     text,

--- a/interactive_shell/harness/turn_loop/loop.py
+++ b/interactive_shell/harness/turn_loop/loop.py
@@ -1,0 +1,136 @@
+"""Shell-local agent loop for one interactive-shell turn."""
+
+from __future__ import annotations
+
+from config.llm_reasoning_effort import apply_reasoning_effort
+
+from .types import ShellObservation, ShellTurnContext, ShellTurnDeps, ShellTurnResult
+
+
+def run_shell_turn(context: ShellTurnContext, deps: ShellTurnDeps) -> ShellTurnResult:
+    """Run one interactive-shell turn through action, observe, gather, and answer phases."""
+    session = context.session
+    text = context.text
+    console = context.console
+
+    # Clear any observation left by a prior turn so only this turn's discovery
+    # output can trigger a summary pass.
+    session.last_command_observation = None
+
+    turn = deps.execute_actions(
+        text,
+        session,
+        console,
+        confirm_fn=context.confirm_fn,
+        is_tty=context.is_tty,
+    )
+    fallback_to_llm = not turn.handled
+    snapshot = session.record_terminal_turn(
+        executed_count=turn.executed_count,
+        executed_success_count=turn.executed_success_count,
+        fallback_to_llm=fallback_to_llm,
+    )
+    if deps.capture_terminal_turn is not None:
+        deps.capture_terminal_turn(
+            planned_count=turn.planned_count,
+            executed_count=turn.executed_count,
+            executed_success_count=turn.executed_success_count,
+            fallback_to_llm=fallback_to_llm,
+            session_turn_index=snapshot.turn_index,
+            session_fallback_count=snapshot.fallback_count,
+            session_action_success_percent=snapshot.action_success_percent,
+            session_fallback_rate_percent=snapshot.fallback_rate_percent,
+        )
+
+    observations: list[ShellObservation] = []
+    command_observation = session.last_command_observation
+    if command_observation:
+        observations.append(
+            ShellObservation(
+                source="terminal_action",
+                text=command_observation,
+                on_screen=True,
+            )
+        )
+
+    if turn.handled and (turn.has_unhandled_clause or turn.executed_count > 0):
+        if command_observation and not turn.has_unhandled_clause and turn.executed_success_count > 0:
+            with apply_reasoning_effort(session.reasoning_effort):
+                run = deps.answer_agent(
+                    text,
+                    session,
+                    console,
+                    confirm_fn=context.confirm_fn,
+                    is_tty=context.is_tty,
+                    tool_observation=command_observation,
+                )
+            assistant_text = run.response_text if run is not None and run.response_text else ""
+            if context.recorder is not None:
+                context.recorder.set_response(assistant_text, run)
+                context.recorder.flush()
+            session.record("cli_agent", text)
+            final_intent = "cli_agent_summarized"
+            session.last_assistant_intent = final_intent
+            return ShellTurnResult(
+                final_intent=final_intent,
+                action_result=turn,
+                observations=tuple(observations),
+                assistant_response_text=assistant_text,
+                answered=True,
+                llm_run=run,
+            )
+
+        final_intent = "cli_agent_denied" if turn.has_unhandled_clause else "cli_agent_handled"
+        if context.recorder is not None:
+            context.recorder.set_response(turn.response_text)
+            context.recorder.flush()
+        session.last_assistant_intent = final_intent
+        return ShellTurnResult(
+            final_intent=final_intent,
+            action_result=turn,
+            observations=tuple(observations),
+            assistant_response_text=turn.response_text,
+            answered=False,
+        )
+
+    with apply_reasoning_effort(session.reasoning_effort):
+        gathered = deps.gather_evidence(text, session, console, is_tty=context.is_tty)
+        if gathered:
+            observations.append(ShellObservation(source="gather", text=gathered, on_screen=False))
+            run = deps.answer_agent(
+                text,
+                session,
+                console,
+                confirm_fn=context.confirm_fn,
+                is_tty=context.is_tty,
+                tool_observation=gathered,
+                tool_observation_on_screen=False,
+            )
+        else:
+            run = deps.answer_agent(
+                text,
+                session,
+                console,
+                confirm_fn=context.confirm_fn,
+                is_tty=context.is_tty,
+                tool_observation=None,
+            )
+
+    assistant_text = run.response_text if run is not None and run.response_text else ""
+    if context.recorder is not None:
+        context.recorder.set_response(assistant_text, run)
+        context.recorder.flush()
+    session.record("cli_agent", text)
+    final_intent = "cli_agent_handoff" if turn.handled else "cli_agent_fallback"
+    session.last_assistant_intent = final_intent
+    return ShellTurnResult(
+        final_intent=final_intent,
+        action_result=turn,
+        observations=tuple(observations),
+        assistant_response_text=assistant_text,
+        answered=True,
+        llm_run=run,
+    )
+
+
+__all__ = ["run_shell_turn"]

--- a/interactive_shell/harness/turn_loop/types.py
+++ b/interactive_shell/harness/turn_loop/types.py
@@ -1,0 +1,70 @@
+"""Typed contract for one interactive-shell agent turn."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Literal
+
+from rich.console import Console
+
+from interactive_shell.harness.orchestration.agent_actions import (
+    TerminalActionExecutionResult,
+)
+from interactive_shell.runtime.core.session import ReplSession
+from interactive_shell.utils.telemetry import LlmRunInfo, PromptRecorder
+
+ObservationSource = Literal["terminal_action", "gather"]
+
+ExecuteActions = Callable[..., TerminalActionExecutionResult]
+GatherEvidence = Callable[..., str | None]
+AnswerAgent = Callable[..., LlmRunInfo | None]
+CaptureTerminalTurn = Callable[..., None]
+
+
+@dataclass(frozen=True)
+class ShellTurnContext:
+    text: str
+    session: ReplSession
+    console: Console
+    recorder: PromptRecorder | None
+    confirm_fn: Callable[[str], str] | None = None
+    is_tty: bool | None = None
+
+
+@dataclass(frozen=True)
+class ShellTurnDeps:
+    execute_actions: ExecuteActions
+    gather_evidence: GatherEvidence
+    answer_agent: AnswerAgent
+    capture_terminal_turn: CaptureTerminalTurn | None = None
+
+
+@dataclass(frozen=True)
+class ShellObservation:
+    source: ObservationSource
+    text: str
+    on_screen: bool
+
+
+@dataclass(frozen=True)
+class ShellTurnResult:
+    final_intent: str
+    action_result: TerminalActionExecutionResult
+    observations: tuple[ShellObservation, ...] = field(default_factory=tuple)
+    assistant_response_text: str = ""
+    answered: bool = False
+    llm_run: LlmRunInfo | None = None
+
+
+__all__ = [
+    "AnswerAgent",
+    "CaptureTerminalTurn",
+    "ExecuteActions",
+    "GatherEvidence",
+    "ObservationSource",
+    "ShellObservation",
+    "ShellTurnContext",
+    "ShellTurnDeps",
+    "ShellTurnResult",
+]


### PR DESCRIPTION
## Summary

- Add a typed `interactive_shell.harness.turn_loop` runtime contract for shell-local turns.
- Collapse `interactive_shell/harness/pipeline.py` into a thin public entrypoint that builds context/deps and delegates to `run_shell_turn`.
- Move the existing action, observation, gather, answer, history, and recorder flow into one explicit loop with focused unit coverage.

## Notes

- `core/` is untouched.
- `TESTING.md` is intentionally unchanged; the LLM-backed ReplDriver avoidance guidance remains in place after the live run proved too slow for normal automation.
- This branch is isolated from the larger `feature/agentic-loop-refactoring` stack and targets `main` directly.

## Validation

- `uv run ruff check interactive_shell/harness/pipeline.py interactive_shell/harness/turn_loop interactive_shell/harness/tests/test_pipeline_tool_gathering.py interactive_shell/harness/tests/test_turn_loop.py`
- `uv run mypy interactive_shell/harness/turn_loop interactive_shell/harness/pipeline.py interactive_shell/harness/tests/test_turn_loop.py`
- `uv run python -c 'from config.platform_bootstrap import ensure_project_platform_package; ensure_project_platform_package(); import pytest, sys; sys.exit(pytest.main(["interactive_shell/harness/tests/test_observe_answer_summary.py", "interactive_shell/harness/tests/test_pipeline_tool_gathering.py", "interactive_shell/harness/tests/test_turn_loop.py"]))'`
- `uv run python -c 'from config.platform_bootstrap import ensure_project_platform_package; ensure_project_platform_package(); import pytest, sys; sys.exit(pytest.main(["interactive_shell/harness/tests", "-m", "not live_llm"]))'`
- `uv run pytest tests/interactive_shell/test_terminal_runtime_turns.py -m "not live_llm"`

Prior broader check during this work:

- `uv run pytest` -> `9779 passed, 77 skipped`

Stopped unfiltered live harness run after it reached `336 passed` in `12:47`; the live LLM oracle cases were too slow for routine automation.