### PR TITLE
fix(llm): honor every provider's retry-after hint in both clients

### DIFF
--- a/.github/workflows/ci-labels-windows.yml
+++ b/.github/workflows/ci-labels-windows.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   # Keep in sync with ci.yml — single source of truth for lint/typecheck/coverage targets.
-  PYTHON_SOURCE_PATHS: "cli config core infra/deployment integrations platform tools"
+  PYTHON_SOURCE_PATHS: "cli config core infra/deployment integrations interactive_shell platform tools"
 
 concurrency:
   group: ci-labels-windows-${{ github.ref }}
@@ -101,7 +101,7 @@ jobs:
       - name: Run full tests
         run: >-
           uv run python -m pytest -n auto -v
-          --cov=cli --cov=config --cov=core --cov=infra/deployment --cov=integrations --cov=platform --cov=tools
+          --cov=cli --cov=config --cov=core --cov=infra/deployment --cov=integrations --cov=interactive_shell --cov=platform --cov=tools
           --cov-report=term-missing
           --cov-report=html
           --ignore=tests/e2e/kubernetes_local_alert_simulation

--- a/.github/workflows/ci-labels-windows.yml
+++ b/.github/workflows/ci-labels-windows.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Run full tests
         run: >-
           uv run python -m pytest -n auto -v
-          --cov=cli --cov=config --cov=core --cov=infra/deployment --cov=integrations --cov=interactive_shell --cov=platform --cov=tools
+          --cov=cli --cov=config --cov=core --cov=infra.deployment --cov=integrations --cov=interactive_shell --cov=platform --cov=tools
           --cov-report=term-missing
           --cov-report=html
           --ignore=tests/e2e/kubernetes_local_alert_simulation

--- a/core/runtime/llm/llm_client.py
+++ b/core/runtime/llm/llm_client.py
@@ -58,6 +58,7 @@ from config.config import (
 from config.llm_credentials import resolve_llm_api_key
 from config.llm_reasoning_effort import get_active_reasoning_effort
 from core.domain.types.root_cause_categories import VALID_ROOT_CAUSE_CATEGORIES
+from core.runtime.llm.llm_retry import extract_retry_after_seconds
 
 logger = logging.getLogger(__name__)
 
@@ -748,30 +749,6 @@ def _format_openai_connection_error(err: Exception, provider_label: str) -> str:
     )
 
 
-def _parse_retry_after(err: Exception) -> float:
-    """Extract the suggested retry delay in seconds from a RateLimitError.
-
-    Google/Gemini embeds the delay in the error body's ``details`` array as a
-    ``retryDelay`` field (e.g. ``"5s"``), and also in the human-readable
-    message (``"Please retry in 5.478238622s"``).  Returns 0 if nothing is
-    found so callers can fall back to their own backoff.
-    """
-    body = getattr(err, "body", None)
-    if isinstance(body, dict):
-        error_obj = body.get("error", {})
-        if isinstance(error_obj, dict):
-            for detail in error_obj.get("details", []):
-                delay_str = detail.get("retryDelay", "")
-                if delay_str:
-                    m = re.search(r"^(\d+(?:\.\d+)?)\s*s$", str(delay_str).strip())
-                    if m:
-                        return min(float(m.group(1)), 60.0)
-    m = re.search(r"[Rr]etry in (\d+(?:\.\d+)?)s", str(err))
-    if m:
-        return min(float(m.group(1)), 60.0)
-    return 0.0
-
-
 def _uses_max_completion_tokens(model: str) -> bool:
     """Reasoning models (o1, o3, o4, gpt-5 series) require max_completion_tokens."""
     return model.startswith(("o1", "o3", "o4", "gpt-5"))
@@ -959,7 +936,7 @@ class OpenAILLMClient:
                         f"{self._provider_label} rate limit exceeded (HTTP 429) after multiple retries. "
                         "Check your quota and billing details."
                     ) from err
-                suggested = _parse_retry_after(err)
+                suggested = extract_retry_after_seconds(err) or 0.0
                 wait = max(suggested, backoff_seconds)
                 time.sleep(wait)
                 backoff_seconds = wait * 2
@@ -1096,7 +1073,7 @@ class OpenAILLMClient:
                         f"{self._provider_label} rate limit exceeded (HTTP 429) after multiple retries. "
                         "Check your quota and billing details."
                     ) from err
-                suggested = _parse_retry_after(err)
+                suggested = extract_retry_after_seconds(err) or 0.0
                 wait = max(suggested, backoff_seconds)
                 time.sleep(wait)
                 backoff_seconds = wait * 2

--- a/core/runtime/llm/llm_retry.py
+++ b/core/runtime/llm/llm_retry.py
@@ -43,10 +43,14 @@ DEFAULT_INITIAL_BACKOFF_SEC = 2.0
 # multi-second TPM resets, short enough that operator interruption is fast.
 RETRY_AFTER_MAX_SEC = 30.0
 
-# Body-text pattern OpenAI uses: ``"Please try again in 94ms"`` or
-# ``"try again in 36s"``. Anthropic does not include a body hint; relies on
-# the HTTP ``retry-after`` header instead.
-_BODY_RETRY_HINT_RE = re.compile(r"try again in (\d+(?:\.\d+)?)\s*(ms|s)\b", re.IGNORECASE)
+# Body-text patterns providers embed in the error message:
+#   - OpenAI:        ``"Please try again in 94ms"`` / ``"try again in 36s"``
+#   - Google/Gemini: ``"Please retry in 5.478s"``
+# Anthropic does not include a body hint; it relies on the HTTP ``retry-after``
+# header instead.
+_BODY_RETRY_HINT_RE = re.compile(
+    r"(?:try again in|retry in) (\d+(?:\.\d+)?)\s*(ms|s)\b", re.IGNORECASE
+)
 
 # Substrings present in the error text of OpenAI's RateLimitError, Anthropic's
 # RateLimitError, the RuntimeError wrappers opensre's clients raise on top of
@@ -190,18 +194,48 @@ def is_credit_exhausted_error(exc: BaseException) -> bool:
     return any(hint in text for hint in _CREDIT_EXHAUSTED_HINTS)
 
 
+def _structured_retry_delay_seconds(exc: BaseException) -> float | None:
+    """Return Google/Gemini's structured retry hint in seconds, or ``None``.
+
+    Gemini does not set an HTTP ``retry-after`` header. It carries the delay in
+    a ``RetryInfo`` entry of the error body's ``details`` array, e.g.::
+
+        {"error": {"details": [
+            {"@type": ".../google.rpc.RetryInfo", "retryDelay": "5s"},
+        ]}}
+
+    The value is a protobuf ``Duration`` string (``"5s"`` / ``"5.478s"``).
+    """
+    body = getattr(exc, "body", None)
+    if not isinstance(body, dict):
+        return None
+    error_obj = body.get("error")
+    if not isinstance(error_obj, dict):
+        return None
+    for detail in error_obj.get("details", []):
+        delay = detail.get("retryDelay") if isinstance(detail, dict) else None
+        if delay:
+            match = re.match(r"^(\d+(?:\.\d+)?)\s*s$", str(delay).strip())
+            if match:
+                return float(match.group(1))
+    return None
+
+
 def extract_retry_after_seconds(exc: BaseException) -> float | None:
     """Return the provider-suggested retry delay in seconds, or ``None``.
 
-    Looks in two places, in priority order:
+    Looks in three places, in priority order:
 
       1. The HTTP ``retry-after`` header on the underlying response object.
          Both Anthropic and OpenAI SDK errors expose ``err.response.headers``.
          RFC 7231 allows the value to be either ``"<integer seconds>"`` or
          an HTTP-date; we honor the integer form and skip dates (rare in
          practice and not worth the parsing complexity).
-      2. OpenAI's body-text hint: ``"Please try again in 94ms"``. The
-         regex tolerates either ``ms`` or ``s`` units.
+      2. Google/Gemini's structured ``error.details[].retryDelay`` body hint
+         (Gemini ships no ``retry-after`` header).
+      3. The body-text hint providers embed in the message:
+         OpenAI's ``"Please try again in 94ms"`` or Gemini's
+         ``"Please retry in 5.478s"``. The regex tolerates ``ms`` or ``s``.
 
     The result is capped at :data:`RETRY_AFTER_MAX_SEC` to bound pathological
     cases (a misconfigured proxy returning ``retry-after: 3600`` should not
@@ -225,6 +259,10 @@ def extract_retry_after_seconds(exc: BaseException) -> float | None:
                         return min(seconds, RETRY_AFTER_MAX_SEC)
                 except (ValueError, TypeError):
                     pass  # HTTP-date form; fall through to body parsing.
+
+    structured = _structured_retry_delay_seconds(exc)
+    if structured is not None:
+        return min(structured, RETRY_AFTER_MAX_SEC)
 
     match = _BODY_RETRY_HINT_RE.search(str(exc))
     if match:

--- a/core/runtime/llm/llm_retry.py
+++ b/core/runtime/llm/llm_retry.py
@@ -212,7 +212,7 @@ def _structured_retry_delay_seconds(exc: BaseException) -> float | None:
     error_obj = body.get("error")
     if not isinstance(error_obj, dict):
         return None
-    for detail in error_obj.get("details", []):
+    for detail in error_obj.get("details") or []:
         delay = detail.get("retryDelay") if isinstance(detail, dict) else None
         if delay:
             match = re.match(r"^(\d+(?:\.\d+)?)\s*s$", str(delay).strip())

--- a/tests/core/runtime/llm/test_llm_client.py
+++ b/tests/core/runtime/llm/test_llm_client.py
@@ -1328,47 +1328,10 @@ def test_anthropic_invoke_stream_not_found_raises_friendly_runtime_error(monkeyp
 
 
 # ---------------------------------------------------------------------------
-# _parse_retry_after — retry delay extraction
-# ---------------------------------------------------------------------------
-
-
-def test_parse_retry_after_reads_body_details() -> None:
-    """Extracts retryDelay from a Google/Gemini-style error body."""
-
-    class _FakeErr(Exception):
-        body = {
-            "error": {
-                "details": [
-                    {"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "5s"},
-                ]
-            }
-        }
-
-    assert llm_client._parse_retry_after(_FakeErr()) == 5.0
-
-
-def test_parse_retry_after_reads_message_fallback() -> None:
-    """Falls back to parsing 'retry in Xs' from the error message string."""
-    err = Exception("Please retry in 8.5s due to quota exceeded")
-    assert llm_client._parse_retry_after(err) == 8.5
-
-
-def test_parse_retry_after_caps_at_sixty_seconds() -> None:
-    """Never returns more than 60 seconds to prevent runaway waits."""
-
-    class _FakeErr(Exception):
-        body = {"error": {"details": [{"retryDelay": "120s"}]}}
-
-    assert llm_client._parse_retry_after(_FakeErr()) == 60.0
-
-
-def test_parse_retry_after_returns_zero_when_no_hint() -> None:
-    """Returns 0 when neither body nor message contains a delay."""
-    assert llm_client._parse_retry_after(Exception("quota exceeded")) == 0.0
-
-
-# ---------------------------------------------------------------------------
 # OpenAILLMClient.invoke — RateLimitError handling
+#
+# Retry-delay extraction (Gemini retryDelay, headers, body text) is unit-tested
+# in tests/utils/test_llm_retry.py against the shared extract_retry_after_seconds.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/utils/test_llm_retry.py
+++ b/tests/utils/test_llm_retry.py
@@ -389,6 +389,13 @@ def test_extract_retry_after_reads_gemini_retry_in_message() -> None:
     assert llm_retry.extract_retry_after_seconds(err) == 8.5
 
 
+def test_extract_retry_after_tolerates_null_details() -> None:
+    # A body with "details": null must not raise (no hint -> None).
+    err = RuntimeError("rate limited")
+    err.body = {"error": {"details": None}}  # type: ignore[attr-defined]
+    assert llm_retry.extract_retry_after_seconds(err) is None
+
+
 def test_extract_retry_after_skips_http_date_format() -> None:
     """HTTP-date Retry-After is allowed by RFC 7231 but rare. We don't parse
     it — fall through to body text or None."""

--- a/tests/utils/test_llm_retry.py
+++ b/tests/utils/test_llm_retry.py
@@ -355,6 +355,40 @@ def test_extract_retry_after_returns_none_when_no_hint_present() -> None:
     assert llm_retry.extract_retry_after_seconds(err) is None
 
 
+def _err_with_retry_delay(retry_delay: str, msg: str = "rate limited") -> RuntimeError:
+    """Build an error carrying a Gemini-style RetryInfo body (no header)."""
+    err = RuntimeError(msg)
+    err.body = {  # type: ignore[attr-defined]
+        "error": {
+            "details": [
+                {"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": retry_delay},
+            ]
+        }
+    }
+    return err
+
+
+def test_extract_retry_after_reads_gemini_structured_retry_delay() -> None:
+    # Gemini ships no retry-after header; the hint lives in error.details[].retryDelay.
+    assert llm_retry.extract_retry_after_seconds(_err_with_retry_delay("5s")) == 5.0
+
+
+def test_extract_retry_after_reads_gemini_fractional_retry_delay() -> None:
+    err = _err_with_retry_delay("5.478s")
+    assert llm_retry.extract_retry_after_seconds(err) == pytest.approx(5.478)
+
+
+def test_extract_retry_after_caps_gemini_retry_delay_at_max() -> None:
+    err = _err_with_retry_delay("120s")
+    assert llm_retry.extract_retry_after_seconds(err) == llm_retry.RETRY_AFTER_MAX_SEC
+
+
+def test_extract_retry_after_reads_gemini_retry_in_message() -> None:
+    # Gemini's human-readable form: "Please retry in 8.5s".
+    err = RuntimeError("Please retry in 8.5s due to quota exceeded")
+    assert llm_retry.extract_retry_after_seconds(err) == 8.5
+
+
 def test_extract_retry_after_skips_http_date_format() -> None:
     """HTTP-date Retry-After is allowed by RFC 7231 but rare. We don't parse
     it — fall through to body text or None."""


### PR DESCRIPTION
Fixes #3171

#### Describe the changes you have made in this PR -

The provider retry-after hint that drives 429 backoff was parsed in **two
independent places**, and each covered only a subset of providers — so each LLM
client was blind to the hint shape the other handled:

- **Investigation loop** (`agent_llm_client._rate_limit_sleep_seconds`) used the
  shared `extract_retry_after_seconds`, which read the HTTP `Retry-After` header
  and OpenAI's body hint but **not** Gemini's structured `retryDelay` → on a
  Gemini 429 the investigation ignored Gemini's explicit delay and fell back to
  blind jitter.
- **Chat client** (`llm_client._parse_retry_after`) read Gemini's `retryDelay`
  and a `"retry in Xs"` message but **not** the `Retry-After` header or OpenAI's
  `"try again in 94ms"` body hint → chat ignored the most common
  Anthropic/OpenAI signal.

This PR folds Gemini's structured `retryDelay` (and the `"retry in Xs"` message
form) into the shared `extract_retry_after_seconds`, then deletes the chat
client's duplicate `_parse_retry_after` and points both call sites at the shared
extractor. Both clients now honor **every** provider hint — header, structured
`retryDelay`, and body text — from one source of truth.

Behavior notes:
- The chat client now *also* honors the `Retry-After` header and OpenAI's
  `"try again in"` body hint (previously ignored).
- The investigation loop now *also* honors Gemini's `retryDelay` (previously
  ignored).
- The chat client's bespoke 60s cap is unified to the shared
  `RETRY_AFTER_MAX_SEC` (30s) — the documented bound that keeps a misconfigured
  hint from hanging the loop.

The `0.0`-fallback contract at the chat call sites is preserved
(`extract_retry_after_seconds(err) or 0.0`, then `max(suggested, backoff)`).

### Demo/Screenshot for feature changes and bug fixes -

<img width="1160" height="269" alt="image" src="https://github.com/user-attachments/assets/91e9e22f-b134-446d-8dd4-f0dcb36eea1d" />


Tests (all pass):

```
$ uv run python -m pytest tests/core/runtime/llm/ tests/utils/test_llm_retry.py -q
262 passed

$ make lint / format-check / typecheck   (changed files)
All checks passed!  •  formatted  •  Success: no issues found
```

Retry-delay extraction is now unit-tested in one place
(`tests/utils/test_llm_retry.py`), with the four Gemini cases moved out of
`test_llm_client.py` and folded in next to the existing header/body-text cases.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I traced the two retry-after parsers and found they covered disjoint provider
hint shapes — the shared extractor (used by the investigation loop) missed
Gemini's `retryDelay`, and the chat client's private parser missed the
`Retry-After` header and OpenAI's body hint. I added a small
`_structured_retry_delay_seconds` helper for Gemini's `RetryInfo` body and
broadened the body-text regex to also match `"retry in Xs"`, inserted the
structured check into the shared extractor between the header and body-text
branches, then deleted the chat duplicate and routed both call sites through the
shared function (keeping the `0.0` fallback). I verified the unified caps,
fallbacks, and all provider shapes with the consolidated unit tests.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
