### PR TITLE
feat(llm): add Pi CLI (pi.dev) as a BYOK subprocess LLM provider

### DIFF
--- a/cli/wizard/config.py
+++ b/cli/wizard/config.py
@@ -425,6 +425,24 @@ GROK_CLI_MODELS = (
 )
 
 
+def _pi_adapter_factory() -> LLMCLIAdapter:
+    from integrations.llm_cli.pi_cli import PiAdapter
+
+    return PiAdapter()
+
+
+# Pi is BYOK/multi-provider; models use the ``provider/model`` form. These are a
+# convenience shortlist — ``allow_custom_models=True`` lets users type any model
+# (and PI_MODEL overrides at runtime). Run ``pi --list-models`` for the full set.
+PI_MODELS = (
+    ModelOption(value="", label="CLI default (no --model; use Pi configured model)"),
+    ModelOption(value="google/gemini-2.5-flash-lite", label="google/gemini-2.5-flash-lite"),
+    ModelOption(value="google/gemini-2.5-flash", label="google/gemini-2.5-flash"),
+    ModelOption(value="anthropic/claude-haiku-4-5", label="anthropic/claude-haiku-4-5"),
+    ModelOption(value="openai/gpt-4o-mini", label="openai/gpt-4o-mini"),
+)
+
+
 KIMI_MODELS = (
     ModelOption(
         value="",
@@ -676,6 +694,19 @@ SUPPORTED_PROVIDERS = (
         credential_kind="cli",
         credential_secret=False,
         adapter_factory=_grok_cli_adapter_factory,
+        allow_custom_models=True,
+    ),
+    ProviderOption(
+        value="pi",
+        label="Pi CLI (pi.dev, BYOK multi-provider)",
+        group="Local CLI providers",
+        api_key_env="",
+        model_env="PI_MODEL",
+        default_model="",
+        models=PI_MODELS,
+        credential_kind="cli",
+        credential_secret=False,
+        adapter_factory=_pi_adapter_factory,
         allow_custom_models=True,
     ),
     ProviderOption(

--- a/config/config.py
+++ b/config/config.py
@@ -171,6 +171,7 @@ LLMProvider = Literal[
     "kimi",
     "copilot",
     "grok-cli",
+    "pi",
 ]
 
 KEYLESS_LLM_PROVIDERS = frozenset(
@@ -186,6 +187,7 @@ KEYLESS_LLM_PROVIDERS = frozenset(
         "kimi",
         "copilot",
         "grok-cli",
+        "pi",
     }
 )
 LLM_PROVIDER_API_KEY_ENVS = {
@@ -452,6 +454,7 @@ class LLMSettings(StrictConfigModel):
             "kimi",
             "copilot",
             "grok-cli",
+            "pi",
         )
         if provider in valid_providers:
             return provider

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -22,6 +22,7 @@ OpenSRE is provider-agnostic: bring your own model. Selection is controlled by t
 | Claude Code CLI| `claude-code`| `claude login` (CLI)            | Claude Code CLI default                       | Claude Code CLI default                         |
 | GitHub Copilot CLI| `copilot`| `copilot login` or `gh auth login` (CLI) | Copilot CLI default                           | Copilot CLI default                             |
 | Google Antigravity CLI| `antigravity-cli`| `agy` (browser OAuth, OS keyring) | Whatever the local `agy` config is set to (switch via `/models` inside agy) | same as reasoning model |
+| Pi CLI (BYOK)| `pi`          | provider API key env or `pi` → `/login` | Pi configured model (`PI_MODEL` to override) | same as reasoning model |
 
 OpenSRE distinguishes two model slots per provider:
 
@@ -302,6 +303,37 @@ CLI adapters.
 
 > **Not to be confused with `groq`.** The `grok-cli` provider is xAI's Grok Build CLI. The
 > separate `groq` provider is the Groq HTTP API (a different company); the two are unrelated.
+
+### Pi CLI
+
+```bash
+export LLM_PROVIDER=pi
+# Authenticate Pi separately. Either path works — the adapter detects both:
+pi                       # then run /login for an OAuth subscription or to store a key
+# …or export a provider API key Pi understands (BYOK), e.g. for Gemini:
+export GEMINI_API_KEY=...
+
+export PI_MODEL=google/gemini-2.5-flash-lite  # provider/model; unset → Pi configured default
+export PI_BIN=                                # explicit path to the `pi` binary (optional)
+```
+
+Requires the [Pi CLI](https://pi.dev) (`npm i -g @earendil-works/pi-coding-agent`). Pi is
+bring-your-own-key across ~30 providers, so `PI_MODEL` uses the `provider/model` form
+(for example `google/gemini-2.5-flash-lite`, `anthropic/claude-haiku-4-5`, `openai/gpt-4o-mini`);
+run `pi --list-models` for the full catalog. If `PI_MODEL` is unset, OpenSRE omits `--model`
+and Pi uses its configured default. If `PI_BIN` is unset, the binary is resolved via `PATH`
+and known install locations.
+
+Invocations run as `pi -p PROMPT` (non-interactive print mode), so each OpenSRE call is a
+single headless turn with no TTY.
+
+**Auth detection:** Pi has no non-interactive auth-status command, so OpenSRE detects auth
+from state: (1) a supported provider API key in the environment (`GEMINI_API_KEY`,
+`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, …) → authenticated; (2) otherwise, credentials stored
+in `~/.pi/agent/auth.json` (written by `pi`'s `/login`, covering OAuth subscriptions and
+stored keys) → authenticated; (3) neither → not authenticated. Provider API keys are forwarded
+**only** to the Pi subprocess, never via the shared CLI env allowlist, so they cannot leak into
+other CLI adapters.
 
 See [`integrations/llm_cli/AGENTS.md`](https://github.com/Tracer-Cloud/opensre/blob/main/integrations/llm_cli/AGENTS.md) for the adapter pattern used to add new CLI providers.
 

--- a/integrations/llm_cli/AGENTS.md
+++ b/integrations/llm_cli/AGENTS.md
@@ -22,6 +22,7 @@ Use this package when adding a new **non-interactive** LLM that shells out to a 
 | `opencode.py`        | Multi-provider CLI: `--version`, then `opencode auth list` (see `_parse_opencode_auth_list_output`). |
 | `kimi.py`            | `kimi --print` path: `--version`, `kimi login status`, then env/config.toml fallback (`KIMI_API_KEY`). |
 | `copilot.py`         | `copilot -p` path: `--version`, then env tokens, then `gh auth status` (and `--hostname` when `COPILOT_GH_HOST` / `GH_HOST` targets a non-default host); otherwise `logged_in=None`. Plaintext `$COPILOT_HOME/config.json` is not inspected. No OS keychain probes. |
+| `pi_cli.py`          | Pi CLI (pi.dev, BYOK multi-provider) `pi -p` print mode: `--version`, then state-based auth (provider API key in env, else `~/.pi/agent/auth.json` from `/login`) — Pi has no non-interactive auth-status command. Provider keys forwarded via `CLIInvocation.env` (`PI_PROVIDER_ENV_KEYS`), never the blanket prefix. |
 | `grok_cli.py`        | xAI Grok Build CLI (`grok -p --output-format plain`): `--version`, then `grok models` (~0.5 s, no LLM call) to classify auth — looks for "You are logged in" / "logged in with" in output. `XAI_API_KEY` env promotes to authenticated as a headless/CI fallback even when the probe result is unclear. `XAI_API_KEY` forwarded only via `CLIInvocation.env` (`XAI_CLI_ENV_KEYS`), never the blanket prefix. Never passes `--always-approve`. |
 
 

--- a/integrations/llm_cli/env_overrides.py
+++ b/integrations/llm_cli/env_overrides.py
@@ -79,6 +79,43 @@ COPILOT_CLI_ENV_KEYS: Final[tuple[str, ...]] = (
     "GITHUB_TOKEN",
 )
 
+# Pi CLI (pi.dev) is bring-your-own-key across ~30 providers; it reads a
+# per-provider API-key env var (see https://pi.dev/docs/latest/providers).
+# These are secrets, so — like the Grok/Copilot tuples above — they are
+# forwarded *exclusively* via the Pi adapter's ``CLIInvocation.env`` and are
+# NOT covered by the ``PI_`` entry in ``_SAFE_SUBPROCESS_ENV_PREFIXES`` (that
+# prefix only carries Pi's own non-secret ``PI_*`` config vars). Keep this list
+# aligned with Pi's provider catalog when it adds providers.
+PI_PROVIDER_ENV_KEYS: Final[tuple[str, ...]] = (
+    "ANTHROPIC_API_KEY",
+    "ANT_LING_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "OPENAI_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "NVIDIA_API_KEY",
+    "GEMINI_API_KEY",
+    "MISTRAL_API_KEY",
+    "GROQ_API_KEY",
+    "CEREBRAS_API_KEY",
+    "CLOUDFLARE_API_KEY",
+    "XAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "AI_GATEWAY_API_KEY",
+    "ZAI_API_KEY",
+    "ZAI_CODING_CN_API_KEY",
+    "OPENCODE_API_KEY",
+    "HF_TOKEN",
+    "FIREWORKS_API_KEY",
+    "TOGETHER_API_KEY",
+    "KIMI_API_KEY",
+    "MINIMAX_API_KEY",
+    "MINIMAX_CN_API_KEY",
+    "XIAOMI_API_KEY",
+    "XIAOMI_TOKEN_PLAN_CN_API_KEY",
+    "XIAOMI_TOKEN_PLAN_AMS_API_KEY",
+    "XIAOMI_TOKEN_PLAN_SGP_API_KEY",
+)
+
 
 def nonempty_env_values(keys: tuple[str, ...]) -> dict[str, str]:
     """Return ``{name: value}`` for keys with non-empty stripped values in ``os.environ``."""

--- a/integrations/llm_cli/pi_cli.py
+++ b/integrations/llm_cli/pi_cli.py
@@ -1,0 +1,293 @@
+"""Pi CLI adapter (``pi -p``, non-interactive / print mode).
+
+Pi (https://pi.dev, repo: earendil-works/pi) is an open-source, bring-your-own-key
+coding-agent CLI that runs the same agent loop against ~30 providers (Anthropic,
+OpenAI, Google Gemini, xAI, DeepSeek, …). OpenSRE uses it purely as a one-shot
+text responder inside the ReAct loop, so invocations run in headless ``-p`` print
+mode (no TTY, no approval prompts).
+
+Env vars
+--------
+PI_BIN     Optional explicit path to the ``pi`` binary. Blank or non-runnable
+           paths are ignored; PATH + fallbacks still apply.
+PI_MODEL   Optional model override in Pi's ``provider/model`` form
+           (e.g. ``google/gemini-2.5-flash-lite``, ``anthropic/claude-haiku``).
+           Unset or empty → omit ``--model`` and the CLI's configured default
+           applies. Registered as ``model_env_key`` in ``registry.py``.
+
+Per-provider API keys (``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``,
+``GEMINI_API_KEY``, …) are forwarded to the Pi subprocess via
+``CLIInvocation.env`` (see ``PI_PROVIDER_ENV_KEYS`` in ``env_overrides.py``).
+
+Auth probe
+----------
+Pi exposes **no** non-interactive auth-status command — ``/login`` / ``/logout``
+are interactive TUI slash commands only. But Pi stores credentials in a readable
+file, so (mirroring the Kimi / Claude Code adapters) we detect auth from state
+rather than a probe subprocess. Resolution order:
+
+1. A supported provider API key in the environment → ``True`` (BYOK / headless).
+2. ``~/.pi/agent/auth.json`` present with credential content → ``True``. This is
+   the signal for users who authenticated via ``/login`` (OAuth subscriptions or
+   stored API keys) and have no provider key exported.
+3. Neither present → ``False`` (run ``pi`` and ``/login``, or export a key).
+4. Credential file present but unreadable / unparseable → ``None`` (unclear;
+   invocation will verify).
+
+This matches Pi's own credential-resolution priority (``--api-key`` flag >
+``auth.json`` > env var) and avoids depending on the undocumented auth behavior
+of ``pi --list-models``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from integrations.llm_cli.base import CLIInvocation, CLIProbe
+from integrations.llm_cli.binary_resolver import (
+    candidate_binary_names as _candidate_binary_names,
+)
+from integrations.llm_cli.binary_resolver import (
+    default_cli_fallback_paths as _default_cli_fallback_paths,
+)
+from integrations.llm_cli.binary_resolver import (
+    resolve_cli_binary,
+)
+from integrations.llm_cli.constants import DEFAULT_EXEC_TIMEOUT_SEC
+from integrations.llm_cli.env_overrides import (
+    PI_PROVIDER_ENV_KEYS,
+    nonempty_env_values,
+)
+from integrations.llm_cli.probe_utils import run_version_probe
+from integrations.llm_cli.semver_utils import parse_semver_three_part
+
+_PROBE_TIMEOUT_SEC = 8.0
+_AUTH_HINT = "Run `pi` then `/login`, or export a provider API key (e.g. GEMINI_API_KEY)."
+
+
+def _pi_agent_dir() -> Path:
+    """Return Pi's agent config dir, honoring ``PI_AGENT_DIR`` / ``PI_CONFIG_DIR``.
+
+    Defaults to ``~/.pi/agent`` (where Pi stores ``auth.json``). The override env
+    var names are best-effort; whatever ``PI_*`` dir var Pi uses is also forwarded
+    to the subprocess via the ``PI_`` prefix allowlist.
+    """
+    override = (
+        os.environ.get("PI_AGENT_DIR", "").strip() or os.environ.get("PI_CONFIG_DIR", "").strip()
+    )
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".pi" / "agent"
+
+
+def _has_provider_api_key() -> str | None:
+    """Return the name of the first supported provider API key set in env, else None."""
+    for key in PI_PROVIDER_ENV_KEYS:
+        if os.environ.get(key, "").strip():
+            return key
+    return None
+
+
+def _auth_json_has_credentials() -> tuple[bool | None, str]:
+    """Inspect ``<agent-dir>/auth.json`` for stored credentials.
+
+    Returns ``(True, detail)`` when the file holds at least one credential entry,
+    ``(False, detail)`` when it is absent, and ``(None, detail)`` when it exists
+    but cannot be read or parsed (auth state unclear).
+    """
+    auth_path = _pi_agent_dir() / "auth.json"
+    try:
+        if not auth_path.exists():
+            return False, f"No credentials at {auth_path}. {_AUTH_HINT}"
+        raw = auth_path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        return None, f"Could not read {auth_path}: {exc}"
+
+    if not raw:
+        return False, f"{auth_path} is empty. {_AUTH_HINT}"
+
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as exc:
+        return None, f"Could not parse {auth_path}: {exc}"
+
+    # Pi stores a JSON object keyed by provider/credential; any non-empty entry
+    # means the user has logged in or stored a key. Be permissive about the exact
+    # schema (it may evolve) — presence of content is the signal.
+    if isinstance(data, dict) and any(data.values()):
+        return True, "Authenticated via ~/.pi/agent/auth.json (pi /login)."
+    if isinstance(data, list) and data:
+        return True, "Authenticated via ~/.pi/agent/auth.json (pi /login)."
+    return False, f"No credential entries in {auth_path}. {_AUTH_HINT}"
+
+
+def _classify_pi_auth() -> tuple[bool | None, str]:
+    """Resolve Pi auth state from env keys then the stored credential file."""
+    api_key = _has_provider_api_key()
+    if api_key:
+        return True, f"Authenticated via {api_key}."
+    return _auth_json_has_credentials()
+
+
+def _pi_env_overrides() -> dict[str, str]:
+    """Subprocess env overrides: disable color and forward provider API keys."""
+    env: dict[str, str] = {"NO_COLOR": "1"}
+    env.update(nonempty_env_values(PI_PROVIDER_ENV_KEYS))
+    for key in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"):
+        val = os.environ.get(key, "").strip()
+        if val:
+            env[key] = val
+    return env
+
+
+def _fallback_pi_paths() -> list[str]:
+    return _default_cli_fallback_paths("pi")
+
+
+class PiAdapter:
+    """Non-interactive Pi CLI (``pi -p``, print mode, no TTY)."""
+
+    name = "pi"
+    binary_env_key = "PI_BIN"
+    install_hint = "npm i -g @earendil-works/pi-coding-agent"
+    auth_hint = _AUTH_HINT.removesuffix(".")
+    min_version: str | None = None
+    default_exec_timeout_sec = DEFAULT_EXEC_TIMEOUT_SEC
+
+    def _resolve_binary(self) -> str | None:
+        return resolve_cli_binary(
+            explicit_env_key="PI_BIN",
+            binary_names=_candidate_binary_names("pi"),
+            fallback_paths=_fallback_pi_paths,
+        )
+
+    def _probe_binary(self, binary_path: str) -> CLIProbe:
+        version_output, version_error = run_version_probe(
+            binary_path,
+            timeout_sec=_PROBE_TIMEOUT_SEC,
+        )
+        if version_error:
+            return CLIProbe(
+                installed=False,
+                version=None,
+                logged_in=None,
+                bin_path=None,
+                detail=version_error,
+            )
+
+        version = parse_semver_three_part(version_output or "")
+        logged_in, auth_detail = _classify_pi_auth()
+        return CLIProbe(
+            installed=True,
+            version=version,
+            logged_in=logged_in,
+            bin_path=binary_path,
+            detail=auth_detail,
+        )
+
+    def detect(self) -> CLIProbe:
+        binary = self._resolve_binary()
+        if not binary:
+            return CLIProbe(
+                installed=False,
+                version=None,
+                logged_in=None,
+                bin_path=None,
+                detail=(
+                    "Pi CLI not found on PATH or known install locations. "
+                    f"Install with: {self.install_hint} or set PI_BIN."
+                ),
+            )
+        return self._probe_binary(binary)
+
+    def build(
+        self,
+        *,
+        prompt: str,
+        model: str | None,
+        workspace: str,
+        reasoning_effort: str | None = None,
+    ) -> CLIInvocation:
+        # Pi print mode has no reasoning-effort flag (thinking level is part of
+        # the model string, e.g. ``sonnet:high``); accept the param for protocol
+        # parity and discard it.
+        _ = reasoning_effort
+        binary = self._resolve_binary()
+        if not binary:
+            raise RuntimeError(
+                f"Pi CLI not found. {self.install_hint} or set PI_BIN to the full binary path."
+            )
+
+        ws = (workspace or "").strip()
+        cwd = str(Path(ws).expanduser()) if ws else os.getcwd()
+
+        # ``pi -p PROMPT`` runs a single non-interactive turn (no TTY) and prints
+        # the model's answer to stdout for parse(). Prompt is passed as an argv
+        # arg (the documented print-mode form). Pi keeps its default tools and
+        # context-file (AGENTS.md / CLAUDE.md) discovery enabled, matching the
+        # other default-agent CLI adapters (claude-code, opencode, gemini-cli).
+        argv: list[str] = [
+            binary,
+            "-p",
+            prompt,
+        ]
+
+        resolved_model = (model or "").strip()
+        if resolved_model:
+            argv.extend(["--model", resolved_model])
+
+        env = _pi_env_overrides()
+
+        return CLIInvocation(
+            argv=tuple(argv),
+            stdin=None,
+            cwd=cwd,
+            env=env,
+            timeout_sec=self.default_exec_timeout_sec,
+        )
+
+    def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
+        result = (stdout or "").strip()
+        if not result:
+            raise RuntimeError(
+                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
+                + " (empty output)"
+            )
+        return result
+
+    def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
+        from integrations.llm_cli.failure_explain import explain_cli_failure
+
+        err = (stderr or "").strip()
+        out = (stdout or "").strip()
+        combined = f"{err}\n{out}".lower()
+        extra: tuple[str, ...] = ()
+        if (
+            "not logged in" in combined
+            or "not authenticated" in combined
+            or "no credentials" in combined
+            or "unauthorized" in combined
+            or "401" in combined
+            or ("api key" in combined and ("invalid" in combined or "missing" in combined))
+        ):
+            extra = (f"Authentication failed. {_AUTH_HINT}",)
+        elif "model" in combined and ("not found" in combined or "invalid" in combined):
+            extra = (
+                "Model not found. Check PI_MODEL format: provider/model "
+                "(e.g. google/gemini-2.5-flash-lite).",
+            )
+        elif "rate limit" in combined or "quota" in combined:
+            extra = (
+                "Rate limited or quota exceeded. Try again later or check your provider plan.",
+            )
+
+        return explain_cli_failure(
+            exit_label="pi -p",
+            stdout=stdout,
+            stderr=stderr,
+            returncode=returncode,
+            extra_messages=extra,
+            always_include_output_snippet=bool(extra),
+        )

--- a/integrations/llm_cli/registry.py
+++ b/integrations/llm_cli/registry.py
@@ -71,6 +71,12 @@ def _grok_cli_factory() -> LLMCLIAdapter:
     return GrokCLIAdapter()
 
 
+def _pi_factory() -> LLMCLIAdapter:
+    from integrations.llm_cli.pi_cli import PiAdapter
+
+    return PiAdapter()
+
+
 CLI_PROVIDER_REGISTRY: dict[str, CLIProviderRegistration] = {
     "codex": CLIProviderRegistration(adapter_factory=_codex_factory, model_env_key="CODEX_MODEL"),
     "cursor": CLIProviderRegistration(
@@ -95,6 +101,7 @@ CLI_PROVIDER_REGISTRY: dict[str, CLIProviderRegistration] = {
     "grok-cli": CLIProviderRegistration(
         adapter_factory=_grok_cli_factory, model_env_key="GROK_CLI_MODEL"
     ),
+    "pi": CLIProviderRegistration(adapter_factory=_pi_factory, model_env_key="PI_MODEL"),
 }
 
 

--- a/integrations/llm_cli/subprocess_env.py
+++ b/integrations/llm_cli/subprocess_env.py
@@ -64,6 +64,13 @@ _SAFE_SUBPROCESS_ENV_PREFIXES = (
     "ANTIGRAVITY_",
     "OPENCODE_",
     "KIMI_",
+    # Pi CLI (pi.dev) non-secret config vars (e.g. ``PI_AGENT_DIR`` /
+    # ``PI_CONFIG_DIR``, ``PI_BIN``, ``PI_MODEL``). Pi's per-provider API keys
+    # are NOT ``PI_``-prefixed (they are ``ANTHROPIC_API_KEY`` etc.) and are
+    # forwarded only via the Pi adapter's ``CLIInvocation.env`` — see
+    # ``PI_PROVIDER_ENV_KEYS`` in ``env_overrides.py`` — so this prefix carries
+    # no secrets.
+    "PI_",
     # NOTE: deliberately NO ``COPILOT_`` entry. ``COPILOT_GITHUB_TOKEN`` is a
     # GitHub PAT; if we forwarded it via this prefix allowlist it would leak
     # into every other CLI subprocess (Codex, Kimi, Claude Code, etc.). All

--- a/tests/integrations/llm_cli/test_pi_adapter.py
+++ b/tests/integrations/llm_cli/test_pi_adapter.py
@@ -1,0 +1,257 @@
+"""Tests for the Pi CLI adapter (``pi -p`` non-interactive print mode).
+
+Unit tests mock the version probe, ``shutil.which``, and the credential file so
+they run fully offline. The final ``live_llm`` test exercises a real ``pi``
+binary against a real Gemini model and self-skips unless both are available.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from integrations.llm_cli.pi_cli import PiAdapter
+
+_PROBE = "integrations.llm_cli.pi_cli.run_version_probe"
+_WHICH = "integrations.llm_cli.binary_resolver.shutil.which"
+
+
+# --------------------------------------------------------------------------- #
+# detect()
+# --------------------------------------------------------------------------- #
+@patch(_PROBE, return_value=("pi 0.5.0", None))
+@patch(_WHICH, return_value="/usr/bin/pi")
+def test_detect_logged_in_via_provider_env_key(
+    _mock_which: MagicMock, _mock_probe: MagicMock
+) -> None:
+    with patch.dict(os.environ, {"GEMINI_API_KEY": "  test-key  "}, clear=True):
+        probe = PiAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is True
+    assert probe.bin_path == "/usr/bin/pi"
+    assert probe.version == "0.5.0"
+    assert "GEMINI_API_KEY" in probe.detail
+
+
+@patch(_PROBE, return_value=("pi 0.5.0", None))
+@patch(_WHICH, return_value="/usr/bin/pi")
+def test_detect_logged_in_via_auth_json(
+    _mock_which: MagicMock, _mock_probe: MagicMock, tmp_path: Path
+) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "auth.json").write_text(
+        '{"anthropic": {"type": "oauth", "access": "tok"}}', encoding="utf-8"
+    )
+
+    with patch.dict(os.environ, {"PI_AGENT_DIR": str(agent_dir)}, clear=True):
+        probe = PiAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is True
+    assert "auth.json" in probe.detail
+
+
+@patch(_PROBE, return_value=("pi 0.5.0", None))
+@patch(_WHICH, return_value="/usr/bin/pi")
+def test_detect_not_logged_in_when_no_key_and_no_auth_file(
+    _mock_which: MagicMock, _mock_probe: MagicMock, tmp_path: Path
+) -> None:
+    with patch.dict(os.environ, {"PI_AGENT_DIR": str(tmp_path)}, clear=True):
+        probe = PiAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is False
+    assert "/login" in probe.detail or "API key" in probe.detail
+
+
+@patch(_PROBE, return_value=("pi 0.5.0", None))
+@patch(_WHICH, return_value="/usr/bin/pi")
+def test_detect_unreadable_auth_json_returns_none(
+    _mock_which: MagicMock, _mock_probe: MagicMock, tmp_path: Path
+) -> None:
+    (tmp_path / "auth.json").write_text("not-json{", encoding="utf-8")
+
+    with patch.dict(os.environ, {"PI_AGENT_DIR": str(tmp_path)}, clear=True):
+        probe = PiAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is None  # unclear, invocation will verify
+
+
+@patch(_PROBE, return_value=("pi 0.5.0", None))
+@patch(_WHICH, return_value="/usr/bin/pi")
+def test_detect_empty_auth_json_not_logged_in(
+    _mock_which: MagicMock, _mock_probe: MagicMock, tmp_path: Path
+) -> None:
+    (tmp_path / "auth.json").write_text("{}", encoding="utf-8")
+
+    with patch.dict(os.environ, {"PI_AGENT_DIR": str(tmp_path)}, clear=True):
+        probe = PiAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is False
+
+
+@patch(_PROBE, return_value=(None, "`/usr/bin/pi --version` failed: boom"))
+@patch(_WHICH, return_value="/usr/bin/pi")
+def test_detect_version_probe_failure_marks_not_installed(
+    _mock_which: MagicMock, _mock_probe: MagicMock
+) -> None:
+    probe = PiAdapter().detect()
+    assert probe.installed is False
+    assert probe.logged_in is None
+    assert "boom" in probe.detail
+
+
+@patch(_WHICH, return_value=None)
+def test_detect_binary_missing(_mock_which: MagicMock) -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        probe = PiAdapter().detect()
+    assert probe.installed is False
+    assert probe.bin_path is None
+    assert "Pi CLI not found" in probe.detail
+
+
+# --------------------------------------------------------------------------- #
+# build()
+# --------------------------------------------------------------------------- #
+@patch(_WHICH, return_value="/usr/bin/pi")
+def test_build_print_mode_and_model_flag(_mock_which: MagicMock) -> None:
+    inv = PiAdapter().build(prompt="hello", model="google/gemini-2.5-flash-lite", workspace="")
+    assert inv.stdin is None
+    assert inv.argv[0] == "/usr/bin/pi"
+    assert "-p" in inv.argv
+    assert "hello" in inv.argv
+    assert "--model" in inv.argv
+    idx = inv.argv.index("--model")
+    assert inv.argv[idx + 1] == "google/gemini-2.5-flash-lite"
+    assert inv.env is not None and inv.env.get("NO_COLOR") == "1"
+    assert inv.cwd == os.getcwd()
+
+
+@patch(_WHICH, return_value="/usr/bin/pi")
+def test_build_omits_model_when_empty(_mock_which: MagicMock) -> None:
+    inv = PiAdapter().build(prompt="p", model="", workspace="")
+    assert "--model" not in inv.argv
+
+
+@patch(_WHICH, return_value="/usr/bin/pi")
+def test_build_forwards_provider_api_key(_mock_which: MagicMock) -> None:
+    with patch.dict(
+        os.environ,
+        {"GEMINI_API_KEY": "sk-gemini", "SOME_UNRELATED_SECRET": "nope"},
+        clear=True,
+    ):
+        inv = PiAdapter().build(prompt="p", model="google/gemini-2.5-flash-lite", workspace="")
+    assert inv.env is not None
+    assert inv.env["GEMINI_API_KEY"] == "sk-gemini"
+    assert "SOME_UNRELATED_SECRET" not in inv.env
+
+
+@patch(_WHICH, return_value=None)
+def test_build_raises_when_binary_missing(_mock_which: MagicMock) -> None:
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        pytest.raises(RuntimeError, match="Pi CLI not found"),
+    ):
+        PiAdapter().build(prompt="p", model=None, workspace="")
+
+
+# --------------------------------------------------------------------------- #
+# registry / parse / explain_failure
+# --------------------------------------------------------------------------- #
+def test_pi_registry_entry() -> None:
+    from integrations.llm_cli.registry import get_cli_provider_registration
+
+    reg = get_cli_provider_registration("pi")
+    assert reg is not None
+    assert reg.model_env_key == "PI_MODEL"
+    assert reg.adapter_factory().name == "pi"
+
+
+def test_parse_strips_and_raises_on_empty() -> None:
+    adapter = PiAdapter()
+    assert adapter.parse(stdout="  pong  \n", stderr="", returncode=0) == "pong"
+    with pytest.raises(RuntimeError, match="empty output"):
+        adapter.parse(stdout="   ", stderr="", returncode=0)
+
+
+def test_explain_failure_classifies_messages() -> None:
+    adapter = PiAdapter()
+
+    auth = adapter.explain_failure(stdout="", stderr="Error: not logged in", returncode=1)
+    assert "Authentication failed" in auth
+
+    model = adapter.explain_failure(stdout="", stderr="model not found: foo", returncode=1)
+    assert "PI_MODEL format" in model
+
+    quota = adapter.explain_failure(stdout="", stderr="rate limit exceeded", returncode=1)
+    assert "Rate limited" in quota
+
+
+# --------------------------------------------------------------------------- #
+# runner integration (real adapter, mocked subprocess)
+# --------------------------------------------------------------------------- #
+@patch("integrations.llm_cli.runner.subprocess.run")
+@patch(_PROBE, return_value=("pi 0.5.0", None))
+@patch(_WHICH, return_value="/usr/bin/pi")
+def test_cli_backed_client_invoke_forwards_pi_env(
+    _mock_which: MagicMock, _mock_probe: MagicMock, mock_run: MagicMock
+) -> None:
+    from integrations.llm_cli.runner import CLIBackedLLMClient
+
+    mock_run.return_value = MagicMock(returncode=0, stdout="answer\n", stderr="")
+
+    with (
+        patch("platform.guardrails.engine.get_guardrail_engine") as gr,
+        patch.dict(os.environ, {"GEMINI_API_KEY": "sk-gemini"}, clear=False),
+    ):
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(
+            PiAdapter(), model="google/gemini-2.5-flash-lite", max_tokens=256
+        )
+        resp = client.invoke("hello")
+
+    assert resp.content == "answer"
+    env = mock_run.call_args.kwargs["env"]
+    assert env["GEMINI_API_KEY"] == "sk-gemini"
+    assert env["NO_COLOR"] == "1"
+
+
+# --------------------------------------------------------------------------- #
+# live model test (real pi + real Gemini) — self-skips without creds/binary
+# --------------------------------------------------------------------------- #
+def _require_live_pi_gemini() -> str:
+    """Skip unless the ``pi`` binary is installed and a Gemini key is present."""
+    import shutil
+
+    binary = shutil.which("pi") or os.environ.get("PI_BIN", "").strip()
+    if not binary:
+        pytest.skip("pi binary not installed; skipping live Pi test")
+    if not os.environ.get("GEMINI_API_KEY", "").strip():
+        pytest.skip("GEMINI_API_KEY not set; skipping live Pi test")
+    return os.environ.get("PI_MODEL", "").strip() or "google/gemini-2.5-flash-lite"
+
+
+@pytest.mark.integration
+@pytest.mark.live_llm
+def test_live_pi_gemini_round_trip() -> None:
+    model = _require_live_pi_gemini()
+
+    from integrations.llm_cli.runner import CLIBackedLLMClient
+
+    adapter = PiAdapter()
+    probe = adapter.detect()
+    assert probe.installed is True, probe.detail
+    assert probe.logged_in is not False, f"Pi reports not authenticated: {probe.detail}"
+
+    client = CLIBackedLLMClient(adapter, model=model, max_tokens=256)
+    resp = client.invoke("Reply with exactly one word: pong")
+
+    assert resp.content.strip(), "Pi returned an empty response"
+    assert "pong" in resp.content.lower()


### PR DESCRIPTION
Fixes #3085 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

This PR adds Pi cli as a new LLM provider you can use with OpenSRE. Pi is a bring-your-own-key tool that can talk to many model providers (Gemini, Anthropic, OpenAI, Groq, and more), so you can now point OpenSRE at Pi and pick whichever underlying model you have a key for. The change wires Pi in everywhere a provider needs to live, selecting it via LLM_PROVIDER=pi, the onboarding wizard, auto-detecting whether you're logged in, and forwarding your API key safely to it and follows the exact same pattern as the existing CLI providers (Codex, Claude Code, etc.). It also includes documentation and tests, including a live end-to-end test that was verified working against a real Gemini model.

### Demo/Screenshot for feature changes and bug fixes - 


https://github.com/user-attachments/assets/f99368c5-afc6-436e-b483-c4dccb020e0d


<img width="1043" height="501" alt="image" src="https://github.com/user-attachments/assets/b1f8ccf3-f84b-449d-a5f9-113dd23b7e88" />



<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Pi slots into OpenSRE's existing LLM-CLI framework, so instead of inventing anything new I followed the same adapter pattern the other command-line providers like Codex and Claude Code already use. I added a small Pi adapter that knows how to detect whether Pi is installed, check if you're authenticated, and run it in one-shot mode to get a response back, then registered it as a selectable provider and added it to the setup wizard, docs, and tests. The one real decision was how to tell if you're logged in, since Pi has no command for that, so I detect it from state instead, treating you as authenticated if a provider API key is in your environment or if Pi has stored credentials from a previous login, which mirrors how the Kimi and Claude Code adapters already work. Everything else is deliberately consistent with the existing providers so it behaves predictably and was straightforward to verify, including a live run using Gemini API key.

<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
