### PR TITLE
Create top-level context package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Before any push or PR creation follow **[CI.md](CI.md)** — lint, format, typec
 | Path                  | What it does                                                                                       |
 | --------------------- | -------------------------------------------------------------------------------------------------- |
 | `core/`               | Investigation orchestration, the shared runtime tool-calling loop, and domain logic (state, types, correlation rules). |
+| `context/`            | First-class top-level home for context assembly, budgets, trimming, and evidence envelopes shared by agents. |
 | `cli/`                | Command-line interface, onboarding wizard, local LLM helpers, and CLI tests support.               |
 | `interactive_shell/`  | Interactive terminal (REPL) loop, slash commands, chat/help surfaces, action-planning harness, and terminal UI. |
 | `integrations/`       | Per-integration config normalization, verification, clients, helpers, store/catalog logic, and the Hermes log pipeline. |
@@ -48,6 +49,7 @@ Main packages one level deeper:
 - `cli/` — Command-line interface, onboarding wizard, local LLM helpers, and CLI tests support.
 - `interactive_shell/` — Interactive terminal (TTY) loop, slash-command surface, chat/help handoff, session runtime, and terminal UI. REPL watchdog slash commands (`/watch`, `/watches`, `/unwatch`): PR demo steps live under **Interactive shell: REPL watchdog demo** in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#interactive-shell-repl-watchdog-demo).
 - `config/constants/` — Shared prompt and other static constants.
+- `context/` — First-class context assembly boundary for building, trimming, ranking, and packaging incident evidence before agent/runtime consumption.
 - `infra/deployment/` — Single top-level home for deployment-facing code, split by concern:
     - `infra/deployment/entrypoints/` — SDK and MCP entrypoints exposed to external runtimes.
     - `infra/deployment/operations/` — _Runtime / infra_ around a deployment (health polling, EC2 output files, provider dry-run validation).
@@ -102,6 +104,8 @@ Investigations are coordinated in `core/orchestration/pipeline.py` and exposed v
 Files to touch:
 
 - `core/orchestration/pipeline.py` for high-level stage ordering.
+- `context/` for shared context assembly, trimming, ranking, and evidence-envelope logic
+  that runs before agent/runtime consumption.
 - `core/domain/` for pure investigation rules (alert source mapping, tool planning,
   category alignment, correlation scoring).
 - `core/runtime/` for shared LLM runtime helpers (tool loop and LLM invoke error

--- a/context/README.md
+++ b/context/README.md
@@ -1,0 +1,21 @@
+# Context
+
+`context/` is the top-level home for OpenSRE context assembly.
+
+Use this package for code that gathers, normalizes, trims, and packages the incident context an agent needs before it reasons or calls tools. The goal is to make context a first-class architectural boundary instead of scattering context-building logic across orchestration, runtime, integrations, tools, and the interactive shell.
+
+## Belongs here
+
+- Provider-agnostic context builders and envelopes.
+- Context budget, trimming, ranking, and summarization policies.
+- Shared contracts for the evidence bundle passed into agent/runtime code.
+- Composition logic that assembles data from `core/`, `integrations/`, and `tools/` without owning those layers.
+
+## Does not belong here
+
+- Agent orchestration or stage sequencing; keep that in `core/orchestration/`.
+- The LLM/tool-calling loop; keep that in `core/runtime/`.
+- External clients, config, and verification; keep those in `integrations/`.
+- Agent-callable tool implementations; keep those in `tools/`.
+- Terminal UI, REPL session state, and slash commands; keep those in `interactive_shell/`.
+- Platform services such as guardrails, masking, auth, telemetry, notifications, and sandboxing; keep those in `platform/`.

--- a/context/__init__.py
+++ b/context/__init__.py
@@ -1,0 +1,7 @@
+"""Top-level context assembly package for OpenSRE.
+
+This package is intentionally small while context builders are migrated into a
+single first-class architectural boundary.
+"""
+
+__all__: list[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ azure_sql = [
 include = [
   "cli*",
   "config*",
+  "context*",
   "core*",
   "infra*",
   "integrations*",
@@ -159,6 +160,8 @@ data_file = ".pytest_cache/.coverage"
 [tool.vulture]
 paths = [
   "cli",
+  "config",
+  "context",
   "core",
   "infra/deployment",
   "integrations",


### PR DESCRIPTION
## Summary

- add a root-level `context/` package as the first-class home for context assembly
- document the intended boundary for context builders, envelopes, trimming, ranking, and evidence packaging
- include `context*` in package discovery and add `context` to vulture scan paths
- update `AGENTS.md` so the repo map treats `context/` as a high-level architectural entity

## Test plan

Not run locally; structural package/docs/metadata-only change.