### PR TITLE
fix(integrations): correct Supabase verifier result fields

### DIFF
--- a/integrations/supabase/verifier.py
+++ b/integrations/supabase/verifier.py
@@ -1,18 +1,4 @@
-"""Supabase integration verifier.
-
-KNOWN BUG, preserved on purpose: the first positional arg ends up in
-the ``service`` field of the result dict and the literal ``"supabase"``
-ends up in the ``source`` field — the two are swapped relative to every
-other verifier. This mirrors the original ``_verify_supabase`` from the
-pre-#3022 monolith. Downstream consumers that filter on
-``result["service"] == "supabase"`` will not see Supabase rows; they
-must filter on ``result["source"] == "supabase"`` instead.
-
-TODO(opensre): file a tracking issue for the fix. Pinned by
-``TestSupabasePreservedArgSwap`` in
-``tests/integrations/test_verification_registry.py`` — that test must
-be updated alongside any behavior change.
-"""
+"""Supabase integration verifier."""
 
 from __future__ import annotations
 
@@ -26,10 +12,10 @@ from integrations.verification import (
 
 
 @register_verifier("supabase")
-def verify_supabase(service: str, config: dict[str, Any]) -> dict[str, str]:
+def verify_supabase(source: str, config: dict[str, Any]) -> dict[str, str]:
     return verify_with_validation_result(
-        service,
         "supabase",
+        source,
         config,
         build_config=build_supabase_config,
         validate_config=validate_supabase_config,

--- a/tests/integrations/test_verification_registry.py
+++ b/tests/integrations/test_verification_registry.py
@@ -299,17 +299,8 @@ class TestAlertmanagerRegistration:
         assert get_verifier("alertmanager") is verify_alertmanager
 
 
-class TestSupabasePreservedArgSwap:
-    """Pin the pre-#37 arg-name swap in ``verify_supabase``.
-
-    The original ``_verify_supabase`` passed its first positional arg
-    as ``service`` (not ``source``) and the literal ``"supabase"`` as
-    ``source``. That's almost certainly a typo. This test locks in
-    the existing behavior so any "fix" PR has to consciously break it
-    and ship a separate ticket.
-    """
-
-    def test_first_arg_lands_in_service_field_and_source_is_supabase(
+class TestSupabaseVerifierRouting:
+    def test_source_arg_lands_in_source_field_and_service_is_supabase(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from integrations.supabase import verifier as _supabase_verifier
@@ -333,8 +324,6 @@ class TestSupabasePreservedArgSwap:
 
         out = verifier("local store", {"placeholder": True})
 
-        # The "swap": the source passed in lands as service; "supabase"
-        # lands as source. Do not fix without a behavior-change PR.
-        assert out["service"] == "local store"
-        assert out["source"] == "supabase"
+        assert out["service"] == "supabase"
+        assert out["source"] == "local store"
         assert out["status"] == "passed"


### PR DESCRIPTION
Fixes #3175

#### Describe the changes you have made in this PR -

The Supabase verifier was passing the runtime `source` argument into the verification result's `service` field and hardcoding `"supabase"` into the `source` field. This made `opensre integrations verify supabase` report rows like `service="local store"` and `source="supabase"`, unlike the rest of the verifier registry.

This PR changes `verify_supabase` to bind `service="supabase"` and pass the caller-provided source through as `source`. It also updates the registry regression test that previously pinned the known swapped-field behavior so it now asserts the corrected result shape.

### Demo/Screenshot for feature changes and bug fixes - 

Focused verification output:

```bash
uv run pytest tests/integrations/test_verification_registry.py tests/integrations/test_supabase.py -q
# 60 passed

uv run pytest tests/integrations/test_verify.py -q
# 31 passed

make lint
# All checks passed!

make format-check
# 1989 files already formatted

make typecheck
# Success: no issues found in 915 source files
```

Additional note: I also tried `make test-scope`, but this local checkout expanded it to a broad suite because the diff against local `main` included thousands of unrelated files from the pre-existing untracked nested `opensre/` tree. That broad run failed on unrelated local/sandbox issues such as socket/network permission errors and writes to `/Users/johnzakkam/.opensre/opensre.json`; the focused Supabase, verification, lint, format, and typecheck commands above passed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The verifier registry calls each verifier with the effective integration source as the first argument. Other validation verifiers keep the service name fixed and pass that runtime source into `verify_with_validation_result`. Supabase was the outlier: it named the first argument `service`, used it as the result service, and hardcoded `"supabase"` as the result source.

The fix is deliberately small: rename the first parameter to `source`, call `verify_with_validation_result("supabase", source, ...)`, and update the registry test to assert `service == "supabase"` and `source == "local store"`. This keeps the verifier contract consistent without changing Supabase config validation or connectivity behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.