### PR TITLE
fix(interactive_shell): guard turn-route match exhaustiveness (CodeQL)

### DIFF
--- a/interactive_shell/harness/turn.py
+++ b/interactive_shell/harness/turn.py
@@ -10,7 +10,7 @@ module is the imperative shell around it.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Literal
+from typing import Literal, assert_never
 
 from rich.console import Console
 
@@ -129,7 +129,8 @@ def handle_message_with_agent(
 
     observation = session.agent.last_observation
 
-    match _route_turn(action_result, observation):
+    route = _route_turn(action_result, observation)
+    match route:
         case "summarize_observation":
             with apply_reasoning_effort(turn_ctx.reasoning_effort):
                 run = response_generator(
@@ -173,6 +174,9 @@ def handle_message_with_agent(
                 assistant_response_text=_response_text(run),
                 llm_run=run,
             )
+
+        case _:
+            assert_never(route)
 
     return accounting.finalize(result)
 


### PR DESCRIPTION
## Summary

Follow-up to #3182. CodeQL raised an error-level alert on `main`:
`Local variable 'result' may be used before it is initialized` in
`handle_message_with_agent` (`interactive_shell/harness/turn.py`).

`_route_turn` returns an exhaustive `Literal[...]` and all three values are
handled, so `result` is always bound at runtime — but the `match` had no
wildcard, so static analysis couldn't prove it. This binds the route to a
variable and adds a `case _: assert_never(route)` guard, making the match
provably exhaustive while keeping mypy's literal exhaustiveness check (the
default branch is unreachable at runtime).

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] `uv run python -m pytest interactive_shell/harness/tests/test_turn_loop.py`
- [ ] CodeQL alert clears on this PR

Made with [Cursor](https://cursor.com)