### PR TITLE
Refactor interactive shell around ShellAgent lifecycle

### DIFF
--- a/docs/interactive-shell-action-policy.md
+++ b/docs/interactive-shell-action-policy.md
@@ -95,7 +95,7 @@ output:
    found on `session.agent.last_observation`
    (`_record_integrations_observation` in
    `interactive_shell/command_registry/integrations.py`).
-2. `handle_message_with_agent` resets that field at the start of every action-agent
+2. `run_agent_prompt` resets that field at the start of every action-agent
    turn and, when a discovery command produced an observation and succeeded,
    calls the conversational assistant with `tool_observation=...`
    (inside the handled-turn observation branch in `pipeline.py`). The assistant

--- a/docs/turn-scenario-test-gap.md
+++ b/docs/turn-scenario-test-gap.md
@@ -34,7 +34,7 @@ text. The test infrastructure provides confidence that does not exist.
 
 ## 1. The Two Execution Paths — Only One Is Tested
 
-When a REPL turn enters `handle_message_with_agent`, two independent paths
+When a REPL turn enters `run_agent_prompt`, two independent paths
 can fire:
 
 | Path | What it does | Oracle coverage |
@@ -350,7 +350,7 @@ scenario fixtures follow.
 
 - The no-mocks policy on the LLM path. The planner, classifier, and
   conversational assistant all continue to hit the real LLM in turn tests.
-- The turn-execution oracle still invokes `handle_message_with_agent` directly.
+- The turn-execution oracle still invokes `run_agent_prompt` directly.
 - Any existing passing scenario. The `resolved_integrations_override` is opt-in;
   existing scenarios without it keep the current no-op gather behaviour and
   continue to pass.

--- a/interactive_shell/controller.py
+++ b/interactive_shell/controller.py
@@ -10,11 +10,6 @@ from prompt_toolkit.patch_stdout import patch_stdout
 from rich.console import Console
 
 from core.domain.alerts import inbox as _alert_inbox
-from interactive_shell.harness.agent import (
-    AgentTurnCoordinator,
-    run_agent_turn_queue,
-    run_input_loop,
-)
 from interactive_shell.harness.llm_context.session import (
     ReplRuntimeContext,
     ReplSession,
@@ -36,6 +31,11 @@ from interactive_shell.runtime.input.actions import (
     IgnoreInput,
     InputAction,
     SubmitTurn,
+)
+from interactive_shell.runtime.turn_host import (
+    ShellTurnHost,
+    run_agent_prompt_queue,
+    run_input_loop,
 )
 
 log = logging.getLogger(__name__)
@@ -97,7 +97,7 @@ class InteractiveShellController:
             self.spinner,
             self.runtime_context.pt_session,
         )
-        self.turn_coordinator = AgentTurnCoordinator(
+        self.turn_host = ShellTurnHost(
             session=self.session,
             state=self.state,
             spinner=self.spinner,
@@ -139,9 +139,9 @@ class InteractiveShellController:
             self.prompt.invalidate_prompt,
         )
         self.tasks = self.background.start_all(
-            lambda: run_agent_turn_queue(
+            lambda: run_agent_prompt_queue(
                 state=self.state,
-                run_turn=self.turn_coordinator.run_turn,
+                run_prompt=self.turn_host.run_prompt,
             )
         )
 
@@ -172,6 +172,7 @@ class InteractiveShellController:
     async def _shutdown_runtime(self) -> None:
         self.state.request_exit()
         self.state.cancel_current_dispatch()
+        await self.turn_host.stop()
 
         for _label, task in self.tasks:
             task.cancel()

--- a/interactive_shell/entrypoint.py
+++ b/interactive_shell/entrypoint.py
@@ -66,7 +66,7 @@ async def repl_main(initial_input: str | None = None, _config: ReplConfig | None
 
     if initial_input:
         session.warm_resolved_integrations()
-        return run_initial_input(initial_input, session)
+        return await run_initial_input(initial_input, session)
 
     # Open the session file now that we know this is an interactive REPL run.
     session.storage.open_session(session)

--- a/interactive_shell/harness/agent.py
+++ b/interactive_shell/harness/agent.py
@@ -1,252 +1,182 @@
-"""Runtime driver for interactive OpenSRE shell turns."""
+"""Durable shell agent for interactive-shell prompts.
+
+``ShellAgent`` is the shell-facing agent object. It owns the live session,
+lifecycle state, active-prompt guard, event subscribers, and injected runtime
+primitives. Per-prompt action/answer mechanics live in ``agent_loop.py``.
+"""
 
 from __future__ import annotations
 
 import asyncio
-import contextlib
-import logging
-import threading
-from collections.abc import Awaitable, Callable, Coroutine, Iterator
-from typing import Any
+from collections.abc import Callable
+from contextlib import suppress
 
 from rich.console import Console
 
-from interactive_shell.harness.turn import handle_message_with_agent
-from interactive_shell.runtime import ReplSession
-from interactive_shell.runtime.agent_presentation import (
-    AgentEvent,
-    AgentEventSink,
-    ConsoleAgentEventSink,
+from interactive_shell.harness.agent_loop import (
+    GatherEvidence,
+    ResponseGenerator,
+    RunToolCallingTurn,
+    run_agent_prompt,
 )
-from interactive_shell.runtime.background.workers import BackgroundTaskManager
-from interactive_shell.runtime.core.confirmation import (
-    DispatchCancelled,
-    request_confirmation_via_prompt,
-)
-from interactive_shell.runtime.core.state import ReplState, SpinnerState
-from interactive_shell.runtime.input import PromptInputReader
-from interactive_shell.runtime.input.actions import (
-    InputAction,
-    ShellInputSnapshot,
-    decide_input_action,
-)
-from interactive_shell.runtime.utils.input_policy import turn_needs_exclusive_stdin
-from interactive_shell.ui.output.repl_progress import repl_safe_progress_scope
-from interactive_shell.ui.streaming.console import StreamingConsole
-from interactive_shell.utils.error_handling.exception_reporting import report_exception
+from interactive_shell.harness.events import AgentEvent, AgentEventSink
+from interactive_shell.harness.llm_context.session import ReplSession
+from interactive_shell.harness.state import ConversationState
+from interactive_shell.runtime.core.confirmation import DispatchCancelled
+from interactive_shell.runtime.core.turn_accounting import ShellTurnResult
 from interactive_shell.utils.telemetry import PromptRecorder
-from platform.analytics.repl_context import bind_cli_session_id, reset_cli_session_id
-
-_logger = logging.getLogger(__name__)
-_AGENT_TURN_KIND = "agent"
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Core utilities
-# ─────────────────────────────────────────────────────────────────────────────
+class ShellAgent:
+    """Stateful owner of the interactive-shell agent lifecycle.
 
-
-@contextlib.contextmanager
-def _bound_cli_session(session_id: str) -> Iterator[None]:
-    """Temporarily bind the CLI session ID for the current turn."""
-    token = bind_cli_session_id(session_id)
-    try:
-        yield
-    finally:
-        reset_cli_session_id(token)
-
-
-def _setup_turn_presentation(
-    runner: AgentTurnCoordinator, user_input: str
-) -> tuple[StreamingConsole, AgentEventSink, PromptRecorder | None, threading.Event]:
-    """Create console, event emitter, recorder, and cancellation primitive for a turn."""
-    cancel_event = threading.Event()
-
-    console = StreamingConsole(
-        runner.spinner,
-        cancel_event,
-        prompt_invalidator=runner.invalidate_prompt,
-        highlight=False,
-        force_terminal=True,
-        color_system="truecolor",
-        legacy_windows=False,
-    )
-
-    event_sink = ConsoleAgentEventSink(
-        session=runner.session,
-        spinner=runner.spinner,
-        console=console,
-    )
-
-    recorder = PromptRecorder.start(
-        session=runner.session,
-        text=user_input,
-        turn_kind=_AGENT_TURN_KIND,
-    )
-
-    return console, event_sink, recorder, cancel_event
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Turn Coordinator
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-class AgentTurnCoordinator:
-    """Orchestrates the full lifecycle of one agent turn."""
+    The shell agent owns shell/session state, event subscribers, lifecycle
+    state, and active prompt execution. It delegates one prompt's action/answer
+    loop to ``run_agent_prompt``. That loop may use ``core.runtime.agent.Agent``
+    through ``tool_calling.py`` as a disposable tool-calling primitive.
+    """
 
     def __init__(
         self,
-        *,
         session: ReplSession,
-        state: ReplState,
-        spinner: SpinnerState,
-        invalidate_prompt: Callable[[], None],
+        *,
+        execute_actions: RunToolCallingTurn | None = None,
+        gather_evidence: GatherEvidence | None = None,
+        response_generator: ResponseGenerator | None = None,
+        event_sink: AgentEventSink | None = None,
     ) -> None:
         self.session = session
-        self.state = state
-        self.spinner = spinner
-        self.invalidate_prompt = invalidate_prompt
+        self._execute_actions = execute_actions
+        self._gather_evidence = gather_evidence
+        self._response_generator = response_generator
+        self._event_sinks: list[AgentEventSink] = []
+        self._started = False
+        self._active_prompt: asyncio.Task[ShellTurnResult] | None = None
+        if event_sink is not None:
+            self.subscribe(event_sink)
 
-    async def run_turn(self, user_input: str) -> None:
-        """Execute a complete agent turn with presentation and lifecycle management."""
-        console, event_sink, recorder, cancel_event = _setup_turn_presentation(self, user_input)
+    @property
+    def state(self) -> ConversationState:
+        """Return the shell-owned conversational state for this session."""
+        return self.session.agent
 
-        progress_scope = (
-            contextlib.nullcontext()
-            if turn_needs_exclusive_stdin(user_input, self.session)
-            else repl_safe_progress_scope()
-        )
+    @property
+    def started(self) -> bool:
+        """Whether the shell agent has been started and not yet stopped."""
+        return self._started
 
-        with progress_scope:
-            await self._execute_turn_lifecycle(
-                user_input=user_input,
+    @property
+    def active(self) -> bool:
+        """Whether a prompt is currently running."""
+        return self._active_prompt is not None and not self._active_prompt.done()
+
+    def subscribe(self, sink: AgentEventSink) -> Callable[[], None]:
+        """Subscribe to lifecycle events and return an unsubscribe callback."""
+        self._event_sinks.append(sink)
+
+        def _unsubscribe() -> None:
+            with suppress(ValueError):
+                self._event_sinks.remove(sink)
+
+        return _unsubscribe
+
+    def start(self) -> None:
+        """Start the shell agent lifecycle."""
+        if self._started:
+            return
+        self._started = True
+        self._emit(AgentEvent(type="agent_start"))
+
+    async def prompt(
+        self,
+        text: str,
+        *,
+        console: Console,
+        recorder: PromptRecorder | None,
+        confirm_fn: Callable[[str], str] | None = None,
+        is_tty: bool | None = None,
+    ) -> ShellTurnResult:
+        """Run one submitted user prompt through the shell agent."""
+        if not self._started:
+            raise RuntimeError("ShellAgent.start() must be called before prompt().")
+        if self.active:
+            raise RuntimeError("ShellAgent is already processing a prompt.")
+
+        task = asyncio.current_task()
+        if task is None:
+            raise RuntimeError("ShellAgent.prompt() requires a running asyncio task.")
+        self._active_prompt = task  # type: ignore[assignment]
+
+        try:
+            return await asyncio.to_thread(
+                self._run_prompt_lifecycle,
+                text,
                 console=console,
                 recorder=recorder,
-                event_sink=event_sink,
-                cancel_event=cancel_event,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
             )
-
-    async def _execute_turn_lifecycle(
-        self,
-        user_input: str,
-        console: StreamingConsole,
-        recorder: PromptRecorder | None,
-        event_sink: AgentEventSink,
-        cancel_event: threading.Event,
-    ) -> None:
-        """Manage turn lifecycle: dispatch tracking, execution, and final events."""
-        task = asyncio.current_task()
-        if task is not None:
-            self.state.start_dispatch(task=task, cancel_event=cancel_event)
-        else:
-            self.state.attach_cancel_event(cancel_event)
-
-        await event_sink(AgentEvent(type="turn_start", text=user_input))
-
-        try:
-            await self._run_agent_handler(user_input, console, recorder)
-        except asyncio.CancelledError:
-            await event_sink(AgentEvent(type="turn_interrupted"))
-            raise
-        except DispatchCancelled:
-            await event_sink(AgentEvent(type="turn_interrupted"))
-        except Exception as exc:
-            report_exception(exc, context="interactive_shell.turn")
-            await event_sink(AgentEvent(type="turn_error", error=exc))
         finally:
-            self.state.finish_dispatch(cancel_event)
-            await event_sink(AgentEvent(type="turn_end"))
+            self._active_prompt = None
 
-    async def _run_agent_handler(
-        self, user_input: str, output: StreamingConsole, recorder: PromptRecorder | None
-    ) -> None:
-        """Execute the core agent logic in a thread with proper session context."""
+    def abort(self) -> None:
+        """Cancel the active prompt task, if one is running."""
+        if self._active_prompt is not None and not self._active_prompt.done():
+            self._active_prompt.cancel()
 
-        def confirm_fn(prompt: str) -> str:
-            return request_confirmation_via_prompt(self.state, prompt)
+    async def wait_idle(self) -> None:
+        """Wait until the active prompt task finishes."""
+        task = self._active_prompt
+        if task is None or task is asyncio.current_task():
+            return
+        with suppress(asyncio.CancelledError):
+            await task
 
-        with _bound_cli_session(self.session.session_id):
-            await asyncio.to_thread(
-                handle_message_with_agent,
-                user_input,
-                self.session,
-                output,
+    async def stop(self) -> None:
+        """Stop the shell agent lifecycle after any active prompt settles."""
+        await self.wait_idle()
+        if not self._started:
+            return
+        self._started = False
+        self._emit(AgentEvent(type="agent_stop"))
+
+    def _run_prompt_lifecycle(
+        self,
+        text: str,
+        *,
+        console: Console,
+        recorder: PromptRecorder | None,
+        confirm_fn: Callable[[str], str] | None,
+        is_tty: bool | None,
+    ) -> ShellTurnResult:
+        """Run the sync prompt loop and emit lifecycle events."""
+        self._emit(AgentEvent(type="prompt_start", text=text))
+        try:
+            return run_agent_prompt(
+                text,
+                session=self.session,
+                console=console,
                 recorder=recorder,
                 confirm_fn=confirm_fn,
-                is_tty=None,
+                is_tty=is_tty,
+                execute_actions=self._execute_actions,
+                gather_evidence=self._gather_evidence,
+                response_generator=self._response_generator,
             )
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Top-level loops
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-async def run_input_loop(
-    *,
-    state: ReplState,
-    session: ReplSession,
-    background: BackgroundTaskManager | None,
-    input_reader: PromptInputReader,
-    echo_console: Console,
-    handle_input_action: Callable[[InputAction], Awaitable[bool]],
-) -> None:
-    """Continuously read and process user input events until exit."""
-    while not state.exit_requested:
-        if background:
-            background.drain_turn_start_output(echo_console)
-
-        event = await input_reader.read()
-
-        action = decide_input_action(
-            event,
-            ShellInputSnapshot(
-                exit_requested=state.exit_requested,
-                dispatch_running=state.is_dispatch_running(),
-                awaiting_confirmation=state.is_awaiting_confirmation(),
-            ),
-            needs_exclusive_stdin=lambda text: turn_needs_exclusive_stdin(text, session),
-        )
-
-        if not await handle_input_action(action):
-            return
-
-
-async def run_agent_turn_queue(
-    *,
-    state: ReplState,
-    run_turn: Callable[[str], Coroutine[Any, Any, None]],
-) -> None:
-    """Process turns from the queue until the REPL is shutting down."""
-    while not state.exit_requested:
-        try:
-            user_input = await state.queue.get()
-        except asyncio.CancelledError:
-            return
-
-        if state.exit_requested:
-            state.queue.task_done()
-            return
-
-        turn_task = asyncio.create_task(run_turn(user_input))
-        state.attach_turn_task(turn_task)
-
-        try:
-            await turn_task
-        except asyncio.CancelledError:
-            _logger.debug("Queued agent turn was cancelled")
+        except DispatchCancelled:
+            self._emit(AgentEvent(type="prompt_interrupted"))
+            raise
         except Exception as exc:
-            _logger.debug("Queued agent turn failed: %s", exc)
+            self._emit(AgentEvent(type="prompt_error", error=exc))
+            raise
         finally:
-            state.clear_current_task()
-            state.queue.task_done()
+            self._emit(AgentEvent(type="prompt_end"))
+
+    def _emit(self, event: AgentEvent) -> None:
+        for sink in tuple(self._event_sinks):
+            sink(event)
 
 
 __all__ = [
-    "AgentEvent",
-    "AgentEventSink",
-    "AgentTurnCoordinator",
-    "run_agent_turn_queue",
-    "run_input_loop",
+    "ShellAgent",
 ]

--- a/interactive_shell/harness/agent_context.py
+++ b/interactive_shell/harness/agent_context.py
@@ -1,14 +1,14 @@
-"""Per-turn immutable context snapshot for the interactive-shell agent.
+"""Agent-owned per-prompt immutable context snapshot.
 
-Assembled once at the start of each turn from the live ``ReplSession``.
-All fields reflect session state at turn-start and do not change while the
-turn runs, so downstream code reads a stable snapshot rather than a live,
+Assembled once at the start of each prompt from the live ``ReplSession``.
+All fields reflect session state at prompt start and do not change while the
+prompt runs, so downstream code reads a stable snapshot rather than a live,
 concurrently-mutated object.
 
 Usage::
 
-    turn_ctx = TurnContext.from_session(text, session)
-    # pass turn_ctx to action agent + conversational assistant
+    agent_ctx = AgentContext.from_session(text, session)
+    # pass agent_ctx to action agent + conversational assistant
     # keep passing session for writes (recording history, token usage, etc.)
 """
 
@@ -26,46 +26,33 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
-class TurnContext:
-    """Immutable per-turn snapshot assembled from ``ReplSession`` at turn start.
-
-    Carries everything the action agent and conversational assistant need to
-    build prompts and ground answers, frozen at the moment the turn begins.
-
-    The live ``ReplSession`` is still passed separately to callers that need
-    to write state (recording history, persisting token usage, updating intent).
-    """
+class AgentContext:
+    """Immutable per-prompt snapshot assembled from ``ReplSession`` at prompt start."""
 
     text: str
-    """Raw user input text for this turn."""
+    """Raw user input text for this prompt."""
 
     conversation_messages: tuple[ConversationMessage, ...]
-    """Snapshot of recent CLI conversation as :class:`ConversationMessage`
-    values, oldest first, capped to ``MAX_CONVERSATION_MESSAGES`` entries at
-    assembly time."""
+    """Snapshot of recent CLI conversation, oldest first."""
 
     configured_integrations: tuple[str, ...]
-    """Integration names known to be configured at turn start."""
+    """Integration names known to be configured at prompt start."""
 
     configured_integrations_known: bool
     """Whether ``configured_integrations`` reflects real state (vs unknown)."""
 
     last_state: dict[str, Any] | None
-    """Final ``AgentState`` from the most recent investigation (follow-up grounding)."""
+    """Final ``AgentState`` from the most recent investigation."""
 
     last_synthetic_observation_path: str | None
-    """Path to latest synthetic-run observation file (failure explanation context)."""
+    """Path to latest synthetic-run observation file."""
 
     reasoning_effort: ReasoningEffortChoice | None
-    """Session-scoped reasoning effort preference for LLM calls this turn."""
+    """Session-scoped reasoning effort preference for LLM calls this prompt."""
 
     @classmethod
-    def from_session(cls, text: str, session: ReplSession) -> TurnContext:
-        """Snapshot the relevant session fields for one turn.
-
-        Call this once at the top of ``handle_message_with_agent`` before any
-        mutations happen, then pass the returned context downstream.
-        """
+    def from_session(cls, text: str, session: ReplSession) -> AgentContext:
+        """Snapshot the relevant session fields for one prompt."""
         messages = session.agent.messages
         snapshot: tuple[ConversationMessage, ...] = tuple(
             ConversationMessage.from_role_content(role, content)
@@ -83,4 +70,4 @@ class TurnContext:
         )
 
 
-__all__ = ["TurnContext"]
+__all__ = ["AgentContext"]

--- a/interactive_shell/harness/agent_loop.py
+++ b/interactive_shell/harness/agent_loop.py
@@ -1,10 +1,9 @@
-"""Turn routing for one interactive-shell turn.
+"""Per-prompt shell agent loop.
 
-Decides, from the tool-calling action result and any left-over discovery
-observation, which of three paths a turn takes (summarize an observation,
-finish without the LLM, or gather evidence and answer), then performs the
-chosen path's effects. The path choice is the pure :func:`_route_turn`; this
-module is the imperative shell around it.
+This module owns the repeatable mechanics for one submitted shell prompt:
+snapshot context, clear stale observations, run the action-agent pass, route the
+result, optionally gather evidence, optionally call the assistant, and finalize
+accounting. The durable lifecycle object lives in ``harness/agent.py``.
 """
 
 from __future__ import annotations
@@ -15,10 +14,10 @@ from typing import Literal
 from rich.console import Console
 
 from config.llm_reasoning_effort import apply_reasoning_effort
+from interactive_shell.harness.agent_context import AgentContext
+from interactive_shell.harness.llm_context.session import ReplSession
 from interactive_shell.harness.response import generate_response
 from interactive_shell.harness.tool_calling import run_tool_calling_turn
-from interactive_shell.harness.turn_context import TurnContext
-from interactive_shell.runtime import ReplSession
 from interactive_shell.runtime.core.turn_accounting import (
     ShellTurnAccounting,
     ShellTurnResult,
@@ -36,10 +35,10 @@ def _response_text(run: LlmRunInfo | None) -> str:
     return run.response_text if run is not None and run.response_text else ""
 
 
-def _route_turn(
+def _route_prompt(
     action_result: ToolCallingTurnResult, observation: str | None
 ) -> Literal["summarize_observation", "handled_without_llm", "gather_and_answer"]:
-    """Decide the turn path from the action result and any left-over observation."""
+    """Decide the prompt path from the action result and any left-over observation."""
     if (
         action_result.handled
         and observation is not None
@@ -60,7 +59,7 @@ def _gather_and_answer(
     response_generator: ResponseGenerator,
     confirm_fn: Callable[[str], str] | None,
     is_tty: bool | None,
-    turn_ctx: TurnContext,
+    agent_ctx: AgentContext,
 ) -> LlmRunInfo | None:
     gathered = gather_evidence(text, session, console, is_tty=is_tty)
 
@@ -76,12 +75,12 @@ def _gather_and_answer(
         confirm_fn=confirm_fn,
         is_tty=is_tty,
         tool_observation=gathered or None,
-        turn_ctx=turn_ctx,
+        agent_ctx=agent_ctx,
         **on_screen,
     )
 
 
-def handle_message_with_agent(
+def run_agent_prompt(
     text: str,
     session: ReplSession,
     console: Console,
@@ -93,28 +92,20 @@ def handle_message_with_agent(
     gather_evidence: GatherEvidence | None = None,
     response_generator: ResponseGenerator | None = None,
 ) -> ShellTurnResult:
-    """Run one interactive-shell turn through three paths, in order:
-
-    1. ``summarize_observation`` — a successful action left discovery output, so
-       summarize it into a direct answer.
-    2. ``handled_without_llm`` — the action fully handled the turn; stop without the LLM.
-    3. ``gather_and_answer`` — nothing was handled; gather evidence and answer.
-
-    The path choice is the pure ``_route_turn``; this function is the imperative
-    shell that performs the chosen path's effects.
-    """
+    """Run one prompt through the shell agent's action/answer loop."""
     execute_actions = execute_actions or run_tool_calling_turn
     gather_evidence = gather_evidence or gather_tool_evidence
     response_generator = response_generator or generate_response
 
-    # Snapshot session state before any turn mutations. Both the action agent
-    # and the conversational assistant read from this frozen context so their
-    # prompts reflect a consistent turn-start view rather than live session state.
-    turn_ctx = TurnContext.from_session(text, session)
+    # Snapshot session state before any prompt mutations. Both the action
+    # agent and the conversational assistant read from this frozen context so
+    # prompts reflect a consistent prompt-start view rather than live session
+    # state.
+    agent_ctx = AgentContext.from_session(text, session)
     accounting = ShellTurnAccounting(session=session, text=text, recorder=recorder)
 
-    # Clear any observation left by a prior turn so only this turn's discovery
-    # output can trigger a summary pass.
+    # Clear any observation left by a prior prompt so only this prompt's
+    # discovery output can trigger a summary pass.
     session.agent.reset_observation()
 
     action_result = execute_actions(
@@ -123,15 +114,15 @@ def handle_message_with_agent(
         console,
         confirm_fn=confirm_fn,
         is_tty=is_tty,
-        turn_ctx=turn_ctx,
+        agent_ctx=agent_ctx,
     )
     accounting.record_action_result(action_result)
 
     observation = session.agent.last_observation
 
-    route = _route_turn(action_result, observation)
+    route = _route_prompt(action_result, observation)
     if route == "summarize_observation":
-        with apply_reasoning_effort(turn_ctx.reasoning_effort):
+        with apply_reasoning_effort(agent_ctx.reasoning_effort):
             run = response_generator(
                 text,
                 session,
@@ -139,7 +130,7 @@ def handle_message_with_agent(
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
                 tool_observation=observation,
-                turn_ctx=turn_ctx,
+                agent_ctx=agent_ctx,
             )
         return accounting.finalize(
             ShellTurnResult(
@@ -160,7 +151,7 @@ def handle_message_with_agent(
         )
 
     if route == "gather_and_answer":
-        with apply_reasoning_effort(turn_ctx.reasoning_effort):
+        with apply_reasoning_effort(agent_ctx.reasoning_effort):
             run = _gather_and_answer(
                 text=text,
                 session=session,
@@ -169,7 +160,7 @@ def handle_message_with_agent(
                 response_generator=response_generator,
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
-                turn_ctx=turn_ctx,
+                agent_ctx=agent_ctx,
             )
         return accounting.finalize(
             ShellTurnResult(
@@ -187,5 +178,5 @@ __all__ = [
     "GatherEvidence",
     "ResponseGenerator",
     "RunToolCallingTurn",
-    "handle_message_with_agent",
+    "run_agent_prompt",
 ]

--- a/interactive_shell/harness/events.py
+++ b/interactive_shell/harness/events.py
@@ -1,0 +1,41 @@
+"""Shell-agent event contracts.
+
+This module is intentionally UI-free. The shell agent emits these events;
+runtime presentation code decides how to render them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from typing import Any, Literal
+
+AgentEventType = Literal[
+    "agent_start",
+    "agent_stop",
+    "prompt_start",
+    "prompt_interrupted",
+    "prompt_error",
+    "prompt_end",
+]
+
+
+@dataclass(frozen=True)
+class AgentEvent:
+    """Lifecycle event emitted by the shell agent."""
+
+    type: AgentEventType
+    text: str | None = None
+    error: Exception | None = None
+
+
+AgentEventSink = Callable[[AgentEvent], None]
+AsyncAgentEventSink = Callable[[AgentEvent], Coroutine[Any, Any, None]]
+
+
+__all__ = [
+    "AgentEvent",
+    "AgentEventSink",
+    "AgentEventType",
+    "AsyncAgentEventSink",
+]

--- a/interactive_shell/harness/llm_context/action_prompt.py
+++ b/interactive_shell/harness/llm_context/action_prompt.py
@@ -9,25 +9,25 @@ from interactive_shell.harness.llm_context.action_prompt_text import SYSTEM_PROM
 from interactive_shell.harness.llm_context.conversation_history import format_recent_conversation
 
 if TYPE_CHECKING:
-    from interactive_shell.harness.turn_context import TurnContext
+    from interactive_shell.harness.agent_context import AgentContext
 
 _MAX_TEXT_LEN = 512
 _USER_TEMPLATE = "USER MESSAGE (literal): <<<{text}>>>"
 
 
-def build_action_system_prompt(turn_ctx: TurnContext) -> str:
+def build_action_system_prompt(agent_ctx: AgentContext) -> str:
     return (
         SYSTEM_PROMPT_BASE
         + "\n\n"
-        + connected_integrations_block(turn_ctx)
-        + recent_conversation_block(turn_ctx)
+        + connected_integrations_block(agent_ctx)
+        + recent_conversation_block(agent_ctx)
     )
 
 
-def connected_integrations_block(turn_ctx: TurnContext) -> str:
+def connected_integrations_block(agent_ctx: AgentContext) -> str:
     """Render which integrations are connected for this shell action turn."""
-    known = turn_ctx.configured_integrations_known
-    configured = turn_ctx.configured_integrations
+    known = agent_ctx.configured_integrations_known
+    configured = agent_ctx.configured_integrations
     if known and configured:
         listing = ", ".join(sorted(str(name) for name in configured))
     elif known:
@@ -44,8 +44,8 @@ def connected_integrations_block(turn_ctx: TurnContext) -> str:
     return f"CONNECTED INTEGRATIONS (this install, right now): {listing}\n{gate_note}\n"
 
 
-def recent_conversation_block(turn_ctx: TurnContext) -> str:
-    history = format_recent_conversation(list(turn_ctx.conversation_messages))
+def recent_conversation_block(agent_ctx: AgentContext) -> str:
+    history = format_recent_conversation(list(agent_ctx.conversation_messages))
     return (
         "RECENT CONVERSATION (context only, oldest first; use it ONLY to resolve "
         "follow-up references in the USER MESSAGE below — do NOT re-run turns that "

--- a/interactive_shell/harness/llm_context/assistant_prompt.py
+++ b/interactive_shell/harness/llm_context/assistant_prompt.py
@@ -19,6 +19,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from interactive_shell.harness.agent_context import AgentContext
 from interactive_shell.harness.llm_context.conversation_history import format_recent_conversation
 from interactive_shell.harness.llm_context.grounding.investigation_flow_reference import (
     build_investigation_flow_reference_text,
@@ -34,7 +35,6 @@ from interactive_shell.harness.llm_context.rules import (
 from interactive_shell.harness.llm_context.session import (
     SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST,
 )
-from interactive_shell.harness.turn_context import TurnContext
 from interactive_shell.runtime import ReplSession
 
 _logger = logging.getLogger(__name__)
@@ -229,7 +229,7 @@ def _load_synthetic_observation_text(
     return raw
 
 
-def _build_integration_guard(ctx: TurnContext) -> str:
+def _build_integration_guard(ctx: AgentContext) -> str:
     """Render the no-integrations guidance block (pure over the snapshot)."""
     if not (ctx.configured_integrations_known and not ctx.configured_integrations):
         return ""
@@ -243,7 +243,7 @@ def _build_integration_guard(ctx: TurnContext) -> str:
     )
 
 
-def _build_synthetic_failure_block(ctx: TurnContext) -> str:
+def _build_synthetic_failure_block(ctx: AgentContext) -> str:
     obs_path = ctx.last_synthetic_observation_path
     if not obs_path:
         return ""
@@ -271,7 +271,7 @@ def build_cli_agent_prompt(
     session: ReplSession,
     tool_observation: str | None,
     tool_observation_on_screen: bool,
-    turn_ctx: TurnContext,
+    agent_ctx: AgentContext,
 ) -> str:
     """Read grounding sources / files / snapshot once and render the prompt string.
 
@@ -282,20 +282,20 @@ def build_cli_agent_prompt(
 
     system = build_assistant_system_prompt(
         session.grounding.cli.build_text(),
-        format_recent_conversation(list(turn_ctx.conversation_messages)),
+        format_recent_conversation(list(agent_ctx.conversation_messages)),
         agents_md=session.grounding.agents_md.build_text(),
         investigation_flow=build_investigation_flow_reference_text(),
         prior_investigation=(
-            _summarize_last_state(turn_ctx.last_state) if turn_ctx.last_state is not None else ""
+            _summarize_last_state(agent_ctx.last_state) if agent_ctx.last_state is not None else ""
         ),
         environment=build_environment_block(session),
     )
 
-    integration_guard = _build_integration_guard(turn_ctx)
+    integration_guard = _build_integration_guard(agent_ctx)
     observation_block = build_observation_block(
         tool_observation, on_screen=tool_observation_on_screen
     )
-    synthetic_block = _build_synthetic_failure_block(turn_ctx)
+    synthetic_block = _build_synthetic_failure_block(agent_ctx)
 
     return (
         f"{system}\n"

--- a/interactive_shell/harness/response.py
+++ b/interactive_shell/harness/response.py
@@ -19,8 +19,8 @@ from rich.markup import escape
 from integrations.llm_cli.errors import CLITimeoutError
 from interactive_shell.harness.action_exec import _execute_action_plan
 from interactive_shell.harness.action_plan import _parse_action_plan
+from interactive_shell.harness.agent_context import AgentContext
 from interactive_shell.harness.llm_context.assistant_prompt import build_cli_agent_prompt
-from interactive_shell.harness.turn_context import TurnContext
 from interactive_shell.runtime import ReplSession
 from interactive_shell.runtime.agent_presentation import render_json_like_response
 from interactive_shell.runtime.core.token_accounting import build_llm_run_info
@@ -90,27 +90,27 @@ def generate_response(
     is_tty: bool | None = None,
     tool_observation: str | None = None,
     tool_observation_on_screen: bool = True,
-    turn_ctx: TurnContext | None = None,
+    agent_ctx: AgentContext | None = None,
 ) -> LlmRunInfo | None:
     """Generate one turn's final assistant response (guidance only; no investigation run).
 
-    ``turn_ctx`` is the immutable per-turn snapshot assembled at turn start.
+    ``agent_ctx`` is the immutable per-prompt snapshot assembled at prompt start.
     When present, snapshot fields (conversation history, integration state,
     prior investigation, synthetic-run path) are read from it rather than from
-    the live session, so prompt construction reflects a stable turn-start view.
+    the live session, so prompt construction reflects a stable prompt-start view.
     """
     client = _load_reasoning_client(console)
     if client is None:
         return None
 
-    ctx = turn_ctx or TurnContext.from_session(message, session)
+    ctx = agent_ctx or AgentContext.from_session(message, session)
 
     prompt = build_cli_agent_prompt(
         message=message,
         session=session,
         tool_observation=tool_observation,
         tool_observation_on_screen=tool_observation_on_screen,
-        turn_ctx=ctx,
+        agent_ctx=ctx,
     )
 
     run_info = _stream_response(

--- a/interactive_shell/harness/tests/_oracle_runtime.py
+++ b/interactive_shell/harness/tests/_oracle_runtime.py
@@ -19,6 +19,7 @@ from rich.console import Console
 # cannot be resolved the scenario is skipped, never failed (env gap, not bug).
 LIVE_INTEGRATION_SENTINEL = "@live"
 
+from interactive_shell.harness.agent_loop import run_agent_prompt
 from interactive_shell.harness.llm_context.session import ReplSession
 from interactive_shell.harness.tests._oracle_normalize import (
     normalize_history_entry,
@@ -30,7 +31,6 @@ from interactive_shell.harness.tests.scenario_loader import (
     ScenarioCapabilities,
     ScenarioCase,
 )
-from interactive_shell.harness.turn import handle_message_with_agent
 from interactive_shell.tools.tool_contracts import ToolExecutor
 from interactive_shell.tools.tool_registry import (
     REGISTRY,
@@ -409,7 +409,7 @@ def run_oracle_once(case: ScenarioCase, monkeypatch: pytest.MonkeyPatch) -> Orac
     session_token = bind_cli_session_id(session.session_id)
     try:
         recorder = PromptRecorder.start(session=session, text=prompt, turn_kind=_AGENT_TURN_KIND)
-        handle_message_with_agent(
+        run_agent_prompt(
             prompt,
             session,
             console,

--- a/interactive_shell/harness/tests/orchestration/test_action_prompt.py
+++ b/interactive_shell/harness/tests/orchestration/test_action_prompt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from interactive_shell.harness.agent_context import AgentContext
 from interactive_shell.harness.llm_context import (
     SYSTEM_PROMPT_BASE,
     build_action_system_prompt,
@@ -10,7 +11,6 @@ from interactive_shell.harness.llm_context import (
 )
 from interactive_shell.harness.llm_context.conversation_history import NO_HISTORY_PLACEHOLDER
 from interactive_shell.harness.llm_context.models import coerce_messages
-from interactive_shell.harness.turn_context import TurnContext
 
 
 def _ctx(
@@ -18,8 +18,8 @@ def _ctx(
     messages: list[tuple[str, str]] | None = None,
     integrations: tuple[str, ...] = (),
     integrations_known: bool = False,
-) -> TurnContext:
-    return TurnContext(
+) -> AgentContext:
+    return AgentContext(
         text="",
         conversation_messages=coerce_messages(messages or []),
         configured_integrations=integrations,

--- a/interactive_shell/harness/tests/orchestration/test_agent_actions.py
+++ b/interactive_shell/harness/tests/orchestration/test_agent_actions.py
@@ -21,6 +21,7 @@ import interactive_shell.tools.llm_provider_tool as llm_provider_tool
 import interactive_shell.tools.shell.execution as shell_execution
 import interactive_shell.tools.slash_tool as slash_tool
 from core.runtime.llm.agent_llm_client import AgentLLMResponse, ToolCall
+from interactive_shell.harness.agent_loop import run_agent_prompt
 from interactive_shell.harness.llm_context.session import ReplSession
 from interactive_shell.harness.tests._planned_action import (
     PlannedAction,
@@ -29,7 +30,6 @@ from interactive_shell.harness.tests._planned_action import (
 from interactive_shell.harness.tests.orchestration.action_execution_test_harness import (
     FakeActionLLM,
 )
-from interactive_shell.harness.turn import handle_message_with_agent
 from interactive_shell.tools.tool_registry import (
     TOOL_KIND_TO_NAME,
     ToolKind,
@@ -1280,10 +1280,10 @@ def test_execute_cli_actions_counts_planned_and_executed(monkeypatch: object) ->
 
     session = ReplSession()
     console, _ = _capture()
-    # Analytics now fire from ShellTurnAccounting inside handle_message_with_agent,
+    # Analytics now fire from ShellTurnAccounting inside run_agent_prompt,
     # not from run_tool_calling_turn directly. Drive the full turn with a no-op
     # answer agent so no real LLM is invoked.
-    result = handle_message_with_agent(
+    result = run_agent_prompt(
         "run `pwd`",
         session,
         console,
@@ -1358,8 +1358,8 @@ def test_execute_cli_actions_executes_matched_clause_ignoring_unhandled(
 
     session = ReplSession()
     console, _ = _capture()
-    # Analytics now fire from ShellTurnAccounting inside handle_message_with_agent.
-    result = handle_message_with_agent(
+    # Analytics now fire from ShellTurnAccounting inside run_agent_prompt.
+    result = run_agent_prompt(
         "check health",
         session,
         console,

--- a/interactive_shell/harness/tests/test_observe_answer_summary.py
+++ b/interactive_shell/harness/tests/test_observe_answer_summary.py
@@ -12,8 +12,8 @@ import io
 
 from rich.console import Console
 
+from interactive_shell.harness.agent_loop import run_agent_prompt
 from interactive_shell.harness.llm_context.session import ReplSession
-from interactive_shell.harness.turn import handle_message_with_agent
 from interactive_shell.runtime.core.turn_accounting import (
     ToolCallingTurnResult,
 )
@@ -54,7 +54,7 @@ def test_discovery_output_is_summarized_into_a_direct_answer() -> None:
         return LlmRunInfo(response_text="No — Sentry is not configured.")
 
     session = ReplSession()
-    handle_message_with_agent(
+    run_agent_prompt(
         "is sentry installed?",
         session,
         _console(),
@@ -91,7 +91,7 @@ def test_no_observation_keeps_silent_handled_turn() -> None:
         return None
 
     session = ReplSession()
-    handle_message_with_agent(
+    run_agent_prompt(
         "deploy the remote instance",
         session,
         _console(),
@@ -128,7 +128,7 @@ def test_failed_discovery_is_not_summarized() -> None:
         return None
 
     session = ReplSession()
-    handle_message_with_agent(
+    run_agent_prompt(
         "is sentry installed?",
         session,
         _console(),
@@ -166,7 +166,7 @@ def test_observation_is_reset_each_turn() -> None:
 
     session = ReplSession()
     session.agent.last_observation = "stale observation from a previous turn"
-    handle_message_with_agent(
+    run_agent_prompt(
         "deploy the remote instance",
         session,
         _console(),

--- a/interactive_shell/harness/tests/test_pipeline_tool_gathering.py
+++ b/interactive_shell/harness/tests/test_pipeline_tool_gathering.py
@@ -8,8 +8,8 @@ from typing import Any
 
 from rich.console import Console
 
+from interactive_shell.harness.agent_loop import run_agent_prompt
 from interactive_shell.harness.llm_context.session import ReplSession
-from interactive_shell.harness.turn import handle_message_with_agent
 from interactive_shell.runtime.core.turn_accounting import (
     ToolCallingTurnResult,
 )
@@ -42,7 +42,7 @@ def _record_answer() -> tuple[list[dict[str, Any]], Callable[..., None]]:
 def test_gather_string_threads_offscreen_observation() -> None:
     calls, fake_answer = _record_answer()
 
-    handle_message_with_agent(
+    run_agent_prompt(
         "question",
         ReplSession(),
         _console(),
@@ -60,7 +60,7 @@ def test_gather_string_threads_offscreen_observation() -> None:
 def test_gather_none_passes_through_without_observation() -> None:
     calls, fake_answer = _record_answer()
 
-    handle_message_with_agent(
+    run_agent_prompt(
         "question",
         ReplSession(),
         _console(),
@@ -96,7 +96,7 @@ def test_existing_command_observation_skips_gather() -> None:
             handled=True,
         )
 
-    handle_message_with_agent(
+    run_agent_prompt(
         "question",
         ReplSession(),
         _console(),

--- a/interactive_shell/harness/tests/test_shell_agent.py
+++ b/interactive_shell/harness/tests/test_shell_agent.py
@@ -1,0 +1,132 @@
+"""ShellAgent lifecycle and boundary tests."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import io
+import threading
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+from interactive_shell.harness.agent import ShellAgent
+from interactive_shell.harness.events import AgentEvent
+from interactive_shell.harness.llm_context.session import ReplSession
+from interactive_shell.runtime.core.confirmation import DispatchCancelled
+from interactive_shell.runtime.core.turn_accounting import ToolCallingTurnResult
+
+
+def _console() -> Console:
+    return Console(file=io.StringIO(), force_terminal=False, color_system=None, width=80)
+
+
+def _handled(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    return ToolCallingTurnResult(
+        planned_count=1,
+        executed_count=1,
+        executed_success_count=1,
+        has_unhandled_clause=False,
+        handled=True,
+        response_text="handled",
+    )
+
+
+def test_shell_agent_start_prompt_stop_lifecycle_events() -> None:
+    async def _run() -> None:
+        events: list[AgentEvent] = []
+        agent = ShellAgent(
+            ReplSession(),
+            execute_actions=_handled,
+            response_generator=lambda *_a, **_k: None,
+            event_sink=events.append,
+        )
+
+        agent.start()
+        result = await agent.prompt("run something", console=_console(), recorder=None)
+        await agent.stop()
+
+        assert result.final_intent == "cli_agent_handled"
+        assert [event.type for event in events] == [
+            "agent_start",
+            "prompt_start",
+            "prompt_end",
+            "agent_stop",
+        ]
+
+    asyncio.run(_run())
+
+
+def test_shell_agent_requires_start_before_prompt() -> None:
+    async def _run() -> None:
+        agent = ShellAgent(ReplSession(), execute_actions=_handled)
+
+        with pytest.raises(RuntimeError, match="start"):
+            await agent.prompt("run something", console=_console(), recorder=None)
+
+    asyncio.run(_run())
+
+
+def test_shell_agent_emits_interruption_event() -> None:
+    async def _run() -> None:
+        events: list[AgentEvent] = []
+
+        def _cancelled(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+            raise DispatchCancelled()
+
+        agent = ShellAgent(ReplSession(), execute_actions=_cancelled, event_sink=events.append)
+        agent.start()
+
+        with pytest.raises(DispatchCancelled):
+            await agent.prompt("cancel me", console=_console(), recorder=None)
+
+        assert [event.type for event in events] == [
+            "agent_start",
+            "prompt_start",
+            "prompt_interrupted",
+            "prompt_end",
+        ]
+
+    asyncio.run(_run())
+
+
+def test_shell_agent_rejects_concurrent_prompt() -> None:
+    async def _run() -> None:
+        started = threading.Event()
+        release = threading.Event()
+
+        def _blocking(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+            started.set()
+            assert release.wait(timeout=5)
+            return _handled()
+
+        agent = ShellAgent(ReplSession(), execute_actions=_blocking)
+        agent.start()
+        first = asyncio.create_task(agent.prompt("first", console=_console(), recorder=None))
+        assert await asyncio.to_thread(started.wait, 5)
+
+        with pytest.raises(RuntimeError, match="already processing"):
+            await agent.prompt("second", console=_console(), recorder=None)
+
+        release.set()
+        await first
+
+    asyncio.run(_run())
+
+
+def test_shell_agent_lifecycle_modules_do_not_import_core_domain_or_orchestration() -> None:
+    for module_name in ("agent.py", "agent_loop.py"):
+        module_path = Path(__file__).parents[1] / module_name
+        tree = ast.parse(module_path.read_text())
+
+        imports: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module is not None:
+                imports.append(node.module)
+
+        assert not any(
+            name.startswith(("core.domain", "core.orchestration")) for name in imports
+        ), module_name

--- a/interactive_shell/harness/tests/test_turn_loop.py
+++ b/interactive_shell/harness/tests/test_turn_loop.py
@@ -7,8 +7,8 @@ from typing import Any
 
 from rich.console import Console
 
+from interactive_shell.harness.agent_loop import run_agent_prompt
 from interactive_shell.harness.llm_context.session import ReplSession
-from interactive_shell.harness.turn import handle_message_with_agent
 from interactive_shell.runtime.core.turn_accounting import (
     ToolCallingTurnResult,
 )
@@ -48,7 +48,7 @@ def test_recorder_flushes_once_for_chat_fallback() -> None:
     def _answer(*_args: Any, **_kwargs: Any) -> LlmRunInfo:
         return run_info
 
-    result = handle_message_with_agent(
+    result = run_agent_prompt(
         "question",
         ReplSession(),
         _console(),
@@ -77,7 +77,7 @@ def test_recorder_flushes_once_for_silent_handled_turn() -> None:
             response_text="command output",
         )
 
-    result = handle_message_with_agent(
+    result = run_agent_prompt(
         "run something",
         ReplSession(),
         _console(),

--- a/interactive_shell/harness/tests/test_turn_scenarios.py
+++ b/interactive_shell/harness/tests/test_turn_scenarios.py
@@ -378,11 +378,11 @@ def _assert_live_action_planning_once(case: ScenarioCase) -> None:
     from core.runtime.llm import agent_llm_client
 
     llm = agent_llm_client.get_agent_llm()
-    from interactive_shell.harness.turn_context import TurnContext
+    from interactive_shell.harness.agent_context import AgentContext
 
     result = Agent(
         llm=llm,
-        system=build_action_system_prompt(TurnContext.from_session(prompt, session)),
+        system=build_action_system_prompt(AgentContext.from_session(prompt, session)),
         tools=[_planning_probe_tool(tool) for tool in tools],
         resolved_integrations={},
         max_iterations=_LIVE_PLANNING_MAX_ITERATIONS,

--- a/interactive_shell/harness/tool_calling.py
+++ b/interactive_shell/harness/tool_calling.py
@@ -23,12 +23,12 @@ from rich.markup import escape
 from core.runtime.agent import Agent
 from core.runtime.llm.agent_llm_client import AgentLLMResponse, ToolCall
 from integrations.llm_cli.failure_explain import is_context_length_overflow
+from interactive_shell.harness.agent_context import AgentContext
 from interactive_shell.harness.llm_context import (
     build_action_system_prompt,
     build_action_user_message,
 )
 from interactive_shell.harness.llm_context.session import ReplSession
-from interactive_shell.harness.turn_context import TurnContext
 from interactive_shell.runtime.core.turn_accounting import ToolCallingTurnResult
 from interactive_shell.tools.tool_contracts import ToolContext
 from interactive_shell.tools.tool_registry import REGISTRY
@@ -157,13 +157,13 @@ def run_tool_calling_turn(
     confirm_fn: Callable[[str], str] | None = None,
     is_tty: bool | None = None,
     deps: ToolCallingDeps | None = None,
-    turn_ctx: TurnContext | None = None,
+    agent_ctx: AgentContext | None = None,
 ) -> ToolCallingTurnResult:
     """Run one shell tool-calling turn through the shared agent harness.
 
-    ``turn_ctx`` is the immutable per-turn snapshot assembled at turn start
-    in ``handle_message_with_agent``. When present it is used to build the
-    action-agent system prompt so the prompt reflects turn-start state rather
+    ``agent_ctx`` is the immutable per-prompt snapshot assembled at prompt start
+    in ``run_agent_prompt``. When present it is used to build the
+    action-agent system prompt so the prompt reflects prompt-start state rather
     than the live (potentially mid-mutation) session.
     """
     history_start = len(session.history)
@@ -196,7 +196,7 @@ def run_tool_calling_turn(
             deps.llm_factory if deps is not None and deps.llm_factory else _default_llm_factory
         )
         user_message = build_action_user_message(message)
-        effective_ctx = turn_ctx or TurnContext.from_session(message, session)
+        effective_ctx = agent_ctx or AgentContext.from_session(message, session)
         system_prompt = build_action_system_prompt(effective_ctx)
 
     try:

--- a/interactive_shell/runtime/AGENTS.md
+++ b/interactive_shell/runtime/AGENTS.md
@@ -44,9 +44,10 @@ The runtime package is intentionally split into focused concerns:
 - `core/state.py` — runtime state and transition helpers only.
 - `core/turn_detection.py` — pure prompt text classification only.
 - `utils/input_policy.py` — terminal stdin/spinner gating decisions only.
-- `agent_presentation.py` — terminal presentation for the agent turn only (agent
+- `agent_presentation.py` — terminal presentation for the agent prompt only (agent
   lifecycle events, presentation-state reducer/renderer, `ConsoleAgentEventSink`,
   JSON-like assistant response rendering).
+- `turn_host.py` — terminal/runtime host for `ShellAgent` prompts only.
 - `../controller.py` — stable async entrypoint and async prompt runtime/event loop
   orchestration, submitted prompt handling, queued-turn consumption,
   prompt-mediated confirmation waits, turn telemetry, one-turn pipeline
@@ -76,16 +77,19 @@ The interactive runtime must keep this shape:
 3. `InteractiveShellController.start_interactive_shell` owns prompt lifecycle,
    submitted input handling, queued-turn consumption, and per-turn task
    scheduling.
-4. The module-level `interactive_shell.controller.run_agent_turn_queue` runs each turn via an
-   injected `run_turn` callable, which in production is `AgentTurnCoordinator.run_turn` (in
-   `harness/agent.py`). `AgentTurnCoordinator` holds the turn dependencies (`session`, `state`,
-   `spinner`, `invalidate_prompt`) directly; `run_turn` owns shell presentation (console,
-   spinner, recorder, progress scope) and delegates to `_execute_turn_lifecycle`
-   (dispatch state + lifecycle phases via `AgentEvent` emissions), which performs the one-turn
-   shell pipeline handoff through `_run_agent_handler`. The terminal presentation for those
-   `AgentEvent` emissions lives in `runtime/agent_presentation.py` (`AgentEvent`, `AgentEventSink`,
-   `AgentPresentationState`, `_reduce_agent_presentation`, `_render_agent_presentation_transition`,
-   `ConsoleAgentEventSink`, `render_json_like_response`).
+4. `runtime.turn_host.run_agent_prompt_queue` consumes queued prompts through an
+   injected `run_prompt` callable, which in production is
+   `ShellTurnHost.run_prompt`.
+5. `ShellTurnHost` owns terminal/runtime dependencies (`session`, `state`,
+   `spinner`, `invalidate_prompt`), presentation setup, prompt-mediated
+   confirmation, and dispatch state. It calls the durable
+   `harness.agent.ShellAgent`.
+6. `harness.agent.ShellAgent` owns shell-agent lifecycle, event subscribers,
+   active prompt state, and the shell session. It delegates one submitted prompt
+   to `harness.agent_loop.run_agent_prompt`.
+7. `harness.agent_loop.run_agent_prompt` owns one prompt's action/answer
+   mechanics and accounting finalization. The terminal presentation for
+   `AgentEvent` emissions lives in `runtime/agent_presentation.py`.
 
 Do not invert this dependency direction.
 
@@ -95,10 +99,10 @@ Do not invert this dependency direction.
 flowchart TD
   runRepl["interactive_shell.entrypoint.run_repl"] --> replMain["interactive_shell.entrypoint.repl_main"]
   replMain --> controller["interactive_shell.controller.InteractiveShellController"]
-  controller --> shellTurn["AgentTurnCoordinator.run_turn"]
-  shellTurn --> executeTurn["_execute_turn_lifecycle"]
-  executeTurn --> dispatchTurn["_run_agent_handler"]
-  dispatchTurn --> sideEffects["slash/help/agent/follow-up/investigation side effects"]
+  controller --> shellHost["runtime.turn_host.ShellTurnHost.run_prompt"]
+  shellHost --> shellAgent["harness.agent.ShellAgent.prompt"]
+  shellAgent --> promptLoop["harness.agent_loop.run_agent_prompt"]
+  promptLoop --> sideEffects["slash/help/agent/follow-up/investigation side effects"]
   controller --> replState["core.state.ReplState"]
   controller --> spinnerState["core.state.SpinnerState"]
   controller --> inputReader["input.PromptInputReader"]
@@ -134,26 +138,26 @@ flowchart TD
 ## Turn execution rules
 
 - Do not reintroduce `dispatch.py` or any compatibility-only forwarding module.
-- The turn execution lives in `harness/agent.py`: `AgentTurnCoordinator.run_turn` owns shell
-  presentation (StreamingConsole, spinner, recorder, progress scope) and constructs a
-  `ConsoleAgentEventSink`; `_execute_turn_lifecycle` owns dispatch state and emits
-  `AgentEvent` objects; `_run_agent_handler` owns the `handle_message_with_agent` handoff.
-  `AgentTurnCoordinator` holds its turn dependencies (`session`, `state`, `spinner`,
-  `invalidate_prompt`) directly. The module-level
-  `interactive_shell.controller.run_agent_turn_queue` takes an injected `run_turn` callable
-  (production: `AgentTurnCoordinator.run_turn`). Keep terminal side effects (spinner, prompt
-  suppression, `console.print`, CPR drain) in `ConsoleAgentEventSink` — defined in
-  `runtime/agent_presentation.py`, its imperative shell routes each event through the pure
-  `_reduce_agent_presentation` and the effectful `_render_agent_presentation_transition` — not in
-  `_execute_turn_lifecycle`. `harness/agent.py` imports the presentation surface (`AgentEvent`,
-  `AgentEventSink`, `ConsoleAgentEventSink`, `render_json_like_response`) from that module.
+- The terminal host lives in `runtime/turn_host.py`: `ShellTurnHost.run_prompt`
+  owns shell presentation (StreamingConsole, spinner, recorder, progress scope),
+  constructs a `ConsoleAgentEventSink`, owns dispatch state, and calls
+  `ShellAgent.prompt`.
+- The durable shell agent lives in `harness/agent.py`: `ShellAgent` owns
+  lifecycle (`start`, `prompt`, `stop`, `wait_idle`, `abort`), event
+  subscribers, active prompt state, and the live shell session.
+- The per-prompt loop lives in `harness/agent_loop.py`: `run_agent_prompt` owns
+  prompt context snapshots, observation reset, action/response routing,
+  accounting finalization, and calls into `tool_calling.py`.
+- Keep terminal side effects (spinner, prompt suppression, `console.print`, CPR
+  drain) in `ConsoleAgentEventSink` — defined in `runtime/agent_presentation.py`
+  — not in `ShellAgent` or `run_agent_prompt`.
 - Put cancel/confirm/correction text classifiers in `core/turn_detection.py`.
 - Put stdin blocking and spinner decisions in `utils/input_policy.py`.
-- Keep prompt-mediated confirmation waiting in `controller.py`.
+- Keep prompt-mediated confirmation waiting in `turn_host.py`.
 - Turn accounting is consolidated behind `ShellTurnAccounting` in
   `interactive_shell/turn_accounting.py` (alongside the `ToolCallingTurnResult`
-  and `ShellTurnResult` turn data model), invoked from `handle_message_with_agent`
-  in `harness/agent.py`. It owns action-agent analytics, terminal-turn aggregate
+  and `ShellTurnResult` turn data model), invoked from `run_agent_prompt`
+  in `harness/agent_loop.py`. It owns action-agent analytics, terminal-turn aggregate
   telemetry, prompt-recorder flush, conversational-turn persistence, and the final
   assistant-intent stamp. `run_tool_calling_turn` (in `harness/tool_calling.py`)
   returns facts only (`ToolCallingTurnResult` with `accounting_status` of
@@ -165,17 +169,18 @@ flowchart TD
 - `../controller.py` owns:
   - `InteractiveShellController`
   - `start_interactive_shell` shell lifecycle orchestration
+  - `ShellTurnHost` construction and shutdown
+  - queued prompt submission
+- `turn_host.py` owns:
   - `run_input_loop` (module-level) — read and handle user input until exit
-  - `run_agent_turn_queue` (module-level) — consume queued turns until exit (runs an injected `run_turn`)
-  - `AgentTurnCoordinator` (in `harness/agent.py`) — holds turn dependencies directly; `run_turn` drives presentation and delegates to `_execute_turn_lifecycle` / `_run_agent_handler`
+  - `run_agent_prompt_queue` (module-level) — consume queued prompts until exit (runs an injected `run_prompt`)
+  - `ShellTurnHost` — terminal/runtime dependencies, presentation, dispatch state, prompt-mediated confirmation, and `ShellAgent` invocation
   - `ConsoleAgentEventSink` (in `runtime/agent_presentation.py`) — terminal presentation for agent lifecycle events over `_reduce_agent_presentation` / `_render_agent_presentation_transition`
-  - prompt input acceptance until exit
-  - submitted prompt rendering and cancel/confirm/queue handling
   - queued turn consumption
   - per-turn task lifecycle
   - dispatch start/finish state transitions
   - prompt-mediated confirmation waiting
-  - turn telemetry and `handle_message_with_agent` invocation
+  - turn telemetry and `run_agent_prompt` invocation
   - current turn cancellation helpers
   - coordination between prompt, background, and shutdown helpers
 - `core/prompt_manager.py` owns:

--- a/interactive_shell/runtime/agent_presentation.py
+++ b/interactive_shell/runtime/agent_presentation.py
@@ -1,9 +1,9 @@
-"""Terminal presentation for the interactive shell agent turn.
+"""Terminal presentation for the interactive shell agent prompt.
 
-This module owns the **UI / presentation** side of one submitted shell turn: the
-agent lifecycle event contract, the pure presentation-state reducer, the
-effectful terminal transition renderer, the ``ConsoleAgentEventSink`` imperative
-shell that wires them together, and the JSON-like assistant response renderer.
+This module owns the **UI / presentation** side of one submitted shell prompt:
+the pure presentation-state reducer, the effectful terminal transition renderer,
+the ``ConsoleAgentEventSink`` imperative shell that wires them together, and the
+JSON-like assistant response renderer.
 
 Keeping this separate from ``harness/agent.py`` isolates spinner lifecycle,
 prompt suppression, markdown rendering, interruption/error messages, and stale
@@ -13,14 +13,13 @@ CPR draining from the turn's action-routing and prompt-construction logic.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Literal
 
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.markup import escape
 
+from interactive_shell.harness.events import AgentEvent, AsyncAgentEventSink
 from interactive_shell.harness.llm_context.session import ReplSession
 from interactive_shell.runtime.core.state import SpinnerState
 from interactive_shell.runtime.utils.input_policy import turn_should_show_spinner
@@ -33,18 +32,6 @@ from interactive_shell.ui import (
 )
 from interactive_shell.ui.components.cpr_stdin import drain_stale_cpr_bytes
 from interactive_shell.ui.streaming.console import StreamingConsole
-
-
-@dataclass(frozen=True)
-class AgentEvent:
-    """Agent lifecycle event emitted during one submitted shell turn."""
-
-    type: Literal["turn_start", "turn_interrupted", "turn_error", "turn_end"]
-    text: str | None = None
-    error: Exception | None = None
-
-
-AgentEventSink = Callable[[AgentEvent], Awaitable[None]]
 
 
 @dataclass(frozen=True)
@@ -62,14 +49,14 @@ def _reduce_agent_presentation(
     should_show_spinner: bool,
 ) -> AgentPresentationState:
     """Compute the next presentation state for *event* (pure)."""
-    if event.type == "turn_start":
+    if event.type == "prompt_start":
         return AgentPresentationState(
             show_spinner=should_show_spinner,
             prompt_suppressed=should_show_spinner,
         )
-    if event.type == "turn_end":
+    if event.type == "prompt_end":
         return AgentPresentationState()
-    if event.type in {"turn_interrupted", "turn_error"}:
+    if event.type in {"prompt_interrupted", "prompt_error", "agent_start", "agent_stop"}:
         return state
     raise ValueError(f"Unknown agent event type: {event.type!r}")
 
@@ -86,23 +73,25 @@ async def _render_agent_presentation_transition(
     from interactive_shell.ui.output import set_prompt_suppress_fn
 
     match event.type:
-        case "turn_start":
+        case "prompt_start":
             if current.show_spinner:
                 spinner.start()
                 set_prompt_suppress_fn(console.suppress_prompt_spinner)
-        case "turn_interrupted":
+        case "prompt_interrupted":
             console.print(f"[{WARNING}]· interrupted[/]")
-        case "turn_error":
+        case "prompt_error":
             exc = event.error
             if exc is None:
-                raise ValueError("turn_error event requires an error")
-            console.print(f"[{ERROR}]turn error:[/] {escape(str(exc))}")
-        case "turn_end":
+                raise ValueError("prompt_error event requires an error")
+            console.print(f"[{ERROR}]prompt error:[/] {escape(str(exc))}")
+        case "prompt_end":
             set_prompt_suppress_fn(None)
             if previous.show_spinner:
                 spinner.stop()
             await asyncio.sleep(0.05)
             drain_stale_cpr_bytes()
+        case "agent_start" | "agent_stop":
+            return
         case _:
             raise ValueError(f"Unknown agent event type: {event.type!r}")
 
@@ -157,7 +146,7 @@ def render_json_like_response(console: Console, text: str) -> None:
 
 __all__ = [
     "AgentEvent",
-    "AgentEventSink",
+    "AsyncAgentEventSink",
     "AgentPresentationState",
     "ConsoleAgentEventSink",
     "render_json_like_response",

--- a/interactive_shell/runtime/startup/initial_input.py
+++ b/interactive_shell/runtime/startup/initial_input.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from rich.console import Console
 
+from interactive_shell.harness.agent import ShellAgent
 from interactive_shell.harness.llm_context.session import ReplSession
-from interactive_shell.harness.turn import handle_message_with_agent
 from interactive_shell.ui import render_banner
 from interactive_shell.ui.input_prompt.rendering import render_submitted_prompt
 from interactive_shell.utils.telemetry import PromptRecorder
@@ -14,7 +14,7 @@ from platform.analytics.repl_context import bind_cli_session_id, reset_cli_sessi
 _TURN_KIND = "agent"
 
 
-def run_initial_input(
+async def run_initial_input(
     initial_input: str,
     session: ReplSession,
 ) -> int:
@@ -25,24 +25,30 @@ def run_initial_input(
         legacy_windows=False,
     )
     render_banner(console)
-    for line in initial_input.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            continue
-        render_submitted_prompt(console, session, stripped)
-        session_token = bind_cli_session_id(session.session_id)
-        try:
-            recorder = PromptRecorder.start(session=session, text=stripped, turn_kind=_TURN_KIND)
-            handle_message_with_agent(
-                stripped,
-                session,
-                console,
-                recorder=recorder,
-                confirm_fn=None,
-                is_tty=False,
-            )
-        finally:
-            reset_cli_session_id(session_token)
+    agent = ShellAgent(session)
+    agent.start()
+    try:
+        for line in initial_input.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            render_submitted_prompt(console, session, stripped)
+            session_token = bind_cli_session_id(session.session_id)
+            try:
+                recorder = PromptRecorder.start(
+                    session=session, text=stripped, turn_kind=_TURN_KIND
+                )
+                await agent.prompt(
+                    stripped,
+                    console=console,
+                    recorder=recorder,
+                    confirm_fn=None,
+                    is_tty=False,
+                )
+            finally:
+                reset_cli_session_id(session_token)
+    finally:
+        await agent.stop()
     return 0
 
 

--- a/interactive_shell/runtime/turn_host.py
+++ b/interactive_shell/runtime/turn_host.py
@@ -1,0 +1,290 @@
+"""Runtime host for interactive OpenSRE shell prompts."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import threading
+from collections.abc import Awaitable, Callable, Coroutine, Iterator
+from concurrent.futures import Future
+from typing import Any
+
+from rich.console import Console
+
+from interactive_shell.harness.agent import ShellAgent
+from interactive_shell.harness.events import (
+    AgentEvent,
+    AgentEventSink,
+    AgentEventType,
+    AsyncAgentEventSink,
+)
+from interactive_shell.harness.llm_context.session import ReplSession
+from interactive_shell.runtime.agent_presentation import ConsoleAgentEventSink
+from interactive_shell.runtime.background.workers import BackgroundTaskManager
+from interactive_shell.runtime.core.confirmation import (
+    DispatchCancelled,
+    request_confirmation_via_prompt,
+)
+from interactive_shell.runtime.core.state import ReplState, SpinnerState
+from interactive_shell.runtime.input import PromptInputReader
+from interactive_shell.runtime.input.actions import (
+    InputAction,
+    ShellInputSnapshot,
+    decide_input_action,
+)
+from interactive_shell.runtime.utils.input_policy import turn_needs_exclusive_stdin
+from interactive_shell.ui.output.repl_progress import repl_safe_progress_scope
+from interactive_shell.ui.streaming.console import StreamingConsole
+from interactive_shell.utils.error_handling.exception_reporting import report_exception
+from interactive_shell.utils.telemetry import PromptRecorder
+from platform.analytics.repl_context import bind_cli_session_id, reset_cli_session_id
+
+_logger = logging.getLogger(__name__)
+_AGENT_TURN_KIND = "agent"
+_ONCE_EVENTS: frozenset[AgentEventType] = frozenset(
+    {"prompt_start", "prompt_interrupted", "prompt_error", "prompt_end"}
+)
+
+
+@contextlib.contextmanager
+def _bound_cli_session(session_id: str) -> Iterator[None]:
+    """Temporarily bind the CLI session ID for the current prompt."""
+    token = bind_cli_session_id(session_id)
+    try:
+        yield
+    finally:
+        reset_cli_session_id(token)
+
+
+class _ThreadedAgentEventBridge:
+    """Bridge sync shell-agent events to the async terminal presentation sink."""
+
+    def __init__(
+        self,
+        *,
+        loop: asyncio.AbstractEventLoop,
+        sink: AsyncAgentEventSink,
+    ) -> None:
+        self._loop = loop
+        self._sink = sink
+        self._loop_thread_id = threading.get_ident()
+        self._lock = threading.Lock()
+        self._emitted: set[AgentEventType] = set()
+
+    def __call__(self, event: AgentEvent) -> None:
+        if not self._claim(event):
+            return
+        if threading.get_ident() == self._loop_thread_id:
+            self._loop.create_task(self._sink(event))
+            return
+        future: Future[None] = asyncio.run_coroutine_threadsafe(self._sink(event), self._loop)
+        future.result()
+
+    async def emit_async(self, event: AgentEvent) -> None:
+        if not self._claim(event):
+            return
+        await self._sink(event)
+
+    def _claim(self, event: AgentEvent) -> bool:
+        if event.type not in _ONCE_EVENTS:
+            return True
+        with self._lock:
+            if event.type in self._emitted:
+                return False
+            self._emitted.add(event.type)
+            return True
+
+
+def _setup_prompt_presentation(
+    runner: ShellTurnHost, user_input: str
+) -> tuple[StreamingConsole, AsyncAgentEventSink, PromptRecorder | None, threading.Event]:
+    """Create console, event sink, recorder, and cancellation primitive for a prompt."""
+    cancel_event = threading.Event()
+
+    console = StreamingConsole(
+        runner.spinner,
+        cancel_event,
+        prompt_invalidator=runner.invalidate_prompt,
+        highlight=False,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+    )
+
+    event_sink = ConsoleAgentEventSink(
+        session=runner.session,
+        spinner=runner.spinner,
+        console=console,
+    )
+
+    recorder = PromptRecorder.start(
+        session=runner.session,
+        text=user_input,
+        turn_kind=_AGENT_TURN_KIND,
+    )
+
+    return console, event_sink, recorder, cancel_event
+
+
+class ShellTurnHost:
+    """Terminal/runtime host for a stateful shell agent."""
+
+    def __init__(
+        self,
+        *,
+        session: ReplSession,
+        state: ReplState,
+        spinner: SpinnerState,
+        invalidate_prompt: Callable[[], None],
+        agent: ShellAgent | None = None,
+    ) -> None:
+        self.session = session
+        self.state = state
+        self.spinner = spinner
+        self.invalidate_prompt = invalidate_prompt
+        self.agent = agent or ShellAgent(session)
+
+    async def run_prompt(self, user_input: str) -> None:
+        """Execute a complete agent prompt with presentation and runtime state."""
+        console, event_sink, recorder, cancel_event = _setup_prompt_presentation(self, user_input)
+
+        progress_scope = (
+            contextlib.nullcontext()
+            if turn_needs_exclusive_stdin(user_input, self.session)
+            else repl_safe_progress_scope()
+        )
+
+        with progress_scope:
+            await self._execute_prompt_lifecycle(
+                user_input=user_input,
+                console=console,
+                recorder=recorder,
+                event_sink=event_sink,
+                cancel_event=cancel_event,
+            )
+
+    async def stop(self) -> None:
+        """Stop the hosted shell agent."""
+        await self.agent.stop()
+
+    async def _execute_prompt_lifecycle(
+        self,
+        user_input: str,
+        console: StreamingConsole,
+        recorder: PromptRecorder | None,
+        event_sink: AsyncAgentEventSink,
+        cancel_event: threading.Event,
+    ) -> None:
+        """Manage dispatch tracking around the shell-owned agent."""
+        task = asyncio.current_task()
+        if task is not None:
+            self.state.start_dispatch(task=task, cancel_event=cancel_event)
+        else:
+            self.state.attach_cancel_event(cancel_event)
+
+        loop = asyncio.get_running_loop()
+        event_bridge = _ThreadedAgentEventBridge(loop=loop, sink=event_sink)
+        unsubscribe = self.agent.subscribe(event_bridge)
+
+        try:
+            self.agent.start()
+            await self._run_agent_prompt(user_input, console, recorder)
+        except asyncio.CancelledError:
+            await event_bridge.emit_async(AgentEvent(type="prompt_interrupted"))
+            raise
+        except DispatchCancelled:
+            await event_bridge.emit_async(AgentEvent(type="prompt_interrupted"))
+        except Exception as exc:
+            report_exception(exc, context="interactive_shell.prompt")
+            await event_bridge.emit_async(AgentEvent(type="prompt_error", error=exc))
+        finally:
+            self.state.finish_dispatch(cancel_event)
+            await event_bridge.emit_async(AgentEvent(type="prompt_end"))
+            unsubscribe()
+
+    async def _run_agent_prompt(
+        self, user_input: str, output: StreamingConsole, recorder: PromptRecorder | None
+    ) -> None:
+        """Execute the shell agent prompt with proper session context."""
+
+        def confirm_fn(prompt: str) -> str:
+            return request_confirmation_via_prompt(self.state, prompt)
+
+        with _bound_cli_session(self.session.session_id):
+            await self.agent.prompt(
+                user_input,
+                console=output,
+                recorder=recorder,
+                confirm_fn=confirm_fn,
+                is_tty=None,
+            )
+
+
+async def run_input_loop(
+    *,
+    state: ReplState,
+    session: ReplSession,
+    background: BackgroundTaskManager | None,
+    input_reader: PromptInputReader,
+    echo_console: Console,
+    handle_input_action: Callable[[InputAction], Awaitable[bool]],
+) -> None:
+    """Continuously read and process user input events until exit."""
+    while not state.exit_requested:
+        if background:
+            background.drain_turn_start_output(echo_console)
+
+        event = await input_reader.read()
+
+        action = decide_input_action(
+            event,
+            ShellInputSnapshot(
+                exit_requested=state.exit_requested,
+                dispatch_running=state.is_dispatch_running(),
+                awaiting_confirmation=state.is_awaiting_confirmation(),
+            ),
+            needs_exclusive_stdin=lambda text: turn_needs_exclusive_stdin(text, session),
+        )
+
+        if not await handle_input_action(action):
+            return
+
+
+async def run_agent_prompt_queue(
+    *,
+    state: ReplState,
+    run_prompt: Callable[[str], Coroutine[Any, Any, None]],
+) -> None:
+    """Process prompts from the queue until the REPL is shutting down."""
+    while not state.exit_requested:
+        try:
+            user_input = await state.queue.get()
+        except asyncio.CancelledError:
+            return
+
+        if state.exit_requested:
+            state.queue.task_done()
+            return
+
+        prompt_task = asyncio.create_task(run_prompt(user_input))
+        state.attach_turn_task(prompt_task)
+
+        try:
+            await prompt_task
+        except asyncio.CancelledError:
+            _logger.debug("Queued agent prompt was cancelled")
+        except Exception as exc:
+            _logger.debug("Queued agent prompt failed: %s", exc)
+        finally:
+            state.clear_current_task()
+            state.queue.task_done()
+
+
+__all__ = [
+    "AgentEvent",
+    "AgentEventSink",
+    "ShellTurnHost",
+    "run_agent_prompt_queue",
+    "run_input_loop",
+]

--- a/tests/integrations/llm_cli/test_pi_adapter.py
+++ b/tests/integrations/llm_cli/test_pi_adapter.py
@@ -17,6 +17,7 @@ from integrations.llm_cli.pi_cli import PiAdapter
 
 _PROBE = "integrations.llm_cli.pi_cli.run_version_probe"
 _WHICH = "integrations.llm_cli.binary_resolver.shutil.which"
+_PI_FALLBACK_PATHS = "integrations.llm_cli.pi_cli._fallback_pi_paths"
 
 
 # --------------------------------------------------------------------------- #
@@ -108,8 +109,9 @@ def test_detect_version_probe_failure_marks_not_installed(
     assert "boom" in probe.detail
 
 
+@patch(_PI_FALLBACK_PATHS, return_value=[])
 @patch(_WHICH, return_value=None)
-def test_detect_binary_missing(_mock_which: MagicMock) -> None:
+def test_detect_binary_missing(_mock_which: MagicMock, _mock_fallbacks: MagicMock) -> None:
     with patch.dict(os.environ, {}, clear=True):
         probe = PiAdapter().detect()
     assert probe.installed is False
@@ -153,8 +155,11 @@ def test_build_forwards_provider_api_key(_mock_which: MagicMock) -> None:
     assert "SOME_UNRELATED_SECRET" not in inv.env
 
 
+@patch(_PI_FALLBACK_PATHS, return_value=[])
 @patch(_WHICH, return_value=None)
-def test_build_raises_when_binary_missing(_mock_which: MagicMock) -> None:
+def test_build_raises_when_binary_missing(
+    _mock_which: MagicMock, _mock_fallbacks: MagicMock
+) -> None:
     with (
         patch.dict(os.environ, {}, clear=True),
         pytest.raises(RuntimeError, match="Pi CLI not found"),

--- a/tests/interactive_shell/llm_context/test_prompt_characterization.py
+++ b/tests/interactive_shell/llm_context/test_prompt_characterization.py
@@ -28,6 +28,7 @@ from typing import Any
 
 import pytest
 
+from interactive_shell.harness.agent_context import AgentContext
 from interactive_shell.harness.llm_context import (
     build_action_system_prompt,
     build_action_user_message,
@@ -35,7 +36,6 @@ from interactive_shell.harness.llm_context import (
 from interactive_shell.harness.llm_context.assistant_prompt import build_cli_agent_prompt
 from interactive_shell.harness.llm_context.models import coerce_messages
 from interactive_shell.harness.llm_context.session import InMemorySessionStorage, ReplSession
-from interactive_shell.harness.turn_context import TurnContext
 
 _SNAPSHOT_PATH = Path(__file__).with_name("prompt_characterization_snapshot.json")
 
@@ -64,7 +64,7 @@ class _StubGrounding:
         return None
 
 
-def _turn_ctx(
+def _agent_ctx(
     *,
     text: str = "hello",
     conversation_messages: tuple[tuple[str, str], ...] = (),
@@ -72,8 +72,8 @@ def _turn_ctx(
     configured_integrations_known: bool = False,
     last_state: dict[str, Any] | None = None,
     last_synthetic_observation_path: str | None = None,
-) -> TurnContext:
-    return TurnContext(
+) -> AgentContext:
+    return AgentContext(
         text=text,
         conversation_messages=coerce_messages(conversation_messages),
         configured_integrations=configured_integrations,
@@ -107,13 +107,13 @@ def _build_cases(tmp_path: Path) -> dict[str, str]:
 
     # --- action system prompt: the three CONNECTED INTEGRATIONS states ---
     cases["action_system_unknown"] = build_action_system_prompt(
-        _turn_ctx(configured_integrations_known=False)
+        _agent_ctx(configured_integrations_known=False)
     )
     cases["action_system_none"] = build_action_system_prompt(
-        _turn_ctx(configured_integrations_known=True)
+        _agent_ctx(configured_integrations_known=True)
     )
     cases["action_system_listed_with_history"] = build_action_system_prompt(
-        _turn_ctx(
+        _agent_ctx(
             configured_integrations=("github", "datadog"),
             configured_integrations_known=True,
             conversation_messages=convo,
@@ -132,7 +132,7 @@ def _build_cases(tmp_path: Path) -> dict[str, str]:
         session=_session(),
         tool_observation=None,
         tool_observation_on_screen=True,
-        turn_ctx=_turn_ctx(text="how do I configure datadog?"),
+        agent_ctx=_agent_ctx(text="how do I configure datadog?"),
     )
 
     cases["cli_agent_no_integrations_guard"] = build_cli_agent_prompt(
@@ -140,7 +140,7 @@ def _build_cases(tmp_path: Path) -> dict[str, str]:
         session=_session(configured_integrations_known=True),
         tool_observation=None,
         tool_observation_on_screen=True,
-        turn_ctx=_turn_ctx(text="set up sentry", configured_integrations_known=True),
+        agent_ctx=_agent_ctx(text="set up sentry", configured_integrations_known=True),
     )
 
     cases["cli_agent_integrations_listed_with_prior_state"] = build_cli_agent_prompt(
@@ -151,7 +151,7 @@ def _build_cases(tmp_path: Path) -> dict[str, str]:
         ),
         tool_observation=None,
         tool_observation_on_screen=True,
-        turn_ctx=_turn_ctx(
+        agent_ctx=_agent_ctx(
             text="why did checkout fail?",
             configured_integrations=("datadog", "github"),
             configured_integrations_known=True,
@@ -174,7 +174,7 @@ def _build_cases(tmp_path: Path) -> dict[str, str]:
         ),
         tool_observation="datadog: configured (connection_verified=true)",
         tool_observation_on_screen=True,
-        turn_ctx=_turn_ctx(
+        agent_ctx=_agent_ctx(
             text="is datadog configured?",
             configured_integrations=("datadog",),
             configured_integrations_known=True,
@@ -189,7 +189,7 @@ def _build_cases(tmp_path: Path) -> dict[str, str]:
         ),
         tool_observation="sentry issues: [#1 NPE in checkout]",
         tool_observation_on_screen=False,
-        turn_ctx=_turn_ctx(
+        agent_ctx=_agent_ctx(
             text="any open sentry issues for checkout?",
             configured_integrations=("sentry",),
             configured_integrations_known=True,
@@ -206,7 +206,7 @@ def _build_cases(tmp_path: Path) -> dict[str, str]:
         session=_session(),
         tool_observation=None,
         tool_observation_on_screen=True,
-        turn_ctx=_turn_ctx(
+        agent_ctx=_agent_ctx(
             text="why did it fail?",
             last_synthetic_observation_path=str(obs_path),
         ),

--- a/tests/interactive_shell/runtime/test_entrypoint_integrations.py
+++ b/tests/interactive_shell/runtime/test_entrypoint_integrations.py
@@ -209,7 +209,11 @@ def test_repl_main_identifies_saved_github_username(monkeypatch: Any) -> None:
         "platform.analytics.cli.identify_saved_github_username",
         lambda: identified.append("called"),
     )
-    monkeypatch.setattr(entrypoint, "run_initial_input", lambda *_args, **_kwargs: 0)
+
+    async def _run_initial_input(*_args: Any, **_kwargs: Any) -> int:
+        return 0
+
+    monkeypatch.setattr(entrypoint, "run_initial_input", _run_initial_input)
 
     class _Session:
         active_theme_name = None

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -469,16 +469,29 @@ def test_run_text_investigation_uses_background_launcher_when_mode_enabled(
 def test_run_initial_input_dispatches_as_non_tty(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[dict[str, object]] = []
 
-    def _fake_handle_message_with_agent(*args: object, **kwargs: object) -> None:
+    async def _fake_prompt(*args: object, **kwargs: object) -> None:
         calls.append(kwargs)
+
+    class _FakeShellAgent:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+        async def prompt(self, *args: object, **kwargs: object) -> None:
+            await _fake_prompt(*args, **kwargs)
+
+        async def stop(self) -> None:
+            pass
 
     monkeypatch.setattr(
         startup_initial_input,
-        "handle_message_with_agent",
-        _fake_handle_message_with_agent,
+        "ShellAgent",
+        _FakeShellAgent,
     )
 
-    assert startup_initial_input.run_initial_input("/remote", ReplSession()) == 0
+    assert asyncio.run(startup_initial_input.run_initial_input("/remote", ReplSession())) == 0
     assert len(calls) == 1
     assert calls[0]["is_tty"] is False
 
@@ -1262,7 +1275,7 @@ class TestRequestConfirmationViaPrompt:
         """
         state = loop_state.ReplState()
         # Active dispatch must have a cancel event parked; in production
-        # ``interactive_shell.harness.agent.AgentTurnCoordinator.run_turn`` allocates this before invoking the
+        # ``interactive_shell.runtime.turn_host.ShellTurnHost.run_prompt`` allocates this before invoking the
         # confirm_fn. Never set in this test.
         state.current_cancel_event = threading.Event()
 

--- a/tests/interactive_shell/test_terminal_runtime_turns.py
+++ b/tests/interactive_shell/test_terminal_runtime_turns.py
@@ -8,11 +8,11 @@ import pytest
 from rich.console import Console
 
 from core.runtime.llm.agent_llm_client import AgentLLMResponse, ToolCall
+from interactive_shell.harness.agent_loop import run_agent_prompt
 from interactive_shell.harness.llm_context.session import ReplSession
 from interactive_shell.harness.tests.orchestration.action_execution_test_harness import (
     FakeActionLLM,
 )
-from interactive_shell.harness.turn import handle_message_with_agent
 from interactive_shell.runtime.core.turn_accounting import (
     ToolCallingTurnResult,
 )
@@ -155,7 +155,7 @@ def test_turn_needs_exclusive_stdin_for_config(
     )
 
 
-def test_handle_message_with_agent_nitro_prompt_uses_cli_agent_actions(
+def test_run_agent_prompt_nitro_prompt_uses_cli_agent_actions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     nitro_prompt = (
@@ -190,7 +190,7 @@ def test_handle_message_with_agent_nitro_prompt_uses_cli_agent_actions(
 
     session = ReplSession()
     console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
-    handle_message_with_agent(
+    run_agent_prompt(
         nitro_prompt,
         session,
         console,
@@ -205,7 +205,7 @@ def test_handle_message_with_agent_nitro_prompt_uses_cli_agent_actions(
     assert llm_calls == []
 
 
-def test_handle_message_with_agent_nitro_prompt_executes_remote_then_investigation(
+def test_run_agent_prompt_nitro_prompt_executes_remote_then_investigation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     nitro_prompt = (
@@ -261,7 +261,7 @@ def test_handle_message_with_agent_nitro_prompt_executes_remote_then_investigati
 
     session = ReplSession()
     console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
-    handle_message_with_agent(
+    run_agent_prompt(
         nitro_prompt,
         session,
         console,

--- a/tests/interactive_shell/utils/telemetry/test_execution_integration.py
+++ b/tests/interactive_shell/utils/telemetry/test_execution_integration.py
@@ -4,8 +4,8 @@ import io
 
 from rich.console import Console
 
+from interactive_shell.harness.agent_loop import run_agent_prompt
 from interactive_shell.harness.llm_context.session import ReplSession
-from interactive_shell.harness.turn import handle_message_with_agent
 from interactive_shell.runtime.core.turn_accounting import (
     ToolCallingTurnResult,
 )
@@ -28,7 +28,7 @@ def _console() -> Console:
     return Console(file=io.StringIO(), force_terminal=False, highlight=False)
 
 
-def test_handle_message_with_agent_cli_agent_empty_response_is_recorded_empty() -> None:
+def test_run_agent_prompt_cli_agent_empty_response_is_recorded_empty() -> None:
     recorder = _FakeRecorder()
 
     def fake_execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
@@ -45,7 +45,7 @@ def test_handle_message_with_agent_cli_agent_empty_response_is_recorded_empty() 
 
     session = ReplSession()
     output = io.StringIO()
-    handle_message_with_agent(
+    run_agent_prompt(
         "show datadog integration details",
         session,
         Console(file=output, force_terminal=False, highlight=False),


### PR DESCRIPTION
## Summary
- Introduce `ShellAgent` as the durable shell-owned agent object with `start()`, `prompt()`, `stop()`, lifecycle events, and injected runtime primitives.
- Rename the old turn loop into `agent_loop.py` and `turn_context.py` into `agent_context.py`, deleting the old module paths rather than leaving compatibility shims.
- Move terminal coordination into `interactive_shell/runtime/turn_host.py`, keeping UI/spinner/cancellation concerns out of the harness agent.
- Keep core tool-calling primitives as dependencies while preserving shell-owned state outside `core.runtime.agent.Agent`.

## Validation
- `make lint`
- `make format-check`
- `make typecheck`
- `make test-scope` (escalated to coverage suite: 9588 passed, 23 skipped)

## Notes
- Also tightens Pi CLI missing-binary tests so host-local fallback binaries do not leak into the missing-binary cases.