### PR TITLE
Add LLM provider auth login flows

### DIFF
--- a/cli/commands/__init__.py
+++ b/cli/commands/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import click
 
 from cli.commands.agent import fleet
+from cli.commands.auth import auth_command
 from cli.commands.config import config_command
 from cli.commands.cron import cron_command
 from cli.commands.debug import debug_command
@@ -30,6 +31,7 @@ from cli.commands.watchdog import watchdog_command
 _COMMANDS: tuple[click.Command, ...] = (
     investigate_command,
     onboard,
+    auth_command,
     config_command,
     remote,
     tests,

--- a/cli/commands/auth.py
+++ b/cli/commands/auth.py
@@ -1,0 +1,179 @@
+"""CLI commands for LLM provider authentication."""
+
+from __future__ import annotations
+
+import sys
+import webbrowser
+from collections.abc import Iterable
+
+import click
+
+from cli.llm_auth.providers import ProviderAuthProfile, iter_auth_profiles, resolve_auth_profile
+from cli.llm_auth.service import (
+    AuthSetupError,
+    configure_api_key_provider,
+    configure_cli_subscription_provider,
+    logout_provider,
+    provider_status,
+)
+
+
+def _provider_choices() -> str:
+    return ", ".join(profile.name for profile in iter_auth_profiles())
+
+
+def _resolve_or_raise(provider: str) -> ProviderAuthProfile:
+    try:
+        return resolve_auth_profile(provider)
+    except KeyError as exc:
+        raise click.UsageError(
+            f"Unknown auth provider '{provider}'. Choose one of: {_provider_choices()}."
+        ) from exc
+
+
+def _prompt_provider() -> ProviderAuthProfile:
+    click.echo("Subscription logins:")
+    for profile in iter_auth_profiles():
+        if profile.kind == "cli_subscription":
+            click.echo(f"  {profile.name:<10} {profile.label}")
+    click.echo("API-key providers:")
+    api_key_names = [profile.name for profile in iter_auth_profiles() if profile.kind == "api_key"]
+    click.echo(f"  {', '.join(api_key_names)}")
+    provider = click.prompt("Provider", type=str).strip()
+    return _resolve_or_raise(provider)
+
+
+def _maybe_open_setup_page(profile: ProviderAuthProfile, *, enabled: bool) -> None:
+    if not enabled or not profile.setup_url:
+        return
+    if not sys.stdin.isatty():
+        click.echo(f"Setup page: {profile.setup_url}")
+        return
+    if click.confirm(f"Open {profile.label} setup page in your browser?", default=True):
+        webbrowser.open(profile.setup_url)
+
+
+def _status_lines(providers: Iterable[ProviderAuthProfile]) -> list[str]:
+    lines = [f"{'Provider':<14} {'Status':<8} {'Source':<11} Detail"]
+    for profile in providers:
+        status = provider_status(profile.name)
+        state = "ok" if status.authenticated else "missing"
+        lines.append(f"{profile.name:<14} {state:<8} {status.source:<11} {status.detail}")
+    return lines
+
+
+@click.group(name="auth", invoke_without_command=True)
+@click.pass_context
+def auth_command(ctx: click.Context) -> None:
+    """Log in to LLM providers and inspect local auth state."""
+    if ctx.invoked_subcommand is None:
+        for line in _status_lines(iter_auth_profiles()):
+            click.echo(line)
+
+
+@auth_command.command(name="login")
+@click.argument("provider", required=False)
+@click.option("--api-key", help="API key to store for API-key providers.")
+@click.option("--model", help="Reasoning model to persist with the provider selection.")
+@click.option(
+    "--set-provider/--no-set-provider",
+    default=True,
+    show_default=True,
+    help="Persist LLM_PROVIDER and provider model settings after login.",
+)
+@click.option(
+    "--validate/--no-validate",
+    default=True,
+    show_default=True,
+    help="Run a tiny live validation request before storing API keys.",
+)
+@click.option(
+    "--open-browser/--no-open-browser",
+    default=True,
+    show_default=True,
+    help="Offer to open the provider setup page for API-key flows.",
+)
+@click.option(
+    "--launch-login/--no-launch-login",
+    default=True,
+    show_default=True,
+    help="Launch the vendor CLI login command for subscription flows when needed.",
+)
+def auth_login(
+    provider: str | None,
+    api_key: str | None,
+    model: str | None,
+    set_provider: bool,
+    validate: bool,
+    open_browser: bool,
+    launch_login: bool,
+) -> None:
+    """Configure one LLM provider auth path."""
+    profile = _resolve_or_raise(provider) if provider else _prompt_provider()
+    try:
+        if profile.kind == "api_key":
+            _maybe_open_setup_page(profile, enabled=open_browser)
+            resolved_key = api_key
+            if resolved_key is None:
+                resolved_key = click.prompt(
+                    f"{profile.label} key",
+                    hide_input=True,
+                    confirmation_prompt=False,
+                    type=str,
+                )
+            result = configure_api_key_provider(
+                profile=profile,
+                api_key=resolved_key,
+                model=model,
+                set_provider=set_provider,
+                validate=validate,
+            )
+        else:
+            _maybe_open_setup_page(profile, enabled=open_browser)
+            result = configure_cli_subscription_provider(
+                profile=profile,
+                model=model,
+                set_provider=set_provider,
+                launch_login=launch_login,
+            )
+    except AuthSetupError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo(f"Authenticated: {profile.label}")
+    click.echo(f"Provider     : {result.provider}")
+    click.echo(f"Credential   : {result.source}")
+    if result.model:
+        click.echo(f"Model        : {result.model}")
+    if result.env_path:
+        click.echo(f"Env          : {result.env_path}")
+    click.echo(f"Status       : {result.detail}")
+    click.echo("Verify       : opensre auth status")
+
+
+@auth_command.command(name="status")
+@click.argument("provider", required=False)
+def auth_status(provider: str | None) -> None:
+    """Show provider auth status."""
+    profiles = (_resolve_or_raise(provider),) if provider else iter_auth_profiles()
+    for line in _status_lines(profiles):
+        click.echo(line)
+
+
+@auth_command.command(name="logout")
+@click.argument("provider")
+@click.option(
+    "--vendor",
+    is_flag=True,
+    help="Also run the vendor CLI logout command for subscription providers.",
+)
+def auth_logout(provider: str, vendor: bool) -> None:
+    """Clear OpenSRE-managed auth for a provider."""
+    _resolve_or_raise(provider)
+    try:
+        detail = logout_provider(provider, vendor=vendor)
+    except AuthSetupError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(detail)
+
+
+__all__ = ["auth_command"]

--- a/cli/commands/config.py
+++ b/cli/commands/config.py
@@ -77,7 +77,8 @@ def _emit_llm_config() -> None:
     if key_env:
         click.echo(f"{key_env:<16}: {_masked(key_value)}")
     click.echo()
-    click.echo("To change LLM settings, run: opensre onboard")
+    click.echo("To log in or change LLM auth, run: opensre auth login")
+    click.echo("To rerun the full setup wizard, run: opensre onboard")
     click.echo("Local CLI YAML: opensre config show / opensre config set …")
 
 

--- a/cli/llm_auth/__init__.py
+++ b/cli/llm_auth/__init__.py
@@ -1,0 +1,27 @@
+"""CLI-owned LLM provider auth orchestration."""
+
+from cli.llm_auth.providers import (
+    ProviderAuthProfile,
+    iter_auth_profiles,
+    resolve_auth_profile,
+)
+from cli.llm_auth.service import (
+    AuthSetupError,
+    AuthStatus,
+    configure_api_key_provider,
+    configure_cli_subscription_provider,
+    logout_provider,
+    provider_status,
+)
+
+__all__ = [
+    "AuthSetupError",
+    "AuthStatus",
+    "ProviderAuthProfile",
+    "configure_api_key_provider",
+    "configure_cli_subscription_provider",
+    "iter_auth_profiles",
+    "logout_provider",
+    "provider_status",
+    "resolve_auth_profile",
+]

--- a/cli/llm_auth/providers.py
+++ b/cli/llm_auth/providers.py
@@ -1,0 +1,109 @@
+"""Provider metadata for browser-assisted LLM auth setup."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from cli.wizard.config import PROVIDER_BY_VALUE, SUPPORTED_PROVIDERS, ProviderOption
+
+AuthKind = Literal["api_key", "cli_subscription"]
+
+
+@dataclass(frozen=True)
+class ProviderAuthProfile:
+    """User-facing auth metadata for one provider setup path."""
+
+    name: str
+    provider_value: str
+    label: str
+    kind: AuthKind
+    aliases: tuple[str, ...] = ()
+    setup_url: str | None = None
+    auth_hint: str = ""
+
+    @property
+    def all_names(self) -> tuple[str, ...]:
+        return (self.name, self.provider_value, *self.aliases)
+
+
+_API_KEY_SETUP_URLS: dict[str, str] = {
+    "anthropic": "https://console.anthropic.com/settings/keys",
+    "openai": "https://platform.openai.com/api-keys",
+    "openrouter": "https://openrouter.ai/keys",
+    "deepseek": "https://platform.deepseek.com/api_keys",
+    "gemini": "https://aistudio.google.com/app/apikey",
+    "nvidia": "https://build.nvidia.com/",
+    "minimax": "https://intl.minimaxi.com/user-center/basic-information/interface-key",
+    "groq": "https://console.groq.com/keys",
+}
+
+
+_SUBSCRIPTION_PROFILES: tuple[ProviderAuthProfile, ...] = (
+    ProviderAuthProfile(
+        name="chatgpt",
+        provider_value="codex",
+        label="ChatGPT subscription via Codex CLI",
+        kind="cli_subscription",
+        aliases=("openai-chatgpt", "openai-codex", "codex-cli"),
+        setup_url="https://github.com/openai/codex",
+        auth_hint="Run: codex login",
+    ),
+    ProviderAuthProfile(
+        name="claude",
+        provider_value="claude-code",
+        label="Claude subscription via Claude Code CLI",
+        kind="cli_subscription",
+        aliases=("claude-ai", "claude-subscription", "anthropic-claude", "claude-code-cli"),
+        setup_url="https://github.com/anthropics/claude-code",
+        auth_hint="Run: claude auth login",
+    ),
+)
+
+
+def _api_key_profiles() -> tuple[ProviderAuthProfile, ...]:
+    profiles: list[ProviderAuthProfile] = []
+    for provider in SUPPORTED_PROVIDERS:
+        if provider.credential_kind != "api_key":
+            continue
+        profiles.append(
+            ProviderAuthProfile(
+                name=provider.value,
+                provider_value=provider.value,
+                label=f"{provider.label} API key",
+                kind="api_key",
+                setup_url=_API_KEY_SETUP_URLS.get(provider.value),
+                auth_hint=f"Paste {provider.api_key_env}",
+            )
+        )
+    return tuple(profiles)
+
+
+def iter_auth_profiles() -> tuple[ProviderAuthProfile, ...]:
+    """Return all supported auth setup paths."""
+    return (*_SUBSCRIPTION_PROFILES, *_api_key_profiles())
+
+
+def resolve_auth_profile(raw_name: str) -> ProviderAuthProfile:
+    """Resolve a user-supplied provider/auth alias to an auth profile."""
+    normalized = raw_name.strip().lower()
+    if not normalized:
+        raise KeyError(raw_name)
+    for profile in iter_auth_profiles():
+        if normalized in {name.lower() for name in profile.all_names}:
+            return profile
+    raise KeyError(raw_name)
+
+
+def provider_for_profile(profile: ProviderAuthProfile) -> ProviderOption:
+    """Return the wizard provider option for an auth profile."""
+    return PROVIDER_BY_VALUE[profile.provider_value]
+
+
+__all__ = [
+    "AuthKind",
+    "ProviderAuthProfile",
+    "iter_auth_profiles",
+    "provider_for_profile",
+    "resolve_auth_profile",
+]

--- a/cli/llm_auth/service.py
+++ b/cli/llm_auth/service.py
@@ -1,0 +1,271 @@
+"""Shared LLM auth setup operations for CLI, wizard, and REPL wrappers."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from cli.llm_auth.providers import (
+    ProviderAuthProfile,
+    provider_for_profile,
+    resolve_auth_profile,
+)
+from cli.wizard.config import ProviderOption
+from cli.wizard.env_sync import sync_provider_env
+from cli.wizard.validation import validate_provider_credentials
+from config.llm_auth.records import (
+    delete_provider_auth_record,
+    resolve_provider_auth_record,
+    save_provider_auth_record,
+)
+from config.llm_credentials import (
+    delete_llm_api_key,
+    llm_api_key_source,
+    save_llm_api_key,
+)
+
+
+class AuthSetupError(RuntimeError):
+    """Raised when provider auth setup cannot complete."""
+
+
+SaveSecret = Callable[[str, str], None]
+
+
+@dataclass(frozen=True)
+class AuthStatus:
+    """Status row for one provider auth path."""
+
+    provider: str
+    label: str
+    authenticated: bool
+    source: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class AuthSetupResult:
+    """Result from configuring a provider auth path."""
+
+    provider: str
+    model: str
+    source: str
+    detail: str
+    env_path: Path | None
+
+
+def _save_auth_record(
+    *,
+    provider: ProviderOption,
+    profile: ProviderAuthProfile,
+    source: str,
+    detail: str,
+) -> None:
+    save_provider_auth_record(
+        provider=provider.value,
+        auth_name=profile.name,
+        kind=profile.kind,
+        source=source,
+        detail=detail,
+    )
+
+
+def persist_api_key_secret(
+    env_var: str,
+    value: str,
+    *,
+    save_secret: SaveSecret = save_llm_api_key,
+) -> None:
+    """Persist one API-key secret through the shared auth service boundary."""
+    try:
+        save_secret(env_var, value)
+    except RuntimeError as exc:
+        raise AuthSetupError(str(exc)) from exc
+
+
+def configure_api_key_provider(
+    *,
+    profile: ProviderAuthProfile,
+    api_key: str,
+    model: str | None = None,
+    set_provider: bool = True,
+    validate: bool = True,
+    env_path: Path | None = None,
+) -> AuthSetupResult:
+    """Validate and persist an API-key provider credential."""
+    provider = provider_for_profile(profile)
+    if provider.credential_kind != "api_key" or not provider.api_key_env:
+        raise AuthSetupError(f"{provider.label} does not use an OpenSRE-managed API key.")
+
+    normalized_key = api_key.strip()
+    if not normalized_key:
+        raise AuthSetupError(f"{provider.api_key_env} cannot be empty.")
+
+    selected_model = (model if model is not None else provider.default_model).strip()
+    if validate:
+        validation = validate_provider_credentials(
+            provider=provider,
+            api_key=normalized_key,
+            model=selected_model,
+        )
+        if not validation.ok:
+            raise AuthSetupError(validation.detail)
+
+    try:
+        save_llm_api_key(provider.api_key_env, normalized_key)
+    except RuntimeError as exc:
+        raise AuthSetupError(str(exc)) from exc
+
+    written_path = (
+        sync_provider_env(provider=provider, model=selected_model, env_path=env_path)
+        if set_provider
+        else None
+    )
+    detail = f"{provider.api_key_env} stored in the system keychain."
+    _save_auth_record(provider=provider, profile=profile, source="keyring", detail=detail)
+    return AuthSetupResult(
+        provider=provider.value,
+        model=selected_model,
+        source="keyring",
+        detail=detail,
+        env_path=written_path,
+    )
+
+
+def _subscription_login_command(profile: ProviderAuthProfile, binary_path: str) -> list[str]:
+    if profile.provider_value == "codex":
+        return [binary_path, "login"]
+    if profile.provider_value == "claude-code":
+        return [binary_path, "auth", "login"]
+    raise AuthSetupError(f"No interactive login command is registered for {profile.label}.")
+
+
+def _run_vendor_login(profile: ProviderAuthProfile, binary_path: str) -> None:
+    try:
+        result = subprocess.run(_subscription_login_command(profile, binary_path), check=False)
+    except OSError as exc:
+        raise AuthSetupError(f"Could not launch {profile.label} login: {exc}") from exc
+    if result.returncode != 0:
+        raise AuthSetupError(f"{profile.label} login exited with code {result.returncode}.")
+
+
+def configure_cli_subscription_provider(
+    *,
+    profile: ProviderAuthProfile,
+    model: str | None = None,
+    set_provider: bool = True,
+    launch_login: bool = True,
+    env_path: Path | None = None,
+) -> AuthSetupResult:
+    """Configure a CLI-backed subscription provider such as ChatGPT/Codex or Claude Code."""
+    provider = provider_for_profile(profile)
+    if provider.credential_kind != "cli" or provider.adapter_factory is None:
+        raise AuthSetupError(f"{provider.label} is not a CLI-backed subscription provider.")
+
+    adapter = provider.adapter_factory()
+    probe = adapter.detect()
+    if not probe.installed:
+        raise AuthSetupError(f"{probe.detail} Install: {adapter.install_hint}")
+
+    if probe.logged_in is not True:
+        if launch_login and probe.bin_path and os.isatty(0):
+            _run_vendor_login(profile, probe.bin_path)
+            probe = adapter.detect()
+        if probe.logged_in is not True:
+            raise AuthSetupError(f"{probe.detail} {adapter.auth_hint}")
+
+    selected_model = (model if model is not None else provider.default_model).strip()
+    written_path = (
+        sync_provider_env(provider=provider, model=selected_model, env_path=env_path)
+        if set_provider
+        else None
+    )
+    detail = probe.detail or f"{provider.label} is authenticated."
+    _save_auth_record(provider=provider, profile=profile, source="vendor-cli", detail=detail)
+    return AuthSetupResult(
+        provider=provider.value,
+        model=selected_model,
+        source="vendor-cli",
+        detail=detail,
+        env_path=written_path,
+    )
+
+
+def provider_status(raw_name: str) -> AuthStatus:
+    """Return auth status for an auth profile or provider alias."""
+    profile = resolve_auth_profile(raw_name)
+    provider = provider_for_profile(profile)
+    record = resolve_provider_auth_record(provider.value)
+
+    if profile.kind == "api_key":
+        source = llm_api_key_source(provider.api_key_env)
+        authenticated = source != "none"
+        detail = (
+            f"{provider.api_key_env} resolved from {source}."
+            if authenticated
+            else f"{provider.api_key_env} is not configured."
+        )
+        if record.get("detail") and authenticated:
+            detail = record["detail"]
+        return AuthStatus(provider.value, profile.label, authenticated, source, detail)
+
+    if provider.adapter_factory is None:
+        return AuthStatus(provider.value, profile.label, False, "none", "No adapter registered.")
+    probe = provider.adapter_factory().detect()
+    authenticated = probe.installed and probe.logged_in is True
+    source = "vendor-cli" if authenticated else "none"
+    detail = probe.detail
+    if record.get("detail") and authenticated:
+        detail = record["detail"]
+    return AuthStatus(provider.value, profile.label, authenticated, source, detail)
+
+
+def logout_provider(raw_name: str, *, vendor: bool = False) -> str:
+    """Clear OpenSRE-managed auth for a provider.
+
+    For API-key providers this deletes the keyring API key. For subscription
+    CLI providers, OpenSRE clears only its metadata unless ``vendor=True`` is
+    requested; the actual session belongs to the vendor CLI.
+    """
+    profile = resolve_auth_profile(raw_name)
+    provider = provider_for_profile(profile)
+    delete_provider_auth_record(provider.value)
+
+    if profile.kind == "api_key":
+        delete_llm_api_key(provider.api_key_env)
+        return f"Removed {provider.api_key_env} from OpenSRE's keyring store."
+
+    if not vendor:
+        return (
+            f"Cleared OpenSRE auth metadata for {profile.label}. "
+            f"Vendor CLI session remains; logout with: {profile.auth_hint.replace('login', 'logout')}"
+        )
+
+    if provider.adapter_factory is None:
+        raise AuthSetupError(f"No adapter is registered for {provider.label}.")
+    probe = provider.adapter_factory().detect()
+    if not probe.installed or not probe.bin_path:
+        raise AuthSetupError(f"{provider.label} CLI is not installed.")
+    command = profile.auth_hint.replace("Run: ", "").replace("login", "logout").split()
+    try:
+        result = subprocess.run([probe.bin_path, *command[1:]], check=False)
+    except OSError as exc:
+        raise AuthSetupError(f"Could not launch vendor logout: {exc}") from exc
+    if result.returncode != 0:
+        raise AuthSetupError(f"Vendor logout exited with code {result.returncode}.")
+    return f"Logged out of {profile.label} via vendor CLI."
+
+
+__all__ = [
+    "AuthSetupError",
+    "AuthSetupResult",
+    "AuthStatus",
+    "configure_api_key_provider",
+    "configure_cli_subscription_provider",
+    "logout_provider",
+    "persist_api_key_secret",
+    "provider_status",
+]

--- a/cli/wizard/_ui.py
+++ b/cli/wizard/_ui.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.rule import Rule
 from rich.text import Text
 
+from cli.llm_auth.service import AuthSetupError, persist_api_key_secret
 from cli.wizard.config import PROVIDER_BY_VALUE, ProviderOption
 from cli.wizard.integration_health import IntegrationHealthResult
 from cli.wizard.probes import ProbeResult
@@ -324,8 +325,8 @@ def _prompt_value(
 
 def _persist_llm_api_key(env_var: str, value: str) -> bool:
     try:
-        save_llm_api_key(env_var, value)
-    except RuntimeError as exc:
+        persist_api_key_secret(env_var, value, save_secret=save_llm_api_key)
+    except AuthSetupError as exc:
         _console.print(f"[{ERROR}]  {GLYPH_ERROR}  {exc}[/]")
         _console.print(
             f"[{WARNING}]  {GLYPH_WARNING}  OpenSRE could not save your API key to the local system keychain.[/]"

--- a/config/llm_auth/__init__.py
+++ b/config/llm_auth/__init__.py
@@ -1,0 +1,15 @@
+"""Config-owned storage helpers for LLM provider auth metadata."""
+
+from config.llm_auth.records import (
+    delete_provider_auth_record,
+    provider_auth_record_name,
+    resolve_provider_auth_record,
+    save_provider_auth_record,
+)
+
+__all__ = [
+    "delete_provider_auth_record",
+    "provider_auth_record_name",
+    "resolve_provider_auth_record",
+    "save_provider_auth_record",
+]

--- a/config/llm_auth/records.py
+++ b/config/llm_auth/records.py
@@ -1,0 +1,66 @@
+"""Keyring-backed metadata records for LLM provider auth."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from config.llm_credentials import (
+    delete_llm_credential_record,
+    resolve_llm_credential_record,
+    save_llm_credential_record,
+)
+
+_AUTH_RECORD_PREFIX = "provider-auth:"
+
+
+def provider_auth_record_name(provider: str) -> str:
+    """Return the keyring record name for one LLM provider auth status record."""
+    normalized = provider.strip().lower()
+    if not normalized:
+        raise ValueError("provider must not be empty")
+    return f"{_AUTH_RECORD_PREFIX}{normalized}"
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat()
+
+
+def save_provider_auth_record(
+    *,
+    provider: str,
+    auth_name: str,
+    kind: str,
+    source: str,
+    detail: str,
+) -> None:
+    """Persist non-token auth metadata for a provider."""
+    provider_value = provider.strip().lower()
+    save_llm_credential_record(
+        provider_auth_record_name(provider_value),
+        {
+            "provider": provider_value,
+            "auth_name": auth_name,
+            "kind": kind,
+            "source": source,
+            "detail": detail,
+            "updated_at": _utc_now(),
+        },
+    )
+
+
+def resolve_provider_auth_record(provider: str) -> dict[str, str]:
+    """Resolve non-token auth metadata for a provider."""
+    return resolve_llm_credential_record(provider_auth_record_name(provider))
+
+
+def delete_provider_auth_record(provider: str) -> None:
+    """Delete non-token auth metadata for a provider."""
+    delete_llm_credential_record(provider_auth_record_name(provider))
+
+
+__all__ = [
+    "delete_provider_auth_record",
+    "provider_auth_record_name",
+    "resolve_provider_auth_record",
+    "save_provider_auth_record",
+]

--- a/config/llm_credentials.py
+++ b/config/llm_credentials.py
@@ -1,9 +1,11 @@
-"""Secure local storage helpers for LLM API keys."""
+"""Secure local storage helpers for LLM credentials."""
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
+from collections.abc import Mapping
 from typing import Final
 
 import keyring
@@ -12,6 +14,7 @@ import keyring.errors
 import platform
 
 _KEYRING_SERVICE: Final = "opensre.llm"
+_RECORD_PREFIX: Final = "record:"
 _DISABLED_VALUES: Final = frozenset({"1", "true", "yes", "on"})
 
 
@@ -38,6 +41,20 @@ def resolve_llm_api_key(env_var: str) -> str:
         return (keyring.get_password(_KEYRING_SERVICE, env_var) or "").strip()
     except keyring.errors.KeyringError:
         return ""
+
+
+def llm_api_key_source(env_var: str) -> str:
+    """Return where an LLM credential resolves from: ``env``, ``keyring``, or ``none``."""
+    if os.getenv(env_var, "").strip():
+        return "env"
+    if _keyring_is_disabled():
+        return "none"
+    try:
+        if (keyring.get_password(_KEYRING_SERVICE, env_var) or "").strip():
+            return "keyring"
+    except keyring.errors.KeyringError:
+        return "none"
+    return "none"
 
 
 def has_llm_api_key(env_var: str) -> bool:
@@ -115,4 +132,74 @@ def delete_llm_api_key(env_var: str) -> None:
     try:
         keyring.delete_password(_KEYRING_SERVICE, env_var)
     except keyring.errors.KeyringError:
+        return
+
+
+def _record_username(record_name: str) -> str:
+    normalized = record_name.strip()
+    if not normalized:
+        raise ValueError("record_name must not be empty")
+    return f"{_RECORD_PREFIX}{normalized}"
+
+
+def save_llm_credential_record(record_name: str, values: Mapping[str, str]) -> None:
+    """Persist a small JSON credential metadata record in the system keychain.
+
+    These records are for auth metadata such as provider/source/status. API keys
+    still use :func:`save_llm_api_key`; OAuth or vendor CLI tokens must remain
+    in the vendor-owned credential store unless the vendor returns a supported
+    API credential explicitly meant for OpenSRE.
+    """
+    normalized = {
+        str(key).strip(): str(value).strip()
+        for key, value in values.items()
+        if str(key).strip() and str(value).strip()
+    }
+    if not normalized:
+        delete_llm_credential_record(record_name)
+        return
+    if _keyring_is_disabled():
+        raise RuntimeError("Secure local credential storage is disabled on this machine.")
+    try:
+        keyring.set_password(
+            _KEYRING_SERVICE,
+            _record_username(record_name),
+            json.dumps(normalized, sort_keys=True),
+        )
+    except keyring.errors.KeyringError as exc:
+        raise RuntimeError(
+            "Secure local credential storage is unavailable on this machine."
+        ) from exc
+
+
+def resolve_llm_credential_record(record_name: str) -> dict[str, str]:
+    """Resolve a JSON credential metadata record from the local keychain."""
+    if _keyring_is_disabled():
+        return {}
+    try:
+        raw = keyring.get_password(_KEYRING_SERVICE, _record_username(record_name)) or ""
+    except keyring.errors.KeyringError:
+        return {}
+    if not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {
+        str(key): str(value)
+        for key, value in parsed.items()
+        if isinstance(key, str) and isinstance(value, str)
+    }
+
+
+def delete_llm_credential_record(record_name: str) -> None:
+    """Remove a JSON credential metadata record from the local keychain."""
+    if _keyring_is_disabled():
+        return
+    try:
+        keyring.delete_password(_KEYRING_SERVICE, _record_username(record_name))
+    except (keyring.errors.KeyringError, ValueError):
         return

--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -121,6 +121,8 @@ These commands delegate to the same Click CLI you would run outside the REPL.
 
 | Command | What it does |
 | --- | --- |
+| `/auth` | Log in to LLM providers, show provider auth status, or clear credentials |
+| `/login` | Shortcut for `/auth login` (`/login chatgpt`, `/login claude`, `/login deepseek`) |
 | `/onboard` | Interactive onboarding wizard |
 | `/remote` | Connect to and operate remote deployed agents |
 | `/config` | Show or edit `~/.opensre/config.yml` |

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -62,6 +62,29 @@ export OPENAI_TOOLCALL_MODEL=gpt-5.4-mini
 
 A shared `LLM_MAX_TOKENS` (default `4096`) controls the response token budget for every provider.
 
+## Login and secret storage
+
+Use `opensre auth` for provider login without writing secrets to `.env`:
+
+| Command | What it does |
+| ------- | ------------ |
+| `opensre auth` | Show auth status for subscription and API-key providers |
+| `opensre auth login deepseek` | Open DeepSeek setup guidance, validate `DEEPSEEK_API_KEY`, store it in the system keychain, and select DeepSeek |
+| `opensre auth login claude` | Configure the `claude-code` provider through Claude Code CLI subscription login |
+| `opensre auth login chatgpt` | Configure the `codex` provider through Codex CLI / ChatGPT subscription login |
+| `opensre auth logout deepseek` | Remove OpenSRE-managed DeepSeek credentials from the keychain |
+
+`opensre auth login` never reads browser cookies, browser profiles, browser local storage, or IndexedDB. API-key providers use hidden paste prompts plus keyring storage. Subscription providers delegate OAuth/session handling to the vendor CLI that owns the browser login flow.
+
+Inside the interactive shell, use the same flows through `/auth` or `/login`:
+
+```bash
+/login chatgpt
+/login claude
+/login deepseek
+/auth status
+```
+
 ## API providers
 
 ### Anthropic
@@ -115,6 +138,7 @@ export DEEPSEEK_TOOLCALL_MODEL=deepseek-v4-flash
 ```
 
 Uses DeepSeek's official OpenAI-compatible API endpoint at `https://api.deepseek.com`.
+Run `opensre auth login deepseek` for browser-assisted key setup and secure local storage.
 
 ### Google Gemini
 
@@ -207,6 +231,7 @@ export CODEX_BIN=
 ```
 
 Requires the [OpenAI Codex CLI](https://github.com/openai/codex). If `CODEX_MODEL` is unset, OpenSRE omits `-m` so `codex exec` uses the CLI's currently configured model. If `CODEX_BIN` is unset, the binary is resolved via `PATH` and known install locations.
+Run `opensre auth login chatgpt` to detect the Codex CLI login and persist `LLM_PROVIDER=codex`.
 
 ### Claude Code
 
@@ -220,6 +245,7 @@ export CLAUDE_CODE_BIN=
 ```
 
 Requires the [Claude Code CLI](https://github.com/anthropics/claude-code) (`npm i -g @anthropic-ai/claude-code`). If `CLAUDE_CODE_MODEL` is unset, OpenSRE omits the `--model` flag and the CLI uses its configured default. If `CLAUDE_CODE_BIN` is unset, the binary is resolved via `PATH` and known install locations.
+Run `opensre auth login claude` to detect Claude subscription login and persist `LLM_PROVIDER=claude-code`.
 
 ### GitHub Copilot
 

--- a/interactive_shell/command_registry/cli_parity.py
+++ b/interactive_shell/command_registry/cli_parity.py
@@ -110,6 +110,15 @@ def _cmd_onboard(session: ReplSession, console: Console, args: list[str]) -> boo
     return run_cli_command(console, ["onboard", *args])
 
 
+def _cmd_auth(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+    capture_output = not args or args[0].lower() in {"status", "logout"}
+    return run_cli_command(console, ["auth", *args], capture_output=capture_output)
+
+
+def _cmd_login(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+    return run_cli_command(console, ["auth", "login", *args])
+
+
 def _cmd_remote(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
     return run_cli_command(console, ["remote", *args])
 
@@ -284,6 +293,18 @@ def _cmd_misses(session: ReplSession, console: Console, args: list[str]) -> bool
 
 
 COMMANDS: list[SlashCommand] = [
+    SlashCommand(
+        "/auth",
+        "Log in to LLM providers and inspect local auth state.",
+        _cmd_auth,
+        usage=("/auth", "/auth status", "/auth login deepseek", "/auth logout deepseek"),
+    ),
+    SlashCommand(
+        "/login",
+        "Shortcut for LLM provider login.",
+        _cmd_login,
+        usage=("/login", "/login chatgpt", "/login claude", "/login deepseek"),
+    ),
     SlashCommand(
         "/onboard",
         "Run the interactive onboarding wizard.",

--- a/interactive_shell/command_registry/slash_catalog.py
+++ b/interactive_shell/command_registry/slash_catalog.py
@@ -58,6 +58,11 @@ _MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
         "User asks about the alert inbox, listener, or queued alerts",
         anti_examples=("User wants to investigate an alert body (use investigation_start)",),
     ),
+    "/auth": _mcp(
+        "Log in to LLM providers and inspect local auth state. Subcommands: login, status, logout.",
+        "User asks to log in, authenticate, connect an LLM provider, or check provider auth",
+        anti_examples=("User asks to configure an observability integration (use /integrations)",),
+    ),
     "/background": _mcp(
         "Manage session-local background investigation mode and completed RCA summaries. "
         "Subcommands: on, off, status, list, show <task_id>, use <task_id>, notify list, notify set.",
@@ -165,6 +170,12 @@ _MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
     "/last": _mcp(
         "Reprint the most recent investigation report from this session.",
         "User asks to show the last investigation result or report again",
+    ),
+    "/login": _mcp(
+        "Shortcut for /auth login. Supports subscription aliases chatgpt and claude, "
+        "and API-key providers such as deepseek.",
+        "User asks to log in to ChatGPT, Claude, DeepSeek, or another LLM provider",
+        anti_examples=("User asks to log in to a non-LLM integration (use /integrations or /mcp)",),
     ),
     "/rca": _mcp(
         "Browse persisted RCA reports across sessions. Subcommands: history, show <id>, save <path>.",

--- a/interactive_shell/harness/tests/orchestration/test_slash_tool.py
+++ b/interactive_shell/harness/tests/orchestration/test_slash_tool.py
@@ -41,10 +41,14 @@ def _record_dispatch(monkeypatch: pytest.MonkeyPatch) -> list[str]:
 @pytest.mark.parametrize(
     ("command", "args", "expected"),
     [
+        ("/auth", ["login", "deepseek"], "/auth login deepseek"),
+        ("/login", ["deepseek"], "/login deepseek"),
         ("/integrations", ["remove", "github"], "/integrations remove github"),
         ("/integrations", ["setup", "datadog"], "/integrations setup datadog"),
         ("/mcp", ["connect", "github"], "/mcp connect github"),
         ("/mcp", ["disconnect", "github"], "/mcp disconnect github"),
+        ("/auth", [], "/auth"),
+        ("/login", [], "/login"),
         ("/integrations", [], "/integrations"),
         ("/mcp", [], "/mcp"),
     ],

--- a/interactive_shell/runtime/utils/input_policy.py
+++ b/interactive_shell/runtime/utils/input_policy.py
@@ -20,6 +20,7 @@ def _literal_slash_command_text(text: str) -> str | None:
 _EXCLUSIVE_STDIN_MENU_COMMANDS: frozenset[str] = frozenset(
     {
         "/history",
+        "/auth",
         "/help",
         "/integrations",
         "/investigate",
@@ -69,7 +70,7 @@ _EXCLUSIVE_STDIN_SUBCOMMANDS: frozenset[tuple[str, str]] = frozenset(
     }
 )
 _WAIT_FOR_COMPLETION_COMMANDS: frozenset[str] = frozenset(
-    {"/exit", "/quit", "/update", "/onboard", "/config"}
+    {"/exit", "/quit", "/update", "/onboard", "/config", "/auth", "/login"}
 )
 
 

--- a/interactive_shell/tools/slash_tool.py
+++ b/interactive_shell/tools/slash_tool.py
@@ -28,9 +28,11 @@ from interactive_shell.ui.execution_confirm import execution_allowed
 # terminal's cursor-position replies (ESC[row;colR) leak into the input line as
 # literal keystrokes. Defer them through ``queue_auto_command`` so the loop
 # re-dispatches the command as a deterministic turn it runs with exclusive stdin.
-_INTERACTIVE_PICKER_MENUS: frozenset[str] = frozenset({"/integrations", "/mcp"})
+_INTERACTIVE_PICKER_MENUS: frozenset[str] = frozenset({"/auth", "/login", "/integrations", "/mcp"})
 _INTERACTIVE_PICKER_SUBCOMMANDS: frozenset[tuple[str, str]] = frozenset(
     {
+        ("/auth", "login"),
+        ("/auth", "logout"),
         ("/integrations", "setup"),
         ("/integrations", "remove"),
         ("/mcp", "connect"),
@@ -47,6 +49,8 @@ def _slash_drives_interactive_picker(name: str, slash_args: list[str]) -> bool:
     """
     if not repl_tty_interactive():
         return False
+    if name == "/login":
+        return True
     if not slash_args:
         return name in _INTERACTIVE_PICKER_MENUS
     return (name, slash_args[0].lower()) in _INTERACTIVE_PICKER_SUBCOMMANDS

--- a/tests/cli/test_auth_command.py
+++ b/tests/cli/test_auth_command.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import keyring
+from click.testing import CliRunner
+
+from cli.__main__ import cli
+from cli.llm_auth.service import AuthSetupResult
+from config.llm_credentials import resolve_llm_api_key
+from tests.shared.keyring_backend import MemoryKeyring
+
+
+def _patch_auth_env(monkeypatch, tmp_path: Path) -> Path:
+    env_path = tmp_path / ".env"
+    monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.setattr("cli.wizard.env_sync.PROJECT_ENV_PATH", env_path)
+    monkeypatch.setattr("cli.wizard.store.get_store_path", lambda: tmp_path / "opensre.json")
+    return env_path
+
+
+def test_auth_login_deepseek_stores_keyring_not_env(monkeypatch, tmp_path: Path) -> None:
+    env_path = _patch_auth_env(monkeypatch, tmp_path)
+
+    previous_backend = keyring.get_keyring()
+    keyring.set_keyring(MemoryKeyring())
+    try:
+        result = CliRunner().invoke(
+            cli,
+            [
+                "auth",
+                "login",
+                "deepseek",
+                "--api-key",
+                "deepseek-secret",
+                "--no-validate",
+                "--no-open-browser",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Authenticated: DeepSeek API key" in result.output
+        assert resolve_llm_api_key("DEEPSEEK_API_KEY") == "deepseek-secret"
+        env_content = env_path.read_text(encoding="utf-8")
+        assert "LLM_PROVIDER=deepseek\n" in env_content
+        assert "DEEPSEEK_API_KEY=" not in env_content
+    finally:
+        keyring.set_keyring(previous_backend)
+
+
+def test_auth_status_provider_reports_keyring_source(monkeypatch, tmp_path: Path) -> None:
+    _patch_auth_env(monkeypatch, tmp_path)
+    previous_backend = keyring.get_keyring()
+    keyring.set_keyring(MemoryKeyring())
+    try:
+        CliRunner().invoke(
+            cli,
+            [
+                "auth",
+                "login",
+                "deepseek",
+                "--api-key",
+                "deepseek-secret",
+                "--no-validate",
+                "--no-open-browser",
+            ],
+        )
+
+        result = CliRunner().invoke(cli, ["auth", "status", "deepseek"])
+
+        assert result.exit_code == 0, result.output
+        assert "deepseek" in result.output
+        assert "ok" in result.output
+        assert "keyring" in result.output
+    finally:
+        keyring.set_keyring(previous_backend)
+
+
+def test_auth_login_chatgpt_delegates_to_subscription_provider(monkeypatch, tmp_path: Path) -> None:
+    _patch_auth_env(monkeypatch, tmp_path)
+    calls: list[tuple[str, bool]] = []
+
+    def _fake_configure(**kwargs):
+        calls.append((kwargs["profile"].name, kwargs["launch_login"]))
+        return AuthSetupResult(
+            provider="codex",
+            model="",
+            source="vendor-cli",
+            detail="Logged in.",
+            env_path=tmp_path / ".env",
+        )
+
+    monkeypatch.setattr("cli.commands.auth.configure_cli_subscription_provider", _fake_configure)
+
+    result = CliRunner().invoke(
+        cli,
+        ["auth", "login", "chatgpt", "--no-launch-login", "--no-open-browser"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [("chatgpt", False)]
+    assert "Provider     : codex" in result.output
+
+
+def test_auth_logout_deepseek_removes_keyring_secret(monkeypatch, tmp_path: Path) -> None:
+    _patch_auth_env(monkeypatch, tmp_path)
+    previous_backend = keyring.get_keyring()
+    keyring.set_keyring(MemoryKeyring())
+    try:
+        CliRunner().invoke(
+            cli,
+            [
+                "auth",
+                "login",
+                "deepseek",
+                "--api-key",
+                "deepseek-secret",
+                "--no-validate",
+                "--no-open-browser",
+            ],
+        )
+
+        result = CliRunner().invoke(cli, ["auth", "logout", "deepseek"])
+
+        assert result.exit_code == 0, result.output
+        assert resolve_llm_api_key("DEEPSEEK_API_KEY") == ""
+    finally:
+        keyring.set_keyring(previous_backend)

--- a/tests/config/test_llm_auth.py
+++ b/tests/config/test_llm_auth.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import keyring
+import pytest
+
+from cli.llm_auth.providers import ProviderAuthProfile, resolve_auth_profile
+from cli.llm_auth.service import (
+    AuthSetupError,
+    configure_api_key_provider,
+    configure_cli_subscription_provider,
+)
+from cli.wizard.config import ModelOption, ProviderOption
+from cli.wizard.validation import ValidationResult
+from config.llm_credentials import resolve_llm_api_key, resolve_llm_credential_record
+from integrations.llm_cli.base import CLIProbe
+from tests.shared.keyring_backend import MemoryKeyring
+
+
+def test_resolve_auth_profile_accepts_subscription_aliases() -> None:
+    assert resolve_auth_profile("chatgpt").provider_value == "codex"
+    assert resolve_auth_profile("openai-codex").provider_value == "codex"
+    assert resolve_auth_profile("claude").provider_value == "claude-code"
+    assert resolve_auth_profile("deepseek").provider_value == "deepseek"
+
+
+def test_configure_deepseek_api_key_stores_keyring_and_nonsecret_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "cli.wizard.store.get_store_path",
+        lambda: tmp_path / "opensre.json",
+    )
+    monkeypatch.setattr(
+        "cli.llm_auth.service.validate_provider_credentials",
+        lambda **_kwargs: ValidationResult(ok=True, detail="ok"),
+    )
+
+    previous_backend = keyring.get_keyring()
+    keyring.set_keyring(MemoryKeyring())
+    try:
+        env_path = tmp_path / ".env"
+        result = configure_api_key_provider(
+            profile=resolve_auth_profile("deepseek"),
+            api_key="deepseek-secret",
+            model="deepseek-v4-flash",
+            env_path=env_path,
+        )
+
+        assert result.provider == "deepseek"
+        assert resolve_llm_api_key("DEEPSEEK_API_KEY") == "deepseek-secret"
+        env_content = env_path.read_text(encoding="utf-8")
+        assert "LLM_PROVIDER=deepseek\n" in env_content
+        assert "DEEPSEEK_REASONING_MODEL=deepseek-v4-flash\n" in env_content
+        assert "DEEPSEEK_API_KEY=" not in env_content
+        assert resolve_llm_credential_record("provider-auth:deepseek")["source"] == "keyring"
+    finally:
+        keyring.set_keyring(previous_backend)
+
+
+def test_configure_api_key_does_not_store_when_validation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "cli.llm_auth.service.validate_provider_credentials",
+        lambda **_kwargs: ValidationResult(ok=False, detail="rejected"),
+    )
+
+    previous_backend = keyring.get_keyring()
+    keyring.set_keyring(MemoryKeyring())
+    try:
+        with pytest.raises(AuthSetupError, match="rejected"):
+            configure_api_key_provider(
+                profile=resolve_auth_profile("deepseek"),
+                api_key="bad-key",
+            )
+        assert resolve_llm_api_key("DEEPSEEK_API_KEY") == ""
+    finally:
+        keyring.set_keyring(previous_backend)
+
+
+class _FakeAdapter:
+    name = "fake"
+    binary_env_key = "FAKE_BIN"
+    install_hint = "install fake"
+    auth_hint = "Run: fake login"
+    min_version = None
+    default_exec_timeout_sec = 30.0
+
+    def detect(self) -> CLIProbe:
+        return CLIProbe(
+            installed=True,
+            version="1.0.0",
+            logged_in=True,
+            bin_path="/usr/bin/fake",
+            detail="Logged in.",
+        )
+
+
+def test_configure_cli_subscription_syncs_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+    monkeypatch.setattr(
+        "cli.wizard.store.get_store_path",
+        lambda: tmp_path / "opensre.json",
+    )
+    fake_provider = ProviderOption(
+        value="codex",
+        label="OpenAI Codex CLI",
+        group="Local CLI providers",
+        api_key_env="",
+        model_env="CODEX_MODEL",
+        default_model="",
+        models=(ModelOption(value="", label="default"),),
+        credential_kind="cli",
+        adapter_factory=lambda: _FakeAdapter(),
+    )
+    monkeypatch.setattr("cli.llm_auth.service.provider_for_profile", lambda _profile: fake_provider)
+
+    previous_backend = keyring.get_keyring()
+    keyring.set_keyring(MemoryKeyring())
+    try:
+        env_path = tmp_path / ".env"
+        result = configure_cli_subscription_provider(
+            profile=ProviderAuthProfile(
+                name="chatgpt",
+                provider_value="codex",
+                label="ChatGPT subscription via Codex CLI",
+                kind="cli_subscription",
+            ),
+            model="gpt-5-codex",
+            env_path=env_path,
+        )
+
+        assert result.provider == "codex"
+        env_content = env_path.read_text(encoding="utf-8")
+        assert "LLM_PROVIDER=codex\n" in env_content
+        assert "CODEX_MODEL=gpt-5-codex\n" in env_content
+        assert resolve_llm_credential_record("provider-auth:codex")["source"] == "vendor-cli"
+    finally:
+        keyring.set_keyring(previous_backend)

--- a/tests/interactive_shell/test_terminal_runtime_turns.py
+++ b/tests/interactive_shell/test_terminal_runtime_turns.py
@@ -155,6 +155,20 @@ def test_turn_needs_exclusive_stdin_for_config(
     )
 
 
+def test_turn_needs_exclusive_stdin_for_auth_and_login(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(loop_input_policy, "repl_tty_interactive", lambda: True)
+    session = ReplSession()
+
+    assert loop_input_policy.turn_needs_exclusive_stdin("/auth", session) is True
+    assert loop_input_policy.turn_needs_exclusive_stdin("/auth login deepseek", session) is True
+    assert loop_input_policy.turn_needs_exclusive_stdin("/auth status", session) is True
+    assert loop_input_policy.turn_needs_exclusive_stdin("/login", session) is True
+    assert loop_input_policy.turn_needs_exclusive_stdin("/login chatgpt", session) is True
+    assert loop_input_policy.turn_needs_exclusive_stdin("login chatgpt", session) is False
+
+
 def test_run_agent_prompt_nitro_prompt_uses_cli_agent_actions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_llm_credentials.py
+++ b/tests/test_llm_credentials.py
@@ -19,6 +19,44 @@ def test_resolve_env_credential_prefers_env_over_keyring(monkeypatch) -> None:
         keyring.set_keyring(previous_backend)
 
 
+def test_llm_api_key_source_reports_env_keyring_and_none(monkeypatch) -> None:
+    monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    previous_backend = keyring.get_keyring()
+    keyring.set_keyring(MemoryKeyring())
+    try:
+        assert llm_credentials.llm_api_key_source("OPENAI_API_KEY") == "none"
+        llm_credentials.save_llm_api_key("OPENAI_API_KEY", "from-keyring")
+        assert llm_credentials.llm_api_key_source("OPENAI_API_KEY") == "keyring"
+        monkeypatch.setenv("OPENAI_API_KEY", "from-env")
+        assert llm_credentials.llm_api_key_source("OPENAI_API_KEY") == "env"
+    finally:
+        keyring.set_keyring(previous_backend)
+
+
+def test_llm_credential_record_round_trips_in_keyring(monkeypatch) -> None:
+    monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+
+    previous_backend = keyring.get_keyring()
+    keyring.set_keyring(MemoryKeyring())
+    try:
+        llm_credentials.save_llm_credential_record(
+            "provider-auth:deepseek",
+            {"provider": "deepseek", "source": "keyring", "empty": ""},
+        )
+
+        assert llm_credentials.resolve_llm_credential_record("provider-auth:deepseek") == {
+            "provider": "deepseek",
+            "source": "keyring",
+        }
+
+        llm_credentials.delete_llm_credential_record("provider-auth:deepseek")
+        assert llm_credentials.resolve_llm_credential_record("provider-auth:deepseek") == {}
+    finally:
+        keyring.set_keyring(previous_backend)
+
+
 def test_get_keyring_setup_instructions_for_linux_without_gnome_keyring(monkeypatch) -> None:
     backend_class = type("Keyring", (), {})
     backend_class.__module__ = "keyring.backends.fail"


### PR DESCRIPTION
## Summary
- Add `opensre auth login/status/logout` for LLM provider auth.
- Add DeepSeek API-key setup with keyring-backed secret storage and OpenAI-compatible validation.
- Add subscription login paths for ChatGPT via the existing Codex CLI provider and Claude via the existing Claude Code CLI provider.
- Add keyring-backed provider auth metadata records, onboarding reuse for API-key persistence, and REPL `/auth` / `/login` commands.
- Update LLM provider and interactive-shell docs.

## Testing
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run lint-imports`
- `uv run python -m pytest tests/test_llm_credentials.py tests/config/test_llm_auth.py tests/cli/test_auth_command.py tests/cli/wizard/test_flow.py tests/interactive_shell/command_registry/test_slash_catalog.py interactive_shell/harness/tests/orchestration/test_slash_tool.py tests/interactive_shell/test_terminal_runtime_turns.py -q` (92 passed)
- `make test-scope ARGS='--base origin/main'` (1814 passed, 1 skipped)

CI status: green after rebase onto `origin/main`.
