### PR TITLE
Fix CodeQL security scanning alerts

### DIFF
--- a/.github/scripts/good_first_issue_assign.py
+++ b/.github/scripts/good_first_issue_assign.py
@@ -121,7 +121,6 @@ def _request_json(url: str, token: str) -> Any:
 
 
 def _search_issue_total_count(query: str, token: str) -> int:
-    params = urllib.parse.urlencode({"q": query})
     url = _github_api_url("/search/issues", {"q": query})
     try:
         data = _request_json(url, token)

--- a/core/agent/context.py
+++ b/core/agent/context.py
@@ -43,7 +43,8 @@ class TurnContextSource(Protocol):
     # Read-only here; ``ReplSession`` stores a tuple. A property matches
     # covariantly, so any concrete ``Sequence[str]`` implementation satisfies it.
     @property
-    def configured_integrations(self) -> Sequence[str]: ...
+    def configured_integrations(self) -> Sequence[str]:
+        raise NotImplementedError
 
 
 @dataclass(frozen=True)

--- a/core/agent/engine.py
+++ b/core/agent/engine.py
@@ -499,6 +499,8 @@ def run_turn(
                 assistant_response_text=_response_text(run),
                 llm_run=run,
             )
+        case _:
+            raise AssertionError(f"Unknown route intent: {route.intent!r}")
 
     return accounting.finalize(result)
 

--- a/core/agent/ports.py
+++ b/core/agent/ports.py
@@ -66,7 +66,8 @@ class SessionStore(Protocol):
     # Read-only here; ``ReplSession`` stores a tuple. A property matches
     # covariantly, so any concrete ``Sequence[str]`` implementation satisfies it.
     @property
-    def configured_integrations(self) -> Sequence[str]: ...
+    def configured_integrations(self) -> Sequence[str]:
+        raise NotImplementedError
 
     last_state: dict[str, Any] | None
     last_synthetic_observation_path: str | None
@@ -100,7 +101,8 @@ class ToolProvider(Protocol):
 class ErrorReporter(Protocol):
     """Reports caught exceptions (telemetry / logging)."""
 
-    def report(self, exc: BaseException, *, context: str, expected: bool = False) -> None: ...
+    def report(self, exc: BaseException, *, context: str, expected: bool = False) -> None:
+        raise NotImplementedError
 
 
 @runtime_checkable
@@ -112,31 +114,39 @@ class PromptContextProvider(Protocol):
     caches, the headless adapter returns empty strings.
     """
 
-    def cli_reference(self) -> str: ...
+    def cli_reference(self) -> str:
+        raise NotImplementedError
 
-    def agents_md(self) -> str: ...
+    def agents_md(self) -> str:
+        raise NotImplementedError
 
-    def investigation_flow(self) -> str: ...
+    def investigation_flow(self) -> str:
+        raise NotImplementedError
 
-    def environment_block(self) -> str: ...
+    def environment_block(self) -> str:
+        raise NotImplementedError
 
-    def suggested_synthetic_prompt(self) -> str: ...
+    def suggested_synthetic_prompt(self) -> str:
+        raise NotImplementedError
 
-    def log_diagnostics(self, reason: str) -> None: ...
+    def log_diagnostics(self, reason: str) -> None:
+        raise NotImplementedError
 
 
 @runtime_checkable
 class ReasoningClientProvider(Protocol):
     """Provides the streaming reasoning LLM client for the assistant answer."""
 
-    def get(self) -> Any | None: ...
+    def get(self) -> Any | None:
+        raise NotImplementedError
 
 
 @runtime_checkable
 class RunRecordFactory(Protocol):
     """Builds the opaque per-answer LLM-run record (telemetry) from raw inputs."""
 
-    def build(self, *, client: Any, prompt: str, response_text: str, started: float) -> Any: ...
+    def build(self, *, client: Any, prompt: str, response_text: str, started: float) -> Any:
+        raise NotImplementedError
 
 
 @runtime_checkable
@@ -170,9 +180,11 @@ ExecuteActions = Callable[..., ToolCallingTurnResult]
 class TurnAccounting(Protocol):
     """Records analytics/telemetry for a turn and finalizes the result."""
 
-    def record_action_result(self, action_result: ToolCallingTurnResult) -> None: ...
+    def record_action_result(self, action_result: ToolCallingTurnResult) -> None:
+        raise NotImplementedError
 
-    def finalize(self, result: ShellTurnResult) -> ShellTurnResult: ...
+    def finalize(self, result: ShellTurnResult) -> ShellTurnResult:
+        raise NotImplementedError
 
 
 __all__ = [

--- a/interactive_shell/agent_shell/agent.py
+++ b/interactive_shell/agent_shell/agent.py
@@ -26,7 +26,7 @@ from rich.console import Console
 from rich.markup import escape
 
 from core.agent import engine
-from core.agent.action_plan import ActionPlanAction, parse_action_plan
+from core.agent.action_plan import ActionPlanAction
 from core.agent.context import TurnContext
 from core.agent.results import ShellTurnResult, ToolCallingTurnResult
 from interactive_shell.agent_shell.adapters import (
@@ -69,9 +69,6 @@ from interactive_shell.ui.streaming.console import StreamingConsole
 from interactive_shell.utils.error_handling.exception_reporting import report_exception
 from interactive_shell.utils.telemetry import LlmRunInfo, PromptRecorder
 from platform.analytics.repl_context import bind_cli_session_id, reset_cli_session_id
-
-# Re-exported for the parser's pure helpers; execution lives in action_dispatch.
-_parse_action_plan = parse_action_plan
 
 _logger = logging.getLogger(__name__)
 

--- a/interactive_shell/agent_shell/tool_calling.py
+++ b/interactive_shell/agent_shell/tool_calling.py
@@ -8,7 +8,6 @@ output sink, registry-backed tool provider, error reporter) and delegates to it.
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable
 from typing import Any
 
@@ -23,8 +22,6 @@ from interactive_shell.agent_shell.adapters import (
     ShellOutputSink,
     ShellToolProvider,
 )
-
-log = logging.getLogger(__name__)
 
 
 def _default_llm_factory() -> Any:

--- a/interactive_shell/tools/claude_code_executor.py
+++ b/interactive_shell/tools/claude_code_executor.py
@@ -46,16 +46,20 @@ _DEFAULT_IMPLEMENT_PERMISSION_MODE = "acceptEdits"
 
 class _ClaudeInvocation(Protocol):
     @property
-    def argv(self) -> tuple[str, ...]: ...
+    def argv(self) -> tuple[str, ...]:
+        raise NotImplementedError
 
     @property
-    def stdin(self) -> str | None: ...
+    def stdin(self) -> str | None:
+        raise NotImplementedError
 
     @property
-    def cwd(self) -> str: ...
+    def cwd(self) -> str:
+        raise NotImplementedError
 
     @property
-    def env(self) -> dict[str, str] | None: ...
+    def env(self) -> dict[str, str] | None:
+        raise NotImplementedError
 
 
 def _recent_cli_agent_context(session: ReplSession, *, limit: int = 6) -> str:

--- a/tests/config/test_llm_auth.py
+++ b/tests/config/test_llm_auth.py
@@ -119,7 +119,7 @@ def test_configure_cli_subscription_syncs_provider(
         default_model="",
         models=(ModelOption(value="", label="default"),),
         credential_kind="cli",
-        adapter_factory=lambda: _FakeAdapter(),
+        adapter_factory=_FakeAdapter,
     )
     monkeypatch.setattr("cli.llm_auth.service.provider_for_profile", lambda _profile: fake_provider)
 

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -964,7 +964,7 @@ class TestReplState:
             cancel = threading.Event()
             state.start_dispatch(task=task, cancel_event=cancel)
             assert state.is_dispatch_running() is True
-            await task
+            assert await task is None
             state.finish_dispatch(cancel)
             assert state.phase is loop_state.TurnPhase.IDLE
             state.clear_current_task()


### PR DESCRIPTION
## Summary
- remove unused globals/locals and unnecessary lambda flagged by CodeQL
- replace Protocol ellipsis bodies with explicit NotImplementedError implementations to avoid ineffectual statements
- add an explicit unknown-route guard so run_turn always initializes its result

## Validation
- uv run python -m pytest tests/config/test_llm_auth.py tests/interactive_shell/test_terminal_runtime.py tests/github/test_good_first_issue_assign.py tests/interactive_shell/chat/test_cli_agent.py
- make lint
- make format-check
- make typecheck
- make test-scope (9758 passed, 52 skipped)