### PR TITLE
Clear remaining CodeQL flow alerts

### DIFF
--- a/core/agent/engine.py
+++ b/core/agent/engine.py
@@ -459,48 +459,45 @@ def run_turn(
     observation = session.last_command_observation
     route = _route_turn(_routing_input_from_result(action_result, observation))
 
-    match route.intent:
-        case "summarize_observation":
-            with apply_reasoning_effort(turn_ctx.reasoning_effort):
-                run = answer(
-                    text,
-                    confirm_fn=confirm_fn,
-                    is_tty=is_tty,
-                    tool_observation=observation,
-                    turn_ctx=turn_ctx,
-                )
-            result = ShellTurnResult(
-                final_intent="cli_agent_summarized",
-                action_result=action_result,
-                assistant_response_text=_response_text(run),
-                llm_run=run,
+    if route.intent == "summarize_observation":
+        with apply_reasoning_effort(turn_ctx.reasoning_effort):
+            run = answer(
+                text,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+                tool_observation=observation,
+                turn_ctx=turn_ctx,
             )
-
-        case "handled_without_llm":
-            result = ShellTurnResult(
-                final_intent="cli_agent_handled",
-                action_result=action_result,
-                assistant_response_text=action_result.response_text,
+        result = ShellTurnResult(
+            final_intent="cli_agent_summarized",
+            action_result=action_result,
+            assistant_response_text=_response_text(run),
+            llm_run=run,
+        )
+    elif route.intent == "handled_without_llm":
+        result = ShellTurnResult(
+            final_intent="cli_agent_handled",
+            action_result=action_result,
+            assistant_response_text=action_result.response_text,
+        )
+    elif route.intent == "gather_and_answer":
+        with apply_reasoning_effort(turn_ctx.reasoning_effort):
+            run = _gather_and_answer(
+                text=text,
+                answer=answer,
+                gather=gather,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+                turn_ctx=turn_ctx,
             )
-
-        case "gather_and_answer":
-            with apply_reasoning_effort(turn_ctx.reasoning_effort):
-                run = _gather_and_answer(
-                    text=text,
-                    answer=answer,
-                    gather=gather,
-                    confirm_fn=confirm_fn,
-                    is_tty=is_tty,
-                    turn_ctx=turn_ctx,
-                )
-            result = ShellTurnResult(
-                final_intent="cli_agent_fallback",
-                action_result=action_result,
-                assistant_response_text=_response_text(run),
-                llm_run=run,
-            )
-        case _:
-            raise AssertionError(f"Unknown route intent: {route.intent!r}")
+        result = ShellTurnResult(
+            final_intent="cli_agent_fallback",
+            action_result=action_result,
+            assistant_response_text=_response_text(run),
+            llm_run=run,
+        )
+    else:
+        raise AssertionError(f"Unknown route intent: {route.intent!r}")
 
     return accounting.finalize(result)
 

--- a/interactive_shell/agent_shell/action_dispatch.py
+++ b/interactive_shell/agent_shell/action_dispatch.py
@@ -302,19 +302,17 @@ def _plan_action_effects(
     action: ActionPlanAction, env: ActionPlanningEnv
 ) -> tuple[HarnessInstruction, ...]:
     """Translate one action into the instructions that realize it (pure)."""
-    match action.kind:
-        case "switch_llm_provider":
-            return _plan_switch_llm_provider(action)
-        case "switch_toolcall_model":
-            return _plan_switch_toolcall_model(action)
-        case "slash":
-            return _plan_slash_action(action, env)
-        case "run_cli_command":
-            return _plan_cli_command(action, env)
-        case "run_interactive":
-            return _plan_interactive_command(action, env)
-        case _:
-            return (_print_error(f"unsupported action: {action.kind or '?'}"),)
+    if action.kind == "switch_llm_provider":
+        return _plan_switch_llm_provider(action)
+    if action.kind == "switch_toolcall_model":
+        return _plan_switch_toolcall_model(action)
+    if action.kind == "slash":
+        return _plan_slash_action(action, env)
+    if action.kind == "run_cli_command":
+        return _plan_cli_command(action, env)
+    if action.kind == "run_interactive":
+        return _plan_interactive_command(action, env)
+    return (_print_error(f"unsupported action: {action.kind or '?'}"),)
 
 
 def _plan_requested_actions_header(

--- a/interactive_shell/agent_shell/agent.py
+++ b/interactive_shell/agent_shell/agent.py
@@ -220,18 +220,16 @@ def _reduce_agent_presentation(
     should_show_spinner: bool,
 ) -> AgentPresentationState:
     """Compute the next presentation state for *event* (pure)."""
-    match event.type:
-        case "turn_start":
-            return AgentPresentationState(
-                show_spinner=should_show_spinner,
-                prompt_suppressed=should_show_spinner,
-            )
-        case "turn_end":
-            return AgentPresentationState()
-        case "turn_interrupted" | "turn_error":
-            return state
-        case _:
-            raise ValueError(f"Unknown agent event type: {event.type!r}")
+    if event.type == "turn_start":
+        return AgentPresentationState(
+            show_spinner=should_show_spinner,
+            prompt_suppressed=should_show_spinner,
+        )
+    if event.type == "turn_end":
+        return AgentPresentationState()
+    if event.type in {"turn_interrupted", "turn_error"}:
+        return state
+    raise ValueError(f"Unknown agent event type: {event.type!r}")
 
 
 async def _render_agent_presentation_transition(


### PR DESCRIPTION
## Summary
- rewrite remaining CodeQL-flagged match statements as explicit conditional branches
- preserve existing fallback behavior while making return/result paths obvious to CodeQL

## Validation
- uv run python -m pytest tests/interactive_shell/chat/test_cli_agent.py tests/interactive_shell/test_terminal_runtime.py tests/core/agent/test_turn_scenarios.py -q
- make lint
- make format-check
- make typecheck
- make test-scope (9759 passed, 52 skipped)