### PR TITLE
[codex] Add branded installer progress

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -7,6 +7,206 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+function Test-OpenSreVerboseInstall {
+    $value = [string]$env:OPENSRE_INSTALL_VERBOSE
+    return ($value -eq "1" -or $value -eq "true" -or $value -eq "TRUE" -or $value -eq "yes" -or $value -eq "YES")
+}
+
+function Test-OpenSreInteractiveHost {
+    try {
+        if ([System.Console]::IsOutputRedirected) {
+            return $false
+        }
+    }
+    catch {
+        if ($null -eq $Host -or $null -eq $Host.UI) {
+            return $false
+        }
+    }
+
+    try {
+        if ($null -eq $Host -or $null -eq $Host.UI -or $null -eq $Host.UI.RawUI) {
+            return $false
+        }
+
+        $null = $Host.UI.RawUI.WindowSize
+    }
+    catch {
+        return $false
+    }
+
+    return $true
+}
+
+function Write-OpenSreLine {
+    param(
+        [AllowEmptyString()]
+        [string]$Message,
+        [string]$Color = ""
+    )
+
+    if ((Test-OpenSreInteractiveHost) -and $Color) {
+        Write-Host $Message -ForegroundColor $Color
+        return
+    }
+
+    Write-Host $Message
+}
+
+function Write-OpenSreDetail {
+    param(
+        [AllowEmptyString()]
+        [string]$Message
+    )
+
+    if (-not $Message) {
+        return
+    }
+
+    Write-OpenSreLine -Message "  $Message" -Color "DarkGray"
+}
+
+function Write-OpenSreHeader {
+    param(
+        [string]$Channel = "",
+        [string]$RequestedVersion = "",
+        [string]$InstallDir = "",
+        [string]$Repo = ""
+    )
+
+    Write-OpenSreLine -Message "OpenSRE installer" -Color "Cyan"
+    Write-OpenSreLine -Message "Installing the OpenSRE CLI for Windows." -Color "DarkGray"
+
+    if (Test-OpenSreVerboseInstall) {
+        Write-OpenSreDetail -Message "Verbose logging enabled by OPENSRE_INSTALL_VERBOSE=1."
+        if ($Repo) {
+            Write-OpenSreDetail -Message "Repository: $Repo"
+        }
+        if ($Channel) {
+            Write-OpenSreDetail -Message "Channel: $Channel"
+        }
+        if ($RequestedVersion) {
+            Write-OpenSreDetail -Message "Requested version: $RequestedVersion"
+        }
+        if ($InstallDir) {
+            Write-OpenSreDetail -Message "Install directory: $InstallDir"
+        }
+    }
+}
+
+function Write-OpenSreProgressLine {
+    param(
+        [string]$Label,
+        [Int64]$DownloadedBytes,
+        [Int64]$TotalBytes = -1
+    )
+
+    if (-not (Test-OpenSreInteractiveHost) -or (Test-OpenSreVerboseInstall)) {
+        return
+    }
+
+    if ($TotalBytes -gt 0) {
+        $percent = [Math]::Min(100, [Math]::Floor(($DownloadedBytes * 100) / $TotalBytes))
+        [System.Console]::Write("`r  {0}% {1} ({2}/{3} bytes)" -f $percent, $Label, $DownloadedBytes, $TotalBytes)
+        return
+    }
+
+    [System.Console]::Write("`r  {0} ({1} bytes)" -f $Label, $DownloadedBytes)
+}
+
+function Clear-OpenSreProgressLine {
+    if (-not (Test-OpenSreInteractiveHost) -or (Test-OpenSreVerboseInstall)) {
+        return
+    }
+
+    [System.Console]::Write("`r{0}`r" -f (" " * 100))
+}
+
+function Invoke-OpenSreStep {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [scriptblock]$Operation,
+        [string]$Detail = ""
+    )
+
+    Write-OpenSreLine -Message $Name -Color "Cyan"
+    Write-OpenSreDetail -Message $Detail
+
+    if ($Operation) {
+        try {
+            $result = & $Operation
+            Write-OpenSreLine -Message "  OK $Name" -Color "Green"
+            return $result
+        }
+        catch {
+            Write-OpenSreLine -Message "  FAILED $Name" -Color "Red"
+            throw
+        }
+    }
+}
+
+function Invoke-OpenSreStreamDownload {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Uri,
+        [Parameter(Mandatory = $true)]
+        [string]$OutFile,
+        [Parameter(Mandatory = $true)]
+        [string]$Label
+    )
+
+    $request = [System.Net.HttpWebRequest]::Create($Uri)
+    $headers = Get-OpenSreRequestHeaders
+    foreach ($key in $headers.Keys) {
+        if ($key -eq "User-Agent") {
+            $request.UserAgent = [string]$headers[$key]
+        }
+        elseif ($key -eq "Accept") {
+            $request.Accept = [string]$headers[$key]
+        }
+        else {
+            $request.Headers[$key] = [string]$headers[$key]
+        }
+    }
+
+    $response = $request.GetResponse()
+    try {
+        $totalBytes = [Int64]$response.ContentLength
+        $inputStream = $response.GetResponseStream()
+        $outputStream = [System.IO.File]::Open($OutFile, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write)
+        try {
+            $buffer = New-Object byte[] 65536
+            [Int64]$downloadedBytes = 0
+
+            while ($true) {
+                $read = $inputStream.Read($buffer, 0, $buffer.Length)
+                if ($read -le 0) {
+                    break
+                }
+
+                $outputStream.Write($buffer, 0, $read)
+                $downloadedBytes += $read
+                Write-OpenSreProgressLine -Label $Label -DownloadedBytes $downloadedBytes -TotalBytes $totalBytes
+            }
+        }
+        finally {
+            if ($outputStream) {
+                $outputStream.Dispose()
+            }
+            if ($inputStream) {
+                $inputStream.Dispose()
+            }
+            Clear-OpenSreProgressLine
+        }
+    }
+    finally {
+        if ($response) {
+            $response.Dispose()
+        }
+    }
+}
+
 function Get-OpenSreDefaultInstallDir {
     $userHome = if ($HOME) { $HOME } else { [System.Environment]::GetFolderPath("UserProfile") }
     return Join-Path $userHome ".local\bin"
@@ -123,18 +323,31 @@ function Invoke-OpenSreRestMethod {
         $params.UseBasicParsing = $true
     }
 
+    if (Test-OpenSreVerboseInstall) {
+        Write-OpenSreDetail -Message "GET $Uri"
+    }
+
     return Invoke-OpenSreWithRetry -Description "fetch release metadata from GitHub" -Operation {
         Invoke-RestMethod @params
     }
 }
 
-function Invoke-OpenSreWebRequest {
+function Invoke-OpenSreDownloadFileWithProgress {
     param(
         [Parameter(Mandatory = $true)]
         [string]$Uri,
         [Parameter(Mandatory = $true)]
-        [string]$OutFile
+        [string]$OutFile,
+        [string]$Label = ""
     )
+
+    if (-not $Label) {
+        $Label = [System.IO.Path]::GetFileName($OutFile)
+    }
+
+    if (-not $Label) {
+        $Label = "file"
+    }
 
     $params = @{
         Uri = $Uri
@@ -147,9 +360,40 @@ function Invoke-OpenSreWebRequest {
         $params.UseBasicParsing = $true
     }
 
+    if (Test-OpenSreVerboseInstall) {
+        Write-OpenSreDetail -Message "Download URL: $Uri"
+        Write-OpenSreDetail -Message "Destination: $OutFile"
+    }
+    else {
+        Write-OpenSreDetail -Message $Label
+    }
+
     Invoke-OpenSreWithRetry -Description "download '$Uri'" -Operation {
-        Invoke-WebRequest @params | Out-Null
+        if ((Test-OpenSreInteractiveHost) -and -not (Test-OpenSreVerboseInstall)) {
+            Invoke-OpenSreStreamDownload -Uri $Uri -OutFile $OutFile -Label $Label
+        }
+        else {
+            $previousProgressPreference = $ProgressPreference
+            try {
+                $ProgressPreference = "SilentlyContinue"
+                Invoke-WebRequest @params | Out-Null
+            }
+            finally {
+                $ProgressPreference = $previousProgressPreference
+            }
+        }
     } | Out-Null
+}
+
+function Invoke-OpenSreWebRequest {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Uri,
+        [Parameter(Mandatory = $true)]
+        [string]$OutFile
+    )
+
+    Invoke-OpenSreDownloadFileWithProgress -Uri $Uri -OutFile $OutFile
 }
 
 function Get-OpenSreRuntimeArchitecture {
@@ -226,13 +470,6 @@ function Get-OpenSreReleaseMetadata {
 
     if ($Channel -eq "main" -and $normalizedVersion) {
         throw "OPENSRE_VERSION cannot be combined with the main install channel."
-    }
-
-    if ($Channel -eq "main") {
-        Write-Host "Fetching latest main build metadata..."
-    }
-    elseif (-not $normalizedVersion) {
-        Write-Host "Fetching latest release version..."
     }
 
     $releaseUri = if ($Channel -eq "main") {
@@ -501,12 +738,34 @@ function Install-OpenSre {
     $requestedVersion = if ($env:OPENSRE_VERSION) { $env:OPENSRE_VERSION.Trim().TrimStart("v") } else { "" }
     $resolvedChannel = if ($Channel) { $Channel.Trim().ToLowerInvariant() } else { "release" }
 
+    Write-OpenSreHeader -Channel $resolvedChannel -RequestedVersion $requestedVersion -InstallDir $installDir -Repo $repo
     Enable-OpenSreTls
 
     $targetArch = Resolve-OpenSreWindowsArchitecture
-    $releaseMetadata = Get-OpenSreReleaseMetadata -Repo $repo -Channel $resolvedChannel -RequestedVersion $requestedVersion
+    $metadataStepName = ""
+    if ($resolvedChannel -eq "main") {
+        $metadataStepName = "[1/6] Fetching latest main build metadata"
+    }
+    elseif ($requestedVersion) {
+        $metadataStepName = "[1/6] Fetching release metadata for v$requestedVersion"
+    }
+    else {
+        $metadataStepName = "[1/6] Fetching latest release version"
+    }
+    $releaseMetadata = Invoke-OpenSreStep -Name $metadataStepName -Operation {
+        Get-OpenSreReleaseMetadata -Repo $repo -Channel $resolvedChannel -RequestedVersion $requestedVersion
+    }
     $version = [string]$releaseMetadata.Version
-    $downloadPlan = Resolve-OpenSreArchiveDownload -Release $releaseMetadata.Release -Version $version -Channel $resolvedChannel -TargetArch $targetArch
+
+    $assetStepName = if ($resolvedChannel -eq "main") {
+        "[2/6] Preparing opensre main build (windows/$targetArch)"
+    }
+    else {
+        "[2/6] Preparing opensre v$version (windows/$targetArch)"
+    }
+    $downloadPlan = Invoke-OpenSreStep -Name $assetStepName -Operation {
+        Resolve-OpenSreArchiveDownload -Release $releaseMetadata.Release -Version $version -Channel $resolvedChannel -TargetArch $targetArch
+    }
     $archive = [string]$downloadPlan.ArchiveName
     $downloadUrl = [string]$downloadPlan.ArchiveUrl
     $checksumUrl = [string]$downloadPlan.ChecksumUrl
@@ -514,33 +773,30 @@ function Install-OpenSre {
     $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("opensre-install-" + [System.Guid]::NewGuid().ToString("N"))
 
     New-Item -ItemType Directory -Path $tmpDir | Out-Null
-    New-Item -ItemType Directory -Force -Path $installDir | Out-Null
 
     try {
         $archivePath = Join-Path $tmpDir $archive
         $checksumPath = "$archivePath.sha256"
 
-        if ($resolvedChannel -eq "main") {
-            Write-Host "Installing opensre main build (windows/$targetArch)..."
-        }
-        else {
-            Write-Host "Installing opensre v$version (windows/$targetArch)..."
-        }
         if ($resolvedArch -ne $targetArch) {
-            Write-Host "Using release asset built for windows/$resolvedArch."
+            Write-OpenSreDetail -Message "Using release asset built for windows/$resolvedArch."
         }
-        Write-Host "Downloading $downloadUrl"
-        Invoke-OpenSreWebRequest -Uri $downloadUrl -OutFile $archivePath
+
+        Invoke-OpenSreStep -Name "[3/6] Downloading release archive" -Operation {
+            Invoke-OpenSreDownloadFileWithProgress -Uri $downloadUrl -OutFile $archivePath -Label $archive
+        }
 
         if ($checksumUrl) {
-            Write-Host "Verifying archive checksum"
-            Invoke-OpenSreWebRequest -Uri $checksumUrl -OutFile $checksumPath
+            $checksumName = [string]$downloadPlan.ChecksumName
+            Invoke-OpenSreStep -Name "[4/6] Downloading and verifying checksum" -Operation {
+                Invoke-OpenSreDownloadFileWithProgress -Uri $checksumUrl -OutFile $checksumPath -Label $checksumName
 
-            $expectedHash = Get-OpenSreExpectedSha256 -ChecksumPath $checksumPath -ArchiveName $archive
-            $actualHash = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+                $expectedHash = Get-OpenSreExpectedSha256 -ChecksumPath $checksumPath -ArchiveName $archive
+                $actualHash = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
 
-            if ($actualHash -ne $expectedHash) {
-                throw "Checksum verification failed for '$archive'. Expected '$expectedHash' but got '$actualHash'."
+                if ($actualHash -ne $expectedHash) {
+                    throw "Checksum verification failed for '$archive'. Expected '$expectedHash' but got '$actualHash'."
+                }
             }
         }
         else {
@@ -552,27 +808,45 @@ function Install-OpenSre {
             }
         }
 
-        Expand-Archive -LiteralPath $archivePath -DestinationPath $tmpDir -Force
+        $verifiedBinary = Invoke-OpenSreStep -Name "[5/6] Extracting and verifying binary" -Operation {
+            Expand-Archive -LiteralPath $archivePath -DestinationPath $tmpDir -Force
 
-        $binaryPath = Get-OpenSreBinaryPathFromArchive -ExtractionRoot $tmpDir -BinaryName $binaryName
-        $binaryVersionInfo = Get-OpenSreBinaryVersionInfo -BinaryPath $binaryPath
-        $binaryVersionText = [string]$binaryVersionInfo.Text
-        $binaryVersion = [string]$binaryVersionInfo.Version
+            $binaryPath = Get-OpenSreBinaryPathFromArchive -ExtractionRoot $tmpDir -BinaryName $binaryName
+            $binaryVersionInfo = Get-OpenSreBinaryVersionInfo -BinaryPath $binaryPath
+            $binaryVersionText = [string]$binaryVersionInfo.Text
+            $binaryVersion = [string]$binaryVersionInfo.Version
+            $installVersion = $version
 
-        if ($resolvedChannel -ne "main" -and $binaryVersionText -notmatch [Regex]::Escape($version)) {
-            if ($requestedVersion) {
-                throw "Downloaded binary version mismatch. Expected '$version' but got '$binaryVersionText'."
+            if ($resolvedChannel -ne "main" -and $binaryVersionText -notmatch [Regex]::Escape($version)) {
+                if ($requestedVersion) {
+                    throw "Downloaded binary version mismatch. Expected '$version' but got '$binaryVersionText'."
+                }
+
+                if (-not $binaryVersion) {
+                    throw "Downloaded binary version mismatch. Expected '$version' but got '$binaryVersionText'."
+                }
+
+                Write-Warning "Latest release metadata reports v$version, but the downloaded binary reports v$binaryVersion. Installing the verified binary anyway."
+                $installVersion = $binaryVersion
             }
 
-            if (-not $binaryVersion) {
-                throw "Downloaded binary version mismatch. Expected '$version' but got '$binaryVersionText'."
+            return [pscustomobject]@{
+                Path = $binaryPath
+                VersionText = $binaryVersionText
+                Version = $binaryVersion
+                InstallVersion = $installVersion
             }
-
-            Write-Warning "Latest release metadata reports v$version, but the downloaded binary reports v$binaryVersion. Installing the verified binary anyway."
-            $version = $binaryVersion
         }
 
-        Copy-Item -LiteralPath $binaryPath -Destination (Join-Path $installDir $binaryName) -Force
+        $binaryPath = [string]$verifiedBinary.Path
+        $binaryVersionText = [string]$verifiedBinary.VersionText
+        $binaryVersion = [string]$verifiedBinary.Version
+        $version = [string]$verifiedBinary.InstallVersion
+
+        Invoke-OpenSreStep -Name "[6/6] Installing binary" -Detail (Join-Path $installDir $binaryName) -Operation {
+            New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+            Copy-Item -LiteralPath $binaryPath -Destination (Join-Path $installDir $binaryName) -Force
+        }
     }
     finally {
         Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue

--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,7 @@ INSTALL_DIR_OVERRIDE=0
 INSTALL_CHANNEL="${OPENSRE_INSTALL_CHANNEL:-release}"
 BIN_NAME="opensre"
 INSTALL_WITH_SUDO=0
+PROGRESS_PID=""
 requested_version="${OPENSRE_VERSION:-}"
 
 [ -n "$INSTALL_DIR" ] && INSTALL_DIR_OVERRIDE=1
@@ -58,6 +59,237 @@ success() {
 
 step() {
   printf '%s%s%s\n' "${COLOR_CYAN:-}" "$*" "${COLOR_RESET:-}"
+}
+
+install_verbose() {
+  case "${OPENSRE_INSTALL_VERBOSE:-}" in
+    1|true|TRUE|yes|YES)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_interactive_terminal() {
+  [ -t 1 ] && [ "${TERM:-}" != "dumb" ] && ! install_verbose
+}
+
+terminal_supports_unicode() {
+  local locale_value="${LC_ALL:-${LC_CTYPE:-${LANG:-}}}"
+
+  case "$locale_value" in
+    *UTF-8*|*utf-8*|*UTF8*|*utf8*)
+      return 0
+      ;;
+  esac
+
+  case "${TERM_PROGRAM:-}" in
+    Apple_Terminal|iTerm.app|vscode|WezTerm)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+progress_frame() {
+  local step_count="$1"
+
+  if terminal_supports_unicode; then
+    case $((step_count % 10)) in
+      0) printf '⠋' ;;
+      1) printf '⠙' ;;
+      2) printf '⠹' ;;
+      3) printf '⠸' ;;
+      4) printf '⠼' ;;
+      5) printf '⠴' ;;
+      6) printf '⠦' ;;
+      7) printf '⠧' ;;
+      8) printf '⠇' ;;
+      *) printf '⠏' ;;
+    esac
+    return
+  fi
+
+  case $((step_count % 4)) in
+    0) printf '-' ;;
+    1) printf '\\' ;;
+    2) printf '|' ;;
+    *) printf '/' ;;
+  esac
+}
+
+draw_progress() {
+  local label="$1"
+  local step_count="$2"
+  local frame
+  local width=24
+  local trail=7
+  local head
+  local bar=""
+  local i=0
+
+  frame="$(progress_frame "$step_count")"
+  head=$((step_count % (width + trail)))
+
+  while [ "$i" -lt "$width" ]; do
+    local age=$((head - i))
+    if [ "$age" -ge 0 ] && [ "$age" -lt "$trail" ]; then
+      if terminal_supports_unicode; then
+        bar="${bar}${COLOR_GREEN:-}█${COLOR_RESET:-}"
+      else
+        bar="${bar}#"
+      fi
+    else
+      if terminal_supports_unicode; then
+        bar="${bar}${COLOR_CYAN:-}░${COLOR_RESET:-}"
+      else
+        bar="${bar}-"
+      fi
+    fi
+    i=$((i + 1))
+  done
+
+  printf '\r\033[K  %s%s%s %s %s%s%s' \
+    "${COLOR_YELLOW:-}" "$frame" "${COLOR_RESET:-}" \
+    "$bar" "${COLOR_BOLD:-}" "$label" "${COLOR_RESET:-}"
+}
+
+animate_progress() {
+  local label="$1"
+  local step_count=0
+
+  while :; do
+    draw_progress "$label" "$step_count"
+    step_count=$((step_count + 1))
+    sleep 0.08
+  done
+}
+
+finish_progress() {
+  local progress_pid="${1:-}"
+
+  if [ -n "$progress_pid" ]; then
+    kill "$progress_pid" 2>/dev/null || true
+    wait "$progress_pid" 2>/dev/null || true
+  fi
+  printf '\r\033[K\033[?25h'
+}
+
+run_with_progress() {
+  local label="$1"
+  shift
+
+  if ! is_interactive_terminal; then
+    step "$label"
+    "$@"
+    return
+  fi
+
+  local log_file
+  local command_pid
+  local status
+  log_file="$(mktemp "${TMPDIR:-/tmp}/opensre-install-progress.XXXXXX")"
+
+  "$@" >"$log_file" 2>&1 &
+  command_pid=$!
+
+  printf '\033[?25l'
+  animate_progress "$label" &
+  PROGRESS_PID=$!
+  trap 'kill "$command_pid" 2>/dev/null || true; finish_progress "$PROGRESS_PID"; rm -f "$log_file"; exit 130' INT TERM
+
+  if wait "$command_pid"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  finish_progress "$PROGRESS_PID"
+  PROGRESS_PID=""
+  trap - INT TERM
+
+  if [ "$status" -ne 0 ]; then
+    printf '%sError:%s %s failed.%s\n' "${COLOR_RED:-}" "${COLOR_RESET:-}" "$label" "${COLOR_RESET:-}" >&2
+    cat "$log_file" >&2
+    rm -f "$log_file"
+    return "$status"
+  fi
+
+  rm -f "$log_file"
+  printf '  %s%s%s %s\n' "${COLOR_GREEN:-}" "${SUCCESS_MARK:-ok}" "${COLOR_RESET:-}" "$label"
+}
+
+capture_with_progress() {
+  local __result_var="$1"
+  local label="$2"
+  shift 2
+
+  if ! is_interactive_terminal; then
+    step "$label"
+    local captured
+    local status
+    if captured="$("$@")"; then
+      printf -v "$__result_var" '%s' "$captured"
+      return
+    else
+      status=$?
+    fi
+
+    if [ -n "$captured" ]; then
+      printf '%s\n' "$captured" >&2
+    fi
+    return "$status"
+  fi
+
+  local stdout_file
+  local stderr_file
+  local command_pid
+  local status
+  stdout_file="$(mktemp "${TMPDIR:-/tmp}/opensre-install-stdout.XXXXXX")"
+  stderr_file="$(mktemp "${TMPDIR:-/tmp}/opensre-install-stderr.XXXXXX")"
+
+  "$@" >"$stdout_file" 2>"$stderr_file" &
+  command_pid=$!
+
+  printf '\033[?25l'
+  animate_progress "$label" &
+  PROGRESS_PID=$!
+  trap 'kill "$command_pid" 2>/dev/null || true; finish_progress "$PROGRESS_PID"; rm -f "$stdout_file" "$stderr_file"; exit 130' INT TERM
+
+  if wait "$command_pid"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  finish_progress "$PROGRESS_PID"
+  PROGRESS_PID=""
+  trap - INT TERM
+
+  if [ "$status" -ne 0 ]; then
+    printf '%sError:%s %s failed.%s\n' "${COLOR_RED:-}" "${COLOR_RESET:-}" "$label" "${COLOR_RESET:-}" >&2
+    cat "$stdout_file" >&2
+    cat "$stderr_file" >&2
+    rm -f "$stdout_file" "$stderr_file"
+    return "$status"
+  fi
+
+  printf -v "$__result_var" '%s' "$(cat "$stdout_file")"
+  rm -f "$stdout_file" "$stderr_file"
+  printf '  %s%s%s %s\n' "${COLOR_GREEN:-}" "${SUCCESS_MARK:-ok}" "${COLOR_RESET:-}" "$label"
+}
+
+print_installer_header() {
+  if ! is_interactive_terminal; then
+    return
+  fi
+
+  log "${COLOR_BOLD:-}${COLOR_CYAN:-}OpenSRE Installer${COLOR_RESET:-}"
+  log "${COLOR_BOLD:-}Installing the OpenSRE CLI${COLOR_RESET:-}"
+  log ""
 }
 
 usage() {
@@ -440,6 +672,51 @@ install_binary() {
   run_with_privilege chmod 0755 "$destination_path" 2>/dev/null || true
 }
 
+prepare_privileged_install() {
+  if [ "$INSTALL_WITH_SUDO" -ne 1 ]; then
+    return
+  fi
+
+  log "Installing into ${INSTALL_DIR} with sudo so '${BIN_NAME}' is available immediately in this shell."
+  if is_interactive_terminal; then
+    sudo -v || die "Could not authorize sudo for install into '${INSTALL_DIR}'."
+  fi
+}
+
+install_verified_binary() {
+  local source_path="$1"
+  local destination_path="$2"
+
+  run_with_privilege mkdir -p "$INSTALL_DIR"
+  install_binary "$source_path" "$destination_path"
+}
+
+download_and_verify_checksum() {
+  local checksum_url="$1"
+  local checksum_path="$2"
+  local archive_path="$3"
+
+  download_to "$checksum_url" "$checksum_path"
+  verify_checksum "$checksum_path" "$archive_path"
+}
+
+extract_and_verify_binary() {
+  local archive_path="$1"
+  local extraction_dir="$2"
+  local extracted_binary_path
+  local extracted_version
+
+  extract_archive "$archive_path" "$extraction_dir"
+  extracted_binary_path="$(get_binary_path_from_archive "$extraction_dir" "$BIN_NAME")"
+  if [ "$INSTALL_CHANNEL" = "main" ]; then
+    extracted_version="$(verify_binary_version "$extracted_binary_path")"
+  else
+    extracted_version="$(verify_binary_version "$extracted_binary_path" "$version")"
+  fi
+
+  printf '%s\n%s\n' "$extracted_binary_path" "$extracted_version"
+}
+
 get_binary_path_from_archive() {
   local extraction_root="$1"
   local binary_name="$2"
@@ -638,18 +915,20 @@ esac
 
 resolve_install_dir
 
+print_installer_header
+
 version="$requested_version"
 release_tag=""
 
 if [ "$INSTALL_CHANNEL" = "main" ]; then
-  step "[1/4] Fetching latest main build metadata..."
+  metadata_step="[1/6] Fetching latest main build metadata"
 elif [ -n "$version" ]; then
-  step "[1/4] Fetching release metadata for v${version}..."
+  metadata_step="[1/6] Fetching release metadata for v${version}"
 else
-  step "[1/4] Fetching latest release version..."
+  metadata_step="[1/6] Fetching latest release version"
 fi
 
-release_json="$(fetch_release_json "$version")" || {
+capture_with_progress release_json "$metadata_step" fetch_release_json "$version" || {
   if [ "$INSTALL_CHANNEL" = "main" ]; then
     die "Failed to query main build metadata from GitHub."
   fi
@@ -698,15 +977,16 @@ checksum_asset="${archive}.sha256"
 checksum_url="${download_url}.sha256"
 
 if [ "$INSTALL_CHANNEL" = "main" ]; then
-  step "[2/4] Preparing opensre main build (${platform}/${target_arch})..."
+  step "[2/6] Preparing opensre main build (${platform}/${target_arch})"
 else
-  step "[2/4] Preparing opensre v${version} (${platform}/${target_arch})..."
+  step "[2/6] Preparing opensre v${version} (${platform}/${target_arch})"
 fi
 if [ "$asset_arch" != "$target_arch" ]; then
   log "Using release asset built for ${platform}/${asset_arch}."
 fi
-step "[3/4] Downloading release archive..."
-log "  ${download_url}"
+if install_verbose; then
+  log "  ${download_url}"
+fi
 
 need_cmd mktemp
 tmp_dir="$(mktemp -d)"
@@ -720,12 +1000,14 @@ cleanup() {
 trap cleanup EXIT
 
 archive_path="${tmp_dir}/${archive}"
-download_to "$download_url" "$archive_path" || die "Failed to download '${archive}'."
+run_with_progress "[3/6] Downloading release archive (${archive})" download_to "$download_url" "$archive_path" \
+  || die "Failed to download '${archive}'."
 
 if release_has_asset "$release_json" "$checksum_asset"; then
   checksum_path="${tmp_dir}/${checksum_asset}"
-  download_to "$checksum_url" "$checksum_path" || die "Failed to download checksum '${checksum_asset}'."
-  verify_checksum "$checksum_path" "$archive_path"
+  run_with_progress "[4/6] Downloading and verifying checksum (${checksum_asset})" \
+    download_and_verify_checksum "$checksum_url" "$checksum_path" "$archive_path" \
+    || die "Failed to download or verify checksum '${checksum_asset}'."
 else
   if [ "$INSTALL_CHANNEL" = "main" ]; then
     warn "Main build release is missing checksum asset '${checksum_asset}'."
@@ -734,21 +1016,12 @@ else
   fi
 fi
 
-if [ "$INSTALL_WITH_SUDO" -eq 1 ]; then
-  log "Installing into ${INSTALL_DIR} with sudo so '${BIN_NAME}' is available immediately in this shell."
-fi
+prepare_privileged_install
 
-step "[4/4] Installing binary..."
-run_with_privilege mkdir -p "$INSTALL_DIR"
-extract_archive "$archive_path" "$tmp_dir"
-
-binary_path="$(get_binary_path_from_archive "$tmp_dir" "$BIN_NAME")"
-if [ "$INSTALL_CHANNEL" = "main" ]; then
-  installed_version="$(verify_binary_version "$binary_path")"
-else
-  installed_version="$(verify_binary_version "$binary_path" "$version")"
-fi
-install_binary "$binary_path" "${INSTALL_DIR}/${BIN_NAME}"
+capture_with_progress verified_binary "[5/6] Extracting and verifying binary" extract_and_verify_binary "$archive_path" "$tmp_dir"
+binary_path="${verified_binary%%$'\n'*}"
+installed_version="${verified_binary#*$'\n'}"
+run_with_progress "[6/6] Installing ${BIN_NAME} to ${INSTALL_DIR}" install_verified_binary "$binary_path" "${INSTALL_DIR}/${BIN_NAME}"
 
 if [ "$INSTALL_CHANNEL" = "main" ]; then
   if [ "$installed_version" = "main" ]; then

--- a/tests/cli/test_install_ps1_progress.py
+++ b/tests/cli/test_install_ps1_progress.py
@@ -1,0 +1,90 @@
+"""Contracts for the PowerShell installer progress helpers."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+INSTALL_PS1 = Path(__file__).parents[2] / "install.ps1"
+
+
+def _powershell() -> str | None:
+    return shutil.which("pwsh") or shutil.which("powershell")
+
+
+def test_install_ps1_defines_branded_progress_helpers() -> None:
+    source = INSTALL_PS1.read_text()
+
+    for helper in (
+        "function Write-OpenSreHeader",
+        "function Test-OpenSreInteractiveHost",
+        "function Invoke-OpenSreStep",
+        "function Invoke-OpenSreDownloadFileWithProgress",
+    ):
+        assert helper in source
+
+    assert "OPENSRE_INSTALL_VERBOSE" in source
+    assert '$ProgressPreference = "SilentlyContinue"' in source
+    assert "$ProgressPreference = $previousProgressPreference" in source
+
+
+def test_install_ps1_avoids_ps7_only_syntax_and_write_progress() -> None:
+    source = INSTALL_PS1.read_text()
+
+    forbidden_snippets = (
+        "$PSStyle",
+        "??",
+        "Join-String",
+        "-SkipHttpErrorCheck",
+        "Write-Progress",
+    )
+    for snippet in forbidden_snippets:
+        assert snippet not in source
+
+
+def test_install_ps1_preserves_retry_contract_source() -> None:
+    source = INSTALL_PS1.read_text()
+
+    assert 'Write-Warning "Attempt $attempt to $Description failed' in source
+    assert "after $attempt attempts" in source
+    assert "$statusCode -ge 400 -and $statusCode -lt 500" in source
+
+
+def test_install_ps1_keeps_download_urls_verbose_only() -> None:
+    source = INSTALL_PS1.read_text()
+
+    assert 'Write-OpenSreDetail -Message "Download URL: $Uri"' in source
+    assert 'Write-OpenSreDetail -Message "Destination: $OutFile"' in source
+    assert "-Detail $downloadUrl" not in source
+    assert "-Detail $checksumUrl" not in source
+
+
+def test_install_ps1_dot_sources_when_powershell_available() -> None:
+    shell = _powershell()
+    if shell is None:
+        pytest.skip("PowerShell is not installed in this environment.")
+
+    script = textwrap.dedent(
+        f"""
+        . '{INSTALL_PS1}' -SkipMain
+        Write-OpenSreHeader -Channel release -RequestedVersion '' -InstallDir 'C:\\opensre' -Repo 'Tracer-Cloud/opensre'
+        Invoke-OpenSreStep -Name 'Unit progress step' -Operation {{ 'result-value' }}
+        """
+    )
+
+    result = subprocess.run(
+        [shell, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    output = result.stdout + result.stderr
+    assert "OpenSRE installer" in output
+    assert "Unit progress step" in output
+    assert "OK Unit progress step" in output
+    assert "result-value" in output

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -100,6 +100,7 @@ def _run_release_metadata_step(
         INSTALL_CHANNEL="{install_channel}"
         version="{version}"
         {block}
+        printf '%s\\n' "$metadata_step"
     """)
     return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
 
@@ -153,7 +154,106 @@ def test_install_sh_has_step_for_explicit_version_fetch() -> None:
     result = _run_release_metadata_step(version="2026.4.29")
 
     assert result.returncode == 0, result.stderr
-    assert "[1/4] Fetching release metadata for v2026.4.29..." in result.stdout
+    assert "[1/6] Fetching release metadata for v2026.4.29" in result.stdout
+
+
+def test_install_sh_defines_progress_helpers() -> None:
+    source = INSTALL_SH.read_text()
+
+    for helper in (
+        "is_interactive_terminal()",
+        "terminal_supports_unicode()",
+        "progress_frame()",
+        "draw_progress()",
+        "finish_progress()",
+        "run_with_progress()",
+        "capture_with_progress()",
+    ):
+        assert helper in source
+
+    assert "OPENSRE_INSTALL_VERBOSE" in source
+    assert "\\033[?25h" in source
+    assert 'trap \'kill "$command_pid"' in source
+
+
+def test_install_sh_progress_plain_when_not_tty() -> None:
+    result = _run_logging_snippet(
+        """
+        run_with_progress "Plain progress step" bash -c 'printf "work complete\\\\n"'
+        """
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 0, result.stderr
+    assert "Plain progress step" in output
+    assert "work complete" in output
+    assert "\x1b[" not in output
+    assert "\r" not in output
+
+
+def test_install_sh_capture_with_progress_keeps_stdout_value_clean() -> None:
+    result = _run_logging_snippet(
+        """
+        is_interactive_terminal() { return 0; }
+        terminal_supports_unicode() { return 1; }
+        capture_with_progress captured_value "Capture value" bash -c 'printf "release-json"'
+        printf '\\nRESULT:%s\\n' "$captured_value"
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "RESULT:release-json" in result.stdout
+    assert "RESULT:Capture value" not in result.stdout
+
+
+def test_install_sh_capture_with_progress_preserves_failure_status_and_logs() -> None:
+    result = _run_logging_snippet(
+        """
+        if capture_with_progress captured_value "Failing capture step" bash -c 'echo hidden-out; echo hidden-err >&2; exit 7'; then
+            exit 99
+        else
+            progress_status=$?
+        fi
+        exit "$progress_status"
+        """
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 7
+    assert "Failing capture step" in output
+    assert "hidden-out" in output
+    assert "hidden-err" in output
+
+
+def test_install_sh_run_with_progress_prints_captured_logs_on_failure() -> None:
+    result = _run_logging_snippet(
+        """
+        is_interactive_terminal() { return 0; }
+        terminal_supports_unicode() { return 1; }
+        if run_with_progress "Failing progress step" bash -c 'echo hidden-out; echo hidden-err >&2; exit 7'; then
+            exit 99
+        else
+            progress_status=$?
+        fi
+        exit "$progress_status"
+        """
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 7
+    assert "Failing progress step failed" in output
+    assert "hidden-out" in output
+    assert "hidden-err" in output
+
+
+def test_install_sh_uses_six_step_extract_verify_install_labels() -> None:
+    source = INSTALL_SH.read_text()
+
+    assert "[4/6] Downloading and verifying checksum" in source
+    assert "[5/6] Extracting and verifying binary" in source
+    assert "[6/6] Installing ${BIN_NAME} to ${INSTALL_DIR}" in source
+    assert "[6/6] Extracting release archive" not in source
+    assert 'capture_with_progress installed_version "Verifying installed binary"' not in source
 
 
 def test_zsh_writes_export_to_zshrc(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add branded, TTY-aware progress helpers to the Bash installer with hidden logs, safe stdout capture, verbose mode, and cursor cleanup traps
- add Windows-compatible PowerShell installer step/download progress helpers without `Write-Progress` or PS7-only syntax
- add installer contracts for non-TTY cleanliness, captured-value purity, failure log replay, PowerShell compatibility, retry behavior, and Pi-aligned quiet output

## Impact
Interactive installs now show a polished OpenSRE progress surface for slow operations while preserving plain logs for CI, pipes, redirected output, and verbose installs. Failure paths replay the captured command output so debugging still has the real cause.

## Validation
- `bash -n install.sh`
- `git diff --check`
- `uv run python -m pytest tests/cli/test_install_sh_path.py tests/cli/test_install_sh_resolution.py tests/cli/test_install_ps1_progress.py` (`37 passed, 1 skipped`)
- `make lint`
- `make format-check`
- `make typecheck`
- `make test-scope` (`9783 passed, 53 skipped`)

PowerShell runtime coverage skipped locally because no `pwsh` or `powershell` executable is installed in this environment; static compatibility contracts ran.