### PR TITLE
[codex] Fix CodeQL LLM import cycles

### DIFF
--- a/core/llm/llm_client.py
+++ b/core/llm/llm_client.py
@@ -58,9 +58,18 @@ from config.config import (
 from config.llm_reasoning_effort import get_active_reasoning_effort
 from core.domain.types.root_cause_categories import VALID_ROOT_CAUSE_CATEGORIES
 from core.llm.llm_retry import extract_retry_after_seconds
+from core.llm.structured_output import (
+    StructuredOutputClient,
+    extract_json_payload,
+    safe_json_loads,
+)
+from core.llm.types import LLMResponse
 from core.provider import resolve_llm_api_key
 
 logger = logging.getLogger(__name__)
+
+_safe_json_loads = safe_json_loads
+_extract_json_payload = extract_json_payload
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Data Types
@@ -188,13 +197,6 @@ class RootCauseResult:
     non_validated_claims: list[str]
     causal_chain: list[str]
     remediation_steps: list[str]
-
-
-@dataclass(frozen=True)
-class LLMResponse:
-    content: str
-    input_tokens: int | None = None
-    output_tokens: int | None = None
 
 
 class LLMClient:
@@ -1090,33 +1092,6 @@ class OpenAILLMClient:
                 backoff_seconds *= 2
 
 
-class StructuredOutputClient:
-    """Wraps any LLM client with `.invoke` (API or CLI subprocess) for Pydantic JSON parsing."""
-
-    def __init__(self, base: Any, model: type[BaseModel]) -> None:
-        self._base = base
-        self._model = model
-
-    def with_config(self, **_kwargs) -> StructuredOutputClient:
-        return self
-
-    def invoke(self, prompt: str) -> Any:
-        schema = self._model.model_json_schema()
-        schema_json = json.dumps(schema, indent=2)
-        wrapped_prompt = (
-            f"{prompt}\n\nReturn ONLY valid JSON that matches this schema:\n{schema_json}\n"
-        )
-        response = self._base.invoke(wrapped_prompt)
-        payload = _extract_json_payload(response.content)
-        try:
-            return self._model.model_validate(payload)
-        except ValidationError:
-            if isinstance(payload, list) and "actions" in self._model.model_fields:
-                fallback = {"actions": payload, "rationale": "LLM returned actions only."}
-                return self._model.model_validate(fallback)
-            raise
-
-
 class SupportsLLMInvoke(Protocol):
     def with_config(self, **_kwargs: Any) -> SupportsLLMInvoke:
         pass
@@ -1176,51 +1151,6 @@ def _extract_text(response: Any) -> str:
             parts.append(block.text)
     text = "".join(parts).strip()
     return text or str(response)
-
-
-def _safe_json_loads(payload: str) -> Any:
-    try:
-        return json.loads(payload)
-    except json.JSONDecodeError:
-        return json.loads(payload, strict=False)
-
-
-def _extract_json_payload(text: str) -> Any:
-    cleaned = text.strip()
-    if cleaned.startswith("```"):
-        cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
-        cleaned = re.sub(r"\s*```$", "", cleaned)
-        cleaned = cleaned.strip()
-    else:
-        # LLM may prefix the code block with prose ("Here is the JSON:")
-        fence_match = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", cleaned)
-        if fence_match:
-            candidate = fence_match.group(1).strip()
-            try:
-                return _safe_json_loads(candidate)
-            except json.JSONDecodeError:
-                pass
-
-    try:
-        return _safe_json_loads(cleaned)
-    except json.JSONDecodeError:
-        logger.debug("Direct JSON parse failed, trying regex extraction")
-
-    obj_match = re.search(r"\{.*\}", cleaned, re.DOTALL)
-    if obj_match:
-        try:
-            return _safe_json_loads(obj_match.group(0))
-        except json.JSONDecodeError:
-            logger.debug("Object regex JSON parse failed, trying array extraction")
-
-    list_match = re.search(r"\[.*\]", cleaned, re.DOTALL)
-    if list_match:
-        try:
-            return _safe_json_loads(list_match.group(0))
-        except json.JSONDecodeError:
-            logger.debug("Array regex JSON parse also failed")
-
-    raise ValueError("LLM did not return valid JSON payload")
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/core/llm/structured_output.py
+++ b/core/llm/structured_output.py
@@ -1,0 +1,83 @@
+"""Structured-output wrapper shared by hosted and CLI-backed LLM clients."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+class StructuredOutputClient:
+    """Wrap any LLM client with ``invoke`` for Pydantic JSON parsing."""
+
+    def __init__(self, base: Any, model: type[BaseModel]) -> None:
+        self._base = base
+        self._model = model
+
+    def with_config(self, **_kwargs: Any) -> StructuredOutputClient:
+        return self
+
+    def invoke(self, prompt: str) -> Any:
+        schema = self._model.model_json_schema()
+        schema_json = json.dumps(schema, indent=2)
+        wrapped_prompt = (
+            f"{prompt}\n\nReturn ONLY valid JSON that matches this schema:\n{schema_json}\n"
+        )
+        response = self._base.invoke(wrapped_prompt)
+        payload = extract_json_payload(response.content)
+        try:
+            return self._model.model_validate(payload)
+        except ValidationError:
+            if isinstance(payload, list) and "actions" in self._model.model_fields:
+                fallback = {"actions": payload, "rationale": "LLM returned actions only."}
+                return self._model.model_validate(fallback)
+            raise
+
+
+def safe_json_loads(payload: str) -> Any:
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
+        return json.loads(payload, strict=False)
+
+
+def extract_json_payload(text: str) -> Any:
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
+        cleaned = re.sub(r"\s*```$", "", cleaned)
+        cleaned = cleaned.strip()
+    else:
+        fence_match = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", cleaned)
+        if fence_match:
+            candidate = fence_match.group(1).strip()
+            try:
+                return safe_json_loads(candidate)
+            except json.JSONDecodeError:
+                pass
+
+    try:
+        return safe_json_loads(cleaned)
+    except json.JSONDecodeError:
+        logger.debug("Direct JSON parse failed, trying regex extraction")
+
+    obj_match = re.search(r"\{.*\}", cleaned, re.DOTALL)
+    if obj_match:
+        try:
+            return safe_json_loads(obj_match.group(0))
+        except json.JSONDecodeError:
+            logger.debug("Object regex JSON parse failed, trying array extraction")
+
+    list_match = re.search(r"\[.*\]", cleaned, re.DOTALL)
+    if list_match:
+        try:
+            return safe_json_loads(list_match.group(0))
+        except json.JSONDecodeError:
+            logger.debug("Array regex JSON parse also failed")
+
+    raise ValueError("LLM did not return valid JSON payload")

--- a/core/llm/types.py
+++ b/core/llm/types.py
@@ -6,6 +6,13 @@ from dataclasses import dataclass, field
 from typing import Any
 
 
+@dataclass(frozen=True)
+class LLMResponse:
+    content: str
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
+
 @dataclass
 class ToolCall:
     """A single tool invocation requested by the LLM."""
@@ -35,4 +42,4 @@ class AgentLLMResponse:
         return bool(self.tool_calls)
 
 
-__all__ = ["AgentLLMResponse", "ToolCall"]
+__all__ = ["AgentLLMResponse", "LLMResponse", "ToolCall"]

--- a/integrations/llm_cli/runner.py
+++ b/integrations/llm_cli/runner.py
@@ -13,7 +13,8 @@ from typing import Any
 from pydantic import BaseModel
 
 from config.llm_reasoning_effort import get_active_reasoning_effort
-from core.llm.llm_client import LLMResponse
+from core.llm.structured_output import StructuredOutputClient
+from core.llm.types import LLMResponse
 from integrations.llm_cli.base import CLIProbe, LLMCLIAdapter
 from integrations.llm_cli.constants import (
     EX_TEMPFAIL as _EX_TEMPFAIL,
@@ -110,8 +111,6 @@ class CLIBackedLLMClient:
 
     def with_structured_output(self, model: type[BaseModel]) -> Any:
         """JSON-schema prompt + parse; same contract as API `StructuredOutputClient`."""
-        from core.llm.llm_client import StructuredOutputClient
-
         return StructuredOutputClient(self, model)
 
     def bind_tools(self, _tools: list[Any]) -> CLIBackedLLMClient:

--- a/tests/test_llm_credentials.py
+++ b/tests/test_llm_credentials.py
@@ -21,6 +21,10 @@ def _security_tool_path(name: str) -> str:
     return f"/usr/bin/{name}"
 
 
+def _darwin_platform() -> str:
+    return "Darwin"
+
+
 def test_resolve_env_credential_prefers_env_over_keyring(monkeypatch) -> None:
     monkeypatch.setenv("GITLAB_ACCESS_TOKEN", "from-env")
     monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
@@ -56,9 +60,9 @@ def test_managed_llm_api_key_source_uses_metadata_without_reading_secret(
     monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setenv("OPENSRE_LLM_AUTH_METADATA_PATH", str(tmp_path / "llm-auth.json"))
-    monkeypatch.setattr(llm_credentials.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(llm_credentials.platform, "system", _darwin_platform)
     monkeypatch.setattr(llm_credentials.shutil, "which", _security_tool_path)
-    monkeypatch.setattr(llm_credentials.keyring, "get_keyring", lambda: _MacOSKeyringBackend())
+    monkeypatch.setattr(llm_credentials.keyring, "get_keyring", _MacOSKeyringBackend)
 
     def _run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         assert command == [
@@ -96,9 +100,9 @@ def test_managed_missing_metadata_reports_none_without_reading_secret(
     monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setenv("OPENSRE_LLM_AUTH_METADATA_PATH", str(tmp_path / "llm-auth.json"))
-    monkeypatch.setattr(llm_credentials.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(llm_credentials.platform, "system", _darwin_platform)
     monkeypatch.setattr(llm_credentials.shutil, "which", _security_tool_path)
-    monkeypatch.setattr(llm_credentials.keyring, "get_keyring", lambda: _MacOSKeyringBackend())
+    monkeypatch.setattr(llm_credentials.keyring, "get_keyring", _MacOSKeyringBackend)
 
     def _run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(command, 44)


### PR DESCRIPTION
## Summary

- Move shared LLM response/structured-output helpers out of hosted-client modules so CLI-backed LLM execution no longer imports `core.llm.llm_client`.
- Keep `LLMResponse`, `ToolCall`, and `AgentLLMResponse` in neutral `core.llm.types` and use `core.llm.structured_output` from both hosted and CLI clients.
- Replace simple lambda wrappers in credential tests with named/direct callables to clear CodeQL `py/unnecessary-lambda` alerts.

## Why

GitHub security/code scanning was flagging open CodeQL import-cycle and unnecessary-lambda alerts around the LLM runtime and credential tests. The dependency direction is now explicit: subprocess CLI integration code depends only on neutral LLM DTOs and structured-output helpers, not the hosted provider router.

## Validation

- `uv run ruff check core/llm/llm_client.py core/llm/types.py core/llm/structured_output.py integrations/llm_cli/runner.py tests/test_llm_credentials.py`
- `uv run pytest tests/test_llm_credentials.py tests/core/runtime/llm/test_llm_client.py::test_extract_json_payload_bare_json tests/core/runtime/llm/test_llm_client.py::test_extract_json_payload_leading_fence tests/core/runtime/llm/test_llm_client.py::test_extract_json_payload_embedded_fence_with_preamble tests/core/runtime/llm/test_llm_client.py::test_extract_json_payload_embedded_fence_trailing_braces_in_prose tests/core/runtime/llm/test_llm_client.py::test_extract_json_payload_raises_when_no_json tests/integrations/llm_cli/test_runner.py`
- `uv run python - <<'PY' ... import smoke ... PY`
- `make format-check`
- `uv run python infra/ci/check_import_cycles.py core/llm/llm_client.py integrations/llm_cli/runner.py core/llm/types.py core/llm/structured_output.py core/provider.py`
- `make lint`
- `make typecheck`

`make test-scope` was also attempted. Because the script compares against local `main` and this checkout's local `main` is stale, it ran a broad suite; it reported `9796 passed, 54 skipped` and two local environment-sensitive failures in `tests/cli/test_doctor.py::test_check_llm_provider_not_set` and `tests/test_config.py::test_resolve_llm_settings_does_not_fall_back_to_openai_when_default_anthropic_key_missing`, both showing local provider metadata resolving to `openai`.
