### PR TITLE
Fix CodeQL import cycles and add wizard CLI browser login

### DIFF
--- a/cli/wizard/_ui.py
+++ b/cli/wizard/_ui.py
@@ -17,9 +17,9 @@ from cli.wizard.integration_health import IntegrationHealthResult
 from cli.wizard.probes import ProbeResult
 from cli.wizard.prompts import select as select_prompt
 from cli.wizard.store import get_store_path, load_local_config
-from config.llm_auth.credentials import save_api_key
+from config.llm_auth.credentials import has_llm_api_key, save_api_key
 from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
-from config.llm_credentials import get_keyring_setup_instructions, has_llm_api_key, save_llm_api_key
+from config.llm_credentials import get_keyring_setup_instructions, save_llm_api_key
 from config.version import get_version
 from integrations.store import get_integration
 from platform.terminal.theme import (

--- a/cli/wizard/env_sync.py
+++ b/cli/wizard/env_sync.py
@@ -10,9 +10,9 @@ from pathlib import Path
 
 from cli.wizard.config import PROJECT_ENV_PATH, ProviderOption
 from config.llm_auth.credentials import delete as delete_provider_auth
-from config.llm_auth.credentials import save_api_key
+from config.llm_auth.credentials import has_llm_api_key, save_api_key
 from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
-from config.llm_credentials import delete_llm_api_key, has_llm_api_key, save_llm_api_key
+from config.llm_credentials import delete_llm_api_key, save_llm_api_key
 
 _ENV_ASSIGNMENT = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=")
 _NON_SECRET_ENV_KEYS: frozenset[str] = frozenset({"DISCORD_PUBLIC_KEY"})

--- a/cli/wizard/flow.py
+++ b/cli/wizard/flow.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import shlex
+import subprocess
 import sys
 from typing import Literal
 
@@ -45,6 +47,10 @@ from platform.terminal.theme import (
 DEFAULT_GITHUB_MCP_MODE = _integration_configurators_module.DEFAULT_GITHUB_MCP_MODE
 DEFAULT_GITHUB_MCP_URL = _integration_configurators_module.DEFAULT_GITHUB_MCP_URL
 WIZARD_TOTAL_STEPS = 4
+_CLI_SUBSCRIPTION_LOGIN_ARGS: dict[str, tuple[str, ...]] = {
+    "claude-code": ("auth", "login"),
+    "codex": ("login",),
+}
 
 __all__ = [
     "DEFAULT_GITHUB_MCP_MODE",
@@ -84,6 +90,46 @@ def _credential_prompt_label(provider: ProviderOption) -> str:
     return provider.label
 
 
+def _subscription_login_command(
+    provider: ProviderOption, binary_path: str | None
+) -> list[str] | None:
+    """Return the vendor CLI login command for subscription-backed LLM providers."""
+    if not binary_path:
+        return None
+    args = _CLI_SUBSCRIPTION_LOGIN_ARGS.get(provider.value)
+    if args is None:
+        return None
+    return [binary_path, *args]
+
+
+def _run_subscription_login(provider: ProviderOption, binary_path: str | None) -> bool:
+    """Launch the provider CLI login flow and report whether it exited cleanly."""
+    command = _subscription_login_command(provider, binary_path)
+    if command is None:
+        auth_hint = provider.adapter_factory().auth_hint if provider.adapter_factory else ""
+        _console.print(
+            f"[{WARNING}]  {GLYPH_WARNING}  No browser login command is registered for "
+            f"{provider.label}. {auth_hint}[/]"
+        )
+        return False
+
+    _console.print(f"[{SECONDARY}]Launching {shlex.join(command)} for browser login…[/]")
+    try:
+        result = subprocess.run(command, check=False)
+    except KeyboardInterrupt:
+        _console.print(f"[{WARNING}]  {GLYPH_WARNING}  Login cancelled.[/]")
+        return False
+    except OSError as exc:
+        _console.print(f"[{WARNING}]  {GLYPH_WARNING}  Could not launch login: {exc}[/]")
+        return False
+    if result.returncode != 0:
+        _console.print(
+            f"[{WARNING}]  {GLYPH_WARNING}  Login exited with code {result.returncode}.[/]"
+        )
+        return False
+    return True
+
+
 def _run_cli_llm_onboarding(provider: ProviderOption) -> Literal["ok", "abort", "repick"]:
     """Probe CLI binary + auth; recovery menu when missing. ``repick`` = choose another LLM."""
     factory = provider.adapter_factory
@@ -109,8 +155,16 @@ def _run_cli_llm_onboarding(provider: ProviderOption) -> Literal["ok", "abort", 
                 if probe.logged_in is False
                 else f"Could not verify {provider.label} login. What next?"
             )
-            action = _choose(
-                status_prompt,
+            choices = []
+            if _subscription_login_command(provider, probe.bin_path) is not None:
+                choices.append(
+                    Choice(
+                        value="login",
+                        label="Open browser login now",
+                        hint=auth_hint,
+                    )
+                )
+            choices.extend(
                 [
                     Choice(
                         value="retry",
@@ -122,11 +176,18 @@ def _run_cli_llm_onboarding(provider: ProviderOption) -> Literal["ok", "abort", 
                         label="Pick a different LLM provider",
                         hint=None,
                     ),
-                ],
-                default="retry",
+                ]
+            )
+            action = _choose(
+                status_prompt,
+                choices,
+                default="login" if choices[0].value == "login" else "retry",
             )
             if action == "repick":
                 return "repick"
+            if action == "login":
+                _run_subscription_login(provider, probe.bin_path)
+                continue
             continue
         _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {probe.detail}[/]")
         action = _choose(

--- a/config/llm_auth/credentials.py
+++ b/config/llm_auth/credentials.py
@@ -244,7 +244,7 @@ def resolve_for_request(provider: str) -> CredentialResolution:
                 detail=f"{spec.api_key_env} resolved from environment.",
             )
 
-        from config.llm_credentials import resolve_llm_api_key
+        from config.llm_keyring import resolve_llm_api_key
 
         key = resolve_llm_api_key(spec.api_key_env)
         if key:
@@ -310,7 +310,7 @@ def resolve_api_key_env_for_request(env_var: str) -> str:
     for provider, provider_env in API_KEY_PROVIDER_ENVS.items():
         if provider_env == normalized:
             return resolve_for_request(provider).api_key
-    from config.llm_credentials import resolve_llm_api_key
+    from config.llm_keyring import resolve_llm_api_key
 
     return resolve_llm_api_key(normalized)
 
@@ -320,7 +320,7 @@ def save_api_key(provider: str, value: str, *, detail: str | None = None) -> Non
     spec = require_provider_spec(provider)
     if not spec.uses_open_sre_api_key:
         raise ValueError(f"{spec.value} does not use an OpenSRE-managed API key")
-    from config.llm_credentials import save_llm_api_key
+    from config.llm_keyring import save_llm_api_key
 
     save_llm_api_key(spec.api_key_env, value)
     save_provider_auth_record(
@@ -339,7 +339,7 @@ def delete(provider: str) -> None:
     """Delete OpenSRE-managed provider auth metadata and API key when applicable."""
     spec = require_provider_spec(provider)
     if spec.uses_open_sre_api_key:
-        from config.llm_credentials import delete_llm_api_key
+        from config.llm_keyring import delete_llm_api_key
 
         delete_llm_api_key(spec.api_key_env)
     delete_provider_auth_record(spec.value)
@@ -377,6 +377,59 @@ def has_api_key_env_status(env_var: str) -> bool:
     return source_for_api_key_env(env_var) != "none"
 
 
+def llm_api_key_source(env_var: str) -> str:
+    """Return where an LLM credential resolves from: ``env``, ``keyring``, or ``none``."""
+    import keyring
+    import keyring.errors
+
+    from config.llm_keyring import (
+        _KEYRING_SERVICE,
+        keyring_is_disabled,
+        macos_keychain_item_exists,
+    )
+
+    prompt_safe_source = source_for_api_key_env(env_var)
+    if prompt_safe_source != "none":
+        return prompt_safe_source
+    if env_var.strip() in set(API_KEY_PROVIDER_ENVS.values()):
+        return "none"
+    if os.getenv(env_var, "").strip():
+        return "env"
+    if keyring_is_disabled():
+        return "none"
+    item_exists = macos_keychain_item_exists(env_var)
+    if item_exists is not None:
+        return "keyring" if item_exists else "none"
+    try:
+        if (keyring.get_password(_KEYRING_SERVICE, env_var) or "").strip():
+            return "keyring"
+    except keyring.errors.KeyringError:
+        return "none"
+    return "none"
+
+
+def has_llm_api_key(env_var: str) -> bool:
+    """Return True when an API key is available from env or secure local storage."""
+    from config.llm_keyring import (
+        keyring_is_disabled,
+        macos_keychain_item_exists,
+        resolve_llm_api_key,
+    )
+
+    if has_api_key_env_status(env_var):
+        return True
+    if env_var.strip() in set(API_KEY_PROVIDER_ENVS.values()):
+        return False
+    if os.getenv(env_var, "").strip():
+        return True
+    if keyring_is_disabled():
+        return False
+    item_exists = macos_keychain_item_exists(env_var)
+    if item_exists is not None:
+        return item_exists
+    return bool(resolve_llm_api_key(env_var))
+
+
 __all__ = [
     "CredentialResolution",
     "CredentialSource",
@@ -384,6 +437,8 @@ __all__ = [
     "MissingLLMCredentialError",
     "delete",
     "has_api_key_env_status",
+    "has_llm_api_key",
+    "llm_api_key_source",
     "require_for_request",
     "resolve_api_key_env_for_request",
     "resolve_for_request",

--- a/config/llm_credentials.py
+++ b/config/llm_credentials.py
@@ -2,63 +2,28 @@
 
 from __future__ import annotations
 
-import json
 import os
-import shutil
-import subprocess
-from collections.abc import Mapping
-from typing import Final
 
-import keyring
-import keyring.errors
+from config.llm_keyring import (
+    delete_llm_api_key,
+    delete_llm_credential_record,
+    get_keyring_setup_instructions,
+    resolve_llm_api_key,
+    resolve_llm_credential_record,
+    save_llm_api_key,
+    save_llm_credential_record,
+)
 
-import platform
-
-_KEYRING_SERVICE: Final = "opensre.llm"
-_RECORD_PREFIX: Final = "record:"
-_DISABLED_VALUES: Final = frozenset({"1", "true", "yes", "on"})
-
-
-def _keyring_is_disabled() -> bool:
-    return os.getenv("OPENSRE_DISABLE_KEYRING", "").strip().lower() in _DISABLED_VALUES
-
-
-def _is_macos_keyring_backend() -> bool:
-    backend = keyring.get_keyring()
-    return backend.__class__.__module__.startswith("keyring.backends.macOS")
-
-
-def _macos_keychain_item_exists(username: str) -> bool | None:
-    """Return whether a macOS Keychain item exists without reading its secret."""
-    if platform.system() != "Darwin":
-        return None
-    if not _is_macos_keyring_backend():
-        return None
-    security_bin = shutil.which("security")
-    if security_bin is None:
-        return None
-    try:
-        result = subprocess.run(
-            [
-                security_bin,
-                "find-generic-password",
-                "-s",
-                _KEYRING_SERVICE,
-                "-a",
-                username,
-            ],
-            check=False,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            timeout=2.0,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode == 0:
-        return True
-    if result.returncode == 44:
-        return False
-    return None
+__all__ = [
+    "delete_llm_api_key",
+    "delete_llm_credential_record",
+    "get_keyring_setup_instructions",
+    "resolve_env_credential",
+    "resolve_llm_api_key",
+    "resolve_llm_credential_record",
+    "save_llm_api_key",
+    "save_llm_credential_record",
+]
 
 
 def resolve_env_credential(env_var: str, *, default: str = "") -> str:
@@ -67,203 +32,3 @@ def resolve_env_credential(env_var: str, *, default: str = "") -> str:
     if env_value:
         return env_value
     return resolve_llm_api_key(env_var)
-
-
-def resolve_llm_api_key(env_var: str) -> str:
-    """Resolve an LLM API key from env first, then the local keychain."""
-    env_value = os.getenv(env_var, "").strip()
-    if env_value:
-        return env_value
-    if _keyring_is_disabled():
-        return ""
-    try:
-        return (keyring.get_password(_KEYRING_SERVICE, env_var) or "").strip()
-    except keyring.errors.KeyringError:
-        return ""
-
-
-def llm_api_key_source(env_var: str) -> str:
-    """Return where an LLM credential resolves from: ``env``, ``keyring``, or ``none``."""
-    from config.llm_auth.credentials import source_for_api_key_env
-    from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
-
-    prompt_safe_source = source_for_api_key_env(env_var)
-    if prompt_safe_source != "none":
-        return prompt_safe_source
-    if env_var.strip() in set(API_KEY_PROVIDER_ENVS.values()):
-        return "none"
-    if os.getenv(env_var, "").strip():
-        return "env"
-    if _keyring_is_disabled():
-        return "none"
-    item_exists = _macos_keychain_item_exists(env_var)
-    if item_exists is not None:
-        return "keyring" if item_exists else "none"
-    try:
-        if (keyring.get_password(_KEYRING_SERVICE, env_var) or "").strip():
-            return "keyring"
-    except keyring.errors.KeyringError:
-        return "none"
-    return "none"
-
-
-def has_llm_api_key(env_var: str) -> bool:
-    """Return True when an API key is available from env or secure local storage."""
-    from config.llm_auth.credentials import has_api_key_env_status
-    from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
-
-    if has_api_key_env_status(env_var):
-        return True
-    if env_var.strip() in set(API_KEY_PROVIDER_ENVS.values()):
-        return False
-    if os.getenv(env_var, "").strip():
-        return True
-    if _keyring_is_disabled():
-        return False
-    item_exists = _macos_keychain_item_exists(env_var)
-    if item_exists is not None:
-        return item_exists
-    return bool(resolve_llm_api_key(env_var))
-
-
-def _keyring_backend_name() -> str:
-    backend = keyring.get_keyring()
-    return f"{backend.__class__.__module__}.{backend.__class__.__name__}"
-
-
-def get_keyring_setup_instructions(env_var: str) -> tuple[str, ...]:
-    """Return platform-specific guidance for fixing secure credential storage."""
-    if _keyring_is_disabled():
-        return (
-            "Secure local credential storage is disabled by OPENSRE_DISABLE_KEYRING.",
-            f"Unset OPENSRE_DISABLE_KEYRING and rerun `opensre onboard` to save {env_var} securely.",
-        )
-
-    backend_name = _keyring_backend_name()
-    if platform.system() == "Linux":
-        lines = [f"Current keyring backend: {backend_name}."]
-        if shutil.which("gnome-keyring-daemon") is None:
-            lines.append("This Ubuntu or EC2 instance is missing the GNOME Keyring daemon.")
-            lines.append(
-                "Install it first: sudo apt update && sudo apt install -y gnome-keyring dbus-user-session"
-            )
-        elif not os.getenv("DBUS_SESSION_BUS_ADDRESS", "").strip():
-            lines.append(
-                "GNOME Keyring is installed, but this shell is not running inside a D-Bus session."
-            )
-        else:
-            lines.append(
-                "This shell has D-Bus available, but the login keyring is still locked or not initialized."
-            )
-
-        lines.extend(
-            [
-                "Start a D-Bus shell: dbus-run-session -- sh",
-                "Inside that shell unlock the keyring: echo '<choose-a-keyring-password>' | gnome-keyring-daemon --unlock",
-                "Then rerun `opensre onboard` in that same shell.",
-                "For deeper diagnostics run `python -m keyring diagnose`.",
-            ]
-        )
-        return tuple(lines)
-
-    return (
-        f"Current keyring backend: {backend_name}.",
-        "Make sure your system keychain service is installed and unlocked, then rerun `opensre onboard`.",
-        "For deeper diagnostics run `python -m keyring diagnose`.",
-    )
-
-
-def save_llm_api_key(env_var: str, value: str) -> None:
-    """Persist an LLM API key in the user's system keychain."""
-    normalized = value.strip()
-    if not normalized:
-        delete_llm_api_key(env_var)
-        return
-    if _keyring_is_disabled():
-        raise RuntimeError("Secure local credential storage is disabled on this machine.")
-    try:
-        keyring.set_password(_KEYRING_SERVICE, env_var, normalized)
-    except keyring.errors.KeyringError as exc:
-        raise RuntimeError(
-            "Secure local credential storage is unavailable on this machine."
-        ) from exc
-
-
-def delete_llm_api_key(env_var: str) -> None:
-    """Remove an LLM API key from the user's system keychain if present."""
-    if _keyring_is_disabled():
-        return
-    try:
-        keyring.delete_password(_KEYRING_SERVICE, env_var)
-    except keyring.errors.KeyringError:
-        return
-
-
-def _record_username(record_name: str) -> str:
-    normalized = record_name.strip()
-    if not normalized:
-        raise ValueError("record_name must not be empty")
-    return f"{_RECORD_PREFIX}{normalized}"
-
-
-def save_llm_credential_record(record_name: str, values: Mapping[str, str]) -> None:
-    """Persist a small JSON credential metadata record in the system keychain.
-
-    These records are for auth metadata such as provider/source/status. API keys
-    still use :func:`save_llm_api_key`; OAuth or vendor CLI tokens must remain
-    in the vendor-owned credential store unless the vendor returns a supported
-    API credential explicitly meant for OpenSRE.
-    """
-    normalized = {
-        str(key).strip(): str(value).strip()
-        for key, value in values.items()
-        if str(key).strip() and str(value).strip()
-    }
-    if not normalized:
-        delete_llm_credential_record(record_name)
-        return
-    if _keyring_is_disabled():
-        raise RuntimeError("Secure local credential storage is disabled on this machine.")
-    try:
-        keyring.set_password(
-            _KEYRING_SERVICE,
-            _record_username(record_name),
-            json.dumps(normalized, sort_keys=True),
-        )
-    except keyring.errors.KeyringError as exc:
-        raise RuntimeError(
-            "Secure local credential storage is unavailable on this machine."
-        ) from exc
-
-
-def resolve_llm_credential_record(record_name: str) -> dict[str, str]:
-    """Resolve a JSON credential metadata record from the local keychain."""
-    if _keyring_is_disabled():
-        return {}
-    try:
-        raw = keyring.get_password(_KEYRING_SERVICE, _record_username(record_name)) or ""
-    except keyring.errors.KeyringError:
-        return {}
-    if not raw.strip():
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
-    if not isinstance(parsed, dict):
-        return {}
-    return {
-        str(key): str(value)
-        for key, value in parsed.items()
-        if isinstance(key, str) and isinstance(value, str)
-    }
-
-
-def delete_llm_credential_record(record_name: str) -> None:
-    """Remove a JSON credential metadata record from the local keychain."""
-    if _keyring_is_disabled():
-        return
-    try:
-        keyring.delete_password(_KEYRING_SERVICE, _record_username(record_name))
-    except (keyring.errors.KeyringError, ValueError):
-        return

--- a/config/llm_keyring.py
+++ b/config/llm_keyring.py
@@ -1,0 +1,211 @@
+"""Low-level keyring storage for LLM credentials and auth metadata."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from collections.abc import Mapping
+from typing import Final
+
+import keyring
+import keyring.errors
+
+import platform
+
+_KEYRING_SERVICE: Final = "opensre.llm"
+RECORD_PREFIX: Final = "record:"
+_DISABLED_VALUES: Final = frozenset({"1", "true", "yes", "on"})
+
+
+def keyring_is_disabled() -> bool:
+    return os.getenv("OPENSRE_DISABLE_KEYRING", "").strip().lower() in _DISABLED_VALUES
+
+
+def _is_macos_keyring_backend() -> bool:
+    backend = keyring.get_keyring()
+    return backend.__class__.__module__.startswith("keyring.backends.macOS")
+
+
+def macos_keychain_item_exists(username: str) -> bool | None:
+    """Return whether a macOS Keychain item exists without reading its secret."""
+    if platform.system() != "Darwin":
+        return None
+    if not _is_macos_keyring_backend():
+        return None
+    security_bin = shutil.which("security")
+    if security_bin is None:
+        return None
+    try:
+        result = subprocess.run(
+            [
+                security_bin,
+                "find-generic-password",
+                "-s",
+                _KEYRING_SERVICE,
+                "-a",
+                username,
+            ],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=2.0,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode == 0:
+        return True
+    if result.returncode == 44:
+        return False
+    return None
+
+
+def resolve_llm_api_key(env_var: str) -> str:
+    """Resolve an LLM API key from env first, then the local keychain."""
+    env_value = os.getenv(env_var, "").strip()
+    if env_value:
+        return env_value
+    if keyring_is_disabled():
+        return ""
+    try:
+        return (keyring.get_password(_KEYRING_SERVICE, env_var) or "").strip()
+    except keyring.errors.KeyringError:
+        return ""
+
+
+def _keyring_backend_name() -> str:
+    backend = keyring.get_keyring()
+    return f"{backend.__class__.__module__}.{backend.__class__.__name__}"
+
+
+def get_keyring_setup_instructions(env_var: str) -> tuple[str, ...]:
+    """Return platform-specific guidance for fixing secure credential storage."""
+    if keyring_is_disabled():
+        return (
+            "Secure local credential storage is disabled by OPENSRE_DISABLE_KEYRING.",
+            f"Unset OPENSRE_DISABLE_KEYRING and rerun `opensre onboard` to save {env_var} securely.",
+        )
+
+    backend_name = _keyring_backend_name()
+    if platform.system() == "Linux":
+        lines = [f"Current keyring backend: {backend_name}."]
+        if shutil.which("gnome-keyring-daemon") is None:
+            lines.append("This Ubuntu or EC2 instance is missing the GNOME Keyring daemon.")
+            lines.append(
+                "Install it first: sudo apt update && sudo apt install -y gnome-keyring dbus-user-session"
+            )
+        elif not os.getenv("DBUS_SESSION_BUS_ADDRESS", "").strip():
+            lines.append(
+                "GNOME Keyring is installed, but this shell is not running inside a D-Bus session."
+            )
+        else:
+            lines.append(
+                "This shell has D-Bus available, but the login keyring is still locked or not initialized."
+            )
+
+        lines.extend(
+            [
+                "Start a D-Bus shell: dbus-run-session -- sh",
+                "Inside that shell unlock the keyring: echo '<choose-a-keyring-password>' | gnome-keyring-daemon --unlock",
+                "Then rerun `opensre onboard` in that same shell.",
+                "For deeper diagnostics run `python -m keyring diagnose`.",
+            ]
+        )
+        return tuple(lines)
+
+    return (
+        f"Current keyring backend: {backend_name}.",
+        "Make sure your system keychain service is installed and unlocked, then rerun `opensre onboard`.",
+        "For deeper diagnostics run `python -m keyring diagnose`.",
+    )
+
+
+def save_llm_api_key(env_var: str, value: str) -> None:
+    """Persist an LLM API key in the user's system keychain."""
+    normalized = value.strip()
+    if not normalized:
+        delete_llm_api_key(env_var)
+        return
+    if keyring_is_disabled():
+        raise RuntimeError("Secure local credential storage is disabled on this machine.")
+    try:
+        keyring.set_password(_KEYRING_SERVICE, env_var, normalized)
+    except keyring.errors.KeyringError as exc:
+        raise RuntimeError(
+            "Secure local credential storage is unavailable on this machine."
+        ) from exc
+
+
+def delete_llm_api_key(env_var: str) -> None:
+    """Remove an LLM API key from the user's system keychain if present."""
+    if keyring_is_disabled():
+        return
+    try:
+        keyring.delete_password(_KEYRING_SERVICE, env_var)
+    except keyring.errors.KeyringError:
+        return
+
+
+def _record_username(record_name: str) -> str:
+    normalized = record_name.strip()
+    if not normalized:
+        raise ValueError("record_name must not be empty")
+    return f"{RECORD_PREFIX}{normalized}"
+
+
+def save_llm_credential_record(record_name: str, values: Mapping[str, str]) -> None:
+    """Persist a small JSON credential metadata record in the system keychain."""
+    normalized = {
+        str(key).strip(): str(value).strip()
+        for key, value in values.items()
+        if str(key).strip() and str(value).strip()
+    }
+    if not normalized:
+        delete_llm_credential_record(record_name)
+        return
+    if keyring_is_disabled():
+        raise RuntimeError("Secure local credential storage is disabled on this machine.")
+    try:
+        keyring.set_password(
+            _KEYRING_SERVICE,
+            _record_username(record_name),
+            json.dumps(normalized, sort_keys=True),
+        )
+    except keyring.errors.KeyringError as exc:
+        raise RuntimeError(
+            "Secure local credential storage is unavailable on this machine."
+        ) from exc
+
+
+def resolve_llm_credential_record(record_name: str) -> dict[str, str]:
+    """Resolve a JSON credential metadata record from the local keychain."""
+    if keyring_is_disabled():
+        return {}
+    try:
+        raw = keyring.get_password(_KEYRING_SERVICE, _record_username(record_name)) or ""
+    except keyring.errors.KeyringError:
+        return {}
+    if not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {
+        str(key): str(value)
+        for key, value in parsed.items()
+        if isinstance(key, str) and isinstance(value, str)
+    }
+
+
+def delete_llm_credential_record(record_name: str) -> None:
+    """Remove a JSON credential metadata record from the local keychain."""
+    if keyring_is_disabled():
+        return
+    try:
+        keyring.delete_password(_KEYRING_SERVICE, _record_username(record_name))
+    except (keyring.errors.KeyringError, ValueError):
+        return

--- a/core/llm/agent_llm_client.py
+++ b/core/llm/agent_llm_client.py
@@ -828,10 +828,10 @@ def get_agent_llm() -> _AgentClientType:
         _agent_client = _create_openai_compat_client(settings, provider)
     elif provider == "bedrock":
         from config.config import BEDROCK_LLM_CONFIG
-        from core.llm.llm_client import _is_anthropic_bedrock_model
+        from core.llm.bedrock_model_ids import is_anthropic_bedrock_model
 
         model = settings.bedrock_reasoning_model
-        if _is_anthropic_bedrock_model(model):
+        if is_anthropic_bedrock_model(model):
             _agent_client = BedrockAgentClient(
                 model=model,
                 max_tokens=BEDROCK_LLM_CONFIG.max_tokens,

--- a/core/llm/bedrock_model_ids.py
+++ b/core/llm/bedrock_model_ids.py
@@ -1,0 +1,27 @@
+"""Bedrock model ID helpers shared by LLM client modules."""
+
+from __future__ import annotations
+
+
+def is_anthropic_bedrock_model(model_id: str) -> bool:
+    """Return True when *model_id* should be routed through the AnthropicBedrock SDK.
+
+    Anthropic model IDs on Bedrock look like:
+      - ``anthropic.claude-*``
+      - ``us.anthropic.claude-*``  (cross-region inference profiles)
+      - ``arn:aws:bedrock:*:foundation-model/anthropic.claude-*``
+      - ``arn:aws:bedrock:*:application-inference-profile/*`` (unknown vendor → Converse)
+
+    For ARN-based application inference profiles we cannot tell the backing
+    foundation model from the ID alone (it may point at Mistral, Llama, etc.).
+    Those ARNs route to the model-agnostic Converse API rather than forcing
+    the Anthropic SDK (which would fail for non-Claude pools).
+    """
+    model_lower = model_id.lower()
+    if "anthropic.claude" in model_lower:
+        return True
+    # Application inference profile ARNs encode no vendor — use converse (all models).
+    if model_lower.startswith("arn:") and "application-inference-profile" in model_lower:
+        return False
+    # Anything else (mistral.*, openai.*, meta.*, etc.) → boto3 converse
+    return False

--- a/core/llm/llm_client.py
+++ b/core/llm/llm_client.py
@@ -57,19 +57,31 @@ from config.config import (
 )
 from config.llm_reasoning_effort import get_active_reasoning_effort
 from core.domain.types.root_cause_categories import VALID_ROOT_CAUSE_CATEGORIES
+from core.llm.bedrock_model_ids import is_anthropic_bedrock_model
 from core.llm.llm_retry import extract_retry_after_seconds
-from core.llm.structured_output import (
-    StructuredOutputClient,
-    extract_json_payload,
-    safe_json_loads,
-)
+from core.llm.structured_output import StructuredOutputClient
 from core.llm.types import LLMResponse
-from core.provider import resolve_llm_api_key
 
 logger = logging.getLogger(__name__)
 
-_safe_json_loads = safe_json_loads
-_extract_json_payload = extract_json_payload
+
+def _resolve_llm_api_key(env_name: str) -> str:
+    from config.llm_auth.credentials import resolve_api_key_env_for_request
+    from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
+
+    resolved = resolve_api_key_env_for_request(env_name)
+    if resolved:
+        return resolved
+    for provider, provider_env in API_KEY_PROVIDER_ENVS.items():
+        if provider_env == env_name:
+            raise RuntimeError(
+                f"Missing credential for LLM provider '{provider}'. Set {env_name} "
+                f"or run `opensre auth login {provider}`."
+            )
+    return resolved
+
+
+resolve_llm_api_key = _resolve_llm_api_key
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Data Types
@@ -369,27 +381,8 @@ class LLMClient:
 
 
 def _is_anthropic_bedrock_model(model_id: str) -> bool:
-    """Return True when *model_id* should be routed through the AnthropicBedrock SDK.
-
-    Anthropic model IDs on Bedrock look like:
-      - ``anthropic.claude-*``
-      - ``us.anthropic.claude-*``  (cross-region inference profiles)
-      - ``arn:aws:bedrock:*:foundation-model/anthropic.claude-*``
-      - ``arn:aws:bedrock:*:application-inference-profile/*`` (unknown vendor → Converse)
-
-    For ARN-based application inference profiles we cannot tell the backing
-    foundation model from the ID alone (it may point at Mistral, Llama, etc.).
-    Those ARNs route to the model-agnostic Converse API rather than forcing
-    the Anthropic SDK (which would fail for non-Claude pools).
-    """
-    model_lower = model_id.lower()
-    if "anthropic.claude" in model_lower:
-        return True
-    # Application inference profile ARNs encode no vendor — use converse (all models).
-    if model_lower.startswith("arn:") and "application-inference-profile" in model_lower:
-        return False
-    # Anything else (mistral.*, openai.*, meta.*, etc.) → boto3 converse
-    return False
+    """Backward-compatible alias for :func:`is_anthropic_bedrock_model`."""
+    return is_anthropic_bedrock_model(model_id)
 
 
 class BedrockLLMClient:

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -49,8 +49,9 @@ opensre onboard
 
 When a provider has more than one supported auth route, onboarding lists the
 auth methods as separate choices. For example, choose **Anthropic API key** for
-`ANTHROPIC_API_KEY` or **Anthropic Claude Code CLI** to reuse a Claude Code
-subscription login.
+`ANTHROPIC_API_KEY` or **Anthropic Claude Code CLI** to use a Claude subscription
+through the Claude Code CLI. If that CLI is installed but not logged in, onboarding
+can launch the vendor browser login and then re-detect the session.
 
 CLI-backed choices delegate browser login, token storage, refresh, and logout to
 the vendor CLI. OpenSRE does not persist those OAuth tokens directly; the
@@ -239,7 +240,7 @@ CLI-backed providers shell out to a vendor CLI instead of an HTTP API. They auth
 
 ```bash
 export LLM_PROVIDER=codex
-# Authenticate the Codex CLI separately:
+# Authenticate through onboarding, `/login chatgpt`, or the Codex CLI directly:
 codex login
 # Optional overrides (all blank-by-default):
 export CODEX_MODEL=
@@ -247,21 +248,23 @@ export CODEX_BIN=
 ```
 
 Requires the [OpenAI Codex CLI](https://github.com/openai/codex). If `CODEX_MODEL` is unset, OpenSRE omits `-m` so `codex exec` uses the CLI's currently configured model. If `CODEX_BIN` is unset, the binary is resolved via `PATH` and known install locations.
-Run `opensre auth login chatgpt` to detect the Codex CLI login and persist `LLM_PROVIDER=codex`.
+Run `opensre onboard`, `/login chatgpt`, or `opensre auth login chatgpt` to launch
+Codex browser login when needed and persist `LLM_PROVIDER=codex`.
 
 ### Claude Code
 
 ```bash
 export LLM_PROVIDER=claude-code
-# Authenticate the Claude Code CLI separately:
-claude login
+# Authenticate through onboarding, `/login claude`, or the Claude Code CLI directly:
+claude auth login
 # Optional overrides (all blank-by-default):
 export CLAUDE_CODE_MODEL=
 export CLAUDE_CODE_BIN=
 ```
 
 Requires the [Claude Code CLI](https://github.com/anthropics/claude-code) (`npm i -g @anthropic-ai/claude-code`). If `CLAUDE_CODE_MODEL` is unset, OpenSRE omits the `--model` flag and the CLI uses its configured default. If `CLAUDE_CODE_BIN` is unset, the binary is resolved via `PATH` and known install locations.
-Run `opensre auth login claude` to detect Claude subscription login and persist `LLM_PROVIDER=claude-code`.
+Run `opensre onboard`, `/login claude`, or `opensre auth login claude` to launch
+Claude browser login when needed and persist `LLM_PROVIDER=claude-code`.
 
 ### GitHub Copilot
 

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from unittest.mock import MagicMock
 
 import pytest
@@ -1181,6 +1182,88 @@ def test_run_cli_llm_onboarding_ok_after_login_retry(monkeypatch) -> None:
     monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "retry")
     result = flow._run_cli_llm_onboarding(provider)
     assert result == "ok"
+    assert len(detect_calls) == 2
+
+
+def test_run_cli_llm_onboarding_launches_codex_browser_login(monkeypatch) -> None:
+    adapter = MagicMock()
+    adapter.name = "codex"
+    adapter.binary_env_key = "CODEX_BIN"
+    adapter.install_hint = "npm i -g @openai/codex"
+    adapter.auth_hint = "Run: codex login"
+    detect_calls: list[object] = []
+
+    def _detect():
+        detect_calls.append(None)
+        if len(detect_calls) == 1:
+            return MagicMock(
+                installed=True,
+                logged_in=False,
+                bin_path="/usr/local/bin/codex",
+                detail="Not logged in.",
+            )
+        return MagicMock(installed=True, logged_in=True, detail="Logged in.")
+
+    adapter.detect = _detect
+    provider = MagicMock()
+    provider.value = "codex"
+    provider.label = "OpenAI Codex CLI"
+    provider.adapter_factory = lambda: adapter
+    login_commands: list[list[str]] = []
+
+    def _fake_run(command: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:
+        del check
+        login_commands.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "login")
+    monkeypatch.setattr(flow.subprocess, "run", _fake_run)
+
+    result = flow._run_cli_llm_onboarding(provider)
+
+    assert result == "ok"
+    assert login_commands == [["/usr/local/bin/codex", "login"]]
+    assert len(detect_calls) == 2
+
+
+def test_run_cli_llm_onboarding_launches_claude_browser_login(monkeypatch) -> None:
+    adapter = MagicMock()
+    adapter.name = "claude-code"
+    adapter.binary_env_key = "CLAUDE_CODE_BIN"
+    adapter.install_hint = "npm i -g @anthropic-ai/claude-code"
+    adapter.auth_hint = "Run: claude auth login"
+    detect_calls: list[object] = []
+
+    def _detect():
+        detect_calls.append(None)
+        if len(detect_calls) == 1:
+            return MagicMock(
+                installed=True,
+                logged_in=False,
+                bin_path="/opt/homebrew/bin/claude",
+                detail="Not authenticated.",
+            )
+        return MagicMock(installed=True, logged_in=True, detail="Authenticated.")
+
+    adapter.detect = _detect
+    provider = MagicMock()
+    provider.value = "claude-code"
+    provider.label = "Anthropic Claude Code CLI"
+    provider.adapter_factory = lambda: adapter
+    login_commands: list[list[str]] = []
+
+    def _fake_run(command: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:
+        del check
+        login_commands.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "login")
+    monkeypatch.setattr(flow.subprocess, "run", _fake_run)
+
+    result = flow._run_cli_llm_onboarding(provider)
+
+    assert result == "ok"
+    assert login_commands == [["/opt/homebrew/bin/claude", "auth", "login"]]
     assert len(detect_calls) == 2
 
 

--- a/tests/core/runtime/llm/test_llm_client.py
+++ b/tests/core/runtime/llm/test_llm_client.py
@@ -5,6 +5,7 @@ from anthropic import AuthenticationError, NotFoundError, PermissionDeniedError
 from anthropic import BadRequestError as AnthropicBadRequestError
 
 from core.llm import llm_client
+from core.llm.structured_output import extract_json_payload
 
 
 class _FakeAnthropicMessages:
@@ -2144,34 +2145,34 @@ def test_format_openai_connection_error_timeout_returns_timeout_message() -> Non
 
 
 # ---------------------------------------------------------------------------
-# _extract_json_payload — embedded code-fence handling (Sentry #1861)
+# extract_json_payload — embedded code-fence handling (Sentry #1861)
 # ---------------------------------------------------------------------------
 
 
 def test_extract_json_payload_bare_json() -> None:
-    assert llm_client._extract_json_payload('{"a": 1}') == {"a": 1}
+    assert extract_json_payload('{"a": 1}') == {"a": 1}
 
 
 def test_extract_json_payload_leading_fence() -> None:
     text = '```json\n{"a": 1}\n```'
-    assert llm_client._extract_json_payload(text) == {"a": 1}
+    assert extract_json_payload(text) == {"a": 1}
 
 
 def test_extract_json_payload_embedded_fence_with_preamble() -> None:
     """LLM returns prose before the code block — Sentry #1861 root cause."""
     text = 'Here is the JSON:\n\n```json\n{"location": "node.py"}\n```'
-    assert llm_client._extract_json_payload(text) == {"location": "node.py"}
+    assert extract_json_payload(text) == {"location": "node.py"}
 
 
 def test_extract_json_payload_embedded_fence_trailing_braces_in_prose() -> None:
     """Greedy regex would over-capture {key} in trailing prose; fence path must win."""
     text = 'Sure!\n\n```json\n{"key": "value"}\n```\n\nThe {key} field represents the identifier.'
-    assert llm_client._extract_json_payload(text) == {"key": "value"}
+    assert extract_json_payload(text) == {"key": "value"}
 
 
 def test_extract_json_payload_raises_when_no_json() -> None:
     with pytest.raises(ValueError, match="LLM did not return valid JSON payload"):
-        llm_client._extract_json_payload("This is plain text with no JSON.")
+        extract_json_payload("This is plain text with no JSON.")
 
 
 # LLMClient.invoke / invoke_stream — usage-limit BadRequestError (HTTP 400) handling

--- a/tests/test_llm_credentials.py
+++ b/tests/test_llm_credentials.py
@@ -5,7 +5,13 @@ import subprocess
 import keyring
 
 import config.llm_credentials as llm_credentials
-from config.llm_auth.credentials import resolve_for_request, status
+import config.llm_keyring as llm_keyring
+from config.llm_auth.credentials import (
+    has_llm_api_key,
+    llm_api_key_source,
+    resolve_for_request,
+    status,
+)
 from config.llm_auth.records import save_provider_auth_record
 from tests.shared.keyring_backend import MemoryKeyring
 
@@ -45,11 +51,11 @@ def test_unmanaged_llm_api_key_source_reports_env_keyring_and_none(monkeypatch) 
     previous_backend = keyring.get_keyring()
     keyring.set_keyring(MemoryKeyring())
     try:
-        assert llm_credentials.llm_api_key_source("EXPERIMENTAL_API_KEY") == "none"
+        assert llm_api_key_source("EXPERIMENTAL_API_KEY") == "none"
         llm_credentials.save_llm_api_key("EXPERIMENTAL_API_KEY", "from-keyring")
-        assert llm_credentials.llm_api_key_source("EXPERIMENTAL_API_KEY") == "keyring"
+        assert llm_api_key_source("EXPERIMENTAL_API_KEY") == "keyring"
         monkeypatch.setenv("EXPERIMENTAL_API_KEY", "from-env")
-        assert llm_credentials.llm_api_key_source("EXPERIMENTAL_API_KEY") == "env"
+        assert llm_api_key_source("EXPERIMENTAL_API_KEY") == "env"
     finally:
         keyring.set_keyring(previous_backend)
 
@@ -60,9 +66,9 @@ def test_managed_llm_api_key_source_uses_metadata_without_reading_secret(
     monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setenv("OPENSRE_LLM_AUTH_METADATA_PATH", str(tmp_path / "llm-auth.json"))
-    monkeypatch.setattr(llm_credentials.platform, "system", _darwin_platform)
-    monkeypatch.setattr(llm_credentials.shutil, "which", _security_tool_path)
-    monkeypatch.setattr(llm_credentials.keyring, "get_keyring", _MacOSKeyringBackend)
+    monkeypatch.setattr(llm_keyring.platform, "system", _darwin_platform)
+    monkeypatch.setattr(llm_keyring.shutil, "which", _security_tool_path)
+    monkeypatch.setattr(llm_keyring.keyring, "get_keyring", _MacOSKeyringBackend)
 
     def _run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         assert command == [
@@ -79,8 +85,8 @@ def test_managed_llm_api_key_source_uses_metadata_without_reading_secret(
     def _get_password(_service: str, _username: str) -> str:
         raise AssertionError("metadata source check must not read the keychain secret")
 
-    monkeypatch.setattr(llm_credentials.subprocess, "run", _run)
-    monkeypatch.setattr(llm_credentials.keyring, "get_password", _get_password)
+    monkeypatch.setattr(llm_keyring.subprocess, "run", _run)
+    monkeypatch.setattr(llm_keyring.keyring, "get_password", _get_password)
     save_provider_auth_record(
         provider="openai",
         auth_name="openai",
@@ -90,8 +96,8 @@ def test_managed_llm_api_key_source_uses_metadata_without_reading_secret(
         env_var="OPENAI_API_KEY",
     )
 
-    assert llm_credentials.llm_api_key_source("OPENAI_API_KEY") == "metadata"
-    assert llm_credentials.has_llm_api_key("OPENAI_API_KEY") is True
+    assert llm_api_key_source("OPENAI_API_KEY") == "metadata"
+    assert has_llm_api_key("OPENAI_API_KEY") is True
 
 
 def test_managed_missing_metadata_reports_none_without_reading_secret(
@@ -100,9 +106,9 @@ def test_managed_missing_metadata_reports_none_without_reading_secret(
     monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setenv("OPENSRE_LLM_AUTH_METADATA_PATH", str(tmp_path / "llm-auth.json"))
-    monkeypatch.setattr(llm_credentials.platform, "system", _darwin_platform)
-    monkeypatch.setattr(llm_credentials.shutil, "which", _security_tool_path)
-    monkeypatch.setattr(llm_credentials.keyring, "get_keyring", _MacOSKeyringBackend)
+    monkeypatch.setattr(llm_keyring.platform, "system", _darwin_platform)
+    monkeypatch.setattr(llm_keyring.shutil, "which", _security_tool_path)
+    monkeypatch.setattr(llm_keyring.keyring, "get_keyring", _MacOSKeyringBackend)
 
     def _run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(command, 44)
@@ -110,11 +116,11 @@ def test_managed_missing_metadata_reports_none_without_reading_secret(
     def _get_password(_service: str, _username: str) -> str:
         raise AssertionError("metadata source check must not read the keychain secret")
 
-    monkeypatch.setattr(llm_credentials.subprocess, "run", _run)
-    monkeypatch.setattr(llm_credentials.keyring, "get_password", _get_password)
+    monkeypatch.setattr(llm_keyring.subprocess, "run", _run)
+    monkeypatch.setattr(llm_keyring.keyring, "get_password", _get_password)
 
-    assert llm_credentials.llm_api_key_source("OPENAI_API_KEY") == "none"
-    assert llm_credentials.has_llm_api_key("OPENAI_API_KEY") is False
+    assert llm_api_key_source("OPENAI_API_KEY") == "none"
+    assert has_llm_api_key("OPENAI_API_KEY") is False
 
 
 def test_request_resolution_marks_deleted_keychain_metadata_stale(monkeypatch, tmp_path) -> None:
@@ -176,9 +182,9 @@ def test_get_keyring_setup_instructions_for_linux_without_gnome_keyring(monkeypa
 
     monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
     monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
-    monkeypatch.setattr(llm_credentials.platform, "system", lambda: "Linux")
-    monkeypatch.setattr(llm_credentials.shutil, "which", lambda _name: None)
-    monkeypatch.setattr(llm_credentials.keyring, "get_keyring", lambda: backend_class())
+    monkeypatch.setattr(llm_keyring.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(llm_keyring.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(llm_keyring.keyring, "get_keyring", lambda: backend_class())
 
     lines = llm_credentials.get_keyring_setup_instructions("ANTHROPIC_API_KEY")
 


### PR DESCRIPTION
## Summary
- Break CodeQL-reported import cycles by extracting `config/llm_keyring.py` and `core/llm/bedrock_model_ids.py`, and routing LLM API key resolution through the auth credentials layer instead of `core.provider`.
- Move prompt-safe credential helpers (`llm_api_key_source`, `has_llm_api_key`) into `config/llm_auth/credentials.py` to eliminate the credentials module cycle.
- Add onboarding wizard support for launching vendor CLI browser login (`claude auth login`, `codex login`) when subscription-backed providers are not authenticated.

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `make format-check`
- [x] `pytest tests/test_llm_credentials.py tests/core/runtime/llm/test_llm_client.py tests/cli/wizard/test_flow.py tests/config/test_llm_auth.py`


Made with [Cursor](https://cursor.com)