### PR TITLE
Fix remote investigation list showing collision suffix in alert names

### DIFF
--- a/infra/deployment/remote/server.py
+++ b/infra/deployment/remote/server.py
@@ -601,15 +601,13 @@ def list_investigations() -> list[InvestigationMeta]:
     items: list[InvestigationMeta] = []
     for path in sorted(INVESTIGATIONS_DIR.glob("*.md"), reverse=True):
         inv_id = path.stem
-        parts = inv_id.split("_", maxsplit=2)
-        alert = parts[2] if len(parts) > 2 else inv_id
         created = _id_to_iso(inv_id)
         items.append(
             InvestigationMeta(
                 id=inv_id,
                 filename=path.name,
                 created_at=created,
-                alert_name=alert.replace("-", " "),
+                alert_name=_alert_name_from_inv_id(inv_id),
             )
         )
     return items
@@ -649,6 +647,22 @@ def _safe_investigation_path(inv_id: str) -> Path:
 
 def _slugify(text: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")[:60]
+
+
+_INV_ID_SUFFIX_RE = re.compile(r"_[0-9a-f]{8}$", re.IGNORECASE)
+
+
+def _alert_name_from_inv_id(inv_id: str) -> str:
+    """Derive a user-visible alert name from a persisted investigation id.
+
+    Ids use ``YYYYMMDD_HHMMSS_<slug>_<8-hex>``; the trailing hex suffix exists
+    only to avoid filename collisions and must not appear in list metadata.
+    """
+    parts = inv_id.split("_", maxsplit=2)
+    slug = parts[2] if len(parts) > 2 else inv_id
+    if _INV_ID_SUFFIX_RE.search(slug):
+        slug = slug[:-9]
+    return slug.replace("-", " ")
 
 
 def _refresh_instance_metadata() -> None:

--- a/infra/deployment/remote/server.py
+++ b/infra/deployment/remote/server.py
@@ -661,7 +661,7 @@ def _alert_name_from_inv_id(inv_id: str) -> str:
     parts = inv_id.split("_", maxsplit=2)
     slug = parts[2] if len(parts) > 2 else inv_id
     if _INV_ID_SUFFIX_RE.search(slug):
-        slug = slug[:-9]
+        slug = _INV_ID_SUFFIX_RE.sub("", slug)
     return slug.replace("-", " ")
 
 

--- a/tests/remote/test_server_utils.py
+++ b/tests/remote/test_server_utils.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi import HTTPException
 
 from infra.deployment.remote.server import (
+    _alert_name_from_inv_id,
     _id_to_iso,
     _make_id,
     _safe_investigation_path,
@@ -290,6 +291,16 @@ def test_id_to_iso_parses_new_suffixed_id() -> None:
     """The ISO-8601 timestamp is still recoverable from the new id format."""
     iso = _id_to_iso("20260101_120000_db-down_deadbeef")
     assert iso.startswith("2026-01-01T12:00:00")
+
+
+def test_alert_name_from_inv_id_strips_collision_suffix() -> None:
+    assert _alert_name_from_inv_id("20260628_123456_cpu-spike-deploy_ab12cd34") == (
+        "cpu spike deploy"
+    )
+
+
+def test_alert_name_from_inv_id_keeps_legacy_ids_without_suffix() -> None:
+    assert _alert_name_from_inv_id("20260101_120000_db-down") == "db down"
 
 
 def test_id_to_iso_returns_empty_on_garbage() -> None:


### PR DESCRIPTION
## Summary
- Strip the 8-character collision-avoidance suffix when deriving `alert_name` from persisted investigation ids
- Add regression tests for suffixed and legacy id formats

Fixes #3184

## Test plan
- [x] `uv run python -m pytest tests/remote/test_server_utils.py -q`