### PR TITLE
Clarify /model UI for provider, reasoning, and toolcall selection

### DIFF
--- a/interactive_shell/command_registry/model/command.py
+++ b/interactive_shell/command_registry/model/command.py
@@ -56,8 +56,8 @@ def _reasoning_model_menu_choices(provider: object) -> list[tuple[str, str]]:
 def _toolcall_model_menu_choices(provider: object) -> list[tuple[str, str]]:
     model_options = list(getattr(provider, "models", ()))
     choices: list[tuple[str, str]] = [
-        ("__keep__", "keep"),
-        ("__match_reasoning__", "match-reasoning"),
+        ("__keep__", "keep current toolcall model"),
+        ("__match_reasoning__", "use same as reasoning model"),
     ]
     for option in model_options:
         value = str(getattr(option, "value", ""))

--- a/interactive_shell/command_registry/model/command.py
+++ b/interactive_shell/command_registry/model/command.py
@@ -101,7 +101,7 @@ def _interactive_set_provider(console: Console) -> bool | None:
         crumb_model = f"{crumb_set}{CRUMB_SEP}{provider_value}"
         while True:
             reasoning_choice = repl_choose_one(
-                title="reasoning model",
+                title="Reasoning model (analysis and final answers)",
                 breadcrumb=crumb_model,
                 choices=_reasoning_model_menu_choices(provider),
             )
@@ -124,7 +124,7 @@ def _interactive_set_provider(console: Console) -> bool | None:
                 crumb_tc = f"{crumb_model}{CRUMB_SEP}toolcall"
                 while True:
                     toolcall_value = repl_choose_one(
-                        title="toolcall model",
+                        title="Toolcall model (investigation tool selection)",
                         breadcrumb=crumb_tc,
                         choices=_toolcall_model_menu_choices(provider),
                     )
@@ -184,7 +184,7 @@ def _interactive_set_toolcall(console: Console) -> bool | None:
         )
         return False
     model_value = repl_choose_one(
-        title="toolcall model",
+        title="Toolcall model (investigation tool selection)",
         breadcrumb=f"{crumb_tc}{CRUMB_SEP}{provider_value}",
         choices=_toolcall_model_menu_choices(provider),
     )
@@ -207,13 +207,13 @@ def _interactive_set_toolcall(console: Console) -> bool | None:
 def _interactive_model_menu(session: ReplSession, console: Console) -> bool:
     while True:
         action = repl_choose_one(
-            title="Select Model and Effort",
+            title="LLM settings",
             breadcrumb=f"{_ROOT}",
             choices=[
-                ("show", "show"),
-                ("set", "set"),
-                ("restore", "restore"),
-                ("toolcall", "toolcall"),
+                ("show", "show current provider and models"),
+                ("set", "change provider and/or reasoning model"),
+                ("restore", "restore provider defaults"),
+                ("toolcall", "set toolcall model (separate from reasoning)"),
                 ("done", "done"),
             ],
         )

--- a/interactive_shell/ui/tables/tables.py
+++ b/interactive_shell/ui/tables/tables.py
@@ -114,8 +114,8 @@ _INTEGRATION_COLS: list[ColumnDef] = [
 
 _MODEL_COLS: list[ColumnDef] = [
     ColumnDef("provider", style="bold", no_wrap=True),
-    ColumnDef("reasoning model"),
-    ColumnDef("toolcall model"),
+    ColumnDef("reasoning model", style=HIGHLIGHT),
+    ColumnDef("toolcall model", style=DIM),
 ]
 
 _TOOL_COLS: list[ColumnDef] = [
@@ -163,9 +163,15 @@ def render_models_table(console: Console, settings: Any) -> None:
         return
     provider = str(getattr(settings, "provider", "unknown"))
     reasoning_model, toolcall_model = resolve_provider_models(settings, provider)
+    repl_print(
+        console,
+        f"[{DIM}]Active provider and model tiers. "
+        "Reasoning handles analysis; toolcall drives investigation tool selection "
+        "(when the provider supports a separate tier).[/]",
+    )
     render_table(
         console,
-        "LLM connection",
+        "LLM settings",
         _MODEL_COLS,
         [(provider, reasoning_model, toolcall_model)],
     )


### PR DESCRIPTION
## Summary
- Rename interactive /model menu choices to describe what each action changes
- Add short helper text above the settings table distinguishing reasoning vs toolcall tiers
- Highlight reasoning model column and dim toolcall column for quicker scanning

Fixes #2114

## Test plan
- [ ] Open `/model` in a TTY and confirm menu text explains reasoning vs toolcall roles
- [ ] Run `/model show` and verify the table header and helper line render correctly