### PR TITLE
Stop showing misleading confidence 0% during investigate

### DIFF
--- a/cli/ui/renderer/formatting.py
+++ b/cli/ui/renderer/formatting.py
@@ -130,4 +130,7 @@ def _validity_score_percent(score: Any) -> str | None:
         # "confidence 0%" misleads users when evidence was never gathered.
         return None
     v = min(1.0, v)
-    return f"{int(v * 100)}%"
+    pct = round(v * 100)
+    if pct == 0:
+        return None
+    return f"{pct}%"

--- a/cli/ui/renderer/formatting.py
+++ b/cli/ui/renderer/formatting.py
@@ -125,5 +125,9 @@ def _validity_score_percent(score: Any) -> str | None:
     v = float(score)
     if not math.isfinite(v):
         return None
-    v = max(0.0, min(1.0, v))
+    if v <= 0.0:
+        # 0.0 is the pipeline default before diagnosis completes; showing
+        # "confidence 0%" misleads users when evidence was never gathered.
+        return None
+    v = min(1.0, v)
     return f"{int(v * 100)}%"

--- a/tests/cli/ui/test_renderer_formatting.py
+++ b/tests/cli/ui/test_renderer_formatting.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from cli.ui.renderer.formatting import (
+    _validity_score_percent,
     format_prior_tools_clause,
     investigation_llm_progress_hint,
 )
@@ -37,3 +38,13 @@ def test_format_prior_tools_clause_truncates_long_lists() -> None:
         max_tools=2,
     )
     assert clause == " after Tool A, Tool B, ..."
+
+
+def test_validity_score_percent_hides_unset_zero() -> None:
+    assert _validity_score_percent(0.0) is None
+    assert _validity_score_percent(0) is None
+
+
+def test_validity_score_percent_formats_positive_scores() -> None:
+    assert _validity_score_percent(0.87) == "87%"
+    assert _validity_score_percent(0.5) == "50%"

--- a/tests/cli/ui/test_renderer_formatting.py
+++ b/tests/cli/ui/test_renderer_formatting.py
@@ -43,8 +43,11 @@ def test_format_prior_tools_clause_truncates_long_lists() -> None:
 def test_validity_score_percent_hides_unset_zero() -> None:
     assert _validity_score_percent(0.0) is None
     assert _validity_score_percent(0) is None
+    assert _validity_score_percent(-0.5) is None
+    assert _validity_score_percent(0.004) is None
 
 
 def test_validity_score_percent_formats_positive_scores() -> None:
     assert _validity_score_percent(0.87) == "87%"
     assert _validity_score_percent(0.5) == "50%"
+    assert _validity_score_percent(0.01) == "1%"


### PR DESCRIPTION
## Summary
- Treat `validity_score` of 0.0 as unset in investigation progress formatting
- Skip the "confidence 0%" progress suffix when no diagnosis score was produced
- Add unit tests for the formatting helper

Fixes #1888

## Test plan
- [x] `uv run python -m pytest tests/cli/ui/test_renderer_formatting.py -q`
- [ ] Run `opensre investigate` without integrations configured and confirm progress no longer shows `confidence 0%`