### PR TITLE
Resolve Grafana API tokens from common credential aliases

### DIFF
--- a/integrations/grafana/__init__.py
+++ b/integrations/grafana/__init__.py
@@ -12,12 +12,11 @@ logger = logging.getLogger(__name__)
 
 _GRAFANA_TOKEN_KEYS = (
     "api_key",
-    "token",
     "api_token",
     "read_token",
     "service_account_token",
     "bearer_token",
-    "key",
+    "token",
     "apiKey",
     "readToken",
 )
@@ -27,8 +26,8 @@ def _resolve_grafana_api_key(credentials: dict[str, Any]) -> str:
     """Return the first non-empty Grafana token field from stored credentials."""
     for key in _GRAFANA_TOKEN_KEYS:
         value = credentials.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
+        if isinstance(value, str) and (stripped := value.strip()):
+            return stripped
     return ""
 
 

--- a/integrations/grafana/__init__.py
+++ b/integrations/grafana/__init__.py
@@ -10,6 +10,27 @@ from integrations.config_models import GrafanaIntegrationConfig
 
 logger = logging.getLogger(__name__)
 
+_GRAFANA_TOKEN_KEYS = (
+    "api_key",
+    "token",
+    "api_token",
+    "read_token",
+    "service_account_token",
+    "bearer_token",
+    "key",
+    "apiKey",
+    "readToken",
+)
+
+
+def _resolve_grafana_api_key(credentials: dict[str, Any]) -> str:
+    """Return the first non-empty Grafana token field from stored credentials."""
+    for key in _GRAFANA_TOKEN_KEYS:
+        value = credentials.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
 
 def classify(
     credentials: dict[str, Any], record_id: str
@@ -18,7 +39,7 @@ def classify(
         cfg = GrafanaIntegrationConfig.model_validate(
             {
                 "endpoint": credentials.get("endpoint", ""),
-                "api_key": credentials.get("api_key", ""),
+                "api_key": _resolve_grafana_api_key(credentials),
                 "username": credentials.get("username", ""),
                 "password": credentials.get("password", ""),
                 "integration_id": record_id,

--- a/tests/integrations/grafana/test_classify.py
+++ b/tests/integrations/grafana/test_classify.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from integrations.grafana import classify
+
+
+def test_classify_accepts_read_token_alias() -> None:
+    cfg, source = classify(
+        {
+            "endpoint": "https://grafana.example.com",
+            "read_token": "sa-token",
+        },
+        "rec-1",
+    )
+    assert source == "grafana"
+    assert cfg is not None
+    assert cfg.api_key == "sa-token"
+
+
+def test_classify_prefers_api_key_over_aliases() -> None:
+    cfg, source = classify(
+        {
+            "endpoint": "https://grafana.example.com",
+            "api_key": "primary",
+            "token": "secondary",
+        },
+        "rec-2",
+    )
+    assert source == "grafana"
+    assert cfg is not None
+    assert cfg.api_key == "primary"

--- a/tests/integrations/grafana/test_classify.py
+++ b/tests/integrations/grafana/test_classify.py
@@ -28,3 +28,28 @@ def test_classify_prefers_api_key_over_aliases() -> None:
     assert source == "grafana"
     assert cfg is not None
     assert cfg.api_key == "primary"
+
+
+def test_classify_prefers_specific_token_alias_over_generic_token() -> None:
+    cfg, source = classify(
+        {
+            "endpoint": "https://grafana.example.com",
+            "api_token": "specific",
+            "token": "generic",
+        },
+        "rec-2b",
+    )
+    assert source == "grafana"
+    assert cfg is not None
+    assert cfg.api_key == "specific"
+
+
+def test_classify_returns_none_when_no_token_alias_present() -> None:
+    cfg, source = classify(
+        {
+            "endpoint": "https://grafana.example.com",
+        },
+        "rec-3",
+    )
+    assert cfg is None
+    assert source is None


### PR DESCRIPTION
## Summary
- Read Grafana service-account tokens from common credential field names, not only `api_key`
- Prefer explicit `api_key` when present, then fall back to aliases like `read_token` and `token`
- Add classify regression tests for alias resolution

Fixes #2836

## Test plan
- [x] `uv run python -m pytest tests/integrations/grafana/test_classify.py -q`
- [ ] Configure Grafana with `read_token` in the integration store and verify `opensre integrations verify grafana` succeeds