### PR TITLE
fix(integrations): log classify failures for remaining integrations

### DIFF
--- a/integrations/bitbucket/__init__.py
+++ b/integrations/bitbucket/__init__.py
@@ -16,7 +16,7 @@ import httpx
 from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
-from integrations._validation_helpers import report_validation_failure
+from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
 logger = logging.getLogger(__name__)
 
@@ -288,7 +288,10 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except Exception:
+    except Exception as exc:
+        report_classify_failure(
+            exc, logger=logger, integration="bitbucket", record_id=record_id
+        )
         return None, None
     if cfg.workspace:
         return cfg, "bitbucket"

--- a/integrations/signoz/__init__.py
+++ b/integrations/signoz/__init__.py
@@ -15,7 +15,7 @@ import httpx
 from pydantic import Field
 
 from config.strict_config import StrictConfigModel
-from integrations._validation_helpers import report_validation_failure
+from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +148,10 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[SigNozConfig 
                 "integration_id": record_id,
             }
         )
-    except Exception:
+    except Exception as exc:
+        report_classify_failure(
+            exc, logger=logger, integration="signoz", record_id=record_id
+        )
         return None, None
     if cfg.is_configured:
         return cfg, "signoz"

--- a/integrations/smtp/__init__.py
+++ b/integrations/smtp/__init__.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from integrations.config_models import SMTPIntegrationConfig
+from integrations._validation_helpers import report_classify_failure
+
+logger = logging.getLogger(__name__)
 
 
 def classify(
-    credentials: dict[str, Any], _record_id: str
+    credentials: dict[str, Any], record_id: str
 ) -> tuple[SMTPIntegrationConfig | None, str | None]:
     try:
         cfg = SMTPIntegrationConfig.model_validate(
@@ -22,6 +26,9 @@ def classify(
                 "default_to": credentials.get("default_to"),
             }
         )
-    except Exception:
+    except Exception as exc:
+        report_classify_failure(
+            exc, logger=logger, integration="smtp", record_id=record_id
+        )
         return None, None
     return cfg, "smtp"

--- a/integrations/tempo/__init__.py
+++ b/integrations/tempo/__init__.py
@@ -18,7 +18,7 @@ import httpx
 from pydantic import Field
 
 from config.strict_config import StrictConfigModel
-from integrations._validation_helpers import report_validation_failure
+from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +162,10 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[TempoConfig |
                 "integration_id": record_id,
             }
         )
-    except Exception:
+    except Exception as exc:
+        report_classify_failure(
+            exc, logger=logger, integration="tempo", record_id=record_id
+        )
         return None, None
     if cfg.is_configured:
         return cfg, "tempo"

--- a/integrations/twilio/__init__.py
+++ b/integrations/twilio/__init__.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 from integrations.config_models import TwilioIntegrationConfig
+from integrations._validation_helpers import report_classify_failure
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,9 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except Exception:
+    except Exception as exc:
+        report_classify_failure(
+            exc, logger=logger, integration="twilio", record_id=record_id
+        )
         return None, None
     return cfg, "twilio"

--- a/integrations/whatsapp/__init__.py
+++ b/integrations/whatsapp/__init__.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 from integrations.config_models import WhatsAppConfig
+from integrations._validation_helpers import report_classify_failure
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,9 @@ def classify(
                 "default_to": credentials.get("default_to"),
             }
         )
-    except Exception:
+    except Exception as exc:
+        report_classify_failure(
+            exc, logger=logger, integration="whatsapp", record_id=record_id
+        )
         return None, None
     return cfg, "whatsapp"

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -120,6 +120,12 @@ _CLASSIFY_PATCH_TARGETS: list[tuple[str, str, str]] = [
     ("victoria_logs", "integrations.victoria_logs", "VictoriaLogsIntegrationConfig"),
     ("splunk", "integrations.splunk", "SplunkIntegrationConfig"),
     ("supabase", "integrations.supabase", "build_supabase_config"),
+    ("whatsapp", "integrations.whatsapp", "WhatsAppConfig"),
+    ("twilio", "integrations.twilio", "TwilioIntegrationConfig"),
+    ("smtp", "integrations.smtp", "SMTPIntegrationConfig"),
+    ("signoz", "integrations.signoz", "build_signoz_config"),
+    ("tempo", "integrations.tempo", "build_tempo_config"),
+    ("bitbucket", "integrations.bitbucket", "BitbucketConfig"),
 ]
 
 


### PR DESCRIPTION
## Summary
- Route whatsapp, twilio, smtp, signoz, tempo, and bitbucket classify failures through `report_classify_failure()` instead of returning silently
- Extend the silent-fallback elimination regression suite to cover these integrations

Fixes #1554

## Test plan
- [x] `uv run python -m pytest tests/integrations/test_catalog_silent_fallback_elimination.py -q`