### PR TITLE
fix(fleet): resolve /kill and /trace by pid or agent name

### DIFF
--- a/interactive_shell/command_registry/agents/kill.py
+++ b/interactive_shell/command_registry/agents/kill.py
@@ -13,7 +13,7 @@ from interactive_shell.ui import DIM, ERROR, HIGHLIGHT, WARNING
 from platform.analytics.events import Event
 from platform.analytics.provider import get_analytics
 from tools.fleet_monitoring.lifecycle import TerminateResult, terminate
-from tools.fleet_monitoring.registry import AgentRegistry
+from tools.fleet_monitoring.registry import AgentRegistry, AgentResolveError, resolve_agent_arg
 
 # Type alias for the optional confirmation callback (used for testing).
 _ConfirmFn = Callable[[str], str]
@@ -26,7 +26,7 @@ def _cmd_agents_kill(
     *,
     confirm_fn: _ConfirmFn | None = None,
 ) -> bool:
-    """Handle ``/fleet kill <pid> [--force]``.
+    """Handle ``/fleet kill <pid|name> [--force]``.
 
     Sends SIGTERM, waits up to 5 s, then escalates to SIGKILL.
     Asks for confirmation unless ``--force`` is present.
@@ -36,15 +36,16 @@ def _cmd_agents_kill(
     positional = [a for a in args if a != "--force"]
 
     if not positional:
-        console.print(f"[{ERROR}]usage:[/] /fleet kill <pid> [--force]")
+        console.print(f"[{ERROR}]usage:[/] /fleet kill <pid|name> [--force]")
         session.mark_latest(ok=False, kind="slash")
         return True
 
-    raw_pid = positional[0]
+    raw_target = positional[0]
+    registry = AgentRegistry()
     try:
-        pid = int(raw_pid)
-    except ValueError:
-        console.print(f"[{ERROR}]invalid pid:[/] {escape(raw_pid)} is not an integer")
+        pid = resolve_agent_arg(raw_target, registry)
+    except AgentResolveError as exc:
+        console.print(f"[{ERROR}]{escape(exc.message)}[/]")
         session.mark_latest(ok=False, kind="slash")
         return True
 
@@ -54,7 +55,6 @@ def _cmd_agents_kill(
         return True
 
     # Look up agent name from registry for friendlier output.
-    registry = AgentRegistry()
     record = registry.get(pid)
     label = f"{record.name} (pid {pid})" if record else f"pid {pid}"
 

--- a/interactive_shell/command_registry/agents/trace.py
+++ b/interactive_shell/command_registry/agents/trace.py
@@ -13,7 +13,7 @@ from rich.text import Text
 
 from interactive_shell.runtime import ReplSession
 from interactive_shell.ui import BOLD_BRAND, DIM, ERROR
-from tools.fleet_monitoring.registry import AgentRegistry
+from tools.fleet_monitoring.registry import AgentRegistry, AgentResolveError, resolve_agent_arg
 from tools.fleet_monitoring.tail import AttachSession, AttachUnsupported, attach
 
 _TRACE_REFRESH_PER_SECOND = 10
@@ -132,17 +132,18 @@ def _cmd_agents_trace(session: ReplSession, console: Console, args: list[str]) -
     we never enter the ``Live`` block on a target we cannot tail.
     """
     if len(args) != 1:
-        console.print(f"[{ERROR}]usage:[/] /fleet trace <pid>")
+        console.print(f"[{ERROR}]usage:[/] /fleet trace <pid|name>")
         session.mark_latest(ok=False, kind="slash")
         return True
+    registry = AgentRegistry()
     try:
-        pid = int(args[0])
-    except ValueError:
-        console.print(f"[{ERROR}]invalid pid:[/] {escape(args[0])}")
+        pid = resolve_agent_arg(args[0], registry)
+    except AgentResolveError as exc:
+        console.print(f"[{ERROR}]{escape(exc.message)}[/]")
         session.mark_latest(ok=False, kind="slash")
         return True
 
-    record = AgentRegistry().get(pid)
+    record = registry.get(pid)
     label = f"{record.name} (pid {pid})" if record else f"pid {pid}"
 
     try:

--- a/tests/fleet_monitoring/test_registry.py
+++ b/tests/fleet_monitoring/test_registry.py
@@ -256,3 +256,38 @@ class TestAgentRegistry:
         rehydrated = reg2.get(7702)
         assert rehydrated is not None
         assert rehydrated.waits_on == ()
+
+
+class TestResolveAgentArg:
+    def test_resolves_registered_pid(self, registry: AgentRegistry, sample_record: AgentRecord) -> None:
+        registry.register(sample_record)
+        from tools.fleet_monitoring.registry import resolve_agent_arg
+
+        assert resolve_agent_arg("8421", registry) == 8421
+
+    def test_resolves_registered_name(self, registry: AgentRegistry, sample_record: AgentRecord) -> None:
+        registry.register(sample_record)
+        from tools.fleet_monitoring.registry import resolve_agent_arg
+
+        assert resolve_agent_arg("claude-code", registry) == 8421
+
+    def test_unregistered_pid_still_returns_for_caller_handling(
+        self, registry: AgentRegistry
+    ) -> None:
+        from tools.fleet_monitoring.registry import resolve_agent_arg
+
+        assert resolve_agent_arg("9999", registry) == 9999
+
+    def test_ambiguous_name_raises(self, registry: AgentRegistry) -> None:
+        from tools.fleet_monitoring.registry import AgentResolveError, resolve_agent_arg
+
+        registry.register(AgentRecord(name="worker", pid=100, command="a"))
+        registry.register(AgentRecord(name="worker", pid=200, command="b"))
+        with pytest.raises(AgentResolveError, match="ambiguous"):
+            resolve_agent_arg("worker", registry)
+
+    def test_unknown_name_raises(self, registry: AgentRegistry) -> None:
+        from tools.fleet_monitoring.registry import AgentResolveError, resolve_agent_arg
+
+        with pytest.raises(AgentResolveError, match="invalid pid or unknown agent name"):
+            resolve_agent_arg("missing-agent", registry)

--- a/tests/fleet_monitoring/test_registry.py
+++ b/tests/fleet_monitoring/test_registry.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from tools.fleet_monitoring.registry import AgentRecord, AgentRegistry
+from tools.fleet_monitoring.registry import AgentRecord, AgentRegistry, AgentResolveError, resolve_agent_arg
 
 
 @pytest.fixture
@@ -261,33 +261,29 @@ class TestAgentRegistry:
 class TestResolveAgentArg:
     def test_resolves_registered_pid(self, registry: AgentRegistry, sample_record: AgentRecord) -> None:
         registry.register(sample_record)
-        from tools.fleet_monitoring.registry import resolve_agent_arg
-
         assert resolve_agent_arg("8421", registry) == 8421
 
     def test_resolves_registered_name(self, registry: AgentRegistry, sample_record: AgentRecord) -> None:
         registry.register(sample_record)
-        from tools.fleet_monitoring.registry import resolve_agent_arg
-
         assert resolve_agent_arg("claude-code", registry) == 8421
 
     def test_unregistered_pid_still_returns_for_caller_handling(
         self, registry: AgentRegistry
     ) -> None:
-        from tools.fleet_monitoring.registry import resolve_agent_arg
+        assert resolve_agent_arg("9999", registry) == 9999
 
+    def test_numeric_pid_does_not_match_numeric_agent_name(
+        self, registry: AgentRegistry
+    ) -> None:
+        registry.register(AgentRecord(name="9999", pid=200, command="worker"))
         assert resolve_agent_arg("9999", registry) == 9999
 
     def test_ambiguous_name_raises(self, registry: AgentRegistry) -> None:
-        from tools.fleet_monitoring.registry import AgentResolveError, resolve_agent_arg
-
         registry.register(AgentRecord(name="worker", pid=100, command="a"))
         registry.register(AgentRecord(name="worker", pid=200, command="b"))
         with pytest.raises(AgentResolveError, match="ambiguous"):
             resolve_agent_arg("worker", registry)
 
     def test_unknown_name_raises(self, registry: AgentRegistry) -> None:
-        from tools.fleet_monitoring.registry import AgentResolveError, resolve_agent_arg
-
         with pytest.raises(AgentResolveError, match="invalid pid or unknown agent name"):
             resolve_agent_arg("missing-agent", registry)

--- a/tools/fleet_monitoring/registry.py
+++ b/tools/fleet_monitoring/registry.py
@@ -177,15 +177,12 @@ def resolve_agent_arg(arg: str, registry: AgentRegistry | None = None) -> int:
     if not token:
         raise AgentResolveError("invalid pid or unknown agent name")
 
-    parsed_pid: int | None = None
     try:
         candidate = int(token)
     except ValueError:
         candidate = -1
     if candidate > 0:
-        parsed_pid = candidate
-        if reg.get(candidate) is not None:
-            return candidate
+        return candidate
 
     name_matches = [record for record in reg.list() if record.name == token]
     if len(name_matches) == 1:
@@ -195,8 +192,5 @@ def resolve_agent_arg(arg: str, registry: AgentRegistry | None = None) -> int:
         raise AgentResolveError(
             f"ambiguous: {len(name_matches)} registered agents named {token} (pids: {pids})"
         )
-
-    if parsed_pid is not None:
-        return parsed_pid
 
     raise AgentResolveError(f"invalid pid or unknown agent name: {token}")

--- a/tools/fleet_monitoring/registry.py
+++ b/tools/fleet_monitoring/registry.py
@@ -156,3 +156,47 @@ class AgentRegistry:
             tmp.replace(self._path)
         except OSError:
             logger.warning("Failed to rewrite agent registry at %s", self._path)
+
+
+class AgentResolveError(Exception):
+    """Raised when a ``/fleet`` PID or agent-name argument cannot be resolved."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+def resolve_agent_arg(arg: str, registry: AgentRegistry | None = None) -> int:
+    """Resolve a ``/fleet kill`` or ``/fleet trace`` argument to a PID.
+
+    Accepts a registered PID, a registered agent name, or an unregistered PID
+    so callers can still reach the existing ``no such process`` path.
+    """
+    reg = registry or AgentRegistry()
+    token = arg.strip()
+    if not token:
+        raise AgentResolveError("invalid pid or unknown agent name")
+
+    parsed_pid: int | None = None
+    try:
+        candidate = int(token)
+    except ValueError:
+        candidate = -1
+    if candidate > 0:
+        parsed_pid = candidate
+        if reg.get(candidate) is not None:
+            return candidate
+
+    name_matches = [record for record in reg.list() if record.name == token]
+    if len(name_matches) == 1:
+        return name_matches[0].pid
+    if len(name_matches) > 1:
+        pids = ", ".join(str(record.pid) for record in name_matches)
+        raise AgentResolveError(
+            f"ambiguous: {len(name_matches)} registered agents named {token} (pids: {pids})"
+        )
+
+    if parsed_pid is not None:
+        return parsed_pid
+
+    raise AgentResolveError(f"invalid pid or unknown agent name: {token}")


### PR DESCRIPTION
## Summary
- Add `resolve_agent_arg()` to match registered PIDs, unique agent names, or unregistered PIDs
- Update `/kill` and `/trace` fleet commands to use the resolver with clearer usage text
- Add registry resolver unit tests

Fixes #1749

## Test plan
- [x] `uv run python -m pytest tests/fleet_monitoring/test_registry.py::TestResolveAgentArg -q`