### PR TITLE
fix(github-actions): align step_number with grouped log sections

### DIFF
--- a/tests/tools/test_github_actions_tool.py
+++ b/tests/tools/test_github_actions_tool.py
@@ -369,3 +369,21 @@ final runner summary
     assert "annotation between groups" in result["log_text"]
     assert "line 2" in result["log_text"]
     assert "final runner summary" in result["log_text"]
+
+
+def test_extract_step_log_step_number_skips_ungrouped_sections() -> None:
+    result = extract_step_log(
+        """##[group]Checkout
+line 1
+##[endgroup]
+ungrouped noise between steps
+##[group]Deploy
+line 2
+##[endgroup]
+""",
+        step_number=2,
+    )
+    assert result["step_name"] == "Deploy"
+    assert result["match_strategy"] == "step_number"
+    assert "line 2" in result["log_text"]
+    assert "ungrouped noise between steps" not in result["log_text"]

--- a/tests/tools/test_github_actions_tool.py
+++ b/tests/tools/test_github_actions_tool.py
@@ -372,18 +372,26 @@ final runner summary
 
 
 def test_extract_step_log_step_number_skips_ungrouped_sections() -> None:
-    result = extract_step_log(
-        """##[group]Checkout
+    log_text = """##[group]Checkout
 line 1
 ##[endgroup]
-ungrouped noise between steps
+ungrouped noise 1
+ungrouped noise 2
+##[group]Build
+build output
+##[endgroup]
+more ungrouped
 ##[group]Deploy
 line 2
 ##[endgroup]
-""",
-        step_number=2,
-    )
-    assert result["step_name"] == "Deploy"
-    assert result["match_strategy"] == "step_number"
-    assert "line 2" in result["log_text"]
-    assert "ungrouped noise between steps" not in result["log_text"]
+"""
+    for step_number, expected_name in ((1, "Checkout"), (2, "Build"), (3, "Deploy")):
+        result = extract_step_log(log_text, step_number=step_number)
+        assert result["step_name"] == expected_name
+        assert result["step_name"] != "ungrouped"
+        assert result["match_strategy"] == "step_number"
+
+    deploy = extract_step_log(log_text, step_number=3)
+    assert "line 2" in deploy["log_text"]
+    assert "ungrouped noise 1" not in deploy["log_text"]
+    assert "more ungrouped" not in deploy["log_text"]

--- a/tools/github_actions_tool/__init__.py
+++ b/tools/github_actions_tool/__init__.py
@@ -207,8 +207,9 @@ def extract_step_log(
     if selected is None and step_number is not None and 1 <= step_number <= group_count:
         group_counter = 0
         for i, section in enumerate(sections):
-            if section.get("name") != UNGROUPED_SECTION_NAME:
-                group_counter += 1
+            if section.get("name") == UNGROUPED_SECTION_NAME:
+                continue
+            group_counter += 1
             if group_counter == step_number:
                 selected = section
                 match_strategy = "step_number"


### PR DESCRIPTION
## Summary
- Skip ungrouped log sections when counting steps for `step_number` matching
- Add regression test for interleaved ungrouped noise between grouped steps

Fixes #2719

## Test plan
- [x] `uv run python -m pytest tests/tools/test_github_actions_tool.py::test_extract_step_log_step_number_skips_ungrouped_sections -q`