### PR TITLE
fix(cli): bootstrap ~/.opensre/.env on startup

### DIFF
--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -19,7 +19,8 @@ from config.platform_bootstrap import ensure_project_platform_package
 ensure_project_platform_package()
 
 import click  # noqa: E402
-from dotenv import load_dotenv  # noqa: E402
+
+from config.env_loading import load_opensre_env_files  # noqa: E402
 
 from cli.commands import register_commands  # noqa: E402
 from config.version import get_version  # noqa: E402
@@ -245,7 +246,7 @@ def _should_capture_cli_exception(exc: click.ClickException) -> bool:
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``opensre`` console script."""
     _ensure_utf8_stdio()
-    load_dotenv(override=False)
+    load_opensre_env_files()
     cli_argv = list(sys.argv[1:] if argv is None else argv)
     try:
         init_sentry(entrypoint=_sentry_entrypoint_for_invocation(cli_argv))

--- a/config/env_loading.py
+++ b/config/env_loading.py
@@ -27,7 +27,7 @@ def load_opensre_env_files() -> None:
     if home_env.is_file():
         load_dotenv(home_env, override=True)
 
-    project_env = os.getenv("OPENSRE_PROJECT_ENV_PATH", "").strip()
+    project_env = shell_exports.get("OPENSRE_PROJECT_ENV_PATH", "").strip()
     if project_env:
         project_path = Path(project_env)
         if project_path.is_file():

--- a/config/env_loading.py
+++ b/config/env_loading.py
@@ -1,0 +1,29 @@
+"""Environment file loading for CLI and runtime startup."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from config.constants import OPENSRE_HOME_DIR
+
+
+def load_opensre_env_files() -> None:
+    """Load user-global then project-level ``.env`` files.
+
+    Precedence (low → high):
+    1. ``~/.opensre/.env`` — durable config for installed-binary users
+    2. cwd ``.env`` or ``OPENSRE_PROJECT_ENV_PATH`` — project overlay wins
+    """
+    home_env = OPENSRE_HOME_DIR / ".env"
+    if home_env.is_file():
+        load_dotenv(home_env, override=False)
+
+    project_env = os.getenv("OPENSRE_PROJECT_ENV_PATH", "").strip()
+    if project_env and Path(project_env).is_file():
+        load_dotenv(project_env, override=True)
+        return
+
+    load_dotenv(override=True)

--- a/config/env_loading.py
+++ b/config/env_loading.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 
@@ -9,21 +10,42 @@ from dotenv import load_dotenv
 
 from config.constants import OPENSRE_HOME_DIR
 
+logger = logging.getLogger(__name__)
+
 
 def load_opensre_env_files() -> None:
     """Load user-global then project-level ``.env`` files.
 
     Precedence (low → high):
     1. ``~/.opensre/.env`` — durable config for installed-binary users
-    2. cwd ``.env`` or ``OPENSRE_PROJECT_ENV_PATH`` — project overlay wins
+    2. cwd ``.env`` or ``OPENSRE_PROJECT_ENV_PATH`` — project overlay
+    3. Shell exports present before startup — never overwritten by files
     """
+    shell_exports = dict(os.environ)
+
     home_env = OPENSRE_HOME_DIR / ".env"
     if home_env.is_file():
-        load_dotenv(home_env, override=False)
+        load_dotenv(home_env, override=True)
 
     project_env = os.getenv("OPENSRE_PROJECT_ENV_PATH", "").strip()
-    if project_env and Path(project_env).is_file():
-        load_dotenv(project_env, override=True)
+    if project_env:
+        project_path = Path(project_env)
+        if project_path.is_file():
+            load_dotenv(project_path, override=True)
+        else:
+            logger.warning(
+                "OPENSRE_PROJECT_ENV_PATH is set but not a file: %s",
+                project_env,
+            )
+            load_dotenv(override=True)
+        _restore_shell_exports(shell_exports)
         return
 
     load_dotenv(override=True)
+    _restore_shell_exports(shell_exports)
+
+
+def _restore_shell_exports(shell_exports: dict[str, str]) -> None:
+    """Re-apply variables that were exported in the shell before file loads."""
+    for key, value in shell_exports.items():
+        os.environ[key] = value

--- a/tests/config/test_env_loading.py
+++ b/tests/config/test_env_loading.py
@@ -62,3 +62,29 @@ def test_load_opensre_env_files_loads_home_only_when_no_project_env(
     load_opensre_env_files()
 
     assert os.environ["LLM_PROVIDER"] == "anthropic"
+
+
+def test_load_opensre_env_files_ignores_home_project_env_path_redirect(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Home ``.env`` must not override a shell-exported project env path."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    decoy = tmp_path / "decoy.env"
+    home.mkdir()
+    project.mkdir()
+    project_env = project / ".env"
+    (home / ".env").write_text(
+        f"OPENSRE_PROJECT_ENV_PATH={decoy}\nLLM_PROVIDER=anthropic\n",
+        encoding="utf-8",
+    )
+    project_env.write_text("LLM_PROVIDER=openai\n", encoding="utf-8")
+    decoy.write_text("LLM_PROVIDER=decoy\n", encoding="utf-8")
+
+    monkeypatch.setattr("config.env_loading.OPENSRE_HOME_DIR", home)
+    monkeypatch.setenv("OPENSRE_PROJECT_ENV_PATH", str(project_env))
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+
+    load_opensre_env_files()
+
+    assert os.environ["LLM_PROVIDER"] == "openai"

--- a/tests/config/test_env_loading.py
+++ b/tests/config/test_env_loading.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from config.env_loading import load_opensre_env_files
+
+
+def test_load_opensre_env_files_prefers_project_over_home(
+    monkeypatch, tmp_path: Path
+) -> None:
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    (home / ".env").write_text("LLM_PROVIDER=anthropic\n", encoding="utf-8")
+    env_file = project / ".env"
+    env_file.write_text("LLM_PROVIDER=openai\n", encoding="utf-8")
+
+    monkeypatch.setattr("config.env_loading.OPENSRE_HOME_DIR", home)
+    monkeypatch.setenv("OPENSRE_PROJECT_ENV_PATH", str(env_file))
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+
+    load_opensre_env_files()
+
+    import os
+
+    assert os.environ["LLM_PROVIDER"] == "openai"

--- a/tests/config/test_env_loading.py
+++ b/tests/config/test_env_loading.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
+
+import pytest
 
 from config.env_loading import load_opensre_env_files
 
 
 def test_load_opensre_env_files_prefers_project_over_home(
-    monkeypatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     home = tmp_path / "home"
     project = tmp_path / "project"
@@ -22,6 +25,40 @@ def test_load_opensre_env_files_prefers_project_over_home(
 
     load_opensre_env_files()
 
-    import os
-
     assert os.environ["LLM_PROVIDER"] == "openai"
+
+
+def test_load_opensre_env_files_keeps_shell_exports_over_project_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    (home / ".env").write_text("LLM_PROVIDER=anthropic\n", encoding="utf-8")
+    (project / ".env").write_text("LLM_PROVIDER=openai\n", encoding="utf-8")
+
+    monkeypatch.setattr("config.env_loading.OPENSRE_HOME_DIR", home)
+    monkeypatch.delenv("OPENSRE_PROJECT_ENV_PATH", raising=False)
+    monkeypatch.setenv("LLM_PROVIDER", "shell-export")
+    monkeypatch.chdir(project)
+
+    load_opensre_env_files()
+
+    assert os.environ["LLM_PROVIDER"] == "shell-export"
+
+
+def test_load_opensre_env_files_loads_home_only_when_no_project_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".env").write_text("LLM_PROVIDER=anthropic\n", encoding="utf-8")
+
+    monkeypatch.setattr("config.env_loading.OPENSRE_HOME_DIR", home)
+    monkeypatch.delenv("OPENSRE_PROJECT_ENV_PATH", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+
+    load_opensre_env_files()
+
+    assert os.environ["LLM_PROVIDER"] == "anthropic"


### PR DESCRIPTION
## Summary
- Load `~/.opensre/.env` before project-level env so installed-binary users keep durable config
- Preserve project override via cwd `.env` or `OPENSRE_PROJECT_ENV_PATH`
- Add unit test for home-vs-project precedence

Fixes #3090

## Test plan
- [x] `uv run python -m pytest tests/config/test_env_loading.py -q`