### PR TITLE
fix(discord): convert Slack mrkdwn links for Discord embeds

### DIFF
--- a/platform/notifications/discord_delivery.py
+++ b/platform/notifications/discord_delivery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Mapping
 from typing import Any
 
@@ -10,6 +11,19 @@ from platform.common.truncation import truncate
 from platform.notifications.delivery_transport import post_json
 
 logger = logging.getLogger(__name__)
+
+_SLACK_LINK_RE = re.compile(r"<(https?://[^|>]+)(?:\|([^>]+))?>")
+
+
+def _slack_mrkdwn_to_discord(text: str) -> str:
+    """Convert Slack-style links to Discord markdown before posting."""
+
+    def _repl(match: re.Match[str]) -> str:
+        url = match.group(1)
+        label = match.group(2)
+        return f"[{label}]({url})" if label else url
+
+    return _SLACK_LINK_RE.sub(_repl, text)
 
 
 def _discord_auth_headers(bot_token: str) -> dict[str, str]:
@@ -112,7 +126,7 @@ def send_discord_report(report: str, discord_ctx: dict[str, Any]) -> tuple[bool,
     embed = {
         "title": truncate("Investigation Complete", _EMBED_TITLE_LIMIT, suffix="…"),
         "color": 15158332,
-        "description": truncate(report, _EMBED_DESCRIPTION_LIMIT, suffix="…"),
+        "description": truncate(_slack_mrkdwn_to_discord(report), _EMBED_DESCRIPTION_LIMIT, suffix="…"),
         "footer": {"text": "OpenSRE Investigation"},
     }
     target = thread_id if thread_id else channel_id

--- a/platform/notifications/discord_delivery.py
+++ b/platform/notifications/discord_delivery.py
@@ -13,17 +13,37 @@ from platform.notifications.delivery_transport import post_json
 logger = logging.getLogger(__name__)
 
 _SLACK_LINK_RE = re.compile(r"<(https?://[^|>]+)(?:\|([^>]+))?>")
+_SLACK_USER_MENTION_RE = re.compile(r"<@([^|>]+)(?:\|([^>]+))?>")
+_SLACK_CHANNEL_MENTION_RE = re.compile(r"<#([^|>]+)(?:\|([^>]+))?>")
+_SLACK_SPECIAL_MENTION_RE = re.compile(r"<!([^>]+)>")
 
 
 def _slack_mrkdwn_to_discord(text: str) -> str:
-    """Convert Slack-style links to Discord markdown before posting."""
+    """Convert Slack-style mrkdwn tokens to Discord-friendly markdown."""
 
-    def _repl(match: re.Match[str]) -> str:
+    def _link_repl(match: re.Match[str]) -> str:
         url = match.group(1)
         label = match.group(2)
         return f"[{label}]({url})" if label else url
 
-    return _SLACK_LINK_RE.sub(_repl, text)
+    def _user_repl(match: re.Match[str]) -> str:
+        label = match.group(2)
+        return f"@{label}" if label else "@user"
+
+    def _channel_repl(match: re.Match[str]) -> str:
+        label = match.group(2)
+        return f"#{label}" if label else "#channel"
+
+    def _special_repl(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name in {"here", "channel", "everyone"}:
+            return f"@{name}"
+        return match.group(0)
+
+    text = _SLACK_LINK_RE.sub(_link_repl, text)
+    text = _SLACK_USER_MENTION_RE.sub(_user_repl, text)
+    text = _SLACK_CHANNEL_MENTION_RE.sub(_channel_repl, text)
+    return _SLACK_SPECIAL_MENTION_RE.sub(_special_repl, text)
 
 
 def _discord_auth_headers(bot_token: str) -> dict[str, str]:

--- a/tests/utils/test_discord_delivery.py
+++ b/tests/utils/test_discord_delivery.py
@@ -228,6 +228,38 @@ def test_send_discord_report_converts_slack_links(monkeypatch: pytest.MonkeyPatc
     assert description == "See [workflow run](https://example.com/run) for details."
 
 
+def test_send_discord_report_converts_bare_slack_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        "platform.notifications.delivery_transport.httpx.post",
+        lambda *_a, **kw: (
+            captured.update({"embeds": kw["json"].get("embeds", [])})
+            or _mock_response(200, {"id": "m-1"})
+        ),  # type: ignore[misc]
+    )
+    report = "Details at <https://example.com/run>."
+    send_discord_report(report, {"channel_id": "chan-1", "bot_token": "tok"})
+    description = captured["embeds"][0]["description"]
+    assert description == "Details at https://example.com/run."
+
+
+def test_send_discord_report_converts_slack_mentions(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        "platform.notifications.delivery_transport.httpx.post",
+        lambda *_a, **kw: (
+            captured.update({"embeds": kw["json"].get("embeds", [])})
+            or _mock_response(200, {"id": "m-1"})
+        ),  # type: ignore[misc]
+    )
+    report = "Page <@U123|alice> in <#C456|incidents> <!here>."
+    send_discord_report(report, {"channel_id": "chan-1", "bot_token": "tok"})
+    description = captured["embeds"][0]["description"]
+    assert description == "Page @alice in #incidents @here."
+
+
 def test_send_discord_report_truncates_description_to_4096(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 

--- a/tests/utils/test_discord_delivery.py
+++ b/tests/utils/test_discord_delivery.py
@@ -212,6 +212,22 @@ def test_send_discord_report_returns_false_on_api_error(monkeypatch: pytest.Monk
     assert "Forbidden" in error
 
 
+def test_send_discord_report_converts_slack_links(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        "platform.notifications.delivery_transport.httpx.post",
+        lambda *_a, **kw: (
+            captured.update({"embeds": kw["json"].get("embeds", [])})
+            or _mock_response(200, {"id": "m-1"})
+        ),  # type: ignore[misc]
+    )
+    report = "See <https://example.com/run|workflow run> for details."
+    send_discord_report(report, {"channel_id": "chan-1", "bot_token": "tok"})
+    description = captured["embeds"][0]["description"]
+    assert description == "See [workflow run](https://example.com/run) for details."
+
+
 def test_send_discord_report_truncates_description_to_4096(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary
- Convert Slack-style `<url|label>` links to Discord markdown before posting investigation reports
- Add regression test for link conversion in embed descriptions

Fixes #2007

## Test plan
- [x] `uv run python -m pytest tests/utils/test_discord_delivery.py::test_send_discord_report_converts_slack_links -q`