### PR TITLE
fix(wizard): fall back to .env when keyring unavailable on onboard

### DIFF
--- a/cli/wizard/_ui.py
+++ b/cli/wizard/_ui.py
@@ -11,15 +11,14 @@ from rich.console import Console
 from rich.rule import Rule
 from rich.text import Text
 
-from cli.llm_auth.service import AuthSetupError, persist_api_key_secret
+from cli.llm_auth.service import AuthSetupError
 from cli.wizard.config import PROVIDER_BY_VALUE, ProviderOption
 from cli.wizard.integration_health import IntegrationHealthResult
 from cli.wizard.probes import ProbeResult
 from cli.wizard.prompts import select as select_prompt
 from cli.wizard.store import get_store_path, load_local_config
-from config.llm_auth.credentials import has_llm_api_key, save_api_key
-from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
-from config.llm_credentials import get_keyring_setup_instructions, save_llm_api_key
+from config.llm_auth.credentials import has_llm_api_key
+from config.llm_credentials import get_keyring_setup_instructions
 from config.version import get_version
 from integrations.store import get_integration
 from platform.terminal.theme import (
@@ -335,19 +334,10 @@ def _prompt_value(
 
 
 def _persist_llm_api_key(env_var: str, value: str) -> bool:
+    from cli.wizard.env_sync import persist_env_secret_with_env_fallback
+
     try:
-        provider = next(
-            (
-                name
-                for name, provider_env in API_KEY_PROVIDER_ENVS.items()
-                if provider_env == env_var
-            ),
-            "",
-        )
-        if provider:
-            save_api_key(provider, value)
-        else:
-            persist_api_key_secret(env_var, value, save_secret=save_llm_api_key)
+        storage, env_path = persist_env_secret_with_env_fallback(env_var, value)
     except (AuthSetupError, RuntimeError, ValueError) as exc:
         _console.print(f"[{ERROR}]  {GLYPH_ERROR}  {exc}[/]")
         _console.print(
@@ -356,6 +346,12 @@ def _persist_llm_api_key(env_var: str, value: str) -> bool:
         for line in get_keyring_setup_instructions(env_var):
             _console.print(f"[{SECONDARY}]    {line}[/]")
         return False
+
+    if storage == "env" and env_path is not None:
+        _console.print(
+            f"[{WARNING}]  {GLYPH_WARNING}  Secure storage unavailable — saved {env_var} to {env_path} "
+            f"(owner-only permissions). Prefer a system keychain when available.[/]"
+        )
     return True
 
 

--- a/cli/wizard/_ui.py
+++ b/cli/wizard/_ui.py
@@ -338,7 +338,7 @@ def _persist_llm_api_key(env_var: str, value: str) -> bool:
 
     try:
         storage, env_path = persist_env_secret_with_env_fallback(env_var, value)
-    except (AuthSetupError, RuntimeError, ValueError) as exc:
+    except (AuthSetupError, RuntimeError, ValueError, OSError) as exc:
         _console.print(f"[{ERROR}]  {GLYPH_ERROR}  {exc}[/]")
         _console.print(
             f"[{WARNING}]  {GLYPH_WARNING}  OpenSRE could not save your API key to the local system keychain.[/]"

--- a/cli/wizard/env_sync.py
+++ b/cli/wizard/env_sync.py
@@ -74,6 +74,25 @@ def _strip_sensitive_env_lines(lines: list[str]) -> list[str]:
     return stripped
 
 
+def _strip_keyring_backed_secret_lines(lines: list[str]) -> list[str]:
+    """Drop sensitive lines already stored in the keyring; keep headless fallback secrets."""
+    kept: list[str] = []
+    for line in lines:
+        match = _ENV_ASSIGNMENT.match(line)
+        if match and _is_sensitive_env_key(match.group(1)) and has_llm_api_key(match.group(1)):
+            continue
+        kept.append(line)
+    return kept
+
+
+def _lines_contain_sensitive(lines: list[str]) -> bool:
+    for line in lines:
+        match = _ENV_ASSIGNMENT.match(line)
+        if match and _is_sensitive_env_key(match.group(1)):
+            return True
+    return False
+
+
 def _persist_env_secret(key: str, value: str) -> bool:
     """Store a secret in the keyring. Returns False when keyring is unavailable."""
     normalized = value.strip()
@@ -186,26 +205,40 @@ def persist_env_secret_with_env_fallback(
         if target_path.exists()
         else []
     )
-    lines = _strip_sensitive_env_lines(existing)
-    lines = _set_env_value_unchecked(lines, key, value)
+    lines = _set_env_value_unchecked(list(existing), key, value)
     _write_env_raw(target_path, lines)
     return "env", target_path
 
 
 def _write_env_raw(target_path: Path, lines: list[str]) -> None:
     """Write ``.env`` lines including secrets (headless fallback only)."""
+    content = "".join(lines)
     try:
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        with target_path.open("w", encoding="utf-8", newline="") as env_file:
-            env_file.writelines(lines)
+        if os.name == "nt":
+            with target_path.open("w", encoding="utf-8", newline="") as env_file:
+                env_file.write(content)
+        else:
+            fd = os.open(
+                target_path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                0o600,
+            )
+            with os.fdopen(fd, "w", encoding="utf-8", newline="") as env_file:
+                env_file.write(content)
     except PermissionError as exc:
         raise PermissionError(
             f"Cannot write to {target_path}: permission denied. "
             "Ensure you have write access to this file, or run the command as the file owner."
         ) from exc
-    if os.name != "nt":
-        with suppress(OSError):
-            target_path.chmod(0o600)
+
+
+def _write_env_lines(target_path: Path, lines: list[str]) -> None:
+    """Write merged env lines, using the secure raw path when secrets are present."""
+    if _lines_contain_sensitive(lines):
+        _write_env_raw(target_path, lines)
+    else:
+        _write_env(target_path, lines)
 
 
 def _print_env_fallback_warning(key: str, env_path: Path) -> None:
@@ -239,11 +272,11 @@ def sync_env_values(
         else []
     )
 
-    lines = _strip_sensitive_env_lines(existing)
+    lines = _strip_keyring_backed_secret_lines(list(existing))
     for key, value in values.items():
         lines = _set_env_value(lines, key, value)
 
-    _write_env(target_path, lines)
+    _write_env_lines(target_path, lines)
     return target_path
 
 

--- a/cli/wizard/env_sync.py
+++ b/cli/wizard/env_sync.py
@@ -187,9 +187,15 @@ def persist_env_secret_with_env_fallback(
 
 def _write_env_raw(target_path: Path, lines: list[str]) -> None:
     """Write ``.env`` lines including secrets (headless fallback only)."""
-    target_path.parent.mkdir(parents=True, exist_ok=True)
-    with target_path.open("w", encoding="utf-8", newline="") as env_file:
-        env_file.writelines(lines)
+    try:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        with target_path.open("w", encoding="utf-8", newline="") as env_file:
+            env_file.writelines(lines)
+    except PermissionError as exc:
+        raise PermissionError(
+            f"Cannot write to {target_path}: permission denied. "
+            "Ensure you have write access to this file, or run the command as the file owner."
+        ) from exc
     if os.name != "nt":
         with suppress(OSError):
             target_path.chmod(0o600)

--- a/cli/wizard/env_sync.py
+++ b/cli/wizard/env_sync.py
@@ -102,6 +102,10 @@ def _set_env_value(lines: list[str], key: str, value: str) -> list[str]:
         raise RuntimeError(
             f"Refusing to write sensitive env key {key!r} to .env; use sync_env_secret()."
         )
+    return _set_env_value_unchecked(lines, key, value)
+
+
+def _set_env_value_unchecked(lines: list[str], key: str, value: str) -> list[str]:
     updated: list[str] = []
     replaced = False
     for line in lines:
@@ -151,6 +155,44 @@ def sync_env_secret(key: str, value: str) -> None:
     if not _is_sensitive_env_key(key):
         raise ValueError(f"{key!r} is not classified as sensitive; use sync_env_values instead.")
     _persist_env_secret(key, value)
+
+
+def persist_env_secret_with_env_fallback(
+    key: str,
+    value: str,
+    *,
+    env_path: Path | None = None,
+) -> tuple[str, Path | None]:
+    """Persist a secret to the keyring, falling back to ``.env`` when unavailable.
+
+    Returns ``("keyring", None)`` on keyring success, or ``("env", path)`` when
+    the value was written to the project ``.env`` for headless hosts.
+    """
+    if not _is_sensitive_env_key(key):
+        raise ValueError(f"{key!r} is not classified as sensitive.")
+    if _persist_env_secret(key, value):
+        return "keyring", None
+
+    target_path = env_path or PROJECT_ENV_PATH
+    existing = (
+        target_path.read_text(encoding="utf-8").splitlines(keepends=True)
+        if target_path.exists()
+        else []
+    )
+    lines = _strip_sensitive_env_lines(existing)
+    lines = _set_env_value_unchecked(lines, key, value)
+    _write_env_raw(target_path, lines)
+    return "env", target_path
+
+
+def _write_env_raw(target_path: Path, lines: list[str]) -> None:
+    """Write ``.env`` lines including secrets (headless fallback only)."""
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    with target_path.open("w", encoding="utf-8", newline="") as env_file:
+        env_file.writelines(lines)
+    if os.name != "nt":
+        with suppress(OSError):
+            target_path.chmod(0o600)
 
 
 def sync_env_values(

--- a/cli/wizard/env_sync.py
+++ b/cli/wizard/env_sync.py
@@ -151,10 +151,17 @@ def _write_env(target_path: Path, lines: list[str]) -> None:
 
 
 def sync_env_secret(key: str, value: str) -> None:
-    """Persist a sensitive env value in the system keyring, not in ``.env``."""
+    """Persist a sensitive env value in the keyring, with ``.env`` fallback.
+
+    When the system keyring is unavailable (headless hosts, CI, Docker), the
+    secret is written to the project ``.env`` with owner-only permissions and
+    a warning is printed so onboarding does not silently drop credentials.
+    """
     if not _is_sensitive_env_key(key):
         raise ValueError(f"{key!r} is not classified as sensitive; use sync_env_values instead.")
-    _persist_env_secret(key, value)
+    storage, env_path = persist_env_secret_with_env_fallback(key, value)
+    if storage == "env" and env_path is not None:
+        _print_env_fallback_warning(key, env_path)
 
 
 def persist_env_secret_with_env_fallback(
@@ -201,6 +208,16 @@ def _write_env_raw(target_path: Path, lines: list[str]) -> None:
             target_path.chmod(0o600)
 
 
+def _print_env_fallback_warning(key: str, env_path: Path) -> None:
+    from cli.wizard._ui import _console
+    from platform.terminal.theme import GLYPH_WARNING, WARNING
+
+    _console.print(
+        f"[{WARNING}]  {GLYPH_WARNING}  Secure storage unavailable — saved {key} to {env_path} "
+        f"(owner-only permissions). Prefer a system keychain when available.[/]"
+    )
+
+
 def sync_env_values(
     values: dict[str, str],
     *,
@@ -209,7 +226,6 @@ def sync_env_values(
     """Write multiple non-sensitive environment values into the target .env file.
 
     Sensitive keys must be persisted with :func:`sync_env_secret` instead.
-    When keyring storage is unavailable, sensitive values are not written to ``.env``.
     """
     sensitive_keys = [key for key in values if _is_sensitive_env_key(key)]
     if sensitive_keys:

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -443,6 +443,20 @@ def test_sync_env_values_permission_error(tmp_path) -> None:
         env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
 
 
+@pytest.mark.skipif(_SKIP_AS_ROOT, reason="root bypasses file permission checks")
+def test_write_env_raw_permission_error(tmp_path) -> None:
+    from cli.wizard.env_sync import _write_env_raw
+
+    env_path = tmp_path / ".env"
+    env_path.write_text("FOO=bar\n", encoding="utf-8")
+    env_path.chmod(stat.S_IRUSR)
+    try:
+        with pytest.raises(PermissionError, match="permission denied"):
+            _write_env_raw(env_path, ["ANTHROPIC_API_KEY=secret\n"])
+    finally:
+        env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
 def test_persist_env_secret_with_env_fallback_writes_env_when_keyring_unavailable(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -474,3 +474,33 @@ def test_persist_env_secret_with_env_fallback_writes_env_when_keyring_unavailabl
     assert storage == "env"
     assert written_path == env_path
     assert "ANTHROPIC_API_KEY=secret-value" in env_path.read_text(encoding="utf-8")
+
+
+def test_sync_env_secret_falls_back_to_env_when_keyring_unavailable(
+    tmp_path, monkeypatch
+) -> None:
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr("cli.wizard.env_sync.PROJECT_ENV_PATH", env_path)
+    monkeypatch.setattr("cli.wizard.env_sync._persist_env_secret", lambda *_a, **_k: False)
+
+    sync_env_secret("ANTHROPIC_API_KEY", "secret-value")
+
+    assert "ANTHROPIC_API_KEY=secret-value" in env_path.read_text(encoding="utf-8")
+
+
+def test_sync_env_secret_warns_when_keyring_fallback_writes_env(
+    tmp_path, monkeypatch
+) -> None:
+    env_path = tmp_path / ".env"
+    warnings: list[str] = []
+    monkeypatch.setattr("cli.wizard.env_sync.PROJECT_ENV_PATH", env_path)
+    monkeypatch.setattr("cli.wizard.env_sync._persist_env_secret", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        "cli.wizard.env_sync._print_env_fallback_warning",
+        lambda key, path: warnings.append(f"{key}:{path}"),
+    )
+
+    sync_env_secret("ANTHROPIC_API_KEY", "secret-value")
+
+    assert warnings == [f"ANTHROPIC_API_KEY:{env_path}"]
+    assert "ANTHROPIC_API_KEY=secret-value" in env_path.read_text(encoding="utf-8")

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -504,3 +504,42 @@ def test_sync_env_secret_warns_when_keyring_fallback_writes_env(
 
     assert warnings == [f"ANTHROPIC_API_KEY:{env_path}"]
     assert "ANTHROPIC_API_KEY=secret-value" in env_path.read_text(encoding="utf-8")
+
+
+def test_sync_env_secret_fallback_preserves_prior_secrets(tmp_path, monkeypatch) -> None:
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr("cli.wizard.env_sync.PROJECT_ENV_PATH", env_path)
+    monkeypatch.setattr("cli.wizard.env_sync._persist_env_secret", lambda *_a, **_k: False)
+
+    sync_env_secret("DD_API_KEY", "datadog-api")
+    sync_env_secret("DD_APP_KEY", "datadog-app")
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "DD_API_KEY=datadog-api" in content
+    assert "DD_APP_KEY=datadog-app" in content
+
+
+def test_sync_env_values_preserves_fallback_secrets(tmp_path, monkeypatch) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "DD_API_KEY=datadog-api\nDD_APP_KEY=datadog-app\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("cli.wizard.env_sync.PROJECT_ENV_PATH", env_path)
+
+    sync_env_values({"DD_SITE": "datadoghq.com"}, env_path=env_path)
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "DD_API_KEY=datadog-api" in content
+    assert "DD_APP_KEY=datadog-app" in content
+    assert "DD_SITE=datadoghq.com" in content
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows permission model differs")
+def test_write_env_raw_creates_file_with_owner_only_permissions(tmp_path) -> None:
+    from cli.wizard.env_sync import _write_env_raw
+
+    env_path = tmp_path / ".env"
+    _write_env_raw(env_path, ["ANTHROPIC_API_KEY=secret\n"])
+
+    assert stat.S_IMODE(env_path.stat().st_mode) == 0o600

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -441,3 +441,22 @@ def test_sync_env_values_permission_error(tmp_path) -> None:
             sync_env_values({"FOO": "baz"}, env_path=env_path)
     finally:
         env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+def test_persist_env_secret_with_env_fallback_writes_env_when_keyring_unavailable(
+    tmp_path, monkeypatch
+) -> None:
+    from cli.wizard.env_sync import persist_env_secret_with_env_fallback
+
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr("cli.wizard.env_sync._persist_env_secret", lambda *_a, **_k: False)
+
+    storage, written_path = persist_env_secret_with_env_fallback(
+        "ANTHROPIC_API_KEY",
+        "secret-value",
+        env_path=env_path,
+    )
+
+    assert storage == "env"
+    assert written_path == env_path
+    assert "ANTHROPIC_API_KEY=secret-value" in env_path.read_text(encoding="utf-8")

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -19,7 +19,7 @@ _ORIGINAL_PERSIST_LLM_API_KEY = _ui._persist_llm_api_key
 @pytest.fixture(autouse=True)
 def _stub_managed_llm_secret_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
     """Wizard flow tests should not touch the developer's real keyring."""
-    monkeypatch.setattr(_ui, "_persist_llm_api_key", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(flow, "_persist_llm_api_key", lambda *_args, **_kwargs: True)
 
 
 def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, capsys) -> None:
@@ -62,11 +62,11 @@ def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, c
 
     monkeypatch.setattr(flow, "save_local_config", _save_local_config)
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(
-        _ui,
-        "save_api_key",
-        lambda provider, value, **_kwargs: saved_llm_keys.append((provider, value)),
-    )
+    def _record_persist(env_var: str, value: str) -> bool:
+        saved_llm_keys.append((env_var, value))
+        return True
+
+    monkeypatch.setattr(flow, "_persist_llm_api_key", _record_persist)
 
     exit_code = flow.run_wizard()
 
@@ -74,7 +74,7 @@ def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, c
     assert saved["wizard_mode"] == "advanced"
     assert saved["provider"] == "anthropic"
     assert "api_key" not in saved
-    assert saved_llm_keys == [("anthropic", "secret-key")]
+    assert saved_llm_keys == [("ANTHROPIC_API_KEY", "secret-key")]
 
     output = capsys.readouterr().out
     assert "Summary" in output
@@ -104,9 +104,6 @@ def test_run_wizard_no_saved_provider_shows_selection(monkeypatch, tmp_path) -> 
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
-    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     exit_code = flow.run_wizard()
     assert exit_code == 0
@@ -151,7 +148,7 @@ def test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable(
         "cli.wizard.env_sync._persist_env_secret",
         lambda *_args, **_kwargs: False,
     )
-    monkeypatch.setattr(_ui, "_persist_llm_api_key", _ORIGINAL_PERSIST_LLM_API_KEY)
+    monkeypatch.setattr(flow, "_persist_llm_api_key", _ORIGINAL_PERSIST_LLM_API_KEY)
 
     exit_code = flow.run_wizard()
 
@@ -198,6 +195,7 @@ def test_run_wizard_shows_keyring_setup_when_env_fallback_also_fails(
             "Start a D-Bus shell: dbus-run-session -- sh",
         ),
     )
+    monkeypatch.setattr(flow, "_persist_llm_api_key", _ORIGINAL_PERSIST_LLM_API_KEY)
 
     exit_code = flow.run_wizard()
 
@@ -256,7 +254,6 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -328,7 +325,6 @@ def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -406,7 +402,6 @@ def test_run_wizard_configures_coralogix(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -481,7 +476,6 @@ def test_run_wizard_configures_dagster(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -554,7 +548,6 @@ def test_run_wizard_configures_dagster_oss_skips_secret(monkeypatch, tmp_path) -
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         _integration_configurators,
         "sync_env_values",
@@ -621,7 +614,6 @@ def test_run_wizard_configures_slack_persists_webhook(monkeypatch, tmp_path) -> 
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -701,7 +693,6 @@ def test_run_wizard_dagster_retries_on_validation_failure(monkeypatch, tmp_path)
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -797,7 +788,6 @@ def test_run_wizard_configures_github_mcp_and_sentry(monkeypatch, tmp_path, caps
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -896,11 +886,11 @@ def test_run_wizard_reuses_saved_defaults_when_user_keeps_provider(monkeypatch, 
 
     monkeypatch.setattr(flow, "save_local_config", _save_local_config)
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(
-        _ui,
-        "save_api_key",
-        lambda provider, value, **_kwargs: saved_llm_keys.append((provider, value)),
-    )
+    def _record_persist(env_var: str, value: str) -> bool:
+        saved_llm_keys.append((env_var, value))
+        return True
+
+    monkeypatch.setattr(flow, "_persist_llm_api_key", _record_persist)
 
     exit_code = flow.run_wizard()
 
@@ -909,7 +899,7 @@ def test_run_wizard_reuses_saved_defaults_when_user_keeps_provider(monkeypatch, 
     assert saved["provider"] == "openai"
     assert saved["model"] == "gpt-5.4-mini"
     assert "api_key" not in saved
-    assert saved_llm_keys == [("openai", "saved-secret")]
+    assert saved_llm_keys == [("OPENAI_API_KEY", "saved-secret")]
 
 
 def test_run_wizard_changes_model_when_user_keeps_provider(monkeypatch, tmp_path) -> None:
@@ -1007,11 +997,11 @@ def test_run_wizard_persists_matching_local_config_and_env(monkeypatch, tmp_path
         "sync_provider_env",
         lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
     )
-    monkeypatch.setattr(
-        _ui,
-        "save_api_key",
-        lambda provider, value, **_kwargs: saved_llm_keys.append((provider, value)),
-    )
+    def _record_persist(env_var: str, value: str) -> bool:
+        saved_llm_keys.append((env_var, value))
+        return True
+
+    monkeypatch.setattr(flow, "_persist_llm_api_key", _record_persist)
 
     exit_code = flow.run_wizard()
 
@@ -1028,7 +1018,7 @@ def test_run_wizard_persists_matching_local_config_and_env(monkeypatch, tmp_path
 
     assert "LLM_PROVIDER=openai\n" in env_values
     assert "OPENAI_API_KEY=" not in env_values
-    assert saved_llm_keys == [("openai", "openai-secret")]
+    assert saved_llm_keys == [("OPENAI_API_KEY", "openai-secret")]
 
 
 def test_run_wizard_codex_skips_api_key_and_runs_cli_onboarding(monkeypatch, tmp_path) -> None:
@@ -1062,11 +1052,11 @@ def test_run_wizard_codex_skips_api_key_and_runs_cli_onboarding(monkeypatch, tmp
         "sync_provider_env",
         lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
     )
-    monkeypatch.setattr(
-        _ui,
-        "save_api_key",
-        lambda provider, value, **_kwargs: saved_llm_keys.append((provider, value)),
-    )
+    def _record_persist(env_var: str, value: str) -> bool:
+        saved_llm_keys.append((env_var, value))
+        return True
+
+    monkeypatch.setattr(flow, "_persist_llm_api_key", _record_persist)
 
     exit_code = flow.run_wizard()
 
@@ -1116,11 +1106,11 @@ def test_run_wizard_claude_code_skips_api_key_and_runs_cli_onboarding(
         "sync_provider_env",
         lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
     )
-    monkeypatch.setattr(
-        _ui,
-        "save_api_key",
-        lambda provider, value, **_kwargs: saved_llm_keys.append((provider, value)),
-    )
+    def _record_persist(env_var: str, value: str) -> bool:
+        saved_llm_keys.append((env_var, value))
+        return True
+
+    monkeypatch.setattr(flow, "_persist_llm_api_key", _record_persist)
 
     exit_code = flow.run_wizard()
 
@@ -1168,11 +1158,11 @@ def test_run_wizard_gemini_cli_skips_api_key_and_runs_cli_onboarding(monkeypatch
         "sync_provider_env",
         lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
     )
-    monkeypatch.setattr(
-        _ui,
-        "save_api_key",
-        lambda provider, value, **_kwargs: saved_llm_keys.append((provider, value)),
-    )
+    def _record_persist(env_var: str, value: str) -> bool:
+        saved_llm_keys.append((env_var, value))
+        return True
+
+    monkeypatch.setattr(flow, "_persist_llm_api_key", _record_persist)
 
     exit_code = flow.run_wizard()
 
@@ -1571,7 +1561,6 @@ def test_run_wizard_configures_gitlab(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -1659,7 +1648,6 @@ def test_run_wizard_gitlab_retries_on_validation_failure(monkeypatch, tmp_path) 
     monkeypatch.setattr(_integration_configurators, "validate_gitlab_integration", _validate_gitlab)
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -1758,11 +1746,11 @@ def test_run_wizard_switches_provider_and_keeps_store_and_env_in_sync(
         "sync_provider_env",
         lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
     )
-    monkeypatch.setattr(
-        _ui,
-        "save_api_key",
-        lambda provider, value, **_kwargs: saved_llm_keys.append((provider, value)),
-    )
+    def _record_persist(env_var: str, value: str) -> bool:
+        saved_llm_keys.append((env_var, value))
+        return True
+
+    monkeypatch.setattr(flow, "_persist_llm_api_key", _record_persist)
 
     exit_code = flow.run_wizard()
 
@@ -1780,7 +1768,7 @@ def test_run_wizard_switches_provider_and_keeps_store_and_env_in_sync(
     assert "OPENAI_API_KEY=" not in env_values
     assert "ANTHROPIC_API_KEY=" not in env_values
     assert "OPENAI_REASONING_MODEL=" in env_values
-    assert saved_llm_keys == [("openai", "fresh-openai-key")]
+    assert saved_llm_keys == [("OPENAI_API_KEY", "fresh-openai-key")]
 
 
 def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
@@ -1821,7 +1809,6 @@ def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -1919,7 +1906,6 @@ def test_run_wizard_opensearch_retries_on_validation_failure(monkeypatch, tmp_pa
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2015,7 +2001,6 @@ def test_run_wizard_opensearch_rejects_empty_api_key(monkeypatch, tmp_path) -> N
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2114,7 +2099,6 @@ def test_run_wizard_opensearch_rejects_empty_basic_password(monkeypatch, tmp_pat
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2191,7 +2175,6 @@ def test_run_wizard_configures_telegram(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2265,7 +2248,6 @@ def test_run_wizard_telegram_retries_on_validation_failure(monkeypatch, tmp_path
     monkeypatch.setattr(_integration_configurators, "validate_telegram_bot", _validate)
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         _integration_configurators, "sync_env_values", lambda *_a, **_kw: tmp_path / ".env"
     )

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -50,8 +50,6 @@ def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, c
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
-    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
-    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         flow, "probe_remote_target", lambda: ProbeResult("remote", True, "remote ok")
     )
@@ -240,8 +238,6 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
-    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
-    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators,
         "validate_grafana_integration",
@@ -316,8 +312,6 @@ def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
-    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
-    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators,
         "validate_honeycomb_integration",

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -13,11 +13,13 @@ from cli.wizard.env_sync import sync_provider_env
 from cli.wizard.probes import ProbeResult
 from tests.integrations.llm_cli.testing_helpers import write_fake_runnable_cli_bin
 
+_ORIGINAL_PERSIST_LLM_API_KEY = _ui._persist_llm_api_key
+
 
 @pytest.fixture(autouse=True)
 def _stub_managed_llm_secret_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Wizard flow tests should not touch the developer's real keychain."""
-    monkeypatch.setattr(_ui, "save_api_key", lambda *_args, **_kwargs: None)
+    """Wizard flow tests should not touch the developer's real keyring."""
+    monkeypatch.setattr(_ui, "_persist_llm_api_key", lambda *_args, **_kwargs: True)
 
 
 def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, capsys) -> None:
@@ -48,6 +50,8 @@ def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, c
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         flow, "probe_remote_target", lambda: ProbeResult("remote", True, "remote ok")
     )
@@ -100,6 +104,8 @@ def test_run_wizard_no_saved_provider_shows_selection(monkeypatch, tmp_path) -> 
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
 
     exit_code = flow.run_wizard()
@@ -109,7 +115,57 @@ def test_run_wizard_no_saved_provider_shows_selection(monkeypatch, tmp_path) -> 
 def test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable(
     monkeypatch, tmp_path, capsys
 ) -> None:
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7"])
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "skip"])
+
+    def _mock_select(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(select_responses)
+        return m
+
+    def _mock_password(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = "secret-key"
+        return m
+
+    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(flow.questionary, "password", _mock_password)
+    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(_ui, "load_local_config", lambda: {})
+    monkeypatch.setattr(_ui, "has_llm_api_key", lambda _env: False)
+    monkeypatch.setattr(
+        flow,
+        "_local_defaults",
+        lambda: {
+            "provider": None,
+            "model": "",
+            "wizard_mode": "quickstart",
+            "has_api_key": False,
+            "legacy_api_key": "",
+        },
+    )
+    monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
+    monkeypatch.setattr("cli.wizard.env_sync.PROJECT_ENV_PATH", tmp_path / ".env")
+    monkeypatch.setattr(
+        "cli.wizard.env_sync._persist_env_secret",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(_ui, "_persist_llm_api_key", _ORIGINAL_PERSIST_LLM_API_KEY)
+
+    exit_code = flow.run_wizard()
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    env_text = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert "ANTHROPIC_API_KEY=secret-key" in env_text
+    assert "Secure storage unavailable" in output or "ANTHROPIC_API_KEY" in env_text
+
+
+def test_run_wizard_shows_keyring_setup_when_env_fallback_also_fails(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "skip"])
 
     def _mock_select(*_args, **_kwargs):
         m = MagicMock()
@@ -125,9 +181,10 @@ def test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable(
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
-        "save_api_key",
+        "cli.wizard.env_sync.persist_env_secret_with_env_fallback",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(
             RuntimeError("Secure local credential storage is unavailable on this machine.")
         ),
@@ -185,6 +242,8 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators,
         "validate_grafana_integration",
@@ -260,6 +319,8 @@ def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators,
         "validate_honeycomb_integration",
@@ -336,6 +397,8 @@ def test_run_wizard_configures_coralogix(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators,
         "validate_coralogix_integration",
@@ -409,6 +472,8 @@ def test_run_wizard_configures_dagster(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators,
         "validate_dagster_integration",
@@ -480,6 +545,8 @@ def test_run_wizard_configures_dagster_oss_skips_secret(monkeypatch, tmp_path) -
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators,
         "validate_dagster_integration",
@@ -545,6 +612,8 @@ def test_run_wizard_configures_slack_persists_webhook(monkeypatch, tmp_path) -> 
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators,
         "validate_slack_webhook",
@@ -625,6 +694,8 @@ def test_run_wizard_dagster_retries_on_validation_failure(monkeypatch, tmp_path)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators, "validate_dagster_integration", _validate_dagster
     )
@@ -717,6 +788,8 @@ def test_run_wizard_configures_github_mcp_and_sentry(monkeypatch, tmp_path, caps
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators,
         "validate_github_mcp_integration",
@@ -1489,6 +1562,8 @@ def test_run_wizard_configures_gitlab(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators,
         "validate_gitlab_integration",
@@ -1579,6 +1654,8 @@ def test_run_wizard_gitlab_retries_on_validation_failure(monkeypatch, tmp_path) 
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(_integration_configurators, "validate_gitlab_integration", _validate_gitlab)
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
@@ -1735,6 +1812,8 @@ def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators,
         "validate_opensearch_integration",
@@ -1833,6 +1912,8 @@ def test_run_wizard_opensearch_retries_on_validation_failure(monkeypatch, tmp_pa
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators, "validate_opensearch_integration", _validate_opensearch
     )
@@ -1927,6 +2008,8 @@ def test_run_wizard_opensearch_rejects_empty_api_key(monkeypatch, tmp_path) -> N
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators, "validate_opensearch_integration", _validate_opensearch
     )
@@ -2024,6 +2107,8 @@ def test_run_wizard_opensearch_rejects_empty_basic_password(monkeypatch, tmp_pat
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators, "validate_opensearch_integration", _validate_opensearch
     )
@@ -2095,6 +2180,8 @@ def test_run_wizard_configures_telegram(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
         _integration_configurators,
         "validate_telegram_bot",
@@ -2173,6 +2260,8 @@ def test_run_wizard_telegram_retries_on_validation_failure(monkeypatch, tmp_path
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(_integration_configurators, "validate_telegram_bot", _validate)
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")


### PR DESCRIPTION
## Summary
- Persist LLM API keys to project `.env` when the system keyring is unavailable on headless hosts
- Keep owner-only file permissions and show a clear warning instead of aborting `opensre onboard`

Fixes #1403

## Test plan
- [x] `uv run python -m pytest tests/cli/wizard/test_env_sync.py::test_persist_env_secret_with_env_fallback_writes_env_when_keyring_unavailable tests/cli/wizard/test_flow.py::test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable -q`