### PR TITLE
fix(investigate): diagnose from evidence when agent emits no text

### DIFF
--- a/core/domain/diagnosis/__init__.py
+++ b/core/domain/diagnosis/__init__.py
@@ -13,6 +13,7 @@ from core.domain.diagnosis.result import (
     normalize_root_cause_category,
     result_to_state,
     root_cause_category_instruction_for_source,
+    synthesize_diagnosis_text_from_evidence,
     taxonomy_categories_for_alert_source,
 )
 
@@ -27,5 +28,6 @@ __all__ = [
     "normalize_root_cause_category",
     "result_to_state",
     "root_cause_category_instruction_for_source",
+    "synthesize_diagnosis_text_from_evidence",
     "taxonomy_categories_for_alert_source",
 ]

--- a/core/domain/diagnosis/result.py
+++ b/core/domain/diagnosis/result.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+import json
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -141,7 +142,11 @@ def synthesize_diagnosis_text_from_evidence(
     for key, value in evidence.items():
         if value in (None, {}, [], ""):
             continue
-        lines.append(f"- **{key}**: evidence collected")
+        try:
+            snippet = json.dumps(value, default=str)[:200]
+        except TypeError:
+            snippet = str(value)[:200]
+        lines.append(f"- **{key}**: {snippet}")
     for entry in evidence_entries[:8]:
         tool = str(entry.get("tool") or entry.get("source") or "tool")
         summary = str(

--- a/core/domain/diagnosis/result.py
+++ b/core/domain/diagnosis/result.py
@@ -120,6 +120,40 @@ def extract_last_assistant_text(messages: list[dict[str, Any]]) -> str:
     return ""
 
 
+def synthesize_diagnosis_text_from_evidence(
+    evidence: dict[str, Any],
+    evidence_entries: list[dict[str, Any]],
+    *,
+    alert_name: str = "",
+) -> str:
+    """Build a parseable conclusion when the agent collected evidence but emitted no text."""
+    if not evidence and not evidence_entries:
+        return ""
+
+    title = alert_name.strip() or "alert"
+    lines = [
+        f"## Investigation summary for {title}",
+        "",
+        "The investigation gathered tool evidence but did not emit a final text conclusion.",
+        "Infer root cause from the collected evidence below.",
+        "",
+    ]
+    for key, value in evidence.items():
+        if value in (None, {}, [], ""):
+            continue
+        lines.append(f"- **{key}**: evidence collected")
+    for entry in evidence_entries[:8]:
+        tool = str(entry.get("tool") or entry.get("source") or "tool")
+        summary = str(
+            entry.get("summary") or entry.get("content") or entry.get("output") or ""
+        ).strip()
+        if summary:
+            lines.append(f"- **{tool}**: {summary[:400]}")
+        else:
+            lines.append(f"- **{tool}**: result recorded")
+    return "\n".join(lines)
+
+
 def taxonomy_categories_for_alert_source(alert_source: str) -> set[str]:
     source = alert_source.strip().lower()
     if source == "hermes":

--- a/tests/tools/investigation/test_diagnose_node.py
+++ b/tests/tools/investigation/test_diagnose_node.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from core.domain.diagnosis import (
@@ -20,6 +18,7 @@ def test_synthesize_diagnosis_text_from_evidence_includes_tool_summaries() -> No
     assert "CheckoutErrors" in text
     assert "alertmanager" in text
     assert "2 firing alerts" in text
+    assert "firing" in text
 
 
 def test_parse_diagnosis_falls_back_to_evidence_when_assistant_text_missing(

--- a/tests/tools/investigation/test_diagnose_node.py
+++ b/tests/tools/investigation/test_diagnose_node.py
@@ -57,3 +57,27 @@ def test_parse_diagnosis_falls_back_to_evidence_when_assistant_text_missing(
 def test_parse_diagnosis_returns_unknown_without_text_or_evidence() -> None:
     result = node.parse_diagnosis([], {}, alert_name="SilentAlert")
     assert "insufficient evidence" in result.root_cause.lower()
+
+
+def test_parse_diagnosis_logs_when_evidence_synthesis_is_used(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        node,
+        "_parse_via_structured_output",
+        lambda *_args, **_kwargs: InvestigationResult(
+            root_cause="ok",
+            root_cause_category="unknown",
+            validity_score=0.5,
+        ),
+    )
+
+    with caplog.at_level("INFO", logger=node.logger.name):
+        node.parse_diagnosis(
+            [{"role": "assistant", "content": ""}],
+            {"alertmanager_alerts": [{"status": "firing"}]},
+            alert_name="CheckoutErrors",
+            evidence_entries=[{"tool": "alertmanager", "summary": "2 firing alerts"}],
+        )
+
+    assert any("synthesizing diagnosis prompt" in record.message for record in caplog.records)

--- a/tests/tools/investigation/test_diagnose_node.py
+++ b/tests/tools/investigation/test_diagnose_node.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.domain.diagnosis import (
+    InvestigationResult,
+    synthesize_diagnosis_text_from_evidence,
+)
+from tools.investigation.stages.diagnose import node
+
+
+def test_synthesize_diagnosis_text_from_evidence_includes_tool_summaries() -> None:
+    text = synthesize_diagnosis_text_from_evidence(
+        {"alertmanager_alerts": [{"status": "firing"}]},
+        [{"tool": "alertmanager", "summary": "2 firing alerts on checkout"}],
+        alert_name="CheckoutErrors",
+    )
+    assert "CheckoutErrors" in text
+    assert "alertmanager" in text
+    assert "2 firing alerts" in text
+
+
+def test_parse_diagnosis_falls_back_to_evidence_when_assistant_text_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[str] = []
+
+    def _fake_structured(
+        last_text: str,
+        evidence: dict,
+        *,
+        alert_source: str = "",
+    ) -> InvestigationResult:
+        captured.append(last_text)
+        return InvestigationResult(
+            root_cause="Alertmanager shows checkout failures",
+            root_cause_category="application_tier_load_spike",
+            validity_score=0.6,
+        )
+
+    monkeypatch.setattr(node, "_parse_via_structured_output", _fake_structured)
+
+    result = node.parse_diagnosis(
+        [{"role": "assistant", "content": ""}],
+        {"alertmanager_alerts": [{"status": "firing"}]},
+        alert_name="CheckoutErrors",
+        alert_source="alertmanager",
+        evidence_entries=[{"tool": "alertmanager", "summary": "2 firing alerts"}],
+    )
+
+    assert captured
+    assert "alertmanager" in captured[0]
+    assert result.root_cause == "Alertmanager shows checkout failures"
+
+
+def test_parse_diagnosis_returns_unknown_without_text_or_evidence() -> None:
+    result = node.parse_diagnosis([], {}, alert_name="SilentAlert")
+    assert "insufficient evidence" in result.root_cause.lower()

--- a/tools/investigation/stages/diagnose/node.py
+++ b/tools/investigation/stages/diagnose/node.py
@@ -41,6 +41,13 @@ def parse_diagnosis(
             evidence_entries or [],
             alert_name=alert_name,
         )
+        if last_text:
+            logger.info(
+                "Agent emitted no final text; synthesizing diagnosis prompt from "
+                "%d evidence keys and %d evidence entries",
+                len(evidence),
+                len(evidence_entries or []),
+            )
     if not last_text:
         return InvestigationResult.unknown(alert_name)
 

--- a/tools/investigation/stages/diagnose/node.py
+++ b/tools/investigation/stages/diagnose/node.py
@@ -15,6 +15,7 @@ from core.domain.diagnosis import (
     build_investigation_result,
     extract_last_assistant_text,
     result_to_state,
+    synthesize_diagnosis_text_from_evidence,
     taxonomy_categories_for_alert_source,
 )
 
@@ -26,6 +27,7 @@ def parse_diagnosis(
     evidence: dict[str, Any],
     alert_name: str = "",
     alert_source: str = "",
+    evidence_entries: list[dict[str, Any]] | None = None,
 ) -> InvestigationResult:
     """Parse the agent's final response into a structured InvestigationResult.
 
@@ -33,6 +35,12 @@ def parse_diagnosis(
     Falls back to parse_root_cause() if structured output fails.
     """
     last_text = extract_last_assistant_text(messages)
+    if not last_text:
+        last_text = synthesize_diagnosis_text_from_evidence(
+            evidence,
+            evidence_entries or [],
+            alert_name=alert_name,
+        )
     if not last_text:
         return InvestigationResult.unknown(alert_name)
 
@@ -62,6 +70,7 @@ def diagnose(state: InvestigationState) -> dict[str, Any]:
         evidence,
         str(state.get("alert_name") or ""),
         alert_source=resolve_alert_source(cast(dict[str, Any], state)),
+        evidence_entries=_list_of_dicts(state.get("evidence_entries")),
     )
     result.evidence = evidence
     result.evidence_entries = _list_of_dicts(state.get("evidence_entries"))


### PR DESCRIPTION
## Summary
- Synthesize a parseable diagnosis prompt from collected evidence when the agent exits without assistant text
- Prevents immediate "insufficient evidence" results on valid Alertmanager investigations

Fixes #2408

## Test plan
- [x] `uv run python -m pytest tests/tools/investigation/test_diagnose_node.py -q`