### PR TITLE
fix(ui): stop duplicate diagnose streaming output

### DIFF
--- a/cli/ui/renderer/diagnose.py
+++ b/cli/ui/renderer/diagnose.py
@@ -25,6 +25,7 @@ from cli.ui.renderer.constants import (
     _WHITE,
     _render_source,
 )
+from rich.text import Text
 from core.domain.stream import StreamEvent
 from interactive_shell.ui.output import (
     ProgressTracker,
@@ -36,6 +37,7 @@ from interactive_shell.ui.output import (
 )
 from platform.analytics.events import Event
 from platform.analytics.provider import get_analytics
+from platform.terminal.theme import MARKDOWN_THEME
 
 
 class _DiagnoseStreamRenderer:
@@ -110,7 +112,7 @@ class _DiagnoseStreamRenderer:
             spinner,
             console=self._console,
             refresh_per_second=_DIAGNOSE_LIVE_REFRESH,
-            transient=False,
+            transient=True,
         )
 
         # Shrink the gap: stop previous display immediately before starting new one
@@ -160,9 +162,9 @@ class _DiagnoseStreamRenderer:
         # Throttle Markdown re-parse to once per refresh window; the final
         # flush in :meth:`finish` guarantees the latest buffer is rendered
         # before the Live region closes.
-        now = time.monotonic()
         if now - self._last_render >= _DIAGNOSE_RENDER_INTERVAL_S:
-            self._live.update(Markdown("".join(self.buffer)))
+            # Plain text during Live avoids Markdown re-layout flicker/duplication (#1782).
+            self._live.update(Text("".join(self.buffer)))
             self._last_render = now
 
     def finish(self, message: str | None = None) -> None:
@@ -174,16 +176,14 @@ class _DiagnoseStreamRenderer:
         elapsed = time.monotonic() - self._started
 
         if self._live is not None:
-            # Final flush: any chunks pending in the last throttle window
-            # render here so the user sees the complete reasoning.
-            if self.buffer:
-                self._live.update(Markdown("".join(self.buffer)))
             try:
                 self._live.stop()
             finally:
                 self._live = None
-                # Unregister only if we own it (safeguard against subsequent activations)
                 unregister_live_console(self._console)
+            if self.buffer and self._console is not None:
+                with self._console.use_theme(MARKDOWN_THEME):
+                    self._console.print(Markdown("".join(self.buffer)))
             sys.stdout.write(
                 f"  {_GREEN}●{_RESET}  {_BOLD}{_WHITE}{_DIAGNOSE_NODE}{_RESET}"
                 f"  {_DIM}{elapsed:.1f}s{_RESET}"

--- a/cli/ui/renderer/diagnose.py
+++ b/cli/ui/renderer/diagnose.py
@@ -25,7 +25,6 @@ from cli.ui.renderer.constants import (
     _WHITE,
     _render_source,
 )
-from rich.text import Text
 from core.domain.stream import StreamEvent
 from interactive_shell.ui.output import (
     ProgressTracker,
@@ -159,9 +158,8 @@ class _DiagnoseStreamRenderer:
                     preview = "…" + preview[-77:]
                 self._tracker.update_subtext(_DIAGNOSE_NODE, preview, duration=30.0)
             return
-        # Throttle Markdown re-parse to once per refresh window; the final
-        # flush in :meth:`finish` guarantees the latest buffer is rendered
-        # before the Live region closes.
+        # Throttle Live updates; final Markdown renders once in finish().
+        now = time.monotonic()
         if now - self._last_render >= _DIAGNOSE_RENDER_INTERVAL_S:
             # Plain text during Live avoids Markdown re-layout flicker/duplication (#1782).
             self._live.update(Text("".join(self.buffer)))

--- a/tests/remote/test_renderer.py
+++ b/tests/remote/test_renderer.py
@@ -1103,9 +1103,7 @@ class TestStreamRendererDiagnoseThrottle:
             renderer._handle_event(self._make_diagnose_chunk(f"c{i} "))
         renderer._handle_event(self._make_diagnose_end())
 
-        # Clock never advanced past 0.0 — every per-chunk render was gated.
-        # Only the unconditional final flush in _DiagnoseStreamRenderer.finish
-        # fires, producing exactly one Markdown parse.
+        # Streaming uses plain Text in Live; one Markdown render happens at finish.
         assert parse_count[0] == 1, (
             f"expected 1 parse (final flush only), got {parse_count[0]}; "
             "throttle is letting intra-window updates through"
@@ -1136,9 +1134,9 @@ class TestStreamRendererDiagnoseThrottle:
             renderer._handle_event(self._make_diagnose_chunk(f"c{i} "))
         renderer._handle_event(self._make_diagnose_end())
 
-        # 10 in-loop renders + 1 final flush. Tolerance for boundary effects.
-        assert 9 <= parse_count[0] <= 12, (
-            f"expected ~10–11 parses across 10 windows, got {parse_count[0]}"
+        # Plain-text Live updates during windows; one Markdown render at finish.
+        assert 1 <= parse_count[0] <= 2, (
+            f"expected 1–2 parses across 10 windows, got {parse_count[0]}"
         )
         # Throttle's purpose: parse count must stay << total chunks.
         assert parse_count[0] < 50
@@ -1165,10 +1163,9 @@ class TestStreamRendererDiagnoseThrottle:
         renderer._handle_event(self._make_diagnose_chunk("tail-2"))
         renderer._handle_event(self._make_diagnose_end())
 
-        # All chunks must be in the buffer at finish (final flush picks them up).
+        # All chunks must be in the buffer at finish (final Markdown print picks them up).
         assert "".join(renderer._diagnose.buffer) == "early tail-1 tail-2"
-        # Two parses: one in-loop render at "early " + one final flush.
-        assert parse_count[0] == 2
+        assert parse_count[0] == 1
 
     @patch("cli.ui.renderer.diagnose.Live")
     @patch("interactive_shell.ui.output.tracker._EventLogDisplay")

--- a/tests/remote/test_renderer.py
+++ b/tests/remote/test_renderer.py
@@ -1084,6 +1084,32 @@ class TestStreamRendererDiagnoseThrottle:
         monkeypatch.setattr(renderer_module, "Markdown", _SpyMarkdown)
         return fake_time, parse_count
 
+    def test_append_chunk_updates_live_with_text_when_region_is_open(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        from cli.ui.renderer.diagnose import _DiagnoseStreamRenderer
+        from rich.text import Text
+
+        renderer = _DiagnoseStreamRenderer()
+        mock_live = MagicMock()
+        renderer._live = mock_live
+        renderer._last_render = 0.0
+
+        fake_time = [1.0]
+        monkeypatch.setattr(
+            "cli.ui.renderer.diagnose.time.monotonic",
+            lambda: fake_time[0],
+        )
+
+        renderer.append_chunk(self._make_diagnose_chunk("token "))
+
+        mock_live.update.assert_called_once()
+        rendered = mock_live.update.call_args[0][0]
+        assert isinstance(rendered, Text)
+        assert "token " in str(rendered)
+
     @patch("cli.ui.renderer.diagnose.Live")
     @patch("interactive_shell.ui.output.tracker._EventLogDisplay")
     @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "rich"})


### PR DESCRIPTION
## Summary
- Stream plain text in the diagnose Live region during token delivery
- Render Markdown once after Live stops to avoid repeated output on Windows terminals

Fixes #1782

## Test plan
- [x] `uv run python -m pytest tests/remote/test_renderer.py -k DiagnoseStream -q`