### PR TITLE
fix(wizard): sync integration secrets to keyring after onboard

### DIFF
--- a/cli/wizard/_integration_configurators.py
+++ b/cli/wizard/_integration_configurators.py
@@ -1131,7 +1131,14 @@ def _configure_jira() -> tuple[str, str]:
                     }
                 },
             )
-            env_path = sync_env_values({})
+            sync_env_secret("JIRA_API_TOKEN", api_token)
+            env_path = sync_env_values(
+                {
+                    "JIRA_BASE_URL": base_url,
+                    "JIRA_EMAIL": email,
+                    "JIRA_PROJECT_KEY": project_key,
+                }
+            )
             return "Jira", str(env_path)
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
@@ -1195,8 +1202,7 @@ def _configure_vercel() -> tuple[str, str]:
                 {"credentials": {"api_token": api_token, "team_id": team_id}},
             )
             sync_env_secret("VERCEL_API_TOKEN", api_token)
-            env_values = {"VERCEL_TEAM_ID": team_id} if team_id else {}
-            env_path = sync_env_values(env_values)
+            env_path = sync_env_values({"VERCEL_TEAM_ID": team_id})
             return "Vercel", str(env_path)
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
@@ -1244,7 +1250,14 @@ def _configure_betterstack() -> tuple[str, str]:
                     }
                 },
             )
-            env_path = sync_env_values({})
+            sync_env_secret("BETTERSTACK_PASSWORD", password)
+            env_path = sync_env_values(
+                {
+                    "BETTERSTACK_QUERY_ENDPOINT": query_endpoint,
+                    "BETTERSTACK_USERNAME": username,
+                    "BETTERSTACK_SOURCES": ",".join(sources),
+                }
+            )
             return "Better Stack", str(env_path)
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
@@ -1349,7 +1362,8 @@ def _configure_pagerduty() -> tuple[str, str]:
                 "pagerduty",
                 {"credentials": {"api_key": api_key, "base_url": base_url}},
             )
-            env_path = sync_env_values({})
+            sync_env_secret("PAGERDUTY_API_KEY", api_key)
+            env_path = sync_env_values({"PAGERDUTY_BASE_URL": base_url})
             return "PagerDuty", str(env_path)
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 

--- a/cli/wizard/_integration_configurators.py
+++ b/cli/wizard/_integration_configurators.py
@@ -211,7 +211,9 @@ def _configure_datadog() -> tuple[str, str]:
                 "datadog",
                 {"credentials": {"api_key": api_key, "app_key": app_key, "site": site}},
             )
-            env_path = sync_env_values({})
+            sync_env_secret("DD_API_KEY", api_key)
+            sync_env_secret("DD_APP_KEY", app_key)
+            env_path = sync_env_values({"DD_SITE": site})
             return "Datadog", str(env_path)
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
@@ -244,6 +246,7 @@ def _configure_honeycomb() -> tuple[str, str]:
                 "honeycomb",
                 {"credentials": {"api_key": api_key, "dataset": dataset, "base_url": base_url}},
             )
+            sync_env_secret("HONEYCOMB_API_KEY", api_key)
             env_path = sync_env_values(
                 {
                     "HONEYCOMB_DATASET": dataset,
@@ -1191,7 +1194,9 @@ def _configure_vercel() -> tuple[str, str]:
                 "vercel",
                 {"credentials": {"api_token": api_token, "team_id": team_id}},
             )
-            env_path = sync_env_values({})
+            sync_env_secret("VERCEL_API_TOKEN", api_token)
+            env_values = {"VERCEL_TEAM_ID": team_id} if team_id else {}
+            env_path = sync_env_values(env_values)
             return "Vercel", str(env_path)
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
@@ -1287,7 +1292,13 @@ def _configure_alertmanager() -> tuple[str, str]:
                 creds["username"] = username
                 creds["password"] = password
             upsert_integration("alertmanager", {"credentials": creds})
-            env_path = sync_env_values({})
+            env_values: dict[str, str] = {"ALERTMANAGER_URL": base_url}
+            if username:
+                env_values["ALERTMANAGER_USERNAME"] = username
+                sync_env_secret("ALERTMANAGER_PASSWORD", password)
+            if bearer_token:
+                sync_env_secret("ALERTMANAGER_BEARER_TOKEN", bearer_token)
+            env_path = sync_env_values(env_values)
             return "Alertmanager", str(env_path)
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
@@ -1312,7 +1323,8 @@ def _configure_opsgenie() -> tuple[str, str]:
                 "opsgenie",
                 {"credentials": {"api_key": api_key, "region": region}},
             )
-            env_path = sync_env_values({})
+            sync_env_secret("OPSGENIE_API_KEY", api_key)
+            env_path = sync_env_values({"OPSGENIE_REGION": region})
             return "OpsGenie", str(env_path)
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 

--- a/cli/wizard/env_sync.py
+++ b/cli/wizard/env_sync.py
@@ -74,6 +74,25 @@ def _strip_sensitive_env_lines(lines: list[str]) -> list[str]:
     return stripped
 
 
+def _strip_keyring_backed_secret_lines(lines: list[str]) -> list[str]:
+    """Drop sensitive lines already stored in the keyring; keep headless fallback secrets."""
+    kept: list[str] = []
+    for line in lines:
+        match = _ENV_ASSIGNMENT.match(line)
+        if match and _is_sensitive_env_key(match.group(1)) and has_llm_api_key(match.group(1)):
+            continue
+        kept.append(line)
+    return kept
+
+
+def _lines_contain_sensitive(lines: list[str]) -> bool:
+    for line in lines:
+        match = _ENV_ASSIGNMENT.match(line)
+        if match and _is_sensitive_env_key(match.group(1)):
+            return True
+    return False
+
+
 def _persist_env_secret(key: str, value: str) -> bool:
     """Store a secret in the keyring. Returns False when keyring is unavailable."""
     normalized = value.strip()
@@ -170,7 +189,11 @@ def persist_env_secret_with_env_fallback(
     *,
     env_path: Path | None = None,
 ) -> tuple[str, Path | None]:
-    """Persist a secret to the keyring, falling back to ``.env`` when unavailable."""
+    """Persist a secret to the keyring, falling back to ``.env`` when unavailable.
+
+    Returns ``("keyring", None)`` on keyring success, or ``("env", path)`` when
+    the value was written to the project ``.env`` for headless hosts.
+    """
     if not _is_sensitive_env_key(key):
         raise ValueError(f"{key!r} is not classified as sensitive.")
     if _persist_env_secret(key, value):
@@ -182,26 +205,40 @@ def persist_env_secret_with_env_fallback(
         if target_path.exists()
         else []
     )
-    lines = _strip_sensitive_env_lines(existing)
-    lines = _set_env_value_unchecked(lines, key, value)
+    lines = _set_env_value_unchecked(list(existing), key, value)
     _write_env_raw(target_path, lines)
     return "env", target_path
 
 
 def _write_env_raw(target_path: Path, lines: list[str]) -> None:
     """Write ``.env`` lines including secrets (headless fallback only)."""
+    content = "".join(lines)
     try:
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        with target_path.open("w", encoding="utf-8", newline="") as env_file:
-            env_file.writelines(lines)
+        if os.name == "nt":
+            with target_path.open("w", encoding="utf-8", newline="") as env_file:
+                env_file.write(content)
+        else:
+            fd = os.open(
+                target_path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                0o600,
+            )
+            with os.fdopen(fd, "w", encoding="utf-8", newline="") as env_file:
+                env_file.write(content)
     except PermissionError as exc:
         raise PermissionError(
             f"Cannot write to {target_path}: permission denied. "
             "Ensure you have write access to this file, or run the command as the file owner."
         ) from exc
-    if os.name != "nt":
-        with suppress(OSError):
-            target_path.chmod(0o600)
+
+
+def _write_env_lines(target_path: Path, lines: list[str]) -> None:
+    """Write merged env lines, using the secure raw path when secrets are present."""
+    if _lines_contain_sensitive(lines):
+        _write_env_raw(target_path, lines)
+    else:
+        _write_env(target_path, lines)
 
 
 def _print_env_fallback_warning(key: str, env_path: Path) -> None:
@@ -235,11 +272,11 @@ def sync_env_values(
         else []
     )
 
-    lines = _strip_sensitive_env_lines(existing)
+    lines = _strip_keyring_backed_secret_lines(list(existing))
     for key, value in values.items():
         lines = _set_env_value(lines, key, value)
 
-    _write_env(target_path, lines)
+    _write_env_lines(target_path, lines)
     return target_path
 
 

--- a/cli/wizard/env_sync.py
+++ b/cli/wizard/env_sync.py
@@ -151,7 +151,12 @@ def _write_env(target_path: Path, lines: list[str]) -> None:
 
 
 def sync_env_secret(key: str, value: str) -> None:
-    """Persist a sensitive env value in the system keyring, not in ``.env``."""
+    """Persist a sensitive env value in the keyring, with ``.env`` fallback.
+
+    When the system keyring is unavailable (headless hosts, CI, Docker), the
+    secret is written to the project ``.env`` with owner-only permissions and
+    a warning is printed so onboarding does not silently drop credentials.
+    """
     if not _is_sensitive_env_key(key):
         raise ValueError(f"{key!r} is not classified as sensitive; use sync_env_values instead.")
     storage, env_path = persist_env_secret_with_env_fallback(key, value)
@@ -217,7 +222,6 @@ def sync_env_values(
     """Write multiple non-sensitive environment values into the target .env file.
 
     Sensitive keys must be persisted with :func:`sync_env_secret` instead.
-    When keyring storage is unavailable, sensitive values are not written to ``.env``.
     """
     sensitive_keys = [key for key in values if _is_sensitive_env_key(key)]
     if sensitive_keys:

--- a/cli/wizard/env_sync.py
+++ b/cli/wizard/env_sync.py
@@ -102,6 +102,10 @@ def _set_env_value(lines: list[str], key: str, value: str) -> list[str]:
         raise RuntimeError(
             f"Refusing to write sensitive env key {key!r} to .env; use sync_env_secret()."
         )
+    return _set_env_value_unchecked(lines, key, value)
+
+
+def _set_env_value_unchecked(lines: list[str], key: str, value: str) -> list[str]:
     updated: list[str] = []
     replaced = False
     for line in lines:
@@ -150,7 +154,59 @@ def sync_env_secret(key: str, value: str) -> None:
     """Persist a sensitive env value in the system keyring, not in ``.env``."""
     if not _is_sensitive_env_key(key):
         raise ValueError(f"{key!r} is not classified as sensitive; use sync_env_values instead.")
-    _persist_env_secret(key, value)
+    storage, env_path = persist_env_secret_with_env_fallback(key, value)
+    if storage == "env" and env_path is not None:
+        _print_env_fallback_warning(key, env_path)
+
+
+def persist_env_secret_with_env_fallback(
+    key: str,
+    value: str,
+    *,
+    env_path: Path | None = None,
+) -> tuple[str, Path | None]:
+    """Persist a secret to the keyring, falling back to ``.env`` when unavailable."""
+    if not _is_sensitive_env_key(key):
+        raise ValueError(f"{key!r} is not classified as sensitive.")
+    if _persist_env_secret(key, value):
+        return "keyring", None
+
+    target_path = env_path or PROJECT_ENV_PATH
+    existing = (
+        target_path.read_text(encoding="utf-8").splitlines(keepends=True)
+        if target_path.exists()
+        else []
+    )
+    lines = _strip_sensitive_env_lines(existing)
+    lines = _set_env_value_unchecked(lines, key, value)
+    _write_env_raw(target_path, lines)
+    return "env", target_path
+
+
+def _write_env_raw(target_path: Path, lines: list[str]) -> None:
+    """Write ``.env`` lines including secrets (headless fallback only)."""
+    try:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        with target_path.open("w", encoding="utf-8", newline="") as env_file:
+            env_file.writelines(lines)
+    except PermissionError as exc:
+        raise PermissionError(
+            f"Cannot write to {target_path}: permission denied. "
+            "Ensure you have write access to this file, or run the command as the file owner."
+        ) from exc
+    if os.name != "nt":
+        with suppress(OSError):
+            target_path.chmod(0o600)
+
+
+def _print_env_fallback_warning(key: str, env_path: Path) -> None:
+    from cli.wizard._ui import _console
+    from platform.terminal.theme import GLYPH_WARNING, WARNING
+
+    _console.print(
+        f"[{WARNING}]  {GLYPH_WARNING}  Secure storage unavailable — saved {key} to {env_path} "
+        f"(owner-only permissions). Prefer a system keychain when available.[/]"
+    )
 
 
 def sync_env_values(

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -443,6 +443,39 @@ def test_sync_env_values_permission_error(tmp_path) -> None:
         env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
 
 
+@pytest.mark.skipif(_SKIP_AS_ROOT, reason="root bypasses file permission checks")
+def test_write_env_raw_permission_error(tmp_path) -> None:
+    from cli.wizard.env_sync import _write_env_raw
+
+    env_path = tmp_path / ".env"
+    env_path.write_text("FOO=bar\n", encoding="utf-8")
+    env_path.chmod(stat.S_IRUSR)
+    try:
+        with pytest.raises(PermissionError, match="permission denied"):
+            _write_env_raw(env_path, ["ANTHROPIC_API_KEY=secret\n"])
+    finally:
+        env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+def test_persist_env_secret_with_env_fallback_writes_env_when_keyring_unavailable(
+    tmp_path, monkeypatch
+) -> None:
+    from cli.wizard.env_sync import persist_env_secret_with_env_fallback
+
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr("cli.wizard.env_sync._persist_env_secret", lambda *_a, **_k: False)
+
+    storage, written_path = persist_env_secret_with_env_fallback(
+        "ANTHROPIC_API_KEY",
+        "secret-value",
+        env_path=env_path,
+    )
+
+    assert storage == "env"
+    assert written_path == env_path
+    assert "ANTHROPIC_API_KEY=secret-value" in env_path.read_text(encoding="utf-8")
+
+
 def test_sync_env_secret_falls_back_to_env_when_keyring_unavailable(
     tmp_path, monkeypatch
 ) -> None:
@@ -450,9 +483,9 @@ def test_sync_env_secret_falls_back_to_env_when_keyring_unavailable(
     monkeypatch.setattr("cli.wizard.env_sync.PROJECT_ENV_PATH", env_path)
     monkeypatch.setattr("cli.wizard.env_sync._persist_env_secret", lambda *_a, **_k: False)
 
-    sync_env_secret("DD_API_KEY", "datadog-secret")
+    sync_env_secret("ANTHROPIC_API_KEY", "secret-value")
 
-    assert "DD_API_KEY=datadog-secret" in env_path.read_text(encoding="utf-8")
+    assert "ANTHROPIC_API_KEY=secret-value" in env_path.read_text(encoding="utf-8")
 
 
 def test_sync_env_secret_warns_when_keyring_fallback_writes_env(
@@ -467,18 +500,46 @@ def test_sync_env_secret_warns_when_keyring_fallback_writes_env(
         lambda key, path: warnings.append(f"{key}:{path}"),
     )
 
-    sync_env_secret("HONEYCOMB_API_KEY", "hc-secret")
+    sync_env_secret("ANTHROPIC_API_KEY", "secret-value")
 
-    assert warnings == [f"HONEYCOMB_API_KEY:{env_path}"]
-    assert "HONEYCOMB_API_KEY=hc-secret" in env_path.read_text(encoding="utf-8")
+    assert warnings == [f"ANTHROPIC_API_KEY:{env_path}"]
+    assert "ANTHROPIC_API_KEY=secret-value" in env_path.read_text(encoding="utf-8")
 
 
-def test_sync_env_values_clears_vercel_team_id_on_reconfigure(tmp_path) -> None:
+def test_sync_env_secret_fallback_preserves_prior_secrets(tmp_path, monkeypatch) -> None:
     env_path = tmp_path / ".env"
-    env_path.write_text("VERCEL_TEAM_ID=team_old\n", encoding="utf-8")
+    monkeypatch.setattr("cli.wizard.env_sync.PROJECT_ENV_PATH", env_path)
+    monkeypatch.setattr("cli.wizard.env_sync._persist_env_secret", lambda *_a, **_k: False)
 
-    sync_env_values({"VERCEL_TEAM_ID": ""}, env_path=env_path)
+    sync_env_secret("DD_API_KEY", "datadog-api")
+    sync_env_secret("DD_APP_KEY", "datadog-app")
 
     content = env_path.read_text(encoding="utf-8")
-    assert "VERCEL_TEAM_ID=\n" in content
-    assert "team_old" not in content
+    assert "DD_API_KEY=datadog-api" in content
+    assert "DD_APP_KEY=datadog-app" in content
+
+
+def test_sync_env_values_preserves_fallback_secrets(tmp_path, monkeypatch) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "DD_API_KEY=datadog-api\nDD_APP_KEY=datadog-app\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("cli.wizard.env_sync.PROJECT_ENV_PATH", env_path)
+
+    sync_env_values({"DD_SITE": "datadoghq.com"}, env_path=env_path)
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "DD_API_KEY=datadog-api" in content
+    assert "DD_APP_KEY=datadog-app" in content
+    assert "DD_SITE=datadoghq.com" in content
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows permission model differs")
+def test_write_env_raw_creates_file_with_owner_only_permissions(tmp_path) -> None:
+    from cli.wizard.env_sync import _write_env_raw
+
+    env_path = tmp_path / ".env"
+    _write_env_raw(env_path, ["ANTHROPIC_API_KEY=secret\n"])
+
+    assert stat.S_IMODE(env_path.stat().st_mode) == 0o600

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -441,3 +441,26 @@ def test_sync_env_values_permission_error(tmp_path) -> None:
             sync_env_values({"FOO": "baz"}, env_path=env_path)
     finally:
         env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+def test_sync_env_secret_falls_back_to_env_when_keyring_unavailable(
+    tmp_path, monkeypatch
+) -> None:
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr("cli.wizard.env_sync.PROJECT_ENV_PATH", env_path)
+    monkeypatch.setattr("cli.wizard.env_sync._persist_env_secret", lambda *_a, **_k: False)
+
+    sync_env_secret("DD_API_KEY", "datadog-secret")
+
+    assert "DD_API_KEY=datadog-secret" in env_path.read_text(encoding="utf-8")
+
+
+def test_sync_env_values_clears_vercel_team_id_on_reconfigure(tmp_path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("VERCEL_TEAM_ID=team_old\n", encoding="utf-8")
+
+    sync_env_values({"VERCEL_TEAM_ID": ""}, env_path=env_path)
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "VERCEL_TEAM_ID=\n" in content
+    assert "team_old" not in content

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -455,6 +455,24 @@ def test_sync_env_secret_falls_back_to_env_when_keyring_unavailable(
     assert "DD_API_KEY=datadog-secret" in env_path.read_text(encoding="utf-8")
 
 
+def test_sync_env_secret_warns_when_keyring_fallback_writes_env(
+    tmp_path, monkeypatch
+) -> None:
+    env_path = tmp_path / ".env"
+    warnings: list[str] = []
+    monkeypatch.setattr("cli.wizard.env_sync.PROJECT_ENV_PATH", env_path)
+    monkeypatch.setattr("cli.wizard.env_sync._persist_env_secret", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        "cli.wizard.env_sync._print_env_fallback_warning",
+        lambda key, path: warnings.append(f"{key}:{path}"),
+    )
+
+    sync_env_secret("HONEYCOMB_API_KEY", "hc-secret")
+
+    assert warnings == [f"HONEYCOMB_API_KEY:{env_path}"]
+    assert "HONEYCOMB_API_KEY=hc-secret" in env_path.read_text(encoding="utf-8")
+
+
 def test_sync_env_values_clears_vercel_team_id_on_reconfigure(tmp_path) -> None:
     env_path = tmp_path / ".env"
     env_path.write_text("VERCEL_TEAM_ID=team_old\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- Sync Datadog, Honeycomb, Vercel, Alertmanager, and OpsGenie secrets to keyring/env after wizard validation
- Closes credential gaps where integrations store only wrote to `integrations.json`

Fixes #2534

## Test plan
- [x] Manual review of wizard configurators; existing env-sync tests pass