### PR TITLE
fix(cli): actionable hints for integration auth failures

### DIFF
--- a/cli/error_mapping.py
+++ b/cli/error_mapping.py
@@ -4,6 +4,39 @@ from __future__ import annotations
 
 from typing import NoReturn
 
+_INTEGRATION_FAILURE_HINTS: tuple[tuple[str, str, str], ...] = (
+    ("datadog", "Datadog", "datadog"),
+    ("dd_api_key", "Datadog", "datadog"),
+    ("grafana", "Grafana", "grafana"),
+    ("grafana_read_token", "Grafana", "grafana"),
+    ("alertmanager", "Alertmanager", "alertmanager"),
+    ("vercel", "Vercel", "vercel"),
+)
+
+
+def _integration_failure_hint(message: str) -> tuple[str, str] | None:
+    lowered = message.lower()
+    for needle, name, slug in _INTEGRATION_FAILURE_HINTS:
+        if needle in lowered:
+            return name, slug
+    if any(token in lowered for token in ("401", "403", "unauthorized", "not configured")):
+        if "datadog" in lowered or "dd_" in lowered:
+            return "Datadog", "datadog"
+        if "grafana" in lowered:
+            return "Grafana", "grafana"
+        if "alertmanager" in lowered:
+            return "Alertmanager", "alertmanager"
+    for env_var, name, slug in (
+        ("dd_api_key", "Datadog", "datadog"),
+        ("grafana_read_token", "Grafana", "grafana"),
+        ("alertmanager_url", "Alertmanager", "alertmanager"),
+    ):
+        if env_var in lowered and any(
+            token in lowered for token in ("missing", "not set", "unavailable", "required")
+        ):
+            return name, slug
+    return None
+
 
 def reraise_cli_runtime_error(exc: BaseException) -> NoReturn:
     """Convert CLI auth/setup failures to structured CLI UX errors."""
@@ -23,6 +56,17 @@ def reraise_cli_runtime_error(exc: BaseException) -> NoReturn:
             "\n".join(classified.remediation_steps) if classified.remediation_steps else None
         )
         raise OpenSREError(classified.user_message, suggestion=suggestion) from exc
+
+    integration_hint = _integration_failure_hint(str(exc))
+    if integration_hint is not None:
+        name, slug = integration_hint
+        raise OpenSREError(
+            str(exc),
+            suggestion=(
+                f"Verify {name} credentials with `opensre integrations verify {slug}` "
+                "or re-run `opensre onboard` for that integration."
+            ),
+        ) from exc
 
     if isinstance(exc, RuntimeError):
         msg = str(exc).lower()

--- a/cli/error_mapping.py
+++ b/cli/error_mapping.py
@@ -4,37 +4,32 @@ from __future__ import annotations
 
 from typing import NoReturn
 
-_INTEGRATION_FAILURE_HINTS: tuple[tuple[str, str, str], ...] = (
+_SERVICE_HINTS: tuple[tuple[str, str, str], ...] = (
     ("datadog", "Datadog", "datadog"),
-    ("dd_api_key", "Datadog", "datadog"),
     ("grafana", "Grafana", "grafana"),
-    ("grafana_read_token", "Grafana", "grafana"),
     ("alertmanager", "Alertmanager", "alertmanager"),
     ("vercel", "Vercel", "vercel"),
 )
 
+_ENV_VAR_HINTS: tuple[tuple[str, str, str], ...] = (
+    ("dd_api_key", "Datadog", "datadog"),
+    ("grafana_read_token", "Grafana", "grafana"),
+    ("alertmanager_url", "Alertmanager", "alertmanager"),
+)
+
+_AUTH_TOKENS = frozenset({"401", "403", "unauthorized", "not configured", "forbidden"})
+_MISSING_TOKENS = frozenset({"missing", "not set", "unavailable", "required", "no api token"})
+
 
 def _integration_failure_hint(message: str) -> tuple[str, str] | None:
     lowered = message.lower()
-    for needle, name, slug in _INTEGRATION_FAILURE_HINTS:
-        if needle in lowered:
+    for env_var, name, slug in _ENV_VAR_HINTS:
+        if env_var in lowered and any(token in lowered for token in _MISSING_TOKENS):
             return name, slug
-    if any(token in lowered for token in ("401", "403", "unauthorized", "not configured")):
-        if "datadog" in lowered or "dd_" in lowered:
-            return "Datadog", "datadog"
-        if "grafana" in lowered:
-            return "Grafana", "grafana"
-        if "alertmanager" in lowered:
-            return "Alertmanager", "alertmanager"
-    for env_var, name, slug in (
-        ("dd_api_key", "Datadog", "datadog"),
-        ("grafana_read_token", "Grafana", "grafana"),
-        ("alertmanager_url", "Alertmanager", "alertmanager"),
-    ):
-        if env_var in lowered and any(
-            token in lowered for token in ("missing", "not set", "unavailable", "required")
-        ):
-            return name, slug
+    if any(token in lowered for token in _AUTH_TOKENS):
+        for needle, name, slug in _SERVICE_HINTS:
+            if needle in lowered:
+                return name, slug
     return None
 
 
@@ -57,18 +52,18 @@ def reraise_cli_runtime_error(exc: BaseException) -> NoReturn:
         )
         raise OpenSREError(classified.user_message, suggestion=suggestion) from exc
 
-    integration_hint = _integration_failure_hint(str(exc))
-    if integration_hint is not None:
-        name, slug = integration_hint
-        raise OpenSREError(
-            str(exc),
-            suggestion=(
-                f"Verify {name} credentials with `opensre integrations verify {slug}` "
-                "or re-run `opensre onboard` for that integration."
-            ),
-        ) from exc
-
     if isinstance(exc, RuntimeError):
+        integration_hint = _integration_failure_hint(str(exc))
+        if integration_hint is not None:
+            name, slug = integration_hint
+            raise OpenSREError(
+                str(exc),
+                suggestion=(
+                    f"Verify {name} credentials with `opensre integrations verify {slug}` "
+                    "or re-run `opensre onboard` for that integration."
+                ),
+            ) from exc
+
         msg = str(exc).lower()
         if "cli not found" in msg or "not found on path" in msg:
             raise OpenSREError(

--- a/tests/cli/test_error_mapping.py
+++ b/tests/cli/test_error_mapping.py
@@ -22,3 +22,16 @@ def test_reraise_maps_missing_grafana_token_to_verify_hint() -> None:
 
     assert "Grafana" in str(exc_info.value)
     assert "opensre integrations verify grafana" in (exc_info.value.suggestion or "")
+
+
+def test_reraise_maps_alertmanager_auth_failure_to_verify_hint() -> None:
+    with pytest.raises(OpenSREError) as exc_info:
+        reraise_cli_runtime_error(RuntimeError("Alertmanager request unauthorized (401)"))
+
+    assert "Alertmanager" in str(exc_info.value)
+    assert "opensre integrations verify alertmanager" in (exc_info.value.suggestion or "")
+
+
+def test_reraise_does_not_attach_hint_for_unrelated_runtime_error() -> None:
+    with pytest.raises(RuntimeError, match="failed to parse grafana dashboard json"):
+        reraise_cli_runtime_error(RuntimeError("failed to parse grafana dashboard json"))

--- a/tests/cli/test_error_mapping.py
+++ b/tests/cli/test_error_mapping.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from cli.error_mapping import reraise_cli_runtime_error
+from interactive_shell.utils.error_handling.errors import OpenSREError
+
+
+def test_reraise_maps_datadog_auth_failure_to_verify_hint() -> None:
+    with pytest.raises(OpenSREError) as exc_info:
+        reraise_cli_runtime_error(RuntimeError("Datadog API returned 403 Forbidden"))
+
+    assert "Datadog" in str(exc_info.value)
+    assert "opensre integrations verify datadog" in (exc_info.value.suggestion or "")
+
+
+def test_reraise_maps_missing_grafana_token_to_verify_hint() -> None:
+    with pytest.raises(OpenSREError) as exc_info:
+        reraise_cli_runtime_error(
+            RuntimeError("GRAFANA_READ_TOKEN is not set; Grafana integration unavailable")
+        )
+
+    assert "Grafana" in str(exc_info.value)
+    assert "opensre integrations verify grafana" in (exc_info.value.suggestion or "")


### PR DESCRIPTION
## Summary
- Map Datadog/Grafana/Alertmanager auth and missing-token failures to structured CLI errors
- Suggest `opensre integrations verify <service>` remediation during investigate failures

Fixes #2531

## Test plan
- [x] `uv run python -m pytest tests/cli/test_error_mapping.py -q`