### PR TITLE
[codex] Disable Codex auth status browser probe

### DIFF
--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -93,6 +93,12 @@ Use `opensre auth` for provider login without writing secrets to `.env`:
 
 `opensre auth` and `/auth status` are prompt-safe: they do not read API-key secrets from Keychain. For API-key providers they inspect environment variables plus non-secret metadata in `~/.opensre/llm-auth.json`. If a key was deleted directly from Keychain, status may show the old metadata until you run `opensre auth verify <provider>` or start a request; that verification marks the provider `stale` when the secret is gone.
 
+For Codex CLI auth, automated or non-interactive status checks do not run
+`codex login status`, because some Codex versions can open browser OAuth while
+checking a session. Run `codex login`, `/login chatgpt`, or
+`opensre auth login chatgpt` from an interactive terminal when you need to
+refresh the browser login.
+
 Inside the interactive shell, use the same flows through `/auth` or `/login`:
 
 ```bash

--- a/integrations/llm_cli/codex.py
+++ b/integrations/llm_cli/codex.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 
 from integrations.llm_cli.base import CLIInvocation, CLIProbe
 from integrations.llm_cli.binary_resolver import (
@@ -30,6 +31,16 @@ from integrations.llm_cli.semver_utils import parse_semver_three_part, semver_to
 
 _PROBE_TIMEOUT_SEC = 3.0
 _READ_ONLY_SANDBOX = "read-only"
+_AUTH_STATUS_PROBE_ENV = "OPENSRE_CODEX_AUTH_STATUS_PROBE"
+_AUTOMATION_ENV_KEYS = (
+    "CI",
+    "GITHUB_ACTIONS",
+    "PYTEST_CURRENT_TEST",
+    "PYTEST_VERSION",
+    "TOX_ENV_NAME",
+    "NOX_CURRENT_SESSION",
+)
+_TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 
 
 def _classify_codex_auth(returncode: int, stdout: str, stderr: str) -> tuple[bool | None, str]:
@@ -84,6 +95,19 @@ def _has_openai_api_key() -> bool:
     return bool(os.environ.get("OPENAI_API_KEY", "").strip())
 
 
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUTHY_ENV_VALUES
+
+
+def _should_probe_codex_login_status() -> bool:
+    override = os.environ.get(_AUTH_STATUS_PROBE_ENV)
+    if override is not None:
+        return override.strip().lower() in _TRUTHY_ENV_VALUES
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return False
+    return not any(_env_truthy(name) for name in _AUTOMATION_ENV_KEYS)
+
+
 class CodexAdapter:
     """Non-interactive Codex CLI (`codex exec` with read-only sandbox)."""
 
@@ -127,23 +151,33 @@ class CodexAdapter:
                 f"upgrade: {self.install_hint}@latest"
             )
 
-        try:
-            auth_proc = subprocess.run(
-                [binary_path, "login", "status"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=_PROBE_TIMEOUT_SEC,
-                check=False,
+        logged_in: bool | None
+        auth_detail: str
+        if not _should_probe_codex_login_status():
+            logged_in = None
+            auth_detail = (
+                "Codex CLI installed; login status was not checked in automated or "
+                "non-interactive mode to avoid launching browser OAuth. Run `codex login` "
+                "in an interactive terminal if needed."
             )
-        except (OSError, subprocess.TimeoutExpired):
-            logged_in: bool | None = None
-            auth_detail = "Could not verify login status (timeout or OS error)."
         else:
-            logged_in, auth_detail = _classify_codex_auth(
-                auth_proc.returncode, auth_proc.stdout, auth_proc.stderr
-            )
+            try:
+                auth_proc = subprocess.run(
+                    [binary_path, "login", "status"],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=_PROBE_TIMEOUT_SEC,
+                    check=False,
+                )
+            except (OSError, subprocess.TimeoutExpired):
+                logged_in = None
+                auth_detail = "Could not verify login status (timeout or OS error)."
+            else:
+                logged_in, auth_detail = _classify_codex_auth(
+                    auth_proc.returncode, auth_proc.stdout, auth_proc.stderr
+                )
 
         if logged_in is not True and _has_openai_api_key():
             # Allow API-key auth when ChatGPT/session login is absent or unclear.

--- a/tests/integrations/llm_cli/test_codex_adapter.py
+++ b/tests/integrations/llm_cli/test_codex_adapter.py
@@ -11,9 +11,18 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from integrations.llm_cli.binary_resolver import diagnose_binary_path, npm_prefix_bin_dirs
-from integrations.llm_cli.codex import CodexAdapter, _fallback_codex_paths
+from integrations.llm_cli.codex import (
+    _AUTH_STATUS_PROBE_ENV,
+    CodexAdapter,
+    _fallback_codex_paths,
+)
 from integrations.llm_cli.text import flatten_messages_to_prompt
 from tests.integrations.llm_cli.testing_helpers import write_fake_runnable_cli_bin
+
+
+@pytest.fixture(autouse=True)
+def _enable_codex_auth_status_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_AUTH_STATUS_PROBE_ENV, "1")
 
 
 def _posix_path_set(paths: list[str]) -> set[str]:
@@ -95,6 +104,29 @@ def test_detect_not_logged_in(
     probe = CodexAdapter().detect()
     assert probe.installed is True
     assert probe.logged_in is False
+
+
+@patch("integrations.llm_cli.codex.subprocess.run")
+@patch("integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_skips_login_status_probe_under_automation(
+    mock_which: MagicMock, mock_run: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(_AUTH_STATUS_PROBE_ENV, raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_codex_adapter.py::case (call)")
+    mock_which.return_value = "/usr/bin/codex"
+
+    def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+        if len(args) >= 2 and args[1] == "--version":
+            return _version_proc()
+        raise AssertionError(f"unexpected auth probe: {args}")
+
+    mock_run.side_effect = side_effect
+    probe = CodexAdapter().detect()
+    assert probe.installed is True
+    assert probe.logged_in is None
+    assert "login status was not checked" in probe.detail
+    assert mock_run.call_count == 1
 
 
 @patch("integrations.llm_cli.codex.subprocess.run")


### PR DESCRIPTION
## Summary

- Skip `codex login status` during automated or non-interactive Codex auth probes so routine validation cannot open browser OAuth.
- Keep explicit interactive login flows (`codex login`, `/login chatgpt`, `opensre auth login chatgpt`) as the path that can launch browser sign-in.
- Add a regression test proving automated detection does not spawn the login-status subprocess, and document the behavior for Codex CLI auth status checks.

## Root Cause

`CodexAdapter.detect()` ran `codex login status` as part of ordinary status detection. Some Codex CLI versions can open OpenAI browser OAuth while checking a session, so automated tests that enumerate provider status could repeatedly open `auth.openai.com/choose-an-account`.

## Validation

- `git diff --check refs/heads/main...HEAD`
- `uv run python -m pytest tests/integrations/llm_cli/test_codex_adapter.py -q`
- `make lint`
- `make format-check`
- `make typecheck`
- `make test-scope ARGS='--base refs/heads/main'`

Note: this local checkout has both a tag and branch named `main`, so the scoped test run used the qualified base ref to avoid an unrelated full-suite expansion.