### PR TITLE
[codex] Disable Codex login status by default

### DIFF
--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -93,11 +93,10 @@ Use `opensre auth` for provider login without writing secrets to `.env`:
 
 `opensre auth` and `/auth status` are prompt-safe: they do not read API-key secrets from Keychain. For API-key providers they inspect environment variables plus non-secret metadata in `~/.opensre/llm-auth.json`. If a key was deleted directly from Keychain, status may show the old metadata until you run `opensre auth verify <provider>` or start a request; that verification marks the provider `stale` when the secret is gone.
 
-For Codex CLI auth, automated or non-interactive status checks do not run
-`codex login status`, because some Codex versions can open browser OAuth while
-checking a session. Run `codex login`, `/login chatgpt`, or
-`opensre auth login chatgpt` from an interactive terminal when you need to
-refresh the browser login.
+For Codex CLI auth, status checks do not run `codex login status` by default,
+because some Codex versions can open browser OAuth while checking a session.
+Run `codex login`, `/login chatgpt`, or `opensre auth login chatgpt` from an
+interactive terminal when you need to refresh the browser login.
 
 Inside the interactive shell, use the same flows through `/auth` or `/login`:
 

--- a/integrations/llm_cli/AGENTS.md
+++ b/integrations/llm_cli/AGENTS.md
@@ -18,7 +18,7 @@ Use this package when adding a new **non-interactive** LLM that shells out to a 
 | `binary_resolver.py` | Shared executable resolution helpers (`env -> PATH -> fallback paths`).                     |
 | `runner.py`          | `CLIBackedLLMClient`: guardrails, `detect()`, `subprocess.run`, ANSI strip, `LLMResponse`.  |
 | `text.py`            | `flatten_messages_to_prompt` for stdin from chat-style payloads.                            |
-| `codex.py`           | Reference adapter: binary resolution, `codex exec`, probe via `--version` + `login status`. |
+| `codex.py`           | Reference adapter: binary resolution, `codex exec`, `--version`, and opt-in-only `login status` probing. |
 | `opencode.py`        | Multi-provider CLI: `--version`, then `opencode auth list` (see `_parse_opencode_auth_list_output`). |
 | `kimi.py`            | `kimi --print` path: `--version`, `kimi login status`, then env/config.toml fallback (`KIMI_API_KEY`). |
 | `copilot.py`         | `copilot -p` path: `--version`, then env tokens, then `gh auth status` (and `--hostname` when `COPILOT_GH_HOST` / `GH_HOST` targets a non-default host); otherwise `logged_in=None`. Plaintext `$COPILOT_HOME/config.json` is not inspected. No OS keychain probes. |
@@ -82,7 +82,7 @@ Document both vars in the adapter module docstring or a one-line comment near `b
 | `False` | Binary found but definitely **not** authenticated. | Prompts user to run the login command (`auth_hint`). |
 | `None` | Binary found but auth **status is unclear** (network error, unexpected output, etc.). | Asks user to retry or repick provider. |
 
-Recommended probe sequence (mirrors Codex):
+Recommended probe sequence for CLIs with safe non-interactive auth-status commands:
 
 1. Run `<binary> --version` — if it fails, return `installed=False` immediately.
 2. Run `<binary> <auth-status-command>` — parse stdout/stderr to classify `logged_in`.
@@ -93,6 +93,12 @@ Recommended probe sequence (mirrors Codex):
    connection and shouldn't be forced to re-authenticate.
 
 See `_classify_codex_auth` in `codex.py` for a complete reference implementation.
+
+**Codex exception:** do not run `codex login status` by default. Some Codex CLI
+versions can open browser OAuth while checking a session, so the Codex adapter
+only runs that command when `OPENSRE_CODEX_AUTH_STATUS_PROBE=1` is explicitly
+set. The normal prompt-safe status path reports `logged_in=None` and lets
+`codex exec` surface request-time auth failures.
 
 **OpenCode** is multi-provider: users may rely on `auth.json`, environment API keys, or both.
 Run `opencode auth list` after `--version` and parse the reported credential/environment

--- a/integrations/llm_cli/codex.py
+++ b/integrations/llm_cli/codex.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import sys
 
 from integrations.llm_cli.base import CLIInvocation, CLIProbe
 from integrations.llm_cli.binary_resolver import (
@@ -32,14 +31,6 @@ from integrations.llm_cli.semver_utils import parse_semver_three_part, semver_to
 _PROBE_TIMEOUT_SEC = 3.0
 _READ_ONLY_SANDBOX = "read-only"
 _AUTH_STATUS_PROBE_ENV = "OPENSRE_CODEX_AUTH_STATUS_PROBE"
-_AUTOMATION_ENV_KEYS = (
-    "CI",
-    "GITHUB_ACTIONS",
-    "PYTEST_CURRENT_TEST",
-    "PYTEST_VERSION",
-    "TOX_ENV_NAME",
-    "NOX_CURRENT_SESSION",
-)
 _TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 
 
@@ -95,17 +86,8 @@ def _has_openai_api_key() -> bool:
     return bool(os.environ.get("OPENAI_API_KEY", "").strip())
 
 
-def _env_truthy(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in _TRUTHY_ENV_VALUES
-
-
 def _should_probe_codex_login_status() -> bool:
-    override = os.environ.get(_AUTH_STATUS_PROBE_ENV)
-    if override is not None:
-        return override.strip().lower() in _TRUTHY_ENV_VALUES
-    if not (sys.stdin.isatty() and sys.stdout.isatty()):
-        return False
-    return not any(_env_truthy(name) for name in _AUTOMATION_ENV_KEYS)
+    return os.environ.get(_AUTH_STATUS_PROBE_ENV, "").strip().lower() in _TRUTHY_ENV_VALUES
 
 
 class CodexAdapter:
@@ -156,9 +138,9 @@ class CodexAdapter:
         if not _should_probe_codex_login_status():
             logged_in = None
             auth_detail = (
-                "Codex CLI installed; login status was not checked in automated or "
-                "non-interactive mode to avoid launching browser OAuth. Run `codex login` "
-                "in an interactive terminal if needed."
+                "Codex CLI installed; login status was not checked to avoid launching "
+                "browser OAuth. Run `codex login` in an interactive terminal if needed, "
+                f"or set {_AUTH_STATUS_PROBE_ENV}=1 to opt in to `codex login status`."
             )
         else:
             try:

--- a/tests/integrations/llm_cli/test_codex_adapter.py
+++ b/tests/integrations/llm_cli/test_codex_adapter.py
@@ -108,12 +108,11 @@ def test_detect_not_logged_in(
 
 @patch("integrations.llm_cli.codex.subprocess.run")
 @patch("integrations.llm_cli.binary_resolver.shutil.which")
-def test_detect_skips_login_status_probe_under_automation(
+def test_detect_skips_login_status_probe_by_default(
     mock_which: MagicMock, mock_run: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv(_AUTH_STATUS_PROBE_ENV, raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_codex_adapter.py::case (call)")
     mock_which.return_value = "/usr/bin/codex"
 
     def side_effect(args: list[str], **kwargs: object) -> MagicMock:
@@ -126,6 +125,7 @@ def test_detect_skips_login_status_probe_under_automation(
     assert probe.installed is True
     assert probe.logged_in is None
     assert "login status was not checked" in probe.detail
+    assert _AUTH_STATUS_PROBE_ENV in probe.detail
     assert mock_run.call_count == 1
 
 


### PR DESCRIPTION
## Summary

- Disable `codex login status` by default for Codex CLI detection, including interactive status paths.
- Keep explicit browser login commands (`codex login`, `/login chatgpt`, `opensre auth login chatgpt`) unchanged.
- Update the Codex regression test and docs/internal adapter guidance to describe the opt-in probe.

## Root Cause

PR #3236 only skipped `codex login status` in automated or non-interactive contexts. Users can still run prompt-safe status flows from an interactive terminal, and some Codex CLI versions open browser OAuth from `codex login status` itself. That means the status probe must be disabled by default everywhere, not just in automation.

This PR only runs `codex login status` when `OPENSRE_CODEX_AUTH_STATUS_PROBE=1` is explicitly set. The normal status result reports `logged_in=None` and lets `codex exec` surface request-time auth failures without opening OAuth during status checks.

## Validation

- `git diff --check`
- `uv run python -m pytest tests/integrations/llm_cli/test_codex_adapter.py -q`
- `make lint`
- `make format-check`
- `make typecheck`
- `make test-scope ARGS='--base refs/remotes/origin/main'`