### PR TITLE
[codex] Make main build the default installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
             fi
 
             echo "channel=main" >> "$GITHUB_OUTPUT"
-            echo "tag_name=nightly" >> "$GITHUB_OUTPUT"
+            echo "tag_name=main-build" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -181,7 +181,7 @@ jobs:
           if-no-files-found: error
 
   build-binaries:
-    if: needs.prepare.outputs.channel == 'main' || needs.verify.result == 'success'
+    if: always() && (needs.prepare.outputs.channel == 'main' || needs.verify.result == 'success')
     needs: [verify, prepare]
     strategy:
       fail-fast: false
@@ -454,10 +454,9 @@ jobs:
           CB='```'
           {
             printf '## Install\n\n'
-            printf '### cURL (macOS / Linux)\n\n%sbash\ncurl -fsSL https://install.opensre.com | bash\n%s\n\n' "$CB" "$CB"
-            printf '### cURL (macOS / Linux, latest main build)\n\n%sbash\ncurl -fsSL https://install.opensre.com | bash -s -- --main\n%s\n\n' "$CB" "$CB"
+            printf '### cURL (macOS / Linux)\n\n%sbash\ncurl -fsSL https://install.opensre.com | bash -s -- --release --version %s\n%s\n\n' "$CB" "${TAG_NAME#v}" "$CB"
             printf '### Homebrew (macOS / Linux)\n\n%sbash\nbrew tap tracer-cloud/tap\nbrew install tracer-cloud/tap/opensre\n%s\n\n' "$CB" "$CB"
-            printf '### PowerShell (Windows)\n\n%spowershell\nirm https://install.opensre.com | iex\n%s\n\n' "$CB" "$CB"
+            printf '### PowerShell (Windows)\n\n%spowershell\n$env:OPENSRE_INSTALL_CHANNEL="release"; $env:OPENSRE_VERSION="%s"; irm https://install.opensre.com | iex\n%s\n\n' "$CB" "${TAG_NAME#v}" "$CB"
             printf '### Python\n\n%sbash\npipx install opensre\n%s\n\n' "$CB" "$CB"
           } > RELEASE_NOTES.md
           cat GENERATED_CHANGELOG.md >> RELEASE_NOTES.md
@@ -547,7 +546,7 @@ jobs:
           bash .github/scripts/sync-homebrew-tap-formula.sh
 
   publish-main-release:
-    if: needs.prepare.outputs.channel == 'main'
+    if: always() && needs.prepare.outputs.channel == 'main' && needs.build-binaries.result == 'success'
     runs-on: ubuntu-latest
     needs:
       - prepare
@@ -576,19 +575,19 @@ jobs:
           {
             printf '## Main build\n\nRolling binary build from `main`.\n\n'
             printf -- '- Commit: `%s`\n- Built: %s\n\n' "$short_sha" "$built_at"
-            printf '### Install\n\nStable:\n\n%sbash\ncurl -fsSL https://install.opensre.com | bash\n%s\n\n' "$CB" "$CB"
-            printf 'Main:\n\n%sbash\ncurl -fsSL https://install.opensre.com | bash -s -- --main\n%s\n\n' "$CB" "$CB"
-            printf 'Windows stable:\n\n%spowershell\nirm https://install.opensre.com | iex\n%s\n' "$CB" "$CB"
+            printf '### Install\n\nmacOS / Linux:\n\n%sbash\ncurl -fsSL https://install.opensre.com | bash\n%s\n\n' "$CB" "$CB"
+            printf 'Equivalent explicit main channel:\n\n%sbash\ncurl -fsSL https://install.opensre.com | bash -s -- --main\n%s\n\n' "$CB" "$CB"
+            printf 'Windows:\n\n%spowershell\nirm https://install.opensre.com | iex\n%s\n' "$CB" "$CB"
           } > MAIN_RELEASE_NOTES.md
 
-      - name: Move nightly tag to the latest commit
+      - name: Move main build tag to the latest commit
         shell: bash
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -f nightly "$GITHUB_SHA"
-          git push origin refs/tags/nightly --force
+          git tag -f "${{ needs.prepare.outputs.tag_name }}" "$GITHUB_SHA"
+          git push origin "refs/tags/${{ needs.prepare.outputs.tag_name }}" --force
 
       - name: Publish rolling main release
         env:
@@ -597,16 +596,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          if gh release view nightly --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            gh release upload nightly main-release-assets/* --repo "${{ github.repository }}" --clobber
-            gh release edit nightly \
+          tag_name="${{ needs.prepare.outputs.tag_name }}"
+
+          if gh release view "$tag_name" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release upload "$tag_name" main-release-assets/* --repo "${{ github.repository }}" --clobber
+            gh release edit "$tag_name" \
               --repo "${{ github.repository }}" \
               --title "Main" \
               --notes-file MAIN_RELEASE_NOTES.md
             exit 0
           fi
 
-          gh release create nightly \
+          gh release create "$tag_name" \
             main-release-assets/* \
             --repo "${{ github.repository }}" \
             --target "$GITHUB_SHA" \

--- a/README.md
+++ b/README.md
@@ -88,15 +88,15 @@ Our mission is to build AI SRE agents on top of this, scale it to thousands of r
 
 ## Install
 
-The root installer URL auto-detects Unix shell vs PowerShell. Add `--main` when you want the latest rolling build from `main` instead of the latest stable release.
+The root installer URL auto-detects Unix shell vs PowerShell and installs the latest build from `main`. OpenSRE moves quickly, so `main` is the latest stable version for normal installs.
 
-Latest stable release:
+macOS / Linux:
 
 ```bash
 curl -fsSL https://install.opensre.com | bash
 ```
 
-Latest build from `main`:
+Equivalent explicit main-channel form:
 
 ```bash
 curl -fsSL https://install.opensre.com | bash -s -- --main

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -7,7 +7,7 @@ slug: "quickstart"
   <Step title="Install OpenSRE">
     <Tabs>
       <Tab title="macOS / Linux">
-        Choose one install method:
+        Choose one install method. The one-line installer tracks the latest stable build from `main`.
 
         ```bash
         brew tap tracer-cloud/tap

--- a/install.ps1
+++ b/install.ps1
@@ -1,12 +1,13 @@
 param(
     [ValidateSet("release", "main")]
-    [string]$Channel = $(if ($env:OPENSRE_INSTALL_CHANNEL) { $env:OPENSRE_INSTALL_CHANNEL } else { "release" }),
+    [string]$Channel = $(if ($env:OPENSRE_INSTALL_CHANNEL) { $env:OPENSRE_INSTALL_CHANNEL } else { "main" }),
     [switch]$SkipMain
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $script:OpenSreProgressStep = 0
+$script:OpenSreChannelExplicit = $PSBoundParameters.ContainsKey("Channel") -or [bool]$env:OPENSRE_INSTALL_CHANNEL
 
 function Test-OpenSreVerboseInstall {
     $value = [string]$env:OPENSRE_INSTALL_VERBOSE
@@ -758,8 +759,10 @@ function Get-OpenSreReleaseMetadata {
         throw "OPENSRE_VERSION cannot be combined with the main install channel."
     }
 
+    $mainReleaseTag = if ($env:OPENSRE_MAIN_RELEASE_TAG) { $env:OPENSRE_MAIN_RELEASE_TAG } else { "main-build" }
+
     $releaseUri = if ($Channel -eq "main") {
-        "https://api.github.com/repos/$Repo/releases/tags/nightly"
+        "https://api.github.com/repos/$Repo/releases/tags/$mainReleaseTag"
     }
     elseif ($normalizedVersion) {
         "https://api.github.com/repos/$Repo/releases/tags/v$normalizedVersion"
@@ -1023,6 +1026,11 @@ function Install-OpenSre {
     $binaryName = "opensre.exe"
     $requestedVersion = if ($env:OPENSRE_VERSION) { $env:OPENSRE_VERSION.Trim().TrimStart("v") } else { "" }
     $resolvedChannel = if ($Channel) { $Channel.Trim().ToLowerInvariant() } else { "release" }
+    $channelExplicit = [bool]$script:OpenSreChannelExplicit
+
+    if ($requestedVersion -and $resolvedChannel -eq "main" -and -not $channelExplicit) {
+        $resolvedChannel = "release"
+    }
 
     Show-OpenSreIntro
     Write-OpenSreHeader -Channel $resolvedChannel -RequestedVersion $requestedVersion -InstallDir $installDir -Repo $repo

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,10 @@ USER_INSTALL_DIR_CANDIDATES="${OPENSRE_USER_INSTALL_DIR_CANDIDATES:-$HOME/.local
 SYSTEM_INSTALL_DIR_CANDIDATES="${OPENSRE_SYSTEM_INSTALL_DIR_CANDIDATES:-/opt/homebrew/bin:/usr/local/bin:/opt/local/bin}"
 INSTALL_DIR="${OPENSRE_INSTALL_DIR:-}"
 INSTALL_DIR_OVERRIDE=0
-INSTALL_CHANNEL="${OPENSRE_INSTALL_CHANNEL:-release}"
+INSTALL_CHANNEL="${OPENSRE_INSTALL_CHANNEL:-main}"
+INSTALL_CHANNEL_EXPLICIT=0
+[ -n "${OPENSRE_INSTALL_CHANNEL:-}" ] && INSTALL_CHANNEL_EXPLICIT=1
+MAIN_RELEASE_TAG="${OPENSRE_MAIN_RELEASE_TAG:-main-build}"
 BIN_NAME="opensre"
 INSTALL_WITH_SUDO=0
 PROGRESS_PID=""
@@ -527,13 +530,14 @@ print_installer_header() {
 
 usage() {
   cat <<'EOF'
-Usage: install.sh [--main] [--version <version>] [--install-dir <path>]
+Usage: install.sh [--main] [--release] [--version <version>] [--install-dir <path>]
 
 Installs the OpenSRE CLI.
 
 Options:
-  --main                Install the rolling build published from the main branch.
-  --version <version>   Install a specific release version (for example 2026.4.29).
+  --main                Install the latest build published from the main branch (default).
+  --release             Install the latest versioned release instead of main.
+  --version <version>   Install a specific versioned release (for example 2026.4.29).
   --install-dir <path>  Install into a specific directory.
   -h, --help            Show this help text.
 
@@ -549,9 +553,11 @@ parse_args() {
     case "$1" in
       --main)
         INSTALL_CHANNEL="main"
+        INSTALL_CHANNEL_EXPLICIT=1
         ;;
       --release)
         INSTALL_CHANNEL="release"
+        INSTALL_CHANNEL_EXPLICIT=1
         ;;
       --version)
         [ "$#" -ge 2 ] || die "--version requires a value."
@@ -581,6 +587,10 @@ parse_args() {
       die "Unsupported install channel: ${INSTALL_CHANNEL}"
       ;;
   esac
+
+  if [ -n "$requested_version" ] && [ "$INSTALL_CHANNEL" = "main" ] && [ "$INSTALL_CHANNEL_EXPLICIT" -eq 0 ]; then
+    INSTALL_CHANNEL="release"
+  fi
 
   if [ "$INSTALL_CHANNEL" = "main" ] && [ -n "$requested_version" ]; then
     die "--version cannot be combined with --main."
@@ -629,7 +639,7 @@ fetch_release_json() {
   local api_url
 
   if [ "$INSTALL_CHANNEL" = "main" ]; then
-    api_url="https://api.github.com/repos/${REPO}/releases/tags/nightly"
+    api_url="https://api.github.com/repos/${REPO}/releases/tags/${MAIN_RELEASE_TAG}"
   elif [ -n "$version" ]; then
     api_url="https://api.github.com/repos/${REPO}/releases/tags/v${version}"
   else

--- a/tests/cli/test_install_ps1_progress.py
+++ b/tests/cli/test_install_ps1_progress.py
@@ -62,6 +62,17 @@ def test_install_ps1_preserves_retry_contract_source() -> None:
     assert "$statusCode -ge 400 -and $statusCode -lt 500" in source
 
 
+def test_install_ps1_defaults_to_main_build_channel() -> None:
+    source = INSTALL_PS1.read_text()
+
+    assert 'else { "main" }' in source
+    assert 'else { "main-build" }' in source
+    assert "releases/tags/$mainReleaseTag" in source
+    assert "$script:OpenSreChannelExplicit" in source
+    assert '$resolvedChannel = "release"' in source
+    assert "releases/tags/nightly" not in source
+
+
 def test_install_ps1_keeps_download_urls_verbose_only() -> None:
     source = INSTALL_PS1.read_text()
 

--- a/tests/cli/test_install_readme.py
+++ b/tests/cli/test_install_readme.py
@@ -1,0 +1,19 @@
+"""Contracts for README install instructions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_README = Path(__file__).resolve().parents[2] / "README.md"
+
+
+def test_readme_presents_main_as_default_install_channel() -> None:
+    source = _README.read_text()
+
+    assert "installs the latest build from `main`" in source
+    assert "main` is the latest stable version" in source
+    assert "curl -fsSL https://install.opensre.com | bash" in source
+    assert "Equivalent explicit main-channel form" in source
+    assert "Latest stable release:" not in source
+    assert "Latest build from `main`:" not in source
+    assert "instead of the latest stable release" not in source

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -167,6 +167,15 @@ def test_install_sh_has_step_for_explicit_version_fetch() -> None:
     assert "[1/6] Fetching release metadata for v2026.4.29" in result.stdout
 
 
+def test_install_sh_defaults_to_main_build_channel() -> None:
+    source = INSTALL_SH.read_text()
+
+    assert 'INSTALL_CHANNEL="${OPENSRE_INSTALL_CHANNEL:-main}"' in source
+    assert 'MAIN_RELEASE_TAG="${OPENSRE_MAIN_RELEASE_TAG:-main-build}"' in source
+    assert "releases/tags/${MAIN_RELEASE_TAG}" in source
+    assert "releases/tags/nightly" not in source
+
+
 def test_install_sh_defines_progress_helpers() -> None:
     source = INSTALL_SH.read_text()
 

--- a/tests/infra_ci/test_release_workflow.py
+++ b/tests/infra_ci/test_release_workflow.py
@@ -1,0 +1,30 @@
+"""Contracts for the binary release workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+
+def test_main_release_uses_main_build_tag_not_nightly() -> None:
+    source = _RELEASE_WORKFLOW.read_text()
+
+    assert "tag_name=main-build" in source
+    assert "refs/tags/${{ needs.prepare.outputs.tag_name }}" in source
+    assert 'gh release view "$tag_name"' in source
+    assert "nightly" not in source
+
+
+def test_main_binary_publish_runs_when_verify_is_skipped_on_push() -> None:
+    source = _RELEASE_WORKFLOW.read_text()
+
+    assert (
+        "if: always() && (needs.prepare.outputs.channel == 'main' || "
+        "needs.verify.result == 'success')"
+    ) in source
+    assert (
+        "if: always() && needs.prepare.outputs.channel == 'main' && "
+        "needs.build-binaries.result == 'success'"
+    ) in source


### PR DESCRIPTION
## Summary

- make the default Unix and PowerShell installers resolve the latest published main build
- keep `--main` as an explicit alias and keep versioned installs available through `--release --version` or `OPENSRE_VERSION`
- publish rolling main artifacts under `main-build` instead of stale `nightly`
- fix the release workflow so main push binary publishing runs even when the push-only `verify` job is skipped
- update README/quickstart install wording and add contract tests for installer, README, and release workflow behavior

## Root Cause

The installer documented `--main` as the latest main build, but it resolved that path through the `nightly` GitHub release. That release had stopped refreshing because the release workflow's binary jobs depended on a skipped `verify` job on `main` pushes, so users could install a stale binary even immediately after downloading from the installer.

## Validation

- `uv run python -m pytest tests/cli/test_install_sh_path.py tests/cli/test_install_ps1_progress.py tests/cli/test_install_readme.py tests/infra_ci/test_release_workflow.py -q`
- `make format-check`
- `make lint`
- `make typecheck`
- `make test-scope`
