### PR TITLE
fix(wizard): preserve headless .env fallback secrets on sync

### DIFF
--- a/cli/wizard/env_sync.py
+++ b/cli/wizard/env_sync.py
@@ -74,6 +74,25 @@ def _strip_sensitive_env_lines(lines: list[str]) -> list[str]:
     return stripped
 
 
+def _strip_keyring_backed_secret_lines(lines: list[str]) -> list[str]:
+    """Drop sensitive lines already stored in the keyring; keep headless fallback secrets."""
+    kept: list[str] = []
+    for line in lines:
+        match = _ENV_ASSIGNMENT.match(line)
+        if match and _is_sensitive_env_key(match.group(1)) and has_llm_api_key(match.group(1)):
+            continue
+        kept.append(line)
+    return kept
+
+
+def _lines_contain_sensitive(lines: list[str]) -> bool:
+    for line in lines:
+        match = _ENV_ASSIGNMENT.match(line)
+        if match and _is_sensitive_env_key(match.group(1)):
+            return True
+    return False
+
+
 def _persist_env_secret(key: str, value: str) -> bool:
     """Store a secret in the keyring. Returns False when keyring is unavailable."""
     normalized = value.strip()
@@ -146,6 +165,37 @@ def _write_env(target_path: Path, lines: list[str]) -> None:
             target_path.chmod(0o600)
 
 
+def _write_env_raw(target_path: Path, lines: list[str]) -> None:
+    """Write ``.env`` lines including headless fallback secrets (owner-only on Unix)."""
+    content = "".join(lines)
+    try:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        if os.name == "nt":
+            with target_path.open("w", encoding="utf-8", newline="") as env_file:
+                env_file.write(content)
+        else:
+            fd = os.open(
+                target_path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                0o600,
+            )
+            with os.fdopen(fd, "w", encoding="utf-8", newline="") as env_file:
+                env_file.write(content)
+    except PermissionError as exc:
+        raise PermissionError(
+            f"Cannot write to {target_path}: permission denied. "
+            "Ensure you have write access to this file, or run the command as the file owner."
+        ) from exc
+
+
+def _write_env_lines(target_path: Path, lines: list[str]) -> None:
+    """Write merged env lines, using the secure raw path when fallback secrets remain."""
+    if _lines_contain_sensitive(lines):
+        _write_env_raw(target_path, lines)
+    else:
+        _write_env(target_path, lines)
+
+
 def sync_env_secret(key: str, value: str) -> None:
     """Persist a sensitive env value in the system keyring, not in ``.env``."""
     if not _is_sensitive_env_key(key):
@@ -161,7 +211,9 @@ def sync_env_values(
     """Write multiple non-sensitive environment values into the target .env file.
 
     Sensitive keys must be persisted with :func:`sync_env_secret` instead.
-    When keyring storage is unavailable, sensitive values are not written to ``.env``.
+    Existing sensitive assignments are removed from ``.env`` only when the same
+    key is already stored in the keyring, so headless fallback secrets survive
+    unrelated non-secret updates.
     """
     sensitive_keys = [key for key in values if _is_sensitive_env_key(key)]
     if sensitive_keys:
@@ -175,11 +227,11 @@ def sync_env_values(
         else []
     )
 
-    lines = _strip_sensitive_env_lines(existing)
+    lines = _strip_keyring_backed_secret_lines(list(existing))
     for key, value in values.items():
         lines = _set_env_value(lines, key, value)
 
-    _write_env(target_path, lines)
+    _write_env_lines(target_path, lines)
     return target_path
 
 

--- a/cli/wizard/env_sync.py
+++ b/cli/wizard/env_sync.py
@@ -186,6 +186,9 @@ def _write_env_raw(target_path: Path, lines: list[str]) -> None:
             f"Cannot write to {target_path}: permission denied. "
             "Ensure you have write access to this file, or run the command as the file owner."
         ) from exc
+    if os.name != "nt":
+        with suppress(OSError):
+            target_path.chmod(0o600)
 
 
 def _write_env_lines(target_path: Path, lines: list[str]) -> None:

--- a/cli/wizard/env_sync.py
+++ b/cli/wizard/env_sync.py
@@ -378,7 +378,7 @@ def sync_provider_env(
     for key, value in values.items():
         lines = _set_env_value(lines, key, value)
 
-    _write_env(target_path, lines)
+    _write_env_lines(target_path, lines)
 
     for key in keys_to_remove:
         os.environ.pop(key, None)

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -441,3 +441,76 @@ def test_sync_env_values_permission_error(tmp_path) -> None:
             sync_env_values({"FOO": "baz"}, env_path=env_path)
     finally:
         env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+def test_strip_keyring_backed_secret_lines_removes_only_keyring_backed(
+    monkeypatch,
+) -> None:
+    from cli.wizard.env_sync import _strip_keyring_backed_secret_lines
+
+    lines = [
+        "TELEGRAM_BOT_TOKEN=fallback\n",
+        "DD_API_KEY=in-keyring\n",
+        "DD_SITE=old\n",
+    ]
+    monkeypatch.setattr(
+        "cli.wizard.env_sync.has_llm_api_key",
+        lambda key: key == "DD_API_KEY",
+    )
+
+    kept = _strip_keyring_backed_secret_lines(lines)
+
+    assert kept == ["TELEGRAM_BOT_TOKEN=fallback\n", "DD_SITE=old\n"]
+
+
+def test_sync_env_values_preserves_telegram_bot_token_fallback(tmp_path) -> None:
+    """Regression for #3223: headless fallback secrets must survive unrelated syncs."""
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "TELEGRAM_BOT_TOKEN=manual-fallback-token\nDD_SITE=old\n",
+        encoding="utf-8",
+    )
+
+    sync_env_values({"DD_SITE": "datadoghq.eu"}, env_path=env_path)
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "TELEGRAM_BOT_TOKEN=manual-fallback-token" in content
+    assert "DD_SITE=datadoghq.eu" in content
+
+
+def test_sync_env_values_preserves_multiple_fallback_secrets(tmp_path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "DD_API_KEY=datadog-api\nDD_APP_KEY=datadog-app\n",
+        encoding="utf-8",
+    )
+
+    sync_env_values({"DD_SITE": "datadoghq.com"}, env_path=env_path)
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "DD_API_KEY=datadog-api" in content
+    assert "DD_APP_KEY=datadog-app" in content
+    assert "DD_SITE=datadoghq.com" in content
+
+
+def test_sync_env_values_empty_update_preserves_fallback_secrets(tmp_path) -> None:
+    """Wizard paths call ``sync_env_values({})`` after integration setup."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("TELEGRAM_BOT_TOKEN=manual-fallback-token\n", encoding="utf-8")
+
+    sync_env_values({}, env_path=env_path)
+
+    assert "TELEGRAM_BOT_TOKEN=manual-fallback-token" in env_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows permission model differs")
+def test_write_env_raw_creates_file_with_owner_only_permissions(tmp_path) -> None:
+    from cli.wizard.env_sync import _write_env_raw
+
+    env_path = tmp_path / ".env"
+    _write_env_raw(env_path, ["TELEGRAM_BOT_TOKEN=fallback\n", "DD_SITE=datadoghq.eu\n"])
+
+    assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+    content = env_path.read_text(encoding="utf-8")
+    assert "TELEGRAM_BOT_TOKEN=fallback" in content
+    assert "DD_SITE=datadoghq.eu" in content

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -514,3 +514,16 @@ def test_write_env_raw_creates_file_with_owner_only_permissions(tmp_path) -> Non
     content = env_path.read_text(encoding="utf-8")
     assert "TELEGRAM_BOT_TOKEN=fallback" in content
     assert "DD_SITE=datadoghq.eu" in content
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows permission model differs")
+def test_write_env_raw_tightens_permissions_on_existing_file(tmp_path) -> None:
+    from cli.wizard.env_sync import _write_env_raw
+
+    env_path = tmp_path / ".env"
+    env_path.write_text("TELEGRAM_BOT_TOKEN=old\n", encoding="utf-8")
+    env_path.chmod(0o644)
+
+    _write_env_raw(env_path, ["TELEGRAM_BOT_TOKEN=fallback\n"])
+
+    assert stat.S_IMODE(env_path.stat().st_mode) == 0o600

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -103,6 +103,27 @@ def test_sync_provider_env_updates_provider_specific_keys(tmp_path, monkeypatch)
     assert "OPENAI_MODEL=gpt-5-mini\n" in content
 
 
+def test_sync_provider_env_preserves_integration_fallback_secrets(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("OPENAI_REASONING_MODEL", raising=False)
+    monkeypatch.delenv("OPENAI_MODEL", raising=False)
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "TELEGRAM_BOT_TOKEN=manual-fallback-token\nLLM_PROVIDER=anthropic\n",
+        encoding="utf-8",
+    )
+
+    sync_provider_env(
+        provider=PROVIDER_BY_VALUE["openai"],
+        model="gpt-5-mini",
+        env_path=env_path,
+    )
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "TELEGRAM_BOT_TOKEN=manual-fallback-token" in content
+    assert "LLM_PROVIDER=openai\n" in content
+
+
 def test_sync_provider_env_updates_wizard_store(tmp_path, monkeypatch) -> None:
     store_path = tmp_path / "opensre.json"
     env_path = tmp_path / ".env"


### PR DESCRIPTION
Fixes #3223

#### Describe the changes you have made in this PR -

`sync_env_values()` was wiping every sensitive line out of `.env` before writing, even when the only thing being updated was something harmless like `DD_SITE`. If you had manually added `TELEGRAM_BOT_TOKEN` for a headless box (which the docs suggest), the next wizard sync would silently delete it.

Fix is two steps:
1. When merging into existing `.env`, only drop sensitive keys that are **already in the keyring** — leave fallback secrets alone.
2. When writing back, use a raw write path if fallback secrets are still present, because `_PublicEnvLines` would strip them again on save.

Keyring-backed secrets still get removed from `.env` (unchanged — see existing `test_sync_env_values_routes_secrets_to_keyring`).

Added regression tests including the exact repro from the issue (`TELEGRAM_BOT_TOKEN` + unrelated `sync_env_values` call).

### Demo/Screenshot for feature changes and bug fixes -

**Combined (before → after):**

<video src="https://github.com/sreecharan-desu/opensre/releases/download/pr-3223-demo/demo_combined.mp4" controls width="100%"></video>

![demo combined](https://github.com/sreecharan-desu/opensre/releases/download/pr-3223-demo/demo_combined.gif)

<details>
<summary>Before / after separately</summary>

**Before (main):**

<video src="https://github.com/sreecharan-desu/opensre/releases/download/pr-3223-demo/before_main.mp4" controls width="100%"></video>

![before main](https://github.com/sreecharan-desu/opensre/releases/download/pr-3223-demo/before_main.gif)

**After (fix + pytest):**

<video src="https://github.com/sreecharan-desu/opensre/releases/download/pr-3223-demo/after_fix.mp4" controls width="100%"></video>

![after fix](https://github.com/sreecharan-desu/opensre/releases/download/pr-3223-demo/after_fix.gif)

</details>

Quick text version of what the videos show:

```
# before (main)
TELEGRAM_BOT_TOKEN=manual-fallback-token
DD_SITE=old
→ sync_env_values({'DD_SITE': 'datadoghq.eu'})
→ DD_SITE=datadoghq.eu    # token gone

# after (this PR)
→ TELEGRAM_BOT_TOKEN=manual-fallback-token
→ DD_SITE=datadoghq.eu    # both stay
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug had two layers — stripping on read *and* stripping on write — so fixing only the merge step wasn't enough; I traced it by running the issue repro and watching the file contents after each call. Considered always keeping secrets in `.env` but that would fight the keyring-first design; instead I only skip stripping when the key isn't in keyring yet. `_strip_keyring_backed_secret_lines` handles merge, `_write_env_lines` picks raw vs public write based on whether sensitive lines remain.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

**Tests run locally:**
`make lint && make format-check && make typecheck`
`pytest tests/cli/wizard/test_env_sync.py` (40 passed)