### PR TITLE
fix(ci): test-scope reporting rule target must be a tuple, not a bare string

### DIFF
--- a/infra/ci/test_scope_rules.py
+++ b/infra/ci/test_scope_rules.py
@@ -27,7 +27,7 @@ RULES: tuple[PathRule, ...] = (
     # Shared core (always escalate)
     PathRule("core/domain/", (), always_escalate=True),
     PathRule("core/", ("tests/core/",)),
-    PathRule("tools/investigation/reporting/", ("tests/delivery/")),
+    PathRule("tools/investigation/reporting/", ("tests/delivery/",)),
     PathRule("tools/investigation/", (), always_escalate=True),
     PathRule("utils/", (), always_escalate=True),
     # Specific sub-packages before their parent

--- a/tests/infra_ci/test_test_scope_rules.py
+++ b/tests/infra_ci/test_test_scope_rules.py
@@ -64,3 +64,19 @@ def test_changed_test_file_is_targeted() -> None:
     escalate, targets, _ = rules.classify([path])
     assert not escalate
     assert targets == [path]
+
+
+def test_reporting_rule_routes_to_tests_delivery() -> None:
+    rules = _rules_module()
+    escalate, targets, _ = rules.classify(["tools/investigation/reporting/publish.py"])
+    assert not escalate
+    assert targets == ["tests/delivery/"]
+
+
+def test_all_rule_targets_are_tuples_not_bare_strings() -> None:
+    # A single target written as ("x") is a str, not a tuple — classify() would
+    # then iterate it character by character. infra/ci is outside the mypy paths
+    # so this footgun isn't caught by typecheck; guard it here for every rule.
+    rules = _rules_module()
+    for rule in rules.RULES:
+        assert isinstance(rule.test_targets, tuple), rule.path_prefix

--- a/tests/infra_ci/test_test_scope_rules.py
+++ b/tests/infra_ci/test_test_scope_rules.py
@@ -67,6 +67,12 @@ def test_changed_test_file_is_targeted() -> None:
 
 
 def test_reporting_rule_routes_to_tests_delivery() -> None:
+    # classify() drops targets that don't exist on disk, so make the dependency
+    # explicit: a missing dir here means "recreate it or update the rule", not
+    # "the routing changed".
+    assert Path("tests/delivery/").is_dir(), (
+        "tests/delivery/ missing — update the rule or recreate the dir"
+    )
     rules = _rules_module()
     escalate, targets, _ = rules.classify(["tools/investigation/reporting/publish.py"])
     assert not escalate


### PR DESCRIPTION
Fixes #3241

#### Describe the changes you have made in this PR -

The `make test-scope` routing rule for the investigation reporting package was
missing a trailing comma, making its `test_targets` a **string instead of a
one-element tuple**:

```python
PathRule("tools/investigation/reporting/", ("tests/delivery/")),   # ("x") == str, not ("x",)
```

`classify()` iterates `test_targets`, so it walked the string character by
character. Every single-char "target" was dropped by the `Path(t).exists()`
filter — except `"/"`, which exists — so a change under
`tools/investigation/reporting/` resolved to `targets == ["/"]` and
`make test-scope` would run `pytest /` (the filesystem root) instead of
`tests/delivery/` (7 real test files). Restructure fallout from #3190.

This PR:
- adds the missing trailing comma so the target is a proper one-element tuple;
- adds two unit tests: one asserting the reporting rule routes to
  `tests/delivery/`, and one asserting **every** rule's `test_targets` is a
  tuple — `infra/ci/` is outside `PYTHON_SOURCE_PATHS`, so mypy never flagged
  `str` where `tuple[str, ...]` was expected, and this guard catches the whole
  class of bare-`("x")` footgun regardless of mypy scope.

### Demo/Screenshot for feature changes and bug fixes -


BEFORE

<img width="1038" height="77" alt="image" src="https://github.com/user-attachments/assets/e916b691-a4c7-4986-a7fd-5e92a2c4f1a9" />

AFTER

<img width="1211" height="268" alt="image" src="https://github.com/user-attachments/assets/e8052466-84cb-4453-8255-12364857e0e4" />

<img width="1380" height="259" alt="image" src="https://github.com/user-attachments/assets/3abb47b6-03ed-4eef-806f-07a5f27352b9" />


Lint and format pass on both files.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I spotted the missing comma while re-reading the rewritten RULES table after the
#3190 restructure, confirmed `("tests/delivery/")` is a `str` (not a tuple) and
that `classify()` therefore iterated it into single-char targets resolving to
`["/"]`, and traced why CI missed it: `infra/ci/` is outside the mypy paths.
Fixed the comma and added a routing test plus a table-wide tuple guard so the
same footgun can't silently return on a future rule.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
