### PR TITLE
Add onboarding OAuth auth method flow

### DIFF
--- a/cli/wizard/_ui.py
+++ b/cli/wizard/_ui.py
@@ -17,6 +17,12 @@ from cli.wizard.integration_health import IntegrationHealthResult
 from cli.wizard.probes import ProbeResult
 from cli.wizard.prompts import select as select_prompt
 from cli.wizard.store import get_store_path, load_local_config
+from config.llm_auth.auth_method import (
+    OAUTH_AUTH_METHOD,
+    canonical_llm_provider,
+    get_configured_llm_auth_method,
+    normalize_llm_auth_method,
+)
 from config.llm_auth.credentials import has_llm_api_key, save_api_key
 from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
 from config.llm_credentials import get_keyring_setup_instructions, save_llm_api_key
@@ -71,6 +77,10 @@ class Choice:
     hint: str | None = None
 
 
+class WizardBack(KeyboardInterrupt):
+    """Raised when a prompt-level cancel should move back one wizard step."""
+
+
 def _as_mapping(value: object) -> Mapping[str, object]:
     return value if isinstance(value, Mapping) else {}
 
@@ -93,12 +103,28 @@ def _local_defaults() -> dict[str, str | bool | None]:
     targets = _as_mapping(stored.get("targets"))
     local = _as_mapping(targets.get("local"))
     raw_provider = local.get("provider")
-    provider = PROVIDER_BY_VALUE.get(_string_value(raw_provider)) if raw_provider else None
-    api_key_env = _string_value(local.get("api_key_env"), provider.api_key_env if provider else "")
-    is_cli = bool(provider and provider.credential_kind == "cli")
+    raw_provider_value = _string_value(raw_provider) if raw_provider else ""
+    provider_value = canonical_llm_provider(raw_provider_value) if raw_provider_value else ""
+    provider = PROVIDER_BY_VALUE.get(provider_value) if provider_value else None
+    raw_provider_option = PROVIDER_BY_VALUE.get(raw_provider_value) if raw_provider_value else None
+    api_key_provider = raw_provider_option or provider
+    api_key_env = _string_value(
+        local.get("api_key_env"), api_key_provider.api_key_env if api_key_provider else ""
+    )
+    is_cli = bool(raw_provider_option and raw_provider_option.credential_kind == "cli")
+    is_oauth_backend = bool(raw_provider_value and raw_provider_value != provider_value)
+    raw_auth_method = local.get("auth_method")
+    auth_method = (
+        normalize_llm_auth_method(raw_auth_method if isinstance(raw_auth_method, str) else None)
+        if raw_auth_method
+        else get_configured_llm_auth_method(_string_value(raw_provider))
+    )
+    if is_oauth_backend:
+        auth_method = OAUTH_AUTH_METHOD
     return {
         "wizard_mode": _string_value(wizard.get("mode"), "quickstart"),
-        "provider": _string_value(raw_provider) if raw_provider else None,
+        "provider": provider_value if raw_provider_value else None,
+        "auth_method": auth_method,
         "model": _string_value(local.get("model")),
         "api_key_env": api_key_env,
         "has_api_key": True if is_cli else bool(api_key_env and has_llm_api_key(api_key_env)),
@@ -205,7 +231,13 @@ def _provider_model_prompt_label(provider: ProviderOption) -> str:
     return provider.label
 
 
-def _choose_model(provider: ProviderOption, *, default: str | None) -> str:
+def _choose_model(
+    provider: ProviderOption,
+    *,
+    default: str | None,
+    prompt_label: str | None = None,
+    back_on_cancel: bool = False,
+) -> str:
     """Prompt the user to pick a model from ``provider.models``.
 
     Choices come from the curated config in ``cli/wizard/config.py``.
@@ -240,11 +272,12 @@ def _choose_model(provider: ProviderOption, *, default: str | None) -> str:
     if default_value and not any(c.value == default_value for c in choices):
         default_value = curated_choices[0].value if curated_choices else _CUSTOM_MODEL_SENTINEL
 
-    provider_label = _provider_model_prompt_label(provider)
+    provider_label = prompt_label or _provider_model_prompt_label(provider)
     selection = _choose(
         f"Choose {provider_label} model",
         choices,
         default=default_value or None,
+        back_on_cancel=back_on_cancel,
     )
 
     if selection != _CUSTOM_MODEL_SENTINEL:
@@ -254,6 +287,7 @@ def _choose_model(provider: ProviderOption, *, default: str | None) -> str:
         f"Custom {provider_label} model ID ({provider.model_env})",
         default=resolved_default,
         allow_empty=False,
+        back_on_cancel=back_on_cancel,
     )
 
 
@@ -264,6 +298,7 @@ def _choose(
     default: str | None = None,
     group_order: tuple[str, ...] | None = None,
     trailing_choices: list[Choice] | None = None,
+    back_on_cancel: bool = False,
 ) -> str:
     if group_order is not None:
         q_choices = _grouped_questionary_choices(
@@ -286,6 +321,8 @@ def _choose(
     ).ask()
 
     if result is None:
+        if back_on_cancel:
+            raise WizardBack
         raise KeyboardInterrupt
     return str(result)
 
@@ -303,6 +340,7 @@ def _prompt_value(
     default: str = "",
     secret: bool = False,
     allow_empty: bool = False,
+    back_on_cancel: bool = False,
 ) -> str:
     while True:
         instruction = "(Enter to keep current)" if default else None
@@ -322,6 +360,8 @@ def _prompt_value(
             ).ask()
 
         if result is None:
+            if back_on_cancel:
+                raise WizardBack
             raise KeyboardInterrupt
 
         value = str(result).strip()

--- a/cli/wizard/env_sync.py
+++ b/cli/wizard/env_sync.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from cli.wizard.config import PROJECT_ENV_PATH, ProviderOption
+from config.llm_auth.auth_method import LLM_AUTH_METHOD_ENV
 from config.llm_auth.credentials import delete as delete_provider_auth
 from config.llm_auth.credentials import has_llm_api_key, save_api_key
 from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
@@ -199,14 +200,22 @@ def sync_reasoning_model_env(
     return target_path
 
 
-def _sync_llm_selection_to_store(*, provider: ProviderOption, model: str) -> None:
+def _sync_llm_selection_to_store(
+    *,
+    provider: ProviderOption,
+    model: str,
+    model_provider: ProviderOption | None = None,
+    auth_method: str | None = None,
+) -> None:
     from cli.wizard.store import update_local_llm_selection
 
+    resolved_model_provider = model_provider or provider
     update_local_llm_selection(
         provider=provider.value,
         model=model,
         api_key_env=provider.api_key_env or "",
-        model_env=provider.model_env,
+        model_env=resolved_model_provider.model_env,
+        auth_method=auth_method,
     )
 
 
@@ -267,6 +276,8 @@ def sync_provider_env(
     provider: ProviderOption,
     model: str,
     toolcall_model: str | None = None,
+    model_provider: ProviderOption | None = None,
+    auth_method: str | None = None,
     env_path: Path | None = None,
 ) -> Path:
     """Write non-secret provider settings into the project .env.
@@ -278,6 +289,7 @@ def sync_provider_env(
     """
     from cli.wizard.config import SUPPORTED_PROVIDERS
 
+    resolved_model_provider = model_provider or provider
     target_path = env_path or PROJECT_ENV_PATH
     existing = (
         target_path.read_text(encoding="utf-8").splitlines(keepends=True)
@@ -291,14 +303,16 @@ def sync_provider_env(
     for p in SUPPORTED_PROVIDERS:
         keys_to_remove |= _provider_specific_keys(p)
 
+    keys_to_remove.add(LLM_AUTH_METHOD_ENV)
+
     # Keep the active provider's model keys but always remove API key entries
     # (API keys are persisted via the system keyring, not .env).
-    active_non_secret: set[str] = {provider.model_env}
-    if provider.legacy_model_env:
-        active_non_secret.add(provider.legacy_model_env)
-    if provider.toolcall_model_env:
-        active_non_secret.add(provider.toolcall_model_env)
-    classification_env = _classification_model_env(provider)
+    active_non_secret: set[str] = {resolved_model_provider.model_env}
+    if resolved_model_provider.legacy_model_env:
+        active_non_secret.add(resolved_model_provider.legacy_model_env)
+    if resolved_model_provider.toolcall_model_env:
+        active_non_secret.add(resolved_model_provider.toolcall_model_env)
+    classification_env = _classification_model_env(resolved_model_provider)
     if classification_env:
         active_non_secret.add(classification_env)
     keys_to_remove -= active_non_secret
@@ -314,11 +328,16 @@ def sync_provider_env(
 
     lines = _remove_keys(existing, keys_to_remove)
 
-    values: dict[str, str] = {"LLM_PROVIDER": provider.value, provider.model_env: model}
-    if provider.legacy_model_env:
-        values[provider.legacy_model_env] = model
-    if toolcall_model and provider.toolcall_model_env:
-        values[provider.toolcall_model_env] = toolcall_model
+    values: dict[str, str] = {
+        "LLM_PROVIDER": provider.value,
+        resolved_model_provider.model_env: model,
+    }
+    if auth_method:
+        values[LLM_AUTH_METHOD_ENV] = auth_method
+    if resolved_model_provider.legacy_model_env:
+        values[resolved_model_provider.legacy_model_env] = model
+    if toolcall_model and resolved_model_provider.toolcall_model_env:
+        values[resolved_model_provider.toolcall_model_env] = toolcall_model
 
     for key, value in values.items():
         lines = _set_env_value(lines, key, value)
@@ -332,6 +351,11 @@ def sync_provider_env(
         if preserved is not None:
             values[key] = preserved
     os.environ.update(values)
-    _sync_llm_selection_to_store(provider=provider, model=model)
+    _sync_llm_selection_to_store(
+        provider=provider,
+        model=model,
+        model_provider=resolved_model_provider,
+        auth_method=auth_method,
+    )
 
     return target_path

--- a/cli/wizard/flow.py
+++ b/cli/wizard/flow.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import os
+import re
 import shlex
 import subprocess
 import sys
+import threading
+from dataclasses import dataclass
 from typing import Literal
 
 import questionary
@@ -14,6 +17,7 @@ from rich.text import Text
 import cli.wizard._integration_configurators as _integration_configurators_module
 from cli.wizard._ui import (
     Choice,
+    WizardBack,
     _choose,
     _choose_model,
     _confirm,
@@ -34,6 +38,14 @@ from cli.wizard.integration_health import IntegrationHealthResult
 from cli.wizard.probes import ProbeResult, probe_local_target, probe_remote_target
 from cli.wizard.store import get_store_path, save_local_config
 from cli.wizard.validation import build_demo_action_response as _build_demo_action_response
+from config.llm_auth.auth_method import (
+    API_KEY_AUTH_METHOD,
+    OAUTH_AUTH_METHOD,
+    OAUTH_BACKEND_PROVIDER_BY_PROVIDER,
+    LLMAuthMethod,
+    normalize_llm_auth_method,
+    supports_oauth_auth_method,
+)
 from integrations.llm_cli.binary_resolver import diagnose_binary_path
 from platform.terminal.theme import (
     ERROR,
@@ -51,6 +63,10 @@ _CLI_SUBSCRIPTION_LOGIN_ARGS: dict[str, tuple[str, ...]] = {
     "claude-code": ("auth", "login"),
     "codex": ("login",),
 }
+_HIDDEN_ONBOARDING_BACKEND_PROVIDERS = frozenset(OAUTH_BACKEND_PROVIDER_BY_PROVIDER.values())
+_CODEX_CONFIG_ERROR_RE = re.compile(
+    r"Error loading configuration:\s*(?P<location>[^\n]+config\.toml:\d+:\d+):\s*(?P<detail>[^\n]+)"
+)
 
 __all__ = [
     "DEFAULT_GITHUB_MCP_MODE",
@@ -82,6 +98,92 @@ def _credential_line_for_saved_summary(provider: ProviderOption) -> str:
     return f"{provider.label} ({cli_adapter.auth_hint})"
 
 
+@dataclass(frozen=True)
+class _SubscriptionLoginResult:
+    ok: bool
+    detail: str = ""
+    config_error: bool = False
+
+
+@dataclass(frozen=True)
+class _LoginProcessResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+def _provider_choice_label(provider: ProviderOption) -> str:
+    if provider.value == "openai":
+        return "OpenAI"
+    if provider.value == "anthropic":
+        return "Anthropic"
+    return provider.label
+
+
+def _onboarding_provider_options() -> tuple[ProviderOption, ...]:
+    return tuple(
+        provider
+        for provider in SUPPORTED_PROVIDERS
+        if provider.value not in _HIDDEN_ONBOARDING_BACKEND_PROVIDERS
+    )
+
+
+def _auth_method_label(auth_method: str) -> str:
+    return "OAuth" if normalize_llm_auth_method(auth_method) == OAUTH_AUTH_METHOD else "API key"
+
+
+def _choose_auth_method(
+    provider: ProviderOption,
+    *,
+    default: str | None,
+) -> LLMAuthMethod:
+    if provider.value in _HIDDEN_ONBOARDING_BACKEND_PROVIDERS:
+        return OAUTH_AUTH_METHOD
+    if not supports_oauth_auth_method(provider.value):
+        return API_KEY_AUTH_METHOD
+    method = _choose(
+        f"Choose {provider.label.removesuffix(' API key')} auth method",
+        [
+            Choice(
+                value=OAUTH_AUTH_METHOD,
+                label="OAuth",
+                hint="Browser login managed by onboarding",
+            ),
+            Choice(
+                value=API_KEY_AUTH_METHOD,
+                label="API key",
+                hint=f"Paste {provider.api_key_env}",
+            ),
+        ],
+        default=default
+        if default in {API_KEY_AUTH_METHOD, OAUTH_AUTH_METHOD}
+        else OAUTH_AUTH_METHOD,
+        back_on_cancel=True,
+    )
+    return normalize_llm_auth_method(method)
+
+
+def _oauth_backend_provider(provider: ProviderOption, auth_method: str) -> ProviderOption:
+    if normalize_llm_auth_method(auth_method) != OAUTH_AUTH_METHOD:
+        return provider
+    backend = OAUTH_BACKEND_PROVIDER_BY_PROVIDER.get(provider.value)
+    if backend is None:
+        return provider
+    return PROVIDER_BY_VALUE[backend]
+
+
+def _persisted_auth_method(
+    provider: ProviderOption, auth_method: str | None
+) -> LLMAuthMethod | None:
+    if auth_method is None:
+        return None
+    if provider.value in _HIDDEN_ONBOARDING_BACKEND_PROVIDERS or supports_oauth_auth_method(
+        provider.value
+    ):
+        return normalize_llm_auth_method(auth_method)
+    return None
+
+
 def _credential_prompt_label(provider: ProviderOption) -> str:
     """Provider label without the credential kind when the choice already includes it."""
     suffix = f" {provider.credential_label}"
@@ -102,35 +204,115 @@ def _subscription_login_command(
     return [binary_path, *args]
 
 
-def _run_subscription_login(provider: ProviderOption, binary_path: str | None) -> bool:
+def _stream_login_pipe(pipe, chunks: list[str]) -> None:
+    try:
+        for line in pipe:
+            chunks.append(line)
+            _console.print(line.rstrip("\n"), markup=False)
+    finally:
+        pipe.close()
+
+
+def _run_login_process(command: list[str]) -> _LoginProcessResult:
+    proc = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    stdout_chunks: list[str] = []
+    stderr_chunks: list[str] = []
+    threads: list[threading.Thread] = []
+    if proc.stdout is not None:
+        thread = threading.Thread(
+            target=_stream_login_pipe,
+            args=(proc.stdout, stdout_chunks),
+            daemon=True,
+        )
+        thread.start()
+        threads.append(thread)
+    if proc.stderr is not None:
+        thread = threading.Thread(
+            target=_stream_login_pipe,
+            args=(proc.stderr, stderr_chunks),
+            daemon=True,
+        )
+        thread.start()
+        threads.append(thread)
+    returncode = proc.wait()
+    for thread in threads:
+        thread.join()
+    return _LoginProcessResult(
+        returncode=returncode,
+        stdout="".join(stdout_chunks),
+        stderr="".join(stderr_chunks),
+    )
+
+
+def _subscription_login_error(
+    provider: ProviderOption, result: _LoginProcessResult
+) -> _SubscriptionLoginResult:
+    text = "\n".join(
+        part.strip()
+        for part in (getattr(result, "stdout", "") or "", getattr(result, "stderr", "") or "")
+        if part and part.strip()
+    )
+    if provider.value == "codex":
+        match = _CODEX_CONFIG_ERROR_RE.search(text)
+        if match:
+            return _SubscriptionLoginResult(
+                ok=False,
+                config_error=True,
+                detail=(
+                    "Codex CLI could not start because its local config is invalid: "
+                    f"{match.group('location')} ({match.group('detail')}). "
+                    "Fix that file, then retry OAuth login."
+                ),
+            )
+    tail = text[:500]
+    return _SubscriptionLoginResult(
+        ok=False,
+        detail=(
+            f"Login exited with code {result.returncode}: {tail}"
+            if tail
+            else f"Login exited with code {result.returncode}."
+        ),
+    )
+
+
+def _run_subscription_login(
+    provider: ProviderOption, binary_path: str | None
+) -> _SubscriptionLoginResult:
     """Launch the provider CLI login flow and report whether it exited cleanly."""
     command = _subscription_login_command(provider, binary_path)
     if command is None:
         auth_hint = provider.adapter_factory().auth_hint if provider.adapter_factory else ""
-        _console.print(
-            f"[{WARNING}]  {GLYPH_WARNING}  No browser login command is registered for "
-            f"{provider.label}. {auth_hint}[/]"
-        )
-        return False
+        detail = f"No browser login command is registered for {provider.label}. {auth_hint}"
+        _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
+        return _SubscriptionLoginResult(ok=False, detail=detail)
 
     _console.print(f"[{SECONDARY}]Launching {shlex.join(command)} for browser login…[/]")
     try:
-        result = subprocess.run(command, check=False)
+        result = _run_login_process(command)
     except KeyboardInterrupt:
         _console.print(f"[{WARNING}]  {GLYPH_WARNING}  Login cancelled.[/]")
-        return False
+        return _SubscriptionLoginResult(ok=False, detail="Login cancelled.")
     except OSError as exc:
-        _console.print(f"[{WARNING}]  {GLYPH_WARNING}  Could not launch login: {exc}[/]")
-        return False
+        detail = f"Could not launch login: {exc}"
+        _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
+        return _SubscriptionLoginResult(ok=False, detail=detail)
     if result.returncode != 0:
-        _console.print(
-            f"[{WARNING}]  {GLYPH_WARNING}  Login exited with code {result.returncode}.[/]"
-        )
-        return False
-    return True
+        login_result = _subscription_login_error(provider, result)
+        _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {login_result.detail}[/]")
+        return login_result
+    return _SubscriptionLoginResult(ok=True)
 
 
-def _run_cli_llm_onboarding(provider: ProviderOption) -> Literal["ok", "abort", "repick"]:
+def _run_cli_llm_onboarding(
+    provider: ProviderOption, *, display_label: str | None = None
+) -> Literal["ok", "abort", "repick"]:
     """Probe CLI binary + auth; recovery menu when missing. ``repick`` = choose another LLM."""
     factory = provider.adapter_factory
     if factory is None:
@@ -143,6 +325,7 @@ def _run_cli_llm_onboarding(provider: ProviderOption) -> Literal["ok", "abort", 
     install_hint = adapter.install_hint
     auth_hint = adapter.auth_hint
     name = adapter.name
+    provider_label = display_label or provider.label
     for _attempt in range(10):
         probe = adapter.detect()
         if probe.installed and probe.logged_in is True:
@@ -151,9 +334,9 @@ def _run_cli_llm_onboarding(provider: ProviderOption) -> Literal["ok", "abort", 
         if probe.installed and probe.logged_in is not True:
             _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {probe.detail}[/]")
             status_prompt = (
-                f"{provider.label} requires login. What next?"
+                f"{provider_label} requires login. What next?"
                 if probe.logged_in is False
-                else f"Could not verify {provider.label} login. What next?"
+                else f"Could not verify {provider_label} login. What next?"
             )
             choices = []
             if _subscription_login_command(provider, probe.bin_path) is not None:
@@ -181,17 +364,36 @@ def _run_cli_llm_onboarding(provider: ProviderOption) -> Literal["ok", "abort", 
             action = _choose(
                 status_prompt,
                 choices,
-                default="login" if choices[0].value == "login" else "retry",
+                default="login" if choices and choices[0].value == "login" else "retry",
             )
             if action == "repick":
                 return "repick"
             if action == "login":
-                _run_subscription_login(provider, probe.bin_path)
+                login_result = _run_subscription_login(provider, probe.bin_path)
+                if login_result.config_error:
+                    recovery = _choose(
+                        f"{provider_label} OAuth could not start. What next?",
+                        [
+                            Choice(
+                                value="retry",
+                                label="Retry after fixing local config",
+                                hint=login_result.detail,
+                            ),
+                            Choice(
+                                value="repick",
+                                label="Pick a different LLM provider",
+                                hint=None,
+                            ),
+                        ],
+                        default="retry",
+                    )
+                    if recovery == "repick":
+                        return "repick"
                 continue
             continue
         _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {probe.detail}[/]")
         action = _choose(
-            f"{provider.label} not found. What next?",
+            f"{provider_label} not found. What next?",
             [
                 Choice(
                     value="retry",
@@ -236,10 +438,18 @@ def run_wizard(_argv: list[str] | None = None) -> int:
     default_wizard_mode = (
         defaults["wizard_mode"] if isinstance(defaults["wizard_mode"], str) else "quickstart"
     )
+    raw_saved_auth_method = defaults.get("auth_method")
+    saved_auth_method = (
+        normalize_llm_auth_method(raw_saved_auth_method)
+        if isinstance(raw_saved_auth_method, str)
+        else API_KEY_AUTH_METHOD
+    )
+    provider_options = _onboarding_provider_options()
+    provider_option_values = {p.value for p in provider_options}
     default_provider_value = (
         saved_provider_value
-        if saved_provider_value in PROVIDER_BY_VALUE
-        else SUPPORTED_PROVIDERS[0].value
+        if saved_provider_value in provider_option_values
+        else provider_options[0].value
     )
 
     _step_header(1, WIZARD_TOTAL_STEPS, "Setup Mode")
@@ -280,6 +490,8 @@ def run_wizard(_argv: list[str] | None = None) -> int:
 
     force_repick = False
     provider: ProviderOption
+    model_provider: ProviderOption
+    auth_method: LLMAuthMethod | None
     model: str
     while True:
         _step_header(2, WIZARD_TOTAL_STEPS, "LLM Provider")
@@ -287,9 +499,15 @@ def run_wizard(_argv: list[str] | None = None) -> int:
             PROVIDER_BY_VALUE.get(saved_provider_value) if saved_provider_value else None
         )
         if saved_provider is not None and not force_repick:
-            current_model = saved_model_value or saved_provider.default_model
+            saved_model_provider = _oauth_backend_provider(saved_provider, saved_auth_method)
+            current_model = saved_model_value or saved_model_provider.default_model
+            auth_segment = (
+                f"  ·  {_auth_method_label(saved_auth_method)}"
+                if supports_oauth_auth_method(saved_provider.value)
+                else ""
+            )
             _console.print(
-                f"[{SECONDARY}]current provider  {saved_provider.label}  ·  {current_model}[/]"
+                f"[{SECONDARY}]current provider  {_provider_choice_label(saved_provider)}{auth_segment}  ·  {current_model}[/]"
             )
             change_provider = _confirm("Change provider?", default=False)
         else:
@@ -297,29 +515,42 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         force_repick = False
 
         if change_provider:
-            provider = PROVIDER_BY_VALUE[
-                _choose(
-                    "Choose your LLM provider",
-                    [
-                        Choice(
-                            value=p.value,
-                            label=p.label,
-                            hint=p.group,
-                        )
-                        for p in SUPPORTED_PROVIDERS
-                    ],
-                    default=default_provider_value,
-                )
-            ]
-            model = provider.default_model
-            if provider.credential_kind not in ("cli", "none"):
+            try:
+                provider = PROVIDER_BY_VALUE[
+                    _choose(
+                        "Choose your LLM provider",
+                        [
+                            Choice(
+                                value=p.value,
+                                label=_provider_choice_label(p),
+                                hint=p.group,
+                            )
+                            for p in provider_options
+                        ],
+                        default=default_provider_value,
+                    )
+                ]
+                auth_method = _choose_auth_method(provider, default=OAUTH_AUTH_METHOD)
+                model_provider = _oauth_backend_provider(provider, auth_method)
+            except WizardBack:
+                force_repick = True
+                continue
+            model = model_provider.default_model
+            if auth_method == API_KEY_AUTH_METHOD and provider.credential_kind not in (
+                "cli",
+                "none",
+            ):
                 _step(provider.credential_label.title())
                 try:
                     api_key = _prompt_value(
                         f"{_credential_prompt_label(provider)} {provider.credential_label} ({provider.api_key_env})",
                         default=provider.credential_default,
                         secret=provider.credential_secret,
+                        back_on_cancel=True,
                     )
+                except WizardBack:
+                    force_repick = True
+                    continue
                 except KeyboardInterrupt:
                     _console.print(f"\n[{WARNING}]Setup cancelled.[/]")
                     return 1
@@ -328,8 +559,13 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         else:
             assert saved_provider is not None
             provider = saved_provider
-            model = saved_model_value or provider.default_model
-            if provider.credential_kind not in ("cli", "none"):
+            auth_method = saved_auth_method
+            model_provider = _oauth_backend_provider(provider, auth_method)
+            model = saved_model_value or model_provider.default_model
+            if auth_method == API_KEY_AUTH_METHOD and provider.credential_kind not in (
+                "cli",
+                "none",
+            ):
                 has_api_key = bool(defaults["has_api_key"])
                 legacy_api_key = str(defaults["legacy_api_key"] or "").strip()
                 if not has_api_key and legacy_api_key:
@@ -343,7 +579,11 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                             f"{_credential_prompt_label(provider)} {provider.credential_label} ({provider.api_key_env})",
                             default=provider.credential_default,
                             secret=provider.credential_secret,
+                            back_on_cancel=True,
                         )
+                    except WizardBack:
+                        force_repick = True
+                        continue
                     except KeyboardInterrupt:
                         _console.print(f"\n[{WARNING}]Setup cancelled.[/]")
                         return 1
@@ -351,15 +591,43 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                         return 1
 
         if change_provider:
-            model = _choose_model(provider, default=model)
-        elif provider.models:
+            try:
+                model = _choose_model(
+                    model_provider,
+                    default=model,
+                    prompt_label=(
+                        f"{_provider_choice_label(provider)} OAuth"
+                        if auth_method == OAUTH_AUTH_METHOD
+                        else _provider_choice_label(provider)
+                    ),
+                    back_on_cancel=True,
+                )
+            except WizardBack:
+                force_repick = True
+                continue
+        elif model_provider.models:
             current_display = model or "CLI default"
             _console.print(f"[{SECONDARY}]current model  {current_display}[/]")
             if _confirm("Change model?", default=False):
-                model = _choose_model(provider, default=model)
+                model = _choose_model(
+                    model_provider,
+                    default=model,
+                    prompt_label=(
+                        f"{_provider_choice_label(provider)} OAuth"
+                        if auth_method == OAUTH_AUTH_METHOD
+                        else _provider_choice_label(provider)
+                    ),
+                )
 
-        if provider.credential_kind == "cli":
-            cli_out = _run_cli_llm_onboarding(provider)
+        if model_provider.credential_kind == "cli":
+            cli_out = _run_cli_llm_onboarding(
+                model_provider,
+                display_label=(
+                    f"{_provider_choice_label(provider)} OAuth"
+                    if auth_method == OAUTH_AUTH_METHOD
+                    else None
+                ),
+            )
             if cli_out == "abort":
                 return 1
             if cli_out == "repick":
@@ -371,15 +639,22 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         "local": local_probe.as_dict(),
         "remote": remote_probe.as_dict(),
     }
+    persisted_auth_method = _persisted_auth_method(provider, auth_method)
     saved_path = save_local_config(
         wizard_mode=wizard_mode,
         provider=provider.value,
         model=model,
         api_key_env=provider.api_key_env,
-        model_env=provider.model_env,
+        model_env=model_provider.model_env,
+        auth_method=persisted_auth_method,
         probes=probes,
     )
-    env_path = sync_provider_env(provider=provider, model=model)
+    env_path = sync_provider_env(
+        provider=provider,
+        model=model,
+        model_provider=model_provider,
+        auth_method=persisted_auth_method,
+    )
 
     _step_header(3, WIZARD_TOTAL_STEPS, "Integrations")
     try:

--- a/cli/wizard/store.py
+++ b/cli/wizard/store.py
@@ -47,6 +47,7 @@ def save_local_config(
     api_key_env: str,
     model_env: str,
     probes: dict[str, dict[str, object]],
+    auth_method: str | None = None,
     path: Path | None = None,
 ) -> Path:
     """Persist the local wizard configuration to disk."""
@@ -67,6 +68,8 @@ def save_local_config(
         "model_env": model_env,
         "updated_at": timestamp,
     }
+    if auth_method:
+        targets["local"]["auth_method"] = auth_method
     data["probes"] = probes
 
     store_path.parent.mkdir(parents=True, exist_ok=True)
@@ -80,6 +83,7 @@ def update_local_llm_selection(
     model: str,
     api_key_env: str = "",
     model_env: str = "",
+    auth_method: str | None = None,
     path: Path | None = None,
 ) -> Path:
     """Merge LLM provider/model into the wizard store without resetting other fields."""
@@ -92,6 +96,10 @@ def update_local_llm_selection(
     local["model"] = model
     local["api_key_env"] = api_key_env
     local["model_env"] = model_env
+    if auth_method:
+        local["auth_method"] = auth_method
+    else:
+        local.pop("auth_method", None)
     local["updated_at"] = timestamp
     store_path.parent.mkdir(parents=True, exist_ok=True)
     store_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")

--- a/config/config.py
+++ b/config/config.py
@@ -14,6 +14,11 @@ from typing import Literal
 from pydantic import Field, ValidationError, field_validator, model_validator
 
 from config.grafana_cloud import load_env
+from config.llm_auth.auth_method import (
+    LLM_AUTH_METHOD_ENV,
+    effective_llm_provider,
+    get_configured_llm_auth_method,
+)
 from config.llm_auth.credentials import status as credential_status
 from config.llm_auth.provider_catalog import (
     API_KEY_PROVIDER_ENVS,
@@ -189,6 +194,9 @@ def get_configured_llm_provider() -> str:
 def get_llm_provider_api_key_env(provider: str | None = None) -> str | None:
     """Return the API-key env var required by an LLM provider, if any."""
     provider_name = (provider or get_configured_llm_provider()).strip().lower()
+    auth_method = get_configured_llm_auth_method(provider_name)
+    if effective_llm_provider(provider_name, auth_method) != provider_name:
+        return None
     return LLM_PROVIDER_API_KEY_ENVS.get(provider_name)
 
 
@@ -492,10 +500,15 @@ def describe_llm_resolution(
     lines = [
         f"configured provider : {resolution.configured_provider}",
         f"resolved provider   : {resolution.resolved_provider}",
+        f"auth method         : {get_configured_llm_auth_method(resolution.resolved_provider)}",
         "fell back           : no",
         f"providers attempted : {', '.join(resolution.attempted_providers)}",
     ]
-    auth_status = credential_status(resolution.resolved_provider)
+    auth_provider = effective_llm_provider(
+        resolution.resolved_provider,
+        get_configured_llm_auth_method(resolution.resolved_provider),
+    )
+    auth_status = credential_status(auth_provider)
     lines.append(f"credential status   : {auth_status.source} ({auth_status.detail})")
     return "\n".join(lines)
 
@@ -519,7 +532,9 @@ def llm_provider_error_context(
 def has_credentials_for_active_llm_provider() -> bool:
     """Return prompt-safe auth availability for the configured LLM provider."""
     settings = resolve_llm_settings()
-    auth_status = credential_status(settings.provider)
+    auth_status = credential_status(
+        effective_llm_provider(settings.provider, os.getenv(LLM_AUTH_METHOD_ENV))
+    )
     return auth_status.configured and not auth_status.stale
 
 

--- a/config/llm_auth/__init__.py
+++ b/config/llm_auth/__init__.py
@@ -1,5 +1,17 @@
 """Config-owned storage helpers for LLM provider auth metadata."""
 
+from config.llm_auth.auth_method import (
+    API_KEY_AUTH_METHOD,
+    LLM_AUTH_METHOD_ENV,
+    OAUTH_AUTH_METHOD,
+    OAUTH_BACKEND_PROVIDER_BY_PROVIDER,
+    OAUTH_PROVIDER_BY_BACKEND_PROVIDER,
+    canonical_llm_provider,
+    effective_llm_provider,
+    get_configured_llm_auth_method,
+    normalize_llm_auth_method,
+    supports_oauth_auth_method,
+)
 from config.llm_auth.credentials import (
     CredentialResolution,
     CredentialSource,
@@ -32,17 +44,26 @@ from config.llm_auth.records import (
 
 __all__ = [
     "API_KEY_PROVIDER_ENVS",
+    "API_KEY_AUTH_METHOD",
     "CredentialResolution",
     "CredentialSource",
     "CredentialStatus",
     "KEYLESS_PROVIDER_VALUES",
+    "LLM_AUTH_METHOD_ENV",
     "MissingLLMCredentialError",
+    "OAUTH_AUTH_METHOD",
+    "OAUTH_BACKEND_PROVIDER_BY_PROVIDER",
+    "OAUTH_PROVIDER_BY_BACKEND_PROVIDER",
     "PROVIDER_SPECS",
     "ProviderSpec",
     "SUPPORTED_PROVIDER_VALUES",
+    "canonical_llm_provider",
     "delete",
     "delete_provider_auth_record",
+    "effective_llm_provider",
+    "get_configured_llm_auth_method",
     "has_api_key_env_status",
+    "normalize_llm_auth_method",
     "provider_auth_record_name",
     "provider_spec",
     "require_for_request",
@@ -53,5 +74,6 @@ __all__ = [
     "save_provider_auth_record",
     "source_for_api_key_env",
     "status",
+    "supports_oauth_auth_method",
     "verify",
 ]

--- a/config/llm_auth/auth_method.py
+++ b/config/llm_auth/auth_method.py
@@ -1,0 +1,75 @@
+"""LLM provider auth-method selection.
+
+The public provider remains the vendor name (for example ``openai``), while
+some auth methods use a provider-specific runtime backend under the hood.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+LLM_AUTH_METHOD_ENV = "LLM_AUTH_METHOD"
+LLMAuthMethod = Literal["api_key", "oauth"]
+
+API_KEY_AUTH_METHOD: LLMAuthMethod = "api_key"
+OAUTH_AUTH_METHOD: LLMAuthMethod = "oauth"
+
+OAUTH_BACKEND_PROVIDER_BY_PROVIDER: dict[str, str] = {
+    "openai": "codex",
+    "anthropic": "claude-code",
+}
+OAUTH_PROVIDER_BY_BACKEND_PROVIDER: dict[str, str] = {
+    backend: provider for provider, backend in OAUTH_BACKEND_PROVIDER_BY_PROVIDER.items()
+}
+
+
+def normalize_llm_auth_method(value: str | None) -> LLMAuthMethod:
+    """Return a supported auth method, defaulting to API-key auth."""
+    normalized = (value or "").strip().lower()
+    if normalized == OAUTH_AUTH_METHOD:
+        return OAUTH_AUTH_METHOD
+    return API_KEY_AUTH_METHOD
+
+
+def supports_oauth_auth_method(provider: str) -> bool:
+    """Whether onboarding exposes OAuth for this public provider."""
+    return provider.strip().lower() in OAUTH_BACKEND_PROVIDER_BY_PROVIDER
+
+
+def canonical_llm_provider(provider: str) -> str:
+    """Map legacy OAuth backend provider values to their public provider."""
+    normalized_provider = provider.strip().lower()
+    return OAUTH_PROVIDER_BY_BACKEND_PROVIDER.get(normalized_provider, normalized_provider)
+
+
+def get_configured_llm_auth_method(provider: str | None = None) -> LLMAuthMethod:
+    """Return the active auth method from env, with legacy CLI compatibility."""
+    normalized_provider = (provider or os.getenv("LLM_PROVIDER") or "").strip().lower()
+    if normalized_provider in OAUTH_PROVIDER_BY_BACKEND_PROVIDER:
+        return OAUTH_AUTH_METHOD
+    return normalize_llm_auth_method(os.getenv(LLM_AUTH_METHOD_ENV))
+
+
+def effective_llm_provider(provider: str, auth_method: str | None = None) -> str:
+    """Map a public provider/auth pair to the runtime provider implementation."""
+    normalized_provider = provider.strip().lower()
+    method = normalize_llm_auth_method(auth_method)
+    if method == OAUTH_AUTH_METHOD:
+        return OAUTH_BACKEND_PROVIDER_BY_PROVIDER.get(normalized_provider, normalized_provider)
+    return normalized_provider
+
+
+__all__ = [
+    "API_KEY_AUTH_METHOD",
+    "LLM_AUTH_METHOD_ENV",
+    "LLMAuthMethod",
+    "OAUTH_AUTH_METHOD",
+    "OAUTH_BACKEND_PROVIDER_BY_PROVIDER",
+    "OAUTH_PROVIDER_BY_BACKEND_PROVIDER",
+    "canonical_llm_provider",
+    "effective_llm_provider",
+    "get_configured_llm_auth_method",
+    "normalize_llm_auth_method",
+    "supports_oauth_auth_method",
+]

--- a/core/llm/llm_client.py
+++ b/core/llm/llm_client.py
@@ -55,6 +55,7 @@ from config.config import (
     LLMModelConfig,
     resolve_llm_settings,
 )
+from config.llm_auth.auth_method import effective_llm_provider, get_configured_llm_auth_method
 from config.llm_reasoning_effort import get_active_reasoning_effort
 from core.domain.types.root_cause_categories import VALID_ROOT_CAUSE_CATEGORIES
 from core.llm.bedrock_model_ids import is_anthropic_bedrock_model
@@ -1229,29 +1230,30 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
             raise RuntimeError(msg or str(exc)) from exc
         raise RuntimeError(str(exc)) from exc
     provider = settings.provider
+    runtime_provider = effective_llm_provider(provider, get_configured_llm_auth_method(provider))
 
     def _fallback_model(provider_prefix: str) -> str | None:
         if model_type == "toolcall":
             return None
         return _select_model(settings, provider_prefix, "toolcall")
 
-    if provider == "openai":
+    if runtime_provider == "openai":
         config = OPENAI_LLM_CONFIG
         return OpenAILLMClient(
             model=_select_model(settings, "openai", model_type),
             model_fallback=_fallback_model("openai"),
             max_tokens=config.max_tokens,
         )
-    elif (compat := _OPENAI_COMPATIBLE_PROVIDERS.get(provider)) is not None:
+    elif (compat := _OPENAI_COMPATIBLE_PROVIDERS.get(runtime_provider)) is not None:
         return OpenAILLMClient(
-            model=_select_model(settings, provider, model_type),
-            model_fallback=_fallback_model(provider),
+            model=_select_model(settings, runtime_provider, model_type),
+            model_fallback=_fallback_model(runtime_provider),
             max_tokens=compat.config.max_tokens,
             base_url=compat.base_url,
             api_key_env=compat.api_key_env,
             temperature=compat.temperature,
         )
-    elif provider == "ollama":
+    elif runtime_provider == "ollama":
         from config.config import OLLAMA_LLM_CONFIG
 
         # Ollama exposes a single local model regardless of tier.
@@ -1264,7 +1266,7 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
             api_key_env="OLLAMA_API_KEY",
             api_key_default="ollama",
         )
-    elif provider == "bedrock":
+    elif runtime_provider == "bedrock":
         from config.config import BEDROCK_LLM_CONFIG
 
         config = BEDROCK_LLM_CONFIG
@@ -1272,7 +1274,7 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
             model=_select_model(settings, "bedrock", model_type),
             max_tokens=config.max_tokens,
         )
-    elif (cli_reg := _get_cli_provider_registration(provider)) is not None:
+    elif (cli_reg := _get_cli_provider_registration(runtime_provider)) is not None:
         from config.config import DEFAULT_MAX_TOKENS
         from integrations.llm_cli.runner import CLIBackedLLMClient
 

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -3,16 +3,16 @@ title: "LLM Providers"
 description: "Supported LLM APIs and CLIs, environment variables, and how to switch between them."
 ---
 
-OpenSRE is provider-agnostic: bring your own model. Selection is controlled by the `LLM_PROVIDER` environment variable, with per-provider API key and model overrides. Defaults are tracked in [`config/config.py`](https://github.com/Tracer-Cloud/opensre/blob/main/config/config.py) and routing lives in [`core/llm/llm_client.py`](https://github.com/Tracer-Cloud/opensre/blob/main/core/llm/llm_client.py).
+OpenSRE is provider-agnostic: bring your own model. Selection is controlled by the `LLM_PROVIDER` environment variable, with `LLM_AUTH_METHOD` selecting API-key or OAuth auth where both are supported. Defaults are tracked in [`config/config.py`](https://github.com/Tracer-Cloud/opensre/blob/main/config/config.py) and routing lives in [`core/llm/llm_client.py`](https://github.com/Tracer-Cloud/opensre/blob/main/core/llm/llm_client.py).
 
 ## Quick reference
 
 | Provider     | `LLM_PROVIDER` | Auth                            | Reasoning model default                       | Toolcall model default                          |
 | ------------ | -------------- | ------------------------------- | --------------------------------------------- | ----------------------------------------------- |
-| Anthropic API key | `anthropic` | `ANTHROPIC_API_KEY`             | `claude-sonnet-4-6`                           | `claude-haiku-4-5-20251001`                     |
-| Anthropic Claude Code CLI | `claude-code` | `claude auth login` (Claude Code CLI) | Claude Code CLI default                 | Claude Code CLI default                         |
-| OpenAI API key | `openai`     | `OPENAI_API_KEY`                | `gpt-5.4-mini`                                | `gpt-5.4-mini`                                  |
-| OpenAI Codex CLI | `codex`    | `codex login` (CLI)             | Codex CLI default                             | Codex CLI default                               |
+| Anthropic API key | `anthropic` + `LLM_AUTH_METHOD=api_key` | `ANTHROPIC_API_KEY` | `claude-sonnet-4-6` | `claude-haiku-4-5-20251001` |
+| Anthropic OAuth | `anthropic` + `LLM_AUTH_METHOD=oauth` | Onboarding launches `claude auth login` | Claude Code CLI default | Claude Code CLI default |
+| OpenAI API key | `openai` + `LLM_AUTH_METHOD=api_key` | `OPENAI_API_KEY` | `gpt-5.4-mini` | `gpt-5.4-mini` |
+| OpenAI OAuth | `openai` + `LLM_AUTH_METHOD=oauth` | Onboarding launches `codex login` | Codex CLI default | Codex CLI default |
 | OpenRouter   | `openrouter`   | `OPENROUTER_API_KEY`            | `openrouter/auto`                             | `openrouter/auto`                               |
 | DeepSeek     | `deepseek`     | `DEEPSEEK_API_KEY`              | `deepseek-v4-pro`                             | `deepseek-v4-flash`                             |
 | Google Gemini API key | `gemini` | `GEMINI_API_KEY`               | `gemini-3.1-pro-preview`                      | `gemini-3.1-flash-lite-preview`                 |
@@ -47,16 +47,15 @@ Or run the onboarding wizard, which writes the same values to `.env`:
 opensre onboard
 ```
 
-When a provider has more than one supported auth route, onboarding lists the
-auth methods as separate choices. For example, choose **Anthropic API key** for
-`ANTHROPIC_API_KEY` or **Anthropic Claude Code CLI** to use a Claude subscription
-through the Claude Code CLI. If that CLI is installed but not logged in, onboarding
-can launch the vendor browser login and then re-detect the session.
+When a provider has more than one supported auth route, onboarding asks for the
+provider first, then the auth method. For example, choose **Anthropic** and then
+**OAuth** to use a Claude subscription through the onboarding flow, or choose
+**API key** to paste `ANTHROPIC_API_KEY`. OpenSRE keeps the provider as
+`anthropic` or `openai`; `LLM_AUTH_METHOD=oauth` selects the OAuth-backed runtime.
 
-CLI-backed choices delegate browser login, token storage, refresh, and logout to
-the vendor CLI. OpenSRE does not persist those OAuth tokens directly; the
-provider value selects the CLI runtime that already owns the authenticated
-session.
+OAuth browser login, token storage, refresh, and logout are delegated to the
+vendor CLI that owns that account session. OpenSRE owns the onboarding UX and
+does not persist OAuth tokens directly.
 
 In the interactive shell, `/model` shows curated quick-pick choices for common models. Providers
 with fast-changing or account-gated catalogs (OpenAI, OpenRouter, Gemini, NVIDIA, Bedrock, local
@@ -241,10 +240,11 @@ CLI-backed providers shell out to a vendor CLI instead of an HTTP API. They auth
 
 **Investigation timeouts:** Each ReAct turn runs one full CLI subprocess with the system prompt, tool schemas, and conversation history. The shared default subprocess budget is **300 seconds** (Python adds a small buffer). Override per provider when needed, for example `GEMINI_CLI_TIMEOUT_SECONDS`, `CLAUDE_CODE_TIMEOUT_SECONDS`, or `ANTIGRAVITY_CLI_TIMEOUT_SECONDS` (clamped 30–600 where the adapter supports it).
 
-### OpenAI Codex
+### OpenAI OAuth backend
 
 ```bash
-export LLM_PROVIDER=codex
+export LLM_PROVIDER=openai
+export LLM_AUTH_METHOD=oauth
 # Authenticate through onboarding, `/login chatgpt`, or the Codex CLI directly:
 codex login
 # Optional overrides (all blank-by-default):
@@ -254,12 +254,15 @@ export CODEX_BIN=
 
 Requires the [OpenAI Codex CLI](https://github.com/openai/codex). If `CODEX_MODEL` is unset, OpenSRE omits `-m` so `codex exec` uses the CLI's currently configured model. If `CODEX_BIN` is unset, the binary is resolved via `PATH` and known install locations.
 Run `opensre onboard`, `/login chatgpt`, or `opensre auth login chatgpt` to launch
-Codex browser login when needed and persist `LLM_PROVIDER=codex`.
+Codex browser login when needed and persist `LLM_PROVIDER=openai` with
+`LLM_AUTH_METHOD=oauth`. Existing `LLM_PROVIDER=codex` configs still work for
+backward compatibility.
 
-### Claude Code
+### Anthropic OAuth backend
 
 ```bash
-export LLM_PROVIDER=claude-code
+export LLM_PROVIDER=anthropic
+export LLM_AUTH_METHOD=oauth
 # Authenticate through onboarding, `/login claude`, or the Claude Code CLI directly:
 claude auth login
 # Optional overrides (all blank-by-default):
@@ -269,7 +272,9 @@ export CLAUDE_CODE_BIN=
 
 Requires the [Claude Code CLI](https://github.com/anthropics/claude-code) (`npm i -g @anthropic-ai/claude-code`). If `CLAUDE_CODE_MODEL` is unset, OpenSRE omits the `--model` flag and the CLI uses its configured default. If `CLAUDE_CODE_BIN` is unset, the binary is resolved via `PATH` and known install locations.
 Run `opensre onboard`, `/login claude`, or `opensre auth login claude` to launch
-Claude browser login when needed and persist `LLM_PROVIDER=claude-code`.
+Claude browser login when needed and persist `LLM_PROVIDER=anthropic` with
+`LLM_AUTH_METHOD=oauth`. Existing `LLM_PROVIDER=claude-code` configs still work
+for backward compatibility.
 
 ### GitHub Copilot
 

--- a/tests/cli/wizard/test_config.py
+++ b/tests/cli/wizard/test_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from cli.wizard.config import PROJECT_ENV_PATH, PROJECT_ROOT, SUPPORTED_PROVIDERS
+from cli.wizard.flow import _onboarding_provider_options
 
 
 def test_project_env_path_defaults_to_repo_root() -> None:
@@ -11,8 +12,8 @@ def test_project_env_path_defaults_to_repo_root() -> None:
     assert PROJECT_ENV_PATH == PROJECT_ROOT / ".env"
 
 
-def test_provider_catalog_shows_auth_method_alternatives_together() -> None:
-    """Onboarding should expose API-key and CLI choices where both exist."""
+def test_provider_catalog_keeps_legacy_cli_providers_registered() -> None:
+    """Legacy CLI provider values remain registered for existing configs."""
     labels_by_value = {provider.value: provider.label for provider in SUPPORTED_PROVIDERS}
     values = [provider.value for provider in SUPPORTED_PROVIDERS]
 
@@ -37,3 +38,13 @@ def test_provider_catalog_shows_auth_method_alternatives_together() -> None:
     assert labels_by_value["groq"] == "Groq API key"
     assert labels_by_value["grok-cli"] == "xAI Grok Build CLI"
     assert values.index("groq") < values.index("grok-cli") < values.index("cursor")
+
+
+def test_onboarding_provider_options_hide_openai_anthropic_oauth_backends() -> None:
+    """Onboarding presents OpenAI/Anthropic auth methods under the provider."""
+    values = [provider.value for provider in _onboarding_provider_options()]
+
+    assert "anthropic" in values
+    assert "openai" in values
+    assert "claude-code" not in values
+    assert "codex" not in values

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -184,6 +184,36 @@ def test_sync_provider_env_codex_writes_codex_model(tmp_path, monkeypatch) -> No
     assert "CODEX_MODEL=\n" in content
 
 
+def test_sync_provider_env_openai_oauth_writes_auth_method_and_codex_model(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("LLM_AUTH_METHOD", raising=False)
+    monkeypatch.delenv("CODEX_MODEL", raising=False)
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "LLM_PROVIDER=anthropic\nANTHROPIC_REASONING_MODEL=claude-opus-4-7\n",
+        encoding="utf-8",
+    )
+
+    sync_provider_env(
+        provider=PROVIDER_BY_VALUE["openai"],
+        model="",
+        model_provider=PROVIDER_BY_VALUE["codex"],
+        auth_method="oauth",
+        env_path=env_path,
+    )
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "LLM_PROVIDER=openai\n" in content
+    assert "LLM_AUTH_METHOD=oauth\n" in content
+    assert "CODEX_MODEL=\n" in content
+    assert "ANTHROPIC_REASONING_MODEL=" not in content
+    assert os.environ["LLM_PROVIDER"] == "openai"
+    assert os.environ["LLM_AUTH_METHOD"] == "oauth"
+    assert os.environ["CODEX_MODEL"] == ""
+
+
 def test_sync_provider_env_gemini_cli_writes_model(tmp_path, monkeypatch) -> None:
     monkeypatch.delenv("LLM_PROVIDER", raising=False)
     monkeypatch.delenv("GEMINI_CLI_MODEL", raising=False)

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,7 +21,9 @@ def _stub_managed_llm_secret_persistence(monkeypatch: pytest.MonkeyPatch) -> Non
 
 def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, capsys) -> None:
     # advanced -> falls back to local -> change provider? Yes -> pick anthropic -> skip integrations
-    select_responses = iter(["advanced", "remote", "anthropic", "claude-opus-4-7", "skip"])
+    select_responses = iter(
+        ["advanced", "remote", "anthropic", "api_key", "claude-opus-4-7", "skip"]
+    )
     confirm_responses = iter([True, True])  # "use local instead?" and "Change provider?"
 
     def _mock_select(*_args, **_kwargs):
@@ -80,9 +81,21 @@ def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, c
     assert output.index("Summary") < output.index("Done.")
 
 
+def test_prompt_value_can_signal_wizard_back(monkeypatch) -> None:
+    def _mock_password(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = None
+        return m
+
+    monkeypatch.setattr(_ui.questionary, "password", _mock_password)
+
+    with pytest.raises(_ui.WizardBack):
+        _ui._prompt_value("OpenAI API key", secret=True, back_on_cancel=True)
+
+
 def test_run_wizard_no_saved_provider_shows_selection(monkeypatch, tmp_path) -> None:
     """With no saved config the provider list is shown immediately (no confirm prompt)."""
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "skip"])
+    select_responses = iter(["quickstart", "anthropic", "api_key", "claude-opus-4-7", "skip"])
 
     def _mock_select(*_args, **_kwargs):
         m = MagicMock()
@@ -109,7 +122,7 @@ def test_run_wizard_no_saved_provider_shows_selection(monkeypatch, tmp_path) -> 
 def test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable(
     monkeypatch, tmp_path, capsys
 ) -> None:
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7"])
+    select_responses = iter(["quickstart", "anthropic", "api_key", "claude-opus-4-7"])
 
     def _mock_select(*_args, **_kwargs):
         m = MagicMock()
@@ -153,7 +166,7 @@ def test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable(
 
 
 def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, capsys) -> None:
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "grafana"])
+    select_responses = iter(["quickstart", "anthropic", "api_key", "claude-opus-4-7", "grafana"])
     saved_integrations: list[tuple[str, dict]] = []
     synced_env_values: list[dict[str, str]] = []
 
@@ -234,7 +247,7 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
 
 
 def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "honeycomb"])
+    select_responses = iter(["quickstart", "anthropic", "api_key", "claude-opus-4-7", "honeycomb"])
     password_responses = iter(["llm-secret", "hny_test"])
     text_responses = iter(["prod-api", "https://api.honeycomb.io"])
     saved_integrations: list[tuple[str, dict]] = []
@@ -304,7 +317,7 @@ def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
 
 
 def test_run_wizard_configures_coralogix(monkeypatch, tmp_path) -> None:
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "coralogix"])
+    select_responses = iter(["quickstart", "anthropic", "api_key", "claude-opus-4-7", "coralogix"])
     password_responses = iter(["llm-secret", "cx_test"])
     text_responses = iter(
         [
@@ -382,7 +395,7 @@ def test_run_wizard_configures_coralogix(monkeypatch, tmp_path) -> None:
 
 
 def test_run_wizard_configures_dagster(monkeypatch, tmp_path) -> None:
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "dagster"])
+    select_responses = iter(["quickstart", "anthropic", "api_key", "claude-opus-4-7", "dagster"])
     password_responses = iter(["llm-secret", "dag_test_token"])
     text_responses = iter(["http://localhost:3000"])
     saved_integrations: list[tuple[str, dict]] = []
@@ -454,7 +467,7 @@ def test_run_wizard_configures_dagster(monkeypatch, tmp_path) -> None:
 
 def test_run_wizard_configures_dagster_oss_skips_secret(monkeypatch, tmp_path) -> None:
     """OSS path: empty api_token must not call sync_env_secret."""
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "dagster"])
+    select_responses = iter(["quickstart", "anthropic", "api_key", "claude-opus-4-7", "dagster"])
     password_responses = iter(["llm-secret", ""])
     text_responses = iter(["http://localhost:3000"])
     synced_env_values: list[dict[str, str]] = []
@@ -518,7 +531,7 @@ def test_run_wizard_configures_slack_persists_webhook(monkeypatch, tmp_path) -> 
     readable afterwards). The webhook is a secret, so it belongs in the store,
     not `.env` — `sync_env_values` is called with an empty mapping.
     """
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "slack"])
+    select_responses = iter(["quickstart", "anthropic", "api_key", "claude-opus-4-7", "slack"])
     # webhook_url is prompted with secret=True, so it comes from the password mock.
     password_responses = iter(["llm-secret", "https://hooks.slack.com/services/T0/B0/XXXXX"])
     saved_integrations: list[tuple[str, dict]] = []
@@ -584,7 +597,7 @@ def test_run_wizard_dagster_retries_on_validation_failure(monkeypatch, tmp_path)
     Proves the retry loop recovers from N consecutive failures (not just one),
     and that only the final successful attempt reaches the persistence layer.
     """
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "dagster"])
+    select_responses = iter(["quickstart", "anthropic", "api_key", "claude-opus-4-7", "dagster"])
     # Two wrong tokens, then the correct one.
     password_responses = iter(["llm-secret", "bad_token_1", "bad_token_2", "dag_good"])
     # endpoint is prompted on each retry (three attempts total).
@@ -673,6 +686,7 @@ def test_run_wizard_configures_github_mcp_and_sentry(monkeypatch, tmp_path, caps
         [
             "quickstart",
             "anthropic",
+            "api_key",
             "claude-opus-4-7",
             "github",
             flow.DEFAULT_GITHUB_MCP_MODE,
@@ -904,7 +918,7 @@ def test_run_wizard_changes_model_when_user_keeps_provider(monkeypatch, tmp_path
 
 
 def test_run_wizard_persists_matching_local_config_and_env(monkeypatch, tmp_path) -> None:
-    select_responses = iter(["quickstart", "openai", "gpt-5.4-mini", "skip"])
+    select_responses = iter(["quickstart", "openai", "api_key", "gpt-5.4-mini", "skip"])
     saved_llm_keys: list[tuple[str, str]] = []
 
     def _mock_select(*_args, **_kwargs):
@@ -968,7 +982,7 @@ def test_run_wizard_codex_skips_api_key_and_runs_cli_onboarding(monkeypatch, tmp
         m.ask.return_value = next(select_responses)
         return m
 
-    def _cli_onboarding(provider):
+    def _cli_onboarding(provider, **_kwargs):
         cli_onboarding_providers.append(provider.value)
         return "ok"
 
@@ -1008,6 +1022,111 @@ def test_run_wizard_codex_skips_api_key_and_runs_cli_onboarding(monkeypatch, tmp
     assert payload["targets"]["local"]["model_env"] == "CODEX_MODEL"
     assert "LLM_PROVIDER=codex\n" in env_values
     assert "CODEX_MODEL=\n" in env_values
+    assert "LLM_AUTH_METHOD=oauth\n" in env_values
+
+
+def test_run_wizard_openai_oauth_is_onboarding_auth_method(monkeypatch, tmp_path) -> None:
+    select_responses = iter(["quickstart", "openai", "oauth", "", "skip"])
+    saved_llm_keys: list[tuple[str, str]] = []
+    cli_onboarding_providers: list[str] = []
+
+    def _mock_select(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(select_responses)
+        return m
+
+    def _cli_onboarding(provider, **kwargs):
+        cli_onboarding_providers.append(provider.value)
+        assert kwargs["display_label"] == "OpenAI OAuth"
+        return "ok"
+
+    store_path = tmp_path / "opensre.json"
+    env_path = tmp_path / ".env"
+
+    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(_ui, "get_store_path", lambda: store_path)
+    monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "_run_cli_llm_onboarding", _cli_onboarding)
+    monkeypatch.setattr(
+        flow,
+        "save_local_config",
+        lambda **kwargs: wizard_store.save_local_config(path=store_path, **kwargs),
+    )
+    monkeypatch.setattr(
+        flow,
+        "sync_provider_env",
+        lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
+    )
+    monkeypatch.setattr(
+        _ui,
+        "save_api_key",
+        lambda provider, value, **_kwargs: saved_llm_keys.append((provider, value)),
+    )
+
+    exit_code = flow.run_wizard()
+
+    assert exit_code == 0
+    assert cli_onboarding_providers == ["codex"]
+    assert saved_llm_keys == []
+
+    payload = json.loads(store_path.read_text(encoding="utf-8"))
+    env_values = env_path.read_text(encoding="utf-8")
+    assert payload["targets"]["local"]["provider"] == "openai"
+    assert payload["targets"]["local"]["auth_method"] == "oauth"
+    assert payload["targets"]["local"]["api_key_env"] == "OPENAI_API_KEY"
+    assert payload["targets"]["local"]["model_env"] == "CODEX_MODEL"
+    assert "LLM_PROVIDER=openai\n" in env_values
+    assert "LLM_AUTH_METHOD=oauth\n" in env_values
+    assert "CODEX_MODEL=\n" in env_values
+    assert "OPENAI_API_KEY=" not in env_values
+
+
+def test_run_wizard_anthropic_oauth_is_onboarding_auth_method(monkeypatch, tmp_path) -> None:
+    select_responses = iter(["quickstart", "anthropic", "oauth", "", "skip"])
+    cli_onboarding_providers: list[str] = []
+
+    def _mock_select(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(select_responses)
+        return m
+
+    def _cli_onboarding(provider, **kwargs):
+        cli_onboarding_providers.append(provider.value)
+        assert kwargs["display_label"] == "Anthropic OAuth"
+        return "ok"
+
+    store_path = tmp_path / "opensre.json"
+    env_path = tmp_path / ".env"
+
+    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(_ui, "get_store_path", lambda: store_path)
+    monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "_run_cli_llm_onboarding", _cli_onboarding)
+    monkeypatch.setattr(
+        flow,
+        "save_local_config",
+        lambda **kwargs: wizard_store.save_local_config(path=store_path, **kwargs),
+    )
+    monkeypatch.setattr(
+        flow,
+        "sync_provider_env",
+        lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
+    )
+
+    exit_code = flow.run_wizard()
+
+    assert exit_code == 0
+    assert cli_onboarding_providers == ["claude-code"]
+
+    payload = json.loads(store_path.read_text(encoding="utf-8"))
+    env_values = env_path.read_text(encoding="utf-8")
+    assert payload["targets"]["local"]["provider"] == "anthropic"
+    assert payload["targets"]["local"]["auth_method"] == "oauth"
+    assert payload["targets"]["local"]["api_key_env"] == "ANTHROPIC_API_KEY"
+    assert payload["targets"]["local"]["model_env"] == "CLAUDE_CODE_MODEL"
+    assert "LLM_PROVIDER=anthropic\n" in env_values
+    assert "LLM_AUTH_METHOD=oauth\n" in env_values
+    assert "CLAUDE_CODE_MODEL=\n" in env_values
 
 
 def test_run_wizard_claude_code_skips_api_key_and_runs_cli_onboarding(
@@ -1022,7 +1141,7 @@ def test_run_wizard_claude_code_skips_api_key_and_runs_cli_onboarding(
         m.ask.return_value = next(select_responses)
         return m
 
-    def _cli_onboarding(provider):
+    def _cli_onboarding(provider, **_kwargs):
         cli_onboarding_providers.append(provider.value)
         return "ok"
 
@@ -1074,7 +1193,7 @@ def test_run_wizard_gemini_cli_skips_api_key_and_runs_cli_onboarding(monkeypatch
         m.ask.return_value = next(select_responses)
         return m
 
-    def _cli_onboarding(provider):
+    def _cli_onboarding(provider, **_kwargs):
         cli_onboarding_providers.append(provider.value)
         return "ok"
 
@@ -1211,19 +1330,60 @@ def test_run_cli_llm_onboarding_launches_codex_browser_login(monkeypatch) -> Non
     provider.adapter_factory = lambda: adapter
     login_commands: list[list[str]] = []
 
-    def _fake_run(command: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:
-        del check
+    def _fake_run(command: list[str]) -> flow._LoginProcessResult:
         login_commands.append(command)
-        return subprocess.CompletedProcess(command, 0)
+        return flow._LoginProcessResult(returncode=0)
 
     monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "login")
-    monkeypatch.setattr(flow.subprocess, "run", _fake_run)
+    monkeypatch.setattr(flow, "_run_login_process", _fake_run)
 
     result = flow._run_cli_llm_onboarding(provider)
 
     assert result == "ok"
     assert login_commands == [["/usr/local/bin/codex", "login"]]
     assert len(detect_calls) == 2
+
+
+def test_run_cli_llm_onboarding_surfaces_codex_config_error(monkeypatch) -> None:
+    adapter = MagicMock()
+    adapter.name = "codex"
+    adapter.binary_env_key = "CODEX_BIN"
+    adapter.install_hint = "npm i -g @openai/codex"
+    adapter.auth_hint = "Run: codex login"
+    adapter.detect.return_value = MagicMock(
+        installed=True,
+        logged_in=None,
+        bin_path="/opt/homebrew/bin/codex",
+        detail="Auth status unknown.",
+    )
+    provider = MagicMock()
+    provider.value = "codex"
+    provider.label = "OpenAI Codex CLI"
+    provider.adapter_factory = lambda: adapter
+
+    choices: list[str] = ["login", "repick"]
+
+    def _choose(*_args, **_kwargs):
+        return choices.pop(0)
+
+    def _fake_run(command: list[str]) -> flow._LoginProcessResult:
+        del command
+        return flow._LoginProcessResult(
+            returncode=1,
+            stdout="",
+            stderr=(
+                "Error loading configuration: "
+                "/Users/me/.codex/config.toml:17:16: unknown variant `priority`, "
+                "expected `fast` or `flex`"
+            ),
+        )
+
+    monkeypatch.setattr(flow, "_choose", _choose)
+    monkeypatch.setattr(flow, "_run_login_process", _fake_run)
+
+    result = flow._run_cli_llm_onboarding(provider, display_label="OpenAI OAuth")
+
+    assert result == "repick"
 
 
 def test_run_cli_llm_onboarding_launches_claude_browser_login(monkeypatch) -> None:
@@ -1252,13 +1412,12 @@ def test_run_cli_llm_onboarding_launches_claude_browser_login(monkeypatch) -> No
     provider.adapter_factory = lambda: adapter
     login_commands: list[list[str]] = []
 
-    def _fake_run(command: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:
-        del check
+    def _fake_run(command: list[str]) -> flow._LoginProcessResult:
         login_commands.append(command)
-        return subprocess.CompletedProcess(command, 0)
+        return flow._LoginProcessResult(returncode=0)
 
     monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "login")
-    monkeypatch.setattr(flow.subprocess, "run", _fake_run)
+    monkeypatch.setattr(flow, "_run_login_process", _fake_run)
 
     result = flow._run_cli_llm_onboarding(provider)
 
@@ -1462,7 +1621,7 @@ def test_credential_line_for_saved_summary_cli_without_factory() -> None:
 
 
 def test_run_wizard_configures_gitlab(monkeypatch, tmp_path) -> None:
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "gitlab"])
+    select_responses = iter(["quickstart", "anthropic", "api_key", "claude-opus-4-7", "gitlab"])
     password_responses = iter(["llm-secret", "glpat_test"])
     text_responses = iter(["https://gitlab.example.com/api/v4"])
     saved_integrations: list[tuple[str, dict]] = []
@@ -1537,7 +1696,7 @@ def test_run_wizard_configures_gitlab(monkeypatch, tmp_path) -> None:
 
 def test_run_wizard_gitlab_retries_on_validation_failure(monkeypatch, tmp_path) -> None:
     """When GitLab validation fails the first time, the wizard retries and succeeds."""
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "gitlab"])
+    select_responses = iter(["quickstart", "anthropic", "api_key", "claude-opus-4-7", "gitlab"])
     # First attempt: wrong token; second attempt: correct token
     password_responses = iter(["llm-secret", "bad_token", "glpat_good"])
     # base_url is prompted on each retry
@@ -1626,7 +1785,7 @@ def test_run_wizard_switches_provider_and_keeps_store_and_env_in_sync(
     monkeypatch, tmp_path
 ) -> None:
     # Saved: anthropic. User says yes to "Change provider?" and picks openai.
-    select_responses = iter(["quickstart", "openai", "gpt-5.4-mini", "skip"])
+    select_responses = iter(["quickstart", "openai", "api_key", "gpt-5.4-mini", "skip"])
     confirm_responses = iter([True])  # "Change provider?" -> Yes
     saved_llm_keys: list[tuple[str, str]] = []
 
@@ -1708,7 +1867,9 @@ def test_run_wizard_switches_provider_and_keeps_store_and_env_in_sync(
 
 def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
     """Happy path: user picks opensearch, enters URL + basic auth, all gets persisted."""
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "opensearch", "basic"])
+    select_responses = iter(
+        ["quickstart", "anthropic", "api_key", "claude-opus-4-7", "opensearch", "basic"]
+    )
     password_responses = iter(["llm-secret", "secret-pass"])
     text_responses = iter(["https://my-cluster.example.com", "admin"])
     saved_integrations: list[tuple[str, dict]] = []
@@ -1791,7 +1952,7 @@ def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
 def test_run_wizard_opensearch_retries_on_validation_failure(monkeypatch, tmp_path) -> None:
     """When OpenSearch validation fails the first time, the wizard retries and succeeds."""
     select_responses = iter(
-        ["quickstart", "anthropic", "claude-opus-4-7", "opensearch", "basic", "basic"]
+        ["quickstart", "anthropic", "api_key", "claude-opus-4-7", "opensearch", "basic", "basic"]
     )
     password_responses = iter(["llm-secret", "wrong-pass", "correct-pass"])
     text_responses = iter(
@@ -1888,7 +2049,15 @@ def test_run_wizard_opensearch_rejects_empty_api_key(monkeypatch, tmp_path) -> N
     """
     # User picks: opensearch -> api_key auth -> (rejected, empty) -> api_key auth retry
     select_responses = iter(
-        ["quickstart", "anthropic", "claude-opus-4-7", "opensearch", "api_key", "api_key"]
+        [
+            "quickstart",
+            "anthropic",
+            "api_key",
+            "claude-opus-4-7",
+            "opensearch",
+            "api_key",
+            "api_key",
+        ]
     )
     # First api_key prompt: empty (rejected). Second: valid key.
     password_responses = iter(["llm-secret", "", "valid-api-key"])
@@ -1983,7 +2152,7 @@ def test_run_wizard_opensearch_rejects_empty_basic_password(monkeypatch, tmp_pat
     """
     # User picks: opensearch -> basic auth -> (rejected, empty pass) -> basic auth retry
     select_responses = iter(
-        ["quickstart", "anthropic", "claude-opus-4-7", "opensearch", "basic", "basic"]
+        ["quickstart", "anthropic", "api_key", "claude-opus-4-7", "opensearch", "basic", "basic"]
     )
     # First password prompt: empty (rejected). Second attempt: valid password.
     password_responses = iter(["llm-secret", "", "real-pass"])
@@ -2068,7 +2237,7 @@ def test_run_wizard_opensearch_rejects_empty_basic_password(monkeypatch, tmp_pat
 
 
 def test_run_wizard_configures_telegram(monkeypatch, tmp_path) -> None:
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "telegram"])
+    select_responses = iter(["quickstart", "anthropic", "api_key", "claude-opus-4-7", "telegram"])
     password_responses = iter(["llm-secret", "123:ABC"])
     text_responses = iter(["-1001234567890"])
     saved_integrations: list[tuple[str, dict]] = []
@@ -2140,7 +2309,7 @@ def test_run_wizard_configures_telegram(monkeypatch, tmp_path) -> None:
 
 
 def test_run_wizard_telegram_retries_on_validation_failure(monkeypatch, tmp_path) -> None:
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "telegram"])
+    select_responses = iter(["quickstart", "anthropic", "api_key", "claude-opus-4-7", "telegram"])
     password_responses = iter(["llm-secret", "bad-token", "123:GOOD"])
     text_responses = iter(["-1001", "-1001"])
     saved_integrations: list[tuple[str, dict]] = []

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -620,6 +620,11 @@ def test_onboard_interactive_smoke(cli_sandbox: CliSandbox) -> None:
         actions=[
             PtyAction(expect="How do you want to get started?", send=b"\r"),
             PtyAction(expect="Choose your LLM provider", send=b"\r"),
+            PtyAction(
+                expect="Choose Anthropic auth method",
+                send=b"\r",
+                stagger_j=1,
+            ),
             PtyAction(expect="Anthropic API key", send=b"smoke-test-key\r"),
             PtyAction(expect="Choose Anthropic model", send=b"\r"),
             PtyAction(
@@ -645,12 +650,13 @@ def test_onboard_interactive_smoke(cli_sandbox: CliSandbox) -> None:
 
 
 @pytest.mark.parametrize(
-    ("_cli_binary", "provider_key", "provider_label", "pty_timeout"),
+    ("_cli_binary", "provider_key", "provider_label", "uses_oauth", "pty_timeout"),
     [
         pytest.param(
             "codex",
-            "codex",
-            "OpenAI Codex CLI",
+            "openai",
+            "OpenAI OAuth",
+            True,
             60.0,
             marks=pytest.mark.skipif(
                 shutil.which("codex") is None,
@@ -661,6 +667,7 @@ def test_onboard_interactive_smoke(cli_sandbox: CliSandbox) -> None:
             "opencode",
             "opencode",
             "OpenCode CLI",
+            False,
             120.0,
             marks=pytest.mark.skipif(
                 shutil.which("opencode") is None,
@@ -675,6 +682,7 @@ def test_onboard_interactive_smoke_cli_provider_repick_when_unauthenticated(
     _cli_binary: str,
     provider_key: str,
     provider_label: str,
+    uses_oauth: bool,
     pty_timeout: float,
 ) -> None:
     """PTY: quickstart → local CLI LLM → repick when unauthenticated, then finish as Anthropic.
@@ -684,13 +692,17 @@ def test_onboard_interactive_smoke_cli_provider_repick_when_unauthenticated(
     is accepted before choosing repick. Skips when the CLI binary for each parametrized
     case is not on PATH.
     """
-    from cli.wizard.config import SUPPORTED_PROVIDERS
+    from cli.wizard.flow import _onboarding_provider_options
 
     stagger_j = next(
-        (i for i, provider in enumerate(SUPPORTED_PROVIDERS) if provider.value == provider_key),
+        (
+            i
+            for i, provider in enumerate(_onboarding_provider_options())
+            if provider.value == provider_key
+        ),
         -1,
     )
-    assert stagger_j >= 0, f"Provider '{provider_key}' missing from SUPPORTED_PROVIDERS"
+    assert stagger_j >= 0, f"Provider '{provider_key}' missing from onboarding providers"
 
     login_prompt: tuple[str, ...] = (
         f"{provider_label} requires login. What next?",
@@ -700,30 +712,43 @@ def test_onboard_interactive_smoke_cli_provider_repick_when_unauthenticated(
         f"Choose {provider_label} model",
         "Model",
     )
+    actions = [
+        PtyAction(expect="How do you want to get started?", send=b"\r"),
+        PtyAction(expect="Choose your LLM provider", send=b"\r", stagger_j=stagger_j),
+    ]
+    if uses_oauth:
+        actions.append(PtyAction(expect="Choose OpenAI auth method", send=b"\r"))
+    actions.extend(
+        [
+            PtyAction(expect=model_prompt, send=b"\r", timeout=30.0),
+            PtyAction(
+                expect=login_prompt,
+                send=b"\r",
+                stagger_j=2 if uses_oauth else 1,
+                timeout=90.0,
+            ),
+            PtyAction(expect="Choose your LLM provider", send=b"\r"),
+            PtyAction(
+                expect="Choose Anthropic auth method",
+                send=b"\r",
+                stagger_j=1,
+            ),
+            PtyAction(expect="Anthropic API key", send=b"smoke-test-key\r"),
+            PtyAction(expect="Choose Anthropic model", send=b"\r"),
+            PtyAction(
+                expect="Choose an integration to configure",
+                send=b"\r",
+                stagger_j=1,
+                stagger_key=b"k",
+            ),
+        ]
+    )
+
     try:
         result = _run_cli_pty(
             cli_sandbox,
             "onboard",
-            actions=[
-                PtyAction(expect="How do you want to get started?", send=b"\r"),
-                PtyAction(expect="Choose your LLM provider", send=b"\r", stagger_j=stagger_j),
-                PtyAction(expect=model_prompt, send=b"\r", timeout=30.0),
-                PtyAction(
-                    expect=login_prompt,
-                    send=b"\r",
-                    stagger_j=1,
-                    timeout=90.0,
-                ),
-                PtyAction(expect="Choose your LLM provider", send=b"\r"),
-                PtyAction(expect="Anthropic API key", send=b"smoke-test-key\r"),
-                PtyAction(expect="Choose Anthropic model", send=b"\r"),
-                PtyAction(
-                    expect="Choose an integration to configure",
-                    send=b"\r",
-                    stagger_j=1,
-                    stagger_key=b"k",
-                ),
-            ],
+            actions=actions,
             timeout=pty_timeout,
             extra_env={
                 "OPENAI_API_KEY": "",
@@ -736,7 +761,7 @@ def test_onboard_interactive_smoke_cli_provider_repick_when_unauthenticated(
         msg = str(exc)
         if (
             _cli_binary == "codex"
-            and "Choose OpenAI Codex CLI model" in msg
+            and "Choose OpenAI OAuth model" in msg
             and "requires login" in msg
         ):
             pytest.skip(

--- a/tests/core/runtime/llm/test_llm_client.py
+++ b/tests/core/runtime/llm/test_llm_client.py
@@ -1111,6 +1111,7 @@ def test_openai_invoke_stream_does_not_retry_after_yielding(monkeypatch) -> None
 
 def test_create_llm_client_openai_reasoning_sets_toolcall_fallback(monkeypatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_AUTH_METHOD", "api_key")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.setenv("OPENAI_REASONING_MODEL", "gpt-5.4 mini")
     monkeypatch.setenv("OPENAI_TOOLCALL_MODEL", "gpt-5.4-mini")
@@ -1121,6 +1122,42 @@ def test_create_llm_client_openai_reasoning_sets_toolcall_fallback(monkeypatch) 
         assert isinstance(client, llm_client.OpenAILLMClient)
         assert client._model == "gpt-5.4 mini"
         assert client._model_fallback == "gpt-5.4-mini"
+    finally:
+        llm_client.reset_llm_singletons()
+
+
+def test_create_llm_client_openai_oauth_routes_to_codex(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_AUTH_METHOD", "oauth")
+    monkeypatch.setenv("CODEX_MODEL", "gpt-5.5")
+    llm_client.reset_llm_singletons()
+    try:
+        from integrations.llm_cli.codex import CodexAdapter
+        from integrations.llm_cli.runner import CLIBackedLLMClient
+
+        client = llm_client._create_llm_client("reasoning")
+
+        assert isinstance(client, CLIBackedLLMClient)
+        assert isinstance(client._adapter, CodexAdapter)
+        assert client._model == "gpt-5.5"
+    finally:
+        llm_client.reset_llm_singletons()
+
+
+def test_create_llm_client_anthropic_oauth_routes_to_claude_code(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+    monkeypatch.setenv("LLM_AUTH_METHOD", "oauth")
+    monkeypatch.setenv("CLAUDE_CODE_MODEL", "claude-opus-4-7")
+    llm_client.reset_llm_singletons()
+    try:
+        from integrations.llm_cli.claude_code import ClaudeCodeAdapter
+        from integrations.llm_cli.runner import CLIBackedLLMClient
+
+        client = llm_client._create_llm_client("reasoning")
+
+        assert isinstance(client, CLIBackedLLMClient)
+        assert isinstance(client._adapter, ClaudeCodeAdapter)
+        assert client._model == "claude-opus-4-7"
     finally:
         llm_client.reset_llm_singletons()
 


### PR DESCRIPTION
## Summary
- move OpenAI and Anthropic OAuth selection into onboarding auth-method prompts
- persist canonical providers with LLM_AUTH_METHOD=oauth while routing runtime calls to Codex or Claude Code backends
- update docs, wizard tests, runtime tests, and PTY onboarding smoke coverage

## Verification
- make lint
- make format-check
- make typecheck
- make test-scope