### PR TITLE
fix(telegram): sanitize root-cause markdown before HTML rendering

### DIFF
--- a/tests/delivery/test_report_provenance.py
+++ b/tests/delivery/test_report_provenance.py
@@ -67,6 +67,20 @@ def test_format_telegram_message_does_not_treat_lonely_asterisk_as_bold() -> Non
     assert "<b>3</b>" not in body
 
 
+def test_format_telegram_message_renders_double_star_bold_in_root_cause() -> None:
+    state = _make_state()
+    state["severity"] = "high"
+    state["alert_name"] = "HighMemory"
+    state["pipeline_name"] = "checkout"
+    state["root_cause"] = "The pod **api-server** exhausted its memory limit"
+    ctx = build_report_context(state)
+    body = format_telegram_message(ctx)
+    assert "<b>api-server</b>" in body
+    # Internal bold placeholders must never leak into the rendered message.
+    assert "«B" not in body
+    assert "**" not in body
+
+
 def test_format_telegram_message_omits_banner_only_root_cause() -> None:
     state = _make_state()
     state["severity"] = "info"

--- a/tools/investigation/reporting/formatters/report.py
+++ b/tools/investigation/reporting/formatters/report.py
@@ -554,7 +554,7 @@ def format_telegram_message(ctx: ReportContext) -> str:
     elif baseline_noise and top_log:
         parts.append("<code>" + html.escape(top_log) + "</code>")
     else:
-        rc = _to_telegram_html_body(root_cause_sentence)
+        rc = _to_telegram_html_body(_sanitize_for_slack(root_cause_sentence))
         if top_log:
             rc += "\n<code>" + html.escape(top_log) + "</code>"
         parts.append(rc)


### PR DESCRIPTION
Fixes #3248

#### Describe the changes you have made in this PR -

The Telegram RCA root-cause line was rendered by calling `_to_telegram_html_body(root_cause_sentence)` directly. Every other caller of `_to_telegram_html_body` in this file — the claim lines, provenance, and remediation sections — first runs the text through `_sanitize_for_slack`, which collapses standard `**bold**` markdown into the single-star `*bold*` form that the Telegram bold parser expects.

Because the root-cause path skipped that step, raw `**bold**` reached `_star_pairs_to_bold_placeholders`. Its single-star regex matched the *inner* `*api-server*` of `**api-server**` first (creating placeholder `«B0»`), then matched the leftover outer `*«B0»*` (creating `«B1» = <b>«B0»</b>`); the flat replacement pass substituted `«B1»` but never re-expanded the nested `«B0»`, so the literal token `«B0»` leaked into the user-visible message.

The fix routes the root-cause sentence through `_sanitize_for_slack` like every sibling call site — a one-line change that restores consistency rather than adding new logic. A regression test (`test_format_telegram_message_renders_double_star_bold_in_root_cause`) asserts the body contains `<b>api-server</b>` and never an internal `«B` placeholder or raw `**`.

### Demo/Screenshot for feature changes and bug fixes -

Repro on `main` (before the fix):

```
$ uv run python -c "from tools.investigation.reporting.formatters.report import format_telegram_message; print(format_telegram_message({'alert_name':'HighMemory','pipeline_name':'checkout','severity':'high','root_cause':'The pod **api-server** exhausted its memory limit because of a leak.'}))"
🟠 <b>HighMemory</b> · checkout
<i>severity: HIGH</i>

The pod <b>«B0»</b> exhausted its memory limit because of a leak     ← leaked placeholder
```

After the fix:

```
The pod <b>api-server</b> exhausted its memory limit because of a leak   ← correct bold
```

Local checks (per `CI.md`):

```
make lint          → All checks passed!
make format-check  → 2037 files already formatted
make typecheck     → Success: no issues found in 922 source files
make test-scope    → 79 passed   (tests/delivery/, incl. the new regression test)
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: the Telegram RCA renderer showed an internal placeholder token (`«B0»`) instead of bolded text whenever the root cause used `**bold**` markdown — which LLM-generated RCA text does routinely.

I traced all five callers of `_to_telegram_html_body` and found the root-cause sentence was the only one not pre-sanitized with `_sanitize_for_slack`. That asymmetry is the root cause: the bold parser only understands single-star `*x*`, and `_sanitize_for_slack` is what converts `**x**` → `*x*` everywhere else.

I considered making `_to_telegram_html_body` normalize `**` internally (more defensive), but chose to fix the one inconsistent call site instead — it is the minimal change, matches the established pattern in the same function, and does not alter the helper's contract. Verified the existing lonely-asterisk test (`2 * 3 = 6`) still passes, since `_sanitize_for_slack` only rewrites paired `**` and markdown headers.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
