### PR TITLE
fix(remote): do not default agent port for explicit https URLs

### DIFF
--- a/infra/deployment/remote/client.py
+++ b/infra/deployment/remote/client.py
@@ -82,14 +82,18 @@ def normalize_url(url: str) -> str:
     """Normalize a URL or bare IP into a full base URL.
 
     Accepts:
-        - "http://1.2.3.4:2024" -> returned as-is
-        - "1.2.3.4:2024"        -> "http://1.2.3.4:2024"
-        - "1.2.3.4"             -> "http://1.2.3.4:2024"
+        - "http://1.2.3.4:2024"         -> returned as-is
+        - "1.2.3.4:2024"                -> "http://1.2.3.4:2024"
+        - "1.2.3.4"                     -> "http://1.2.3.4:2024"
+        - "https://agent.example.com"   -> returned as-is (https implies port 443)
     """
     url = url.rstrip("/")
+    explicit_https = url.startswith("https://")
     if not url.startswith(("http://", "https://")):
         url = f"http://{url}"
-    if url.count(":") == 1 and not url.split("//")[1].count(":"):
+    # Only default the agent port for plaintext/bare hosts. An explicit https://
+    # URL implies the standard port 443, so leave it untouched.
+    if not explicit_https and url.count(":") == 1 and not url.split("//")[1].count(":"):
         url = f"{url}:{DEFAULT_PORT}"
     return url
 

--- a/tests/remote/test_client.py
+++ b/tests/remote/test_client.py
@@ -36,6 +36,10 @@ class TestNormalizeUrl:
     def test_hostname_without_port(self) -> None:
         assert normalize_url("http://agent.local") == f"http://agent.local:{DEFAULT_PORT}"
 
+    def test_https_without_port_is_left_unchanged(self) -> None:
+        # An explicit https:// URL implies port 443; do not append the agent default port.
+        assert normalize_url("https://opensre.example.com") == "https://opensre.example.com"
+
 
 class TestRemoteAgentClientInit:
     def test_base_url_normalized(self) -> None:


### PR DESCRIPTION
Fixes #3250

#### Describe the changes you have made in this PR -

`normalize_url()` defaults the agent port `:2024` for any URL whose authority has no explicit port. The guard `url.count(":") == 1` counts the scheme's own colon, so an explicit `https://host` (one colon in `https:`, none in the authority) matched the condition and was rewritten to `https://host:2024`. A remote deployment behind a load balancer / reverse proxy on standard HTTPS (443) would then be contacted on `:2024` and fail to connect.

The fix records whether the caller supplied an explicit `https://` scheme and skips the default-port append in that case — an explicit `https://` already implies port 443. Plaintext `http://` URLs and bare hosts/IPs still default to `:2024` exactly as before (that is the intended dev convention, covered by existing tests).

A regression test (`test_https_without_port_is_left_unchanged`) locks in the corrected behavior, and the docstring gains the `https://` example.

### Demo/Screenshot for feature changes and bug fixes -

Behavior before vs after (`uv run python` from repo root):

```
input                                  before (main)                          after (this PR)
'https://example.com'               -> 'https://example.com:2024'   (bug)  -> 'https://example.com'
'https://opensre.mycompany.com/api' -> '...:2024' before path        (bug) -> 'https://opensre.mycompany.com/api'
'http://agent.local'                -> 'http://agent.local:2024'           -> 'http://agent.local:2024'   (unchanged)
'1.2.3.4'                           -> 'http://1.2.3.4:2024'               -> 'http://1.2.3.4:2024'        (unchanged)
'https://x.com:2024'                -> 'https://x.com:2024'                -> 'https://x.com:2024'         (unchanged)
```

Local checks (per `CI.md`):

```
make lint          → All checks passed!
make format-check  → 2037 files already formatted
make typecheck     → Success: no issues found in 922 source files
make test-scope    → 324 passed   (tests/remote/, incl. the new regression test)
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: `normalize_url` is meant to turn bare IPs/hosts into a full agent base URL (defaulting the dev port `:2024`), but it also mangled explicit `https://` URLs by appending `:2024`, so a production remote on standard HTTPS could not be reached.

Root cause is the port-detection heuristic `url.count(":") == 1`, which double-counts the scheme colon. I considered parsing the authority with `urlsplit` to count ports robustly, but the minimal and lowest-risk change is to gate the existing append on "the user did not give an explicit `https://`", which preserves every current code path (verified against all existing `TestNormalizeUrl` cases) while fixing only the broken one. `http://` and bare-host defaulting are intentional and untouched.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
