### PR TITLE
fix(integrations): guard remaining env-loader model_validate calls so one bad cred can't abort discovery

### DIFF
--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -382,21 +382,25 @@ def load_env_integrations() -> list[dict[str, Any]]:
         grafana_endpoint = os.getenv("GRAFANA_INSTANCE_URL", "").strip()
         grafana_api_key = os.getenv("GRAFANA_READ_TOKEN", "").strip()
     if grafana_endpoint and grafana_api_key:
-        grafana_config = GrafanaIntegrationConfig.model_validate(
-            {
-                "endpoint": grafana_endpoint,
-                "api_key": grafana_api_key,
-            }
-        )
-        integrations.append(
-            _active_env_record(
-                "grafana",
+        try:
+            grafana_config = GrafanaIntegrationConfig.model_validate(
                 {
-                    "endpoint": grafana_config.endpoint,
-                    "api_key": grafana_config.api_key,
-                },
+                    "endpoint": grafana_endpoint,
+                    "api_key": grafana_api_key,
+                }
             )
-        )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="grafana")
+        else:
+            integrations.append(
+                _active_env_record(
+                    "grafana",
+                    {
+                        "endpoint": grafana_config.endpoint,
+                        "api_key": grafana_config.api_key,
+                    },
+                )
+            )
 
     datadog_multi = _parse_instances_env("DD_INSTANCES", "datadog")
     if datadog_multi is not None:
@@ -409,19 +413,23 @@ def load_env_integrations() -> list[dict[str, Any]]:
         datadog_app_key = os.getenv("DD_APP_KEY", "").strip()
         datadog_site = os.getenv("DD_SITE", "datadoghq.com").strip() or "datadoghq.com"
     if datadog_api_key and datadog_app_key:
-        datadog_config = DatadogIntegrationConfig.model_validate(
-            {
-                "api_key": datadog_api_key,
-                "app_key": datadog_app_key,
-                "site": datadog_site,
-            }
-        )
-        integrations.append(
-            _active_env_record(
-                "datadog",
-                datadog_config.model_dump(exclude={"integration_id"}),
+        try:
+            datadog_config = DatadogIntegrationConfig.model_validate(
+                {
+                    "api_key": datadog_api_key,
+                    "app_key": datadog_app_key,
+                    "site": datadog_site,
+                }
             )
-        )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="datadog")
+        else:
+            integrations.append(
+                _active_env_record(
+                    "datadog",
+                    datadog_config.model_dump(exclude={"integration_id"}),
+                )
+            )
 
     groundcover_multi = _parse_instances_env("GROUNDCOVER_INSTANCES", "groundcover")
     if groundcover_multi is not None:
@@ -463,19 +471,23 @@ def load_env_integrations() -> list[dict[str, Any]]:
     else:
         honeycomb_api_key = os.getenv("HONEYCOMB_API_KEY", "").strip()
     if honeycomb_api_key:
-        honeycomb_config = HoneycombIntegrationConfig.model_validate(
-            {
-                "api_key": honeycomb_api_key,
-                "dataset": os.getenv("HONEYCOMB_DATASET", "").strip(),
-                "base_url": os.getenv("HONEYCOMB_API_URL", "").strip(),
-            }
-        )
-        integrations.append(
-            _active_env_record(
-                "honeycomb",
-                honeycomb_config.model_dump(exclude={"integration_id"}),
+        try:
+            honeycomb_config = HoneycombIntegrationConfig.model_validate(
+                {
+                    "api_key": honeycomb_api_key,
+                    "dataset": os.getenv("HONEYCOMB_DATASET", "").strip(),
+                    "base_url": os.getenv("HONEYCOMB_API_URL", "").strip(),
+                }
             )
-        )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="honeycomb")
+        else:
+            integrations.append(
+                _active_env_record(
+                    "honeycomb",
+                    honeycomb_config.model_dump(exclude={"integration_id"}),
+                )
+            )
 
     coralogix_multi = _parse_instances_env("CORALOGIX_INSTANCES", "coralogix")
     if coralogix_multi is not None:
@@ -484,20 +496,24 @@ def load_env_integrations() -> list[dict[str, Any]]:
     else:
         coralogix_api_key = os.getenv("CORALOGIX_API_KEY", "").strip()
     if coralogix_api_key:
-        coralogix_config = CoralogixIntegrationConfig.model_validate(
-            {
-                "api_key": coralogix_api_key,
-                "base_url": os.getenv("CORALOGIX_API_URL", "").strip(),
-                "application_name": os.getenv("CORALOGIX_APPLICATION_NAME", "").strip(),
-                "subsystem_name": os.getenv("CORALOGIX_SUBSYSTEM_NAME", "").strip(),
-            }
-        )
-        integrations.append(
-            _active_env_record(
-                "coralogix",
-                coralogix_config.model_dump(exclude={"integration_id"}),
+        try:
+            coralogix_config = CoralogixIntegrationConfig.model_validate(
+                {
+                    "api_key": coralogix_api_key,
+                    "base_url": os.getenv("CORALOGIX_API_URL", "").strip(),
+                    "application_name": os.getenv("CORALOGIX_APPLICATION_NAME", "").strip(),
+                    "subsystem_name": os.getenv("CORALOGIX_SUBSYSTEM_NAME", "").strip(),
+                }
             )
-        )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="coralogix")
+        else:
+            integrations.append(
+                _active_env_record(
+                    "coralogix",
+                    coralogix_config.model_dump(exclude={"integration_id"}),
+                )
+            )
 
     aws_multi = _parse_instances_env("AWS_INSTANCES", "aws")
     if aws_multi is not None:
@@ -516,45 +532,53 @@ def load_env_integrations() -> list[dict[str, Any]]:
         aws_secret_access_key = os.getenv("AWS_SECRET_ACCESS_KEY", "").strip()
         aws_session_token = os.getenv("AWS_SESSION_TOKEN", "").strip()
     if aws_role_arn:
-        aws_config = AWSIntegrationConfig.model_validate(
-            {
-                "role_arn": aws_role_arn,
-                "external_id": aws_external_id,
-                "region": aws_region,
-            }
-        )
-        integrations.append(
-            _active_env_record(
-                "aws",
-                {"region": aws_config.region},
-                role_arn=aws_config.role_arn,
-                external_id=aws_config.external_id,
+        try:
+            aws_config = AWSIntegrationConfig.model_validate(
+                {
+                    "role_arn": aws_role_arn,
+                    "external_id": aws_external_id,
+                    "region": aws_region,
+                }
             )
-        )
-    elif aws_access_key_id and aws_secret_access_key:
-        aws_config = AWSIntegrationConfig.model_validate(
-            {
-                "region": aws_region,
-                "credentials": {
-                    "access_key_id": aws_access_key_id,
-                    "secret_access_key": aws_secret_access_key,
-                    "session_token": aws_session_token,
-                },
-            }
-        )
-        aws_credentials = aws_config.credentials
-        if aws_credentials is not None:
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="aws")
+        else:
             integrations.append(
                 _active_env_record(
                     "aws",
-                    {
-                        "access_key_id": aws_credentials.access_key_id,
-                        "secret_access_key": aws_credentials.secret_access_key,
-                        "session_token": aws_credentials.session_token,
-                        "region": aws_config.region,
-                    },
+                    {"region": aws_config.region},
+                    role_arn=aws_config.role_arn,
+                    external_id=aws_config.external_id,
                 )
             )
+    elif aws_access_key_id and aws_secret_access_key:
+        try:
+            aws_config = AWSIntegrationConfig.model_validate(
+                {
+                    "region": aws_region,
+                    "credentials": {
+                        "access_key_id": aws_access_key_id,
+                        "secret_access_key": aws_secret_access_key,
+                        "session_token": aws_session_token,
+                    },
+                }
+            )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="aws")
+        else:
+            aws_credentials = aws_config.credentials
+            if aws_credentials is not None:
+                integrations.append(
+                    _active_env_record(
+                        "aws",
+                        {
+                            "access_key_id": aws_credentials.access_key_id,
+                            "secret_access_key": aws_credentials.secret_access_key,
+                            "session_token": aws_credentials.session_token,
+                            "region": aws_config.region,
+                        },
+                    )
+                )
 
     github_mode = os.getenv("GITHUB_MCP_MODE", "streamable-http").strip() or "streamable-http"
     github_url = os.getenv("GITHUB_MCP_URL", "").strip()
@@ -880,15 +904,19 @@ def load_env_integrations() -> list[dict[str, Any]]:
 
     whatsapp_from_number = os.getenv("TWILIO_WHATSAPP_FROM", "").strip()
     if twilio_account_sid and twilio_auth_token and whatsapp_from_number:
-        wa_config = WhatsAppConfig.model_validate(
-            {
-                "account_sid": twilio_account_sid,
-                "auth_token": twilio_auth_token,
-                "from_number": whatsapp_from_number,
-                "default_to": os.getenv("WHATSAPP_DEFAULT_TO", "").strip() or None,
-            }
-        )
-        integrations.append(_active_env_record("whatsapp", wa_config.model_dump()))
+        try:
+            wa_config = WhatsAppConfig.model_validate(
+                {
+                    "account_sid": twilio_account_sid,
+                    "auth_token": twilio_auth_token,
+                    "from_number": whatsapp_from_number,
+                    "default_to": os.getenv("WHATSAPP_DEFAULT_TO", "").strip() or None,
+                }
+            )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="whatsapp")
+        else:
+            integrations.append(_active_env_record("whatsapp", wa_config.model_dump()))
 
     # Twilio SMS integration — independent of the legacy WhatsApp record.
     # Hydrated when account+token are present AND an SMS sender is set
@@ -1346,21 +1374,26 @@ def load_env_integrations() -> list[dict[str, Any]]:
         splunk_url = os.getenv("SPLUNK_URL", "").strip()
         splunk_token = os.getenv("SPLUNK_TOKEN", "").strip()
         if splunk_url and splunk_token:
-            splunk_config = SplunkIntegrationConfig.model_validate(
-                {
-                    "base_url": splunk_url,
-                    "token": splunk_token,
-                    "index": os.getenv("SPLUNK_INDEX", "main").strip(),
-                    "verify_ssl": os.getenv("SPLUNK_VERIFY_SSL", "true").strip().lower() != "false",
-                    "ca_bundle": os.getenv("SPLUNK_CA_BUNDLE", "").strip(),
-                }
-            )
-            integrations.append(
-                _active_env_record(
-                    "splunk",
-                    splunk_config.model_dump(exclude={"integration_id"}),
+            try:
+                splunk_config = SplunkIntegrationConfig.model_validate(
+                    {
+                        "base_url": splunk_url,
+                        "token": splunk_token,
+                        "index": os.getenv("SPLUNK_INDEX", "main").strip(),
+                        "verify_ssl": os.getenv("SPLUNK_VERIFY_SSL", "true").strip().lower()
+                        != "false",
+                        "ca_bundle": os.getenv("SPLUNK_CA_BUNDLE", "").strip(),
+                    }
                 )
-            )
+            except Exception as exc:
+                _report_env_loader_failure(exc, integration="splunk")
+            else:
+                integrations.append(
+                    _active_env_record(
+                        "splunk",
+                        splunk_config.model_dump(exclude={"integration_id"}),
+                    )
+                )
 
     supabase_url = os.getenv("SUPABASE_URL", "").strip()
     supabase_service_key = os.getenv("SUPABASE_SERVICE_KEY", "").strip()

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -291,6 +291,47 @@ _ENV_LOADER_CASES: list[tuple[str, dict[str, str], str]] = [
         },
         "build_mongodb_atlas_config",
     ),
+    # Early env-loader blocks that #1468 never guarded — a malformed cred here
+    # aborted discovery of every later integration (the #2036 class of bug).
+    (
+        "grafana",
+        {"GRAFANA_INSTANCE_URL": "https://g.example", "GRAFANA_READ_TOKEN": "t"},
+        "GrafanaIntegrationConfig",
+    ),
+    (
+        "datadog",
+        {"DD_API_KEY": "k", "DD_APP_KEY": "a"},
+        "DatadogIntegrationConfig",
+    ),
+    (
+        "honeycomb",
+        {"HONEYCOMB_API_KEY": "k"},
+        "HoneycombIntegrationConfig",
+    ),
+    (
+        "coralogix",
+        {"CORALOGIX_API_KEY": "k"},
+        "CoralogixIntegrationConfig",
+    ),
+    (
+        "aws",
+        {"AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/x"},
+        "AWSIntegrationConfig",
+    ),
+    (
+        "whatsapp",
+        {
+            "TWILIO_ACCOUNT_SID": "sid",
+            "TWILIO_AUTH_TOKEN": "tok",
+            "TWILIO_WHATSAPP_FROM": "+15551234567",
+        },
+        "WhatsAppConfig",
+    ),
+    (
+        "splunk",
+        {"SPLUNK_URL": "https://s.example", "SPLUNK_TOKEN": "t"},
+        "SplunkIntegrationConfig",
+    ),
 ]
 
 

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -319,6 +319,12 @@ _ENV_LOADER_CASES: list[tuple[str, dict[str, str], str]] = [
         "AWSIntegrationConfig",
     ),
     (
+        # The access-key path is a separate elif branch with its own guard.
+        "aws",
+        {"AWS_ACCESS_KEY_ID": "key", "AWS_SECRET_ACCESS_KEY": "secret"},
+        "AWSIntegrationConfig",
+    ),
+    (
         "whatsapp",
         {
             "TWILIO_ACCOUNT_SID": "sid",


### PR DESCRIPTION
Fixes #3254

#### Describe the changes you have made in this PR -

`load_env_integrations()` validates each vendor's env config with `model_validate`.
Most blocks are wrapped in a `try/except _report_env_loader_failure(...)` guard
(from #1468 / the #2036 regression fix) so one bad cred is reported and skipped
while the rest still load. **Seven early blocks were never wrapped**: `grafana`,
`datadog`, `honeycomb`, `coralogix`, `aws` (both the role-ARN and access-key
paths), `whatsapp`, and `splunk`.

For those, a single malformed value (e.g. a typo'd `GRAFANA_INSTANCE_URL`) raises
a `ValidationError` that propagates out of the loader and **aborts discovery of
every other integration**. In the welcome-banner path
(`configured_integration_services`) that exception is swallowed to an empty list,
so the user sees none of their integrations and gets no hint why — the exact
#2036 bug, never closed for these vendors.

This PR:
- wraps the seven blocks in the same `try/except _report_env_loader_failure/else`
  guard the other vendors already use (the only logic change is the guard — the
  large diff is re-indentation of the existing bodies);
- extends the existing parametrized `test_env_loader_failure_reports_and_skips`
  to cover all seven, proving each is reported via `report_exception`
  (`event=env_loader_failed`) and skipped without aborting the loader.

The repo's existing `test_one_failing_env_loader_does_not_abort_remaining_integrations`
(#2036) already covers the "survivor continues" contract; these vendors now fall
under the same guarantee.

### Demo/Screenshot for feature changes and bug fixes -

A valid Datadog config plus a Grafana loader forced to raise (Grafana loads
before Datadog):


BEFORE (main):
<img width="1037" height="115" alt="image" src="https://github.com/user-attachments/assets/ded5f6b7-eb8d-4c3a-aaaa-124c5d5ae4e5" />

AFTER (this branch):
  
<img width="1041" height="86" alt="image" src="https://github.com/user-attachments/assets/64647545-d009-4d9c-8fbd-23678c6ac81c" />


Tests / gate:

<img width="1032" height="200" alt="image" src="https://github.com/user-attachments/assets/15b11695-edd0-4cae-bf58-1d3be80b9a2d" />

<img width="962" height="149" alt="image" src="https://github.com/user-attachments/assets/51601661-c16d-44f6-8842-d0c064dc01df" />


(One unrelated pre-existing failure on this machine — `test_copilot_adapter.py::test_detect_when_binary_not_found` — fails identically on clean `main`; not touched by this PR.)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I scanned every `model_validate` call inside `load_env_integrations`, classified
each as guarded/unguarded by whether a `try:` wraps it, and found seven early
blocks that #1468 never retrofitted. I wrapped each in the identical
`try/except _report_env_loader_failure(exc, integration=...)/else` pattern the
rest of the loader uses (so behavior is consistent and reviewable), then added
the seven to the existing env-loader parametrized test. I verified with a
before/after that a forced grafana failure aborts the whole loader on `main` but
is contained on this branch, and confirmed the unrelated copilot test failure
pre-exists on `main`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
