### PR TITLE
fix(integrations): report signoz/jenkins/tempo/twilio env-loader failures (finish #1468)

### DIFF
--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -940,9 +940,9 @@ def load_env_integrations() -> list[dict[str, Any]]:
         }
         try:
             twilio_config = TwilioIntegrationConfig.model_validate(twilio_payload)
-        except Exception:
-            twilio_config = None
-        if twilio_config is not None:
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="twilio")
+        else:
             integrations.append(
                 _active_env_record(
                     "twilio",
@@ -1420,8 +1420,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     signoz_config.model_dump(exclude={"integration_id"}),
                 )
             )
-    except Exception:
-        logger.debug("Failed to load SigNoz config from env", exc_info=True)
+    except Exception as exc:
+        _report_env_loader_failure(exc, integration="signoz")
 
     try:
         jenkins_config = jenkins_config_from_env()
@@ -1432,8 +1432,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     jenkins_config.model_dump(exclude={"integration_id"}),
                 )
             )
-    except Exception:
-        logger.debug("Failed to load Jenkins config from env", exc_info=True)
+    except Exception as exc:
+        _report_env_loader_failure(exc, integration="jenkins")
 
     try:
         tempo_config = tempo_config_from_env()
@@ -1444,8 +1444,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     tempo_config.model_dump(exclude={"integration_id"}),
                 )
             )
-    except Exception:
-        logger.debug("Failed to load Tempo config from env", exc_info=True)
+    except Exception as exc:
+        _report_env_loader_failure(exc, integration="tempo")
 
     temporal_url = os.getenv("TEMPORAL_API_URL", "").strip()
     temporal_namespace = os.getenv("TEMPORAL_NAMESPACE", "default").strip()

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -338,6 +338,32 @@ _ENV_LOADER_CASES: list[tuple[str, dict[str, str], str]] = [
         {"SPLUNK_URL": "https://s.example", "SPLUNK_TOKEN": "t"},
         "SplunkIntegrationConfig",
     ),
+    # Stragglers still on the pre-#1468 swallow pattern: signoz/jenkins/tempo
+    # logged only at debug (exc_info=True); twilio dropped to None silently.
+    (
+        "signoz",
+        {},
+        "signoz_config_from_env",
+    ),
+    (
+        "jenkins",
+        {},
+        "jenkins_config_from_env",
+    ),
+    (
+        "tempo",
+        {},
+        "tempo_config_from_env",
+    ),
+    (
+        "twilio",
+        {
+            "TWILIO_ACCOUNT_SID": "sid",
+            "TWILIO_AUTH_TOKEN": "tok",
+            "TWILIO_SMS_FROM": "+15551234567",
+        },
+        "TwilioIntegrationConfig",
+    ),
 ]
 
 


### PR DESCRIPTION
Fixes #3256

#### Describe the changes you have made in this PR -

`_report_env_loader_failure` (from #1468) routes per-vendor failures in
`load_env_integrations()` to Sentry + a warning, replacing the old
`except Exception: pass` / `logger.debug(..., exc_info=True)` swallows — its
docstring says exactly that. Four blocks were never migrated:

- **signoz**, **jenkins**, **tempo** — `except Exception: logger.debug(..., exc_info=True)`.
  Debug logging is off by default, so a misconfiguration is invisible and never
  reaches Sentry.
- **twilio** (SMS) — `except Exception: twilio_config = None`. Fully silent: no
  log, no Sentry, no trace.

Every other env-loader vendor (supabase, vercel, argocd, and grafana/datadog/…
after #3254) already routes through the helper. This PR converts the last four
to match and extends the existing `test_env_loader_failure_reports_and_skips`
parametrization to cover them (now 69 passing in the file).

The diff is small — swap each `except` body for
`_report_env_loader_failure(exc, integration=...)`; the twilio block also drops
its `twilio_config = None` / `if ... is not None` dance for a clean `else`.

### Demo/Screenshot for feature changes and bug fixes -


BEFORE


AFTER  (all four)
  <img width="1036" height="210" alt="image" src="https://github.com/user-attachments/assets/9902e540-a251-4531-9415-eafed1c98d5b" /> skipped

<img width="951" height="710" alt="image" src="https://github.com/user-attachments/assets/9fdfa2db-2df8-48bb-8a3b-44ba3bc46c33" />

<img width="1040" height="195" alt="image" src="https://github.com/user-attachments/assets/7a3fa3ac-4176-4415-ae13-0c6864420b55" />

<img width="917" height="144" alt="image" src="https://github.com/user-attachments/assets/6fb717ef-1898-4a6c-a06c-7f47ef3b819a" />


### Note on secret exposure

This matches the leak surface already accepted for the ~17 other vendors using
the helper. Slack is the one intentional exception — its secret lives in the
webhook URL that Pydantic's `ValidationError` reliably embeds — and that block is
deliberately left logging a static message; this PR does not touch it.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I grepped `load_env_integrations` for the remaining `logger.debug(..., exc_info=True)`
and silent `= None` swallows, found exactly four (signoz/jenkins/tempo/twilio),
and confirmed every other vendor already uses `_report_env_loader_failure`. I
routed the four through the same helper and added them to the existing
parametrized env-loader test. I checked `report_exception`'s behavior and the
Slack precedent to confirm the secret-exposure surface is identical to the
already-accepted vendors (Slack intentionally excluded), so this is a
consistency fix, not a new exposure.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
