### PR TITLE
[codex] Fix OAuth-backed LLM onboarding

### DIFF
--- a/cli/wizard/flow.py
+++ b/cli/wizard/flow.py
@@ -7,8 +7,8 @@ import re
 import shlex
 import subprocess
 import sys
-import threading
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 import questionary
@@ -67,6 +67,14 @@ _HIDDEN_ONBOARDING_BACKEND_PROVIDERS = frozenset(OAUTH_BACKEND_PROVIDER_BY_PROVI
 _CODEX_CONFIG_ERROR_RE = re.compile(
     r"Error loading configuration:\s*(?P<location>[^\n]+config\.toml:\d+:\d+):\s*(?P<detail>[^\n]+)"
 )
+_CODEX_CONFIG_LOCATION_RE = re.compile(r"^(?P<path>.+config\.toml):(?P<line>\d+):(?P<column>\d+)$")
+_CODEX_STALE_SERVICE_TIER_DETAIL_RE = re.compile(
+    r"unknown variant [`'\"]priority[`'\"], expected [`'\"]fast[`'\"] or [`'\"]flex[`'\"]"
+)
+_CODEX_PRIORITY_SERVICE_TIER_RE = re.compile(
+    r"^(?P<prefix>[ \t]*service_tier[ \t]*=[ \t]*)(?P<quote>[\"'])"
+    r"priority(?P=quote)(?P<suffix>[ \t]*(?:#.*)?)?(?P<newline>\r?\n)?$"
+)
 
 __all__ = [
     "DEFAULT_GITHUB_MCP_MODE",
@@ -103,6 +111,8 @@ class _SubscriptionLoginResult:
     ok: bool
     detail: str = ""
     config_error: bool = False
+    config_error_location: str = ""
+    config_error_detail: str = ""
 
 
 @dataclass(frozen=True)
@@ -110,6 +120,12 @@ class _LoginProcessResult:
     returncode: int
     stdout: str = ""
     stderr: str = ""
+
+
+@dataclass(frozen=True)
+class _CodexConfigRepairResult:
+    ok: bool
+    detail: str
 
 
 def _provider_choice_label(provider: ProviderOption) -> str:
@@ -204,50 +220,114 @@ def _subscription_login_command(
     return [binary_path, *args]
 
 
-def _stream_login_pipe(pipe, chunks: list[str]) -> None:
+def _subscription_login_preflight_command(
+    provider: ProviderOption, binary_path: str | None
+) -> list[str] | None:
+    """Return a non-OAuth command that validates config before interactive login."""
+    if not binary_path:
+        return None
+    if provider.value == "codex":
+        return [binary_path, "login", "--help"]
+    return None
+
+
+def _parse_codex_config_error_location(location: str) -> tuple[Path, int] | None:
+    match = _CODEX_CONFIG_LOCATION_RE.match(location.strip())
+    if match is None:
+        return None
     try:
-        for line in pipe:
-            chunks.append(line)
-            _console.print(line.rstrip("\n"), markup=False)
-    finally:
-        pipe.close()
+        line_no = int(match.group("line"))
+    except ValueError:
+        return None
+    if line_no < 1:
+        return None
+    return Path(match.group("path")).expanduser(), line_no
 
 
-def _run_login_process(command: list[str]) -> _LoginProcessResult:
-    proc = subprocess.Popen(
+def _codex_priority_service_tier_repair_hint(*, location: str, detail: str) -> str | None:
+    if not _CODEX_STALE_SERVICE_TIER_DETAIL_RE.search(detail):
+        return None
+    parsed = _parse_codex_config_error_location(location)
+    if parsed is None:
+        return None
+    path, line_no = parsed
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    except OSError:
+        return None
+    if line_no > len(lines):
+        return None
+    if _CODEX_PRIORITY_SERVICE_TIER_RE.match(lines[line_no - 1]) is None:
+        return None
+    return f"Change {path}:{line_no} service_tier from priority to fast"
+
+
+def _repair_codex_priority_service_tier(*, location: str, detail: str) -> _CodexConfigRepairResult:
+    hint = _codex_priority_service_tier_repair_hint(location=location, detail=detail)
+    if hint is None:
+        return _CodexConfigRepairResult(
+            ok=False,
+            detail="This Codex config error is not one OpenSRE can repair safely.",
+        )
+    parsed = _parse_codex_config_error_location(location)
+    if parsed is None:
+        return _CodexConfigRepairResult(ok=False, detail=f"Could not parse {location}.")
+
+    path, line_no = parsed
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    except OSError as exc:
+        return _CodexConfigRepairResult(
+            ok=False,
+            detail=f"Could not read {path}: {exc}",
+        )
+    if line_no > len(lines):
+        return _CodexConfigRepairResult(
+            ok=False,
+            detail=f"Could not repair {path}: line {line_no} is outside the file.",
+        )
+
+    match = _CODEX_PRIORITY_SERVICE_TIER_RE.match(lines[line_no - 1])
+    if match is None:
+        return _CodexConfigRepairResult(
+            ok=False,
+            detail=f'Could not repair {path}: line {line_no} is no longer service_tier = "priority".',
+        )
+
+    lines[line_no - 1] = (
+        f"{match.group('prefix')}{match.group('quote')}fast{match.group('quote')}"
+        f"{match.group('suffix') or ''}{match.group('newline') or ''}"
+    )
+    try:
+        path.write_text("".join(lines), encoding="utf-8")
+    except OSError as exc:
+        return _CodexConfigRepairResult(
+            ok=False,
+            detail=f"Could not update {path}: {exc}",
+        )
+    return _CodexConfigRepairResult(ok=True, detail=hint)
+
+
+def _run_login_preflight_process(command: list[str]) -> _LoginProcessResult:
+    result = subprocess.run(
         command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        check=False,
+        capture_output=True,
         text=True,
         encoding="utf-8",
         errors="replace",
     )
-    stdout_chunks: list[str] = []
-    stderr_chunks: list[str] = []
-    threads: list[threading.Thread] = []
-    if proc.stdout is not None:
-        thread = threading.Thread(
-            target=_stream_login_pipe,
-            args=(proc.stdout, stdout_chunks),
-            daemon=True,
-        )
-        thread.start()
-        threads.append(thread)
-    if proc.stderr is not None:
-        thread = threading.Thread(
-            target=_stream_login_pipe,
-            args=(proc.stderr, stderr_chunks),
-            daemon=True,
-        )
-        thread.start()
-        threads.append(thread)
-    returncode = proc.wait()
-    for thread in threads:
-        thread.join()
     return _LoginProcessResult(
-        returncode=returncode,
-        stdout="".join(stdout_chunks),
-        stderr="".join(stderr_chunks),
+        returncode=result.returncode,
+        stdout=result.stdout or "",
+        stderr=result.stderr or "",
+    )
+
+
+def _run_interactive_login_process(command: list[str]) -> _LoginProcessResult:
+    result = subprocess.run(command, check=False)
+    return _LoginProcessResult(
+        returncode=result.returncode,
     )
 
 
@@ -262,12 +342,16 @@ def _subscription_login_error(
     if provider.value == "codex":
         match = _CODEX_CONFIG_ERROR_RE.search(text)
         if match:
+            location = match.group("location")
+            detail = match.group("detail")
             return _SubscriptionLoginResult(
                 ok=False,
                 config_error=True,
+                config_error_location=location,
+                config_error_detail=detail,
                 detail=(
                     "Codex CLI could not start because its local config is invalid: "
-                    f"{match.group('location')} ({match.group('detail')}). "
+                    f"{location} ({detail}). "
                     "Fix that file, then retry OAuth login."
                 ),
             )
@@ -293,9 +377,22 @@ def _run_subscription_login(
         _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
         return _SubscriptionLoginResult(ok=False, detail=detail)
 
+    preflight_command = _subscription_login_preflight_command(provider, binary_path)
+    if preflight_command is not None:
+        try:
+            preflight_result = _run_login_preflight_process(preflight_command)
+        except OSError as exc:
+            detail = f"Could not check login config: {exc}"
+            _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
+            return _SubscriptionLoginResult(ok=False, detail=detail)
+        if preflight_result.returncode != 0:
+            login_result = _subscription_login_error(provider, preflight_result)
+            _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {login_result.detail}[/]")
+            return login_result
+
     _console.print(f"[{SECONDARY}]Launching {shlex.join(command)} for browser login…[/]")
     try:
-        result = _run_login_process(command)
+        result = _run_interactive_login_process(command)
     except KeyboardInterrupt:
         _console.print(f"[{WARNING}]  {GLYPH_WARNING}  Login cancelled.[/]")
         return _SubscriptionLoginResult(ok=False, detail="Login cancelled.")
@@ -308,6 +405,68 @@ def _run_subscription_login(
         _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {login_result.detail}[/]")
         return login_result
     return _SubscriptionLoginResult(ok=True)
+
+
+def _recover_subscription_config_error(
+    provider: ProviderOption,
+    *,
+    provider_label: str,
+    binary_path: str | None,
+    login_result: _SubscriptionLoginResult,
+) -> Literal["ok", "continue", "repick"]:
+    repair_hint: str | None = None
+    if provider.value == "codex":
+        repair_hint = _codex_priority_service_tier_repair_hint(
+            location=login_result.config_error_location,
+            detail=login_result.config_error_detail,
+        )
+
+    choices: list[Choice] = []
+    if repair_hint is not None:
+        choices.append(
+            Choice(
+                value="repair",
+                label="Apply known Codex config fix and retry",
+                hint=repair_hint,
+            )
+        )
+    choices.extend(
+        [
+            Choice(
+                value="retry",
+                label="Retry after fixing local config",
+                hint=login_result.detail,
+            ),
+            Choice(
+                value="repick",
+                label="Pick a different LLM provider",
+                hint=None,
+            ),
+        ]
+    )
+    recovery = _choose(
+        f"{provider_label} OAuth could not start. What next?",
+        choices,
+        default="repair" if repair_hint is not None else "retry",
+    )
+    if recovery == "repick":
+        return "repick"
+    if recovery != "repair":
+        return "continue"
+
+    repair_result = _repair_codex_priority_service_tier(
+        location=login_result.config_error_location,
+        detail=login_result.config_error_detail,
+    )
+    if not repair_result.ok:
+        _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {repair_result.detail}[/]")
+        return "continue"
+
+    _console.print(f"[{SECONDARY}]  Updated Codex config: {repair_result.detail}.[/]")
+    retry_result = _run_subscription_login(provider, binary_path)
+    if retry_result.ok:
+        return "ok"
+    return "continue"
 
 
 def _run_cli_llm_onboarding(
@@ -370,23 +529,17 @@ def _run_cli_llm_onboarding(
                 return "repick"
             if action == "login":
                 login_result = _run_subscription_login(provider, probe.bin_path)
+                if login_result.ok:
+                    return "ok"
                 if login_result.config_error:
-                    recovery = _choose(
-                        f"{provider_label} OAuth could not start. What next?",
-                        [
-                            Choice(
-                                value="retry",
-                                label="Retry after fixing local config",
-                                hint=login_result.detail,
-                            ),
-                            Choice(
-                                value="repick",
-                                label="Pick a different LLM provider",
-                                hint=None,
-                            ),
-                        ],
-                        default="retry",
+                    recovery = _recover_subscription_config_error(
+                        provider,
+                        provider_label=provider_label,
+                        binary_path=probe.bin_path,
+                        login_result=login_result,
                     )
+                    if recovery == "ok":
+                        return "ok"
                     if recovery == "repick":
                         return "repick"
                 continue

--- a/core/llm/agent_llm_client.py
+++ b/core/llm/agent_llm_client.py
@@ -815,18 +815,29 @@ def get_agent_llm() -> _AgentClientType:
     except ValidationError as exc:
         raise RuntimeError(str(exc)) from exc
 
+    from config.llm_auth.auth_method import effective_llm_provider, get_configured_llm_auth_method
+
     provider = settings.provider
-    if provider == "openai":
+    runtime_provider = effective_llm_provider(provider, get_configured_llm_auth_method(provider))
+    if runtime_provider == "openai":
         from config.config import OPENAI_LLM_CONFIG
 
         _agent_client = OpenAIAgentClient(
             model=settings.openai_reasoning_model,
             max_tokens=OPENAI_LLM_CONFIG.max_tokens,
         )
-    elif provider in ("openrouter", "deepseek", "gemini", "nvidia", "minimax", "groq", "ollama"):
+    elif runtime_provider in (
+        "openrouter",
+        "deepseek",
+        "gemini",
+        "nvidia",
+        "minimax",
+        "groq",
+        "ollama",
+    ):
         # All OpenAI-compatible providers
-        _agent_client = _create_openai_compat_client(settings, provider)
-    elif provider == "bedrock":
+        _agent_client = _create_openai_compat_client(settings, runtime_provider)
+    elif runtime_provider == "bedrock":
         from config.config import BEDROCK_LLM_CONFIG
         from core.llm.bedrock_model_ids import is_anthropic_bedrock_model
 
@@ -841,7 +852,7 @@ def get_agent_llm() -> _AgentClientType:
                 model=model,
                 max_tokens=BEDROCK_LLM_CONFIG.max_tokens,
             )
-    elif (cli_reg := _get_cli_provider_registration(provider)) is not None:
+    elif (cli_reg := _get_cli_provider_registration(runtime_provider)) is not None:
         model_name = os.getenv(cli_reg.model_env_key, "").strip() or None
         _agent_client = CLIBackedAgentClient(cli_reg.adapter_factory(), model=model_name)
     else:

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -1328,20 +1328,27 @@ def test_run_cli_llm_onboarding_launches_codex_browser_login(monkeypatch) -> Non
     provider.value = "codex"
     provider.label = "OpenAI Codex CLI"
     provider.adapter_factory = lambda: adapter
+    preflight_commands: list[list[str]] = []
     login_commands: list[list[str]] = []
 
-    def _fake_run(command: list[str]) -> flow._LoginProcessResult:
+    def _fake_preflight(command: list[str]) -> flow._LoginProcessResult:
+        preflight_commands.append(command)
+        return flow._LoginProcessResult(returncode=0)
+
+    def _fake_login(command: list[str]) -> flow._LoginProcessResult:
         login_commands.append(command)
         return flow._LoginProcessResult(returncode=0)
 
     monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "login")
-    monkeypatch.setattr(flow, "_run_login_process", _fake_run)
+    monkeypatch.setattr(flow, "_run_login_preflight_process", _fake_preflight)
+    monkeypatch.setattr(flow, "_run_interactive_login_process", _fake_login)
 
     result = flow._run_cli_llm_onboarding(provider)
 
     assert result == "ok"
+    assert preflight_commands == [["/usr/local/bin/codex", "login", "--help"]]
     assert login_commands == [["/usr/local/bin/codex", "login"]]
-    assert len(detect_calls) == 2
+    assert len(detect_calls) == 1
 
 
 def test_run_cli_llm_onboarding_surfaces_codex_config_error(monkeypatch) -> None:
@@ -1366,7 +1373,7 @@ def test_run_cli_llm_onboarding_surfaces_codex_config_error(monkeypatch) -> None
     def _choose(*_args, **_kwargs):
         return choices.pop(0)
 
-    def _fake_run(command: list[str]) -> flow._LoginProcessResult:
+    def _fake_preflight(command: list[str]) -> flow._LoginProcessResult:
         del command
         return flow._LoginProcessResult(
             returncode=1,
@@ -1379,11 +1386,78 @@ def test_run_cli_llm_onboarding_surfaces_codex_config_error(monkeypatch) -> None
         )
 
     monkeypatch.setattr(flow, "_choose", _choose)
-    monkeypatch.setattr(flow, "_run_login_process", _fake_run)
+    monkeypatch.setattr(flow, "_run_login_preflight_process", _fake_preflight)
+    monkeypatch.setattr(flow, "_run_interactive_login_process", MagicMock())
 
     result = flow._run_cli_llm_onboarding(provider, display_label="OpenAI OAuth")
 
     assert result == "repick"
+    flow._run_interactive_login_process.assert_not_called()
+
+
+def test_run_cli_llm_onboarding_repairs_codex_stale_service_tier(monkeypatch, tmp_path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        'model = "gpt-5.5"\nservice_tier = "priority"\n[features]\n',
+        encoding="utf-8",
+    )
+
+    adapter = MagicMock()
+    adapter.name = "codex"
+    adapter.binary_env_key = "CODEX_BIN"
+    adapter.install_hint = "npm i -g @openai/codex"
+    adapter.auth_hint = "Run: codex login"
+    adapter.detect.return_value = MagicMock(
+        installed=True,
+        logged_in=None,
+        bin_path="/opt/homebrew/bin/codex",
+        detail="Auth status unknown.",
+    )
+    provider = MagicMock()
+    provider.value = "codex"
+    provider.label = "OpenAI Codex CLI"
+    provider.adapter_factory = lambda: adapter
+
+    choices = iter(["login", "repair"])
+    preflight_results = iter(
+        [
+            flow._LoginProcessResult(
+                returncode=1,
+                stdout="",
+                stderr=(
+                    "Error loading configuration: "
+                    f"{config_path}:2:16: unknown variant `priority`, expected `fast` or `flex`"
+                ),
+            ),
+            flow._LoginProcessResult(returncode=0),
+        ]
+    )
+    preflight_commands: list[list[str]] = []
+    login_commands: list[list[str]] = []
+
+    def _fake_preflight(command: list[str]) -> flow._LoginProcessResult:
+        preflight_commands.append(command)
+        return next(preflight_results)
+
+    def _fake_login(command: list[str]) -> flow._LoginProcessResult:
+        login_commands.append(command)
+        return flow._LoginProcessResult(returncode=0)
+
+    monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: next(choices))
+    monkeypatch.setattr(flow, "_run_login_preflight_process", _fake_preflight)
+    monkeypatch.setattr(flow, "_run_interactive_login_process", _fake_login)
+
+    result = flow._run_cli_llm_onboarding(provider, display_label="OpenAI OAuth")
+
+    assert result == "ok"
+    assert preflight_commands == [
+        ["/opt/homebrew/bin/codex", "login", "--help"],
+        ["/opt/homebrew/bin/codex", "login", "--help"],
+    ]
+    assert login_commands == [["/opt/homebrew/bin/codex", "login"]]
+    assert config_path.read_text(encoding="utf-8") == (
+        'model = "gpt-5.5"\nservice_tier = "fast"\n[features]\n'
+    )
 
 
 def test_run_cli_llm_onboarding_launches_claude_browser_login(monkeypatch) -> None:
@@ -1412,18 +1486,18 @@ def test_run_cli_llm_onboarding_launches_claude_browser_login(monkeypatch) -> No
     provider.adapter_factory = lambda: adapter
     login_commands: list[list[str]] = []
 
-    def _fake_run(command: list[str]) -> flow._LoginProcessResult:
+    def _fake_login(command: list[str]) -> flow._LoginProcessResult:
         login_commands.append(command)
         return flow._LoginProcessResult(returncode=0)
 
     monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "login")
-    monkeypatch.setattr(flow, "_run_login_process", _fake_run)
+    monkeypatch.setattr(flow, "_run_interactive_login_process", _fake_login)
 
     result = flow._run_cli_llm_onboarding(provider)
 
     assert result == "ok"
     assert login_commands == [["/opt/homebrew/bin/claude", "auth", "login"]]
-    assert len(detect_calls) == 2
+    assert len(detect_calls) == 1
 
 
 def test_run_cli_llm_onboarding_repick_when_auth_status_unclear(monkeypatch) -> None:

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -885,6 +885,48 @@ def test_get_agent_llm_returns_cli_backed_client_for_cli_providers(
     )
 
 
+def test_get_agent_llm_openai_oauth_routes_to_codex_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    from core.llm.agent_llm_client import (
+        CLIBackedAgentClient,
+        get_agent_llm,
+        reset_agent_client,
+    )
+
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_AUTH_METHOD", "oauth")
+    monkeypatch.setenv("CODEX_MODEL", "gpt-5.5")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    reset_agent_client()
+    client = get_agent_llm()
+
+    assert isinstance(client, CLIBackedAgentClient)
+    assert client._adapter.name == "codex"
+    assert client._model == "gpt-5.5"
+
+
+def test_get_agent_llm_anthropic_oauth_routes_to_claude_code_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from core.llm.agent_llm_client import (
+        CLIBackedAgentClient,
+        get_agent_llm,
+        reset_agent_client,
+    )
+
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+    monkeypatch.setenv("LLM_AUTH_METHOD", "oauth")
+    monkeypatch.setenv("CLAUDE_CODE_MODEL", "claude-opus-4-7")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    reset_agent_client()
+    client = get_agent_llm()
+
+    assert isinstance(client, CLIBackedAgentClient)
+    assert client._adapter.name == "claude-code"
+    assert client._model == "claude-opus-4-7"
+
+
 def test_cli_backed_agent_client_tool_call_parsing() -> None:
     """CLIBackedAgentClient correctly parses a JSON tool_calls response."""
     import types as _types


### PR DESCRIPTION
## Summary
- route OpenAI OAuth and Anthropic OAuth agent runtime calls through their CLI-backed providers instead of SDK clients that require API keys
- run Codex login as an interactive process so its localhost OAuth callback listener remains attached during browser login
- preflight Codex config before browser login and offer a known repair for stale `service_tier = "priority"`
- keep the fast `opensre --version` path and lazy CLI command loading type-clean under current lint/type gates

## Root cause
OpenAI OAuth was being treated inconsistently: generic LLM creation already mapped OAuth auth to CLI-backed providers, but the agent LLM client still branched on the raw provider and selected the OpenAI SDK path, which requires `OPENAI_API_KEY`. Separately, onboarding wrapped CLI login in a captured subprocess path that was not suitable for browser OAuth callback handling.

## Validation
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python infra/ci/run_test_scope.py --base origin/main` (`1181 passed, 30 skipped`)
