### PR TITLE
[codex] Fix CLI OAuth login status handling

### DIFF
--- a/cli/llm_auth/service.py
+++ b/cli/llm_auth/service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -186,11 +185,13 @@ def configure_cli_subscription_provider(
     if not probe.installed:
         raise AuthSetupError(f"{probe.detail} Install: {adapter.install_hint}")
 
+    login_completed = False
     if probe.logged_in is not True:
-        if launch_login and probe.bin_path and os.isatty(0):
+        if launch_login and probe.bin_path:
             _run_vendor_login(profile, probe.bin_path)
+            login_completed = True
             probe = adapter.detect()
-        if probe.logged_in is not True:
+        if probe.logged_in is not True and not login_completed:
             raise AuthSetupError(f"{probe.detail} {adapter.auth_hint}")
 
     selected_model = (model if model is not None else provider.default_model).strip()
@@ -199,7 +200,11 @@ def configure_cli_subscription_provider(
         if set_provider
         else None
     )
-    detail = probe.detail or f"{provider.label} is authenticated."
+    detail = (
+        f"{provider.label} login completed via {adapter.auth_hint.replace('Run: ', '')}."
+        if login_completed and probe.logged_in is not True
+        else probe.detail or f"{provider.label} is authenticated."
+    )
     _save_auth_record(provider=provider, profile=profile, source="vendor-cli", detail=detail)
     return AuthSetupResult(
         provider=provider.value,

--- a/tests/config/test_llm_auth.py
+++ b/tests/config/test_llm_auth.py
@@ -106,6 +106,28 @@ class _FakeAdapter:
         )
 
 
+class _InconclusiveAfterLoginAdapter:
+    name = "fake"
+    binary_env_key = "FAKE_BIN"
+    install_hint = "install fake"
+    auth_hint = "Run: fake login"
+    min_version = None
+    default_exec_timeout_sec = 30.0
+
+    def __init__(self) -> None:
+        self.detect_calls = 0
+
+    def detect(self) -> CLIProbe:
+        self.detect_calls += 1
+        return CLIProbe(
+            installed=True,
+            version="1.0.0",
+            logged_in=False if self.detect_calls == 1 else None,
+            bin_path="/usr/bin/fake",
+            detail="Login status unknown.",
+        )
+
+
 def test_configure_cli_subscription_syncs_provider(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -148,6 +170,58 @@ def test_configure_cli_subscription_syncs_provider(
         env_content = env_path.read_text(encoding="utf-8")
         assert "LLM_PROVIDER=codex\n" in env_content
         assert "CODEX_MODEL=gpt-5-codex\n" in env_content
+        assert resolve_provider_auth_record("codex")["source"] == "vendor-cli"
+    finally:
+        keyring.set_keyring(previous_backend)
+
+
+def test_configure_cli_subscription_accepts_successful_login_when_status_probe_unknown(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+    monkeypatch.setenv("OPENSRE_LLM_AUTH_METADATA_PATH", str(tmp_path / "llm-auth.json"))
+    monkeypatch.setattr(
+        "cli.wizard.store.get_store_path",
+        lambda: tmp_path / "opensre.json",
+    )
+    fake_provider = ProviderOption(
+        value="codex",
+        label="OpenAI Codex CLI",
+        group="Local CLI providers",
+        api_key_env="",
+        model_env="CODEX_MODEL",
+        default_model="",
+        models=(ModelOption(value="", label="default"),),
+        credential_kind="cli",
+        adapter_factory=_InconclusiveAfterLoginAdapter,
+        allow_custom_models=True,
+    )
+    monkeypatch.setattr("cli.llm_auth.service.provider_for_profile", lambda _profile: fake_provider)
+    login_commands: list[tuple[str, str]] = []
+
+    def _fake_run_vendor_login(profile: ProviderAuthProfile, binary_path: str) -> None:
+        login_commands.append((profile.provider_value, binary_path))
+
+    monkeypatch.setattr("cli.llm_auth.service._run_vendor_login", _fake_run_vendor_login)
+
+    previous_backend = keyring.get_keyring()
+    keyring.set_keyring(MemoryKeyring())
+    try:
+        env_path = tmp_path / ".env"
+        result = configure_cli_subscription_provider(
+            profile=ProviderAuthProfile(
+                name="chatgpt",
+                provider_value="codex",
+                label="ChatGPT subscription via Codex CLI",
+                kind="cli_subscription",
+            ),
+            model="gpt-5-codex",
+            env_path=env_path,
+        )
+
+        assert login_commands == [("codex", "/usr/bin/fake")]
+        assert result.provider == "codex"
+        assert result.detail == "OpenAI Codex CLI login completed via fake login."
         assert resolve_provider_auth_record("codex")["source"] == "vendor-cli"
     finally:
         keyring.set_keyring(previous_backend)


### PR DESCRIPTION
## Summary
- allow CLI subscription login flows to launch even when stdin is not a TTY-gated path
- accept a successful vendor login command when the post-login status probe remains inconclusive
- record a clear auth detail for completed vendor login flows and cover the behavior with tests

## Root cause
The auth-service path still assumed post-login status detection had to return `logged_in=True`. Browser OAuth CLIs can complete successfully while their immediate status probe remains unavailable or intentionally inconclusive, especially when callback handling is owned by the vendor CLI process.

## Validation
- `uv run pytest tests/config/test_llm_auth.py tests/cli/test_auth_command.py -q` (`10 passed`)
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python infra/ci/run_test_scope.py --base origin/main` (`719 passed, 1 skipped`)
