### PR TITLE
[codex] Avoid keychain reads during REPL startup

### DIFF
--- a/cli/llm_auth/service.py
+++ b/cli/llm_auth/service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -186,11 +185,13 @@ def configure_cli_subscription_provider(
     if not probe.installed:
         raise AuthSetupError(f"{probe.detail} Install: {adapter.install_hint}")
 
+    login_completed = False
     if probe.logged_in is not True:
-        if launch_login and probe.bin_path and os.isatty(0):
+        if launch_login and probe.bin_path:
             _run_vendor_login(profile, probe.bin_path)
+            login_completed = True
             probe = adapter.detect()
-        if probe.logged_in is not True:
+        if probe.logged_in is not True and not login_completed:
             raise AuthSetupError(f"{probe.detail} {adapter.auth_hint}")
 
     selected_model = (model if model is not None else provider.default_model).strip()
@@ -199,7 +200,11 @@ def configure_cli_subscription_provider(
         if set_provider
         else None
     )
-    detail = probe.detail or f"{provider.label} is authenticated."
+    detail = (
+        f"{provider.label} login completed via {adapter.auth_hint.replace('Run: ', '')}."
+        if login_completed and probe.logged_in is not True
+        else probe.detail or f"{provider.label} is authenticated."
+    )
     _save_auth_record(provider=provider, profile=profile, source="vendor-cli", detail=detail)
     return AuthSetupResult(
         provider=provider.value,

--- a/core/agent_harness/session/state.py
+++ b/core/agent_harness/session/state.py
@@ -453,20 +453,19 @@ class ReplSession:
                 self.accumulated_context[key] = value
 
     def hydrate_configured_integrations(self) -> None:
-        """Resolve configured integrations (env + local store) onto the session.
+        """Load configured integration names (env + local store) onto the session.
 
         Run at REPL boot and again whenever an integration is added or removed
         so capability checks and the tool-gathering pass reflect the current
-        store state instead of a stale boot-time snapshot. Resolution covers
-        both environment variables and the local ``~/.opensre`` store, so an
-        integration configured via ``/integrations setup`` (which writes to the
-        store) is seen here. Best-effort: any failure leaves the previously
-        known state untouched.
+        store state instead of a stale boot-time snapshot. This startup path is
+        intentionally metadata-only: it must not resolve keyring-backed secrets.
+        Full integration configs are resolved on demand when a turn needs tools
+        or an investigation starts.
         """
         try:
-            from integrations.verify import resolve_effective_integrations
+            from integrations.catalog import configured_integration_services
 
-            self.configured_integrations = tuple(sorted(resolve_effective_integrations()))
+            self.configured_integrations = tuple(sorted(configured_integration_services()))
             self.configured_integrations_known = True
         except Exception:
             # Best-effort: keep whatever state we already had (default unknown).

--- a/integrations/catalog.py
+++ b/integrations/catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from integrations import _catalog_impl
@@ -49,6 +50,104 @@ def resolve_effective_integrations(
     )
 
 
+def _env_is_set(name: str) -> bool:
+    return bool(os.getenv(name, "").strip())
+
+
+def _any_env(*names: str) -> bool:
+    return any(_env_is_set(name) for name in names)
+
+
+def _all_env(*names: str) -> bool:
+    return all(_env_is_set(name) for name in names)
+
+
+def load_env_integration_services() -> list[str]:
+    """Return integration services visible from plain env vars only.
+
+    This is the startup-safe companion to :func:`load_env_integrations`: it must
+    not resolve secrets from the OS keyring or build validated runtime configs.
+    It exists for surfaces that only need to display configured service names
+    before the first prompt.
+    """
+    services: list[str] = []
+
+    def add(service: str, configured: bool) -> None:
+        if configured:
+            services.append(service)
+
+    add(
+        "grafana",
+        _all_env("GRAFANA_INSTANCE_URL", "GRAFANA_READ_TOKEN") or _env_is_set("GRAFANA_INSTANCES"),
+    )
+    add("datadog", _all_env("DD_API_KEY", "DD_APP_KEY") or _env_is_set("DD_INSTANCES"))
+    add(
+        "groundcover",
+        _any_env("GROUNDCOVER_API_KEY", "GROUNDCOVER_MCP_TOKEN", "GROUNDCOVER_INSTANCES"),
+    )
+    add("honeycomb", _any_env("HONEYCOMB_API_KEY", "HONEYCOMB_INSTANCES"))
+    add("coralogix", _any_env("CORALOGIX_API_KEY", "CORALOGIX_INSTANCES"))
+    add(
+        "aws",
+        _any_env("AWS_INSTANCES", "AWS_ROLE_ARN")
+        or _all_env("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"),
+    )
+    add(
+        "github",
+        (_env_is_set("GITHUB_MCP_COMMAND") and os.getenv("GITHUB_MCP_MODE", "").strip() == "stdio")
+        or _env_is_set("GITHUB_MCP_URL"),
+    )
+    add("sentry", _all_env("SENTRY_ORG_SLUG", "SENTRY_AUTH_TOKEN"))
+    add("gitlab", _env_is_set("GITLAB_ACCESS_TOKEN"))
+    add("mongodb", _env_is_set("MONGODB_CONNECTION_STRING"))
+    add(
+        "argocd",
+        _env_is_set("ARGOCD_INSTANCES")
+        or (
+            _env_is_set("ARGOCD_BASE_URL")
+            and (
+                _any_env("ARGOCD_AUTH_TOKEN", "ARGOCD_TOKEN")
+                or _all_env("ARGOCD_USERNAME", "ARGOCD_PASSWORD")
+            )
+        ),
+    )
+    add("helm", os.getenv("OSRE_HELM_INTEGRATION", "").strip().lower() in {"1", "true", "yes"})
+    add("vercel", _env_is_set("VERCEL_API_TOKEN"))
+    add("opsgenie", _env_is_set("OPSGENIE_API_KEY"))
+    add("pagerduty", _env_is_set("PAGERDUTY_API_KEY"))
+    add("incident_io", _env_is_set("INCIDENT_IO_API_KEY"))
+    add("jira", _all_env("JIRA_BASE_URL", "JIRA_EMAIL", "JIRA_API_TOKEN"))
+    add("discord", _env_is_set("DISCORD_BOT_TOKEN"))
+    add("telegram", _env_is_set("TELEGRAM_BOT_TOKEN"))
+    add("smtp", _env_is_set("SMTP_HOST"))
+    add("whatsapp", _all_env("TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN", "TWILIO_WHATSAPP_FROM"))
+    add(
+        "twilio",
+        _all_env("TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN")
+        and _any_env("TWILIO_SMS_FROM", "TWILIO_SMS_MESSAGING_SERVICE_SID"),
+    )
+    add(
+        "mongodb_atlas",
+        _all_env(
+            "MONGODB_ATLAS_PUBLIC_KEY", "MONGODB_ATLAS_PRIVATE_KEY", "MONGODB_ATLAS_PROJECT_ID"
+        ),
+    )
+    add(
+        "openclaw",
+        (
+            _env_is_set("OPENCLAW_MCP_COMMAND")
+            and os.getenv("OPENCLAW_MCP_MODE", "").strip().lower() == "stdio"
+        )
+        or _env_is_set("OPENCLAW_MCP_URL"),
+    )
+    add("posthog_mcp", _any_env("POSTHOG_MCP_COMMAND", "POSTHOG_MCP_URL", "POSTHOG_MCP_AUTH_TOKEN"))
+    add("sentry_mcp", _any_env("SENTRY_MCP_COMMAND", "SENTRY_MCP_URL", "SENTRY_MCP_AUTH_TOKEN"))
+    add("mariadb", _all_env("MARIADB_HOST", "MARIADB_DATABASE"))
+    add("opensearch", _env_is_set("OPENSEARCH_URL"))
+
+    return list(dict.fromkeys(services))
+
+
 def configured_integration_services() -> list[str]:
     """Return lowercase service keys for integrations configured via env or the local store.
 
@@ -62,11 +161,11 @@ def configured_integration_services() -> list[str]:
     services: list[str] = []
 
     try:
-        env_records = load_env_integrations()
+        env_services = load_env_integration_services()
     except Exception:
-        env_records = []
-    for record in env_records:
-        service = str(record.get("service", "")).strip().lower()
+        env_services = []
+    for service in env_services:
+        service = str(service).strip().lower()
         if service:
             services.append(service)
 
@@ -121,22 +220,45 @@ def configured_integration_health() -> list[tuple[str, str]]:
     if not services:
         return []
 
+    store_config_by_service: dict[str, dict[str, Any]] = {}
     try:
-        effective = resolve_effective_integrations()
+        store_records = load_integrations()
     except Exception:
-        # Health can't be determined offline; list everything without alarming.
-        return [(service, "ok") for service in services]
+        store_records = []
+    for record in store_records:
+        if str(record.get("status", "active")).strip().lower() != "active":
+            continue
+        service = str(record.get("service", "")).strip().lower()
+        if not service:
+            continue
+        credentials = record.get("credentials")
+        if isinstance(credentials, dict):
+            store_config_by_service.setdefault(service, credentials)
+            continue
+        instances = record.get("instances")
+        if isinstance(instances, list):
+            for instance in instances:
+                if not isinstance(instance, dict):
+                    continue
+                instance_credentials = instance.get("credentials")
+                if isinstance(instance_credentials, dict):
+                    store_config_by_service.setdefault(service, instance_credentials)
+                    break
 
     health: list[tuple[str, str]] = []
     for service in services:
-        entry = effective.get(service)
-        if entry is None:
-            # Present in the store/env but its credentials did not classify into
-            # a usable config (a required secret is missing).
-            health.append((service, "incomplete"))
-            continue
-        config = entry.get("config") if isinstance(entry, dict) else None
-        if isinstance(config, dict) and _hosted_mcp_missing_token(service, config):
+        config = store_config_by_service.get(service, {})
+        if service == "posthog_mcp" and not config:
+            config = {
+                "mode": os.getenv("POSTHOG_MCP_MODE", "streamable-http").strip().lower(),
+                "auth_token": os.getenv("POSTHOG_MCP_AUTH_TOKEN", "").strip(),
+            }
+        elif service == "sentry_mcp" and not config:
+            config = {
+                "mode": os.getenv("SENTRY_MCP_MODE", "streamable-http").strip().lower(),
+                "auth_token": os.getenv("SENTRY_MCP_AUTH_TOKEN", "").strip(),
+            }
+        if _hosted_mcp_missing_token(service, config):
             health.append((service, "incomplete"))
             continue
         health.append((service, "ok"))
@@ -147,6 +269,7 @@ __all__ = [
     "classify_integrations",
     "configured_integration_health",
     "configured_integration_services",
+    "load_env_integration_services",
     "load_env_integrations",
     "load_integrations",
     "merge_integrations_by_service",

--- a/interactive_shell/controller.py
+++ b/interactive_shell/controller.py
@@ -161,7 +161,6 @@ class InteractiveShellController:
         self.tasks: list[tuple[str, asyncio.Task[None]]] = []
 
     async def start_interactive_shell(self) -> None:
-        self.session.schedule_warm_resolved_integrations()
         with _alert_listener(self.config, self.service_console, existing=self.inbox) as inbox:
             self.inbox = inbox
             self.runtime_context.inbox = inbox

--- a/tests/config/test_llm_auth.py
+++ b/tests/config/test_llm_auth.py
@@ -106,6 +106,28 @@ class _FakeAdapter:
         )
 
 
+class _InconclusiveAfterLoginAdapter:
+    name = "fake"
+    binary_env_key = "FAKE_BIN"
+    install_hint = "install fake"
+    auth_hint = "Run: fake login"
+    min_version = None
+    default_exec_timeout_sec = 30.0
+
+    def __init__(self) -> None:
+        self.detect_calls = 0
+
+    def detect(self) -> CLIProbe:
+        self.detect_calls += 1
+        return CLIProbe(
+            installed=True,
+            version="1.0.0",
+            logged_in=False if self.detect_calls == 1 else None,
+            bin_path="/usr/bin/fake",
+            detail="Login status unknown.",
+        )
+
+
 def test_configure_cli_subscription_syncs_provider(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -148,6 +170,58 @@ def test_configure_cli_subscription_syncs_provider(
         env_content = env_path.read_text(encoding="utf-8")
         assert "LLM_PROVIDER=codex\n" in env_content
         assert "CODEX_MODEL=gpt-5-codex\n" in env_content
+        assert resolve_provider_auth_record("codex")["source"] == "vendor-cli"
+    finally:
+        keyring.set_keyring(previous_backend)
+
+
+def test_configure_cli_subscription_accepts_successful_login_when_status_probe_unknown(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+    monkeypatch.setenv("OPENSRE_LLM_AUTH_METADATA_PATH", str(tmp_path / "llm-auth.json"))
+    monkeypatch.setattr(
+        "cli.wizard.store.get_store_path",
+        lambda: tmp_path / "opensre.json",
+    )
+    fake_provider = ProviderOption(
+        value="codex",
+        label="OpenAI Codex CLI",
+        group="Local CLI providers",
+        api_key_env="",
+        model_env="CODEX_MODEL",
+        default_model="",
+        models=(ModelOption(value="", label="default"),),
+        credential_kind="cli",
+        adapter_factory=_InconclusiveAfterLoginAdapter,
+        allow_custom_models=True,
+    )
+    monkeypatch.setattr("cli.llm_auth.service.provider_for_profile", lambda _profile: fake_provider)
+    login_commands: list[tuple[str, str]] = []
+
+    def _fake_run_vendor_login(profile: ProviderAuthProfile, binary_path: str) -> None:
+        login_commands.append((profile.provider_value, binary_path))
+
+    monkeypatch.setattr("cli.llm_auth.service._run_vendor_login", _fake_run_vendor_login)
+
+    previous_backend = keyring.get_keyring()
+    keyring.set_keyring(MemoryKeyring())
+    try:
+        env_path = tmp_path / ".env"
+        result = configure_cli_subscription_provider(
+            profile=ProviderAuthProfile(
+                name="chatgpt",
+                provider_value="codex",
+                label="ChatGPT subscription via Codex CLI",
+                kind="cli_subscription",
+            ),
+            model="gpt-5-codex",
+            env_path=env_path,
+        )
+
+        assert login_commands == [("codex", "/usr/bin/fake")]
+        assert result.provider == "codex"
+        assert result.detail == "OpenAI Codex CLI login completed via fake login."
         assert resolve_provider_auth_record("codex")["source"] == "vendor-cli"
     finally:
         keyring.set_keyring(previous_backend)

--- a/tests/integrations/test_configured_integration_services.py
+++ b/tests/integrations/test_configured_integration_services.py
@@ -15,13 +15,8 @@ from integrations import catalog
 def test_returns_lowercase_service_keys_deduplicated(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         catalog,
-        "load_env_integrations",
-        lambda: [
-            {"service": "GitLab"},
-            {"service": "datadog"},
-            {"service": "gitlab"},  # duplicate (case-insensitive)
-            {"service": ""},  # ignored
-        ],
+        "load_env_integration_services",
+        lambda: ["GitLab", "datadog", "gitlab", ""],
     )
     monkeypatch.setattr(catalog, "load_integrations", list)
     assert catalog.configured_integration_services() == ["gitlab", "datadog"]
@@ -30,8 +25,8 @@ def test_returns_lowercase_service_keys_deduplicated(monkeypatch: Any) -> None:
 def test_includes_active_store_integrations_and_dedupes_with_env(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         catalog,
-        "load_env_integrations",
-        lambda: [{"service": "sentry"}, {"service": "gitlab"}],
+        "load_env_integration_services",
+        lambda: ["sentry", "gitlab"],
     )
     monkeypatch.setattr(
         catalog,
@@ -47,19 +42,19 @@ def test_includes_active_store_integrations_and_dedupes_with_env(monkeypatch: An
 
 
 def test_returns_empty_list_when_env_loader_raises(monkeypatch: Any) -> None:
-    def _boom() -> list[dict[str, Any]]:
+    def _boom() -> list[str]:
         raise RuntimeError("env unreadable")
 
-    monkeypatch.setattr(catalog, "load_env_integrations", _boom)
+    monkeypatch.setattr(catalog, "load_env_integration_services", _boom)
     monkeypatch.setattr(catalog, "load_integrations", list)
     assert catalog.configured_integration_services() == []
 
 
 def test_store_only_when_env_loader_raises(monkeypatch: Any) -> None:
-    def _boom() -> list[dict[str, Any]]:
+    def _boom() -> list[str]:
         raise RuntimeError("env unreadable")
 
-    monkeypatch.setattr(catalog, "load_env_integrations", _boom)
+    monkeypatch.setattr(catalog, "load_env_integration_services", _boom)
     monkeypatch.setattr(
         catalog,
         "load_integrations",
@@ -69,9 +64,32 @@ def test_store_only_when_env_loader_raises(monkeypatch: Any) -> None:
 
 
 def test_empty_when_no_integrations(monkeypatch: Any) -> None:
-    monkeypatch.setattr(catalog, "load_env_integrations", list)
+    monkeypatch.setattr(catalog, "load_env_integration_services", list)
     monkeypatch.setattr(catalog, "load_integrations", list)
     assert catalog.configured_integration_services() == []
+
+
+def test_configured_services_do_not_call_full_env_loader(monkeypatch: Any) -> None:
+    def _full_loader_should_not_run() -> list[dict[str, Any]]:
+        raise AssertionError("startup metadata path must not resolve env integrations")
+
+    monkeypatch.setattr(catalog, "load_env_integrations", _full_loader_should_not_run)
+    monkeypatch.setattr(catalog, "load_env_integration_services", lambda: ["gitlab"])
+    monkeypatch.setattr(catalog, "load_integrations", list)
+
+    assert catalog.configured_integration_services() == ["gitlab"]
+
+
+def test_env_service_list_uses_plain_env_without_keyring(monkeypatch: Any) -> None:
+    monkeypatch.setenv("GITLAB_ACCESS_TOKEN", "from-env")
+    monkeypatch.delenv("POSTHOG_MCP_AUTH_TOKEN", raising=False)
+
+    def _keyring_should_not_run(*_args: Any, **_kwargs: Any) -> str:
+        raise AssertionError("startup metadata path must not read keyring")
+
+    monkeypatch.setattr("keyring.get_password", _keyring_should_not_run)
+
+    assert "gitlab" in catalog.load_env_integration_services()
 
 
 class TestConfiguredIntegrationHealth:
@@ -86,41 +104,34 @@ class TestConfiguredIntegrationHealth:
         monkeypatch.setattr(
             catalog, "configured_integration_services", lambda: ["datadog", "gitlab"]
         )
-        monkeypatch.setattr(
-            catalog,
-            "resolve_effective_integrations",
-            lambda: {
-                "datadog": {"source": "store", "config": {"api_key": "k", "app_key": "a"}},
-                "gitlab": {"source": "store", "config": {"auth_token": "t"}},
-            },
-        )
+        monkeypatch.setattr(catalog, "load_integrations", list)
         assert catalog.configured_integration_health() == [
             ("datadog", "ok"),
             ("gitlab", "ok"),
         ]
 
-    def test_incomplete_when_present_but_not_classified(self, monkeypatch: Any) -> None:
-        # Present in the store/env but its required secret did not classify into
-        # a usable config, so it resolves to nothing effective.
-        monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["datadog"])
-        monkeypatch.setattr(catalog, "resolve_effective_integrations", dict)
-        assert catalog.configured_integration_health() == [("datadog", "incomplete")]
-
     def test_hosted_mcp_without_token_is_incomplete(self, monkeypatch: Any) -> None:
         monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["posthog_mcp"])
         monkeypatch.setattr(
             catalog,
-            "resolve_effective_integrations",
-            lambda: {
-                "posthog_mcp": {
-                    "source": "store",
-                    "config": {
-                        "mode": "streamable-http",
-                        "url": "https://mcp.posthog.com/mcp",
-                        "auth_token": "",
-                    },
-                },
-            },
+            "load_integrations",
+            lambda: [
+                {
+                    "service": "posthog_mcp",
+                    "status": "active",
+                    "instances": [
+                        {
+                            "name": "default",
+                            "tags": {},
+                            "credentials": {
+                                "mode": "streamable-http",
+                                "url": "https://mcp.posthog.com/mcp",
+                                "auth_token": "",
+                            },
+                        }
+                    ],
+                }
+            ],
         )
         assert catalog.configured_integration_health() == [("posthog_mcp", "incomplete")]
 
@@ -128,17 +139,24 @@ class TestConfiguredIntegrationHealth:
         monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["posthog_mcp"])
         monkeypatch.setattr(
             catalog,
-            "resolve_effective_integrations",
-            lambda: {
-                "posthog_mcp": {
-                    "source": "store",
-                    "config": {
-                        "mode": "streamable-http",
-                        "url": "https://mcp.posthog.com/mcp",
-                        "auth_token": "phx_secret",
-                    },
-                },
-            },
+            "load_integrations",
+            lambda: [
+                {
+                    "service": "posthog_mcp",
+                    "status": "active",
+                    "instances": [
+                        {
+                            "name": "default",
+                            "tags": {},
+                            "credentials": {
+                                "mode": "streamable-http",
+                                "url": "https://mcp.posthog.com/mcp",
+                                "auth_token": "phx_secret",
+                            },
+                        }
+                    ],
+                }
+            ],
         )
         assert catalog.configured_integration_health() == [("posthog_mcp", "ok")]
 
@@ -147,13 +165,20 @@ class TestConfiguredIntegrationHealth:
         monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["posthog_mcp"])
         monkeypatch.setattr(
             catalog,
-            "resolve_effective_integrations",
-            lambda: {
-                "posthog_mcp": {
-                    "source": "store",
-                    "config": {"mode": "stdio", "command": "npx", "auth_token": ""},
-                },
-            },
+            "load_integrations",
+            lambda: [
+                {
+                    "service": "posthog_mcp",
+                    "status": "active",
+                    "instances": [
+                        {
+                            "name": "default",
+                            "tags": {},
+                            "credentials": {"mode": "stdio", "command": "npx", "auth_token": ""},
+                        }
+                    ],
+                }
+            ],
         )
         assert catalog.configured_integration_health() == [("posthog_mcp", "ok")]
 
@@ -161,28 +186,29 @@ class TestConfiguredIntegrationHealth:
         # Only the hosted-MCP token rule applies; an unrelated service that
         # classified successfully stays "ok" even if it lacks an auth_token key.
         monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["github"])
-        monkeypatch.setattr(
-            catalog,
-            "resolve_effective_integrations",
-            lambda: {
-                "github": {
-                    "source": "store",
-                    "config": {"mode": "streamable-http", "auth_token": ""},
-                },
-            },
-        )
+        monkeypatch.setattr(catalog, "load_integrations", list)
         assert catalog.configured_integration_health() == [("github", "ok")]
 
     def test_empty_when_no_integrations(self, monkeypatch: Any) -> None:
         monkeypatch.setattr(catalog, "configured_integration_services", list)
         assert catalog.configured_integration_health() == []
 
-    def test_defaults_ok_when_resolution_raises(self, monkeypatch: Any) -> None:
-        def _boom() -> dict[str, Any]:
+    def test_defaults_ok_when_store_load_raises(self, monkeypatch: Any) -> None:
+        def _boom() -> list[dict[str, Any]]:
             raise RuntimeError("store unreadable")
 
         monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["datadog"])
-        monkeypatch.setattr(catalog, "resolve_effective_integrations", _boom)
+        monkeypatch.setattr(catalog, "load_integrations", _boom)
         # Resolution failure must not crash the banner or alarm the user: when
         # health can't be determined offline, every service falls back to "ok".
+        assert catalog.configured_integration_health() == [("datadog", "ok")]
+
+    def test_health_does_not_call_effective_resolution(self, monkeypatch: Any) -> None:
+        def _resolve_should_not_run() -> dict[str, Any]:
+            raise AssertionError("startup health must not resolve secrets")
+
+        monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["datadog"])
+        monkeypatch.setattr(catalog, "load_integrations", list)
+        monkeypatch.setattr(catalog, "resolve_effective_integrations", _resolve_should_not_run)
+
         assert catalog.configured_integration_health() == [("datadog", "ok")]

--- a/tests/interactive_shell/command_registry/test_integrations_refresh.py
+++ b/tests/interactive_shell/command_registry/test_integrations_refresh.py
@@ -29,8 +29,8 @@ def _noop_cli_command(*_args: Any, **_kwargs: Any) -> bool:
 
 def test_refresh_integration_state_rehydrates_and_clears_cache(monkeypatch: Any) -> None:
     monkeypatch.setattr(
-        "integrations.verify.resolve_effective_integrations",
-        lambda: {"gitlab": {}, "sentry": {}},
+        "integrations.catalog.configured_integration_services",
+        lambda: ["gitlab", "sentry"],
     )
     refreshed = {"gitlab": {"token": "x"}, "sentry": {"dsn": "y"}}
     monkeypatch.setattr(
@@ -57,8 +57,12 @@ def test_setup_subcommand_refreshes_configured_integrations(monkeypatch: Any) ->
 
     store: dict[str, dict[str, Any]] = {"gitlab": {}}
     monkeypatch.setattr(
-        "integrations.verify.resolve_effective_integrations",
-        lambda: dict(store),
+        "integrations.catalog.configured_integration_services",
+        lambda: list(store),
+    )
+    monkeypatch.setattr(
+        "tools.investigation.stages.resolve_integrations.resolve_integrations_quiet",
+        lambda _state: dict(store),
     )
 
     session = ReplSession()
@@ -78,8 +82,12 @@ def test_remove_subcommand_refreshes_configured_integrations(monkeypatch: Any) -
 
     store: dict[str, dict[str, Any]] = {"gitlab": {}, "sentry": {}}
     monkeypatch.setattr(
-        "integrations.verify.resolve_effective_integrations",
-        lambda: dict(store),
+        "integrations.catalog.configured_integration_services",
+        lambda: list(store),
+    )
+    monkeypatch.setattr(
+        "tools.investigation.stages.resolve_integrations.resolve_integrations_quiet",
+        lambda _state: dict(store),
     )
 
     session = ReplSession()
@@ -98,8 +106,12 @@ def test_mcp_connect_refreshes_configured_integrations(monkeypatch: Any) -> None
 
     store: dict[str, dict[str, Any]] = {"gitlab": {}}
     monkeypatch.setattr(
-        "integrations.verify.resolve_effective_integrations",
-        lambda: dict(store),
+        "integrations.catalog.configured_integration_services",
+        lambda: list(store),
+    )
+    monkeypatch.setattr(
+        "tools.investigation.stages.resolve_integrations.resolve_integrations_quiet",
+        lambda _state: dict(store),
     )
 
     session = ReplSession()

--- a/tests/interactive_shell/runtime/test_entrypoint_integrations.py
+++ b/tests/interactive_shell/runtime/test_entrypoint_integrations.py
@@ -23,20 +23,20 @@ def _console() -> Console:
 
 def test_hydrate_populates_session_from_effective_resolution(monkeypatch: Any) -> None:
     monkeypatch.setattr(
-        "integrations.verify.resolve_effective_integrations",
-        lambda: {"gitlab": {}, "datadog": {}},
+        "integrations.catalog.configured_integration_services",
+        lambda: ["gitlab", "datadog"],
     )
     session = ReplSession()
     session.hydrate_configured_integrations()
     assert session.configured_integrations_known is True
-    # Resolution covers env + local store and is returned in sorted order.
+    # Metadata discovery covers env + local store and is returned in sorted order.
     assert session.configured_integrations == ("datadog", "gitlab")
 
 
 def test_hydrate_marks_known_even_when_none_configured(monkeypatch: Any) -> None:
     monkeypatch.setattr(
-        "integrations.verify.resolve_effective_integrations",
-        dict,
+        "integrations.catalog.configured_integration_services",
+        list,
     )
     session = ReplSession()
     session.hydrate_configured_integrations()
@@ -124,8 +124,8 @@ def test_stale_background_warm_does_not_overwrite_refreshed_cache() -> None:
 
 def test_hydrate_entrypoint_does_not_warm_before_prompt(monkeypatch: Any) -> None:
     monkeypatch.setattr(
-        "integrations.verify.resolve_effective_integrations",
-        lambda: {"datadog": {}},
+        "integrations.catalog.configured_integration_services",
+        lambda: ["datadog"],
     )
     resolve_calls: list[str] = []
 
@@ -166,11 +166,11 @@ def test_schedule_warm_resolved_integrations_runs_in_background(
 
 
 def test_hydrate_leaves_unknown_on_failure(monkeypatch: Any) -> None:
-    def _boom() -> dict[str, Any]:
+    def _boom() -> list[str]:
         raise RuntimeError("catalog blew up")
 
     monkeypatch.setattr(
-        "integrations.verify.resolve_effective_integrations",
+        "integrations.catalog.configured_integration_services",
         _boom,
     )
     session = ReplSession()


### PR DESCRIPTION
## Summary
- add startup-safe integration service discovery that uses only local store metadata and plain env-var presence
- change REPL startup hydration to avoid resolving full integration configs and keyring-backed secrets
- stop scheduling full integration warmup before the first prompt, while preserving explicit refresh/tool/investigation resolution paths

## Root Cause
OpenSRE startup rendered integration health and hydrated REPL session capabilities by calling full integration resolution. That path can fall through to `resolve_env_credential()`, which reads from the OS keyring for absent env vars and can trigger macOS Keychain prompts before the user enters a command.

## Validation
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run pytest tests/integrations/test_configured_integration_services.py tests/interactive_shell/runtime/test_entrypoint_integrations.py tests/interactive_shell/runtime/test_context.py tests/interactive_shell/command_registry/test_integrations_refresh.py tests/interactive_shell/command_registry/test_repl_data.py -q`
- startup smoke with `keyring.get_password` patched to raise

Note: `make test-scope` escalated to full `make test-cov` due base diff breadth and was interrupted on request at 92% after showing passing progress up to that point.
