### PR TITLE
[codex] fix Codex OAuth callback login

### DIFF
--- a/cli/llm_auth/service.py
+++ b/cli/llm_auth/service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -186,11 +185,13 @@ def configure_cli_subscription_provider(
     if not probe.installed:
         raise AuthSetupError(f"{probe.detail} Install: {adapter.install_hint}")
 
+    login_completed = False
     if probe.logged_in is not True:
-        if launch_login and probe.bin_path and os.isatty(0):
+        if launch_login and probe.bin_path:
             _run_vendor_login(profile, probe.bin_path)
+            login_completed = True
             probe = adapter.detect()
-        if probe.logged_in is not True:
+        if probe.logged_in is not True and not login_completed:
             raise AuthSetupError(f"{probe.detail} {adapter.auth_hint}")
 
     selected_model = (model if model is not None else provider.default_model).strip()
@@ -199,7 +200,11 @@ def configure_cli_subscription_provider(
         if set_provider
         else None
     )
-    detail = probe.detail or f"{provider.label} is authenticated."
+    detail = (
+        f"{provider.label} login completed via {adapter.auth_hint.replace('Run: ', '')}."
+        if login_completed and probe.logged_in is not True
+        else probe.detail or f"{provider.label} is authenticated."
+    )
     _save_auth_record(provider=provider, profile=profile, source="vendor-cli", detail=detail)
     return AuthSetupResult(
         provider=provider.value,

--- a/cli/llm_auth/service.py
+++ b/cli/llm_auth/service.py
@@ -12,9 +12,10 @@ from cli.llm_auth.providers import (
     provider_for_profile,
     resolve_auth_profile,
 )
-from cli.wizard.config import ProviderOption
+from cli.wizard.config import PROVIDER_BY_VALUE, ProviderOption
 from cli.wizard.env_sync import sync_provider_env
 from cli.wizard.validation import validate_provider_credentials
+from config.llm_auth.auth_method import OAUTH_AUTH_METHOD
 from config.llm_auth.credentials import (
     delete as delete_provider_auth,
 )
@@ -35,6 +36,7 @@ from config.llm_auth.records import (
 from config.llm_credentials import (
     save_llm_api_key,
 )
+from integrations.llm_cli.codex_oauth import CodexOAuthError, run_codex_oauth_login
 
 
 class AuthSetupError(RuntimeError):
@@ -150,21 +152,12 @@ def configure_api_key_provider(
     )
 
 
-def _subscription_login_command(profile: ProviderAuthProfile, binary_path: str) -> list[str]:
-    if profile.provider_value == "codex":
-        return [binary_path, "login"]
-    if profile.provider_value == "claude-code":
-        return [binary_path, "auth", "login"]
-    raise AuthSetupError(f"No interactive login command is registered for {profile.label}.")
-
-
-def _run_vendor_login(profile: ProviderAuthProfile, binary_path: str) -> None:
+def _managed_codex_login_detail() -> str:
     try:
-        result = subprocess.run(_subscription_login_command(profile, binary_path), check=False)
-    except OSError as exc:
-        raise AuthSetupError(f"Could not launch {profile.label} login: {exc}") from exc
-    if result.returncode != 0:
-        raise AuthSetupError(f"{profile.label} login exited with code {result.returncode}.")
+        result = run_codex_oauth_login()
+    except CodexOAuthError as exc:
+        raise AuthSetupError(str(exc)) from exc
+    return result.detail
 
 
 def configure_cli_subscription_provider(
@@ -185,13 +178,44 @@ def configure_cli_subscription_provider(
     if not probe.installed:
         raise AuthSetupError(f"{probe.detail} Install: {adapter.install_hint}")
 
-    login_completed = False
     if probe.logged_in is not True:
-        if launch_login and probe.bin_path:
-            _run_vendor_login(profile, probe.bin_path)
-            login_completed = True
+        if profile.provider_value == "codex" and launch_login:
+            detail = _managed_codex_login_detail()
+            selected_model = (model if model is not None else provider.default_model).strip()
+            public_provider = PROVIDER_BY_VALUE["openai"]
+            written_path = (
+                sync_provider_env(
+                    provider=public_provider,
+                    model=selected_model,
+                    model_provider=provider,
+                    auth_method=OAUTH_AUTH_METHOD,
+                    env_path=env_path,
+                )
+                if set_provider
+                else None
+            )
+            _save_auth_record(
+                provider=provider,
+                profile=profile,
+                source="codex-oauth",
+                detail=detail,
+            )
+            return AuthSetupResult(
+                provider=provider.value,
+                model=selected_model,
+                source="codex-oauth",
+                detail=detail,
+                env_path=written_path,
+            )
+        if profile.provider_value == "claude-code" and launch_login and probe.bin_path:
+            try:
+                result = subprocess.run([probe.bin_path, "auth", "login"], check=False)
+            except OSError as exc:
+                raise AuthSetupError(f"Could not launch {profile.label} login: {exc}") from exc
+            if result.returncode != 0:
+                raise AuthSetupError(f"{profile.label} login exited with code {result.returncode}.")
             probe = adapter.detect()
-        if probe.logged_in is not True and not login_completed:
+        if probe.logged_in is not True:
             raise AuthSetupError(f"{probe.detail} {adapter.auth_hint}")
 
     selected_model = (model if model is not None else provider.default_model).strip()
@@ -200,11 +224,7 @@ def configure_cli_subscription_provider(
         if set_provider
         else None
     )
-    detail = (
-        f"{provider.label} login completed via {adapter.auth_hint.replace('Run: ', '')}."
-        if login_completed and probe.logged_in is not True
-        else probe.detail or f"{provider.label} is authenticated."
-    )
+    detail = probe.detail or f"{provider.label} is authenticated."
     _save_auth_record(provider=provider, profile=profile, source="vendor-cli", detail=detail)
     return AuthSetupResult(
         provider=provider.value,
@@ -236,6 +256,22 @@ def provider_status(raw_name: str) -> AuthStatus:
             detail,
             verified=resolved.verified,
             stale=resolved.stale,
+        )
+
+    record_verified = (record.get("verified") or "").strip().lower()
+    record_stale = (record.get("stale") or "").strip().lower()
+    if (
+        record.get("source") == "codex-oauth"
+        and record_verified != "false"
+        and record_stale != "true"
+    ):
+        return AuthStatus(
+            provider.value,
+            profile.label,
+            True,
+            "codex-oauth",
+            record.get("detail") or "OpenAI OAuth tokens are stored for Codex.",
+            verified=True,
         )
 
     if provider.adapter_factory is None:

--- a/cli/wizard/flow.py
+++ b/cli/wizard/flow.py
@@ -46,7 +46,9 @@ from config.llm_auth.auth_method import (
     normalize_llm_auth_method,
     supports_oauth_auth_method,
 )
+from config.llm_auth.records import save_provider_auth_record
 from integrations.llm_cli.binary_resolver import diagnose_binary_path
+from integrations.llm_cli.codex_oauth import CodexOAuthError, run_codex_oauth_login
 from platform.terminal.theme import (
     ERROR,
     GLYPH_ERROR,
@@ -370,6 +372,26 @@ def _run_subscription_login(
     provider: ProviderOption, binary_path: str | None
 ) -> _SubscriptionLoginResult:
     """Launch the provider CLI login flow and report whether it exited cleanly."""
+    if provider.value == "codex":
+        _console.print(
+            f"[{SECONDARY}]Starting OpenSRE Codex OAuth server on http://localhost:1455[/]"
+        )
+        try:
+            oauth_result = run_codex_oauth_login()
+        except CodexOAuthError as exc:
+            detail = str(exc)
+            _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
+            return _SubscriptionLoginResult(ok=False, detail=detail)
+        save_provider_auth_record(
+            provider="codex",
+            auth_name="chatgpt",
+            kind="cli_subscription",
+            source="codex-oauth",
+            detail=oauth_result.detail,
+        )
+        _console.print(f"[{SECONDARY}]{oauth_result.detail}[/]")
+        return _SubscriptionLoginResult(ok=True, detail=oauth_result.detail)
+
     command = _subscription_login_command(provider, binary_path)
     if command is None:
         auth_hint = provider.adapter_factory().auth_hint if provider.adapter_factory else ""

--- a/config/llm_auth/credentials.py
+++ b/config/llm_auth/credentials.py
@@ -152,6 +152,19 @@ def status(provider: str) -> CredentialStatus:
         )
 
     if spec.credential_kind == "cli":
+        record = resolve_provider_auth_record(spec.value)
+        record_source = _normalize_source(record.get("source"), fallback="metadata")
+        stale = _bool_record_value(record, "stale", False)
+        verified = _bool_record_value(record, "verified", False)
+        if record and verified and not stale:
+            return CredentialStatus(
+                provider=spec.value,
+                configured=True,
+                source="cli" if record_source in {"metadata", "unknown", "none"} else record_source,
+                verified=True,
+                stale=False,
+                detail=record.get("detail") or f"{spec.label} auth metadata is present.",
+            )
         try:
             from integrations.llm_cli.registry import get_cli_provider_registration
 

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -12,7 +12,7 @@ OpenSRE is provider-agnostic: bring your own model. Selection is controlled by t
 | Anthropic API key | `anthropic` + `LLM_AUTH_METHOD=api_key` | `ANTHROPIC_API_KEY` | `claude-sonnet-4-6` | `claude-haiku-4-5-20251001` |
 | Anthropic OAuth | `anthropic` + `LLM_AUTH_METHOD=oauth` | Onboarding launches `claude auth login` | Claude Code CLI default | Claude Code CLI default |
 | OpenAI API key | `openai` + `LLM_AUTH_METHOD=api_key` | `OPENAI_API_KEY` | `gpt-5.4-mini` | `gpt-5.4-mini` |
-| OpenAI OAuth | `openai` + `LLM_AUTH_METHOD=oauth` | Onboarding launches `codex login` | Codex CLI default | Codex CLI default |
+| OpenAI OAuth | `openai` + `LLM_AUTH_METHOD=oauth` | OpenSRE opens `localhost:1455` for Codex-compatible OAuth | Codex CLI default | Codex CLI default |
 | OpenRouter   | `openrouter`   | `OPENROUTER_API_KEY`            | `openrouter/auto`                             | `openrouter/auto`                               |
 | DeepSeek     | `deepseek`     | `DEEPSEEK_API_KEY`              | `deepseek-v4-pro`                             | `deepseek-v4-flash`                             |
 | Google Gemini API key | `gemini` | `GEMINI_API_KEY`               | `gemini-3.1-pro-preview`                      | `gemini-3.1-flash-lite-preview`                 |
@@ -84,18 +84,24 @@ Use `opensre auth` for provider login without writing secrets to `.env`:
 | `opensre auth` | Show auth status for subscription and API-key providers |
 | `opensre auth login deepseek` | Open DeepSeek setup guidance, validate `DEEPSEEK_API_KEY`, store it in the system keychain, and select DeepSeek |
 | `opensre auth login claude` | Configure the `claude-code` provider through Claude Code CLI subscription login |
-| `opensre auth login chatgpt` | Configure the `codex` provider through Codex CLI / ChatGPT subscription login |
+| `opensre auth login chatgpt` | Configure the `codex` provider through OpenSRE-managed ChatGPT OAuth |
 | `opensre auth verify deepseek` | Intentionally resolve DeepSeek credentials and refresh stale local metadata |
 | `opensre auth logout deepseek` | Remove OpenSRE-managed DeepSeek credentials and metadata |
 
-`opensre auth login` never reads browser cookies, browser profiles, browser local storage, or IndexedDB. API-key providers use hidden paste prompts plus keyring storage. Subscription providers delegate OAuth/session handling to the vendor CLI that owns the browser login flow.
+`opensre auth login` never reads browser cookies, browser profiles, browser local storage, or IndexedDB. API-key providers use hidden paste prompts plus keyring storage. OpenAI OAuth is handled by OpenSRE's local Codex-compatible callback server; other subscription providers delegate OAuth/session handling to the vendor CLI that owns the browser login flow.
 
 `opensre auth` and `/auth status` are prompt-safe: they do not read API-key secrets from Keychain. For API-key providers they inspect environment variables plus non-secret metadata in `~/.opensre/llm-auth.json`. If a key was deleted directly from Keychain, status may show the old metadata until you run `opensre auth verify <provider>` or start a request; that verification marks the provider `stale` when the secret is gone.
 
 For Codex CLI auth, status checks do not run `codex login status` by default,
 because some Codex versions can open browser OAuth while checking a session.
-Run `codex login`, `/login chatgpt`, or `opensre auth login chatgpt` from an
-interactive terminal when you need to refresh the browser login.
+Run `/login chatgpt` or `opensre auth login chatgpt` from an interactive
+terminal when you need to refresh the browser login. OpenSRE starts its own
+temporary callback server on `http://localhost:1455/auth/callback`, exchanges
+the short-lived OAuth code, and writes Codex-compatible tokens to the local
+Codex auth store before redirecting the browser to the Codex-style
+`/success?id_token=...` completion page. If a browser flow reaches `/success`
+with token material directly, OpenSRE stores that token material instead of
+dropping the callback. Use `codex login` only as a direct CLI fallback.
 
 Inside the interactive shell, use the same flows through `/auth` or `/login`:
 
@@ -236,7 +242,7 @@ Run any local model exposed by an [Ollama](https://ollama.com/) daemon. No API k
 
 ## CLI providers (subprocess)
 
-CLI-backed providers shell out to a vendor CLI instead of an HTTP API. They authenticate via the vendor's own login command; OpenSRE detects the binary on `PATH` (or via an explicit env var) and reuses the existing session.
+CLI-backed providers shell out to a vendor CLI instead of an HTTP API during inference. OpenSRE detects the binary on `PATH` (or via an explicit env var) and reuses the existing session. OpenAI OAuth is stored by OpenSRE in Codex-compatible auth format; other CLI-backed providers authenticate via the vendor's own login command.
 
 **Investigation timeouts:** Each ReAct turn runs one full CLI subprocess with the system prompt, tool schemas, and conversation history. The shared default subprocess budget is **300 seconds** (Python adds a small buffer). Override per provider when needed, for example `GEMINI_CLI_TIMEOUT_SECONDS`, `CLAUDE_CODE_TIMEOUT_SECONDS`, or `ANTIGRAVITY_CLI_TIMEOUT_SECONDS` (clamped 30–600 where the adapter supports it).
 
@@ -245,8 +251,8 @@ CLI-backed providers shell out to a vendor CLI instead of an HTTP API. They auth
 ```bash
 export LLM_PROVIDER=openai
 export LLM_AUTH_METHOD=oauth
-# Authenticate through onboarding, `/login chatgpt`, or the Codex CLI directly:
-codex login
+# Authenticate through onboarding or `/login chatgpt`:
+opensre auth login chatgpt
 # Optional overrides (all blank-by-default):
 export CODEX_MODEL=
 export CODEX_BIN=
@@ -254,9 +260,9 @@ export CODEX_BIN=
 
 Requires the [OpenAI Codex CLI](https://github.com/openai/codex). If `CODEX_MODEL` is unset, OpenSRE omits `-m` so `codex exec` uses the CLI's currently configured model. If `CODEX_BIN` is unset, the binary is resolved via `PATH` and known install locations.
 Run `opensre onboard`, `/login chatgpt`, or `opensre auth login chatgpt` to launch
-Codex browser login when needed and persist `LLM_PROVIDER=openai` with
-`LLM_AUTH_METHOD=oauth`. Existing `LLM_PROVIDER=codex` configs still work for
-backward compatibility.
+OpenSRE-managed Codex browser login on `localhost:1455` and persist
+`LLM_PROVIDER=openai` with `LLM_AUTH_METHOD=oauth`. Existing
+`LLM_PROVIDER=codex` configs still work for backward compatibility.
 
 ### Anthropic OAuth backend
 

--- a/integrations/llm_cli/codex_oauth.py
+++ b/integrations/llm_cli/codex_oauth.py
@@ -1,0 +1,514 @@
+"""OpenSRE-managed OpenAI Codex OAuth browser login."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import tempfile
+import threading
+import webbrowser
+from collections.abc import Callable, Mapping
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import httpx
+
+CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+CODEX_OAUTH_PORT = 1455
+CODEX_OAUTH_CALLBACK_PATH = "/auth/callback"
+CODEX_OAUTH_REDIRECT_URI = f"http://localhost:{CODEX_OAUTH_PORT}{CODEX_OAUTH_CALLBACK_PATH}"
+CODEX_OAUTH_AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize"
+CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+CODEX_OAUTH_SCOPE = "openid profile email offline_access api.connectors.read api.connectors.invoke"
+CODEX_OAUTH_AUTH_MODE = "chatgpt"
+CODEX_OAUTH_TIMEOUT_SECONDS = 300.0
+
+
+class CodexOAuthError(RuntimeError):
+    """Raised when OpenSRE-managed Codex OAuth login fails."""
+
+
+@dataclass(frozen=True)
+class CodexOAuthResult:
+    """Result of a completed Codex OAuth login."""
+
+    account_id: str
+    auth_path: Path
+    detail: str
+
+
+@dataclass(frozen=True)
+class _OAuthRequest:
+    state: str
+    code_verifier: str
+    authorize_url: str
+
+
+@dataclass(frozen=True)
+class _CallbackResult:
+    login: CodexOAuthResult | None = None
+    error: str = ""
+    error_description: str = ""
+
+
+def codex_home() -> Path:
+    """Return the Codex home directory used for auth persistence."""
+    override = os.getenv("CODEX_HOME", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".codex"
+
+
+def codex_auth_path() -> Path:
+    """Return the Codex-compatible auth file path."""
+    return codex_home() / "auth.json"
+
+
+def _base64_url_no_padding(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _new_pkce_verifier() -> str:
+    return secrets.token_urlsafe(64)
+
+
+def _pkce_challenge(verifier: str) -> str:
+    return _base64_url_no_padding(hashlib.sha256(verifier.encode("ascii")).digest())
+
+
+def build_codex_oauth_request() -> _OAuthRequest:
+    """Build the Codex OAuth authorize request with state and PKCE."""
+    state = secrets.token_urlsafe(32)
+    verifier = _new_pkce_verifier()
+    params = {
+        "response_type": "code",
+        "client_id": CODEX_OAUTH_CLIENT_ID,
+        "redirect_uri": CODEX_OAUTH_REDIRECT_URI,
+        "scope": CODEX_OAUTH_SCOPE,
+        "code_challenge": _pkce_challenge(verifier),
+        "code_challenge_method": "S256",
+        "id_token_add_organizations": "true",
+        "codex_cli_simplified_flow": "true",
+        "state": state,
+        "originator": "codex_cli_rs",
+    }
+    return _OAuthRequest(
+        state=state,
+        code_verifier=verifier,
+        authorize_url=f"{CODEX_OAUTH_AUTHORIZE_URL}?{urlencode(params)}",
+    )
+
+
+class _CallbackHTTPServer(ThreadingHTTPServer):
+    expected_state: str
+    code_verifier: str
+    post: Callable[..., httpx.Response]
+    callback_result: _CallbackResult | None
+    callback_event: threading.Event
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    server: _CallbackHTTPServer
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path == "/success":
+            if self.server.callback_result is None:
+                self._handle_success_token_callback(parsed.query)
+                return
+            self._write_page(200, "OpenSRE OAuth login completed. You can close this tab.")
+            return
+        if parsed.path != CODEX_OAUTH_CALLBACK_PATH:
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        query = parse_qs(parsed.query, keep_blank_values=True)
+        received_state = query.get("state", [""])[0]
+        if received_state != self.server.expected_state:
+            self.server.callback_result = _CallbackResult(
+                error="invalid_state",
+                error_description="OAuth callback state did not match the login request.",
+            )
+            self._write_page(
+                400,
+                "OpenSRE OAuth login failed. Return to the terminal and retry.",
+            )
+            self.server.callback_event.set()
+            return
+
+        provider_error = query.get("error", [""])[0]
+        if provider_error:
+            self.server.callback_result = _CallbackResult(
+                error=provider_error,
+                error_description=query.get("error_description", [""])[0],
+            )
+            self._write_page(
+                400,
+                "OpenSRE OAuth login was not completed. Return to the terminal.",
+            )
+            self.server.callback_event.set()
+            return
+
+        code = query.get("code", [""])[0].strip()
+        if not code:
+            self.server.callback_result = _CallbackResult(
+                error="missing_code",
+                error_description="OAuth callback did not include an authorization code.",
+            )
+            self._write_page(
+                400,
+                "OpenSRE OAuth login failed. Return to the terminal and retry.",
+            )
+            self.server.callback_event.set()
+            return
+
+        try:
+            token_response = exchange_codex_oauth_code(
+                code=code,
+                code_verifier=self.server.code_verifier,
+                post=self.server.post,
+            )
+            result = persist_codex_auth_tokens(token_response)
+        except CodexOAuthError as exc:
+            self.server.callback_result = _CallbackResult(
+                error="token_exchange_failed",
+                error_description=str(exc),
+            )
+            self._write_page(
+                400,
+                "OpenSRE OAuth login failed while saving credentials. Return to the terminal.",
+            )
+            self.server.callback_event.set()
+            return
+
+        self.server.callback_result = _CallbackResult(login=result)
+        self._redirect(_compose_success_url(token_response))
+        self.server.callback_event.set()
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        """Suppress callback URL logging so codes and state are not emitted."""
+
+    def _handle_success_token_callback(self, query_string: str) -> None:
+        query = parse_qs(query_string, keep_blank_values=True)
+        id_token = query.get("id_token", [""])[0].strip()
+        if not id_token:
+            self.server.callback_result = _CallbackResult(
+                error="missing_token",
+                error_description="OAuth success callback did not include an id_token.",
+            )
+            self._write_page(
+                400,
+                "OpenSRE OAuth login failed. Return to the terminal and retry.",
+            )
+            self.server.callback_event.set()
+            return
+
+        token_response = {
+            "access_token": query.get("access_token", [id_token])[0].strip() or id_token,
+            "refresh_token": query.get("refresh_token", [""])[0].strip(),
+            "id_token": id_token,
+        }
+        account_id = query.get("account_id", [""])[0].strip()
+        if account_id:
+            token_response["account_id"] = account_id
+        try:
+            result = persist_codex_auth_tokens(
+                token_response,
+                require_refresh_token=False,
+                detail_prefix="OpenAI OAuth success token stored",
+            )
+        except CodexOAuthError as exc:
+            self.server.callback_result = _CallbackResult(
+                error="token_persist_failed",
+                error_description=str(exc),
+            )
+            self._write_page(
+                400,
+                "OpenSRE OAuth login failed while saving credentials. Return to the terminal.",
+            )
+            self.server.callback_event.set()
+            return
+
+        self.server.callback_result = _CallbackResult(login=result)
+        self._write_page(200, "OpenSRE OAuth login completed. You can close this tab.")
+        self.server.callback_event.set()
+
+    def _redirect(self, location: str) -> None:
+        self.send_response(302)
+        self.send_header("Location", location)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def _write_page(self, status: int, message: str) -> None:
+        body = (
+            '<!doctype html><html><head><meta charset="utf-8">'
+            "<title>OpenSRE OAuth</title></head><body>"
+            f"<p>{message}</p></body></html>"
+        ).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def wait_for_codex_oauth_callback(
+    *,
+    request: _OAuthRequest,
+    open_browser: Callable[[str], bool] = webbrowser.open,
+    post: Callable[..., httpx.Response] = httpx.post,
+    timeout_seconds: float = CODEX_OAUTH_TIMEOUT_SECONDS,
+) -> CodexOAuthResult:
+    """Open the browser and wait for OpenAI to redirect back with Codex auth."""
+    event = threading.Event()
+    try:
+        server = _CallbackHTTPServer(("localhost", CODEX_OAUTH_PORT), _CallbackHandler)
+    except OSError as exc:
+        raise CodexOAuthError(
+            f"Could not bind localhost:{CODEX_OAUTH_PORT}. "
+            f"Free port {CODEX_OAUTH_PORT}, then retry OpenAI OAuth login."
+        ) from exc
+
+    server.expected_state = request.state
+    server.code_verifier = request.code_verifier
+    server.post = post
+    server.callback_result = None
+    server.callback_event = event
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        if not open_browser(request.authorize_url):
+            raise CodexOAuthError(
+                "Could not open the browser automatically. "
+                f"Open this URL manually to continue OAuth login: {request.authorize_url}"
+            )
+        if not event.wait(timeout_seconds):
+            raise CodexOAuthError("Timed out waiting for OpenAI OAuth callback.")
+        result = server.callback_result
+        if result is None:
+            raise CodexOAuthError("OAuth callback completed without a result.")
+        if result.error:
+            detail = f": {result.error_description}" if result.error_description else ""
+            raise CodexOAuthError(f"OpenAI OAuth callback failed ({result.error}){detail}.")
+        if result.login is None:
+            raise CodexOAuthError("OAuth callback completed without stored Codex auth.")
+        return result.login
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5.0)
+
+
+def exchange_codex_oauth_code(
+    *,
+    code: str,
+    code_verifier: str,
+    post: Callable[..., httpx.Response] = httpx.post,
+) -> dict[str, object]:
+    """Exchange an authorization code for OpenAI OAuth tokens."""
+    try:
+        response = post(
+            CODEX_OAUTH_TOKEN_URL,
+            data={
+                "grant_type": "authorization_code",
+                "client_id": CODEX_OAUTH_CLIENT_ID,
+                "code": code,
+                "redirect_uri": CODEX_OAUTH_REDIRECT_URI,
+                "code_verifier": code_verifier,
+            },
+            headers={"Accept": "application/json"},
+            timeout=30.0,
+        )
+    except httpx.HTTPError as exc:
+        raise CodexOAuthError(f"OpenAI OAuth token exchange failed: {exc}") from exc
+    if response.status_code != 200:
+        raise CodexOAuthError(
+            f"OpenAI OAuth token exchange failed with HTTP {response.status_code}."
+        )
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise CodexOAuthError("OpenAI OAuth token exchange returned invalid JSON.") from exc
+    if not isinstance(data, dict):
+        raise CodexOAuthError("OpenAI OAuth token exchange returned an unexpected payload.")
+    return data
+
+
+def _decode_jwt_payload(token: str) -> dict[str, object]:
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+    padded = parts[1] + "=" * (-len(parts[1]) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
+        data = json.loads(decoded)
+    except (ValueError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _account_id_from_token_payload(payload: Mapping[str, object]) -> str:
+    auth_claim = payload.get("https://api.openai.com/auth")
+    if isinstance(auth_claim, Mapping):
+        chatgpt_account_id = auth_claim.get("chatgpt_account_id")
+        if isinstance(chatgpt_account_id, str) and chatgpt_account_id.strip():
+            return chatgpt_account_id.strip()
+    for key in ("account_id", "user_id", "sub"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _required_token(data: Mapping[str, object], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise CodexOAuthError(f"OpenAI OAuth token response did not include {key}.")
+    return value.strip()
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(UTC).replace(tzinfo=None).isoformat(timespec="microseconds") + "Z"
+
+
+def codex_auth_payload(
+    token_response: Mapping[str, object],
+    *,
+    require_refresh_token: bool = True,
+) -> dict[str, object]:
+    """Convert OpenAI's token response to Codex's auth.json shape."""
+    access_token = _required_token(token_response, "access_token")
+    if require_refresh_token:
+        refresh_token = _required_token(token_response, "refresh_token")
+    else:
+        refresh_token = str(token_response.get("refresh_token") or "").strip()
+    id_token = _required_token(token_response, "id_token")
+    account_id = ""
+    raw_account_id = token_response.get("account_id")
+    if isinstance(raw_account_id, str):
+        account_id = raw_account_id.strip()
+    if not account_id:
+        account_id = _account_id_from_token_payload(_decode_jwt_payload(id_token))
+    if not account_id:
+        raise CodexOAuthError("Could not derive ChatGPT account id from OpenAI OAuth tokens.")
+
+    return {
+        "OPENAI_API_KEY": None,
+        "auth_mode": CODEX_OAUTH_AUTH_MODE,
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "id_token": id_token,
+            "account_id": account_id,
+        },
+        "last_refresh": _utc_timestamp(),
+    }
+
+
+def persist_codex_auth_tokens(
+    token_response: Mapping[str, object],
+    *,
+    require_refresh_token: bool = True,
+    detail_prefix: str = "OpenAI OAuth tokens stored",
+) -> CodexOAuthResult:
+    """Persist an OpenAI token response in Codex-compatible auth.json format."""
+    payload = codex_auth_payload(
+        token_response,
+        require_refresh_token=require_refresh_token,
+    )
+    auth_path = write_codex_auth(payload)
+    account_id = str(payload["tokens"]["account_id"])  # type: ignore[index]
+    return CodexOAuthResult(
+        account_id=account_id,
+        auth_path=auth_path,
+        detail=f"{detail_prefix} for Codex at {auth_path}.",
+    )
+
+
+def _compose_success_url(token_response: Mapping[str, object]) -> str:
+    id_token = _required_token(token_response, "id_token")
+    access_token = str(token_response.get("access_token") or "")
+    token_claims = _decode_jwt_payload(id_token)
+    access_claims = _decode_jwt_payload(access_token)
+    params = {
+        "id_token": id_token,
+        "needs_setup": str(
+            bool(token_claims.get("is_org_owner"))
+            and not bool(token_claims.get("completed_platform_onboarding"))
+        ).lower(),
+        "org_id": str(token_claims.get("organization_id") or ""),
+        "project_id": str(token_claims.get("project_id") or ""),
+        "plan_type": str(access_claims.get("chatgpt_plan_type") or ""),
+        "platform_url": "https://platform.openai.com",
+    }
+    return f"http://localhost:{CODEX_OAUTH_PORT}/success?{urlencode(params)}"
+
+
+def write_codex_auth(payload: Mapping[str, object], *, path: Path | None = None) -> Path:
+    """Atomically write Codex auth.json with owner-only permissions."""
+    auth_path = path or codex_auth_path()
+    auth_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    with suppress(OSError):
+        auth_path.parent.chmod(0o700)
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{auth_path.name}.",
+        suffix=".tmp",
+        dir=str(auth_path.parent),
+        text=True,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(dict(payload), handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.chmod(tmp_name, 0o600)
+        os.replace(tmp_name, auth_path)
+        with suppress(OSError):
+            auth_path.chmod(0o600)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+    return auth_path
+
+
+def run_codex_oauth_login(
+    *,
+    open_browser: Callable[[str], bool] = webbrowser.open,
+    post: Callable[..., httpx.Response] = httpx.post,
+    timeout_seconds: float = CODEX_OAUTH_TIMEOUT_SECONDS,
+) -> CodexOAuthResult:
+    """Complete the OpenSRE-managed Codex OAuth flow and persist auth.json."""
+    request = build_codex_oauth_request()
+    return wait_for_codex_oauth_callback(
+        request=request,
+        open_browser=open_browser,
+        post=post,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+__all__ = [
+    "CODEX_OAUTH_CALLBACK_PATH",
+    "CODEX_OAUTH_CLIENT_ID",
+    "CODEX_OAUTH_PORT",
+    "CODEX_OAUTH_REDIRECT_URI",
+    "CodexOAuthError",
+    "CodexOAuthResult",
+    "build_codex_oauth_request",
+    "codex_auth_path",
+    "codex_auth_payload",
+    "exchange_codex_oauth_code",
+    "persist_codex_auth_tokens",
+    "run_codex_oauth_login",
+    "wait_for_codex_oauth_callback",
+    "write_codex_auth",
+]

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -10,6 +10,7 @@ from cli.wizard import _integration_configurators, _ui, flow
 from cli.wizard import store as wizard_store
 from cli.wizard.env_sync import sync_provider_env
 from cli.wizard.probes import ProbeResult
+from integrations.llm_cli.codex_oauth import CodexOAuthResult
 from tests.integrations.llm_cli.testing_helpers import write_fake_runnable_cli_bin
 
 
@@ -1304,7 +1305,7 @@ def test_run_cli_llm_onboarding_ok_after_login_retry(monkeypatch) -> None:
     assert len(detect_calls) == 2
 
 
-def test_run_cli_llm_onboarding_launches_codex_browser_login(monkeypatch) -> None:
+def test_run_cli_llm_onboarding_launches_managed_codex_oauth(monkeypatch, tmp_path) -> None:
     adapter = MagicMock()
     adapter.name = "codex"
     adapter.binary_env_key = "CODEX_BIN"
@@ -1328,30 +1329,28 @@ def test_run_cli_llm_onboarding_launches_codex_browser_login(monkeypatch) -> Non
     provider.value = "codex"
     provider.label = "OpenAI Codex CLI"
     provider.adapter_factory = lambda: adapter
-    preflight_commands: list[list[str]] = []
-    login_commands: list[list[str]] = []
+    oauth_calls: list[object] = []
 
-    def _fake_preflight(command: list[str]) -> flow._LoginProcessResult:
-        preflight_commands.append(command)
-        return flow._LoginProcessResult(returncode=0)
-
-    def _fake_login(command: list[str]) -> flow._LoginProcessResult:
-        login_commands.append(command)
-        return flow._LoginProcessResult(returncode=0)
+    def _fake_codex_oauth_login() -> CodexOAuthResult:
+        oauth_calls.append(None)
+        return CodexOAuthResult(
+            account_id="account-123",
+            auth_path=tmp_path / "codex-home" / "auth.json",
+            detail="OpenAI OAuth tokens stored for Codex.",
+        )
 
     monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "login")
-    monkeypatch.setattr(flow, "_run_login_preflight_process", _fake_preflight)
-    monkeypatch.setattr(flow, "_run_interactive_login_process", _fake_login)
+    monkeypatch.setattr(flow, "run_codex_oauth_login", _fake_codex_oauth_login)
+    monkeypatch.setenv("OPENSRE_LLM_AUTH_METADATA_PATH", str(tmp_path / "llm-auth.json"))
 
     result = flow._run_cli_llm_onboarding(provider)
 
     assert result == "ok"
-    assert preflight_commands == [["/usr/local/bin/codex", "login", "--help"]]
-    assert login_commands == [["/usr/local/bin/codex", "login"]]
+    assert oauth_calls == [None]
     assert len(detect_calls) == 1
 
 
-def test_run_cli_llm_onboarding_surfaces_codex_config_error(monkeypatch) -> None:
+def test_run_cli_llm_onboarding_surfaces_managed_codex_oauth_error(monkeypatch) -> None:
     adapter = MagicMock()
     adapter.name = "codex"
     adapter.binary_env_key = "CODEX_BIN"
@@ -1373,91 +1372,18 @@ def test_run_cli_llm_onboarding_surfaces_codex_config_error(monkeypatch) -> None
     def _choose(*_args, **_kwargs):
         return choices.pop(0)
 
-    def _fake_preflight(command: list[str]) -> flow._LoginProcessResult:
-        del command
-        return flow._LoginProcessResult(
-            returncode=1,
-            stdout="",
-            stderr=(
-                "Error loading configuration: "
-                "/Users/me/.codex/config.toml:17:16: unknown variant `priority`, "
-                "expected `fast` or `flex`"
-            ),
-        )
-
     monkeypatch.setattr(flow, "_choose", _choose)
-    monkeypatch.setattr(flow, "_run_login_preflight_process", _fake_preflight)
+    monkeypatch.setattr(
+        flow,
+        "run_codex_oauth_login",
+        MagicMock(side_effect=flow.CodexOAuthError("Could not bind localhost:1455.")),
+    )
     monkeypatch.setattr(flow, "_run_interactive_login_process", MagicMock())
 
     result = flow._run_cli_llm_onboarding(provider, display_label="OpenAI OAuth")
 
     assert result == "repick"
     flow._run_interactive_login_process.assert_not_called()
-
-
-def test_run_cli_llm_onboarding_repairs_codex_stale_service_tier(monkeypatch, tmp_path) -> None:
-    config_path = tmp_path / "config.toml"
-    config_path.write_text(
-        'model = "gpt-5.5"\nservice_tier = "priority"\n[features]\n',
-        encoding="utf-8",
-    )
-
-    adapter = MagicMock()
-    adapter.name = "codex"
-    adapter.binary_env_key = "CODEX_BIN"
-    adapter.install_hint = "npm i -g @openai/codex"
-    adapter.auth_hint = "Run: codex login"
-    adapter.detect.return_value = MagicMock(
-        installed=True,
-        logged_in=None,
-        bin_path="/opt/homebrew/bin/codex",
-        detail="Auth status unknown.",
-    )
-    provider = MagicMock()
-    provider.value = "codex"
-    provider.label = "OpenAI Codex CLI"
-    provider.adapter_factory = lambda: adapter
-
-    choices = iter(["login", "repair"])
-    preflight_results = iter(
-        [
-            flow._LoginProcessResult(
-                returncode=1,
-                stdout="",
-                stderr=(
-                    "Error loading configuration: "
-                    f"{config_path}:2:16: unknown variant `priority`, expected `fast` or `flex`"
-                ),
-            ),
-            flow._LoginProcessResult(returncode=0),
-        ]
-    )
-    preflight_commands: list[list[str]] = []
-    login_commands: list[list[str]] = []
-
-    def _fake_preflight(command: list[str]) -> flow._LoginProcessResult:
-        preflight_commands.append(command)
-        return next(preflight_results)
-
-    def _fake_login(command: list[str]) -> flow._LoginProcessResult:
-        login_commands.append(command)
-        return flow._LoginProcessResult(returncode=0)
-
-    monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: next(choices))
-    monkeypatch.setattr(flow, "_run_login_preflight_process", _fake_preflight)
-    monkeypatch.setattr(flow, "_run_interactive_login_process", _fake_login)
-
-    result = flow._run_cli_llm_onboarding(provider, display_label="OpenAI OAuth")
-
-    assert result == "ok"
-    assert preflight_commands == [
-        ["/opt/homebrew/bin/codex", "login", "--help"],
-        ["/opt/homebrew/bin/codex", "login", "--help"],
-    ]
-    assert login_commands == [["/opt/homebrew/bin/codex", "login"]]
-    assert config_path.read_text(encoding="utf-8") == (
-        'model = "gpt-5.5"\nservice_tier = "fast"\n[features]\n'
-    )
 
 
 def test_run_cli_llm_onboarding_launches_claude_browser_login(monkeypatch) -> None:

--- a/tests/config/test_llm_auth.py
+++ b/tests/config/test_llm_auth.py
@@ -13,9 +13,10 @@ from cli.llm_auth.service import (
 )
 from cli.wizard.config import ModelOption, ProviderOption
 from cli.wizard.validation import ValidationResult
-from config.llm_auth.records import resolve_provider_auth_record
+from config.llm_auth.records import resolve_provider_auth_record, save_provider_auth_record
 from config.llm_credentials import resolve_llm_api_key
 from integrations.llm_cli.base import CLIProbe
+from integrations.llm_cli.codex_oauth import CodexOAuthResult
 from tests.shared.keyring_backend import MemoryKeyring
 
 
@@ -106,7 +107,7 @@ class _FakeAdapter:
         )
 
 
-class _InconclusiveAfterLoginAdapter:
+class _InconclusiveCodexAdapter:
     name = "fake"
     binary_env_key = "FAKE_BIN"
     install_hint = "install fake"
@@ -114,15 +115,11 @@ class _InconclusiveAfterLoginAdapter:
     min_version = None
     default_exec_timeout_sec = 30.0
 
-    def __init__(self) -> None:
-        self.detect_calls = 0
-
     def detect(self) -> CLIProbe:
-        self.detect_calls += 1
         return CLIProbe(
             installed=True,
             version="1.0.0",
-            logged_in=False if self.detect_calls == 1 else None,
+            logged_in=None,
             bin_path="/usr/bin/fake",
             detail="Login status unknown.",
         )
@@ -175,7 +172,7 @@ def test_configure_cli_subscription_syncs_provider(
         keyring.set_keyring(previous_backend)
 
 
-def test_configure_cli_subscription_accepts_successful_login_when_status_probe_unknown(
+def test_configure_cli_subscription_uses_managed_codex_oauth_when_status_probe_unknown(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
@@ -193,16 +190,21 @@ def test_configure_cli_subscription_accepts_successful_login_when_status_probe_u
         default_model="",
         models=(ModelOption(value="", label="default"),),
         credential_kind="cli",
-        adapter_factory=_InconclusiveAfterLoginAdapter,
+        adapter_factory=_InconclusiveCodexAdapter,
         allow_custom_models=True,
     )
     monkeypatch.setattr("cli.llm_auth.service.provider_for_profile", lambda _profile: fake_provider)
-    login_commands: list[tuple[str, str]] = []
+    oauth_calls: list[object] = []
 
-    def _fake_run_vendor_login(profile: ProviderAuthProfile, binary_path: str) -> None:
-        login_commands.append((profile.provider_value, binary_path))
+    def _fake_codex_oauth_login() -> CodexOAuthResult:
+        oauth_calls.append(None)
+        return CodexOAuthResult(
+            account_id="account-123",
+            auth_path=tmp_path / "codex-home" / "auth.json",
+            detail="OpenAI OAuth tokens stored for Codex.",
+        )
 
-    monkeypatch.setattr("cli.llm_auth.service._run_vendor_login", _fake_run_vendor_login)
+    monkeypatch.setattr("cli.llm_auth.service.run_codex_oauth_login", _fake_codex_oauth_login)
 
     previous_backend = keyring.get_keyring()
     keyring.set_keyring(MemoryKeyring())
@@ -219,9 +221,35 @@ def test_configure_cli_subscription_accepts_successful_login_when_status_probe_u
             env_path=env_path,
         )
 
-        assert login_commands == [("codex", "/usr/bin/fake")]
+        assert oauth_calls == [None]
         assert result.provider == "codex"
-        assert result.detail == "OpenAI Codex CLI login completed via fake login."
-        assert resolve_provider_auth_record("codex")["source"] == "vendor-cli"
+        assert result.source == "codex-oauth"
+        assert result.detail == "OpenAI OAuth tokens stored for Codex."
+        env_content = env_path.read_text(encoding="utf-8")
+        assert "LLM_PROVIDER=openai\n" in env_content
+        assert "LLM_AUTH_METHOD=oauth\n" in env_content
+        assert "CODEX_MODEL=gpt-5-codex\n" in env_content
+        assert resolve_provider_auth_record("codex")["source"] == "codex-oauth"
     finally:
         keyring.set_keyring(previous_backend)
+
+
+def test_codex_oauth_metadata_counts_as_prompt_safe_cli_status(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OPENSRE_LLM_AUTH_METADATA_PATH", str(tmp_path / "llm-auth.json"))
+    save_provider_auth_record(
+        provider="codex",
+        auth_name="chatgpt",
+        kind="cli_subscription",
+        source="codex-oauth",
+        detail="OpenAI OAuth tokens stored for Codex.",
+    )
+
+    from config.llm_auth.credentials import status
+
+    result = status("codex")
+
+    assert result.configured is True
+    assert result.source == "cli"
+    assert result.detail == "OpenAI OAuth tokens stored for Codex."

--- a/tests/config/test_llm_auth.py
+++ b/tests/config/test_llm_auth.py
@@ -106,6 +106,28 @@ class _FakeAdapter:
         )
 
 
+class _InconclusiveAfterLoginAdapter:
+    name = "fake"
+    binary_env_key = "FAKE_BIN"
+    install_hint = "install fake"
+    auth_hint = "Run: fake login"
+    min_version = None
+    default_exec_timeout_sec = 30.0
+
+    def __init__(self) -> None:
+        self.detect_calls = 0
+
+    def detect(self) -> CLIProbe:
+        self.detect_calls += 1
+        return CLIProbe(
+            installed=True,
+            version="1.0.0",
+            logged_in=False if self.detect_calls == 1 else None,
+            bin_path="/usr/bin/fake",
+            detail="Login status unknown.",
+        )
+
+
 def test_configure_cli_subscription_syncs_provider(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -148,6 +170,58 @@ def test_configure_cli_subscription_syncs_provider(
         env_content = env_path.read_text(encoding="utf-8")
         assert "LLM_PROVIDER=codex\n" in env_content
         assert "CODEX_MODEL=gpt-5-codex\n" in env_content
+        assert resolve_provider_auth_record("codex")["source"] == "vendor-cli"
+    finally:
+        keyring.set_keyring(previous_backend)
+
+
+def test_configure_cli_subscription_accepts_successful_login_when_status_probe_unknown(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+    monkeypatch.setenv("OPENSRE_LLM_AUTH_METADATA_PATH", str(tmp_path / "llm-auth.json"))
+    monkeypatch.setattr(
+        "cli.wizard.store.get_store_path",
+        lambda: tmp_path / "opensre.json",
+    )
+    fake_provider = ProviderOption(
+        value="codex",
+        label="OpenAI Codex CLI",
+        group="Local CLI providers",
+        api_key_env="",
+        model_env="CODEX_MODEL",
+        default_model="",
+        models=(ModelOption(value="", label="default"),),
+        credential_kind="cli",
+        adapter_factory=_InconclusiveAfterLoginAdapter,
+        allow_custom_models=True,
+    )
+    monkeypatch.setattr("cli.llm_auth.service.provider_for_profile", lambda _profile: fake_provider)
+    login_commands: list[tuple[str, str]] = []
+
+    def _fake_run_vendor_login(profile: ProviderAuthProfile, binary_path: str) -> None:
+        login_commands.append((profile.provider_value, binary_path))
+
+    monkeypatch.setattr("cli.llm_auth.service._run_vendor_login", _fake_run_vendor_login)
+
+    previous_backend = keyring.get_keyring()
+    keyring.set_keyring(MemoryKeyring())
+    try:
+        env_path = tmp_path / ".env"
+        result = configure_cli_subscription_provider(
+            profile=ProviderAuthProfile(
+                name="chatgpt",
+                provider_value="codex",
+                label="ChatGPT subscription via Codex CLI",
+                kind="cli_subscription",
+            ),
+            model="gpt-5-codex",
+            env_path=env_path,
+        )
+
+        assert login_commands == [("codex", "/usr/bin/fake")]
+        assert result.provider == "codex"
+        assert result.detail == "OpenAI Codex CLI login completed via fake login."
         assert resolve_provider_auth_record("codex")["source"] == "vendor-cli"
     finally:
         keyring.set_keyring(previous_backend)

--- a/tests/integrations/llm_cli/test_codex_oauth.py
+++ b/tests/integrations/llm_cli/test_codex_oauth.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import base64
+import json
+import socket
+import stat
+from pathlib import Path
+
+import httpx
+import pytest
+
+from integrations.llm_cli import codex_oauth
+
+
+def _json_response(payload: dict[str, object], status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=payload)
+
+
+def _jwt(payload: dict[str, object]) -> str:
+    def _part(data: dict[str, object]) -> str:
+        raw = json.dumps(data, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    return f"{_part({'alg': 'none'})}.{_part(payload)}.sig"
+
+
+def _token_response() -> dict[str, object]:
+    return {
+        "access_token": "access-token",
+        "refresh_token": "refresh-token",
+        "id_token": _jwt(
+            {
+                "https://api.openai.com/auth": {
+                    "chatgpt_account_id": "account-123",
+                }
+            }
+        ),
+    }
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("localhost", 0))
+        return int(sock.getsockname()[1])
+
+
+def test_build_codex_oauth_request_uses_pkce_and_localhost_callback() -> None:
+    request = codex_oauth.build_codex_oauth_request()
+
+    assert f"client_id={codex_oauth.CODEX_OAUTH_CLIENT_ID}" in request.authorize_url
+    assert "redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback" in request.authorize_url
+    assert "code_challenge_method=S256" in request.authorize_url
+    assert "code_challenge=" in request.authorize_url
+    assert "code=" not in request.authorize_url
+    assert len(request.state) >= 32
+    assert len(request.code_verifier) >= 43
+
+
+def test_wait_for_codex_oauth_callback_writes_tokens_and_redirects_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex-home"))
+    port = _free_port()
+    monkeypatch.setattr(codex_oauth, "CODEX_OAUTH_PORT", port)
+    request = codex_oauth.build_codex_oauth_request()
+
+    def _open_browser(_url: str) -> bool:
+        response = httpx.get(
+            f"http://localhost:{port}/auth/callback",
+            params={"code": "auth-code", "state": request.state},
+            follow_redirects=False,
+            timeout=5.0,
+        )
+        assert response.status_code == 302
+        assert response.headers["Location"].startswith(f"http://localhost:{port}/success?")
+        assert "id_token=" in response.headers["Location"]
+        return True
+
+    result = codex_oauth.wait_for_codex_oauth_callback(
+        request=request,
+        open_browser=_open_browser,
+        post=lambda *_args, **_kwargs: _json_response(_token_response()),
+        timeout_seconds=5.0,
+    )
+
+    assert result.account_id == "account-123"
+    assert result.auth_path == tmp_path / "codex-home" / "auth.json"
+    data = json.loads(result.auth_path.read_text(encoding="utf-8"))
+    assert data["tokens"]["access_token"] == "access-token"
+    captured = capsys.readouterr()
+    assert "auth-code" not in captured.out
+    assert "auth-code" not in captured.err
+    assert "access-token" not in captured.out
+    assert "access-token" not in captured.err
+    assert "refresh-token" not in captured.out
+    assert "refresh-token" not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"code": "auth-code", "state": "wrong"}, "invalid_state"),
+        ({}, "missing_code"),
+        ({"error": "access_denied"}, "access_denied"),
+    ],
+)
+def test_wait_for_codex_oauth_callback_rejects_invalid_callbacks(
+    monkeypatch: pytest.MonkeyPatch,
+    params: dict[str, str],
+    message: str,
+) -> None:
+    port = _free_port()
+    monkeypatch.setattr(codex_oauth, "CODEX_OAUTH_PORT", port)
+    request = codex_oauth.build_codex_oauth_request()
+    params = {**params, "state": params.get("state", request.state)}
+
+    def _open_browser(_url: str) -> bool:
+        response = httpx.get(
+            f"http://localhost:{port}/auth/callback",
+            params=params,
+            timeout=5.0,
+        )
+        assert response.status_code == 400
+        return True
+
+    with pytest.raises(codex_oauth.CodexOAuthError, match=message):
+        codex_oauth.wait_for_codex_oauth_callback(
+            request=request,
+            open_browser=_open_browser,
+            timeout_seconds=5.0,
+        )
+
+
+def test_wait_for_codex_oauth_callback_stores_success_id_token_callback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex-home"))
+    port = _free_port()
+    monkeypatch.setattr(codex_oauth, "CODEX_OAUTH_PORT", port)
+    request = codex_oauth.build_codex_oauth_request()
+    id_token = _jwt(
+        {
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "account-from-success",
+            }
+        }
+    )
+
+    def _open_browser(_url: str) -> bool:
+        response = httpx.get(
+            f"http://localhost:{port}/success",
+            params={"id_token": id_token},
+            timeout=5.0,
+        )
+        assert response.status_code == 200
+        return True
+
+    result = codex_oauth.wait_for_codex_oauth_callback(
+        request=request,
+        open_browser=_open_browser,
+        timeout_seconds=5.0,
+    )
+
+    assert result.account_id == "account-from-success"
+    data = json.loads(result.auth_path.read_text(encoding="utf-8"))
+    assert data["tokens"]["id_token"] == id_token
+    assert data["tokens"]["access_token"] == id_token
+    assert data["tokens"]["refresh_token"] == ""
+
+
+def test_wait_for_codex_oauth_callback_reports_port_in_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    port = _free_port()
+    monkeypatch.setattr(codex_oauth, "CODEX_OAUTH_PORT", port)
+    request = codex_oauth.build_codex_oauth_request()
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("localhost", port))
+        sock.listen(1)
+        with pytest.raises(codex_oauth.CodexOAuthError, match=f"port {port}"):
+            codex_oauth.wait_for_codex_oauth_callback(
+                request=request,
+                open_browser=lambda _url: True,
+                timeout_seconds=0.1,
+            )
+
+
+def test_exchange_codex_oauth_code_posts_code_without_logging_tokens() -> None:
+    calls: list[dict[str, object]] = []
+
+    def _post(*args: object, **kwargs: object) -> httpx.Response:
+        calls.append({"args": args, "kwargs": kwargs})
+        return _json_response(_token_response())
+
+    result = codex_oauth.exchange_codex_oauth_code(
+        code="auth-code",
+        code_verifier="verifier",
+        post=_post,
+    )
+
+    assert result["access_token"] == "access-token"
+    data = calls[0]["kwargs"]["data"]  # type: ignore[index]
+    assert data["grant_type"] == "authorization_code"
+    assert data["code"] == "auth-code"
+    assert data["redirect_uri"] == codex_oauth.CODEX_OAUTH_REDIRECT_URI
+    assert data["code_verifier"] == "verifier"
+
+
+def test_exchange_codex_oauth_code_rejects_failed_response() -> None:
+    def _post(*_args: object, **_kwargs: object) -> httpx.Response:
+        return _json_response({"error": "invalid_grant"}, status_code=400)
+
+    with pytest.raises(codex_oauth.CodexOAuthError, match="HTTP 400"):
+        codex_oauth.exchange_codex_oauth_code(
+            code="auth-code",
+            code_verifier="verifier",
+            post=_post,
+        )
+
+
+def test_codex_auth_payload_and_write_auth_shape(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex-home"))
+    payload = codex_oauth.codex_auth_payload(_token_response())
+
+    assert payload["OPENAI_API_KEY"] is None
+    assert payload["auth_mode"] == "chatgpt"
+    assert payload["tokens"]["access_token"] == "access-token"  # type: ignore[index]
+    assert payload["tokens"]["refresh_token"] == "refresh-token"  # type: ignore[index]
+    assert payload["tokens"]["account_id"] == "account-123"  # type: ignore[index]
+
+    path = codex_oauth.write_codex_auth(payload)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data == payload
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+
+
+def test_run_codex_oauth_login_writes_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex-home"))
+    request = codex_oauth.build_codex_oauth_request()
+    monkeypatch.setattr(codex_oauth, "build_codex_oauth_request", lambda: request)
+    monkeypatch.setattr(
+        codex_oauth,
+        "wait_for_codex_oauth_callback",
+        lambda **_kwargs: codex_oauth.CodexOAuthResult(
+            account_id="account-123",
+            auth_path=tmp_path / "codex-home" / "auth.json",
+            detail="OpenAI OAuth tokens stored for Codex.",
+        ),
+    )
+
+    def _post(*_args: object, **_kwargs: object) -> httpx.Response:
+        raise AssertionError("token exchange should happen in the callback server")
+
+    result = codex_oauth.run_codex_oauth_login(
+        open_browser=lambda _url: True,
+        post=_post,
+    )
+
+    assert result.account_id == "account-123"
+    assert result.auth_path == tmp_path / "codex-home" / "auth.json"
+    assert "OpenAI OAuth tokens stored" in result.detail


### PR DESCRIPTION
## Summary
- add an OpenSRE-managed Codex OAuth callback server on localhost:1455
- exchange /auth/callback codes into Codex-compatible auth.json credentials before redirecting the browser to /success?id_token=...
- tolerate direct /success?id_token=... callbacks by persisting returned token material instead of hanging or rejecting the path
- route opensre auth login chatgpt, onboarding, and /login chatgpt through the managed flow and keep codex login as fallback documentation

## Root Cause
OpenSRE previously relied on Codex CLI delegation/status probing, so onboarding could complete browser login while OpenSRE still could not verify or own the callback/token persistence. The Codex browser flow expects a localhost callback on port 1455, exchanges the authorization code, persists Codex credentials, then redirects the browser to a success URL carrying id_token metadata.

## Validation
- make lint
- make format-check
- make typecheck
- uv run pytest tests/integrations/llm_cli/test_codex_oauth.py tests/config/test_llm_auth.py tests/cli/wizard/test_flow.py tests/cli/test_auth_command.py -q
- make verify-integrations
- make test-scope (escalated to make test-cov: 9955 passed, 53 skipped)
