### PR TITLE
[codex] add telegram send message tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,10 +88,12 @@ Steps:
 
 1. Pick the simplest shape that fits the tool. Use a `BaseTool` subclass for richer behavior; use `@tool(...)` from `tools.tool_decorator` for a lightweight function tool.
 2. Declare clear metadata: `name`, `description`, `source`, `input_schema`, and any `use_cases`, `requires`, `outputs`, or `retrieval_controls` you need.
-3. Keep the tool self-contained. Put reusable transport or integration-specific parsing code in `integrations/<name>/` or shared tool glue in `tools/utils/` rather than copying it into the tool body.
-4. If the tool should appear in both investigation and chat surfaces, set `surfaces=("investigation", "chat")`.
-5. Add tests that cover schema shape, availability, extraction, and the runtime behavior that the planner depends on.
-6. Before opening or approving the PR, follow [TOOL_INTEGRATION_CHECKLIST.md](TOOL_INTEGRATION_CHECKLIST.md) for tool/integration-specific wiring, payload, docs, and regression checks.
+3. Treat tool packages as production code, not registry placeholders. A tool package may not be an empty or nearly-empty `__init__.py` whose only purpose is discovery. Directionally, non-trivial tools should use focused sibling modules such as `tool.py`, `client.py`/`delivery.py`, `validation.py`, `models.py`, or `results.py`; `__init__.py` should usually be a small registry entrypoint that imports the public tool object.
+4. Keep separation of concerns. Put reusable transport or integration-specific parsing code in `integrations/<name>/` or shared tool glue in `tools/utils/` rather than copying it into the tool body. Split validation, credential/parameter resolution, dispatch/client calls, result normalization, and error handling into focused helpers or sibling files instead of tangling them inside `run()`.
+5. Return stable, planner-friendly results. Expected failures should produce a structured error shape; external side effects must declare `side_effect_level`, require approval when appropriate, and avoid leaking secrets through `extract_params`, return values, logs, or traceable tool-call kwargs.
+6. If the tool should appear in both investigation and chat surfaces, set `surfaces=("investigation", "chat")`.
+7. Add tests that cover schema shape, availability, extraction, success, failure, and the runtime behavior that the planner depends on.
+8. Before opening or approving the PR, follow [TOOL_INTEGRATION_CHECKLIST.md](TOOL_INTEGRATION_CHECKLIST.md) for tool/integration-specific wiring, payload, docs, and regression checks.
 
 ### Changing the investigation pipeline
 
@@ -188,6 +190,13 @@ Test commands, turn-handling rules, CI-only paths: **[CI.md](CI.md)**. Live REPL
 - External-system code: `integrations/` owns config, clients, verifiers, and integration-local helpers; `tools/` owns every `@tool(...)` function and `BaseTool` class. Do not reintroduce top-level `vendors/` or `services/` packages.
 - Compatibility shims: Do not leave modules whose only job is to re-export symbols from a new
   location. Update callers to the canonical module and delete the old path.
+- Empty or monolithic tool packages: Do not add a `tools/<name>/__init__.py`
+  that exists only to make discovery pass, and do not hide a non-trivial tool
+  implementation entirely in `__init__.py`. Use sibling modules for validation,
+  models, delivery/client calls, result shaping, and error handling whenever the
+  tool is more than a small function. Every tool must meet the implementation
+  and quality standards in the Adding a Tool section and
+  [TOOL_INTEGRATION_CHECKLIST.md](TOOL_INTEGRATION_CHECKLIST.md).
 - Interactive-shell action selection: do not implement regex/keyword/fuzzy
   intent routing, literal slash-command shortcuts, or deterministic action
   bypasses around the action-agent AgentTool path. Engineers have been fired

--- a/TOOL_INTEGRATION_CHECKLIST.md
+++ b/TOOL_INTEGRATION_CHECKLIST.md
@@ -24,16 +24,30 @@ This file is the detailed definition of done for tool and integration work. Use 
 functions, `BaseTool` classes, or registry-discovered modules under
 `integrations/`; tools should call integration-local clients and helpers.
 
+Tool packages must be substantive production modules. Do not add an empty
+`tools/<name>/__init__.py`, a discovery-only package, or a thin wrapper that
+only satisfies registry import mechanics. Directionally, any tool with
+validation, credential or parameter resolution, external transport/client
+calls, output normalization, or error handling should split those concerns into
+focused sibling files such as `tool.py`, `models.py`, `validation.py`,
+`delivery.py`/`client.py`, and `results.py`. In that layout, `__init__.py`
+should be a small registry entrypoint that imports the public tool object.
+
 ### Contract and implementation
 
 - [ ] Pick the simplest shape that fits the tool (`@tool(...)` for lightweight tools, richer class only when needed)
+- [ ] The tool package is not an empty or discovery-only `__init__.py`; non-trivial tools use sibling modules for implementation concerns and keep `__init__.py` as a small registry entrypoint
 - [ ] Metadata is complete and accurate: `name`, `description`, `source`, `surfaces`, `requires`, and any `use_cases` / `outputs` / `retrieval_controls`
 - [ ] `input_schema` matches the actual runtime arguments and required fields
 - [ ] `is_available` only returns `True` when the tool can genuinely run
 - [ ] `extract_params` maps resolved integration state into tool args correctly
+- [ ] Secrets are not exposed through `extract_params`, return values, logs, or traceable tool-call kwargs
+- [ ] Validation, parameter/credential resolution, transport/client calls, and result formatting are separated into focused helpers or sibling files so each can be tested or reasoned about independently
 - [ ] Failure responses have a stable, investigation-friendly shape
+- [ ] Expected external failures (missing config, auth failure, rate limit, upstream 4xx/5xx) return structured errors; unexpected exceptions either use the global `BaseTool` wrapper intentionally or are migrated with telemetry coverage
 - [ ] Tool output is normalized enough for the planner/LLM to consume reliably
 - [ ] Reusable transport or integration-specific parsing logic lives in `integrations/<name>/` or `tools/utils/` rather than being copied into the tool body
+- [ ] External side effects declare `side_effect_level`, `requires_approval`, `approval_reason`, and `approval_scope` where appropriate
 - [ ] If the tool should appear in both investigation and chat, set `surfaces=("investigation", "chat")`
 - [ ] Output that may contain secrets, tokens, or PII is run through `platform/masking/` before being returned
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -11,72 +11,83 @@ directly and call ``.run(initial_messages)``.
 
 from __future__ import annotations
 
-from core.agent import Agent, AgentRunResult, LoopEventCallback, ToolLoopResult
-from core.context_budget import (
-    context_budget_ceiling_for_model,
-    enforce_context_budget,
-    estimate_message_tokens,
-    trim_lowest_value_tool_pair,
-    truncate_content,
-)
-from core.events import (
-    AgentEndEvent,
-    AgentStartEvent,
-    LegacyLoopEventCallback,
-    LegacyRuntimeEventCallback,
-    MessageStartEvent,
-    MessageUpdateEvent,
-    ProviderRequestEndEvent,
-    ProviderRequestStartEvent,
-    RuntimeEvent,
-    RuntimeEventCallback,
-    RuntimeEventKind,
-    RuntimeEventType,
-    ToolExecutionEndEvent,
-    ToolExecutionStartEvent,
-    ToolExecutionUpdateEvent,
-    TurnEndEvent,
-    TurnStartEvent,
-    legacy_callback_payload,
-    runtime_event_from_legacy,
-)
-from core.execution import (
-    BeforeToolCallResult,
-    ToolExecutionHooks,
-    ToolExecutionPatch,
-    ToolExecutionRequest,
-    ToolExecutionResult,
-    execute_tool_calls,
-    execute_tools,
-    public_tool_input,
-    summarise,
-    tool_source,
-)
-from core.llm_invoke_errors import LLMInvokeFailure, classify_llm_invoke_failure
-from core.messages import (
-    AppRuntimeMessage,
-    AssistantRuntimeMessage,
-    RuntimeMessage,
-    ToolResultRuntimeMessage,
-    UserRuntimeMessage,
-    build_assistant_message,
-    build_synthetic_assistant_tool_call_message,
-    build_tool_result_messages,
-    convert_to_llm_messages,
-    ensure_runtime_messages,
-    runtime_assistant_message,
-    runtime_synthetic_assistant_tool_call_message,
-    runtime_tool_result_message,
-    user_runtime_message,
-)
-from core.provider import ProviderHooks, ProviderRequest, resolve_llm_api_key
-from core.types import (
-    AgentTool,
-    AgentToolContext,
-    AgentToolExecutor,
-    RuntimeTool,
-    ToolExecutionMode,
-)
+from importlib import import_module
+from typing import Any
+
+_EXPORT_MODULES = {
+    "Agent": "core.agent",
+    "AgentRunResult": "core.agent",
+    "LoopEventCallback": "core.agent",
+    "ToolLoopResult": "core.agent",
+    "context_budget_ceiling_for_model": "core.context_budget",
+    "enforce_context_budget": "core.context_budget",
+    "estimate_message_tokens": "core.context_budget",
+    "trim_lowest_value_tool_pair": "core.context_budget",
+    "truncate_content": "core.context_budget",
+    "AgentEndEvent": "core.events",
+    "AgentStartEvent": "core.events",
+    "LegacyLoopEventCallback": "core.events",
+    "LegacyRuntimeEventCallback": "core.events",
+    "MessageStartEvent": "core.events",
+    "MessageUpdateEvent": "core.events",
+    "ProviderRequestEndEvent": "core.events",
+    "ProviderRequestStartEvent": "core.events",
+    "RuntimeEvent": "core.events",
+    "RuntimeEventCallback": "core.events",
+    "RuntimeEventKind": "core.events",
+    "RuntimeEventType": "core.events",
+    "ToolExecutionEndEvent": "core.events",
+    "ToolExecutionStartEvent": "core.events",
+    "ToolExecutionUpdateEvent": "core.events",
+    "TurnEndEvent": "core.events",
+    "TurnStartEvent": "core.events",
+    "legacy_callback_payload": "core.events",
+    "runtime_event_from_legacy": "core.events",
+    "BeforeToolCallResult": "core.execution",
+    "ToolExecutionHooks": "core.execution",
+    "ToolExecutionPatch": "core.execution",
+    "ToolExecutionRequest": "core.execution",
+    "ToolExecutionResult": "core.execution",
+    "execute_tool_calls": "core.execution",
+    "execute_tools": "core.execution",
+    "public_tool_input": "core.execution",
+    "summarise": "core.execution",
+    "tool_source": "core.execution",
+    "LLMInvokeFailure": "core.llm_invoke_errors",
+    "classify_llm_invoke_failure": "core.llm_invoke_errors",
+    "AppRuntimeMessage": "core.messages",
+    "AssistantRuntimeMessage": "core.messages",
+    "RuntimeMessage": "core.messages",
+    "ToolResultRuntimeMessage": "core.messages",
+    "UserRuntimeMessage": "core.messages",
+    "build_assistant_message": "core.messages",
+    "build_synthetic_assistant_tool_call_message": "core.messages",
+    "build_tool_result_messages": "core.messages",
+    "convert_to_llm_messages": "core.messages",
+    "ensure_runtime_messages": "core.messages",
+    "runtime_assistant_message": "core.messages",
+    "runtime_synthetic_assistant_tool_call_message": "core.messages",
+    "runtime_tool_result_message": "core.messages",
+    "user_runtime_message": "core.messages",
+    "ProviderHooks": "core.provider",
+    "ProviderRequest": "core.provider",
+    "resolve_llm_api_key": "core.provider",
+    "AgentTool": "core.types",
+    "AgentToolContext": "core.types",
+    "AgentToolExecutor": "core.types",
+    "RuntimeTool": "core.types",
+    "ToolExecutionMode": "core.types",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _EXPORT_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(module_name), name)
+    globals()[name] = value
+    return value
+
 
 __all__ = [
     "Agent",

--- a/core/domain/types/evidence.py
+++ b/core/domain/types/evidence.py
@@ -62,6 +62,7 @@ EvidenceSource = Literal[
     "ec2",
     "hermes",
     "twilio",
+    "telegram",
     "redis",
     "temporal",
 ]

--- a/docs/messaging/telegram.mdx
+++ b/docs/messaging/telegram.mdx
@@ -149,6 +149,39 @@ Findings should appear in the configured chat. Long reports are truncated to Tel
 
 ---
 
+## Programmatic messaging: `telegram_send_message` tool
+
+When the Telegram integration is configured, OpenSRE exposes a
+`telegram_send_message` tool. The tool can send user-requested action messages,
+incident notifications, or follow-up updates to the configured default chat, or
+to an explicit `chat_id` when one is supplied. It uses plain text mode, so
+user-provided `<`, `>`, and `&` characters are sent as ordinary message text
+rather than Telegram HTML.
+
+```json
+{
+  "name": "telegram_send_message",
+  "arguments": {
+    "chat_id": "-1001234567890",
+    "message": "DB CPU is back below 70%; keeping the incident open for 10 minutes."
+  }
+}
+```
+
+The tool resolves the bot token from the same credential chain as the watchdog:
+integration store, then `TELEGRAM_BOT_TOKEN`, then the system keyring.
+If `chat_id` is omitted, it sends through the configured `default_chat_id`, so a
+user can ask OpenSRE to send a message through the configured Telegram bot
+without knowing or exposing the bot token.
+
+Delivery is an external side effect, so the tool is approval-gated in runtime
+surfaces that enforce tool approvals. Its result includes a stable `status`,
+`sent`, `error_type`, `chat_id`, `reply_to_message_id`, and `message_length`
+shape so follow-up tool calls can tell configuration failures from Telegram
+delivery failures.
+
+---
+
 ## Troubleshooting
 
 `opensre integrations verify telegram` only calls Telegram's `getMe` endpoint, so it surfaces token-validity errors but cannot detect chat-routing problems. Delivery-time errors only show up when an investigation actually posts.

--- a/tests/tools/test_telegram_send_message_tool.py
+++ b/tests/tools/test_telegram_send_message_tool.py
@@ -1,0 +1,220 @@
+"""Tests for tools/TelegramSendMessageTool - Telegram message action surface."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+
+from tools.telegram_send_message_tool import TelegramSendMessageTool, telegram_send_message
+
+
+@pytest.fixture
+def telegram_source() -> dict[str, Any]:
+    """The flat/runtime ``sources`` shape passed to is_available()."""
+    return {
+        "telegram": {
+            "bot_token": "123:abc",
+            "default_chat_id": "-100123",
+        }
+    }
+
+
+def test_metadata_declares_telegram_source() -> None:
+    metadata = TelegramSendMessageTool.metadata()
+    assert metadata.name == "telegram_send_message"
+    assert metadata.source == "telegram"
+    assert metadata.side_effect_level == "external"
+    assert telegram_send_message.requires_approval is True
+    assert telegram_send_message.approval_scope == "one_shot"
+
+
+def test_registered_tool_is_available_on_chat_and_investigation_surfaces() -> None:
+    registered = telegram_send_message.__opensre_registered_tool__
+    assert registered.surfaces == ("investigation", "chat")
+    assert registered.requires_approval is True
+
+
+def test_is_available_true_when_bot_token_configured(telegram_source: dict[str, Any]) -> None:
+    assert telegram_send_message.is_available(telegram_source) is True
+
+
+def test_is_available_false_when_no_telegram() -> None:
+    assert telegram_send_message.is_available({}) is False
+
+
+def test_is_available_false_when_bot_token_missing(telegram_source: dict[str, Any]) -> None:
+    telegram_source["telegram"]["bot_token"] = ""
+    assert telegram_send_message.is_available(telegram_source) is False
+
+
+def test_extract_params_returns_no_credentials(telegram_source: dict[str, Any]) -> None:
+    """extract_params output is serialized into traces - it must hold no secrets."""
+    params = telegram_send_message.extract_params(telegram_source)
+    assert params == {}
+
+
+def test_init_is_only_registry_entrypoint() -> None:
+    import tools.telegram_send_message_tool as package
+
+    source = inspect.getsource(package)
+    assert "from tools.telegram_send_message_tool.tool import" in source
+    assert "class TelegramSendMessageTool" not in source
+
+
+def test_run_resolves_credentials_internally_and_dispatches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _Creds:
+        bot_token = "123:abc"
+        chat_id = "-100999"
+
+    def _fake_load(*, chat_id_override: str | None = None) -> _Creds:
+        captured["chat_id_override"] = chat_id_override
+        return _Creds()
+
+    def _fake_send(
+        report: str,
+        ctx: dict[str, Any],
+        *,
+        parse_mode: str = "HTML",
+        reply_markup: dict[str, Any] | None = None,
+    ) -> tuple[bool, str]:
+        captured["report"] = report
+        captured["ctx"] = ctx
+        captured["parse_mode"] = parse_mode
+        captured["reply_markup"] = reply_markup
+        return True, ""
+
+    monkeypatch.setattr(
+        "tools.telegram_send_message_tool.delivery.load_credentials_from_env", _fake_load
+    )
+    monkeypatch.setattr(
+        "tools.telegram_send_message_tool.delivery.send_telegram_report", _fake_send
+    )
+
+    result = telegram_send_message.run(
+        message=" page on-call ",
+        chat_id=" -100999 ",
+        reply_to_message_id=" 42 ",
+    )
+
+    assert result["status"] == "sent"
+    assert result["sent"] is True
+    assert result["chat_id"] == "-100999"
+    assert result["reply_to_message_id"] == "42"
+    assert result["message_length"] == len("page on-call")
+    assert captured["chat_id_override"] == "-100999"
+    assert captured["report"] == "page on-call"
+    assert captured["ctx"] == {
+        "bot_token": "123:abc",
+        "chat_id": "-100999",
+        "reply_to_message_id": "42",
+    }
+    assert captured["parse_mode"] == ""
+
+
+def test_run_sends_user_requested_action_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class _Creds:
+        bot_token = "123:abc"
+        chat_id = "-100default"
+
+    monkeypatch.setattr(
+        "tools.telegram_send_message_tool.delivery.load_credentials_from_env",
+        lambda **_kwargs: _Creds(),
+    )
+
+    def _fake_send(report: str, ctx: dict[str, Any], **_kwargs: Any) -> tuple[bool, str]:
+        captured["report"] = report
+        captured["ctx"] = ctx
+        return True, ""
+
+    monkeypatch.setattr(
+        "tools.telegram_send_message_tool.delivery.send_telegram_report", _fake_send
+    )
+
+    result = telegram_send_message.run(message="Tell the team the database failover is complete.")
+
+    assert result["status"] == "sent"
+    assert captured["report"] == "Tell the team the database failover is complete."
+    assert captured["ctx"]["chat_id"] == "-100default"
+
+
+def test_run_falls_back_to_default_chat(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class _Creds:
+        bot_token = "123:abc"
+        chat_id = "-100default"
+
+    def _fake_load(*, chat_id_override: str | None = None) -> _Creds:
+        captured["chat_id_override"] = chat_id_override
+        return _Creds()
+
+    monkeypatch.setattr(
+        "tools.telegram_send_message_tool.delivery.load_credentials_from_env", _fake_load
+    )
+    monkeypatch.setattr(
+        "tools.telegram_send_message_tool.delivery.send_telegram_report",
+        lambda _report, _ctx, **_kwargs: (True, ""),
+    )
+
+    result = telegram_send_message.run(message="hi")
+
+    assert result["status"] == "sent"
+    assert result["sent"] is True
+    assert result["chat_id"] == "-100default"
+    assert captured["chat_id_override"] is None
+
+
+def test_run_failed_when_message_is_empty() -> None:
+    result = telegram_send_message.run(message="  ", chat_id="-100123")
+
+    assert result["status"] == "failed"
+    assert result["sent"] is False
+    assert result["available"] is True
+    assert result["error_type"] == "validation_error"
+    assert "empty" in result["error"].lower()
+
+
+def test_run_failed_when_telegram_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "tools.telegram_send_message_tool.delivery.load_credentials_from_env",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("Telegram is not configured.")),
+    )
+
+    result = telegram_send_message.run(message="hi", chat_id="-100123")
+
+    assert result["status"] == "failed"
+    assert result["sent"] is False
+    assert result["available"] is False
+    assert result["error_type"] == "configuration_error"
+    assert "not configured" in result["error"].lower()
+
+
+def test_run_propagates_send_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Creds:
+        bot_token = "123:abc"
+        chat_id = "-100123"
+
+    monkeypatch.setattr(
+        "tools.telegram_send_message_tool.delivery.load_credentials_from_env",
+        lambda **_kwargs: _Creds(),
+    )
+    monkeypatch.setattr(
+        "tools.telegram_send_message_tool.delivery.send_telegram_report",
+        lambda _r, _c, **_kwargs: (False, "telegram rejected"),
+    )
+
+    result = telegram_send_message.run(message="hi", chat_id="-100123")
+
+    assert result["status"] == "failed"
+    assert result["sent"] is False
+    assert result["error"] == "telegram rejected"
+    assert result["error_type"] == "delivery_error"
+    assert result["chat_id"] == "-100123"

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -1152,6 +1152,7 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         "temporal_task_queue",
         "temporal_workflow_history",
         "temporal_workflows",
+        "telegram_send_message",
         "twilio_notify",
         "vercel_deployment_logs",
         "vercel_deployment_status",

--- a/tools/telegram_send_message_tool/__init__.py
+++ b/tools/telegram_send_message_tool/__init__.py
@@ -1,0 +1,9 @@
+"""Registry entrypoint for the Telegram send-message tool."""
+
+from __future__ import annotations
+
+from tools.telegram_send_message_tool.tool import TelegramSendMessageTool, telegram_send_message
+
+TOOL_MODULES = ("tool",)
+
+__all__ = ["TelegramSendMessageTool", "telegram_send_message"]

--- a/tools/telegram_send_message_tool/constants.py
+++ b/tools/telegram_send_message_tool/constants.py
@@ -1,0 +1,7 @@
+"""Shared constants for Telegram message tools."""
+
+from __future__ import annotations
+
+from core.domain.types.evidence import EvidenceSource
+
+SOURCE: EvidenceSource = "telegram"

--- a/tools/telegram_send_message_tool/delivery.py
+++ b/tools/telegram_send_message_tool/delivery.py
@@ -1,0 +1,37 @@
+"""Credential resolution and transport dispatch for Telegram messages."""
+
+from __future__ import annotations
+
+from platform.notifications.telegram_delivery import send_telegram_report
+from tools.telegram_send_message_tool.models import TelegramDeliveryTarget
+from tools.watch_dog.alarms import load_credentials_from_env
+
+
+def resolve_target(
+    chat_id: str,
+    reply_to_message_id: str,
+) -> tuple[TelegramDeliveryTarget | None, str]:
+    try:
+        creds = load_credentials_from_env(chat_id_override=chat_id or None)
+    except Exception as exc:
+        return None, str(exc)
+    return (
+        TelegramDeliveryTarget(
+            bot_token=creds.bot_token,
+            chat_id=creds.chat_id,
+            reply_to_message_id=reply_to_message_id,
+        ),
+        "",
+    )
+
+
+def dispatch_message(message: str, target: TelegramDeliveryTarget) -> tuple[bool, str]:
+    return send_telegram_report(
+        message,
+        {
+            "bot_token": target.bot_token,
+            "chat_id": target.chat_id,
+            "reply_to_message_id": target.reply_to_message_id,
+        },
+        parse_mode="",
+    )

--- a/tools/telegram_send_message_tool/models.py
+++ b/tools/telegram_send_message_tool/models.py
@@ -1,0 +1,26 @@
+"""Typed models for Telegram message delivery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TelegramDeliveryTarget:
+    """Resolved Telegram delivery destination.
+
+    ``bot_token`` is deliberately excluded from repr so failed assertions,
+    tracebacks, or debug logs do not leak the Telegram credential.
+    """
+
+    bot_token: str
+    chat_id: str
+    reply_to_message_id: str = ""
+
+    def __repr__(self) -> str:
+        return (
+            "TelegramDeliveryTarget("
+            f"chat_id={self.chat_id!r}, "
+            f"reply_to_message_id={self.reply_to_message_id!r}, "
+            "bot_token=<redacted>)"
+        )

--- a/tools/telegram_send_message_tool/results.py
+++ b/tools/telegram_send_message_tool/results.py
@@ -1,0 +1,44 @@
+"""Stable result shapes for Telegram message delivery."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools.telegram_send_message_tool.constants import SOURCE
+from tools.telegram_send_message_tool.models import TelegramDeliveryTarget
+
+
+def failed_result(
+    *,
+    available: bool,
+    error: str,
+    error_type: str,
+    chat_id: str = "",
+    reply_to_message_id: str = "",
+    message_length: int = 0,
+) -> dict[str, Any]:
+    return {
+        "source": SOURCE,
+        "available": available,
+        "status": "failed",
+        "sent": False,
+        "error": error,
+        "error_type": error_type,
+        "chat_id": chat_id,
+        "reply_to_message_id": reply_to_message_id,
+        "message_length": message_length,
+    }
+
+
+def sent_result(*, target: TelegramDeliveryTarget, message_length: int) -> dict[str, Any]:
+    return {
+        "source": SOURCE,
+        "available": True,
+        "status": "sent",
+        "sent": True,
+        "error": "",
+        "error_type": "",
+        "chat_id": target.chat_id,
+        "reply_to_message_id": target.reply_to_message_id,
+        "message_length": message_length,
+    }

--- a/tools/telegram_send_message_tool/tool.py
+++ b/tools/telegram_send_message_tool/tool.py
@@ -1,0 +1,117 @@
+"""Agent-callable Telegram message action."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools.base import BaseTool
+from tools.telegram_send_message_tool.constants import SOURCE
+from tools.telegram_send_message_tool.delivery import dispatch_message, resolve_target
+from tools.telegram_send_message_tool.results import failed_result, sent_result
+from tools.telegram_send_message_tool.validation import normalize_optional_text, validate_message
+from tools.tool_decorator import tool
+
+
+class TelegramSendMessageTool(BaseTool):
+    """Send a plain-text message via the configured Telegram integration."""
+
+    name = "telegram_send_message"
+    source = SOURCE
+    description = (
+        "Send a plain-text message via the configured Telegram integration. "
+        "Use this for explicit user-requested Telegram message actions and for "
+        "incident notifications. The tool resolves credentials internally and "
+        "returns structured delivery status without exposing secrets."
+    )
+    use_cases = [
+        "Sending a user-requested message to the configured Telegram default chat",
+        "Posting a concise incident notification to a Telegram chat or channel",
+        "Following up after an investigation with a short status update",
+    ]
+    requires = ["telegram"]
+    side_effect_level = "external"
+    requires_approval = True
+    approval_reason = "This tool sends a message to an external Telegram chat."
+    approval_scope = "one_shot"
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "message": {
+                "type": "string",
+                "description": "Plain-text message body. Long messages are truncated to Telegram's limit.",
+            },
+            "chat_id": {
+                "type": "string",
+                "description": (
+                    "Optional Telegram chat or channel id. Defaults to the configured "
+                    "default_chat_id when omitted."
+                ),
+            },
+            "reply_to_message_id": {
+                "type": "string",
+                "description": "Optional Telegram message id to reply to.",
+            },
+        },
+        "required": ["message"],
+    }
+    outputs = {
+        "status": "delivery dispatch status - 'sent' or 'failed'",
+        "sent": "boolean delivery result for easy downstream checks",
+        "error": "error detail when status is 'failed'",
+        "error_type": "stable failure class: validation_error, configuration_error, or delivery_error",
+        "chat_id": "Telegram chat id used for delivery",
+        "reply_to_message_id": "Telegram message id used for reply threading, when supplied",
+        "message_length": "length of the normalized message submitted for delivery",
+    }
+
+    def is_available(self, sources: dict[str, Any]) -> bool:
+        telegram = sources.get("telegram") or {}
+        return bool(telegram.get("bot_token"))
+
+    # extract_params intentionally stays empty. It is serialized into tool-call
+    # traces, so Telegram credentials must be resolved inside run() only.
+
+    def run(
+        self,
+        message: str,
+        chat_id: str = "",
+        reply_to_message_id: str = "",
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        chat_id = normalize_optional_text(chat_id)
+        reply_to_message_id = normalize_optional_text(reply_to_message_id)
+        valid, normalized_message, validation_error = validate_message(message)
+        if not valid:
+            return failed_result(
+                available=True,
+                error=validation_error,
+                error_type="validation_error",
+                chat_id=chat_id,
+                reply_to_message_id=reply_to_message_id,
+            )
+
+        target, resolution_error = resolve_target(chat_id, reply_to_message_id)
+        if target is None:
+            return failed_result(
+                available=False,
+                error=resolution_error,
+                error_type="configuration_error",
+                chat_id=chat_id,
+                reply_to_message_id=reply_to_message_id,
+                message_length=len(normalized_message),
+            )
+
+        ok, error = dispatch_message(normalized_message, target)
+        if not ok:
+            return failed_result(
+                available=True,
+                error=error,
+                error_type="delivery_error",
+                chat_id=target.chat_id,
+                reply_to_message_id=target.reply_to_message_id,
+                message_length=len(normalized_message),
+            )
+        return sent_result(target=target, message_length=len(normalized_message))
+
+
+telegram_send_message = tool(TelegramSendMessageTool(), surfaces=("investigation", "chat"))

--- a/tools/telegram_send_message_tool/validation.py
+++ b/tools/telegram_send_message_tool/validation.py
@@ -1,0 +1,14 @@
+"""Input normalization and validation for Telegram message actions."""
+
+from __future__ import annotations
+
+
+def normalize_optional_text(value: str) -> str:
+    return str(value or "").strip()
+
+
+def validate_message(message: str) -> tuple[bool, str, str]:
+    normalized = str(message or "").strip()
+    if not normalized:
+        return False, "", "Message cannot be empty."
+    return True, normalized, ""


### PR DESCRIPTION
## Summary
- Add an approval-gated `telegram_send_message` tool for OpenSRE to send user-requested Telegram action messages, incident notifications, and follow-up updates through the configured Telegram bot/default chat or an explicit `chat_id`.
- Split the tool into focused sibling modules for metadata/runtime, credential resolution and delivery, validation, result shaping, and models instead of hiding implementation in `__init__.py`.
- Update Telegram docs plus repo/tool quality policy to make non-trivial tool packages substantive, separated by concern, tested, and error-handled.

## Validation
- `uv run pytest tests/tools/test_telegram_send_message_tool.py tests/tools/test_telemetry.py::test_every_registered_tool_is_migrated_or_allowlisted tests/tools/test_registry.py -q`
- `make lint`
- `make format-check`
- `make typecheck`
- `make verify-integrations`
- `make test-scope` (`9968 passed, 55 skipped`)

## Notes
- `make verify-integrations` confirmed the configured Telegram bot connection (`@opensre_bot_28_june_vin_bot`).