### PR TITLE
fix posthog mcp project scoping

### DIFF
--- a/tests/tools/test_posthog_mcp_tool.py
+++ b/tests/tools/test_posthog_mcp_tool.py
@@ -27,6 +27,8 @@ _CONNECTION_PARAMS = frozenset(
         "posthog_token",
         "posthog_command",
         "posthog_args",
+        "posthog_organization_id",
+        "posthog_project_id",
     }
 )
 
@@ -81,6 +83,8 @@ def test_tools_available_when_connection_verified() -> None:
                 "url": "https://mcp.posthog.com/mcp",
                 "mode": "streamable-http",
                 "auth_token": "phx_secret",
+                "organization_id": "org_123",
+                "project_id": "proj_456",
             }
         }
     )
@@ -102,12 +106,16 @@ def test_extract_params_maps_source_fields() -> None:
                 "url": "https://mcp.posthog.com/mcp",
                 "mode": "streamable-http",
                 "auth_token": "phx_secret",
+                "organization_id": "org_123",
+                "project_id": "proj_456",
             }
         }
     )
     assert params["posthog_url"] == "https://mcp.posthog.com/mcp"
     assert params["posthog_mode"] == "streamable-http"
     assert params["posthog_token"] == "phx_secret"
+    assert params["posthog_organization_id"] == "org_123"
+    assert params["posthog_project_id"] == "proj_456"
 
 
 def test_call_tool_requires_tool_name() -> None:
@@ -191,6 +199,22 @@ def test_resolve_config_recovers_from_guessed_mode(guessed_mode: str) -> None:
     assert config is not None
     assert config.mode == "streamable-http"
     assert config.url == "https://mcp.posthog.com/mcp"
+
+
+def test_resolve_config_preserves_project_scope_from_injected_params() -> None:
+    config = _resolve_config(
+        posthog_url="https://mcp.posthog.com/mcp",
+        posthog_mode="streamable-http",
+        posthog_token="phx_secret",
+        posthog_organization_id="org_123",
+        posthog_project_id="proj_456",
+    )
+
+    assert config is not None
+    assert config.organization_id == "org_123"
+    assert config.project_id == "proj_456"
+    assert config.request_headers["x-posthog-organization-id"] == "org_123"
+    assert config.request_headers["x-posthog-project-id"] == "proj_456"
 
 
 def test_resolve_config_stdio_without_command_falls_back_to_http() -> None:

--- a/tools/posthog_mcp_tool/__init__.py
+++ b/tools/posthog_mcp_tool/__init__.py
@@ -82,6 +82,8 @@ def _resolve_config(
     posthog_token: str | None,
     posthog_command: str | None = None,
     posthog_args: list[str] | None = None,
+    posthog_organization_id: str | None = None,
+    posthog_project_id: str | None = None,
 ) -> PostHogMCPConfig | None:
     env_config = posthog_mcp_config_from_env()
     if any((posthog_url, posthog_mode, posthog_token, posthog_command, posthog_args)):
@@ -112,8 +114,9 @@ def _resolve_config(
             "command": command,
             "args": posthog_args or (list(env_config.args) if env_config else []),
             "headers": env_config.headers if env_config else {},
-            "organization_id": env_config.organization_id if env_config else "",
-            "project_id": env_config.project_id if env_config else "",
+            "organization_id": posthog_organization_id
+            or (env_config.organization_id if env_config else ""),
+            "project_id": posthog_project_id or (env_config.project_id if env_config else ""),
             "features": list(env_config.features) if env_config else [],
             "read_only": env_config.read_only if env_config else True,
         }
@@ -135,6 +138,10 @@ def _posthog_mcp_extract_params(sources: dict[str, dict]) -> PostHogMCPParams:
         "posthog_token": _first_string(posthog, "posthog_token", "auth_token"),
         "posthog_command": _first_string(posthog, "posthog_command", "command"),
         "posthog_args": _first_list(posthog, "posthog_args", "args"),
+        "posthog_organization_id": _first_string(
+            posthog, "posthog_organization_id", "organization_id"
+        ),
+        "posthog_project_id": _first_string(posthog, "posthog_project_id", "project_id"),
     }
 
 
@@ -195,6 +202,8 @@ def _normalize_tool_result(result: PostHogMCPToolCallResult) -> PostHogMCPRespon
             "posthog_token": {"type": "string"},
             "posthog_command": {"type": "string"},
             "posthog_args": {"type": "array", "items": {"type": "string"}},
+            "posthog_organization_id": {"type": "string"},
+            "posthog_project_id": {"type": "string"},
         },
         "required": [],
     },
@@ -208,6 +217,8 @@ def _normalize_tool_result(result: PostHogMCPToolCallResult) -> PostHogMCPRespon
         "posthog_token",
         "posthog_command",
         "posthog_args",
+        "posthog_organization_id",
+        "posthog_project_id",
     ),
     is_available=_posthog_mcp_available,
     extract_params=_posthog_mcp_extract_params,
@@ -220,6 +231,8 @@ def list_posthog_tools(
     posthog_token: str | None = None,
     posthog_command: str | None = None,
     posthog_args: list[str] | None = None,
+    posthog_organization_id: str | None = None,
+    posthog_project_id: str | None = None,
     **_kwargs: object,
 ) -> PostHogMCPResponse:
     """List tools available from the configured PostHog MCP server.
@@ -234,6 +247,8 @@ def list_posthog_tools(
         posthog_token,
         posthog_command,
         posthog_args,
+        posthog_organization_id,
+        posthog_project_id,
     )
     if config is None:
         payload = _unavailable_response("PostHog MCP integration is not configured.")
@@ -299,6 +314,8 @@ def list_posthog_tools(
             "posthog_token": {"type": "string"},
             "posthog_command": {"type": "string"},
             "posthog_args": {"type": "array", "items": {"type": "string"}},
+            "posthog_organization_id": {"type": "string"},
+            "posthog_project_id": {"type": "string"},
         },
         "required": ["tool_name"],
     },
@@ -312,6 +329,8 @@ def list_posthog_tools(
         "posthog_token",
         "posthog_command",
         "posthog_args",
+        "posthog_organization_id",
+        "posthog_project_id",
     ),
     is_available=_posthog_mcp_available,
     extract_params=_posthog_mcp_extract_params,
@@ -324,6 +343,8 @@ def call_posthog_tool(
     posthog_token: str | None = None,
     posthog_command: str | None = None,
     posthog_args: list[str] | None = None,
+    posthog_organization_id: str | None = None,
+    posthog_project_id: str | None = None,
     **_kwargs: object,
 ) -> PostHogMCPResponse:
     """Call a specific PostHog MCP tool by name."""
@@ -340,6 +361,8 @@ def call_posthog_tool(
         posthog_token,
         posthog_command,
         posthog_args,
+        posthog_organization_id,
+        posthog_project_id,
     )
     if config is None:
         return _unavailable_response(


### PR DESCRIPTION
## Summary
- Preserve PostHog MCP organization/project IDs when injecting verified integration config into chat and investigation tools.
- Add regression coverage that confirms project-scoped headers are sent to the hosted MCP server.

## Test plan
- `uv run python -m pytest tests/tools/test_posthog_mcp_tool.py`


Made with [Cursor](https://cursor.com)