### PR TITLE
[codex] Throttle failed watchdog Telegram alarms

### DIFF
--- a/tests/watch_dog/test_alarms.py
+++ b/tests/watch_dog/test_alarms.py
@@ -348,8 +348,8 @@ def test_cooldown_is_per_threshold_name(monkeypatch: pytest.MonkeyPatch) -> None
 def test_dispatch_returns_false_on_transport_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # A failed Telegram call must NOT arm the cooldown, otherwise a transient
-    # outage would silently swallow the next real alarm.
+    # A failed Telegram call still arms cooldown; otherwise a bad token, bad
+    # chat id, or network outage can retry on every watchdog sample.
     calls: list[dict[str, Any]] = []
     _stub_telegram(monkeypatch, ok=False, error="network down", captured=calls)
     _patch_clock(monkeypatch, [100.0, 105.0])
@@ -361,7 +361,26 @@ def test_dispatch_returns_false_on_transport_failure(
 
     assert dispatcher.dispatch("max_cpu", "first") is False
     assert dispatcher.dispatch("max_cpu", "second") is False
-    assert len(calls) == 2
+    assert len(calls) == 1
+    assert calls[0]["text"] == "first"
+
+
+def test_failed_dispatch_retries_after_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+    _stub_telegram(monkeypatch, ok=False, error="network down", captured=calls)
+    _patch_clock(monkeypatch, [100.0, 105.0, 450.0])
+
+    dispatcher = AlarmDispatcher(
+        AlarmCredentials(bot_token="tok", chat_id="chat-1"),
+        cooldown_seconds=300.0,
+    )
+
+    assert dispatcher.dispatch("max_cpu", "first") is False
+    assert dispatcher.dispatch("max_cpu", "suppressed") is False
+    assert dispatcher.dispatch("max_cpu", "retry") is False
+    assert [call["text"] for call in calls] == ["first", "retry"]
 
 
 def test_dispatch_uses_credentials_from_constructor(

--- a/tools/watch_dog/alarms.py
+++ b/tools/watch_dog/alarms.py
@@ -168,16 +168,8 @@ class AlarmDispatcher:
         if ok:
             return True
 
-        # Roll back the reservation only if it's still ours, so a transient
-        # failure does not silently swallow the next real alarm. Compare-and-
-        # delete prevents stomping on a parallel successful dispatch that
-        # may have updated the slot in the meantime.
-        with self._lock:
-            if self._last_dispatched.get(threshold_name) == now:
-                del self._last_dispatched[threshold_name]
-
         logger.warning(
-            "[watchdog] alarm delivery failed: name=%s error=%s",
+            "[watchdog] alarm delivery failed and cooldown remains armed: name=%s error=%s",
             threshold_name,
             error,
         )


### PR DESCRIPTION
## Summary

- Keep watchdog Telegram alarm cooldown armed when Telegram delivery fails.
- Add regression coverage that failed sends are suppressed inside cooldown and retried after cooldown.

## Root Cause

The watchdog dispatcher reserved a per-threshold cooldown slot before calling Telegram, but deleted that reservation when delivery failed. A bad token, bad chat id, or transient network failure could therefore retry on every watchdog sample and fan out hundreds of Telegram send attempts.

## Validation

- `make lint`
- `make format-check`
- `make typecheck`
- `uv run pytest tests/watch_dog/test_alarms.py tests/watch_dog/test_runner.py tests/interactive_shell/test_watch_cmds.py -q`