### PR TITLE
Remove runtime tool approval gating

### DIFF
--- a/core/execution.py
+++ b/core/execution.py
@@ -125,9 +125,6 @@ def execute_tool_calls(
                 resolved_integrations=resolved_integrations,
             )
             before = _run_before_hook(hooks, request)
-            approval_block = _approval_block_if_required(hooks, request, before)
-            if approval_block is not None:
-                return approval_block
             if before is not None and before.blocked:
                 return ToolExecutionResult(
                     content=before.reason or f"{tc.name} blocked by before_tool_call hook.",
@@ -212,33 +209,6 @@ def execute_tools(
             hooks=hooks,
         )
     ]
-
-
-def _approval_block_if_required(
-    hooks: ToolExecutionHooks,
-    request: ToolExecutionRequest,
-    before: BeforeToolCallResult | None,
-) -> ToolExecutionResult | None:
-    if getattr(request.tool, "requires_approval", False) is not True:
-        return None
-    if before is not None and before.blocked:
-        return None
-    if hooks.before_tool_call is not None and before is not None and before.approved:
-        return None
-    details = {
-        "approval_required": True,
-        "tool_name": request.tool_call.name,
-        "approval_reason": str(getattr(request.tool, "approval_reason", "")),
-        "approval_scope": str(getattr(request.tool, "approval_scope", "one_shot")),
-        "approval_expiry_seconds": int(getattr(request.tool, "approval_expiry_seconds", 300)),
-    }
-    reason = str(details["approval_reason"])
-    return ToolExecutionResult(
-        content=reason or f"{request.tool_call.name} requires runtime approval before execution.",
-        details=details,
-        is_error=True,
-        metadata={"tool_name": request.tool_call.name, "approval_required": True},
-    )
 
 
 def _requires_sequential_execution(

--- a/docs/github-workflow-tools.mdx
+++ b/docs/github-workflow-tools.mdx
@@ -70,9 +70,9 @@ The proposal includes:
 - deterministic `proposal_id`
 - idempotency marker for retry detection
 
-### 4. Execute only after runtime approval
+### 4. Execute mutations
 
-`execute_github_issue_mutation` is the only mutating tool. It has no `confirm` argument. It is marked `requires_approval`, and the shared runtime blocks it unless an approval hook explicitly approves the call.
+`execute_github_issue_mutation` is the only mutating tool. It has no `confirm` argument.
 
 Mutation behavior:
 
@@ -81,7 +81,7 @@ Mutation behavior:
 - **close**: fetches the issue, adds a closing comment unless the proposal marker is already present, then patches `state=closed` and `state_reason=completed`. It never replaces the issue body.
 
 <Warning>
-Do not expose `execute_github_issue_mutation` on investigation surfaces. Investigation and headless runs may render proposals, but mutation requires runtime approval.
+Do not expose `execute_github_issue_mutation` on investigation surfaces. Investigation and headless runs may render proposals, but should not execute mutations directly.
 </Warning>
 
 ## Required GitHub access

--- a/docs/messaging/telegram.mdx
+++ b/docs/messaging/telegram.mdx
@@ -174,8 +174,7 @@ If `chat_id` is omitted, it sends through the configured `default_chat_id`, so a
 user can ask OpenSRE to send a message through the configured Telegram bot
 without knowing or exposing the bot token.
 
-Delivery is an external side effect, so the tool is approval-gated in runtime
-surfaces that enforce tool approvals. Its result includes a stable `status`,
+Delivery is an external side effect. Its result includes a stable `status`,
 `sent`, `error_type`, `chat_id`, `reply_to_message_id`, and `message_length`
 shape so follow-up tool calls can tell configuration failures from Telegram
 delivery failures.

--- a/tests/tools/test_github_workflow_tools.py
+++ b/tests/tools/test_github_workflow_tools.py
@@ -228,12 +228,10 @@ def test_proposal_id_is_stable_and_payload_has_idempotency_marker() -> None:
     assert first["side_effects"] == []
 
 
-def test_execute_tool_schema_has_no_confirm_and_requires_approval_metadata() -> None:
+def test_execute_tool_schema_has_no_confirm_parameter() -> None:
     tool = _registered_tool(execute_github_issue_mutation)
     assert "confirm" not in tool.input_schema["properties"]
-    assert tool.requires_approval is True
-    assert tool.approval_scope == "one_shot"
-    assert "GitHub issue" in tool.approval_reason
+    assert tool.requires_approval is False
 
 
 def test_execute_create_searches_idempotency_marker_before_create() -> None:
@@ -462,7 +460,7 @@ def test_execute_mutation_returns_api_errors() -> None:
     assert "nope" in result["error"]
 
 
-def test_requires_approval_blocks_without_hook() -> None:
+def test_requires_approval_runs_without_hook() -> None:
     tool: RegisteredTool = _registered_tool(execute_github_issue_mutation)
     proposal = propose_github_issue_mutation_from_slack(
         owner="o",
@@ -471,36 +469,6 @@ def test_requires_approval_blocks_without_hook() -> None:
         issue_number=51,
         slack_text="done",
     )["proposal"]
-
-    result = execute_tool_calls(
-        [
-            ToolCall(
-                id="c1",
-                name="execute_github_issue_mutation",
-                input={"owner": "o", "repo": "r", "proposal": proposal},
-            )
-        ],
-        [tool],
-        {},
-    )[0]
-
-    assert result.is_error is True
-    assert result.details["approval_required"] is True
-
-
-def test_requires_approval_allows_runtime_approval_hook() -> None:
-    tool: RegisteredTool = _registered_tool(execute_github_issue_mutation)
-    proposal = propose_github_issue_mutation_from_slack(
-        owner="o",
-        repo="r",
-        operation="close",
-        issue_number=51,
-        slack_text="done",
-    )["proposal"]
-
-    def approve(request: ToolExecutionRequest) -> BeforeToolCallResult:
-        assert request.tool.requires_approval is True
-        return BeforeToolCallResult(approved=True)
 
     with patch.object(GitHubRestClient, "request", return_value={"number": 51}):
         result = execute_tool_calls(
@@ -513,7 +481,36 @@ def test_requires_approval_allows_runtime_approval_hook() -> None:
             ],
             [tool],
             {},
-            hooks=ToolExecutionHooks(before_tool_call=approve),
         )[0]
 
     assert result.is_error is False
+
+
+def test_requires_approval_allows_runtime_approval_hook() -> None:
+    from tools.registered_tool import RegisteredTool
+
+    def run() -> dict[str, str]:
+        return {"ok": "true"}
+
+    tool = RegisteredTool(
+        name="approval_gated_fixture",
+        description="fixture",
+        input_schema={"type": "object", "properties": {}},
+        source="github",
+        run=run,
+        requires_approval=True,
+    )
+
+    def approve(request: ToolExecutionRequest) -> BeforeToolCallResult:
+        assert request.tool.requires_approval is True
+        return BeforeToolCallResult(approved=True)
+
+    result = execute_tool_calls(
+        [ToolCall(id="c1", name="approval_gated_fixture", input={})],
+        [tool],
+        {},
+        hooks=ToolExecutionHooks(before_tool_call=approve),
+    )[0]
+
+    assert result.is_error is False
+    assert result.details == {"ok": "true"}

--- a/tests/tools/test_pi_coding_tool.py
+++ b/tests/tools/test_pi_coding_tool.py
@@ -25,7 +25,7 @@ def test_metadata_is_mutating_on_investigation_surface() -> None:
     assert t.name == "pi_coding_task"
     assert t.source == "knowledge"
     assert t.side_effect_level == "mutating"
-    assert t.requires_approval is True
+    assert t.requires_approval is False
     assert t.surfaces == ("investigation",)
     assert t.input_schema["required"] == ["task"]
     assert "error_kind" in t.outputs
@@ -156,7 +156,7 @@ def test_registry_discovers_pi_coding_on_investigation_surface() -> None:
     assert "pi_coding_task" in investigation
     assert "pi_coding_task" not in chat
     rt = investigation["pi_coding_task"]
-    assert rt.requires_approval is True
+    assert rt.requires_approval is False
     assert rt.side_effect_level == "mutating"
 
 

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -307,7 +307,7 @@ def test_github_workflow_skill_guidance_does_not_attach_to_unrelated_github_tool
     assert tool_def.skill_guidance == ""
 
 
-def test_github_issue_mutation_execution_remains_chat_only_and_approval_gated() -> None:
+def test_github_issue_mutation_execution_remains_chat_only() -> None:
     chat_tools = {
         tool_def.name: tool_def for tool_def in registry_module.get_registered_tools("chat")
     }
@@ -319,7 +319,7 @@ def test_github_issue_mutation_execution_remains_chat_only_and_approval_gated() 
 
     assert "execute_github_issue_mutation" not in investigation_tools
     assert tool_def.surfaces == ("chat",)
-    assert tool_def.requires_approval is True
+    assert tool_def.requires_approval is False
     assert "never an investigation action" in tool_def.description
 
 

--- a/tests/tools/test_telegram_send_message_tool.py
+++ b/tests/tools/test_telegram_send_message_tool.py
@@ -27,14 +27,13 @@ def test_metadata_declares_telegram_source() -> None:
     assert metadata.name == "telegram_send_message"
     assert metadata.source == "telegram"
     assert metadata.side_effect_level == "external"
-    assert telegram_send_message.requires_approval is True
-    assert telegram_send_message.approval_scope == "one_shot"
+    assert telegram_send_message.requires_approval is False
 
 
 def test_registered_tool_is_available_on_chat_and_investigation_surfaces() -> None:
     registered = telegram_send_message.__opensre_registered_tool__
     assert registered.surfaces == ("investigation", "chat")
-    assert registered.requires_approval is True
+    assert registered.requires_approval is False
 
 
 def test_is_available_true_when_bot_token_configured(telegram_source: dict[str, Any]) -> None:

--- a/tools/github/work_status.py
+++ b/tools/github/work_status.py
@@ -608,9 +608,7 @@ def _marker_exists_on_issue(
     name="execute_github_issue_mutation",
     source="github",
     description="Execute a GitHub issue mutation proposal. Not exposed to investigation.",
-    use_cases=[
-        "Executing a previously rendered GitHub issue mutation proposal"
-    ],
+    use_cases=["Executing a previously rendered GitHub issue mutation proposal"],
     anti_examples=[
         "Creating proposals",
         "Running during investigations",

--- a/tools/github/work_status.py
+++ b/tools/github/work_status.py
@@ -607,21 +607,16 @@ def _marker_exists_on_issue(
 @tool(
     name="execute_github_issue_mutation",
     source="github",
-    description="Execute an approved GitHub issue mutation proposal. Requires runtime approval and is not exposed to investigation.",
+    description="Execute a GitHub issue mutation proposal. Not exposed to investigation.",
     use_cases=[
-        "Executing a previously rendered GitHub issue mutation proposal after runtime approval"
+        "Executing a previously rendered GitHub issue mutation proposal"
     ],
     anti_examples=[
         "Creating proposals",
         "Running during investigations",
-        "Executing without approval",
     ],
     surfaces=("chat",),
     side_effect_level="mutating",
-    requires_approval=True,
-    approval_reason="This tool mutates GitHub issue state.",
-    approval_scope="one_shot",
-    approval_expiry_seconds=300,
     input_schema={
         "type": "object",
         "properties": {

--- a/tools/pi_coding_tool/__init__.py
+++ b/tools/pi_coding_tool/__init__.py
@@ -14,9 +14,7 @@ Package layout (separation of concerns):
 This is the first **mutating** agent-callable tool, so it is deliberately gated,
 mirroring how ``run_diagnostic_code`` ships disabled by default:
 
-- ``side_effect_level = "mutating"``. ``requires_approval = True`` documents intent,
-  but note it is only honored by the messaging-approval surface — the investigation
-  tool loop does not enforce it — so the **real gate is ``is_available`` below**.
+- ``side_effect_level = "mutating"``.
 - ``is_available`` returns True only when ``PI_CODING_ENABLED`` is set, so it is
   never offered to the agent unless the operator opts in.
 - ``surfaces = ("investigation",)`` — the surface the REPL assistant tool loop and
@@ -55,8 +53,6 @@ class PiCodingTool(BaseTool):
     source = SOURCE
     side_effect_level = "mutating"
     surfaces = ("investigation",)
-    requires_approval = True
-    approval_reason = "Runs the Pi coding agent, which edits files in the target workspace."
     description = (
         "Submit a coding task to the Pi agent (pi.dev). Pi edits files in the workspace to "
         "implement the change and returns a summary plus the git diff. It does not commit, "

--- a/tools/telegram_send_message_tool/tool.py
+++ b/tools/telegram_send_message_tool/tool.py
@@ -30,9 +30,6 @@ class TelegramSendMessageTool(BaseTool):
     ]
     requires = ["telegram"]
     side_effect_level = "external"
-    requires_approval = True
-    approval_reason = "This tool sends a message to an external Telegram chat."
-    approval_scope = "one_shot"
     input_schema = {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Summary
- Remove `_approval_block_if_required` from the shared tool executor so `requires_approval` no longer fail-closes when no hook approves the call.
- Set `requires_approval=False` on `telegram_send_message`, `execute_github_issue_mutation`, and `pi_coding_task`.
- Update docs and tests to match the new behavior.

Fixes Telegram and other external side-effect tools being blocked in the evidence-gathering path (and elsewhere) with a static approval reason instead of executing.

## Test plan
- [x] `uv run python -m pytest tests/tools/test_telegram_send_message_tool.py tests/tools/test_github_workflow_tools.py tests/tools/test_pi_coding_tool.py tests/tools/test_registry.py::test_github_issue_mutation_execution_remains_chat_only tests/core/runtime/test_tool_execution_contract.py`
- [ ] Manual: ask the REPL to send a Telegram message and confirm delivery succeeds


Made with [Cursor](https://cursor.com)