### PR TITLE
Fix release binary tool registry packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,6 +271,9 @@ jobs:
           --noconfirm
           --collect-data cli
           --collect-data config
+          --collect-submodules integrations
+          --collect-submodules interactive_shell
+          --collect-submodules tools
           --add-data "platform:platform"
           --add-data ".stdlib_vendor:_opensre_stdlib_platform"
 

--- a/tests/infra_ci/test_release_workflow.py
+++ b/tests/infra_ci/test_release_workflow.py
@@ -47,3 +47,11 @@ def test_binary_build_syncs_and_smokes_expected_version() -> None:
     assert 'sync_release_version.py --tag "$TAG_NAME"' in source
     assert "Binary version mismatch: expected %s but saw %s" in source
     assert "$VERSION_NAME" in source
+
+
+def test_binary_build_bundles_registry_discovered_tool_modules() -> None:
+    source = _RELEASE_WORKFLOW.read_text()
+
+    assert "--collect-submodules tools" in source
+    assert "--collect-submodules interactive_shell" in source
+    assert "--collect-submodules integrations" in source


### PR DESCRIPTION
## Summary
- bundle dynamically discovered tool, interactive shell, and integration submodules in the PyInstaller release binary
- add a release workflow regression test so registry-discovered tool modules stay included

## Why
The source checkout registry exposes the unified tools, including Telegram. The installed release binary can miss dynamically imported modules, which causes messages like `Skipping tools.interactive_shell.actions.*: No module named 'tools.interactive_shell.actions'` and prevents chat-surface tools from being available.

## Verification
- `make lint`
- `make format-check`
- `make typecheck`
- `make test-scope` (escalated to full suite: 10012 passed, 55 skipped)
- focused registry/tool tests: `uv run python -m pytest tests/infra_ci/test_release_workflow.py tests/core/agent/test_tool_registry.py tests/tools/test_registry.py tests/tools/test_telegram_send_message_tool.py -q`
- local PyInstaller release build completed and analyzed hidden imports under `tools.interactive_shell.actions.*`
- binary smoke: `./dist/opensre --version`, `./dist/opensre -h`