### PR TITLE
Keep Telegram gateway poll logs off the REPL terminal

### DIFF
--- a/gateway/background.py
+++ b/gateway/background.py
@@ -38,12 +38,22 @@ class TelegramGatewayBackground:
         self._thread.join(timeout=timeout)
 
 
+def _configure_co_located_gateway_logging() -> None:
+    """Keep co-located gateway diagnostics off the interactive REPL terminal."""
+    gateway_logger = logging.getLogger("gateway")
+    if gateway_logger.handlers:
+        return
+    gateway_logger.addHandler(logging.NullHandler())
+    gateway_logger.propagate = False
+
+
 def run_poll_loop(settings: GatewaySettings, stop_event: threading.Event) -> None:
     """Run the Telegram long-poll loop until ``stop_event`` is set."""
     runner = GatewayRunner(settings)
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     runner.bind_loop(loop)
+    runner.clear_webhook()
     poller = TelegramPoller(settings.bot_token)
 
     async def _loop_body() -> None:
@@ -86,6 +96,7 @@ def try_start_telegram_gateway_background() -> TelegramGatewayBackground | None:
     stop_event = threading.Event()
 
     def _target() -> None:
+        _configure_co_located_gateway_logging()
         run_poll_loop(settings, stop_event)
 
     thread = threading.Thread(
@@ -94,7 +105,7 @@ def try_start_telegram_gateway_background() -> TelegramGatewayBackground | None:
         daemon=True,
     )
     thread.start()
-    logger.info("[telegram-gateway] auto-start poll mode active")
+    logger.debug("[telegram-gateway] auto-start poll mode active")
     return TelegramGatewayBackground(thread=thread, stop_event=stop_event)
 
 

--- a/gateway/platforms/telegram/poller.py
+++ b/gateway/platforms/telegram/poller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 from typing import Any
@@ -14,6 +15,19 @@ from gateway.platforms.telegram.webhook import parse_update
 logger = logging.getLogger(__name__)
 
 _API = "https://api.telegram.org/bot{token}/getUpdates"
+_CONFLICT_ERROR_CODE = 409
+_DEFAULT_RETRY_SECONDS = 2.0
+_MAX_CONFLICT_BACKOFF_SECONDS = 30.0
+_WARNING_COOLDOWN_SECONDS = 60.0
+
+
+def _decode_telegram_response(response: httpx.Response) -> dict[str, Any]:
+    """Parse a Telegram Bot API JSON body regardless of HTTP status."""
+    try:
+        data = response.json()
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 class TelegramPoller:
@@ -23,6 +37,8 @@ class TelegramPoller:
         self._token = bot_token
         self._timeout = timeout
         self._offset = 0
+        self._conflict_backoff_seconds = _DEFAULT_RETRY_SECONDS
+        self._last_warning_monotonic = 0.0
 
     def poll_once(self) -> list[TelegramInboundMessage]:
         url = _API.format(token=self._token)
@@ -33,15 +49,17 @@ class TelegramPoller:
         }
         try:
             response = httpx.get(url, params=params, timeout=float(self._timeout + 5))
-            data = response.json() if response.status_code == 200 else {}
         except Exception as exc:
-            logger.warning("[telegram-gateway] getUpdates failed: %s", exc)
-            time.sleep(2)
+            self._log_transient("[telegram-gateway] getUpdates failed: %s", exc)
+            time.sleep(_DEFAULT_RETRY_SECONDS)
             return []
-        if not isinstance(data, dict) or not data.get("ok"):
-            logger.warning("[telegram-gateway] getUpdates not ok: %s", data)
-            time.sleep(2)
+
+        data = _decode_telegram_response(response)
+        if not data.get("ok"):
+            self._handle_poll_error(data=data, response=response)
             return []
+
+        self._conflict_backoff_seconds = _DEFAULT_RETRY_SECONDS
         result = data.get("result")
         if not isinstance(result, list):
             return []
@@ -56,6 +74,47 @@ class TelegramPoller:
             if parsed is not None:
                 events.append(parsed)
         return events
+
+    def _handle_poll_error(
+        self,
+        *,
+        data: dict[str, Any],
+        response: httpx.Response,
+    ) -> None:
+        error_code = data.get("error_code")
+        description = str(
+            data.get("description")
+            or response.text.strip()
+            or f"HTTP {response.status_code}"
+        )
+        if error_code == _CONFLICT_ERROR_CODE:
+            logger.debug(
+                "[telegram-gateway] getUpdates conflict (retry in %.0fs): %s",
+                self._conflict_backoff_seconds,
+                description,
+            )
+            time.sleep(self._conflict_backoff_seconds)
+            self._conflict_backoff_seconds = min(
+                self._conflict_backoff_seconds * 2,
+                _MAX_CONFLICT_BACKOFF_SECONDS,
+            )
+            return
+
+        self._log_transient(
+            "[telegram-gateway] getUpdates not ok (HTTP %s, error_code=%s): %s",
+            response.status_code,
+            error_code,
+            description,
+        )
+        time.sleep(_DEFAULT_RETRY_SECONDS)
+
+    def _log_transient(self, message: str, *args: object) -> None:
+        now = time.monotonic()
+        if now - self._last_warning_monotonic < _WARNING_COOLDOWN_SECONDS:
+            logger.debug(message, *args)
+            return
+        self._last_warning_monotonic = now
+        logger.warning(message, *args)
 
     def run_forever(self, handler: Any) -> None:
         logger.info("[telegram-gateway] starting long-poll loop")

--- a/tests/gateway/test_background.py
+++ b/tests/gateway/test_background.py
@@ -22,7 +22,9 @@ def test_telegram_gateway_auto_start_can_be_disabled(monkeypatch: object) -> Non
     assert telegram_gateway_auto_start_enabled() is False
 
 
-def test_co_located_gateway_logging_does_not_propagate_to_root(caplog: pytest.LogCaptureFixture) -> None:
+def test_co_located_gateway_logging_does_not_propagate_to_root(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     caplog.set_level(logging.WARNING)
     _configure_co_located_gateway_logging()
     logging.getLogger("gateway.platforms.telegram.poller").warning(

--- a/tests/gateway/test_background.py
+++ b/tests/gateway/test_background.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from gateway.background import (
+    _configure_co_located_gateway_logging,
     telegram_gateway_auto_start_enabled,
     try_start_telegram_gateway_background,
 )
@@ -16,6 +20,15 @@ def test_telegram_gateway_auto_start_enabled_defaults_true() -> None:
 def test_telegram_gateway_auto_start_can_be_disabled(monkeypatch: object) -> None:
     monkeypatch.setenv("TELEGRAM_GATEWAY_AUTO_START", "false")  # type: ignore[attr-defined]
     assert telegram_gateway_auto_start_enabled() is False
+
+
+def test_co_located_gateway_logging_does_not_propagate_to_root(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.WARNING)
+    _configure_co_located_gateway_logging()
+    logging.getLogger("gateway.platforms.telegram.poller").warning(
+        "[telegram-gateway] getUpdates not ok: {}",
+    )
+    assert not any("getUpdates not ok" in record.message for record in caplog.records)
 
 
 @patch("gateway.background.run_poll_loop")

--- a/tests/gateway/test_telegram_poller.py
+++ b/tests/gateway/test_telegram_poller.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from gateway.platforms.telegram.poller import TelegramPoller, _decode_telegram_response
+
+
+def test_decode_telegram_response_parses_non_200_json() -> None:
+    response = httpx.Response(
+        409,
+        json={
+            "ok": False,
+            "error_code": 409,
+            "description": "Conflict: terminated by other getUpdates request",
+        },
+    )
+    data = _decode_telegram_response(response)
+    assert data["ok"] is False
+    assert data["error_code"] == 409
+
+
+@patch("gateway.platforms.telegram.poller.time.sleep")
+@patch("gateway.platforms.telegram.poller.httpx.get")
+def test_poll_once_conflict_is_debug_not_warning(
+    mock_get: MagicMock,
+    mock_sleep: MagicMock,
+    caplog: object,
+) -> None:
+    import logging
+
+    caplog.set_level(logging.DEBUG, logger="gateway.platforms.telegram.poller")
+    mock_get.return_value = httpx.Response(
+        409,
+        json={
+            "ok": False,
+            "error_code": 409,
+            "description": "Conflict: terminated by other getUpdates request",
+        },
+    )
+    poller = TelegramPoller("tok")
+    assert poller.poll_once() == []
+    mock_sleep.assert_called_once_with(2.0)
+    assert not any(
+        "[telegram-gateway] getUpdates not ok" in record.message
+        for record in caplog.records
+    )
+
+
+@patch("gateway.platforms.telegram.poller.time.sleep")
+@patch("gateway.platforms.telegram.poller.httpx.get")
+def test_poll_once_success_resets_conflict_backoff(mock_get: MagicMock, mock_sleep: MagicMock) -> None:
+    mock_get.side_effect = [
+        httpx.Response(
+            409,
+            json={"ok": False, "error_code": 409, "description": "conflict"},
+        ),
+        httpx.Response(200, json={"ok": True, "result": []}),
+    ]
+    poller = TelegramPoller("tok")
+    poller._conflict_backoff_seconds = 8.0
+    assert poller.poll_once() == []
+    assert poller.poll_once() == []
+    assert poller._conflict_backoff_seconds == 2.0
+
+
+@patch("gateway.platforms.telegram.poller.time.sleep")
+@patch("gateway.platforms.telegram.poller.httpx.get")
+def test_poll_once_parses_inbound_message(mock_get: MagicMock, mock_sleep: MagicMock) -> None:
+    mock_get.return_value = httpx.Response(
+        200,
+        json={
+            "ok": True,
+            "result": [
+                {
+                    "update_id": 7,
+                    "message": {
+                        "message_id": 11,
+                        "from": {"id": 42},
+                        "chat": {"id": 99, "type": "private"},
+                        "text": "hello",
+                    },
+                }
+            ],
+        },
+    )
+    events = TelegramPoller("tok").poll_once()
+    assert len(events) == 1
+    assert events[0].text == "hello"
+    assert events[0].chat_id == "99"
+    mock_sleep.assert_not_called()

--- a/tests/gateway/test_telegram_poller.py
+++ b/tests/gateway/test_telegram_poller.py
@@ -43,14 +43,15 @@ def test_poll_once_conflict_is_debug_not_warning(
     assert poller.poll_once() == []
     mock_sleep.assert_called_once_with(2.0)
     assert not any(
-        "[telegram-gateway] getUpdates not ok" in record.message
-        for record in caplog.records
+        "[telegram-gateway] getUpdates not ok" in record.message for record in caplog.records
     )
 
 
 @patch("gateway.platforms.telegram.poller.time.sleep")
 @patch("gateway.platforms.telegram.poller.httpx.get")
-def test_poll_once_success_resets_conflict_backoff(mock_get: MagicMock, mock_sleep: MagicMock) -> None:
+def test_poll_once_success_resets_conflict_backoff(
+    mock_get: MagicMock, mock_sleep: MagicMock
+) -> None:
     mock_get.side_effect = [
         httpx.Response(
             409,


### PR DESCRIPTION
## Summary
- Silence `gateway.*` log output when the poll loop auto-starts alongside the interactive shell
- Parse Telegram `getUpdates` JSON on non-200 responses (fixes empty `{}` warnings on 409 conflicts)
- Back off on polling conflicts, clear webhooks before poll mode, and add regression tests

## Test plan
- [x] `uv run python -m pytest tests/gateway/test_telegram_poller.py tests/gateway/test_background.py`
- [x] `make lint`

Made with [Cursor](https://cursor.com)