### PR TITLE
fix(installer): only auto-launch onboarding from a real terminal (#3273)

### DIFF
--- a/docs/install-local.mdx
+++ b/docs/install-local.mdx
@@ -32,7 +32,7 @@ brew install tracer-cloud/tap/opensre
 curl -fsSL https://install.opensre.com | bash
 ```
 
-The install script launches onboarding automatically in an interactive terminal. To install only the binary:
+When you run the installer directly from an interactive terminal, it launches onboarding automatically once the install finishes. When the installer is piped (the `curl … | bash` form above), it skips the auto-launch and prints a "Next steps" hint instead — run `opensre onboard` yourself to start setup. To opt out of the auto-launch entirely:
 
 ```bash
 curl -fsSL https://install.opensre.com | OPENSRE_AUTO_LAUNCH=0 bash

--- a/install.ps1
+++ b/install.ps1
@@ -1035,6 +1035,19 @@ function Start-OpenSreOnboardingAfterInstall {
         return
     }
 
+    # If stdin is redirected (e.g. the installer is piped), the full-screen
+    # onboarding prompt cannot take control of the terminal and exits with a
+    # terminal I/O error mid-render (issue #3273). Skip the auto-launch; the
+    # "Next steps" output already tells the user to run onboarding themselves.
+    try {
+        if ([System.Console]::IsInputRedirected) {
+            return
+        }
+    }
+    catch {
+        return
+    }
+
     if (-not (Test-Path -LiteralPath $BinaryPath -PathType Leaf)) {
         Write-Warning "Could not auto-launch onboarding; $BinaryPath was not found."
         return

--- a/install.sh
+++ b/install.sh
@@ -1139,7 +1139,15 @@ launch_onboarding_after_install() {
   if auto_launch_disabled; then
     return
   fi
-  if [ ! -t 1 ] || [ ! -r /dev/tty ] || [ ! -w /dev/tty ]; then
+
+  # Only auto-launch the interactive wizard when the installer itself is
+  # attached to a real terminal on both stdin and stdout. When the installer is
+  # piped (the documented `curl … | bash`), stdin is the pipe rather than a
+  # terminal, so onboarding's full-screen prompt cannot reliably take control of
+  # the terminal and exits with a "terminal I/O error" mid-render (issue #3273).
+  # In that case we skip the launch; the "Next steps" hint already tells the user
+  # to run `${BIN_NAME} onboard` in their own terminal, where it works.
+  if [ ! -t 0 ] || [ ! -t 1 ]; then
     return
   fi
 
@@ -1150,7 +1158,7 @@ launch_onboarding_after_install() {
   fi
 
   log "Launching ${BIN_NAME} onboard..."
-  "$installed_binary" onboard </dev/tty >/dev/tty 2>&1 || \
+  "$installed_binary" onboard || \
     warn "Onboarding exited before completion. Run '${BIN_NAME} onboard' to retry."
 }
 

--- a/tests/cli/test_install_ps1_progress.py
+++ b/tests/cli/test_install_ps1_progress.py
@@ -81,6 +81,10 @@ def test_install_ps1_contains_auto_onboarding_launch_hook() -> None:
     assert "OPENSRE_AUTO_LAUNCH" in source
     assert "& $BinaryPath onboard" in source
     assert "Start-OpenSreOnboardingAfterInstall -BinaryPath $installedBinaryPath" in source
+    # A redirected/piped host must be treated as non-interactive so the
+    # full-screen prompt is not launched into a terminal it cannot control
+    # (issue #3273).
+    assert "[System.Console]::IsInputRedirected" in source
 
 
 def test_install_ps1_keeps_download_urls_verbose_only() -> None:

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -165,15 +165,32 @@ def test_install_sh_contains_auto_onboarding_launch_hook() -> None:
 
     assert "OPENSRE_AUTO_LAUNCH" in source
     assert "launch_onboarding_after_install" in source
-    assert '"$installed_binary" onboard </dev/tty >/dev/tty 2>&1' in source
+    assert '"$installed_binary" onboard' in source
+
+
+def test_install_sh_auto_onboarding_requires_interactive_stdin() -> None:
+    """Auto-launch must be gated on a real terminal on stdin (issue #3273).
+
+    The documented install path is ``curl … | bash``, where stdin is the curl
+    pipe rather than a terminal. Launching the full-screen wizard there fails
+    with a terminal I/O error mid-render, so the launch must be skipped unless
+    the installer itself is attached to an interactive terminal.
+    """
+    source = INSTALL_SH.read_text()
+
+    # Gate on stdin being a terminal, and no longer redirect from /dev/tty.
+    assert "[ ! -t 0 ]" in source
+    assert "</dev/tty >/dev/tty 2>&1" not in source
 
 
 def test_install_sh_auto_onboarding_noops_without_tty() -> None:
+    # stdin is redirected from /dev/null so the gate is exercised deterministically
+    # regardless of how the test runner's own stdin is wired.
     result = _run_logging_snippet(
         """
         INSTALL_DIR="/tmp"
         BIN_NAME="opensre"
-        launch_onboarding_after_install
+        launch_onboarding_after_install </dev/null
         """
     )
 


### PR DESCRIPTION
Closes #3273.

### What was happening

The auto-launch added in #3271 runs `opensre onboard` from inside the piped `curl … | bash` installer, redirecting `</dev/tty >/dev/tty`. The onboarding wizard renders a full-screen prompt_toolkit UI, and launched that way it can't reliably take control of the inherited `/dev/tty`, so prompt_toolkit raises an `OSError`. Onboarding then dies with "terminal I/O error" after it has already painted half the setup screen.

I confirmed the prompt itself isn't broken — it works fine under a real PTY (Python 3.14, prompt_toolkit 3.0.52). The problem is the launch context, not the wizard.

### The fix

Only auto-launch when the installer itself is attached to a real terminal on stdin and stdout, and drop the `/dev/tty` redirect:

- `curl … | bash` (the documented path): stdin is the pipe, so we skip the launch and fall back to the existing "Next steps: run `opensre onboard`" hint. No more half-rendered UI or scary error.
- `bash install.sh` in a terminal: stdin is the tty, so onboarding still auto-launches and inherits a genuine controlling terminal.

`install.ps1` gets the matching `IsInputRedirected` guard, scoped to the auto-launch path so the installer's progress UI is untouched.

I avoided a runtime "can I prompt?" probe on purpose: the reliable way to detect this (entering raw mode) can get the process stopped by `SIGTTOU`/`SIGTTIN`, which would turn the error into a hang.

### Verification

- PTY-vs-pipe demo: piped install skips the launch; an interactive PTY launches onboarding.
- `bash -n install.sh` clean; install/onboard test suites pass; ruff lint + format clean.
- Updated the install-sh/ps1 contract tests and `docs/install-local.mdx` to match the new behavior.

### Screenshots

Piped install — auto-launch skipped, clean next-steps hint:

<img width="1371" height="299" alt="image" src="https://github.com/user-attachments/assets/c6bea6db-63d6-4ee7-8c7b-39f06907377f" />