### PR TITLE
test(gateway): pin known Telegram gateway bugs with xfail regressions

### DIFF
--- a/tests/gateway/test_approvals.py
+++ b/tests/gateway/test_approvals.py
@@ -48,3 +48,28 @@ def test_callback_approves_waiter(approval_service: TelegramApprovalService) -> 
     )
     thread.join(timeout=2)
     assert result == ["yes"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="bug: handle_callback calls store.resolve() (UPDATE+commit) before verifying "
+    "the caller owns the approval, so a non-owner can flip another chat's pending status",
+)
+def test_callback_from_non_owner_leaves_approval_pending(
+    approval_service: TelegramApprovalService,
+) -> None:
+    approval_id = approval_service._store.create(
+        chat_id="42",
+        message_id="pending",
+        tool_name="dangerous_tool",
+        payload_hash="hash",
+        expires_at=time.time() + 60,
+    )
+    approval_service.handle_callback(
+        user_id="99",  # not the owner ("42")
+        callback_data=f"approve:{approval_id}",
+        callback_query_id="cq",
+    )
+    row = approval_service._store.get(approval_id)
+    assert row is not None
+    assert row["status"] == "pending"

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import load_gateway_settings
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="bug: int(port_raw) raises ValueError on a blank TELEGRAM_WEBHOOK_PORT "
+    "instead of falling back to the default port",
+)
+def test_blank_webhook_port_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok")
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_PORT", "")
+    with patch("gateway.config.get_integration", return_value=None):
+        settings = load_gateway_settings()
+    assert settings.webhook_port == 8443

--- a/tests/gateway/test_session_resolver.py
+++ b/tests/gateway/test_session_resolver.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.session.resolver import SessionResolver
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="bug: resolve() reopens the session but never reloads the persisted "
+    "transcript into agent.messages, so every inbound message starts amnesiac",
+)
+def test_resolve_rehydrates_persisted_transcript() -> None:
+    bindings = MagicMock()
+    bindings.get_session_id.return_value = "sess-1"
+    resolver = SessionResolver(bindings)
+
+    fake_storage = MagicMock()
+    fake_storage.load_session.return_value = {
+        "session_id": "sess-1",
+        "cli_agent_messages": [("user", "hi"), ("assistant", "hello")],
+        "accumulated_context": {},
+        "history": [],
+    }
+    resolver._storage = fake_storage
+
+    # Identity bootstrap so the test does not warm real integrations / hit the network.
+    with patch("gateway.session.resolver._bootstrap_session", side_effect=lambda s: s):
+        session = resolver.resolve(user_id="42")
+
+    assert session.agent.messages == [("user", "hi"), ("assistant", "hello")]

--- a/tests/gateway/test_telegram_poller.py
+++ b/tests/gateway/test_telegram_poller.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import httpx
+import pytest
 
 from gateway.platforms.telegram.poller import TelegramPoller, _decode_telegram_response
 
@@ -91,3 +92,34 @@ def test_poll_once_parses_inbound_message(mock_get: MagicMock, mock_sleep: Magic
     assert events[0].text == "hello"
     assert events[0].chat_id == "99"
     mock_sleep.assert_not_called()
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="bug: int(update_id) in poll_once is outside the request try/except, so a "
+    "malformed update_id in the result list crashes the whole poll batch",
+)
+@patch("gateway.platforms.telegram.poller.time.sleep")
+@patch("gateway.platforms.telegram.poller.httpx.get")
+def test_poll_once_tolerates_non_integer_update_id(
+    mock_get: MagicMock, mock_sleep: MagicMock
+) -> None:
+    mock_get.return_value = httpx.Response(
+        200,
+        json={
+            "ok": True,
+            "result": [
+                {
+                    "update_id": "bad",
+                    "message": {
+                        "message_id": 1,
+                        "from": {"id": 42},
+                        "chat": {"id": 42, "type": "private"},
+                        "text": "hi",
+                    },
+                }
+            ],
+        },
+    )
+    events = TelegramPoller("tok").poll_once()
+    assert isinstance(events, list)

--- a/tests/gateway/test_webhook_parser.py
+++ b/tests/gateway/test_webhook_parser.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from gateway.platforms.telegram.webhook import parse_update
 
 
@@ -50,3 +52,24 @@ def test_ignores_group_messages() -> None:
         }
     )
     assert event is None
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="bug: int(update_id) is outside any guard, so a non-integer update_id "
+    "raises ValueError out of parse_update instead of being handled",
+)
+def test_parse_tolerates_non_integer_update_id() -> None:
+    event = parse_update(
+        {
+            "update_id": "not-an-int",
+            "message": {
+                "message_id": 10,
+                "from": {"id": 42},
+                "chat": {"id": 42, "type": "private"},
+                "text": "hello",
+            },
+        }
+    )
+    assert event is not None
+    assert event.text == "hello"


### PR DESCRIPTION
Relates to: newly found bugs in the Telegram gateway (no tracked issue yet — happy to open one per bug if preferred).

#### Describe the changes you have made in this PR -

While going over the freshly merged Telegram gateway I hit four behaviours that looked wrong and had no test around them. This PR doesn't fix them — it pins each one with a regression test so the behaviour is captured and the fix has a guard. Every test is `@pytest.mark.xfail(strict=True)`: it fails today (which is the proof the bug is real), so CI stays green now, and the moment the underlying bug is fixed the test flips to XPASS and strict mode fails CI — forcing whoever fixes it to delete the `xfail` marker. Tripwire, not dead weight.

The four bugs:

- **Session resolver never rehydrates the transcript.** `gateway/session/resolver.py` does `ReplSession(session_id=existing)` + `reopen_session()` (a no-op in the JSONL backend) and returns. The REPL's own `/resume` path (`session_cmds/resume.py`) additionally does `session.agent.messages = list(messages)`. The gateway skips that, so every inbound Telegram message starts with an empty transcript — the "two-way chat" has no memory across turns.
- **Approval resolved before ownership is checked.** `gateway/approvals/telegram.py:handle_callback` calls `store.resolve()` (which runs `UPDATE ... SET status` + commit) and only then compares `row["chat_id"]` to `user_id`. So a caller who isn't the owner still flips the persisted status of someone else's pending approval before being rejected.
- **Blank `TELEGRAM_WEBHOOK_PORT` crashes settings load.** `gateway/config.py` does `int(port_raw)` with no guard, so an empty `TELEGRAM_WEBHOOK_PORT=` in `.env` raises `ValueError` instead of falling back to the default port (this also silently skips the co-located auto-start, which only swallows the error).
- **Non-integer `update_id` is unguarded.** `int(update.get("update_id") or 0)` sits outside any try/except in both `parse_update` (`webhook.py`) and the `poll_once` loop (`poller.py`), so a malformed update raises out of the parser / crashes the whole poll batch.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run python -m pytest tests/gateway/test_session_resolver.py \
    tests/gateway/test_config.py tests/gateway/test_webhook_parser.py \
    tests/gateway/test_telegram_poller.py tests/gateway/test_approvals.py -q -rxX

XFAIL tests/gateway/test_session_resolver.py::test_resolve_rehydrates_persisted_transcript
  - bug: resolve() reopens the session but never reloads the persisted transcript
XFAIL tests/gateway/test_config.py::test_blank_webhook_port_falls_back_to_default
  - bug: int(port_raw) raises ValueError on a blank TELEGRAM_WEBHOOK_PORT
XFAIL tests/gateway/test_webhook_parser.py::test_parse_tolerates_non_integer_update_id
  - bug: int(update_id) is outside any guard
XFAIL tests/gateway/test_telegram_poller.py::test_poll_once_tolerates_non_integer_update_id
  - bug: int(update_id) in poll_once is outside the request try/except
XFAIL tests/gateway/test_approvals.py::test_callback_from_non_owner_leaves_approval_pending
  - bug: handle_callback mutates the approval row before the ownership check

========================= 8 passed, 5 xfailed in 0.54s =========================
```

`ruff check` and `ruff format --check` clean on the changed files; `mypy` clean on the two new files.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem these tests solve is coverage debt: the new gateway shipped with several reachable bugs that no test exercised, so a future refactor could quietly change the (already wrong) behaviour with nothing to catch it.

I considered two alternatives and rejected both. Plain failing (red) tests would break CI and block unrelated work. "Characterization" tests that assert the *current* buggy behaviour would pass today but enshrine the bug as expected — the opposite of what I want. `xfail(strict=True)` is the middle path: it documents the bug, keeps the suite green, and converts into a hard failure the instant the bug is fixed, which is exactly when you want to be told to remove the marker.

Each test is deliberately the smallest thing that fails if the specific bug is present. The resolver test injects a fake storage whose `load_session` returns a known transcript and asserts the resolved session carries it (it doesn't, today). The approvals test creates a pending approval owned by one chat, fires the callback as a different user, and asserts the stored status is still `pending`. The config test sets a blank port env var and asserts the default is used. The two `update_id` tests feed a non-integer id through the webhook parser and the poll batch and assert neither raises.

I deliberately did **not** add tests for two other issues I found — the single SQLite connection shared across threads, and the fire-and-forget `asyncio.create_task` in the webhook handler — because both are timing-dependent or only assertable once a fix exists, and a flaky test is worse than none.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
