### PR TITLE
feat(tools): add fix_sentry_issue tool (Sentry URL -> Pi fix diff)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,13 @@ XAI_API_KEY=
 # Optional per-task timeout in seconds (clamped 60-1800; default 600).
 # PI_CODING_TIMEOUT_SECONDS=
 
+# --- Fix a Sentry issue (paste a Sentry issue URL, Pi proposes the fix) ---
+# Resolves the issue from Sentry (needs SENTRY_ORG_SLUG + SENTRY_AUTH_TOKEN below)
+# and runs the Pi coding agent in the current repo. Returns a diff for review;
+# it never commits or pushes. OFF unless PI_ISSUE_FIX_ENABLED is truthy. Reuses
+# the PI_CODING_MODEL / PI_CODING_WORKSPACE / PI_CODING_TIMEOUT_SECONDS settings.
+# PI_ISSUE_FIX_ENABLED=1
+
 # Maximum tokens for LLM responses (default: 4096).
 LLM_MAX_TOKENS=4096
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -160,6 +160,7 @@
               "jira",
               "integrations/trello",
               "pi-coding",
+              "fix-sentry-issue",
               "vercel"
             ]
           },

--- a/docs/fix-sentry-issue.mdx
+++ b/docs/fix-sentry-issue.mdx
@@ -1,0 +1,62 @@
+---
+title: "Fix a Sentry issue"
+description: "Paste a Sentry issue URL and have the Pi coding agent propose a fix as a reviewable diff."
+---
+
+The **Sentry issue-fix tool** lets you point OpenSRE at a [Sentry](https://sentry.io) issue and
+have the [Pi](https://pi.dev) coding agent propose a fix. OpenSRE fetches the issue context,
+runs Pi in your current repository, and returns a summary plus the git diff.
+
+It **does not commit, push, or open a pull request** — it only edits the working tree so you can
+review the diff. (Committing and opening a PR is a planned follow-up.)
+
+<Warning>
+This is a **mutating** tool — it changes files on disk. It is **disabled by default**: it only
+becomes available when `PI_ISSUE_FIX_ENABLED=1`, Sentry is configured, and the Pi CLI is
+installed. Enable it deliberately.
+</Warning>
+
+## Quick reference
+
+| Env var | What it does |
+| --- | --- |
+| `PI_ISSUE_FIX_ENABLED` | Opt-in switch for this tool. Set to `1` to enable. Off by default. |
+| `SENTRY_ORG_SLUG` / `SENTRY_AUTH_TOKEN` | Sentry org + token used to fetch the issue (`SENTRY_URL` for self-hosted). |
+| `PI_CODING_MODEL` | Pi model used for the fix (shared with the Pi coding tool). |
+| `PI_CODING_WORKSPACE` | Repository Pi edits. Defaults to the current directory. |
+| `PI_CODING_TIMEOUT_SECONDS` | Per-run timeout (default 600, clamped 60–1800). |
+
+## Enable it
+
+1. Configure Sentry (org + token) and install/authenticate the Pi CLI:
+   ```bash
+   export SENTRY_ORG_SLUG=your-org
+   export SENTRY_AUTH_TOKEN=...           # token with issue read access
+   npm i -g @earendil-works/pi-coding-agent
+   ```
+2. Turn the tool on:
+   ```bash
+   export PI_ISSUE_FIX_ENABLED=1
+   export PI_CODING_MODEL=anthropic/claude-haiku-4-5   # optional
+   ```
+
+## How it works
+
+1. You paste a Sentry issue URL (e.g. `https://your-org.sentry.io/issues/12345/`) and ask
+   OpenSRE to fix it.
+2. OpenSRE resolves the issue from Sentry and builds a short, **masked** task (title, error,
+   culprit, location) — your Sentry token is never sent to Pi.
+3. Pi edits the current repository to implement the fix.
+4. You get back `success`, a `summary`, `changed_files`, and the `diff` to review.
+
+## Supported URLs
+
+- `https://<org>.sentry.io/issues/<id>/`
+- `https://sentry.io/organizations/<org>/issues/<id>/`
+- self-hosted `https://sentry.<company>.com/organizations/<org>/issues/<id>/`
+
+## Notes
+
+- Nothing is committed or pushed; you review the diff and decide what to do.
+- If the tool is disabled, the URL is unsupported, Sentry is unconfigured, or Pi is missing,
+  it returns a clear `error_kind` instead of running.

--- a/integrations/sentry/issue_url.py
+++ b/integrations/sentry/issue_url.py
@@ -1,0 +1,63 @@
+"""Parse a Sentry issue URL into its organization + issue id.
+
+Supports the common Sentry issue URL shapes (SaaS and self-hosted):
+
+- ``https://<org>.sentry.io/issues/<id>/``
+- ``https://<org>.sentry.io/issues/<id>/events/<event>/``
+- ``https://sentry.io/organizations/<org>/issues/<id>/``
+- ``https://sentry.example.com/organizations/<org>/issues/<id>/`` (self-hosted)
+
+The ``issue_id`` is what the Sentry API (``get_sentry_issue``) needs; ``org`` is
+returned when present in the URL so callers can cross-check it against config.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+# /issues/<id>  — id is alphanumeric (Sentry short ids) or numeric.
+_ISSUE_ID_RE = re.compile(r"/issues/([A-Za-z0-9_-]+)")
+# /organizations/<org>/  — explicit org segment (sentry.io SaaS + self-hosted).
+_ORG_PATH_RE = re.compile(r"/organizations/([A-Za-z0-9_.-]+)")
+
+
+@dataclass(frozen=True)
+class SentryIssueRef:
+    """A Sentry issue identified from a URL."""
+
+    issue_id: str
+    organization_slug: str = ""
+
+
+def parse_sentry_issue_url(url: str | None) -> SentryIssueRef | None:
+    """Return the issue id (+ org if present) for a Sentry issue URL, else ``None``."""
+    raw = (url or "").strip()
+    if not raw:
+        return None
+
+    parsed = urlparse(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    if "sentry" not in parsed.netloc.lower():
+        return None
+
+    issue_match = _ISSUE_ID_RE.search(parsed.path)
+    if not issue_match:
+        return None
+    issue_id = issue_match.group(1)
+
+    org = ""
+    org_match = _ORG_PATH_RE.search(parsed.path)
+    if org_match:
+        org = org_match.group(1)
+    else:
+        # ``<org>.sentry.io`` subdomain form.
+        host = parsed.netloc.lower()
+        if host.endswith(".sentry.io"):
+            subdomain = host.removesuffix(".sentry.io")
+            if subdomain and subdomain != "www":
+                org = subdomain
+
+    return SentryIssueRef(issue_id=issue_id, organization_slug=org)

--- a/tests/integrations/test_sentry_issue_url.py
+++ b/tests/integrations/test_sentry_issue_url.py
@@ -1,0 +1,45 @@
+"""Tests for parsing Sentry issue URLs."""
+
+from __future__ import annotations
+
+from integrations.sentry.issue_url import parse_sentry_issue_url
+
+
+def test_subdomain_form() -> None:
+    ref = parse_sentry_issue_url("https://myorg.sentry.io/issues/12345/")
+    assert ref is not None
+    assert ref.issue_id == "12345"
+    assert ref.organization_slug == "myorg"
+
+
+def test_subdomain_form_with_event_suffix() -> None:
+    ref = parse_sentry_issue_url("https://myorg.sentry.io/issues/ABC123/events/latest/")
+    assert ref is not None
+    assert ref.issue_id == "ABC123"
+    assert ref.organization_slug == "myorg"
+
+
+def test_organizations_path_form() -> None:
+    ref = parse_sentry_issue_url("https://sentry.io/organizations/acme/issues/999/")
+    assert ref is not None
+    assert ref.issue_id == "999"
+    assert ref.organization_slug == "acme"
+
+
+def test_self_hosted_form() -> None:
+    ref = parse_sentry_issue_url("https://sentry.example.com/organizations/acme/issues/77/")
+    assert ref is not None
+    assert ref.issue_id == "77"
+    assert ref.organization_slug == "acme"
+
+
+def test_non_sentry_url_is_rejected() -> None:
+    # Must not match a GitHub issue URL just because it has /issues/<n>.
+    assert parse_sentry_issue_url("https://github.com/foo/bar/issues/123") is None
+
+
+def test_garbage_inputs() -> None:
+    assert parse_sentry_issue_url("") is None
+    assert parse_sentry_issue_url(None) is None
+    assert parse_sentry_issue_url("not a url") is None
+    assert parse_sentry_issue_url("https://myorg.sentry.io/dashboard/") is None

--- a/tests/tools/test_fix_sentry_issue.py
+++ b/tests/tools/test_fix_sentry_issue.py
@@ -1,0 +1,154 @@
+"""Tests for the Sentry issue-fix tool: gating, context, lifecycle, error_kind."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+from integrations.pi import PiCodingResult
+from tools.fix_sentry_issue import FixSentryIssueTool, fix_sentry_issue
+from tools.fix_sentry_issue.context import gather_issue_context
+
+_CONFIG = "tools.fix_sentry_issue.context.sentry_config_from_env"
+_GET_ISSUE = "tools.fix_sentry_issue.context.get_sentry_issue"
+_VERIFY = "tools.fix_sentry_issue.runner.verify_pi_coding"
+_RUN = "tools.fix_sentry_issue.runner.run_pi_coding_task"
+
+_ISSUE = {
+    "title": "TypeError: 'NoneType' object is not subscriptable",
+    "culprit": "app.handlers.process_event",
+    "level": "error",
+    "count": "42",
+    "metadata": {
+        "type": "TypeError",
+        "value": "'NoneType' object is not subscriptable",
+        "filename": "app/handlers.py",
+        "function": "process_event",
+    },
+}
+_URL = "https://acme.sentry.io/issues/12345/"
+
+
+# --------------------------------------------------------------------------- #
+# metadata + availability
+# --------------------------------------------------------------------------- #
+def test_metadata_is_mutating_on_investigation_surface() -> None:
+    t = fix_sentry_issue
+    assert t.name == "fix_sentry_issue"
+    assert t.source == "sentry"
+    assert t.side_effect_level == "mutating"
+    assert t.requires_approval is True
+    assert t.surfaces == ("investigation",)
+    assert t.input_schema["required"] == ["sentry_url"]
+    assert "error_kind" in t.outputs
+    assert t.metadata().name == "fix_sentry_issue"
+
+
+def test_is_available_off_by_default_then_opt_in() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("PI_ISSUE_FIX_ENABLED", None)
+        assert fix_sentry_issue.is_available({}) is False
+    with patch.dict(os.environ, {"PI_ISSUE_FIX_ENABLED": "1"}, clear=False):
+        assert fix_sentry_issue.is_available({}) is True
+
+
+# --------------------------------------------------------------------------- #
+# context building
+# --------------------------------------------------------------------------- #
+@patch(_GET_ISSUE, return_value=_ISSUE)
+@patch(_CONFIG, return_value=MagicMock())
+def test_gather_issue_context_builds_masked_task(
+    _mock_cfg: MagicMock, _mock_issue: MagicMock
+) -> None:
+    ctx = gather_issue_context(_URL)
+    assert ctx.issue_id == "12345"
+    assert "Issue:" in ctx.task
+    assert "TypeError" in ctx.task
+    assert "app/handlers.py" in ctx.task
+
+
+# --------------------------------------------------------------------------- #
+# run() lifecycle + error_kind
+# --------------------------------------------------------------------------- #
+def test_run_disabled() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("PI_ISSUE_FIX_ENABLED", None)
+        out = fix_sentry_issue.run(sentry_url=_URL)
+    assert out["success"] is False
+    assert out["error_kind"] == "disabled"
+
+
+def test_run_invalid_url() -> None:
+    with patch.dict(os.environ, {"PI_ISSUE_FIX_ENABLED": "1"}, clear=False):
+        out = fix_sentry_issue.run(sentry_url="https://github.com/foo/bar/issues/1")
+    assert out["error_kind"] == "invalid_input"
+
+
+@patch(_CONFIG, return_value=None)
+def test_run_sentry_unavailable(_mock_cfg: MagicMock) -> None:
+    with patch.dict(os.environ, {"PI_ISSUE_FIX_ENABLED": "1"}, clear=False):
+        out = fix_sentry_issue.run(sentry_url=_URL)
+    assert out["error_kind"] == "sentry_unavailable"
+
+
+@patch(_GET_ISSUE, return_value={})
+@patch(_CONFIG, return_value=MagicMock())
+def test_run_issue_not_found(_mock_cfg: MagicMock, _mock_issue: MagicMock) -> None:
+    with patch.dict(os.environ, {"PI_ISSUE_FIX_ENABLED": "1"}, clear=False):
+        out = fix_sentry_issue.run(sentry_url=_URL)
+    assert out["error_kind"] == "issue_not_found"
+
+
+@patch(_VERIFY, return_value=(False, "pi not installed"))
+@patch(_GET_ISSUE, return_value=_ISSUE)
+@patch(_CONFIG, return_value=MagicMock())
+def test_run_cli_unavailable(
+    _mock_cfg: MagicMock, _mock_issue: MagicMock, _mock_verify: MagicMock
+) -> None:
+    with patch.dict(os.environ, {"PI_ISSUE_FIX_ENABLED": "1"}, clear=False):
+        out = fix_sentry_issue.run(sentry_url=_URL)
+    assert out["error_kind"] == "cli_unavailable"
+
+
+@patch(_RUN)
+@patch(_VERIFY, return_value=(True, "ok"))
+@patch(_GET_ISSUE, return_value=_ISSUE)
+@patch(_CONFIG, return_value=MagicMock())
+def test_run_success(
+    _mock_cfg: MagicMock, _mock_issue: MagicMock, _mock_verify: MagicMock, mock_run: MagicMock
+) -> None:
+    mock_run.return_value = PiCodingResult(
+        success=True,
+        summary="Guarded the None case in process_event.",
+        changed_files=["app/handlers.py"],
+        diff="diff --git a/app/handlers.py b/app/handlers.py\n",
+        returncode=0,
+    )
+    with patch.dict(os.environ, {"PI_ISSUE_FIX_ENABLED": "1"}, clear=False):
+        out = fix_sentry_issue.run(sentry_url=_URL)
+    assert out["success"] is True
+    assert out["error_kind"] is None
+    assert out["issue_id"] == "12345"
+    assert out["changed_files"] == ["app/handlers.py"]
+    assert "diff --git" in out["diff"]
+    # the synthesized Sentry task was passed to the Pi client
+    assert "Sentry issue" in mock_run.call_args.args[0]
+
+
+# --------------------------------------------------------------------------- #
+# registry discovery
+# --------------------------------------------------------------------------- #
+def test_registry_discovers_fix_sentry_issue_on_investigation_surface() -> None:
+    from tools.registry import get_registered_tool_map
+
+    investigation = get_registered_tool_map("investigation")
+    chat = get_registered_tool_map("chat")
+    assert "fix_sentry_issue" in investigation
+    assert "fix_sentry_issue" not in chat
+    rt = investigation["fix_sentry_issue"]
+    assert rt.requires_approval is True
+    assert rt.side_effect_level == "mutating"
+
+
+def test_tool_subclass_constructs() -> None:
+    assert isinstance(fix_sentry_issue, FixSentryIssueTool)

--- a/tests/tools/test_fix_sentry_issue.py
+++ b/tests/tools/test_fix_sentry_issue.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 from unittest.mock import MagicMock, patch
 
+import httpx
+
 from integrations.pi import PiCodingResult
 from tools.fix_sentry_issue import FixSentryIssueTool, fix_sentry_issue
 from tools.fix_sentry_issue.context import gather_issue_context
@@ -93,10 +95,40 @@ def test_run_sentry_unavailable(_mock_cfg: MagicMock) -> None:
 
 @patch(_GET_ISSUE, return_value={})
 @patch(_CONFIG, return_value=MagicMock())
-def test_run_issue_not_found(_mock_cfg: MagicMock, _mock_issue: MagicMock) -> None:
+def test_run_issue_not_found_empty_response(_mock_cfg: MagicMock, _mock_issue: MagicMock) -> None:
     with patch.dict(os.environ, {"PI_ISSUE_FIX_ENABLED": "1"}, clear=False):
         out = fix_sentry_issue.run(sentry_url=_URL)
     assert out["error_kind"] == "issue_not_found"
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    req = httpx.Request("GET", "https://acme.sentry.io/api/0/issues/12345/")
+    return httpx.HTTPStatusError("err", request=req, response=httpx.Response(status, request=req))
+
+
+@patch(_GET_ISSUE, side_effect=_http_status_error(404))
+@patch(_CONFIG, return_value=MagicMock())
+def test_run_issue_not_found_on_http_404(_mock_cfg: MagicMock, _mock_issue: MagicMock) -> None:
+    # The common real failure: valid URL, issue id doesn't exist -> Sentry 404.
+    with patch.dict(os.environ, {"PI_ISSUE_FIX_ENABLED": "1"}, clear=False):
+        out = fix_sentry_issue.run(sentry_url=_URL)
+    assert out["error_kind"] == "issue_not_found"
+
+
+@patch(_GET_ISSUE, side_effect=_http_status_error(403))
+@patch(_CONFIG, return_value=MagicMock())
+def test_run_sentry_auth_error_on_http_403(_mock_cfg: MagicMock, _mock_issue: MagicMock) -> None:
+    with patch.dict(os.environ, {"PI_ISSUE_FIX_ENABLED": "1"}, clear=False):
+        out = fix_sentry_issue.run(sentry_url=_URL)
+    assert out["error_kind"] == "sentry_unavailable"
+
+
+@patch(_GET_ISSUE, side_effect=httpx.ConnectError("boom"))
+@patch(_CONFIG, return_value=MagicMock())
+def test_run_sentry_network_error(_mock_cfg: MagicMock, _mock_issue: MagicMock) -> None:
+    with patch.dict(os.environ, {"PI_ISSUE_FIX_ENABLED": "1"}, clear=False):
+        out = fix_sentry_issue.run(sentry_url=_URL)
+    assert out["error_kind"] == "sentry_unavailable"
 
 
 @patch(_VERIFY, return_value=(False, "pi not installed"))

--- a/tests/tools/test_fix_sentry_issue.py
+++ b/tests/tools/test_fix_sentry_issue.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 
 from integrations.pi import PiCodingResult
+from integrations.sentry import SentryConfig
 from tools.fix_sentry_issue import FixSentryIssueTool, fix_sentry_issue
 from tools.fix_sentry_issue.context import gather_issue_context
 
@@ -67,6 +68,15 @@ def test_gather_issue_context_builds_masked_task(
     assert "Issue:" in ctx.task
     assert "TypeError" in ctx.task
     assert "app/handlers.py" in ctx.task
+
+
+@patch(_GET_ISSUE, return_value=_ISSUE)
+@patch(_CONFIG, return_value=SentryConfig(organization_slug="env-org", auth_token="tok"))
+def test_gather_uses_org_from_url_over_config(_mock_cfg: MagicMock, mock_issue: MagicMock) -> None:
+    # URL org is "acme"; config org is "env-org" — the URL must win.
+    gather_issue_context("https://acme.sentry.io/issues/12345/")
+    used_config = mock_issue.call_args.kwargs["config"]
+    assert used_config.organization_slug == "acme"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -1009,6 +1009,9 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         "execute_github_issue_mutation",
         "execute_python_code",
         "fetch_failed_run",
+        # fix_sentry_issue catches only its own FixIssueError for known states;
+        # unexpected errors escape to the global #1476 wrapper.
+        "fix_sentry_issue",
         "generate_work_status_report",
         "get_airflow_dag_runs",
         "get_airflow_metrics",

--- a/tools/fix_sentry_issue/__init__.py
+++ b/tools/fix_sentry_issue/__init__.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from tools.base import BaseTool
+from core.tool_framework.base import BaseTool
 from tools.fix_sentry_issue.context import gather_issue_context
 from tools.fix_sentry_issue.errors import FixIssueError
 from tools.fix_sentry_issue.runner import (

--- a/tools/fix_sentry_issue/__init__.py
+++ b/tools/fix_sentry_issue/__init__.py
@@ -1,0 +1,120 @@
+"""Sentry issue-fix tool: paste a Sentry issue URL and Pi proposes the fix.
+
+PR 1 of the issue-fix flow: resolve the issue from Sentry, run the Pi coding agent
+in the **current workspace**, and return a summary + git diff for review. It does
+**not** commit, push, or open a PR (that is a follow-up PR).
+
+Package layout (separation of concerns, like ``tools/pi_coding_tool``):
+
+- ``errors.py``    — :class:`FixIssueError` + stable ``error_kind`` constants.
+- ``context.py``   — Sentry URL parse + issue fetch, compacted into a masked task.
+- ``runner.py``    — opt-in gate, Pi CLI readiness, the Pi run, result shaping.
+- ``__init__.py``  — this file: the agent-facing :class:`BaseTool` contract. The
+  class lives here because the tool registry discovers instances by
+  ``__class__.__module__`` and does not recurse into sub-modules.
+
+Gating mirrors ``pi_coding_task`` (it is the same mutating capability, issue-driven):
+``side_effect_level = "mutating"`` and ``is_available`` is True only when
+``PI_ISSUE_FIX_ENABLED`` is set, so it is never offered unless the operator opts in.
+Secrets (Sentry token) never enter the Pi prompt — the issue context is masked.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools.base import BaseTool
+from tools.fix_sentry_issue.context import gather_issue_context
+from tools.fix_sentry_issue.errors import FixIssueError
+from tools.fix_sentry_issue.runner import (
+    SOURCE,
+    ensure_cli_ready,
+    ensure_enabled,
+    error_output,
+    is_issue_fix_enabled,
+    run_fix,
+    to_output,
+)
+
+
+class FixSentryIssueTool(BaseTool):
+    """Resolve a Sentry issue and have Pi propose a fix (diff for review)."""
+
+    name = "fix_sentry_issue"
+    display_name = "Fix Sentry issue"
+    source = SOURCE
+    side_effect_level = "mutating"
+    surfaces = ("investigation",)
+    requires_approval = True
+    approval_reason = "Runs the Pi coding agent to edit files based on a Sentry issue."
+    description = (
+        "Given a Sentry issue URL, fetch the issue context and run the Pi coding agent "
+        "(pi.dev) to propose a fix in the current repository, returning a summary plus the "
+        "git diff. It does not commit, push, or open a PR. Disabled unless "
+        "PI_ISSUE_FIX_ENABLED=1, Sentry is configured, and the Pi CLI is installed."
+    )
+    use_cases = [
+        "A user pastes a Sentry issue link and asks OpenSRE to fix it",
+        "Turn a known Sentry error into a reviewable code change",
+    ]
+    anti_examples = [
+        "Investigating an issue without changing code (use the read-only Sentry tools)",
+        "Shipping/committing the fix (not supported yet)",
+    ]
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "sentry_url": {
+                "type": "string",
+                "description": "URL of the Sentry issue to fix (.../issues/<id>/).",
+            },
+            "workspace": {
+                "type": "string",
+                "description": (
+                    "Absolute path to the repository to edit. "
+                    "Defaults to PI_CODING_WORKSPACE or the current directory."
+                ),
+                "nullable": True,
+            },
+            "model": {
+                "type": "string",
+                "description": "Optional Pi model override (provider/model). Defaults to PI_CODING_MODEL.",
+                "nullable": True,
+            },
+        },
+        "required": ["sentry_url"],
+    }
+    outputs = {
+        "success": "True when Pi produced a fix and exited cleanly",
+        "error_kind": "Stable failure category (disabled, invalid_input, sentry_unavailable, "
+        "issue_not_found, cli_unavailable, timeout, execution_error) or None on success",
+        "issue_id": "The resolved Sentry issue id",
+        "summary": "Pi's summary of the fix",
+        "changed_files": "Files modified in the working tree",
+        "diff": "git diff of the proposed fix (truncated if large)",
+        "error": "Human-readable error detail when the run failed",
+    }
+
+    def is_available(self, _sources: dict[str, dict]) -> bool:
+        """Only available when explicitly opted in (cheap flag check)."""
+        return is_issue_fix_enabled()
+
+    def run(
+        self,
+        sentry_url: str,
+        workspace: str | None = None,
+        model: str | None = None,
+    ) -> dict[str, Any]:
+        try:
+            ensure_enabled()
+            ctx = gather_issue_context(sentry_url)
+            ensure_cli_ready()
+        except FixIssueError as exc:
+            return error_output(exc.kind, exc.message)
+
+        # Unexpected exceptions propagate to BaseTool.__call__ (Sentry-reported).
+        return to_output(ctx.issue_id, run_fix(ctx, workspace, model))
+
+
+# Module-level instance so the tool registry auto-discovers it (see tools/registry.py).
+fix_sentry_issue = FixSentryIssueTool()

--- a/tools/fix_sentry_issue/context.py
+++ b/tools/fix_sentry_issue/context.py
@@ -131,5 +131,9 @@ def gather_issue_context(sentry_url: str | None) -> IssueContext:
         )
 
     config = _resolve_config()
+    if ref.organization_slug:
+        # The org in the issue URL is authoritative for *which* org to query; the
+        # env token still authenticates. Falls back to the configured org otherwise.
+        config = config.model_copy(update={"organization_slug": ref.organization_slug})
     issue = _fetch_issue(config, ref.issue_id)
     return IssueContext(issue_id=ref.issue_id, task=_build_task(issue))

--- a/tools/fix_sentry_issue/context.py
+++ b/tools/fix_sentry_issue/context.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import httpx
+
 from integrations.sentry import SentryConfig, get_sentry_issue, sentry_config_from_env
 from integrations.sentry.issue_url import parse_sentry_issue_url
 from platform.masking import MaskingContext, MaskingPolicy
@@ -85,6 +87,40 @@ def _build_task(issue: dict) -> str:
     return "\n".join(lines)
 
 
+def _fetch_issue(config: SentryConfig, issue_id: str) -> dict:
+    """Fetch the issue, mapping HTTP/network errors to a clean FixIssueError.
+
+    ``get_sentry_issue`` calls ``raise_for_status()``, so a missing issue (404) or
+    a bad token (401/403) raises ``httpx.HTTPStatusError`` — the most common
+    real-world failures. Map them to ``error_kind`` rather than letting them escape
+    as unexpected system errors.
+    """
+    try:
+        issue = get_sentry_issue(config=config, issue_id=issue_id)
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        if status == 404:
+            raise FixIssueError(
+                ERR_ISSUE_NOT_FOUND, f"Sentry issue {issue_id} not found (404). Check the URL."
+            ) from exc
+        if status in (401, 403):
+            raise FixIssueError(
+                ERR_SENTRY_UNAVAILABLE,
+                f"Sentry rejected the request ({status}); check SENTRY_AUTH_TOKEN access.",
+            ) from exc
+        raise FixIssueError(
+            ERR_SENTRY_UNAVAILABLE, f"Sentry request failed (HTTP {status})."
+        ) from exc
+    except httpx.RequestError as exc:
+        raise FixIssueError(ERR_SENTRY_UNAVAILABLE, f"Could not reach Sentry: {exc}") from exc
+
+    if not issue:
+        raise FixIssueError(
+            ERR_ISSUE_NOT_FOUND, f"Sentry issue {issue_id} not found (empty response)."
+        )
+    return issue
+
+
 def gather_issue_context(sentry_url: str | None) -> IssueContext:
     """Parse the URL, fetch the issue, and build the masked task. Raises FixIssueError."""
     ref = parse_sentry_issue_url(sentry_url)
@@ -95,10 +131,5 @@ def gather_issue_context(sentry_url: str | None) -> IssueContext:
         )
 
     config = _resolve_config()
-    issue = get_sentry_issue(config=config, issue_id=ref.issue_id)
-    if not issue:
-        raise FixIssueError(
-            ERR_ISSUE_NOT_FOUND,
-            f"Sentry issue {ref.issue_id} not found (check the URL and token access).",
-        )
+    issue = _fetch_issue(config, ref.issue_id)
     return IssueContext(issue_id=ref.issue_id, task=_build_task(issue))

--- a/tools/fix_sentry_issue/context.py
+++ b/tools/fix_sentry_issue/context.py
@@ -1,0 +1,104 @@
+"""Gather Sentry issue context and turn it into a coding task for Pi.
+
+Resolves the Sentry config, parses the issue URL, fetches the issue, and compacts
+it into a short, **masked** task description. The output is fed (as untrusted text)
+to the Pi coding client, which adds its own safety rules + prompt-injection guard.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from integrations.sentry import SentryConfig, get_sentry_issue, sentry_config_from_env
+from integrations.sentry.issue_url import parse_sentry_issue_url
+from platform.masking import MaskingContext, MaskingPolicy
+from tools.fix_sentry_issue.errors import (
+    ERR_INVALID_INPUT,
+    ERR_ISSUE_NOT_FOUND,
+    ERR_SENTRY_UNAVAILABLE,
+    FixIssueError,
+)
+
+_MAX_VALUE_CHARS = 500
+
+
+@dataclass(frozen=True)
+class IssueContext:
+    """Resolved issue identity + the masked task description handed to Pi."""
+
+    issue_id: str
+    task: str
+
+
+def _resolve_config() -> SentryConfig:
+    config = sentry_config_from_env()
+    if config is None:
+        raise FixIssueError(
+            ERR_SENTRY_UNAVAILABLE,
+            "Sentry is not configured. Set SENTRY_ORG_SLUG and SENTRY_AUTH_TOKEN "
+            "(and SENTRY_URL for self-hosted).",
+        )
+    return config
+
+
+def _build_task(issue: dict) -> str:
+    """Compact a Sentry issue dict into a short, masked coding task for Pi."""
+    masker = MaskingContext(MaskingPolicy.from_env())
+
+    def field(value: object, *, limit: int | None = None) -> str:
+        text = str(value or "").strip()
+        if limit:
+            text = text[:limit]
+        return masker.mask(text)
+
+    raw_meta = issue.get("metadata")
+    meta = raw_meta if isinstance(raw_meta, dict) else {}
+    title = field(issue.get("title"))
+    culprit = field(issue.get("culprit"))
+    etype = field(meta.get("type"))
+    evalue = field(meta.get("value"), limit=_MAX_VALUE_CHARS)
+    filename = field(meta.get("filename"))
+    function = field(meta.get("function"))
+    level = field(issue.get("level"))
+    count = field(issue.get("count"))
+
+    error = f"{etype}: {evalue}" if etype and evalue else (etype or evalue)
+    if filename and function:
+        location = f"{filename} in {function}"
+    else:
+        location = filename or function
+
+    lines = ["Fix the root cause of this Sentry issue in the current repository.", ""]
+    if title:
+        lines.append(f"Issue: {title}")
+    if error:
+        lines.append(f"Error: {error}")
+    if culprit:
+        lines.append(f"Culprit: {culprit}")
+    if location:
+        lines.append(f"Location: {location}")
+    if level:
+        lines.append(f"Level: {level}")
+    if count:
+        lines.append(f"Times seen: {count}")
+    lines += ["", "Make a minimal, correct fix and explain what you changed and why."]
+    return "\n".join(lines)
+
+
+def gather_issue_context(sentry_url: str | None) -> IssueContext:
+    """Parse the URL, fetch the issue, and build the masked task. Raises FixIssueError."""
+    ref = parse_sentry_issue_url(sentry_url)
+    if ref is None:
+        raise FixIssueError(
+            ERR_INVALID_INPUT,
+            "Not a recognizable Sentry issue URL (expected .../issues/<id>/).",
+        )
+
+    config = _resolve_config()
+    issue = get_sentry_issue(config=config, issue_id=ref.issue_id)
+    if not issue:
+        raise FixIssueError(
+            ERR_ISSUE_NOT_FOUND,
+            f"Sentry issue {ref.issue_id} not found (check the URL and token access).",
+        )
+    return IssueContext(issue_id=ref.issue_id, task=_build_task(issue))

--- a/tools/fix_sentry_issue/errors.py
+++ b/tools/fix_sentry_issue/errors.py
@@ -1,0 +1,21 @@
+"""Error model for the Sentry issue-fix tool."""
+
+from __future__ import annotations
+
+# Stable failure categories surfaced in the tool's ``error_kind`` output field.
+ERR_DISABLED = "disabled"
+ERR_INVALID_INPUT = "invalid_input"
+ERR_SENTRY_UNAVAILABLE = "sentry_unavailable"
+ERR_ISSUE_NOT_FOUND = "issue_not_found"
+ERR_CLI_UNAVAILABLE = "cli_unavailable"
+ERR_TIMEOUT = "timeout"
+ERR_EXECUTION = "execution_error"
+
+
+class FixIssueError(Exception):
+    """An expected, user-actionable failure with a stable ``kind``."""
+
+    def __init__(self, kind: str, message: str) -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.message = message

--- a/tools/fix_sentry_issue/runner.py
+++ b/tools/fix_sentry_issue/runner.py
@@ -1,0 +1,92 @@
+"""Lifecycle/orchestration for the Sentry issue-fix tool.
+
+Thin free functions the tool's ``run`` drives: opt-in gate, Pi CLI readiness, the
+Pi coding run (reusing ``integrations/pi``), and result shaping. No shipping here —
+this PR returns the diff for review; commit/PR is a follow-up.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any, Final
+
+from integrations.pi import (
+    PiCodingResult,
+    pi_coding_model,
+    pi_coding_timeout_seconds,
+    pi_coding_workspace,
+    run_pi_coding_task,
+    verify_pi_coding,
+)
+from tools.fix_sentry_issue.context import IssueContext
+from tools.fix_sentry_issue.errors import (
+    ERR_CLI_UNAVAILABLE,
+    ERR_DISABLED,
+    ERR_EXECUTION,
+    ERR_TIMEOUT,
+    FixIssueError,
+)
+
+SOURCE: Final = "sentry"
+_TRUTHY = {"1", "true", "yes", "on"}
+_INSTALL_HINT = "npm i -g @earendil-works/pi-coding-agent"
+
+
+def is_issue_fix_enabled(env: Mapping[str, str] | None = None) -> bool:
+    """Whether the Sentry issue-fix tool is opted in via ``PI_ISSUE_FIX_ENABLED``."""
+    source = env if env is not None else os.environ
+    return source.get("PI_ISSUE_FIX_ENABLED", "").strip().lower() in _TRUTHY
+
+
+def ensure_enabled() -> None:
+    if not is_issue_fix_enabled():
+        raise FixIssueError(
+            ERR_DISABLED,
+            "Sentry issue-fix tool is disabled. Set PI_ISSUE_FIX_ENABLED=1 "
+            "(plus Sentry config and the Pi CLI) to enable it.",
+        )
+
+
+def ensure_cli_ready() -> None:
+    available, detail = verify_pi_coding()
+    if not available:
+        raise FixIssueError(
+            ERR_CLI_UNAVAILABLE, f"Pi CLI is not ready: {detail}. Install with: {_INSTALL_HINT}"
+        )
+
+
+def run_fix(ctx: IssueContext, workspace: str | None, model: str | None) -> PiCodingResult:
+    return run_pi_coding_task(
+        ctx.task,
+        workspace=workspace or pi_coding_workspace(),
+        model=model or pi_coding_model(),
+        timeout_sec=pi_coding_timeout_seconds(),
+    )
+
+
+def to_output(issue_id: str, result: PiCodingResult) -> dict[str, Any]:
+    error_kind: str | None = None
+    if not result.success:
+        error_kind = ERR_TIMEOUT if result.timed_out else ERR_EXECUTION
+    return {
+        "source": SOURCE,
+        "success": result.success,
+        "error_kind": error_kind,
+        "issue_id": issue_id,
+        "summary": result.summary,
+        "changed_files": result.changed_files,
+        "diff": result.diff,
+        "diff_truncated": result.diff_truncated,
+        "error": result.error,
+    }
+
+
+def error_output(kind: str, message: str, issue_id: str = "") -> dict[str, Any]:
+    return {
+        "source": SOURCE,
+        "success": False,
+        "error_kind": kind,
+        "issue_id": issue_id,
+        "error": message,
+    }


### PR DESCRIPTION
Fixes #3253 (partially, PR - 1)

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

This PR - 1 adds a fix_sentry_issue tool: you paste a Sentry issue link and opensre has the Pi coding agent propose a fix. It pulls the issue details from Sentry, runs Pi in your current repo, and returns a summary plus the git diff to review. It does not commit or push anything yet (that comes in the next PR). The tool is off by default and only turns on with PI_ISSUE_FIX_ENABLED=1 once Sentry and Pi are set up, and your Sentry token is never sent to Pi.

### Demo/Screenshot for feature changes and bug fixes - 


https://github.com/user-attachments/assets/ab56c749-eaf1-44a6-aba8-39ace20b97f7


<img width="1916" height="966" alt="image" src="https://github.com/user-attachments/assets/3d71a46e-45b3-42a9-a51d-2bcfa5c1c57f" />


<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I reused what was already there instead of building new machinery. The Pi run goes through the existing integrations/pi client from the last PR, and the Sentry issue is fetched with the existing Sentry client, so this PR is mostly a small orchestration layer on top. I split it into focused files like the Pi tool (a URL parser, a context builder, a runner, and the tool itself), kept it gated off by default, masked the Sentry details before they reach Pi, and returned a clear error kind for each failure case. It only edits the working tree and returns a diff, so there is no commit or push to worry about yet.

<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
