### PR TITLE
fix(repl): handle unknown slash typos before tool validation

### DIFF
--- a/core/agent_harness/session/state.py
+++ b/core/agent_harness/session/state.py
@@ -416,15 +416,22 @@ class ReplSession:
         *,
         ok: bool = True,
         response_text: str | None = None,
+        slash_outcome: str | None = None,
     ) -> None:
         """Append an entry to the session history.
 
         Supports kinds: "shell", "slash", "alert", "chat", "incoming_alert", etc.
         For "incoming_alert", use record_incoming_alert() instead to preserve metadata.
+
+        ``slash_outcome`` tags typo-style slash failures (for example
+        ``unknown_command`` or ``invalid_subcommand``) so analytics can
+        distinguish them from handler failures.
         """
         entry: dict[str, Any] = {"type": kind, "text": text, "ok": ok}
         if response_text:
             entry["response_text"] = response_text
+        if slash_outcome:
+            entry["slash_outcome"] = slash_outcome
 
         self.history.append(entry)
 
@@ -472,6 +479,7 @@ class ReplSession:
         *,
         response_text: str | None = None,
         ok: bool | None = None,
+        slash_outcome: str | None = None,
     ) -> None:
         """Update the newest history row of ``kind`` with analytics outcome text."""
         for latest in reversed(self.history):
@@ -479,6 +487,8 @@ class ReplSession:
                 continue
             if ok is not None:
                 latest["ok"] = ok
+            if slash_outcome:
+                latest["slash_outcome"] = slash_outcome
             if response_text and response_text.strip():
                 latest["response_text"] = response_text.strip()
             return

--- a/surfaces/interactive_shell/command_registry/__init__.py
+++ b/surfaces/interactive_shell/command_registry/__init__.py
@@ -6,9 +6,9 @@ import os
 import shlex
 from collections.abc import Callable
 from itertools import chain
+from typing import Any
 
 from rich.console import Console
-from rich.markup import escape
 
 from surfaces.interactive_shell.command_registry.agents import COMMANDS as AGENTS_COMMANDS
 from surfaces.interactive_shell.command_registry.alerts import COMMANDS as ALERTS_COMMANDS
@@ -44,7 +44,10 @@ from surfaces.interactive_shell.command_registry.session_cmds import COMMANDS as
 from surfaces.interactive_shell.command_registry.settings_cmds import (
     COMMANDS as SETTINGS_COMMANDS,
 )
-from surfaces.interactive_shell.command_registry.suggestions import closest_choice
+from surfaces.interactive_shell.command_registry.suggestions import (
+    format_unknown_slash_message,
+    resolve_literal_slash_typo,
+)
 from surfaces.interactive_shell.command_registry.system import COMMANDS as SYSTEM_COMMANDS
 from surfaces.interactive_shell.command_registry.tasks_cmds import COMMANDS as TASK_COMMANDS
 from surfaces.interactive_shell.command_registry.theme import COMMANDS as THEME_COMMANDS
@@ -52,7 +55,6 @@ from surfaces.interactive_shell.command_registry.tools_cmds import COMMANDS as T
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.command_registry.watch_cmds import COMMANDS as WATCH_COMMANDS
 from surfaces.interactive_shell.runtime import ReplSession
-from surfaces.interactive_shell.ui import ERROR
 from surfaces.interactive_shell.ui.execution_confirm import execution_allowed
 from surfaces.interactive_shell.utils.telemetry.console_capture import capture_console_segment
 from surfaces.interactive_shell.utils.telemetry.turn_outcome import format_terminal_turn_outcome
@@ -96,22 +98,34 @@ def _latest_record_ok(session: ReplSession, kind: str, *, default: bool = True) 
     return default
 
 
+def _latest_slash_record(session: ReplSession) -> dict[str, Any] | None:
+    for entry in reversed(session.history):
+        if entry.get("type") == "slash":
+            return entry
+    return None
+
+
 def _attach_slash_analytics(
     session: ReplSession,
     command_line: str,
     *,
     captured_output: str,
 ) -> None:
+    latest = _latest_slash_record(session)
     ok = _latest_record_ok(session, "slash")
-    session.complete_latest_record(
-        "slash",
-        response_text=format_terminal_turn_outcome(
+    if latest is not None and latest.get("slash_outcome"):
+        response_text = str(latest.get("response_text") or "").strip()
+    else:
+        response_text = format_terminal_turn_outcome(
             command_line,
             kind="slash",
             ok=ok,
             captured_output=captured_output,
             outcome_hint=session.pop_turn_outcome_hint(),
-        ),
+        )
+    session.complete_latest_record(
+        "slash",
+        response_text=response_text,
     )
 
 
@@ -138,9 +152,20 @@ def dispatch_slash(
     stripped = command_line.strip()
     slash_recorded = False
 
-    def record_slash(*, ok: bool = True) -> None:
+    def record_slash(
+        *,
+        ok: bool = True,
+        response_text: str | None = None,
+        slash_outcome: str | None = None,
+    ) -> None:
         nonlocal slash_recorded
-        session.record("slash", stripped, ok=ok)
+        session.record(
+            "slash",
+            stripped,
+            ok=ok,
+            response_text=response_text,
+            slash_outcome=slash_outcome,
+        )
         slash_recorded = True
 
     try:
@@ -184,26 +209,33 @@ def dispatch_slash(
                     args = parts[1:]
                 cmd = SLASH_COMMANDS.get(name)
                 if cmd is None:
-                    suggestion = closest_choice(name, tuple(SLASH_COMMANDS))
-                    record_slash(ok=False)
+                    typo_message = format_unknown_slash_message(
+                        stripped,
+                        command_names=tuple(SLASH_COMMANDS),
+                    )
+                    record_slash(
+                        ok=False,
+                        response_text=typo_message,
+                        slash_outcome="unknown_command",
+                    )
                     console.print()
-                    if suggestion is None:
-                        console.print(
-                            f"[{ERROR}]unknown command:[/] {escape(name)}  "
-                            "(type [bold]/help[/bold])"
-                        )
-                    else:
-                        console.print(
-                            f"[{ERROR}]unknown command:[/] {escape(name)}  "
-                            f"Did you mean [bold]{escape(suggestion)}[/bold]? "
-                            "(type [bold]/help[/bold])"
-                        )
+                    console.print(typo_message)
+                    return True
+                typo = resolve_literal_slash_typo(stripped, SLASH_COMMANDS)
+                if typo is not None:
+                    record_slash(
+                        ok=False,
+                        response_text=typo.message,
+                        slash_outcome=typo.outcome,
+                    )
+                    console.print()
+                    console.print(typo.message)
                     return True
                 if cmd.validate_args is not None:
                     validation_error = cmd.validate_args(args)
                     if validation_error is not None:
-                        console.print(validation_error)
                         record_slash(ok=False)
+                        console.print(validation_error)
                         return True
                 if policy_precleared:
                     if name not in _DEFER_SLASH_RECORDING:

--- a/surfaces/interactive_shell/command_registry/integrations.py
+++ b/surfaces/interactive_shell/command_registry/integrations.py
@@ -417,12 +417,14 @@ def _interactive_mcp_menu(session: ReplSession, console: Console) -> bool:
 
 _INTEGRATIONS_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("list", "list all configured integrations"),
+    ("ls", "alias for list"),
     ("verify", "run health checks on all integrations"),
     ("show", "show details for a single integration"),
 )
 
 _MCP_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("list", "list connected MCP servers"),
+    ("ls", "alias for list"),
     ("connect", "add an MCP server via opensre integrations setup"),
     ("disconnect", "remove an MCP server"),
 )

--- a/surfaces/interactive_shell/command_registry/suggestions.py
+++ b/surfaces/interactive_shell/command_registry/suggestions.py
@@ -81,10 +81,7 @@ def format_invalid_subcommand_message(
             f"Try one of: {choices_text}. "
             f"Type /help for the full command list."
         )
-    return (
-        f"Invalid subcommand: {subcommand}. "
-        f"Type /help for the full command list."
-    )
+    return f"Invalid subcommand: {subcommand}. Type /help for the full command list."
 
 
 def resolve_literal_slash_typo(

--- a/surfaces/interactive_shell/command_registry/suggestions.py
+++ b/surfaces/interactive_shell/command_registry/suggestions.py
@@ -33,13 +33,13 @@ def closest_choice(value: str, choices: list[str] | tuple[str, ...]) -> str | No
 
 
 def subcommand_hints(cmd: SlashCommand) -> tuple[str, ...]:
-    """Return known first-argument subcommands for ``cmd`` when enumerable."""
-    hints: set[str] = {keyword.lower() for keyword, _label in cmd.first_arg_completions}
-    for line in cmd.usage:
-        parts = line.strip().split()
-        if len(parts) >= 2 and parts[0].lower() == cmd.name.lower():
-            hints.add(parts[1].lower())
-    return tuple(sorted(hints))
+    """Return enumerable first-argument keywords for ``cmd``.
+
+    Only ``first_arg_completions`` are used — usage strings often contain
+    free-form placeholders like ``<session-id-prefix>`` that must not be
+    treated as literal subcommands.
+    """
+    return tuple(sorted({keyword.lower() for keyword, _label in cmd.first_arg_completions}))
 
 
 def _looks_like_path_or_template_arg(value: str) -> bool:

--- a/surfaces/interactive_shell/command_registry/suggestions.py
+++ b/surfaces/interactive_shell/command_registry/suggestions.py
@@ -11,7 +11,6 @@ from surfaces.interactive_shell.command_registry.types import SlashCommand
 
 SlashOutcome = Literal["unknown_command", "invalid_subcommand"]
 
-_PATH_LIKE_ARG_RE = re.compile(r"[/\\]|\.(?:json|md|txt|yml|yaml)\b", re.IGNORECASE)
 _RICH_TAG_RE = re.compile(r"\[[^\]]+\]")
 
 
@@ -40,13 +39,6 @@ def subcommand_hints(cmd: SlashCommand) -> tuple[str, ...]:
     treated as literal subcommands.
     """
     return tuple(sorted({keyword.lower() for keyword, _label in cmd.first_arg_completions}))
-
-
-def _looks_like_path_or_template_arg(value: str) -> bool:
-    stripped = value.strip()
-    if not stripped:
-        return False
-    return bool(_PATH_LIKE_ARG_RE.search(stripped))
 
 
 def format_unknown_slash_message(
@@ -111,15 +103,6 @@ def resolve_literal_slash_typo(
     if cmd.validate_args is not None:
         validation_error = cmd.validate_args(args)
         if validation_error is not None and args:
-            return LiteralSlashTypo(
-                message=format_invalid_subcommand_message(cmd, args),
-                outcome="invalid_subcommand",
-            )
-
-    hints = subcommand_hints(cmd)
-    if args and hints and not _looks_like_path_or_template_arg(args[0]):
-        first_arg = args[0].lower()
-        if first_arg not in hints:
             return LiteralSlashTypo(
                 message=format_invalid_subcommand_message(cmd, args),
                 outcome="invalid_subcommand",

--- a/surfaces/interactive_shell/command_registry/suggestions.py
+++ b/surfaces/interactive_shell/command_registry/suggestions.py
@@ -2,7 +2,25 @@
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
 from difflib import get_close_matches
+from typing import Literal
+
+from surfaces.interactive_shell.command_registry.types import SlashCommand
+
+SlashOutcome = Literal["unknown_command", "invalid_subcommand"]
+
+_PATH_LIKE_ARG_RE = re.compile(r"[/\\]|\.(?:json|md|txt|yml|yaml)\b", re.IGNORECASE)
+_RICH_TAG_RE = re.compile(r"\[[^\]]+\]")
+
+
+@dataclass(frozen=True, slots=True)
+class LiteralSlashTypo:
+    """A user-typed literal slash line that should not run."""
+
+    message: str
+    outcome: SlashOutcome
 
 
 def closest_choice(value: str, choices: list[str] | tuple[str, ...]) -> str | None:
@@ -14,4 +32,117 @@ def closest_choice(value: str, choices: list[str] | tuple[str, ...]) -> str | No
     return matches[0] if matches else None
 
 
-__all__ = ["closest_choice"]
+def subcommand_hints(cmd: SlashCommand) -> tuple[str, ...]:
+    """Return known first-argument subcommands for ``cmd`` when enumerable."""
+    hints: set[str] = {keyword.lower() for keyword, _label in cmd.first_arg_completions}
+    for line in cmd.usage:
+        parts = line.strip().split()
+        if len(parts) >= 2 and parts[0].lower() == cmd.name.lower():
+            hints.add(parts[1].lower())
+    return tuple(sorted(hints))
+
+
+def _looks_like_path_or_template_arg(value: str) -> bool:
+    stripped = value.strip()
+    if not stripped:
+        return False
+    return bool(_PATH_LIKE_ARG_RE.search(stripped))
+
+
+def format_unknown_slash_message(
+    command_line: str,
+    *,
+    command_names: tuple[str, ...],
+) -> str:
+    """Plain-text guidance for an unknown slash command root."""
+    stripped = command_line.strip()
+    name = stripped.split()[0] if stripped else stripped
+    suggestion = closest_choice(name, command_names)
+    if suggestion:
+        return (
+            f"Unknown command: {name}. "
+            f"Did you mean {suggestion}? "
+            "Type /help for the full command list."
+        )
+    return f"Unknown command: {name}. Type /help for the full command list."
+
+
+def format_invalid_subcommand_message(
+    cmd: SlashCommand,
+    args: list[str],
+) -> str:
+    """Plain-text guidance for an invalid subcommand on a known slash command."""
+    subcommand = args[0] if args else ""
+    hints = subcommand_hints(cmd)
+    if hints:
+        choices_text = ", ".join(f"{cmd.name} {hint}" for hint in hints)
+        return (
+            f"Invalid subcommand: {subcommand}. "
+            f"Try one of: {choices_text}. "
+            f"Type /help for the full command list."
+        )
+    return (
+        f"Invalid subcommand: {subcommand}. "
+        f"Type /help for the full command list."
+    )
+
+
+def resolve_literal_slash_typo(
+    command_line: str,
+    registry: dict[str, SlashCommand],
+) -> LiteralSlashTypo | None:
+    """Return typo guidance when a user-typed literal slash line should not run."""
+    stripped = command_line.strip()
+    if not stripped.startswith("/"):
+        return None
+
+    parts = stripped.split()
+    if not parts:
+        return None
+
+    name = parts[0].lower()
+    args = parts[1:]
+    command_names = tuple(registry)
+
+    cmd = registry.get(name)
+    if cmd is None:
+        return LiteralSlashTypo(
+            message=format_unknown_slash_message(stripped, command_names=command_names),
+            outcome="unknown_command",
+        )
+
+    if cmd.validate_args is not None:
+        validation_error = cmd.validate_args(args)
+        if validation_error is not None and args:
+            return LiteralSlashTypo(
+                message=format_invalid_subcommand_message(cmd, args),
+                outcome="invalid_subcommand",
+            )
+
+    hints = subcommand_hints(cmd)
+    if args and hints and not _looks_like_path_or_template_arg(args[0]):
+        first_arg = args[0].lower()
+        if first_arg not in hints:
+            return LiteralSlashTypo(
+                message=format_invalid_subcommand_message(cmd, args),
+                outcome="invalid_subcommand",
+            )
+
+    return None
+
+
+def strip_rich_markup(text: str) -> str:
+    """Best-effort plain text for analytics payloads sourced from Rich strings."""
+    return _RICH_TAG_RE.sub("", text).strip()
+
+
+__all__ = [
+    "LiteralSlashTypo",
+    "SlashOutcome",
+    "closest_choice",
+    "format_invalid_subcommand_message",
+    "format_unknown_slash_message",
+    "resolve_literal_slash_typo",
+    "strip_rich_markup",
+    "subcommand_hints",
+]

--- a/surfaces/interactive_shell/command_registry/tools_cmds.py
+++ b/surfaces/interactive_shell/command_registry/tools_cmds.py
@@ -26,6 +26,9 @@ _cmd_tools = make_list_root_handler(
 
 _TOOLS_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("list", "list registered tools (investigation + chat surfaces)"),
+    ("ls", "alias for list"),
+    ("tool", "alias for list"),
+    ("tools", "alias for list"),
 )
 
 COMMANDS: list[SlashCommand] = [

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -15,6 +15,8 @@ from core.agent_harness.turn_orchestrator import answer_cli_agent as run_core_an
 from core.agent_harness.turn_orchestrator import run_turn
 from core.agent_harness.turn_results import ShellTurnResult, ToolCallingTurnResult
 from core.execution import ToolExecutionHooks
+from surfaces.interactive_shell.command_registry import SLASH_COMMANDS
+from surfaces.interactive_shell.command_registry.suggestions import resolve_literal_slash_typo
 from surfaces.interactive_shell.runtime.agent_harness_adapters import (
     ShellErrorReporter,
     ShellOutputSink,
@@ -47,6 +49,34 @@ def _resolve_output_sink(console: Console, output: OutputSink | None) -> OutputS
     return ShellOutputSink(console)
 
 
+def _complete_literal_slash_typo_turn(
+    message: str,
+    session: ReplSession,
+    output: OutputSink,
+) -> ToolCallingTurnResult | None:
+    """Handle unknown slash roots and invalid subcommands before tool validation."""
+    typo = resolve_literal_slash_typo(message, SLASH_COMMANDS)
+    if typo is None:
+        return None
+    output.print()
+    output.print(typo.message)
+    session.record(
+        "slash",
+        message.strip(),
+        ok=False,
+        response_text=typo.message,
+        slash_outcome=typo.outcome,
+    )
+    return ToolCallingTurnResult(
+        0,
+        1,
+        0,
+        False,
+        True,
+        response_text=typo.message,
+    )
+
+
 def run_action_tool_turn(
     message: str,
     session: ReplSession,
@@ -61,6 +91,10 @@ def run_action_tool_turn(
     tool_hooks: ToolExecutionHooks | None = None,
 ) -> ToolCallingTurnResult:
     """Run one action-selection turn through core with shell adapters bound."""
+    resolved_output = _resolve_output_sink(console, output)
+    typo_result = _complete_literal_slash_typo_turn(message, session, resolved_output)
+    if typo_result is not None:
+        return typo_result
     effective_deps = (
         deps
         if deps is not None and deps.llm_factory is not None
@@ -69,7 +103,7 @@ def run_action_tool_turn(
     return run_agent_turn(
         message,
         session,
-        output=_resolve_output_sink(console, output),
+        output=resolved_output,
         tools=ShellToolProvider(session, console, request_exit=request_exit),
         confirm_fn=confirm_fn,
         is_tty=is_tty,

--- a/surfaces/interactive_shell/utils/telemetry/recorder.py
+++ b/surfaces/interactive_shell/utils/telemetry/recorder.py
@@ -56,6 +56,7 @@ def _latest_slash_outcome(session: Any) -> str | None:
         outcome = entry.get("slash_outcome")
         if isinstance(outcome, str) and outcome:
             return outcome
+        return None
     return None
 
 

--- a/surfaces/interactive_shell/utils/telemetry/recorder.py
+++ b/surfaces/interactive_shell/utils/telemetry/recorder.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from config.version import get_version
 from core.agent_harness.session.prompt_history.policy import redact_text
+from platform.analytics.provider import JsonValue
 from surfaces.interactive_shell.utils.telemetry.config import PromptLogConfig
 from surfaces.interactive_shell.utils.telemetry.integration_snapshot import (
     build_turn_integration_snapshot,
@@ -43,6 +44,19 @@ class LlmRunInfo:
     input_tokens: int | None = None
     output_tokens: int | None = None
     response_text: str | None = None
+
+
+def _latest_slash_outcome(session: Any) -> str | None:
+    history = getattr(session, "history", None)
+    if not isinstance(history, list):
+        return None
+    for entry in reversed(history):
+        if not isinstance(entry, dict) or entry.get("type") != "slash":
+            continue
+        outcome = entry.get("slash_outcome")
+        if isinstance(outcome, str) and outcome:
+            return outcome
+    return None
 
 
 class PromptRecorder:
@@ -181,33 +195,35 @@ class PromptRecorder:
         if self._config.posthog_enabled:
             with contextlib.suppress(Exception):
                 integration_snapshot = build_turn_integration_snapshot(self._session)
-                capture_ai_generation(
-                    {
-                        "$ai_trace_id": self._turn_id,
-                        "$ai_session_id": self._session_id,
-                        "$ai_span_id": self._turn_id,
-                        "$ai_span_name": f"surfaces.interactive_shell.{self._turn_kind}",
-                        "$ai_model": self._model or NO_CONVERSATIONAL_AGENT,
-                        "$ai_provider": self._provider or NO_CONVERSATIONAL_AGENT,
-                        "$ai_input": [{"role": "user", "content": self._prompt}],
-                        "$ai_output_choices": [
-                            {
-                                "role": "assistant",
-                                "content": self._response,
-                            }
-                        ],
-                        "$ai_latency": (
-                            round((self._latency_ms or 0) / 1000.0, 3) if self._latency_ms else 0.0
-                        ),
-                        "$ai_input_tokens": self._input_tokens or 0,
-                        "$ai_output_tokens": self._output_tokens or 0,
-                        "cli_turn_kind": self._turn_kind,
-                        "cli_session_id": self._session_id,
-                        "cli_turn_id": self._turn_id,
-                        "opensre_version": get_version(),
-                        **integration_snapshot,
-                    }
-                )
+                posthog_properties: dict[str, JsonValue] = {
+                    "$ai_trace_id": self._turn_id,
+                    "$ai_session_id": self._session_id,
+                    "$ai_span_id": self._turn_id,
+                    "$ai_span_name": f"surfaces.interactive_shell.{self._turn_kind}",
+                    "$ai_model": self._model or NO_CONVERSATIONAL_AGENT,
+                    "$ai_provider": self._provider or NO_CONVERSATIONAL_AGENT,
+                    "$ai_input": [{"role": "user", "content": self._prompt}],
+                    "$ai_output_choices": [
+                        {
+                            "role": "assistant",
+                            "content": self._response,
+                        }
+                    ],
+                    "$ai_latency": (
+                        round((self._latency_ms or 0) / 1000.0, 3) if self._latency_ms else 0.0
+                    ),
+                    "$ai_input_tokens": self._input_tokens or 0,
+                    "$ai_output_tokens": self._output_tokens or 0,
+                    "cli_turn_kind": self._turn_kind,
+                    "cli_session_id": self._session_id,
+                    "cli_turn_id": self._turn_id,
+                    "opensre_version": get_version(),
+                    **integration_snapshot,
+                }
+                slash_outcome = _latest_slash_outcome(self._session)
+                if slash_outcome:
+                    posthog_properties["slash_outcome"] = slash_outcome
+                capture_ai_generation(posthog_properties)
 
 
 def _sanitize_text(text: str, *, config: PromptLogConfig) -> str:

--- a/tests/interactive_shell/command_registry/test_suggestions.py
+++ b/tests/interactive_shell/command_registry/test_suggestions.py
@@ -47,24 +47,34 @@ def test_resolve_literal_slash_typo_unknown_root() -> None:
     assert "Did you mean /investigate?" in typo.message
 
 
-def test_resolve_literal_slash_typo_invalid_subcommand() -> None:
-    typo = resolve_literal_slash_typo("/integrations bogus", SLASH_COMMANDS)
-    assert typo is not None
-    assert typo.outcome == "invalid_subcommand"
-    assert "Invalid subcommand: bogus" in typo.message
-    assert "/integrations list" in typo.message
-
-
 @pytest.mark.parametrize(
     "command_line",
     [
         "/resume redis",
         "/help model",
         "/help /model",
+        "/integrations ls",
+        "/tools ls",
+        "/tools tool",
+        "/mcp ls",
     ],
 )
 def test_resolve_literal_slash_typo_allows_free_form_first_args(command_line: str) -> None:
     assert resolve_literal_slash_typo(command_line, SLASH_COMMANDS) is None
+
+
+def test_dispatch_invalid_subcommand_is_handled_by_command_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.integrations.repl_data.load_verified_integrations",
+        lambda: [],
+    )
+    session = ReplSession()
+    console, buf = _capture()
+    assert dispatch_slash("/integrations bogus", session, console) is True
+    assert "unknown subcommand" in buf.getvalue().lower()
+    assert resolve_literal_slash_typo("/integrations bogus", SLASH_COMMANDS) is None
 
 
 def test_subcommand_hints_ignores_usage_placeholders() -> None:

--- a/tests/interactive_shell/command_registry/test_suggestions.py
+++ b/tests/interactive_shell/command_registry/test_suggestions.py
@@ -1,0 +1,87 @@
+"""Tests for slash typo suggestion helpers."""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+
+from core.agent_harness.session import ReplSession
+from surfaces.interactive_shell.command_registry import SLASH_COMMANDS, dispatch_slash
+from surfaces.interactive_shell.command_registry.suggestions import (
+    format_invalid_subcommand_message,
+    format_unknown_slash_message,
+    resolve_literal_slash_typo,
+)
+from surfaces.interactive_shell.runtime.shell_turn_execution import run_action_tool_turn
+
+
+def _capture() -> tuple[Console, io.StringIO]:
+    buf = io.StringIO()
+    return Console(file=buf, force_terminal=False, highlight=False), buf
+
+
+def test_format_unknown_slash_message_without_suggestion_points_to_help() -> None:
+    message = format_unknown_slash_message(
+        "/made-up",
+        command_names=tuple(SLASH_COMMANDS),
+    )
+    assert message == "Unknown command: /made-up. Type /help for the full command list."
+
+
+def test_format_unknown_slash_message_with_suggestion() -> None:
+    message = format_unknown_slash_message(
+        "/modle",
+        command_names=tuple(SLASH_COMMANDS),
+    )
+    assert "Did you mean /model?" in message
+    assert "Type /help" in message
+
+
+def test_resolve_literal_slash_typo_unknown_root() -> None:
+    typo = resolve_literal_slash_typo("/invest", SLASH_COMMANDS)
+    assert typo is not None
+    assert typo.outcome == "unknown_command"
+    assert "Did you mean /investigate?" in typo.message
+
+
+def test_resolve_literal_slash_typo_invalid_subcommand() -> None:
+    typo = resolve_literal_slash_typo("/integrations bogus", SLASH_COMMANDS)
+    assert typo is not None
+    assert typo.outcome == "invalid_subcommand"
+    assert "Invalid subcommand: bogus" in typo.message
+    assert "/integrations list" in typo.message
+
+
+def test_format_invalid_subcommand_message_lists_known_subcommands() -> None:
+    cmd = SLASH_COMMANDS["/integrations"]
+    message = format_invalid_subcommand_message(cmd, ["bogus"])
+    assert "Invalid subcommand: bogus" in message
+    assert "/integrations list" in message
+
+
+def test_dispatch_unknown_command_records_full_response_and_outcome() -> None:
+    session = ReplSession()
+    console, buf = _capture()
+    assert dispatch_slash("/modle", session, console) is True
+    output = buf.getvalue()
+    assert "Unknown command" in output
+    latest = session.history[-1]
+    assert latest["ok"] is False
+    assert latest["slash_outcome"] == "unknown_command"
+    assert latest["response_text"] == latest["response_text"].strip()
+    assert "Type /help" in latest["response_text"]
+
+
+def test_run_action_tool_turn_handles_unknown_literal_slash_before_tool_validation() -> None:
+    session = ReplSession()
+    console, buf = _capture()
+    result = run_action_tool_turn("/invest", session, console)
+    assert result.handled is True
+    assert result.response_text
+    assert "Unknown command" in result.response_text
+    assert "Unknown command" in buf.getvalue()
+    latest = session.history[-1]
+    assert latest["type"] == "slash"
+    assert latest["slash_outcome"] == "unknown_command"
+    assert latest["response_text"] == result.response_text

--- a/tests/interactive_shell/command_registry/test_suggestions.py
+++ b/tests/interactive_shell/command_registry/test_suggestions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 
+import pytest
 from rich.console import Console
 
 from core.agent_harness.session import ReplSession
@@ -12,6 +13,7 @@ from surfaces.interactive_shell.command_registry.suggestions import (
     format_invalid_subcommand_message,
     format_unknown_slash_message,
     resolve_literal_slash_typo,
+    subcommand_hints,
 )
 from surfaces.interactive_shell.runtime.shell_turn_execution import run_action_tool_turn
 
@@ -51,6 +53,25 @@ def test_resolve_literal_slash_typo_invalid_subcommand() -> None:
     assert typo.outcome == "invalid_subcommand"
     assert "Invalid subcommand: bogus" in typo.message
     assert "/integrations list" in typo.message
+
+
+@pytest.mark.parametrize(
+    "command_line",
+    [
+        "/resume redis",
+        "/help model",
+        "/help /model",
+    ],
+)
+def test_resolve_literal_slash_typo_allows_free_form_first_args(command_line: str) -> None:
+    assert resolve_literal_slash_typo(command_line, SLASH_COMMANDS) is None
+
+
+def test_subcommand_hints_ignores_usage_placeholders() -> None:
+    resume = SLASH_COMMANDS["/resume"]
+    assert subcommand_hints(resume) == ()
+    help_cmd = SLASH_COMMANDS["/help"]
+    assert subcommand_hints(help_cmd) == ()
 
 
 def test_format_invalid_subcommand_message_lists_known_subcommands() -> None:

--- a/tests/interactive_shell/test_command_registry.py
+++ b/tests/interactive_shell/test_command_registry.py
@@ -51,7 +51,7 @@ def test_dispatch_unknown_command_stays_in_repl() -> None:
     session = ReplSession()
     console, buf = _capture()
     assert dispatch_slash("/not-a-real-slash", session, console) is True
-    assert "unknown command" in buf.getvalue()
+    assert "Unknown command" in buf.getvalue()
 
 
 def test_registry_first_arg_completion_hints_co_located_with_handlers() -> None:

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -249,14 +249,14 @@ class TestDispatchSlash:
         session = ReplSession()
         console, buf = _capture()
         assert dispatch_slash("/made-up", session, console) is True
-        assert "unknown command" in buf.getvalue()
+        assert "Unknown command" in buf.getvalue()
 
     def test_unknown_command_suggests_close_match(self) -> None:
         session = ReplSession()
         console, buf = _capture()
         assert dispatch_slash("/modle", session, console) is True
         output = buf.getvalue()
-        assert "unknown command" in output
+        assert "Unknown command" in output
         assert "Did you mean" in output
         assert "/model" in output
 

--- a/tests/interactive_shell/utils/telemetry/test_recorder.py
+++ b/tests/interactive_shell/utils/telemetry/test_recorder.py
@@ -300,4 +300,3 @@ def test_prompt_recorder_uses_only_latest_slash_outcome(monkeypatch, tmp_path: P
     recorder.set_response("github and datadog")
     recorder.flush()
     assert "slash_outcome" not in captured[0]
-

--- a/tests/interactive_shell/utils/telemetry/test_recorder.py
+++ b/tests/interactive_shell/utils/telemetry/test_recorder.py
@@ -259,3 +259,45 @@ def test_prompt_recorder_uses_no_conversational_agent_without_llm_run(
     recorder.flush()
     assert captured[0]["$ai_model"] == "no_conversational_agent"
     assert captured[0]["$ai_provider"] == "no_conversational_agent"
+
+
+def test_prompt_recorder_uses_only_latest_slash_outcome(monkeypatch, tmp_path: Path) -> None:
+    captured: list[dict[str, object]] = []
+    cfg = PromptLogConfig(
+        enabled=True,
+        local_enabled=False,
+        posthog_enabled=True,
+        redact=False,
+        max_chars=1000,
+        log_path=tmp_path / "prompt_log.jsonl",
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.PromptLogConfig.load", lambda: cfg
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.build_turn_integration_snapshot",
+        lambda _session: {},
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.capture_ai_generation",
+        lambda payload: captured.append(payload),
+    )
+    session = ReplSession()
+    session.record(
+        "slash",
+        "/modle",
+        ok=False,
+        response_text="Unknown command: /modle.",
+        slash_outcome="unknown_command",
+    )
+    session.record("slash", "/help", ok=True, response_text="slash /help (succeeded)")
+    recorder = PromptRecorder.start(
+        session=session,
+        text="what integrations are configured?",
+        turn_kind="agent",
+    )
+    assert recorder is not None
+    recorder.set_response("github and datadog")
+    recorder.flush()
+    assert "slash_outcome" not in captured[0]
+


### PR DESCRIPTION
## Summary

- Intercepts literal slash typos (`/invest`, `/modle`, `/integrations bogus`) before `slash_invoke` enum validation, which previously produced silent empty turns
- Unifies typo messaging via `resolve_literal_slash_typo` / shared formatters: close-match suggestions when confident, otherwise points to `/help`; invalid subcommands list known options when available
- Records full `response_text` on slash history rows with `slash_outcome` (`unknown_command` | `invalid_subcommand`) and forwards `slash_outcome` to PostHog `$ai_generation` events

Fixes #3311

## Test plan

- [x] `uv run python -m pytest tests/interactive_shell/command_registry/test_suggestions.py`
- [x] `uv run python -m pytest tests/interactive_shell/test_command_registry.py`
- [x] `make lint`
- [x] `make typecheck`
- [ ] Manual: type `/invest` at REPL → see suggestion + `/help` pointer; PostHog row has `slash_outcome=unknown_command` and full message in `$ai_output_choices`