### PR TITLE
fix: record one session history row per REPL user turn

### DIFF
--- a/core/agent_harness/action_agent.py
+++ b/core/agent_harness/action_agent.py
@@ -50,17 +50,22 @@ _EXECUTED_HISTORY_TYPES = {
     "implementation",
     "cli_command",
 }
-_LEGACY_HISTORY_TOOL_NAMES = {
-    "alert_sample",
-    "cli_exec",
-    "code_implement",
-    "investigation_start",
-    "llm_set_provider",
-    "shell_run",
-    "slash_invoke",
-    "synthetic_run",
-    "task_cancel",
-}
+# Action tools that append their own ``session.history`` row when executed.
+# Keep this as the single catalogue: the shell observer and generic tool-result
+# accounting both key off it so new tools cannot silently double-record turns.
+SELF_RECORDING_ACTION_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "alert_sample",
+        "cli_exec",
+        "code_implement",
+        "investigation_start",
+        "llm_set_provider",
+        "shell_run",
+        "slash_invoke",
+        "synthetic_run",
+        "task_cancel",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -162,7 +167,7 @@ def _generic_tool_results(result: Any) -> list[tuple[ToolCall, Any]]:
     return [
         (tool_call, tool_result)
         for tool_call, tool_result in getattr(result, "tool_results", [])
-        if tool_call.name not in _LEGACY_HISTORY_TOOL_NAMES
+        if tool_call.name not in SELF_RECORDING_ACTION_TOOL_NAMES
         and tool_call.name != "assistant_handoff"
     ]
 
@@ -391,6 +396,7 @@ def run_agent_turn(
 
 
 __all__ = [
+    "SELF_RECORDING_ACTION_TOOL_NAMES",
     "ToolCallingDeps",
     "run_agent_turn",
 ]

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -34,6 +34,22 @@ _SIMPLE_TOOL_LABELS: dict[str, tuple[str, str]] = {
     "shell_run": ("shell", "command"),
 }
 
+# Action tools that write their own ``session.history`` row on execution. The
+# observer must not also record a duplicate ``cli_agent`` turn for these.
+_SELF_RECORDING_ACTION_TOOLS: frozenset[str] = frozenset(
+    {
+        "alert_sample",
+        "cli_exec",
+        "code_implement",
+        "investigation_start",
+        "llm_set_provider",
+        "shell_run",
+        "slash_invoke",
+        "synthetic_run",
+        "task_cancel",
+    }
+)
+
 
 def tool_call_display(tool_name: str, args: dict[str, Any]) -> tuple[str, str]:
     """Return a ``(label, content)`` pair describing a planned tool call."""
@@ -54,7 +70,12 @@ def tool_call_display(tool_name: str, args: dict[str, Any]) -> tuple[str, str]:
 
 
 class ActionRenderObserver:
-    """Agent event observer that records internal planner actions."""
+    """Agent event observer that records planner turns not owned by action tools.
+
+    Self-recording tools (``slash_invoke``, ``shell_run``, etc.) append their own
+    history row; chat turns are recorded later by turn accounting when the
+    assistant runs.
+    """
 
     def __init__(self, *, session: ReplSession, console: Console, message: str) -> None:
         self.session = session
@@ -78,7 +99,7 @@ class ActionRenderObserver:
         name = str(data.get("name", "")).strip()
         if not name or name == "assistant_handoff":
             return
-        if self.planned_count == 0:
+        if self.planned_count == 0 and name not in _SELF_RECORDING_ACTION_TOOLS:
             self.session.record("cli_agent", self.message)
             self._recorded_cli_agent = True
         self.planned_count += 1

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from rich.console import Console
 
+from core.agent_harness.action_agent import SELF_RECORDING_ACTION_TOOL_NAMES
 from surfaces.interactive_shell.runtime import ReplSession
 
 # Tools whose preview is just ``(label, single-arg)``. The display content is the
@@ -33,23 +34,6 @@ _SIMPLE_TOOL_LABELS: dict[str, tuple[str, str]] = {
     "code_implement": ("implementation", "task"),
     "shell_run": ("shell", "command"),
 }
-
-# Action tools that write their own ``session.history`` row on execution. The
-# observer must not also record a duplicate ``cli_agent`` turn for these.
-_SELF_RECORDING_ACTION_TOOLS: frozenset[str] = frozenset(
-    {
-        "alert_sample",
-        "cli_exec",
-        "code_implement",
-        "investigation_start",
-        "llm_set_provider",
-        "shell_run",
-        "slash_invoke",
-        "synthetic_run",
-        "task_cancel",
-    }
-)
-
 
 def tool_call_display(tool_name: str, args: dict[str, Any]) -> tuple[str, str]:
     """Return a ``(label, content)`` pair describing a planned tool call."""
@@ -82,7 +66,6 @@ class ActionRenderObserver:
         self.console = console
         self.message = message
         self.planned_count = 0
-        self._recorded_cli_agent = False
 
     def __call__(self, kind: str, data: dict[str, Any]) -> None:
         if kind == "tool_update":
@@ -99,9 +82,8 @@ class ActionRenderObserver:
         name = str(data.get("name", "")).strip()
         if not name or name == "assistant_handoff":
             return
-        if self.planned_count == 0 and name not in _SELF_RECORDING_ACTION_TOOLS:
+        if self.planned_count == 0 and name not in SELF_RECORDING_ACTION_TOOL_NAMES:
             self.session.record("cli_agent", self.message)
-            self._recorded_cli_agent = True
         self.planned_count += 1
 
 

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -35,6 +35,7 @@ _SIMPLE_TOOL_LABELS: dict[str, tuple[str, str]] = {
     "shell_run": ("shell", "command"),
 }
 
+
 def tool_call_display(tool_name: str, args: dict[str, Any]) -> tuple[str, str]:
     """Return a ``(label, content)`` pair describing a planned tool call."""
     if tool_name == "slash_invoke":

--- a/tests/core/agent/orchestration/test_agent_actions.py
+++ b/tests/core/agent/orchestration/test_agent_actions.py
@@ -292,11 +292,6 @@ def test_execute_cli_actions_dispatches_planned_commands(monkeypatch: object) ->
     assert handled.handled is True
     assert dispatched == ["/health", "/integrations list"]
     assert session.history == [
-        {
-            "type": "cli_agent",
-            "text": "check the health of my opensre and then show me all connected services",
-            "ok": True,
-        },
         {"type": "slash", "text": "/health", "ok": True},
         {"type": "slash", "text": "/integrations list", "ok": True},
     ]
@@ -423,11 +418,6 @@ def test_execute_cli_actions_switches_llm_provider(monkeypatch: object) -> None:
     assert handled.handled is True
     assert switches == ["anthropic"]
     assert session.history == [
-        {
-            "type": "cli_agent",
-            "text": "switch from the current ollama model to setting the model to anthropic",
-            "ok": True,
-        },
         {"type": "slash", "text": "/model set anthropic", "ok": True},
     ]
     output = buf.getvalue()
@@ -523,7 +513,6 @@ def test_execute_cli_actions_runs_implementation_action(monkeypatch: object) -> 
     assert handled.handled is True
     assert calls == ["/history search"]
     assert session.history == [
-        {"type": "cli_agent", "text": "please implement /history search", "ok": True},
         {"type": "implementation", "text": "/history search", "ok": True},
     ]
     output = buf.getvalue()
@@ -565,14 +554,6 @@ def test_execute_cli_actions_answers_discord_then_dispatches_datadog(
     assert handled.handled is True
     assert dispatched == ["/integrations show datadog"]
     assert session.history == [
-        {
-            "type": "cli_agent",
-            "text": (
-                "tell me about what the discord integration can do and then tell me what "
-                "datadog services I have connections to"
-            ),
-            "ok": True,
-        },
         {"type": "slash", "text": "/integrations show datadog", "ok": True},
     ]
     output = buf.getvalue()
@@ -612,14 +593,6 @@ def test_compound_prompt_executes_all_supported_tasks(monkeypatch: object) -> No
     assert handled.handled is True
     assert dispatched == ["/integrations list", "/remote"]
     assert session.history == [
-        {
-            "type": "cli_agent",
-            "text": (
-                "tell me how you are doing AND show me all the services we are connected to "
-                "AND then deploy OpenSRE to EC2"
-            ),
-            "ok": True,
-        },
         {"type": "slash", "text": "/integrations list", "ok": True},
         {"type": "slash", "text": "/remote", "ok": True},
     ]
@@ -843,17 +816,11 @@ def test_execute_cli_actions_lists_all_actions_before_synthetic_rds(monkeypatch:
         "001-replication-lag",
     ]
 
-    assert session.history[:2] == [
-        {
-            "type": "cli_agent",
-            "text": (
-                "show me which services are connected and after that run a synthetic test "
-                "RDS database"
-            ),
-            "ok": True,
-        },
-        {"type": "slash", "text": "/integrations list", "ok": True},
-    ]
+    assert session.history[0] == {
+        "type": "slash",
+        "text": "/integrations list",
+        "ok": True,
+    }
 
     for _ in range(100):
         recent = session.task_registry.list_recent(1)
@@ -918,12 +885,7 @@ def test_execute_cli_actions_cancels_single_running_synthetic_task() -> None:
     assert handled.handled is True
     assert task.cancel_requested.is_set()
     proc.terminate.assert_called_once()
-    assert session.history[0] == {
-        "type": "cli_agent",
-        "text": "kill the syntehtic_test because it is runnign way too long",
-        "ok": True,
-    }
-    slash_entry = session.history[1]
+    slash_entry = session.history[0]
     assert slash_entry == {
         "type": "slash",
         "text": f"/cancel {task.task_id}",
@@ -992,7 +954,6 @@ def test_execute_cli_actions_runs_shell_command(monkeypatch: object) -> None:
 
     assert shell_turn_execution.run_action_tool_turn("run `pwd`", session, console).handled is True
     assert session.history == [
-        {"type": "cli_agent", "text": "run `pwd`", "ok": True},
         {"type": "shell", "text": "pwd", "ok": True},
     ]
     output = buf.getvalue()
@@ -1016,7 +977,6 @@ def test_execute_cli_actions_cd_preserves_windows_paths(monkeypatch: object) -> 
     assert shell_turn_execution.run_action_tool_turn(message, session, console).handled is True
     assert changed_directories == [Path(r"C:\Users\Alice")]
     assert session.history == [
-        {"type": "cli_agent", "text": message, "ok": True},
         {"type": "shell", "text": r"cd C:\Users\Alice", "ok": True},
     ]
 
@@ -1041,7 +1001,6 @@ def test_execute_cli_actions_cd_dispatches_case_insensitively(monkeypatch: objec
     assert shell_turn_execution.run_action_tool_turn(message, session, console).handled is True
     assert changed_directories == [Path(r"C:\Users\Alice")]
     assert session.history == [
-        {"type": "cli_agent", "text": message, "ok": True},
         {"type": "shell", "text": r"CD C:\Users\Alice", "ok": True},
     ]
 
@@ -1062,7 +1021,6 @@ def test_execute_cli_actions_cd_handles_trailing_backslash_on_windows(monkeypatc
     assert shell_turn_execution.run_action_tool_turn(message, session, console).handled is True
     assert changed_directories == [Path("C:\\")]
     assert session.history == [
-        {"type": "cli_agent", "text": message, "ok": True},
         {"type": "shell", "text": "cd C:\\", "ok": True},
     ]
 
@@ -1083,7 +1041,6 @@ def test_execute_cli_actions_cd_strips_quotes_on_windows(monkeypatch: object) ->
     assert shell_turn_execution.run_action_tool_turn(message, session, console).handled is True
     assert changed_directories == [Path(r"C:\Users\Alice")]
     assert session.history == [
-        {"type": "cli_agent", "text": message, "ok": True},
         {"type": "shell", "text": r'cd "C:\Users\Alice"', "ok": True},
     ]
 

--- a/tests/core/agent/orchestration/test_agent_actions_harness.py
+++ b/tests/core/agent/orchestration/test_agent_actions_harness.py
@@ -145,10 +145,11 @@ def test_literal_slash_command_dispatches_deterministically_without_llm(
 
     monkeypatch.setattr(slash_tool, "dispatch_slash", _fake_dispatch)
     harness = ActionExecutionHarness(llm=FakeActionLLM([no_tool_response()]))
+    session = ReplSession()
 
     result = run_action_tool_turn(
         "/sessions",
-        ReplSession(),
+        session,
         harness.console,
         deps=harness.deps,
     )
@@ -156,6 +157,7 @@ def test_literal_slash_command_dispatches_deterministically_without_llm(
     assert result.handled is True
     assert result.planned_count == 1
     assert dispatched == ["/sessions"]
+    assert session.history == [{"type": "slash", "text": "/sessions", "ok": True}]
     # The deterministic path must not consult the action-agent LLM.
     assert harness.llm.invocations == 0
 

--- a/tests/core/agent/prompt_turn_contracts.yml
+++ b/tests/core/agent/prompt_turn_contracts.yml
@@ -113,9 +113,6 @@
   expected_terminal_response_contains:
     - "sample alert generic"
   expected_session_history_delta:
-    - type: "cli_agent"
-      text: "run a sample alert"
-      ok: true
     - type: "alert"
       text: "sample:generic"
       ok: true
@@ -132,9 +129,6 @@
   expected_terminal_response_contains:
     - "sample alert generic"
   expected_session_history_delta:
-    - type: "cli_agent"
-      text: "try a sample alert"
-      ok: true
     - type: "alert"
       text: "sample:generic"
       ok: true
@@ -151,9 +145,6 @@
   expected_terminal_response_contains:
     - "synthetic test rds_postgres:002-connection-exhaustion"
   expected_session_history_delta:
-    - type: "cli_agent"
-      text: "run synthetic test 002-connection-exhaustion"
-      ok: true
     - type: "synthetic_test"
       text: "rds_postgres:002-connection-exhaustion"
       ok: true
@@ -170,9 +161,6 @@
   expected_terminal_response_contains:
     - "synthetic test rds_postgres:003-storage-full"
   expected_session_history_delta:
-    - type: "cli_agent"
-      text: "run synthetic test 003-storage-full"
-      ok: true
     - type: "synthetic_test"
       text: "rds_postgres:003-storage-full"
       ok: true
@@ -189,9 +177,6 @@
   expected_terminal_response_contains:
     - "synthetic test rds_postgres:005-failover"
   expected_session_history_delta:
-    - type: "cli_agent"
-      text: "run synthetic test 005 now"
-      ok: true
     - type: "synthetic_test"
       text: "rds_postgres:005-failover"
       ok: true
@@ -208,9 +193,6 @@
   expected_terminal_response_contains:
     - "synthetic test rds_postgres:004-cpu-saturation-bad-query"
   expected_session_history_delta:
-    - type: "cli_agent"
-      text: "launch synthetic test 004-cpu-saturation-bad-query"
-      ok: true
     - type: "synthetic_test"
       text: "rds_postgres:004-cpu-saturation-bad-query"
       ok: true
@@ -227,9 +209,6 @@
   expected_terminal_response_contains:
     - "ran /integrations list"
   expected_session_history_delta:
-    - type: "cli_agent"
-      text: "show me connected services"
-      ok: true
     - type: "slash"
       text: "/integrations list"
       ok: true
@@ -251,9 +230,6 @@
     - "ran /health"
     - "ran /integrations list"
   expected_session_history_delta:
-    - type: "cli_agent"
-      text: "check the health of my opensre and then show me all connected services"
-      ok: true
     - type: "slash"
       text: "/health"
       ok: true

--- a/tests/core/agent/scenarios/complex_shell_prompts/314-windows-crash-multisource-query.yml
+++ b/tests/core/agent/scenarios/complex_shell_prompts/314-windows-crash-multisource-query.yml
@@ -59,8 +59,6 @@ response_contract:
   - shell
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: alert
     ok: true
 runs: 5

--- a/tests/core/agent/scenarios/complex_shell_prompts/320-priority-prompt-connected-services.yml
+++ b/tests/core/agent/scenarios/complex_shell_prompts/320-priority-prompt-connected-services.yml
@@ -42,8 +42,6 @@ response_contract:
   - I cannot help
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: slash
     ok: true
 runs: 3

--- a/tests/core/agent/scenarios/complex_shell_prompts/336-explicit-investigate-no-integrations-dispatch.yml
+++ b/tests/core/agent/scenarios/complex_shell_prompts/336-explicit-investigate-no-integrations-dispatch.yml
@@ -46,8 +46,6 @@ response_contract:
   - shell
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: alert
     ok: true
 runs: 5

--- a/tests/core/agent/scenarios/complex_shell_prompts/340-rca-verb-pasted-json-dispatch.yml
+++ b/tests/core/agent/scenarios/complex_shell_prompts/340-rca-verb-pasted-json-dispatch.yml
@@ -50,8 +50,6 @@ response_contract:
   - shell
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: alert
     ok: true
 runs: 5

--- a/tests/core/agent/scenarios/compound/405-slash-then-sample-alert-success.yml
+++ b/tests/core/agent/scenarios/compound/405-slash-then-sample-alert-success.yml
@@ -37,8 +37,6 @@ response_contract:
   must_not_contain: []
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: slash
     ok: true
   - type: alert

--- a/tests/core/agent/scenarios/compound/406-slash-then-investigate-sample-alert.yml
+++ b/tests/core/agent/scenarios/compound/406-slash-then-investigate-sample-alert.yml
@@ -40,8 +40,6 @@ response_contract:
   - investigation
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: slash
     ok: true
   - type: alert

--- a/tests/core/agent/scenarios/investigations/300-sample-alert-run.yml
+++ b/tests/core/agent/scenarios/investigations/300-sample-alert-run.yml
@@ -24,8 +24,6 @@ response_contract:
   must_not_contain: []
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: alert
     ok: true
 runs: 1

--- a/tests/core/agent/scenarios/investigations/301-sample-alert-paraphrase.yml
+++ b/tests/core/agent/scenarios/investigations/301-sample-alert-paraphrase.yml
@@ -24,8 +24,6 @@ response_contract:
   must_not_contain: []
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: alert
     ok: true
 runs: 1

--- a/tests/core/agent/scenarios/investigations/302-sample-alert-investigate-phrasing.yml
+++ b/tests/core/agent/scenarios/investigations/302-sample-alert-investigate-phrasing.yml
@@ -30,8 +30,6 @@ response_contract:
   - investigation
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: alert
     ok: true
 runs: 3

--- a/tests/core/agent/scenarios/investigations/302-synthetic-connection-exhaustion.yml
+++ b/tests/core/agent/scenarios/investigations/302-synthetic-connection-exhaustion.yml
@@ -30,8 +30,6 @@ response_contract:
   must_not_contain: []
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: synthetic_test
     ok: true
 runs: 1

--- a/tests/core/agent/scenarios/investigations/303-synthetic-storage-full.yml
+++ b/tests/core/agent/scenarios/investigations/303-synthetic-storage-full.yml
@@ -30,8 +30,6 @@ response_contract:
   must_not_contain: []
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: synthetic_test
     ok: true
 runs: 1

--- a/tests/core/agent/scenarios/investigations/304-synthetic-bare-numeric-id.yml
+++ b/tests/core/agent/scenarios/investigations/304-synthetic-bare-numeric-id.yml
@@ -30,8 +30,6 @@ response_contract:
   must_not_contain: []
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: synthetic_test
     ok: true
 runs: 1

--- a/tests/core/agent/scenarios/investigations/305-synthetic-cpu-saturation.yml
+++ b/tests/core/agent/scenarios/investigations/305-synthetic-cpu-saturation.yml
@@ -30,8 +30,6 @@ response_contract:
   must_not_contain: []
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: synthetic_test
     ok: true
 runs: 1

--- a/tests/core/agent/scenarios/investigations/306-pasted-alert-json-payload.yml
+++ b/tests/core/agent/scenarios/investigations/306-pasted-alert-json-payload.yml
@@ -28,8 +28,6 @@ response_contract:
   - $ /
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: alert
     ok: true
 runs: 3

--- a/tests/core/agent/scenarios/investigations/309-freeform-database-slow.yml
+++ b/tests/core/agent/scenarios/investigations/309-freeform-database-slow.yml
@@ -33,8 +33,6 @@ response_contract:
   - $ /
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: alert
     ok: true
 runs: 3

--- a/tests/core/agent/scenarios/investigations/315-quoted-directive-investigation.yml
+++ b/tests/core/agent/scenarios/investigations/315-quoted-directive-investigation.yml
@@ -42,8 +42,6 @@ response_contract:
   - $ /
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: alert
     ok: true
 runs: 3

--- a/tests/core/agent/scenarios/local_execution/200-show-connected-integrations.yml
+++ b/tests/core/agent/scenarios/local_execution/200-show-connected-integrations.yml
@@ -35,8 +35,6 @@ response_contract:
   must_not_contain: []
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: slash
     ok: true
 runs: 1

--- a/tests/core/agent/scenarios/local_execution/201-show-connected-services.yml
+++ b/tests/core/agent/scenarios/local_execution/201-show-connected-services.yml
@@ -36,8 +36,6 @@ response_contract:
   must_not_contain: []
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: slash
     ok: true
 runs: 1

--- a/tests/core/agent/scenarios/local_execution/202-health-then-connected-services.yml
+++ b/tests/core/agent/scenarios/local_execution/202-health-then-connected-services.yml
@@ -42,8 +42,6 @@ response_contract:
   must_not_contain: []
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: slash
     ok: true
   - type: slash

--- a/tests/core/agent/scenarios/local_execution/203-cli-verify-dry-run.yml
+++ b/tests/core/agent/scenarios/local_execution/203-cli-verify-dry-run.yml
@@ -29,8 +29,6 @@ response_contract:
   must_not_contain: []
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: cli_command
     ok: true
 runs: 1

--- a/tests/core/agent/scenarios/local_execution/205-sentry-configured-check-verify.yml
+++ b/tests/core/agent/scenarios/local_execution/205-sentry-configured-check-verify.yml
@@ -33,8 +33,6 @@ response_contract:
   must_not_contain: []
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: slash
     ok: true
 runs: 1

--- a/tests/core/agent/scenarios/remote/501-nitro-connect-then-investigate.yml
+++ b/tests/core/agent/scenarios/remote/501-nitro-connect-then-investigate.yml
@@ -34,8 +34,6 @@ response_contract:
   must_not_contain: []
 history:
   expected:
-  - type: cli_agent
-    ok: true
   - type: slash
     ok: true
   - type: alert

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -124,7 +124,5 @@ def test_chat_turn_records_single_cli_agent_history_entry() -> None:
         answer_agent=_answer,
     )
 
-    assert session.history == [
-        {"type": "cli_agent", "text": "what broke in prod?", "ok": True}
-    ]
+    assert session.history == [{"type": "cli_agent", "text": "what broke in prod?", "ok": True}]
     assert _prompt_turn_number(session) == 2

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -3,24 +3,128 @@
 from __future__ import annotations
 
 import io
+from dataclasses import dataclass
 
+import pytest
 from rich.console import Console
 
+import tools.interactive_shell.actions.slash as slash_tool
 from core.agent_harness.session import ReplSession
+from core.agent_harness.turn_results import ToolCallingTurnResult
+from surfaces.interactive_shell.runtime.shell_turn_execution import (
+    execute_shell_turn,
+    run_action_tool_turn,
+)
 from surfaces.interactive_shell.ui.action_rendering import ActionRenderObserver
+from surfaces.interactive_shell.ui.input_prompt.rendering import _prompt_turn_number
+from tests.core.agent.orchestration.action_execution_test_harness import (
+    ActionExecutionHarness,
+    FakeActionLLM,
+    no_tool_response,
+)
 
 
-def test_action_observer_records_without_printing_internal_plan() -> None:
+def test_slash_invoke_tool_start_does_not_record_cli_agent() -> None:
     session = ReplSession()
     buffer = io.StringIO()
     console = Console(file=buffer, force_terminal=False, highlight=False)
-    observer = ActionRenderObserver(session=session, console=console, message="run /model show")
+    observer = ActionRenderObserver(session=session, console=console, message="/model show")
 
     observer(
         "tool_start",
         {"name": "slash_invoke", "input": {"command": "/model", "args": ["show"]}},
     )
 
-    assert session.history == [{"type": "cli_agent", "text": "run /model show", "ok": True}]
+    assert session.history == []
     assert observer.planned_count == 1
     assert buffer.getvalue() == ""
+
+
+def test_shell_run_tool_start_does_not_record_cli_agent() -> None:
+    session = ReplSession()
+    console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+    observer = ActionRenderObserver(session=session, console=console, message="!true")
+
+    observer("tool_start", {"name": "shell_run", "input": {"command": "true"}})
+
+    assert session.history == []
+    assert observer.planned_count == 1
+
+
+def test_literal_slash_command_records_single_history_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dispatched: list[str] = []
+
+    def _fake_dispatch(
+        command: str,
+        session: ReplSession,
+        console: Console,
+        **_kwargs: object,
+    ) -> bool:
+        dispatched.append(command)
+        session.record("slash", command, ok=True)
+        return True
+
+    monkeypatch.setattr(slash_tool, "dispatch_slash", _fake_dispatch)
+    session = ReplSession()
+    harness = ActionExecutionHarness(llm=FakeActionLLM([no_tool_response()]))
+
+    result = run_action_tool_turn(
+        "/model show",
+        session,
+        harness.console,
+        deps=harness.deps,
+    )
+
+    assert result.handled is True
+    assert dispatched == ["/model show"]
+    assert session.history == [{"type": "slash", "text": "/model show", "ok": True}]
+    assert _prompt_turn_number(session) == 2
+
+
+@dataclass
+class _FakeLlmRun:
+    response_text: str = "hello back"
+
+
+def test_chat_turn_records_single_cli_agent_history_entry() -> None:
+    session = ReplSession()
+    console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+
+    def _no_actions(
+        _text: str,
+        _session: ReplSession,
+        _console: Console,
+        **kwargs: object,
+    ) -> ToolCallingTurnResult:
+        return ToolCallingTurnResult(
+            planned_count=0,
+            executed_count=0,
+            executed_success_count=0,
+            has_unhandled_clause=False,
+            handled=False,
+            accounting_status="not_run",
+        )
+
+    def _answer(
+        _text: str,
+        _session: ReplSession,
+        _console: Console,
+        **kwargs: object,
+    ) -> _FakeLlmRun:
+        return _FakeLlmRun()
+
+    execute_shell_turn(
+        "what broke in prod?",
+        session,
+        console,
+        recorder=None,
+        execute_actions=_no_actions,
+        answer_agent=_answer,
+    )
+
+    assert session.history == [
+        {"type": "cli_agent", "text": "what broke in prod?", "ok": True}
+    ]
+    assert _prompt_turn_number(session) == 2


### PR DESCRIPTION
Fixes #3323

## Summary

- Stop `ActionRenderObserver` from writing a duplicate `cli_agent` history row when self-recording action tools (`slash_invoke`, `shell_run`, `investigation_start`, etc.) already persist the turn
- Keeps the `[N]` prompt counter aligned with user-visible turns: slash commands and chat both advance by 1
- Update oracle scenario fixtures and add regression tests for slash/chat counter behavior

## Test plan

- [x] `uv run python -m pytest tests/interactive_shell/ui/test_action_rendering.py`
- [x] `uv run python -m pytest tests/core/agent/orchestration/test_agent_actions_harness.py`
- [x] `uv run python -m pytest tests/core/agent/test_turn_fixture_integrity.py`