### PR TITLE
docs: update .cursor/rules/integrations.mdc — remove stale services/references

### DIFF
--- a/.cursor/rules/integrations.mdc
+++ b/.cursor/rules/integrations.mdc
@@ -18,8 +18,6 @@ integrations/
 ├── datadog/
 │   ├── tools/
 │   └── correlation/         # Vendor-specific sub-packages where needed
-├── sentry/
-│   └── tools/
 ├── <vendor>/            # One directory per vendor (60+ vendors)
 │   └── tools/             # Vendor tools live here
 ├── opensre_mcp.py       # MCP server implementation

--- a/.cursor/rules/integrations.mdc
+++ b/.cursor/rules/integrations.mdc
@@ -8,30 +8,38 @@ globs:
 
 ## Directory Structure
 
-```
-services/
-├── grafana/          # Vendor-specific client packages
-├── datadog/
-├── s3_client.py      # Single-file clients
-└── vercel/
+All vendor integrations live under `integrations/<vendor>/`. There is no
+`services/` directory — it was removed in the V0.2 Phase 1 refactor.
 
+```
 integrations/
-├── clients/
-│   └── prefect/      # Legacy location — new clients go in services/
-├── opensre_mcp.py    # MCP server implementation
+├── grafana/
+│   └── tools/               # Vendor tools (moved from tools/ in T-3)
+├── datadog/
+│   ├── tools/
+│   └── correlation/         # Vendor-specific sub-packages where needed
+├── sentry/
+│   └── tools/
+├── <vendor>/            # One directory per vendor (60+ vendors)
+│   └── tools/             # Vendor tools live here
+├── opensre_mcp.py       # MCP server implementation
 └── ...
 ```
 ## Adding a New Integration
 
-1. Create a client under `services/<vendor>/`
-2. Implement connection, authentication, and API methods
-3. Create a tool under `tools/<VendorTool>/` that uses the client
-4. Wire availability into `resolve_integrations` node if the integration requires runtime discovery
-5. Add the vendor to `EvidenceSource` literal in `core/domain/types/evidence.py` if it's a new source type
+1. Create a directory `integrations/<vendor>/`
+2. Add client code (connection, auth, API methods) directly in the vendor dir
+3. Create a tool under `integrations/<vendor>/tools/<tool_name>/` that uses the client
+4. Wire availability into `resolve_integrations` node if the integration requires
+   runtime discovery
+5. Add the vendor to `EvidenceSource` literal in `core/domain/types/evidence.py`
+   if it is a new source type
 
 ## Conventions
 
 - Clients should be stateless or use context managers for connection lifecycle
 - Return `{"success": bool, "data": ..., "error": ...}` from client methods
-- Keep API-specific logic in the client; tool handles param extraction and result formatting
+- Keep API-specific logic in the client; the tool handles param extraction and
+  result formatting
 - MCP tools are registered via `opensre-mcp` entry point in `pyproject.toml`
+- All directory names use **snake_case** — no PascalCase


### PR DESCRIPTION
Closes #3322

 services/ was removed in T-1b (PR #3314). Updates the Cursor rule to reflect the
 correct integrations/<vendor>/tools/ layout so AI agents generate code in the right place.
 Companion to #3320 (tools.mdc fix).