### PR TITLE
fix(release): use workflow-scoped token to move the main-build tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -575,6 +575,20 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          # The rolling `main-build` tag is force-moved to each new main commit
+          # below. Whenever main has advanced past a commit that touches
+          # .github/workflows/**, the default GITHUB_TOKEN (the
+          # github-actions[bot] GitHub App) is refused with "refusing to allow a
+          # GitHub App to create or update workflow ... without `workflows`
+          # permission" — and that scope cannot be granted via the permissions
+          # block. MAIN_BUILD_TAG_TOKEN must be a token that carries workflow
+          # write access (classic PAT with `repo` + `workflow`, a fine-grained
+          # PAT with Contents + Workflows: write, or a GitHub App token). It is
+          # persisted so the tag push below authenticates with it. Falls back to
+          # GITHUB_TOKEN so the rest of the job still runs if the secret is unset
+          # (the tag push will then fail as before until the secret is added).
+          token: ${{ secrets.MAIN_BUILD_TAG_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: true
 
       - name: Download main release artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

The `Release` workflow fails on `main` with:

```
! [remote rejected]   main-build -> main-build (refusing to allow a GitHub App to create or update workflow `.github/workflows/release.yml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/Tracer-Cloud/opensre'
```

- The `publish-main-release` job force-moves the rolling `main-build` tag to each new `main` commit (`git tag -f main-build $SHA` + `git push --force`).
- Whenever `main` has advanced past a commit that touches `.github/workflows/**` (recently `chore: move ci into github folder`, `chore: install script`, `chore: relocate infra/scripts scripts`), that tag push is rejected: the default `GITHUB_TOKEN` (the `github-actions[bot]` GitHub App) is not allowed to create/update workflow files, and the `workflows` permission **cannot** be granted through the workflow `permissions:` block.
- This became a bigger deal after #3239 made `main-build` the default installer channel (previously the same code ran for the `nightly` tag).

This checks out `publish-main-release` with a workflow-scoped token (`MAIN_BUILD_TAG_TOKEN`) and persists it, so the tag push authenticates with a token that carries `workflows` write access. Falls back to `GITHUB_TOKEN` when the secret is unset so the rest of the job still runs.

## Required follow-up (repo admin)

This fix only takes effect once the secret exists. Create a token with workflow write access and add it as `MAIN_BUILD_TAG_TOKEN`:

- Classic PAT with `repo` + `workflow` scopes, **or**
- Fine-grained PAT scoped to `Tracer-Cloud/opensre` with `Contents: write` + `Workflows: write`.

```bash
gh secret set MAIN_BUILD_TAG_TOKEN --repo Tracer-Cloud/opensre --body "<token>"
```

## Test plan

- [ ] Add `MAIN_BUILD_TAG_TOKEN` secret.
- [ ] Push to `main` (or `workflow_dispatch` with channel `main`) and confirm the `Move main build tag to the latest commit` step force-pushes `main-build` without the `workflows` rejection.
- [ ] Confirm the `Main` prerelease is updated to the new commit/assets.