### PR TITLE
fix: remove eager lifecycle import causing runpy RuntimeWarning

### DIFF
--- a/platform/deployment/__init__.py
+++ b/platform/deployment/__init__.py
@@ -1,5 +1,1 @@
 """EC2 deployment: web and gateway containers on a single instance."""
-
-from platform.deployment.lifecycle import deploy, destroy
-
-__all__ = ["deploy", "destroy"]


### PR DESCRIPTION
## Summary

- `platform/deployment/__init__.py` eagerly imported `deploy`/`destroy` from `lifecycle.py`, causing `python -m platform.deployment.lifecycle` to register the module in `sys.modules` before `runpy` could execute it
- This produced a `RuntimeWarning: ... found in sys.modules after import of package ... prior to execution` on every `make deploy` / `make destroy` run
- Fix: remove the re-exports — no callers used the package-level shorthand; the canonical import path `platform.deployment.lifecycle` is unaffected

## Test plan

- [ ] `make deploy` / `make destroy` no longer emit the `RuntimeWarning`
- [ ] `uv run python -W error::RuntimeWarning -m platform.deployment.lifecycle --help` exits 0
- [ ] `pytest tests/test_ec2_instance.py tests/test_ec2_deploy.py` passes

Fixes #3605

Made with [Cursor](https://cursor.com)