### PR TITLE
chore(config): remove LEGACY_TRACER_HOME_DIR

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -26,9 +26,9 @@ from config.constants.sentry import (
 )
 
 OPENSRE_HOME_DIR: Path = Path.home() / ".opensre"
-LEGACY_TRACER_HOME_DIR: Path = Path.home() / ".tracer"
 INTEGRATIONS_STORE_PATH: Path = OPENSRE_HOME_DIR / "integrations.json"
-LEGACY_INTEGRATIONS_STORE_PATH: Path = LEGACY_TRACER_HOME_DIR / "integrations.json"
+# Legacy read-fallback for migrating pre-OpenSRE installs from ~/.tracer.
+LEGACY_INTEGRATIONS_STORE_PATH: Path = Path.home() / ".tracer" / "integrations.json"
 OPENSRE_TMP_DIR: Path = Path(tempfile.gettempdir()) / "opensre"
 
 
@@ -63,7 +63,6 @@ __all__ = [
     "INTEGRATIONS_STORE_PATH",
     "IS_WINDOWS",
     "LEGACY_INTEGRATIONS_STORE_PATH",
-    "LEGACY_TRACER_HOME_DIR",
     "ensure_opensre_tmp_dir",
     "OPENSRE_HOME_DIR",
     "OPENSRE_TMP_DIR",

--- a/surfaces/cli/lifecycle/uninstall.py
+++ b/surfaces/cli/lifecycle/uninstall.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from config.constants import LEGACY_TRACER_HOME_DIR, OPENSRE_HOME_DIR
+from config.constants import LEGACY_INTEGRATIONS_STORE_PATH, OPENSRE_HOME_DIR
 from config.version import PACKAGE_NAME
 
 
@@ -40,7 +40,11 @@ def _pip_uninstall() -> int:
 
 
 def _data_dirs() -> list[Path]:
-    return [OPENSRE_HOME_DIR, LEGACY_TRACER_HOME_DIR, Path.home() / ".config" / "opensre"]
+    return [
+        OPENSRE_HOME_DIR,
+        LEGACY_INTEGRATIONS_STORE_PATH.parent,
+        Path.home() / ".config" / "opensre",
+    ]
 
 
 def _is_onedir_binary(exe_path: Path) -> bool:


### PR DESCRIPTION
## Summary

* Fixes #3588
* Removed `LEGACY_TRACER_HOME_DIR` from `config/constants/__init__.py` because it is no longer needed as a shared constant.
* Kept `LEGACY_INTEGRATIONS_STORE_PATH` as the single legacy fallback for migrating older installs from `~/.tracer/integrations.json`.
* Updated uninstall cleanup to use `LEGACY_INTEGRATIONS_STORE_PATH.parent` so the legacy `.tracer` directory is still handled correctly.

## Implementation approach

This PR cleans up legacy constants based on actual usage.

I removed `LEGACY_TRACER_HOME_DIR` because it was no longer required as an exported shared constant. I kept `LEGACY_INTEGRATIONS_STORE_PATH` because it is still used for legacy migration support.

To avoid breaking uninstall cleanup for older installs, I updated `surfaces/cli/lifecycle/uninstall.py` to derive the legacy `.tracer` directory from `LEGACY_INTEGRATIONS_STORE_PATH.parent`.

I wrote the code changes myself and used AI assistance only for guidance around validation commands and checks. I reviewed the final changes and test output myself.

### Demo/Screenshot for feature changes and bug fixes -

Terminal verification used for this change:

```powershell
uv run --no-sync python -m pytest tests/integrations/test_store_migration.py::test_legacy_store_is_moved_to_opensre_path tests/cli/test_uninstall.py::test_data_dirs_includes_legacy_config_opensre_path -v
uv run --no-sync python -m mypy config\constants\__init__.py integrations\store.py surfaces\cli\lifecycle\uninstall.py
uv run --no-sync python -m ruff check config\constants\__init__.py surfaces\cli\lifecycle\uninstall.py integrations\store.py tests\cli\test_uninstall.py tests\integrations\test_store_migration.py
uv run --no-sync python -m ruff format --check config\constants\__init__.py surfaces\cli\lifecycle\uninstall.py integrations\store.py tests\cli\test_uninstall.py tests\integrations\test_store_migration.py
```