### PR TITLE
fix(core/agent_harness): use tuple for AgentConfig.tools to respect frozen=True

### DIFF
--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -78,7 +78,7 @@ from core.agent_harness.agent_builder import AgentConfig, build_agent
 config = AgentConfig(
     llm=llm_client,                    # or None to fall back to get_agent_llm()
     system=system_prompt,
-    tools=agent_tools,
+    tools=tuple(agent_tools),
     resolved_integrations=resolved,
     max_iterations=6,
     tool_resources={},                  # optional

--- a/core/agent_harness/agent_builder.py
+++ b/core/agent_harness/agent_builder.py
@@ -39,7 +39,7 @@ class AgentConfig:
 
     llm: Any
     system: str
-    tools: list[Any]
+    tools: tuple[Any, ...]
     resolved_integrations: dict[str, Any]
     max_iterations: int
     tool_resources: dict[str, Any] = field(default_factory=dict)

--- a/core/agent_harness/agents/action_agent.py
+++ b/core/agent_harness/agents/action_agent.py
@@ -335,7 +335,7 @@ def _build_action_agent(
     config = AgentConfig(
         llm=llm,
         system=system,
-        tools=agent_tools,
+        tools=tuple(agent_tools),
         resolved_integrations=_resolved_integrations_for_turn(session, turn_ctx),
         max_iterations=_MAX_TOOL_CALLING_ITERATIONS,
         tool_resources=tool_resources,

--- a/core/agent_harness/agents/evidence_agent.py
+++ b/core/agent_harness/agents/evidence_agent.py
@@ -185,7 +185,7 @@ def _build_evidence_agent(
     config = AgentConfig(
         llm=llm,
         system=_build_gather_system_prompt(session),
-        tools=gather_tools,
+        tools=tuple(gather_tools),
         resolved_integrations=resolved,
         max_iterations=_MAX_GATHER_ITERATIONS,
         on_runtime_event=runtime_event_callback_from_observer(on_progress),

--- a/gateway/start_gateway.py
+++ b/gateway/start_gateway.py
@@ -54,7 +54,7 @@ def build_gateway_agent(
     config = AgentConfig(
         llm=None,
         system=_SYSTEM_PROMPT_BASE,
-        tools=list(tools),
+        tools=tuple(tools),
         resolved_integrations=resolved_integrations,
         max_iterations=6,
     )


### PR DESCRIPTION
**Problem:** `AgentConfig(frozen=True)` with `tools: list[Any]` gives false immutability — callers can still `config.tools.append(...)` and silently mutate state.

**Fix:** Changed `tools` type to `tuple[Any, ...]` in `AgentConfig` and updated all 3 call sites to convert with `tuple()`. The `Agent.__init__` already converts the value to a list internally (`list(tools)`), so this is fully compatible.

Closes #3613