### PR TITLE
feat(llm): enable Anthropic Claude Fable 5 as a selectable model

### DIFF
--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -126,6 +126,11 @@ export ANTHROPIC_TOOLCALL_MODEL=claude-haiku-4-5-20251001
 
 The default. Uses the Anthropic Python SDK directly. Get an API key at [console.anthropic.com](https://console.anthropic.com/).
 
+Claude Fable 5 (`claude-fable-5`), Anthropic's most capable model, is also selectable
+(`/model set claude-fable-5`, or via the onboarding wizard and the Claude Code CLI
+provider). It is priced above the Opus tier, so the defaults stay unchanged — opt in
+explicitly when you want it.
+
 ### OpenAI
 
 ```bash

--- a/surfaces/cli/wizard/config.py
+++ b/surfaces/cli/wizard/config.py
@@ -105,6 +105,7 @@ class ProviderOption:
 # Source: https://docs.anthropic.com/en/docs/about-claude/models/overview
 ANTHROPIC_MODELS = (
     ModelOption(value=ANTHROPIC_REASONING_MODEL, label="Claude Opus 4.7"),
+    ModelOption(value="claude-fable-5", label="Claude Fable 5 — most capable"),
     ModelOption(value="claude-sonnet-4-6", label="Claude Sonnet 4.6"),
     ModelOption(value="claude-haiku-4-5", label="Claude Haiku 4.5"),
 )
@@ -252,7 +253,8 @@ CLAUDE_CODE_MODELS = (
         value="",
         label="CLI default (no --model; use Claude Code configured model)",
     ),
-    ModelOption(value="claude-opus-4-7", label="Claude Opus 4.7 — most capable"),
+    ModelOption(value="claude-fable-5", label="Claude Fable 5 — most capable"),
+    ModelOption(value="claude-opus-4-7", label="Claude Opus 4.7"),
     ModelOption(value="claude-sonnet-4-6", label="Claude Sonnet 4.6 — balanced"),
     ModelOption(value="claude-haiku-4-5", label="Claude Haiku 4.5 — fast, cost-efficient"),
 )

--- a/tests/cli/wizard/test_config.py
+++ b/tests/cli/wizard/test_config.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from surfaces.cli.wizard.config import PROJECT_ENV_PATH, PROJECT_ROOT, SUPPORTED_PROVIDERS
+from surfaces.cli.wizard.config import (
+    ANTHROPIC_MODELS,
+    CLAUDE_CODE_MODELS,
+    PROJECT_ENV_PATH,
+    PROJECT_ROOT,
+    SUPPORTED_PROVIDERS,
+)
 from surfaces.cli.wizard.flow import _onboarding_provider_options
 
 
@@ -38,6 +44,18 @@ def test_provider_catalog_keeps_legacy_cli_providers_registered() -> None:
     assert labels_by_value["groq"] == "Groq API key"
     assert labels_by_value["grok-cli"] == "xAI Grok Build CLI"
     assert values.index("groq") < values.index("grok-cli") < values.index("cursor")
+
+
+def test_claude_fable_5_is_selectable_without_custom_models() -> None:
+    """#3621: anthropic keeps a curated list, so Fable 5 must be in it explicitly."""
+    anthropic_values = [model.value for model in ANTHROPIC_MODELS]
+    claude_code_values = [model.value for model in CLAUDE_CODE_MODELS]
+
+    assert "claude-fable-5" in anthropic_values
+    assert "claude-fable-5" in claude_code_values
+    # Defaults stay unchanged: Fable 5 is pricier and opt-in only.
+    assert anthropic_values[0] != "claude-fable-5"
+    assert claude_code_values[0] == ""
 
 
 def test_onboarding_provider_options_hide_openai_anthropic_oauth_backends() -> None:

--- a/tests/fleet_monitoring/test_pricing.py
+++ b/tests/fleet_monitoring/test_pricing.py
@@ -187,6 +187,25 @@ class TestModelPricesTable:
         for model in ("claude-sonnet-4-5", "claude-opus-4-1", "claude-3-5-sonnet-20241022"):
             assert model in MODEL_PRICES or usd_per_token_blended(model) is not None
 
+    def test_claude_fable_5_has_a_price(self) -> None:
+        # #3621: claude-fable-5 must not render ``-`` on the dashboard.
+        # $10/$50 per MTok, cache read $1.00, cache write $12.50.
+        usage = TokenUsage(
+            input_tokens=100,
+            cache_read_input_tokens=2000,
+            cache_creation_input_tokens=500,
+            output_tokens=50,
+        )
+        cost = usd_for_usage(usage, "claude-fable-5")
+        expected = (100 * 10e-6) + (2000 * 1.0e-6) + (500 * 12.5e-6) + (50 * 50e-6)
+        assert cost == pytest.approx(expected)
+
+    def test_claude_fable_5_dated_suffix_falls_back_to_family(self) -> None:
+        # A future date-suffixed release id resolves via the family prefix.
+        rate = usd_per_token_blended("claude-fable-5-20260609")
+        assert rate is not None
+        assert rate == usd_per_token_blended("claude-fable-5")
+
     def test_codex_default_models_have_prices(self) -> None:
         # Same guarantee for the codex side. ``gpt-5-codex`` is the
         # default model the Codex CLI configures for paid accounts.

--- a/tools/fleet_monitoring/pricing.py
+++ b/tools/fleet_monitoring/pricing.py
@@ -164,6 +164,9 @@ MODEL_PRICES: dict[str, ModelPrice] = {
     "claude-opus-4-7": _price(
         5.00, 25.00, cache_read_usd_per_million=0.50, cache_write_usd_per_million=6.25
     ),
+    "claude-fable-5": _price(
+        10.00, 50.00, cache_read_usd_per_million=1.00, cache_write_usd_per_million=12.50
+    ),
     # OpenAI / Codex.
     "gpt-4o": _price(2.50, 10.00, cache_read_usd_per_million=1.25),
     "gpt-4o-2024-05-13": _price(5.00, 15.00),
@@ -204,6 +207,7 @@ _UNSORTED_FAMILY_FALLBACKS: tuple[tuple[str, str], ...] = (
     ("claude-3-5-sonnet", "claude-3-5-sonnet-20241022"),
     ("claude-3-5-haiku", "claude-3-5-haiku-20241022"),
     ("claude-haiku-4-5", "claude-haiku-4-5"),
+    ("claude-fable-5", "claude-fable-5"),
     ("claude-sonnet-4-6", "claude-sonnet-4-6"),
     ("claude-sonnet-4-5", "claude-sonnet-4-5"),
     ("claude-sonnet-4", "claude-sonnet-4"),


### PR DESCRIPTION
- Adds `claude-fable-5` to `ANTHROPIC_MODELS` and `CLAUDE_CODE_MODELS` in the CLI wizard config, making it selectable via `/model set` and the onboarding wizard without changing existing defaults.
- Adds pricing for `claude-fable-5` ($10/$50 per MTok input/output, $1.00 cache read, $12.50 cache write) and a family-fallback entry in the fleet-monitoring price table to prevent the dashboard from rendering `-` for $/hr.
- Updates `docs/llm-providers.mdx` to document the new model.
- Adds regression tests for catalog membership and pricing lookup.

Closes #3621