### PR TITLE
refactor(credentials): streamline credential resolution for Telegram,Slack, and Discord services

### DIFF
--- a/platform/scheduler/credentials.py
+++ b/platform/scheduler/credentials.py
@@ -18,21 +18,12 @@ def resolve_telegram_credentials(task_params: dict[str, str]) -> dict[str, str]:
 
     Priority: task.params > integration store > environment variable.
     """
-    bot_token = task_params.get("bot_token", "")
-    if bot_token:
-        return {"bot_token": bot_token}
-
-    # Try integration store
-    bot_token = _get_integration_credential("telegram", "bot_token")
-    if bot_token:
-        return {"bot_token": bot_token}
-
-    # Fall back to environment
-    bot_token = os.getenv("TELEGRAM_BOT_TOKEN", "")
-    if bot_token:
-        return {"bot_token": bot_token}
-
-    return {}
+    return _resolve_credentials(
+        task_params,
+        service="telegram",
+        credential_key="bot_token",
+        env_vars=("TELEGRAM_BOT_TOKEN",),
+    )
 
 
 def resolve_slack_credentials(task_params: dict[str, str]) -> dict[str, str]:
@@ -40,21 +31,12 @@ def resolve_slack_credentials(task_params: dict[str, str]) -> dict[str, str]:
 
     Priority: task.params > integration store > environment variable.
     """
-    access_token = task_params.get("access_token", "")
-    if access_token:
-        return {"access_token": access_token}
-
-    # Try integration store
-    access_token = _get_integration_credential("slack", "access_token")
-    if access_token:
-        return {"access_token": access_token}
-
-    # Fall back to environment
-    access_token = os.getenv("SLACK_BOT_TOKEN", "") or os.getenv("SLACK_ACCESS_TOKEN", "")
-    if access_token:
-        return {"access_token": access_token}
-
-    return {}
+    return _resolve_credentials(
+        task_params,
+        service="slack",
+        credential_key="access_token",
+        env_vars=("SLACK_BOT_TOKEN", "SLACK_ACCESS_TOKEN"),
+    )
 
 
 def resolve_discord_credentials(task_params: dict[str, str]) -> dict[str, str]:
@@ -62,19 +44,34 @@ def resolve_discord_credentials(task_params: dict[str, str]) -> dict[str, str]:
 
     Priority: task.params > integration store > environment variable.
     """
-    bot_token = task_params.get("bot_token", "")
-    if bot_token:
-        return {"bot_token": bot_token}
+    return _resolve_credentials(
+        task_params,
+        service="discord",
+        credential_key="bot_token",
+        env_vars=("DISCORD_BOT_TOKEN",),
+    )
 
-    # Try integration store
-    bot_token = _get_integration_credential("discord", "bot_token")
-    if bot_token:
-        return {"bot_token": bot_token}
 
-    # Fall back to environment
-    bot_token = os.getenv("DISCORD_BOT_TOKEN", "")
-    if bot_token:
-        return {"bot_token": bot_token}
+def _resolve_credentials(
+    task_params: dict[str, str],
+    *,
+    service: str,
+    credential_key: str,
+    env_vars: tuple[str, ...],
+) -> dict[str, str]:
+    """Resolve a single credential from task params, integration store, or env."""
+    value = task_params.get(credential_key, "")
+    if value:
+        return {credential_key: value}
+
+    value = _get_integration_credential(service, credential_key)
+    if value:
+        return {credential_key: value}
+
+    for env_var in env_vars:
+        value = os.getenv(env_var, "")
+        if value:
+            return {credential_key: value}
 
     return {}
 

--- a/tests/scheduler/test_credentials.py
+++ b/tests/scheduler/test_credentials.py
@@ -49,6 +49,26 @@ class TestSlackCredentials:
         creds = resolve_slack_credentials({})
         assert creds == {"access_token": "xoxb-from-env"}
 
+    def test_from_env_access_token_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        monkeypatch.setenv("SLACK_ACCESS_TOKEN", "xoxp-from-access-env")
+        monkeypatch.setattr(
+            "platform.scheduler.credentials._get_integration_credential",
+            lambda *_: "",
+        )
+        creds = resolve_slack_credentials({})
+        assert creds == {"access_token": "xoxp-from-access-env"}
+
+    def test_from_env_bot_token_takes_priority(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-primary")
+        monkeypatch.setenv("SLACK_ACCESS_TOKEN", "xoxp-secondary")
+        monkeypatch.setattr(
+            "platform.scheduler.credentials._get_integration_credential",
+            lambda *_: "",
+        )
+        creds = resolve_slack_credentials({})
+        assert creds == {"access_token": "xoxb-primary"}
+
     def test_empty_when_nothing_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
         monkeypatch.delenv("SLACK_ACCESS_TOKEN", raising=False)


### PR DESCRIPTION
This pull request refactors the way credentials for Telegram, Slack, and Discord are resolved in `credentials.py`. The main improvement is the introduction of a shared helper function to reduce code duplication and improve maintainability.

Credential resolution refactor:

* Extracted the common logic for resolving credentials into a new private helper function `_resolve_credentials`, which handles the lookup order (task params, integration store, environment variables) for any service.
* Updated `resolve_telegram_credentials`, `resolve_slack_credentials`, and `resolve_discord_credentials` to use the new `_resolve_credentials` helper, simplifying each function and making the codebase easier to maintain.
/fix #3527 