### PR TITLE
refactor: replace custom error extraction functions with centralized error handling in Discord and Slack integrations

### DIFF
--- a/integrations/discord/delivery.py
+++ b/integrations/discord/delivery.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
 from typing import Any
 
 from platform.common.truncation import truncate
+from platform.notifications.delivery_errors import extract_http_error
 from platform.notifications.delivery_transport import post_json
 
 logger = logging.getLogger(__name__)
@@ -23,24 +23,6 @@ def _redact_token(text: str, bot_token: str) -> str:
     if bot_token and bot_token in text:
         return text.replace(bot_token, "<redacted>")
     return text
-
-
-def _extract_error(data: Mapping[str, Any], status_code: int, text: str) -> str:
-    """Return a human-readable error string from a Discord API response.
-
-    Tries ``data["message"]`` / ``data["error"]`` first, then falls back to
-    the raw response body or the HTTP status code so non-JSON failure bodies
-    (HTML, plain text) never cause a crash.
-    """
-    msg = data.get("message")
-    if msg:
-        return str(msg)
-    err = data.get("error")
-    if err:
-        return str(err)
-    if text:
-        return text[:500]
-    return f"HTTP {status_code}"
 
 
 def post_discord_message(
@@ -65,7 +47,7 @@ def post_discord_message(
         return False, safe_error, ""
     if response.status_code not in (200, 201):
         logger.warning("[discord] post message failed: %s", response.status_code)
-        error_message = _extract_error(response.data, response.status_code, response.text)
+        error_message = extract_http_error(response.data, response.status_code, response.text)
         safe_error = _redact_token(error_message, bot_token)
         logger.warning("[discord] post message failed: %s", safe_error)
         return False, safe_error, ""
@@ -93,7 +75,7 @@ def create_discord_thread(
         logger.warning("[discord] create thread exception: %s", safe_error)
         return False, safe_error, ""
     if response.status_code not in (200, 201):
-        error_message = _extract_error(response.data, response.status_code, response.text)
+        error_message = extract_http_error(response.data, response.status_code, response.text)
         safe_error = _redact_token(error_message, bot_token)
         logger.warning("[discord] create thread failed: %s", safe_error)
         return False, safe_error, ""

--- a/integrations/slack/delivery.py
+++ b/integrations/slack/delivery.py
@@ -8,6 +8,7 @@ import re
 from typing import Any
 
 from config.config import SLACK_CHANNEL
+from platform.notifications.delivery_errors import extract_http_error
 from platform.notifications.delivery_transport import post_json
 from platform.observability import debug_print
 
@@ -22,21 +23,6 @@ def _redact_token(text: str, access_token: str) -> str:
     if access_token and access_token in text:
         redacted = text.replace(access_token, "<redacted>")
     return _ACCESS_TOKEN_RE.sub(r"\1<redacted>", redacted)
-
-
-def _extract_error(data: dict[str, Any], status_code: int, text: str) -> str:
-    """Return a human-readable error string from a Slack API response.
-
-    Tries ``data["error"]`` first, then falls back to the raw response body
-    or the HTTP status code so non-JSON failure bodies (HTML, plain text)
-    never cause a crash.
-    """
-    error = data.get("error")
-    if error:
-        return str(error)
-    if text:
-        return text[:500]
-    return f"HTTP {status_code}"
 
 
 def _slack_bearer_headers(token: str) -> dict[str, str]:
@@ -313,7 +299,7 @@ def _post_direct(
     if response.data.get("ok") is not True:
         error = response.data.get("error")
         if not error:
-            error = _extract_error(dict(response.data), response.status_code, response.text)
+            error = extract_http_error(response.data, response.status_code, response.text)
         safe_error = _redact_token(str(error), token)
         response_meta = response.data.get("response_metadata", {})
         logger.error(

--- a/platform/notifications/delivery_errors.py
+++ b/platform/notifications/delivery_errors.py
@@ -1,0 +1,37 @@
+"""Shared HTTP error extraction for outbound notification delivery helpers.
+
+Slack and Discord delivery modules both receive a ``DeliveryResponse`` from
+``delivery_transport.post_json`` and need a human-readable error string when
+the provider rejects the request. The fallback chain — JSON error fields, then
+raw response body, then HTTP status — is identical; only the JSON key names
+differ per provider (``message`` for Discord, ``error`` for Slack).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+_ERROR_TEXT_TRUNCATE = 500
+
+
+def extract_http_error(
+    data: Mapping[str, Any],
+    status_code: int,
+    text: str,
+) -> str:
+    """Return a human-readable error string from an HTTP API response.
+
+    Tries ``data["message"]`` and ``data["error"]`` first, then falls back to
+    the raw response body or the HTTP status code so non-JSON failure bodies
+    (HTML, plain text) never cause a crash.
+    """
+    msg = data.get("message")
+    if msg:
+        return str(msg)
+    err = data.get("error")
+    if err:
+        return str(err)
+    if text:
+        return text[:_ERROR_TEXT_TRUNCATE]
+    return f"HTTP {status_code}"

--- a/tests/utils/test_delivery_errors.py
+++ b/tests/utils/test_delivery_errors.py
@@ -1,0 +1,28 @@
+"""Tests for shared HTTP error extraction in notification delivery."""
+
+from __future__ import annotations
+
+from platform.notifications.delivery_errors import extract_http_error
+
+
+class TestExtractHttpError:
+    def test_prefers_message_field(self) -> None:
+        result = extract_http_error({"message": "Missing Permissions"}, 403, "html")
+        assert result == "Missing Permissions"
+
+    def test_falls_back_to_error_field(self) -> None:
+        result = extract_http_error({"error": "channel_not_found"}, 400, "html body")
+        assert result == "channel_not_found"
+
+    def test_falls_back_to_text_when_no_error_fields(self) -> None:
+        result = extract_http_error({}, 502, "<html>Bad Gateway</html>")
+        assert result == "<html>Bad Gateway</html>"
+
+    def test_falls_back_to_http_status_when_no_data(self) -> None:
+        result = extract_http_error({}, 500, "")
+        assert result == "HTTP 500"
+
+    def test_truncates_text_to_500_chars(self) -> None:
+        long_text = "x" * 1000
+        result = extract_http_error({}, 502, long_text)
+        assert len(result) == 500

--- a/tests/utils/test_discord_delivery.py
+++ b/tests/utils/test_discord_delivery.py
@@ -302,29 +302,6 @@ class TestDiscordRedaction:
         assert result == "some error"
 
 
-class TestDiscordExtractError:
-    def test_prefers_message_field(self) -> None:
-        result = discord_delivery._extract_error({"message": "Missing Permissions"}, 403, "html")
-        assert result == "Missing Permissions"
-
-    def test_falls_back_to_error_field(self) -> None:
-        result = discord_delivery._extract_error({"error": "invalid_form_data"}, 400, "html")
-        assert result == "invalid_form_data"
-
-    def test_falls_back_to_text(self) -> None:
-        result = discord_delivery._extract_error({}, 502, "<html>Bad Gateway</html>")
-        assert result == "<html>Bad Gateway</html>"
-
-    def test_falls_back_to_http_status(self) -> None:
-        result = discord_delivery._extract_error({}, 500, "")
-        assert result == "HTTP 500"
-
-    def test_truncates_text_to_500_chars(self) -> None:
-        long_text = "x" * 1000
-        result = discord_delivery._extract_error({}, 502, long_text)
-        assert len(result) == 500
-
-
 class TestDiscordNonJsonBody:
     def test_post_discord_message_handles_html_error_body(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/utils/test_slack_delivery.py
+++ b/tests/utils/test_slack_delivery.py
@@ -517,25 +517,6 @@ class TestRedaction:
         assert "xoxb-<redacted>" in result
 
 
-class TestExtractError:
-    def test_prefers_error_field(self) -> None:
-        result = slack_delivery._extract_error({"error": "channel_not_found"}, 400, "html body")
-        assert result == "channel_not_found"
-
-    def test_falls_back_to_text_when_no_error_field(self) -> None:
-        result = slack_delivery._extract_error({}, 502, "<html>Bad Gateway</html>")
-        assert result == "<html>Bad Gateway</html>"
-
-    def test_falls_back_to_http_status_when_no_data(self) -> None:
-        result = slack_delivery._extract_error({}, 500, "")
-        assert result == "HTTP 500"
-
-    def test_truncates_text_to_500_chars(self) -> None:
-        long_text = "x" * 1000
-        result = slack_delivery._extract_error({}, 502, long_text)
-        assert len(result) == 500
-
-
 class TestNonJsonBody:
     def test_post_direct_handles_html_error_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from platform.notifications.delivery_transport import DeliveryResponse


### PR DESCRIPTION
This pull request refactors error handling for outbound notification delivery to Slack and Discord by introducing a shared error extraction utility. The change removes duplicated error extraction logic from both integrations, centralizes it in a new module, and adds dedicated unit tests for the shared function.

**Refactoring and code reuse:**

* Introduced a new shared function `extract_http_error` in `platform/notifications/delivery_errors.py` to handle human-readable error extraction from HTTP API responses for both Slack and Discord, unifying the fallback logic for error messages.
* Updated `integrations/discord/delivery.py` and `integrations/slack/delivery.py` to use the new `extract_http_error` function, removing their local `_extract_error` implementations and replacing all usages accordingly. [[1]](diffhunk://#diff-c7ddde23fe4e3e76fb0858e9bec7553760f54c2dc26bb141954e3e63b42f6dd5L6-R9) [[2]](diffhunk://#diff-c7ddde23fe4e3e76fb0858e9bec7553760f54c2dc26bb141954e3e63b42f6dd5L28-L45) [[3]](diffhunk://#diff-c7ddde23fe4e3e76fb0858e9bec7553760f54c2dc26bb141954e3e63b42f6dd5L68-R50) [[4]](diffhunk://#diff-c7ddde23fe4e3e76fb0858e9bec7553760f54c2dc26bb141954e3e63b42f6dd5L96-R78) [[5]](diffhunk://#diff-068eefdabdf5c984b514bc0ca3d50adc48490b5302ea86ba8b23a0f1144babd6R11) [[6]](diffhunk://#diff-068eefdabdf5c984b514bc0ca3d50adc48490b5302ea86ba8b23a0f1144babd6L27-L41) [[7]](diffhunk://#diff-068eefdabdf5c984b514bc0ca3d50adc48490b5302ea86ba8b23a0f1144babd6L316-R302)

**Testing improvements:**

* Added comprehensive unit tests for `extract_http_error` in `tests/utils/test_delivery_errors.py`, covering all fallback scenarios and text truncation.
* Removed now-obsolete tests for the old `_extract_error` functions from both `tests/utils/test_discord_delivery.py` and `tests/utils/test_slack_delivery.py`. [[1]](diffhunk://#diff-4235d28a4e7c4a24ac93479ce284cf48b27b4a7d947aff37c14bdcf655575a29L305-L327) [[2]](diffhunk://#diff-fd4ab8fc4927e27c63d3afb4818da5429c847cb41aba544a077161e58391614aL520-L538)
/fix #3524 