### PR TITLE
refactor: streamline REPL session bootstrap process and validation in interactive shell runtime

### DIFF
--- a/.github/ci/check_direct_imports.py
+++ b/.github/ci/check_direct_imports.py
@@ -40,10 +40,6 @@ _FORBIDDEN_DIRECT: dict[str, frozenset[str]] = {
 # Format: ``"source.module -> dest.module"`` (exact modules from the graph).
 _BASELINE_IGNORES: frozenset[str] = frozenset(
     {
-        # Gateway hosts the interactive_shell runtime — pre-existing reuse
-        # to be burned down by extracting shared runtime primitives out of
-        # ``surfaces/interactive_shell/`` and into a layer below ``surfaces``.
-        "gateway.storage.session.resolver -> surfaces.interactive_shell.runtime.context",
         # tools/interactive_shell action tools reach UP into surfaces/interactive_shell
         # for runtime / command_registry / UI primitives. Clears when the action
         # tools themselves are refactored to be UI-agnostic (e.g. return

--- a/core/agent_harness/session/__init__.py
+++ b/core/agent_harness/session/__init__.py
@@ -15,6 +15,10 @@ singletons provide the production JSONL backends used by agent surfaces.
 
 from __future__ import annotations
 
+from core.agent_harness.session.bootstrap import (
+    ReplSessionBootstrapSpec,
+    bootstrap_repl_session,
+)
 from core.agent_harness.session.repo import JsonlSessionRepo
 from core.agent_harness.session.state import (
     SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST,
@@ -58,6 +62,8 @@ __all__ = [
     "JsonlSessionRepo",
     "JsonlSessionStorage",
     "ReplSession",
+    "ReplSessionBootstrapSpec",
+    "bootstrap_repl_session",
     "SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST",
     "SessionPersistenceSource",
     "SessionRepo",

--- a/core/agent_harness/session/bootstrap.py
+++ b/core/agent_harness/session/bootstrap.py
@@ -1,0 +1,50 @@
+"""Surface-agnostic session bootstrap for agent surfaces."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, InstanceOf, model_validator
+
+from core.agent_harness.session.state import ReplSession
+from core.agent_harness.session.tasks import TaskRegistry
+
+
+class ReplSessionBootstrapSpec(BaseModel):
+    """Pydantic-enforced inputs for preparing a reusable agent session."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+    session: InstanceOf[ReplSession] = Field(default_factory=ReplSession)
+    hydrate_integrations: bool = True
+    persistent_tasks: bool = True
+
+    @model_validator(mode="after")
+    def apply_to_session(self) -> Self:
+        """Apply the canonical startup mutations to the validated session."""
+        if self.hydrate_integrations:
+            self.session.hydrate_configured_integrations()
+        if self.persistent_tasks:
+            self.session.task_registry = TaskRegistry.persistent()
+        return self
+
+
+def bootstrap_repl_session(
+    session: ReplSession | None = None,
+    *,
+    hydrate_integrations: bool = True,
+    persistent_tasks: bool = True,
+) -> ReplSession:
+    """Return a session with the shared surface-agnostic bootstrap defaults."""
+    spec = ReplSessionBootstrapSpec(
+        session=session or ReplSession(),
+        hydrate_integrations=hydrate_integrations,
+        persistent_tasks=persistent_tasks,
+    )
+    return spec.session
+
+
+__all__ = [
+    "ReplSessionBootstrapSpec",
+    "bootstrap_repl_session",
+]

--- a/gateway/storage/session/resolver.py
+++ b/gateway/storage/session/resolver.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from core.agent_harness.session import DEFAULT_SESSION_REPO, DEFAULT_SESSION_STORAGE, ReplSession
+from core.agent_harness.session import (
+    DEFAULT_SESSION_REPO,
+    DEFAULT_SESSION_STORAGE,
+    ReplSession,
+    ReplSessionBootstrapSpec,
+)
 from gateway.session.gateway_chat_context import inject_gateway_chat_context
 from gateway.storage.session.bindings import SessionBindingStore
-from surfaces.interactive_shell.runtime.context import ReplSessionBootstrapSpec
 
 logger = logging.getLogger(__name__)
 

--- a/surfaces/interactive_shell/runtime/__init__.py
+++ b/surfaces/interactive_shell/runtime/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from core.agent_harness.session import ReplSessionBootstrapSpec
 from core.agent_harness.session.background import (
     BackgroundInvestigationRecord,
     BackgroundNotificationPreferences,
@@ -9,7 +10,6 @@ from core.agent_harness.session.tasks import TaskRegistry
 from platform.common.task_types import TaskKind, TaskRecord, TaskStatus
 from surfaces.interactive_shell.runtime.context import (
     ReplRuntimeContext,
-    ReplSessionBootstrapSpec,
     create_repl_runtime_context,
     prepare_repl_session,
 )

--- a/surfaces/interactive_shell/runtime/context.py
+++ b/surfaces/interactive_shell/runtime/context.py
@@ -7,48 +7,16 @@ from typing import Self
 
 import click
 from prompt_toolkit import PromptSession
-from pydantic import BaseModel, ConfigDict, Field, InstanceOf, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, InstanceOf, model_validator
 
+from core.agent_harness.session.bootstrap import ReplSessionBootstrapSpec
 from core.agent_harness.session.state import ReplSession
-from core.agent_harness.session.tasks import TaskRegistry
 from core.domain.alerts import inbox as _alert_inbox
 from surfaces.interactive_shell.runtime.core.state import (
     ReplState,
     SpinnerState,
     create_repl_mutable_state,
 )
-
-
-class ReplSessionBootstrapSpec(BaseModel):
-    """Pydantic-enforced inputs for preparing a REPL session."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
-
-    session: InstanceOf[ReplSession] = Field(default_factory=ReplSession)
-    pt_session: PromptSession[str] | None = None
-    active_theme_name: str | None = None
-    hydrate_integrations: bool = True
-    persistent_tasks: bool = True
-
-    @field_validator("active_theme_name")
-    @classmethod
-    def _active_theme_name_must_not_be_blank(cls, value: str | None) -> str | None:
-        if value is not None and not value.strip():
-            raise ValueError("active_theme_name must not be blank")
-        return value
-
-    @model_validator(mode="after")
-    def apply_to_session(self) -> Self:
-        """Apply the canonical startup mutations to the validated session."""
-        self.session.active_theme_name = self.active_theme_name or _current_theme_name()
-        _bind_shell_grounding(self.session)
-        if self.hydrate_integrations:
-            self.session.hydrate_configured_integrations()
-        if self.persistent_tasks:
-            self.session.task_registry = TaskRegistry.persistent()
-        if self.pt_session is not None:
-            self.session.prompt_history_backend = self.pt_session.history
-        return self
 
 
 class ReplRuntimeContext(BaseModel):
@@ -113,6 +81,12 @@ def _bind_shell_grounding(session: ReplSession) -> None:
     session.grounding.set_command_group_provider(_cli_command_group)
 
 
+def _validate_active_theme_name(active_theme_name: str | None) -> str | None:
+    if active_theme_name is not None and not active_theme_name.strip():
+        raise ValueError("active_theme_name must not be blank")
+    return active_theme_name
+
+
 def prepare_repl_session(
     session: ReplSession | None = None,
     *,
@@ -122,14 +96,17 @@ def prepare_repl_session(
     persistent_tasks: bool = True,
 ) -> ReplSession:
     """Return a session with the same defaults used by REPL boot."""
-    spec = ReplSessionBootstrapSpec(
+    validated_theme_name = _validate_active_theme_name(active_theme_name)
+    prepared = ReplSessionBootstrapSpec(
         session=session or ReplSession(),
-        pt_session=pt_session,
-        active_theme_name=active_theme_name,
         hydrate_integrations=hydrate_integrations,
         persistent_tasks=persistent_tasks,
-    )
-    return spec.session
+    ).session
+    prepared.active_theme_name = validated_theme_name or _current_theme_name()
+    _bind_shell_grounding(prepared)
+    if pt_session is not None:
+        prepared.prompt_history_backend = pt_session.history
+    return prepared
 
 
 def create_repl_runtime_context(
@@ -163,7 +140,6 @@ def create_repl_runtime_context(
 
 __all__ = [
     "ReplRuntimeContext",
-    "ReplSessionBootstrapSpec",
     "create_repl_runtime_context",
     "prepare_repl_session",
 ]

--- a/tests/core/agent_harness/session/test_bootstrap.py
+++ b/tests/core/agent_harness/session/test_bootstrap.py
@@ -1,0 +1,86 @@
+"""Tests for surface-agnostic session bootstrap."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.agent_harness.session import ReplSession
+from core.agent_harness.session.bootstrap import (
+    ReplSessionBootstrapSpec,
+    bootstrap_repl_session,
+)
+from core.agent_harness.session.tasks import TaskRegistry
+
+
+def test_bootstrap_spec_hydrates_integrations_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hydrate_calls: list[str] = []
+
+    def _hydrate(self: ReplSession) -> None:
+        hydrate_calls.append(self.session_id)
+        self.configured_integrations = ("github",)
+        self.configured_integrations_known = True
+
+    monkeypatch.setattr(ReplSession, "hydrate_configured_integrations", _hydrate)
+
+    session = ReplSession()
+    prepared = ReplSessionBootstrapSpec(session=session).session
+
+    assert prepared is session
+    assert hydrate_calls == [session.session_id]
+    assert session.configured_integrations == ("github",)
+    assert session.configured_integrations_known is True
+
+
+def test_bootstrap_spec_can_skip_hydration(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        ReplSession,
+        "hydrate_configured_integrations",
+        lambda _self: (_ for _ in ()).throw(AssertionError("hydrated")),
+    )
+
+    session = ReplSessionBootstrapSpec(
+        session=ReplSession(),
+        hydrate_integrations=False,
+    ).session
+
+    assert isinstance(session, ReplSession)
+
+
+def test_bootstrap_spec_uses_persistent_tasks_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = TaskRegistry()
+    monkeypatch.setattr(TaskRegistry, "persistent", staticmethod(lambda: registry))
+
+    session = ReplSessionBootstrapSpec(session=ReplSession()).session
+
+    assert session.task_registry is registry
+
+
+def test_bootstrap_spec_can_skip_persistent_tasks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        TaskRegistry,
+        "persistent",
+        staticmethod(lambda: (_ for _ in ()).throw(AssertionError("persistent"))),
+    )
+
+    session = ReplSessionBootstrapSpec(
+        session=ReplSession(),
+        persistent_tasks=False,
+    ).session
+
+    assert isinstance(session, ReplSession)
+
+
+def test_bootstrap_repl_session_returns_prepared_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = TaskRegistry()
+    monkeypatch.setattr(TaskRegistry, "persistent", staticmethod(lambda: registry))
+    monkeypatch.setattr(ReplSession, "hydrate_configured_integrations", lambda _self: None)
+
+    session = bootstrap_repl_session(ReplSession())
+
+    assert session.task_registry is registry

--- a/tests/interactive_shell/runtime/test_context.py
+++ b/tests/interactive_shell/runtime/test_context.py
@@ -15,7 +15,6 @@ from core.agent_harness.session.tasks import TaskRegistry
 from surfaces.interactive_shell.controller import InteractiveShellController
 from surfaces.interactive_shell.runtime.context import (
     ReplRuntimeContext,
-    ReplSessionBootstrapSpec,
     create_repl_runtime_context,
 )
 from surfaces.interactive_shell.runtime.core.state import (
@@ -121,8 +120,8 @@ def test_context_rejects_invalid_state_contracts() -> None:
     with pytest.raises(ValidationError):
         ReplRuntimeContext(session=object())  # type: ignore[arg-type]
 
-    with pytest.raises(ValidationError):
-        ReplSessionBootstrapSpec(active_theme_name=" ")
+    with pytest.raises(ValueError, match="active_theme_name must not be blank"):
+        create_repl_runtime_context(active_theme_name=" ")
 
 
 def test_context_assignment_validates_inbox_type() -> None:


### PR DESCRIPTION
This pull request refactors the session bootstrapping logic to make it surface-agnostic and reusable across different parts of the codebase. The main change is moving the `ReplSessionBootstrapSpec` and related functionality from the interactive shell runtime to a new, shared module in `core.agent_harness.session.bootstrap`. This improves modularity and reduces code duplication. The pull request also updates imports and usage throughout the codebase to use the new shared bootstrap logic, and adds new tests for the refactored functionality.

**Session bootstrap refactoring and modularization:**

* Moved `ReplSessionBootstrapSpec` and its logic from `surfaces/interactive_shell/runtime/context.py` to a new file `core/agent_harness/session/bootstrap.py`, making it surface-agnostic and reusable. Added a new `bootstrap_repl_session` helper function.
* Updated imports across the codebase to use the new shared `ReplSessionBootstrapSpec` and removed the old definition from the interactive shell runtime. This includes changes in `core.agent_harness.session`, `gateway.storage.session.resolver`, and `surfaces.interactive_shell.runtime`. [[1]](diffhunk://#diff-28274560be454a3aa03ae61ad887838a98aca57ab5b78a292bb05d687a180226R18-R21) [[2]](diffhunk://#diff-28274560be454a3aa03ae61ad887838a98aca57ab5b78a292bb05d687a180226R65-R66) [[3]](diffhunk://#diff-405fcbeca83061dc12ac53ea9de5a9b21b413d632a6a117dfb5f09731484465dL8-L11) [[4]](diffhunk://#diff-e66c8389677121ced918394b3d016f0bee9f2b8de515749adec1bbe37b8a5bbcR3) [[5]](diffhunk://#diff-e66c8389677121ced918394b3d016f0bee9f2b8de515749adec1bbe37b8a5bbcL12) [[6]](diffhunk://#diff-2833903a99fcdb41f8fedc7405e98808f4c1ac92a1e4265fcc495acfd98984c3L10-L13) [[7]](diffhunk://#diff-2833903a99fcdb41f8fedc7405e98808f4c1ac92a1e4265fcc495acfd98984c3L22-L53) [[8]](diffhunk://#diff-2833903a99fcdb41f8fedc7405e98808f4c1ac92a1e4265fcc495acfd98984c3L166)

**Interactive shell runtime adjustments:**

* Refactored `prepare_repl_session` in `surfaces/interactive_shell/runtime/context.py` to use the new shared bootstrap logic, and moved theme name validation to a helper function. [[1]](diffhunk://#diff-2833903a99fcdb41f8fedc7405e98808f4c1ac92a1e4265fcc495acfd98984c3R84-R89) [[2]](diffhunk://#diff-2833903a99fcdb41f8fedc7405e98808f4c1ac92a1e4265fcc495acfd98984c3L125-R109)
* Updated tests to reflect the new location and usage of the bootstrap logic, and adjusted validation tests accordingly. [[1]](diffhunk://#diff-3c56109646aeeece30b89d293d2d312d30275afade716771ae40486dc130859aL18) [[2]](diffhunk://#diff-3c56109646aeeece30b89d293d2d312d30275afade716771ae40486dc130859aL124-R124)

**Testing and validation:**

* Added comprehensive tests for the new surface-agnostic session bootstrap logic in `tests/core/agent_harness/session/test_bootstrap.py`.

**Code cleanup:**

* Removed the now-unnecessary direct import ignore for the old dependency in `.github/ci/check_direct_imports.py`.

/fix #3537 