### PR TITLE
#3601 Feat: require GitHub login as first step in opensre onboard

### DIFF
--- a/surfaces/cli/wizard/flow.py
+++ b/surfaces/cli/wizard/flow.py
@@ -57,6 +57,9 @@ from surfaces.cli.wizard.integration_health import IntegrationHealthResult
 from surfaces.cli.wizard.probes import ProbeResult, probe_local_target, probe_remote_target
 from surfaces.cli.wizard.store import get_store_path, save_local_config
 from surfaces.cli.wizard.validation import build_demo_action_response as _build_demo_action_response
+from surfaces.interactive_shell.runtime.startup.first_launch_github import (
+    require_startup_github_login,
+)
 
 DEFAULT_GITHUB_MCP_MODE = _integration_configurators_module.DEFAULT_GITHUB_MCP_MODE
 DEFAULT_GITHUB_MCP_URL = _integration_configurators_module.DEFAULT_GITHUB_MCP_URL
@@ -673,6 +676,8 @@ def _run_cli_llm_onboarding(
 def run_wizard(_argv: list[str] | None = None) -> int:
     """Run the interactive wizard."""
     _render_header()
+    if not require_startup_github_login(_console):
+        return 1
     defaults = _local_defaults()
     saved_provider_value = defaults["provider"] if isinstance(defaults["provider"], str) else None
     saved_model_value = defaults["model"] if isinstance(defaults["model"], str) else ""


### PR DESCRIPTION
Fixes #3601

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->
<img width="1919" height="933" alt="image" src="https://github.com/user-attachments/assets/2f2f51b2-47a2-4b81-bc42-adfaa35135af" />
<img width="1607" height="502" alt="image" src="https://github.com/user-attachments/assets/ac1bdfa6-a738-4231-ab9a-c2454750c5b6" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->
I checked where the opensre onboard flow starts from, it is being handled by surfaces/cli/wizard/flow.py. Since the github login function was already built, used it just after the graphic is displayed and if authentication fails, it returns 1 to exit gracefully otherwise we continue with the followup setup
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
