### PR TITLE
feat(core/agent_harness): add AgentHarness startup wrapper (T-3b, #3359)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,9 +155,26 @@ Basic steps:
 5. Run `make verify-integrations` before treating the integration as complete.
 6. Before opening or approving the PR, follow [TOOL_INTEGRATION_CHECKLIST.md](TOOL_INTEGRATION_CHECKLIST.md) for integration completeness, investigation wiring, docs, and demo/test requirements.
 
+### Large multi-surface refactors
+
+A consolidation refactor collapses behavior that has diverged across
+multiple surfaces (`interactive_shell/`, `gateway/`, `tools/investigation/`,
+`core/agent_harness/`, etc.) into one shared class or module — e.g. the
+`agent_harness` T-2/T-3 series (session management, integration resolution,
+startup consolidation). These are higher-risk than a normal feature or tool
+change: they touch several call sites at once and the source issue's file
+paths tend to be stale by the time work starts.
+
+Before starting this class of work, follow
+[REFACTOR_CHECKLIST.md](REFACTOR_CHECKLIST.md) — it covers dependency
+ordering, re-validating the issue against current repo state, incremental
+per-surface migration, and the import-boundary tests that must keep
+enforcing the new pattern.
+
 ## 3. Rules (if X -> do Y)
 
 - If core agent or pipeline logic changes -> run `make test-cov` and `make typecheck`.
+- If a change consolidates or re-homes behavior across multiple surfaces (a "refactor" issue, not a localized fix) -> follow [REFACTOR_CHECKLIST.md](REFACTOR_CHECKLIST.md) before writing code and before opening the PR.
 - If a new feature is shipped (tool, CLI command, pipeline behavior, integration) -> add a `docs/` page or section covering usage, configuration, and examples before the PR is opened.
 - If a new `docs/` page is added or renamed -> register it in `docs/docs.json` under the correct `pages` array in the same PR (path without `.mdx`, e.g. `messaging/whatsapp` for `docs/messaging/whatsapp.mdx`).
 - If an existing feature changes behavior, flags, or config shape -> update the relevant `docs/` page in the same PR; docs and code must stay in sync.
@@ -206,3 +223,7 @@ Test commands, turn-handling rules, CI-only paths: **[CI.md](CI.md)**. Live REPL
 ## 6. New Integration Checklist
 
 Follow [TOOL_INTEGRATION_CHECKLIST.md](TOOL_INTEGRATION_CHECKLIST.md) — it is the single definition of done for all tool and integration work.
+
+## 7. Large Refactor Checklist
+
+Follow [REFACTOR_CHECKLIST.md](REFACTOR_CHECKLIST.md) — it is the single definition of done for refactors that consolidate or re-home behavior across multiple surfaces (see "Large multi-surface refactors" above).

--- a/REFACTOR_CHECKLIST.md
+++ b/REFACTOR_CHECKLIST.md
@@ -1,0 +1,96 @@
+# Large Refactor Definition of Done
+
+Use this checklist for any refactor that **consolidates or re-homes
+behavior across multiple surfaces or packages** — e.g. collapsing
+per-surface initialization into a shared class, centralizing session or
+config handling, or merging duplicated logic that has diverged across
+`interactive_shell/`, `gateway/`, `tools/investigation/`, `core/`, etc.
+
+It does not apply to a localized bug fix or a single-file cleanup — use it
+when the change touches "every surface does X its own way" style problems
+(the T-2/T-3 `agent_harness` consolidation series is the reference case).
+Use it together with [AGENTS.md](AGENTS.md) and [CI.md](CI.md).
+
+## 1. Before writing code
+
+- [ ] Re-read the issue/design doc against the **current** tree, not the tree it
+      was written against. Refactor issues rot fast — file paths, package
+      names, and even which surfaces exist can drift within days. Grep for
+      every path and class name the issue references and confirm it still
+      exists (or find its current equivalent) before planning around it.
+- [ ] Enumerate every call site that currently owns the behavior being
+      consolidated, per surface, with `file:function` references — not just
+      the ones named in the issue. Duplicated logic tends to have silently
+      diverged (different error handling, an extra cache, a missing case) —
+      note the differences, don't assume they're identical copies.
+- [ ] Check the dependency chain: is this refactor blocked on another
+      open issue/PR that hasn't landed? If a prerequisite is still in flight,
+      decide explicitly whether to (a) wait, (b) build the consolidated
+      class against today's per-surface state and re-point it once the
+      prerequisite lands, or (c) do the minimum of the prerequisite inline.
+      Don't silently assume a "should be done first" step is done.
+- [ ] Check who else is assigned to this issue or its prerequisites, and
+      whether a branch/PR already exists for it (`gh pr list --search
+      "<keyword>"`). Large refactors are easy to collide on.
+- [ ] Identify the architectural invariant the refactor must preserve or
+      establish (e.g. a one-way import boundary between packages) and find
+      the test that enforces it, or note that one needs to be added.
+
+## 2. Design
+
+- [ ] Prefer one canonical construction/entry-point pattern over adding a
+      second one. If the codebase already has a documented pattern for this
+      class of problem (e.g. `AGENTS.md` "Pattern A" for agent construction),
+      extend it — don't introduce a parallel mechanism.
+- [ ] Plan the migration as incremental per-surface cutovers, not a single
+      big-bang change that rewrites every surface at once. Each surface
+      should be swappable to the new consolidated path independently, with
+      the old per-surface code removed in the same commit that migrates it
+      (no dead code left "just in case").
+- [ ] No compatibility shims or forwarding modules for the old per-surface
+      logic once a surface is migrated. Delete it in the same change per
+      [AGENTS.md](AGENTS.md)'s no-compat-shim rule.
+- [ ] Decide the rollback story before merging: since there are no
+      compat shims, rollback means reverting the commit/PR, not toggling a
+      flag. Confirm this is acceptable for the affected surfaces (does
+      anything depend on the old behavior being live in production between
+      merge and full rollout?).
+
+## 3. Implementation
+
+- [ ] Land the shared/consolidated class or module first, covered by tests,
+      before touching any surface's call site.
+- [ ] Migrate one surface per commit (or per small PR) where practical, so a
+      regression in surface B doesn't block or get bundled with surface A's
+      migration.
+- [ ] Remove the per-surface logic being replaced in the same change that
+      migrates that surface — don't leave both paths live.
+- [ ] Update or add the import-boundary / architecture test that encodes the
+      invariant from step 1, so a future change can't silently reintroduce
+      the per-surface pattern this refactor removed.
+
+## 4. Verification
+
+- [ ] `make test-cov` and `make typecheck` pass (required for any core
+      agent/pipeline change per [AGENTS.md](AGENTS.md)).
+- [ ] Existing tests for every migrated surface still pass unmodified in
+      behavior (not just unmodified in assertions — re-read what they assert
+      if the consolidation changed timing/ordering of side effects like
+      integration resolution or session load).
+- [ ] Exercise at least one real (non-mocked) path per migrated surface —
+      e.g. an interactive-shell session via `ReplDriver`
+      ([TESTING.md](TESTING.md)), a gateway dispatch, an investigation run —
+      to confirm the consolidated path behaves the same as the old
+      per-surface path end to end.
+
+## 5. Docs and closeout
+
+- [ ] Update the relevant package `AGENTS.md` (e.g.
+      `core/agent_harness/AGENTS.md`) to describe the new consolidated
+      pattern and explicitly forbid the old per-surface pattern, the same way
+      existing "Do NOT reintroduce X" notes are written.
+- [ ] Update `docs/DEVELOPMENT.md` or other contributor docs if the
+      refactor changes a documented architecture boundary.
+- [ ] Check off acceptance criteria on the source issue against what was
+      actually shipped, not what was planned — note any criteria that ended
+      up out of scope and why.

--- a/core/agent_harness/__init__.py
+++ b/core/agent_harness/__init__.py
@@ -20,6 +20,7 @@ from core.agent_harness.agents.evidence_agent import gather_tool_evidence
 from core.agent_harness.agents.evidence_agent import gather_tool_evidence as gather_evidence
 from core.agent_harness.agents.headless_agent import dispatch_message_to_headless_agent
 from core.agent_harness.agents.turn_orchestrator import answer_cli_agent, run_turn
+from core.agent_harness.harness import AgentHarness, HarnessConfig, HarnessStartupResult
 from core.agent_harness.models.turn_context import (
     AgentRuntimeRequest,
     TurnContext,
@@ -28,7 +29,10 @@ from core.agent_harness.models.turn_context import (
 from core.agent_harness.models.turn_results import ShellTurnResult, ToolCallingTurnResult
 
 __all__ = [
+    "AgentHarness",
     "AgentRuntimeRequest",
+    "HarnessConfig",
+    "HarnessStartupResult",
     "ShellTurnResult",
     "ToolCallingDeps",
     "ToolCallingTurnResult",

--- a/core/agent_harness/agents/evidence_agent.py
+++ b/core/agent_harness/agents/evidence_agent.py
@@ -26,11 +26,6 @@ from core.agent_harness.prompts.conversation_memory import (
     NO_HISTORY_PLACEHOLDER,
     format_recent_conversation,
 )
-from core.agent_harness.session.integrations_cache import (
-    has_only_runtime_metadata,
-    has_resolved_integrations,
-    merge_resolved_integrations,
-)
 from core.domain.alerts.alert_source import SECONDARY_TOOL_SOURCES
 from core.events import runtime_event_callback_from_observer
 from integrations.github.repo_scope import (
@@ -55,21 +50,9 @@ PersistToolCalls = Callable[[list[tuple[Any, Any]]], None]
 
 def _resolve_session_integrations(session: SessionStore) -> dict[str, Any]:
     """Resolve integration configs once per session and cache the result."""
-    cached = session.resolved_integrations_cache
-    if cached is not None and (
-        has_resolved_integrations(cached) or not has_only_runtime_metadata(cached)
-    ):
-        return cached
+    from core.agent_harness.integrations.resolution import resolve_and_cache_integrations
 
-    from core.agent_harness.integrations.resolution import resolve_integrations
-
-    resolved = resolve_integrations()
-    if resolved:
-        session.resolved_integrations_cache = merge_resolved_integrations(
-            cached,
-            resolved,
-        )
-    return session.resolved_integrations_cache or {}
+    return resolve_and_cache_integrations(session)
 
 
 def _truncate(text: str, limit: int) -> str:

--- a/core/agent_harness/harness.py
+++ b/core/agent_harness/harness.py
@@ -1,0 +1,157 @@
+"""``AgentHarness`` — consolidated agent startup for every surface.
+
+Startup behavior for a turn-driving agent was previously scattered across
+surfaces: the interactive shell, the gateway, and the investigation pipeline
+each resolved integrations, loaded prior session history, and read env vars
+in their own way (see ``AGENTS.md`` "Large multi-surface refactors" and
+https://github.com/Tracer-Cloud/opensre/issues/3359). Session lifecycle
+itself — create / resolve / rotate / restore / integration hydration — is
+already owned by :class:`~core.agent_harness.session.manager.SessionManager`
+(issue #3357). ``AgentHarness`` sits one layer above that: it is the single
+call surfaces make to get a bootstrapped session *and* the other two startup
+concerns ``SessionManager`` does not own — env resolution and grounding
+context — in one call, instead of each surface sequencing
+``load_dotenv`` + ``SessionManager`` + its own prompt-context wiring itself.
+
+The four responsibilities from #3359:
+
+1. **Resolving integrations** — delegated to ``SessionManager``'s bootstrap
+   (``hydrate_integrations`` / ``warm_integrations`` on :meth:`HarnessConfig`),
+   plus :meth:`AgentHarness.resolve_integrations` for on-demand full resolution
+   once a session exists (thin wrapper over
+   :meth:`~core.agent_harness.session.state.Session.get_integrations`).
+2. **Loading context** — the surface's injected
+   :class:`~core.agent_harness.ports.PromptContextProvider`, if any. The
+   harness does not render grounding text itself (``ports.py`` already models
+   that as a per-surface concern); this step exists so surfaces get it from
+   the same call as everything else.
+3. **Loading previous session history from disk** — ``session_id`` +
+   ``SessionManager.resolve()``, which loads the persisted session and
+   restores its conversation context.
+4. **Resolving env variables** — a single ``load_dotenv`` call.
+
+This module must not import ``interactive_shell`` / ``surfaces.interactive_shell``
+(enforced by ``tests/core/agent/test_import_boundaries.py``) — surfaces build a
+:class:`HarnessConfig` from their own prompt-context provider and hand it in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from dotenv import load_dotenv
+
+from core.agent_harness.session import SessionManager
+
+if TYPE_CHECKING:
+    from core.agent_harness.ports import PromptContextProvider
+    from core.agent_harness.session.state import Session
+
+
+@dataclass(frozen=True)
+class HarnessConfig:
+    """What a surface hands :class:`AgentHarness` to start up an agent.
+
+    Every field is optional so a surface only opts into the behavior it
+    needs: a fresh gateway turn has nothing to resume (``session_id=None``);
+    a headless action-only turn has no grounded context (``prompts=None``).
+    """
+
+    session_id: str | None = None
+    prompts: PromptContextProvider | None = None
+    load_env: bool = True
+    hydrate_integrations: bool = True
+    # None defers to SessionManager's own per-operation default: eager warm on
+    # resolve() (a resumed session needs tools ready immediately), lazy on
+    # create() (a fresh session can warm on first turn).
+    warm_integrations: bool | None = None
+    persistent_tasks: bool = True
+    open_storage: bool = True
+    session_manager: SessionManager | None = None
+
+
+@dataclass(frozen=True)
+class HarnessStartupResult:
+    """Outcome of :meth:`AgentHarness.startup`."""
+
+    session: Session
+    prompts: PromptContextProvider | None
+
+
+class AgentHarness:
+    """Runs the startup steps every surface needs, in a fixed order.
+
+    Order matters: env vars must be resolved before session creation
+    (integration hydration/warm may depend on env-provided credentials), and
+    context loading is independent of both so it runs last for readability,
+    not because anything depends on it running after.
+    """
+
+    def __init__(self, config: HarnessConfig | None = None) -> None:
+        self._config = config or HarnessConfig()
+        self._session_manager = self._config.session_manager or SessionManager()
+
+    def resolve_env_variables(self) -> None:
+        """Load a local ``.env`` file into the process environment, once.
+
+        ``override=False`` matches every existing call site (gateway,
+        ``integrations/__main__.py``): a variable already set in the real
+        environment wins over the ``.env`` file.
+        """
+        if self._config.load_env:
+            load_dotenv(override=False)
+
+    def load_or_create_session(self) -> Session:
+        """Resume a persisted session if ``session_id`` was given, else create one.
+
+        Delegates entirely to :class:`SessionManager` — this method does not
+        duplicate its bootstrap/restore logic, it just picks which lifecycle
+        call to make based on whether the surface is resuming.
+        """
+        manager = self._session_manager
+        if self._config.session_id:
+            # SessionManager.resolve()'s own default is True: a resumed
+            # session needs tools ready immediately.
+            warm = (
+                True if self._config.warm_integrations is None else self._config.warm_integrations
+            )
+            return manager.resolve(
+                self._config.session_id,
+                hydrate_integrations=self._config.hydrate_integrations,
+                warm_integrations=warm,
+                persistent_tasks=self._config.persistent_tasks,
+            )
+        # SessionManager.create()'s own default is False: a fresh session can
+        # warm lazily on first turn.
+        warm = False if self._config.warm_integrations is None else self._config.warm_integrations
+        return manager.create(
+            hydrate_integrations=self._config.hydrate_integrations,
+            warm_integrations=warm,
+            persistent_tasks=self._config.persistent_tasks,
+            open_storage=self._config.open_storage,
+        )
+
+    def resolve_integrations(self, session: Session) -> dict[str, Any]:
+        """Full, cache-aware integration config resolution for ``session``.
+
+        Thin wrapper over ``Session.get_integrations()`` so callers that
+        already went through :meth:`load_or_create_session` don't need to
+        know that method exists on ``Session`` — they go through the harness
+        for every startup concern.
+        """
+        return session.get_integrations().resolved_integrations
+
+    def load_context(self) -> PromptContextProvider | None:
+        """Return the surface's grounding-context provider, if any."""
+        return self._config.prompts
+
+    def startup(self) -> HarnessStartupResult:
+        """Run env resolution, session bootstrap/resume, and context loading."""
+        self.resolve_env_variables()
+        session = self.load_or_create_session()
+        prompts = self.load_context()
+        return HarnessStartupResult(session=session, prompts=prompts)
+
+
+__all__ = ["AgentHarness", "HarnessConfig", "HarnessStartupResult"]

--- a/core/agent_harness/integrations/resolution.py
+++ b/core/agent_harness/integrations/resolution.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -24,6 +24,9 @@ from integrations.catalog import (
 from integrations.catalog import (
     merge_local_integrations as _merge_local_integrations,
 )
+
+if TYPE_CHECKING:
+    from core.agent_harness.ports import SessionStore
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +65,35 @@ class IntegrationResolutionResult(StrictConfigModel):
 def resolve_integrations(state: Mapping[str, Any] | None = None) -> dict[str, Any]:
     """Return integration configs keyed by service for any runtime consumer."""
     return resolve_integrations_with_metadata(state).resolved_integrations
+
+
+def resolve_and_cache_integrations(session: SessionStore) -> dict[str, Any]:
+    """Resolve integration configs once per session and cache the result.
+
+    Canonical, surface-agnostic sync resolver: checks
+    ``session.resolved_integrations_cache`` first, resolves via
+    :func:`resolve_integrations` on a miss, and merges the result back onto the
+    cache (preserving any runtime-only metadata keys already present). Callers
+    that need async/off-critical-path warmup (e.g. the interactive shell's
+    boot-time warm) layer that behavior on top of this function rather than
+    reimplementing the cache check.
+    """
+    from core.agent_harness.session.integrations_cache import (
+        has_only_runtime_metadata,
+        has_resolved_integrations,
+        merge_resolved_integrations,
+    )
+
+    cached = session.resolved_integrations_cache
+    if cached is not None and (
+        has_resolved_integrations(cached) or not has_only_runtime_metadata(cached)
+    ):
+        return cached
+
+    resolved = resolve_integrations()
+    if resolved:
+        session.resolved_integrations_cache = merge_resolved_integrations(cached, resolved)
+    return session.resolved_integrations_cache or {}
 
 
 def resolve_integrations_with_metadata(
@@ -211,6 +243,7 @@ def _strip_bearer(token: str) -> str:
 __all__ = [
     "IntegrationResolutionRequest",
     "IntegrationResolutionResult",
+    "resolve_and_cache_integrations",
     "resolve_integrations",
     "resolve_integrations_with_metadata",
 ]

--- a/gateway/manager.py
+++ b/gateway/manager.py
@@ -13,11 +13,10 @@ from __future__ import annotations
 import logging
 import signal
 
-from dotenv import load_dotenv
 from rich.console import Console
 
+from core.agent_harness.harness import AgentHarness, HarnessConfig
 from core.agent_harness.providers.default_providers import DefaultToolProvider
-from core.agent_harness.session import SessionManager
 from gateway.config.configure_gateway_logging import configure_gateway_logging
 from gateway.config.get_gateway_settings import GatewaySettings
 from gateway.polling.telegram_gateway_background import TelegramGatewayBackground
@@ -35,12 +34,13 @@ class GatewayManager:
 
     def start_gateway(self, *, wait: bool = True) -> GatewayManager:
         """Assemble the turn handler, start the worker, and own its lifecycle."""
-        load_dotenv(override=False)
+        harness = AgentHarness(HarnessConfig(open_storage=False))
+        harness.resolve_env_variables()
         logger = configure_gateway_logging()
 
         # Compose the transport-agnostic turn handler from a booted session's
         # action tools (precomputed once per process, reused each turn).
-        session = SessionManager().create(open_storage=False)
+        session = harness.load_or_create_session()
         console = Console(force_terminal=False)
         tools = DefaultToolProvider(session, console).action_tools(
             confirm_fn=None,

--- a/gateway/tests/main/test_agent_life_cycle.py
+++ b/gateway/tests/main/test_agent_life_cycle.py
@@ -67,14 +67,14 @@ def test_gateway_start_returns_running_gateway_handle(monkeypatch) -> None:
             assert kwargs.get("open_storage") is False
             return FakeSession()
 
-    monkeypatch.setattr("gateway.manager.load_dotenv", lambda **_kwargs: None)
+    monkeypatch.setattr("core.agent_harness.harness.load_dotenv", lambda **_kwargs: None)
     monkeypatch.setattr("gateway.manager.configure_gateway_logging", lambda: logger)
     monkeypatch.setattr("gateway.telegram_gateway.load_gateway_settings", lambda: settings)
     monkeypatch.setattr(
         "gateway.manager.signal.signal",
         lambda signum, handler: signal_calls.append((signum, handler)),
     )
-    monkeypatch.setattr("gateway.manager.SessionManager", FakeSessionManager)
+    monkeypatch.setattr("core.agent_harness.harness.SessionManager", FakeSessionManager)
 
     class FakeDefaultToolProvider(DefaultToolProvider):
         def action_tools(
@@ -199,11 +199,11 @@ def test_polled_telegram_message_reaches_start_gateway_agent_callback(monkeypatc
             assert chat_id == "chat-1"
             return self._session
 
-    monkeypatch.setattr("gateway.manager.load_dotenv", lambda **_kwargs: None)
+    monkeypatch.setattr("core.agent_harness.harness.load_dotenv", lambda **_kwargs: None)
     monkeypatch.setattr("gateway.manager.configure_gateway_logging", lambda: logger)
     monkeypatch.setattr("gateway.telegram_gateway.load_gateway_settings", lambda: settings)
     monkeypatch.setattr("gateway.manager.signal.signal", lambda *_args: None)
-    monkeypatch.setattr("gateway.manager.SessionManager", FakeSessionManager)
+    monkeypatch.setattr("core.agent_harness.harness.SessionManager", FakeSessionManager)
 
     class FakeDefaultToolProvider(DefaultToolProvider):
         def action_tools(

--- a/tests/core/agent_harness/test_harness.py
+++ b/tests/core/agent_harness/test_harness.py
@@ -1,0 +1,169 @@
+"""Tests for :class:`core.agent_harness.harness.AgentHarness`.
+
+Covers the startup responsibilities the harness consolidates: env
+resolution, session bootstrap/resume (delegated to
+:class:`~core.agent_harness.session.manager.SessionManager`), on-demand
+integration resolution, and context loading — plus the ordering
+``startup()`` runs them in.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import core.agent_harness.harness as harness_module
+from core.agent_harness.harness import AgentHarness, HarnessConfig
+from core.agent_harness.session import Session
+
+
+class _FakeSessionManager:
+    """Records create()/resolve() calls instead of touching real storage."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+        self.create_calls: list[dict[str, Any]] = []
+        self.resolve_calls: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> Session:
+        self.create_calls.append(kwargs)
+        return self.session
+
+    def resolve(self, session_id: str, **kwargs: Any) -> Session:
+        self.resolve_calls.append({"session_id": session_id, **kwargs})
+        return self.session
+
+
+def test_resolve_env_variables_calls_load_dotenv(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(harness_module, "load_dotenv", lambda **kwargs: calls.append(kwargs))
+    harness = AgentHarness()
+
+    harness.resolve_env_variables()
+
+    assert calls == [{"override": False}]
+
+
+def test_resolve_env_variables_skipped_when_load_env_false(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(harness_module, "load_dotenv", lambda **kwargs: calls.append(kwargs))
+    harness = AgentHarness(HarnessConfig(load_env=False))
+
+    harness.resolve_env_variables()
+
+    assert calls == []
+
+
+def test_load_or_create_session_creates_when_no_session_id() -> None:
+    manager = _FakeSessionManager(Session())
+    harness = AgentHarness(HarnessConfig(session_manager=manager))  # type: ignore[arg-type]
+
+    session = harness.load_or_create_session()
+
+    assert session is manager.session
+    assert manager.create_calls == [
+        {
+            "hydrate_integrations": True,
+            "warm_integrations": False,
+            "persistent_tasks": True,
+            "open_storage": True,
+        }
+    ]
+    assert manager.resolve_calls == []
+
+
+def test_load_or_create_session_resolves_when_session_id_given() -> None:
+    manager = _FakeSessionManager(Session())
+    harness = AgentHarness(
+        HarnessConfig(session_id="abc123", session_manager=manager)  # type: ignore[arg-type]
+    )
+
+    session = harness.load_or_create_session()
+
+    assert session is manager.session
+    assert manager.resolve_calls == [
+        {
+            "session_id": "abc123",
+            "hydrate_integrations": True,
+            "warm_integrations": True,
+            "persistent_tasks": True,
+        }
+    ]
+    assert manager.create_calls == []
+
+
+def test_load_or_create_session_forwards_explicit_warm_integrations() -> None:
+    manager = _FakeSessionManager(Session())
+    harness = AgentHarness(
+        HarnessConfig(warm_integrations=True, session_manager=manager)  # type: ignore[arg-type]
+    )
+
+    harness.load_or_create_session()
+
+    assert manager.create_calls == [
+        {
+            "hydrate_integrations": True,
+            "persistent_tasks": True,
+            "open_storage": True,
+            "warm_integrations": True,
+        }
+    ]
+
+
+def test_resolve_integrations_delegates_to_session() -> None:
+    session = Session()
+    session.resolved_integrations_cache = {"datadog": {"api_key": "x"}}
+    harness = AgentHarness()
+
+    resolved = harness.resolve_integrations(session)
+
+    assert resolved == {"datadog": {"api_key": "x"}}
+
+
+def test_load_context_returns_configured_prompts() -> None:
+    sentinel = object()
+    harness = AgentHarness(HarnessConfig(prompts=sentinel))  # type: ignore[arg-type]
+
+    assert harness.load_context() is sentinel
+
+
+def test_load_context_returns_none_by_default() -> None:
+    harness = AgentHarness()
+
+    assert harness.load_context() is None
+
+
+def test_startup_runs_env_then_session_then_context(monkeypatch: Any) -> None:
+    session = Session()
+    manager = _FakeSessionManager(session)
+    sentinel = object()
+    order: list[str] = []
+    monkeypatch.setattr(
+        harness_module.AgentHarness,
+        "resolve_env_variables",
+        lambda _self: order.append("env"),
+    )
+    original_load_session = harness_module.AgentHarness.load_or_create_session
+
+    def _tracked_load_session(self: AgentHarness) -> Session:
+        order.append("session")
+        return original_load_session(self)
+
+    monkeypatch.setattr(
+        harness_module.AgentHarness, "load_or_create_session", _tracked_load_session
+    )
+    original_context = harness_module.AgentHarness.load_context
+
+    def _tracked_context(self: AgentHarness) -> Any:
+        order.append("context")
+        return original_context(self)
+
+    monkeypatch.setattr(harness_module.AgentHarness, "load_context", _tracked_context)
+
+    harness = AgentHarness(
+        HarnessConfig(prompts=sentinel, session_manager=manager)  # type: ignore[arg-type]
+    )
+    result = harness.startup()
+
+    assert order == ["env", "session", "context"]
+    assert result.session is session
+    assert result.prompts is sentinel

--- a/tests/core/agent_harness/test_harness.py
+++ b/tests/core/agent_harness/test_harness.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 from typing import Any
 
 import core.agent_harness.harness as harness_module
-from core.agent_harness.harness import AgentHarness, HarnessConfig
 from core.agent_harness.session import Session
 
 
@@ -36,7 +35,7 @@ class _FakeSessionManager:
 def test_resolve_env_variables_calls_load_dotenv(monkeypatch: Any) -> None:
     calls: list[dict[str, Any]] = []
     monkeypatch.setattr(harness_module, "load_dotenv", lambda **kwargs: calls.append(kwargs))
-    harness = AgentHarness()
+    harness = harness_module.AgentHarness()
 
     harness.resolve_env_variables()
 
@@ -46,7 +45,7 @@ def test_resolve_env_variables_calls_load_dotenv(monkeypatch: Any) -> None:
 def test_resolve_env_variables_skipped_when_load_env_false(monkeypatch: Any) -> None:
     calls: list[dict[str, Any]] = []
     monkeypatch.setattr(harness_module, "load_dotenv", lambda **kwargs: calls.append(kwargs))
-    harness = AgentHarness(HarnessConfig(load_env=False))
+    harness = harness_module.AgentHarness(harness_module.HarnessConfig(load_env=False))
 
     harness.resolve_env_variables()
 
@@ -55,7 +54,7 @@ def test_resolve_env_variables_skipped_when_load_env_false(monkeypatch: Any) -> 
 
 def test_load_or_create_session_creates_when_no_session_id() -> None:
     manager = _FakeSessionManager(Session())
-    harness = AgentHarness(HarnessConfig(session_manager=manager))  # type: ignore[arg-type]
+    harness = harness_module.AgentHarness(harness_module.HarnessConfig(session_manager=manager))  # type: ignore[arg-type]
 
     session = harness.load_or_create_session()
 
@@ -73,8 +72,8 @@ def test_load_or_create_session_creates_when_no_session_id() -> None:
 
 def test_load_or_create_session_resolves_when_session_id_given() -> None:
     manager = _FakeSessionManager(Session())
-    harness = AgentHarness(
-        HarnessConfig(session_id="abc123", session_manager=manager)  # type: ignore[arg-type]
+    harness = harness_module.AgentHarness(
+        harness_module.HarnessConfig(session_id="abc123", session_manager=manager)  # type: ignore[arg-type]
     )
 
     session = harness.load_or_create_session()
@@ -93,8 +92,8 @@ def test_load_or_create_session_resolves_when_session_id_given() -> None:
 
 def test_load_or_create_session_forwards_explicit_warm_integrations() -> None:
     manager = _FakeSessionManager(Session())
-    harness = AgentHarness(
-        HarnessConfig(warm_integrations=True, session_manager=manager)  # type: ignore[arg-type]
+    harness = harness_module.AgentHarness(
+        harness_module.HarnessConfig(warm_integrations=True, session_manager=manager)  # type: ignore[arg-type]
     )
 
     harness.load_or_create_session()
@@ -112,7 +111,7 @@ def test_load_or_create_session_forwards_explicit_warm_integrations() -> None:
 def test_resolve_integrations_delegates_to_session() -> None:
     session = Session()
     session.resolved_integrations_cache = {"datadog": {"api_key": "x"}}
-    harness = AgentHarness()
+    harness = harness_module.AgentHarness()
 
     resolved = harness.resolve_integrations(session)
 
@@ -121,13 +120,13 @@ def test_resolve_integrations_delegates_to_session() -> None:
 
 def test_load_context_returns_configured_prompts() -> None:
     sentinel = object()
-    harness = AgentHarness(HarnessConfig(prompts=sentinel))  # type: ignore[arg-type]
+    harness = harness_module.AgentHarness(harness_module.HarnessConfig(prompts=sentinel))  # type: ignore[arg-type]
 
     assert harness.load_context() is sentinel
 
 
 def test_load_context_returns_none_by_default() -> None:
-    harness = AgentHarness()
+    harness = harness_module.AgentHarness()
 
     assert harness.load_context() is None
 
@@ -144,7 +143,7 @@ def test_startup_runs_env_then_session_then_context(monkeypatch: Any) -> None:
     )
     original_load_session = harness_module.AgentHarness.load_or_create_session
 
-    def _tracked_load_session(self: AgentHarness) -> Session:
+    def _tracked_load_session(self: harness_module.AgentHarness) -> Session:
         order.append("session")
         return original_load_session(self)
 
@@ -153,14 +152,14 @@ def test_startup_runs_env_then_session_then_context(monkeypatch: Any) -> None:
     )
     original_context = harness_module.AgentHarness.load_context
 
-    def _tracked_context(self: AgentHarness) -> Any:
+    def _tracked_context(self: harness_module.AgentHarness) -> Any:
         order.append("context")
         return original_context(self)
 
     monkeypatch.setattr(harness_module.AgentHarness, "load_context", _tracked_context)
 
-    harness = AgentHarness(
-        HarnessConfig(prompts=sentinel, session_manager=manager)  # type: ignore[arg-type]
+    harness = harness_module.AgentHarness(
+        harness_module.HarnessConfig(prompts=sentinel, session_manager=manager)  # type: ignore[arg-type]
     )
     result = harness.startup()
 


### PR DESCRIPTION
Fixes #3359

## Describe the changes you have made in this PR

Adds `AgentHarness` (`core/agent_harness/harness.py`) — a single call surfaces
make at startup to get: env vars resolved (`load_dotenv`), a bootstrapped
session (create-or-resume, delegated to `SessionManager` from #3357), and
their grounding-context provider — instead of each surface sequencing these
steps itself.

**Composes with `SessionManager`, doesn't duplicate it.** #3357 (merged
earlier today) already centralized session create/resolve/rotate/restore and
integration hydration behind `SessionManager`. `AgentHarness` sits one layer
above it: `load_or_create_session()` picks `SessionManager.create()` vs
`.resolve()` based on whether a `session_id` was given, and
`resolve_integrations(session)` is a thin wrapper over
`Session.get_integrations()`. It does not re-implement session lifecycle.

**Extracted a real duplicate.** `evidence_agent.py`'s private
`_resolve_session_integrations()` had its own copy of the cache-check logic
(cache hit/miss, `has_resolved_integrations`/`has_only_runtime_metadata`,
merge-back). Lifted it to `resolve_and_cache_integrations()` in
`core/agent_harness/integrations/resolution.py` so both the evidence agent and
`AgentHarness` share one implementation. Related to #3358 (still open) but
scoped narrowly — this doesn't touch `Session.get_integrations()`'s own
async/generation-guarded warm path.

**Migrated one surface end-to-end.** `gateway/manager.py::GatewayManager.start_gateway`
now calls `AgentHarness(...).resolve_env_variables()` +
`.load_or_create_session()` instead of inlining `load_dotenv` +
`SessionManager().create(...)` itself. Chosen as the first migration because
it was the simplest 1:1 swap.

**Intentionally not migrated yet:** the interactive shell (its integration
warmup has async/generation-guard concurrency `AgentHarness` doesn't
replicate) and the investigation pipeline (resolves integrations through a
stage-graph node, not a direct call site). Migrating those means either
porting that concurrency logic into the harness or accepting a behavior
change — real design decisions, not mechanical moves, and better as
follow-up PRs than bundled into one big diff.

**Added `REFACTOR_CHECKLIST.md`**, a standing definition-of-done for
consolidation refactors like this one (dependency ordering, re-validating an
issue's file paths against current repo state before planning, incremental
per-surface migration, import-boundary enforcement) — linked from `AGENTS.md`.

## Note on issue dependencies

#3359 lists #3357 and #3358 as dependencies. #3357 merged as #3630 earlier
today. #3358 is still open and assigned to @YauhenBichel — this PR's
`resolve_and_cache_integrations()` extraction is a small, narrowly-scoped
slice that may overlap with his eventual #3358 work; flagging for visibility
rather than blocking on it, since the extraction here doesn't touch
`SessionManager`/`Session` and is low collision risk.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

## Test plan

- [x] `tests/core/agent_harness/test_harness.py` — new, covers env resolution, create-vs-resolve routing (including the `warm_integrations` default-per-operation behavior), on-demand integration resolution, context loading, and `startup()` ordering
- [x] `gateway/tests/main/test_agent_life_cycle.py` — updated fakes to patch `AgentHarness`'s dependencies (`core.agent_harness.harness.load_dotenv` / `SessionManager`) instead of `gateway.manager`'s
- [x] `tests/core/agent_harness/test_evidence_agent.py` — unchanged, still passes against the extracted resolver
- [x] `tests/core/agent/test_import_boundaries.py` — still passes (harness.py imports nothing shell-specific)
- [x] Full local run: `tests/core`, `tests/cli`, `gateway/tests` — 1351 passed, 31 skipped
- [x] `ruff check`, `ruff format --check`, `mypy` clean on all touched files (one pre-existing unrelated mypy error and one pre-existing unrelated ruff import-sort warning in `gateway/tests/main/test_agent_life_cycle.py`, confirmed present on `main` before this change)

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions