### PR TITLE
feat(llm): add azure-openai provider via LiteLLM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,6 +173,14 @@ GROQ_REASONING_MODEL=
 GROQ_CLASSIFICATION_MODEL=
 GROQ_TOOLCALL_MODEL=
 
+# Azure OpenAI (routes via LiteLLM; model values are deployment names in your resource)
+AZURE_OPENAI_BASE_URL=
+AZURE_OPENAI_API_KEY=
+AZURE_OPENAI_API_VERSION=2024-10-21
+AZURE_OPENAI_REASONING_MODEL=
+AZURE_OPENAI_CLASSIFICATION_MODEL=
+AZURE_OPENAI_TOOLCALL_MODEL=
+
 # --- First integrations to set up ------------------------------------------
 
 # For a first real RCA run, one of Grafana / Datadog / Honeycomb / Coralogix

--- a/config/config.py
+++ b/config/config.py
@@ -142,9 +142,9 @@ GROQ_CLASSIFICATION_MODEL = "llama-3.3-70b-versatile"
 GROQ_TOOLCALL_MODEL = "llama-3.1-8b-instant"
 
 # Azure OpenAI deployment-name defaults (must match your Azure deployment names).
-AZURE_OPENAI_REASONING_MODEL = "gpt-4.1"
-AZURE_OPENAI_CLASSIFICATION_MODEL = "gpt-4o-mini"
-AZURE_OPENAI_TOOLCALL_MODEL = "gpt-4o-mini"
+AZURE_OPENAI_REASONING_MODEL = "gpt-5.4-mini"
+AZURE_OPENAI_CLASSIFICATION_MODEL = "gpt-5.4-mini"
+AZURE_OPENAI_TOOLCALL_MODEL = "gpt-5.4-mini"
 DEFAULT_AZURE_OPENAI_API_VERSION = "2024-10-21"
 
 # Base URLs for OpenAI-compatible providers
@@ -459,15 +459,10 @@ class LLMSettings(StrictConfigModel):
 
     @model_validator(mode="after")
     def _require_api_key_for_selected_provider(self) -> "LLMSettings":
-        if self.provider == "azure-openai":
-            if not self.azure_openai_base_url:
-                raise ValueError(
-                    "LLM provider 'azure-openai' requires AZURE_OPENAI_BASE_URL to be set."
-                )
-            if not self.azure_openai_api_version:
-                raise ValueError(
-                    "LLM provider 'azure-openai' requires AZURE_OPENAI_API_VERSION to be set."
-                )
+        if self.provider == "azure-openai" and not self.azure_openai_base_url:
+            raise ValueError(
+                "LLM provider 'azure-openai' requires AZURE_OPENAI_BASE_URL to be set."
+            )
         return self
 
     @classmethod

--- a/config/config.py
+++ b/config/config.py
@@ -141,6 +141,12 @@ GROQ_REASONING_MODEL = "llama-3.3-70b-versatile"
 GROQ_CLASSIFICATION_MODEL = "llama-3.3-70b-versatile"
 GROQ_TOOLCALL_MODEL = "llama-3.1-8b-instant"
 
+# Azure OpenAI deployment-name defaults (must match your Azure deployment names).
+AZURE_OPENAI_REASONING_MODEL = "gpt-4.1"
+AZURE_OPENAI_CLASSIFICATION_MODEL = "gpt-4o-mini"
+AZURE_OPENAI_TOOLCALL_MODEL = "gpt-4o-mini"
+DEFAULT_AZURE_OPENAI_API_VERSION = "2024-10-21"
+
 # Base URLs for OpenAI-compatible providers
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 DEEPSEEK_BASE_URL = "https://api.deepseek.com"  # no /v1 — DeepSeek serves the OpenAI-compatible API at the root path
@@ -169,6 +175,7 @@ LLMProvider = Literal[
     "bedrock",
     "minimax",
     "groq",
+    "azure-openai",
     "codex",
     "cursor",
     "claude-code",
@@ -331,6 +338,26 @@ def _llm_settings_env_payload(provider: str) -> dict[str, object]:
             os.getenv("GROQ_MODEL", GROQ_TOOLCALL_MODEL),
         ).strip()
         or GROQ_TOOLCALL_MODEL,
+        "azure_openai_base_url": os.getenv("AZURE_OPENAI_BASE_URL", "").strip(),
+        "azure_openai_api_version": os.getenv(
+            "AZURE_OPENAI_API_VERSION", DEFAULT_AZURE_OPENAI_API_VERSION
+        ).strip()
+        or DEFAULT_AZURE_OPENAI_API_VERSION,
+        "azure_openai_reasoning_model": os.getenv(
+            "AZURE_OPENAI_REASONING_MODEL",
+            os.getenv("AZURE_OPENAI_MODEL", AZURE_OPENAI_REASONING_MODEL),
+        ).strip()
+        or AZURE_OPENAI_REASONING_MODEL,
+        "azure_openai_classification_model": os.getenv(
+            "AZURE_OPENAI_CLASSIFICATION_MODEL",
+            os.getenv("AZURE_OPENAI_MODEL", AZURE_OPENAI_CLASSIFICATION_MODEL),
+        ).strip()
+        or AZURE_OPENAI_CLASSIFICATION_MODEL,
+        "azure_openai_toolcall_model": os.getenv(
+            "AZURE_OPENAI_TOOLCALL_MODEL",
+            os.getenv("AZURE_OPENAI_MODEL", AZURE_OPENAI_TOOLCALL_MODEL),
+        ).strip()
+        or AZURE_OPENAI_TOOLCALL_MODEL,
         "bedrock_reasoning_model": os.getenv(
             "BEDROCK_REASONING_MODEL", BEDROCK_REASONING_MODEL
         ).strip()
@@ -362,6 +389,9 @@ class LLMSettings(StrictConfigModel):
     nvidia_api_key: str = ""
     minimax_api_key: str = ""
     groq_api_key: str = ""
+    azure_openai_api_key: str = ""
+    azure_openai_base_url: str = ""
+    azure_openai_api_version: str = DEFAULT_AZURE_OPENAI_API_VERSION
     ollama_model: str = DEFAULT_OLLAMA_MODEL
     ollama_host: str = DEFAULT_OLLAMA_HOST
     anthropic_reasoning_model: str = ANTHROPIC_REASONING_MODEL
@@ -388,6 +418,9 @@ class LLMSettings(StrictConfigModel):
     groq_reasoning_model: str = GROQ_REASONING_MODEL
     groq_classification_model: str = GROQ_CLASSIFICATION_MODEL
     groq_toolcall_model: str = GROQ_TOOLCALL_MODEL
+    azure_openai_reasoning_model: str = AZURE_OPENAI_REASONING_MODEL
+    azure_openai_classification_model: str = AZURE_OPENAI_CLASSIFICATION_MODEL
+    azure_openai_toolcall_model: str = AZURE_OPENAI_TOOLCALL_MODEL
     bedrock_reasoning_model: str = BEDROCK_REASONING_MODEL
     bedrock_classification_model: str = BEDROCK_CLASSIFICATION_MODEL
     bedrock_toolcall_model: str = BEDROCK_TOOLCALL_MODEL
@@ -400,6 +433,13 @@ class LLMSettings(StrictConfigModel):
         if not host.startswith(("http://", "https://")):
             host = f"http://{host}"
         return host
+
+    @field_validator("azure_openai_base_url", mode="before")
+    @classmethod
+    def _normalize_azure_openai_base_url(cls, value: object) -> str:
+        from core.llm.azure_openai import normalize_azure_openai_base_url
+
+        return normalize_azure_openai_base_url(str(value or ""))
 
     @field_validator("provider", mode="before")
     @classmethod
@@ -419,6 +459,15 @@ class LLMSettings(StrictConfigModel):
 
     @model_validator(mode="after")
     def _require_api_key_for_selected_provider(self) -> "LLMSettings":
+        if self.provider == "azure-openai":
+            if not self.azure_openai_base_url:
+                raise ValueError(
+                    "LLM provider 'azure-openai' requires AZURE_OPENAI_BASE_URL to be set."
+                )
+            if not self.azure_openai_api_version:
+                raise ValueError(
+                    "LLM provider 'azure-openai' requires AZURE_OPENAI_API_VERSION to be set."
+                )
         return self
 
     @classmethod
@@ -571,6 +620,13 @@ GROQ_LLM_CONFIG = LLMModelConfig(
     reasoning_model=GROQ_REASONING_MODEL,
     classification_model=GROQ_CLASSIFICATION_MODEL,
     toolcall_model=GROQ_TOOLCALL_MODEL,
+    max_tokens=DEFAULT_MAX_TOKENS,
+)
+
+AZURE_OPENAI_LLM_CONFIG = LLMModelConfig(
+    reasoning_model=AZURE_OPENAI_REASONING_MODEL,
+    classification_model=AZURE_OPENAI_CLASSIFICATION_MODEL,
+    toolcall_model=AZURE_OPENAI_TOOLCALL_MODEL,
     max_tokens=DEFAULT_MAX_TOKENS,
 )
 

--- a/config/llm_auth/provider_catalog.py
+++ b/config/llm_auth/provider_catalog.py
@@ -21,6 +21,8 @@ class ProviderSpec:
     toolcall_model_env: str | None = None
     classification_model_env: str | None = None
     cli_model_env: str | None = None
+    endpoint_env: str = ""
+    api_version_env: str = ""
     allow_custom_models: bool = False
 
     @property
@@ -114,6 +116,19 @@ PROVIDER_SPECS: tuple[ProviderSpec, ...] = (
         legacy_model_env="GROQ_MODEL",
         toolcall_model_env="GROQ_TOOLCALL_MODEL",
         classification_model_env="GROQ_CLASSIFICATION_MODEL",
+        allow_custom_models=True,
+    ),
+    ProviderSpec(
+        value="azure-openai",
+        label="Azure OpenAI",
+        credential_kind="api_key",
+        api_key_env="AZURE_OPENAI_API_KEY",
+        model_env="AZURE_OPENAI_REASONING_MODEL",
+        legacy_model_env="AZURE_OPENAI_MODEL",
+        toolcall_model_env="AZURE_OPENAI_TOOLCALL_MODEL",
+        classification_model_env="AZURE_OPENAI_CLASSIFICATION_MODEL",
+        endpoint_env="AZURE_OPENAI_BASE_URL",
+        api_version_env="AZURE_OPENAI_API_VERSION",
         allow_custom_models=True,
     ),
     ProviderSpec(

--- a/core/llm/agent_llm_client.py
+++ b/core/llm/agent_llm_client.py
@@ -18,7 +18,7 @@ from core.llm.sdk.agent_clients import (
     _try_parse_tool_call_json,
 )
 from core.llm.tool_schema_normalize import build_openai_tool_specs
-from core.llm.transport_mode import current_llm_transport, use_litellm_transport
+from core.llm.transport_mode import current_llm_transport, use_litellm_for_provider
 from core.llm.types import AgentLLMClient
 
 __all__ = [
@@ -82,7 +82,7 @@ def get_agent_llm() -> _AgentClientType:
         _agent_state.transport = transport
         return _agent_state.client
 
-    if use_litellm_transport():
+    if use_litellm_for_provider(runtime_provider):
         from core.llm.litellm.routing import build_litellm_agent_client
 
         _agent_state.client = build_litellm_agent_client(settings, runtime_provider)

--- a/core/llm/agent_llm_client.py
+++ b/core/llm/agent_llm_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from core.llm.client_cache_key import current_llm_client_cache_key
 from core.llm.openai_compat_providers import (
     is_openai_compat_provider,
     resolve_openai_compat_provider,
@@ -18,7 +19,7 @@ from core.llm.sdk.agent_clients import (
     _try_parse_tool_call_json,
 )
 from core.llm.tool_schema_normalize import build_openai_tool_specs
-from core.llm.transport_mode import current_llm_transport, use_litellm_for_provider
+from core.llm.transport_mode import use_litellm_for_provider
 from core.llm.types import AgentLLMClient
 
 __all__ = [
@@ -48,7 +49,7 @@ class _AgentClientState:
     """
 
     client: _AgentClientType | None = None
-    transport: str | None = None
+    cache_key: tuple[str, str] | None = None
 
 
 _agent_state = _AgentClientState()
@@ -56,8 +57,8 @@ _agent_state = _AgentClientState()
 
 def get_agent_llm() -> _AgentClientType:
     """Return a singleton tool-calling LLM client for the investigation agent."""
-    transport = current_llm_transport()
-    if _agent_state.client is not None and _agent_state.transport != transport:
+    cache_key = current_llm_client_cache_key()
+    if _agent_state.client is not None and _agent_state.cache_key != cache_key:
         _agent_state.client = None
     if _agent_state.client is not None:
         return _agent_state.client
@@ -79,14 +80,14 @@ def get_agent_llm() -> _AgentClientType:
     if (cli_reg := _get_cli_provider_registration(runtime_provider)) is not None:
         model_name = os.getenv(cli_reg.model_env_key, "").strip() or None
         _agent_state.client = CLIBackedAgentClient(cli_reg.adapter_factory(), model=model_name)
-        _agent_state.transport = transport
+        _agent_state.cache_key = cache_key
         return _agent_state.client
 
     if use_litellm_for_provider(runtime_provider):
         from core.llm.litellm.routing import build_litellm_agent_client
 
         _agent_state.client = build_litellm_agent_client(settings, runtime_provider)
-        _agent_state.transport = transport
+        _agent_state.cache_key = cache_key
         return _agent_state.client
 
     if runtime_provider == "openai":
@@ -121,7 +122,7 @@ def get_agent_llm() -> _AgentClientType:
             max_tokens=ANTHROPIC_LLM_CONFIG.max_tokens,
         )
 
-    _agent_state.transport = transport
+    _agent_state.cache_key = cache_key
     return _agent_state.client
 
 
@@ -147,4 +148,4 @@ def _get_cli_provider_registration(provider: str) -> Any:
 def reset_agent_client() -> None:
     """Reset the singleton (for tests / config changes)."""
     _agent_state.client = None
-    _agent_state.transport = None
+    _agent_state.cache_key = None

--- a/core/llm/azure_openai.py
+++ b/core/llm/azure_openai.py
@@ -43,24 +43,29 @@ def azure_openai_litellm_model(deployment: str) -> str:
     return f"azure/{name}"
 
 
+def resolve_azure_openai_api_version(value: str = "") -> str:
+    """Return the configured Azure API version, falling back to the OpenSRE default."""
+    from config.config import DEFAULT_AZURE_OPENAI_API_VERSION
+
+    version = (value or os.getenv(AZURE_OPENAI_API_VERSION_ENV, "")).strip()
+    return version or DEFAULT_AZURE_OPENAI_API_VERSION
+
+
 def azure_openai_endpoint_configured() -> bool:
-    """Return True when non-secret Azure OpenAI endpoint settings are present."""
+    """Return True when the Azure OpenAI resource URL is present."""
     base = os.getenv(AZURE_OPENAI_BASE_URL_ENV, "").strip()
-    version = os.getenv(AZURE_OPENAI_API_VERSION_ENV, "").strip()
-    return bool(base and version)
+    return bool(base)
 
 
 def resolve_azure_openai_request_kwargs(settings: Any, *, model_type: ModelType) -> dict[str, str]:
     """Resolve LiteLLM request fields for Azure OpenAI from runtime settings."""
     base_url = normalize_azure_openai_base_url(str(getattr(settings, "azure_openai_base_url", "")))
-    api_version = str(getattr(settings, "azure_openai_api_version", "")).strip()
+    api_version = resolve_azure_openai_api_version(
+        str(getattr(settings, "azure_openai_api_version", ""))
+    )
     if not base_url:
         raise RuntimeError(
             f"LLM provider '{AZURE_OPENAI_PROVIDER}' requires {AZURE_OPENAI_BASE_URL_ENV}."
-        )
-    if not api_version:
-        raise RuntimeError(
-            f"LLM provider '{AZURE_OPENAI_PROVIDER}' requires {AZURE_OPENAI_API_VERSION_ENV}."
         )
     deployment = select_azure_openai_model(settings, model_type)
     return {
@@ -80,6 +85,7 @@ __all__ = [
     "azure_openai_litellm_model",
     "is_azure_openai_provider",
     "normalize_azure_openai_base_url",
+    "resolve_azure_openai_api_version",
     "resolve_azure_openai_request_kwargs",
     "select_azure_openai_model",
 ]

--- a/core/llm/azure_openai.py
+++ b/core/llm/azure_openai.py
@@ -1,0 +1,85 @@
+"""Azure OpenAI provider helpers for LiteLLM routing and validation."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from core.llm.openai_compat_providers import ModelType
+
+AZURE_OPENAI_PROVIDER = "azure-openai"
+
+AZURE_OPENAI_BASE_URL_ENV = "AZURE_OPENAI_BASE_URL"
+AZURE_OPENAI_API_VERSION_ENV = "AZURE_OPENAI_API_VERSION"
+AZURE_OPENAI_API_KEY_ENV = "AZURE_OPENAI_API_KEY"
+
+
+def is_azure_openai_provider(provider: str) -> bool:
+    """Return whether *provider* is the Azure OpenAI LLM slug."""
+    return provider.strip().lower() == AZURE_OPENAI_PROVIDER
+
+
+def normalize_azure_openai_base_url(value: str) -> str:
+    """Normalize an Azure OpenAI resource endpoint URL."""
+    base = (value or "").strip()
+    if not base:
+        return ""
+    if not base.startswith(("http://", "https://")):
+        base = f"https://{base}"
+    return base.rstrip("/")
+
+
+def select_azure_openai_model(settings: Any, model_type: ModelType) -> str:
+    """Return the configured Azure deployment name for *model_type*."""
+    attr = f"azure_openai_{model_type}_model"
+    return str(getattr(settings, attr))
+
+
+def azure_openai_litellm_model(deployment: str) -> str:
+    """Build the LiteLLM model string for an Azure deployment name."""
+    name = deployment.strip()
+    if name.startswith("azure/"):
+        return name
+    return f"azure/{name}"
+
+
+def azure_openai_endpoint_configured() -> bool:
+    """Return True when non-secret Azure OpenAI endpoint settings are present."""
+    base = os.getenv(AZURE_OPENAI_BASE_URL_ENV, "").strip()
+    version = os.getenv(AZURE_OPENAI_API_VERSION_ENV, "").strip()
+    return bool(base and version)
+
+
+def resolve_azure_openai_request_kwargs(settings: Any, *, model_type: ModelType) -> dict[str, str]:
+    """Resolve LiteLLM request fields for Azure OpenAI from runtime settings."""
+    base_url = normalize_azure_openai_base_url(str(getattr(settings, "azure_openai_base_url", "")))
+    api_version = str(getattr(settings, "azure_openai_api_version", "")).strip()
+    if not base_url:
+        raise RuntimeError(
+            f"LLM provider '{AZURE_OPENAI_PROVIDER}' requires {AZURE_OPENAI_BASE_URL_ENV}."
+        )
+    if not api_version:
+        raise RuntimeError(
+            f"LLM provider '{AZURE_OPENAI_PROVIDER}' requires {AZURE_OPENAI_API_VERSION_ENV}."
+        )
+    deployment = select_azure_openai_model(settings, model_type)
+    return {
+        "litellm_model": azure_openai_litellm_model(deployment),
+        "api_base": base_url,
+        "api_version": api_version,
+        "api_key_env": AZURE_OPENAI_API_KEY_ENV,
+    }
+
+
+__all__ = [
+    "AZURE_OPENAI_API_KEY_ENV",
+    "AZURE_OPENAI_API_VERSION_ENV",
+    "AZURE_OPENAI_BASE_URL_ENV",
+    "AZURE_OPENAI_PROVIDER",
+    "azure_openai_endpoint_configured",
+    "azure_openai_litellm_model",
+    "is_azure_openai_provider",
+    "normalize_azure_openai_base_url",
+    "resolve_azure_openai_request_kwargs",
+    "select_azure_openai_model",
+]

--- a/core/llm/client_cache_key.py
+++ b/core/llm/client_cache_key.py
@@ -1,0 +1,17 @@
+"""Cache-key helpers for LLM singleton invalidation."""
+
+from __future__ import annotations
+
+
+def current_llm_client_cache_key() -> tuple[str, str]:
+    """Return ``(transport, runtime_provider)`` for singleton cache invalidation."""
+    from config.config import get_configured_llm_provider
+    from config.llm_auth.auth_method import effective_llm_provider, get_configured_llm_auth_method
+    from core.llm.transport_mode import current_llm_transport
+
+    configured = get_configured_llm_provider()
+    runtime = effective_llm_provider(configured, get_configured_llm_auth_method(configured))
+    return (current_llm_transport(), runtime)
+
+
+__all__ = ["current_llm_client_cache_key"]

--- a/core/llm/litellm/clients.py
+++ b/core/llm/litellm/clients.py
@@ -45,6 +45,7 @@ class LiteLLMAgentClient:
         litellm_model: str,
         max_tokens: int = 4096,
         api_base: str | None = None,
+        api_version: str | None = None,
         api_key_env: str | None = None,
         api_key_default: str = "",
         temperature: float | None = None,
@@ -54,6 +55,7 @@ class LiteLLMAgentClient:
         self._litellm_model = litellm_model
         self._max_tokens = max_tokens
         self._api_base = api_base
+        self._api_version = api_version
         self._api_key_env = api_key_env
         self._api_key_default = api_key_default
         self._temperature = temperature
@@ -99,6 +101,8 @@ class LiteLLMAgentClient:
             kwargs["api_key"] = api_key
         if self._api_base is not None:
             kwargs["api_base"] = self._api_base
+        if self._api_version is not None:
+            kwargs["api_version"] = self._api_version
         if self._temperature is not None:
             kwargs["temperature"] = self._temperature
         if tools:
@@ -138,6 +142,7 @@ class LiteLLMLLMClient:
         max_tokens: int = 1024,
         temperature: float | None = None,
         api_base: str | None = None,
+        api_version: str | None = None,
         api_key_env: str | None = None,
         api_key_default: str = "",
         credential_resolver: Callable[[str], str] | None = None,
@@ -150,6 +155,7 @@ class LiteLLMLLMClient:
         self._max_tokens = max_tokens
         self._temperature = temperature
         self._api_base = api_base
+        self._api_version = api_version
         self._api_key_env = api_key_env
         self._api_key_default = api_key_default
         self._credential_resolver = credential_resolver
@@ -213,6 +219,8 @@ class LiteLLMLLMClient:
             kwargs["api_key"] = api_key
         if self._api_base is not None:
             kwargs["api_base"] = self._api_base
+        if self._api_version is not None:
+            kwargs["api_version"] = self._api_version
         if self._temperature is not None:
             kwargs["temperature"] = self._temperature
         if self._bound_tools:

--- a/core/llm/litellm/routing.py
+++ b/core/llm/litellm/routing.py
@@ -11,6 +11,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.llm.azure_openai import (
+    is_azure_openai_provider,
+    resolve_azure_openai_request_kwargs,
+)
 from core.llm.litellm.clients import LiteLLMAgentClient, LiteLLMLLMClient
 from core.llm.openai_compat_providers import (
     ModelType,
@@ -51,6 +55,18 @@ def build_litellm_agent_client(settings: Any, provider: str) -> LiteLLMAgentClie
         return LiteLLMAgentClient(
             litellm_model=f"bedrock/{model}",
             max_tokens=BEDROCK_LLM_CONFIG.max_tokens,
+        )
+
+    if is_azure_openai_provider(provider):
+        from config.config import AZURE_OPENAI_LLM_CONFIG
+
+        azure = resolve_azure_openai_request_kwargs(settings, model_type="reasoning")
+        return LiteLLMAgentClient(
+            litellm_model=azure["litellm_model"],
+            max_tokens=AZURE_OPENAI_LLM_CONFIG.max_tokens,
+            api_base=azure["api_base"],
+            api_version=azure["api_version"],
+            api_key_env=azure["api_key_env"],
         )
 
     if is_openai_compat_provider(provider):
@@ -122,6 +138,24 @@ def build_litellm_llm_client(
             litellm_model=f"bedrock/{model}",
             model_fallback=(_fallback("bedrock") and f"bedrock/{_fallback('bedrock')}") or None,
             max_tokens=BEDROCK_LLM_CONFIG.max_tokens,
+            usage_callback=usage_callback,
+        )
+
+    if is_azure_openai_provider(provider):
+        from config.config import AZURE_OPENAI_LLM_CONFIG
+
+        azure = resolve_azure_openai_request_kwargs(settings, model_type=model_type)
+        raw_fallback = _fallback("azure_openai")
+        fallback_model = (
+            f"azure/{raw_fallback}" if raw_fallback and not raw_fallback.startswith("azure/") else raw_fallback
+        )
+        return LiteLLMLLMClient(
+            litellm_model=azure["litellm_model"],
+            model_fallback=fallback_model or None,
+            max_tokens=AZURE_OPENAI_LLM_CONFIG.max_tokens,
+            api_base=azure["api_base"],
+            api_version=azure["api_version"],
+            api_key_env=azure["api_key_env"],
             usage_callback=usage_callback,
         )
 

--- a/core/llm/litellm/routing.py
+++ b/core/llm/litellm/routing.py
@@ -146,12 +146,14 @@ def build_litellm_llm_client(
 
         azure = resolve_azure_openai_request_kwargs(settings, model_type=model_type)
         raw_fallback = _fallback("azure_openai")
-        fallback_model = (
-            f"azure/{raw_fallback}" if raw_fallback and not raw_fallback.startswith("azure/") else raw_fallback
-        )
+        azure_fallback_model: str | None = None
+        if raw_fallback:
+            azure_fallback_model = (
+                raw_fallback if raw_fallback.startswith("azure/") else f"azure/{raw_fallback}"
+            )
         return LiteLLMLLMClient(
             litellm_model=azure["litellm_model"],
-            model_fallback=fallback_model or None,
+            model_fallback=azure_fallback_model,
             max_tokens=AZURE_OPENAI_LLM_CONFIG.max_tokens,
             api_base=azure["api_base"],
             api_version=azure["api_version"],

--- a/core/llm/llm_client.py
+++ b/core/llm/llm_client.py
@@ -25,6 +25,7 @@ from config.config import (
 )
 from config.llm_auth.auth_method import effective_llm_provider, get_configured_llm_auth_method
 from core.domain.types.root_cause_categories import VALID_ROOT_CAUSE_CATEGORIES
+from core.llm.client_cache_key import current_llm_client_cache_key
 from core.llm.openai_chat_completions import _RETRY_MAX_ATTEMPTS
 from core.llm.openai_compat_providers import (
     ModelType,
@@ -32,7 +33,7 @@ from core.llm.openai_compat_providers import (
     resolve_openai_compat_provider,
 )
 from core.llm.provider_credentials import resolve_llm_api_key
-from core.llm.transport_mode import current_llm_transport, use_litellm_for_provider
+from core.llm.transport_mode import use_litellm_for_provider
 from core.llm.types import LLMResponse
 from core.llm.usage import UsageHook, emit_usage, set_usage_hook
 
@@ -134,7 +135,7 @@ class _LLMSingletonState:
     llm: _LLMClientType | None = None
     llm_for_classification: _LLMClientType | None = None
     llm_for_tools: _LLMClientType | None = None
-    transport: str | None = None
+    cache_key: tuple[str, str] | None = None
 
 
 _llm_state = _LLMSingletonState()
@@ -145,16 +146,16 @@ def reset_llm_singletons() -> None:
     _llm_state.llm = None
     _llm_state.llm_for_classification = None
     _llm_state.llm_for_tools = None
-    _llm_state.transport = None
+    _llm_state.cache_key = None
 
 
-def _ensure_llm_transport_current() -> None:
-    transport = current_llm_transport()
-    if _llm_state.transport != transport:
+def _ensure_llm_cache_current() -> None:
+    cache_key = current_llm_client_cache_key()
+    if _llm_state.cache_key != cache_key:
         _llm_state.llm = None
         _llm_state.llm_for_classification = None
         _llm_state.llm_for_tools = None
-        _llm_state.transport = transport
+        _llm_state.cache_key = cache_key
 
 
 def _get_cli_provider_registration(provider: str) -> CLIProviderRegistration | None:
@@ -249,7 +250,7 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
 
 def get_llm_for_reasoning() -> _LLMClientType:
     """Return the singleton LLM client for complex reasoning tasks."""
-    _ensure_llm_transport_current()
+    _ensure_llm_cache_current()
     if _llm_state.llm is None:
         _llm_state.llm = _create_llm_client(model_type="reasoning")
     return _llm_state.llm
@@ -257,7 +258,7 @@ def get_llm_for_reasoning() -> _LLMClientType:
 
 def get_llm_for_classification() -> _LLMClientType:
     """Return the singleton LLM client for the mid-tier classification tier."""
-    _ensure_llm_transport_current()
+    _ensure_llm_cache_current()
     if _llm_state.llm_for_classification is None:
         _llm_state.llm_for_classification = _create_llm_client(model_type="classification")
     return _llm_state.llm_for_classification
@@ -265,7 +266,7 @@ def get_llm_for_classification() -> _LLMClientType:
 
 def get_llm_for_tools() -> _LLMClientType:
     """Return the singleton lightweight LLM client for tool selection / action planning."""
-    _ensure_llm_transport_current()
+    _ensure_llm_cache_current()
     if _llm_state.llm_for_tools is None:
         _llm_state.llm_for_tools = _create_llm_client(model_type="toolcall")
     return _llm_state.llm_for_tools

--- a/core/llm/llm_client.py
+++ b/core/llm/llm_client.py
@@ -32,7 +32,7 @@ from core.llm.openai_compat_providers import (
     resolve_openai_compat_provider,
 )
 from core.llm.provider_credentials import resolve_llm_api_key
-from core.llm.transport_mode import current_llm_transport, use_litellm_transport
+from core.llm.transport_mode import current_llm_transport, use_litellm_for_provider
 from core.llm.types import LLMResponse
 from core.llm.usage import UsageHook, emit_usage, set_usage_hook
 
@@ -199,7 +199,7 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
             model_type=model_type,
         )
 
-    if use_litellm_transport():
+    if use_litellm_for_provider(runtime_provider):
         from core.llm.litellm.routing import build_litellm_llm_client
 
         return build_litellm_llm_client(

--- a/core/llm/transport_mode.py
+++ b/core/llm/transport_mode.py
@@ -17,6 +17,13 @@ def use_litellm_transport() -> bool:
     return os.getenv(LLM_TRANSPORT_ENV, "").strip().lower() == "litellm"
 
 
+def use_litellm_for_provider(provider: str) -> bool:
+    """Return ``True`` when *provider* must route through LiteLLM."""
+    from core.llm.azure_openai import is_azure_openai_provider
+
+    return use_litellm_transport() or is_azure_openai_provider(provider)
+
+
 def current_llm_transport() -> str:
     """Normalized ``OPENSRE_LLM_TRANSPORT`` value (empty when unset)."""
     return os.getenv(LLM_TRANSPORT_ENV, "").strip().lower()

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -82,9 +82,9 @@ All configuration options for OpenSRE can be set via environment variables. This
 | `AZURE_OPENAI_API_KEY` | | API key for Azure OpenAI | `llm_credentials` |
 | `AZURE_OPENAI_API_VERSION` | `2024-10-21` | Azure OpenAI API version | `config` |
 | `AZURE_OPENAI_MODEL` | | Shared deployment name for all slots | `config` |
-| `AZURE_OPENAI_REASONING_MODEL` | `gpt-4.1` | Deployment for reasoning tasks | `config` |
-| `AZURE_OPENAI_CLASSIFICATION_MODEL` | `gpt-4o-mini` | Deployment for classification | `config` |
-| `AZURE_OPENAI_TOOLCALL_MODEL` | `gpt-4o-mini` | Deployment for tool calling | `config` |
+| `AZURE_OPENAI_REASONING_MODEL` | `gpt-5.4-mini` | Deployment for reasoning tasks | `config` |
+| `AZURE_OPENAI_CLASSIFICATION_MODEL` | `gpt-5.4-mini` | Deployment for classification | `config` |
+| `AZURE_OPENAI_TOOLCALL_MODEL` | `gpt-5.4-mini` | Deployment for tool calling | `config` |
 
 ### Amazon Bedrock
 | Variable | Default | Description | Module |

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -9,8 +9,9 @@ All configuration options for OpenSRE can be set via environment variables. This
 
 | Variable | Default | Description | Module |
 |----------|---------|-------------|--------|
-| `LLM_PROVIDER` | `anthropic` | Primary LLM provider (`anthropic`, `openai`, `openrouter`, `deepseek`, `gemini`, `nvidia`, `minimax`, `groq`, `bedrock`, `ollama`, `codex`, `claude-code`, `cursor`, `gemini-cli`, `antigravity-cli`, `opencode`, `kimi`, `copilot`, `grok-cli`, `pi`) | `config` |
+| `LLM_PROVIDER` | `anthropic` | Primary LLM provider (`anthropic`, `openai`, `openrouter`, `deepseek`, `gemini`, `nvidia`, `minimax`, `groq`, `azure-openai`, `bedrock`, `ollama`, `codex`, `claude-code`, `cursor`, `gemini-cli`, `antigravity-cli`, `opencode`, `kimi`, `copilot`, `grok-cli`, `pi`) | `config` |
 | `LLM_MAX_TOKENS` | `4096` | Maximum tokens for LLM responses | `config` |
+| `OPENSRE_LLM_TRANSPORT` | `sdk` | LLM transport for API providers: `sdk` (native SDKs) or `litellm` | `core/llm/transport_mode` |
 
 ### Anthropic
 | Variable | Default | Description | Module |
@@ -73,6 +74,17 @@ All configuration options for OpenSRE can be set via environment variables. This
 | `GROQ_MODEL` | | Shared model for all tasks | `config` |
 | `GROQ_REASONING_MODEL` | | Override model for reasoning | `config` |
 | `GROQ_TOOLCALL_MODEL` | | Override model for tool calling | `config` |
+
+### Azure OpenAI
+| Variable | Default | Description | Module |
+|----------|---------|-------------|--------|
+| `AZURE_OPENAI_BASE_URL` | | Azure OpenAI resource URL (`https://<resource>.openai.azure.com`) | `config` |
+| `AZURE_OPENAI_API_KEY` | | API key for Azure OpenAI | `llm_credentials` |
+| `AZURE_OPENAI_API_VERSION` | `2024-10-21` | Azure OpenAI API version | `config` |
+| `AZURE_OPENAI_MODEL` | | Shared deployment name for all slots | `config` |
+| `AZURE_OPENAI_REASONING_MODEL` | `gpt-4.1` | Deployment for reasoning tasks | `config` |
+| `AZURE_OPENAI_CLASSIFICATION_MODEL` | `gpt-4o-mini` | Deployment for classification | `config` |
+| `AZURE_OPENAI_TOOLCALL_MODEL` | `gpt-4o-mini` | Deployment for tool calling | `config` |
 
 ### Amazon Bedrock
 | Variable | Default | Description | Module |

--- a/docs/investigation-tool-calling.md
+++ b/docs/investigation-tool-calling.md
@@ -118,8 +118,9 @@ When set to `litellm`, both investigation (`get_agent_llm()`) and non-agent LLM 
 native vendor SDK clients under `core/llm/sdk/`.
 
 Supported providers: `anthropic`, `openai`, `bedrock`, and OpenAI-compatible providers
-(`deepseek`, `groq`, `openrouter`, `gemini`, `nvidia`, `minimax`, `ollama`). Set the matching
-API key and model env vars from `.env.example` as usual.
+(`deepseek`, `groq`, `openrouter`, `gemini`, `nvidia`, `minimax`, `ollama`), plus
+`azure-openai` (always via LiteLLM). Set the matching API key and model env vars from
+`.env.example` as usual. User-facing setup: [LLM Providers](/llm-providers#litellm-transport).
 
 CLI-backed providers (`codex`, `claude-code`, `opencode`, `kimi`, `copilot`, etc.) always use
 their subprocess path regardless of this setting.

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -24,7 +24,7 @@ OpenSRE is provider-agnostic: bring your own model. Selection is controlled by t
 | Ollama (local)| `ollama`     | None (local daemon)             | `llama3.2`                                    | `llama3.2`                                      |
 | GitHub Copilot CLI| `copilot`| `copilot login` or `gh auth login` (CLI) | Copilot CLI default                           | Copilot CLI default                             |
 | xAI Groq API key | `groq`      | `GROQ_API_KEY`                  | `llama-3.3-70b-versatile`                     | `llama-3.1-8b-instant`                          |
-| Azure OpenAI | `azure-openai` | `AZURE_OPENAI_API_KEY` + resource URL | `gpt-4.1` (deployment name)            | `gpt-4o-mini` (deployment name)                 |
+| Azure OpenAI | `azure-openai` | `AZURE_OPENAI_API_KEY` + resource URL | `gpt-5.4-mini` (deployment name)            | `gpt-5.4-mini` (deployment name)                 |
 | xAI Grok Build CLI | `grok-cli` | `grok login` (CLI)             | Grok Build CLI default                        | Grok Build CLI default                          |
 | Pi CLI (BYOK)| `pi`          | provider API key env or `pi` → `/login` | Pi configured model (`PI_MODEL` to override) | same as reasoning model |
 
@@ -186,28 +186,31 @@ export OPENSRE_LLM_TRANSPORT=litellm   # set automatically by `opensre onboard`
 
 export AZURE_OPENAI_BASE_URL=https://your-resource.openai.azure.com
 export AZURE_OPENAI_API_KEY=...
-export AZURE_OPENAI_API_VERSION=2024-10-21
+# Optional override; defaults to 2024-10-21 when unset:
+# export AZURE_OPENAI_API_VERSION=2024-10-21
 
 # Deployment names (must exist in your Azure resource):
-export AZURE_OPENAI_REASONING_MODEL=gpt-4.1
-export AZURE_OPENAI_TOOLCALL_MODEL=gpt-4o-mini
-export AZURE_OPENAI_CLASSIFICATION_MODEL=gpt-4o-mini
+export AZURE_OPENAI_REASONING_MODEL=gpt-5.4-mini
+export AZURE_OPENAI_TOOLCALL_MODEL=gpt-5.4-mini
+export AZURE_OPENAI_CLASSIFICATION_MODEL=gpt-5.4-mini
 ```
 
 Quick setup:
 
 ```bash
-opensre onboard   # choose Azure OpenAI; paste resource URL, API key, API version, deployment
+opensre onboard   # choose Azure OpenAI; paste resource URL, API key, deployment
 ```
+
+Onboarding asks only for your **resource URL**, **API key**, and **reasoning deployment name**. OpenSRE sets `AZURE_OPENAI_API_VERSION=2024-10-21` and `OPENSRE_LLM_TRANSPORT=litellm` automatically unless you override them in `.env`.
 
 In the REPL, switch provider or deployment like any other API provider:
 
 ```bash
-/model set azure-openai gpt-4.1
-/model set azure-openai gpt-4.1 --toolcall-model gpt-4o-mini
+/model set azure-openai gpt-5.4-mini
+/model set azure-openai gpt-5.4-mini --toolcall-model gpt-5.4-nano
 ```
 
-Common deployment names in the onboarding picker include `gpt-4.1`, `gpt-4.1-mini`, `gpt-4o`, `gpt-4o-mini`, `gpt-5`, `gpt-5-mini`, and `o3-mini`. Use custom names when your Azure deployment names differ (`allow_custom_models` is enabled).
+Common deployment names in the onboarding picker include `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5-mini`, `gpt-4.1`, and `o3-mini`. Use custom names when your Azure deployment names differ (`allow_custom_models` is enabled).
 
 ### OpenRouter
 

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -24,6 +24,7 @@ OpenSRE is provider-agnostic: bring your own model. Selection is controlled by t
 | Ollama (local)| `ollama`     | None (local daemon)             | `llama3.2`                                    | `llama3.2`                                      |
 | GitHub Copilot CLI| `copilot`| `copilot login` or `gh auth login` (CLI) | Copilot CLI default                           | Copilot CLI default                             |
 | xAI Groq API key | `groq`      | `GROQ_API_KEY`                  | `llama-3.3-70b-versatile`                     | `llama-3.1-8b-instant`                          |
+| Azure OpenAI | `azure-openai` | `AZURE_OPENAI_API_KEY` + resource URL | `gpt-4.1` (deployment name)            | `gpt-4o-mini` (deployment name)                 |
 | xAI Grok Build CLI | `grok-cli` | `grok login` (CLI)             | Grok Build CLI default                        | Grok Build CLI default                          |
 | Pi CLI (BYOK)| `pi`          | provider API key env or `pi` → `/login` | Pi configured model (`PI_MODEL` to override) | same as reasoning model |
 
@@ -74,6 +75,38 @@ export OPENAI_TOOLCALL_MODEL=gpt-5.4-mini
 ```
 
 A shared `LLM_MAX_TOKENS` (default `4096`) controls the response token budget for every provider.
+
+## LiteLLM transport
+
+OpenSRE can route **hosted API providers** through [LiteLLM](https://docs.litellm.ai/) instead of native vendor SDKs. This is opt-in for most providers and **required** for Azure OpenAI.
+
+| Command / variable | What it does |
+| ------------------ | ------------ |
+| `export OPENSRE_LLM_TRANSPORT=litellm` | Route API providers through LiteLLM |
+| unset or `export OPENSRE_LLM_TRANSPORT=sdk` | Use native SDK clients (default) |
+| `opensre onboard` → **Azure OpenAI** | Writes `OPENSRE_LLM_TRANSPORT=litellm` automatically |
+
+**CLI-backed providers** (`codex`, `claude-code`, `copilot`, `pi`, etc.) always use their subprocess path — LiteLLM does not affect them.
+
+### Providers supported via LiteLLM
+
+When `OPENSRE_LLM_TRANSPORT=litellm` (or when using `LLM_PROVIDER=azure-openai`), OpenSRE builds investigation tool schemas the same way as the SDK path and passes them to `litellm.completion(..., tools=..., tool_choice="auto")`. LiteLLM handles provider routing; OpenSRE keeps schema normalization, retries, and message replay.
+
+| `LLM_PROVIDER` | Native SDK path (default) | LiteLLM path | Notes |
+| -------------- | ------------------------- | ------------ | ----- |
+| `anthropic` | Anthropic SDK | `anthropic/<model>` | Opt-in via `OPENSRE_LLM_TRANSPORT=litellm` |
+| `openai` | OpenAI SDK | `openai/<model>` | Opt-in |
+| `bedrock` | boto3 / AnthropicBedrock / Converse | `bedrock/<model-id>` | Opt-in; uses AWS credential chain |
+| `openrouter` | OpenAI-compatible SDK | `openai/<model>` + OpenRouter base URL | Opt-in |
+| `deepseek` | OpenAI-compatible SDK | `openai/<model>` + DeepSeek base URL | Opt-in |
+| `gemini` | OpenAI-compatible SDK | `openai/<model>` + Gemini base URL | Opt-in |
+| `nvidia` | OpenAI-compatible SDK | `openai/<model>` + NVIDIA NIM base URL | Opt-in |
+| `minimax` | OpenAI-compatible SDK | `openai/<model>` + MiniMax base URL | Opt-in |
+| `groq` | OpenAI-compatible SDK | `openai/<model>` + Groq base URL | Opt-in |
+| `ollama` | OpenAI-compatible SDK | `openai/<model>` + `${OLLAMA_HOST}/v1` | Opt-in |
+| `azure-openai` | — | `azure/<deployment>` | **Always** via LiteLLM |
+
+For providers beyond this list, LiteLLM supports [100+ backends](https://docs.litellm.ai/docs/providers). OpenSRE only wires the slugs above today — use one of them, or open an issue if you need another first-class provider.
 
 ## Login and secret storage
 
@@ -142,6 +175,39 @@ export OPENAI_TOOLCALL_MODEL=gpt-5.4-mini
 ```
 
 Uses the OpenAI SDK. Reasoning models (`o1`, `o3`, `o4`, `gpt-5*`) automatically use `max_completion_tokens` instead of `max_tokens`.
+
+### Azure OpenAI
+
+Azure OpenAI routes through LiteLLM. Model env vars hold **deployment names** from your Azure resource, not public OpenAI model IDs.
+
+```bash
+export LLM_PROVIDER=azure-openai
+export OPENSRE_LLM_TRANSPORT=litellm   # set automatically by `opensre onboard`
+
+export AZURE_OPENAI_BASE_URL=https://your-resource.openai.azure.com
+export AZURE_OPENAI_API_KEY=...
+export AZURE_OPENAI_API_VERSION=2024-10-21
+
+# Deployment names (must exist in your Azure resource):
+export AZURE_OPENAI_REASONING_MODEL=gpt-4.1
+export AZURE_OPENAI_TOOLCALL_MODEL=gpt-4o-mini
+export AZURE_OPENAI_CLASSIFICATION_MODEL=gpt-4o-mini
+```
+
+Quick setup:
+
+```bash
+opensre onboard   # choose Azure OpenAI; paste resource URL, API key, API version, deployment
+```
+
+In the REPL, switch provider or deployment like any other API provider:
+
+```bash
+/model set azure-openai gpt-4.1
+/model set azure-openai gpt-4.1 --toolcall-model gpt-4o-mini
+```
+
+Common deployment names in the onboarding picker include `gpt-4.1`, `gpt-4.1-mini`, `gpt-4o`, `gpt-4o-mini`, `gpt-5`, `gpt-5-mini`, and `o3-mini`. Use custom names when your Azure deployment names differ (`allow_custom_models` is enabled).
 
 ### OpenRouter
 
@@ -213,6 +279,20 @@ export MINIMAX_TOOLCALL_MODEL=MiniMax-M2.7-highspeed
 ```
 
 OpenAI-compatible endpoint at `https://api.minimax.io/v1`. Temperature is fixed to `1.0` to match MiniMax recommendations.
+
+### Groq
+
+```bash
+export LLM_PROVIDER=groq
+export GROQ_API_KEY=gsk_...
+# Optional override:
+export GROQ_MODEL=llama-3.3-70b-versatile
+# Or per-slot:
+export GROQ_REASONING_MODEL=llama-3.3-70b-versatile
+export GROQ_TOOLCALL_MODEL=llama-3.1-8b-instant
+```
+
+Uses Groq's OpenAI-compatible API at `https://api.groq.com/openai/v1`.
 
 ### Amazon Bedrock
 
@@ -446,5 +526,7 @@ OpenSRE caches LLM clients on first use. To switch providers within a single pro
 
 - Provider literals and defaults: [`config/config.py`](https://github.com/Tracer-Cloud/opensre/blob/main/config/config.py) (`LLMProvider`, `LLMSettings`).
 - Runtime routing: [`core/llm/llm_client.py`](https://github.com/Tracer-Cloud/opensre/blob/main/core/llm/llm_client.py) (`_create_llm_client`).
+- LiteLLM routing (when enabled): [`core/llm/litellm/routing.py`](https://github.com/Tracer-Cloud/opensre/blob/main/core/llm/litellm/routing.py).
+- Investigation tool-calling adapters: [`docs/investigation-tool-calling.md`](/investigation-tool-calling).
 - API-backed provider guide: [`core/llm/AGENTS.md`](https://github.com/Tracer-Cloud/opensre/blob/main/core/llm/AGENTS.md).
 - CLI-backed provider guide: [`integrations/llm_cli/AGENTS.md`](https://github.com/Tracer-Cloud/opensre/blob/main/integrations/llm_cli/AGENTS.md).

--- a/surfaces/cli/wizard/config.py
+++ b/surfaces/cli/wizard/config.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 from config.config import (
     ANTHROPIC_REASONING_MODEL,
+    AZURE_OPENAI_REASONING_MODEL,
     BEDROCK_REASONING_MODEL,
     DEEPSEEK_REASONING_MODEL,
     DEFAULT_OLLAMA_HOST,
@@ -58,6 +59,8 @@ class ProviderOption:
     #: unset, ``sync_provider_env`` falls back to replacing ``_REASONING_MODEL``
     #: with ``_CLASSIFICATION_MODEL`` in ``model_env``.
     classification_model_env: str | None = None
+    endpoint_env: str = ""
+    api_version_env: str = ""
     #: Human-readable name for the credential requested during onboarding. Most
     #: providers want an API key; Ollama wants a host URL. Used as the wizard
     #: prompt label, e.g. ``{label} {credential_label} ({api_key_env})``.
@@ -89,6 +92,8 @@ class ProviderOption:
                 self.classification_model_env,
                 spec.classification_model_env,
             ),
+            "endpoint_env": (self.endpoint_env, spec.endpoint_env),
+            "api_version_env": (self.api_version_env, spec.api_version_env),
             "credential_kind": (catalog_kind, spec.credential_kind),
             "allow_custom_models": (self.allow_custom_models, spec.allow_custom_models),
         }
@@ -190,6 +195,18 @@ GROQ_MODELS = (
     ModelOption(value="openai/gpt-oss-20b", label="GPT-OSS 20B"),
     ModelOption(value="qwen/qwen3-32b", label="Qwen3 32B"),
     ModelOption(value="meta-llama/llama-4-scout-17b-16e-instruct", label="Llama 4 Scout 17B"),
+)
+
+# Azure OpenAI model values are deployment names in your resource.
+AZURE_OPENAI_MODELS = (
+    ModelOption(value=AZURE_OPENAI_REASONING_MODEL, label="gpt-4.1 deployment"),
+    ModelOption(value="gpt-4.1-mini", label="gpt-4.1-mini deployment"),
+    ModelOption(value="gpt-4.1-nano", label="gpt-4.1-nano deployment"),
+    ModelOption(value="gpt-4o", label="gpt-4o deployment"),
+    ModelOption(value="gpt-4o-mini", label="gpt-4o-mini deployment"),
+    ModelOption(value="gpt-5", label="gpt-5 deployment"),
+    ModelOption(value="gpt-5-mini", label="gpt-5-mini deployment"),
+    ModelOption(value="o3-mini", label="o3-mini deployment"),
 )
 
 BEDROCK_MODELS = (
@@ -675,6 +692,22 @@ SUPPORTED_PROVIDERS = (
         legacy_model_env="GROQ_MODEL",
         toolcall_model_env="GROQ_TOOLCALL_MODEL",
         classification_model_env="GROQ_CLASSIFICATION_MODEL",
+        allow_custom_models=True,
+    ),
+    ProviderOption(
+        value="azure-openai",
+        label="Azure OpenAI",
+        group="Hosted providers",
+        api_key_env="AZURE_OPENAI_API_KEY",
+        model_env="AZURE_OPENAI_REASONING_MODEL",
+        default_model=AZURE_OPENAI_REASONING_MODEL,
+        models=AZURE_OPENAI_MODELS,
+        legacy_model_env="AZURE_OPENAI_MODEL",
+        toolcall_model_env="AZURE_OPENAI_TOOLCALL_MODEL",
+        classification_model_env="AZURE_OPENAI_CLASSIFICATION_MODEL",
+        endpoint_env="AZURE_OPENAI_BASE_URL",
+        api_version_env="AZURE_OPENAI_API_VERSION",
+        credential_default="https://your-resource.openai.azure.com",
         allow_custom_models=True,
     ),
     ProviderOption(

--- a/surfaces/cli/wizard/config.py
+++ b/surfaces/cli/wizard/config.py
@@ -198,14 +198,16 @@ GROQ_MODELS = (
 )
 
 # Azure OpenAI model values are deployment names in your resource.
+# Source: https://learn.microsoft.com/en-us/azure/ai-foundry/model-inference/concepts/models
 AZURE_OPENAI_MODELS = (
-    ModelOption(value=AZURE_OPENAI_REASONING_MODEL, label="gpt-4.1 deployment"),
-    ModelOption(value="gpt-4.1-mini", label="gpt-4.1-mini deployment"),
-    ModelOption(value="gpt-4.1-nano", label="gpt-4.1-nano deployment"),
-    ModelOption(value="gpt-4o", label="gpt-4o deployment"),
-    ModelOption(value="gpt-4o-mini", label="gpt-4o-mini deployment"),
-    ModelOption(value="gpt-5", label="gpt-5 deployment"),
+    ModelOption(value=AZURE_OPENAI_REASONING_MODEL, label="gpt-5.4-mini deployment"),
+    ModelOption(value="gpt-5.5", label="gpt-5.5 deployment"),
+    ModelOption(value="gpt-5.4", label="gpt-5.4 deployment"),
+    ModelOption(value="gpt-5.4-nano", label="gpt-5.4-nano deployment"),
     ModelOption(value="gpt-5-mini", label="gpt-5-mini deployment"),
+    ModelOption(value="gpt-5", label="gpt-5 deployment"),
+    ModelOption(value="gpt-4.1", label="gpt-4.1 deployment"),
+    ModelOption(value="gpt-4.1-mini", label="gpt-4.1-mini deployment"),
     ModelOption(value="o3-mini", label="o3-mini deployment"),
 )
 

--- a/surfaces/cli/wizard/env_sync.py
+++ b/surfaces/cli/wizard/env_sync.py
@@ -253,6 +253,10 @@ def _provider_specific_keys(p: ProviderOption) -> set[str]:
         keys.add(p.legacy_model_env)
     if p.toolcall_model_env:
         keys.add(p.toolcall_model_env)
+    if p.endpoint_env:
+        keys.add(p.endpoint_env)
+    if p.api_version_env:
+        keys.add(p.api_version_env)
     classification_env = _classification_model_env(p)
     if classification_env:
         keys.add(classification_env)
@@ -286,6 +290,7 @@ def sync_provider_env(
     toolcall_model: str | None = None,
     model_provider: ProviderOption | None = None,
     auth_method: str | None = None,
+    extra_env: dict[str, str] | None = None,
     env_path: Path | None = None,
 ) -> Path:
     """Write non-secret provider settings into the project .env.
@@ -335,6 +340,12 @@ def sync_provider_env(
         values[resolved_model_provider.legacy_model_env] = model
     if toolcall_model and resolved_model_provider.toolcall_model_env:
         values[resolved_model_provider.toolcall_model_env] = toolcall_model
+    if provider.value == "azure-openai":
+        from core.llm.transport_mode import LLM_TRANSPORT_ENV
+
+        values[LLM_TRANSPORT_ENV] = "litellm"
+    if extra_env:
+        values.update(extra_env)
 
     for key, value in values.items():
         lines = _set_env_value(lines, key, value)

--- a/surfaces/cli/wizard/env_sync.py
+++ b/surfaces/cli/wizard/env_sync.py
@@ -315,6 +315,9 @@ def sync_provider_env(
         keys_to_remove |= _provider_specific_keys(p)
 
     keys_to_remove.add(LLM_AUTH_METHOD_ENV)
+    from core.llm.transport_mode import LLM_TRANSPORT_ENV
+
+    keys_to_remove.add(LLM_TRANSPORT_ENV)
 
     # Keep the active provider's model keys but always remove API key entries
     # (API keys are persisted via the system keyring, not .env).
@@ -326,6 +329,11 @@ def sync_provider_env(
     classification_env = _classification_model_env(resolved_model_provider)
     if classification_env:
         active_non_secret.add(classification_env)
+    if provider.value == "azure-openai":
+        if provider.endpoint_env:
+            active_non_secret.add(provider.endpoint_env)
+        if provider.api_version_env:
+            active_non_secret.add(provider.api_version_env)
     keys_to_remove -= active_non_secret
 
     lines = _remove_keys(existing, keys_to_remove)
@@ -341,9 +349,11 @@ def sync_provider_env(
     if toolcall_model and resolved_model_provider.toolcall_model_env:
         values[resolved_model_provider.toolcall_model_env] = toolcall_model
     if provider.value == "azure-openai":
-        from core.llm.transport_mode import LLM_TRANSPORT_ENV
-
         values[LLM_TRANSPORT_ENV] = "litellm"
+        if provider.api_version_env:
+            from core.llm.azure_openai import resolve_azure_openai_api_version
+
+            values[provider.api_version_env] = resolve_azure_openai_api_version()
     if extra_env:
         values.update(extra_env)
 

--- a/surfaces/cli/wizard/env_sync.py
+++ b/surfaces/cli/wizard/env_sync.py
@@ -354,6 +354,13 @@ def sync_provider_env(
             from core.llm.azure_openai import resolve_azure_openai_api_version
 
             values[provider.api_version_env] = resolve_azure_openai_api_version()
+        if provider.endpoint_env:
+            preserved_base = (
+                _env_value_from_lines(lines, provider.endpoint_env)
+                or os.getenv(provider.endpoint_env, "").strip()
+            )
+            if preserved_base:
+                values[provider.endpoint_env] = preserved_base
     if extra_env:
         values.update(extra_env)
 

--- a/surfaces/cli/wizard/flow.py
+++ b/surfaces/cli/wizard/flow.py
@@ -224,10 +224,22 @@ def _credential_prompt_label(provider: ProviderOption) -> str:
     return provider.label
 
 
+def _azure_openai_endpoint_env(provider: ProviderOption) -> dict[str, str]:
+    """Return Azure endpoint env vars, using the default API version when unset."""
+    from core.llm.azure_openai import resolve_azure_openai_api_version
+
+    return {
+        provider.endpoint_env: os.getenv(provider.endpoint_env, "").strip(),
+        provider.api_version_env: resolve_azure_openai_api_version(),
+    }
+
+
 def _prompt_azure_openai_endpoint_settings(provider: ProviderOption) -> dict[str, str] | None:
-    """Collect Azure OpenAI endpoint settings during onboarding."""
-    from config.config import DEFAULT_AZURE_OPENAI_API_VERSION
-    from core.llm.azure_openai import normalize_azure_openai_base_url
+    """Collect Azure OpenAI resource URL during onboarding."""
+    from core.llm.azure_openai import (
+        normalize_azure_openai_base_url,
+        resolve_azure_openai_api_version,
+    )
 
     if not provider.endpoint_env or not provider.api_version_env:
         return {}
@@ -240,12 +252,6 @@ def _prompt_azure_openai_endpoint_settings(provider: ProviderOption) -> dict[str
             secret=False,
             back_on_cancel=True,
         )
-        api_version = _prompt_value(
-            f"Azure OpenAI API version ({provider.api_version_env})",
-            default=os.getenv(provider.api_version_env, DEFAULT_AZURE_OPENAI_API_VERSION),
-            secret=False,
-            back_on_cancel=True,
-        )
     except WizardBack:
         return None
 
@@ -253,13 +259,9 @@ def _prompt_azure_openai_endpoint_settings(provider: ProviderOption) -> dict[str
     if not normalized_base:
         _console.print(f"[{ERROR}]Azure OpenAI resource URL is required.[/]")
         return None
-    version = api_version.strip()
-    if not version:
-        _console.print(f"[{ERROR}]Azure OpenAI API version is required.[/]")
-        return None
     return {
         provider.endpoint_env: normalized_base,
-        provider.api_version_env: version,
+        provider.api_version_env: resolve_azure_openai_api_version(),
     }
 
 
@@ -270,10 +272,7 @@ def _ensure_azure_openai_endpoint_settings(provider: ProviderOption) -> dict[str
     if provider.value != "azure-openai":
         return {}
     if azure_openai_endpoint_configured():
-        return {
-            provider.endpoint_env: os.getenv(provider.endpoint_env, "").strip(),
-            provider.api_version_env: os.getenv(provider.api_version_env, "").strip(),
-        }
+        return _azure_openai_endpoint_env(provider)
     return _prompt_azure_openai_endpoint_settings(provider)
 
 

--- a/surfaces/cli/wizard/flow.py
+++ b/surfaces/cli/wizard/flow.py
@@ -224,6 +224,59 @@ def _credential_prompt_label(provider: ProviderOption) -> str:
     return provider.label
 
 
+def _prompt_azure_openai_endpoint_settings(provider: ProviderOption) -> dict[str, str] | None:
+    """Collect Azure OpenAI endpoint settings during onboarding."""
+    from config.config import DEFAULT_AZURE_OPENAI_API_VERSION
+    from core.llm.azure_openai import normalize_azure_openai_base_url
+
+    if not provider.endpoint_env or not provider.api_version_env:
+        return {}
+
+    _step("Azure endpoint")
+    try:
+        base_url = _prompt_value(
+            f"Azure OpenAI resource URL ({provider.endpoint_env})",
+            default=os.getenv(provider.endpoint_env, provider.credential_default),
+            secret=False,
+            back_on_cancel=True,
+        )
+        api_version = _prompt_value(
+            f"Azure OpenAI API version ({provider.api_version_env})",
+            default=os.getenv(provider.api_version_env, DEFAULT_AZURE_OPENAI_API_VERSION),
+            secret=False,
+            back_on_cancel=True,
+        )
+    except WizardBack:
+        return None
+
+    normalized_base = normalize_azure_openai_base_url(base_url)
+    if not normalized_base:
+        _console.print(f"[{ERROR}]Azure OpenAI resource URL is required.[/]")
+        return None
+    version = api_version.strip()
+    if not version:
+        _console.print(f"[{ERROR}]Azure OpenAI API version is required.[/]")
+        return None
+    return {
+        provider.endpoint_env: normalized_base,
+        provider.api_version_env: version,
+    }
+
+
+def _ensure_azure_openai_endpoint_settings(provider: ProviderOption) -> dict[str, str] | None:
+    """Return Azure endpoint env vars, prompting when missing."""
+    from core.llm.azure_openai import azure_openai_endpoint_configured
+
+    if provider.value != "azure-openai":
+        return {}
+    if azure_openai_endpoint_configured():
+        return {
+            provider.endpoint_env: os.getenv(provider.endpoint_env, "").strip(),
+            provider.api_version_env: os.getenv(provider.api_version_env, "").strip(),
+        }
+    return _prompt_azure_openai_endpoint_settings(provider)
+
+
 def _subscription_login_command(
     provider: ProviderOption, binary_path: str | None
 ) -> list[str] | None:
@@ -682,6 +735,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
     model_provider: ProviderOption
     auth_method: LLMAuthMethod | None
     model: str
+    provider_extra_env: dict[str, str] = {}
     while True:
         _step_header(2, WIZARD_TOTAL_STEPS, "LLM Provider")
         saved_provider = (
@@ -745,6 +799,12 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                     return 1
                 if not _persist_llm_api_key(provider.api_key_env, api_key):
                     return 1
+                azure_env = _ensure_azure_openai_endpoint_settings(provider)
+                if azure_env is None:
+                    force_repick = True
+                    continue
+                provider_extra_env = azure_env
+                os.environ.update(azure_env)
         else:
             assert saved_provider is not None
             provider = saved_provider
@@ -778,6 +838,12 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                         return 1
                     if not _persist_llm_api_key(provider.api_key_env, api_key):
                         return 1
+            azure_env = _ensure_azure_openai_endpoint_settings(provider)
+            if azure_env is None:
+                force_repick = True
+                continue
+            provider_extra_env = azure_env
+            os.environ.update(azure_env)
 
         if change_provider:
             try:
@@ -843,6 +909,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         model=model,
         model_provider=model_provider,
         auth_method=persisted_auth_method,
+        extra_env=provider_extra_env or None,
     )
 
     _step_header(3, WIZARD_TOTAL_STEPS, "Integrations")

--- a/surfaces/cli/wizard/validation.py
+++ b/surfaces/cli/wizard/validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Any
 
@@ -80,6 +81,54 @@ def _provider_validation_label(provider: ProviderOption) -> str:
     return provider.label
 
 
+def _check_azure_openai(
+    *,
+    api_key: str,
+    model: str,
+    base_url: str,
+    api_version: str,
+) -> ValidationResult:
+    """Validate Azure OpenAI credentials with a tiny chat completion."""
+    from core.llm.azure_openai import normalize_azure_openai_base_url
+
+    normalized_base = normalize_azure_openai_base_url(base_url)
+    if not normalized_base:
+        return ValidationResult(
+            ok=False,
+            detail="Azure OpenAI resource URL is missing. Set AZURE_OPENAI_BASE_URL.",
+        )
+    if not api_version.strip():
+        return ValidationResult(
+            ok=False,
+            detail="Azure OpenAI API version is missing. Set AZURE_OPENAI_API_VERSION.",
+        )
+
+    openai_client_cls, openai_auth_error = _load_openai_client()
+    azure_base = f"{normalized_base}/openai/deployments/{model}"
+    try:
+        client = openai_client_cls(
+            api_key=api_key,
+            base_url=azure_base,
+            default_query={"api-version": api_version.strip()},
+            timeout=30.0,
+        )
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "Reply with exactly: OpenSRE ready"}],
+            max_tokens=24,
+        )
+        sample_text = (response.choices[0].message.content or "").strip()
+        return ValidationResult(
+            ok=True,
+            detail="Azure OpenAI API key validated.",
+            sample_response=sample_text,
+        )
+    except openai_auth_error:
+        return ValidationResult(ok=False, detail="Azure OpenAI rejected the API key.")
+    except Exception as err:
+        return ValidationResult(ok=False, detail=f"Validation request failed: {err}")
+
+
 def _check_ollama(host: str, model: str) -> ValidationResult:
     """Check Ollama server connectivity and verify model responds to inference."""
     import httpx
@@ -138,6 +187,14 @@ def validate_provider_credentials(
     """Run a tiny live request against the selected provider."""
     if provider.value == "ollama":
         return _check_ollama(host=api_key, model=model)
+
+    if provider.value == "azure-openai":
+        return _check_azure_openai(
+            api_key=api_key,
+            model=model,
+            base_url=os.getenv(provider.endpoint_env, "").strip(),
+            api_version=os.getenv(provider.api_version_env, "").strip(),
+        )
 
     anthropic_client_cls, anthropic_auth_error = _load_anthropic_client()
     openai_client_cls, openai_auth_error = _load_openai_client()

--- a/surfaces/cli/wizard/validation.py
+++ b/surfaces/cli/wizard/validation.py
@@ -97,11 +97,9 @@ def _check_azure_openai(
             ok=False,
             detail="Azure OpenAI resource URL is missing. Set AZURE_OPENAI_BASE_URL.",
         )
-    if not api_version.strip():
-        return ValidationResult(
-            ok=False,
-            detail="Azure OpenAI API version is missing. Set AZURE_OPENAI_API_VERSION.",
-        )
+    from core.llm.azure_openai import resolve_azure_openai_api_version
+
+    resolved_api_version = resolve_azure_openai_api_version(api_version)
 
     openai_client_cls, openai_auth_error = _load_openai_client()
     azure_base = f"{normalized_base}/openai/deployments/{model}"
@@ -109,14 +107,18 @@ def _check_azure_openai(
         client = openai_client_cls(
             api_key=api_key,
             base_url=azure_base,
-            default_query={"api-version": api_version.strip()},
+            default_query={"api-version": resolved_api_version},
             timeout=30.0,
         )
-        response = client.chat.completions.create(
-            model=model,
-            messages=[{"role": "user", "content": "Reply with exactly: OpenSRE ready"}],
-            max_tokens=24,
-        )
+        request_kwargs: dict[str, object] = {
+            "model": model,
+            "messages": [{"role": "user", "content": "Reply with exactly: OpenSRE ready"}],
+        }
+        if model.startswith(("o1", "o3", "o4", "gpt-5")):
+            request_kwargs["max_completion_tokens"] = 24
+        else:
+            request_kwargs["max_tokens"] = 24
+        response = client.chat.completions.create(**request_kwargs)
         sample_text = (response.choices[0].message.content or "").strip()
         return ValidationResult(
             ok=True,

--- a/surfaces/interactive_shell/command_registry/model/switching.py
+++ b/surfaces/interactive_shell/command_registry/model/switching.py
@@ -91,8 +91,7 @@ def switch_llm_provider(
         if not azure_openai_endpoint_configured():
             console.print(
                 f"[{ERROR}]missing Azure OpenAI endpoint config:[/] "
-                "set AZURE_OPENAI_BASE_URL and AZURE_OPENAI_API_VERSION, "
-                "or run [bold]opensre onboard[/bold]."
+                "set AZURE_OPENAI_BASE_URL, or run [bold]opensre onboard[/bold]."
             )
             return False
     if provider.credential_secret and provider.api_key_env and not auth_status.configured:

--- a/surfaces/interactive_shell/command_registry/model/switching.py
+++ b/surfaces/interactive_shell/command_registry/model/switching.py
@@ -85,6 +85,16 @@ def switch_llm_provider(
     # provider has no credential path. Stale metadata gets a warning, because
     # confirming it requires an intentional request-time credential read.
     auth_status = credential_status(provider.value)
+    if provider.value == "azure-openai":
+        from core.llm.azure_openai import azure_openai_endpoint_configured
+
+        if not azure_openai_endpoint_configured():
+            console.print(
+                f"[{ERROR}]missing Azure OpenAI endpoint config:[/] "
+                "set AZURE_OPENAI_BASE_URL and AZURE_OPENAI_API_VERSION, "
+                "or run [bold]opensre onboard[/bold]."
+            )
+            return False
     if provider.credential_secret and provider.api_key_env and not auth_status.configured:
         console.print(
             f"[{ERROR}]missing credential for {provider.value}:[/] "

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -470,6 +470,33 @@ def test_sync_provider_env_sets_and_clears_azure_litellm_transport(
     assert os.environ["OPENSRE_LLM_TRANSPORT"] == "litellm"
 
 
+def test_sync_provider_env_preserves_azure_endpoint_on_model_switch(
+    tmp_path, monkeypatch
+) -> None:
+    env_path = tmp_path / ".env"
+    azure = PROVIDER_BY_VALUE["azure-openai"]
+    env_path.write_text(
+        "LLM_PROVIDER=azure-openai\n"
+        "OPENSRE_LLM_TRANSPORT=litellm\n"
+        "AZURE_OPENAI_BASE_URL=https://example.openai.azure.com\n"
+        "AZURE_OPENAI_API_VERSION=2024-10-21\n"
+        "AZURE_OPENAI_REASONING_MODEL=gpt-5.4-mini\n",
+        encoding="utf-8",
+    )
+
+    sync_provider_env(
+        provider=azure,
+        model="gpt-5.4",
+        env_path=env_path,
+    )
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "AZURE_OPENAI_BASE_URL=https://example.openai.azure.com\n" in content
+    assert "AZURE_OPENAI_API_VERSION=2024-10-21\n" in content
+    assert "AZURE_OPENAI_REASONING_MODEL=gpt-5.4\n" in content
+    assert os.environ["AZURE_OPENAI_BASE_URL"] == "https://example.openai.azure.com"
+
+
 @pytest.mark.skipif(_SKIP_AS_ROOT, reason="root bypasses file permission checks")
 def test_sync_provider_env_permission_error(tmp_path) -> None:
     env_path = tmp_path / ".env"

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -431,6 +431,45 @@ def test_sync_provider_env_writes_toolcall_model_atomically(tmp_path, monkeypatc
     assert os.environ["OPENAI_TOOLCALL_MODEL"] == "gpt-5.4-nano"
 
 
+def test_sync_provider_env_sets_and_clears_azure_litellm_transport(
+    tmp_path, monkeypatch
+) -> None:
+    env_path = tmp_path / ".env"
+    azure = PROVIDER_BY_VALUE["azure-openai"]
+    env_path.write_text(
+        "LLM_PROVIDER=anthropic\n"
+        "OPENSRE_LLM_TRANSPORT=litellm\n"
+        "AZURE_OPENAI_BASE_URL=https://example.openai.azure.com\n",
+        encoding="utf-8",
+    )
+
+    sync_provider_env(
+        provider=PROVIDER_BY_VALUE["openai"],
+        model="gpt-5.4-mini",
+        env_path=env_path,
+    )
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "LLM_PROVIDER=openai\n" in content
+    assert "OPENSRE_LLM_TRANSPORT=" not in content
+
+    sync_provider_env(
+        provider=azure,
+        model="gpt-5.4-mini",
+        extra_env={
+            "AZURE_OPENAI_BASE_URL": "https://example.openai.azure.com",
+            "AZURE_OPENAI_API_VERSION": "2024-10-21",
+        },
+        env_path=env_path,
+    )
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "LLM_PROVIDER=azure-openai\n" in content
+    assert "OPENSRE_LLM_TRANSPORT=litellm\n" in content
+    assert "AZURE_OPENAI_API_VERSION=2024-10-21\n" in content
+    assert os.environ["OPENSRE_LLM_TRANSPORT"] == "litellm"
+
+
 @pytest.mark.skipif(_SKIP_AS_ROOT, reason="root bypasses file permission checks")
 def test_sync_provider_env_permission_error(tmp_path) -> None:
     env_path = tmp_path / ".env"

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -431,9 +431,7 @@ def test_sync_provider_env_writes_toolcall_model_atomically(tmp_path, monkeypatc
     assert os.environ["OPENAI_TOOLCALL_MODEL"] == "gpt-5.4-nano"
 
 
-def test_sync_provider_env_sets_and_clears_azure_litellm_transport(
-    tmp_path, monkeypatch
-) -> None:
+def test_sync_provider_env_sets_and_clears_azure_litellm_transport(tmp_path, monkeypatch) -> None:
     env_path = tmp_path / ".env"
     azure = PROVIDER_BY_VALUE["azure-openai"]
     env_path.write_text(
@@ -470,9 +468,7 @@ def test_sync_provider_env_sets_and_clears_azure_litellm_transport(
     assert os.environ["OPENSRE_LLM_TRANSPORT"] == "litellm"
 
 
-def test_sync_provider_env_preserves_azure_endpoint_on_model_switch(
-    tmp_path, monkeypatch
-) -> None:
+def test_sync_provider_env_preserves_azure_endpoint_on_model_switch(tmp_path, monkeypatch) -> None:
     env_path = tmp_path / ".env"
     azure = PROVIDER_BY_VALUE["azure-openai"]
     env_path.write_text(

--- a/tests/core/runtime/llm/test_azure_openai_routing.py
+++ b/tests/core/runtime/llm/test_azure_openai_routing.py
@@ -15,9 +15,9 @@ def _azure_settings() -> SimpleNamespace:
         provider="azure-openai",
         azure_openai_base_url="https://example.openai.azure.com/",
         azure_openai_api_version="2024-10-21",
-        azure_openai_reasoning_model="gpt-4.1",
-        azure_openai_classification_model="gpt-4o-mini",
-        azure_openai_toolcall_model="gpt-4o-mini",
+        azure_openai_reasoning_model="gpt-5.4-mini",
+        azure_openai_classification_model="gpt-5.4-mini",
+        azure_openai_toolcall_model="gpt-5.4-nano",
     )
 
 
@@ -25,7 +25,7 @@ def test_build_litellm_agent_client_for_azure_openai() -> None:
     client = build_litellm_agent_client(_azure_settings(), "azure-openai")
 
     assert isinstance(client, LiteLLMAgentClient)
-    assert client._litellm_model == "azure/gpt-4.1"
+    assert client._litellm_model == "azure/gpt-5.4-mini"
     assert client._api_base == "https://example.openai.azure.com"
     assert client._api_version == "2024-10-21"
     assert client._api_key_env == "AZURE_OPENAI_API_KEY"
@@ -39,10 +39,10 @@ def test_build_litellm_llm_client_for_azure_openai() -> None:
     )
 
     assert isinstance(client, LiteLLMLLMClient)
-    assert client._litellm_model == "azure/gpt-4.1"
+    assert client._litellm_model == "azure/gpt-5.4-mini"
     assert client._api_base == "https://example.openai.azure.com"
     assert client._api_version == "2024-10-21"
-    assert client._model_fallback == "azure/gpt-4o-mini"
+    assert client._model_fallback == "azure/gpt-5.4-nano"
 
 
 def test_azure_openai_requires_base_url_in_settings() -> None:

--- a/tests/core/runtime/llm/test_azure_openai_routing.py
+++ b/tests/core/runtime/llm/test_azure_openai_routing.py
@@ -1,0 +1,52 @@
+"""Azure OpenAI LiteLLM routing tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from core.llm.litellm.clients import LiteLLMAgentClient, LiteLLMLLMClient
+from core.llm.litellm.routing import build_litellm_agent_client, build_litellm_llm_client
+
+
+def _azure_settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        provider="azure-openai",
+        azure_openai_base_url="https://example.openai.azure.com/",
+        azure_openai_api_version="2024-10-21",
+        azure_openai_reasoning_model="gpt-4.1",
+        azure_openai_classification_model="gpt-4o-mini",
+        azure_openai_toolcall_model="gpt-4o-mini",
+    )
+
+
+def test_build_litellm_agent_client_for_azure_openai() -> None:
+    client = build_litellm_agent_client(_azure_settings(), "azure-openai")
+
+    assert isinstance(client, LiteLLMAgentClient)
+    assert client._litellm_model == "azure/gpt-4.1"
+    assert client._api_base == "https://example.openai.azure.com"
+    assert client._api_version == "2024-10-21"
+    assert client._api_key_env == "AZURE_OPENAI_API_KEY"
+
+
+def test_build_litellm_llm_client_for_azure_openai() -> None:
+    client = build_litellm_llm_client(
+        _azure_settings(),
+        "azure-openai",
+        "reasoning",
+    )
+
+    assert isinstance(client, LiteLLMLLMClient)
+    assert client._litellm_model == "azure/gpt-4.1"
+    assert client._api_base == "https://example.openai.azure.com"
+    assert client._api_version == "2024-10-21"
+    assert client._model_fallback == "azure/gpt-4o-mini"
+
+
+def test_azure_openai_requires_base_url_in_settings() -> None:
+    settings = _azure_settings()
+    settings.azure_openai_base_url = ""
+    with pytest.raises(RuntimeError, match="AZURE_OPENAI_BASE_URL"):
+        build_litellm_agent_client(settings, "azure-openai")

--- a/tests/core/runtime/llm/test_llm_client_cache.py
+++ b/tests/core/runtime/llm/test_llm_client_cache.py
@@ -1,0 +1,55 @@
+"""LLM singleton cache invalidation tests."""
+
+from __future__ import annotations
+
+from core.llm import agent_llm_client, llm_client
+
+
+def test_llm_singleton_invalidates_on_provider_change(monkeypatch) -> None:
+    created: list[object] = []
+
+    def fake_create(*, model_type: str) -> object:
+        marker = object()
+        created.append(marker)
+        return marker
+
+    monkeypatch.setattr(llm_client, "_create_llm_client", fake_create)
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+    llm_client.reset_llm_singletons()
+
+    first = llm_client.get_llm_for_reasoning()
+    monkeypatch.setenv("LLM_PROVIDER", "azure-openai")
+    monkeypatch.setenv("AZURE_OPENAI_BASE_URL", "https://example.openai.azure.com")
+    second = llm_client.get_llm_for_reasoning()
+
+    assert first is not second
+    assert len(created) == 2
+
+
+def test_agent_singleton_invalidates_on_provider_change(monkeypatch) -> None:
+    created: list[object] = []
+
+    class _StubAgentClient:
+        pass
+
+    def fake_build(_settings: object, provider: str) -> _StubAgentClient:
+        client = _StubAgentClient()
+        created.append(client)
+        return client
+
+    monkeypatch.setattr(
+        "core.llm.litellm.routing.build_litellm_agent_client",
+        fake_build,
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "azure-openai")
+    monkeypatch.setenv("AZURE_OPENAI_BASE_URL", "https://example.openai.azure.com")
+    agent_llm_client.reset_agent_client()
+
+    first = agent_llm_client.get_agent_llm()
+    monkeypatch.setenv("LLM_PROVIDER", "deepseek")
+    monkeypatch.setenv("DEEPSEEK_REASONING_MODEL", "deepseek-v4-pro")
+    monkeypatch.setenv("OPENSRE_LLM_TRANSPORT", "litellm")
+    second = agent_llm_client.get_agent_llm()
+
+    assert first is not second
+    assert len(created) == 2


### PR DESCRIPTION
Fixes #3631

#### Describe the changes you have made in this PR -

- Add first-class `azure-openai` LLM provider routed through LiteLLM (`azure/<deployment>` model IDs).
- Introduce `use_litellm_for_provider()` so Azure always uses LiteLLM while other providers stay on native SDKs unless `OPENSRE_LLM_TRANSPORT=litellm`.
- Wire onboarding (`opensre onboard`), credential validation, REPL `/model` switching, and `.env.example` for Azure resource URL, API version, and deployment names.
- Document LiteLLM transport, supported provider matrix, Azure OpenAI setup, and env vars in `docs/llm-providers.mdx` and `docs/configuration/environment-variables.mdx`.
- Add routing tests for Azure OpenAI LiteLLM client construction.

### Demo/Screenshot for feature changes and bug fixes -
Terminal test run:

```
uv run python -m pytest tests/core/runtime/llm/test_azure_openai_routing.py -q
# 3 passed
```

Example env after onboard:

```bash
LLM_PROVIDER=azure-openai
OPENSRE_LLM_TRANSPORT=litellm
AZURE_OPENAI_BASE_URL=https://your-resource.openai.azure.com
AZURE_OPENAI_API_VERSION=2024-10-21
AZURE_OPENAI_REASONING_MODEL=gpt-4.1
AZURE_OPENAI_TOOLCALL_MODEL=gpt-4o-mini
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Azure OpenAI differs from other OpenAI-compatible providers: models are deployment names scoped to a resource URL and API version. Rather than a generic custom endpoint, we added a dedicated `azure-openai` provider slug that always routes through the existing `LiteLLMAgentClient` / `LiteLLMLLMClient` stack. Small helpers in `core/llm/azure_openai.py` normalize the resource URL and resolve LiteLLM kwargs; routing lives in `core/llm/litellm/routing.py`. Onboarding prompts for base URL and API version, sets `OPENSRE_LLM_TRANSPORT=litellm`, and validates credentials with a tiny chat completion against the deployment. Alternative considered: a generic `custom-openai` provider — rejected in favor of explicit Azure env vars and wizard UX matching other first-class providers.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
