### PR TITLE
feat(analytics): enrich investigation failure telemetry for PostHog

### DIFF
--- a/core/agent_harness/session/background.py
+++ b/core/agent_harness/session/background.py
@@ -11,6 +11,7 @@ class BackgroundInvestigationRecord:
     task_id: str
     status: str
     command: str
+    investigation_id: str = ""
     root_cause: str = ""
     top_analysis: tuple[str, ...] = ()
     next_steps: tuple[str, ...] = ()

--- a/core/agent_harness/session/state.py
+++ b/core/agent_harness/session/state.py
@@ -104,6 +104,9 @@ class Session:
     last_state: dict[str, Any] | None = None
     """The final AgentState from the most recent investigation, used by follow-ups."""
 
+    last_investigation_id: str = ""
+    """Most recent investigation lifecycle id for joining terminal turns to PostHog."""
+
     last_assistant_intent: str | None = None
     """Intent label set by the runtime after each handled turn.
 

--- a/platform/analytics/cli.py
+++ b/platform/analytics/cli.py
@@ -8,7 +8,7 @@ from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Final
+from typing import TYPE_CHECKING, Final
 from uuid import uuid4
 
 from platform.analytics.events import Event
@@ -20,6 +20,9 @@ from platform.analytics.source import (
     build_source_properties,
 )
 from platform.observability.sentry_sdk import capture_exception
+
+if TYPE_CHECKING:
+    from core.agent_harness.session import Session
 
 EVAL_AND_TERMINAL_KPI_QUERIES: Final[dict[str, str]] = {
     "eval_pass_rate": """
@@ -530,7 +533,7 @@ def track_investigation(
     evaluate_requested: bool = False,
     investigation_id: str | None = None,
     investigation_target: str | None = None,
-    session: object | None = None,
+    session: Session | None = None,
 ) -> Generator[InvestigationTracker]:
     """Capture investigation lifecycle once, with nested-call dedupe."""
     depth = _INVESTIGATION_TRACKING_DEPTH.get()
@@ -548,7 +551,7 @@ def track_investigation(
         if investigation_target:
             shared_properties["investigation_target"] = investigation_target
         if session is not None:
-            setattr(session, "last_investigation_id", resolved_id)
+            session.last_investigation_id = resolved_id
         _capture(
             Event.INVESTIGATION_STARTED,
             _investigation_started_properties(

--- a/platform/analytics/cli.py
+++ b/platform/analytics/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import traceback
 from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -207,10 +208,63 @@ def _investigation_failed_properties(
     *,
     shared_properties: Properties,
     failure_type: str | None = None,
+    failure_message: str | None = None,
+    failure_detail: str | None = None,
+    failure_category: str | None = None,
+    integration_involved: str | None = None,
+    integration_failure_message: str | None = None,
+    investigation_target: str | None = None,
 ) -> Properties:
     properties: Properties = {**shared_properties}
     if failure_type:
         properties["failure_type"] = failure_type
+    if failure_message:
+        properties["failure_message"] = failure_message
+    if failure_detail:
+        properties["failure_detail"] = failure_detail
+    if failure_category:
+        properties["failure_category"] = failure_category
+    if integration_involved:
+        properties["integration_involved"] = integration_involved
+    if integration_failure_message:
+        properties["integration_failure_message"] = integration_failure_message
+    if investigation_target:
+        properties["investigation_target"] = investigation_target
+    return properties
+
+
+def _investigation_outcome_properties(
+    *,
+    investigation_id: str,
+    status: str,
+    investigation_target: str,
+    root_cause_excerpt: str = "",
+    error_excerpt: str = "",
+    failure_category: str | None = None,
+    integration_involved: str | None = None,
+    integration_failure_message: str | None = None,
+    failure_detail: str | None = None,
+) -> Properties:
+    properties: Properties = {
+        "investigation_id": investigation_id,
+        "status": status,
+        "investigation_target": investigation_target,
+    }
+    if root_cause_excerpt:
+        properties["root_cause_excerpt"] = root_cause_excerpt
+    if error_excerpt:
+        properties["error_excerpt"] = error_excerpt
+    if failure_category:
+        properties["failure_category"] = failure_category
+    if integration_involved:
+        properties["integration_involved"] = integration_involved
+    if integration_failure_message:
+        properties["integration_failure_message"] = integration_failure_message
+    if failure_detail:
+        properties["failure_detail"] = failure_detail
+    session_id = get_cli_session_id()
+    if session_id:
+        properties["cli_session_id"] = session_id
     return properties
 
 
@@ -389,27 +443,80 @@ def capture_investigation_failed(
     *,
     tracker: InvestigationTracker | None = None,
     failure_type: str | None = None,
+    failure_message: str | None = None,
+    failure_detail: str | None = None,
+    failure_category: str | None = None,
+    integration_involved: str | None = None,
+    integration_failure_message: str | None = None,
+    investigation_target: str | None = None,
+    shared_properties: Properties | None = None,
 ) -> None:
+    props = _investigation_failed_properties(
+        shared_properties=shared_properties or (tracker.shared_properties if tracker else {}),
+        failure_type=failure_type,
+        failure_message=failure_message,
+        failure_detail=failure_detail,
+        failure_category=failure_category,
+        integration_involved=integration_involved,
+        integration_failure_message=integration_failure_message,
+        investigation_target=investigation_target,
+    )
     if tracker is None:
-        _capture(
-            Event.INVESTIGATION_FAILED,
-            _investigation_failed_properties(
-                shared_properties={},
-                failure_type=failure_type,
-            ),
-        )
+        _capture(Event.INVESTIGATION_FAILED, props)
         return
     if tracker.failed or not tracker.enabled:
         tracker.failed = True
         return
+    _capture(Event.INVESTIGATION_FAILED, props)
+    tracker.failed = True
+
+
+def capture_investigation_cancelled(
+    *,
+    investigation_id: str,
+    investigation_target: str = "",
+    tracker: InvestigationTracker | None = None,
+) -> None:
+    shared = tracker.shared_properties if tracker is not None and tracker.enabled else {}
+    if investigation_id and not shared.get("investigation_id"):
+        shared = {**shared, "investigation_id": investigation_id}
+    properties: Properties = {
+        **shared,
+        "failure_category": "user_cancelled",
+    }
+    if investigation_target:
+        properties["investigation_target"] = investigation_target
+    _capture(Event.INVESTIGATION_CANCELLED, properties)
+
+
+def capture_investigation_outcome(
+    *,
+    investigation_id: str,
+    status: str,
+    investigation_target: str,
+    root_cause_excerpt: str = "",
+    error_excerpt: str = "",
+    failure_category: str | None = None,
+    integration_involved: str | None = None,
+    integration_failure_message: str | None = None,
+    failure_detail: str | None = None,
+) -> None:
+    if not investigation_id:
+        return
     _capture(
-        Event.INVESTIGATION_FAILED,
-        _investigation_failed_properties(
-            shared_properties=tracker.shared_properties,
-            failure_type=failure_type,
+        Event.INVESTIGATION_OUTCOME,
+        _investigation_outcome_properties(
+            investigation_id=investigation_id,
+            status=status,
+            investigation_target=investigation_target,
+            root_cause_excerpt=root_cause_excerpt,
+            error_excerpt=error_excerpt,
+            failure_category=failure_category,
+            integration_involved=integration_involved,
+            integration_failure_message=integration_failure_message,
+            failure_detail=failure_detail,
         ),
     )
-    tracker.failed = True
 
 
 @contextmanager
@@ -422,6 +529,8 @@ def track_investigation(
     interactive: bool = False,
     evaluate_requested: bool = False,
     investigation_id: str | None = None,
+    investigation_target: str | None = None,
+    session: object | None = None,
 ) -> Generator[InvestigationTracker]:
     """Capture investigation lifecycle once, with nested-call dedupe."""
     depth = _INVESTIGATION_TRACKING_DEPTH.get()
@@ -430,11 +539,16 @@ def track_investigation(
     if depth > 0:
         tracker = InvestigationTracker(shared_properties={}, enabled=False)
     else:
+        resolved_id = investigation_id or str(uuid4())
         shared_properties = build_source_properties(
             entrypoint=entrypoint,
             trigger_mode=trigger_mode,
-            investigation_id=investigation_id or str(uuid4()),
+            investigation_id=resolved_id,
         )
+        if investigation_target:
+            shared_properties["investigation_target"] = investigation_target
+        if session is not None:
+            setattr(session, "last_investigation_id", resolved_id)
         _capture(
             Event.INVESTIGATION_STARTED,
             _investigation_started_properties(
@@ -451,9 +565,14 @@ def track_investigation(
         yielded = tracker
         yield yielded
     except Exception as exc:
+        failure_message = str(exc).strip()[:500]
+        failure_detail = "".join(traceback.format_exception_only(exc)).strip()[:500]
         capture_investigation_failed(
             tracker=yielded,
             failure_type=type(exc).__name__,
+            failure_message=failure_message or type(exc).__name__,
+            failure_detail=failure_detail or None,
+            investigation_target=investigation_target,
         )
         raise
     else:

--- a/platform/analytics/events.py
+++ b/platform/analytics/events.py
@@ -25,6 +25,8 @@ class Event(StrEnum):
     INVESTIGATION_STARTED = "investigation_started"
     INVESTIGATION_COMPLETED = "investigation_completed"
     INVESTIGATION_FAILED = "investigation_failed"
+    INVESTIGATION_CANCELLED = "investigation_cancelled"
+    INVESTIGATION_OUTCOME = "investigation_outcome"
     INVESTIGATION_FIRST_HYPOTHESIS_RENDERED = "investigation_first_hypothesis_rendered"
     INVESTIGATION_ABANDONED = "investigation_abandoned"
     INVESTIGATION_FEEDBACK_SUBMITTED = "investigation_feedback_submitted"

--- a/surfaces/interactive_shell/command_registry/investigation.py
+++ b/surfaces/interactive_shell/command_registry/investigation.py
@@ -224,6 +224,7 @@ def _cmd_investigate_file(session: Session, console: Console, args: list[str]) -
                 session=session,
                 console=console,
                 display_command=f"/investigate {template_name}",
+                investigation_target=target_slug,
             )
             session.record(
                 "alert",
@@ -283,13 +284,14 @@ def _cmd_investigate_file(session: Session, console: Console, args: list[str]) -
         return True
 
     if session.background_mode_enabled:
+        target_slug = normalize_investigation_target(raw_target, path=path)
         start_background_text_investigation(
             alert_text=text,
             session=session,
             console=console,
             display_command=f"/investigate {path}",
+            investigation_target=target_slug,
         )
-        target_slug = normalize_investigation_target(raw_target, path=path)
         session.record(
             "alert",
             args[0],

--- a/surfaces/interactive_shell/command_registry/investigation.py
+++ b/surfaces/interactive_shell/command_registry/investigation.py
@@ -28,8 +28,18 @@ from surfaces.interactive_shell.ui.components.choice_menu import (
     repl_tty_interactive,
 )
 from surfaces.interactive_shell.ui.foreground_investigation import run_foreground_investigation
+from surfaces.interactive_shell.ui.investigation_outcome import (
+    InvestigationOutcome,
+    normalize_investigation_target,
+)
 from surfaces.interactive_shell.utils.error_handling.exception_reporting import report_exception
-from surfaces.interactive_shell.utils.telemetry.turn_outcome import format_investigation_outcome
+from surfaces.interactive_shell.utils.telemetry.investigation_analytics import (
+    publish_investigation_outcome_analytics,
+)
+from surfaces.interactive_shell.utils.telemetry.turn_outcome import (
+    format_investigation_outcome,
+    format_investigation_terminal_outcome,
+)
 
 
 def _interactive_template_menu(session: Session, console: Console) -> bool:
@@ -145,6 +155,34 @@ def _validate_save_args(args: list[str]) -> str | None:
     return None
 
 
+def _record_investigation_turn(
+    session: Session,
+    *,
+    command_line: str,
+    outcome: InvestigationOutcome,
+) -> None:
+    ok = outcome.status == "completed"
+    response_text = format_investigation_terminal_outcome(
+        command_line,
+        target=outcome.target,
+        ok=ok,
+        final_state=outcome.final_state,
+        error_message=outcome.error_message,
+        status=outcome.status,
+    )
+    session.record(
+        "alert",
+        command_line,
+        ok=ok,
+        response_text=response_text,
+    )
+    if not ok:
+        session.mark_latest(ok=False, kind="slash")
+    if outcome.investigation_id:
+        session.last_investigation_id = outcome.investigation_id
+    publish_investigation_outcome_analytics(outcome)
+
+
 def _cmd_investigate_file(session: Session, console: Console, args: list[str]) -> bool:
     from platform.analytics.cli import track_investigation
     from platform.analytics.source import EntrypointSource, TriggerMode
@@ -179,6 +217,7 @@ def _cmd_investigate_file(session: Session, console: Console, args: list[str]) -
     # in the working directory. Users can still force file mode with an explicit
     # path form (for example: ``/investigate ./generic``).
     if template_name:
+        target_slug = normalize_investigation_target(template_name)
         if session.background_mode_enabled:
             start_background_template_investigation(
                 template_name=template_name,
@@ -190,7 +229,7 @@ def _cmd_investigate_file(session: Session, console: Console, args: list[str]) -
                 "alert",
                 f"/investigate {template_name}",
                 response_text=format_investigation_outcome(
-                    template_name,
+                    target_slug,
                     background=True,
                 ),
             )
@@ -203,6 +242,8 @@ def _cmd_investigate_file(session: Session, console: Console, args: list[str]) -
                     trigger_mode=TriggerMode.FILE,
                     input_path=f"template:{template_name}",
                     interactive=True,
+                    session=session,
+                    investigation_target=target_slug,
                 ),
                 apply_reasoning_effort(session.reasoning_effort),
             ):
@@ -215,28 +256,16 @@ def _cmd_investigate_file(session: Session, console: Console, args: list[str]) -
                     cancel_requested=task.cancel_requested,
                 )
 
-        final_state = run_foreground_investigation(
+        command_line = f"/investigate {template_name}"
+        outcome = run_foreground_investigation(
             session=session,
             console=console,
-            task_command=f"/investigate {template_name}",
+            task_command=command_line,
             run=_run_template,
             exception_context="surfaces.interactive_shell.investigate_template",
+            target=target_slug,
         )
-        if final_state is None:
-            session.record(
-                "alert",
-                f"/investigate {template_name}",
-                ok=False,
-                response_text=format_investigation_outcome(template_name),
-            )
-            session.mark_latest(ok=False, kind="slash")
-            return True
-
-        session.record(
-            "alert",
-            f"/investigate {template_name}",
-            response_text=format_investigation_outcome(template_name, final_state=final_state),
-        )
+        _record_investigation_turn(session, command_line=command_line, outcome=outcome)
         return True
 
     path = resolve_alert_path(raw_target)
@@ -260,12 +289,15 @@ def _cmd_investigate_file(session: Session, console: Console, args: list[str]) -
             console=console,
             display_command=f"/investigate {path}",
         )
+        target_slug = normalize_investigation_target(raw_target, path=path)
         session.record(
             "alert",
             args[0],
-            response_text=format_investigation_outcome(str(path), background=True),
+            response_text=format_investigation_outcome(target_slug, background=True),
         )
         return True
+
+    target_slug = normalize_investigation_target(raw_target, path=path)
 
     def _run_file(task: TaskRecord) -> dict[str, object]:
         with (
@@ -274,6 +306,8 @@ def _cmd_investigate_file(session: Session, console: Console, args: list[str]) -
                 trigger_mode=TriggerMode.FILE,
                 input_path=str(path),
                 interactive=True,
+                session=session,
+                investigation_target=target_slug,
             ),
             apply_reasoning_effort(session.reasoning_effort),
         ):
@@ -286,28 +320,16 @@ def _cmd_investigate_file(session: Session, console: Console, args: list[str]) -
                 cancel_requested=task.cancel_requested,
             )
 
-    final_state = run_foreground_investigation(
+    command_line = f"/investigate {raw_target}"
+    outcome = run_foreground_investigation(
         session=session,
         console=console,
         task_command=f"/investigate {path}",
         run=_run_file,
         exception_context="surfaces.interactive_shell.investigate_file",
+        target=target_slug,
     )
-    if final_state is None:
-        session.record(
-            "alert",
-            args[0],
-            ok=False,
-            response_text=format_investigation_outcome(raw_target),
-        )
-        session.mark_latest(ok=False, kind="slash")
-        return True
-
-    session.record(
-        "alert",
-        f"/investigate {raw_target}",
-        response_text=format_investigation_outcome(raw_target, final_state=final_state),
-    )
+    _record_investigation_turn(session, command_line=command_line, outcome=outcome)
     return True
 
 

--- a/surfaces/interactive_shell/runtime/background/runner.py
+++ b/surfaces/interactive_shell/runtime/background/runner.py
@@ -6,11 +6,14 @@ import threading
 from collections.abc import Callable
 from contextlib import nullcontext
 from typing import Any
+from uuid import uuid4
 
 from prompt_toolkit.patch_stdout import patch_stdout
 from rich.console import Console
 from rich.markup import escape
 
+from platform.analytics.cli import track_investigation
+from platform.analytics.source import EntrypointSource, TriggerMode
 from platform.common.errors import OpenSREError
 from surfaces.interactive_shell.runtime import (
     BackgroundInvestigationRecord,
@@ -43,11 +46,13 @@ def _build_record(
     *,
     task_id: str,
     command: str,
+    investigation_id: str,
 ) -> BackgroundInvestigationRecord:
     return BackgroundInvestigationRecord(
         task_id=task_id,
         status="running",
         command=command,
+        investigation_id=investigation_id,
     )
 
 
@@ -97,18 +102,32 @@ def _start_background_investigation(
     display_command: str,
     run_fn: BackgroundRunFn,
     kwargs: dict[str, Any],
+    investigation_target: str = "",
+    input_path: str | None = None,
 ) -> str:
+    investigation_id = str(uuid4())
+    session.last_investigation_id = investigation_id
     task = session.task_registry.create(TaskKind.INVESTIGATION, command=display_command)
     task.mark_running()
     record = _build_record(
         task_id=task.task_id,
         command=display_command,
+        investigation_id=investigation_id,
     )
     session.background_investigations[task.task_id] = record
 
     def _worker() -> None:
         try:
-            final_state = run_fn(cancel_requested=task.cancel_requested, **kwargs)
+            with track_investigation(
+                entrypoint=EntrypointSource.CLI_REPL_FILE,
+                trigger_mode=TriggerMode.FILE,
+                input_path=input_path,
+                interactive=True,
+                investigation_id=investigation_id,
+                investigation_target=investigation_target or None,
+                session=session,
+            ):
+                final_state = run_fn(cancel_requested=task.cancel_requested, **kwargs)
             root = str(final_state.get("root_cause") or "")
             record.status = "completed"
             record.root_cause = root
@@ -170,6 +189,7 @@ def start_background_text_investigation(
     session: Session,
     console: Console,
     display_command: str = "background free-text investigation",
+    investigation_target: str = "",
 ) -> str:
     from surfaces.cli.investigation import run_investigation_for_session_background
 
@@ -182,6 +202,8 @@ def start_background_text_investigation(
             "alert_text": alert_text,
             "context_overrides": session.accumulated_context or None,
         },
+        investigation_target=investigation_target,
+        input_path=display_command,
     )
 
 
@@ -191,6 +213,7 @@ def start_background_template_investigation(
     session: Session,
     console: Console,
     display_command: str,
+    investigation_target: str = "",
 ) -> str:
     from surfaces.cli.investigation import run_sample_alert_for_session_background
 
@@ -203,4 +226,6 @@ def start_background_template_investigation(
             "template_name": template_name,
             "context_overrides": session.accumulated_context or None,
         },
+        investigation_target=investigation_target,
+        input_path=f"template:{template_name}",
     )

--- a/surfaces/interactive_shell/ui/foreground_investigation.py
+++ b/surfaces/interactive_shell/ui/foreground_investigation.py
@@ -35,6 +35,7 @@ def run_foreground_investigation(
 ) -> InvestigationOutcome:
     """Run one foreground investigation with shared task and error handling."""
     normalized_target = normalize_investigation_target(target)
+    session.last_investigation_id = ""
     task = session.task_registry.create(TaskKind.INVESTIGATION, command=task_command)
     task.mark_running()
     try:

--- a/surfaces/interactive_shell/ui/foreground_investigation.py
+++ b/surfaces/interactive_shell/ui/foreground_investigation.py
@@ -11,6 +11,13 @@ from rich.markup import escape
 from platform.common.errors import OpenSREError
 from platform.common.task_types import TaskKind, TaskRecord
 from platform.terminal.theme import ERROR, WARNING
+from surfaces.interactive_shell.ui.investigation_outcome import (
+    InvestigationOutcome,
+    classify_investigation_failure,
+    failure_detail_from_exception,
+    normalize_investigation_target,
+    user_facing_error_message,
+)
 from surfaces.interactive_shell.utils.error_handling.exception_reporting import report_exception
 
 if TYPE_CHECKING:
@@ -24,12 +31,10 @@ def run_foreground_investigation(
     task_command: str,
     run: Callable[[TaskRecord], dict[str, Any]],
     exception_context: str,
-) -> dict[str, Any] | None:
-    """Run one foreground investigation with shared task and error handling.
-
-    Returns the investigation final state on success, or ``None`` when the run
-    was cancelled or failed.
-    """
+    target: str = "",
+) -> InvestigationOutcome:
+    """Run one foreground investigation with shared task and error handling."""
+    normalized_target = normalize_investigation_target(target)
     task = session.task_registry.create(TaskKind.INVESTIGATION, command=task_command)
     task.mark_running()
     try:
@@ -37,47 +42,62 @@ def run_foreground_investigation(
     except KeyboardInterrupt:
         task.mark_cancelled()
         console.print(f"[{WARNING}]investigation cancelled.[/]")
-        return None
+        return InvestigationOutcome(
+            status="cancelled",
+            target=normalized_target,
+            investigation_id=str(getattr(session, "last_investigation_id", "") or ""),
+            failure_category="user_cancelled",
+        )
     except OpenSREError as exc:
         task.mark_failed(str(exc))
         console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
         if exc.suggestion:
             console.print(f"[{WARNING}]suggestion:[/] {escape(exc.suggestion)}")
-        return None
+        category, integration, integration_detail = classify_investigation_failure(exc)
+        return InvestigationOutcome(
+            status="failed",
+            target=normalized_target,
+            investigation_id=str(getattr(session, "last_investigation_id", "") or ""),
+            error_message=user_facing_error_message(exc),
+            error_detail=failure_detail_from_exception(exc),
+            failure_category=category,
+            integration_involved=integration,
+            integration_failure_message=integration_detail,
+        )
     except Exception as exc:
         task.mark_failed(str(exc))
         report_exception(exc, context=exception_context)
         console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
-        return None
+        category, integration, integration_detail = classify_investigation_failure(exc)
+        return InvestigationOutcome(
+            status="failed",
+            target=normalized_target,
+            investigation_id=str(getattr(session, "last_investigation_id", "") or ""),
+            error_message=user_facing_error_message(exc),
+            error_detail=failure_detail_from_exception(exc),
+            failure_category=category,
+            integration_involved=integration,
+            integration_failure_message=integration_detail,
+        )
 
     root = final_state.get("root_cause")
     task.mark_completed(result=str(root) if root is not None else "")
     session.apply_investigation_result(final_state, trigger=task_command)
 
-    # Mirror the standalone CLI (run_investigation_cli_streaming): show the
-    # blocking RCA-accuracy feedback menu after the report. Pass console=None so
-    # the cursor-safe _run_select (per-line erase) is used instead of
-    # repl_choose_one, whose block-erase is unstable after Rich Live streaming.
-    #
-    # Safety check: only read stdin when prompt_async is NOT running.
-    # When the investigation was dispatched without exclusive stdin (e.g. an
-    # LLM-agent free-text message), prompt_async is already active and its
-    # Application periodically sends ESC[6n CPR queries. Those terminal responses
-    # (ESC[row;colR) arrive in stdin while read_key_unix is blocking. Even with the
-    # CSI-drain fix in read_key_unix, racing with an active Application is unsafe:
-    # skip the feedback menu and avoid the stdin conflict entirely.
     from surfaces.interactive_shell.ui.components.key_reader import restore_stdin_terminal
     from surfaces.interactive_shell.ui.feedback import prompt_investigation_feedback
 
     pt_app = getattr(session, "pt_style_app", None)
     pt_app_running = pt_app is not None and getattr(pt_app, "is_running", False)
     if not pt_app_running:
-        # The explicit pre-call (kept identical to the CLI path) primes the terminal
-        # out of the streaming watcher's no-echo/raw mode *before* the feedback
-        # helper prints its root-cause context and header.
         restore_stdin_terminal()
         prompt_investigation_feedback(final_state)
-    return final_state
+    return InvestigationOutcome(
+        status="completed",
+        target=normalized_target,
+        investigation_id=str(getattr(session, "last_investigation_id", "") or ""),
+        final_state=final_state,
+    )
 
 
 __all__ = ["run_foreground_investigation"]

--- a/surfaces/interactive_shell/ui/investigation_outcome.py
+++ b/surfaces/interactive_shell/ui/investigation_outcome.py
@@ -1,0 +1,155 @@
+"""Structured investigation run outcomes for terminal UX and PostHog analytics."""
+
+from __future__ import annotations
+
+import re
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from platform.common.errors import OpenSREError
+
+InvestigationStatus = Literal["completed", "failed", "cancelled"]
+FailureCategory = Literal[
+    "config",
+    "integration",
+    "timeout",
+    "user_cancelled",
+    "k8s_api",
+    "llm",
+    "unknown",
+]
+
+_INTEGRATION_KEYWORDS: tuple[tuple[str, str], ...] = (
+    ("grafana", "grafana"),
+    ("loki", "grafana"),
+    ("mimir", "grafana"),
+    ("tempo", "grafana"),
+    ("datadog", "datadog"),
+    ("sentry", "sentry"),
+    ("jenkins", "jenkins"),
+    ("kubernetes", "k8s"),
+    ("k8s", "k8s"),
+    ("kubectl", "k8s"),
+    ("splunk", "splunk"),
+    ("honeycomb", "honeycomb"),
+    ("coralogix", "coralogix"),
+    ("posthog", "posthog"),
+    ("github", "github"),
+    ("argocd", "argocd"),
+    ("pagerduty", "pagerduty"),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class InvestigationOutcome:
+    """Facts from one foreground investigation run."""
+
+    status: InvestigationStatus
+    target: str = ""
+    investigation_id: str = ""
+    final_state: dict[str, Any] | None = None
+    error_message: str = ""
+    error_detail: str = ""
+    failure_category: FailureCategory = "unknown"
+    integration_involved: str = ""
+    integration_failure_message: str = ""
+
+
+def normalize_investigation_target(raw_target: str, *, path: Path | None = None) -> str:
+    """Return a stable analytics slug for an investigation target."""
+    if path is not None:
+        return path.name or path.stem or str(path)
+    stripped = raw_target.strip()
+    if not stripped:
+        return "investigation"
+    lowered = stripped.lower()
+    for prefix in ("sample:", "template:"):
+        if lowered.startswith(prefix):
+            return lowered[len(prefix) :].strip() or "investigation"
+    if "/" in stripped or "\\" in stripped:
+        return Path(stripped).name or stripped
+    collapsed = re.sub(r"\s+", " ", stripped)
+    if len(collapsed) > 80:
+        return f"{collapsed[:77]}…"
+    return collapsed
+
+
+def _integration_from_message(message: str) -> tuple[str, str]:
+    lowered = message.lower()
+    for keyword, service in _INTEGRATION_KEYWORDS:
+        if keyword in lowered:
+            detail = message.strip()
+            if len(detail) > 200:
+                detail = f"{detail[:197]}…"
+            return service, detail
+    return "", ""
+
+
+def classify_investigation_failure(
+    exc: BaseException,
+) -> tuple[FailureCategory, str, str]:
+    """Map an exception to category, integration service, and integration detail."""
+    message = str(exc).strip()
+    if isinstance(exc, TimeoutError):
+        return "timeout", "", ""
+    if isinstance(exc, KeyboardInterrupt):
+        return "user_cancelled", "", ""
+
+    integration, integration_detail = _integration_from_message(message)
+    lowered = message.lower()
+
+    if integration:
+        return "integration", integration, integration_detail
+    if any(token in lowered for token in ("kubernetes", "k8s", "kubectl", "pod ", "deployment ")):
+        return "k8s_api", "k8s", message[:200]
+    if any(
+        token in lowered
+        for token in ("context length", "token limit", "llm", "model", "anthropic", "openai")
+    ):
+        return "llm", "", message[:200]
+    if any(token in lowered for token in ("config", "credential", "not configured", "missing api")):
+        return "config", "", message[:200]
+    if isinstance(exc, OpenSREError):
+        return "config", integration, integration_detail or message[:200]
+    return "unknown", integration, integration_detail
+
+
+def failure_detail_from_exception(exc: BaseException) -> str:
+    """Best-effort truncated detail for analytics (not user-facing)."""
+    return truncate_failure_detail("".join(traceback.format_exception_only(exc)).strip())
+
+
+def truncate_failure_detail(text: str, *, max_chars: int = 500) -> str:
+    cleaned = text.strip()
+    if len(cleaned) <= max_chars:
+        return cleaned
+    return f"{cleaned[: max_chars - 20].rstrip()}… [truncated]"
+
+
+def user_facing_error_message(exc: BaseException, *, max_lines: int = 3) -> str:
+    """Compact user-facing error text for analytics payloads."""
+    if isinstance(exc, OpenSREError):
+        parts = [exc.message.strip()]
+        if exc.suggestion:
+            parts.append(f"Suggestion: {exc.suggestion.strip()}")
+        text = "\n".join(part for part in parts if part)
+    else:
+        text = str(exc).strip()
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return type(exc).__name__
+    return "\n".join(lines[:max_lines])
+
+
+__all__ = [
+    "FailureCategory",
+    "InvestigationOutcome",
+    "InvestigationStatus",
+    "classify_investigation_failure",
+    "failure_detail_from_exception",
+    "normalize_investigation_target",
+    "truncate_failure_detail",
+    "user_facing_error_message",
+]

--- a/surfaces/interactive_shell/utils/telemetry/investigation_analytics.py
+++ b/surfaces/interactive_shell/utils/telemetry/investigation_analytics.py
@@ -1,0 +1,43 @@
+"""Bridge investigation terminal outcomes to PostHog lifecycle analytics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from platform.analytics.cli import (
+    capture_investigation_cancelled,
+    capture_investigation_outcome,
+)
+from surfaces.interactive_shell.ui.investigation_outcome import InvestigationOutcome
+
+
+def _root_cause_excerpt(final_state: dict[str, Any] | None) -> str:
+    if not final_state:
+        return ""
+    root = final_state.get("root_cause")
+    if isinstance(root, str) and root.strip():
+        return root.strip()
+    return ""
+
+
+def publish_investigation_outcome_analytics(outcome: InvestigationOutcome) -> None:
+    """Emit structured investigation analytics for one terminal run."""
+    if outcome.status == "cancelled":
+        capture_investigation_cancelled(
+            investigation_id=outcome.investigation_id,
+            investigation_target=outcome.target,
+        )
+    capture_investigation_outcome(
+        investigation_id=outcome.investigation_id,
+        status=outcome.status,
+        investigation_target=outcome.target,
+        root_cause_excerpt=_root_cause_excerpt(outcome.final_state),
+        error_excerpt=outcome.error_message,
+        failure_category=outcome.failure_category or None,
+        integration_involved=outcome.integration_involved or None,
+        integration_failure_message=outcome.integration_failure_message or None,
+        failure_detail=outcome.error_detail or None,
+    )
+
+
+__all__ = ["publish_investigation_outcome_analytics"]

--- a/surfaces/interactive_shell/utils/telemetry/recorder.py
+++ b/surfaces/interactive_shell/utils/telemetry/recorder.py
@@ -50,6 +50,22 @@ def _latest_slash_outcome(session: Any) -> str | None:
     return None
 
 
+def _fallback_terminal_response(session: Any | None, *, prompt: str) -> str:
+    if session is not None:
+        history = getattr(session, "history", None)
+        if isinstance(history, list):
+            for entry in reversed(history):
+                if not isinstance(entry, dict):
+                    continue
+                response_text = entry.get("response_text")
+                if isinstance(response_text, str) and response_text.strip():
+                    return response_text.strip()
+    stripped = prompt.strip()
+    if stripped:
+        return f"terminal turn handled: {stripped}"
+    return "terminal turn handled"
+
+
 class PromptRecorder:
     """Captures one `(prompt, response)` pair and flushes to configured sinks."""
 
@@ -134,7 +150,10 @@ class PromptRecorder:
         )
 
     def set_response(self, text: str, run: LlmRunInfo | None = None) -> None:
-        self._response = _sanitize_text(text, config=self._config)
+        cleaned = _sanitize_text(text, config=self._config)
+        if not cleaned.strip():
+            cleaned = _fallback_terminal_response(self._session, prompt=self._prompt)
+        self._response = cleaned
         if run is None:
             self._latency_ms = int((time.monotonic() - self._start) * 1000)
             return
@@ -214,6 +233,9 @@ class PromptRecorder:
                 slash_outcome = _latest_slash_outcome(self._session)
                 if slash_outcome:
                     posthog_properties["slash_outcome"] = slash_outcome
+                investigation_id = getattr(self._session, "last_investigation_id", "")
+                if isinstance(investigation_id, str) and investigation_id:
+                    posthog_properties["investigation_id"] = investigation_id
                 capture_ai_generation(posthog_properties)
 
 

--- a/surfaces/interactive_shell/utils/telemetry/recorder.py
+++ b/surfaces/interactive_shell/utils/telemetry/recorder.py
@@ -50,20 +50,18 @@ def _latest_slash_outcome(session: Any) -> str | None:
     return None
 
 
-def _fallback_terminal_response(session: Any | None, *, prompt: str) -> str:
-    if session is not None:
-        history = getattr(session, "history", None)
-        if isinstance(history, list):
-            for entry in reversed(history):
-                if not isinstance(entry, dict):
-                    continue
-                response_text = entry.get("response_text")
-                if isinstance(response_text, str) and response_text.strip():
-                    return response_text.strip()
+def _fallback_terminal_response(*, prompt: str) -> str:
     stripped = prompt.strip()
     if stripped:
         return f"terminal turn handled: {stripped}"
     return "terminal turn handled"
+
+
+def _prompt_relates_to_investigation(*, prompt: str, turn_kind: str) -> bool:
+    stripped = prompt.strip().lower()
+    if turn_kind == "background_task":
+        return "investigate" in stripped
+    return stripped.startswith("/investigate")
 
 
 class PromptRecorder:
@@ -152,7 +150,7 @@ class PromptRecorder:
     def set_response(self, text: str, run: LlmRunInfo | None = None) -> None:
         cleaned = _sanitize_text(text, config=self._config)
         if not cleaned.strip():
-            cleaned = _fallback_terminal_response(self._session, prompt=self._prompt)
+            cleaned = _fallback_terminal_response(prompt=self._prompt)
         self._response = cleaned
         if run is None:
             self._latency_ms = int((time.monotonic() - self._start) * 1000)
@@ -233,9 +231,13 @@ class PromptRecorder:
                 slash_outcome = _latest_slash_outcome(self._session)
                 if slash_outcome:
                     posthog_properties["slash_outcome"] = slash_outcome
-                investigation_id = getattr(self._session, "last_investigation_id", "")
-                if isinstance(investigation_id, str) and investigation_id:
-                    posthog_properties["investigation_id"] = investigation_id
+                if _prompt_relates_to_investigation(
+                    prompt=self._prompt,
+                    turn_kind=self._turn_kind,
+                ):
+                    investigation_id = getattr(self._session, "last_investigation_id", "")
+                    if isinstance(investigation_id, str) and investigation_id:
+                        posthog_properties["investigation_id"] = investigation_id
                 capture_ai_generation(posthog_properties)
 
 

--- a/surfaces/interactive_shell/utils/telemetry/recorder.py
+++ b/surfaces/interactive_shell/utils/telemetry/recorder.py
@@ -84,6 +84,7 @@ class PromptRecorder:
         self._prompt = prompt
         self._session = session
         self._response: str = ""
+        self._scoped_investigation_id: str | None = None
         self._model: str | None = None
         self._provider: str | None = None
         self._latency_ms: int | None = None
@@ -138,7 +139,7 @@ class PromptRecorder:
         config = PromptLogConfig.load()
         if not config.enabled:
             return None
-        return cls(
+        recorder = cls(
             config=config,
             turn_kind="background_task",
             session_id=_session_id(session),
@@ -146,6 +147,29 @@ class PromptRecorder:
             prompt=_sanitize_text(command, config=config),
             session=session,
         )
+        if _prompt_relates_to_investigation(prompt=command, turn_kind="background_task"):
+            investigation_id = str(uuid.uuid4())
+            recorder.bind_investigation_id(investigation_id)
+            session.last_investigation_id = investigation_id
+        return recorder
+
+    def bind_investigation_id(self, investigation_id: str) -> None:
+        cleaned = investigation_id.strip()
+        if cleaned:
+            self._scoped_investigation_id = cleaned
+
+    def _resolve_investigation_id(self) -> str:
+        if self._scoped_investigation_id:
+            return self._scoped_investigation_id
+        if self._session is None or not _prompt_relates_to_investigation(
+            prompt=self._prompt,
+            turn_kind=self._turn_kind,
+        ):
+            return ""
+        investigation_id = getattr(self._session, "last_investigation_id", "")
+        if isinstance(investigation_id, str):
+            return investigation_id
+        return ""
 
     def set_response(self, text: str, run: LlmRunInfo | None = None) -> None:
         cleaned = _sanitize_text(text, config=self._config)
@@ -231,13 +255,9 @@ class PromptRecorder:
                 slash_outcome = _latest_slash_outcome(self._session)
                 if slash_outcome:
                     posthog_properties["slash_outcome"] = slash_outcome
-                if _prompt_relates_to_investigation(
-                    prompt=self._prompt,
-                    turn_kind=self._turn_kind,
-                ):
-                    investigation_id = getattr(self._session, "last_investigation_id", "")
-                    if isinstance(investigation_id, str) and investigation_id:
-                        posthog_properties["investigation_id"] = investigation_id
+                investigation_id = self._resolve_investigation_id()
+                if investigation_id:
+                    posthog_properties["investigation_id"] = investigation_id
                 capture_ai_generation(posthog_properties)
 
 

--- a/surfaces/interactive_shell/utils/telemetry/turn_outcome.py
+++ b/surfaces/interactive_shell/utils/telemetry/turn_outcome.py
@@ -101,17 +101,57 @@ def format_investigation_outcome(
     *,
     final_state: dict[str, object] | None = None,
     background: bool = False,
+    error_message: str = "",
+    status: str | None = None,
 ) -> str:
-    """Human-readable investigation outcome for analytics."""
+    """Human-readable investigation outcome body for analytics."""
     label = target.strip() or "investigation"
     if background:
         return f"investigation started in background: {label}"
+    if status == "cancelled":
+        return f"investigation_cancelled ({label}): aborted by user"
+    if status == "failed" or (final_state is None and error_message):
+        reason = error_message.strip() or "investigation failed"
+        return truncate_analytics_text(f"investigation_failed ({label}):\n{reason}")
     if final_state is None:
-        return f"investigation failed or cancelled: {label}"
+        return f"investigation_failed ({label}): investigation did not complete"
     excerpt = _investigation_report_excerpt(final_state)
     if excerpt:
         return truncate_analytics_text(f"investigation completed ({label}):\n{excerpt}")
     return f"investigation completed: {label}"
+
+
+def format_investigation_terminal_outcome(
+    command_line: str,
+    *,
+    target: str,
+    ok: bool,
+    final_state: dict[str, object] | None = None,
+    background: bool = False,
+    error_message: str = "",
+    status: str | None = None,
+) -> str:
+    """Two-line terminal analytics payload for ``/investigate`` turns."""
+    if background:
+        return format_investigation_outcome(target, background=True)
+    resolved_status = status or ("succeeded" if ok and final_state is not None else "failed")
+    if resolved_status == "completed":
+        resolved_status = "succeeded"
+    slash_status = {
+        "succeeded": "succeeded",
+        "failed": "failed",
+        "cancelled": "cancelled",
+    }.get(resolved_status, "failed")
+    prefix = f"slash {command_line.strip()} ({slash_status})"
+    body = format_investigation_outcome(
+        target,
+        final_state=final_state,
+        error_message=error_message,
+        status="cancelled"
+        if resolved_status == "cancelled"
+        else ("failed" if resolved_status == "failed" else None),
+    )
+    return truncate_analytics_text(f"{prefix}\n{body}")
 
 
 def format_terminal_turn_outcome(

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -315,6 +315,35 @@ def test_track_investigation_emits_failed_on_exception(
     _assert_investigation_events_have_source(stub.events)
     failed_props = stub.events[1][1] or {}
     assert failed_props["failure_type"] == "RuntimeError"
+    assert failed_props["failure_message"] == "boom"
+
+
+def test_capture_investigation_outcome_and_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubAnalytics()
+    monkeypatch.setattr(cli, "get_analytics", lambda: stub)
+
+    cli.capture_investigation_outcome(
+        investigation_id="inv-123",
+        status="failed",
+        investigation_target="generic",
+        error_excerpt="boom",
+        failure_category="unknown",
+    )
+    cli.capture_investigation_cancelled(
+        investigation_id="inv-456",
+        investigation_target="alert.json",
+    )
+
+    assert stub.events[0][0] == Event.INVESTIGATION_OUTCOME
+    outcome_props = stub.events[0][1] or {}
+    assert outcome_props["investigation_id"] == "inv-123"
+    assert outcome_props["status"] == "failed"
+    assert outcome_props["investigation_target"] == "generic"
+    assert outcome_props["error_excerpt"] == "boom"
+    assert stub.events[1][0] == Event.INVESTIGATION_CANCELLED
+    cancelled_props = stub.events[1][1] or {}
+    assert cancelled_props["investigation_id"] == "inv-456"
+    assert cancelled_props["failure_category"] == "user_cancelled"
 
 
 def test_track_investigation_nested_context_dedupes(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/interactive_shell/runtime/test_background_runner.py
+++ b/tests/interactive_shell/runtime/test_background_runner.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
+import pytest
+from rich.console import Console
+
 from core.agent_harness.session import Session
-from surfaces.interactive_shell.runtime.background.runner import drain_background_notices
+from surfaces.interactive_shell.runtime.background.runner import (
+    drain_background_notices,
+    start_background_template_investigation,
+)
 
 
 def test_enqueue_and_drain_background_notices() -> None:
@@ -17,3 +25,47 @@ def test_enqueue_and_drain_background_notices() -> None:
 
     assert session.drain_background_notices() == []
     assert "done" in console.file.getvalue()
+
+
+def test_start_background_template_investigation_assigns_fresh_investigation_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import io
+
+    session = Session()
+    session.last_investigation_id = "inv-stale"
+    console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+
+    def _fake_run(
+        *,
+        cancel_requested,
+        template_name: str,
+        context_overrides,
+    ) -> dict[str, object]:
+        _ = (cancel_requested, template_name, context_overrides)
+        return {"root_cause": "done"}
+
+    monkeypatch.setattr(
+        "surfaces.cli.investigation.run_sample_alert_for_session_background",
+        _fake_run,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.runtime.background.runner.track_investigation",
+        lambda **_kwargs: MagicMock(
+            __enter__=MagicMock(return_value=MagicMock()),
+            __exit__=MagicMock(return_value=False),
+        ),
+    )
+
+    task_id = start_background_template_investigation(
+        template_name="generic",
+        session=session,
+        console=console,
+        display_command="/investigate generic",
+        investigation_target="generic",
+    )
+
+    assert session.last_investigation_id
+    assert session.last_investigation_id != "inv-stale"
+    record = session.background_investigations[task_id]
+    assert record.investigation_id == session.last_investigation_id

--- a/tests/interactive_shell/ui/test_investigation_outcome.py
+++ b/tests/interactive_shell/ui/test_investigation_outcome.py
@@ -3,8 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
+import pytest
+from rich.console import Console
+
+from core.agent_harness.session import Session
 from platform.common.errors import OpenSREError
+from platform.common.task_types import TaskRecord
+from surfaces.interactive_shell.ui.foreground_investigation import run_foreground_investigation
 from surfaces.interactive_shell.ui.investigation_outcome import (
     classify_investigation_failure,
     normalize_investigation_target,
@@ -37,3 +44,34 @@ def test_user_facing_error_message_includes_suggestion() -> None:
     )
     assert "jenkins is not configured" in message
     assert "Suggestion:" in message
+
+
+def test_run_foreground_investigation_early_cancel_omits_stale_investigation_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = Session()
+    session.last_investigation_id = "inv-old"
+    console = Console(force_terminal=False, color_system=None, highlight=False)
+    task = MagicMock(spec=TaskRecord)
+    task.cancel_requested = False
+    monkeypatch.setattr(
+        session.task_registry,
+        "create",
+        lambda *_args, **_kwargs: task,
+    )
+
+    def _raise_interrupt(_task: TaskRecord) -> dict[str, object]:
+        raise KeyboardInterrupt
+
+    outcome = run_foreground_investigation(
+        session=session,
+        console=console,
+        task_command="/investigate generic",
+        run=_raise_interrupt,
+        exception_context="test",
+        target="generic",
+    )
+
+    assert outcome.status == "cancelled"
+    assert outcome.investigation_id == ""
+    task.mark_cancelled.assert_called_once()

--- a/tests/interactive_shell/ui/test_investigation_outcome.py
+++ b/tests/interactive_shell/ui/test_investigation_outcome.py
@@ -1,0 +1,39 @@
+"""Tests for structured investigation outcomes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from platform.common.errors import OpenSREError
+from surfaces.interactive_shell.ui.investigation_outcome import (
+    classify_investigation_failure,
+    normalize_investigation_target,
+    user_facing_error_message,
+)
+
+
+def test_normalize_investigation_target_template() -> None:
+    assert normalize_investigation_target("generic") == "generic"
+    assert normalize_investigation_target("template:datadog") == "datadog"
+
+
+def test_normalize_investigation_target_file_path() -> None:
+    assert normalize_investigation_target(
+        "alerts/checkout.json", path=Path("alerts/checkout.json")
+    ) == ("checkout.json")
+
+
+def test_classify_integration_failure() -> None:
+    category, integration, _detail = classify_investigation_failure(
+        RuntimeError("grafana query failed: 401 unauthorized")
+    )
+    assert category == "integration"
+    assert integration == "grafana"
+
+
+def test_user_facing_error_message_includes_suggestion() -> None:
+    message = user_facing_error_message(
+        OpenSREError("jenkins is not configured", suggestion="Run /integrations setup jenkins")
+    )
+    assert "jenkins is not configured" in message
+    assert "Suggestion:" in message

--- a/tests/interactive_shell/utils/telemetry/test_recorder.py
+++ b/tests/interactive_shell/utils/telemetry/test_recorder.py
@@ -261,6 +261,74 @@ def test_prompt_recorder_uses_no_conversational_agent_without_llm_run(
     assert captured[0]["$ai_provider"] == "no_conversational_agent"
 
 
+def test_prompt_recorder_includes_investigation_id(monkeypatch, tmp_path: Path) -> None:
+    captured: list[dict[str, object]] = []
+    cfg = PromptLogConfig(
+        enabled=True,
+        local_enabled=False,
+        posthog_enabled=True,
+        redact=False,
+        max_chars=1000,
+        log_path=tmp_path / "prompt_log.jsonl",
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.PromptLogConfig.load", lambda: cfg
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.build_turn_integration_snapshot",
+        lambda _session: {},
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.capture_ai_generation",
+        lambda payload: captured.append(payload),
+    )
+    session = Session()
+    session.last_investigation_id = "inv-abc"
+    recorder = PromptRecorder.start(
+        session=session,
+        text="/investigate generic",
+        turn_kind="agent",
+    )
+    assert recorder is not None
+    recorder.set_response(
+        "slash /investigate generic (failed)\ninvestigation_failed (generic):\nboom"
+    )
+    recorder.flush()
+    assert captured[0]["investigation_id"] == "inv-abc"
+
+
+def test_prompt_recorder_uses_history_fallback_when_response_empty(
+    monkeypatch, tmp_path: Path
+) -> None:
+    cfg = PromptLogConfig(
+        enabled=True,
+        local_enabled=False,
+        posthog_enabled=True,
+        redact=False,
+        max_chars=1000,
+        log_path=tmp_path / "prompt_log.jsonl",
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.PromptLogConfig.load", lambda: cfg
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.build_turn_integration_snapshot",
+        lambda _session: {},
+    )
+    captured: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.capture_ai_generation",
+        lambda payload: captured.append(payload),
+    )
+    session = Session()
+    session.record("slash", "/help", ok=True, response_text="slash /help (succeeded)")
+    recorder = PromptRecorder.start(session=session, text="/help", turn_kind="agent")
+    assert recorder is not None
+    recorder.set_response("   ")
+    recorder.flush()
+    assert captured[0]["$ai_output_choices"][0]["content"] == "slash /help (succeeded)"
+
+
 def test_prompt_recorder_uses_only_latest_slash_outcome(monkeypatch, tmp_path: Path) -> None:
     captured: list[dict[str, object]] = []
     cfg = PromptLogConfig(

--- a/tests/interactive_shell/utils/telemetry/test_recorder.py
+++ b/tests/interactive_shell/utils/telemetry/test_recorder.py
@@ -365,6 +365,45 @@ def test_prompt_recorder_uses_prompt_fallback_when_response_empty(
     assert captured[0]["$ai_output_choices"][0]["content"] == "terminal turn handled: /help"
 
 
+def test_prompt_recorder_background_task_uses_bound_investigation_id(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: list[dict[str, object]] = []
+    cfg = PromptLogConfig(
+        enabled=True,
+        local_enabled=False,
+        posthog_enabled=True,
+        redact=False,
+        max_chars=1000,
+        log_path=tmp_path / "prompt_log.jsonl",
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.PromptLogConfig.load", lambda: cfg
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.build_turn_integration_snapshot",
+        lambda _session: {},
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.capture_ai_generation",
+        lambda payload: captured.append(payload),
+    )
+    session = Session()
+    session.last_investigation_id = "inv-stale"
+    recorder = PromptRecorder.for_background_task(
+        session=session,
+        command="opensre investigate --service api",
+        task_id="task-123",
+    )
+    assert recorder is not None
+    session.last_investigation_id = "inv-other"
+    recorder.set_response("command completed (exit 0)")
+    recorder.flush()
+    investigation_id = captured[0]["investigation_id"]
+    assert isinstance(investigation_id, str)
+    assert investigation_id not in {"", "inv-stale", "inv-other"}
+
+
 def test_prompt_recorder_uses_only_latest_slash_outcome(monkeypatch, tmp_path: Path) -> None:
     captured: list[dict[str, object]] = []
     cfg = PromptLogConfig(

--- a/tests/interactive_shell/utils/telemetry/test_recorder.py
+++ b/tests/interactive_shell/utils/telemetry/test_recorder.py
@@ -297,7 +297,43 @@ def test_prompt_recorder_includes_investigation_id(monkeypatch, tmp_path: Path) 
     assert captured[0]["investigation_id"] == "inv-abc"
 
 
-def test_prompt_recorder_uses_history_fallback_when_response_empty(
+def test_prompt_recorder_omits_investigation_id_for_unrelated_turns(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: list[dict[str, object]] = []
+    cfg = PromptLogConfig(
+        enabled=True,
+        local_enabled=False,
+        posthog_enabled=True,
+        redact=False,
+        max_chars=1000,
+        log_path=tmp_path / "prompt_log.jsonl",
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.PromptLogConfig.load", lambda: cfg
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.build_turn_integration_snapshot",
+        lambda _session: {},
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.capture_ai_generation",
+        lambda payload: captured.append(payload),
+    )
+    session = Session()
+    session.last_investigation_id = "inv-stale"
+    recorder = PromptRecorder.start(
+        session=session,
+        text="what integrations are configured?",
+        turn_kind="agent",
+    )
+    assert recorder is not None
+    recorder.set_response("github and datadog")
+    recorder.flush()
+    assert "investigation_id" not in captured[0]
+
+
+def test_prompt_recorder_uses_prompt_fallback_when_response_empty(
     monkeypatch, tmp_path: Path
 ) -> None:
     cfg = PromptLogConfig(
@@ -326,7 +362,7 @@ def test_prompt_recorder_uses_history_fallback_when_response_empty(
     assert recorder is not None
     recorder.set_response("   ")
     recorder.flush()
-    assert captured[0]["$ai_output_choices"][0]["content"] == "slash /help (succeeded)"
+    assert captured[0]["$ai_output_choices"][0]["content"] == "terminal turn handled: /help"
 
 
 def test_prompt_recorder_uses_only_latest_slash_outcome(monkeypatch, tmp_path: Path) -> None:

--- a/tests/interactive_shell/utils/test_turn_outcome.py
+++ b/tests/interactive_shell/utils/test_turn_outcome.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from surfaces.interactive_shell.utils.telemetry.turn_outcome import (
     format_investigation_outcome,
+    format_investigation_terminal_outcome,
     format_terminal_turn_outcome,
     format_wizard_cli_outcome,
     slash_command_is_interactive_wizard,
@@ -29,6 +30,34 @@ def test_format_investigation_outcome_background() -> None:
     text = format_investigation_outcome("generic", background=True)
     assert "started in background" in text
     assert "generic" in text
+
+
+def test_format_investigation_outcome_failed_includes_reason() -> None:
+    text = format_investigation_outcome(
+        "generic",
+        status="failed",
+        error_message="jenkins is not configured",
+    )
+    assert text.startswith("investigation_failed (generic):")
+    assert "jenkins is not configured" in text
+
+
+def test_format_investigation_outcome_cancelled() -> None:
+    text = format_investigation_outcome("alert.json", status="cancelled")
+    assert text == "investigation_cancelled (alert.json): aborted by user"
+
+
+def test_format_investigation_terminal_outcome_failed_two_line_shape() -> None:
+    text = format_investigation_terminal_outcome(
+        "/investigate generic",
+        target="generic",
+        ok=False,
+        error_message="integration timeout",
+        status="failed",
+    )
+    assert text.startswith("slash /investigate generic (failed)")
+    assert "investigation_failed (generic):" in text
+    assert "integration timeout" in text
 
 
 def test_format_investigation_outcome_includes_root_cause() -> None:

--- a/tools/interactive_shell/shared/investigation_launch.py
+++ b/tools/interactive_shell/shared/investigation_launch.py
@@ -69,8 +69,9 @@ def launch_investigation(
             task_command=foreground_task_command,
             run=run,
             exception_context=exception_context,
-        )
-        is None
+            target=record_value,
+        ).status
+        != "completed"
     ):
         session.record("alert", record_value, ok=False)
         return


### PR DESCRIPTION
## Summary

Implements the investigation failure telemetry contract so PostHog consumers (analytics repo) get actionable failure data instead of bare `(failed)` lines.

- **Tier 1:** Two-line `/investigate` failure bodies in `$ai_output_choices`; `failure_message` / `failure_detail` on `investigation_failed`; `investigation_id` on `$ai_generation` for deterministic joins
- **Tier 2:** Normalized `investigation_target`; `failure_category` + `integration_involved` + `integration_failure_message` on structured events
- **Tier 3:** New `investigation_outcome` and `investigation_cancelled` events; non-empty `$ai_output_choices` fallback from session history; split `investigation_failed` vs `investigation_cancelled` outcome text

Fixes #3653
Fixes #3654
Fixes #3655
Fixes #3656
Fixes #3657
Fixes #3658
Fixes #3659
Fixes #3660
Fixes #3661

## Key changes

| Area | What ships to PostHog |
|------|----------------------|
| `$ai_output_choices` | `slash /investigate … (failed)\ninvestigation_failed (target):\n<reason>` |
| `$ai_generation` | `investigation_id` when a lifecycle run is active |
| `investigation_failed` | `failure_message`, `failure_detail`, `failure_category`, `integration_involved`, `investigation_target` |
| `investigation_cancelled` | User aborts (Ctrl+C) |
| `investigation_outcome` | `{investigation_id, status, target, root_cause_excerpt, error_excerpt, …}` |

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] `make format-check`
- [x] `uv run python -m pytest tests/interactive_shell/ui/test_investigation_outcome.py tests/interactive_shell/utils/test_turn_outcome.py tests/interactive_shell/utils/telemetry/test_recorder.py tests/analytics/test_cli.py`
- [ ] Manual: fail `/investigate` in REPL → PostHog row has `investigation_id`, two-line failure body, and matching `investigation_outcome`