### PR TITLE
refactor(agent): structured context, cross-surface parity, and stale-process guards

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -86,6 +86,13 @@ class AgentRunResult:
     tool_results: list[tuple[ToolCall, ToolExecutionResult]] = field(default_factory=list)
     terminated_by_tool: bool = False
     hit_iteration_cap: bool = False
+    final_system_prompt: str = ""
+    """The system prompt actually sent to the LLM on the last provider request.
+
+    Recorded so debugging can answer "what was influencing the agent when it made
+    this decision?" without re-deriving the prompt by hand. Captured after the
+    ``_before_provider_request`` hook, so it reflects any per-turn edits.
+    """
 
 
 # Backward-compat alias — callers that still reference ToolLoopResult compile unchanged.
@@ -227,6 +234,7 @@ class Agent[RuntimeToolT: RuntimeTool]:
         executed: list[tuple[ToolCall, Any]] = []
         tool_results: list[tuple[ToolCall, ToolExecutionResult]] = []
         final_text = ""
+        final_system_prompt = system
         hit_cap = True
         terminated_by_tool = False
         self._emit_runtime(
@@ -257,6 +265,7 @@ class Agent[RuntimeToolT: RuntimeTool]:
                 metadata={"iteration": iteration},
             )
             provider_request = self._before_provider_request(provider_request)
+            final_system_prompt = provider_request.system
             self._emit_runtime(
                 ProviderRequestStartEvent(
                     iteration=iteration,
@@ -401,6 +410,7 @@ class Agent[RuntimeToolT: RuntimeTool]:
             tool_results=tool_results,
             terminated_by_tool=terminated_by_tool,
             hit_iteration_cap=hit_cap,
+            final_system_prompt=final_system_prompt,
         )
         self._emit_runtime(
             AgentEndEvent(

--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -79,13 +79,15 @@ to it instead of re-implementing bootstrap + persistence:
   :meth:`SessionManager.rebind_for_resume` then :meth:`SessionManager.restore_context`.
   REPL exit calls :meth:`SessionManager.close` via
   :meth:`SessionManager.for_session`.
-- **gateway** — `gateway/manager.py` bootstraps the process-wide action-tool
-  list via :meth:`SessionManager.create` (``open_storage=False``).
+- **gateway** — `gateway/manager.py` bootstraps the process via
+  :meth:`SessionManager.create` (``open_storage=False``).
   `gateway/storage/session/resolver.py::SessionResolver` owns per-chat
   chat-id ↔ session-id binding + metadata; it delegates `create` / `resolve` /
   `rotate` to `SessionManager`. Turn dispatch uses
-  `Agent.dispatch_message_to_headless_agent` via `gateway/turn_handler.py` —
-  there is no separate gateway-owned `Agent` instance.
+  `Agent.dispatch_message_to_headless_agent` via `gateway/turn_handler.py` with
+  :class:`~core.agent_harness.providers.default_providers.DefaultToolProvider`
+  built from the **live per-chat session** each turn (same tool resolution as
+  shell). There is no separate gateway-owned ``Agent`` instance.
 - **headless** — ephemeral in-memory sessions (``headless_agent.InMemorySessionStore``)
   bypass ``SessionManager`` by design: they never persist to JSONL and do not
   need create/resolve/rotate/close. Tool-calling turns still run through the
@@ -124,9 +126,20 @@ Action (`agents/action_agent.py::_build_action_agent`) and evidence
 (`agents/evidence_agent.py::_build_evidence_agent`) assemble an
 ``AgentConfig`` and call ``build_agent``. The gateway turn path does not
 construct a persistent ``Agent`` — it uses
-``Agent.dispatch_message_to_headless_agent`` with precomputed action tools.
-When ``Agent.__init__``'s signature changes, ``agent_builder.py`` is the single
-edit site for harness surfaces that call ``build_agent``.
+``Agent.dispatch_message_to_headless_agent`` with per-turn
+:class:`~core.agent_harness.providers.default_providers.DefaultToolProvider`
+from the live chat session. When ``Agent.__init__``'s signature changes,
+``agent_builder.py`` is the single edit site for harness surfaces that call
+``build_agent``.
+
+## Agent context and data stores
+
+See [`docs/agent-context-data-stores.md`](../../docs/agent-context-data-stores.md)
+for the four-store model (``Session``, ``MutableAgentState``, ``TurnContext``,
+JSONL), prompt debug paths, and the ``MutableAgentState`` production audit.
+Turn assembly starts with ``TurnContext.from_session`` in
+``agents/turn_orchestrator.py``; system prompts from ``Agent.run`` are persisted
+via ``core/agent_harness/debug/prompt_trace.py``.
 
 **Do NOT** reintroduce per-surface `Agent` subclasses that override
 `build_llm` / `build_system_prompt` / `build_tools` / `resolved_integrations`

--- a/core/agent_harness/accounting/token_accounting.py
+++ b/core/agent_harness/accounting/token_accounting.py
@@ -22,6 +22,7 @@ class LlmRunInfo:
     input_tokens: int | None = None
     output_tokens: int | None = None
     response_text: str | None = None
+    final_system_prompt: str | None = None
 
 
 def estimate_tokens(text: str) -> int:
@@ -99,6 +100,7 @@ def build_llm_run_info(
     client: object | None = None,
     model: str | None = None,
     provider: str | None = None,
+    final_system_prompt: str | None = None,
 ) -> LlmRunInfo:
     """Record token usage and assemble metadata for prompt logging."""
     inp, out, _estimated = record_llm_turn(session, prompt=prompt, response=response_text)
@@ -110,6 +112,7 @@ def build_llm_run_info(
         input_tokens=inp,
         output_tokens=out,
         response_text=response_text,
+        final_system_prompt=final_system_prompt,
     )
 
 

--- a/core/agent_harness/agents/action_agent.py
+++ b/core/agent_harness/agents/action_agent.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from core.agent import Agent
 from core.agent_harness.agent_builder import AgentConfig, build_agent
+from core.agent_harness.debug.prompt_trace import persist_turn_system_prompt
 from core.agent_harness.models.turn_context import TurnContext
 from core.agent_harness.models.turn_results import ToolCallingTurnResult
 from core.agent_harness.ports import (
@@ -388,6 +389,11 @@ def run_action_agent_turn(
             observer=observer,
         )
         result = agent.run([{"role": "user", "content": user_message}])
+        persist_turn_system_prompt(
+            session,
+            phase="action_agent",
+            system_prompt=result.final_system_prompt,
+        )
     except Exception as exc:
         if is_context_length_overflow(str(exc)):
             log.debug("shell action prompt overflow; falling through to assistant", exc_info=True)

--- a/core/agent_harness/agents/evidence_agent.py
+++ b/core/agent_harness/agents/evidence_agent.py
@@ -26,6 +26,7 @@ from core.agent_harness.prompts.conversation_memory import (
     NO_HISTORY_PLACEHOLDER,
     format_recent_conversation,
 )
+from core.agent_harness.prompts.gather import build_gather_system_prompt
 from core.domain.alerts.alert_source import SECONDARY_TOOL_SOURCES
 from core.events import runtime_event_callback_from_observer
 from integrations.github.repo_scope import (
@@ -85,33 +86,6 @@ def _format_observation(executed: list[tuple[Any, Any]]) -> str:
             f"Tool: {tc.name}\nArguments: {args}\nResult: {_truncate(body, _MAX_PER_TOOL_CHARS)}"
         )
     return _truncate("\n\n".join(blocks), _MAX_OBSERVATION_CHARS)
-
-
-def _build_gather_system_prompt(session: SessionStore) -> str:
-    configured = (
-        ", ".join(session.configured_integrations)
-        if session.configured_integrations
-        else "(unknown)"
-    )
-    return (
-        "You are the data-gathering step of the OpenSRE terminal assistant. The "
-        "user asked a question that may be answerable with live data from the "
-        "connected integrations. You have access to the same tools the "
-        "investigation pipeline uses (logs, metrics, GitHub, error trackers, "
-        "cloud APIs, etc.).\n"
-        "Call the tools needed to gather evidence relevant to the user's "
-        "question. Derive arguments (such as owner/repo, service names, time "
-        "ranges, or search queries) from the user's message. Make tool calls "
-        "ONLY when they will help answer the question; if no tool is relevant, "
-        "respond with a short plain-text note and call nothing.\n"
-        "For GitHub repository metadata such as star count, forks, visibility, "
-        "or default branch, call get_github_repository — do not use "
-        "search_github_code or search_github_issues for those questions.\n"
-        "Do NOT write the final user-facing answer here — a later step composes "
-        "that from the tool results you collect. Stop calling tools as soon as "
-        "you have enough data.\n"
-        f"Configured integrations in this session: {configured}."
-    )
 
 
 def _resolve_gather_integrations(session: SessionStore, message: str) -> dict[str, Any]:
@@ -181,7 +155,7 @@ def _build_evidence_agent(
     """Build the Agent for one evidence-gather turn."""
     config = AgentConfig(
         llm=llm,
-        system=_build_gather_system_prompt(session),
+        system=build_gather_system_prompt(session),
         tools=tuple(gather_tools),
         resolved_integrations=resolved,
         max_iterations=_MAX_GATHER_ITERATIONS,

--- a/core/agent_harness/agents/evidence_agent.py
+++ b/core/agent_harness/agents/evidence_agent.py
@@ -21,6 +21,7 @@ from typing import Any, Protocol
 
 from core.agent import Agent
 from core.agent_harness.agent_builder import AgentConfig, build_agent
+from core.agent_harness.debug.prompt_trace import persist_turn_system_prompt
 from core.agent_harness.ports import ErrorReporter, SessionStore, ToolEventObserver
 from core.agent_harness.prompts.conversation_memory import (
     NO_HISTORY_PLACEHOLDER,
@@ -204,6 +205,11 @@ def gather_tool_evidence(
         )
         result = agent.run(
             [{"role": "user", "content": _build_gather_user_message(session, message)}]
+        )
+        persist_turn_system_prompt(
+            session,
+            phase="gather_agent",
+            system_prompt=result.final_system_prompt,
         )
     except KeyboardInterrupt:
         if on_progress is not None:

--- a/core/agent_harness/debug/__init__.py
+++ b/core/agent_harness/debug/__init__.py
@@ -1,0 +1,5 @@
+"""Debug helpers for agent turns (prompt tracing, audit hooks)."""
+
+from core.agent_harness.debug.prompt_trace import persist_turn_system_prompt
+
+__all__ = ["persist_turn_system_prompt"]

--- a/core/agent_harness/debug/prompt_trace.py
+++ b/core/agent_harness/debug/prompt_trace.py
@@ -1,0 +1,38 @@
+"""Persist assembled system prompts to the session JSONL for debugging."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def persist_turn_system_prompt(
+    session: Any,
+    *,
+    phase: str,
+    system_prompt: str,
+) -> None:
+    """Append the system prompt the LLM saw for one agent phase.
+
+    Writes a ``message`` entry with ``role=system`` and metadata
+    ``debug=system_prompt`` so ``/trace`` and session JSONL readers can find
+    what influenced the model without re-deriving prompts by hand.
+    """
+    text = system_prompt.strip()
+    if not text:
+        return
+
+    storage = getattr(session, "storage", None)
+    session_id = getattr(session, "session_id", "")
+    append_message = getattr(storage, "append_message", None)
+    if not callable(append_message) or not isinstance(session_id, str) or not session_id:
+        return
+
+    append_message(
+        session_id,
+        role="system",
+        content=text,
+        metadata={"kind": phase, "debug": "system_prompt"},
+    )
+
+
+__all__ = ["persist_turn_system_prompt"]

--- a/core/agent_harness/models/turn_context.py
+++ b/core/agent_harness/models/turn_context.py
@@ -1,5 +1,8 @@
 """Per-turn immutable context snapshot for the agentic turn engine.
 
+See ``docs/agent-context-data-stores.md`` for how this fits with ``Session``,
+``MutableAgentState``, and JSONL persistence.
+
 Assembled once at the start of each turn from any object satisfying
 :class:`TurnContextSource` (the interactive shell passes its ``Session``;
 headless callers pass an in-memory session store). All fields reflect session
@@ -183,6 +186,7 @@ class TurnContext:
             if isinstance(role, str) and isinstance(content, str)
         )
         runtime_input = _select_runtime_request_input(text, session)
+        last_observation = _read_last_observation(session, runtime_input)
         return cls(
             text=text,
             conversation_messages=snapshot,
@@ -198,7 +202,7 @@ class TurnContext:
             tool_resources=dict(getattr(runtime_input, "tool_resources", {}) or {}),
             max_iterations=int(getattr(runtime_input, "max_iterations", 1)),
             model=getattr(runtime_input, "model", None),
-            last_observation=getattr(runtime_input, "last_observation", None),
+            last_observation=last_observation,
         )
 
     def render_system_prompt(self) -> str:
@@ -219,6 +223,24 @@ class TurnContext:
             raise ValueError("TurnContext.max_iterations must be positive.")
         if not self.active_tools:
             raise ValueError("TurnContext.active_tools must include at least one tool.")
+
+
+def _read_last_observation(session: TurnContextSource, runtime_input: Any | None) -> str | None:
+    """Read the last tool observation from runtime input or the live session."""
+    from_runtime = getattr(runtime_input, "last_observation", None)
+    if isinstance(from_runtime, str) and from_runtime.strip():
+        return from_runtime
+
+    agent = getattr(session, "agent", None)
+    agent_observation = getattr(agent, "last_observation", None)
+    if isinstance(agent_observation, str) and agent_observation.strip():
+        return agent_observation
+
+    session_observation = getattr(session, "last_command_observation", None)
+    if isinstance(session_observation, str) and session_observation.strip():
+        return session_observation
+
+    return None
 
 
 __all__ = [

--- a/core/agent_harness/prompts/__init__.py
+++ b/core/agent_harness/prompts/__init__.py
@@ -29,6 +29,7 @@ from core.agent_harness.prompts.assistant_agent_prompt import (
     build_environment_block,
 )
 from core.agent_harness.prompts.envelope import PromptBlock, PromptEnvelope
+from core.agent_harness.prompts.gather import build_gather_system_prompt
 
 __all__ = [
     "_SYSTEM_PROMPT_BASE",
@@ -44,6 +45,7 @@ __all__ = [
     "build_action_system_prompt_envelope",
     "build_action_user_message",
     "build_assistant_system_prompt",
+    "build_gather_system_prompt",
     "build_cli_agent_prompt",
     "build_cli_agent_prompt_envelope",
     "build_cli_agent_prompt_from_provider",

--- a/core/agent_harness/prompts/__init__.py
+++ b/core/agent_harness/prompts/__init__.py
@@ -29,7 +29,10 @@ from core.agent_harness.prompts.assistant_agent_prompt import (
     build_environment_block,
 )
 from core.agent_harness.prompts.envelope import PromptBlock, PromptEnvelope
-from core.agent_harness.prompts.gather import build_gather_system_prompt
+from core.agent_harness.prompts.gather import (
+    build_gather_system_prompt,
+    build_gather_system_prompt_from_turn_context,
+)
 
 __all__ = [
     "_SYSTEM_PROMPT_BASE",
@@ -46,6 +49,7 @@ __all__ = [
     "build_action_user_message",
     "build_assistant_system_prompt",
     "build_gather_system_prompt",
+    "build_gather_system_prompt_from_turn_context",
     "build_cli_agent_prompt",
     "build_cli_agent_prompt_envelope",
     "build_cli_agent_prompt_from_provider",

--- a/core/agent_harness/prompts/gather.py
+++ b/core/agent_harness/prompts/gather.py
@@ -1,0 +1,47 @@
+"""System prompt for the evidence-gathering pass of the terminal assistant.
+
+This is the fourth harness-surface prompt builder. It lives here, in the single
+``core/agent_harness/prompts/`` home, alongside the action and assistant builders
+so every harness prompt is constructed in one place (issue #3434, Problem 2).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core.agent_harness.ports import SessionStore
+
+
+def build_gather_system_prompt(session: SessionStore) -> str:
+    """Build the system prompt for one evidence-gathering turn.
+
+    The gather pass calls read-only integration tools to collect evidence for a
+    user question; a later step composes the user-facing answer from what it
+    returns. The prompt names the configured integrations so the model scopes its
+    tool calls to what is actually connected.
+    """
+    configured = (
+        ", ".join(session.configured_integrations)
+        if session.configured_integrations
+        else "(unknown)"
+    )
+    return (
+        "You are the data-gathering step of the OpenSRE terminal assistant. The "
+        "user asked a question that may be answerable with live data from the "
+        "connected integrations. You have access to the same tools the "
+        "investigation pipeline uses (logs, metrics, GitHub, error trackers, "
+        "cloud APIs, etc.).\n"
+        "Call the tools needed to gather evidence relevant to the user's "
+        "question. Derive arguments (such as owner/repo, service names, time "
+        "ranges, or search queries) from the user's message. Make tool calls "
+        "ONLY when they will help answer the question; if no tool is relevant, "
+        "respond with a short plain-text note and call nothing.\n"
+        "For GitHub repository metadata such as star count, forks, visibility, "
+        "or default branch, call get_github_repository — do not use "
+        "search_github_code or search_github_issues for those questions.\n"
+        "Do NOT write the final user-facing answer here — a later step composes "
+        "that from the tool results you collect. Stop calling tools as soon as "
+        "you have enough data.\n"
+        f"Configured integrations in this session: {configured}."
+    )

--- a/core/agent_harness/prompts/gather.py
+++ b/core/agent_harness/prompts/gather.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from core.agent_harness.models.turn_context import TurnContext
     from core.agent_harness.ports import SessionStore
 
 
@@ -45,3 +46,18 @@ def build_gather_system_prompt(session: SessionStore) -> str:
         "you have enough data.\n"
         f"Configured integrations in this session: {configured}."
     )
+
+
+def build_gather_system_prompt_from_turn_context(turn_ctx: TurnContext) -> str:
+    """Build the gather system prompt from a :class:`TurnContext` snapshot.
+
+    Uses the same integration list the action and assistant agents saw at
+    turn start. Prefer this when a ``TurnContext`` is already available.
+    """
+
+    class _GatherSessionView:
+        @property
+        def configured_integrations(self) -> tuple[str, ...]:
+            return turn_ctx.configured_integrations
+
+    return build_gather_system_prompt(_GatherSessionView())  # type: ignore[arg-type]

--- a/core/agent_harness/providers/default_providers.py
+++ b/core/agent_harness/providers/default_providers.py
@@ -209,6 +209,7 @@ class DefaultTurnAccounting:
                 kind="chat",
                 prompt=self._text,
                 response=response,
+                llm_run=result.llm_run,
             )
         with contextlib.suppress(AttributeError):
             self._session.last_assistant_intent = result.final_intent
@@ -221,6 +222,7 @@ def _append_turn_detail(
     kind: str,
     prompt: str,
     response: str,
+    llm_run: Any | None = None,
 ) -> None:
     storage = getattr(session, "storage", None)
     append_turn_detail = getattr(storage, "append_turn_detail", None)
@@ -228,7 +230,18 @@ def _append_turn_detail(
     if not callable(append_turn_detail) or not isinstance(session_id, str) or not session_id:
         return
     try:
-        append_turn_detail(session_id, kind, prompt, response=response)
+        append_turn_detail(
+            session_id,
+            kind,
+            prompt,
+            response=response,
+            model=getattr(llm_run, "model", None) if llm_run is not None else None,
+            provider=getattr(llm_run, "provider", None) if llm_run is not None else None,
+            latency_ms=getattr(llm_run, "latency_ms", None) if llm_run is not None else None,
+            system_prompt=getattr(llm_run, "final_system_prompt", None)
+            if llm_run is not None
+            else None,
+        )
     except Exception:
         log.debug("failed to persist default turn detail", exc_info=True)
 

--- a/core/agent_harness/providers/default_providers.py
+++ b/core/agent_harness/providers/default_providers.py
@@ -37,6 +37,25 @@ def _tool_input_preview(value: Any) -> str:
     return preview
 
 
+def _llm_client_unavailable_message(exc: Exception) -> str:
+    """Render the reasoning-client import failure, hinting at the common cause.
+
+    An ``ImportError`` from the ``core.llm`` graph on a long-running process is
+    almost always a stale process: the code changed on disk while the process
+    kept running, so a lazily-imported new module can't find a symbol in a
+    boot-cached old one. Point the operator at a restart instead of leaving them
+    with a bare ``cannot import name …``.
+    """
+    base = f"LLM client unavailable: {escape(str(exc))}"
+    if isinstance(exc, ImportError):
+        return (
+            f"{base} — this usually means the OpenSRE code changed while this "
+            "process was running. Restart it (relaunch with `uv run opensre …`) "
+            "to load the updated modules."
+        )
+    return base
+
+
 class DefaultToolProvider:
     """:class:`core.agent_harness.ports.ToolProvider` backed by action tools."""
 
@@ -137,7 +156,7 @@ class DefaultReasoningClientProvider:
                     context="core.agent_harness.default_reasoning_client.import",
                 )
             if self._output is not None:
-                self._output.render_error(f"LLM client unavailable: {escape(str(exc))}")
+                self._output.render_error(_llm_client_unavailable_message(exc))
             return None
         return get_llm_for_reasoning()
 

--- a/core/agent_harness/session/storage/jsonl.py
+++ b/core/agent_harness/session/storage/jsonl.py
@@ -69,6 +69,7 @@ class JsonlSessionStorage:
         model: str | None = None,
         provider: str | None = None,
         latency_ms: int | None = None,
+        system_prompt: str | None = None,
     ) -> None:
         metadata = {
             key: value
@@ -78,6 +79,7 @@ class JsonlSessionStorage:
                 "model": model,
                 "provider": provider,
                 "latency_ms": latency_ms,
+                "system_prompt": system_prompt,
             }.items()
             if value is not None
         }

--- a/core/agent_harness/session/storage/memory.py
+++ b/core/agent_harness/session/storage/memory.py
@@ -53,6 +53,7 @@ class InMemorySessionStorage:
         model: str | None = None,
         provider: str | None = None,
         latency_ms: int | None = None,
+        system_prompt: str | None = None,
     ) -> None:
         metadata = {
             key: value
@@ -62,6 +63,7 @@ class InMemorySessionStorage:
                 "model": model,
                 "provider": provider,
                 "latency_ms": latency_ms,
+                "system_prompt": system_prompt,
             }.items()
             if value is not None
         }
@@ -74,6 +76,26 @@ class InMemorySessionStorage:
                 "message",
                 {"role": "assistant", "content": response, "metadata": metadata},
             )
+
+    def append_message(
+        self,
+        session_id: str,
+        *,
+        role: str,
+        content: str,
+        metadata: dict[str, Any] | None = None,
+        parent_id: str | None = None,
+    ) -> str:
+        return self._append(
+            session_id,
+            "message",
+            {
+                "role": role,
+                "content": content,
+                "metadata": dict(metadata or {}),
+            },
+            parent_id=parent_id,
+        )
 
     def append_tool_call(
         self,

--- a/core/agent_harness/session/types.py
+++ b/core/agent_harness/session/types.py
@@ -53,6 +53,7 @@ class SessionStorage(Protocol):
         model: str | None = None,
         provider: str | None = None,
         latency_ms: int | None = None,
+        system_prompt: str | None = None,
     ) -> None:
         raise NotImplementedError
 

--- a/core/context/state/agent_state.py
+++ b/core/context/state/agent_state.py
@@ -1,4 +1,16 @@
-"""Shared mutable agent state and immutable turn-request snapshots."""
+"""Shared mutable agent state and immutable turn-request snapshots.
+
+Production usage (see ``docs/agent-context-data-stores.md``):
+
+* ``messages`` / ``last_observation`` / ``clear()`` — the live CLI transcript
+  embedded on ``Session`` as ``session.agent``.
+* Everything else in this module (``set_model``, ``begin_run``, ``subscribe``,
+  etc.) exists for tests and future runtime-request wiring; it is **not** on
+  any live harness path today.
+
+``core.agent.Agent`` does **not** read from ``MutableAgentState``; prompts and
+tools are assembled per turn via ``TurnContext`` + ``AgentConfig``.
+"""
 
 from __future__ import annotations
 

--- a/core/llm/preload.py
+++ b/core/llm/preload.py
@@ -1,0 +1,22 @@
+"""Force the LLM client module graph to load as one consistent snapshot.
+
+A long-running process (the gateway, the interactive shell) caches each module
+the first time it is imported and never reloads it. When some ``core.llm`` modules
+load at boot and others load lazily on first use, a code change *in between* can
+leave the process holding a mix of old and new modules — e.g. a freshly-imported
+new client doing ``from core.llm.transport_mode import <symbol>`` against a
+transport module that was cached (without that symbol) at boot. The result is a
+cryptic ``ImportError`` deep inside a turn.
+
+Importing the whole client graph at startup closes that window: the process is
+then either fully-old or fully-new — both internally consistent. This does **not**
+let a running process pick up code changes; restarting is still required for that.
+It only removes the mixed-version failure mode.
+"""
+
+from __future__ import annotations
+
+
+def preload_llm_clients() -> None:
+    """Import the LLM client modules so ``core.llm.*`` resolves at one instant."""
+    from core.llm import agent_llm_client, llm_client  # noqa: F401

--- a/docs/agent-context-data-stores.md
+++ b/docs/agent-context-data-stores.md
@@ -286,6 +286,66 @@ tail -f ~/.config/opensre/prompt_log.jsonl
 result.final_system_prompt  # last system prompt sent to the provider
 ```
 
+### Verify it yourself
+
+**Real session (needs an LLM key).** Run a turn, then read the prompt back out of
+the newest session file — no need to know the session id:
+
+```bash
+uv run opensre           # ask anything that hits the agent, then exit
+newest=$(ls -t ~/.opensre/sessions/*.jsonl | head -1)
+jq 'select(.type=="message" and .role=="system") | {kind: .metadata.kind, content}' "$newest"
+```
+
+You should see the assembled system prompt with `kind` = `action_agent` or
+`gather_agent` — the thing this issue said was never recorded.
+
+**No key (deterministic).** Proves capture → persist → read-back with a fake LLM
+and a throwaway session:
+
+```python
+import json
+from core.agent import Agent
+from core.agent_harness.debug.prompt_trace import persist_turn_system_prompt
+from core.agent_harness.prompts import build_gather_system_prompt
+from core.agent_harness.session.paths import session_path
+from core.agent_harness.session.storage.jsonl import JsonlSessionStorage
+from core.llm.types import AgentLLMResponse
+
+
+class FakeLLM:
+    def tool_schemas(self, tools):
+        return []
+
+    def invoke(self, messages, *, system=None, tools=None):
+        return AgentLLMResponse(content="done", tool_calls=[], raw_content=None)
+
+    def build_assistant_message(self, content, tool_calls):
+        return {"role": "assistant", "content": content}
+
+
+class Sess:
+    configured_integrations = ("github",)
+    storage = JsonlSessionStorage()
+    session_id = "prompt-verify-demo"
+    started_at = 1700000000.0
+
+
+system = build_gather_system_prompt(Sess())
+result = Agent(llm=FakeLLM(), system=system, tools=[], resolved_integrations={}, max_iterations=1).run(
+    [{"role": "user", "content": "hi"}]
+)
+Sess.storage.open_session(Sess())
+persist_turn_system_prompt(Sess(), phase="gather_agent", system_prompt=result.final_system_prompt)
+
+path = session_path("prompt-verify-demo")
+rows = [json.loads(x) for x in path.read_text().splitlines()]
+system_row = next(r for r in rows if r.get("role") == "system")
+assert system_row["content"] == result.final_system_prompt  # captured == persisted
+print("OK:", system_row["metadata"])
+path.unlink()
+```
+
 ### Prompt builders (single harness home)
 
 | Phase | Builder | Module |

--- a/docs/agent-context-data-stores.md
+++ b/docs/agent-context-data-stores.md
@@ -105,8 +105,19 @@ domain-specific prompt, which lives with the investigation stage that uses it.
 ## Seeing the final prompt (debuggability)
 
 The **assembled system prompt is captured on every agent turn** (issue #3434,
-Problem 1). `Agent.run(...)` records the final system prompt onto its result
-(`AgentRunResult.final_system_prompt`) and persists it to the JSONL trace, so you
-can answer "what was influencing the agent when it made this decision?" by reading
-the session file or `/trace` output — you no longer have to re-derive the prompt by
-hand.
+Problem 1). `core/agent.py::Agent.run(...)` records the exact system prompt sent to
+the LLM onto its result — `AgentRunResult.final_system_prompt` — captured *after*
+the `_before_provider_request` hook, so it reflects any per-turn edits, not a
+pre-hook approximation.
+
+The capture lives in the shared core loop, **not** in any one surface, so every
+surface (interactive shell, CLI, gateway/Telegram, headless) records the same
+thing from the same place. That answers "what was influencing the agent when it
+made this decision?" without re-deriving the prompt by hand.
+
+**Follow-up (not yet wired):** persisting `final_system_prompt` to the per-session
+JSONL trace so `/trace` can render it. That belongs in the core turn record (the
+shared run-record path), *not* in the shell-only `PromptRecorder` — recording it in
+one surface is exactly the per-surface divergence this restructure is removing. The
+shell's `PromptRecorder` today records the *user* input text, not the system
+prompt, and is a separate, surface-local mechanism.

--- a/docs/agent-context-data-stores.md
+++ b/docs/agent-context-data-stores.md
@@ -140,7 +140,7 @@ hydrated by `SessionResolver` before each turn.
 ## Store 2 — `MutableAgentState` (audit)
 
 **File:** `core/context/state/agent_state.py`  
-**Access:** `session.agent` (compat: `session.cli_agent_messages`,
+**Access:** `session.agent` (compatibility: `session.cli_agent_messages`,
 `session.last_command_observation`)
 
 ### Production API (use these)
@@ -211,7 +211,7 @@ when a snapshot exists; the session-only overload remains for adapters.
 
 | Entry type | Contents |
 |------------|----------|
-| `session` | Header (version, cwd, opensre version) |
+| `session` | Header (version, working directory, opensre version) |
 | `message` | User/assistant/system chat rows + metadata |
 | `tool_call` / `tool_result` | Tool execution audit |
 | `compaction` | Context compaction summary |

--- a/docs/agent-context-data-stores.md
+++ b/docs/agent-context-data-stores.md
@@ -1,0 +1,112 @@
+# Agent context & data stores
+
+> Contributor reference. If you are trying to understand "what state is the agent
+> actually looking at right now?", start here.
+
+A single agent turn touches **four** in-memory/on-disk stores. They are *not*
+merged into one object — but each has one clear owner and one clear job. This
+page says which is which, so you can find and debug context quickly.
+
+## The four stores at a glance
+
+| # | Store | Lives in | Owns (its one job) | Lifecycle owner |
+|---|-------|----------|--------------------|-----------------|
+| 1 | **`Session`** | `core/agent_harness/session/state.py` | The whole REPL/gateway session: identity, history, integration cache, per-session prefs, background tasks. | `SessionManager` |
+| 2 | **`MutableAgentState`** | `core/context/state/agent_state.py` | The **conversation only**: the running `(role, text)` message list + the last tool observation. Held on `Session` as `session.agent`. | `Session` (embeds it) |
+| 3 | **`TurnContext`** | `core/agent_harness/models/turn_context.py` | An **immutable snapshot of one turn**, taken at turn start, so prompt building sees a stable view (not mid-mutation session state). | Built fresh per turn |
+| 4 | **JSONL session file** | `core/agent_harness/session/storage/jsonl.py` | **Durable history on disk**: turns, tool calls, investigation results, compaction. | `SessionStorage` protocol |
+
+Rule of thumb:
+- **Session** = "everything we remember for this process."
+- **MutableAgentState** = "the chat transcript" (a slice of Session).
+- **TurnContext** = "a photo of the session at the instant this turn began."
+- **JSONL** = "the same thing, written to disk so `/resume` and `/trace` work."
+
+## Store 1 — `Session` (the hub)
+
+`Session` is the process-wide session object used by **every** surface (interactive
+shell *and* headless gateway — it is not REPL-specific). Its lifecycle
+(create / resolve / rotate / close) is owned by `SessionManager`; see
+[`core/agent_harness/AGENTS.md`](../core/agent_harness/AGENTS.md).
+
+Cohesive slices have been factored out so `Session` reads as composition, not a
+grab-bag: `session.tokens` (`TokenUsage`), `session.metrics` (`TerminalMetrics`),
+`session.agent` (`MutableAgentState`, store #2), `session.storage`
+(`SessionStorage`, store #4).
+
+## Store 2 — `MutableAgentState` (conversation only)
+
+**What it actually does in production:** holds the conversation transcript and the
+last tool observation. That's it. Reached through `session.agent`:
+
+- `session.agent.messages` — the `(role, text)` list (also via the
+  `session.cli_agent_messages` compatibility property).
+- `session.agent.last_observation` — the last turn's tool/command output (also via
+  `session.last_command_observation`).
+- `session.agent.clear()` — reset on `/new`.
+
+**Audit result (issue #3434):** `MutableAgentState` is a ~340-line Zustand-style
+store with a much larger API — `system_prompt`, `model`, `available_tools`,
+`active_tools`, `run_status`, `pending_tool_calls`, `subscribe()`, `snapshot()`,
+`begin_run()`, and a family of `set_*` mutators. **In production, none of that
+extra API is used** — only `messages` / `last_observation` / `clear()` are.
+
+**Is it wired into the `Agent` class?** **No.** `core/agent.py` does not import or
+touch `MutableAgentState`. The `Agent` loop takes its system prompt, tools, and
+integrations as explicit constructor arguments (via `AgentConfig` /
+`build_agent`), not from `MutableAgentState`. So `MutableAgentState.system_prompt`
+is written once at construction and never read by the runtime.
+
+Practical implication: treat `session.agent` as "the transcript." Do not reach for
+its `set_model` / `begin_run` / `snapshot` machinery — it is not on any live path.
+(Slimming it to the used surface is tracked as a follow-up.)
+
+## Store 3 — `TurnContext` (one-turn snapshot)
+
+Built once per turn via `TurnContext.from_session(text, session)` and passed to the
+prompt builders. Because it is an **immutable** snapshot, a prompt reflects
+turn-start state even if the session mutates mid-turn.
+
+**There is exactly one `TurnContext` type — no surface-specific variants.** (Issue
+#3434 mentioned a `ShellTurnContext`; it does not exist. `ReplRuntimeContext`,
+`GroundingContext`, `ActionToolContext`, etc. are unrelated objects, not
+`TurnContext` subclasses.) So there is nothing to "consolidate" here — the single
+type is already the shared base.
+
+`TurnContext` can also drive `Agent.run(agent_context=...)`: it carries
+`system_prompt`, `active_tools`, `resolved_integrations`, and `max_iterations` for
+the runtime-request path.
+
+## Store 4 — JSONL session file (durable)
+
+Every turn, tool call, investigation result, and compaction is appended to a
+per-session JSONL file through the `SessionStorage` protocol
+(`JsonlSessionStorage` in production, `InMemorySessionStorage` in tests). This is
+what `/resume` reloads and what `/trace` reads. It is intentionally decoupled from
+the in-memory stores: the on-disk format can change without touching `Session`.
+
+## Where prompts are built
+
+System prompts are assembled per surface, then handed to the agent as a plain
+string (`AgentConfig.system`). After issue #3434 the builders live in **two**
+homes:
+
+| Surface | Builder | Home |
+|---------|---------|------|
+| Action agent | `build_action_system_prompt` | `core/agent_harness/prompts/` |
+| Conversational assistant | `build_assistant_system_prompt` | `core/agent_harness/prompts/` |
+| Evidence gather | `build_gather_system_prompt` | `core/agent_harness/prompts/` |
+| Investigation pipeline | `build_investigation_system_prompt` | `tools/investigation/stages/gather_evidence/prompt.py` |
+
+Home 1 — **`core/agent_harness/prompts/`** — is the single home for every
+harness-surface prompt. Home 2 is the investigation pipeline's own
+domain-specific prompt, which lives with the investigation stage that uses it.
+
+## Seeing the final prompt (debuggability)
+
+The **assembled system prompt is captured on every agent turn** (issue #3434,
+Problem 1). `Agent.run(...)` records the final system prompt onto its result
+(`AgentRunResult.final_system_prompt`) and persists it to the JSONL trace, so you
+can answer "what was influencing the agent when it made this decision?" by reading
+the session file or `/trace` output — you no longer have to re-derive the prompt by
+hand.

--- a/docs/agent-context-data-stores.md
+++ b/docs/agent-context-data-stores.md
@@ -1,123 +1,293 @@
-# Agent context & data stores
+# Agent context and data stores
 
-> Contributor reference. If you are trying to understand "what state is the agent
-> actually looking at right now?", start here.
+> **Start here** if you are asking: *what state is the agent looking at right
+> now?* or *where do I debug the prompt that was sent to the model?*
 
-A single agent turn touches **four** in-memory/on-disk stores. They are *not*
-merged into one object — but each has one clear owner and one clear job. This
-page says which is which, so you can find and debug context quickly.
+This page maps the four in-memory/on-disk stores, how they relate, and where
+to look when something diverges between shell, gateway, and headless paths.
 
-## The four stores at a glance
+---
 
-| # | Store | Lives in | Owns (its one job) | Lifecycle owner |
-|---|-------|----------|--------------------|-----------------|
-| 1 | **`Session`** | `core/agent_harness/session/state.py` | The whole REPL/gateway session: identity, history, integration cache, per-session prefs, background tasks. | `SessionManager` |
-| 2 | **`MutableAgentState`** | `core/context/state/agent_state.py` | The **conversation only**: the running `(role, text)` message list + the last tool observation. Held on `Session` as `session.agent`. | `Session` (embeds it) |
-| 3 | **`TurnContext`** | `core/agent_harness/models/turn_context.py` | An **immutable snapshot of one turn**, taken at turn start, so prompt building sees a stable view (not mid-mutation session state). | Built fresh per turn |
-| 4 | **JSONL session file** | `core/agent_harness/session/storage/jsonl.py` | **Durable history on disk**: turns, tool calls, investigation results, compaction. | `SessionStorage` protocol |
+## Quick lookup
 
-Rule of thumb:
-- **Session** = "everything we remember for this process."
-- **MutableAgentState** = "the chat transcript" (a slice of Session).
-- **TurnContext** = "a photo of the session at the instant this turn began."
-- **JSONL** = "the same thing, written to disk so `/resume` and `/trace` work."
+| I want to… | Look at… |
+|------------|----------|
+| See live session state (integrations, history, metrics) | `Session` — `core/agent_harness/session/state.py` |
+| See the chat transcript the assistant uses | `session.agent.messages` (`MutableAgentState`) |
+| See what one turn looked like **at turn start** | `TurnContext.from_session(text, session)` |
+| Resume or trace a past session | JSONL file — `~/.opensre/sessions/{session_id}.jsonl` |
+| See the **system prompt** sent to `Agent.run` | `AgentRunResult.final_system_prompt` (in-memory) or JSONL `role=system` entries |
+| See the **user-facing composed prompt** for the assistant | Session JSONL `message` user rows, or `~/.config/opensre/prompt_log.jsonl` (shell only) |
+| Understand turn routing (action vs answer) | `run_turn` — `core/agent_harness/agents/turn_orchestrator.py` |
 
-## Store 1 — `Session` (the hub)
+---
 
-`Session` is the process-wide session object used by **every** surface (interactive
-shell *and* headless gateway — it is not REPL-specific). Its lifecycle
-(create / resolve / rotate / close) is owned by `SessionManager`; see
-[`core/agent_harness/AGENTS.md`](../core/agent_harness/AGENTS.md).
+## Architecture (four stores)
 
-Cohesive slices have been factored out so `Session` reads as composition, not a
-grab-bag: `session.tokens` (`TokenUsage`), `session.metrics` (`TerminalMetrics`),
-`session.agent` (`MutableAgentState`, store #2), `session.storage`
-(`SessionStorage`, store #4).
+```mermaid
+flowchart TB
+    subgraph turn_start [Turn start]
+        UserInput[User message]
+        Session[Session hub]
+        TC[TurnContext snapshot]
+        UserInput --> TC
+        Session --> TC
+    end
 
-## Store 2 — `MutableAgentState` (conversation only)
+    subgraph agents [Agent phases]
+        Action[Action agent - Agent.run]
+        Gather[Gather agent - Agent.run]
+        Answer[Assistant - invoke_stream]
+    end
 
-**What it actually does in production:** holds the conversation transcript and the
-last tool observation. That's it. Reached through `session.agent`:
+    TC --> Action
+    TC --> Gather
+    TC --> Answer
+    Session --> Action
+    Session --> Gather
+    Session --> Answer
 
-- `session.agent.messages` — the `(role, text)` list (also via the
-  `session.cli_agent_messages` compatibility property).
-- `session.agent.last_observation` — the last turn's tool/command output (also via
-  `session.last_command_observation`).
-- `session.agent.clear()` — reset on `/new`.
+    subgraph persist [Persistence]
+        AgentState[session.agent messages]
+        JSONL[Session JSONL file]
+    end
 
-**Audit result (issue #3434):** `MutableAgentState` is a ~340-line Zustand-style
-store with a much larger API — `system_prompt`, `model`, `available_tools`,
-`active_tools`, `run_status`, `pending_tool_calls`, `subscribe()`, `snapshot()`,
-`begin_run()`, and a family of `set_*` mutators. **In production, none of that
-extra API is used** — only `messages` / `last_observation` / `clear()` are.
+    Action --> AgentState
+    Answer --> AgentState
+    Action --> JSONL
+    Gather --> JSONL
+    Answer --> JSONL
+    Session --> JSONL
+```
 
-**Is it wired into the `Agent` class?** **No.** `core/agent.py` does not import or
-touch `MutableAgentState`. The `Agent` loop takes its system prompt, tools, and
-integrations as explicit constructor arguments (via `AgentConfig` /
-`build_agent`), not from `MutableAgentState`. So `MutableAgentState.system_prompt`
-is written once at construction and never read by the runtime.
+**Rule of thumb**
 
-Practical implication: treat `session.agent` as "the transcript." Do not reach for
-its `set_model` / `begin_run` / `snapshot` machinery — it is not on any live path.
-(Slimming it to the used surface is tracked as a follow-up.)
+| Store | One-line job |
+|-------|----------------|
+| `Session` | Everything this process remembers |
+| `MutableAgentState` (`session.agent`) | The chat transcript + last tool observation |
+| `TurnContext` | A frozen photo of session state at turn start |
+| JSONL session file | Durable copy for `/resume`, `/trace`, and audit |
 
-## Store 3 — `TurnContext` (one-turn snapshot)
+---
 
-Built once per turn via `TurnContext.from_session(text, session)` and passed to the
-prompt builders. Because it is an **immutable** snapshot, a prompt reflects
-turn-start state even if the session mutates mid-turn.
+## Turn flow (one message)
 
-**There is exactly one `TurnContext` type — no surface-specific variants.** (Issue
-#3434 mentioned a `ShellTurnContext`; it does not exist. `ReplRuntimeContext`,
-`GroundingContext`, `ActionToolContext`, etc. are unrelated objects, not
-`TurnContext` subclasses.) So there is nothing to "consolidate" here — the single
-type is already the shared base.
+```mermaid
+sequenceDiagram
+    participant Surface as Shell / Gateway / Headless
+    participant TO as run_turn
+    participant TC as TurnContext
+    participant Action as action_agent
+    participant Gather as evidence_agent
+    participant Answer as answer_cli_agent
+    participant JSONL as Session JSONL
 
-`TurnContext` can also drive `Agent.run(agent_context=...)`: it carries
-`system_prompt`, `active_tools`, `resolved_integrations`, and `max_iterations` for
-the runtime-request path.
+    Surface->>TO: message + Session
+    TO->>TC: TurnContext.from_session
+    TO->>Action: execute_actions (uses TC)
+    alt action handled
+        Action->>JSONL: persist_turn_system_prompt (action)
+        TO-->>Surface: cli_agent_handled
+    else fall through
+        TO->>Gather: gather (optional)
+        Gather->>JSONL: persist_turn_system_prompt (gather)
+        TO->>Answer: answer (uses TC)
+        Answer->>JSONL: append_turn_detail (user + assistant)
+        TO-->>Surface: cli_agent_fallback
+    end
+```
 
-## Store 4 — JSONL session file (durable)
+All surfaces call the same `run_turn` engine. Gateway uses
+`Agent.dispatch_message_to_headless_agent` with `DefaultToolProvider(session, …)`
+so action tools resolve from the **live** session integrations each turn (same as
+shell).
 
-Every turn, tool call, investigation result, and compaction is appended to a
-per-session JSONL file through the `SessionStorage` protocol
-(`JsonlSessionStorage` in production, `InMemorySessionStorage` in tests). This is
-what `/resume` reloads and what `/trace` reads. It is intentionally decoupled from
-the in-memory stores: the on-disk format can change without touching `Session`.
+---
 
-## Where prompts are built
+## Glossary (disambiguation)
 
-System prompts are assembled per surface, then handed to the agent as a plain
-string (`AgentConfig.system`). After issue #3434 the builders live in **two**
-homes:
+| Name | What it is **not** |
+|------|---------------------|
+| `MutableAgentState` | Not `core.agent.Agent` state; not investigation `AgentState` TypedDict |
+| `TurnContext` | Not `ReplRuntimeContext`, `GroundingContext`, or `ActionToolContext` |
+| `AgentContextInput` | Not a store — selector output from `select_agent_context_input()` |
+| `Agent.run(agent_context=…)` | Not used on live shell/gateway paths yet (tests only); production uses `AgentConfig` |
+| `PromptRecorder` | Not the system prompt — records user prompt + assistant response (shell telemetry) |
 
-| Surface | Builder | Home |
-|---------|---------|------|
-| Action agent | `build_action_system_prompt` | `core/agent_harness/prompts/` |
-| Conversational assistant | `build_assistant_system_prompt` | `core/agent_harness/prompts/` |
-| Evidence gather | `build_gather_system_prompt` | `core/agent_harness/prompts/` |
-| Investigation pipeline | `build_investigation_system_prompt` | `tools/investigation/stages/gather_evidence/prompt.py` |
+---
 
-Home 1 — **`core/agent_harness/prompts/`** — is the single home for every
-harness-surface prompt. Home 2 is the investigation pipeline's own
-domain-specific prompt, which lives with the investigation stage that uses it.
+## Store 1 — `Session`
 
-## Seeing the final prompt (debuggability)
+**File:** `core/agent_harness/session/state.py`  
+**Lifecycle:** `SessionManager` — `core/agent_harness/session/manager.py`
 
-The **assembled system prompt is captured on every agent turn** (issue #3434,
-Problem 1). `core/agent.py::Agent.run(...)` records the exact system prompt sent to
-the LLM onto its result — `AgentRunResult.final_system_prompt` — captured *after*
-the `_before_provider_request` hook, so it reflects any per-turn edits, not a
-pre-hook approximation.
+Composition (not a grab-bag):
 
-The capture lives in the shared core loop, **not** in any one surface, so every
-surface (interactive shell, CLI, gateway/Telegram, headless) records the same
-thing from the same place. That answers "what was influencing the agent when it
-made this decision?" without re-deriving the prompt by hand.
+| Slice | Type | Role |
+|-------|------|------|
+| `session.agent` | `MutableAgentState` | Transcript |
+| `session.storage` | `SessionStorage` | JSONL writer |
+| `session.tokens` | `TokenUsage` | Token accounting |
+| `session.metrics` | `TerminalMetrics` | Terminal metrics |
+| `session.resolved_integrations_cache` | `dict` | Integration configs for tools |
 
-**Follow-up (not yet wired):** persisting `final_system_prompt` to the per-session
-JSONL trace so `/trace` can render it. That belongs in the core turn record (the
-shared run-record path), *not* in the shell-only `PromptRecorder` — recording it in
-one surface is exactly the per-surface divergence this restructure is removing. The
-shell's `PromptRecorder` today records the *user* input text, not the system
-prompt, and is a separate, surface-local mechanism.
+Used by **every** surface (shell, gateway, headless). Gateway chat sessions are
+hydrated by `SessionResolver` before each turn.
+
+---
+
+## Store 2 — `MutableAgentState` (audit)
+
+**File:** `core/context/state/agent_state.py`  
+**Access:** `session.agent` (compat: `session.cli_agent_messages`,
+`session.last_command_observation`)
+
+### Production API (use these)
+
+| API | Purpose |
+|-----|---------|
+| `.messages` / setter | Conversation `(role, text)` pairs |
+| `.last_observation` | Last tool/command output for grounding |
+| `.clear()` | Reset on `/new` |
+
+### Unused in production (tests / future only)
+
+| API | Status |
+|-----|--------|
+| `set_system_prompt`, `set_model`, `set_*_tools` | Never called on live paths |
+| `begin_run` / `end_run`, `mark_tool_pending` | Never called on live paths |
+| `subscribe()`, `snapshot()` | Test-only |
+| `record_turn()` | Orchestrator appends to `cli_agent_messages` directly instead |
+
+**Important:** `core.agent.Agent` does **not** read `MutableAgentState`. Tools
+and system prompts are assembled per turn via `TurnContext` + `AgentConfig`.
+
+**Follow-up:** slim the class to transcript + observation only (issue #3434).
+
+---
+
+## Store 3 — `TurnContext` (unified)
+
+**File:** `core/agent_harness/models/turn_context.py`  
+**There is exactly one type** — no `ShellTurnContext` or surface variants.
+
+Built once per turn:
+
+```python
+turn_ctx = TurnContext.from_session(text, session)
+```
+
+Passed to action prompts, assistant prompts, and shell adapters. The live
+`Session` is still passed separately for writes (history, tokens, persistence).
+
+### Field reference
+
+| Field | Populated by `from_session`? | Used by |
+|-------|------------------------------|---------|
+| `text` | Yes | All agents |
+| `conversation_messages` | Yes (capped) | Action + assistant prompts |
+| `configured_integrations` | Yes | Prompts, tool availability |
+| `last_state` | Yes | Follow-up grounding (RCA) |
+| `last_synthetic_observation_path` | Yes | Synthetic failure context |
+| `reasoning_effort` | Yes | LLM calls |
+| `last_observation` | Yes (session → agent → runtime input) | Assistant grounding |
+| `system_prompt`, `active_tools`, … | Only if `select_agent_context_input` populated | `Agent.run(agent_context=…)` tests |
+| `working_directory`, `terminal_capabilities`, … | **No** (reserved / unused) | Do not rely on these |
+
+Runtime-request fields are empty in production because `MutableAgentState` is
+never populated with tools/prompt — builders read `TurnContext` snapshot fields
+and assemble `AgentConfig` separately.
+
+**Gather alignment:** prefer `build_gather_system_prompt_from_turn_context(turn_ctx)`
+when a snapshot exists; the session-only overload remains for adapters.
+
+---
+
+## Store 4 — JSONL session file
+
+**Path:** `~/.opensre/sessions/{session_id}.jsonl`  
+**Protocol:** `SessionStorage` — `core/agent_harness/session/types.py`
+
+| Entry type | Contents |
+|------------|----------|
+| `session` | Header (version, cwd, opensre version) |
+| `message` | User/assistant/system chat rows + metadata |
+| `tool_call` / `tool_result` | Tool execution audit |
+| `compaction` | Context compaction summary |
+| `investigation_result` | RCA output |
+| `custom_message` / `turn_stub` | Turn kind stubs from `Session.record` |
+
+Reload: `SessionRepo.load_session` → `SessionManager.restore_context`.
+
+---
+
+## Prompt recording (debug)
+
+Three layers — know which you need:
+
+| Layer | What is captured | Where | Surfaces |
+|-------|------------------|-------|----------|
+| **A. `AgentRunResult.final_system_prompt`** | Exact system string after `_before_provider_request` | In-memory on `Agent.run` result | Action + gather (`Agent.run`) |
+| **B. `persist_turn_system_prompt`** | Same system prompt appended to JSONL | `message` row, `role=system`, `metadata.debug=system_prompt` | Action + gather (wired in harness) |
+| **C. `append_turn_detail`** | User prompt + assistant response (+ optional `metadata.system_prompt` from `LlmRunInfo`) | Session JSONL `message` rows | Gateway/headless via `DefaultTurnAccounting`; shell via `PromptRecorder.flush` |
+| **D. `PromptRecorder`** | User prompt + response text (telemetry) | `~/.config/opensre/prompt_log.jsonl` | Shell only |
+
+### Debug cookbook
+
+**Find action/gather system prompt in session file:**
+
+```bash
+jq 'select(.type=="message" and .role=="system")' \
+  ~/.opensre/sessions/YOUR_SESSION_ID.jsonl
+```
+
+**Find assistant turn with metadata:**
+
+```bash
+jq 'select(.type=="message" and .metadata.kind=="chat")' \
+  ~/.opensre/sessions/YOUR_SESSION_ID.jsonl
+```
+
+**Shell global prompt log:**
+
+```bash
+tail -f ~/.config/opensre/prompt_log.jsonl
+# Disable: OPENSRE_PROMPT_LOG_DISABLED=1
+# Path override: OPENSRE_PROMPT_LOG_PATH
+```
+
+**In code after `Agent.run`:**
+
+```python
+result.final_system_prompt  # last system prompt sent to the provider
+```
+
+### Prompt builders (single harness home)
+
+| Phase | Builder | Module |
+|-------|---------|--------|
+| Action | `build_action_system_prompt` | `core/agent_harness/prompts/` |
+| Assistant | `build_assistant_system_prompt` | `core/agent_harness/prompts/` |
+| Gather | `build_gather_system_prompt` / `_from_turn_context` | `core/agent_harness/prompts/gather.py` |
+| Investigation | `build_investigation_system_prompt` | `tools/investigation/stages/gather_evidence/prompt.py` |
+
+The assistant path is a **categorical exception**: it streams via
+`invoke_stream(prompt)` and does not use `Agent.run` (see
+`core/agent_harness/AGENTS.md`).
+
+---
+
+## Related docs
+
+- `core/agent_harness/AGENTS.md` — package boundaries, session lifecycle, agent construction
+- `gateway/AGENTS.md` — gateway turn handler and per-chat sessions
+
+---
+
+## Follow-ups (issue #3434)
+
+1. Slim `MutableAgentState` to transcript + observation only
+2. Wire assistant composed prompt split into system vs user blocks in JSONL
+3. Route production action/gather through `Agent.run(agent_context=TurnContext)` instead of parallel `AgentConfig` assembly
+4. Populate or remove reserved `TurnContext` shell fields (`working_directory`, etc.)

--- a/docs/agent-context-data-stores.md
+++ b/docs/agent-context-data-stores.md
@@ -24,40 +24,63 @@ to look when something diverges between shell, gateway, and headless paths.
 
 ## Architecture (four stores)
 
+One picture: the four surfaces funnel into one core engine; the four stores
+(numbered) carry state through the turn; the four prompt builders live in one
+home; and the assembled prompt is captured for debugging.
+
 ```mermaid
 flowchart TB
-    subgraph turn_start [Turn start]
-        UserInput[User message]
-        Session[Session hub]
-        TC[TurnContext snapshot]
-        UserInput --> TC
-        Session --> TC
+    subgraph surfaces [Different flows - thin adapters]
+        SH[Interactive shell]
+        CLI[CLI one-shot]
+        GW[Gateway / Telegram]
+        HL[Headless API]
+    end
+    SH --> DISP
+    CLI --> DISP
+    GW --> DISP
+    HL --> DISP
+    DISP[dispatch_message_to_headless_agent] --> RT[run_turn - one core engine]
+
+    subgraph stores [The four data stores]
+        S1["1 Session - hub (owner: SessionManager)"]
+        S2["2 session.agent = MutableAgentState - transcript only, not read by Agent"]
+        S3["3 TurnContext - immutable snapshot at turn start"]
+        S4["4 JSONL session file (owner: SessionStorage)"]
     end
 
-    subgraph agents [Agent phases]
-        Action[Action agent - Agent.run]
-        Gather[Gather agent - Agent.run]
-        Answer[Assistant - invoke_stream]
+    RT -->|TurnContext.from_session| S3
+    S1 --- S2
+    S1 --> S3
+
+    S3 --> ROUTE{route}
+    ROUTE -->|action| A1[action_agent]
+    ROUTE -->|gather| A2[evidence_agent]
+    ROUTE -->|answer| A3[assistant]
+
+    subgraph prompts [One prompt home: core/agent_harness/prompts/]
+        P1[build_action_system_prompt]
+        P2[build_gather_system_prompt]
+        P3[build_assistant_system_prompt]
     end
+    PI[build_investigation_system_prompt - investigation stage]
 
-    TC --> Action
-    TC --> Gather
-    TC --> Answer
-    Session --> Action
-    Session --> Gather
-    Session --> Answer
+    A1 --> P1
+    A2 --> P2
+    A3 --> P3
 
-    subgraph persist [Persistence]
-        AgentState[session.agent messages]
-        JSONL[Session JSONL file]
-    end
+    P1 --> RUN
+    P2 --> RUN
+    P3 --> RUN
+    RUN["Agent.run()"] -->|capture after _before_provider_request| FP[AgentRunResult.final_system_prompt]
 
-    Action --> AgentState
-    Answer --> AgentState
-    Action --> JSONL
-    Gather --> JSONL
-    Answer --> JSONL
-    Session --> JSONL
+    A1 --> S2
+    A3 --> S2
+    FP -->|persist_turn_system_prompt| S4
+    A1 --> S4
+    A2 --> S4
+    A3 --> S4
+    S1 --> S4
 ```
 
 **Rule of thumb**

--- a/docs/messaging/telegram.mdx
+++ b/docs/messaging/telegram.mdx
@@ -187,13 +187,22 @@ OpenSRE can also run a **Telegram messaging gateway** so you can chat with the a
 
 ### Allow your Telegram user
 
-Find your numeric user id with [@userinfobot](https://t.me/userinfobot), then either:
+Find your **numeric user id** with [@userinfobot](https://t.me/userinfobot), then either:
 
 ```bash
 opensre messaging allow -p telegram -u 123456789
 ```
 
 or set `TELEGRAM_ALLOWED_USERS=123456789` in `.env`.
+
+<Warning>
+  Use the **numeric user id** (Telegram's `from.id`), not a `@username` and not
+  your bot's handle. Inbound authorization only ever matches the numeric id, so a
+  `@handle` produces an allow-list entry that can never match a real sender — you
+  will see `User <id> is not in the allowed users list` for every message. The CLI
+  now rejects non-numeric Telegram ids, but older entries may still be wrong; check
+  with `opensre messaging status -p telegram` and re-add with the numeric id.
+</Warning>
 
 Optional DM pairing (same policy as other messaging platforms):
 
@@ -220,6 +229,27 @@ The gateway uses the same headless agent harness as the interactive shell, with 
 - **Action tools** — `shell_run` and `investigation_start`
 
 Investigation delivery, watchdog alerts, and cron still use the outbound-only paths documented above — they do not require the gateway process.
+
+### Deploying the gateway to a remote host
+
+Running the gateway on a server with `make deploy` (EC2) is different from local
+use in one important way: **the remote host cannot read your local machine's
+keychain**. Guided setup stores the bot token (and your LLM API key) in the system
+keyring, which is perfect locally but does not travel to the deployed instance.
+
+So `make deploy` validates that the required secrets are present as **plaintext
+env vars** in `.env`, and aborts if they are only in the keychain:
+
+```bash
+TELEGRAM_BOT_TOKEN=<numeric-id>:<token-secret>
+TELEGRAM_ALLOWED_USERS=123456789        # numeric user id(s), comma-separated
+ANTHROPIC_API_KEY=...                    # or your provider's key env
+```
+
+If `make deploy` reports `MISSING: Telegram gateway bot configuration` or
+`MISSING: LLM provider configuration` even though local setup succeeded, this is
+why — copy the values into `.env` (or `.env.deploy.example`) for the deploy. A
+"missing" here means "not in the deploy env", not "not configured".
 
 ---
 

--- a/docs/messaging/telegram.mdx
+++ b/docs/messaging/telegram.mdx
@@ -197,7 +197,7 @@ or set `TELEGRAM_ALLOWED_USERS=123456789` in `.env`.
 
 <Warning>
   Use the **numeric user id** (Telegram's `from.id`), not a `@username` and not
-  your bot's handle. Inbound authorization only ever matches the numeric id, so a
+  the bot handle. Inbound authorization only ever matches the numeric id, so a
   `@handle` produces an allow-list entry that can never match a real sender — you
   will see `User <id> is not in the allowed users list` for every message. The CLI
   now rejects non-numeric Telegram ids, but older entries may still be wrong; check

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -13,11 +13,10 @@ Pytest discovers these tests through `pytest.ini`; scoped CI maps changes under
 
 ## Layout
 
-- `manager.py` — process composition root: bootstraps action tools via
-  `SessionManager.create(open_storage=False)`, builds the turn handler, starts
-  the Telegram worker, owns signals and shutdown.
+- `manager.py` — process composition root: builds the turn handler, starts the
+  Telegram worker, owns signals and shutdown.
 - `turn_handler.py` — transport-agnostic turn callback:
-  `build_gateway_turn_handler(tools=..., console=...)` returns
+  `build_gateway_turn_handler(console=...)` returns
   `(text, session, sink, logger) -> None` that drives
   `Agent.dispatch_message_to_headless_agent(...)`.
 - `telegram_gateway.py` — wires the handler into the Telegram polling worker.
@@ -26,15 +25,16 @@ Pytest discovers these tests through `pytest.ini`; scoped CI maps changes under
 
 ## Gateway turn dispatch
 
-- **No persistent gateway `Agent` instance.** Tools are precomputed once at
-  process start from a boot `Session`; each inbound message gets a per-chat
-  `Session` from `SessionResolver` and is handled by the shared headless
-  dispatch path (`core.agent_harness.agents.headless_agent`).
+- **No persistent gateway `Agent` instance.** Each inbound message gets a
+  per-chat `Session` from `SessionResolver` and is handled by the shared
+  headless dispatch path (`core.agent_harness.agents.headless_agent`).
 - The turn handler callback signature is exactly four arguments: `text`,
   `session`, `sink`, and `logger`. Do not reintroduce `chat_id` into this
   contract; the sink owns chat transport details.
-- Reuse `DefaultToolProvider` with `precomputed_action_tools=tools` so the
-  gateway does not rebuild or filter the action-tool list per turn.
+- Resolve action tools from the live per-chat `Session` each turn via
+  `DefaultToolProvider(session, console)` — same as the interactive shell.
+  Do **not** precompute tools at process start; chat sessions carry their own
+  integration context after `SessionResolver.resolve`.
 - Per-chat session lifecycle (create / resolve / rotate / restore) is owned by
   `SessionResolver` → `SessionManager`, not by `GatewayManager`.
 

--- a/gateway/manager.py
+++ b/gateway/manager.py
@@ -16,6 +16,7 @@ import signal
 from rich.console import Console
 
 from core.agent_harness.harness import AgentHarness, HarnessConfig
+from core.llm.preload import preload_llm_clients
 from gateway.config.configure_gateway_logging import configure_gateway_logging
 from gateway.config.get_gateway_settings import GatewaySettings
 from gateway.polling.telegram_gateway_background import TelegramGatewayBackground
@@ -36,6 +37,12 @@ class GatewayManager:
         harness = AgentHarness(HarnessConfig(open_storage=False))
         harness.resolve_env_variables()
         logger = configure_gateway_logging()
+
+        # Load the LLM client graph as one consistent snapshot at boot, so a
+        # later code change can't leave this long-running process holding a mix
+        # of old and new core.llm modules (a lazy first-use import against a
+        # boot-cached transport module fails with a cryptic ImportError).
+        preload_llm_clients()
 
         # Compose the transport-agnostic turn handler. Action tools are resolved
         # per turn from each chat's live session inside the handler (not here).

--- a/gateway/manager.py
+++ b/gateway/manager.py
@@ -16,7 +16,6 @@ import signal
 from rich.console import Console
 
 from core.agent_harness.harness import AgentHarness, HarnessConfig
-from core.agent_harness.providers.default_providers import DefaultToolProvider
 from gateway.config.configure_gateway_logging import configure_gateway_logging
 from gateway.config.get_gateway_settings import GatewaySettings
 from gateway.polling.telegram_gateway_background import TelegramGatewayBackground
@@ -38,15 +37,10 @@ class GatewayManager:
         harness.resolve_env_variables()
         logger = configure_gateway_logging()
 
-        # Compose the transport-agnostic turn handler from a booted session's
-        # action tools (precomputed once per process, reused each turn).
-        session = harness.load_or_create_session()
+        # Compose the transport-agnostic turn handler. Action tools are resolved
+        # per turn from each chat's live session inside the handler (not here).
         console = Console(force_terminal=False)
-        tools = DefaultToolProvider(session, console).action_tools(
-            confirm_fn=None,
-            is_tty=False,
-        )
-        handler = build_gateway_turn_handler(tools=tools, console=console)
+        handler = build_gateway_turn_handler(console=console)
 
         worker, settings = start_telegram_worker(logger=logger, handler=handler)
 

--- a/gateway/tests/main/test_agent_life_cycle.py
+++ b/gateway/tests/main/test_agent_life_cycle.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -33,13 +32,12 @@ from core.agent_harness.providers.default_providers import (
 )
 from core.agent_harness.session import Session
 from core.agent_harness.session.storage.memory import InMemorySessionStorage
-from core.agent_harness.tools.action_tools import get_action_tool
 from gateway.config.get_gateway_settings import GatewaySettings, TelegramInboundMessage
+from gateway.manager import GatewayManager, start_gateway
 from gateway.polling.handle_polled_inbound_telegram_msg import (
     handle_polled_inbound_telegram_message,
 )
 from gateway.session.enforce_inbound_telegram_message_security import InboundDecision
-from gateway.manager import GatewayManager, start_gateway
 
 
 def test_gateway_start_returns_running_gateway_handle(monkeypatch) -> None:
@@ -47,25 +45,8 @@ def test_gateway_start_returns_running_gateway_handle(monkeypatch) -> None:
     logger = logging.getLogger("gateway.lifecycle.test")
     handle = MagicMock()
     dispatch = MagicMock()
-    tools = [MagicMock()]
-    integrations = {"shell": {"enabled": True}}
     signal_calls: list[tuple[int, Any]] = []
     background_kwargs: dict[str, Any] = {}
-
-    class FakeSession:
-        def __init__(self) -> None:
-            self.hydrated = False
-
-        def hydrate_configured_integrations(self) -> None:
-            self.hydrated = True
-
-        def get_integrations(self) -> SimpleNamespace:
-            return SimpleNamespace(resolved_integrations=integrations)
-
-    class FakeSessionManager:
-        def create(self, **kwargs: Any) -> FakeSession:
-            assert kwargs.get("open_storage") is False
-            return FakeSession()
 
     monkeypatch.setattr("core.agent_harness.harness.load_dotenv", lambda **_kwargs: None)
     monkeypatch.setattr("gateway.manager.configure_gateway_logging", lambda: logger)
@@ -74,22 +55,6 @@ def test_gateway_start_returns_running_gateway_handle(monkeypatch) -> None:
         "gateway.manager.signal.signal",
         lambda signum, handler: signal_calls.append((signum, handler)),
     )
-    monkeypatch.setattr("core.agent_harness.harness.SessionManager", FakeSessionManager)
-
-    class FakeDefaultToolProvider(DefaultToolProvider):
-        def action_tools(
-            self,
-            *,
-            confirm_fn: Any,
-            is_tty: bool | None,
-        ) -> list[MagicMock]:
-            _ = (confirm_fn, is_tty)
-            if self._precomputed_action_tools is not None:
-                return list(self._precomputed_action_tools)
-            assert self._resolved_integrations() is integrations
-            return tools
-
-    monkeypatch.setattr("gateway.manager.DefaultToolProvider", FakeDefaultToolProvider)
     # Dispatch is a static entry point; patch it on the class to spy the callback.
     monkeypatch.setattr("gateway.turn_handler.Agent.dispatch_message_to_headless_agent", dispatch)
 
@@ -139,7 +104,7 @@ def test_gateway_start_returns_running_gateway_handle(monkeypatch) -> None:
     assert dispatch_args.kwargs["output"] is sink
     tool_provider = dispatch_args.kwargs["tools"]
     assert isinstance(tool_provider, DefaultToolProvider)
-    assert tool_provider.action_tools(confirm_fn=None, is_tty=False) == tools
+    assert tool_provider._precomputed_action_tools is None
     with patch.object(logger, "info") as mock_info:
         tool_provider.observer(message="hello")(
             "tool_start",
@@ -167,23 +132,7 @@ def test_polled_telegram_message_reaches_start_gateway_agent_callback(monkeypatc
     )
     logger = logging.getLogger("gateway.lifecycle.e2e.test")
     handle = MagicMock()
-    slash_tool = get_action_tool("slash_invoke")
-    assert slash_tool is not None
-    tools: list[Any] = [slash_tool]
-    integrations: dict[str, Any] = {}
     background_kwargs: dict[str, Any] = {}
-
-    class FakeBootSession:
-        def hydrate_configured_integrations(self) -> None:
-            return None
-
-        def get_integrations(self) -> SimpleNamespace:
-            return SimpleNamespace(resolved_integrations=integrations)
-
-    class FakeSessionManager:
-        def create(self, **kwargs: Any) -> FakeBootSession:
-            assert kwargs.get("open_storage") is False
-            return FakeBootSession()
 
     class FakeSessionResolver:
         def __init__(self, session: Session) -> None:
@@ -203,21 +152,6 @@ def test_polled_telegram_message_reaches_start_gateway_agent_callback(monkeypatc
     monkeypatch.setattr("gateway.manager.configure_gateway_logging", lambda: logger)
     monkeypatch.setattr("gateway.telegram_gateway.load_gateway_settings", lambda: settings)
     monkeypatch.setattr("gateway.manager.signal.signal", lambda *_args: None)
-    monkeypatch.setattr("core.agent_harness.harness.SessionManager", FakeSessionManager)
-
-    class FakeDefaultToolProvider(DefaultToolProvider):
-        def action_tools(
-            self,
-            *,
-            confirm_fn: Any,
-            is_tty: bool | None,
-        ) -> list[Any]:
-            _ = (confirm_fn, is_tty)
-            if self._precomputed_action_tools is not None:
-                return list(self._precomputed_action_tools)
-            return tools
-
-    monkeypatch.setattr("gateway.manager.DefaultToolProvider", FakeDefaultToolProvider)
 
     def _start_telegram_gateway_background(**kwargs: Any) -> MagicMock:
         background_kwargs.update(kwargs)

--- a/gateway/tests/test_turn_handler.py
+++ b/gateway/tests/test_turn_handler.py
@@ -1,0 +1,66 @@
+"""Tests for gateway turn handler wiring."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+from rich.console import Console
+
+from core.agent_harness.models.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.session import Session
+from core.agent_harness.session.storage.memory import InMemorySessionStorage
+from gateway.turn_handler import build_gateway_turn_handler
+
+
+def test_turn_handler_resolves_action_tools_from_live_session(monkeypatch: Any) -> None:
+    """Per-chat session integrations must drive the action tool list each turn.
+
+    Precomputing tools at gateway boot (from an empty boot session) left the
+    action agent with no integration-scoped tools, so ``run_turn`` fell through
+    to the answer CLI agent on Telegram while the shell worked.
+    """
+    recorded: list[dict[str, Any] | None] = []
+
+    def _fake_get_tools(
+        _ctx: Any,
+        *,
+        resolved_integrations: dict[str, Any] | None = None,
+    ) -> list[Any]:
+        recorded.append(resolved_integrations)
+        return [MagicMock(name="slack_send_message")]
+
+    monkeypatch.setattr(
+        "core.agent_harness.providers.default_providers.get_action_tools_from_integrations_context",
+        _fake_get_tools,
+    )
+
+    dispatch = MagicMock(
+        return_value=ShellTurnResult(
+            final_intent="cli_agent_handled",
+            action_result=ToolCallingTurnResult(
+                planned_count=1,
+                executed_count=1,
+                executed_success_count=1,
+                has_unhandled_clause=False,
+                handled=True,
+            ),
+        )
+    )
+    monkeypatch.setattr(
+        "gateway.turn_handler.Agent.dispatch_message_to_headless_agent",
+        dispatch,
+    )
+
+    session = Session(storage=InMemorySessionStorage())
+    chat_integrations = {"slack": {"webhook_url": "https://hooks.example/test"}}
+    session.resolved_integrations_cache = chat_integrations
+
+    handler = build_gateway_turn_handler(console=Console(force_terminal=False))
+    handler("send slack update", session, MagicMock(), logging.getLogger("test.turn_handler"))
+
+    tool_provider = dispatch.call_args.kwargs["tools"]
+    tools = tool_provider.action_tools(confirm_fn=None, is_tty=False)
+    assert len(tools) == 1
+    assert recorded == [chat_integrations]

--- a/gateway/turn_handler.py
+++ b/gateway/turn_handler.py
@@ -23,20 +23,19 @@ from core.agent_harness.providers.default_providers import (
     DefaultTurnAccounting,
 )
 from core.agent_harness.session import Session
-from core.tool_framework.registered_tool import RegisteredTool
 from gateway.polling.handle_polled_inbound_telegram_msg import GatewayAgentCallback
 
 
 def build_gateway_turn_handler(
     *,
-    tools: list[RegisteredTool],
     console: Console,
 ) -> GatewayAgentCallback:
     """Return a callback that services one inbound gateway message.
 
-    ``tools`` are precomputed once per process and reused each turn. The
-    returned callback builds fresh per-turn providers and drives the static
-    headless dispatch — there is no persistent per-transport agent.
+    Action tools are resolved from the live per-chat ``session`` on every turn
+    (same as the interactive shell), so integration-scoped tools stay available
+    after ``SessionResolver`` hydrates the chat session. The callback drives the
+    shared headless dispatch — there is no persistent per-transport agent.
     """
 
     def handle(
@@ -53,7 +52,6 @@ def build_gateway_turn_handler(
             tools=DefaultToolProvider(
                 session,
                 console,
-                precomputed_action_tools=tools,
                 tool_action_logger=logger,
             ),
             prompts=DefaultPromptContextProvider(session),

--- a/surfaces/cli/commands/messaging.py
+++ b/surfaces/cli/commands/messaging.py
@@ -20,6 +20,33 @@ _console = Console(highlight=False)
 _PLATFORM_CHOICES = [p.value for p in MessagingPlatform]
 
 
+def _validate_allow_user_id(platform: str, user_id: str) -> str:
+    """Normalize + validate a user id for ``allow``; raise on non-native values.
+
+    Inbound authorization matches the platform-native user id (Telegram
+    ``from.id``, Slack ``user_id``, Discord member id) — never a ``@username``.
+    Accepting a handle silently produces an allow-list entry that can never
+    match a real sender, which is exactly the "user X is not allowed" trap.
+    """
+    uid = user_id.strip()
+    if not uid:
+        raise click.BadParameter("user id must not be empty.", param_hint="--user-id")
+    if uid.startswith("@"):
+        raise click.BadParameter(
+            f"'{uid}' is a @username, not a platform user id. Inbound auth matches the "
+            "numeric platform user id, not the handle — get it from @userinfobot or the "
+            "bot's getUpdates response.",
+            param_hint="--user-id",
+        )
+    if platform == MessagingPlatform.TELEGRAM.value and not uid.isdigit():
+        raise click.BadParameter(
+            f"Telegram user ids are numeric (e.g. 6514715683); got '{uid}'. Use the numeric "
+            "from.id, not a username or display name.",
+            param_hint="--user-id",
+        )
+    return uid
+
+
 def _load_identity_policy(service: str) -> tuple[dict | None, MessagingIdentityPolicy]:
     """Load the integration record and its identity policy."""
     record = get_integration(service)
@@ -137,6 +164,7 @@ def pair_command(platform: str) -> None:
 def allow_command(platform: str, user_id: str) -> None:
     """Manually add a user to the allowed-users list (bypasses DM pairing)."""
     service = platform.lower()
+    user_id = _validate_allow_user_id(service, user_id)
     record, policy = _load_identity_policy(service)
 
     if user_id in policy.allowed_user_ids:

--- a/tests/cli/test_messaging.py
+++ b/tests/cli/test_messaging.py
@@ -87,6 +87,39 @@ class TestMessagingAllowCommand:
         assert result.exit_code == 0
         assert "already in the allowed list" in result.output
 
+    def test_allow_rejects_at_handle(self, _isolated_store: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            messaging, ["allow", "--platform", "telegram", "--user-id", "@opensre_yauhen_bot"]
+        )
+        assert result.exit_code != 0
+        assert "@username" in result.output
+        # Nothing should have been persisted for a rejected id.
+        data = json.loads(_isolated_store.read_text())
+        assert data["integrations"] == []
+
+    def test_allow_rejects_non_numeric_telegram_id(self, _isolated_store: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(messaging, ["allow", "--platform", "telegram", "--user-id", "user1"])
+        assert result.exit_code != 0
+        assert "numeric" in result.output
+
+    def test_allow_accepts_numeric_telegram_id(self, _isolated_store: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            messaging, ["allow", "--platform", "telegram", "--user-id", " 6514715683 "]
+        )
+        assert result.exit_code == 0
+        assert "Added user 6514715683" in result.output  # normalized (stripped)
+
+    def test_allow_accepts_slack_native_id(self, _isolated_store: Path) -> None:
+        # Non-Telegram platforms keep their native id shape (Slack U..., etc.);
+        # only the @handle guard applies.
+        runner = CliRunner()
+        result = runner.invoke(messaging, ["allow", "--platform", "slack", "--user-id", "U12345"])
+        assert result.exit_code == 0
+        assert "Added user U12345" in result.output
+
 
 class TestMessagingRevokeCommand:
     def test_revoke_removes_user(self, _isolated_store: Path) -> None:
@@ -118,9 +151,9 @@ class TestMessagingStatusCommand:
 
     def test_status_with_configured_integration(self, _isolated_store: Path) -> None:
         runner = CliRunner()
-        # Set up a user first
-        runner.invoke(messaging, ["allow", "--platform", "telegram", "--user-id", "user1"])
+        # Set up a user first (Telegram ids are numeric)
+        runner.invoke(messaging, ["allow", "--platform", "telegram", "--user-id", "6514715683"])
         result = runner.invoke(messaging, ["status", "--platform", "telegram"])
         assert result.exit_code == 0
         assert "Inbound enabled" in result.output
-        assert "user1" in result.output
+        assert "6514715683" in result.output

--- a/tests/core/agent/orchestration/conftest.py
+++ b/tests/core/agent/orchestration/conftest.py
@@ -1,0 +1,23 @@
+"""Shared fixtures for cross-surface orchestration tests.
+
+The parity harness records probe runs and resolved integrations in module-level
+lists. They are reset inside ``wire_tool_registry``, but a test that drives a
+surface without going through that path would otherwise inherit stale entries.
+This autouse fixture resets them before every test, so the reset no longer
+depends on which configure helper a test happens to call.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.core.agent.orchestration.cross_surface_parity_harness import (
+    reset_integrations_seen,
+    reset_probe_runs,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_parity_harness_state() -> None:
+    reset_probe_runs()
+    reset_integrations_seen()

--- a/tests/core/agent/orchestration/cross_surface_parity_harness.py
+++ b/tests/core/agent/orchestration/cross_surface_parity_harness.py
@@ -282,7 +282,7 @@ def wire_tool_registry(monkeypatch: Any, tools: list[RegisteredTool]) -> None:
 def wire_llms(
     monkeypatch: Any, *, action_mode: str, action_tool_name: str = "parity_probe"
 ) -> None:
-    monkeypatch.setattr("core.llm.llm_client.get_llm_for_reasoning", lambda: FakeReasoningClient())
+    monkeypatch.setattr("core.llm.llm_client.get_llm_for_reasoning", FakeReasoningClient)
     monkeypatch.setattr(
         "core.llm.agent_llm_client.get_agent_llm",
         lambda: FakeActionLLM(action_mode, tool_name=action_tool_name),

--- a/tests/core/agent/orchestration/cross_surface_parity_harness.py
+++ b/tests/core/agent/orchestration/cross_surface_parity_harness.py
@@ -1,0 +1,446 @@
+"""Shared harness for cross-surface turn parity tests.
+
+Every client (interactive shell, headless dispatch, ``Agent`` static entry,
+gateway turn handler) must route through the same ``run_turn`` engine and produce
+the same outcome for the same input, tools, and LLM wiring.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from rich.console import Console
+
+from core.agent import Agent
+from core.agent_harness.agents.headless_agent import (
+    BufferOutputSink,
+    NoopTurnAccounting,
+    dispatch_message_to_headless_agent,
+)
+from core.agent_harness.models.turn_results import ShellTurnResult
+from core.agent_harness.providers.default_prompt_context import DefaultPromptContextProvider
+from core.agent_harness.providers.default_providers import (
+    DefaultReasoningClientProvider,
+    DefaultToolProvider,
+)
+from core.agent_harness.session import InMemorySessionStorage, Session
+from core.llm.types import AgentLLMResponse, ToolCall
+from core.tool_framework.registered_tool import RegisteredTool
+from gateway.turn_handler import build_gateway_turn_handler
+from surfaces.interactive_shell.runtime.shell_turn_execution import execute_shell_turn
+
+Surface = Literal["shell", "headless", "agent_static", "gateway_handler"]
+
+ALL_SURFACES: tuple[Surface, ...] = (
+    "shell",
+    "headless",
+    "agent_static",
+    "gateway_handler",
+)
+
+PARITY_ANSWER = "PARITY_ANSWER"
+
+_PROBE_RUNS: list[dict[str, Any]] = []
+_INTEGRATIONS_SEEN: list[dict[str, Any]] = []
+
+
+@dataclass(frozen=True)
+class TurnSnapshot:
+    """Normalized turn outcome used to compare surfaces."""
+
+    final_intent: str
+    action_handled: bool
+    action_planned: int
+    answered: bool
+    assistant_text: str
+    probe_ran: bool
+
+    @classmethod
+    def from_result(cls, result: ShellTurnResult, *, probe_ran: bool) -> TurnSnapshot:
+        return cls(
+            final_intent=result.final_intent,
+            action_handled=result.action_result.handled,
+            action_planned=result.action_result.planned_count,
+            answered=result.answered,
+            assistant_text=(result.assistant_response_text or "").strip(),
+            probe_ran=probe_ran,
+        )
+
+
+def probe_tool() -> RegisteredTool:
+    def _run(**kwargs: Any) -> dict[str, Any]:
+        _PROBE_RUNS.append(kwargs)
+        return {"status": "probe executed"}
+
+    return RegisteredTool(
+        name="parity_probe",
+        description="Controlled action tool for cross-surface parity tests.",
+        input_schema={"type": "object", "properties": {}, "additionalProperties": True},
+        source="knowledge",
+        surfaces=("action",),
+        run=_run,
+        is_available=lambda _sources: True,
+    )
+
+
+def shell_run_tool(*, output: str = "parity-shell-ok") -> RegisteredTool:
+    def _run(**kwargs: Any) -> dict[str, Any]:
+        _PROBE_RUNS.append(kwargs)
+        return {"stdout": output, "exit_code": 0, "response_text": output}
+
+    return RegisteredTool(
+        name="shell_run",
+        description="Shell runner stub for bang-command parity tests.",
+        input_schema={
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "additionalProperties": True,
+        },
+        source="knowledge",
+        surfaces=("action",),
+        run=_run,
+        is_available=lambda _sources: True,
+    )
+
+
+def integration_gated_tool(*, integration: str = "slack") -> RegisteredTool:
+    """Action tool that is only available when ``integration`` is in session sources."""
+
+    tool_name = f"{integration}_parity_probe"
+
+    def _run(**kwargs: Any) -> dict[str, Any]:
+        _PROBE_RUNS.append({"integration": integration, **kwargs})
+        return {"status": f"{integration} probe executed"}
+
+    def _is_available(sources: dict[str, Any]) -> bool:
+        item = sources.get(integration)
+        if isinstance(item, dict):
+            return bool(item.get("webhook_url") or item.get("connection_verified"))
+        return bool(item)
+
+    return RegisteredTool(
+        name=tool_name,
+        description=f"Integration-gated probe for {integration} parity tests.",
+        input_schema={"type": "object", "properties": {}, "additionalProperties": True},
+        source=integration,
+        surfaces=("action",),
+        run=_run,
+        is_available=_is_available,
+    )
+
+
+class FakeActionLLM:
+    """Action-agent LLM: one tool call in ``tool`` mode, else text-only completion."""
+
+    def __init__(self, mode: str, *, tool_name: str = "parity_probe") -> None:
+        self._mode = mode
+        self._tool_name = tool_name
+        self._emitted = False
+
+    def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
+        return [{"name": getattr(t, "name", str(t))} for t in tools]
+
+    def invoke(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        system: str | None = None,
+        tools: Any = None,
+    ) -> AgentLLMResponse:
+        _ = (messages, system, tools)
+        if self._mode == "tool" and not self._emitted:
+            self._emitted = True
+            return AgentLLMResponse(
+                content="",
+                tool_calls=[ToolCall(id="c1", name=self._tool_name, input={})],
+                raw_content=None,
+            )
+        return AgentLLMResponse(content="done", tool_calls=[], raw_content=None)
+
+    @staticmethod
+    def build_assistant_message(content: str, tool_calls: list[ToolCall]) -> dict[str, Any]:
+        return {"role": "assistant", "content": content, "tool_calls": list(tool_calls)}
+
+    @staticmethod
+    def build_tool_result_message(tool_calls: list[ToolCall], results: list[Any]) -> dict[str, Any]:
+        return {"role": "tool", "content": "[]", "results": list(zip(tool_calls, results))}
+
+
+class FakeReasoningClient:
+    """Answer/assistant agent: streams a canned reply."""
+
+    def invoke_stream(self, _prompt: Any) -> Iterator[str]:
+        yield PARITY_ANSWER
+
+
+class RecordingGatewaySink:
+    """Minimal gateway sink that records stream/finalize output for assertions."""
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+        self.streamed: list[str] = []
+        self.finalized: str | None = None
+
+    def print(self, message: str = "") -> None:
+        if message:
+            self.lines.append(message)
+
+    def render_response_header(self, label: str) -> None:
+        self.lines.append(f"[{label}]")
+
+    def render_error(self, message: str) -> None:
+        self.lines.append(f"ERROR: {message}")
+
+    def stream(
+        self,
+        *,
+        label: str,
+        chunks: Iterator[str],
+        suppress_if_starts_with: str | None = None,
+    ) -> str:
+        _ = (label, suppress_if_starts_with)
+        text = "".join(str(chunk) for chunk in chunks)
+        self.streamed.append(text)
+        return text
+
+    def finalize(self, text: str) -> None:
+        self.finalized = text
+
+    @property
+    def outbound_text(self) -> str:
+        if self.finalized:
+            return self.finalized.strip()
+        if self.streamed:
+            return self.streamed[-1].strip()
+        return "\n".join(self.lines).strip()
+
+
+def console() -> Console:
+    return Console(file=io.StringIO(), force_terminal=False, highlight=False, width=100)
+
+
+def fresh_session(*, integrations: dict[str, Any] | None = None) -> Session:
+    session = Session(storage=InMemorySessionStorage())
+    session.resolved_integrations_cache = dict(integrations or {})
+    return session
+
+
+def reset_probe_runs() -> None:
+    _PROBE_RUNS.clear()
+
+
+def reset_integrations_seen() -> None:
+    _INTEGRATIONS_SEEN.clear()
+
+
+def integrations_seen() -> list[dict[str, Any]]:
+    return list(_INTEGRATIONS_SEEN)
+
+
+def probe_run_count() -> int:
+    return len(_PROBE_RUNS)
+
+
+def wire_tool_registry(monkeypatch: Any, tools: list[RegisteredTool]) -> None:
+    reset_probe_runs()
+    reset_integrations_seen()
+    monkeypatch.setattr(
+        "core.agent_harness.tools.action_tools.get_registered_tools",
+        lambda _surface=None: list(tools),
+    )
+    by_name = {tool.name: tool for tool in tools}
+    monkeypatch.setattr(
+        "core.agent_harness.tools.action_tools.get_registered_tool_map",
+        lambda _surface=None: dict(by_name),
+    )
+
+    from core.agent_harness.tools.action_tools import _sources_for_context
+
+    def _resolve_from_integrations(
+        ctx: Any,
+        *,
+        resolved_integrations: dict[str, Any] | None = None,
+    ) -> list[RegisteredTool]:
+        _INTEGRATIONS_SEEN.append(dict(resolved_integrations or {}))
+        sources = _sources_for_context(ctx, resolved_integrations)
+        return [tool for tool in tools if tool.is_available(sources)]
+
+    monkeypatch.setattr(
+        "core.agent_harness.providers.default_providers.get_action_tools_from_integrations_context",
+        _resolve_from_integrations,
+    )
+    monkeypatch.setattr(
+        "core.agent_harness.tools.action_tools.get_action_tools_from_integrations_context",
+        _resolve_from_integrations,
+    )
+
+
+def wire_llms(
+    monkeypatch: Any, *, action_mode: str, action_tool_name: str = "parity_probe"
+) -> None:
+    monkeypatch.setattr("core.llm.llm_client.get_llm_for_reasoning", lambda: FakeReasoningClient())
+    monkeypatch.setattr(
+        "core.llm.agent_llm_client.get_agent_llm",
+        lambda: FakeActionLLM(action_mode, tool_name=action_tool_name),
+    )
+
+
+def _dispatch_turn(
+    message: str,
+    session: Session,
+    *,
+    gather_enabled: bool = True,
+) -> ShellTurnResult:
+    output = BufferOutputSink()
+    return dispatch_message_to_headless_agent(
+        message,
+        tools=DefaultToolProvider(session, console()),
+        session=session,
+        output=output,
+        prompts=DefaultPromptContextProvider(session),
+        reasoning=DefaultReasoningClientProvider(output=output),
+        accounting=NoopTurnAccounting(),
+        gather_enabled=gather_enabled,
+    )
+
+
+def snapshot_shell(message: str, *, integrations: dict[str, Any] | None = None) -> TurnSnapshot:
+    session = fresh_session(integrations=integrations)
+    before = probe_run_count()
+    result = execute_shell_turn(
+        message,
+        session,
+        console(),
+        recorder=None,
+        is_tty=False,
+    )
+    return TurnSnapshot.from_result(result, probe_ran=probe_run_count() > before)
+
+
+def snapshot_headless(message: str, *, integrations: dict[str, Any] | None = None) -> TurnSnapshot:
+    session = fresh_session(integrations=integrations)
+    before = probe_run_count()
+    result = _dispatch_turn(message, session, gather_enabled=True)
+    return TurnSnapshot.from_result(result, probe_ran=probe_run_count() > before)
+
+
+def snapshot_agent_static(
+    message: str, *, integrations: dict[str, Any] | None = None
+) -> TurnSnapshot:
+    session = fresh_session(integrations=integrations)
+    output = BufferOutputSink()
+    before = probe_run_count()
+    result = Agent.dispatch_message_to_headless_agent(
+        message,
+        tools=DefaultToolProvider(session, console()),
+        session=session,
+        output=output,
+        prompts=DefaultPromptContextProvider(session),
+        reasoning=DefaultReasoningClientProvider(output=output),
+        accounting=NoopTurnAccounting(),
+        gather_enabled=True,
+    )
+    return TurnSnapshot.from_result(result, probe_ran=probe_run_count() > before)
+
+
+def snapshot_gateway_handler(
+    message: str,
+    monkeypatch: Any,
+    *,
+    integrations: dict[str, Any] | None = None,
+) -> TurnSnapshot:
+    session = fresh_session(integrations=integrations)
+    sink = RecordingGatewaySink()
+    captured: list[ShellTurnResult] = []
+    real_dispatch = Agent.dispatch_message_to_headless_agent
+
+    def _spy(*args: Any, **kwargs: Any) -> ShellTurnResult:
+        result = real_dispatch(*args, **kwargs)
+        captured.append(result)
+        return result
+
+    monkeypatch.setattr("gateway.turn_handler.Agent.dispatch_message_to_headless_agent", _spy)
+    before = probe_run_count()
+    handler = build_gateway_turn_handler(console=console())
+    handler(message, session, sink, logging.getLogger("test.parity.gateway"))
+    assert len(captured) == 1, "gateway handler must dispatch exactly one headless turn"
+    return TurnSnapshot.from_result(captured[0], probe_ran=probe_run_count() > before)
+
+
+def run_surface(
+    surface: Surface,
+    message: str,
+    monkeypatch: Any,
+    *,
+    integrations: dict[str, Any] | None = None,
+) -> TurnSnapshot:
+    if surface == "shell":
+        return snapshot_shell(message, integrations=integrations)
+    if surface == "headless":
+        return snapshot_headless(message, integrations=integrations)
+    if surface == "agent_static":
+        return snapshot_agent_static(message, integrations=integrations)
+    if surface == "gateway_handler":
+        return snapshot_gateway_handler(message, monkeypatch, integrations=integrations)
+    raise AssertionError(f"unknown surface: {surface}")
+
+
+def assert_surfaces_match(
+    snapshots: dict[Surface, TurnSnapshot],
+    *,
+    reference: Surface = "shell",
+) -> None:
+    ref = snapshots[reference]
+    for surface, snap in snapshots.items():
+        assert snap == ref, (
+            f"surface {surface!r} diverged from {reference!r}:\n"
+            f"  reference: {ref}\n"
+            f"  actual:    {snap}"
+        )
+
+
+def collect_all_surfaces(
+    message: str,
+    monkeypatch: Any,
+    *,
+    integrations: dict[str, Any] | None = None,
+) -> dict[Surface, TurnSnapshot]:
+    snapshots: dict[Surface, TurnSnapshot] = {}
+    for surface in ALL_SURFACES:
+        snapshots[surface] = run_surface(
+            surface,
+            message,
+            monkeypatch,
+            integrations=integrations,
+        )
+    return snapshots
+
+
+def run_gateway_turn_with_sink(
+    message: str,
+    monkeypatch: Any,
+    *,
+    integrations: dict[str, Any] | None = None,
+) -> tuple[TurnSnapshot, RecordingGatewaySink]:
+    """Run one gateway turn and return both routing snapshot and transport sink."""
+    session = fresh_session(integrations=integrations)
+    sink = RecordingGatewaySink()
+    captured: list[ShellTurnResult] = []
+    real_dispatch = Agent.dispatch_message_to_headless_agent
+
+    def _spy(*args: Any, **kwargs: Any) -> ShellTurnResult:
+        result = real_dispatch(*args, **kwargs)
+        captured.append(result)
+        return result
+
+    monkeypatch.setattr("gateway.turn_handler.Agent.dispatch_message_to_headless_agent", _spy)
+    before = probe_run_count()
+    handler = build_gateway_turn_handler(console=console())
+    handler(message, session, sink, logging.getLogger("test.parity.gateway.sink"))
+    assert len(captured) == 1, "gateway handler must dispatch exactly one headless turn"
+    snapshot = TurnSnapshot.from_result(captured[0], probe_ran=probe_run_count() > before)
+    return snapshot, sink

--- a/tests/core/agent/orchestration/test_cross_surface_components.py
+++ b/tests/core/agent/orchestration/test_cross_surface_components.py
@@ -1,0 +1,138 @@
+"""Component-level tests for modules on the shell ↔ gateway turn path."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from rich.console import Console
+
+from core.agent import Agent
+from core.agent_harness.agents.turn_orchestrator import run_turn
+from core.agent_harness.models.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.providers.default_providers import DefaultToolProvider
+from core.agent_harness.session import InMemorySessionStorage, Session
+from gateway.turn_handler import build_gateway_turn_handler
+
+
+def test_gateway_turn_handler_delegates_to_agent_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def _spy(*args: Any, **kwargs: Any) -> ShellTurnResult:
+        captured.append((args, kwargs))
+        return ShellTurnResult(
+            final_intent="cli_agent_handled",
+            action_result=ToolCallingTurnResult(
+                planned_count=1,
+                executed_count=1,
+                executed_success_count=1,
+                has_unhandled_clause=False,
+                handled=True,
+                response_text="gateway-ok",
+            ),
+            assistant_response_text="gateway-ok",
+        )
+
+    monkeypatch.setattr("gateway.turn_handler.Agent.dispatch_message_to_headless_agent", _spy)
+
+    session = Session(storage=InMemorySessionStorage())
+    sink = MagicMock()
+    handler = build_gateway_turn_handler(console=Console(force_terminal=False))
+    handler("hello gateway", session, sink, logging.getLogger("test.gateway.module"))
+
+    assert len(captured) == 1
+    args, kwargs = captured[0]
+    assert args == ("hello gateway",)
+    assert kwargs["session"] is session
+    assert kwargs["output"] is sink
+    assert kwargs["gather_enabled"] is True
+    assert isinstance(kwargs["tools"], DefaultToolProvider)
+    assert kwargs["tools"]._precomputed_action_tools is None
+    sink.finalize.assert_called_once_with("gateway-ok")
+
+
+def test_gateway_turn_handler_does_not_finalize_answered_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "gateway.turn_handler.Agent.dispatch_message_to_headless_agent",
+        lambda *_args, **_kwargs: ShellTurnResult(
+            final_intent="cli_agent_fallback",
+            action_result=ToolCallingTurnResult(0, 0, 0, False, False),
+            assistant_response_text="streamed answer",
+            llm_run=object(),
+        ),
+    )
+
+    session = Session(storage=InMemorySessionStorage())
+    sink = MagicMock()
+    handler = build_gateway_turn_handler(console=Console(force_terminal=False))
+    handler("why", session, sink, logging.getLogger("test.gateway.module.answer"))
+
+    sink.finalize.assert_not_called()
+
+
+def test_run_turn_routes_unhandled_action_to_answer_callback() -> None:
+    action = ToolCallingTurnResult(0, 0, 0, False, False)
+    answer_calls: list[str] = []
+
+    def execute_actions(_text: str, **_kwargs: object) -> ToolCallingTurnResult:
+        return action
+
+    def answer(text: str, **_kwargs: object) -> object:
+        answer_calls.append(text)
+        return type("Run", (), {"response_text": "answered"})()
+
+    def gather(_text: str, **_kwargs: object) -> None:
+        return None
+
+    class _Accounting:
+        def record_action_result(self, _result: ToolCallingTurnResult) -> None:
+            return None
+
+        def finalize(self, result: ShellTurnResult) -> ShellTurnResult:
+            return result
+
+    session = Session(storage=InMemorySessionStorage())
+    result = run_turn(
+        "question?",
+        session,
+        execute_actions=execute_actions,
+        answer=answer,
+        gather=gather,
+        accounting=_Accounting(),
+    )
+
+    assert answer_calls == ["question?"]
+    assert result.final_intent == "cli_agent_fallback"
+    assert result.answered is True
+
+
+def test_agent_static_dispatch_forwards_to_headless_with_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``Agent.dispatch_message_to_headless_agent`` forwards message and kwargs."""
+    captured: dict[str, Any] = {}
+
+    def _fake(message: str, **kwargs: object) -> ShellTurnResult:
+        captured["message"] = message
+        captured.update(kwargs)
+        return ShellTurnResult(
+            final_intent="cli_agent_handled",
+            action_result=ToolCallingTurnResult(0, 0, 0, False, True),
+        )
+
+    monkeypatch.setattr(
+        "core.agent_harness.agents.headless_agent.dispatch_message_to_headless_agent",
+        _fake,
+    )
+
+    from core.agent_harness.agents.headless_agent import NullToolProvider
+
+    tools = NullToolProvider()
+    Agent.dispatch_message_to_headless_agent("ping", tools=tools, gather_enabled=True)
+    assert captured["message"] == "ping"
+    assert captured["tools"] is tools
+    assert captured["gather_enabled"] is True

--- a/tests/core/agent/orchestration/test_cross_surface_parity.py
+++ b/tests/core/agent/orchestration/test_cross_surface_parity.py
@@ -1,0 +1,240 @@
+"""Cross-surface parity: every client routes and replies identically.
+
+Surfaces under test:
+
+* ``shell`` — ``execute_shell_turn`` (interactive REPL / CLI one-shot)
+* ``headless`` — ``dispatch_message_to_headless_agent``
+* ``agent_static`` — ``Agent.dispatch_message_to_headless_agent``
+* ``gateway_handler`` — ``build_gateway_turn_handler`` (Telegram/API gateway)
+
+Each test wires ONE tool registry and ONE pair of LLMs, drives the same message
+through all four entry points, and asserts identical routing + response shape.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+import tools.interactive_shell.actions.slash as slash_tool
+from core.agent_harness.tools.action_tools import get_action_tool
+from gateway.turn_handler import build_gateway_turn_handler
+from tests.core.agent.orchestration.cross_surface_parity_harness import (
+    ALL_SURFACES,
+    PARITY_ANSWER,
+    RecordingGatewaySink,
+    assert_surfaces_match,
+    collect_all_surfaces,
+    console,
+    fresh_session,
+    integration_gated_tool,
+    integrations_seen,
+    probe_run_count,
+    probe_tool,
+    run_gateway_turn_with_sink,
+    run_surface,
+    shell_run_tool,
+    wire_llms,
+    wire_tool_registry,
+)
+
+SLACK_INTEGRATIONS = {"slack": {"webhook_url": "https://hooks.example/test"}}
+
+
+@pytest.fixture
+def parity_env(monkeypatch: pytest.MonkeyPatch):
+    """Register the parity probe tool and expose LLM mode setters."""
+
+    def _configure(
+        *,
+        tools: list[Any],
+        action_mode: str,
+        action_tool_name: str = "parity_probe",
+    ) -> None:
+        wire_tool_registry(monkeypatch, tools)
+        wire_llms(monkeypatch, action_mode=action_mode, action_tool_name=action_tool_name)
+
+    def _configure_with_slash(*, action_mode: str = "text") -> list[str]:
+        slash = get_action_tool("slash_invoke")
+        assert slash is not None
+        dispatched: list[str] = []
+
+        def _fake_dispatch(command: str, session: Any, console: Any, **_kwargs: object) -> bool:
+            _ = (session, console)
+            dispatched.append(command)
+            return True
+
+        monkeypatch.setattr(slash_tool, "dispatch_slash", _fake_dispatch)
+        _configure(tools=[slash, probe_tool()], action_mode=action_mode)
+        return dispatched
+
+    return _configure, _configure_with_slash
+
+
+def test_all_surfaces_execute_action_tool(parity_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    configure, _ = parity_env
+    configure(tools=[probe_tool()], action_mode="tool")
+
+    snapshots = collect_all_surfaces("run the parity probe", monkeypatch)
+    assert_surfaces_match(snapshots)
+
+    for snap in snapshots.values():
+        assert snap.probe_ran is True
+        assert snap.action_handled is True
+        assert snap.final_intent == "cli_agent_handled"
+        assert snap.answered is False
+
+
+def test_all_surfaces_answer_questions_via_assistant(
+    parity_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    configure, _ = parity_env
+    configure(tools=[probe_tool()], action_mode="text")
+
+    snapshots = collect_all_surfaces("what is the meaning of opensre", monkeypatch)
+    assert_surfaces_match(snapshots)
+
+    for snap in snapshots.values():
+        assert snap.probe_ran is False
+        assert snap.action_handled is False
+        assert snap.final_intent == "cli_agent_fallback"
+        assert snap.answered is True
+        assert PARITY_ANSWER in snap.assistant_text
+
+
+def test_all_surfaces_literal_slash_uses_action_agent(
+    parity_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, configure_with_slash = parity_env
+    dispatched = configure_with_slash(action_mode="text")
+
+    snapshots = collect_all_surfaces("/status", monkeypatch)
+    assert_surfaces_match(snapshots)
+
+    assert all(item == "/status" for item in dispatched)
+    assert len(dispatched) == len(ALL_SURFACES)
+    for snap in snapshots.values():
+        assert snap.action_handled is True
+        assert snap.final_intent == "cli_agent_handled"
+        assert snap.answered is False
+
+
+def test_all_surfaces_bang_shell_uses_action_agent(
+    parity_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    configure, _ = parity_env
+    configure(tools=[shell_run_tool()], action_mode="text")
+
+    snapshots = collect_all_surfaces("!echo parity", monkeypatch)
+    assert_surfaces_match(snapshots)
+
+    assert probe_run_count() == len(ALL_SURFACES)
+    for snap in snapshots.values():
+        assert snap.action_handled is True
+        assert snap.final_intent == "cli_agent_handled"
+        assert snap.answered is False
+
+
+def test_all_surfaces_pass_session_integrations_to_tool_resolution(
+    parity_env,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each surface must resolve action tools from the live session integrations."""
+    configure, _ = parity_env
+    configure(tools=[integration_gated_tool(), probe_tool()], action_mode="text")
+
+    for surface in ALL_SURFACES:
+        seen_before = len(integrations_seen())
+        run_surface(surface, "hello", monkeypatch, integrations=SLACK_INTEGRATIONS)
+        recorded = integrations_seen()[seen_before:]
+        assert recorded, f"{surface!r} never resolved tools from session integrations"
+        assert all(item == SLACK_INTEGRATIONS for item in recorded), (
+            f"{surface!r} passed unexpected integrations to tool resolution: {recorded}"
+        )
+
+
+def test_all_surfaces_execute_integration_gated_tool(
+    parity_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Integration-scoped tools must be available on every surface when configured."""
+    configure, _ = parity_env
+    slack_tool = integration_gated_tool()
+    configure(
+        tools=[slack_tool, probe_tool()],
+        action_mode="tool",
+        action_tool_name=slack_tool.name,
+    )
+
+    snapshots = collect_all_surfaces(
+        "send slack update", monkeypatch, integrations=SLACK_INTEGRATIONS
+    )
+    assert_surfaces_match(snapshots)
+
+    for snap in snapshots.values():
+        assert snap.probe_ran is True
+        assert snap.action_handled is True
+        assert snap.final_intent == "cli_agent_handled"
+        assert snap.answered is False
+        assert "slack probe executed" in snap.assistant_text
+
+
+def test_gateway_handler_outbound_finalize_on_action_only_turn(
+    parity_env,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gateway handler must finalize action-only replies (answered=False path)."""
+    configure, _ = parity_env
+    configure(tools=[probe_tool()], action_mode="tool")
+
+    session = fresh_session()
+    sink = RecordingGatewaySink()
+    handler = build_gateway_turn_handler(console=console())
+    handler("run probe", session, sink, logging.getLogger("test.parity.gateway.outbound"))
+
+    assert sink.finalized is not None
+    assert sink.streamed == []
+    assert "probe executed" in sink.finalized
+
+
+def test_gateway_handler_streams_answer_on_assistant_turn(
+    parity_env,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Answer turns stream via the sink; they must not call finalize."""
+    configure, _ = parity_env
+    configure(tools=[probe_tool()], action_mode="text")
+
+    snapshot, sink = run_gateway_turn_with_sink("why opensre", monkeypatch)
+
+    assert snapshot.answered is True
+    assert PARITY_ANSWER in snapshot.assistant_text
+    assert sink.finalized is None
+    assert sink.streamed
+    assert PARITY_ANSWER in sink.streamed[-1]
+    assert PARITY_ANSWER in sink.outbound_text
+
+
+def test_turn_snapshot_fields_action_vs_answer(parity_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Document expected routing facts for action vs answer paths on one surface."""
+    configure, _ = parity_env
+    configure(tools=[probe_tool()], action_mode="tool")
+    action = run_surface("headless", "run probe", monkeypatch)
+
+    configure(tools=[probe_tool()], action_mode="text")
+    answer = run_surface("headless", "why", monkeypatch)
+
+    assert action.final_intent == "cli_agent_handled"
+    assert action.action_handled is True
+    assert action.action_planned == 1
+    assert action.answered is False
+    assert action.probe_ran is True
+    assert "probe executed" in action.assistant_text
+
+    assert answer.final_intent == "cli_agent_fallback"
+    assert answer.action_handled is False
+    assert answer.action_planned == 0
+    assert answer.answered is True
+    assert answer.assistant_text == PARITY_ANSWER
+    assert answer.probe_ran is False

--- a/tests/core/agent/orchestration/test_cross_surface_parity.py
+++ b/tests/core/agent/orchestration/test_cross_surface_parity.py
@@ -39,6 +39,7 @@ from tests.core.agent.orchestration.cross_surface_parity_harness import (
     wire_llms,
     wire_tool_registry,
 )
+from tools.registry import clear_tool_registry_cache
 
 SLACK_INTEGRATIONS = {"slack": {"webhook_url": "https://hooks.example/test"}}
 
@@ -57,6 +58,9 @@ def parity_env(monkeypatch: pytest.MonkeyPatch):
         wire_llms(monkeypatch, action_mode=action_mode, action_tool_name=action_tool_name)
 
     def _configure_with_slash(*, action_mode: str = "text") -> list[str]:
+        # Clear the registry cache so slash_invoke resolves from a fresh
+        # discovery pass, not a set another test warmed (project test convention).
+        clear_tool_registry_cache()
         slash = get_action_tool("slash_invoke")
         assert slash is not None
         dispatched: list[str] = []

--- a/tests/core/agent/scenarios/follow_up/600-follow-up-why-failed.yml
+++ b/tests/core/agent/scenarios/follow_up/600-follow-up-why-failed.yml
@@ -20,7 +20,9 @@ response_contract:
   must_contain_any:
   - why did it fail
   - failed
+  - failure
   - disk full
+  - full disk
   - follow-up
   - alert text
   must_not_contain:

--- a/tests/core/agent/test_turn_context_runtime_request.py
+++ b/tests/core/agent/test_turn_context_runtime_request.py
@@ -174,6 +174,21 @@ class _Session:
         self.agent = _AgentState(tool)
 
 
+def test_turn_context_from_session_reads_last_command_observation_from_session() -> None:
+    class _Session:
+        cli_agent_messages: list[tuple[str, str]] = []
+        configured_integrations = ()
+        configured_integrations_known = True
+        last_state = None
+        last_synthetic_observation_path = None
+        reasoning_effort = None
+        last_command_observation = "tool output from shell"
+
+    ctx = TurnContext.from_session("why", _Session())
+
+    assert ctx.last_observation == "tool output from shell"
+
+
 def test_turn_context_from_session_snapshots_shell_and_runtime_request_fields() -> None:
     tool = _tool()
     session = _Session(tool)

--- a/tests/core/agent_harness/test_llm_client_preload_and_errors.py
+++ b/tests/core/agent_harness/test_llm_client_preload_and_errors.py
@@ -1,0 +1,58 @@
+"""Guards for the stale-process failure mode around the LLM client graph.
+
+Covers the two hardenings: eager preload of the ``core.llm`` client modules, and
+the actionable message shown when the reasoning-client import fails.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from core.agent_harness.providers.default_providers import (
+    DefaultReasoningClientProvider,
+    _llm_client_unavailable_message,
+)
+from core.llm.preload import preload_llm_clients
+
+
+def test_preload_imports_the_llm_client_graph() -> None:
+    preload_llm_clients()
+    assert "core.llm.agent_llm_client" in sys.modules
+    assert "core.llm.llm_client" in sys.modules
+    # transport_mode is pulled in transitively — the whole graph is one snapshot.
+    assert "core.llm.transport_mode" in sys.modules
+
+
+def test_preload_is_idempotent() -> None:
+    preload_llm_clients()
+    preload_llm_clients()  # must not raise on a second call
+
+
+def test_import_error_message_hints_at_restart() -> None:
+    message = _llm_client_unavailable_message(ImportError("cannot import name 'x'"))
+    assert "cannot import name 'x'" in message
+    assert "Restart it" in message
+    assert "uv run opensre" in message
+
+
+def test_non_import_error_message_is_unchanged() -> None:
+    message = _llm_client_unavailable_message(ValueError("boom"))
+    assert message == "LLM client unavailable: boom"
+    assert "Restart" not in message
+
+
+def test_reasoning_provider_renders_actionable_message_on_import_error(monkeypatch) -> None:
+    rendered: list[str] = []
+
+    class FakeOutput:
+        def render_error(self, message: str) -> None:
+            rendered.append(message)
+
+    # Force the lazy import inside get() to fail like a stale process would.
+    monkeypatch.setitem(sys.modules, "core.llm.llm_client", None)
+
+    provider = DefaultReasoningClientProvider(output=FakeOutput())
+    result = provider.get()
+
+    assert result is None
+    assert rendered and "Restart it" in rendered[0]

--- a/tests/core/agent_harness/test_prompt_trace.py
+++ b/tests/core/agent_harness/test_prompt_trace.py
@@ -1,0 +1,36 @@
+"""Tests for prompt trace persistence."""
+
+from __future__ import annotations
+
+from core.agent_harness.debug.prompt_trace import persist_turn_system_prompt
+from core.agent_harness.session import InMemorySessionStorage, Session
+
+
+def test_persist_turn_system_prompt_writes_system_message() -> None:
+    session = Session(storage=InMemorySessionStorage())
+    session.storage.open_session(session)
+
+    persist_turn_system_prompt(
+        session,
+        phase="action_agent",
+        system_prompt="  you are the action agent  ",
+    )
+
+    records = session.storage.read(session.session_id)
+    system_rows = [
+        row for row in records if row.get("type") == "message" and row.get("role") == "system"
+    ]
+    assert len(system_rows) == 1
+    assert system_rows[0]["content"] == "you are the action agent"
+    assert system_rows[0]["metadata"]["kind"] == "action_agent"
+    assert system_rows[0]["metadata"]["debug"] == "system_prompt"
+
+
+def test_persist_turn_system_prompt_noop_on_blank() -> None:
+    session = Session(storage=InMemorySessionStorage())
+    session.storage.open_session(session)
+
+    persist_turn_system_prompt(session, phase="action_agent", system_prompt="   ")
+
+    records = session.storage.read(session.session_id)
+    assert all(row.get("type") != "message" or row.get("role") != "system" for row in records)

--- a/tests/core/runtime/test_loop.py
+++ b/tests/core/runtime/test_loop.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import builtins
 import logging
 from collections.abc import Iterator
+from dataclasses import replace
 from typing import Any, cast
 
 import pytest
@@ -189,6 +190,33 @@ def test_immediate_final_answer_executes_no_tools() -> None:
     assert result.executed == []
     assert result.final_text == "done immediately"
     assert result.hit_iteration_cap is False
+
+
+def test_run_records_final_system_prompt() -> None:
+    # The assembled system prompt is captured on the result so debugging can see
+    # what was influencing the agent, without re-deriving it by hand (issue #3434).
+    llm = FakeLLM(iter([_text_response("done")]))
+
+    result = _agent(llm, _tools(FakeTool("query_logs"))).run([{"role": "user", "content": "hello"}])
+
+    assert result.final_system_prompt == "sys"
+
+
+def test_run_records_system_prompt_edited_by_before_provider_request_hook() -> None:
+    # Capture happens after the _before_provider_request hook, so per-turn edits
+    # to the prompt are what gets recorded (not the pre-hook value).
+    class EditingAgent(Agent):
+        def _before_provider_request(self, request: Any) -> Any:
+            return replace(request, system=request.system + " [edited]")
+
+    llm = FakeLLM(iter([_text_response("done")]))
+    agent = EditingAgent(
+        llm=llm, system="sys", tools=[], resolved_integrations={}, max_iterations=1
+    )
+
+    result = agent.run([{"role": "user", "content": "hello"}])
+
+    assert result.final_system_prompt == "sys [edited]"
 
 
 def test_one_tool_round_then_final() -> None:

--- a/tests/interactive_shell/sessions/test_store.py
+++ b/tests/interactive_shell/sessions/test_store.py
@@ -192,6 +192,23 @@ def test_append_turn_detail_writes_full_prompt_and_response(tmp_path: Path) -> N
     assert messages[0]["metadata"]["latency_ms"] == 1500
 
 
+def test_append_turn_detail_stores_system_prompt_metadata(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn_detail(
+            session.session_id,
+            "chat",
+            "question",
+            response="answer",
+            system_prompt="assistant system block",
+        )
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    messages = [r for r in records if r["type"] == "message"]
+    assert messages[0]["metadata"]["system_prompt"] == "assistant system block"
+
+
 def test_append_turn_detail_omits_none_fields(tmp_path: Path) -> None:
     session = _make_session()
     with _patch_dir(tmp_path):

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -1297,8 +1297,9 @@ class TestInvestigateFileCommand:
             session: Session,
             console: Console,
             display_command: str,
+            investigation_target: str = "",
         ) -> str:
-            _ = (session, console, display_command)
+            _ = (session, console, display_command, investigation_target)
             launches.append(template_name)
             return "bg123"
 
@@ -1537,8 +1538,9 @@ class TestInvestigateFileCommand:
             session: Session,
             console: Console,
             display_command: str,
+            investigation_target: str = "",
         ) -> str:
-            _ = (session, console)
+            _ = (session, console, investigation_target)
             launches.append((alert_text, display_command))
             return "bg123"
 


### PR DESCRIPTION
Fixes #3434 


#### Describe the changes you have made in this PR -

The agent runs behind four surfaces (interactive shell, CLI one-shot, Telegram/API gateway, headless). It was hard to answer two basic questions: "what context is influencing the agent right now?" and "do all surfaces behave the same?". This PR makes the shared core legible and enforces one-core / different-flows: every change lands in `core/` or the shared prompt home — never in a single surface — and a parity suite proves the surfaces stay in lockstep.

## What changed

**1. Agent context is understandable and structured (#3434)**
- New contributor reference `docs/agent-context-data-stores.md`: the four stores
  (`Session`, `MutableAgentState`, `TurnContext`, JSONL), one owner and one job
  each.
- Audit results, code-verified: `MutableAgentState` is conversation-only and is
  not wired into `core/agent.py`; `TurnContext` has no surface-specific variants
  (no `ShellTurnContext`), so there is nothing to consolidate.
- Record the final prompt (Problem 1): `AgentRunResult.final_system_prompt`
  captures the exact system prompt sent to the LLM, taken after the
  `_before_provider_request` hook, in the shared loop — so all four surfaces
  record the same thing from one place.
- Consolidate prompt construction (Problem 2): moved the fourth builder,
  `build_gather_system_prompt`, out of `agents/evidence_agent.py` into the single
  `core/agent_harness/prompts/` home (old private copy removed, no shim).

**2. Cross-surface parity: gateway resolves tools live**
- The gateway precomputed action tools once at boot; on a remote/Linux host that
  resolved to an empty set, so Telegram fell back to the answer-only agent and
  reported itself as the interactive shell instead of executing shell actions.
  It now resolves tools live per turn from each chat's session, identical to the
  shell.
- New parity suite drives one message through all four entry points and asserts
  identical routing and reply shape.

**3. Stale-process hardening**
- `core/llm/preload.py` eager-loads the `core.llm` client graph at gateway boot,
  closing the mixed-version window that produced a cryptic
  `cannot import name 'use_litellm_for_provider'` after a merge.
- The reasoning-client import failure now tells the operator to restart the
  process instead of showing a bare ImportError (all surfaces).

**4. Messaging + docs**
- `messaging allow` rejects `@handle` and non-numeric Telegram user ids (the
  "user X is not in the allowed list" trap).
- Telegram docs: numeric-id warning and a remote-deploy `.env` section
  (keychain secrets don't travel to a deployed host).



---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
