### PR TITLE
fix(scheduler): unify slack and discord scheduler credentials

### DIFF
--- a/platform/scheduler/credentials.py
+++ b/platform/scheduler/credentials.py
@@ -27,12 +27,29 @@ def resolve_telegram_credentials(task_params: dict[str, str]) -> dict[str, str]:
 
 
 def resolve_slack_credentials(task_params: dict[str, str]) -> dict[str, str]:
-    """Resolve Slack access_token from task params, integration store, or env.
+    """Resolve Slack credentials from task params, integration store, or env.
 
     Priority: task.params > integration store > environment variable.
     """
+    webhook_url = task_params.get("webhook_url", "")
+    if webhook_url:
+        return {"webhook_url": webhook_url}
+
+    access_token = task_params.get("access_token", "")
+    if access_token:
+        return {"access_token": access_token}
+
+    webhook = _resolve_credentials(
+        {},
+        service="slack",
+        credential_key="webhook_url",
+        env_vars=("SLACK_WEBHOOK_URL",),
+    )
+    if webhook:
+        return webhook
+
     return _resolve_credentials(
-        task_params,
+        {},
         service="slack",
         credential_key="access_token",
         env_vars=("SLACK_BOT_TOKEN", "SLACK_ACCESS_TOKEN"),

--- a/platform/scheduler/executor.py
+++ b/platform/scheduler/executor.py
@@ -124,13 +124,10 @@ def _deliver_telegram(task: ScheduledTask, message: str) -> tuple[bool, str, str
 
 
 def _deliver_slack(task: ScheduledTask, message: str) -> tuple[bool, str, str]:
-    """Deliver via Slack using direct chat.postMessage (no thread_ts needed).
-
-    Scheduled deliveries start a new top-level message, not a thread reply.
-    Falls back to webhook if no access_token is available.
-    """
+    """Deliver via Slack using the shared Slack delivery helper when possible."""
     creds = resolve_slack_credentials(task.params)
     access_token = creds.get("access_token", "")
+    webhook_url = creds.get("webhook_url", "")
 
     # Strip HTML tags — Slack uses mrkdwn, not HTML
     plain_message = _strip_html(message)
@@ -163,12 +160,21 @@ def _deliver_slack(task: ScheduledTask, message: str) -> tuple[bool, str, str]:
         msg_ts = str(response.data.get("ts", ""))
         return True, "", msg_ts
 
-    # No access_token — cannot deliver to the configured chat_id
+    if webhook_url:
+        from integrations.slack.delivery import send_slack_webhook_message
+
+        ok, error = send_slack_webhook_message(
+            plain_message,
+            webhook_url=webhook_url,
+        )
+        return ok, error, ""
+
     if not task.chat_id:
-        return False, "Missing chat_id for Slack delivery", ""
+        return False, "Missing chat_id or webhook_url for Slack delivery", ""
+
     return (
         False,
-        "Scheduled tasks require a Slack bot access_token; webhook delivery is not supported",
+        "Scheduled tasks require Slack webhook_url or bot access_token",
         "",
     )
 

--- a/tests/scheduler/test_credentials.py
+++ b/tests/scheduler/test_credentials.py
@@ -37,19 +37,24 @@ class TestTelegramCredentials:
 
 class TestSlackCredentials:
     def test_from_params(self) -> None:
+        creds = resolve_slack_credentials({"webhook_url": "https://hooks.slack.com/from-params"})
+        assert creds == {"webhook_url": "https://hooks.slack.com/from-params"}
+
+    def test_from_params_access_token_fallback(self) -> None:
         creds = resolve_slack_credentials({"access_token": "xoxb-from-params"})
         assert creds == {"access_token": "xoxb-from-params"}
 
     def test_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-from-env")
+        monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/from-env")
         monkeypatch.setattr(
             "platform.scheduler.credentials._get_integration_credential",
             lambda *_: "",
         )
         creds = resolve_slack_credentials({})
-        assert creds == {"access_token": "xoxb-from-env"}
+        assert creds == {"webhook_url": "https://hooks.slack.com/from-env"}
 
     def test_from_env_access_token_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
         monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
         monkeypatch.setenv("SLACK_ACCESS_TOKEN", "xoxp-from-access-env")
         monkeypatch.setattr(
@@ -59,17 +64,18 @@ class TestSlackCredentials:
         creds = resolve_slack_credentials({})
         assert creds == {"access_token": "xoxp-from-access-env"}
 
-    def test_from_env_bot_token_takes_priority(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-primary")
-        monkeypatch.setenv("SLACK_ACCESS_TOKEN", "xoxp-secondary")
+    def test_from_env_webhook_takes_priority(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/primary")
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-secondary")
         monkeypatch.setattr(
             "platform.scheduler.credentials._get_integration_credential",
             lambda *_: "",
         )
         creds = resolve_slack_credentials({})
-        assert creds == {"access_token": "xoxb-primary"}
+        assert creds == {"webhook_url": "https://hooks.slack.com/primary"}
 
     def test_empty_when_nothing_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
         monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
         monkeypatch.delenv("SLACK_ACCESS_TOKEN", raising=False)
         monkeypatch.setattr(


### PR DESCRIPTION
Fixes #3567

## What changed

Aligned scheduler credential resolution with the Slack and Discord integrations to remove credential handling inconsistencies.

- Updated `resolve_slack_credentials()` to support the Slack integration webhook model (`webhook_url` / `SLACK_WEBHOOK_URL`).
- Kept legacy Slack access token fallback for backward compatibility.
- Updated scheduler Slack delivery to support webhook-based delivery using the shared Slack integration helper.
- Confirmed Discord scheduler credentials already match the Discord integration credential model (`bot_token`).
- Updated scheduler credential tests and added coverage for webhook priority and access token fallback behavior.

## Why

The scheduler was using Slack-specific credential handling that differed from the implementation in `integrations/slack/`. This created duplication and inconsistent behavior between integrations and scheduler delivery. This change aligns scheduler credential resolution with the integration implementations while preserving compatibility with existing Slack token-based setups.

## Validation

```bash
python -m pytest tests/scheduler/test_credentials.py
# 12 passed

python -m pytest tests/scheduler
# 74 passed
```
<img width="1509" height="707" alt="Ekran görüntüsü 2026-07-03 120534" src="https://github.com/user-attachments/assets/fdcda334-c7ad-4800-a0ef-e2927462edd4" />

