### PR TITLE
docs: add investigation pipeline architecture guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Before any push or PR creation follow **[CI.md](CI.md)** — lint, format, typec
 | `Makefile`            | Canonical local automation for install, test, verify, deploy, and cleanup targets.                 |
 | `README.md`           | Product overview, install, quick start, high-level capabilities, and links to deeper docs.         |
 | `docs/DEVELOPMENT.md` | Contributor workflows: CI parity commands, dev container, benchmark, deployment, telemetry detail. |
+| `docs/investigation-pipeline-architecture.md` | Investigation pipeline stages, ReAct loop control flow, and guardrails (tool cap, stagnation breaker, context budget), with diagrams. |
 | `docs/investigation-tool-calling.md` | Investigation ReAct tool schemas, LLM invoke payloads, and message shapes (all providers). |
 | `SETUP.md`            | Machine setup (all platforms, Windows, MCP/OpenClaw, troubleshooting).                             |
 | `CI.md`               | Mandatory pre-push checklist: lint, format, typecheck, tests — agents MUST follow before pushing. |
@@ -98,7 +99,9 @@ Steps:
 Investigations are coordinated in `tools/investigation/lifecycle.py` and exposed via
 `tools/investigation/capability.py`. Semantic stages live under
 `tools/investigation/stages/`; reporting lives under
-`tools/investigation/reporting/`.
+`tools/investigation/reporting/`. See
+[docs/investigation-pipeline-architecture.md](docs/investigation-pipeline-architecture.md)
+for the end-to-end stage/loop diagrams before making structural changes.
 
 Files to touch:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,6 +36,10 @@ Before a PR, run at least `make lint`, `make format-check`, `make typecheck`, an
 
 Action-planner behavior, postprocessing transforms, compatibility seams, and the rule-extension checklist are documented in [`docs/interactive-shell-action-policy.md`](https://github.com/Tracer-Cloud/opensre/blob/main/docs/interactive-shell-action-policy.md).
 
+## Investigation pipeline architecture
+
+The six-stage investigation pipeline (resolve integrations → extract alert → plan → ReAct evidence loop → diagnose → deliver), the loop's guardrails (tool cap, stagnation breaker, context budget, duplicate detection), and diagrams are documented in [`docs/investigation-pipeline-architecture.md`](investigation-pipeline-architecture.md).
+
 ## Investigation tool calling
 
 Tool schemas, provider adapters (`agent_llm_client.py`), and investigation message shapes are documented in [`docs/investigation-tool-calling.md`](investigation-tool-calling.md) (all LLM providers, not vendor-specific).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -40,6 +40,7 @@
             "pages": [
               "quickstart",
               "investigation-overview",
+              "how-investigations-work",
               "interactive-shell-commands",
               "interactive-shell-assistant",
               "deployment",

--- a/docs/how-investigations-work.mdx
+++ b/docs/how-investigations-work.mdx
@@ -1,0 +1,101 @@
+---
+title: "How an investigation works"
+description: "A plain-language walkthrough of what OpenSRE does between receiving an alert and posting a root-cause report"
+---
+
+Think of OpenSRE as an on-call engineer who never sleeps. It follows the same
+instincts a good on-call engineer would: get paged, decide whether it's
+actually worth waking up for, check the obvious dashboards first, take notes
+as it goes, stop once it has an answer (or has run out of useful things to
+check), and write it up clearly for whoever reads it next.
+
+```mermaid
+flowchart LR
+    A[Alert arrives] --> B{Real incident\nor noise?}
+    B -->|noise| Z[No action taken]
+    B -->|real| C[Plan what to check]
+    C --> D[Investigate]
+    D --> E[Diagnose]
+    E --> F[Report]
+```
+
+## The six stages
+
+<Steps>
+  <Step title="See what's connected">
+    Before looking at anything alert-specific, OpenSRE checks which of your
+    monitoring and infrastructure tools are actually connected — Grafana,
+    Datadog, EKS, and whatever else you've set up. This defines the universe
+    of things it's allowed to check for this investigation.
+  </Step>
+  <Step title="Decide if it's worth investigating">
+    OpenSRE reads the incoming alert and classifies it: a real incident, or
+    noise (a greeting, a "thanks," a reply in an already-closed thread)?
+    Genuine alerts proceed — including informational or "all clear"
+    notifications, since those still carry signal. Chit-chat is ignored and
+    nothing further happens.
+  </Step>
+  <Step title="Sketch a plan">
+    Rather than poking around at random, OpenSRE picks the handful of tools
+    most likely to explain *this specific* alert — matched by source (a
+    Grafana alert starts with Grafana queries, an EKS alert starts with pod
+    and cluster tools) and ranked by relevance. This keeps the investigation
+    focused instead of firing off every tool it has access to.
+  </Step>
+  <Step title="Investigate">
+    This is where the real work happens. OpenSRE works through its plan one
+    step at a time: run a check, look at what came back, decide what to check
+    next. It keeps a running memory of everything it's found, so each new
+    step builds on the last instead of starting from scratch.
+
+    A few habits keep this efficient:
+
+    - It won't run the exact same check twice — if it already has that
+      answer, it reuses it instead of asking again.
+    - If it finds itself going in circles without learning anything new, it
+      stops and writes up what it already has rather than spinning forever.
+    - There's a hard ceiling on how long a single investigation can run, so
+      one stubborn incident can never run away with unbounded time or cost.
+  </Step>
+  <Step title="Diagnose">
+    Once OpenSRE has enough evidence — or has run out of useful things to
+    check — it turns its findings into a structured diagnosis: what
+    happened, the chain of cause and effect, which claims are backed by
+    evidence versus still unconfirmed, and concrete remediation steps. It
+    also attaches a confidence score, so you know how much to trust the
+    conclusion at a glance.
+  </Step>
+  <Step title="Report">
+    Finally, OpenSRE delivers the result however you've configured it — a
+    Slack message in the incident channel, a GitLab comment, or local files
+    you can read directly. See
+    [Investigations overview](/investigation-overview) for what these look
+    like and how to run one yourself.
+  </Step>
+</Steps>
+
+## Why it doesn't lose the thread on long investigations
+
+A thorny incident can mean touching a dozen tools and collecting a lot of
+evidence. OpenSRE actively manages what it's holding onto in its working
+memory so that early findings don't get pushed out by later ones — the same
+reason a good engineer keeps a running incident doc instead of trying to hold
+every detail in their head. If a long investigation starts accumulating more
+than it can usefully reason about at once, OpenSRE trims the least useful
+parts rather than letting the most important early evidence quietly fall out
+of view.
+
+<Note>
+  You don't need to configure any of this — tool selection, note-keeping, and
+  the stop conditions above all happen automatically. This page just explains
+  what's going on behind the spinner.
+</Note>
+
+## Related pages
+
+- [Investigations overview](/investigation-overview) — how to start an
+  investigation and where to find the output.
+- [Interactive Shell Commands](/interactive-shell-commands) — the slash
+  commands available while an investigation runs.
+- [Closed-loop learning](/closed-loop-learning) — how OpenSRE improves future
+  investigations from past outcomes.

--- a/docs/investigation-pipeline-architecture.md
+++ b/docs/investigation-pipeline-architecture.md
@@ -1,0 +1,146 @@
+# Investigation pipeline architecture
+
+Contributor guide to how a single investigation runs end-to-end: the six-stage
+pipeline, the ReAct evidence-gathering loop, and the guardrails that keep it
+bounded. Companion to
+[`investigation-tool-calling.md`](investigation-tool-calling.md), which covers
+tool schema / LLM invoke payload mechanics specifically — this doc covers the
+pipeline and loop control flow around that.
+
+## Where code lives
+
+| Concern                        | Location                                                                                       |
+| ------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Stage ordering                  | `tools/investigation/lifecycle.py` (`run_connected_investigation`)                             |
+| Public runner entrypoint        | `tools/investigation/capability.py`                                                            |
+| Integration discovery           | `tools/investigation/stages/resolve_integrations/node.py`                                      |
+| Alert classification/extraction | `tools/investigation/stages/intake/node.py`                                                    |
+| Pre-loop tool planning          | `tools/investigation/stages/plan_evidence/node.py`, `core/domain/alerts/tool_planning.py`      |
+| ReAct loop (the agent)          | `tools/investigation/stages/gather_evidence/{agent,loop,tools,prompt}.py`                      |
+| Diagnosis parsing               | `tools/investigation/stages/diagnose/node.py`, `core/domain/diagnosis`                          |
+| Report delivery                 | `tools/investigation/reporting/`                                                                |
+| Shared state contract           | `core/context/state/` (`AgentState`, `InvestigationState`, `EvidenceEntry`)                    |
+| Context budget enforcement      | `core/context_budget.py`                                                                        |
+
+## Pipeline overview
+
+Each stage is a pure function — `(state) -> dict of updates`, merged into a
+shared `AgentState` via `apply_state_updates`. A stage exception is reported
+to Sentry and then re-raised; the pipeline never silently swallows a failure.
+
+```mermaid
+flowchart TD
+    A[raw_alert] --> B[resolve_integrations]
+    B --> C[extract_alert]
+    C -->|is_noise = true| Z[Stop — no investigation]
+    C -->|is_noise = false| D[plan_actions]
+    D --> E["ReAct loop\n(ConnectedInvestigationAgent.run)"]
+    E --> F[diagnose]
+    F --> G[deliver]
+    G --> H[Slack / GitLab / report.md]
+```
+
+## Stage by stage
+
+### 1. `resolve_integrations` — what tools exist
+
+Looks up which vendor integrations (Datadog, Grafana, EKS, …) this org has
+connected and credentialed. Not alert-specific — establishes the universe of
+tools everything downstream can draw from.
+
+### 2. `extract_alert` — is this worth investigating
+
+One LLM call classifies the raw alert: noise (chat, greetings, replies in an
+existing thread) short-circuits the pipeline immediately with no tools run.
+A real alert gets structured fields extracted — `alert_name`, `severity`,
+`alert_source`, namespace, error message — plus a computed `incident_window`.
+
+### 3. `plan_actions` — what to check first
+
+Scores every available tool against the alert (`score_tools`, source match +
+tool metadata) and keeps the top `tool_budget` (default 10) as
+`planned_actions`, with a written rationale. Advisory: if nothing scores
+confidently, the loop falls back to its own relevance ranking instead of an
+empty plan.
+
+### 4. The ReAct loop — the core evidence-gathering agent
+
+`ConnectedInvestigationAgent.run()` in `gather_evidence/agent.py`. Before the
+model's first turn: the tool set is narrowed to a hard cap
+(`select_investigation_tools`, `MAX_AGENT_TOOL_SCHEMAS = 32`) using the plan
+from stage 3 if present, otherwise alert-source relevance ranking. A handful
+of "obviously needed" tools may fire as deterministic **seed calls** before
+the LLM gets a turn at all, so the loop starts with free evidence already in
+hand.
+
+```mermaid
+flowchart TD
+    S0["Select ≤32 relevant tools\n(select_investigation_tools)"] --> S1[Build system prompt + alert context]
+    S1 --> S2{Seed calls for\nthis alert_source?}
+    S2 -->|yes| S3["Execute seed tool calls\nrecord as evidence"]
+    S2 -->|no| S4
+    S3 --> S4["Loop: iteration 0..19\n(MAX_INVESTIGATION_LOOPS)"]
+    S4 --> S5["Enforce context budget\n(evict/truncate low-value evidence)"]
+    S5 --> S6[llm.invoke]
+    S6 --> S7{Tool calls\nreturned?}
+    S7 -->|no| S8{Accept\nconclusion?}
+    S8 -->|yes| S9[Done — exit loop]
+    S8 -->|no: nudge| S4
+    S7 -->|yes| S10{Identical to a\nprior call?}
+    S10 -->|yes| S11["Replay cached result,\ntell LLM not to repeat"]
+    S10 -->|no| S12[Execute tool, record evidence]
+    S11 --> S13{2 consecutive\nall-duplicate iterations?}
+    S12 --> S13
+    S13 -->|yes| S14["Force a tool-free\nfinal iteration"]
+    S13 -->|no| S4
+    S14 --> S9
+```
+
+Guardrails inside the loop:
+
+- **Duplicate detection** (`InvestigationToolCallCache`) — identical
+  tool name + args is served from cache instead of re-executed, and the LLM
+  is told explicitly it already has that result.
+- **Stagnation breaker** — after `MAX_STAGNANT_ITERATIONS = 2` consecutive
+  iterations that produced only duplicate calls, the model gets one nudge,
+  then tool access is stripped to force a text-only conclusion rather than
+  burning the rest of the loop budget.
+- **CLI-backed models** (Codex, Claude Code CLI) use a subclass,
+  `CLIBackedInvestigationAgent`, that overrides conclusion acceptance to
+  refuse an early stop until every planned tool has been called — these
+  models tend to write a final answer as soon as they see *some* results.
+- **LLM invoke failures** degrade to a partial "investigation failed" state
+  (`degraded_investigation_from_llm_failure`) instead of crashing, preserving
+  whatever evidence was already gathered.
+
+### 5. `diagnose` — structure the conclusion
+
+The loop's final free-text answer is unstructured. A separate LLM call
+(structured output) parses it into `root_cause`, `root_cause_category`,
+`causal_chain`, `validated_claims` / `non_validated_claims`,
+`remediation_steps`, and a `validity_score`, with a legacy regex-based
+fallback (`parse_root_cause`) if structured parsing fails.
+
+### 6. `deliver` — publish it
+
+Formats and ships the report to whatever's configured on `state` — Slack,
+GitLab writeback, local `report.md`, etc. See
+[`tools/investigation/reporting/`](../tools/investigation/reporting/).
+
+## Guardrails at a glance
+
+| Guardrail            | Constant                              | Defined in                                   | Purpose                                                        |
+| --------------------- | -------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------- |
+| Tool schema cap       | `MAX_AGENT_TOOL_SCHEMAS = 32`         | `gather_evidence/tools.py`                    | Bounds per-turn schema payload regardless of registry size.    |
+| Secondary tool reserve | `MAX_SECONDARY_FALLBACK_TOOLS = 3`    | `gather_evidence/tools.py`                    | Guarantees cheap reasoning/knowledge tools survive the cap.     |
+| Loop iteration cap    | `MAX_INVESTIGATION_LOOPS = 20`        | `config/constants/investigation.py`           | Worst-case runtime bound for the ReAct loop.                   |
+| Stagnation breaker    | `MAX_STAGNANT_ITERATIONS = 2`         | `gather_evidence/tools.py`                    | Stops the loop from spinning on duplicate-only iterations.     |
+| Context budget        | `context_budget_ceiling_for_model()`  | `core/context_budget.py`                      | Evicts/truncates lowest-value evidence before the model's context limit. |
+| Pre-loop plan size    | `tool_budget` (default 10)            | `plan_evidence/node.py`                       | Shortlist size the plan hands the loop before it even starts.  |
+
+## Related docs
+
+- [`investigation-tool-calling.md`](investigation-tool-calling.md) — tool
+  schema / LLM invoke payload mechanics, per provider.
+- [`../AGENTS.md`](../AGENTS.md) — "Changing the investigation pipeline"
+  entry point and checklist for making changes here.

--- a/docs/investigation-pipeline-architecture.md
+++ b/docs/investigation-pipeline-architecture.md
@@ -65,7 +65,8 @@ empty plan.
 
 ### 4. The ReAct loop — the core evidence-gathering agent
 
-`ConnectedInvestigationAgent.run()` in `gather_evidence/agent.py`. Before the
+`ConnectedInvestigationAgent.run()` in
+`tools/investigation/stages/gather_evidence/agent.py`. Before the
 model's first turn: the tool set is narrowed to a hard cap
 (`select_investigation_tools`, `MAX_AGENT_TOOL_SCHEMAS = 32`) using the plan
 from stage 3 if present, otherwise alert-source relevance ranking. A handful
@@ -91,9 +92,9 @@ flowchart TD
     S10 -->|no| S12[Execute tool, record evidence]
     S11 --> S13{2 consecutive\nall-duplicate iterations?}
     S12 --> S13
-    S13 -->|yes| S14["Force a tool-free\nfinal iteration"]
+    S13 -->|yes| S14["Strip tool access;\nloop back for one\nfinal llm.invoke"]
     S13 -->|no| S4
-    S14 --> S9
+    S14 --> S4
 ```
 
 Guardrails inside the loop:
@@ -123,24 +124,25 @@ fallback (`parse_root_cause`) if structured parsing fails.
 
 ### 6. `deliver` — publish it
 
-Formats and ships the report to whatever's configured on `state` — Slack,
-GitLab writeback, local `report.md`, etc. See
-[`tools/investigation/reporting/`](../tools/investigation/reporting/).
+Formats and ships the report to the destinations configured in `state` —
+Slack, GitLab writeback, local `report.md`, etc. See
+[`tools/investigation/reporting/`](https://github.com/Tracer-Cloud/opensre/tree/main/tools/investigation/reporting/).
 
 ## Guardrails at a glance
 
 | Guardrail            | Constant                              | Defined in                                   | Purpose                                                        |
 | --------------------- | -------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------- |
-| Tool schema cap       | `MAX_AGENT_TOOL_SCHEMAS = 32`         | `gather_evidence/tools.py`                    | Bounds per-turn schema payload regardless of registry size.    |
-| Secondary tool reserve | `MAX_SECONDARY_FALLBACK_TOOLS = 3`    | `gather_evidence/tools.py`                    | Guarantees cheap reasoning/knowledge tools survive the cap.     |
+| Tool schema cap       | `MAX_AGENT_TOOL_SCHEMAS = 32`         | `tools/investigation/stages/gather_evidence/tools.py` | Bounds per-turn schema payload regardless of registry size.    |
+| Secondary tool reserve | `MAX_SECONDARY_FALLBACK_TOOLS = 3`    | `tools/investigation/stages/gather_evidence/tools.py` | Guarantees cheap reasoning/knowledge tools survive the cap.     |
 | Loop iteration cap    | `MAX_INVESTIGATION_LOOPS = 20`        | `config/constants/investigation.py`           | Worst-case runtime bound for the ReAct loop.                   |
-| Stagnation breaker    | `MAX_STAGNANT_ITERATIONS = 2`         | `gather_evidence/tools.py`                    | Stops the loop from spinning on duplicate-only iterations.     |
+| Stagnation breaker    | `MAX_STAGNANT_ITERATIONS = 2`         | `tools/investigation/stages/gather_evidence/tools.py` | Stops the loop from spinning on duplicate-only iterations.     |
 | Context budget        | `context_budget_ceiling_for_model()`  | `core/context_budget.py`                      | Evicts/truncates lowest-value evidence before the model's context limit. |
-| Pre-loop plan size    | `tool_budget` (default 10)            | `plan_evidence/node.py`                       | Shortlist size the plan hands the loop before it even starts.  |
+| Pre-loop plan size    | `tool_budget` (default 10)            | `tools/investigation/stages/plan_evidence/node.py` | Shortlist size the plan hands the loop before it even starts.  |
 
 ## Related docs
 
 - [`investigation-tool-calling.md`](investigation-tool-calling.md) — tool
   schema / LLM invoke payload mechanics, per provider.
-- [`../AGENTS.md`](../AGENTS.md) — "Changing the investigation pipeline"
-  entry point and checklist for making changes here.
+- [`AGENTS.md`](https://github.com/Tracer-Cloud/opensre/blob/main/AGENTS.md) —
+  "Changing the investigation pipeline" entry point and checklist for making
+  changes here.

--- a/docs/investigation-pipeline-architecture.md
+++ b/docs/investigation-pipeline-architecture.md
@@ -90,10 +90,13 @@ flowchart TD
     S7 -->|yes| S10{Identical to a\nprior call?}
     S10 -->|yes| S11["Replay cached result,\ntell LLM not to repeat"]
     S10 -->|no| S12[Execute tool, record evidence]
-    S11 --> S13{2 consecutive\nall-duplicate iterations?}
+    S11 --> S13{Any fresh calls\nthis iteration?}
     S12 --> S13
-    S13 -->|yes| S14["Strip tool access;\nloop back for one\nfinal llm.invoke"]
-    S13 -->|no| S4
+    S13 -->|yes| S4
+    S13 -->|no| S15["Send stagnation nudge\n(stagnant_iterations += 1)"]
+    S15 --> S16{stagnant_iterations\n>= 2?}
+    S16 -->|yes| S14["Strip tool access;\nloop back for one\nfinal llm.invoke"]
+    S16 -->|no| S4
     S14 --> S4
 ```
 
@@ -102,10 +105,12 @@ Guardrails inside the loop:
 - **Duplicate detection** (`InvestigationToolCallCache`) — identical
   tool name + args is served from cache instead of re-executed, and the LLM
   is told explicitly it already has that result.
-- **Stagnation breaker** — after `MAX_STAGNANT_ITERATIONS = 2` consecutive
-  iterations that produced only duplicate calls, the model gets one nudge,
-  then tool access is stripped to force a text-only conclusion rather than
-  burning the rest of the loop budget.
+- **Stagnation breaker** — any iteration where every tool call was a
+  replayed duplicate (no fresh evidence) appends a nudge telling the model to
+  stop repeating itself and try something different. After
+  `MAX_STAGNANT_ITERATIONS = 2` such iterations in a row (two nudges), tool
+  access is stripped on the next turn to force a text-only conclusion rather
+  than burning the rest of the loop budget.
 - **CLI-backed models** (Codex, Claude Code CLI) use a subclass,
   `CLIBackedInvestigationAgent`, that overrides conclusion acceptance to
   refuse an early stop until every planned tool has been called — these


### PR DESCRIPTION
## Summary
- Add `docs/investigation-pipeline-architecture.md`: a **contributor** guide covering the six-stage investigation pipeline (resolve integrations → extract alert → plan → ReAct evidence loop → diagnose → deliver) and the ReAct loop's internal control flow, with Mermaid diagrams. Documents the loop's guardrails in one place: tool-schema cap (`MAX_AGENT_TOOL_SCHEMAS=32`), seed calls, duplicate-call caching, the stagnation breaker (`MAX_STAGNANT_ITERATIONS=2`), the iteration cap (`MAX_INVESTIGATION_LOOPS=20`), and context-budget enforcement. Linked from `docs/DEVELOPMENT.md` and `AGENTS.md`, following the same convention as the existing `docs/investigation-tool-calling.md` (not registered in the Mintlify `docs.json` nav).
- Add `docs/how-investigations-work.mdx`: a **user-facing** companion page with the same six-stage story told in plain language — no file paths, function names, or internal constants — for people running OpenSRE, not contributing to it. Registered in `docs.json` under **Getting Started → First steps**, right after `investigation-overview`.

## Why
No existing doc covered the investigation pipeline/loop end-to-end at either altitude — `investigation-tool-calling.md` is scoped narrowly to tool schemas, and `investigation-overview.mdx` covers *how to run* an investigation, not what happens inside one. This came up while walking through issue #3106 (tool-context budgeting) and splits into a contributor reference (mechanics, guardrail constants) and a user-facing explainer (plain-language mental model), each written for its actual audience per `AGENTS.md`'s docs-writing rule.

## Test plan
- [x] Docs-only change — no code paths affected.
- [x] `docs/docs.json` validated as well-formed JSON after the nav addition.
- [ ] Mermaid diagrams render correctly on GitHub and on the Mintlify preview (verify in rendered PR view / docs deploy preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)