### PR TITLE
feat: enhance import checks to include nested imports

### DIFF
--- a/.github/ci/check_direct_imports.py
+++ b/.github/ci/check_direct_imports.py
@@ -1,9 +1,10 @@
 """Enforce forbidden *direct* import edges between top-level packages.
 
-Unlike import-linter (which flags transitive chains), this checker only
-looks at top-level ``import`` / ``from … import`` statements — the same
-AST walk as ``check_import_cycles``. That makes it practical to
-enforce layering incrementally: fix a direct edge, keep the contract.
+Unlike import-linter (which flags transitive chains), this checker looks at
+**module-top-level** and **nested** (function/class-body) ``import`` /
+``from … import`` statements. Module-top-level uses the same AST walk as
+``check_import_cycles``; nested imports close the loophole where lazy
+``surfaces.*`` imports bypass the module-level graph.
 
 Used by ``make check-imports`` (and ``check_imports``) alongside
 import-linter's config contract.
@@ -19,7 +20,12 @@ _CI_DIR = Path(__file__).resolve().parent
 if str(_CI_DIR) not in sys.path:
     sys.path.insert(0, str(_CI_DIR))
 
-from check_import_cycles import _build_graph, discover_first_party_roots  # noqa: E402
+from check_import_cycles import (  # noqa: E402
+    _build_graph,
+    _nested_imports,
+    discover_first_party_roots,
+    module_from_path,
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -83,11 +89,38 @@ _BASELINE_IGNORES: frozenset[str] = frozenset(
     }
 )
 
+# Function/class-body lazy imports that bypass the module-level graph.
+# Format matches ``_BASELINE_IGNORES``; burn down by moving shared code
+# below ``surfaces/`` or making tools UI-agnostic.
+_NESTED_BASELINE_IGNORES: frozenset[str] = frozenset(
+    {
+        # Hermes defers investigation pipeline import until an incident runs.
+        "integrations.hermes.investigation -> tools.investigation.capability",
+        "tools.interactive_shell.actions.investigation -> surfaces.cli.investigation",
+        "tools.interactive_shell.actions.investigation -> surfaces.interactive_shell.runtime.background.runner",
+        "tools.interactive_shell.actions.sample_alert -> surfaces.cli.investigation",
+        "tools.interactive_shell.actions.sample_alert -> surfaces.interactive_shell.runtime.background.runner",
+        "tools.interactive_shell.actions.llm_provider -> surfaces.cli.wizard.config",
+        "tools.interactive_shell.shell.runner -> surfaces.interactive_shell.ui",
+    }
+)
+
 
 @dataclass(frozen=True)
 class DirectViolation:
     source: str
     target: str
+
+    @property
+    def edge(self) -> str:
+        return f"{self.source} -> {self.target}"
+
+
+@dataclass(frozen=True)
+class NestedViolation:
+    source: str
+    target: str
+    lineno: int
 
     @property
     def edge(self) -> str:
@@ -124,23 +157,73 @@ def find_direct_violations(
     return violations
 
 
+def find_nested_direct_violations(
+    root: Path,
+    first_party_roots: tuple[str, ...],
+    *,
+    forbidden: dict[str, frozenset[str]] | None = None,
+    baseline_ignores: frozenset[str] | None = None,
+) -> list[NestedViolation]:
+    rules = forbidden or _FORBIDDEN_DIRECT
+    ignores = baseline_ignores if baseline_ignores is not None else _NESTED_BASELINE_IGNORES
+    roots = frozenset(first_party_roots)
+    violations: list[NestedViolation] = []
+
+    for pkg in first_party_roots:
+        if pkg not in rules:
+            continue
+        pkg_path = root / pkg
+        if not pkg_path.exists():
+            continue
+        for py in pkg_path.rglob("*.py"):
+            if "__pycache__" in py.parts:
+                continue
+            source_module = module_from_path(root, py)
+            source_root = _source_root(source_module)
+            forbidden_roots = rules.get(source_root)
+            if not forbidden_roots:
+                continue
+            source = py.read_text(encoding="utf-8")
+            for target_module, lineno in _nested_imports(source, first_party_roots=roots):
+                target_root = _source_root(target_module)
+                if target_root not in forbidden_roots:
+                    continue
+                violation = NestedViolation(source_module, target_module, lineno)
+                if violation.edge in ignores:
+                    continue
+                violations.append(violation)
+
+    return sorted(violations, key=lambda item: (item.source, item.lineno, item.target))
+
+
 def main(argv: list[str] | None = None) -> int:
     del argv
     root = _REPO_ROOT
     first_party_roots = discover_first_party_roots(root)
     graph = _build_graph(root, first_party_roots)
-    violations = find_direct_violations(graph)
+    module_violations = find_direct_violations(graph)
+    nested_violations = find_nested_direct_violations(root, first_party_roots)
 
-    if not violations:
+    if not module_violations and not nested_violations:
         print(
             "No forbidden direct import edges found "
-            f"(baseline ignores {len(_BASELINE_IGNORES)} known edges)."
+            f"(module baseline: {len(_BASELINE_IGNORES)}, "
+            f"nested baseline: {len(_NESTED_BASELINE_IGNORES)})."
         )
         return 0
 
-    print(f"FAIL: {len(violations)} forbidden direct import edge(s):")
-    for violation in violations:
-        print(f"  {violation.edge}")
+    if module_violations:
+        print(f"FAIL: {len(module_violations)} forbidden module-level direct import edge(s):")
+        for violation in module_violations:
+            print(f"  {violation.edge}")
+
+    if nested_violations:
+        if module_violations:
+            print()
+        print(f"FAIL: {len(nested_violations)} forbidden nested direct import edge(s):")
+        for violation in nested_violations:
+            print(f"  {violation.edge} (line {violation.lineno})")
+
     print(
         "\nFix by moving shared code to a lower layer (platform/common, core/contracts) "
         "or add a temporary baseline entry in .github/ci/check_direct_imports.py "

--- a/.github/ci/check_direct_imports.py
+++ b/.github/ci/check_direct_imports.py
@@ -101,6 +101,7 @@ _NESTED_BASELINE_IGNORES: frozenset[str] = frozenset(
         "tools.interactive_shell.actions.sample_alert -> surfaces.cli.investigation",
         "tools.interactive_shell.actions.sample_alert -> surfaces.interactive_shell.runtime.background.runner",
         "tools.interactive_shell.actions.llm_provider -> surfaces.cli.wizard.config",
+        # Nested only: runner.py also has a module-level ui import (see _BASELINE_IGNORES).
         "tools.interactive_shell.shell.runner -> surfaces.interactive_shell.ui",
     }
 )

--- a/.github/ci/check_import_cycles.py
+++ b/.github/ci/check_import_cycles.py
@@ -192,6 +192,12 @@ def _nested_imports(source: str, *, first_party_roots: frozenset[str]) -> list[t
                 _walk_nested(node.finalbody, nested=nested)
             elif isinstance(node, ast.With | ast.AsyncWith):
                 _walk_nested(node.body, nested=nested)
+            elif isinstance(node, ast.For | ast.AsyncFor | ast.While):
+                _walk_nested(node.body, nested=nested)
+                _walk_nested(node.orelse, nested=nested)
+            elif isinstance(node, ast.Match):
+                for case in node.cases:
+                    _walk_nested(case.body, nested=nested)
 
     _walk_nested(tree.body, nested=False)
     return results

--- a/.github/ci/check_import_cycles.py
+++ b/.github/ci/check_import_cycles.py
@@ -152,6 +152,57 @@ def _top_level_imports(source: str, *, first_party_roots: frozenset[str]) -> set
     return names
 
 
+def _nested_imports(source: str, *, first_party_roots: frozenset[str]) -> list[tuple[str, int]]:
+    """Return ``(target_module, lineno)`` for imports inside function/class bodies.
+
+    Complements ``_top_level_imports``: catches lazy imports that bypass the
+    module-level direct-edge checker while still being layering violations.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    results: list[tuple[str, int]] = []
+
+    def _add(module_path: str, lineno: int) -> None:
+        top = module_path.split(".", 1)[0]
+        if top in first_party_roots:
+            results.append((module_path, lineno))
+
+    def _walk_nested(body: Iterable[ast.stmt], *, nested: bool) -> None:
+        for node in body:
+            if isinstance(node, ast.Import):
+                if nested:
+                    for alias in node.names:
+                        _add(alias.name, node.lineno)
+            elif isinstance(node, ast.ImportFrom):
+                if nested and not node.level and node.module:
+                    _add(node.module, node.lineno)
+            elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                _walk_nested(node.body, nested=True)
+            elif isinstance(node, ast.If):
+                _walk_nested(node.body, nested=nested)
+                _walk_nested(node.orelse, nested=nested)
+            elif isinstance(node, ast.Try | ast.TryStar):
+                _walk_nested(node.body, nested=nested)
+                for handler in node.handlers:
+                    _walk_nested(handler.body, nested=nested)
+                _walk_nested(node.orelse, nested=nested)
+                _walk_nested(node.finalbody, nested=nested)
+            elif isinstance(node, ast.With | ast.AsyncWith):
+                _walk_nested(node.body, nested=nested)
+
+    _walk_nested(tree.body, nested=False)
+    return results
+
+
+def module_from_path(root: Path, py: Path) -> str:
+    """Resolve a repo-relative ``.py`` path to its dotted module name."""
+    module = ".".join(py.with_suffix("").relative_to(root).parts)
+    return module.removesuffix(".__init__")
+
+
 def _build_graph(root: Path, first_party_roots: tuple[str, ...]) -> dict[str, set[str]]:
     """Build the first-party module-level import graph rooted at ``root``."""
     roots = frozenset(first_party_roots)
@@ -163,8 +214,7 @@ def _build_graph(root: Path, first_party_roots: tuple[str, ...]) -> dict[str, se
         for py in pkg_path.rglob("*.py"):
             if "__pycache__" in py.parts:
                 continue
-            module = ".".join(py.with_suffix("").relative_to(root).parts)
-            module = module.removesuffix(".__init__")
+            module = module_from_path(root, py)
             source = py.read_text(encoding="utf-8")
             graph[module].update(_top_level_imports(source, first_party_roots=roots))
     return graph

--- a/.github/ci/check_imports.py
+++ b/.github/ci/check_imports.py
@@ -60,7 +60,7 @@ def import_checks(*, strict_layers: bool = False) -> Sequence[ImportCheck]:
             "Import layers (import-linter)",
             lambda: _run_importlinter(config=layer_config),
         ),
-        ImportCheck("Forbidden direct import edges", check_direct_imports),
+        ImportCheck("Forbidden direct import edges (module + nested)", check_direct_imports),
     )
 
 

--- a/tests/github_ci/test_check_direct_imports.py
+++ b/tests/github_ci/test_check_direct_imports.py
@@ -9,7 +9,12 @@ _CI_DIR = Path(__file__).resolve().parents[2] / ".github" / "ci"
 if str(_CI_DIR) not in sys.path:
     sys.path.insert(0, str(_CI_DIR))
 
-from check_direct_imports import find_direct_violations
+from check_direct_imports import (  # noqa: E402
+    _NESTED_BASELINE_IGNORES,
+    find_direct_violations,
+    find_nested_direct_violations,
+)
+from check_import_cycles import _nested_imports, discover_first_party_roots  # noqa: E402
 
 
 def test_find_direct_violations_flags_new_edge() -> None:
@@ -38,3 +43,92 @@ def test_find_direct_violations_respects_baseline() -> None:
         baseline_ignores=frozenset({"tools.fleet_monitoring -> surfaces.cli.commands.doctor"}),
     )
     assert violations == []
+
+
+def test_nested_imports_ignores_module_top_level() -> None:
+    source = "from surfaces.cli import doctor\n\ndef f():\n    from core.llm import client\n"
+    nested = _nested_imports(source, first_party_roots=frozenset({"surfaces", "core", "tools"}))
+    assert nested == [("core.llm", 4)]
+
+
+def test_nested_imports_flags_function_and_class_bodies() -> None:
+    source = (
+        "class C:\n"
+        "    def m(self):\n"
+        "        from surfaces.cli.wizard import store\n"
+        "def f():\n"
+        "    from surfaces.interactive_shell.ui import DIM\n"
+    )
+    nested = _nested_imports(
+        source,
+        first_party_roots=frozenset({"surfaces", "tools"}),
+    )
+    assert ("surfaces.cli.wizard", 3) in nested
+    assert ("surfaces.interactive_shell.ui", 5) in nested
+
+
+def test_find_nested_direct_violations_flags_new_edge(tmp_path: Path) -> None:
+    module_dir = tmp_path / "tools" / "fleet_monitoring"
+    module_dir.mkdir(parents=True)
+    module_dir.joinpath("__init__.py").write_text(
+        "def run():\n    from surfaces.cli.commands import doctor\n",
+        encoding="utf-8",
+    )
+    violations = find_nested_direct_violations(
+        tmp_path,
+        ("tools", "surfaces", "core"),
+        baseline_ignores=frozenset(),
+    )
+    assert len(violations) == 1
+    assert violations[0].edge == "tools.fleet_monitoring -> surfaces.cli.commands"
+    assert violations[0].lineno == 2
+
+
+def test_find_nested_direct_violations_respects_baseline(tmp_path: Path) -> None:
+    module_dir = tmp_path / "tools" / "fleet_monitoring"
+    module_dir.mkdir(parents=True)
+    module_dir.joinpath("__init__.py").write_text(
+        "def run():\n    from surfaces.cli.commands import doctor\n",
+        encoding="utf-8",
+    )
+    violations = find_nested_direct_violations(
+        tmp_path,
+        ("tools", "surfaces", "core"),
+        baseline_ignores=frozenset(
+            {"tools.fleet_monitoring -> surfaces.cli.commands"},
+        ),
+    )
+    assert violations == []
+
+
+def test_find_nested_direct_violations_ignores_legal_nested_imports(tmp_path: Path) -> None:
+    tools_dir = tmp_path / "tools" / "helper"
+    tools_dir.mkdir(parents=True)
+    tools_dir.joinpath("__init__.py").write_text(
+        "def run():\n    from core.llm import client\n",
+        encoding="utf-8",
+    )
+    core_dir = tmp_path / "core" / "helper"
+    core_dir.mkdir(parents=True)
+    core_dir.joinpath("__init__.py").write_text(
+        "def run():\n    from platform.common import task_types\n",
+        encoding="utf-8",
+    )
+    violations = find_nested_direct_violations(
+        tmp_path,
+        ("tools", "core", "platform", "surfaces"),
+        baseline_ignores=frozenset(),
+    )
+    assert violations == []
+
+
+def test_repo_has_no_unbaselined_nested_direct_imports() -> None:
+    root = Path(__file__).resolve().parents[2]
+    first_party_roots = discover_first_party_roots(root)
+    violations = find_nested_direct_violations(root, first_party_roots)
+    assert violations == [], (
+        "Unexpected nested direct import violations — update _NESTED_BASELINE_IGNORES "
+        "only with linked burn-down issues:\n"
+        + "\n".join(f"  {v.edge} (line {v.lineno})" for v in violations)
+    )
+    assert len(_NESTED_BASELINE_IGNORES) == 7

--- a/tests/github_ci/test_check_direct_imports.py
+++ b/tests/github_ci/test_check_direct_imports.py
@@ -67,6 +67,26 @@ def test_nested_imports_flags_function_and_class_bodies() -> None:
     assert ("surfaces.interactive_shell.ui", 5) in nested
 
 
+def test_nested_imports_flags_imports_inside_for_while_and_match() -> None:
+    source = (
+        "def f():\n"
+        "    for _ in [1]:\n"
+        "        from surfaces.cli import doctor\n"
+        "    while False:\n"
+        "        from surfaces.cli.wizard import store\n"
+        "    match 0:\n"
+        "        case _:\n"
+        "            from surfaces.interactive_shell.ui import DIM\n"
+    )
+    nested = _nested_imports(
+        source,
+        first_party_roots=frozenset({"surfaces", "tools"}),
+    )
+    assert ("surfaces.cli", 3) in nested
+    assert ("surfaces.cli.wizard", 5) in nested
+    assert ("surfaces.interactive_shell.ui", 8) in nested
+
+
 def test_find_nested_direct_violations_flags_new_edge(tmp_path: Path) -> None:
     module_dir = tmp_path / "tools" / "fleet_monitoring"
     module_dir.mkdir(parents=True)


### PR DESCRIPTION
Fixes #3542

Closes the layering loophole where lazy `import` / `from … import` statements inside function or class bodies bypassed the module-level direct-edge CI check. The existing `check_direct_imports` checker only walked top-level imports (same depth as the cycle detector), so `tools → surfaces.*` and similar edges could be hidden with function-scoped imports.

This PR extends the import-graph CI stage to also scan nested imports using the same `_FORBIDDEN_DIRECT` rules, with a separate baseline for known pre-existing violations.

- Add `_nested_imports()` AST helper in `.github/ci/check_import_cycles.py` for imports inside function/class bodies (with line numbers)
- Extend `.github/ci/check_direct_imports.py` with `find_nested_direct_violations()` and `_NESTED_BASELINE_IGNORES` (7 known edges)
- Wire nested scan into existing `make check-imports` / CI stage 3 (no new Makefile target)
- Add unit tests and a repo-wide drift guard in `tests/github_ci/test_check_direct_imports.py`

**Baselined nested violations (guard only — no refactors in this PR):**
- 6 `tools → surfaces.*` lazy imports under `tools/interactive_shell/`
- 1 `integrations → tools` lazy import in `integrations/hermes/investigation.py`

New nested direct edges outside the baseline will fail CI with `source -> target (line N)`.

