### PR TITLE
feat(architecture): add `.importlinter.strict` for transitive layer contracts (T-12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ on:
       - "mypy.ini"
       - "Makefile"
       - ".importlinter"
+      - ".importlinter.strict"
       - ".github/ci/**"
       - ".github/workflows/ci.yml"
 
@@ -40,6 +41,7 @@ on:
       - "mypy.ini"
       - "Makefile"
       - ".importlinter"
+      - ".importlinter.strict"
       - ".github/ci/**"
       - ".github/workflows/ci.yml"
 

--- a/.importlinter
+++ b/.importlinter
@@ -16,3 +16,4 @@ modules =
 
 # Full layered contracts (core ⊄ tools, integrations ⊄ cli, …) live in
 # ``.importlinter.strict`` for local burn-down. Run: ``make check-layers-strict``
+# Regenerate baselines: ``uv run lint-imports --config .importlinter.strict``

--- a/.importlinter.strict
+++ b/.importlinter.strict
@@ -1,0 +1,136 @@
+# Transitive layer contracts for OpenSRE (T-12, issue #3545).
+#
+# Counterpart to .github/ci/check_direct_imports.py (direct edges only).
+# Run: make check-layers-strict
+#
+# Remove ignore_imports entries as refactors land; link the fixing PR/issue.
+
+[importlinter]
+root_packages =
+    surfaces
+    config
+    core
+    gateway
+    integrations
+    platform
+    tools
+
+[importlinter:contract:config-independent]
+name = Config is independent
+type = independence
+modules =
+    config
+
+[importlinter:contract:opensre-layers]
+name = OpenSRE package layers (transitive)
+type = layers
+layers =
+    surfaces | gateway
+    tools | integrations
+    core : platform
+    config
+ignore_imports =
+    # config upward imports (T-4 debt — refactor into lower layers)
+    config.config -> core.llm.azure_openai
+    config.gateway_output_sink -> gateway.polling.telegram_poller.client
+    config.gateway_output_sink -> platform.common.truncation
+    config.llm_auth.credentials -> integrations.llm_cli.registry
+    config.llm_keyring -> platform
+    config.repl_config -> platform.terminal.theme
+    config.webapp -> platform.observability.sentry_sdk
+    # core -> integrations/tools (T-4 debt — agent_harness / llm_cli)
+    core.agent_harness.agents.action_agent -> integrations.llm_cli.failure_explain
+    core.agent_harness.agents.evidence_agent -> integrations.github.repo_scope
+    core.agent_harness.agents.turn_orchestrator -> integrations.llm_cli.errors
+    core.agent_harness.integrations.resolution -> integrations.catalog
+    core.agent_harness.integrations.resolution -> integrations.port
+    core.agent_harness.integrations.resolution -> integrations.store
+    core.agent_harness.session.state -> integrations.catalog
+    core.agent_harness.tools.action_tools -> tools.registry
+    core.llm.agent_llm_client -> integrations.llm_cli.registry
+    core.llm.llm_client -> integrations.llm_cli.registry
+    core.llm.llm_client -> integrations.llm_cli.runner
+    core.llm.sdk.agent_clients -> integrations.llm_cli.runner
+    core.llm.sdk.agent_clients -> integrations.llm_cli.text
+    core.llm_invoke_errors -> integrations.llm_cli.errors
+    # platform -> integrations (T-4 debt — scheduler / observability)
+    platform.analytics.cli -> integrations.github.identity
+    platform.observability.sentry_sdk -> integrations.llm_cli.errors
+    platform.scheduler.credentials -> integrations.catalog
+    platform.scheduler.executor -> integrations.discord.delivery
+    platform.scheduler.executor -> integrations.telegram.delivery
+    # integrations -> tools (hermes investigation bridge)
+    integrations.hermes.investigation -> tools.investigation.capability
+    # surfaces -> gateway (cli gateway command)
+    surfaces.cli.commands.gateway -> gateway.manager
+    # tools.interactive_shell -> surfaces (T-4 debt — issue #3352)
+    tools.interactive_shell.actions.cli_command -> surfaces.interactive_shell.runtime.subprocess_runner
+    tools.interactive_shell.actions.investigation -> surfaces.cli.investigation
+    tools.interactive_shell.actions.investigation -> surfaces.interactive_shell.runtime
+    tools.interactive_shell.actions.investigation -> surfaces.interactive_shell.runtime.background.runner
+    tools.interactive_shell.actions.llm_provider -> surfaces.cli.wizard.config
+    tools.interactive_shell.actions.llm_provider -> surfaces.interactive_shell.command_registry
+    tools.interactive_shell.actions.llm_provider -> surfaces.interactive_shell.ui.execution_confirm
+    tools.interactive_shell.actions.sample_alert -> surfaces.cli.investigation
+    tools.interactive_shell.actions.sample_alert -> surfaces.interactive_shell.runtime
+    tools.interactive_shell.actions.sample_alert -> surfaces.interactive_shell.runtime.background.runner
+    tools.interactive_shell.actions.slash -> surfaces.interactive_shell.command_registry
+    tools.interactive_shell.actions.slash -> surfaces.interactive_shell.command_registry.slash_catalog
+    tools.interactive_shell.actions.slash -> surfaces.interactive_shell.ui
+    tools.interactive_shell.actions.slash -> surfaces.interactive_shell.ui.execution_confirm
+    tools.interactive_shell.actions.slash -> surfaces.interactive_shell.utils.telemetry.turn_outcome
+    tools.interactive_shell.actions.task_cancel -> surfaces.interactive_shell.command_registry
+    tools.interactive_shell.actions.task_cancel -> surfaces.interactive_shell.runtime
+    tools.interactive_shell.actions.task_cancel -> surfaces.interactive_shell.ui.execution_confirm
+    tools.interactive_shell.implementation.claude_code_executor -> surfaces.interactive_shell.runtime
+    tools.interactive_shell.implementation.claude_code_executor -> surfaces.interactive_shell.runtime.subprocess_runner.task_streaming
+    tools.interactive_shell.implementation.claude_code_executor -> surfaces.interactive_shell.ui
+    tools.interactive_shell.implementation.claude_code_executor -> surfaces.interactive_shell.ui.execution_confirm
+    tools.interactive_shell.implementation.claude_code_executor -> surfaces.interactive_shell.utils.error_handling.exception_reporting
+    tools.interactive_shell.shared.investigation_launch -> surfaces.interactive_shell.runtime
+    tools.interactive_shell.shared.investigation_launch -> surfaces.interactive_shell.ui.execution_confirm
+    tools.interactive_shell.shared.investigation_launch -> surfaces.interactive_shell.ui.foreground_investigation
+    tools.interactive_shell.shell.runner -> surfaces.interactive_shell.runtime
+    tools.interactive_shell.shell.runner -> surfaces.interactive_shell.runtime.subprocess_runner.task_streaming
+    tools.interactive_shell.shell.runner -> surfaces.interactive_shell.ui
+    tools.interactive_shell.shell.runner -> surfaces.interactive_shell.ui.execution_confirm
+    tools.interactive_shell.shell.runner -> surfaces.interactive_shell.utils.error_handling.exception_reporting
+    tools.interactive_shell.synthetic.runner -> surfaces.interactive_shell.runtime
+    tools.interactive_shell.synthetic.runner -> surfaces.interactive_shell.runtime.subprocess_runner.task_streaming
+    tools.interactive_shell.synthetic.runner -> surfaces.interactive_shell.ui
+    tools.interactive_shell.synthetic.runner -> surfaces.interactive_shell.ui.execution_confirm
+    tools.interactive_shell.synthetic.runner -> surfaces.interactive_shell.utils.error_handling.exception_reporting
+    # tools -> integrations (T-4 debt — vendor tools / reporting)
+    tools.community_followup_tool -> integrations.github.client
+    tools.community_followup_tool -> integrations.github.helpers
+    tools.community_followup_tool -> integrations.github.tools.workflow
+    tools.fix_sentry_issue.context -> integrations.sentry
+    tools.fix_sentry_issue.context -> integrations.sentry.issue_url
+    tools.fix_sentry_issue.runner -> integrations.pi
+    tools.git_deploy_timeline_tool -> integrations.github.helpers
+    tools.git_deploy_timeline_tool -> integrations.github.mcp
+    tools.interactive_shell.implementation.claude_code_executor -> integrations.llm_cli.claude_code
+    tools.interactive_shell.implementation.claude_code_executor -> integrations.llm_cli.subprocess_env
+    tools.investigation.reporting.delivery.bootstrap -> integrations.discord.reporting_adapter
+    tools.investigation.reporting.delivery.bootstrap -> integrations.openclaw.reporting_adapter
+    tools.investigation.reporting.delivery.bootstrap -> integrations.slack.reporting_adapter
+    tools.investigation.reporting.delivery.bootstrap -> integrations.telegram.reporting_adapter
+    tools.investigation.reporting.delivery.bootstrap -> integrations.twilio.reporting_adapter
+    tools.investigation.reporting.delivery.bootstrap -> integrations.whatsapp.reporting_adapter
+    tools.investigation.reporting.evaluation -> integrations.opensre.llm_eval_judge
+    tools.investigation.reporting.gitlab_writeback -> integrations.gitlab
+    tools.investigation.reporting.upstream_correlation.registry -> integrations.datadog.correlation.registration
+    tools.investigation.state_factory -> integrations.opensre.hf_remote
+    tools.pi_coding_tool -> integrations.pi
+    tools.pi_coding_tool.runner -> integrations.pi
+    tools.pi_coding_tool.validation -> integrations.pi
+    tools.python_execution_tool.credentials -> integrations.github.client
+    tools.python_execution_tool.credentials -> integrations.github.helpers
+    tools.slack_send_message_tool.delivery -> integrations.catalog
+    tools.slack_send_message_tool.delivery -> integrations.slack.delivery
+    tools.watch_dog.runner -> integrations.telegram.alarms
+    tools.watch_dog.runner -> integrations.telegram.credentials
+    tools.work_status_report_tool -> integrations.github.client
+    tools.work_status_report_tool -> integrations.github.helpers
+    tools.work_status_report_tool -> integrations.github.tools.work_status
+    tools.work_status_report_tool -> integrations.github.tools.workflow

--- a/.importlinter.strict
+++ b/.importlinter.strict
@@ -27,6 +27,8 @@ type = layers
 layers =
     surfaces | gateway
     tools | integrations
+    # ``:`` = siblings may cross-import (import-linter multi-item layers).
+    # ``|`` would forbid core <-> platform, but both packages depend on each other.
     core : platform
     config
 ignore_imports =

--- a/Makefile
+++ b/Makefile
@@ -515,6 +515,7 @@ help:
 	@echo "  make format          - Format code with ruff"
 	@echo "  make typecheck       - Type check with mypy"
 	@echo "  make check-imports   - Import cycles, layers, and direct-edge checks"
+	@echo "  make check-layers-strict - Full transitive layer contracts (.importlinter.strict)"
 	@echo "  make check           - Run all checks"
 	@echo "  make benchmark		  - Run benchmark report generation"
 	@echo "  make benchmark-update-readme - Update README from cached benchmark results"

--- a/tests/github_ci/test_check_imports.py
+++ b/tests/github_ci/test_check_imports.py
@@ -7,10 +7,23 @@ from pathlib import Path
 from unittest.mock import patch
 
 _CI_DIR = Path(__file__).resolve().parents[2] / ".github" / "ci"
+_REPO_ROOT = _CI_DIR.parents[1]
 if str(_CI_DIR) not in sys.path:
     sys.path.insert(0, str(_CI_DIR))
 
 from check_imports import import_checks, main
+
+
+def test_importlinter_strict_config_exists() -> None:
+    strict_config = _REPO_ROOT / ".importlinter.strict"
+    assert strict_config.is_file(), "make check-layers-strict requires .importlinter.strict"
+
+
+def test_import_checks_strict_uses_strict_config() -> None:
+    strict_config = _REPO_ROOT / ".importlinter.strict"
+    with patch("check_imports._run_importlinter", return_value=0) as mock_linter:
+        import_checks(strict_layers=True)[1].run()
+    mock_linter.assert_called_once_with(config=strict_config)
 
 
 def test_import_checks_runs_three_stages() -> None:
@@ -36,3 +49,7 @@ def test_main_passes_when_all_stages_pass() -> None:
         patch("check_imports.check_direct_imports", return_value=0),
     ):
         assert main([]) == 0
+
+
+def test_main_strict_passes_with_real_config() -> None:
+    assert main(["--strict"]) == 0

--- a/tests/github_ci/test_check_imports.py
+++ b/tests/github_ci/test_check_imports.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -14,6 +16,46 @@ if str(_CI_DIR) not in sys.path:
 from check_imports import import_checks, main
 
 
+def _run_lint_imports(config_path: Path) -> subprocess.CompletedProcess[str]:
+    lint_imports = Path(sys.executable).with_name("lint-imports")
+    return subprocess.run(
+        [str(lint_imports), "--config", str(config_path)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_layers_contract_core_platform_colon_allows_cross_imports() -> None:
+    """``core : platform`` is documented import-linter syntax for co-dependent siblings.
+
+    ``core | platform`` would forbid legitimate core <-> platform imports and break
+    the contract (see import-linter "Multi-item layers" docs).
+    """
+    strict_text = (_REPO_ROOT / ".importlinter.strict").read_text(encoding="utf-8")
+    assert "core : platform" in strict_text
+
+    piped_text = strict_text.replace("core : platform", "core | platform")
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".importlinter.strict",
+        dir=_REPO_ROOT,
+        delete=False,
+    ) as handle:
+        handle.write(piped_text)
+        piped_config = Path(handle.name)
+
+    try:
+        completed = _run_lint_imports(piped_config)
+        output = completed.stdout + completed.stderr
+        assert completed.returncode != 0
+        assert "core is not allowed to import platform" in output
+        assert "platform is not allowed to import core" in output
+    finally:
+        piped_config.unlink(missing_ok=True)
+
+
 def test_importlinter_strict_config_exists() -> None:
     strict_config = _REPO_ROOT / ".importlinter.strict"
     assert strict_config.is_file(), "make check-layers-strict requires .importlinter.strict"
@@ -23,7 +65,7 @@ def test_import_checks_strict_uses_strict_config() -> None:
     strict_config = _REPO_ROOT / ".importlinter.strict"
     with patch("check_imports._run_importlinter", return_value=0) as mock_linter:
         import_checks(strict_layers=True)[1].run()
-    mock_linter.assert_called_once_with(config=strict_config)
+        mock_linter.assert_called_once_with(config=strict_config)
 
 
 def test_import_checks_runs_three_stages() -> None:


### PR DESCRIPTION

Fixes #3545

- Add `.importlinter.strict` so `make check-layers-strict` runs real transitive layer contracts instead of failing with a missing config file.
- Encode the T-4 layer stack: `surfaces | gateway` → `tools | integrations` → `core : platform` → `config`, plus the existing `config-independent` contract.
- Seed 97 `ignore_imports` baseline entries (grouped by category) for known T-4 architectural debt, mirroring the burn-down pattern in `check_direct_imports.py`.
- Extend `tests/github_ci/test_check_imports.py` to assert the strict config exists, is wired correctly, and passes end-to-end.
- Add `.importlinter.strict` to CI path filters and document `check-layers-strict` in Makefile help.

Strict layer checks are **not** enabled in CI yet (T-14 / #3547). This PR only wires the config and local burn-down tooling.

## Test plan

- [x] `make check-imports` — unchanged; still uses `.importlinter`
- [x] `make check-layers-strict` — both contracts KEPT, 0 broken, all 3 stages pass
- [x] `uv run python -m pytest tests/github_ci/test_check_imports.py -q`
- [x] `make lint`
- [x] `make typecheck`