### PR TITLE
docs(integrations): clarify verification registry role

### DIFF
--- a/integrations/_verifiers_loader.py
+++ b/integrations/_verifiers_loader.py
@@ -8,6 +8,10 @@ Adding a new verifier is one new file in the owning integration package. No
 edits to a central import list are required — this loader walks the integration
 tree.
 
+``integrations.verification`` is intentionally not scanned as an integration
+package. It is the shared registry/decorator API imported by vendor-local
+verifier modules.
+
 Public surface: :func:`register_all_verifiers`. Callers invoke it once
 during startup (``integrations.verify`` and the test suite both do).
 Re-invocation is safe: the registry's ``register_verifier`` decorator
@@ -22,6 +26,8 @@ import pkgutil
 import integrations as _integrations_pkg
 
 _VERIFIER_SUBMODULE = "verifier"
+# ``integrations.verification`` is shared verifier infrastructure, not a vendor
+# integration package with its own ``verifier.py`` module to discover.
 _SKIP_INTEGRATION_PACKAGES = frozenset({"verification", "__pycache__"})
 
 

--- a/integrations/verification/__init__.py
+++ b/integrations/verification/__init__.py
@@ -7,6 +7,11 @@ Each integration verifier registers itself via :func:`register_verifier`
 the registry instead of importing every verifier by name. Adding a new
 verifier becomes a single new ``integrations/<name>/verifier.py`` file with one
 registration call — the loader auto-discovers it.
+
+This package is shared verification infrastructure, not a vendor integration
+package. Vendor-local verifier modules import and register through this API,
+which is why ``integrations._verifiers_loader`` intentionally skips scanning
+``integrations.verification`` as an integration package.
 """
 
 from __future__ import annotations

--- a/tests/integrations/test_verification_registry.py
+++ b/tests/integrations/test_verification_registry.py
@@ -252,6 +252,15 @@ class TestLoaderAutoDiscovery:
         after = sorted(list_verifiers())
         assert before == after
 
+    def test_loader_skips_shared_verification_package_but_registry_api_remains_available(
+        self,
+    ) -> None:
+        from integrations._verifiers_loader import _SKIP_INTEGRATION_PACKAGES
+
+        assert "verification" in _SKIP_INTEGRATION_PACKAGES
+        assert callable(register_verifier)
+        assert callable(get_verifier)
+
 
 class TestVerifyWithValidationResult:
     """Direct tests for ``verify_with_validation_result`` — exercised

--- a/tests/integrations/test_verification_registry.py
+++ b/tests/integrations/test_verification_registry.py
@@ -253,13 +253,22 @@ class TestLoaderAutoDiscovery:
         assert before == after
 
     def test_loader_skips_shared_verification_package_but_registry_api_remains_available(
-        self,
+        self, _isolated_registry: None
     ) -> None:
+        import importlib
+
+        import integrations.aws.verifier as aws_verifier
         from integrations._verifiers_loader import _SKIP_INTEGRATION_PACKAGES
 
+        _reset_for_testing()
+
         assert "verification" in _SKIP_INTEGRATION_PACKAGES
-        assert callable(register_verifier)
-        assert callable(get_verifier)
+        assert get_verifier("aws") is None
+
+        importlib.reload(aws_verifier)
+        register_all_verifiers()
+
+        assert get_verifier("aws") is not None
 
 
 class TestVerifyWithValidationResult:


### PR DESCRIPTION
Fixes #3573

## Summary

I reviewed the legacy `integrations/verification` package and checked where it is used.

I found that `integrations.verification` is still used by many integration verifier modules. It provides the shared registry and registration helpers used by vendor-local `verifier.py` files.

This PR:

* Documents why `_verifiers_loader.py` skips `integrations.verification`.
* Clarifies that `integrations.verification` is shared infrastructure, not a vendor integration package.
* Adds a test to protect this behavior.

## Findings

* `integrations.verification` is not dead code.
* Many verifier modules still import and use it.
* The loader skips it on purpose because it is a shared utility package.

## Validation

```bash
python -m pytest tests/integrations/test_verification_registry.py tests/integrations/test_registry.py
```

Result: 29 passed

<img width="1902" height="1277" alt="Ekran görüntüsü 2026-07-03 150046" src="https://github.com/user-attachments/assets/838a208d-6883-42e8-a8e4-48b55905d75e" />
