### PR TITLE
feat: add X (Twitter) hosted MCP integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -528,6 +528,18 @@ SENTRY_MCP_SKILLS=
 SENTRY_MCP_COMMAND=
 SENTRY_MCP_ARGS=
 
+# X (Twitter) MCP (post, search, timelines, likes via https://github.com/xdevplatform/xmcp)
+# XMCP runs locally by default; point X_MCP_URL at your own instance
+# (optionally tunneled) or launch it directly with X_MCP_COMMAND/X_MCP_ARGS.
+X_MCP_MODE=streamable-http
+X_MCP_URL=http://127.0.0.1:8000/mcp
+X_MCP_AUTH_TOKEN=
+X_MCP_COMMAND=
+X_MCP_ARGS=
+# X API bearer token forwarded to the local xmcp server (its own X API auth,
+# not the MCP transport auth above).
+X_BEARER_TOKEN=
+
 # Google Docs export
 GOOGLE_CREDENTIALS_FILE=
 GOOGLE_DRIVE_FOLDER_ID=

--- a/.github/ci/test_scope_rules.py
+++ b/.github/ci/test_scope_rules.py
@@ -479,6 +479,13 @@ RULES: tuple[PathRule, ...] = (
         ),
     ),
     PathRule(
+        "integrations/x_mcp/",
+        (
+            "tests/integrations/test_x_mcp.py",
+            "tests/tools/test_x_mcp_tool.py",
+        ),
+    ),
+    PathRule(
         "integrations/argocd/",
         (
             "tests/integrations/argocd/",

--- a/core/domain/types/evidence.py
+++ b/core/domain/types/evidence.py
@@ -41,6 +41,7 @@ EvidenceSource = Literal[
     "openclaw",
     "posthog_mcp",
     "sentry_mcp",
+    "x_mcp",
     "mysql",
     "rabbitmq",
     "betterstack",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -140,7 +140,8 @@
               "signoz",
               "tempo",
               "splunk",
-              "victoria_logs"
+              "victoria_logs",
+              "x-mcp"
             ]
           },
           {

--- a/docs/x-mcp.mdx
+++ b/docs/x-mcp.mdx
@@ -1,0 +1,92 @@
+---
+title: "X (Twitter) MCP"
+description: "Connect X's official MCP server so OpenSRE can search, read, and post on X during investigations"
+---
+
+OpenSRE connects to X's official [Model Context Protocol (MCP)](https://github.com/xdevplatform/xmcp) server, exposing X's API — tweet search, timelines, user profiles, likes, retweets, bookmarks, and posting — as tools the agent can call while investigating an incident.
+
+Unlike PostHog or Sentry's always-on hosted MCP servers, XMCP is designed to run **locally**: you clone the [xmcp repo](https://github.com/xdevplatform/xmcp), supply your own X API credentials, and run the server yourself. OpenSRE connects to that local endpoint (or a tunneled URL if you need remote access, e.g. via ngrok).
+
+## Tools
+
+| Tool | What it does |
+| --- | --- |
+| `list_x_tools` | List the tools the connected X MCP server exposes (compact, filterable) |
+| `call_x_tool` | Call a named X MCP tool (e.g. search tweets, inspect a timeline, look up a tweet) |
+
+The agent typically calls `list_x_tools` first to discover what is available, then `call_x_tool` with the chosen tool name and arguments. Pass `name_filter` (space- or comma-separated terms, e.g. `"search tweet"`) to narrow a large tool list, and `include_schema=true` on a narrowed list to fetch the full input schema for the tool you intend to call.
+
+## Prerequisites
+
+- A running instance of [xmcp](https://github.com/xdevplatform/xmcp) with your own X API credentials configured (`X_BEARER_TOKEN`, and OAuth1/OAuth2 credentials if you need write access such as posting)
+- Network access from OpenSRE to the xmcp server's URL (local by default; tunnel it if OpenSRE runs elsewhere)
+
+<Info>
+XMCP authenticates to the X API using its own environment (`X_BEARER_TOKEN`, OAuth credentials) at startup. OpenSRE does not need to know your X API credentials for `streamable-http`/`sse` connections to an already-running server — it only needs the server's URL. An optional auth token can be set if your endpoint sits behind an authenticating tunnel or proxy.
+</Info>
+
+## Setup
+
+### Option 1: Interactive CLI
+
+```bash
+opensre integrations setup x_mcp
+opensre integrations verify x_mcp
+```
+
+You'll be prompted for the xmcp server URL (defaults to `http://127.0.0.1:8000/mcp`) and, optionally, an auth token if the endpoint is tunneled behind an authenticating proxy.
+
+### Option 2: Environment variables
+
+Add to your `.env`:
+
+```bash
+X_MCP_MODE=streamable-http
+X_MCP_URL=http://127.0.0.1:8000/mcp
+X_MCP_AUTH_TOKEN=                     # optional, only for a tunneled/proxied endpoint
+```
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `X_MCP_URL` | `http://127.0.0.1:8000/mcp` | X MCP server URL (local or tunneled) |
+| `X_MCP_MODE` | `streamable-http` | Transport: `streamable-http`, `sse`, or `stdio` |
+| `X_MCP_AUTH_TOKEN` | — | Optional bearer token, only needed if the endpoint requires client auth |
+| `X_MCP_COMMAND` | — | Command to launch the xmcp server directly (`stdio` mode only) |
+| `X_MCP_ARGS` | — | Arguments for the local xmcp command (`stdio` mode only) |
+| `X_BEARER_TOKEN` | — | X API bearer token forwarded to the server when OpenSRE launches it (`stdio` mode only); not sent over the MCP transport |
+
+To have OpenSRE launch the local xmcp server itself instead of connecting to one you already started, use `stdio` mode:
+
+```bash
+X_MCP_MODE=stdio
+X_MCP_COMMAND=python
+X_MCP_ARGS=server.py
+X_BEARER_TOKEN=your_x_api_bearer_token
+```
+
+### Option 3: Persistent store
+
+```json
+{
+  "version": 1,
+  "integrations": [
+    {
+      "id": "x-mcp-local",
+      "service": "x_mcp",
+      "status": "active",
+      "credentials": {
+        "url": "http://127.0.0.1:8000/mcp",
+        "mode": "streamable-http"
+      }
+    }
+  ]
+}
+```
+
+## Verify
+
+```bash
+opensre integrations verify x_mcp
+```
+
+A successful check connects to the MCP server and reports how many tools it discovered. If it fails, confirm the xmcp server is running and reachable at the configured URL, and that its own X API credentials (`X_BEARER_TOKEN`) are valid.

--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -114,6 +114,8 @@ from integrations.vercel import classify as _classify_vercel
 from integrations.vercel.client import VercelConfig
 from integrations.victoria_logs import classify as _classify_victoria_logs
 from integrations.whatsapp import classify as _classify_whatsapp
+from integrations.x_mcp import build_x_mcp_config
+from integrations.x_mcp import classify as _classify_x_mcp
 from platform.common.coercion import safe_int
 from platform.observability.errors import report_exception
 
@@ -256,6 +258,7 @@ _CLASSIFIERS: dict[str, _ClassifyFn] = {
     "openclaw": _classify_openclaw,
     "posthog_mcp": _classify_posthog_mcp,
     "sentry_mcp": _classify_sentry_mcp,
+    "x_mcp": _classify_x_mcp,
     "mysql": _classify_mysql,
     "dagster": _classify_dagster,
     "rabbitmq": _classify_rabbitmq,
@@ -1083,6 +1086,36 @@ def load_env_integrations() -> list[dict[str, Any]]:
             )
         except Exception as exc:
             _report_env_loader_failure(exc, integration="sentry_mcp")
+
+    x_mcp_mode = os.getenv("X_MCP_MODE", "streamable-http").strip().lower()
+    x_mcp_mode = x_mcp_mode or "streamable-http"
+    x_mcp_command = os.getenv("X_MCP_COMMAND", "").strip()
+    x_mcp_token = resolve_env_credential("X_MCP_AUTH_TOKEN")
+    x_mcp_bearer_token = resolve_env_credential("X_BEARER_TOKEN")
+    x_mcp_url = os.getenv("X_MCP_URL", "").strip()
+    if (x_mcp_mode == "stdio" and x_mcp_command) or (x_mcp_mode != "stdio" and x_mcp_url):
+        try:
+            x_mcp_config = build_x_mcp_config(
+                {
+                    "url": x_mcp_url,
+                    "mode": x_mcp_mode,
+                    "command": x_mcp_command,
+                    "args": [part for part in os.getenv("X_MCP_ARGS", "").strip().split() if part],
+                    "auth_token": x_mcp_token,
+                    "bearer_token": x_mcp_bearer_token,
+                }
+            )
+            integrations.append(
+                _active_env_record(
+                    "x_mcp",
+                    {
+                        **x_mcp_config.model_dump(exclude={"integration_id"}),
+                        "connection_verified": True,
+                    },
+                )
+            )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="x_mcp")
 
     mariadb_host = os.getenv("MARIADB_HOST", "").strip()
     mariadb_database = os.getenv("MARIADB_DATABASE", "").strip()

--- a/integrations/catalog.py
+++ b/integrations/catalog.py
@@ -142,6 +142,7 @@ def load_env_integration_services() -> list[str]:
     )
     add("posthog_mcp", _any_env("POSTHOG_MCP_COMMAND", "POSTHOG_MCP_URL", "POSTHOG_MCP_AUTH_TOKEN"))
     add("sentry_mcp", _any_env("SENTRY_MCP_COMMAND", "SENTRY_MCP_URL", "SENTRY_MCP_AUTH_TOKEN"))
+    add("x_mcp", _any_env("X_MCP_COMMAND", "X_MCP_URL", "X_MCP_AUTH_TOKEN", "X_BEARER_TOKEN"))
     add("mariadb", _all_env("MARIADB_HOST", "MARIADB_DATABASE"))
     add("opensearch", _env_is_set("OPENSEARCH_URL"))
 

--- a/integrations/catalog.py
+++ b/integrations/catalog.py
@@ -142,7 +142,7 @@ def load_env_integration_services() -> list[str]:
     )
     add("posthog_mcp", _any_env("POSTHOG_MCP_COMMAND", "POSTHOG_MCP_URL", "POSTHOG_MCP_AUTH_TOKEN"))
     add("sentry_mcp", _any_env("SENTRY_MCP_COMMAND", "SENTRY_MCP_URL", "SENTRY_MCP_AUTH_TOKEN"))
-    add("x_mcp", _any_env("X_MCP_COMMAND", "X_MCP_URL", "X_MCP_AUTH_TOKEN", "X_BEARER_TOKEN"))
+    add("x_mcp", _any_env("X_MCP_COMMAND", "X_MCP_URL", "X_MCP_AUTH_TOKEN"))
     add("mariadb", _all_env("MARIADB_HOST", "MARIADB_DATABASE"))
     add("opensearch", _env_is_set("OPENSEARCH_URL"))
 

--- a/integrations/cli.py
+++ b/integrations/cli.py
@@ -52,6 +52,11 @@ from integrations.verify import (
     verification_exit_code,
     verify_integrations,
 )
+from integrations.x_mcp import (
+    DEFAULT_X_MCP_URL,
+    build_x_mcp_config,
+    validate_x_mcp_config,
+)
 
 _B = ANSI_BOLD
 _R = ANSI_RESET
@@ -934,6 +939,38 @@ def _setup_sentry_mcp() -> None:
     print("    - opensre integrations verify sentry_mcp")
 
 
+def _setup_x_mcp() -> None:
+    # X's MCP server (https://github.com/xdevplatform/xmcp) runs locally by
+    # default, optionally tunneled for remote access — it is not an
+    # always-on hosted endpoint like PostHog/Sentry's. Streamable HTTP is
+    # the transport used by both a bare local server and a tunneled one, so
+    # it stays the default here; do NOT add a transport prompt.
+    mode = "streamable-http"
+    credentials: dict[str, Any] = {"mode": mode}
+    url = _p("X MCP URL", default=DEFAULT_X_MCP_URL)
+    if not url:
+        _die("url is required for remote MCP modes.")
+    credentials["url"] = url
+    credentials["command"] = ""
+    credentials["args"] = []
+
+    credentials["auth_token"] = _p(
+        "Auth token for a tunneled/proxied endpoint (optional)", secret=True, default=""
+    )
+    credentials["bearer_token"] = ""
+
+    print("\n  Validating X MCP...")
+    config = build_x_mcp_config(credentials)
+    result = validate_x_mcp_config(config)
+    print(f"  {result.detail}")
+    if not result.ok:
+        sys.exit(1)
+
+    upsert_integration("x_mcp", {"credentials": credentials})
+    print("  Next:")
+    print("    - opensre integrations verify x_mcp")
+
+
 def _setup_postgresql() -> None:
     host = _p("Host (e.g. localhost or postgres.example.com)")
     database = _p("Database name")
@@ -1240,6 +1277,7 @@ _HANDLERS: dict[str, Any] = {
     "openclaw": _setup_openclaw,
     "posthog_mcp": _setup_posthog_mcp,
     "sentry_mcp": _setup_sentry_mcp,
+    "x_mcp": _setup_x_mcp,
     "postgresql": _setup_postgresql,
     "mysql": _setup_mysql,
     "redis": _setup_redis,

--- a/integrations/effective_models.py
+++ b/integrations/effective_models.py
@@ -93,6 +93,7 @@ class EffectiveIntegrations(StrictConfigModel):
     openclaw: EffectiveIntegrationEntry | None = None
     posthog_mcp: EffectiveIntegrationEntry | None = None
     sentry_mcp: EffectiveIntegrationEntry | None = None
+    x_mcp: EffectiveIntegrationEntry | None = None
     mysql: EffectiveIntegrationEntry | None = None
     snowflake: EffectiveIntegrationEntry | None = None
     azure: EffectiveIntegrationEntry | None = None

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -244,6 +244,14 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
         verify_order=45,
     ),
     IntegrationSpec(
+        service="x_mcp",
+        aliases=("x mcp", "x-mcp", "twitter", "twitter_mcp", "twitter-mcp"),
+        has_verifier=True,
+        direct_effective=True,
+        setup_order=39,
+        verify_order=49,
+    ),
+    IntegrationSpec(
         service="mysql",
         has_verifier=True,
         direct_effective=True,

--- a/integrations/x_mcp/__init__.py
+++ b/integrations/x_mcp/__init__.py
@@ -410,7 +410,13 @@ async def _list_tools_async(config: XMCPConfig) -> list[types.Tool]:
 
 
 def _list_tools_sync(config: XMCPConfig) -> list[types.Tool]:
-    return cast(list[types.Tool], _run_async(_list_tools_async(config)))
+    # Bound session open (transport connect + MCP `initialize` handshake) and
+    # the list_tools RPC together, so a server that accepts a connection but
+    # never completes the handshake or responds cannot hang the pipeline.
+    return cast(
+        list[types.Tool],
+        _run_async(asyncio.wait_for(_list_tools_async(config), timeout=config.timeout_seconds)),
+    )
 
 
 def list_x_mcp_tools(config: XMCPConfig) -> list[XMCPToolDescriptor]:
@@ -432,12 +438,7 @@ async def _call_tool_async(
     arguments: dict[str, object] | None = None,
 ) -> XMCPToolCallResult:
     async with _open_x_mcp_session(config) as session:
-        # Bound the call uniformly across transports so a hung MCP tool cannot
-        # block the investigation pipeline indefinitely.
-        result = await asyncio.wait_for(
-            session.call_tool(tool_name, arguments or {}),
-            timeout=config.timeout_seconds,
-        )
+        result = await session.call_tool(tool_name, arguments or {})
         payload = _tool_result_to_dict(result)
         payload["tool"] = tool_name
         payload["arguments"] = arguments or {}
@@ -450,9 +451,16 @@ def call_x_mcp_tool(
     arguments: dict[str, object] | None = None,
 ) -> XMCPToolCallResult:
     """Call an X MCP tool and normalize the result."""
+    # Bound session open (transport connect + MCP `initialize` handshake) and
+    # the call_tool RPC together, so a server that accepts a connection but
+    # never completes the handshake or responds cannot hang the pipeline.
     return cast(
         XMCPToolCallResult,
-        _run_async(_call_tool_async(config, tool_name, arguments)),
+        _run_async(
+            asyncio.wait_for(
+                _call_tool_async(config, tool_name, arguments), timeout=config.timeout_seconds
+            )
+        ),
     )
 
 

--- a/integrations/x_mcp/__init__.py
+++ b/integrations/x_mcp/__init__.py
@@ -1,0 +1,519 @@
+"""Shared X (Twitter) MCP integration helpers.
+
+X ships an official Model Context Protocol (MCP) server
+(https://github.com/xdevplatform/xmcp) that exposes the X API — posting,
+search, timelines, likes, retweets, bookmarks, and more — as function-calling
+tools. Unlike PostHog/Sentry's always-on hosted MCP servers, XMCP is designed
+to run locally (optionally tunneled for remote access): a user clones the
+repo, supplies their own X API credentials, and runs the server themselves.
+This module centralizes X MCP configuration, validation, and tool-calling so
+the onboarding wizard, verify CLI, chat tools, and investigation actions all
+share the same transport and parsing logic.
+
+Supported transports:
+  - streamable-http  (default) — HTTP-based MCP, typically http://127.0.0.1:8000/mcp
+                       or a tunneled URL (e.g. ngrok) for remote access
+  - sse              — Server-Sent Events MCP transport
+  - stdio            — subprocess-based MCP (opensre launches the local xmcp
+                       server directly, e.g. ``python server.py``)
+
+Authentication: XMCP itself authenticates to the X API using its own
+X_BEARER_TOKEN environment variable at startup. When opensre launches the
+server via ``stdio``, that token is forwarded into the subprocess
+environment. For ``streamable-http``/``sse`` connections to an
+already-running server, an optional bearer token is sent as an Authorization
+header only if configured (useful when the endpoint sits behind an
+authenticating tunnel/proxy); XMCP does not itself require one for a trusted
+local connection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import AsyncIterator, Coroutine, Mapping
+from contextlib import AsyncExitStack, asynccontextmanager
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+import httpx
+from mcp import ClientSession, StdioServerParameters, types  # type: ignore[import-not-found]
+from mcp.client.sse import sse_client  # type: ignore[import-not-found]
+from mcp.client.stdio import stdio_client  # type: ignore[import-not-found]
+from pydantic import Field, field_validator, model_validator
+from typing_extensions import TypedDict
+
+from config.strict_config import StrictConfigModel
+from integrations._validation_helpers import report_classify_failure, report_validation_failure
+from integrations.mcp_streamable_http_compat import streamable_http_client
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_X_MCP_URL = "http://127.0.0.1:8000/mcp"
+DEFAULT_X_MCP_MODE: Literal["streamable-http", "sse", "stdio"] = "streamable-http"
+
+
+class XMCPToolDescriptor(TypedDict):
+    """A tool exposed by the X MCP server."""
+
+    name: str
+    description: str
+    input_schema: object | None
+
+
+class XMCPContentItem(TypedDict, total=False):
+    """Normalized content item returned by an MCP tool call."""
+
+    type: str
+    text: str
+    uri: str
+    mime_type: str
+
+
+class XMCPToolCallResult(TypedDict, total=False):
+    """Normalized response from an X MCP tool call."""
+
+    is_error: bool
+    text: str
+    content: list[XMCPContentItem]
+    structured_content: object | None
+    tool: str
+    arguments: dict[str, object]
+
+
+class XMCPConfig(StrictConfigModel):
+    """Normalized X MCP connection settings."""
+
+    url: str = DEFAULT_X_MCP_URL
+    mode: Literal["stdio", "sse", "streamable-http"] = DEFAULT_X_MCP_MODE
+    auth_token: str = ""
+    bearer_token: str = ""
+    command: str = ""
+    args: tuple[str, ...] = ()
+    headers: dict[str, str] = Field(default_factory=dict)
+    timeout_seconds: float = Field(default=20.0, gt=0)
+    integration_id: str = ""
+
+    @field_validator("url", mode="before")
+    @classmethod
+    def _normalize_url(cls, value: object) -> str:
+        normalized = str(value or "").strip()
+        return normalized.rstrip("/") if normalized else ""
+
+    @field_validator("mode", mode="before")
+    @classmethod
+    def _normalize_mode(cls, value: object) -> str:
+        normalized = str(value or DEFAULT_X_MCP_MODE).strip().lower()
+        normalized = normalized or DEFAULT_X_MCP_MODE
+        # Generic aliases that callers (env, store, or the planner) may emit
+        # all map to the default HTTP transport rather than tripping the
+        # Literal validation. "default" is what the planner tends to guess when
+        # it has no explicit transport to pass.
+        if normalized in {"mcp", "default", "http", "https", "streamable_http"}:
+            return DEFAULT_X_MCP_MODE
+        return normalized
+
+    @field_validator("auth_token", mode="before")
+    @classmethod
+    def _normalize_auth_token(cls, value: object) -> str:
+        token = str(value or "").strip()
+        if token.lower().startswith("bearer "):
+            token = token.split(None, 1)[1].strip()
+        return token
+
+    @field_validator("bearer_token", mode="before")
+    @classmethod
+    def _normalize_bearer_token(cls, value: object) -> str:
+        return str(value or "").strip()
+
+    @field_validator("command", mode="before")
+    @classmethod
+    def _normalize_command(cls, value: object) -> str:
+        return str(value or "").strip()
+
+    @field_validator("args", mode="before")
+    @classmethod
+    def _normalize_args(cls, value: object) -> tuple[str, ...]:
+        if value is None or not isinstance(value, (list, tuple, set)):
+            return ()
+        return tuple(str(arg).strip() for arg in value if str(arg).strip())
+
+    @field_validator("headers", mode="before")
+    @classmethod
+    def _normalize_headers(cls, value: object) -> dict[str, str]:
+        if not isinstance(value, dict):
+            return {}
+        return {str(k): str(v).strip() for k, v in value.items() if str(v).strip()}
+
+    @model_validator(mode="after")
+    def _validate_transport_requirements(self) -> XMCPConfig:
+        if self.mode == "stdio" and not self.command:
+            raise ValueError("X MCP mode 'stdio' requires a non-empty command.")
+        if self.mode != "stdio" and not self.url:
+            raise ValueError(f"X MCP mode '{self.mode}' requires a non-empty url.")
+        return self
+
+    @property
+    def is_configured(self) -> bool:
+        if self.mode == "stdio":
+            return bool(self.command)
+        return bool(self.url)
+
+    @property
+    def request_headers(self) -> dict[str, str]:
+        headers = {k: v for k, v in self.headers.items() if v}
+        if self.auth_token and "Authorization" not in headers:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+        return headers
+
+    @property
+    def subprocess_env(self) -> dict[str, str]:
+        """Extra env vars to forward when launching the server ourselves (stdio)."""
+        env: dict[str, str] = {}
+        if self.bearer_token:
+            env["X_BEARER_TOKEN"] = self.bearer_token
+        return env
+
+
+@dataclass(frozen=True)
+class XMCPValidationResult:
+    """Result of validating an X MCP connection."""
+
+    ok: bool
+    detail: str
+    tool_names: tuple[str, ...] = ()
+
+
+def build_x_mcp_config(raw: Mapping[str, object] | None) -> XMCPConfig:
+    """Build a normalized X MCP config object from env/store data."""
+    payload = dict(raw or {})
+    allowed = set(XMCPConfig.model_fields)
+    sanitized = {key: value for key, value in payload.items() if key in allowed}
+    return XMCPConfig.model_validate(sanitized)
+
+
+def x_mcp_config_from_env() -> XMCPConfig | None:
+    """Load an X MCP config from environment variables."""
+    mode = os.getenv("X_MCP_MODE", DEFAULT_X_MCP_MODE).strip().lower()
+    url = os.getenv("X_MCP_URL", "").strip()
+    command = os.getenv("X_MCP_COMMAND", "").strip()
+    auth_token = os.getenv("X_MCP_AUTH_TOKEN", "").strip()
+    bearer_token = os.getenv("X_BEARER_TOKEN", "").strip()
+    args_env = os.getenv("X_MCP_ARGS", "").strip()
+
+    mode = mode or DEFAULT_X_MCP_MODE
+    if mode == "stdio":
+        if not command:
+            return None
+    else:
+        url = url or DEFAULT_X_MCP_URL
+
+    return build_x_mcp_config(
+        {
+            "url": url,
+            "mode": mode,
+            "command": command,
+            "args": [part for part in args_env.split() if part],
+            "auth_token": auth_token,
+            "bearer_token": bearer_token,
+        }
+    )
+
+
+def x_mcp_runtime_unavailable_reason(config: XMCPConfig) -> str | None:
+    """Return a setup error when the config cannot be used."""
+    if not config.is_configured:
+        return "X MCP is not configured: provide a URL (HTTP/SSE) or command (stdio)."
+    if config.mode == "stdio" and not config.bearer_token:
+        return (
+            "X MCP stdio mode requires an X API bearer token to launch the local server. "
+            "Set X_BEARER_TOKEN."
+        )
+    return None
+
+
+@asynccontextmanager
+async def _open_x_mcp_session(config: XMCPConfig) -> AsyncIterator[ClientSession]:
+    """Open an MCP client session for X using the configured transport."""
+    stack = AsyncExitStack()
+    try:
+        if config.mode == "stdio":
+            if not config.command:
+                raise ValueError(
+                    "Invalid X MCP config: mode=stdio requires command "
+                    "(set X_MCP_COMMAND or pass command in config)."
+                )
+            server_params = StdioServerParameters(
+                command=config.command,
+                args=list(config.args),
+                env={
+                    **os.environ,
+                    # Suppress terminal control codes so the MCP server's stdout
+                    # stays clean JSON-RPC (mirrors integrations/github/mcp.py mitigation).
+                    "NO_COLOR": "1",
+                    "TERM": "dumb",
+                    **config.subprocess_env,
+                },
+            )
+            read_stream, write_stream = await stack.enter_async_context(stdio_client(server_params))
+
+        elif config.mode == "sse":
+            if not config.url:
+                raise ValueError(
+                    "Invalid X MCP config: mode=sse requires url "
+                    "(set X_MCP_URL, e.g. http://127.0.0.1:8000/sse)."
+                )
+            read_stream, write_stream = await stack.enter_async_context(
+                sse_client(
+                    config.url,
+                    headers=config.request_headers,
+                    timeout=config.timeout_seconds,
+                    sse_read_timeout=max(60.0, config.timeout_seconds),
+                )
+            )
+
+        elif config.mode == "streamable-http":
+            if not config.url:
+                raise ValueError(
+                    "Invalid X MCP config: mode=streamable-http requires url "
+                    "(set X_MCP_URL, e.g. http://127.0.0.1:8000/mcp)."
+                )
+            read_timeout = max(60.0, config.timeout_seconds)
+            http_client = await stack.enter_async_context(
+                httpx.AsyncClient(
+                    headers=config.request_headers,
+                    timeout=httpx.Timeout(config.timeout_seconds, read=read_timeout),
+                )
+            )
+            read_stream, write_stream, _ = await stack.enter_async_context(
+                streamable_http_client(
+                    config.url,
+                    http_client=http_client,
+                    headers=config.request_headers,
+                    timeout=config.timeout_seconds,
+                    sse_read_timeout=read_timeout,
+                )
+            )
+
+        else:
+            raise ValueError(
+                f"Unsupported X MCP mode '{config.mode}'. "
+                "Supported modes: stdio, sse, streamable-http."
+            )
+
+        session = await stack.enter_async_context(ClientSession(read_stream, write_stream))
+        await session.initialize()
+        yield session
+
+    finally:
+        await stack.aclose()
+
+
+def _run_async(coro: Coroutine[object, object, object]) -> object:
+    try:
+        return asyncio.run(coro)
+    except BaseException:
+        close = getattr(coro, "close", None)
+        if callable(close):
+            close()
+        raise
+
+
+def _root_cause_message(exc: BaseException) -> str:
+    """Best-effort unwrap for ExceptionGroup/TaskGroup chains."""
+    if isinstance(exc, BaseExceptionGroup) and exc.exceptions:
+        return _root_cause_message(exc.exceptions[0])
+    cause = getattr(exc, "__cause__", None)
+    if isinstance(cause, BaseException):
+        return _root_cause_message(cause)
+    context = getattr(exc, "__context__", None)
+    if isinstance(context, BaseException):
+        return _root_cause_message(context)
+    if isinstance(exc, TimeoutError):
+        return "X MCP tool call timed out"
+    return str(exc).strip() or exc.__class__.__name__
+
+
+def describe_x_mcp_error(err: BaseException, config: XMCPConfig) -> str:
+    """Render a human-readable error with a setup hint when useful."""
+    detail = _root_cause_message(err)
+    hints: list[str] = []
+
+    if isinstance(err, httpx.HTTPStatusError) and err.response.status_code in (401, 403):
+        hints.append(
+            "Authentication failed. If the endpoint is tunneled behind an "
+            "authenticating proxy, set X_MCP_AUTH_TOKEN; otherwise check the "
+            "local xmcp server's own X API credentials (X_BEARER_TOKEN)."
+        )
+    elif isinstance(err, (httpx.ConnectError, httpx.ConnectTimeout)):
+        hints.append(
+            f"Could not reach {config.url}. Confirm the local xmcp server "
+            "(https://github.com/xdevplatform/xmcp) is running and reachable."
+        )
+
+    if "timed out" in detail.lower():
+        hints.append(
+            f"The tool did not return within {config.timeout_seconds:.1f}s. "
+            "Raise XMCPConfig.timeout_seconds if the tool is expected to be slow."
+        )
+
+    if hints:
+        return f"{detail} Hint: {' '.join(hints)}"
+    return detail
+
+
+def _tool_result_to_dict(result: types.CallToolResult) -> XMCPToolCallResult:
+    text_parts: list[str] = []
+    content_items: list[XMCPContentItem] = []
+
+    for item in result.content:
+        if isinstance(item, types.TextContent):
+            text_parts.append(item.text)
+            content_items.append({"type": "text", "text": item.text})
+        elif isinstance(item, types.EmbeddedResource):
+            resource = item.resource
+            if isinstance(resource, types.TextResourceContents):
+                content_items.append(
+                    {
+                        "type": "resource_text",
+                        "uri": str(resource.uri),
+                        "text": resource.text,
+                    }
+                )
+                text_parts.append(resource.text)
+            elif isinstance(resource, types.BlobResourceContents):
+                content_items.append(
+                    {
+                        "type": "resource_blob",
+                        "uri": str(resource.uri),
+                        "mime_type": resource.mimeType or "",
+                    }
+                )
+        else:
+            content_items.append({"type": getattr(item, "type", "unknown")})
+
+    structured = getattr(result, "structuredContent", None)
+    text_output = "\n".join(part.strip() for part in text_parts if part.strip()).strip()
+    return {
+        "is_error": bool(result.isError),
+        "text": text_output,
+        "content": content_items,
+        "structured_content": structured,
+    }
+
+
+async def _list_tools_async(config: XMCPConfig) -> list[types.Tool]:
+    async with _open_x_mcp_session(config) as session:
+        result = await session.list_tools()
+        return list(result.tools)
+
+
+def _list_tools_sync(config: XMCPConfig) -> list[types.Tool]:
+    return cast(list[types.Tool], _run_async(_list_tools_async(config)))
+
+
+def list_x_mcp_tools(config: XMCPConfig) -> list[XMCPToolDescriptor]:
+    """List available tools from the configured X MCP server."""
+    tools = _list_tools_sync(config)
+    return [
+        {
+            "name": tool.name,
+            "description": tool.description or "",
+            "input_schema": getattr(tool, "inputSchema", None),
+        }
+        for tool in tools
+    ]
+
+
+async def _call_tool_async(
+    config: XMCPConfig,
+    tool_name: str,
+    arguments: dict[str, object] | None = None,
+) -> XMCPToolCallResult:
+    async with _open_x_mcp_session(config) as session:
+        # Bound the call uniformly across transports so a hung MCP tool cannot
+        # block the investigation pipeline indefinitely.
+        result = await asyncio.wait_for(
+            session.call_tool(tool_name, arguments or {}),
+            timeout=config.timeout_seconds,
+        )
+        payload = _tool_result_to_dict(result)
+        payload["tool"] = tool_name
+        payload["arguments"] = arguments or {}
+        return payload
+
+
+def call_x_mcp_tool(
+    config: XMCPConfig,
+    tool_name: str,
+    arguments: dict[str, object] | None = None,
+) -> XMCPToolCallResult:
+    """Call an X MCP tool and normalize the result."""
+    return cast(
+        XMCPToolCallResult,
+        _run_async(_call_tool_async(config, tool_name, arguments)),
+    )
+
+
+def validate_x_mcp_config(config: XMCPConfig) -> XMCPValidationResult:
+    """Validate X MCP connectivity by listing available tools."""
+    runtime_error = x_mcp_runtime_unavailable_reason(config)
+    if runtime_error is not None:
+        return XMCPValidationResult(
+            ok=False,
+            detail=f"X MCP validation failed: {runtime_error}",
+        )
+
+    try:
+        tools = list_x_mcp_tools(config)
+        tool_names = tuple(sorted(t["name"] for t in tools))
+        endpoint = config.command if config.mode == "stdio" else config.url
+        if not tool_names:
+            return XMCPValidationResult(
+                ok=False,
+                detail=(
+                    f"X MCP connected via {config.mode} ({endpoint}) but exposed no tools. "
+                    "Check the server's X API credentials or tool allowlist."
+                ),
+            )
+        return XMCPValidationResult(
+            ok=True,
+            detail=(
+                f"X MCP connected via {config.mode} ({endpoint}); "
+                f"discovered {len(tool_names)} tool(s)."
+            ),
+            tool_names=tool_names,
+        )
+    except Exception as err:
+        report_validation_failure(
+            err,
+            logger=logger,
+            integration="x_mcp",
+            method="validate_x_mcp_config",
+        )
+        return XMCPValidationResult(
+            ok=False,
+            detail=f"X MCP validation failed: {describe_x_mcp_error(err, config)}",
+        )
+
+
+def classify(credentials: dict[str, Any], record_id: str) -> tuple[XMCPConfig | None, str | None]:
+    try:
+        cfg = build_x_mcp_config(
+            {
+                "url": credentials.get("url", ""),
+                "mode": credentials.get("mode", "streamable-http"),
+                "command": credentials.get("command", ""),
+                "args": credentials.get("args", []),
+                "auth_token": credentials.get("auth_token", ""),
+                "bearer_token": credentials.get("bearer_token", ""),
+                "integration_id": record_id,
+            }
+        )
+    except Exception as exc:
+        report_classify_failure(exc, logger=logger, integration="x_mcp", record_id=record_id)
+        return None, None
+    if cfg.is_configured:
+        return cfg, "x_mcp"
+    return None, None

--- a/integrations/x_mcp/tools/x_mcp_tool/__init__.py
+++ b/integrations/x_mcp/tools/x_mcp_tool/__init__.py
@@ -1,0 +1,319 @@
+"""X (Twitter) MCP-backed tools.
+
+Exposes the configured X MCP server (https://github.com/xdevplatform/xmcp) —
+tweet creation, search, timelines, likes, retweets, bookmarks, and more — to
+the investigation and chat surfaces. The tool surface is intentionally
+generic — a discovery tool plus a named-call tool — so it keeps working when
+X adds or renames individual MCP-side tools.
+"""
+
+from __future__ import annotations
+
+from core.tool_framework.telemetry import report_run_error
+from core.tool_framework.tool_decorator import tool
+from core.tool_framework.utils.mcp_params import first_list, first_string
+from core.tool_framework.utils.mcp_tool_listing import build_mcp_tool_listing
+from integrations.x_mcp import (
+    XMCPConfig,
+    XMCPToolCallResult,
+    build_x_mcp_config,
+    describe_x_mcp_error,
+    x_mcp_config_from_env,
+    x_mcp_runtime_unavailable_reason,
+)
+from integrations.x_mcp import call_x_mcp_tool as invoke_x_mcp_tool
+from integrations.x_mcp import list_x_mcp_tools as list_x_mcp_server_tools
+
+XMCPParams = dict[str, object]
+XMCPResponse = dict[str, object]
+
+_COMPONENT = "integrations.x_mcp.tools.x_mcp_tool"
+
+
+def _unavailable_response(
+    error: str,
+    *,
+    tool_name: str | None = None,
+    arguments: XMCPParams | None = None,
+) -> XMCPResponse:
+    payload: XMCPResponse = {
+        "source": "x_mcp",
+        "available": False,
+        "error": error,
+    }
+    if tool_name:
+        payload["tool"] = tool_name
+    if arguments is not None:
+        payload["arguments"] = arguments
+    return payload
+
+
+_KNOWN_X_MCP_MODES = frozenset({"stdio", "sse", "streamable-http"})
+
+
+def _resolve_config(
+    x_url: str | None,
+    x_mode: str | None,
+    x_token: str | None,
+    x_command: str | None = None,
+    x_args: list[str] | None = None,
+) -> XMCPConfig | None:
+    env_config = x_mcp_config_from_env()
+    if any((x_url, x_mode, x_token, x_command, x_args)):
+        url = x_url or (env_config.url if env_config else "")
+        command = x_command or (env_config.command if env_config else "")
+
+        # The planner fills these connection params from a loose schema and often
+        # guesses an invalid transport (e.g. "default") or asks for "stdio"
+        # without a command. Drop anything we can't honor so we fall back to
+        # inferring the transport from the configured command/url rather than
+        # building a config that fails XMCPConfig validation.
+        requested_mode = (x_mode or "").strip().lower()
+        if requested_mode not in _KNOWN_X_MCP_MODES:
+            requested_mode = ""
+        if requested_mode == "stdio" and not command:
+            requested_mode = ""
+
+        inferred_mode = (
+            requested_mode
+            or ("stdio" if command else "")
+            or ("streamable-http" if url else "")
+            or (env_config.mode if env_config else "")
+        )
+        raw_config: XMCPParams = {
+            "url": url,
+            "mode": inferred_mode,
+            "auth_token": x_token or (env_config.auth_token if env_config else ""),
+            "bearer_token": env_config.bearer_token if env_config else "",
+            "command": command,
+            "args": x_args or (list(env_config.args) if env_config else []),
+            "headers": env_config.headers if env_config else {},
+        }
+        return build_x_mcp_config(raw_config)
+    return env_config
+
+
+def _x_mcp_available(sources: dict[str, dict]) -> bool:
+    return bool(sources.get("x_mcp", {}).get("connection_verified"))
+
+
+def _x_mcp_extract_params(sources: dict[str, dict]) -> XMCPParams:
+    x = sources.get("x_mcp", {})
+    if not x:
+        return {}
+    return {
+        "x_url": first_string(x, "x_url", "url"),
+        "x_mode": first_string(x, "x_mode", "mode"),
+        "x_token": first_string(x, "x_token", "auth_token"),
+        "x_command": first_string(x, "x_command", "command"),
+        "x_args": first_list(x, "x_args", "args"),
+    }
+
+
+def _normalize_tool_result(result: XMCPToolCallResult) -> XMCPResponse:
+    if result.get("is_error"):
+        return _unavailable_response(
+            str(result.get("text") or "X MCP tool call failed."),
+            tool_name=str(result.get("tool", "")).strip() or None,
+            arguments=result.get("arguments", {}),
+        )
+    return {
+        "source": "x_mcp",
+        "available": True,
+        "tool": result.get("tool"),
+        "arguments": result.get("arguments", {}),
+        "text": result.get("text", ""),
+        "structured_content": result.get("structured_content"),
+        "content": result.get("content", []),
+    }
+
+
+@tool(
+    name="list_x_tools",
+    source="x_mcp",
+    description=(
+        "List the tools exposed by the configured X (Twitter) MCP server. Pass "
+        "name_filter (e.g. 'search tweet timeline') to narrow the list, and "
+        "include_schema=true on a narrowed list to fetch the input schema of the "
+        "specific tool you intend to call."
+    ),
+    use_cases=[
+        "Discovering which X MCP tools are available before calling one",
+        "Finding the right tool for a task by passing a name_filter (e.g. 'search tweet')",
+        "Fetching the input schema of a specific tool with include_schema before calling it",
+    ],
+    surfaces=("investigation", "chat"),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "name_filter": {
+                "type": "string",
+                "description": (
+                    "Optional space- or comma-separated terms; tools whose name or "
+                    "description contains any term are returned (e.g. 'search tweet')."
+                ),
+            },
+            "include_schema": {
+                "type": "boolean",
+                "description": (
+                    "Include each tool's full input_schema. Only honored when the "
+                    "(filtered) result set is small; narrow with name_filter first."
+                ),
+            },
+            "x_url": {"type": "string"},
+            "x_mode": {"type": "string"},
+            "x_token": {"type": "string"},
+            "x_command": {"type": "string"},
+            "x_args": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": [],
+    },
+    # Connection/transport settings are injected from the verified integration
+    # config via extract_params and hidden from the model's tool schema. Exposing
+    # them would let the LLM supply hallucinated values (e.g. mode="mcp" or a base
+    # URL without the /mcp path) that override the verified config and break calls.
+    injected_params=("x_url", "x_mode", "x_token", "x_command", "x_args"),
+    is_available=_x_mcp_available,
+    extract_params=_x_mcp_extract_params,
+)
+def list_x_tools(
+    name_filter: str | None = None,
+    include_schema: bool = False,
+    x_url: str | None = None,
+    x_mode: str | None = None,
+    x_token: str | None = None,
+    x_command: str | None = None,
+    x_args: list[str] | None = None,
+    **_kwargs: object,
+) -> XMCPResponse:
+    """List tools available from the configured X MCP server.
+
+    Returns a compact, bounded view by default so the listing never overflows the
+    agent's context budget.
+    """
+    config = _resolve_config(x_url, x_mode, x_token, x_command, x_args)
+    if config is None:
+        payload = _unavailable_response("X MCP integration is not configured.")
+        payload["tools"] = []
+        return payload
+
+    runtime_error = x_mcp_runtime_unavailable_reason(config)
+    if runtime_error is not None:
+        payload = _unavailable_response(runtime_error)
+        payload["tools"] = []
+        return payload
+
+    try:
+        tools = list_x_mcp_server_tools(config)
+    except Exception as err:
+        report_run_error(
+            err,
+            tool_name="list_x_tools",
+            source="x_mcp",
+            component=_COMPONENT,
+            method="list_x_mcp_server_tools",
+            extras={"transport": config.mode},
+        )
+        payload = _unavailable_response(describe_x_mcp_error(err, config))
+        payload["tools"] = []
+        return payload
+
+    listing = build_mcp_tool_listing(
+        [dict(descriptor) for descriptor in tools],
+        name_filter=(name_filter or "").strip() or None,
+        include_schema=bool(include_schema),
+    )
+    return {
+        "source": "x_mcp",
+        "available": True,
+        "transport": config.mode,
+        "endpoint": config.command if config.mode == "stdio" else config.url,
+        **listing,
+    }
+
+
+@tool(
+    name="call_x_tool",
+    source="x_mcp",
+    description=(
+        "Call a named tool exposed by the configured X (Twitter) MCP server "
+        "(e.g. search tweets, inspect a user's timeline, look up a tweet by ID)."
+    ),
+    use_cases=[
+        "Searching X/Twitter for posts related to an incident (e.g. customer reports, outage chatter)",
+        "Inspecting a user's timeline or a specific tweet during an investigation",
+    ],
+    requires=["tool_name"],
+    surfaces=("investigation", "chat"),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "tool_name": {"type": "string"},
+            "arguments": {"type": "object"},
+            "x_url": {"type": "string"},
+            "x_mode": {"type": "string"},
+            "x_token": {"type": "string"},
+            "x_command": {"type": "string"},
+            "x_args": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["tool_name"],
+    },
+    # Only the MCP tool selection (tool_name) and its arguments are model-supplied.
+    # Connection/transport settings are injected from the verified integration
+    # config; see the note on list_x_tools for why they are hidden from the model.
+    injected_params=("x_url", "x_mode", "x_token", "x_command", "x_args"),
+    is_available=_x_mcp_available,
+    extract_params=_x_mcp_extract_params,
+)
+def call_x_tool(
+    tool_name: str | None = None,
+    arguments: XMCPParams | None = None,
+    x_url: str | None = None,
+    x_mode: str | None = None,
+    x_token: str | None = None,
+    x_command: str | None = None,
+    x_args: list[str] | None = None,
+    **_kwargs: object,
+) -> XMCPResponse:
+    """Call a specific X MCP tool by name."""
+    normalized_tool_name = (tool_name or "").strip()
+    if not normalized_tool_name:
+        return _unavailable_response(
+            "tool_name is required to call an X MCP tool.",
+            arguments=arguments or {},
+        )
+
+    config = _resolve_config(x_url, x_mode, x_token, x_command, x_args)
+    if config is None:
+        return _unavailable_response(
+            "X MCP integration is not configured.",
+            tool_name=normalized_tool_name,
+            arguments=arguments or {},
+        )
+
+    runtime_error = x_mcp_runtime_unavailable_reason(config)
+    if runtime_error is not None:
+        return _unavailable_response(
+            runtime_error,
+            tool_name=normalized_tool_name,
+            arguments=arguments or {},
+        )
+
+    try:
+        result = invoke_x_mcp_tool(config, normalized_tool_name, arguments or {})
+    except Exception as err:
+        report_run_error(
+            err,
+            tool_name="call_x_tool",
+            source="x_mcp",
+            component=_COMPONENT,
+            method="invoke_x_mcp_tool",
+            extras={"mcp_tool": normalized_tool_name, "transport": config.mode},
+        )
+        return _unavailable_response(
+            describe_x_mcp_error(err, config),
+            tool_name=normalized_tool_name,
+            arguments=arguments or {},
+        )
+
+    return _normalize_tool_result(result)

--- a/integrations/x_mcp/verifier.py
+++ b/integrations/x_mcp/verifier.py
@@ -1,0 +1,12 @@
+"""X MCP integration verifier."""
+
+from __future__ import annotations
+
+from integrations.verification import register_validation_verifier
+from integrations.x_mcp import build_x_mcp_config, validate_x_mcp_config
+
+verify_x_mcp = register_validation_verifier(
+    "x_mcp",
+    build_config=build_x_mcp_config,
+    validate_config=validate_x_mcp_config,
+)

--- a/tests/integrations/test_x_mcp.py
+++ b/tests/integrations/test_x_mcp.py
@@ -1,0 +1,186 @@
+"""Unit tests for the X (Twitter) MCP integration."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from integrations.catalog import classify_integrations as _classify_integrations
+from integrations.x_mcp import (
+    DEFAULT_X_MCP_URL,
+    XMCPConfig,
+    build_x_mcp_config,
+    describe_x_mcp_error,
+    validate_x_mcp_config,
+    x_mcp_config_from_env,
+    x_mcp_runtime_unavailable_reason,
+)
+
+# ---------------------------------------------------------------------------
+# XMCPConfig
+# ---------------------------------------------------------------------------
+
+
+class TestXMCPConfig:
+    def test_defaults_to_local_streamable_http(self) -> None:
+        config = XMCPConfig()
+        assert config.mode == "streamable-http"
+        assert config.url == DEFAULT_X_MCP_URL
+        assert config.is_configured is True
+
+    def test_streamable_http_requires_url(self) -> None:
+        with pytest.raises(ValidationError, match="requires a non-empty url"):
+            XMCPConfig(mode="streamable-http", url="")
+
+    def test_stdio_requires_command(self) -> None:
+        with pytest.raises(ValidationError, match="requires a non-empty command"):
+            XMCPConfig(mode="stdio", command="", url="")
+
+    def test_url_trailing_slash_stripped(self) -> None:
+        config = XMCPConfig(url="http://127.0.0.1:8000/mcp/")
+        assert config.url == "http://127.0.0.1:8000/mcp"
+
+    def test_mode_mcp_alias_maps_to_streamable_http(self) -> None:
+        config = XMCPConfig(mode="mcp")
+        assert config.mode == "streamable-http"
+
+    @pytest.mark.parametrize("alias", ["default", "http", "https", "streamable_http"])
+    def test_mode_generic_aliases_map_to_streamable_http(self, alias: str) -> None:
+        config = XMCPConfig(mode=alias)
+        assert config.mode == "streamable-http"
+
+    def test_bearer_prefix_stripped_from_auth_token(self) -> None:
+        config = XMCPConfig(auth_token="Bearer secret")
+        assert config.auth_token == "secret"
+
+    def test_request_headers_include_auth_only_when_set(self) -> None:
+        config = XMCPConfig(auth_token="secret")
+        assert config.request_headers["Authorization"] == "Bearer secret"
+
+    def test_request_headers_empty_without_auth_token(self) -> None:
+        config = XMCPConfig()
+        assert "Authorization" not in config.request_headers
+
+    def test_subprocess_env_forwards_bearer_token(self) -> None:
+        config = XMCPConfig(bearer_token="x_secret", mode="stdio", command="python")
+        assert config.subprocess_env == {"X_BEARER_TOKEN": "x_secret"}
+
+    def test_subprocess_env_empty_without_bearer_token(self) -> None:
+        config = XMCPConfig()
+        assert config.subprocess_env == {}
+
+
+# ---------------------------------------------------------------------------
+# Env loading / runtime gating
+# ---------------------------------------------------------------------------
+
+
+class TestEnvLoading:
+    def test_returns_none_for_stdio_without_command(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("X_MCP_MODE", "stdio")
+        monkeypatch.delenv("X_MCP_COMMAND", raising=False)
+        assert x_mcp_config_from_env() is None
+
+    def test_loads_default_local_config_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in ("X_MCP_URL", "X_MCP_MODE", "X_MCP_AUTH_TOKEN", "X_BEARER_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        config = x_mcp_config_from_env()
+        assert config is not None
+        assert config.url == DEFAULT_X_MCP_URL
+        assert config.mode == "streamable-http"
+
+    def test_runtime_reason_ok_for_http_without_token(self) -> None:
+        config = build_x_mcp_config({"url": DEFAULT_X_MCP_URL})
+        assert x_mcp_runtime_unavailable_reason(config) is None
+
+    def test_runtime_reason_requires_bearer_token_for_stdio(self) -> None:
+        config = build_x_mcp_config({"mode": "stdio", "command": "python", "bearer_token": ""})
+        reason = x_mcp_runtime_unavailable_reason(config)
+        assert reason is not None
+        assert "bearer token" in reason
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_validation_passes_when_tools_listed(self) -> None:
+        config = build_x_mcp_config({"url": DEFAULT_X_MCP_URL})
+        fake_tools = [
+            {"name": "search-tweets", "description": "Search tweets", "input_schema": {}},
+            {"name": "get-timeline", "description": "Get a user timeline", "input_schema": {}},
+        ]
+        with patch(
+            "integrations.x_mcp.list_x_mcp_tools",
+            return_value=fake_tools,
+        ):
+            result = validate_x_mcp_config(config)
+        assert result.ok is True
+        assert result.tool_names == ("get-timeline", "search-tweets")
+        assert "discovered 2 tool(s)" in result.detail
+
+    def test_validation_fails_when_no_tools(self) -> None:
+        config = build_x_mcp_config({"url": DEFAULT_X_MCP_URL})
+        with patch(
+            "integrations.x_mcp.list_x_mcp_tools",
+            return_value=[],
+        ):
+            result = validate_x_mcp_config(config)
+        assert result.ok is False
+        assert "no tools" in result.detail
+
+    def test_validation_handles_exception(self) -> None:
+        config = build_x_mcp_config({"url": DEFAULT_X_MCP_URL})
+        with patch(
+            "integrations.x_mcp.list_x_mcp_tools",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = validate_x_mcp_config(config)
+        assert result.ok is False
+        assert "validation failed" in result.detail
+
+    def test_validation_fails_for_stdio_without_bearer_token(self) -> None:
+        config = build_x_mcp_config({"mode": "stdio", "command": "python"})
+        result = validate_x_mcp_config(config)
+        assert result.ok is False
+        assert "bearer token" in result.detail
+
+
+def test_describe_error_includes_connect_hint() -> None:
+    import httpx
+
+    config = build_x_mcp_config({"url": DEFAULT_X_MCP_URL})
+    err = httpx.ConnectError("connection refused")
+    detail = describe_x_mcp_error(err, config)
+    assert "Could not reach" in detail
+
+
+# ---------------------------------------------------------------------------
+# Catalog classification
+# ---------------------------------------------------------------------------
+
+
+def test_classify_x_mcp_credentials() -> None:
+    records = [
+        {
+            "id": "x-mcp-local",
+            "service": "x_mcp",
+            "status": "active",
+            "credentials": {
+                "url": "http://127.0.0.1:8000/mcp",
+                "mode": "streamable-http",
+            },
+        }
+    ]
+    from tools.investigation.stages.gather_evidence.tools import availability_view
+
+    resolved = _classify_integrations(records)
+    assert "x_mcp" in resolved
+    assert resolved["x_mcp"].url == "http://127.0.0.1:8000/mcp"
+    # connection_verified is set at the tool-availability boundary
+    view = availability_view(resolved)
+    assert view["x_mcp"]["connection_verified"] is True

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -754,6 +754,71 @@ def _sentry_mcp_call_tool_case() -> ToolFailureCase:
     )
 
 
+def _patch_x_mcp_runtime(mp: pytest.MonkeyPatch) -> None:
+    """Shared patches for X MCP cases — bypass the config/runtime guards."""
+    from integrations.x_mcp.tools import x_mcp_tool as mod
+
+    mp.setattr(
+        mod,
+        "x_mcp_config_from_env",
+        MagicMock(
+            return_value=SimpleNamespace(
+                mode="streamable-http",
+                command="",
+                url="http://127.0.0.1:8000/mcp",
+                auth_token="",
+                bearer_token="",
+                args=(),
+                headers={},
+            )
+        ),
+    )
+    mp.setattr(mod, "x_mcp_runtime_unavailable_reason", MagicMock(return_value=None))
+    mp.setattr(mod, "describe_x_mcp_error", MagicMock(return_value="mocked error"))
+
+
+def _x_mcp_list_case() -> ToolFailureCase:
+    def patch(mp: pytest.MonkeyPatch) -> None:
+        from integrations.x_mcp.tools import x_mcp_tool as mod
+
+        _patch_x_mcp_runtime(mp)
+        mp.setattr(mod, "list_x_mcp_server_tools", MagicMock(side_effect=RuntimeError("mcp")))
+
+    def invoke() -> dict[str, Any]:
+        from integrations.x_mcp.tools.x_mcp_tool import list_x_tools
+
+        return list_x_tools()
+
+    return ToolFailureCase(
+        "x_mcp_list_tools",
+        patch,
+        invoke,
+        "list_x_tools",
+        "x_mcp",
+    )
+
+
+def _x_mcp_call_tool_case() -> ToolFailureCase:
+    def patch(mp: pytest.MonkeyPatch) -> None:
+        from integrations.x_mcp.tools import x_mcp_tool as mod
+
+        _patch_x_mcp_runtime(mp)
+        mp.setattr(mod, "invoke_x_mcp_tool", MagicMock(side_effect=RuntimeError("mcp")))
+
+    def invoke() -> dict[str, Any]:
+        from integrations.x_mcp.tools.x_mcp_tool import call_x_tool
+
+        return call_x_tool(tool_name="search-tweets", arguments={})
+
+    return ToolFailureCase(
+        "x_mcp_call_tool",
+        patch,
+        invoke,
+        "call_x_tool",
+        "x_mcp",
+    )
+
+
 _TOOL_FAILURE_CASES: list[ToolFailureCase] = [
     _azure_case(),
     _openobserve_case(),
@@ -780,6 +845,8 @@ _TOOL_FAILURE_CASES: list[ToolFailureCase] = [
     _posthog_mcp_call_tool_case(),
     _sentry_mcp_list_case(),
     _sentry_mcp_call_tool_case(),
+    _x_mcp_list_case(),
+    _x_mcp_call_tool_case(),
 ]
 
 
@@ -978,6 +1045,9 @@ _MIGRATED_TOOL_NAMES: frozenset[str] = frozenset(
         # Sentry MCP — both swallow sites in SentryMCPTool/__init__.py.
         "list_sentry_tools",
         "call_sentry_tool",
+        # X MCP — both swallow sites in x_mcp_tool/__init__.py.
+        "list_x_tools",
+        "call_x_tool",
     }
 )
 

--- a/tests/tools/test_x_mcp_tool.py
+++ b/tests/tools/test_x_mcp_tool.py
@@ -1,0 +1,234 @@
+"""Tests for X (Twitter) MCP function tools."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from integrations.x_mcp.tools.x_mcp_tool import (
+    _resolve_config,
+    call_x_tool,
+    list_x_tools,
+)
+from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+class TestXListToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return list_x_tools.__opensre_registered_tool__
+
+
+class TestXCallToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return call_x_tool.__opensre_registered_tool__
+
+
+_CONNECTION_PARAMS = frozenset({"x_url", "x_mode", "x_token", "x_command", "x_args"})
+
+
+def test_connection_params_are_injected_not_model_supplied() -> None:
+    """Regression: the LLM must not be able to supply connection/transport
+    settings. Hallucinated values (e.g. mode="mcp" or a base URL without the
+    ``/mcp`` path) previously overrode the verified config and broke calls, so
+    these fields are injected from the verified integration and hidden from the
+    model's tool schema.
+    """
+    for tool_fn in (list_x_tools, call_x_tool):
+        rt = tool_fn.__opensre_registered_tool__
+        assert set(rt.injected_params) >= _CONNECTION_PARAMS, (
+            f"{rt.name} must inject connection params, not expose them to the model."
+        )
+        public_props = set(rt.public_input_schema.get("properties", {}))
+        assert public_props.isdisjoint(_CONNECTION_PARAMS), (
+            f"{rt.name} leaks connection params {public_props & _CONNECTION_PARAMS} "
+            "into the model-facing schema."
+        )
+
+
+def test_call_tool_public_schema_exposes_only_tool_selection() -> None:
+    rt = call_x_tool.__opensre_registered_tool__
+    public_props = set(rt.public_input_schema.get("properties", {}))
+    assert public_props == {"tool_name", "arguments"}
+    assert rt.public_input_schema.get("required") == ["tool_name"]
+
+
+def test_list_tool_public_schema_exposes_only_filter_controls() -> None:
+    rt = list_x_tools.__opensre_registered_tool__
+    public_props = set(rt.public_input_schema.get("properties", {}))
+    assert public_props == {"name_filter", "include_schema"}
+    assert public_props.isdisjoint(_CONNECTION_PARAMS)
+
+
+def test_tools_available_when_connection_verified() -> None:
+    sources = mock_agent_state(
+        {
+            "x_mcp": {
+                "connection_verified": True,
+                "url": "http://127.0.0.1:8000/mcp",
+                "mode": "streamable-http",
+            }
+        }
+    )
+    assert list_x_tools.__opensre_registered_tool__.is_available(sources) is True
+    assert call_x_tool.__opensre_registered_tool__.is_available(sources) is True
+
+
+def test_tools_unavailable_without_verification() -> None:
+    sources = mock_agent_state({"x_mcp": {"connection_verified": False}})
+    assert list_x_tools.__opensre_registered_tool__.is_available(sources) is False
+
+
+def test_extract_params_maps_source_fields() -> None:
+    rt = call_x_tool.__opensre_registered_tool__
+    params = rt.extract_params(
+        {
+            "x_mcp": {
+                "connection_verified": True,
+                "url": "http://127.0.0.1:8000/mcp",
+                "mode": "streamable-http",
+            }
+        }
+    )
+    assert params["x_url"] == "http://127.0.0.1:8000/mcp"
+    assert params["x_mode"] == "streamable-http"
+
+
+def test_call_tool_requires_tool_name() -> None:
+    result = call_x_tool(
+        tool_name="",
+        x_url="http://127.0.0.1:8000/mcp",
+    )
+    assert result["available"] is False
+    assert "tool_name is required" in str(result["error"])
+
+
+def test_call_tool_unconfigured_returns_unavailable(monkeypatch) -> None:
+    for var in ("X_MCP_MODE", "X_MCP_URL", "X_MCP_COMMAND", "X_MCP_AUTH_TOKEN", "X_MCP_ARGS"):
+        monkeypatch.setenv(var, "")
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("X_MCP_MODE", "stdio")
+    result = call_x_tool(tool_name="search-tweets")
+    assert result["available"] is False
+    assert "not configured" in str(result["error"])
+
+
+def test_call_tool_passes_through_result() -> None:
+    fake_result = {
+        "is_error": False,
+        "text": "results",
+        "structured_content": {"tweets": [1, 2]},
+        "content": [],
+        "tool": "search-tweets",
+        "arguments": {"query": "outage"},
+    }
+    with patch(
+        "integrations.x_mcp.tools.x_mcp_tool.invoke_x_mcp_tool",
+        return_value=fake_result,
+    ) as mock_invoke:
+        result = call_x_tool(
+            tool_name="search-tweets",
+            arguments={"query": "outage"},
+            x_url="http://127.0.0.1:8000/mcp",
+            x_mode="streamable-http",
+        )
+    mock_invoke.assert_called_once()
+    assert result["available"] is True
+    assert result["source"] == "x_mcp"
+    assert result["structured_content"] == {"tweets": [1, 2]}
+
+
+def test_call_tool_surfaces_mcp_error() -> None:
+    fake_result = {
+        "is_error": True,
+        "text": "permission denied",
+        "tool": "post-tweet",
+        "arguments": {},
+    }
+    with patch(
+        "integrations.x_mcp.tools.x_mcp_tool.invoke_x_mcp_tool",
+        return_value=fake_result,
+    ):
+        result = call_x_tool(
+            tool_name="post-tweet",
+            x_url="http://127.0.0.1:8000/mcp",
+        )
+    assert result["available"] is False
+    assert "permission denied" in str(result["error"])
+
+
+@pytest.mark.parametrize("guessed_mode", ["default", "mcp", "http", "bogus", ""])
+def test_resolve_config_recovers_from_guessed_mode(guessed_mode: str) -> None:
+    """The planner often guesses an invalid transport; fall back to HTTP."""
+    config = _resolve_config(
+        x_url="http://127.0.0.1:8000/mcp",
+        x_mode=guessed_mode,
+        x_token=None,
+    )
+    assert config is not None
+    assert config.mode == "streamable-http"
+    assert config.url == "http://127.0.0.1:8000/mcp"
+
+
+def test_resolve_config_stdio_without_command_falls_back_to_http() -> None:
+    """A 'stdio' request with only a URL must not build a broken stdio config."""
+    config = _resolve_config(
+        x_url="http://127.0.0.1:8000/mcp",
+        x_mode="stdio",
+        x_token=None,
+        x_command="",
+    )
+    assert config is not None
+    assert config.mode == "streamable-http"
+
+
+def test_resolve_config_keeps_explicit_stdio_with_command() -> None:
+    config = _resolve_config(
+        x_url="",
+        x_mode="stdio",
+        x_token=None,
+        x_command="python",
+        x_args=["server.py"],
+    )
+    assert config is not None
+    assert config.mode == "stdio"
+    assert config.command == "python"
+
+
+def test_list_tools_returns_compact_summaries_without_schema() -> None:
+    fake_tools = [
+        {"name": "search-tweets", "description": "Search tweets", "input_schema": {"a": 1}},
+    ]
+    with patch(
+        "integrations.x_mcp.tools.x_mcp_tool.list_x_mcp_server_tools",
+        return_value=fake_tools,
+    ):
+        result = list_x_tools(
+            x_url="http://127.0.0.1:8000/mcp",
+            x_mode="streamable-http",
+        )
+    assert result["available"] is True
+    assert result["transport"] == "streamable-http"
+    assert result["total_tools"] == 1
+    assert result["returned_tools"] == 1
+    assert result["tools"] == [{"name": "search-tweets", "description": "Search tweets"}]
+    assert "input_schema" not in result["tools"][0]
+
+
+def test_list_tools_filters_by_name_or_description() -> None:
+    fake_tools = [
+        {"name": "search-tweets", "description": "Search recent tweets", "input_schema": {}},
+        {"name": "get-timeline", "description": "Get a user timeline", "input_schema": {}},
+        {"name": "post-tweet", "description": "Create a tweet", "input_schema": {}},
+    ]
+    with patch(
+        "integrations.x_mcp.tools.x_mcp_tool.list_x_mcp_server_tools",
+        return_value=fake_tools,
+    ):
+        result = list_x_tools(
+            name_filter="search timeline",
+            x_url="http://127.0.0.1:8000/mcp",
+        )
+    names = {t["name"] for t in result["tools"]}
+    assert names == {"search-tweets", "get-timeline"}
+    assert result["matched_tools"] == 2

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -85,6 +85,7 @@ _INTEGRATION_TOOL_PACKAGES: tuple[str, ...] = (
     "integrations.twilio.tools",
     "integrations.vercel.tools",
     "integrations.victoria_logs.tools",
+    "integrations.x_mcp.tools",
 )
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes #3589

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Adds `integrations/x_mcp/` exposing X's official MCP server ([xdevplatform/xmcp](https://github.com/xdevplatform/xmcp)) as `list_x_tools`/`call_x_tool`, following the existing `posthog_mcp`/`sentry_mcp` pattern (config model, streamable-http/sse/stdio transport client, verifier, generic discover+call tool surface).

XMCP is self-hosted by the user (runs locally, optionally tunneled) rather than an always-on hosted endpoint like PostHog/Sentry's, so `XMCPConfig` has no fixed default host and connection auth is optional (only needed if the endpoint sits behind a tunnel/proxy) — the server authenticates to the X API itself via its own `X_BEARER_TOKEN`, which OpenSRE only forwards when it launches the server itself (`stdio` mode).

Wired into `catalog.py`, `_catalog_impl.py`, `registry.py`, `cli.py` (`opensre integrations setup/verify x_mcp`), `tools/registry.py`, `effective_models.py`, `core/domain/types/evidence.py`. Adds `docs/x-mcp.mdx` (registered in `docs/docs.json`) and `.env.example` vars.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run opensre integrations verify x_mcp
  SERVICE    SOURCE       STATUS      DETAIL
  x_mcp     -            missing     Not configured in local store or env.

$ uv run pytest tests/integrations/test_x_mcp.py tests/tools/test_x_mcp_tool.py -q
collected 55 items
tests/integrations/test_x_mcp.py ........................                [ 43%]
tests/tools/test_x_mcp_tool.py ...............................           [100%]
55 passed in 1.08s
```

Full suite: `make test-cov` → 10096 passed, 54 skipped. `ruff check` and `mypy integrations/x_mcp/` clean.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

X's MCP server (xmcp) has no vendor-hosted endpoint — unlike PostHog/Sentry, it's a FastMCP server the user runs themselves (locally, or tunneled for remote access). The main design decision was adapting the existing hosted-MCP client pattern (`integrations/posthog_mcp/`, `integrations/sentry_mcp/`) to that reality: `XMCPConfig` defaults `url` to `http://127.0.0.1:8000/mcp` instead of a fixed vendor host, and the transport-level `auth_token` is optional (only needed behind an authenticating tunnel/proxy) since a locally-run xmcp server manages its own X API credentials. A separate `bearer_token`/`X_BEARER_TOKEN` field exists purely to forward the X API bearer token into the subprocess environment when OpenSRE launches xmcp itself via `stdio` mode — it is never sent over the MCP transport.

The tool surface is intentionally generic (`list_x_tools` discovery + `call_x_tool` named-call), matching `posthog_mcp_tool`/`sentry_mcp_tool`, so it keeps working as X adds/renames individual MCP-side tools rather than needing a bespoke wrapper per X API endpoint. Connection/transport params are injected from the verified integration config and hidden from the model's tool schema (`injected_params`) so the LLM can't override them with hallucinated values.

Key files: `integrations/x_mcp/__init__.py` (config, transport, validation), `integrations/x_mcp/verifier.py` (CLI verify wiring), `integrations/x_mcp/tools/x_mcp_tool/__init__.py` (the two `@tool`-decorated functions).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.