### PR TITLE
fix(analytics): omit placeholder failure properties on completed outcomes

### DIFF
--- a/surfaces/interactive_shell/utils/telemetry/investigation_analytics.py
+++ b/surfaces/interactive_shell/utils/telemetry/investigation_analytics.py
@@ -27,16 +27,21 @@ def publish_investigation_outcome_analytics(outcome: InvestigationOutcome) -> No
             investigation_id=outcome.investigation_id,
             investigation_target=outcome.target,
         )
+    # Completed runs must not carry placeholder failure properties; consumers
+    # would otherwise have to special-case failure_category == "unknown".
+    not_completed = outcome.status != "completed"
     capture_investigation_outcome(
         investigation_id=outcome.investigation_id,
         status=outcome.status,
         investigation_target=outcome.target,
         root_cause_excerpt=_root_cause_excerpt(outcome.final_state),
-        error_excerpt=outcome.error_message,
-        failure_category=outcome.failure_category or None,
-        integration_involved=outcome.integration_involved or None,
-        integration_failure_message=outcome.integration_failure_message or None,
-        failure_detail=outcome.error_detail or None,
+        error_excerpt=outcome.error_message if not_completed else "",
+        failure_category=(outcome.failure_category or None) if not_completed else None,
+        integration_involved=(outcome.integration_involved or None) if not_completed else None,
+        integration_failure_message=(
+            (outcome.integration_failure_message or None) if not_completed else None
+        ),
+        failure_detail=(outcome.error_detail or None) if not_completed else None,
     )
 
 

--- a/tests/interactive_shell/utils/telemetry/test_investigation_analytics.py
+++ b/tests/interactive_shell/utils/telemetry/test_investigation_analytics.py
@@ -1,0 +1,71 @@
+"""Tests for the investigation outcome analytics bridge."""
+
+from __future__ import annotations
+
+import pytest
+
+from surfaces.interactive_shell.ui.investigation_outcome import InvestigationOutcome
+from surfaces.interactive_shell.utils.telemetry.investigation_analytics import (
+    publish_investigation_outcome_analytics,
+)
+
+
+def _capture_outcome_calls(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.investigation_analytics."
+        "capture_investigation_outcome",
+        lambda **kwargs: calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.investigation_analytics."
+        "capture_investigation_cancelled",
+        lambda **_kwargs: None,
+    )
+    return calls
+
+
+def test_completed_outcome_omits_placeholder_failure_properties(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _capture_outcome_calls(monkeypatch)
+    publish_investigation_outcome_analytics(
+        InvestigationOutcome(
+            status="completed",
+            target="generic",
+            investigation_id="inv-1",
+            final_state={"root_cause": "disk full"},
+        )
+    )
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["status"] == "completed"
+    assert call["root_cause_excerpt"] == "disk full"
+    assert call["error_excerpt"] == ""
+    assert call["failure_category"] is None
+    assert call["integration_involved"] is None
+    assert call["integration_failure_message"] is None
+    assert call["failure_detail"] is None
+
+
+def test_failed_outcome_keeps_failure_properties(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _capture_outcome_calls(monkeypatch)
+    publish_investigation_outcome_analytics(
+        InvestigationOutcome(
+            status="failed",
+            target="generic",
+            investigation_id="inv-2",
+            error_message="grafana query failed: 401",
+            error_detail="RuntimeError: grafana query failed: 401",
+            failure_category="integration",
+            integration_involved="grafana",
+            integration_failure_message="grafana query failed: 401",
+        )
+    )
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["status"] == "failed"
+    assert call["error_excerpt"] == "grafana query failed: 401"
+    assert call["failure_category"] == "integration"
+    assert call["integration_involved"] == "grafana"
+    assert call["failure_detail"] == "RuntimeError: grafana query failed: 401"


### PR DESCRIPTION
## Summary

Follow-up to #3662. Completed `investigation_outcome` events were emitting `failure_category: "unknown"` (the dataclass default) plus empty failure fields, forcing every analytics consumer to special-case placeholders on successful runs.

- Failure properties (`failure_category`, `error_excerpt`, `integration_involved`, `integration_failure_message`, `failure_detail`) are now omitted entirely when `status == "completed"`
- Failed and cancelled outcomes keep the full failure context unchanged

## Test plan

- [x] `make lint`, `make typecheck`, `make format-check`
- [x] New `tests/interactive_shell/utils/telemetry/test_investigation_analytics.py` covers both completed (properties omitted) and failed (properties kept) paths