### PR TITLE
refactor(shell): make shell_turn_execution an adapter-only composition layer

### DIFF
--- a/surfaces/interactive_shell/runtime/AGENTS.md
+++ b/surfaces/interactive_shell/runtime/AGENTS.md
@@ -139,8 +139,11 @@ flowchart TD
   `run_agent_turn` own shell presentation (StreamingConsole, spinner, recorder,
   progress scope), construct a `ConsoleAgentEventSink`, own dispatch state, and
   call `interactive_shell.runtime.shell_turn_execution.execute_shell_turn`.
-- The shell adapter entry lives in `runtime/shell_turn_execution.py`: it binds shell
-  adapters and accounting around `core.agent_harness.agents.turn_orchestrator.run_turn`.
+- The shell adapter entry lives in `runtime/shell_turn_execution.py`: `execute_shell_turn`
+  composes the action-turn (`runtime/action_turn.py`), gather (`runtime/integration_tool_gathering.py`),
+  and answer (`runtime/answer_turn.py`) adapters plus accounting around
+  `core.agent_harness.agents.turn_orchestrator.run_turn`. Each adapter owns its own
+  binding; tests import them from their owning module (not `shell_turn_execution`).
 - The reusable per-prompt loop lives in `core.agent_harness`: turn snapshots,
   observation reset, action/response routing, and core result construction stay
   surface-agnostic.
@@ -154,7 +157,7 @@ flowchart TD
   `interactive_shell/runtime/core/turn_accounting.py`, invoked from
   `interactive_shell.runtime.shell_turn_execution.execute_shell_turn`. It owns action-agent analytics, terminal-turn aggregate
   telemetry, prompt-recorder flush, conversational-turn persistence, and the final
-  assistant-intent stamp. `interactive_shell.runtime.shell_turn_execution.run_action_tool_turn` returns facts
+  assistant-intent stamp. `interactive_shell.runtime.action_turn.run_action_tool_turn` returns facts
   only (`ToolCallingTurnResult` with `accounting_status` of `completed` / `not_run`)
   and emits no analytics itself. Do not re-scatter accounting back into
   `run_action_tool_turn` or standalone `_record_*` helpers.

--- a/surfaces/interactive_shell/runtime/action_turn.py
+++ b/surfaces/interactive_shell/runtime/action_turn.py
@@ -1,0 +1,104 @@
+"""Shell adapter for one action-selection turn.
+
+Binds the interactive shell's console, session, and default providers around
+core ``run_action_agent_turn``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from rich.console import Console
+
+from core.agent_harness.agents.action_agent import ToolCallingDeps, run_action_agent_turn
+from core.agent_harness.models.turn_context import TurnContext
+from core.agent_harness.models.turn_results import ToolCallingTurnResult
+from core.agent_harness.ports import OutputSink
+from core.agent_harness.providers.default_providers import DefaultErrorReporter, DefaultToolProvider
+from core.agent_harness.session import Session
+from core.execution import ToolExecutionHooks
+from surfaces.interactive_shell.command_registry import SLASH_COMMANDS
+from surfaces.interactive_shell.command_registry.suggestions import resolve_literal_slash_typo
+from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink
+from surfaces.interactive_shell.ui.action_rendering import ActionRenderObserver
+
+
+def _default_llm_factory() -> Any:
+    from core.llm import agent_llm_client
+
+    return agent_llm_client.get_agent_llm()
+
+
+def _action_observer_factory(
+    session: Session,
+    console: Console,
+    message: str,
+) -> ActionRenderObserver:
+    return ActionRenderObserver(session=session, console=console, message=message)
+
+
+def _complete_literal_slash_typo_turn(
+    message: str,
+    session: Session,
+    output: OutputSink,
+) -> ToolCallingTurnResult | None:
+    """Handle unknown slash roots and invalid subcommands before tool validation."""
+    typo = resolve_literal_slash_typo(message, SLASH_COMMANDS)
+    if typo is None:
+        return None
+    output.print()
+    output.print(typo.message)
+    session.record(
+        "slash",
+        message.strip(),
+        ok=False,
+        response_text=typo.message,
+        slash_outcome=typo.outcome,
+    )
+    return ToolCallingTurnResult(0, 1, 0, False, True, response_text=typo.message)
+
+
+def run_action_tool_turn(
+    message: str,
+    session: Session,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+    request_exit: Callable[[], None] | None = None,
+    deps: ToolCallingDeps | None = None,
+    turn_ctx: TurnContext | None = None,
+    output: OutputSink | None = None,
+    tool_hooks: ToolExecutionHooks | None = None,
+) -> ToolCallingTurnResult:
+    """Run one action-selection turn through core with shell adapters bound."""
+    resolved_output = resolve_output_sink(console, output)
+    typo_result = _complete_literal_slash_typo_turn(message, session, resolved_output)
+    if typo_result is not None:
+        return typo_result
+    effective_deps = (
+        deps
+        if deps is not None and deps.llm_factory is not None
+        else ToolCallingDeps(llm_factory=_default_llm_factory)
+    )
+    return run_action_agent_turn(
+        message,
+        session,
+        output=resolved_output,
+        tools=DefaultToolProvider(
+            session,
+            console,
+            request_exit=request_exit,
+            observer_factory=_action_observer_factory,
+        ),
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+        deps=effective_deps,
+        turn_ctx=turn_ctx,
+        error_reporter=DefaultErrorReporter(),
+        tool_hooks=tool_hooks,
+    )
+
+
+__all__ = ["run_action_tool_turn"]

--- a/surfaces/interactive_shell/runtime/agent_harness_adapters.py
+++ b/surfaces/interactive_shell/runtime/agent_harness_adapters.py
@@ -11,6 +11,7 @@ from collections.abc import Iterable
 from rich.console import Console
 from rich.markup import escape
 
+from core.agent_harness.ports import OutputSink
 from surfaces.interactive_shell.ui import (
     stream_to_console,
 )
@@ -47,4 +48,11 @@ class ShellOutputSink:
         )
 
 
-__all__ = ["ShellOutputSink"]
+def resolve_output_sink(console: Console, output: OutputSink | None) -> OutputSink:
+    """Return the caller's sink, or a shell sink bound to ``console``."""
+    if output is not None:
+        return output
+    return ShellOutputSink(console)
+
+
+__all__ = ["ShellOutputSink", "resolve_output_sink"]

--- a/surfaces/interactive_shell/runtime/answer_turn.py
+++ b/surfaces/interactive_shell/runtime/answer_turn.py
@@ -1,0 +1,62 @@
+"""Shell adapter for one conversational answer turn.
+
+Binds the interactive shell's Rich output, grounding caches, reasoning client,
+and telemetry around core ``answer_cli_agent``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from rich.console import Console
+
+from core.agent_harness.agents.turn_orchestrator import (
+    answer_cli_agent as run_core_answer_cli_agent,
+)
+from core.agent_harness.models.turn_context import TurnContext
+from core.agent_harness.ports import OutputSink
+from core.agent_harness.providers.default_prompt_context import DefaultPromptContextProvider
+from core.agent_harness.providers.default_providers import (
+    DefaultErrorReporter,
+    DefaultReasoningClientProvider,
+    DefaultRunRecordFactory,
+)
+from core.agent_harness.session import Session
+from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink
+from surfaces.interactive_shell.utils.telemetry import LlmRunInfo
+
+
+def answer_shell_question(
+    message: str,
+    session: Session,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+    tool_observation: str | None = None,
+    tool_observation_on_screen: bool = True,
+    turn_ctx: TurnContext | None = None,
+    output: OutputSink | None = None,
+) -> LlmRunInfo | None:
+    """Answer one shell question through the grounded conversational assistant."""
+    resolved_output = resolve_output_sink(console, output)
+    return run_core_answer_cli_agent(
+        message,
+        session,
+        resolved_output,
+        prompts=DefaultPromptContextProvider(session),
+        reasoning=DefaultReasoningClientProvider(
+            output=resolved_output,
+            error_reporter=DefaultErrorReporter(),
+        ),
+        run_factory=DefaultRunRecordFactory(session),
+        error_reporter=DefaultErrorReporter(),
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+        tool_observation=tool_observation,
+        tool_observation_on_screen=tool_observation_on_screen,
+        turn_ctx=turn_ctx,
+    )
+
+
+__all__ = ["answer_shell_question"]

--- a/surfaces/interactive_shell/runtime/integration_tool_gathering.py
+++ b/surfaces/interactive_shell/runtime/integration_tool_gathering.py
@@ -4,7 +4,7 @@ The bounded think -> call-tools -> observe loop lives in the decoupled
 :func:`core.agent_harness.agents.evidence_agent.gather_tool_evidence`. This module is the terminal adapter:
 it renders each gathering step to the console and persists the gathered tool
 calls into the shell's session storage, then hands the collected observation back
-to :func:`interactive_shell.runtime.shell_turn_execution.answer_shell_question`.
+to :func:`interactive_shell.runtime.answer_turn.answer_shell_question`.
 """
 
 from __future__ import annotations

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -1,175 +1,85 @@
-"""Execute submitted interactive-shell turns through the shared agent harness.
+"""Compose one interactive-shell turn from its action/gather/answer adapters.
 
-Adapter-only: binds the interactive shell's Rich console, session, and default
-providers to the surface-agnostic entry points in ``core.agent_harness``. All
-turn-routing, session compaction, and per-agent LLM/tool wiring live in the
-harness — see ``core/agent_harness/AGENTS.md``.
+Adapter-only: binds the shell's action-turn (``action_turn``), gather pass
+(``integration_tool_gathering``), and answer (``answer_turn``) adapters to the
+surface-agnostic ``run_turn`` engine. Each adapter owns its own binding; this
+file only composes them and attaches turn accounting.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Protocol
 
 from rich.console import Console
 
-from core.agent_harness.agents.action_agent import ToolCallingDeps, run_action_agent_turn
-from core.agent_harness.agents.turn_orchestrator import (
-    answer_cli_agent as run_core_answer_cli_agent,
-)
 from core.agent_harness.agents.turn_orchestrator import run_turn
 from core.agent_harness.models.turn_context import TurnContext
 from core.agent_harness.models.turn_results import ShellTurnResult, ToolCallingTurnResult
 from core.agent_harness.ports import OutputSink
-from core.agent_harness.providers.default_prompt_context import DefaultPromptContextProvider
-from core.agent_harness.providers.default_providers import (
-    DefaultErrorReporter,
-    DefaultReasoningClientProvider,
-    DefaultRunRecordFactory,
-    DefaultToolProvider,
-)
 from core.agent_harness.session import Session
 from core.execution import ToolExecutionHooks
-from surfaces.interactive_shell.command_registry import SLASH_COMMANDS
-from surfaces.interactive_shell.command_registry.suggestions import resolve_literal_slash_typo
-from surfaces.interactive_shell.runtime.agent_harness_adapters import ShellOutputSink
+from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
+from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink
+from surfaces.interactive_shell.runtime.answer_turn import answer_shell_question
 from surfaces.interactive_shell.runtime.core.turn_accounting import ShellTurnAccounting
 from surfaces.interactive_shell.runtime.integration_tool_gathering import (
     gather_integration_tool_evidence,
 )
-from surfaces.interactive_shell.ui.action_rendering import ActionRenderObserver
 from surfaces.interactive_shell.utils.telemetry import LlmRunInfo, PromptRecorder
 
-# Dependency seams used by the harness turn-routing tests.
-RunActionToolTurn = Callable[..., ToolCallingTurnResult]
-GatherEvidence = Callable[..., "str | None"]
-AnswerShellQuestion = Callable[..., "LlmRunInfo | None"]
+
+# Dependency seams: tests inject doubles through the explicit parameters below.
+# Typed as protocols (not bare Callable[..., X]) so an injected double must match
+# the exact call shape execute_shell_turn drives — a mis-shaped double fails at
+# type-check, not at runtime.
+class RunActionToolTurn(Protocol):
+    """Action-selection seam: run one action turn and return its facts."""
+
+    def __call__(
+        self,
+        message: str,
+        session: Session,
+        console: Console,
+        *,
+        confirm_fn: Callable[[str], str] | None = ...,
+        is_tty: bool | None = ...,
+        request_exit: Callable[[], None] | None = ...,
+        turn_ctx: TurnContext | None = ...,
+        output: OutputSink | None = ...,
+        tool_hooks: ToolExecutionHooks | None = ...,
+    ) -> ToolCallingTurnResult: ...
 
 
-def _default_llm_factory() -> Any:
-    from core.llm import agent_llm_client
+class GatherEvidence(Protocol):
+    """Gather seam: collect read-only integration evidence, or None."""
 
-    return agent_llm_client.get_agent_llm()
-
-
-def _resolve_output_sink(console: Console, output: OutputSink | None) -> OutputSink:
-    if output is not None:
-        return output
-    return ShellOutputSink(console)
-
-
-def _action_observer_factory(
-    session: Session,
-    console: Console,
-    message: str,
-) -> ActionRenderObserver:
-    return ActionRenderObserver(session=session, console=console, message=message)
+    def __call__(
+        self,
+        message: str,
+        session: Session,
+        console: Console,
+        *,
+        is_tty: bool | None = ...,
+    ) -> str | None: ...
 
 
-def _complete_literal_slash_typo_turn(
-    message: str,
-    session: Session,
-    output: OutputSink,
-) -> ToolCallingTurnResult | None:
-    """Handle unknown slash roots and invalid subcommands before tool validation."""
-    typo = resolve_literal_slash_typo(message, SLASH_COMMANDS)
-    if typo is None:
-        return None
-    output.print()
-    output.print(typo.message)
-    session.record(
-        "slash",
-        message.strip(),
-        ok=False,
-        response_text=typo.message,
-        slash_outcome=typo.outcome,
-    )
-    return ToolCallingTurnResult(
-        0,
-        1,
-        0,
-        False,
-        True,
-        response_text=typo.message,
-    )
+class AnswerShellQuestion(Protocol):
+    """Answer seam: respond via the grounded conversational assistant."""
 
-
-def run_action_tool_turn(
-    message: str,
-    session: Session,
-    console: Console,
-    *,
-    confirm_fn: Callable[[str], str] | None = None,
-    is_tty: bool | None = None,
-    request_exit: Callable[[], None] | None = None,
-    deps: ToolCallingDeps | None = None,
-    turn_ctx: TurnContext | None = None,
-    output: OutputSink | None = None,
-    tool_hooks: ToolExecutionHooks | None = None,
-) -> ToolCallingTurnResult:
-    """Run one action-selection turn through core with shell adapters bound."""
-    resolved_output = _resolve_output_sink(console, output)
-    typo_result = _complete_literal_slash_typo_turn(message, session, resolved_output)
-    if typo_result is not None:
-        return typo_result
-    effective_deps = (
-        deps
-        if deps is not None and deps.llm_factory is not None
-        else ToolCallingDeps(llm_factory=_default_llm_factory)
-    )
-    return run_action_agent_turn(
-        message,
-        session,
-        output=resolved_output,
-        tools=DefaultToolProvider(
-            session,
-            console,
-            request_exit=request_exit,
-            observer_factory=_action_observer_factory,
-        ),
-        confirm_fn=confirm_fn,
-        is_tty=is_tty,
-        deps=effective_deps,
-        turn_ctx=turn_ctx,
-        error_reporter=DefaultErrorReporter(),
-        tool_hooks=tool_hooks,
-    )
-
-
-def answer_shell_question(
-    message: str,
-    session: Session,
-    console: Console,
-    *,
-    confirm_fn: Callable[[str], str] | None = None,
-    is_tty: bool | None = None,
-    tool_observation: str | None = None,
-    tool_observation_on_screen: bool = True,
-    turn_ctx: TurnContext | None = None,
-    output: OutputSink | None = None,
-) -> LlmRunInfo | None:
-    """Answer one shell question through the grounded conversational assistant.
-
-    Delegates to :func:`core.agent_harness.agents.turn_orchestrator.answer_cli_agent`, supplying the shell
-    adapters for Rich output, grounding caches, reasoning client, and telemetry.
-    """
-    return run_core_answer_cli_agent(
-        message,
-        session,
-        _resolve_output_sink(console, output),
-        prompts=DefaultPromptContextProvider(session),
-        reasoning=DefaultReasoningClientProvider(
-            output=_resolve_output_sink(console, output),
-            error_reporter=DefaultErrorReporter(),
-        ),
-        run_factory=DefaultRunRecordFactory(session),
-        error_reporter=DefaultErrorReporter(),
-        confirm_fn=confirm_fn,
-        is_tty=is_tty,
-        tool_observation=tool_observation,
-        tool_observation_on_screen=tool_observation_on_screen,
-        turn_ctx=turn_ctx,
-    )
+    def __call__(
+        self,
+        message: str,
+        session: Session,
+        console: Console,
+        *,
+        confirm_fn: Callable[[str], str] | None = ...,
+        is_tty: bool | None = ...,
+        tool_observation: str | None = ...,
+        tool_observation_on_screen: bool = ...,
+        turn_ctx: TurnContext | None = ...,
+        output: OutputSink | None = ...,
+    ) -> LlmRunInfo | None: ...
 
 
 def execute_shell_turn(
@@ -189,16 +99,18 @@ def execute_shell_turn(
 ) -> ShellTurnResult:
     """Execute one submitted interactive-shell turn.
 
-    The action driver, gather pass, and conversational assistant are bound to the
-    live ``session``/``console`` here (so injected test doubles keep their
-    ``(text, session, console, ...)`` shape) and handed to
-    :func:`core.agent_harness.agents.turn_orchestrator.run_turn`, which performs the pure path routing.
+    The action driver, gather pass, and conversational assistant default to the
+    shell adapters but are overridable via ``execute_actions`` / ``gather_evidence``
+    / ``answer_agent`` (the test injection seams). They are bound to the live
+    ``session``/``console`` here and handed to
+    :func:`core.agent_harness.agents.turn_orchestrator.run_turn`, which performs
+    the pure path routing.
     """
     _execute = execute_actions or run_action_tool_turn
     _gather = gather_evidence or gather_integration_tool_evidence
     _answer = answer_agent or answer_shell_question
     accounting = ShellTurnAccounting(session=session, text=text, recorder=recorder)
-    resolved_output = _resolve_output_sink(console, output)
+    resolved_output = resolve_output_sink(console, output)
 
     def execute_bound(
         t: str,
@@ -250,7 +162,5 @@ __all__ = [
     "AnswerShellQuestion",
     "GatherEvidence",
     "RunActionToolTurn",
-    "answer_shell_question",
     "execute_shell_turn",
-    "run_action_tool_turn",
 ]

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -3,13 +3,14 @@
 Adapter-only: binds the shell's action-turn (``action_turn``), gather pass
 (``integration_tool_gathering``), and answer (``answer_turn``) adapters to the
 surface-agnostic ``run_turn`` engine. Each adapter owns its own binding; this
-file only composes them and attaches turn accounting.
+file only composes them and attaches turn accounting. The injection contracts
+live in ``turn_seams``.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, Protocol
+from typing import Unpack
 
 from rich.console import Console
 
@@ -26,60 +27,13 @@ from surfaces.interactive_shell.runtime.core.turn_accounting import ShellTurnAcc
 from surfaces.interactive_shell.runtime.integration_tool_gathering import (
     gather_integration_tool_evidence,
 )
+from surfaces.interactive_shell.runtime.turn_seams import (
+    AnswerKwargs,
+    AnswerShellQuestion,
+    GatherEvidence,
+    RunActionToolTurn,
+)
 from surfaces.interactive_shell.utils.telemetry import LlmRunInfo, PromptRecorder
-
-
-# Dependency seams: tests inject doubles through the explicit parameters below.
-# Typed as protocols (not bare Callable[..., X]) so an injected double must match
-# the exact call shape execute_shell_turn drives — a mis-shaped double fails at
-# type-check, not at runtime.
-class RunActionToolTurn(Protocol):
-    """Action-selection seam: run one action turn and return its facts."""
-
-    def __call__(
-        self,
-        message: str,
-        session: Session,
-        console: Console,
-        *,
-        confirm_fn: Callable[[str], str] | None = ...,
-        is_tty: bool | None = ...,
-        request_exit: Callable[[], None] | None = ...,
-        turn_ctx: TurnContext | None = ...,
-        output: OutputSink | None = ...,
-        tool_hooks: ToolExecutionHooks | None = ...,
-    ) -> ToolCallingTurnResult: ...
-
-
-class GatherEvidence(Protocol):
-    """Gather seam: collect read-only integration evidence, or None."""
-
-    def __call__(
-        self,
-        message: str,
-        session: Session,
-        console: Console,
-        *,
-        is_tty: bool | None = ...,
-    ) -> str | None: ...
-
-
-class AnswerShellQuestion(Protocol):
-    """Answer seam: respond via the grounded conversational assistant."""
-
-    def __call__(
-        self,
-        message: str,
-        session: Session,
-        console: Console,
-        *,
-        confirm_fn: Callable[[str], str] | None = ...,
-        is_tty: bool | None = ...,
-        tool_observation: str | None = ...,
-        tool_observation_on_screen: bool = ...,
-        turn_ctx: TurnContext | None = ...,
-        output: OutputSink | None = ...,
-    ) -> LlmRunInfo | None: ...
 
 
 def execute_shell_turn(
@@ -101,8 +55,8 @@ def execute_shell_turn(
 
     The action driver, gather pass, and conversational assistant default to the
     shell adapters but are overridable via ``execute_actions`` / ``gather_evidence``
-    / ``answer_agent`` (the test injection seams). They are bound to the live
-    ``session``/``console`` here and handed to
+    / ``answer_agent`` (the test injection seams, typed in ``turn_seams``). They are
+    bound to the live ``session``/``console`` here and handed to
     :func:`core.agent_harness.agents.turn_orchestrator.run_turn`, which performs
     the pure path routing.
     """
@@ -131,17 +85,10 @@ def execute_shell_turn(
             tool_hooks=tool_hooks,
         )
 
-    def answer_bound(t: str, **kwargs: Any) -> LlmRunInfo | None:
-        # Pure passthrough so the engine controls the exact call shape: when it
-        # omits ``tool_observation_on_screen`` (no evidence gathered) the bound
-        # call omits it too, matching the plain conversational path.
-        return _answer(
-            t,
-            session,
-            console,
-            output=resolved_output,
-            **kwargs,
-        )
+    def answer_bound(t: str, **kwargs: Unpack[AnswerKwargs]) -> LlmRunInfo | None:
+        # run_turn controls which keys are present (it omits tool_observation_on_screen
+        # on the plain path); AnswerKwargs types them without forcing presence.
+        return _answer(t, session, console, output=resolved_output, **kwargs)
 
     def gather_bound(t: str, *, is_tty: bool | None = None) -> str | None:
         return _gather(t, session, console, is_tty=is_tty)
@@ -158,9 +105,4 @@ def execute_shell_turn(
     )
 
 
-__all__ = [
-    "AnswerShellQuestion",
-    "GatherEvidence",
-    "RunActionToolTurn",
-    "execute_shell_turn",
-]
+__all__ = ["execute_shell_turn"]

--- a/surfaces/interactive_shell/runtime/turn_seams.py
+++ b/surfaces/interactive_shell/runtime/turn_seams.py
@@ -1,0 +1,99 @@
+"""Injection contracts for the interactive-shell turn seams.
+
+These protocols describe exactly what ``execute_shell_turn`` requires from the
+action / gather / answer adapters it composes, so an injected test double is
+checked at type-time rather than at runtime. The default adapters
+(``action_turn``, ``answer_turn``, ``integration_tool_gathering``) satisfy them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol, TypedDict
+
+from rich.console import Console
+
+from core.agent_harness.models.turn_context import TurnContext
+from core.agent_harness.models.turn_results import ToolCallingTurnResult
+from core.agent_harness.ports import OutputSink
+from core.agent_harness.session import Session
+from core.execution import ToolExecutionHooks
+from surfaces.interactive_shell.utils.telemetry import LlmRunInfo
+
+
+class RunActionToolTurn(Protocol):
+    """Action-selection seam driven by ``execute_shell_turn``.
+
+    ``deps`` is intentionally not part of the contract: ``execute_shell_turn``
+    never injects it, and the default adapter supplies its own LLM factory.
+    """
+
+    def __call__(
+        self,
+        message: str,
+        session: Session,
+        console: Console,
+        *,
+        confirm_fn: Callable[[str], str] | None = None,
+        is_tty: bool | None = None,
+        request_exit: Callable[[], None] | None = None,
+        turn_ctx: TurnContext | None = None,
+        output: OutputSink | None = None,
+        tool_hooks: ToolExecutionHooks | None = None,
+    ) -> ToolCallingTurnResult:
+        """Run one action turn and return its facts."""
+
+
+class GatherEvidence(Protocol):
+    """Gather seam: collect read-only integration evidence, or None."""
+
+    def __call__(
+        self,
+        message: str,
+        session: Session,
+        console: Console,
+        *,
+        is_tty: bool | None = None,
+    ) -> str | None:
+        """Gather evidence for the message, or return None when nothing applies."""
+
+
+class AnswerKwargs(TypedDict, total=False):
+    """Keyword args ``run_turn`` forwards to the answer seam (all optional).
+
+    ``total=False`` mirrors ``run_turn`` omitting ``tool_observation_on_screen``
+    on the plain (no-evidence) path.
+    """
+
+    confirm_fn: Callable[[str], str] | None
+    is_tty: bool | None
+    tool_observation: str | None
+    tool_observation_on_screen: bool
+    turn_ctx: TurnContext | None
+
+
+class AnswerShellQuestion(Protocol):
+    """Answer seam: respond via the grounded conversational assistant."""
+
+    def __call__(
+        self,
+        message: str,
+        session: Session,
+        console: Console,
+        *,
+        confirm_fn: Callable[[str], str] | None = None,
+        is_tty: bool | None = None,
+        tool_observation: str | None = None,
+        tool_observation_on_screen: bool = True,
+        turn_ctx: TurnContext | None = None,
+        output: OutputSink | None = None,
+    ) -> LlmRunInfo | None:
+        """Answer the question, returning the LLM run info or None."""
+
+
+__all__ = [
+    "AnswerKwargs",
+    "AnswerShellQuestion",
+    "GatherEvidence",
+    "RunActionToolTurn",
+]

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -4,7 +4,7 @@ This module owns the terminal-facing action observer. Planner tool calls are
 internal state by default: the observer records them for history/storage while
 the concrete action executors render user-facing command output. The execution
 orchestration that drives it lives in
-:func:`interactive_shell.runtime.shell_turn_execution.run_action_tool_turn`.
+:func:`interactive_shell.runtime.action_turn.run_action_tool_turn`.
 
 Keeping rendering here means the shell turn-entry adapter stays focused on
 binding core ports while terminal formatting stays in ``ui/``.

--- a/surfaces/interactive_shell/ui/streaming/__init__.py
+++ b/surfaces/interactive_shell/ui/streaming/__init__.py
@@ -64,7 +64,7 @@ STREAM_LABEL_ANSWER = "answer"
 def render_response_header(console: Console, label: str) -> None:
     """Print the ``●`` bullet row marker that opens every assistant
     response (Claude Code-style row layout). Shared with
-    ``shell_turn_execution.run_action_tool_turn`` so the planned-actions path
+    ``action_turn.run_action_tool_turn`` so the planned-actions path
     and the streaming response path use the exact same prefix.
     """
     console.print(f"[{ui_theme.BOLD_BRAND}]●[/] [{ui_theme.DIM}]{label}[/]")

--- a/tests/core/agent/orchestration/test_agent_actions.py
+++ b/tests/core/agent/orchestration/test_agent_actions.py
@@ -14,6 +14,7 @@ import pytest
 from rich.console import Console
 
 import config.constants.platform as platform_module
+import surfaces.interactive_shell.runtime.action_turn as action_turn
 import surfaces.interactive_shell.runtime.shell_turn_execution as shell_turn_execution
 import surfaces.interactive_shell.runtime.subprocess_runner as subprocess_runner
 import tools.interactive_shell.actions.implementation as implementation_tool
@@ -35,9 +36,7 @@ from tools.interactive_shell.action_names import (
     ToolKind,
 )
 
-_ACTION_LLM_FACTORY_PATCH = (
-    "surfaces.interactive_shell.runtime.shell_turn_execution._default_llm_factory"
-)
+_ACTION_LLM_FACTORY_PATCH = "surfaces.interactive_shell.runtime.action_turn._default_llm_factory"
 execute_shell_turn = shell_turn_execution.execute_shell_turn
 
 
@@ -283,7 +282,7 @@ def test_execute_cli_actions_dispatches_planned_commands(monkeypatch: object) ->
 
     session = Session()
     console, buf = _capture()
-    handled = shell_turn_execution.run_action_tool_turn(
+    handled = action_turn.run_action_tool_turn(
         "check the health of my opensre and then show me all connected services",
         session,
         console,
@@ -351,7 +350,7 @@ def test_execute_cli_actions_skips_remaining_actions_when_cancelled(
     session = Session()
     inner_console, buf = _capture()
     console = _CancelAfterFirst(inner_console, dispatched)
-    handled = shell_turn_execution.run_action_tool_turn(
+    handled = action_turn.run_action_tool_turn(
         "check the health of my opensre and then show me all connected services",
         session,
         console,  # type: ignore[arg-type]
@@ -387,9 +386,7 @@ def test_execute_cli_actions_falls_through_for_local_llama_request(monkeypatch: 
 
     session = Session()
     console, _ = _capture()
-    handled = shell_turn_execution.run_action_tool_turn(
-        "please connect to local llama", session, console
-    )
+    handled = action_turn.run_action_tool_turn("please connect to local llama", session, console)
 
     assert handled.handled is False
     assert dispatched == []
@@ -409,7 +406,7 @@ def test_execute_cli_actions_switches_llm_provider(monkeypatch: object) -> None:
 
     session = Session()
     console, buf = _capture()
-    handled = shell_turn_execution.run_action_tool_turn(
+    handled = action_turn.run_action_tool_turn(
         "switch from the current ollama model to setting the model to anthropic",
         session,
         console,
@@ -436,7 +433,7 @@ def test_execute_cli_actions_records_llm_provider_failure(monkeypatch: object) -
 
     session = Session()
     console, _ = _capture()
-    handled = shell_turn_execution.run_action_tool_turn(
+    handled = action_turn.run_action_tool_turn(
         "switch from the current ollama model to setting the model to anthropic",
         session,
         console,
@@ -477,7 +474,7 @@ def test_execute_cli_actions_sets_bare_model_for_active_provider(
 
     session = Session()
     console, buf = _capture()
-    handled = shell_turn_execution.run_action_tool_turn("switch model to gpt 5.5", session, console)
+    handled = action_turn.run_action_tool_turn("switch model to gpt 5.5", session, console)
 
     assert handled.handled is True
     assert reasoning_models == ["gpt-5.5"]
@@ -506,9 +503,7 @@ def test_execute_cli_actions_runs_implementation_action(monkeypatch: object) -> 
 
     session = Session()
     console, buf = _capture()
-    handled = shell_turn_execution.run_action_tool_turn(
-        "please implement /history search", session, console
-    )
+    handled = action_turn.run_action_tool_turn("please implement /history search", session, console)
 
     assert handled.handled is True
     assert calls == ["/history search"]
@@ -540,7 +535,7 @@ def test_execute_cli_actions_answers_discord_then_dispatches_datadog(
 
     session = Session()
     console, buf = _capture()
-    handled = shell_turn_execution.run_action_tool_turn(
+    handled = action_turn.run_action_tool_turn(
         (
             "tell me about what the discord integration can do and then tell me what "
             "datadog services I have connections to"
@@ -579,7 +574,7 @@ def test_compound_prompt_executes_all_supported_tasks(monkeypatch: object) -> No
 
     session = Session()
     console, buf = _capture()
-    handled = shell_turn_execution.run_action_tool_turn(
+    handled = action_turn.run_action_tool_turn(
         (
             "tell me how you are doing AND show me all the services we are connected to "
             "AND then deploy OpenSRE to EC2"
@@ -638,7 +633,7 @@ def test_nitro_prompt_executes_remote_then_investigation(monkeypatch: object) ->
 
     session = Session()
     console, buf = _capture()
-    handled = shell_turn_execution.run_action_tool_turn(_NITRO_PROMPT, session, console)
+    handled = action_turn.run_action_tool_turn(_NITRO_PROMPT, session, console)
 
     assert handled.handled is True
     assert dispatched == ["/remote"]
@@ -668,7 +663,7 @@ def test_services_version_deploy_prompt_executes_in_order(monkeypatch: object) -
 
     session = Session()
     console, buf = _capture()
-    handled = shell_turn_execution.run_action_tool_turn(
+    handled = action_turn.run_action_tool_turn(
         (
             "tell me which services are connected AND then tell me the current CLI version "
             "AND then deploy to EC2 within 90 seconds"
@@ -713,9 +708,7 @@ def test_execute_cli_actions_runs_sample_alert(monkeypatch: object) -> None:
     console, buf = _capture()
 
     assert (
-        shell_turn_execution.run_action_tool_turn(
-            "okay launch a simple alert", session, console
-        ).handled
+        action_turn.run_action_tool_turn("okay launch a simple alert", session, console).handled
         is True
     )
     assert calls == ["generic"]
@@ -756,9 +749,7 @@ def test_execute_cli_actions_sample_alert_opensre_error_marks_task_failed(
     session = Session()
     console, _ = _capture()
     assert (
-        shell_turn_execution.run_action_tool_turn(
-            "okay launch a simple alert", session, console
-        ).handled
+        action_turn.run_action_tool_turn("okay launch a simple alert", session, console).handled
         is True
     )
     inv_tasks = [
@@ -796,7 +787,7 @@ def test_execute_cli_actions_lists_all_actions_before_synthetic_rds(monkeypatch:
 
     session = Session()
     console, buf = _capture()
-    handled = shell_turn_execution.run_action_tool_turn(
+    handled = action_turn.run_action_tool_turn(
         "show me which services are connected and after that run a synthetic test RDS database",
         session,
         console,
@@ -857,9 +848,7 @@ def test_execute_cli_actions_runs_requested_synthetic_scenario(monkeypatch: obje
 
     session = Session()
     console, buf = _capture()
-    handled = shell_turn_execution.run_action_tool_turn(
-        "run synthetic test 005-failover", session, console
-    )
+    handled = action_turn.run_action_tool_turn("run synthetic test 005-failover", session, console)
 
     assert handled.handled is True
     assert popen_calls[0][0][-2:] == ["--scenario", "005-failover"]
@@ -876,7 +865,7 @@ def test_execute_cli_actions_cancels_single_running_synthetic_task() -> None:
     task.attach_process(proc)
 
     console, buf = _capture()
-    handled = shell_turn_execution.run_action_tool_turn(
+    handled = action_turn.run_action_tool_turn(
         "kill the syntehtic_test because it is runnign way too long",
         session,
         console,
@@ -922,7 +911,7 @@ def test_partial_match_executes_matched_clause_and_drops_unhandled(monkeypatch: 
 
     # "sing a song" is chatty filler; v0.1 drops it and still runs the matched
     # "/integrations list" clause instead of failing the whole turn closed.
-    assert shell_turn_execution.run_action_tool_turn(
+    assert action_turn.run_action_tool_turn(
         "show me connected services and sing a song", session, console
     ).handled
     assert dispatched == ["/integrations list"]
@@ -935,7 +924,7 @@ def test_execute_cli_actions_falls_through_for_chat() -> None:
     session = Session()
     console, _ = _capture()
 
-    assert shell_turn_execution.run_action_tool_turn("hey", session, console).handled is False
+    assert action_turn.run_action_tool_turn("hey", session, console).handled is False
     assert session.history == []
 
 
@@ -952,7 +941,7 @@ def test_execute_cli_actions_runs_shell_command(monkeypatch: object) -> None:
     session = Session()
     console, buf = _capture()
 
-    assert shell_turn_execution.run_action_tool_turn("run `pwd`", session, console).handled is True
+    assert action_turn.run_action_tool_turn("run `pwd`", session, console).handled is True
     assert session.history == [
         {"type": "shell", "text": "pwd", "ok": True},
     ]
@@ -974,7 +963,7 @@ def test_execute_cli_actions_cd_preserves_windows_paths(monkeypatch: object) -> 
     console, _ = _capture()
 
     message = r"run `cd C:\Users\Alice`"
-    assert shell_turn_execution.run_action_tool_turn(message, session, console).handled is True
+    assert action_turn.run_action_tool_turn(message, session, console).handled is True
     assert changed_directories == [Path(r"C:\Users\Alice")]
     assert session.history == [
         {"type": "shell", "text": r"cd C:\Users\Alice", "ok": True},
@@ -998,7 +987,7 @@ def test_execute_cli_actions_cd_dispatches_case_insensitively(monkeypatch: objec
     console, _ = _capture()
 
     message = r"run `CD C:\Users\Alice`"
-    assert shell_turn_execution.run_action_tool_turn(message, session, console).handled is True
+    assert action_turn.run_action_tool_turn(message, session, console).handled is True
     assert changed_directories == [Path(r"C:\Users\Alice")]
     assert session.history == [
         {"type": "shell", "text": r"CD C:\Users\Alice", "ok": True},
@@ -1018,7 +1007,7 @@ def test_execute_cli_actions_cd_handles_trailing_backslash_on_windows(monkeypatc
     console, _ = _capture()
 
     message = r"run `cd C:\`"
-    assert shell_turn_execution.run_action_tool_turn(message, session, console).handled is True
+    assert action_turn.run_action_tool_turn(message, session, console).handled is True
     assert changed_directories == [Path("C:\\")]
     assert session.history == [
         {"type": "shell", "text": "cd C:\\", "ok": True},
@@ -1038,7 +1027,7 @@ def test_execute_cli_actions_cd_strips_quotes_on_windows(monkeypatch: object) ->
     console, _ = _capture()
 
     message = r'run `cd "C:\Users\Alice"`'
-    assert shell_turn_execution.run_action_tool_turn(message, session, console).handled is True
+    assert action_turn.run_action_tool_turn(message, session, console).handled is True
     assert changed_directories == [Path(r"C:\Users\Alice")]
     assert session.history == [
         {"type": "shell", "text": r'cd "C:\Users\Alice"', "ok": True},
@@ -1063,9 +1052,7 @@ def test_execute_cli_actions_records_shell_failure(monkeypatch: object) -> None:
     session = Session()
     console, buf = _capture()
 
-    assert (
-        shell_turn_execution.run_action_tool_turn("execute false", session, console).handled is True
-    )
+    assert action_turn.run_action_tool_turn("execute false", session, console).handled is True
     assert calls == [
         (
             ["false"],
@@ -1105,7 +1092,7 @@ def test_execute_cli_actions_shell_command_times_out(monkeypatch: object) -> Non
     session = Session()
     console, buf = _capture()
 
-    assert shell_turn_execution.run_action_tool_turn("run `true`", session, console).handled is True
+    assert action_turn.run_action_tool_turn("run `true`", session, console).handled is True
     assert session.history[-1] == {
         "type": "shell",
         "text": "true",
@@ -1135,10 +1122,7 @@ def test_execute_cli_actions_runs_passthrough_with_shell_true(monkeypatch: objec
     session = Session()
     console, buf = _capture()
 
-    assert (
-        shell_turn_execution.run_action_tool_turn("run `!echo hello`", session, console).handled
-        is True
-    )
+    assert action_turn.run_action_tool_turn("run `!echo hello`", session, console).handled is True
     assert calls == [
         (
             _expected_shell_argv("echo hello"),
@@ -1180,7 +1164,7 @@ def test_execute_cli_actions_dispatches_bang_cd_through_builtin(monkeypatch: obj
     console, buf = _capture()
 
     message = "run `!cd /tmp`"
-    assert shell_turn_execution.run_action_tool_turn(message, session, console).handled is True
+    assert action_turn.run_action_tool_turn(message, session, console).handled is True
     assert dirs == [Path("/tmp")]
     assert session.history[-1] == {"type": "shell", "text": "cd /tmp", "ok": True}
     captured = buf.getvalue()
@@ -1200,7 +1184,7 @@ def test_execute_cli_actions_dispatches_bang_pwd_through_builtin(monkeypatch: ob
     session = Session()
     console, buf = _capture()
 
-    assert shell_turn_execution.run_action_tool_turn("run `!pwd`", session, console).handled is True
+    assert action_turn.run_action_tool_turn("run `!pwd`", session, console).handled is True
     assert session.history[-1] == {"type": "shell", "text": "pwd", "ok": True}
     captured = buf.getvalue()
     assert "/shown" in captured
@@ -1210,7 +1194,7 @@ def test_execute_cli_actions_dispatches_bang_pwd_through_builtin(monkeypatch: ob
 def test_execute_cli_actions_handles_path_with_spaces_run_phrase() -> None:
     session = Session()
     console, buf = _capture()
-    result = shell_turn_execution.run_action_tool_turn(
+    result = action_turn.run_action_tool_turn(
         'run cat "/tmp/file with spaces.txt"', session, console
     )
     assert result.handled is True
@@ -1237,7 +1221,7 @@ def test_execute_cli_actions_backtick_shell_preserves_space_path_token(monkeypat
     console, _ = _capture()
 
     assert (
-        shell_turn_execution.run_action_tool_turn(
+        action_turn.run_action_tool_turn(
             'run `cat "/tmp/file with spaces.txt"`', session, console
         ).handled
         is True
@@ -1298,7 +1282,7 @@ def test_execute_cli_actions_persists_action_agent_llm_unavailable(
 
     session = Session()
     console, buf = _capture()
-    handled = shell_turn_execution.run_action_tool_turn("check health", session, console)
+    handled = action_turn.run_action_tool_turn("check health", session, console)
 
     assert handled.handled is True
     assert handled.has_unhandled_clause is True
@@ -1390,9 +1374,7 @@ def test_execute_cli_actions_bang_prefix_uses_only_explicit_shell_escape(
     console, buf = _capture()
 
     # Multiline !cmd with internal whitespace — the exact shape the user types.
-    handled = shell_turn_execution.run_action_tool_turn(
-        "!curl\n      wttr.in/London", session, console
-    )
+    handled = action_turn.run_action_tool_turn("!curl\n      wttr.in/London", session, console)
 
     assert handled.handled is True
     assert llm_called == []
@@ -1431,7 +1413,7 @@ def test_execute_cli_actions_bang_prefix_single_line_dispatches_to_shell(
     session = Session()
     console, _ = _capture()
 
-    handled = shell_turn_execution.run_action_tool_turn("!echo hello world", session, console)
+    handled = action_turn.run_action_tool_turn("!echo hello world", session, console)
 
     assert handled.handled is True
     assert llm_called == []
@@ -1474,9 +1456,7 @@ def test_execute_cli_actions_handoff_only_plan_falls_through_silently(
 
     session = Session()
     console, buf = _capture()
-    result = shell_turn_execution.run_action_tool_turn(
-        "what is our current model?", session, console
-    )
+    result = action_turn.run_action_tool_turn("what is our current model?", session, console)
 
     # Must fall through (not handled) so the caller invokes the LLM for the real reply.
     assert result.handled is False

--- a/tests/core/agent/orchestration/test_agent_actions_harness.py
+++ b/tests/core/agent/orchestration/test_agent_actions_harness.py
@@ -10,7 +10,7 @@ import tools.interactive_shell.actions.slash as slash_tool
 from core.agent_harness.agents.action_agent import ToolCallingDeps, run_action_agent_turn
 from core.agent_harness.session import Session
 from core.tool_framework.registered_tool import RegisteredTool
-from surfaces.interactive_shell.runtime.shell_turn_execution import run_action_tool_turn
+from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
 from tests.core.agent.orchestration.action_execution_test_harness import (
     ActionExecutionHarness,
     FakeActionLLM,

--- a/tests/core/agent/orchestration/test_model_question_misroute.py
+++ b/tests/core/agent/orchestration/test_model_question_misroute.py
@@ -33,9 +33,7 @@ from tests.core.agent.orchestration.action_execution_test_harness import (
     tool_response,
 )
 
-_ACTION_LLM_FACTORY_PATCH = (
-    "surfaces.interactive_shell.runtime.shell_turn_execution._default_llm_factory"
-)
+_ACTION_LLM_FACTORY_PATCH = "surfaces.interactive_shell.runtime.action_turn._default_llm_factory"
 _PROMPT = "which model is being used now?"
 
 

--- a/tests/interactive_shell/chat/test_cli_agent.py
+++ b/tests/interactive_shell/chat/test_cli_agent.py
@@ -28,8 +28,8 @@ from core.agent_harness.prompts.assistant_agent_prompt import (
 from core.agent_harness.providers import default_prompt_context
 from core.agent_harness.providers.default_prompt_context import DefaultPromptContextProvider
 from core.agent_harness.session import Session
-from surfaces.interactive_shell.runtime import shell_turn_execution as cli_agent
-from surfaces.interactive_shell.runtime.shell_turn_execution import answer_shell_question
+from surfaces.interactive_shell.runtime import answer_turn as cli_agent
+from surfaces.interactive_shell.runtime.answer_turn import answer_shell_question
 
 
 def _build_environment_block(session: Session) -> str:

--- a/tests/interactive_shell/command_registry/test_suggestions.py
+++ b/tests/interactive_shell/command_registry/test_suggestions.py
@@ -15,7 +15,7 @@ from surfaces.interactive_shell.command_registry.suggestions import (
     resolve_literal_slash_typo,
     subcommand_hints,
 )
-from surfaces.interactive_shell.runtime.shell_turn_execution import run_action_tool_turn
+from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
 
 
 def _capture() -> tuple[Console, io.StringIO]:

--- a/tests/interactive_shell/runtime/test_token_accounting.py
+++ b/tests/interactive_shell/runtime/test_token_accounting.py
@@ -16,7 +16,7 @@ from core.agent_harness.accounting.token_accounting import (
     record_llm_turn,
 )
 from core.agent_harness.session import Session
-from surfaces.interactive_shell.runtime.shell_turn_execution import answer_shell_question
+from surfaces.interactive_shell.runtime.answer_turn import answer_shell_question
 from surfaces.interactive_shell.ui.streaming import _CHARS_PER_TOKEN
 
 

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -1831,7 +1831,7 @@ class TestResumeCommand:
         """Action-agent LLM failures must be stored so /resume can show them."""
         from unittest.mock import patch
 
-        from surfaces.interactive_shell.runtime.shell_turn_execution import (
+        from surfaces.interactive_shell.runtime.action_turn import (
             run_action_tool_turn,
         )
 
@@ -1842,7 +1842,7 @@ class TestResumeCommand:
             raise RuntimeError("codex: quota or rate limit exceeded (exit 1)")
 
         with patch(
-            "surfaces.interactive_shell.runtime.shell_turn_execution._default_llm_factory",
+            "surfaces.interactive_shell.runtime.action_turn._default_llm_factory",
             side_effect=_raise,
         ):
             result = run_action_tool_turn("check cpu usage", session, console)

--- a/tests/interactive_shell/test_terminal_runtime_turns.py
+++ b/tests/interactive_shell/test_terminal_runtime_turns.py
@@ -266,7 +266,7 @@ def test_execute_shell_turn_nitro_prompt_executes_remote_then_investigation(
         call_order.append(f"investigation:{alert_text}")
 
     monkeypatch.setattr(
-        "surfaces.interactive_shell.runtime.shell_turn_execution._default_llm_factory",
+        "surfaces.interactive_shell.runtime.action_turn._default_llm_factory",
         lambda: FakeActionLLM(
             [
                 AgentLLMResponse(

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -11,10 +11,8 @@ from rich.console import Console
 import tools.interactive_shell.actions.slash as slash_tool
 from core.agent_harness.models.turn_results import ToolCallingTurnResult
 from core.agent_harness.session import Session
-from surfaces.interactive_shell.runtime.shell_turn_execution import (
-    execute_shell_turn,
-    run_action_tool_turn,
-)
+from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
+from surfaces.interactive_shell.runtime.shell_turn_execution import execute_shell_turn
 from surfaces.interactive_shell.ui.action_rendering import ActionRenderObserver
 from surfaces.interactive_shell.ui.input_prompt.rendering import _prompt_turn_number
 from tests.core.agent.orchestration.action_execution_test_harness import (

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -637,7 +637,7 @@ class TestTimingFooter:
 
 class TestRenderResponseHeader:
     """``render_response_header`` is the bullet-row marker shared with
-    ``shell_turn_execution.run_action_tool_turn`` — three call sites collapsed
+    ``action_turn.run_action_tool_turn`` — three call sites collapsed
     to one helper, so we lock in the visible output here.
     """
 


### PR DESCRIPTION
Fixes #3607 

#### Describe the changes you have made in this PR -

`shell_turn_execution.py` carried three overlapping public functions (`run_action_tool_turn`, `answer_shell_question`, `execute_shell_turn`) that Vincent flagged as not the adapter-only shape he wanted. The two turn adapters were kept public mainly so ~79 test call-sites could reach into them, and the three test-injection seams were loosely typed as `Callable[..., X]`.

This makes the file a clean composition adapter and gives each adapter its own canonical home, so tests import from the owning module instead of reaching into the entry point.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

 **Split into owning modules** (per AGENTS.md "import canonical names from
  owning submodule"):
  - `runtime/action_turn.py` — `run_action_tool_turn` + its helpers
    (`_default_llm_factory`, `_action_observer_factory`, slash-typo pre-check).
  - `runtime/answer_turn.py` — `answer_shell_question`.
  - `runtime/shell_turn_execution.py` — now only `execute_shell_turn`, which
    composes the action / gather / answer adapters around core `run_turn`.
- **Shared helper**: the duplicated `_resolve_output_sink` became
  `resolve_output_sink` in `runtime/agent_harness_adapters.py` (next to
  `ShellOutputSink`).
- **Typed seams (ISP)**: replaced the three `Callable[..., X]` aliases with
  `Protocol`s (`RunActionToolTurn`, `GatherEvidence`, `AnswerShellQuestion`)
  pinning the exact call shape, so a mis-shaped injected double fails at
  type-check, not at runtime.
- **Small cleanup**: `answer_shell_question` resolved its output sink twice; now
  once.
- Updated ~79 test call-sites + 4 monkeypatch targets to the new modules, plus
  docstrings in `action_rendering.py`, `streaming/__init__.py`,
  `integration_tool_gathering.py`, and the AGENTS.md architecture note.


---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
