### PR TITLE
fix(analytics): real model/token telemetry and structured errors on $ai_generation

### DIFF
--- a/core/agent_harness/agents/turn_orchestrator.py
+++ b/core/agent_harness/agents/turn_orchestrator.py
@@ -49,6 +49,13 @@ _ASSISTANT_LABEL = "assistant"
 # ---------------------------------------------------------------------------
 
 
+def stage_turn_error(session: Any, kind: str, message: str) -> None:
+    """Best-effort structured error staging for the turn's telemetry flush."""
+    setter = getattr(session, "set_pending_turn_error", None)
+    if callable(setter):
+        setter(kind, message)
+
+
 def _stream_cli_agent_response(
     *,
     client: Any,
@@ -56,6 +63,7 @@ def _stream_cli_agent_response(
     output: OutputSink,
     run_factory: RunRecordFactory,
     error_reporter: ErrorReporter | None,
+    session: Any | None = None,
 ) -> Any | None:
     try:
         started = time.monotonic()
@@ -73,6 +81,9 @@ def _stream_cli_agent_response(
                 context="core.agent_harness.agents.turn_orchestrator.stream",
                 expected=isinstance(exc, CLITimeoutError),
             )
+        if session is not None:
+            kind = "timeout" if isinstance(exc, CLITimeoutError) else "assistant_error"
+            stage_turn_error(session, kind, str(exc))
         output.render_error(f"assistant failed: {exc}")
         return None
     return run_factory.build(client=client, prompt=prompt, response_text=text_str, started=started)
@@ -140,6 +151,7 @@ def answer_cli_agent(
         output=output,
         run_factory=run_factory,
         error_reporter=error_reporter,
+        session=session,
     )
     if run is None:
         return None

--- a/core/agent_harness/providers/default_providers.py
+++ b/core/agent_harness/providers/default_providers.py
@@ -131,23 +131,37 @@ class DefaultReasoningClientProvider:
         *,
         output: OutputSink | None = None,
         error_reporter: ErrorReporter | None = None,
+        session: Any | None = None,
     ) -> None:
         self._output = output
         self._error_reporter = error_reporter
+        self._session = session
 
     def get(self) -> Any | None:
         try:
             from core.llm.llm_client import get_llm_for_reasoning
         except Exception as exc:
-            if self._error_reporter is not None:
-                self._error_reporter.report(
-                    exc,
-                    context="core.agent_harness.default_reasoning_client.import",
-                )
-            if self._output is not None:
-                self._output.render_error(_llm_client_unavailable_message(exc))
+            self._handle_unavailable(
+                exc, context="core.agent_harness.default_reasoning_client.import"
+            )
             return None
-        return get_llm_for_reasoning()
+        try:
+            return get_llm_for_reasoning()
+        except Exception as exc:
+            self._handle_unavailable(
+                exc, context="core.agent_harness.default_reasoning_client.create"
+            )
+            return None
+
+    def _handle_unavailable(self, exc: Exception, *, context: str) -> None:
+        if self._error_reporter is not None:
+            self._error_reporter.report(exc, context=context)
+        if self._session is not None:
+            from core.agent_harness.agents.turn_orchestrator import stage_turn_error
+
+            stage_turn_error(self._session, "llm_unavailable", str(exc))
+        if self._output is not None:
+            self._output.render_error(_llm_client_unavailable_message(exc))
 
 
 class DefaultRunRecordFactory:

--- a/core/agent_harness/session/state.py
+++ b/core/agent_harness/session/state.py
@@ -144,6 +144,16 @@ class Session:
     _turn_outcome_hint: str | None = field(default=None, repr=False, compare=False)
     """Optional structured outcome set by a terminal handler for analytics."""
 
+    _pending_turn_llm: Any | None = field(default=None, repr=False, compare=False)
+    """LLM run metadata (an ``LlmRunInfo``) staged by a terminal handler for the
+    current turn's prompt-recorder flush. Consumed exactly once via
+    ``pop_pending_turn_llm`` so it cannot leak into later turns."""
+
+    _pending_turn_error: tuple[str, str] | None = field(default=None, repr=False, compare=False)
+    """Structured ``(error_kind, message)`` staged by a failing handler for the
+    current turn's prompt-recorder flush. Consumed exactly once via
+    ``pop_pending_turn_error`` so it cannot leak into later turns."""
+
     accumulated_context: dict[str, Any] = field(default_factory=dict)
     """Reusable infra context — service names, clusters, regions — learned from
     earlier investigations that should seed future ones."""
@@ -422,6 +432,29 @@ class Session:
         hint = self._turn_outcome_hint
         self._turn_outcome_hint = None
         return hint
+
+    def set_pending_turn_llm(self, run: Any | None) -> None:
+        """Stage LLM run metadata for this turn's prompt-recorder flush."""
+        self._pending_turn_llm = run
+
+    def pop_pending_turn_llm(self) -> Any | None:
+        """Return and clear staged LLM run metadata for this turn."""
+        run = self._pending_turn_llm
+        self._pending_turn_llm = None
+        return run
+
+    def set_pending_turn_error(self, kind: str, message: str) -> None:
+        """Stage a structured turn error for this turn's prompt-recorder flush."""
+        kind = kind.strip()
+        message = message.strip()
+        if kind or message:
+            self._pending_turn_error = (kind or "error", message)
+
+    def pop_pending_turn_error(self) -> tuple[str, str] | None:
+        """Return and clear the staged structured turn error."""
+        error = self._pending_turn_error
+        self._pending_turn_error = None
+        return error
 
     def complete_latest_record(
         self,

--- a/core/llm/litellm/clients.py
+++ b/core/llm/litellm/clients.py
@@ -124,7 +124,11 @@ class LiteLLMAgentClient:
             provider_name=self.provider_name,
             model=self._litellm_model,
         )
-        return agent_response_from_completion(response, provider_name=self.provider_name)
+        return agent_response_from_completion(
+            response,
+            provider_name=self.provider_name,
+            model=self._litellm_model,
+        )
 
     @staticmethod
     def build_tool_result_message(tool_calls: list[ToolCall], results: list[Any]) -> dict[str, Any]:

--- a/core/llm/openai_chat_completions.py
+++ b/core/llm/openai_chat_completions.py
@@ -13,6 +13,7 @@ from core.llm.llm_retry import (
     rate_limit_sleep_seconds,
 )
 from core.llm.types import AgentLLMResponse, LLMResponse, ToolCall
+from core.llm.usage import emit_usage
 
 _RETRY_INITIAL_BACKOFF_SEC = 1.0
 _RETRY_MAX_ATTEMPTS = 3
@@ -135,7 +136,12 @@ def build_assistant_message(content: str, tool_calls: list[ToolCall]) -> dict[st
     return msg
 
 
-def agent_response_from_completion(response: Any, *, provider_name: str) -> AgentLLMResponse:
+def agent_response_from_completion(
+    response: Any,
+    *,
+    provider_name: str,
+    model: str | None = None,
+) -> AgentLLMResponse:
     choices = get_attr_or_item(response, "choices", None)
     if not choices:
         raise RuntimeError(
@@ -147,6 +153,8 @@ def agent_response_from_completion(response: Any, *, provider_name: str) -> Agen
         raise RuntimeError(
             f"{provider_name} API returned an unexpected response: {type(response).__name__}"
         )
+    input_tokens, output_tokens = usage_tokens(get_attr_or_item(response, "usage", None))
+    emit_usage(model or provider_name, input_tokens, output_tokens)
     content = str(get_attr_or_item(message, "content", "") or "")
     stop_reason = str(get_attr_or_item(choice, "finish_reason", "stop") or "stop")
     return AgentLLMResponse(

--- a/core/llm/sdk/agent_clients.py
+++ b/core/llm/sdk/agent_clients.py
@@ -30,6 +30,7 @@ from core.llm.openai_chat_completions import (
 )
 from core.llm.tool_schema_normalize import build_openai_tool_specs
 from core.llm.types import AgentLLMResponse, ToolCall
+from core.llm.usage import emit_provider_usage
 
 logger = logging.getLogger(__name__)
 
@@ -188,6 +189,13 @@ class AnthropicAgentClient:
             raise RuntimeError(
                 f"{self.provider_name} API returned an unexpected response: {type(response).__name__}"
             )
+
+        emit_provider_usage(
+            self._model,
+            getattr(response, "usage", None),
+            input_key="input_tokens",
+            output_key="output_tokens",
+        )
 
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
@@ -367,6 +375,13 @@ class BedrockConverseAgentClient:
         if response is None:
             raise RuntimeError("Bedrock invocation failed without a response") from last_err
 
+        emit_provider_usage(
+            self._model,
+            response.get("usage"),
+            input_key="inputTokens",
+            output_key="outputTokens",
+        )
+
         content, raw_tool_calls, stop_reason, raw_message = parse_converse_output(response)
         tool_calls = [
             ToolCall(id=tool_id, name=name, input=inputs)
@@ -523,6 +538,12 @@ class OpenAIAgentClient:
             raise RuntimeError(
                 f"OpenAI API returned an unexpected response: {type(response).__name__}"
             )
+        emit_provider_usage(
+            self._model,
+            getattr(response, "usage", None),
+            input_key="prompt_tokens",
+            output_key="completion_tokens",
+        )
         choice = response.choices[0]
         msg = choice.message
         content = msg.content or ""

--- a/core/llm/usage.py
+++ b/core/llm/usage.py
@@ -53,6 +53,18 @@ def coerce_usage_tokens(
     return inp, out
 
 
+def emit_provider_usage(
+    model: str,
+    usage: Any,
+    *,
+    input_key: str,
+    output_key: str,
+) -> None:
+    """Emit provider-reported usage from an arbitrary usage payload (agent clients)."""
+    inp, out = coerce_usage_tokens(usage, input_key=input_key, output_key=output_key)
+    emit_usage(model, inp, out)
+
+
 def llm_response_with_usage(
     content: str,
     model: str,

--- a/docs/interactive-shell-privacy.mdx
+++ b/docs/interactive-shell-privacy.mdx
@@ -84,7 +84,7 @@ interactive:
 Separately from typed-command history, the interactive shell records each LLM turn — the full prompt sent and the full response received — for chat and follow-up routes. This log is richer than command history (it includes model output, not just what you typed) and is used for two purposes:
 
 1. **Local debugging / `/resume`**: appended as JSON Lines to `~/.opensre/prompt_log.jsonl`, and folded into the session file so `/resume` can restore conversation context.
-2. **Product analytics**: forwarded to PostHog as an `$ai_generation` event (model, provider, latency, token counts, and the prompt/response text) so we can track usage and quality of the AI features.
+2. **Product analytics**: forwarded to PostHog as an `$ai_generation` event (model, provider, latency, token counts, and the prompt/response text) so we can track usage and quality of the AI features. Investigation turns additionally include the model/provider/token usage of the investigation run and an `investigation_id` join key; failed turns carry structured error properties (`$ai_is_error`, `$ai_error`, `error_kind`).
 
 ### Defaults
 

--- a/docs/interactive-shell-privacy.mdx
+++ b/docs/interactive-shell-privacy.mdx
@@ -101,7 +101,7 @@ Separately from typed-command history, the interactive shell records each LLM tu
 | --- | --- | --- |
 | `OPENSRE_PROMPT_LOG_DISABLED` | `0` | Set to `1` to disable prompt/response logging entirely (both local file and PostHog). |
 | `OPENSRE_PROMPT_LOG_LOCAL_DISABLED` | `0` | Set to `1` to skip the local JSONL file while leaving PostHog forwarding (if enabled) unaffected. |
-| `OPENSRE_PROMPT_LOG_REDACT` | `1` | Set to `0` to log/send raw, unredacted prompt and response text. |
+| `OPENSRE_PROMPT_LOG_REDACT` | `1` | Set to `0` to log/send raw prompt and response text without redaction. |
 | `OPENSRE_PROMPT_LOG_PATH` | `~/.opensre/prompt_log.jsonl` | Override the local JSONL file path. |
 
 PostHog forwarding for this event additionally honors the global telemetry opt-outs: set **`OPENSRE_NO_TELEMETRY=1`**, `OPENSRE_ANALYTICS_DISABLED=1`, or `DO_NOT_TRACK=1` to stop all PostHog traffic (including `$ai_generation`) without touching the local JSONL file. See [Environment Variables](/configuration/environment-variables#telemetry-monitoring).
@@ -117,7 +117,7 @@ interactive:
     path: ~/.opensre/prompt_log.jsonl
 ```
 
-Redaction here uses the same built-in pattern set as command history (see [Redaction patterns](#redaction-patterns) above) — it catches known secret shapes, not arbitrary sensitive content. Raw incident details, hostnames, or business context in a prompt are not redacted; only credential-shaped substrings are.
+Redaction here uses the same built-in pattern set as command history (see [Redaction patterns](#redaction-patterns) above) — it catches known secret shapes, not arbitrary sensitive content. Raw incident details, hostnames, or business context in a prompt are not redacted; only credential-shaped substring patterns are.
 
 ## Threat model
 

--- a/gateway/turn_handler.py
+++ b/gateway/turn_handler.py
@@ -58,6 +58,7 @@ def build_gateway_turn_handler(
             reasoning=DefaultReasoningClientProvider(
                 output=sink,
                 error_reporter=error_reporter,
+                session=session,
             ),
             run_factory=DefaultRunRecordFactory(session),
             accounting=DefaultTurnAccounting(session, text),

--- a/surfaces/interactive_shell/command_registry/investigation.py
+++ b/surfaces/interactive_shell/command_registry/investigation.py
@@ -155,6 +155,35 @@ def _validate_save_args(args: list[str]) -> str | None:
     return None
 
 
+def _stage_investigation_turn_telemetry(session: Session, outcome: InvestigationOutcome) -> None:
+    """Stage LLM run metadata and structured errors for this turn's recorder flush."""
+    from core.agent_harness.accounting.token_accounting import LlmRunInfo, record_llm_turn
+
+    if outcome.llm_model or outcome.llm_input_tokens or outcome.llm_output_tokens:
+        session.set_pending_turn_llm(
+            LlmRunInfo(
+                model=outcome.llm_model or None,
+                provider=outcome.llm_provider or None,
+                latency_ms=outcome.duration_ms or None,
+                input_tokens=outcome.llm_input_tokens or None,
+                output_tokens=outcome.llm_output_tokens or None,
+            )
+        )
+        if outcome.llm_input_tokens or outcome.llm_output_tokens:
+            record_llm_turn(
+                session,
+                prompt="",
+                response="",
+                input_tokens=outcome.llm_input_tokens,
+                output_tokens=outcome.llm_output_tokens,
+            )
+    if outcome.status == "failed":
+        session.set_pending_turn_error(
+            outcome.failure_category or "unknown",
+            outcome.error_message or "investigation failed",
+        )
+
+
 def _record_investigation_turn(
     session: Session,
     *,
@@ -180,6 +209,7 @@ def _record_investigation_turn(
         session.mark_latest(ok=False, kind="slash")
     if outcome.investigation_id:
         session.last_investigation_id = outcome.investigation_id
+    _stage_investigation_turn_telemetry(session, outcome)
     publish_investigation_outcome_analytics(outcome)
 
 

--- a/surfaces/interactive_shell/runtime/core/turn_accounting.py
+++ b/surfaces/interactive_shell/runtime/core/turn_accounting.py
@@ -103,9 +103,18 @@ class ShellTurnAccounting:
         )
 
     def _flush_prompt_recorder(self, result: ShellTurnResult) -> None:
+        # Pending turn LLM/error state is consumed unconditionally so a turn
+        # that stages it can never leak it into a later turn's flush.
+        pending_run = self.session.pop_pending_turn_llm()
+        pending_error = self.session.pop_pending_turn_error()
         if self.recorder is None:
             return
-        self.recorder.set_response(result.assistant_response_text, result.llm_run)
+        if pending_error is not None:
+            self.recorder.set_error(pending_error[0], pending_error[1])
+        self.recorder.set_response(
+            result.assistant_response_text,
+            result.llm_run if result.llm_run is not None else pending_run,
+        )
         self.recorder.flush()
 
 

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -161,6 +161,7 @@ def answer_shell_question(
         reasoning=DefaultReasoningClientProvider(
             output=_resolve_output_sink(console, output),
             error_reporter=DefaultErrorReporter(),
+            session=session,
         ),
         run_factory=DefaultRunRecordFactory(session),
         error_reporter=DefaultErrorReporter(),

--- a/surfaces/interactive_shell/runtime/subprocess_runner/background_task_executor.py
+++ b/surfaces/interactive_shell/runtime/subprocess_runner/background_task_executor.py
@@ -124,6 +124,7 @@ def start_background_cli_task(
         task.mark_failed(str(exc))
         if recorder is not None:
             with contextlib.suppress(Exception):
+                recorder.set_error("spawn_failed", str(exc))
                 recorder.set_response(
                     _compose_task_log_response(
                         headline=f"command failed to start: {exc}",
@@ -169,6 +170,7 @@ def start_background_cli_task(
         timed_out = False
         suggest_follow_up = False
         outcome_headline = "command completed (exit 0)"
+        outcome_error_kind = ""
         while proc.poll() is None:
             if time.monotonic() - started_at > timeout_seconds:
                 timed_out = True
@@ -185,6 +187,7 @@ def start_background_cli_task(
         try:
             if timed_out:
                 outcome_headline = f"command timed out after {timeout_seconds} seconds"
+                outcome_error_kind = "timeout"
                 task.mark_failed(f"timed out after {timeout_seconds}s")
                 suggest_follow_up = kind is TaskKind.SYNTHETIC_TEST
                 return
@@ -201,11 +204,13 @@ def start_background_cli_task(
                 diag = _sr_resolve("read_diag", read_diag)(stderr_buf)
                 error_msg = f"exit code {code}" + (f": {diag}" if diag else "")
                 outcome_headline = f"command failed (exit {code})"
+                outcome_error_kind = "cli_exit_nonzero"
                 task.mark_failed(error_msg)
                 console.print(f"[{ERROR}]command failed (exit {code}):[/]")
                 suggest_follow_up = kind is TaskKind.SYNTHETIC_TEST
         except Exception as exc:  # noqa: BLE001
             outcome_headline = f"command error: {exc}"
+            outcome_error_kind = "watcher_error"
             task.mark_failed(str(exc))
             report_exception(exc, context="surfaces.interactive_shell.background_cli_task.watch")
             console.print(f"[{ERROR}]error:[/] {escape(str(exc))}")
@@ -216,6 +221,8 @@ def start_background_cli_task(
             # stderr, exit/timeout/cancel) before the capture buffers are closed.
             if recorder is not None:
                 with contextlib.suppress(Exception):
+                    if outcome_error_kind:
+                        recorder.set_error(outcome_error_kind, outcome_headline)
                     recorder.set_response(
                         _compose_task_log_response(
                             headline=outcome_headline,

--- a/surfaces/interactive_shell/ui/foreground_investigation.py
+++ b/surfaces/interactive_shell/ui/foreground_investigation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -19,9 +20,26 @@ from surfaces.interactive_shell.ui.investigation_outcome import (
     user_facing_error_message,
 )
 from surfaces.interactive_shell.utils.error_handling.exception_reporting import report_exception
+from surfaces.interactive_shell.utils.telemetry.investigation_llm_usage import (
+    InvestigationLlmUsage,
+    observe_investigation_llm_usage,
+    resolve_configured_llm_identity,
+)
 
 if TYPE_CHECKING:
     from core.agent_harness.session import Session
+
+
+def _llm_fields(usage: InvestigationLlmUsage, started: float) -> dict[str, Any]:
+    """LLM identity, token, and timing fields shared by every outcome shape."""
+    provider, configured_model = resolve_configured_llm_identity()
+    return {
+        "llm_model": usage.model or configured_model,
+        "llm_provider": provider,
+        "llm_input_tokens": usage.input_tokens,
+        "llm_output_tokens": usage.output_tokens,
+        "duration_ms": int((time.monotonic() - started) * 1000),
+    }
 
 
 def run_foreground_investigation(
@@ -38,8 +56,10 @@ def run_foreground_investigation(
     session.last_investigation_id = ""
     task = session.task_registry.create(TaskKind.INVESTIGATION, command=task_command)
     task.mark_running()
+    started = time.monotonic()
     try:
-        final_state = run(task)
+        with observe_investigation_llm_usage() as usage:
+            final_state = run(task)
     except KeyboardInterrupt:
         task.mark_cancelled()
         console.print(f"[{WARNING}]investigation cancelled.[/]")
@@ -48,6 +68,7 @@ def run_foreground_investigation(
             target=normalized_target,
             investigation_id=str(getattr(session, "last_investigation_id", "") or ""),
             failure_category="user_cancelled",
+            **_llm_fields(usage, started),
         )
     except OpenSREError as exc:
         task.mark_failed(str(exc))
@@ -64,6 +85,7 @@ def run_foreground_investigation(
             failure_category=category,
             integration_involved=integration,
             integration_failure_message=integration_detail,
+            **_llm_fields(usage, started),
         )
     except Exception as exc:
         task.mark_failed(str(exc))
@@ -79,6 +101,7 @@ def run_foreground_investigation(
             failure_category=category,
             integration_involved=integration,
             integration_failure_message=integration_detail,
+            **_llm_fields(usage, started),
         )
 
     root = final_state.get("root_cause")
@@ -98,6 +121,7 @@ def run_foreground_investigation(
         target=normalized_target,
         investigation_id=str(getattr(session, "last_investigation_id", "") or ""),
         final_state=final_state,
+        **_llm_fields(usage, started),
     )
 
 

--- a/surfaces/interactive_shell/ui/investigation_outcome.py
+++ b/surfaces/interactive_shell/ui/investigation_outcome.py
@@ -55,6 +55,11 @@ class InvestigationOutcome:
     failure_category: FailureCategory = "unknown"
     integration_involved: str = ""
     integration_failure_message: str = ""
+    llm_model: str = ""
+    llm_provider: str = ""
+    llm_input_tokens: int = 0
+    llm_output_tokens: int = 0
+    duration_ms: int = 0
 
 
 def normalize_investigation_target(raw_target: str, *, path: Path | None = None) -> str:

--- a/surfaces/interactive_shell/utils/telemetry/investigation_llm_usage.py
+++ b/surfaces/interactive_shell/utils/telemetry/investigation_llm_usage.py
@@ -1,0 +1,77 @@
+"""Observe LLM usage during a foreground investigation for turn telemetry."""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from core.llm.usage import set_usage_hook
+
+
+@dataclass
+class InvestigationLlmUsage:
+    """Accumulated provider-reported LLM usage for one investigation run."""
+
+    model: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    @property
+    def observed(self) -> bool:
+        return bool(self.model) or self.input_tokens > 0 or self.output_tokens > 0
+
+
+@contextlib.contextmanager
+def observe_investigation_llm_usage() -> Iterator[InvestigationLlmUsage]:
+    """Accumulate provider-reported token usage while the body runs.
+
+    Registration is best-effort: if another owner already holds the process-wide
+    usage hook (`core.llm.usage.set_usage_hook`), the investigation proceeds
+    without usage observation rather than failing.
+    """
+    usage = InvestigationLlmUsage()
+
+    def _hook(model: str, tokens_in: int, tokens_out: int) -> None:
+        if model:
+            usage.model = model
+        usage.input_tokens += tokens_in
+        usage.output_tokens += tokens_out
+
+    registered = False
+    try:
+        set_usage_hook(_hook)
+        registered = True
+    except RuntimeError:
+        pass
+    try:
+        yield usage
+    finally:
+        if registered:
+            set_usage_hook(None)
+
+
+def resolve_configured_llm_identity() -> tuple[str, str]:
+    """Best-effort ``(provider, model)`` from the configured LLM settings."""
+    try:
+        from config.config import resolve_llm_settings
+        from config.llm_auth.auth_method import (
+            effective_llm_provider,
+            get_configured_llm_auth_method,
+        )
+
+        settings = resolve_llm_settings()
+        provider = effective_llm_provider(
+            settings.provider, get_configured_llm_auth_method(settings.provider)
+        )
+        model = str(getattr(settings, f"{provider}_reasoning_model", "") or "")
+        return provider, model
+    except Exception:
+        return "", ""
+
+
+__all__ = [
+    "InvestigationLlmUsage",
+    "observe_investigation_llm_usage",
+    "resolve_configured_llm_identity",
+]

--- a/surfaces/interactive_shell/utils/telemetry/recorder.py
+++ b/surfaces/interactive_shell/utils/telemetry/recorder.py
@@ -85,6 +85,8 @@ class PromptRecorder:
         self._session = session
         self._response: str = ""
         self._scoped_investigation_id: str | None = None
+        self._error_kind: str = ""
+        self._error_message: str = ""
         self._model: str | None = None
         self._provider: str | None = None
         self._latency_ms: int | None = None
@@ -157,6 +159,20 @@ class PromptRecorder:
         cleaned = investigation_id.strip()
         if cleaned:
             self._scoped_investigation_id = cleaned
+
+    def set_error(self, kind: str, message: str) -> None:
+        """Attach a structured turn error emitted as ``$ai_error`` properties.
+
+        The human-readable response text is unaffected; these properties make
+        LLM/provider error detection exact instead of a regex over
+        ``$ai_output_choices``.
+        """
+        kind = kind.strip()
+        message = message.strip()
+        if not (kind or message):
+            return
+        self._error_kind = kind or "error"
+        self._error_message = _sanitize_text(message, config=self._config)
 
     def _resolve_investigation_id(self) -> str:
         if self._scoped_investigation_id:
@@ -258,6 +274,10 @@ class PromptRecorder:
                 investigation_id = self._resolve_investigation_id()
                 if investigation_id:
                     posthog_properties["investigation_id"] = investigation_id
+                if self._error_kind:
+                    posthog_properties["$ai_is_error"] = True
+                    posthog_properties["$ai_error"] = self._error_message or self._error_kind
+                    posthog_properties["error_kind"] = self._error_kind
                 capture_ai_generation(posthog_properties)
 
 

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -1475,3 +1475,58 @@ def test_anthropic_unexpected_response_shape_raises_runtime_error(
 
     with pytest.raises(RuntimeError, match="unexpected response"):
         client.invoke(messages=[{"role": "user", "content": "hello"}])
+
+
+def test_anthropic_agent_client_emits_provider_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Successful agent invokes must report provider token usage via the usage hook
+    so investigation-turn telemetry can carry real token counts (issue #3698)."""
+    from core.llm.usage import set_usage_hook
+
+    _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    response = types.SimpleNamespace(
+        content=[types.SimpleNamespace(type="text", text="hi there")],
+        stop_reason="end_turn",
+        usage=types.SimpleNamespace(input_tokens=123, output_tokens=45),
+    )
+    client = AnthropicAgentClient(model="claude-sonnet-4-6")
+    client._client = types.SimpleNamespace(
+        messages=types.SimpleNamespace(create=lambda **_: response)
+    )
+
+    usage: list[tuple[str, int, int]] = []
+    set_usage_hook(
+        lambda model, tokens_in, tokens_out: usage.append((model, tokens_in, tokens_out))
+    )
+    try:
+        result = client.invoke(messages=[{"role": "user", "content": "hi"}])
+    finally:
+        set_usage_hook(None)
+
+    assert result.content == "hi there"
+    assert usage == [("claude-sonnet-4-6", 123, 45)]
+
+
+def test_bedrock_converse_emits_provider_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    from core.llm.usage import set_usage_hook
+
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    response = _make_converse_response(text="ok")
+    response["usage"] = {"inputTokens": 200, "outputTokens": 30}
+    _stub_boto3_converse(monkeypatch, converse_response=response)
+
+    from core.llm.agent_llm_client import BedrockConverseAgentClient
+
+    usage: list[tuple[str, int, int]] = []
+    set_usage_hook(
+        lambda model, tokens_in, tokens_out: usage.append((model, tokens_in, tokens_out))
+    )
+    try:
+        result = BedrockConverseAgentClient(model=_MISTRAL_MODEL).invoke(
+            messages=[{"role": "user", "content": [{"text": "hi"}]}]
+        )
+    finally:
+        set_usage_hook(None)
+
+    assert result.content == "ok"
+    assert usage == [(_MISTRAL_MODEL, 200, 30)]

--- a/tests/core/runtime/llm/test_litellm_compat.py
+++ b/tests/core/runtime/llm/test_litellm_compat.py
@@ -80,6 +80,29 @@ def test_litellm_agent_client_parses_tool_calls() -> None:
     assert response.raw_content["tool_calls"] == [tool_call]
 
 
+def test_litellm_agent_client_emits_global_usage_hook() -> None:
+    from core.llm.usage import set_usage_hook
+
+    client = LiteLLMAgentClient(
+        litellm_model="openai/deepseek-v4-pro",
+        api_base="https://api.deepseek.com",
+        api_key_env="DEEPSEEK_API_KEY",
+        credential_resolver=lambda _env: "ds-key",
+        completion_func=lambda **_kwargs: _fake_response(content="hello"),
+    )
+
+    usage: list[tuple[str, int, int]] = []
+    set_usage_hook(
+        lambda model, tokens_in, tokens_out: usage.append((model, tokens_in, tokens_out))
+    )
+    try:
+        client.invoke([{"role": "user", "content": "hi"}])
+    finally:
+        set_usage_hook(None)
+
+    assert usage == [("openai/deepseek-v4-pro", 11, 7)]
+
+
 def test_litellm_llm_client_emits_usage_callback() -> None:
     usage: list[tuple[str, int | None, int | None]] = []
     client = LiteLLMLLMClient(

--- a/tests/interactive_shell/runtime/test_turn_accounting.py
+++ b/tests/interactive_shell/runtime/test_turn_accounting.py
@@ -1,0 +1,152 @@
+"""Tests for ShellTurnAccounting's pending turn LLM/error consumption."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.agent_harness.accounting.token_accounting import LlmRunInfo
+from core.agent_harness.models.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.session import Session
+from surfaces.interactive_shell.runtime.core.turn_accounting import ShellTurnAccounting
+
+
+class _FakeRecorder:
+    def __init__(self) -> None:
+        self.errors: list[tuple[str, str]] = []
+        self.responses: list[tuple[str, Any]] = []
+        self.flushed = 0
+
+    def set_error(self, kind: str, message: str) -> None:
+        self.errors.append((kind, message))
+
+    def set_response(self, text: str, run: Any | None = None) -> None:
+        self.responses.append((text, run))
+
+    def flush(self) -> None:
+        self.flushed += 1
+
+
+def _result(*, llm_run: Any | None = None, text: str = "done") -> ShellTurnResult:
+    return ShellTurnResult(
+        final_intent="slash",
+        action_result=ToolCallingTurnResult(
+            planned_count=0,
+            executed_count=0,
+            executed_success_count=0,
+            has_unhandled_clause=False,
+            handled=True,
+        ),
+        assistant_response_text=text,
+        llm_run=llm_run,
+    )
+
+
+def test_finalize_applies_pending_turn_llm_when_no_conversational_run() -> None:
+    session = Session()
+    pending = LlmRunInfo(model="claude-sonnet-4-5", provider="anthropic", input_tokens=100)
+    session.set_pending_turn_llm(pending)
+    recorder = _FakeRecorder()
+    accounting = ShellTurnAccounting(session=session, text="/investigate", recorder=recorder)  # type: ignore[arg-type]
+
+    accounting.finalize(_result())
+
+    assert recorder.responses == [("done", pending)]
+    assert recorder.flushed == 1
+    assert session.pop_pending_turn_llm() is None
+
+
+def test_finalize_prefers_conversational_run_over_pending() -> None:
+    session = Session()
+    session.set_pending_turn_llm(LlmRunInfo(model="stale"))
+    conversational = LlmRunInfo(model="fresh")
+    recorder = _FakeRecorder()
+    accounting = ShellTurnAccounting(session=session, text="hi", recorder=recorder)  # type: ignore[arg-type]
+
+    accounting.finalize(_result(llm_run=conversational))
+
+    assert recorder.responses[0][1] is conversational
+    # The stale pending run was still consumed so it cannot leak later.
+    assert session.pop_pending_turn_llm() is None
+
+
+def test_finalize_sets_structured_error_from_pending_turn_error() -> None:
+    session = Session()
+    session.set_pending_turn_error("config", "ANTHROPIC_API_KEY not set")
+    recorder = _FakeRecorder()
+    accounting = ShellTurnAccounting(session=session, text="/investigate", recorder=recorder)  # type: ignore[arg-type]
+
+    accounting.finalize(_result(text="investigation_failed"))
+
+    assert recorder.errors == [("config", "ANTHROPIC_API_KEY not set")]
+    assert session.pop_pending_turn_error() is None
+
+
+def test_finalize_consumes_pending_state_even_without_recorder() -> None:
+    session = Session()
+    session.set_pending_turn_llm(LlmRunInfo(model="m"))
+    session.set_pending_turn_error("llm", "boom")
+    accounting = ShellTurnAccounting(session=session, text="hi", recorder=None)
+
+    accounting.finalize(_result())
+
+    assert session.pop_pending_turn_llm() is None
+    assert session.pop_pending_turn_error() is None
+
+
+def test_stage_investigation_turn_telemetry_populates_pending_state() -> None:
+    from surfaces.interactive_shell.command_registry.investigation import (
+        _stage_investigation_turn_telemetry,
+    )
+    from surfaces.interactive_shell.ui.investigation_outcome import InvestigationOutcome
+
+    session = Session()
+    outcome = InvestigationOutcome(
+        status="failed",
+        target="generic",
+        investigation_id="inv-1",
+        error_message="Anthropic authentication failed. Check ANTHROPIC_API_KEY.",
+        failure_category="llm",
+        llm_model="claude-sonnet-4-5",
+        llm_provider="anthropic",
+        llm_input_tokens=500,
+        llm_output_tokens=120,
+        duration_ms=4200,
+    )
+
+    _stage_investigation_turn_telemetry(session, outcome)
+
+    run = session.pop_pending_turn_llm()
+    assert run is not None
+    assert run.model == "claude-sonnet-4-5"
+    assert run.provider == "anthropic"
+    assert run.input_tokens == 500
+    assert run.output_tokens == 120
+    assert run.latency_ms == 4200
+    assert session.pop_pending_turn_error() == (
+        "llm",
+        "Anthropic authentication failed. Check ANTHROPIC_API_KEY.",
+    )
+    # Provider-measured tokens also count toward the session totals.
+    assert session.tokens.totals["input"] == 500
+    assert session.tokens.totals["output"] == 120
+
+
+def test_stage_investigation_turn_telemetry_completed_run_has_no_error() -> None:
+    from surfaces.interactive_shell.command_registry.investigation import (
+        _stage_investigation_turn_telemetry,
+    )
+    from surfaces.interactive_shell.ui.investigation_outcome import InvestigationOutcome
+
+    session = Session()
+    _stage_investigation_turn_telemetry(
+        session,
+        InvestigationOutcome(
+            status="completed",
+            target="generic",
+            investigation_id="inv-2",
+            llm_model="claude-sonnet-4-5",
+        ),
+    )
+
+    assert session.pop_pending_turn_llm() is not None
+    assert session.pop_pending_turn_error() is None

--- a/tests/interactive_shell/utils/telemetry/test_investigation_llm_usage.py
+++ b/tests/interactive_shell/utils/telemetry/test_investigation_llm_usage.py
@@ -1,0 +1,43 @@
+"""Tests for the investigation LLM usage observer."""
+
+from __future__ import annotations
+
+from core.llm.usage import emit_usage, set_usage_hook
+from surfaces.interactive_shell.utils.telemetry.investigation_llm_usage import (
+    observe_investigation_llm_usage,
+)
+
+
+def test_observe_accumulates_usage_and_clears_hook() -> None:
+    with observe_investigation_llm_usage() as usage:
+        emit_usage("claude-sonnet-4-5", 100, 20)
+        emit_usage("claude-sonnet-4-5", 50, 10)
+    assert usage.model == "claude-sonnet-4-5"
+    assert usage.input_tokens == 150
+    assert usage.output_tokens == 30
+    assert usage.observed
+    # Hook must be released so later owners can register.
+    set_usage_hook(lambda *_args: None)
+    set_usage_hook(None)
+
+
+def test_observe_tolerates_already_registered_hook() -> None:
+    external: list[tuple[str, int, int]] = []
+    set_usage_hook(lambda model, inp, out: external.append((model, inp, out)))
+    try:
+        with observe_investigation_llm_usage() as usage:
+            emit_usage("m", 10, 5)
+        assert not usage.observed
+        assert external == [("m", 10, 5)]
+        # The pre-existing hook must survive the observer.
+        emit_usage("m", 1, 1)
+        assert len(external) == 2
+    finally:
+        set_usage_hook(None)
+
+
+def test_observe_ignores_usage_outside_scope() -> None:
+    with observe_investigation_llm_usage() as usage:
+        pass
+    emit_usage("m", 10, 5)
+    assert not usage.observed

--- a/tests/interactive_shell/utils/telemetry/test_recorder.py
+++ b/tests/interactive_shell/utils/telemetry/test_recorder.py
@@ -404,6 +404,72 @@ def test_prompt_recorder_background_task_uses_bound_investigation_id(
     assert investigation_id not in {"", "inv-stale", "inv-other"}
 
 
+def test_prompt_recorder_set_error_adds_structured_properties(monkeypatch, tmp_path: Path) -> None:
+    captured: list[dict[str, object]] = []
+    cfg = PromptLogConfig(
+        enabled=True,
+        local_enabled=False,
+        posthog_enabled=True,
+        redact=False,
+        max_chars=1000,
+        log_path=tmp_path / "prompt_log.jsonl",
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.PromptLogConfig.load", lambda: cfg
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.build_turn_integration_snapshot",
+        lambda _session: {},
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.capture_ai_generation",
+        lambda payload: captured.append(payload),
+    )
+    session = Session()
+    recorder = PromptRecorder.start(session=session, text="/investigate generic", turn_kind="agent")
+    assert recorder is not None
+    recorder.set_error("config", "ANTHROPIC_API_KEY not set")
+    recorder.set_response(
+        "slash /investigate generic (failed)\ninvestigation_failed (generic):\n"
+        "ANTHROPIC_API_KEY not set"
+    )
+    recorder.flush()
+    assert captured[0]["$ai_is_error"] is True
+    assert captured[0]["$ai_error"] == "ANTHROPIC_API_KEY not set"
+    assert captured[0]["error_kind"] == "config"
+
+
+def test_prompt_recorder_omits_error_properties_by_default(monkeypatch, tmp_path: Path) -> None:
+    captured: list[dict[str, object]] = []
+    cfg = PromptLogConfig(
+        enabled=True,
+        local_enabled=False,
+        posthog_enabled=True,
+        redact=False,
+        max_chars=1000,
+        log_path=tmp_path / "prompt_log.jsonl",
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.PromptLogConfig.load", lambda: cfg
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.build_turn_integration_snapshot",
+        lambda _session: {},
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.capture_ai_generation",
+        lambda payload: captured.append(payload),
+    )
+    session = Session()
+    recorder = PromptRecorder.start(session=session, text="hello", turn_kind="agent")
+    assert recorder is not None
+    recorder.set_response("world")
+    recorder.flush()
+    assert "$ai_is_error" not in captured[0]
+    assert "$ai_error" not in captured[0]
+    assert "error_kind" not in captured[0]
+
+
 def test_prompt_recorder_uses_only_latest_slash_outcome(monkeypatch, tmp_path: Path) -> None:
     captured: list[dict[str, object]] = []
     cfg = PromptLogConfig(


### PR DESCRIPTION
## Summary

Fixes #3698 and #3699 — the two remaining upstream telemetry gaps identified by the analytics repo.

**Model/token gap on investigation turns (#3698):**
- SDK agent clients (Anthropic, OpenAI, Bedrock Converse) and the LiteLLM agent client now report provider token usage through the shared `core.llm.usage` hook; previously they discarded `response.usage`.
- `run_foreground_investigation` observes usage during the run and attaches model/provider/token/duration facts to the `InvestigationOutcome` (model from provider-reported usage, falling back to the configured LLM settings).
- The investigation turn stages an `LlmRunInfo` for the recorder flush, so `/investigate` turns now emit `$ai_generation` with real `$ai_model`, `$ai_provider`, and token counts instead of the sentinel model and zeros. Measured tokens also count toward the session `/tokens` totals.

**Structured error properties (#3699):**
- `PromptRecorder.set_error(kind, message)` adds `$ai_is_error: true`, `$ai_error`, and `error_kind` to the flushed event (response text unchanged), making LLM ERROR detection exact instead of a regex over `$ai_output_choices`.
- Wired paths: foreground investigation failures (kind = `failure_category`), conversational assistant stream failures (`assistant_error`/`timeout`), reasoning-client unavailability (`llm_unavailable`, now also catching client-construction errors like a missing API key instead of crashing the turn), and background CLI task failures (`cli_exit_nonzero`, `timeout`, `spawn_failed`, `watcher_error`).

**Leak safety:** both signals travel through consume-once pending fields on the session (`set_pending_turn_llm` / `set_pending_turn_error`), popped unconditionally at the turn's recorder flush — a staged value can never bleed into a later turn (same class of bug Greptile flagged on #3662).

## Test plan

- [x] `make lint`, `make format-check`, `make typecheck` pass
- [x] `make test-cov` — 10116 passed, 56 skipped
- [x] Live turn scenarios (`tests/core/agent/test_turn_scenarios.py`) pass
- [x] New unit tests: agent-client usage emission (Anthropic/Bedrock/LiteLLM), usage-hook observer scoping and contention, recorder `$ai_error` properties, pending-state consumption in `ShellTurnAccounting`, investigation-turn staging (failed vs completed)