### PR TITLE
test(core): add regression coverage for _requires_sequential_execution serialization guard

### DIFF
--- a/tests/core/runtime/test_tool_execution_contract.py
+++ b/tests/core/runtime/test_tool_execution_contract.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
+import pytest
+
+import core.execution
 from core.agent import Agent
 from core.execution import (
     BeforeToolCallResult,
@@ -10,6 +14,7 @@ from core.execution import (
     ToolExecutionPatch,
     ToolExecutionRequest,
     ToolExecutionResult,
+    _requires_sequential_execution,
     execute_tool_calls,
     execute_tools,
 )
@@ -33,6 +38,7 @@ def _tool(
     *,
     execute: Any | None = None,
     execution_mode: str | None = None,
+    parallel_safe: bool = True,
 ) -> AgentTool:
     return AgentTool(
         name=name,
@@ -40,6 +46,7 @@ def _tool(
         input_schema=_schema(["value"]),
         execute=execute or (lambda args, _ctx: {"value": args["value"]}),
         execution_mode=execution_mode,  # type: ignore[arg-type]
+        parallel_safe=parallel_safe,
     )
 
 
@@ -252,6 +259,124 @@ def test_parallel_batch_preserves_provider_order() -> None:
     results = execute_tool_calls(calls, tools, {})
 
     assert [result.details for result in results] == [{"order": 2}, {"order": 1}]
+
+
+def _registered_echo(name: str, *, parallel_safe: bool = True) -> RegisteredTool:
+    return RegisteredTool(
+        name=name,
+        description="test registered tool",
+        input_schema=_schema(["value"]),
+        source="knowledge",
+        run=lambda value: {"value": value},
+        parallel_safe=parallel_safe,
+    )
+
+
+def _record_pool_constructions(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    constructions: list[int] = []
+
+    class _RecordingPool(ThreadPoolExecutor):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            constructions.append(1)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(core.execution, "ThreadPoolExecutor", _RecordingPool)
+    return constructions
+
+
+def test_all_parallel_safe_batch_goes_through_thread_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Control for the serialization tests below: proves the recording patch
+    # observes pool construction, so their `constructions == []` assertions
+    # cannot pass vacuously.
+    constructions = _record_pool_constructions(monkeypatch)
+    tools = [_tool("first"), _tool("second")]
+    calls = [_call("first", "a"), _call("second", "b")]
+
+    results = execute_tool_calls(calls, tools, {})
+
+    assert constructions == [1]
+    assert [result.details for result in results] == [{"value": "a"}, {"value": "b"}]
+
+
+def test_non_parallel_safe_registered_tool_serializes_mixed_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructions = _record_pool_constructions(monkeypatch)
+    tools = [
+        _tool("safe_one"),
+        _tool("safe_two"),
+        _registered_echo("stateful", parallel_safe=False),
+    ]
+    calls = [_call("safe_one", "a"), _call("stateful", "b"), _call("safe_two", "c")]
+
+    results = execute_tool_calls(calls, tools, {})
+
+    assert constructions == []
+    assert [result.details for result in results] == [
+        {"value": "a"},
+        {"value": "b"},
+        {"value": "c"},
+    ]
+
+
+def test_agent_tool_sequential_execution_mode_serializes_mixed_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructions = _record_pool_constructions(monkeypatch)
+    tools = [_tool("safe"), _tool("stateful", execution_mode="sequential")]
+    calls = [_call("safe", "a"), _call("stateful", "b")]
+
+    results = execute_tool_calls(calls, tools, {})
+
+    assert constructions == []
+    assert [result.details for result in results] == [{"value": "a"}, {"value": "b"}]
+
+
+def test_agent_tool_parallel_safe_false_serializes_via_execution_mode_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No explicit execution_mode: effective_execution_mode must fall back to
+    # parallel_safe and still force the whole batch sequential.
+    constructions = _record_pool_constructions(monkeypatch)
+    tools = [_tool("safe"), _tool("stateful", parallel_safe=False)]
+    calls = [_call("safe", "a"), _call("stateful", "b")]
+
+    results = execute_tool_calls(calls, tools, {})
+
+    assert constructions == []
+    assert [result.details for result in results] == [{"value": "a"}, {"value": "b"}]
+
+
+def test_requires_sequential_execution_forces_serial_for_stateful_tools() -> None:
+    tools = [
+        _tool("safe"),
+        _tool("sequential_agent", execution_mode="sequential"),
+        _tool("unsafe_agent", parallel_safe=False),
+        _registered_echo("unsafe_registered", parallel_safe=False),
+    ]
+    tool_map = {t.name: t for t in tools}
+
+    # One sequential tool anywhere in the batch forces the whole batch.
+    assert _requires_sequential_execution([_call("safe"), _call("sequential_agent")], tool_map)
+    assert _requires_sequential_execution([_call("safe"), _call("unsafe_agent")], tool_map)
+    assert _requires_sequential_execution([_call("safe"), _call("unsafe_registered")], tool_map)
+
+
+def test_requires_sequential_execution_allows_parallel_otherwise() -> None:
+    tools = [
+        _tool("safe"),
+        # Explicit execution_mode="parallel" overrides parallel_safe=False.
+        _tool("override", execution_mode="parallel", parallel_safe=False),
+        _registered_echo("safe_registered"),
+    ]
+    tool_map = {t.name: t for t in tools}
+
+    assert not _requires_sequential_execution([], tool_map)
+    assert not _requires_sequential_execution([_call("safe"), _call("safe_registered")], tool_map)
+    assert not _requires_sequential_execution([_call("unknown_tool")], tool_map)
+    assert not _requires_sequential_execution([_call("safe"), _call("override")], tool_map)
 
 
 class _FakeLLM:


### PR DESCRIPTION
Fixes #3695

#### Describe the changes you have made in this PR -

Adds the regression coverage requested in #3695 for the `_requires_sequential_execution` serialization guard (`core/execution.py`). Test-only change — no behavior change to `core/execution.py`.

**How the tests work:** a `pytest` `monkeypatch` fixture swaps `core.execution.ThreadPoolExecutor` for a recording subclass, so each test can assert deterministically (no sleeps, no timing races) whether `execute_tool_calls` routed the batch through the thread pool or the sequential branch.

New tests in `tests/core/runtime/test_tool_execution_contract.py`:

1. `test_non_parallel_safe_registered_tool_serializes_mixed_batch` — a batch mixing one `parallel_safe=False` `RegisteredTool` with two parallel-safe `AgentTool`s never constructs the pool, and results stay in provider order.
2. `test_agent_tool_sequential_execution_mode_serializes_mixed_batch` — same guarantee for an `AgentTool` with explicit `execution_mode="sequential"`.
3. `test_agent_tool_parallel_safe_false_serializes_via_execution_mode_fallback` — locks in `effective_execution_mode`'s fallback: `parallel_safe=False` with no explicit mode still serializes.
4. `test_all_parallel_safe_batch_goes_through_thread_pool` — control test proving the recording patch observes pool construction, so tests 1–3 cannot pass vacuously.
5. `test_requires_sequential_execution_forces_serial_for_stateful_tools` / `test_requires_sequential_execution_allows_parallel_otherwise` — direct unit tests for the pure decision logic: empty batch, unknown tool name, all-parallel-safe batch, a single sequential tool anywhere in the batch, and the explicit `execution_mode="parallel"` override of `parallel_safe=False`.

**Acceptance criteria from the issue:**
- [x] A regression test fails if the guard or its call site stops forcing sequential execution for a `parallel_safe=False` `RegisteredTool`
- [x] Equivalent coverage for `AgentTool.effective_execution_mode == "sequential"`
- [x] No behavior change to `core/execution.py`

### Demo/Screenshot for feature changes and bug fixes -

Mutation check proving the tests catch a silently dropped guard. With the call site mutated from `if len(tool_calls) == 1 or _requires_sequential_execution(tool_calls, tool_map):` to `if len(tool_calls) == 1:`:

```
FAILED tests/core/runtime/test_tool_execution_contract.py::test_non_parallel_safe_registered_tool_serializes_mixed_batch
FAILED tests/core/runtime/test_tool_execution_contract.py::test_agent_tool_sequential_execution_mode_serializes_mixed_batch
FAILED tests/core/runtime/test_tool_execution_contract.py::test_agent_tool_parallel_safe_false_serializes_via_execution_mode_fallback
========================= 3 failed, 13 passed in 0.17s =========================
```

With the guard restored (current `main`):

```
============================== 16 passed in 0.25s ==============================
```

Pre-push checks (CI.md): `make lint` ✅ `make format-check` ✅ `make typecheck` ✅ `make test-scope` ✅ (16 passed)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue asks for tests that fail if the serialization guard is ever dropped. The key design decision was how to detect "ran sequentially" vs "ran through the thread pool" without flaky timing tricks (shared counters + sleeps can pass by luck). Instead, the tests patch `core.execution.ThreadPoolExecutor` with a subclass that records construction: sequential batches must record zero constructions, and a control test asserts an all-parallel-safe batch records exactly one — so a refactor that stops using `ThreadPoolExecutor` entirely (e.g. moving to asyncio) breaks the control test loudly rather than making the serialization tests silently vacuous. The decision-logic unit tests pin the guard's edge cases directly (unknown tool → no serialization; explicit `execution_mode="parallel"` overrides `parallel_safe=False`). I verified the tests bite via the mutation check shown in the demo section.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
