### PR TITLE
refactor(agent_harness): centralize evidence agent fallback handling

### DIFF
--- a/core/agent_harness/agents/evidence_agent.py
+++ b/core/agent_harness/agents/evidence_agent.py
@@ -80,7 +80,7 @@ class GatherEvidenceExecutionError(AgentExecutionError):
     """Bounded evidence gathering failed, so the turn falls back gracefully."""
 
 
-def safe_execute[T](
+def _safe_execute[T](
     operation: Callable[[], T],
     *,
     error_reporter: ErrorReporter | None,
@@ -92,8 +92,6 @@ def safe_execute[T](
 
     try:
         return operation()
-    except KeyboardInterrupt:
-        raise
     except Exception as exc:  # noqa: BLE001 - centralized turn-safe fallback boundary
         wrapped = wrap_error(exc)
         if error_reporter is not None:
@@ -163,7 +161,7 @@ def _load_gather_llm_or_none(error_reporter: ErrorReporter | None) -> Any | None
     """
     from core.llm.agent_llm_client import get_agent_llm
 
-    return safe_execute(
+    return _safe_execute(
         get_agent_llm,
         error_reporter=error_reporter,
         context="core.agent_harness.agents.evidence_agent.client",
@@ -216,7 +214,7 @@ def gather_tool_evidence(
     def _run_gather_turn() -> Any | None:
         # Tool discovery + integration resolution + LLM load happen inside the
         # helper so a raise from tool-registry import, credential resolution, or
-        # LLM client init is swallowed by ``safe_execute`` rather than breaking
+        # LLM client init is swallowed by ``_safe_execute`` rather than breaking
         # the turn.
         from tools.investigation.stages.gather_evidence.tools import get_available_tools
 
@@ -246,7 +244,7 @@ def gather_tool_evidence(
         return result
 
     try:
-        result = safe_execute(
+        result = _safe_execute(
             _run_gather_turn,
             error_reporter=error_reporter,
             context="core.agent_harness.agents.evidence_agent",

--- a/core/agent_harness/agents/evidence_agent.py
+++ b/core/agent_harness/agents/evidence_agent.py
@@ -64,6 +64,43 @@ class EvidenceAgentFactory(Protocol):
     ) -> Agent[Any]: ...
 
 
+class AgentExecutionError(RuntimeError):
+    """Base class for failures swallowed to preserve the conversational turn."""
+
+    def __init__(self, message: str, *, cause: BaseException) -> None:
+        super().__init__(message)
+        self.cause = cause
+
+
+class GatherLlmLoadError(AgentExecutionError):
+    """Evidence gather LLM loading failed, so the turn falls back gracefully."""
+
+
+class GatherEvidenceExecutionError(AgentExecutionError):
+    """Bounded evidence gathering failed, so the turn falls back gracefully."""
+
+
+def safe_execute[T](
+    operation: Callable[[], T],
+    *,
+    error_reporter: ErrorReporter | None,
+    context: str,
+    wrap_error: Callable[[BaseException], AgentExecutionError],
+    expected: bool = False,
+) -> T | None:
+    """Run ``operation`` through the one allowed broad-catch fallback boundary."""
+
+    try:
+        return operation()
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:  # noqa: BLE001 - centralized turn-safe fallback boundary
+        wrapped = wrap_error(exc)
+        if error_reporter is not None:
+            error_reporter.report(wrapped.cause, context=context, expected=expected)
+        return None
+
+
 def _truncate(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
@@ -126,16 +163,16 @@ def _load_gather_llm_or_none(error_reporter: ErrorReporter | None) -> Any | None
     """
     from core.llm.agent_llm_client import get_agent_llm
 
-    try:
-        return get_agent_llm()
-    except Exception as exc:  # noqa: BLE001 — deliberate wide catch for fall-back
-        if error_reporter is not None:
-            error_reporter.report(
-                exc,
-                context="core.agent_harness.agents.evidence_agent.client",
-                expected=True,
-            )
-        return None
+    return safe_execute(
+        get_agent_llm,
+        error_reporter=error_reporter,
+        context="core.agent_harness.agents.evidence_agent.client",
+        wrap_error=lambda exc: GatherLlmLoadError(
+            "Failed to load the evidence-gather LLM client.",
+            cause=exc,
+        ),
+        expected=True,
+    )
 
 
 def _build_evidence_agent(
@@ -175,10 +212,12 @@ def gather_tool_evidence(
     Any failure is reported and swallowed (returns ``None``) — gathering must
     never break the conversational turn.
     """
-    try:
+
+    def _run_gather_turn() -> Any | None:
         # Tool discovery + integration resolution + LLM load happen inside the
-        # try so a raise from tool-registry import, credential resolution, or
-        # LLM client init is swallowed rather than breaking the turn.
+        # helper so a raise from tool-registry import, credential resolution, or
+        # LLM client init is swallowed by ``safe_execute`` rather than breaking
+        # the turn.
         from tools.investigation.stages.gather_evidence.tools import get_available_tools
 
         resolved = _resolve_gather_integrations(session, message)
@@ -204,13 +243,24 @@ def gather_tool_evidence(
             phase="gather_agent",
             system_prompt=result.final_system_prompt,
         )
+        return result
+
+    try:
+        result = safe_execute(
+            _run_gather_turn,
+            error_reporter=error_reporter,
+            context="core.agent_harness.agents.evidence_agent",
+            wrap_error=lambda exc: GatherEvidenceExecutionError(
+                "Failed to gather evidence for the current conversational turn.",
+                cause=exc,
+            ),
+        )
     except KeyboardInterrupt:
         if on_progress is not None:
             on_progress("gather_cancelled", {})
         return None
-    except Exception as exc:  # noqa: BLE001 — gathering must not break the turn
-        if error_reporter is not None:
-            error_reporter.report(exc, context="core.agent_harness.agents.evidence_agent")
+
+    if result is None:
         return None
 
     if not result.executed:


### PR DESCRIPTION
## Summary

Fixes #3614

This PR refactors `core/agent_harness/agents/evidence_agent.py` to remove scattered broad `except Exception` handling and centralize the turn-safe fallback behavior.

It introduces a small named exception hierarchy for fallback-related failures:

* `AgentExecutionError`
* `GatherLlmLoadError`
* `GatherEvidenceExecutionError`

It also adds `safe_execute()` as the single centralized broad-catch boundary. The gather flow continues to preserve the existing “must never break the turn” behavior, while downstream reporter filtering is preserved by exposing the original exception through `wrapped.cause`.

## Implementation Approach

This change keeps the existing fallback behavior intact while improving the structure and maintainability of the error-handling flow.

Instead of handling broad exceptions in multiple places, the file now uses a single helper, `safe_execute()`, for intentional broad-catch behavior. `_load_gather_llm_or_none()` now routes LLM-load failures through this helper, and `gather_tool_evidence()` routes the bounded gather execution path through the same centralized boundary.

This makes the fallback behavior explicit, easier to audit, and easier to maintain.

## Tests Run

```bash
uv run python -m ruff check core/agent_harness/agents/evidence_agent.py
uv run python -m ruff format --check core/agent_harness/agents/evidence_agent.py
uv run python -m mypy core/agent_harness/agents/evidence_agent.py
uv run python -m pytest tests/core/agent_harness/test_evidence_agent.py -v
uv run python -m pytest tests/cli/test_exception_reporting.py -v
uv run python -m pytest tests/test_sentry_init.py -v -k "capture_exception_attaches_context"
uv run python -m pytest tests/utils/test_telegram_delivery.py -v -k "send_telegram_report_posts_to_chat or post_telegram_message_success"
```

## Focused Verification

Evidence gather flow:

* `tests/core/agent_harness/test_evidence_agent.py` → `4 passed`

CLI exception reporting:

* `tests/cli/test_exception_reporting.py` → `4 passed`

Interactive shell / telemetry context:

* `tests/test_sentry_init.py -k "capture_exception_attaches_context"` → `1 passed`

Telegram delivery:

* `tests/utils/test_telegram_delivery.py -k "send_telegram_report_posts_to_chat or post_telegram_message_success"` → `2 passed`
