### PR TITLE
feat(shell): allow skipping first-launch GitHub sign-in

### DIFF
--- a/config/repl_config.py
+++ b/config/repl_config.py
@@ -237,3 +237,33 @@ def read_prompt_log_settings() -> dict[str, Any]:
     interactive = _read_config_file()
     raw = interactive.get("prompt_log", {})
     return raw if isinstance(raw, dict) else {}
+
+
+def read_github_login_deferred() -> bool:
+    """Return True when the user skipped the first-launch GitHub sign-in prompt."""
+    interactive = _read_config_file()
+    return ReplConfig._coerce_bool(interactive.get("github_login_deferred"), default=False)
+
+
+def write_github_login_deferred(deferred: bool) -> None:
+    """Persist or clear the first-launch GitHub sign-in deferral flag."""
+    try:
+        import yaml  # type: ignore[import-untyped]
+
+        from config.constants import OPENSRE_HOME_DIR
+
+        config_path = OPENSRE_HOME_DIR / "config.yml"
+        data: dict[str, Any] = {}
+        if config_path.exists():
+            loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                data = loaded
+        interactive = data.get("interactive")
+        if not isinstance(interactive, dict):
+            interactive = {}
+        interactive["github_login_deferred"] = deferred
+        data["interactive"] = interactive
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    except Exception:
+        log.debug("Could not persist github_login_deferred", exc_info=True)

--- a/integrations/github/login.py
+++ b/integrations/github/login.py
@@ -38,6 +38,7 @@ def authenticate_and_configure_github(
     *,
     on_prompt: Callable[[GitHubDeviceCode], None] | None = None,
     open_browser: bool = True,
+    poll_sleep: Callable[[float], None] | None = None,
 ) -> GitHubLoginResult:
     """Run device-flow login, validate, and persist the hosted GitHub MCP integration.
 
@@ -45,7 +46,11 @@ def authenticate_and_configure_github(
     propagate to the caller so it can present a message and decide whether to retry.
     The integration is persisted only when validation succeeds.
     """
-    token = authorize_github_via_device_flow(on_prompt=on_prompt, open_browser=open_browser)
+    token = authorize_github_via_device_flow(
+        on_prompt=on_prompt,
+        open_browser=open_browser,
+        poll_sleep=poll_sleep,
+    )
     credentials: dict[str, object] = {
         "mode": DEFAULT_GITHUB_MCP_MODE,
         "url": DEFAULT_GITHUB_MCP_URL,

--- a/integrations/github/mcp_oauth.py
+++ b/integrations/github/mcp_oauth.py
@@ -184,6 +184,7 @@ def authorize_github_via_device_flow(
     scopes: Sequence[str] = DEFAULT_GITHUB_OAUTH_SCOPES,
     open_browser: bool = True,
     on_prompt: Callable[[GitHubDeviceCode], None] | None = None,
+    poll_sleep: Callable[[float], None] | None = None,
 ) -> GitHubDeviceToken:
     """Run the full browser device flow and return a user access token.
 
@@ -205,4 +206,8 @@ def authorize_github_via_device_flow(
             webbrowser.open(device_code.verification_uri)
         except Exception:  # pragma: no cover - headless/no-browser environments
             logger.debug("Could not open a browser for GitHub device authorization", exc_info=True)
-    return poll_github_device_token(client_id=resolved_client_id, device_code=device_code)
+    return poll_github_device_token(
+        client_id=resolved_client_id,
+        device_code=device_code,
+        sleep=poll_sleep or time.sleep,
+    )

--- a/surfaces/cli/wizard/_ui.py
+++ b/surfaces/cli/wizard/_ui.py
@@ -23,6 +23,7 @@ from config.llm_credentials import get_keyring_setup_instructions, save_llm_api_
 from config.version import get_version
 from integrations.store import get_integration
 from platform.terminal.theme import (
+    BG,
     BRAND,
     DIM,
     ERROR,
@@ -45,21 +46,29 @@ _console = Console(
     highlight=False, force_terminal=True, color_system="truecolor", legacy_windows=False
 )
 
-_STYLE = questionary.Style(
-    [
-        ("qmark", f"fg:{HIGHLIGHT} bold"),
-        ("question", f"fg:{TEXT} bold"),
-        ("answer", f"fg:{BRAND} bold"),
-        ("pointer", f"fg:{HIGHLIGHT} bold"),
-        ("highlighted", f"fg:{TEXT} bg:{HIGHLIGHT} bold"),
-        ("selected", f"fg:{TEXT} bg:default bold"),
-        ("group-header", f"fg:{HIGHLIGHT} bold"),
-        ("separator", f"fg:{DIM}"),
-        ("text", f"fg:{TEXT} bg:default"),
-        ("disabled", f"fg:{SECONDARY} bg:default italic"),
-        ("instruction", f"fg:{SECONDARY} italic"),
-    ]
-)
+
+def _questionary_style() -> questionary.Style:
+    """Build questionary styles from the active terminal theme.
+
+    Highlighted list rows use ``BG`` (dark) on ``HIGHLIGHT`` (light accent) so
+    selected options stay readable across every palette — light ``TEXT`` on a
+    light ``HIGHLIGHT`` background was nearly invisible in green and similar themes.
+    """
+    return questionary.Style(
+        [
+            ("qmark", f"fg:{HIGHLIGHT} bold"),
+            ("question", f"fg:{TEXT} bold"),
+            ("answer", f"fg:{BRAND} bold"),
+            ("pointer", f"fg:{HIGHLIGHT} bold"),
+            ("highlighted", f"fg:{BG} bg:{HIGHLIGHT} bold"),
+            ("selected", f"fg:{TEXT} bg:default bold"),
+            ("group-header", f"fg:{HIGHLIGHT} bold"),
+            ("separator", f"fg:{DIM}"),
+            ("text", f"fg:{TEXT} bg:default"),
+            ("disabled", f"fg:{SECONDARY} bg:default italic"),
+            ("instruction", f"fg:{SECONDARY} italic"),
+        ]
+    )
 
 
 def _group_header_label(group: str) -> str:
@@ -316,7 +325,7 @@ def _choose(
         prompt,
         choices=q_choices,
         default=default,
-        style=_STYLE,
+        style=_questionary_style(),
         instruction="(Use arrows to move, Enter to choose)",
     ).ask()
 
@@ -328,7 +337,7 @@ def _choose(
 
 
 def _confirm(prompt: str, *, default: bool = True) -> bool:
-    result = questionary.confirm(prompt, default=default, style=_STYLE).ask()
+    result = questionary.confirm(prompt, default=default, style=_questionary_style()).ask()
     if result is None:
         raise KeyboardInterrupt
     return bool(result)
@@ -348,14 +357,14 @@ def _prompt_value(
             result = questionary.password(
                 label,
                 default=default,
-                style=_STYLE,
+                style=_questionary_style(),
                 instruction=instruction,
             ).ask()
         else:
             result = questionary.text(
                 label,
                 default=default,
-                style=_STYLE,
+                style=_questionary_style(),
                 instruction=instruction,
             ).ask()
 

--- a/surfaces/interactive_shell/command_registry/integrations.py
+++ b/surfaces/interactive_shell/command_registry/integrations.py
@@ -141,6 +141,12 @@ def _handle_remove(session: Session, console: Console, service: str | None) -> b
     if remove_integration(svc):
         repl_print(console, f"[{HIGHLIGHT}]removed '{escape(svc)}'.[/]")
         capture_integration_removed(svc)
+        if svc == "github":
+            from surfaces.interactive_shell.runtime.startup.first_launch_github import (
+                clear_github_login_deferral,
+            )
+
+            clear_github_login_deferral()
     else:
         repl_print(console, f"[{ERROR}]no integration found for:[/] {escape(svc)}")
         session.mark_latest(ok=False, kind="slash")

--- a/surfaces/interactive_shell/runtime/startup/first_launch_github.py
+++ b/surfaces/interactive_shell/runtime/startup/first_launch_github.py
@@ -84,6 +84,8 @@ def should_require_github_login() -> bool:
 
 def clear_github_login_deferral() -> None:
     """Clear a saved skip so removing GitHub can re-prompt on the next launch."""
+    if not read_github_login_deferred():
+        return
     write_github_login_deferred(False)
 
 
@@ -156,20 +158,27 @@ def _sleep_until_or_cancel(seconds: float) -> None:
         return
 
     import select
+    import termios
+    import tty
 
     from surfaces.interactive_shell.ui.components.key_reader import read_key_unix
 
-    deadline = time.monotonic() + seconds
     fd = sys.stdin.fileno()
-    while time.monotonic() < deadline:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            return
-        ready, _, _ = select.select([fd], [], [], min(remaining, 0.15))
-        if not ready:
-            continue
-        if read_key_unix() == "cancel":
-            raise KeyboardInterrupt
+    old_attrs = termios.tcgetattr(fd)  # type: ignore[attr-defined]
+    try:
+        tty.setraw(fd)  # type: ignore[attr-defined]
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            ready, _, _ = select.select([fd], [], [], min(remaining, 0.15))
+            if not ready:
+                continue
+            if read_key_unix() == "cancel":
+                raise KeyboardInterrupt
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_attrs)  # type: ignore[attr-defined]
 
 
 def _offer_github_login(_console: Console) -> bool:

--- a/surfaces/interactive_shell/runtime/startup/first_launch_github.py
+++ b/surfaces/interactive_shell/runtime/startup/first_launch_github.py
@@ -121,8 +121,7 @@ def _show_device_code(console: Console, code: object) -> None:
     console.print("  3. Approve the request for OpenSRE.")
     console.print()
     console.print(
-        "  [dim]Waiting for you to approve in the browser… "
-        "(Escape or Ctrl-C to skip)[/dim]"
+        "  [dim]Waiting for you to approve in the browser… (Escape or Ctrl-C to skip)[/dim]"
     )
 
 

--- a/surfaces/interactive_shell/runtime/startup/first_launch_github.py
+++ b/surfaces/interactive_shell/runtime/startup/first_launch_github.py
@@ -1,9 +1,10 @@
-"""First-launch mandatory GitHub login gate.
+"""First-launch GitHub login gate.
 
-On the first interactive launch of ``opensre`` (all platforms), the user must
-sign in to GitHub via device flow unless they are in CI/CD, a test harness, or a
-non-interactive session. The sign-in runs the hosted GitHub MCP setup, persists
-the integration, and propagates the authenticated GitHub username to PostHog.
+On the first interactive launch of ``opensre`` (all platforms), the user is
+prompted to sign in to GitHub via device flow unless they skip, are in CI/CD, a
+test harness, or a non-interactive session. The sign-in runs the hosted GitHub
+MCP setup, persists the integration, and propagates the authenticated GitHub
+username to PostHog.
 
 Escape hatch: ``OPENSRE_SKIP_GITHUB_LOGIN=1`` bypasses the gate so a GitHub
 outage or a disabled device flow can never permanently lock anyone out. The gate
@@ -15,10 +16,12 @@ from __future__ import annotations
 import logging
 import os
 import sys
+import time
 
 from rich.console import Console
 from rich.markup import escape
 
+from config.repl_config import read_github_login_deferred, write_github_login_deferred
 from platform.analytics.cli import capture_github_login_completed
 from platform.analytics.source import is_test_run
 from platform.terminal.theme import DEVICE_CODE
@@ -26,6 +29,8 @@ from surfaces.interactive_shell.ui import repl_tty_interactive
 
 _SKIP_ENV_VAR = "OPENSRE_SKIP_GITHUB_LOGIN"
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
+_SIGN_IN_CHOICE = "sign_in"
+_SKIP_CHOICE = "skip"
 
 
 def _skip_requested() -> bool:
@@ -60,8 +65,10 @@ def _github_already_configured() -> bool:
 
 
 def should_require_github_login() -> bool:
-    """Return True when the mandatory first-launch GitHub login must run now."""
+    """Return True when the first-launch GitHub login prompt must run now."""
     if _skip_requested():
+        return False
+    if read_github_login_deferred():
         return False
     if is_test_run():
         return False
@@ -73,6 +80,11 @@ def should_require_github_login() -> bool:
     # (e.g. via ``/integrations remove github``). Re-checking the store is cheap,
     # so the gate always re-runs when GitHub is not currently configured.
     return not _github_already_configured()
+
+
+def clear_github_login_deferral() -> None:
+    """Clear a saved skip so removing GitHub can re-prompt on the next launch."""
+    write_github_login_deferred(False)
 
 
 def _propagate_username(username: str) -> None:
@@ -91,7 +103,8 @@ def _print_intro(console: Console) -> None:
         "incidents against your source. Sign in once with your browser."
     )
     console.print(
-        f"[dim](Set {_SKIP_ENV_VAR}=1 to skip this — e.g. if GitHub sign-in is unavailable.)[/dim]"
+        "[dim](Escape to skip for now, or set "
+        f"{_SKIP_ENV_VAR}=1 if GitHub sign-in is unavailable.)[/dim]"
     )
 
 
@@ -107,15 +120,78 @@ def _show_device_code(console: Console, code: object) -> None:
     console.print(f"  2. Enter this one-time code when GitHub asks: [{DEVICE_CODE}]{user_code}[/]")
     console.print("  3. Approve the request for OpenSRE.")
     console.print()
-    console.print("  [dim]Waiting for you to approve in the browser… (Ctrl-C to cancel)[/dim]")
+    console.print(
+        "  [dim]Waiting for you to approve in the browser… "
+        "(Escape or Ctrl-C to skip)[/dim]"
+    )
 
 
-def _print_quit_guidance(console: Console) -> None:
+def _print_skip_guidance(console: Console) -> None:
     console.print()
     console.print(
-        "GitHub sign-in is required to use OpenSRE. You can try again by relaunching "
-        f"[bold]opensre[/bold], or set [bold]{_SKIP_ENV_VAR}=1[/bold] to bypass this step."
+        "[dim]Skipped GitHub sign-in. Connect later with "
+        "[bold]/integrations setup[/bold] or [bold]/mcp connect github[/bold].[/dim]"
     )
+
+
+def _defer_github_login() -> None:
+    write_github_login_deferred(True)
+
+
+def _sleep_until_or_cancel(seconds: float) -> None:
+    """Sleep up to ``seconds``, raising ``KeyboardInterrupt`` when the user skips."""
+    if seconds <= 0 or not sys.stdin.isatty():
+        time.sleep(seconds)
+        return
+
+    if os.name == "nt":
+        import msvcrt
+
+        from surfaces.interactive_shell.ui.components.key_reader import read_key_windows
+
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            if msvcrt.kbhit() and read_key_windows() == "cancel":  # type: ignore[attr-defined]
+                raise KeyboardInterrupt
+            time.sleep(0.05)
+        return
+
+    import select
+
+    from surfaces.interactive_shell.ui.components.key_reader import read_key_unix
+
+    deadline = time.monotonic() + seconds
+    fd = sys.stdin.fileno()
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        ready, _, _ = select.select([fd], [], [], min(remaining, 0.15))
+        if not ready:
+            continue
+        if read_key_unix() == "cancel":
+            raise KeyboardInterrupt
+
+
+def _offer_github_login(_console: Console) -> bool:
+    """Return True when the user wants to start browser sign-in."""
+    import questionary
+
+    try:
+        choice = questionary.select(
+            "Connect GitHub now?",
+            choices=[
+                questionary.Choice(
+                    "Sign in with GitHub (opens browser)",
+                    value=_SIGN_IN_CHOICE,
+                ),
+                questionary.Choice("Skip for now", value=_SKIP_CHOICE),
+            ],
+            default=_SIGN_IN_CHOICE,
+        ).ask()
+    except (EOFError, KeyboardInterrupt):
+        return False
+    return choice == _SIGN_IN_CHOICE
 
 
 def _ask_retry(_console: Console) -> bool:
@@ -125,21 +201,24 @@ def _ask_retry(_console: Console) -> bool:
         answer = questionary.confirm("Try GitHub sign-in again?", default=True).ask()
     except (EOFError, KeyboardInterrupt):
         return False
+    if answer is None:
+        return False
     return bool(answer)
 
 
 def _attempt_login(console: Console) -> str:
-    """Run one login attempt. Returns ``"success"``, ``"failed"``, or ``"quit"``."""
+    """Run one login attempt. Returns ``"success"``, ``"failed"``, or ``"skipped"``."""
     from integrations.github.login import authenticate_and_configure_github
     from integrations.github.mcp_oauth import GitHubDeviceFlowError
 
     try:
         result = authenticate_and_configure_github(
             on_prompt=lambda code: _show_device_code(console, code),
+            poll_sleep=_sleep_until_or_cancel,
         )
     except (EOFError, KeyboardInterrupt):
-        console.print("\nCancelled.")
-        return "quit"
+        console.print("\nSkipped GitHub sign-in.")
+        return "skipped"
     except GitHubDeviceFlowError as err:
         console.print(f"[yellow]GitHub sign-in is unavailable:[/yellow] {err}")
         return "failed"
@@ -148,6 +227,7 @@ def _attempt_login(console: Console) -> str:
         return "failed"
 
     if result.ok:
+        clear_github_login_deferral()
         # Persisting the GitHub integration (done inside
         # ``authenticate_and_configure_github``) is what suppresses the gate on
         # subsequent launches — there is no separate completion marker to write.
@@ -161,29 +241,38 @@ def _attempt_login(console: Console) -> str:
 
 
 def require_github_login_on_first_launch(console: Console | None = None) -> bool:
-    """Run the mandatory first-launch GitHub login.
+    """Run the first-launch GitHub login prompt.
 
-    Returns True when the caller should proceed into the REPL (login succeeded),
-    and False when the user chose to quit (the caller should exit without
-    starting the REPL).
+    Returns True when the caller should proceed into the REPL (login succeeded or
+    the user skipped), and False only when startup must abort.
     """
     con = console or Console(highlight=False)
     _print_intro(con)
+    if not _offer_github_login(con):
+        _defer_github_login()
+        _print_skip_guidance(con)
+        return True
+
     while True:
         outcome = _attempt_login(con)
         if outcome == "success":
             return True
-        if outcome == "quit" or not _ask_retry(con):
-            _print_quit_guidance(con)
-            return False
+        if outcome == "skipped":
+            _defer_github_login()
+            _print_skip_guidance(con)
+            return True
+        if not _ask_retry(con):
+            _defer_github_login()
+            _print_skip_guidance(con)
+            return True
 
 
 def require_startup_github_login(console: Console) -> bool:
     """Return True when startup may proceed past the GitHub login gate.
 
     On an unexpected gate error we deliberately do NOT fail open into the REPL:
-    that would let a gate bug silently skip mandatory sign-in. Instead we only
-    allow startup when an explicit, documented bypass applies.
+    that would let a gate bug silently skip sign-in. Instead we only allow
+    startup when an explicit, documented bypass applies.
     """
     try:
         if not should_require_github_login():
@@ -197,7 +286,7 @@ def require_startup_github_login(console: Console) -> bool:
         if _github_login_explicitly_bypassed():
             return True
         console.print(
-            "GitHub sign-in is required to use OpenSRE, but the sign-in step could not run. "
+            "GitHub sign-in could not run. "
             f"Set [bold]{_SKIP_ENV_VAR}=1[/bold] to bypass this, then relaunch "
             "[bold]opensre[/bold]."
         )

--- a/surfaces/interactive_shell/runtime/startup/first_launch_github.py
+++ b/surfaces/interactive_shell/runtime/startup/first_launch_github.py
@@ -199,7 +199,9 @@ def _offer_github_login(_console: Console) -> bool:
         ).ask()
     except (EOFError, KeyboardInterrupt):
         return False
-    return choice == _SIGN_IN_CHOICE
+    if choice is None:
+        return False
+    return bool(choice == _SIGN_IN_CHOICE)
 
 
 def _ask_retry(_console: Console) -> bool:

--- a/tests/cli/wizard/test_ui_style.py
+++ b/tests/cli/wizard/test_ui_style.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from platform.terminal.theme import BG, HIGHLIGHT, set_active_theme
+from surfaces.cli.wizard import _ui as wizard_ui
+
+
+def test_questionary_highlighted_style_uses_dark_text_on_highlight_background() -> None:
+    set_active_theme("green")
+    style = wizard_ui._questionary_style()
+    highlighted = next(rule for rule in style.style_rules if rule[0] == "highlighted")
+    assert highlighted[1] == f"fg:{BG} bg:{HIGHLIGHT} bold"

--- a/tests/config/test_repl_config.py
+++ b/tests/config/test_repl_config.py
@@ -6,7 +6,11 @@ import textwrap
 
 import pytest
 
-from config.repl_config import ReplConfig
+from config.repl_config import (
+    ReplConfig,
+    read_github_login_deferred,
+    write_github_login_deferred,
+)
 
 
 class TestReplConfigDefaults:
@@ -346,3 +350,20 @@ class TestThemeRegistry:
         set_active_theme("pink")
         ReplConfig.load(apply_active_theme=False)
         assert get_active_theme_name() == "pink"
+
+
+class TestGithubLoginDeferral:
+    def test_read_defaults_false(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import config.constants as const_module
+
+        monkeypatch.setattr(const_module, "OPENSRE_HOME_DIR", tmp_path)
+        assert read_github_login_deferred() is False
+
+    def test_write_and_read_round_trip(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import config.constants as const_module
+
+        monkeypatch.setattr(const_module, "OPENSRE_HOME_DIR", tmp_path)
+        write_github_login_deferred(True)
+        assert read_github_login_deferred() is True
+        write_github_login_deferred(False)
+        assert read_github_login_deferred() is False

--- a/tests/interactive_shell/runtime/test_first_launch_github.py
+++ b/tests/interactive_shell/runtime/test_first_launch_github.py
@@ -28,6 +28,7 @@ def _force_required(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(flg, "is_test_run", lambda: False)
     monkeypatch.setattr(flg, "repl_tty_interactive", lambda: True)
     monkeypatch.setattr(flg, "_github_already_configured", lambda: False)
+    monkeypatch.setattr(flg, "read_github_login_deferred", lambda: False)
 
 
 def test_gate_required_when_all_conditions_met(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -98,6 +99,12 @@ def test_gate_skipped_in_ci_like_environment(
     assert flg.should_require_github_login() is False
 
 
+def test_gate_skipped_when_github_login_deferred(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_required(monkeypatch)
+    monkeypatch.setattr(flg, "read_github_login_deferred", lambda: True)
+    assert flg.should_require_github_login() is False
+
+
 def test_gate_required_when_stale_github_store_record_has_no_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -140,6 +147,7 @@ def test_device_code_prompt_highlights_user_code(monkeypatch: pytest.MonkeyPatch
 
 
 def test_orchestrator_success_proceeds_and_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console: True)
     monkeypatch.setattr(
         github_login_mod,
         "authenticate_and_configure_github",
@@ -147,38 +155,62 @@ def test_orchestrator_success_proceeds_and_propagates(monkeypatch: pytest.Monkey
     )
     completed: list[str] = []
     monkeypatch.setattr(flg, "capture_github_login_completed", completed.append)
+    cleared: list[bool] = []
+    monkeypatch.setattr(flg, "clear_github_login_deferral", lambda: cleared.append(True))
 
     proceed = flg.require_github_login_on_first_launch(_console())
 
     assert proceed is True
     assert completed == ["octocat"]
+    assert cleared == [True]
 
 
-def test_orchestrator_quit_does_not_proceed(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_orchestrator_skip_at_menu_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console: False)
+    deferred: list[bool] = []
+    monkeypatch.setattr(flg, "write_github_login_deferred", deferred.append)
+
+    proceed = flg.require_github_login_on_first_launch(_console())
+
+    assert proceed is True
+    assert deferred == [True]
+
+
+def test_orchestrator_escape_during_wait_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console: True)
+
     def _raise_cancel(**_kwargs: object) -> GitHubLoginResult:
         raise KeyboardInterrupt
 
     monkeypatch.setattr(github_login_mod, "authenticate_and_configure_github", _raise_cancel)
+    deferred: list[bool] = []
+    monkeypatch.setattr(flg, "write_github_login_deferred", deferred.append)
 
     proceed = flg.require_github_login_on_first_launch(_console())
 
-    assert proceed is False
+    assert proceed is True
+    assert deferred == [True]
 
 
-def test_orchestrator_failure_then_decline_retry_quits(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_orchestrator_failure_then_decline_retry_skips(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console: True)
     monkeypatch.setattr(
         github_login_mod,
         "authenticate_and_configure_github",
         lambda **_kwargs: GitHubLoginResult(ok=False, detail="cannot verify"),
     )
     monkeypatch.setattr(flg, "_ask_retry", lambda _console: False)
+    deferred: list[bool] = []
+    monkeypatch.setattr(flg, "write_github_login_deferred", deferred.append)
 
     proceed = flg.require_github_login_on_first_launch(_console())
 
-    assert proceed is False
+    assert proceed is True
+    assert deferred == [True]
 
 
 def test_orchestrator_retries_until_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console: True)
     calls = {"n": 0}
 
     def _login(**_kwargs: object) -> GitHubLoginResult:
@@ -190,8 +222,27 @@ def test_orchestrator_retries_until_success(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(github_login_mod, "authenticate_and_configure_github", _login)
     monkeypatch.setattr(flg, "_ask_retry", lambda _console: True)
     monkeypatch.setattr(flg, "capture_github_login_completed", lambda _username: None)
+    monkeypatch.setattr(flg, "clear_github_login_deferral", lambda: None)
 
     proceed = flg.require_github_login_on_first_launch(_console())
 
     assert proceed is True
     assert calls["n"] == 2
+
+
+def test_sleep_until_or_cancel_raises_on_escape(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(flg.os, "name", "posix")
+    monkeypatch.setattr(flg.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(flg.sys.stdin, "fileno", lambda: 0)
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.components.key_reader.read_key_unix",
+        lambda **_kwargs: "cancel",
+    )
+
+    def _ready(_fd: int, *_args: object, **_kwargs: object) -> tuple[list[int], list[int], list[int]]:
+        return ([0], [], [])
+
+    monkeypatch.setattr("select.select", _ready)
+
+    with pytest.raises(KeyboardInterrupt):
+        flg._sleep_until_or_cancel(1.0)

--- a/tests/interactive_shell/runtime/test_first_launch_github.py
+++ b/tests/interactive_shell/runtime/test_first_launch_github.py
@@ -230,6 +230,28 @@ def test_orchestrator_retries_until_success(monkeypatch: pytest.MonkeyPatch) -> 
     assert calls["n"] == 2
 
 
+def test_clear_github_login_deferral_noop_when_not_deferred(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(flg, "read_github_login_deferred", lambda: False)
+    writes: list[bool] = []
+    monkeypatch.setattr(flg, "write_github_login_deferred", writes.append)
+
+    flg.clear_github_login_deferral()
+
+    assert writes == []
+
+
+def test_clear_github_login_deferral_clears_when_deferred(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(flg, "read_github_login_deferred", lambda: True)
+    writes: list[bool] = []
+    monkeypatch.setattr(flg, "write_github_login_deferred", writes.append)
+
+    flg.clear_github_login_deferral()
+
+    assert writes == [False]
+
+
 def test_sleep_until_or_cancel_raises_on_escape(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(flg.os, "name", "posix")
     monkeypatch.setattr(flg.sys.stdin, "isatty", lambda: True)
@@ -237,6 +259,13 @@ def test_sleep_until_or_cancel_raises_on_escape(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(
         "surfaces.interactive_shell.ui.components.key_reader.read_key_unix",
         lambda **_kwargs: "cancel",
+    )
+    monkeypatch.setattr("termios.tcgetattr", lambda _fd: [0] * 7)
+    monkeypatch.setattr("tty.setraw", lambda _fd: None)
+    restored: list[bool] = []
+    monkeypatch.setattr(
+        "termios.tcsetattr",
+        lambda _fd, _when, _attrs: restored.append(True),
     )
 
     def _ready(
@@ -248,3 +277,5 @@ def test_sleep_until_or_cancel_raises_on_escape(monkeypatch: pytest.MonkeyPatch)
 
     with pytest.raises(KeyboardInterrupt):
         flg._sleep_until_or_cancel(1.0)
+
+    assert restored == [True]

--- a/tests/interactive_shell/runtime/test_first_launch_github.py
+++ b/tests/interactive_shell/runtime/test_first_launch_github.py
@@ -239,7 +239,9 @@ def test_sleep_until_or_cancel_raises_on_escape(monkeypatch: pytest.MonkeyPatch)
         lambda **_kwargs: "cancel",
     )
 
-    def _ready(_fd: int, *_args: object, **_kwargs: object) -> tuple[list[int], list[int], list[int]]:
+    def _ready(
+        _fd: int, *_args: object, **_kwargs: object
+    ) -> tuple[list[int], list[int], list[int]]:
         return ([0], [], [])
 
     monkeypatch.setattr("select.select", _ready)


### PR DESCRIPTION
## Summary

- Make the first-launch GitHub sign-in prompt skippable instead of blocking REPL startup
- Add a "Skip for now" menu and treat Escape/Ctrl-C during browser device-flow polling as skip
- Persist `interactive.github_login_deferred` in `~/.opensre/config.yml` so skipped users are not re-prompted every launch
- Clear the deferral flag on successful sign-in or when GitHub is removed via `/integrations remove github`

<img width="751" height="168" alt="image" src="https://github.com/user-attachments/assets/b6f55e6b-7768-49ac-8133-2bab0ecb146a" />


## Test plan

- [x] `uv run python -m pytest tests/interactive_shell/runtime/test_first_launch_github.py -q`
- [x] `uv run python -m pytest tests/config/test_repl_config.py -q`
- [x] `uv run ruff check` on touched files
- [ ] Manual: launch `opensre` without GitHub configured, press Escape at the menu or during browser wait, confirm REPL starts
- [ ] Manual: relaunch and confirm the gate stays skipped; run `/integrations remove github` and confirm the gate returns on next launch