### PR TITLE
refactor(agent_harness): name two agent shapes; rename streaming entrypoint (#3615)

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -86,11 +86,12 @@ class AgentRunResult:
 
 
 class Agent[RuntimeToolT: RuntimeTool](AgentEventEmitter, AgentToolFilter):
-    """Stateful, configurable ReAct agent.
+    """Stateful, configurable ReAct agent — the tool-calling agent shape.
 
     Owns the think → call-tools → observe loop and exposes hook methods so
     subclasses can customise stopping logic and tool filtering without
-    re-implementing the loop.
+    re-implementing the loop. For the streaming-answer shape (no tools, streams
+    text), see ``core/agent_harness/AGENTS.md``.
     """
 
     @staticmethod

--- a/core/agent.py
+++ b/core/agent.py
@@ -90,8 +90,8 @@ class Agent[RuntimeToolT: RuntimeTool](AgentEventEmitter, AgentToolFilter):
 
     Owns the think → call-tools → observe loop and exposes hook methods so
     subclasses can customise stopping logic and tool filtering without
-    re-implementing the loop. For the streaming-answer shape (no tools, streams
-    text), see ``core/agent_harness/AGENTS.md``.
+    re-implementing the loop. For the direct-answer shape (no tools), see
+    ``core/agent_harness/AGENTS.md``.
     """
 
     @staticmethod

--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -2,7 +2,7 @@
 
 `agent_harness/` owns the **decoupled agent harness** for two agent shapes:
 the tool-calling loop (`core.agent.Agent` via `build_agent`) and the
-streaming-answer path (`answer_cli_agent` via the `AnswerFn` seam in
+streaming-answer path (`stream_answer` via the `StreamAnswerFn` seam in
 `ports.py`). It orchestrates action tool-calling turns, three-path routing,
 conversational answers, evidence gather, and headless execution. It was
 extracted out of `interactive_shell` so the same harness can run the interactive
@@ -153,8 +153,8 @@ uniformity claim with an exception bolted on:
   tools → observe) driven by `llm.invoke`. Built via `AgentConfig` +
   `build_agent` (the construction pattern above). Used by the action,
   evidence/gather, and investigation agents.
-- **Streaming-answer agent** — `turn_orchestrator.answer_cli_agent`, one no-tool
-  grounded text answer streamed via `client.invoke_stream` (the `AnswerFn`
+- **Streaming-answer agent** — `turn_orchestrator.stream_answer`, one no-tool
+  grounded text answer streamed via `client.invoke_stream` (the `StreamAnswerFn`
   seam in `ports.py` — named `Fn`, not `Agent`, to avoid conflating this
   callable with `core.agent.Agent`). It does **not** use `Agent`, by design: there is no tool
   loop, no observe step, and it streams on a different client method. A genuinely
@@ -168,13 +168,13 @@ shape; if it streams a text answer it is the streaming shape.
 Before opening or merging an agent PR, confirm:
 
 1. **Shape** — State explicitly: tool-calling (`Agent` / `build_agent` /
-   `ExecuteActions`) or streaming-answer (`AnswerFn` / `invoke_stream`).
+   `ExecuteActions`) or streaming-answer (`StreamAnswerFn` / `invoke_stream`).
 2. **Entrypoint docstring** — The public function or class documents which shape
    it implements (three lines max; link here if helpful).
 3. **Docs** — Update this file when harness rules change; update
    `docs/agent-context-data-stores.md` when routing or prompt capture changes
    (diagram must match runtime — assistant never flows through `Agent.run()`).
-4. **Seams** — Inject through `ports.py` callables (`AnswerFn`,
+4. **Seams** — Inject through `ports.py` callables (`StreamAnswerFn`,
    `ExecuteActions`, `EvidenceGatherer`); do not import surface code into
    `agent_harness/`.
 5. **Tests** — Add or extend guards in

--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -1,7 +1,9 @@
 # agent_harness/ package rules
 
-`agent_harness/` owns the **decoupled agent harness** around the shared
-`core.agent.Agent` loop: action tool-calling turns, three-path routing,
+`agent_harness/` owns the **decoupled agent harness** for two agent shapes:
+the tool-calling loop (`core.agent.Agent` via `build_agent`) and the
+streaming-answer path (`answer_cli_agent` via the `AnswerFn` seam in
+`ports.py`). It orchestrates action tool-calling turns, three-path routing,
 conversational answers, evidence gather, and headless execution. It was
 extracted out of `interactive_shell` so the same harness can run the interactive
 terminal and be invoked headlessly via `agent_harness.agents.headless_agent`.
@@ -142,25 +144,56 @@ See `docs/agent-context-data-stores.md`. Turn assembly starts in
 hooks. Those hooks were removed because they let each surface hide per-turn
 configuration on `self`, which diverged routing across surfaces.
 
-## Answer agent — categorical exception
+## Two agent shapes (not one pattern with an exception)
 
-`turn_orchestrator.answer_cli_agent` streams grounded text via
-`client.invoke_stream(prompt)` and does **not** use `core.agent.Agent`. Reason:
-`Agent.run()` is a tool-calling loop; streaming a no-tool text response is a
-different modality. If streaming is added to `Agent` in a future change,
-`answer_cli_agent` should be migrated onto it. Until then, treat this as an
-intentional gap, not a hook-pattern regression.
+The harness has **two** intentional agent shapes. This is a design, not a 4/4
+uniformity claim with an exception bolted on:
 
-## Investigation agent — extends Agent, custom run()
+- **Tool-calling agent** — `core.agent.Agent`, the ReAct loop (think → call
+  tools → observe) driven by `llm.invoke`. Built via `AgentConfig` +
+  `build_agent` (the construction pattern above). Used by the action,
+  evidence/gather, and investigation agents.
+- **Streaming-answer agent** — `turn_orchestrator.answer_cli_agent`, one no-tool
+  grounded text answer streamed via `client.invoke_stream` (the `AnswerFn`
+  seam in `ports.py` — named `Fn`, not `Agent`, to avoid conflating this
+  callable with `core.agent.Agent`). It does **not** use `Agent`, by design: there is no tool
+  loop, no observe step, and it streams on a different client method. A genuinely
+  different modality — not a workaround to be folded into `Agent.run()`.
+
+A new agent is one shape or the other: if it calls tools it is the tool-calling
+shape; if it streams a text answer it is the streaming shape.
+
+### Contributor checklist (agent changes)
+
+Before opening or merging an agent PR, confirm:
+
+1. **Shape** — State explicitly: tool-calling (`Agent` / `build_agent` /
+   `ExecuteActions`) or streaming-answer (`AnswerFn` / `invoke_stream`).
+2. **Entrypoint docstring** — The public function or class documents which shape
+   it implements (three lines max; link here if helpful).
+3. **Docs** — Update this file when harness rules change; update
+   `docs/agent-context-data-stores.md` when routing or prompt capture changes
+   (diagram must match runtime — assistant never flows through `Agent.run()`).
+4. **Seams** — Inject through `ports.py` callables (`AnswerFn`,
+   `ExecuteActions`, `EvidenceGatherer`); do not import surface code into
+   `agent_harness/`.
+5. **Tests** — Add or extend guards in
+   `tests/core/agent_harness/test_agent_shapes.py` when you introduce a new
+   entrypoint or rename a shape seam.
+
+**Read order for new code:** this file → `docs/agent-context-data-stores.md` →
+`agents/turn_orchestrator.py` (`run_turn`) → `core/agent.py` (tool-calling loop
+only).
+
+## Investigation agent — the tool-calling shape with a custom loop
 
 `tools/investigation/stages/gather_evidence/agent.py::ConnectedInvestigationAgent`
-extends `Agent[RegisteredTool]` to reuse the shared event-emission and
-`_filter_tools` infrastructure, then overrides `.run()` with a specialised
-ReAct loop (seed calls, evidence collection, duplicate detection, stagnation
-handling). This is a legitimate use of subclassing — the specialised loop
-cannot delegate to `Agent.run()`'s generic tool-calling loop. The class does
-**not** override the removed config hooks; it assembles its config inline at
-the top of `run()`.
+composes the shared `AgentEventEmitter` and `AgentToolFilter` mixins
+(`core.agent_mixins`) instead of subclassing `Agent`, and owns a specialised
+ReAct `run()` (seed calls, evidence collection, duplicate detection, stagnation
+handling). It is still the tool-calling shape — a specialised loop that reuses
+the two agent hooks by composition rather than delegating to the generic
+`Agent.run()`. It assembles its config inline at the top of `run()`.
 
 ## Keep the loop primitive in core
 

--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -2,8 +2,8 @@
 
 `agent_harness/` owns the **decoupled agent harness** for two agent shapes:
 the tool-calling loop (`core.agent.Agent` via `build_agent`) and the
-streaming-answer path (`stream_answer` via the `StreamAnswerFn` seam in
-`ports.py`). It orchestrates action tool-calling turns, three-path routing,
+direct-answer path (`stream_answer` via the `StreamAnswerFn` seam in
+`ports.py`, no tools). It orchestrates action tool-calling turns, three-path routing,
 conversational answers, evidence gather, and headless execution. It was
 extracted out of `interactive_shell` so the same harness can run the interactive
 terminal and be invoked headlessly via `agent_harness.agents.headless_agent`.
@@ -153,22 +153,20 @@ uniformity claim with an exception bolted on:
   tools → observe) driven by `llm.invoke`. Built via `AgentConfig` +
   `build_agent` (the construction pattern above). Used by the action,
   evidence/gather, and investigation agents.
-- **Streaming-answer agent** — `turn_orchestrator.stream_answer`, one no-tool
-  grounded text answer streamed via `client.invoke_stream` (the `StreamAnswerFn`
-  seam in `ports.py` — named `Fn`, not `Agent`, to avoid conflating this
-  callable with `core.agent.Agent`). It does **not** use `Agent`, by design: there is no tool
-  loop, no observe step, and it streams on a different client method. A genuinely
-  different modality — not a workaround to be folded into `Agent.run()`.
+- **Direct answer (no tools)** — `turn_orchestrator.stream_answer`, one grounded
+  text answer streamed via `client.invoke_stream` (the `StreamAnswerFn` seam in
+  `ports.py`). It does **not** use `Agent`: there is no tool loop and no observe
+  step, and it streams on a different client method.
 
 A new agent is one shape or the other: if it calls tools it is the tool-calling
-shape; if it streams a text answer it is the streaming shape.
+shape; if it answers directly without tools it is the direct-answer shape.
 
 ### Contributor checklist (agent changes)
 
 Before opening or merging an agent PR, confirm:
 
 1. **Shape** — State explicitly: tool-calling (`Agent` / `build_agent` /
-   `ExecuteActions`) or streaming-answer (`StreamAnswerFn` / `invoke_stream`).
+   `ExecuteActions`) or direct answer (`StreamAnswerFn` / `invoke_stream`, no tools).
 2. **Entrypoint docstring** — The public function or class documents which shape
    it implements (three lines max; link here if helpful).
 3. **Docs** — Update this file when harness rules change; update

--- a/core/agent_harness/__init__.py
+++ b/core/agent_harness/__init__.py
@@ -19,7 +19,7 @@ from core.agent_harness.agents.action_agent import (
 from core.agent_harness.agents.evidence_agent import gather_tool_evidence
 from core.agent_harness.agents.evidence_agent import gather_tool_evidence as gather_evidence
 from core.agent_harness.agents.headless_agent import dispatch_message_to_headless_agent
-from core.agent_harness.agents.turn_orchestrator import answer_cli_agent, run_turn
+from core.agent_harness.agents.turn_orchestrator import run_turn, stream_answer
 from core.agent_harness.harness import AgentHarness, HarnessConfig, HarnessStartupResult
 from core.agent_harness.models.turn_context import (
     AgentRuntimeRequest,
@@ -38,10 +38,10 @@ __all__ = [
     "ToolCallingTurnResult",
     "TurnContext",
     "TurnContextSource",
-    "answer_cli_agent",
     "execute_action_agent_turn",
     "gather_evidence",
     "gather_tool_evidence",
     "dispatch_message_to_headless_agent",
     "run_turn",
+    "stream_answer",
 ]

--- a/core/agent_harness/agent_builder.py
+++ b/core/agent_harness/agent_builder.py
@@ -1,17 +1,8 @@
 """Shared factory for building runtime :class:`~core.agent.Agent` instances.
 
-Every agent harness surface (action, evidence, gateway) assembles the
-per-turn configuration in a surface-specific factory, then hands it to
-:func:`build_agent`. If :class:`~core.agent.Agent`'s constructor signature
-changes, this file is the single edit site — all surfaces adopt the change
-automatically.
-
-Investigation composes :class:`~core.agent_mixins.AgentEventEmitter` and
-:class:`~core.agent_mixins.AgentToolFilter` instead of subclassing
-:class:`~core.agent.Agent`, and constructs its own specialised tool-calling
-loop. The LLM/tools wiring it uses at ``run()`` start mirrors the
-:class:`AgentConfig` fields so a future refactor can bring it under the same
-roof without changing shape.
+Each agent harness surface (action, evidence, gateway) assembles its per-turn
+configuration in a surface-specific factory and hands it to :func:`build_agent`,
+the single construction site for :class:`~core.agent.Agent` across surfaces.
 """
 
 from __future__ import annotations

--- a/core/agent_harness/agent_builder.py
+++ b/core/agent_harness/agent_builder.py
@@ -6,9 +6,10 @@ per-turn configuration in a surface-specific factory, then hands it to
 changes, this file is the single edit site — all surfaces adopt the change
 automatically.
 
-Investigation stays a subclass of :class:`~core.agent.Agent` (it reuses
-``_filter_tools`` and the event-emission plumbing) and constructs its own
-loop, but the LLM/tools wiring it uses at ``run()`` start mirrors the
+Investigation composes :class:`~core.agent_mixins.AgentEventEmitter` and
+:class:`~core.agent_mixins.AgentToolFilter` instead of subclassing
+:class:`~core.agent.Agent`, and constructs its own specialised tool-calling
+loop. The LLM/tools wiring it uses at ``run()`` start mirrors the
 :class:`AgentConfig` fields so a future refactor can bring it under the same
 roof without changing shape.
 """

--- a/core/agent_harness/agents/headless_agent.py
+++ b/core/agent_harness/agents/headless_agent.py
@@ -34,7 +34,7 @@ from typing import Any
 
 from core.agent_harness.agents.action_agent import run_action_agent_turn
 from core.agent_harness.agents.evidence_agent import gather_tool_evidence
-from core.agent_harness.agents.turn_orchestrator import answer_cli_agent, run_turn
+from core.agent_harness.agents.turn_orchestrator import run_turn, stream_answer
 from core.agent_harness.models.turn_context import TurnContext
 from core.agent_harness.models.turn_results import ShellTurnResult, ToolCallingTurnResult
 from core.agent_harness.ports import (
@@ -268,7 +268,7 @@ def dispatch_message_to_headless_agent(
         )
 
     def answer(text: str, **kwargs: object) -> object:
-        return answer_cli_agent(
+        return stream_answer(
             text,
             store,
             output,

--- a/core/agent_harness/agents/turn_orchestrator.py
+++ b/core/agent_harness/agents/turn_orchestrator.py
@@ -3,12 +3,12 @@
 This is the surface-agnostic heart of the turn harness, lifted out of the
 interactive shell. It owns:
 
-* ``answer_cli_agent`` — one turn of the grounded conversational assistant
-  (guidance only; no investigation run), streaming a reply and recording the
-  exchange.
+* ``stream_answer`` — one no-tool streamed answer from the grounded
+  conversational assistant (guidance only; no investigation run). A single
+  streaming LLM call with no ReAct loop and no tool use. Records the exchange.
 * ``run_turn`` — the three-path routing (summarize-observation / handled /
   gather+answer) that sequences the action driver, the gather pass, and the
-  assistant.
+  answer path.
 
 All terminal/session/grounding/telemetry concerns are reached through the
 Protocols in :mod:`core.agent_harness.ports`. Nothing here imports ``interactive_shell``.
@@ -24,7 +24,6 @@ from config.llm_reasoning_effort import apply_reasoning_effort
 from core.agent_harness.models.turn_context import TurnContext
 from core.agent_harness.models.turn_results import ShellTurnResult, ToolCallingTurnResult
 from core.agent_harness.ports import (
-    AnswerAgent,
     ConfirmFn,
     ErrorReporter,
     EvidenceGatherer,
@@ -34,6 +33,7 @@ from core.agent_harness.ports import (
     ReasoningClientProvider,
     RunRecordFactory,
     SessionStore,
+    StreamAnswerFn,
     TurnAccounting,
 )
 from core.agent_harness.prompts import build_cli_agent_prompt_from_provider
@@ -56,7 +56,7 @@ def stage_turn_error(session: Any, kind: str, message: str) -> None:
         setter(kind, message)
 
 
-def _stream_cli_agent_response(
+def _stream_response(
     *,
     client: Any,
     prompt: str,
@@ -89,7 +89,7 @@ def _stream_cli_agent_response(
     return run_factory.build(client=client, prompt=prompt, response_text=text_str, started=started)
 
 
-def _record_cli_agent_turn(session: SessionStore, message: str, assistant_text: str) -> None:
+def _record_answer_turn(session: SessionStore, message: str, assistant_text: str) -> None:
     session.cli_agent_messages.append(("user", message))
     session.cli_agent_messages.append(("assistant", assistant_text))
     if len(session.cli_agent_messages) > MAX_CONVERSATION_MESSAGES:
@@ -103,12 +103,11 @@ def _record_action_only_turn(session: SessionStore, message: str, assistant_text
     latest = session.cli_agent_messages[-2:]
     if latest == [("user", message), ("assistant", text)]:
         return
-    _record_cli_agent_turn(session, message, text)
+    _record_answer_turn(session, message, text)
 
 
-def answer_cli_agent(
-    # This function is very important because it is used as the entry point inside interactive shell!!!
-    # This function doesn't execute tools. Only answers text.
+def stream_answer(
+    # No-tool streaming answer shared by the interactive shell and headless surfaces.
     message: str,
     session: SessionStore,
     output: OutputSink,
@@ -123,7 +122,11 @@ def answer_cli_agent(
     tool_observation_on_screen: bool = True,
     turn_ctx: TurnContext | None = None,
 ) -> Any | None:
-    """Run one turn of the conversational assistant (guidance only).
+    """Stream one grounded conversational answer (guidance only, no tools).
+
+    The **streaming-answer** path: a single ``invoke_stream`` call with no ReAct
+    loop and no tool use. The **tool-calling** agent is ``core.agent.Agent`` —
+    see ``core/agent_harness/AGENTS.md``.
 
     ``turn_ctx`` is the immutable per-turn snapshot assembled at turn start.
     When present, snapshot fields (conversation history, integration state,
@@ -145,7 +148,7 @@ def answer_cli_agent(
         turn_ctx=ctx,
     )
 
-    run = _stream_cli_agent_response(
+    run = _stream_response(
         client=client,
         prompt=prompt,
         output=output,
@@ -157,7 +160,7 @@ def answer_cli_agent(
         return None
 
     text_str = getattr(run, "response_text", "") or ""
-    _record_cli_agent_turn(session, message, text_str)
+    _record_answer_turn(session, message, text_str)
 
     return run
 
@@ -220,7 +223,7 @@ def _routing_input_from_result(
 def _gather_and_answer(
     *,
     text: str,
-    answer: AnswerAgent,
+    answer: StreamAnswerFn,
     gather: EvidenceGatherer,
     confirm_fn: ConfirmFn | None,
     is_tty: bool | None,
@@ -248,7 +251,7 @@ def run_turn(
     session: SessionStore,
     *,
     execute_actions: ExecuteActions,
-    answer: AnswerAgent,
+    answer: StreamAnswerFn,
     gather: EvidenceGatherer,
     accounting: TurnAccounting,
     confirm_fn: ConfirmFn | None = None,
@@ -339,6 +342,6 @@ def run_turn(
 
 
 __all__ = [
-    "answer_cli_agent",
     "run_turn",
+    "stream_answer",
 ]

--- a/core/agent_harness/agents/turn_orchestrator.py
+++ b/core/agent_harness/agents/turn_orchestrator.py
@@ -107,7 +107,7 @@ def _record_action_only_turn(session: SessionStore, message: str, assistant_text
 
 
 def stream_answer(
-    # No-tool streaming answer shared by the interactive shell and headless surfaces.
+    # Direct answer (no tools) shared by the interactive shell and headless surfaces.
     message: str,
     session: SessionStore,
     output: OutputSink,
@@ -124,9 +124,9 @@ def stream_answer(
 ) -> Any | None:
     """Stream one grounded conversational answer (guidance only, no tools).
 
-    The **streaming-answer** path: a single ``invoke_stream`` call with no ReAct
-    loop and no tool use. The **tool-calling** agent is ``core.agent.Agent`` —
-    see ``core/agent_harness/AGENTS.md``.
+    The **direct answer** path (no tools): a single ``invoke_stream`` call with
+    no ReAct loop. The **tool-calling** agent is ``core.agent.Agent`` — see
+    ``core/agent_harness/AGENTS.md``.
 
     ``turn_ctx`` is the immutable per-turn snapshot assembled at turn start.
     When present, snapshot fields (conversation history, integration state,

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -149,9 +149,8 @@ class RunRecordFactory(Protocol):
         raise NotImplementedError
 
 
-# Bound streaming-answer callable — the no-tool answer path, not an agent.
-# Returns an opaque LLM-run record (or None). The shell binds
-# session/console/grounding; headless binds a simple core-LLM call.
+# Bound direct-answer callable (no tools):
+# ``answer(text, *, confirm_fn, is_tty, tool_observation, turn_ctx) -> LLM-run record | None``.
 StreamAnswerFn = Callable[..., Any]
 
 # Bound evidence-gather callable: ``gather(text, *, is_tty) -> str | None``.

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -149,9 +149,9 @@ class RunRecordFactory(Protocol):
         raise NotImplementedError
 
 
-# Bound conversational-answer callable. Returns an opaque LLM-run record (or
-# None). The shell binds session/console/grounding; headless binds a simple
-# core-LLM call.
+# Bound streaming-answer callable — the no-tool answer path, not an agent.
+# Returns an opaque LLM-run record (or None). The shell binds
+# session/console/grounding; headless binds a simple core-LLM call.
 StreamAnswerFn = Callable[..., Any]
 
 # Bound evidence-gather callable: ``gather(text, *, is_tty) -> str | None``.

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -152,7 +152,7 @@ class RunRecordFactory(Protocol):
 # Bound conversational-answer callable. Returns an opaque LLM-run record (or
 # None). The shell binds session/console/grounding; headless binds a simple
 # core-LLM call.
-AnswerAgent = Callable[..., Any]
+StreamAnswerFn = Callable[..., Any]
 
 # Bound evidence-gather callable: ``gather(text, *, is_tty) -> str | None``.
 EvidenceGatherer = Callable[..., "str | None"]
@@ -174,7 +174,7 @@ class TurnAccounting(Protocol):
 
 
 __all__ = [
-    "AnswerAgent",
+    "StreamAnswerFn",
     "ConfirmFn",
     "ErrorReporter",
     "EvidenceGatherer",

--- a/docs/agent-context-data-stores.md
+++ b/docs/agent-context-data-stores.md
@@ -357,7 +357,7 @@ path.unlink()
 | Gather | `build_gather_system_prompt` / `_from_turn_context` | `core/agent_harness/prompts/gather.py` |
 | Investigation | `build_investigation_system_prompt` | `tools/investigation/stages/gather_evidence/prompt.py` |
 
-The assistant path is the **streaming-answer** agent shape: it streams via
+The assistant path is the **direct answer** shape (no tools): it streams via
 `invoke_stream(prompt)` and does not use `Agent.run` (the tool-calling shape).
 The two shapes are described in `core/agent_harness/AGENTS.md`.
 

--- a/docs/agent-context-data-stores.md
+++ b/docs/agent-context-data-stores.md
@@ -71,8 +71,10 @@ flowchart TB
 
     P1 --> RUN
     P2 --> RUN
-    P3 --> RUN
-    RUN["Agent.run()"] -->|capture after _before_provider_request| FP[AgentRunResult.final_system_prompt]
+    P3 --> STREAM
+
+    RUN["Agent.run() - tool-calling shape"] -->|capture after _before_provider_request| FP[AgentRunResult.final_system_prompt]
+    STREAM["answer_cli_agent / invoke_stream - streaming shape"]
 
     A1 --> S2
     A3 --> S2
@@ -355,9 +357,9 @@ path.unlink()
 | Gather | `build_gather_system_prompt` / `_from_turn_context` | `core/agent_harness/prompts/gather.py` |
 | Investigation | `build_investigation_system_prompt` | `tools/investigation/stages/gather_evidence/prompt.py` |
 
-The assistant path is a **categorical exception**: it streams via
-`invoke_stream(prompt)` and does not use `Agent.run` (see
-`core/agent_harness/AGENTS.md`).
+The assistant path is the **streaming-answer** agent shape: it streams via
+`invoke_stream(prompt)` and does not use `Agent.run` (the tool-calling shape).
+The two shapes are described in `core/agent_harness/AGENTS.md`.
 
 ---
 

--- a/docs/agent-context-data-stores.md
+++ b/docs/agent-context-data-stores.md
@@ -74,7 +74,7 @@ flowchart TB
     P3 --> STREAM
 
     RUN["Agent.run() - tool-calling shape"] -->|capture after _before_provider_request| FP[AgentRunResult.final_system_prompt]
-    STREAM["answer_cli_agent / invoke_stream - streaming shape"]
+    STREAM["stream_answer / invoke_stream - streaming shape"]
 
     A1 --> S2
     A3 --> S2
@@ -105,7 +105,7 @@ sequenceDiagram
     participant TC as TurnContext
     participant Action as action_agent
     participant Gather as evidence_agent
-    participant Answer as answer_cli_agent
+    participant Answer as stream_answer
     participant JSONL as Session JSONL
 
     Surface->>TO: message + Session

--- a/surfaces/interactive_shell/runtime/answer_turn.py
+++ b/surfaces/interactive_shell/runtime/answer_turn.py
@@ -1,7 +1,7 @@
 """Shell adapter for one conversational answer turn.
 
 Binds the interactive shell's Rich output, grounding caches, reasoning client,
-and telemetry around core ``answer_cli_agent``.
+and telemetry around core ``stream_answer``.
 """
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from rich.console import Console
 
 from core.agent_harness.agents.turn_orchestrator import (
-    answer_cli_agent as run_core_answer_cli_agent,
+    stream_answer as core_stream_answer,
 )
 from core.agent_harness.models.turn_context import TurnContext
 from core.agent_harness.ports import OutputSink
@@ -40,7 +40,7 @@ def answer_shell_question(
 ) -> LlmRunInfo | None:
     """Answer one shell question through the grounded conversational assistant."""
     resolved_output = resolve_output_sink(console, output)
-    return run_core_answer_cli_agent(
+    return core_stream_answer(
         message,
         session,
         resolved_output,

--- a/tests/core/agent_harness/test_agent_shapes.py
+++ b/tests/core/agent_harness/test_agent_shapes.py
@@ -43,7 +43,7 @@ def test_streaming_answer_is_not_tool_calling_shape() -> None:
     assert getattr(stream_answer, "run", None) is None
 
 
-def test_stream_answer_entrypoint_doc_names_streaming_shape() -> None:
+def test_stream_answer_entrypoint_doc_names_direct_answer_shape() -> None:
     doc = inspect.getdoc(stream_answer) or ""
-    assert "streaming-answer" in doc
+    assert "direct answer" in doc
     assert "tool-calling" in doc

--- a/tests/core/agent_harness/test_agent_shapes.py
+++ b/tests/core/agent_harness/test_agent_shapes.py
@@ -21,7 +21,7 @@ def _accept_execute_actions(driver: ExecuteActions) -> ExecuteActions:
     return driver
 
 
-def test_stream_answer_matches_answer_fn_seam() -> None:
+def test_stream_answer_matches_stream_answer_fn_seam() -> None:
     assert _accept_answer(stream_answer) is stream_answer
 
 

--- a/tests/core/agent_harness/test_agent_shapes.py
+++ b/tests/core/agent_harness/test_agent_shapes.py
@@ -1,0 +1,49 @@
+"""Architecture guards for the two agent shapes documented in AGENTS.md."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import Any, get_type_hints
+
+from core.agent import Agent
+from core.agent_harness.agents.action_agent import run_action_agent_turn
+from core.agent_harness.agents.turn_orchestrator import run_turn, stream_answer
+from core.agent_harness.models.turn_results import ToolCallingTurnResult
+from core.agent_harness.ports import ExecuteActions, StreamAnswerFn
+
+
+def _accept_answer(answer: StreamAnswerFn) -> StreamAnswerFn:
+    return answer
+
+
+def _accept_execute_actions(driver: ExecuteActions) -> ExecuteActions:
+    return driver
+
+
+def test_stream_answer_matches_answer_fn_seam() -> None:
+    assert _accept_answer(stream_answer) is stream_answer
+
+
+def test_run_action_agent_turn_matches_execute_actions_seam() -> None:
+    assert _accept_execute_actions(run_action_agent_turn) is run_action_agent_turn
+
+
+def test_run_turn_wires_streaming_and_tool_calling_seams() -> None:
+    hints = get_type_hints(run_turn)
+    assert hints["answer"] == Callable[..., Any]
+    assert hints["execute_actions"] == Callable[..., ToolCallingTurnResult]
+
+
+def test_agent_is_tool_calling_shape() -> None:
+    assert callable(getattr(Agent, "run", None))
+
+
+def test_streaming_answer_is_not_tool_calling_shape() -> None:
+    assert getattr(stream_answer, "run", None) is None
+
+
+def test_stream_answer_entrypoint_doc_names_streaming_shape() -> None:
+    doc = inspect.getdoc(stream_answer) or ""
+    assert "streaming-answer" in doc
+    assert "tool-calling" in doc


### PR DESCRIPTION
Fixes #3615 

#### Describe the changes you have made in this PR -

Resolves #3615 by documenting and naming the harness’s two intentional agent shapes — no runtime behavior change.
- **Tool-calling shape** — `core.agent.Agent` / `build_agent` / `ExecuteActions` (ReAct loop via `llm.invoke`)
- **Streaming-answer shape** — `stream_answer` / `StreamAnswerFn` (single no-tool reply via `invoke_stream`)


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- Replace “categorical exception” framing with explicit two-shape design in `AGENTS.md` (+ contributor checklist)
- Rename public entrypoint `answer_cli_agent` → `stream_answer` and port alias `AnswerAgent` → `StreamAnswerFn`
- Rename private helpers (`_stream_response`, `_record_answer_turn`) for clarity
- Fix architecture diagram so the assistant path does not flow through `Agent.run()`
- Update investigation docs to reflect mixin composition (#3704)
- Add `tests/core/agent_harness/test_agent_shapes.py` architecture guards

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
