### PR TITLE
test(integrations): add azure and openobserve verifier coverage

### DIFF
--- a/tests/integrations/test_azure.py
+++ b/tests/integrations/test_azure.py
@@ -7,14 +7,16 @@ def test_verify_azure_missing_workspace_id() -> None:
     result = verify_azure("local env", {"access_token": "token"})
 
     assert result["status"] == "missing"
-    assert "workspace_id" in result["detail"]
+    # Azure verifier intentionally returns one shared message for either missing field.
+    assert result["detail"] == "Missing workspace_id or access_token."
 
 
 def test_verify_azure_missing_access_token() -> None:
     result = verify_azure("local env", {"workspace_id": "workspace"})
 
     assert result["status"] == "missing"
-    assert "access_token" in result["detail"]
+    # Azure verifier intentionally returns one shared message for either missing field.
+    assert result["detail"] == "Missing workspace_id or access_token."
 
 
 def test_verify_azure_passes_with_default_endpoint() -> None:
@@ -24,7 +26,7 @@ def test_verify_azure_passes_with_default_endpoint() -> None:
     )
 
     assert result["status"] == "passed"
-    assert "https://api.loganalytics.io" in result["detail"]
+    assert result["detail"].endswith("via https://api.loganalytics.io.")
 
 
 def test_verify_azure_passes_with_custom_endpoint() -> None:
@@ -38,4 +40,4 @@ def test_verify_azure_passes_with_custom_endpoint() -> None:
     )
 
     assert result["status"] == "passed"
-    assert "https://custom.loganalytics.example.com" in result["detail"]
+    assert result["detail"].endswith("via https://custom.loganalytics.example.com.")

--- a/tests/integrations/test_azure.py
+++ b/tests/integrations/test_azure.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from integrations.azure.verifier import verify_azure
+
+
+def test_verify_azure_missing_workspace_id() -> None:
+    result = verify_azure("local env", {"access_token": "token"})
+
+    assert result["status"] == "missing"
+    assert "workspace_id" in result["detail"]
+
+
+def test_verify_azure_missing_access_token() -> None:
+    result = verify_azure("local env", {"workspace_id": "workspace"})
+
+    assert result["status"] == "missing"
+    assert "access_token" in result["detail"]
+
+
+def test_verify_azure_passes_with_default_endpoint() -> None:
+    result = verify_azure(
+        "local env",
+        {"workspace_id": "workspace", "access_token": "token"},
+    )
+
+    assert result["status"] == "passed"
+    assert "https://api.loganalytics.io" in result["detail"]
+
+
+def test_verify_azure_passes_with_custom_endpoint() -> None:
+    result = verify_azure(
+        "local env",
+        {
+            "workspace_id": "workspace",
+            "access_token": "token",
+            "endpoint": "https://custom.loganalytics.example.com",
+        },
+    )
+
+    assert result["status"] == "passed"
+    assert "https://custom.loganalytics.example.com" in result["detail"]

--- a/tests/integrations/test_openobserve.py
+++ b/tests/integrations/test_openobserve.py
@@ -24,7 +24,7 @@ def test_verify_openobserve_passes_with_api_token() -> None:
     )
 
     assert result["status"] == "passed"
-    assert "https://openobserve.example.com" in result["detail"]
+    assert result["detail"].endswith("at https://openobserve.example.com.")
 
 
 def test_verify_openobserve_passes_with_username_password() -> None:
@@ -38,3 +38,4 @@ def test_verify_openobserve_passes_with_username_password() -> None:
     )
 
     assert result["status"] == "passed"
+    assert result["detail"].endswith("at https://openobserve.example.com.")

--- a/tests/integrations/test_openobserve.py
+++ b/tests/integrations/test_openobserve.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from integrations.openobserve.verifier import verify_openobserve
+
+
+def test_verify_openobserve_missing_base_url() -> None:
+    result = verify_openobserve("local env", {"api_token": "token"})
+
+    assert result["status"] == "missing"
+    assert "base_url" in result["detail"]
+
+
+def test_verify_openobserve_missing_auth() -> None:
+    result = verify_openobserve("local env", {"base_url": "https://openobserve.example.com"})
+
+    assert result["status"] == "missing"
+    assert "api token" in result["detail"].lower()
+
+
+def test_verify_openobserve_passes_with_api_token() -> None:
+    result = verify_openobserve(
+        "local env",
+        {"base_url": "https://openobserve.example.com/", "api_token": "token"},
+    )
+
+    assert result["status"] == "passed"
+    assert "https://openobserve.example.com" in result["detail"]
+
+
+def test_verify_openobserve_passes_with_username_password() -> None:
+    result = verify_openobserve(
+        "local env",
+        {
+            "base_url": "https://openobserve.example.com",
+            "username": "user",
+            "password": "pass",
+        },
+    )
+
+    assert result["status"] == "passed"


### PR DESCRIPTION
Continues coverage improvements from #3590

## Summary

Adds verifier coverage for Azure and OpenObserve config-presence verifiers.

### Azure
- missing workspace_id
- missing access_token
- default endpoint success
- custom endpoint success

### OpenObserve
- missing base_url
- missing auth
- api_token success
- username/password success

## Validation

python -m ruff check tests/integrations/test_openobserve.py tests/integrations/test_azure.py
python -m ruff format tests/integrations/test_openobserve.py tests/integrations/test_azure.py
python -m pytest tests/integrations/test_openobserve.py tests/integrations/test_azure.py

Result: 8 passed

<img width="1706" height="702" alt="Ekran görüntüsü 2026-07-03 205501" src="https://github.com/user-attachments/assets/f4ce38e2-683b-4608-aa78-359adb928020" />
