### PR TITLE
Fix Bug: Interactive shell loading bar does not spin during LLM/investigation progress

### DIFF
--- a/surfaces/interactive_shell/runtime/agent_presentation.py
+++ b/surfaces/interactive_shell/runtime/agent_presentation.py
@@ -84,6 +84,7 @@ async def _render_agent_presentation_transition(
             if current.show_spinner:
                 spinner.start()
                 set_prompt_suppress_fn(console.suppress_prompt_spinner)
+                console.request_prompt_refresh()
         case "turn_interrupted":
             console.print(f"[{WARNING}]· interrupted[/]")
         case "turn_error":

--- a/surfaces/interactive_shell/runtime/background/workers.py
+++ b/surfaces/interactive_shell/runtime/background/workers.py
@@ -85,11 +85,13 @@ class BackgroundTaskManager:
         # visible prompt redraws while patch_stdout(raw=True) is active and
         # the LLM stream is writing rapidly. This task explicitly invalidates
         # the prompt at 100 ms intervals so the braille glyph cycles smoothly.
+        # Check-before-sleep so the first invalidation fires as soon as streaming
+        # starts rather than always lagging by one full tick interval.
         tick_s = 0.1
         while not self.state.exit_requested:
+            if self.spinner.streaming:
+                self.prompt_invalidator()
             try:
                 await asyncio.sleep(tick_s)
             except asyncio.CancelledError:
                 return
-            if self.spinner.streaming:
-                self.prompt_invalidator()

--- a/surfaces/interactive_shell/ui/output/repl_display.py
+++ b/surfaces/interactive_shell/ui/output/repl_display.py
@@ -44,9 +44,11 @@ def _fit_hint_prefix(prefix: str, *, cols: int | None = None) -> str:
 
 
 def _stdout_is_tty() -> bool:
+    # Use fd 1 directly: sys.stdout may be a FileProxy under patch_stdout(raw=True),
+    # whose fileno() raises UnsupportedOperation and would falsely report non-TTY.
     try:
-        return os.isatty(sys.stdout.fileno())
-    except (AttributeError, io.UnsupportedOperation, OSError):
+        return os.isatty(1)
+    except OSError:
         return False
 
 

--- a/surfaces/interactive_shell/ui/streaming/console.py
+++ b/surfaces/interactive_shell/ui/streaming/console.py
@@ -42,18 +42,20 @@ class StreamingConsole(Console):
     def cancel_requested(self) -> bool:
         return self._cancel_event.is_set()
 
+    def _fire_prompt_refresh(self) -> None:
+        if self._prompt_invalidator is not None:
+            self._prompt_invalidator()
+
     def suppress_prompt_spinner(self) -> None:
         """Stop the REPL spinner before another live renderer owns the footer."""
         if not self._spinner.streaming:
             return
         self._spinner.stop()
-        if self._prompt_invalidator is not None:
-            self._prompt_invalidator()
+        self._fire_prompt_refresh()
 
     def request_prompt_refresh(self) -> None:
         """Trigger an immediate prompt redraw without affecting spinner state."""
-        if self._prompt_invalidator is not None:
-            self._prompt_invalidator()
+        self._fire_prompt_refresh()
 
     def print(self, *args: Any, **kwargs: Any) -> None:
         """Reset the TTY column before each print when not streaming."""

--- a/surfaces/interactive_shell/ui/streaming/console.py
+++ b/surfaces/interactive_shell/ui/streaming/console.py
@@ -50,6 +50,11 @@ class StreamingConsole(Console):
         if self._prompt_invalidator is not None:
             self._prompt_invalidator()
 
+    def request_prompt_refresh(self) -> None:
+        """Trigger an immediate prompt redraw without affecting spinner state."""
+        if self._prompt_invalidator is not None:
+            self._prompt_invalidator()
+
     def print(self, *args: Any, **kwargs: Any) -> None:
         """Reset the TTY column before each print when not streaming."""
         if not self._spinner.streaming and not isinstance(sys.stdout, FileProxy):

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -983,9 +983,7 @@ class TestSpinnerTicker:
             with contextlib.suppress(asyncio.CancelledError):
                 await ticker
 
-            assert len(calls) >= 3, (
-                f"expected ≥3 invalidations in 350 ms, got {len(calls)}"
-            )
+            assert len(calls) >= 3, f"expected ≥3 invalidations in 350 ms, got {len(calls)}"
 
         asyncio.run(_run())
 

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -898,8 +898,8 @@ class TestSpinnerTicker:
 
     def test_ticker_calls_invalidator_immediately_when_streaming(self) -> None:
         """Invalidator is called on the first iteration (before sleep) if streaming."""
-        from surfaces.interactive_shell.runtime.background.workers import BackgroundTaskManager
         from core.agent_harness.session import Session
+        from surfaces.interactive_shell.runtime.background.workers import BackgroundTaskManager
 
         calls: list[int] = []
 
@@ -929,8 +929,8 @@ class TestSpinnerTicker:
 
     def test_ticker_skips_invalidator_when_not_streaming(self) -> None:
         """No invalidation when spinner is idle."""
-        from surfaces.interactive_shell.runtime.background.workers import BackgroundTaskManager
         from core.agent_harness.session import Session
+        from surfaces.interactive_shell.runtime.background.workers import BackgroundTaskManager
 
         calls: list[int] = []
 
@@ -959,8 +959,8 @@ class TestSpinnerTicker:
 
     def test_ticker_fires_repeatedly_at_100ms_interval(self) -> None:
         """Over a 350 ms window the invalidator is called at least 3 times."""
-        from surfaces.interactive_shell.runtime.background.workers import BackgroundTaskManager
         from core.agent_harness.session import Session
+        from surfaces.interactive_shell.runtime.background.workers import BackgroundTaskManager
 
         calls: list[float] = []
 

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import io
 import re
 import subprocess
@@ -883,6 +884,112 @@ def _extract_glyph(ansi_text: str, frames: tuple[str, ...]) -> str:
     return ""
 
 
+# ── Spinner ticker scheduling tests ──────────────────────────────────────────
+
+
+class TestSpinnerTicker:
+    """``BackgroundTaskManager._spinner_ticker`` drives prompt redraws so the
+    braille glyph cycles while streaming is active.
+
+    The check-before-sleep ordering means the invalidator is called without
+    waiting a full tick first — important because the LLM turn may start and
+    complete before the old sleep-first code would have fired even once.
+    """
+
+    def test_ticker_calls_invalidator_immediately_when_streaming(self) -> None:
+        """Invalidator is called on the first iteration (before sleep) if streaming."""
+        from surfaces.interactive_shell.runtime.background.workers import BackgroundTaskManager
+        from core.agent_harness.session import Session
+
+        calls: list[int] = []
+
+        async def _run() -> None:
+            state = loop_state.ReplState()
+            spinner = loop_state.SpinnerState()
+            spinner.start()  # streaming = True before ticker starts
+
+            manager = BackgroundTaskManager(
+                session=Session(),
+                state=state,
+                spinner=spinner,
+                inbox=None,
+                prompt_invalidator=lambda: calls.append(1),
+            )
+
+            ticker = asyncio.create_task(manager._spinner_ticker())
+            # Yield once so ticker runs its first iteration check
+            await asyncio.sleep(0)
+            ticker.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await ticker
+
+            assert len(calls) >= 1, "invalidator must fire on the first iteration, before any sleep"
+
+        asyncio.run(_run())
+
+    def test_ticker_skips_invalidator_when_not_streaming(self) -> None:
+        """No invalidation when spinner is idle."""
+        from surfaces.interactive_shell.runtime.background.workers import BackgroundTaskManager
+        from core.agent_harness.session import Session
+
+        calls: list[int] = []
+
+        async def _run() -> None:
+            state = loop_state.ReplState()
+            spinner = loop_state.SpinnerState()
+            # streaming remains False
+
+            manager = BackgroundTaskManager(
+                session=Session(),
+                state=state,
+                spinner=spinner,
+                inbox=None,
+                prompt_invalidator=lambda: calls.append(1),
+            )
+
+            ticker = asyncio.create_task(manager._spinner_ticker())
+            await asyncio.sleep(0)
+            ticker.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await ticker
+
+            assert calls == [], "invalidator must not fire when spinner is idle"
+
+        asyncio.run(_run())
+
+    def test_ticker_fires_repeatedly_at_100ms_interval(self) -> None:
+        """Over a 350 ms window the invalidator is called at least 3 times."""
+        from surfaces.interactive_shell.runtime.background.workers import BackgroundTaskManager
+        from core.agent_harness.session import Session
+
+        calls: list[float] = []
+
+        async def _run() -> None:
+            state = loop_state.ReplState()
+            spinner = loop_state.SpinnerState()
+            spinner.start()
+
+            manager = BackgroundTaskManager(
+                session=Session(),
+                state=state,
+                spinner=spinner,
+                inbox=None,
+                prompt_invalidator=lambda: calls.append(time.monotonic()),
+            )
+
+            ticker = asyncio.create_task(manager._spinner_ticker())
+            await asyncio.sleep(0.35)
+            ticker.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await ticker
+
+            assert len(calls) >= 3, (
+                f"expected ≥3 invalidations in 350 ms, got {len(calls)}"
+            )
+
+        asyncio.run(_run())
+
+
 # ── Streaming-console adapter tests ──────────────────────────────────────────
 
 
@@ -926,6 +1033,37 @@ class TestStreamingConsole:
         assert console.cancel_requested is True
         cancel.clear()
         assert console.cancel_requested is False
+
+    def test_request_prompt_refresh_calls_invalidator(self) -> None:
+        """request_prompt_refresh() must invoke the prompt_invalidator callable."""
+        import threading as _threading
+
+        spinner = loop_state.SpinnerState()
+        calls: list[int] = []
+        console = StreamingConsole(
+            spinner,
+            _threading.Event(),
+            prompt_invalidator=lambda: calls.append(1),
+            highlight=False,
+            force_terminal=True,
+            color_system=None,
+        )
+        console.request_prompt_refresh()
+        assert calls == [1]
+
+    def test_request_prompt_refresh_is_noop_without_invalidator(self) -> None:
+        """request_prompt_refresh() must not raise when no invalidator is wired."""
+        import threading as _threading
+
+        spinner = loop_state.SpinnerState()
+        console = StreamingConsole(
+            spinner,
+            _threading.Event(),
+            highlight=False,
+            force_terminal=True,
+            color_system=None,
+        )
+        console.request_prompt_refresh()  # must not raise
 
     def test_blank_print_resets_column_without_preparing_new_line(
         self,


### PR DESCRIPTION
Fixes #3298

#### Describe the changes you have made in this PR -

- test(spinner): add tests for spinner ticker scheduling and prompt refresh behavior
- fix(console): add request_prompt_refresh method for immediate prompt redraw
- fix(workers): optimize prompt invalidation during streaming
- fix(repl_display): improve TTY detection for stdout

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [X] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Core Issue: The inline spinner shown during LLM turns in the REPL interface fails to animate properly — it either appears frozen or never starts.

---

## Checklist before requesting a review
- [X] I have added proper PR title and linked to the issue
- [X] I have performed a self-review of my code
- [X] **I can explain the purpose of every function, class, and logic block I added**
- [X] I understand why my changes work and have tested them thoroughly
- [X] I have considered potential edge cases and how my code handles them
- [X] If it is a core feature, I have added thorough tests
- [X] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
