### PR TITLE
refactor(core/agent): split Agent into mixins, loop, hooks, facade

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -19,8 +19,8 @@ from core.agent_mixins import AgentEventEmitter, AgentSteering, AgentToolFilter
 from core.events import RuntimeEventCallback, TupleEventCallback
 from core.execution import ToolExecutionHooks
 from core.llm import agent_llm_client
-from core.messages import MessageFormatter, RuntimeMessageLike
-from core.provider import ProviderHooks
+from core.messages import MessageFormatter, ProviderMessage, RuntimeMessage, RuntimeMessageLike
+from core.provider import ProviderHooks, ProviderRequest
 from core.types import RuntimeTool
 
 if TYPE_CHECKING:
@@ -200,3 +200,18 @@ class Agent[RuntimeToolT: RuntimeTool](AgentEventEmitter, AgentToolFilter, Agent
         Return ``(False, nudge_text)`` to inject a user message and continue.
         """
         return True, None
+
+    # Thin forwarders to ``self._hooks`` (an AgentProviderHookDelegate). Kept as
+    # methods rather than an exposed attribute so AgentLoopHost's contract is
+    # the four calls, not this concrete delegate type — see agent_loop.py.
+    def _transform_context(self, messages: list[RuntimeMessage]) -> list[RuntimeMessage]:
+        return self._hooks.transform_context(messages)
+
+    def _convert_to_llm(self, llm: Any, messages: list[RuntimeMessage]) -> list[ProviderMessage]:
+        return self._hooks.convert_to_llm(llm, messages)
+
+    def _before_request(self, request: ProviderRequest) -> ProviderRequest:
+        return self._hooks.before_request(request)
+
+    def _after_response(self, request: ProviderRequest, response: Any) -> Any:
+        return self._hooks.after_response(request, response)

--- a/core/agent.py
+++ b/core/agent.py
@@ -1,54 +1,27 @@
-"""Stateful ReAct agent — the shared primitive for all tool-calling surfaces."""
+"""Stateful ReAct agent — the shared primitive for all tool-calling surfaces.
+
+``Agent`` is a facade + hook binder: ``__init__`` stores construction-time
+config and ``run()`` wires per-run context into ``core.agent_loop.run_react_loop``,
+the actual algorithm. See ``core/agent_harness/AGENTS.md`` for the direct-answer
+(no-tools) shape and the harness construction pattern.
+"""
 
 from __future__ import annotations
 
 import importlib
-import logging
 from collections import deque
 from collections.abc import Sequence
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from core.agent_mixins import AgentEventEmitter, AgentToolFilter
-from core.context_budget import (
-    context_budget_ceiling_for_model,
-    enforce_context_budget,
-)
-from core.events import (
-    AgentEndEvent,
-    AgentStartEvent,
-    MessageStartEvent,
-    MessageUpdateEvent,
-    ProviderRequestEndEvent,
-    ProviderRequestStartEvent,
-    RuntimeEventCallback,
-    ToolExecutionEndEvent,
-    ToolExecutionStartEvent,
-    ToolExecutionUpdateEvent,
-    TupleEventCallback,
-    TurnEndEvent,
-    TurnStartEvent,
-)
-from core.execution import (
-    ToolExecutionHooks,
-    ToolExecutionRequest,
-    ToolExecutionResult,
-    execute_tool_calls,
-    public_tool_input,
-)
+from core.agent_hooks import AgentProviderHookDelegate
+from core.agent_loop import AgentRunContext, AgentRunResult, run_react_loop
+from core.agent_mixins import AgentEventEmitter, AgentSteering, AgentToolFilter
+from core.events import RuntimeEventCallback, TupleEventCallback
+from core.execution import ToolExecutionHooks
 from core.llm import agent_llm_client
-from core.llm.types import ToolCall
-from core.messages import (
-    MessageFormatter,
-    RuntimeMessage,
-    RuntimeMessageLike,
-    UserRuntimeMessage,
-)
-from core.provider import ProviderHooks, ProviderRequest
+from core.messages import MessageFormatter, RuntimeMessageLike
+from core.provider import ProviderHooks
 from core.types import RuntimeTool
-from platform.observability.tool_trace import redact_sensitive
-
-logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from core.agent_harness.models.turn_context import AgentRuntimeRequest
@@ -66,29 +39,10 @@ if TYPE_CHECKING:
     )
 
 
-@dataclass
-class AgentRunResult:
-    """Outcome of :meth:`Agent.run`.
-
-    ``messages`` is the full conversation, ``final_text`` is the assistant's
-    last no-tool-call turn, ``executed`` is the historical ordered list of raw
-    tool payloads, and ``tool_results`` contains the structured runtime results.
-    """
-
-    messages: list[RuntimeMessage]
-    final_text: str
-    executed: list[tuple[ToolCall, Any]] = field(default_factory=list)
-    tool_results: list[tuple[ToolCall, ToolExecutionResult]] = field(default_factory=list)
-    terminated_by_tool: bool = False
-    hit_iteration_cap: bool = False
-    final_system_prompt: str = ""
-    """System prompt sent to the LLM on the last request (post-hook), for debugging."""
-
-
-class Agent[RuntimeToolT: RuntimeTool](AgentEventEmitter, AgentToolFilter):
+class Agent[RuntimeToolT: RuntimeTool](AgentEventEmitter, AgentToolFilter, AgentSteering):
     """Stateful, configurable ReAct agent — the tool-calling agent shape.
 
-    Owns the think → call-tools → observe loop and exposes hook methods so
+    Wires per-run context into ``run_react_loop`` and exposes hook methods so
     subclasses can customise stopping logic and tool filtering without
     re-implementing the loop. For the direct-answer shape (no tools), see
     ``core/agent_harness/AGENTS.md``.
@@ -181,19 +135,9 @@ class Agent[RuntimeToolT: RuntimeTool](AgentEventEmitter, AgentToolFilter):
         self._on_runtime_event = on_runtime_event
         self._tool_hooks = tool_hooks or ToolExecutionHooks()
         self._tool_resources = dict(tool_resources or {})
-        self._provider_hooks = provider_hooks or ProviderHooks()
+        self._hooks = AgentProviderHookDelegate(provider_hooks or ProviderHooks())
         self._steering_messages: deque[str] = deque()
         self._follow_up_messages: deque[str] = deque()
-
-    def steer(self, message: str) -> None:
-        """Inject a user message into the active run before the next LLM turn."""
-        if message.strip():
-            self._steering_messages.append(message)
-
-    def follow_up(self, message: str) -> None:
-        """Queue a user message to run after the current turn would otherwise stop."""
-        if message.strip():
-            self._follow_up_messages.append(message)
 
     def run(
         self,
@@ -201,7 +145,7 @@ class Agent[RuntimeToolT: RuntimeTool](AgentEventEmitter, AgentToolFilter):
         *,
         agent_context: AgentRuntimeRequest | None = None,
     ) -> AgentRunResult:
-        """Run the think → call-tools → observe loop and return its outcome."""
+        """Resolve per-run context and hand it to ``run_react_loop``."""
         if agent_context is not None:
             agent_context.validate_runtime_request()
             messages = agent_context.runtime_messages()
@@ -233,205 +177,16 @@ class Agent[RuntimeToolT: RuntimeTool](AgentEventEmitter, AgentToolFilter):
             raise ValueError("Agent.run requires initial_messages or agent_context.")
 
         assert self._llm is not None, "Agent.run: llm must be set before the loop"
-        llm = self._llm
-        msg_formatter = MessageFormatter(llm)
-        runtime_tools = list(self._filter_tools(tools))
-        tool_schemas = llm.tool_schemas(runtime_tools)
-        ceiling = context_budget_ceiling_for_model(getattr(llm, "_model", None))
-        executed: list[tuple[ToolCall, Any]] = []
-        tool_results: list[tuple[ToolCall, ToolExecutionResult]] = []
-        final_text = ""
-        final_system_prompt = system
-        hit_cap = True
-        terminated_by_tool = False
-        self._emit_runtime(
-            AgentStartEvent(
-                data={
-                    "tool_count": len(runtime_tools),
-                    "max_iterations": max_iterations,
-                    "message_count": len(messages),
-                }
-            )
-        )
-
-        for iteration in range(max_iterations):
-            self._drain_steering_messages(messages)
-            self._emit_runtime(
-                TurnStartEvent(
-                    iteration=iteration,
-                    data={"message_count": len(messages), "tool_count": len(runtime_tools)},
-                )
-            )
-            transformed_messages = self._transform_context(messages)
-            llm_messages = self._convert_to_llm(transformed_messages)
-            enforce_context_budget(llm_messages, system=system, tools=tool_schemas, ceiling=ceiling)
-            provider_request = ProviderRequest(
-                messages=llm_messages,
-                system=system,
-                tools=tool_schemas,
-                metadata={"iteration": iteration},
-            )
-            provider_request = self._before_provider_request(provider_request)
-            final_system_prompt = provider_request.system
-            self._emit_runtime(
-                ProviderRequestStartEvent(
-                    iteration=iteration,
-                    message_count=len(provider_request.messages),
-                )
-            )
-            response = llm.invoke(
-                provider_request.messages,
-                system=provider_request.system,
-                tools=provider_request.tools,
-            )
-            response = self._after_provider_response(provider_request, response)
-            self._emit_runtime(
-                ProviderRequestEndEvent(
-                    iteration=iteration,
-                    has_tool_calls=response.has_tool_calls,
-                )
-            )
-            assistant_message = msg_formatter.to_assistant_runtime_message(response)
-            self._emit_runtime(MessageStartEvent(message=assistant_message, iteration=iteration))
-            if response.content:
-                self._emit_runtime(
-                    MessageUpdateEvent(
-                        message=assistant_message,
-                        delta=response.content,
-                        iteration=iteration,
-                    )
-                )
-            messages.append(assistant_message)
-
-            if not response.has_tool_calls:
-                accept, nudge = self._should_accept_conclusion(
-                    evidence_count=len(executed), iteration=iteration
-                )
-                if accept:
-                    follow_up = self._pop_follow_up_message()
-                    if follow_up is not None:
-                        messages.append(UserRuntimeMessage(content=follow_up))
-                        self._emit_runtime(
-                            TurnEndEvent(
-                                iteration=iteration,
-                                message=assistant_message,
-                                data={"accepted": False, "queued_follow_up": True},
-                            )
-                        )
-                        continue
-                    final_text = response.content or ""
-                    hit_cap = False
-                    self._emit_runtime(
-                        TurnEndEvent(
-                            iteration=iteration,
-                            message=assistant_message,
-                            data={"accepted": True},
-                        )
-                    )
-                    break
-                if nudge is None:
-                    raise ValueError(
-                        f"{type(self).__name__}._should_accept_conclusion returned "
-                        "(False, None) — a nudge string is required when rejecting "
-                        "the conclusion, otherwise the LLM will loop on an unchanged "
-                        "message history until max_iterations."
-                    )
-                messages.append(UserRuntimeMessage(content=nudge))
-                self._emit_runtime(
-                    TurnEndEvent(
-                        iteration=iteration,
-                        message=assistant_message,
-                        data={"accepted": False, "nudge": True},
-                    )
-                )
-                continue
-
-            for tc in response.tool_calls:
-                self._emit_runtime(
-                    ToolExecutionStartEvent(
-                        tool_call_id=tc.id,
-                        tool_name=tc.name,
-                        args=public_tool_input(tc.input),
-                        iteration=iteration,
-                    )
-                )
-
-            def on_tool_update(
-                request: ToolExecutionRequest,
-                update: Any,
-                *,
-                event_iteration: int = iteration,
-            ) -> None:
-                self._emit_tool_update(request, update, event_iteration=event_iteration)
-
-            hooks = ToolExecutionHooks(
-                before_tool_call=self._tool_hooks.before_tool_call,
-                after_tool_call=self._tool_hooks.after_tool_call,
-                on_tool_update=on_tool_update,
-            )
-            results = execute_tool_calls(
-                response.tool_calls,
-                runtime_tools,
-                resolved,
-                hooks=hooks,
-                tool_resources=tool_resources,
-            )
-            provider_results = [result.provider_content() for result in results]
-            tool_result_message = msg_formatter.to_tool_result_runtime_message(
-                response.tool_calls, provider_results
-            )
-            messages.append(tool_result_message)
-
-            for tc, result in zip(response.tool_calls, results):
-                compat_payload = result.compat_payload()
-                executed.append((tc, compat_payload))
-                tool_results.append((tc, result))
-                self._emit_runtime(
-                    ToolExecutionEndEvent(
-                        tool_call_id=tc.id,
-                        tool_name=tc.name,
-                        args=public_tool_input(tc.input),
-                        result=redact_sensitive(compat_payload),
-                        is_error=result.is_error,
-                        iteration=iteration,
-                        data={"terminate": result.terminate},
-                    )
-                )
-            self._emit_runtime(
-                TurnEndEvent(
-                    iteration=iteration,
-                    message=assistant_message,
-                    tool_results=tuple(result.compat_payload() for result in results),
-                    data={"accepted": False},
-                )
-            )
-            if any(result.terminate for result in results):
-                terminated_by_tool = True
-                hit_cap = False
-                break
-
-        run_result = AgentRunResult(
+        run_context = AgentRunContext[RuntimeToolT](
+            llm=self._llm,
+            system=system,
+            tools=tools,
+            resolved=resolved,
+            tool_resources=tool_resources,
+            max_iterations=max_iterations,
             messages=messages,
-            final_text=final_text,
-            executed=executed,
-            tool_results=tool_results,
-            terminated_by_tool=terminated_by_tool,
-            hit_iteration_cap=hit_cap,
-            final_system_prompt=final_system_prompt,
         )
-        self._emit_runtime(
-            AgentEndEvent(
-                messages=tuple(messages),
-                data={
-                    "final_text": final_text,
-                    "hit_iteration_cap": hit_cap,
-                    "terminated_by_tool": terminated_by_tool,
-                    "message_count": len(messages),
-                    "executed_count": len(executed),
-                },
-            )
-        )
-        return run_result
+        return run_react_loop(run_context, self)
 
     def _should_accept_conclusion(
         self,
@@ -445,75 +200,3 @@ class Agent[RuntimeToolT: RuntimeTool](AgentEventEmitter, AgentToolFilter):
         Return ``(False, nudge_text)`` to inject a user message and continue.
         """
         return True, None
-
-    def _drain_steering_messages(self, messages: list[RuntimeMessage]) -> None:
-        while self._steering_messages:
-            messages.append(UserRuntimeMessage(content=self._steering_messages.popleft()))
-
-    def _pop_follow_up_message(self) -> str | None:
-        if not self._follow_up_messages:
-            return None
-        return self._follow_up_messages.popleft()
-
-    def _emit_tool_update(
-        self,
-        request: ToolExecutionRequest,
-        update: Any,
-        *,
-        event_iteration: int,
-    ) -> None:
-        if self._tool_hooks.on_tool_update is not None:
-            try:
-                self._tool_hooks.on_tool_update(request, update)
-            except Exception:  # noqa: BLE001 - observer failures must not break execution
-                logger.debug(
-                    "[runtime] on_tool_update(%s) raised; ignoring",
-                    request.tool_call.name,
-                    exc_info=True,
-                )
-        self._emit_runtime(
-            ToolExecutionUpdateEvent(
-                tool_call_id=request.tool_call.id,
-                tool_name=request.tool_call.name,
-                args=public_tool_input(request.tool_call.input),
-                partial_result=redact_sensitive(update),
-                iteration=event_iteration,
-            )
-        )
-
-    def _before_provider_request(self, request: ProviderRequest) -> ProviderRequest:
-        try:
-            return self._provider_hooks.apply_before_request(request)
-        except Exception:  # noqa: BLE001 - provider hooks are observability/customization only
-            logger.debug("[runtime] before_provider_request raised; ignoring", exc_info=True)
-            return request
-
-    def _after_provider_response(self, request: ProviderRequest, response: Any) -> Any:
-        try:
-            return self._provider_hooks.apply_after_response(request, response)
-        except Exception:  # noqa: BLE001 - preserve the transcript if hooks fail
-            logger.debug("[runtime] after_provider_response raised; ignoring", exc_info=True)
-            return response
-
-    def _transform_context(self, messages: list[RuntimeMessage]) -> list[RuntimeMessage]:
-        try:
-            return self._provider_hooks.apply_transform_context(messages)
-        except Exception:  # noqa: BLE001 - fall back to the unmodified transcript
-            logger.debug(
-                "[runtime] transform_context raised; using original messages", exc_info=True
-            )
-            return list(messages)
-
-    def _convert_to_llm(self, messages: list[RuntimeMessage]) -> list[dict[str, Any]]:
-        # ``run()`` resolves ``self._llm`` before entering the loop; this method
-        # is a per-iteration helper and never called before then.
-        assert self._llm is not None, (
-            "_convert_to_llm called before run() resolved self._llm — "
-            "callers must go through run(), not private helpers"
-        )
-        llm = self._llm
-        try:
-            return self._provider_hooks.apply_convert_to_llm(llm, messages)
-        except Exception:  # noqa: BLE001 - fall back to the standard provider conversion
-            logger.debug("[runtime] convert_to_llm raised; using default conversion", exc_info=True)
-            return MessageFormatter(llm).to_provider_messages(messages)

--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -180,8 +180,8 @@ Before opening or merging an agent PR, confirm:
    entrypoint or rename a shape seam.
 
 **Read order for new code:** this file → `docs/agent-context-data-stores.md` →
-`agents/turn_orchestrator.py` (`run_turn`) → `core/agent.py` (tool-calling loop
-only).
+`agents/turn_orchestrator.py` (`run_turn`) → `core/agent.py` (facade + wiring)
+→ `core/agent_loop.py` (`run_react_loop`, the tool-calling algorithm).
 
 ## Investigation agent — the tool-calling shape with a custom loop
 
@@ -197,3 +197,38 @@ the two agent hooks by composition rather than delegating to the generic
 
 The ReAct loop primitive is `core.agent.Agent`. `agent_harness/` orchestrates it;
 it does not re-implement it. Do not fork the loop here.
+
+## core/agent* module split (Agent is a facade, not the algorithm owner)
+
+`core/agent.py` is a thin facade + hook binder — `Agent.__init__` stores
+construction-time config and `Agent.run()` resolves per-run context (from
+`agent_context=` or `initial_messages=`) and hands it to
+`core.agent_loop.run_react_loop`, which owns the actual think → call-tools →
+observe algorithm:
+
+- `core/agent_mixins.py` — `AgentEventEmitter` (event dispatch),
+  `AgentToolFilter` (tool-narrowing hook), `AgentSteering` (the
+  `steer`/`follow_up` stop/continue/redirect control-plane). `Agent` composes
+  all three; `ConnectedInvestigationAgent`
+  (`tools/investigation/stages/gather_evidence/agent.py`) composes the first
+  two directly instead of subclassing `Agent`.
+- `core/agent_hooks.py` — `AgentProviderHookDelegate`, a fail-open wrapper
+  around `core.provider.ProviderHooks` (context transform, provider
+  request/response, LLM conversion). A raised hook exception is logged and
+  swallowed; it never breaks the loop.
+- `core/agent_loop.py` — `AgentRunContext` (resolved per-run inputs),
+  `AgentLoopHost` (the `Protocol` `run_react_loop` calls back into — `Agent`
+  implements it via the mixins above plus `_hooks`/`_tool_hooks`), and
+  `run_react_loop` itself. `AgentRunResult` also lives here; `core.agent`
+  re-exports it for the existing `from core.agent import AgentRunResult`
+  import path.
+- `core/agent.py` — the facade: static `dispatch_message_to_headless_agent` /
+  `resolve_integrations` entrypoints, `__init__`, `run()`, and the
+  `_should_accept_conclusion` override hook.
+
+Do not reintroduce hook-method overrides on `Agent` itself (e.g. a subclass
+overriding a private `_before_provider_request`-style method) — customize via
+`provider_hooks=ProviderHooks(...)` at construction instead, which
+`AgentProviderHookDelegate` applies. Subclassing remains the pattern for
+`_filter_tools` and `_should_accept_conclusion`, which are genuine per-agent
+overrides, not seams `ProviderHooks` covers.

--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -218,10 +218,14 @@ observe algorithm:
   swallowed; it never breaks the loop.
 - `core/agent_loop.py` — `AgentRunContext` (resolved per-run inputs),
   `AgentLoopHost` (the `Protocol` `run_react_loop` calls back into — `Agent`
-  implements it via the mixins above plus `_hooks`/`_tool_hooks`), and
-  `run_react_loop` itself. `AgentRunResult` also lives here; `core.agent`
-  re-exports it for the existing `from core.agent import AgentRunResult`
-  import path.
+  implements it via the mixins above plus its own `_transform_context` /
+  `_convert_to_llm` / `_before_request` / `_after_response` forwarders), and
+  `run_react_loop` itself. `AgentLoopHost` intentionally exposes the four
+  provider-hook seams as method calls, not a `_hooks: AgentProviderHookDelegate`
+  attribute — the concrete delegate type is an `Agent` implementation detail,
+  not part of the host contract, so any host can wire the seams however it
+  likes. `AgentRunResult` also lives here; `core.agent` re-exports it for the
+  existing `from core.agent import AgentRunResult` import path.
 - `core/agent.py` — the facade: static `dispatch_message_to_headless_agent` /
   `resolve_integrations` entrypoints, `__init__`, `run()`, and the
   `_should_accept_conclusion` override hook.

--- a/core/agent_hooks.py
+++ b/core/agent_hooks.py
@@ -1,0 +1,63 @@
+"""Provider-hook delegate: applies :class:`~core.provider.ProviderHooks` with
+fail-open error handling so a broken hook never breaks the agent loop.
+
+``Agent`` owns one :class:`AgentProviderHookDelegate` per run and the loop
+(``core.agent_loop.run_react_loop``) calls it at each of the four seams
+(context transform, provider request, provider response, LLM conversion)
+instead of talking to ``ProviderHooks`` directly.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from core.messages import MessageFormatter
+from core.provider import ProviderHooks, ProviderRequest
+
+if TYPE_CHECKING:
+    from core.messages import ProviderMessage, RuntimeMessage
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AgentProviderHookDelegate:
+    """Wraps :class:`ProviderHooks`; swallows hook exceptions and logs instead."""
+
+    hooks: ProviderHooks
+
+    def transform_context(self, messages: Sequence[RuntimeMessage]) -> list[RuntimeMessage]:
+        try:
+            return self.hooks.apply_transform_context(messages)
+        except Exception:  # noqa: BLE001 - fall back to the unmodified transcript
+            logger.debug(
+                "[runtime] transform_context raised; using original messages", exc_info=True
+            )
+            return list(messages)
+
+    def convert_to_llm(self, llm: Any, messages: Sequence[RuntimeMessage]) -> list[ProviderMessage]:
+        try:
+            return self.hooks.apply_convert_to_llm(llm, messages)
+        except Exception:  # noqa: BLE001 - fall back to the standard provider conversion
+            logger.debug("[runtime] convert_to_llm raised; using default conversion", exc_info=True)
+            return MessageFormatter(llm).to_provider_messages(messages)
+
+    def before_request(self, request: ProviderRequest) -> ProviderRequest:
+        try:
+            return self.hooks.apply_before_request(request)
+        except Exception:  # noqa: BLE001 - provider hooks are observability/customization only
+            logger.debug("[runtime] before_provider_request raised; ignoring", exc_info=True)
+            return request
+
+    def after_response(self, request: ProviderRequest, response: Any) -> Any:
+        try:
+            return self.hooks.apply_after_response(request, response)
+        except Exception:  # noqa: BLE001 - preserve the transcript if hooks fail
+            logger.debug("[runtime] after_provider_response raised; ignoring", exc_info=True)
+            return response
+
+
+__all__ = ["AgentProviderHookDelegate"]

--- a/core/agent_loop.py
+++ b/core/agent_loop.py
@@ -89,17 +89,22 @@ class AgentLoopHost[RuntimeToolT: RuntimeTool](Protocol):
     _tool_hooks: ToolExecutionHooks
     _hooks: AgentProviderHookDelegate
 
-    def _filter_tools(self, tools: list[RuntimeToolT]) -> list[RuntimeToolT]: ...
+    def _filter_tools(self, tools: list[RuntimeToolT]) -> list[RuntimeToolT]:
+        pass
 
-    def _emit_runtime(self, event: RuntimeEvent) -> None: ...
+    def _emit_runtime(self, event: RuntimeEvent) -> None:
+        pass
 
-    def _drain_steering_messages(self, messages: list[RuntimeMessage]) -> None: ...
+    def _drain_steering_messages(self, messages: list[RuntimeMessage]) -> None:
+        pass
 
-    def _pop_follow_up_message(self) -> str | None: ...
+    def _pop_follow_up_message(self) -> str | None:
+        pass
 
     def _should_accept_conclusion(
         self, *, evidence_count: int, iteration: int
-    ) -> tuple[bool, str | None]: ...
+    ) -> tuple[bool, str | None]:
+        pass
 
 
 def _emit_tool_update(

--- a/core/agent_loop.py
+++ b/core/agent_loop.py
@@ -14,7 +14,6 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
-from core.agent_hooks import AgentProviderHookDelegate
 from core.context_budget import context_budget_ceiling_for_model, enforce_context_budget
 from core.events import (
     AgentEndEvent,
@@ -38,7 +37,7 @@ from core.execution import (
     public_tool_input,
 )
 from core.llm.types import ToolCall
-from core.messages import MessageFormatter, RuntimeMessage, UserRuntimeMessage
+from core.messages import MessageFormatter, ProviderMessage, RuntimeMessage, UserRuntimeMessage
 from core.provider import ProviderRequest
 from core.types import RuntimeTool
 from platform.observability.tool_trace import redact_sensitive
@@ -83,11 +82,14 @@ class AgentLoopHost[RuntimeToolT: RuntimeTool](Protocol):
 
     ``core.agent.Agent`` implements this via ``AgentEventEmitter``,
     ``AgentToolFilter``, ``AgentSteering`` (``core.agent_mixins``), and its own
-    ``_should_accept_conclusion`` override hook.
+    ``_should_accept_conclusion`` override hook plus thin ``AgentProviderHookDelegate``
+    forwarders (``_transform_context``/``_convert_to_llm``/``_before_request``/
+    ``_after_response``). The provider-hook delegate's concrete type is
+    deliberately *not* part of this contract — only the method calls are —
+    so a host can wire the four seams however it likes.
     """
 
     _tool_hooks: ToolExecutionHooks
-    _hooks: AgentProviderHookDelegate
 
     def _filter_tools(self, tools: list[RuntimeToolT]) -> list[RuntimeToolT]:
         pass
@@ -104,6 +106,18 @@ class AgentLoopHost[RuntimeToolT: RuntimeTool](Protocol):
     def _should_accept_conclusion(
         self, *, evidence_count: int, iteration: int
     ) -> tuple[bool, str | None]:
+        pass
+
+    def _transform_context(self, messages: list[RuntimeMessage]) -> list[RuntimeMessage]:
+        pass
+
+    def _convert_to_llm(self, llm: Any, messages: list[RuntimeMessage]) -> list[ProviderMessage]:
+        pass
+
+    def _before_request(self, request: ProviderRequest) -> ProviderRequest:
+        pass
+
+    def _after_response(self, request: ProviderRequest, response: Any) -> Any:
         pass
 
 
@@ -174,8 +188,8 @@ def run_react_loop[RuntimeToolT: RuntimeTool](
                 data={"message_count": len(messages), "tool_count": len(runtime_tools)},
             )
         )
-        transformed_messages = host._hooks.transform_context(messages)
-        llm_messages = host._hooks.convert_to_llm(llm, transformed_messages)
+        transformed_messages = host._transform_context(messages)
+        llm_messages = host._convert_to_llm(llm, transformed_messages)
         enforce_context_budget(llm_messages, system=system, tools=tool_schemas, ceiling=ceiling)
         provider_request = ProviderRequest(
             messages=llm_messages,
@@ -183,7 +197,7 @@ def run_react_loop[RuntimeToolT: RuntimeTool](
             tools=tool_schemas,
             metadata={"iteration": iteration},
         )
-        provider_request = host._hooks.before_request(provider_request)
+        provider_request = host._before_request(provider_request)
         final_system_prompt = provider_request.system or system
         host._emit_runtime(
             ProviderRequestStartEvent(
@@ -196,7 +210,7 @@ def run_react_loop[RuntimeToolT: RuntimeTool](
             system=provider_request.system,
             tools=provider_request.tools,
         )
-        response = host._hooks.after_response(provider_request, response)
+        response = host._after_response(provider_request, response)
         host._emit_runtime(
             ProviderRequestEndEvent(
                 iteration=iteration,

--- a/core/agent_loop.py
+++ b/core/agent_loop.py
@@ -1,0 +1,344 @@
+"""The ReAct loop algorithm: think -> call tools -> observe.
+
+``run_react_loop`` is the algorithm ``core.agent.Agent`` wires context into. It
+has no direct coupling to ``Agent`` — it only needs an ``AgentRunContext``
+(the resolved, per-run inputs) and an ``AgentLoopHost`` (the narrow set of
+hooks the loop calls back into: event emission, tool filtering, steering,
+conclusion acceptance, and provider hooks). Any object implementing
+``AgentLoopHost`` can drive this loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from core.agent_hooks import AgentProviderHookDelegate
+from core.context_budget import context_budget_ceiling_for_model, enforce_context_budget
+from core.events import (
+    AgentEndEvent,
+    AgentStartEvent,
+    MessageStartEvent,
+    MessageUpdateEvent,
+    ProviderRequestEndEvent,
+    ProviderRequestStartEvent,
+    RuntimeEvent,
+    ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
+    ToolExecutionUpdateEvent,
+    TurnEndEvent,
+    TurnStartEvent,
+)
+from core.execution import (
+    ToolExecutionHooks,
+    ToolExecutionRequest,
+    ToolExecutionResult,
+    execute_tool_calls,
+    public_tool_input,
+)
+from core.llm.types import ToolCall
+from core.messages import MessageFormatter, RuntimeMessage, UserRuntimeMessage
+from core.provider import ProviderRequest
+from core.types import RuntimeTool
+from platform.observability.tool_trace import redact_sensitive
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AgentRunResult:
+    """Outcome of :func:`run_react_loop` (returned as-is by ``Agent.run``).
+
+    ``messages`` is the full conversation, ``final_text`` is the assistant's
+    last no-tool-call turn, ``executed`` is the historical ordered list of raw
+    tool payloads, and ``tool_results`` contains the structured runtime results.
+    """
+
+    messages: list[RuntimeMessage]
+    final_text: str
+    executed: list[tuple[ToolCall, Any]] = field(default_factory=list)
+    tool_results: list[tuple[ToolCall, ToolExecutionResult]] = field(default_factory=list)
+    terminated_by_tool: bool = False
+    hit_iteration_cap: bool = False
+    final_system_prompt: str = ""
+    """System prompt sent to the LLM on the last request (post-hook), for debugging."""
+
+
+@dataclass
+class AgentRunContext[RuntimeToolT: RuntimeTool]:
+    """Resolved, per-run inputs the loop needs — assembled once by ``Agent.run``."""
+
+    llm: Any
+    system: str
+    tools: list[RuntimeToolT]
+    resolved: dict[str, Any]
+    tool_resources: dict[str, Any]
+    max_iterations: int
+    messages: list[RuntimeMessage]
+
+
+class AgentLoopHost[RuntimeToolT: RuntimeTool](Protocol):
+    """The narrow set of hooks ``run_react_loop`` calls back into.
+
+    ``core.agent.Agent`` implements this via ``AgentEventEmitter``,
+    ``AgentToolFilter``, ``AgentSteering`` (``core.agent_mixins``), and its own
+    ``_should_accept_conclusion`` override hook.
+    """
+
+    _tool_hooks: ToolExecutionHooks
+    _hooks: AgentProviderHookDelegate
+
+    def _filter_tools(self, tools: list[RuntimeToolT]) -> list[RuntimeToolT]: ...
+
+    def _emit_runtime(self, event: RuntimeEvent) -> None: ...
+
+    def _drain_steering_messages(self, messages: list[RuntimeMessage]) -> None: ...
+
+    def _pop_follow_up_message(self) -> str | None: ...
+
+    def _should_accept_conclusion(
+        self, *, evidence_count: int, iteration: int
+    ) -> tuple[bool, str | None]: ...
+
+
+def _emit_tool_update(
+    host: AgentLoopHost[Any],
+    request: ToolExecutionRequest,
+    update: Any,
+    *,
+    event_iteration: int,
+) -> None:
+    if host._tool_hooks.on_tool_update is not None:
+        try:
+            host._tool_hooks.on_tool_update(request, update)
+        except Exception:  # noqa: BLE001 - observer failures must not break execution
+            logger.debug(
+                "[runtime] on_tool_update(%s) raised; ignoring",
+                request.tool_call.name,
+                exc_info=True,
+            )
+    host._emit_runtime(
+        ToolExecutionUpdateEvent(
+            tool_call_id=request.tool_call.id,
+            tool_name=request.tool_call.name,
+            args=public_tool_input(request.tool_call.input),
+            partial_result=redact_sensitive(update),
+            iteration=event_iteration,
+        )
+    )
+
+
+def run_react_loop[RuntimeToolT: RuntimeTool](
+    context: AgentRunContext[RuntimeToolT],
+    host: AgentLoopHost[RuntimeToolT],
+) -> AgentRunResult:
+    """Run the think -> call-tools -> observe loop and return its outcome."""
+    llm = context.llm
+    system = context.system
+    resolved = context.resolved
+    tool_resources = context.tool_resources
+    max_iterations = context.max_iterations
+    messages = context.messages
+
+    msg_formatter = MessageFormatter(llm)
+    runtime_tools = list(host._filter_tools(context.tools))
+    tool_schemas = llm.tool_schemas(runtime_tools)
+    ceiling = context_budget_ceiling_for_model(getattr(llm, "_model", None))
+    executed: list[tuple[ToolCall, Any]] = []
+    tool_results: list[tuple[ToolCall, ToolExecutionResult]] = []
+    final_text = ""
+    final_system_prompt = system
+    hit_cap = True
+    terminated_by_tool = False
+    host._emit_runtime(
+        AgentStartEvent(
+            data={
+                "tool_count": len(runtime_tools),
+                "max_iterations": max_iterations,
+                "message_count": len(messages),
+            }
+        )
+    )
+
+    for iteration in range(max_iterations):
+        host._drain_steering_messages(messages)
+        host._emit_runtime(
+            TurnStartEvent(
+                iteration=iteration,
+                data={"message_count": len(messages), "tool_count": len(runtime_tools)},
+            )
+        )
+        transformed_messages = host._hooks.transform_context(messages)
+        llm_messages = host._hooks.convert_to_llm(llm, transformed_messages)
+        enforce_context_budget(llm_messages, system=system, tools=tool_schemas, ceiling=ceiling)
+        provider_request = ProviderRequest(
+            messages=llm_messages,
+            system=system,
+            tools=tool_schemas,
+            metadata={"iteration": iteration},
+        )
+        provider_request = host._hooks.before_request(provider_request)
+        final_system_prompt = provider_request.system or system
+        host._emit_runtime(
+            ProviderRequestStartEvent(
+                iteration=iteration,
+                message_count=len(provider_request.messages),
+            )
+        )
+        response = llm.invoke(
+            provider_request.messages,
+            system=provider_request.system,
+            tools=provider_request.tools,
+        )
+        response = host._hooks.after_response(provider_request, response)
+        host._emit_runtime(
+            ProviderRequestEndEvent(
+                iteration=iteration,
+                has_tool_calls=response.has_tool_calls,
+            )
+        )
+        assistant_message = msg_formatter.to_assistant_runtime_message(response)
+        host._emit_runtime(MessageStartEvent(message=assistant_message, iteration=iteration))
+        if response.content:
+            host._emit_runtime(
+                MessageUpdateEvent(
+                    message=assistant_message,
+                    delta=response.content,
+                    iteration=iteration,
+                )
+            )
+        messages.append(assistant_message)
+
+        if not response.has_tool_calls:
+            accept, nudge = host._should_accept_conclusion(
+                evidence_count=len(executed), iteration=iteration
+            )
+            if accept:
+                follow_up = host._pop_follow_up_message()
+                if follow_up is not None:
+                    messages.append(UserRuntimeMessage(content=follow_up))
+                    host._emit_runtime(
+                        TurnEndEvent(
+                            iteration=iteration,
+                            message=assistant_message,
+                            data={"accepted": False, "queued_follow_up": True},
+                        )
+                    )
+                    continue
+                final_text = response.content or ""
+                hit_cap = False
+                host._emit_runtime(
+                    TurnEndEvent(
+                        iteration=iteration,
+                        message=assistant_message,
+                        data={"accepted": True},
+                    )
+                )
+                break
+            if nudge is None:
+                raise ValueError(
+                    f"{type(host).__name__}._should_accept_conclusion returned "
+                    "(False, None) — a nudge string is required when rejecting "
+                    "the conclusion, otherwise the LLM will loop on an unchanged "
+                    "message history until max_iterations."
+                )
+            messages.append(UserRuntimeMessage(content=nudge))
+            host._emit_runtime(
+                TurnEndEvent(
+                    iteration=iteration,
+                    message=assistant_message,
+                    data={"accepted": False, "nudge": True},
+                )
+            )
+            continue
+
+        for tc in response.tool_calls:
+            host._emit_runtime(
+                ToolExecutionStartEvent(
+                    tool_call_id=tc.id,
+                    tool_name=tc.name,
+                    args=public_tool_input(tc.input),
+                    iteration=iteration,
+                )
+            )
+
+        def on_tool_update(
+            request: ToolExecutionRequest,
+            update: Any,
+            *,
+            event_iteration: int = iteration,
+        ) -> None:
+            _emit_tool_update(host, request, update, event_iteration=event_iteration)
+
+        hooks = ToolExecutionHooks(
+            before_tool_call=host._tool_hooks.before_tool_call,
+            after_tool_call=host._tool_hooks.after_tool_call,
+            on_tool_update=on_tool_update,
+        )
+        results = execute_tool_calls(
+            response.tool_calls,
+            runtime_tools,
+            resolved,
+            hooks=hooks,
+            tool_resources=tool_resources,
+        )
+        provider_results = [result.provider_content() for result in results]
+        tool_result_message = msg_formatter.to_tool_result_runtime_message(
+            response.tool_calls, provider_results
+        )
+        messages.append(tool_result_message)
+
+        for tc, result in zip(response.tool_calls, results):
+            compat_payload = result.compat_payload()
+            executed.append((tc, compat_payload))
+            tool_results.append((tc, result))
+            host._emit_runtime(
+                ToolExecutionEndEvent(
+                    tool_call_id=tc.id,
+                    tool_name=tc.name,
+                    args=public_tool_input(tc.input),
+                    result=redact_sensitive(compat_payload),
+                    is_error=result.is_error,
+                    iteration=iteration,
+                    data={"terminate": result.terminate},
+                )
+            )
+        host._emit_runtime(
+            TurnEndEvent(
+                iteration=iteration,
+                message=assistant_message,
+                tool_results=tuple(result.compat_payload() for result in results),
+                data={"accepted": False},
+            )
+        )
+        if any(result.terminate for result in results):
+            terminated_by_tool = True
+            hit_cap = False
+            break
+
+    run_result = AgentRunResult(
+        messages=messages,
+        final_text=final_text,
+        executed=executed,
+        tool_results=tool_results,
+        terminated_by_tool=terminated_by_tool,
+        hit_iteration_cap=hit_cap,
+        final_system_prompt=final_system_prompt,
+    )
+    host._emit_runtime(
+        AgentEndEvent(
+            messages=tuple(messages),
+            data={
+                "final_text": final_text,
+                "hit_iteration_cap": hit_cap,
+                "terminated_by_tool": terminated_by_tool,
+                "message_count": len(messages),
+                "executed_count": len(executed),
+            },
+        )
+    )
+    return run_result
+
+
+__all__ = ["AgentLoopHost", "AgentRunContext", "AgentRunResult", "run_react_loop"]

--- a/core/agent_mixins.py
+++ b/core/agent_mixins.py
@@ -1,14 +1,17 @@
-"""Reusable agent behavior mixins: event dispatch and tool filtering.
+"""Reusable agent behavior mixins: event dispatch, tool filtering, steering.
 
 ``AgentEventEmitter`` forwards ``(kind, data)`` tuple events and typed runtime
 events to optional callbacks. ``AgentToolFilter`` exposes the tool-narrowing
-hook. ``Agent`` and any custom tool-calling loop compose these mixins.
+hook. ``AgentSteering`` is the stop/continue/redirect control-plane: queued
+user messages injected into (steer) or appended after (follow_up) a run.
+``Agent`` and any custom tool-calling loop compose these mixins.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from collections import deque
+from typing import TYPE_CHECKING, Any
 
 from core.events import (
     RuntimeEvent,
@@ -17,7 +20,11 @@ from core.events import (
     runtime_event_from_tuple,
     tuple_payload_from_event,
 )
+from core.messages import UserRuntimeMessage
 from core.types import RuntimeTool
+
+if TYPE_CHECKING:
+    from core.messages import RuntimeMessage
 
 logger = logging.getLogger(__name__)
 
@@ -69,4 +76,36 @@ class AgentToolFilter[RuntimeToolT: RuntimeTool]:
         return tools
 
 
-__all__ = ["AgentEventEmitter", "AgentToolFilter"]
+class AgentSteering:
+    """Stop/continue/redirect control-plane for the agent loop.
+
+    ``steer`` queues a message injected before the *next* LLM turn; ``follow_up``
+    queues one appended only once the loop would otherwise stop. Instances must
+    initialize ``_steering_messages`` / ``_follow_up_messages`` (e.g. in
+    ``Agent.__init__``) before use.
+    """
+
+    _steering_messages: deque[str]
+    _follow_up_messages: deque[str]
+
+    def steer(self, message: str) -> None:
+        """Inject a user message into the active run before the next LLM turn."""
+        if message.strip():
+            self._steering_messages.append(message)
+
+    def follow_up(self, message: str) -> None:
+        """Queue a user message to run after the current turn would otherwise stop."""
+        if message.strip():
+            self._follow_up_messages.append(message)
+
+    def _drain_steering_messages(self, messages: list[RuntimeMessage]) -> None:
+        while self._steering_messages:
+            messages.append(UserRuntimeMessage(content=self._steering_messages.popleft()))
+
+    def _pop_follow_up_message(self) -> str | None:
+        if not self._follow_up_messages:
+            return None
+        return self._follow_up_messages.popleft()
+
+
+__all__ = ["AgentEventEmitter", "AgentSteering", "AgentToolFilter"]

--- a/tests/core/runtime/test_loop.py
+++ b/tests/core/runtime/test_loop.py
@@ -21,6 +21,7 @@ from core.messages import (
     ToolResultRuntimeMessage,
     UserRuntimeMessage,
 )
+from core.provider import ProviderHooks
 from core.tool_framework.registered_tool import RegisteredTool
 from core.types import AgentTool, AgentToolContext
 
@@ -201,13 +202,18 @@ def test_run_records_final_system_prompt() -> None:
 
 
 def test_run_records_system_prompt_edited_by_before_provider_request_hook() -> None:
-    class EditingAgent(Agent):
-        def _before_provider_request(self, request: Any) -> Any:
-            return replace(request, system=request.system + " [edited]")
-
     llm = FakeLLM(iter([_text_response("done")]))
-    agent = EditingAgent(
-        llm=llm, system="sys", tools=[], resolved_integrations={}, max_iterations=1
+    agent = Agent(
+        llm=llm,
+        system="sys",
+        tools=[],
+        resolved_integrations={},
+        max_iterations=1,
+        provider_hooks=ProviderHooks(
+            before_provider_request=lambda request: replace(
+                request, system=request.system + " [edited]"
+            )
+        ),
     )
 
     result = agent.run([{"role": "user", "content": "hello"}])

--- a/tests/core/test_agent_hooks.py
+++ b/tests/core/test_agent_hooks.py
@@ -1,0 +1,105 @@
+"""Unit tests for AgentProviderHookDelegate: the fail-open ProviderHooks wrapper."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from core.agent_hooks import AgentProviderHookDelegate
+from core.messages import MessageFormatter, UserRuntimeMessage
+from core.provider import ProviderHooks, ProviderRequest
+
+
+def _request() -> ProviderRequest:
+    return ProviderRequest(messages=[], system="sys", tools=None)
+
+
+def test_transform_context_passes_through_by_default() -> None:
+    delegate = AgentProviderHookDelegate(ProviderHooks())
+    messages = [UserRuntimeMessage(content="hi")]
+    assert delegate.transform_context(messages) == messages
+
+
+def test_transform_context_applies_hook() -> None:
+    extra = UserRuntimeMessage(content="injected")
+    hooks = ProviderHooks(transform_context=lambda messages: [*messages, extra])
+    delegate = AgentProviderHookDelegate(hooks)
+    result = delegate.transform_context([UserRuntimeMessage(content="hi")])
+    assert result[-1] is extra
+
+
+def test_transform_context_swallows_hook_exception() -> None:
+    def boom(messages: Any) -> Any:
+        raise RuntimeError("hook broke")
+
+    delegate = AgentProviderHookDelegate(ProviderHooks(transform_context=boom))
+    messages = [UserRuntimeMessage(content="hi")]
+    assert delegate.transform_context(messages) == messages
+
+
+def test_convert_to_llm_falls_back_to_message_formatter() -> None:
+    delegate = AgentProviderHookDelegate(ProviderHooks())
+    message = UserRuntimeMessage(content="hi")
+    result = delegate.convert_to_llm(object(), [message])
+    assert result == MessageFormatter(object()).to_provider_messages([message])
+
+
+def test_convert_to_llm_swallows_hook_exception() -> None:
+    def boom(llm: Any, messages: Any) -> Any:
+        raise RuntimeError("hook broke")
+
+    delegate = AgentProviderHookDelegate(ProviderHooks(convert_to_llm=boom))
+    message = UserRuntimeMessage(content="hi")
+    result = delegate.convert_to_llm(object(), [message])
+    assert result == MessageFormatter(object()).to_provider_messages([message])
+
+
+def test_before_request_passes_through_by_default() -> None:
+    delegate = AgentProviderHookDelegate(ProviderHooks())
+    request = _request()
+    assert delegate.before_request(request) is request
+
+
+def test_before_request_applies_hook() -> None:
+    hooks = ProviderHooks(
+        before_provider_request=lambda request: replace(request, system=request.system + " [x]")
+    )
+    delegate = AgentProviderHookDelegate(hooks)
+    result = delegate.before_request(_request())
+    assert result.system == "sys [x]"
+
+
+def test_before_request_swallows_hook_exception() -> None:
+    def boom(request: ProviderRequest) -> ProviderRequest:
+        raise RuntimeError("hook broke")
+
+    delegate = AgentProviderHookDelegate(ProviderHooks(before_provider_request=boom))
+    request = _request()
+    assert delegate.before_request(request) is request
+
+
+def test_after_response_passes_through_by_default() -> None:
+    delegate = AgentProviderHookDelegate(ProviderHooks())
+    response = object()
+    assert delegate.after_response(_request(), response) is response
+
+
+def test_after_response_applies_hook() -> None:
+    hooks = ProviderHooks(after_provider_response=lambda _request, _response: "edited")
+    delegate = AgentProviderHookDelegate(hooks)
+    assert delegate.after_response(_request(), "original") == "edited"
+
+
+def test_after_response_swallows_hook_exception() -> None:
+    def boom(request: ProviderRequest, response: Any) -> Any:
+        raise RuntimeError("hook broke")
+
+    delegate = AgentProviderHookDelegate(ProviderHooks(after_provider_response=boom))
+    response = object()
+    assert delegate.after_response(_request(), response) is response
+
+
+def test_delegate_stores_the_wrapped_hooks() -> None:
+    hooks = ProviderHooks()
+    delegate = AgentProviderHookDelegate(hooks)
+    assert delegate.hooks is hooks

--- a/tests/core/test_agent_mixins.py
+++ b/tests/core/test_agent_mixins.py
@@ -1,11 +1,13 @@
-"""Unit tests for the AgentEventEmitter and AgentToolFilter mixins."""
+"""Unit tests for the AgentEventEmitter, AgentToolFilter, and AgentSteering mixins."""
 
 from __future__ import annotations
 
+from collections import deque
 from typing import Any
 
-from core.agent_mixins import AgentEventEmitter, AgentToolFilter
+from core.agent_mixins import AgentEventEmitter, AgentSteering, AgentToolFilter
 from core.events import RuntimeEvent, runtime_event_from_tuple
+from core.messages import UserRuntimeMessage
 
 
 class _Emitter(AgentEventEmitter):
@@ -14,6 +16,12 @@ class _Emitter(AgentEventEmitter):
 
 class _Filter(AgentToolFilter):
     pass
+
+
+class _Steering(AgentSteering):
+    def __init__(self) -> None:
+        self._steering_messages: deque[str] = deque()
+        self._follow_up_messages: deque[str] = deque()
 
 
 def test_default_callbacks_are_none() -> None:
@@ -103,3 +111,51 @@ def test_mixins_compose_in_one_class() -> None:
 
     tools: list[Any] = [1, 2, 3]
     assert c._filter_tools(tools) is tools
+
+
+def test_steer_queues_message_drained_into_transcript() -> None:
+    s = _Steering()
+    s.steer("look at the newest deploy first")
+    messages: list[Any] = []
+    s._drain_steering_messages(messages)
+    assert len(messages) == 1
+    assert isinstance(messages[0], UserRuntimeMessage)
+    assert messages[0].content == "look at the newest deploy first"
+
+
+def test_steer_ignores_blank_message() -> None:
+    s = _Steering()
+    s.steer("   ")
+    messages: list[Any] = []
+    s._drain_steering_messages(messages)
+    assert messages == []
+
+
+def test_drain_steering_messages_empties_the_queue() -> None:
+    s = _Steering()
+    s.steer("first")
+    s.steer("second")
+    messages: list[Any] = []
+    s._drain_steering_messages(messages)
+    assert [m.content for m in messages] == ["first", "second"]
+    more: list[Any] = []
+    s._drain_steering_messages(more)
+    assert more == []
+
+
+def test_follow_up_pop_returns_none_when_empty() -> None:
+    s = _Steering()
+    assert s._pop_follow_up_message() is None
+
+
+def test_follow_up_pop_returns_queued_message_once() -> None:
+    s = _Steering()
+    s.follow_up("now summarize the remediation")
+    assert s._pop_follow_up_message() == "now summarize the remediation"
+    assert s._pop_follow_up_message() is None
+
+
+def test_follow_up_ignores_blank_message() -> None:
+    s = _Steering()
+    s.follow_up("  ")
+    assert s._pop_follow_up_message() is None


### PR DESCRIPTION
## Summary
- `core/agent.py` (519 lines, owning algorithm + hooks + facade) is split into four modules per the issue's proposed layout:
  - `core/agent_mixins.py` — adds `AgentSteering` (steer/follow_up control-plane) alongside the existing `AgentEventEmitter`/`AgentToolFilter`.
  - `core/agent_hooks.py` (new) — `AgentProviderHookDelegate`, a fail-open wrapper around `ProviderHooks` for the four provider seams (context transform, before/after request, LLM conversion).
  - `core/agent_loop.py` (new) — `AgentRunContext`, `AgentLoopHost` protocol, and `run_react_loop`, the think → call-tools → observe algorithm with no direct `Agent` coupling. `AgentRunResult` now lives here; `core.agent` re-exports it so existing `from core.agent import AgentRunResult` sites are unaffected.
  - `core/agent.py` — trimmed to the facade: `__init__`, `run()` (resolves per-run context, hands it to `run_react_loop`), and the two static delegation entrypoints (`dispatch_message_to_headless_agent`, `resolve_integrations`).
- Updated `core/agent_harness/AGENTS.md` to document the new split and retire the private-method hook-override pattern — customization now goes through `provider_hooks=ProviderHooks(...)` at construction (a test that subclassed `Agent` to override `_before_provider_request` now uses this public seam instead).
- Sub-tasks #3611 (mixin extraction) and #3615 (streaming design) were already closed; #3683/#3684 (TurnPlan / routing `TurnContext` through assembly) are separate, still-open, differently-scoped issues this PR does not touch — this PR is the structural 5-file split only.

## Test plan
- [x] `make lint`, `make format-check`, `make typecheck` — all pass
- [x] `tests/core/runtime/test_loop.py`, `tests/core/test_agent_mixins.py`, `tests/core/test_agent_hooks.py` (new), `tests/core/agent_harness/test_agent_shapes.py`, `tests/core/agent/test_resolve_integrations.py`, `tests/core/agent/test_turn_context_runtime_request.py` — all pass
- [x] Confirmed the pre-existing import-linter contract failure (`config`/`platform` → `integrations`) and the live-LLM/turn-scenario test failures reproduce identically on `main` — unrelated to this change
- [ ] Full `make test-cov` not run to completion in this session (cancelled per request); targeted core/agent suites above cover the changed surface

Closes #3705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)