### PR TITLE
(T-21): Populate surfaces/shared/ with genuinely justified duplication

### DIFF
--- a/surfaces/cli/ui/renderer/renderer.py
+++ b/surfaces/cli/ui/renderer/renderer.py
@@ -32,8 +32,6 @@ from surfaces.cli.ui.renderer.tools import (
     _tool_event_key,
     _tool_input,
     _tool_output,
-    _tool_short_label,
-    _tool_source_label,
 )
 from surfaces.interactive_shell.ui.output import (
     ProgressTracker,
@@ -42,6 +40,8 @@ from surfaces.interactive_shell.ui.output import (
     get_output_format,
     register_tool_detail_toggle,
 )
+from surfaces.shared.tool_labels import tool_short_label as _tool_short_label
+from surfaces.shared.tool_labels import tool_source_label as _tool_source_label
 from tools.registry import resolve_tool_display_name
 
 

--- a/surfaces/cli/ui/renderer/tools.py
+++ b/surfaces/cli/ui/renderer/tools.py
@@ -1,10 +1,13 @@
-"""Tool-call labeling and payload extraction helpers."""
+"""Tool-call event-payload extraction helpers.
+
+Source/label formatting (``tool_source_label``, ``tool_short_label``) moved
+to ``surfaces.shared.tool_labels`` (T-21) — it was identical to the
+interactive shell's copy.
+"""
 
 from __future__ import annotations
 
 from typing import Any
-
-from tools.registry import get_registered_tool_map, resolve_tool_display_name
 
 
 def _tool_event_key(data: dict[str, Any], name: str) -> str:
@@ -16,46 +19,6 @@ def _tool_event_key(data: dict[str, Any], name: str) -> str:
         or nested.get("tool_call_id")
         or name
     )
-
-
-def _tool_source_label(tool_name: str) -> str:
-    tool = get_registered_tool_map().get(tool_name)
-    source = str(tool.source) if tool is not None else _infer_tool_source(tool_name)
-    if source == "grafana":
-        return "Grafana"
-    if source == "knowledge":
-        return "SRE"
-    if source == "openclaw":
-        return "OpenClaw"
-    return source.replace("_", " ").title() if source else "Tools"
-
-
-def _infer_tool_source(tool_name: str) -> str:
-    lowered = tool_name.lower()
-    for source in ("grafana", "datadog", "cloudwatch", "sentry", "honeycomb", "openclaw"):
-        if source in lowered:
-            return source
-    if lowered.startswith("get_sre_"):
-        return "knowledge"
-    return "tools"
-
-
-def _tool_short_label(tool_name: str, source_label: str) -> str:
-    display = resolve_tool_display_name(tool_name)
-    label = display
-    for prefix in (
-        source_label,
-        source_label.lower(),
-        f"{source_label} ",
-        f"{source_label.lower()} ",
-        "query ",
-        "get ",
-    ):
-        if label.startswith(prefix):
-            label = label[len(prefix) :].strip()
-    if source_label == "Grafana" and label.lower().startswith("grafana "):
-        label = label[len("grafana ") :].strip()
-    return label or display
 
 
 def _tool_input(data: dict[str, Any]) -> Any:

--- a/surfaces/interactive_shell/runtime/integration_tool_gathering.py
+++ b/surfaces/interactive_shell/runtime/integration_tool_gathering.py
@@ -20,11 +20,8 @@ from core.agent_harness.agents import evidence_agent
 from core.agent_harness.agents.evidence_agent import EvidenceAgentFactory
 from core.agent_harness.session import Session
 from surfaces.interactive_shell.ui import DIM
-from surfaces.interactive_shell.ui.output.tool_details import (
-    tool_short_label,
-    tool_source_label,
-)
 from surfaces.interactive_shell.utils.error_handling.exception_reporting import report_exception
+from surfaces.shared.tool_labels import tool_short_label, tool_source_label
 
 # Cap so a chatty tool result can't blow up persistence writes.
 _MAX_PER_TOOL_CHARS = 4_000

--- a/surfaces/interactive_shell/ui/output/tool_details.py
+++ b/surfaces/interactive_shell/ui/output/tool_details.py
@@ -7,47 +7,19 @@ from rich.text import Text
 from platform.observability.tool_trace import format_json_preview
 from platform.terminal.theme import BRAND, DIM, HIGHLIGHT, SECONDARY, TEXT
 from surfaces.interactive_shell.ui.components.time_format import _elapsed_hms, _fmt_timing
-from tools.registry import get_registered_tool_map, resolve_tool_display_name
+from surfaces.shared.tool_labels import tool_short_label, tool_source_label
 
-
-def tool_source_label(tool_name: str) -> str:
-    tool = get_registered_tool_map().get(tool_name)
-    source = str(tool.source) if tool is not None else infer_tool_source(tool_name)
-    if source == "grafana":
-        return "Grafana"
-    if source == "knowledge":
-        return "SRE"
-    if source == "openclaw":
-        return "OpenClaw"
-    return source.replace("_", " ").title() if source else "Tools"
-
-
-def infer_tool_source(tool_name: str) -> str:
-    lowered = tool_name.lower()
-    for source in ("grafana", "datadog", "cloudwatch", "sentry", "honeycomb", "openclaw"):
-        if source in lowered:
-            return source
-    if lowered.startswith("get_sre_"):
-        return "knowledge"
-    return "tools"
-
-
-def tool_short_label(tool_name: str, source_label: str) -> str:
-    display = resolve_tool_display_name(tool_name)
-    label = display
-    for prefix in (
-        source_label,
-        source_label.lower(),
-        f"{source_label} ",
-        f"{source_label.lower()} ",
-        "query ",
-        "get ",
-    ):
-        if label.startswith(prefix):
-            label = label[len(prefix) :].strip()
-    if source_label == "Grafana" and label.lower().startswith("grafana "):
-        label = label[len("grafana ") :].strip()
-    return label or display
+__all__ = [
+    "build_live_tool_detail_rows",
+    "build_tool_call_line",
+    "build_tool_detail_text",
+    "format_tool_summary",
+    "make_tool_detail_record",
+    "record_tool_summary",
+    "tool_detail_body",
+    "tool_short_label",
+    "tool_source_label",
+]
 
 
 def record_tool_summary(

--- a/surfaces/interactive_shell/ui/output/tool_tracking.py
+++ b/surfaces/interactive_shell/ui/output/tool_tracking.py
@@ -16,8 +16,6 @@ from surfaces.interactive_shell.ui.output.tool_details import (
     build_tool_detail_text,
     make_tool_detail_record,
     tool_detail_body,
-    tool_short_label,
-    tool_source_label,
 )
 from surfaces.interactive_shell.ui.output.tool_details import (
     format_tool_summary as _format_tool_summary,
@@ -25,6 +23,7 @@ from surfaces.interactive_shell.ui.output.tool_details import (
 from surfaces.interactive_shell.ui.output.tool_details import (
     record_tool_summary as _record_tool_summary,
 )
+from surfaces.shared.tool_labels import tool_short_label, tool_source_label
 from tools.registry import resolve_tool_display_name
 
 

--- a/surfaces/shared/__init__.py
+++ b/surfaces/shared/__init__.py
@@ -1,15 +1,14 @@
 """Code shared across multiple surfaces.
 
-Starts empty. Add modules here only when concrete duplication appears
-between ``surfaces/cli/``, ``surfaces/interactive_shell/``, and
+Add modules here only when concrete duplication appears between
+``surfaces/cli/``, ``surfaces/interactive_shell/``, and
 ``surfaces/slack_app/``. The intent is a *safety valve*, not a
 default home — if you're tempted to add a module here, double-check
 whether it actually belongs in ``core/``, ``tools/``, or
 ``platform/`` first.
 
-The first plausible candidates (TBD): command-handler dispatch
-primitives that both ``cli`` and ``interactive_shell`` use, response
-formatting shared between ``interactive_shell`` and ``slack_app``.
+- ``tool_labels`` — tool source/label formatting used by both ``cli`` and
+  ``interactive_shell`` while rendering live tool-call activity (T-21).
 """
 
 from __future__ import annotations

--- a/surfaces/shared/tool_labels.py
+++ b/surfaces/shared/tool_labels.py
@@ -1,0 +1,55 @@
+"""Tool source/label formatting shared by ``surfaces/cli`` and ``surfaces/interactive_shell``.
+
+Both surfaces render the same live tool-call activity (a source badge like
+``Grafana`` or ``SRE``, and a short human label with the source prefix
+stripped) while an investigation runs. The two implementations were
+identical, so this is the T-21 extraction: pure formatting with no
+surface-specific state, safe to share.
+"""
+
+from __future__ import annotations
+
+from tools.registry import get_registered_tool_map, resolve_tool_display_name
+
+
+def tool_source_label(tool_name: str) -> str:
+    """Return a human-friendly source badge (e.g. ``Grafana``, ``SRE``) for a tool."""
+    tool = get_registered_tool_map().get(tool_name)
+    source = str(tool.source) if tool is not None else infer_tool_source(tool_name)
+    if source == "grafana":
+        return "Grafana"
+    if source == "knowledge":
+        return "SRE"
+    if source == "openclaw":
+        return "OpenClaw"
+    return source.replace("_", " ").title() if source else "Tools"
+
+
+def infer_tool_source(tool_name: str) -> str:
+    """Guess a tool's source from its name when the registry has no entry for it."""
+    lowered = tool_name.lower()
+    for source in ("grafana", "datadog", "cloudwatch", "sentry", "honeycomb", "openclaw"):
+        if source in lowered:
+            return source
+    if lowered.startswith("get_sre_"):
+        return "knowledge"
+    return "tools"
+
+
+def tool_short_label(tool_name: str, source_label: str) -> str:
+    """Return the tool's display name with its source prefix (if any) stripped."""
+    display = resolve_tool_display_name(tool_name)
+    label = display
+    for prefix in (
+        source_label,
+        source_label.lower(),
+        f"{source_label} ",
+        f"{source_label.lower()} ",
+        "query ",
+        "get ",
+    ):
+        if label.startswith(prefix):
+            label = label[len(prefix) :].strip()
+    if source_label == "Grafana" and label.lower().startswith("grafana "):
+        label = label[len("grafana ") :].strip()
+    return label or display


### PR DESCRIPTION
Closes #3554.

## Summary

Audited `surfaces/cli/` and `surfaces/interactive_shell/` (`surfaces/slack_app/` is still an empty placeholder, nothing to compare against) for true duplication, per T-21's "justified, not a default dumping ground" bar.

Found one genuine case: `surfaces/cli/ui/renderer/tools.py` (`_tool_source_label`, `_infer_tool_source`, `_tool_short_label`) and `surfaces/interactive_shell/ui/output/tool_details.py` (`tool_source_label`, `infer_tool_source`, `tool_short_label`) were byte-for-byte identical — both surfaces render the same live tool-call badge (source label + short name) while an investigation runs, and the logic is pure formatting with no surface-specific state.

Extracted into `surfaces/shared/tool_labels.py`. Updated all four call sites to import the single implementation:
- `surfaces/cli/ui/renderer/renderer.py`
- `surfaces/interactive_shell/ui/output/tool_details.py`
- `surfaces/interactive_shell/ui/output/tool_tracking.py`
- `surfaces/interactive_shell/runtime/integration_tool_gathering.py`

`surfaces/cli/ui/renderer/tools.py` keeps its event-payload extraction helpers (`_tool_event_key`, `_tool_input`, `_tool_output`) — those have no shell-side equivalent, they're CLI-specific SSE event parsing.

Everything else I compared (banner/progress rendering, table rendering, input prompt handling, streaming display) diverges in real ways — Rich `Text` composition, REPL-specific mutable state, different event models — so I didn't force those into `surfaces/shared/` just to populate it.

## Test plan

- [x] `make lint`, `make format-check`, `make typecheck` — all pass
- [x] `pytest tests/cli tests/interactive_shell -m "not live_llm"` — 1985 passed, 1 skipped
- [x] `.github/ci/check_imports.py` (cycles + import-linter layers + forbidden direct imports) — all pass
- [x] Verified the only test referencing these functions (`tests/interactive_shell/tools/test_tool_gathering.py`) patches at the call-site module (`integration_tool_gathering.tool_source_label`), which is unaffected by moving the underlying implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)