### PR TITLE
(T-18): Wire jira/prefect verifiers, fix Elasticsearch tool source key

### DIFF
--- a/docs/jira.mdx
+++ b/docs/jira.mdx
@@ -61,6 +61,22 @@ Add to `~/.opensre/integrations.json`:
 For Jira Data Center/Server, use a personal access token from **Profile** → **Personal Access Tokens** instead.
 </Info>
 
+## Verify
+
+```bash
+opensre integrations verify jira
+```
+
+Expected output on success:
+
+```
+Service: jira
+Status:  passed
+Detail:  Configured for Jira at https://your-org.atlassian.net.
+```
+
+This is a configuration-presence check (`base_url`, `email`, and `api_token` are all set) rather than a live API call.
+
 ## Troubleshooting
 
 | Symptom | Fix |

--- a/docs/prefect.mdx
+++ b/docs/prefect.mdx
@@ -73,12 +73,20 @@ For self-hosted Prefect Server, set `api_url` to your server's API endpoint (no 
 opensre integrations verify prefect
 ```
 
-Expected output on success:
+Expected output on success (self-hosted, `api_url` set):
 
 ```
 Service: prefect
 Status:  passed
 Detail:  Configured for Prefect at http://prefect-server:4200/api.
+```
+
+For Prefect Cloud (only `api_key` set, no `api_url`):
+
+```
+Service: prefect
+Status:  passed
+Detail:  Configured for Prefect at cloud.
 ```
 
 This is a configuration-presence check (`api_url` or `api_key` is set) rather than a live API call.

--- a/docs/prefect.mdx
+++ b/docs/prefect.mdx
@@ -67,6 +67,22 @@ For self-hosted Prefect Server, set `api_url` to your server's API endpoint (no 
 }
 ```
 
+## Verify
+
+```bash
+opensre integrations verify prefect
+```
+
+Expected output on success:
+
+```
+Service: prefect
+Status:  passed
+Detail:  Configured for Prefect at http://prefect-server:4200/api.
+```
+
+This is a configuration-presence check (`api_url` or `api_key` is set) rather than a live API call.
+
 ## Investigation tools
 
 When OpenSRE investigates a Prefect-related alert, three diagnostic tools are available:

--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -80,6 +80,7 @@ from integrations.postgresql import build_postgresql_config
 from integrations.postgresql import classify as _classify_postgresql
 from integrations.posthog_mcp import DEFAULT_POSTHOG_MCP_URL, build_posthog_mcp_config
 from integrations.posthog_mcp import classify as _classify_posthog_mcp
+from integrations.prefect import classify as _classify_prefect
 from integrations.rabbitmq import build_rabbitmq_config
 from integrations.rabbitmq import classify as _classify_rabbitmq
 from integrations.rds import classify as _classify_rds
@@ -281,6 +282,7 @@ _CLASSIFIERS: dict[str, _ClassifyFn] = {
     "tempo": _classify_tempo,
     "temporal": _classify_temporal,
     "smtp": _classify_smtp,
+    "prefect": _classify_prefect,
 }
 
 

--- a/integrations/elasticsearch/tools/__init__.py
+++ b/integrations/elasticsearch/tools/__init__.py
@@ -44,11 +44,11 @@ class ElasticsearchLogsTool(BaseTool):
             "limit": {"type": "integer", "default": 50},
             "index_pattern": {
                 "type": "string",
-                "description": "Index pattern to search (e.g. 'logs-*'). Defaults to ELASTICSEARCH_INDEX_PATTERN env var or '*'.",
+                "description": "Index pattern to search (e.g. 'logs-*'). Defaults to the configured OpenSearch/Elasticsearch index_pattern or '*'.",
             },
             "url": {
                 "type": "string",
-                "description": "Elasticsearch URL (overrides ELASTICSEARCH_URL env var)",
+                "description": "Elasticsearch/OpenSearch URL (overrides the configured OPENSEARCH_URL)",
             },
             "api_key": {
                 "type": "string",
@@ -67,10 +67,13 @@ class ElasticsearchLogsTool(BaseTool):
     }
 
     def is_available(self, sources: dict) -> bool:
-        return bool(sources.get("elasticsearch", {}).get("connection_verified"))
+        # Shares the "opensearch" source: same client, same credentials (see
+        # docs/opensearch.mdx — configuring OpenSearch/Elasticsearch once
+        # enables both the analytics tool and this log-search tool).
+        return bool(sources.get("opensearch", {}).get("connection_verified"))
 
     def extract_params(self, sources: dict) -> dict:
-        es = sources.get("elasticsearch", {})
+        es = sources.get("opensearch", {})
         return {
             "query": es.get("default_query", "*"),
             "time_range_minutes": es.get("time_range_minutes", 60),

--- a/integrations/jira/verifier.py
+++ b/integrations/jira/verifier.py
@@ -1,0 +1,17 @@
+"""Jira integration verifier — config presence check only."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from integrations.verification import register_verifier, result
+
+
+@register_verifier("jira")
+def verify_jira(source: str, config: dict[str, Any]) -> dict[str, str]:
+    base_url = str(config.get("base_url", "")).strip()
+    email = str(config.get("email", "")).strip()
+    api_token = str(config.get("api_token", "")).strip()
+    if not base_url or not email or not api_token:
+        return result("jira", source, "missing", "Missing base_url, email, or api_token.")
+    return result("jira", source, "passed", f"Configured for Jira at {base_url.rstrip('/')}.")

--- a/integrations/prefect/__init__.py
+++ b/integrations/prefect/__init__.py
@@ -1,0 +1,38 @@
+"""Prefect integration classifier."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from integrations._validation_helpers import report_classify_failure
+from integrations.config_models import PrefectIntegrationConfig
+
+logger = logging.getLogger(__name__)
+
+
+def classify(
+    credentials: dict[str, Any], record_id: str
+) -> tuple[PrefectIntegrationConfig | None, str | None]:
+    # Self-hosted Prefect Server needs only ``api_url`` (no key); Prefect Cloud
+    # needs an ``api_key``. Require one of the two explicitly — the config
+    # model's own ``api_url`` default (Prefect Cloud's base URL) must not, by
+    # itself, count as "configured".
+    raw_api_url = str(credentials.get("api_url", "")).strip()
+    raw_api_key = str(credentials.get("api_key", "")).strip()
+    if not raw_api_url and not raw_api_key:
+        return None, None
+    try:
+        cfg = PrefectIntegrationConfig.model_validate(
+            {
+                "api_url": raw_api_url,
+                "api_key": raw_api_key,
+                "account_id": credentials.get("account_id", ""),
+                "workspace_id": credentials.get("workspace_id", ""),
+                "integration_id": record_id,
+            }
+        )
+    except Exception as exc:
+        report_classify_failure(exc, logger=logger, integration="prefect", record_id=record_id)
+        return None, None
+    return cfg, "prefect"

--- a/integrations/prefect/verifier.py
+++ b/integrations/prefect/verifier.py
@@ -1,0 +1,16 @@
+"""Prefect integration verifier — config presence check only."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from integrations.verification import register_verifier, result
+
+
+@register_verifier("prefect")
+def verify_prefect(source: str, config: dict[str, Any]) -> dict[str, str]:
+    api_url = str(config.get("api_url", "")).strip()
+    api_key = str(config.get("api_key", "")).strip()
+    if not api_url and not api_key:
+        return result("prefect", source, "missing", "Missing api_url or api_key.")
+    return result("prefect", source, "passed", f"Configured for Prefect at {api_url or 'cloud'}.")

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -189,8 +189,9 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
     ),
     IntegrationSpec(
         service="jira",
+        has_verifier=True,
         direct_effective=True,
-        verify_order=None,
+        verify_order=50,
     ),
     IntegrationSpec(
         service="discord",
@@ -358,7 +359,7 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
     IntegrationSpec(service="clickhouse", has_verifier=True, verify_order=23),
     IntegrationSpec(service="alicloud", direct_effective=True),
     IntegrationSpec(service="notion"),
-    IntegrationSpec(service="prefect"),
+    IntegrationSpec(service="prefect", has_verifier=True, verify_order=51),
     IntegrationSpec(service="posthog"),
     IntegrationSpec(service="trello"),
     IntegrationSpec(service="rds", setup_order=11),

--- a/tests/integrations/elasticsearch/test_client.py
+++ b/tests/integrations/elasticsearch/test_client.py
@@ -387,10 +387,13 @@ def test_tool_name_and_source() -> None:
 
 
 def test_tool_is_available_when_connection_verified() -> None:
+    # Shares the "opensearch" source (same client, same credentials) — see
+    # docs/opensearch.mdx: configuring OpenSearch/Elasticsearch once enables
+    # both the analytics tool and this log-search tool.
     from integrations.elasticsearch.tools import ElasticsearchLogsTool
 
     t = ElasticsearchLogsTool()
-    sources = {"elasticsearch": {"connection_verified": True, "url": "http://localhost:9200"}}
+    sources = {"opensearch": {"connection_verified": True, "url": "http://localhost:9200"}}
     assert t.is_available(sources) is True
 
 

--- a/tests/integrations/test_prefect_catalog.py
+++ b/tests/integrations/test_prefect_catalog.py
@@ -1,0 +1,51 @@
+"""Tests for Prefect integration classification (T-18: catalog wiring gap).
+
+Prefect had a full client + tools + config model but was never registered
+in ``integrations._catalog_impl``'s classifier map, so a Prefect entry in
+``~/.opensre/integrations.json`` (the documented setup path, see
+docs/prefect.mdx) was silently ignored.
+"""
+
+from __future__ import annotations
+
+from integrations._catalog_impl import _classify_service_instance
+
+
+class TestClassifyPrefect:
+    def test_classify_prefect_cloud_with_api_key(self) -> None:
+        flat_view, key = _classify_service_instance(
+            "prefect",
+            {
+                "api_key": "pnu_test_key",
+                "account_id": "acct-123",
+                "workspace_id": "ws-456",
+            },
+            record_id="test-id",
+        )
+
+        assert key == "prefect"
+        assert flat_view is not None
+        assert flat_view.api_key == "pnu_test_key"
+        assert flat_view.account_id == "acct-123"
+        assert flat_view.workspace_id == "ws-456"
+        assert flat_view.integration_id == "test-id"
+
+    def test_classify_prefect_self_hosted_with_api_url_only(self) -> None:
+        flat_view, key = _classify_service_instance(
+            "prefect",
+            {"api_url": "http://prefect-server:4200/api"},
+            record_id="test-id",
+        )
+
+        assert key == "prefect"
+        assert flat_view is not None
+        assert flat_view.api_url == "http://prefect-server:4200/api"
+        assert flat_view.api_key == ""
+
+    def test_classify_prefect_rejects_empty_credentials(self) -> None:
+        """Neither api_url nor api_key set — the config model's own Cloud
+        default for api_url must not count as "configured"."""
+        flat_view, key = _classify_service_instance("prefect", {}, record_id="test-id")
+
+        assert flat_view is None
+        assert key is None

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -77,7 +77,7 @@ def mock_agent_state(overrides: dict | None = None) -> dict[str, Any]:
             "github_mode": "streamable-http",
             "github_token": "ghp_test",
         },
-        "elasticsearch": {
+        "opensearch": {
             "connection_verified": True,
             "url": "http://localhost:9200",
             "api_key": None,

--- a/tests/tools/test_elasticsearch_logs_tool.py
+++ b/tests/tools/test_elasticsearch_logs_tool.py
@@ -14,9 +14,12 @@ class TestElasticsearchLogsToolContract(BaseToolContract):
 
 
 def test_is_available_requires_connection_verified() -> None:
+    # Shares the "opensearch" source (same client, same credentials) — see
+    # docs/opensearch.mdx: configuring OpenSearch/Elasticsearch once enables
+    # both the analytics tool and this log-search tool.
     tool = ElasticsearchLogsTool()
-    assert tool.is_available({"elasticsearch": {"connection_verified": True}}) is True
-    assert tool.is_available({"elasticsearch": {}}) is False
+    assert tool.is_available({"opensearch": {"connection_verified": True}}) is True
+    assert tool.is_available({"opensearch": {}}) is False
     assert tool.is_available({}) is False
 
 
@@ -74,11 +77,11 @@ def test_run_api_error() -> None:
 
 
 def test_extract_params_includes_basic_auth_credentials() -> None:
-    """extract_params reads username/password from the elasticsearch source dict."""
+    """extract_params reads username/password from the opensearch source dict."""
     tool = ElasticsearchLogsTool()
     sources = mock_agent_state(
         overrides={
-            "elasticsearch": {
+            "opensearch": {
                 "connection_verified": True,
                 "url": "https://my-cluster.example.com",
                 "username": "admin",


### PR DESCRIPTION
Partial progress on #3551 (T-18) — see scope note below for what's intentionally not covered.

Partial progress on #3551 (T-18: full T-1 vendor-first completion).

## Summary

T-18 is genuinely XL (asks for `{config, client, verifier, tools}` completeness across ~73 `integrations/*` folders). Rather than a rushed sweep, I audited the whole tree first and found the raw file-presence signal ("no client.py", "no verifier.py") was mostly false positives — shared AWS/DB drivers, delivery-only integrations, non-vendor utility packages. This PR fixes the narrower set of **real, verified gaps**:

- **jira, prefect**: both had a full client + tools + config model but no `verifier.py`, so `opensre integrations verify` silently skipped them even though their documented setup path (`~/.opensre/integrations.json`) works. Added `integrations/jira/verifier.py` and `integrations/prefect/verifier.py` (config-presence checks, matching the existing `opensearch` pattern). Prefect was also missing its `classify()` function and `_CLASSIFIERS` registration entirely — its documented store-based config was being silently ignored. Both are now flagged `has_verifier=True` in `integrations/registry.py`.

- **Elasticsearch logs tool bug**: `integrations/elasticsearch/tools/ElasticsearchLogsTool` read from a `sources["elasticsearch"]` key that nothing in the codebase ever populates — no catalog wiring, no docs, ever existed for it as a standalone source. I initially assumed the fix was to wire up a new parallel "elasticsearch" catalog entry, but `docs/opensearch.mdx` already documents `query_elasticsearch_logs` as one of two tools that activate together once OpenSearch/Elasticsearch is configured, sharing the same credentials. So the actual bug is simpler: the tool should read the already-fully-wired `sources["opensearch"]` key, not a dead one. Fixed `is_available`/`extract_params` accordingly and updated the shared test fixture (`tests/tools/conftest.py`) and the two test files that asserted the old (dead) key.

- Added a **Verify** section to `jira.mdx` and `prefect.mdx`, and `tests/integrations/test_prefect_catalog.py` covering the new classify path.

## Scope note

Left for separate follow-up (each needs a product judgment call, not a mechanical fix):
- **`trello`** — only has a config model, unreferenced anywhere in `catalog.py`; needs a keep-and-build-out vs. delete-as-dead-code decision.
- **`notion`** — has a client but no `tools/` or `verifier.py`; needs new tool(s) built, not just wiring.
- **`airflow`** — only used for alert-source classification today; would need a real client + tools to become query-able.

## Test plan

- [x] `make lint`, `make format-check`, `make typecheck` — all pass
- [x] `pytest tests/integrations tests/tools` — 4744 passed, 3 skipped (pre-existing skips, unrelated)
- [x] `.github/ci/check_imports.py` (cycles + import-linter layers + forbidden direct imports) — all pass
- [x] `make verify-integrations` — `jira` and `prefect` now appear in the verify table (as `missing`, since neither is configured in this dev environment — same as every other unconfigured integration; confirmed this non-zero exit is pre-existing behavior on `main` too, not something this PR introduces)
- [x] Verified the ES fix by checking `tests/tools/test_opensearch_analytics_tool.py` and the renamed elasticsearch tests together — both tools now correctly share the `opensearch` source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
