### PR TITLE
refactor(investigation): move session runners out of CLI into tools layer (#3535)

### DIFF
--- a/.github/ci/check_direct_imports.py
+++ b/.github/ci/check_direct_imports.py
@@ -56,10 +56,8 @@ _BASELINE_IGNORES: frozenset[str] = frozenset(
         # "approval-required" sentinels instead of calling execution_confirm
         # directly) so the surface owns its own confirmation UX.
         "tools.interactive_shell.actions.cli_command -> surfaces.interactive_shell.runtime.subprocess_runner",
-        "tools.interactive_shell.actions.investigation -> surfaces.interactive_shell.runtime",
         "tools.interactive_shell.actions.llm_provider -> surfaces.interactive_shell.command_registry",
         "tools.interactive_shell.actions.llm_provider -> surfaces.interactive_shell.ui.execution_confirm",
-        "tools.interactive_shell.actions.sample_alert -> surfaces.interactive_shell.runtime",
         "tools.interactive_shell.actions.slash -> surfaces.interactive_shell.command_registry",
         "tools.interactive_shell.actions.slash -> surfaces.interactive_shell.command_registry.slash_catalog",
         "tools.interactive_shell.actions.slash -> surfaces.interactive_shell.ui",
@@ -73,9 +71,6 @@ _BASELINE_IGNORES: frozenset[str] = frozenset(
         "tools.interactive_shell.implementation.claude_code_executor -> surfaces.interactive_shell.ui",
         "tools.interactive_shell.implementation.claude_code_executor -> surfaces.interactive_shell.ui.execution_confirm",
         "tools.interactive_shell.implementation.claude_code_executor -> surfaces.interactive_shell.utils.error_handling.exception_reporting",
-        "tools.interactive_shell.shared.investigation_launch -> surfaces.interactive_shell.runtime",
-        "tools.interactive_shell.shared.investigation_launch -> surfaces.interactive_shell.ui.execution_confirm",
-        "tools.interactive_shell.shared.investigation_launch -> surfaces.interactive_shell.ui.foreground_investigation",
         "tools.interactive_shell.shell.runner -> surfaces.interactive_shell.runtime",
         "tools.interactive_shell.shell.runner -> surfaces.interactive_shell.runtime.subprocess_runner.task_streaming",
         "tools.interactive_shell.shell.runner -> surfaces.interactive_shell.ui",
@@ -96,10 +91,10 @@ _NESTED_BASELINE_IGNORES: frozenset[str] = frozenset(
     {
         # Hermes defers investigation pipeline import until an incident runs.
         "integrations.hermes.investigation -> tools.investigation.capability",
-        "tools.interactive_shell.actions.investigation -> surfaces.cli.investigation",
         "tools.interactive_shell.actions.investigation -> surfaces.interactive_shell.runtime.background.runner",
-        "tools.interactive_shell.actions.sample_alert -> surfaces.cli.investigation",
+        "tools.interactive_shell.actions.investigation -> surfaces.interactive_shell.runtime.investigation_adapter",
         "tools.interactive_shell.actions.sample_alert -> surfaces.interactive_shell.runtime.background.runner",
+        "tools.interactive_shell.actions.sample_alert -> surfaces.interactive_shell.runtime.investigation_adapter",
         "tools.interactive_shell.actions.llm_provider -> surfaces.cli.wizard.config",
         # Nested only: runner.py also has a module-level ui import (see _BASELINE_IGNORES).
         "tools.interactive_shell.shell.runner -> surfaces.interactive_shell.ui",

--- a/.importlinter.strict
+++ b/.importlinter.strict
@@ -67,15 +67,13 @@ ignore_imports =
     surfaces.cli.commands.gateway -> gateway.manager
     # tools.interactive_shell -> surfaces (T-4 debt — issue #3352)
     tools.interactive_shell.actions.cli_command -> surfaces.interactive_shell.runtime.subprocess_runner
-    tools.interactive_shell.actions.investigation -> surfaces.cli.investigation
-    tools.interactive_shell.actions.investigation -> surfaces.interactive_shell.runtime
     tools.interactive_shell.actions.investigation -> surfaces.interactive_shell.runtime.background.runner
+    tools.interactive_shell.actions.investigation -> surfaces.interactive_shell.runtime.investigation_adapter
     tools.interactive_shell.actions.llm_provider -> surfaces.cli.wizard.config
     tools.interactive_shell.actions.llm_provider -> surfaces.interactive_shell.command_registry
     tools.interactive_shell.actions.llm_provider -> surfaces.interactive_shell.ui.execution_confirm
-    tools.interactive_shell.actions.sample_alert -> surfaces.cli.investigation
-    tools.interactive_shell.actions.sample_alert -> surfaces.interactive_shell.runtime
     tools.interactive_shell.actions.sample_alert -> surfaces.interactive_shell.runtime.background.runner
+    tools.interactive_shell.actions.sample_alert -> surfaces.interactive_shell.runtime.investigation_adapter
     tools.interactive_shell.actions.slash -> surfaces.interactive_shell.command_registry
     tools.interactive_shell.actions.slash -> surfaces.interactive_shell.command_registry.slash_catalog
     tools.interactive_shell.actions.slash -> surfaces.interactive_shell.ui
@@ -89,9 +87,6 @@ ignore_imports =
     tools.interactive_shell.implementation.claude_code_executor -> surfaces.interactive_shell.ui
     tools.interactive_shell.implementation.claude_code_executor -> surfaces.interactive_shell.ui.execution_confirm
     tools.interactive_shell.implementation.claude_code_executor -> surfaces.interactive_shell.utils.error_handling.exception_reporting
-    tools.interactive_shell.shared.investigation_launch -> surfaces.interactive_shell.runtime
-    tools.interactive_shell.shared.investigation_launch -> surfaces.interactive_shell.ui.execution_confirm
-    tools.interactive_shell.shared.investigation_launch -> surfaces.interactive_shell.ui.foreground_investigation
     tools.interactive_shell.shell.runner -> surfaces.interactive_shell.runtime
     tools.interactive_shell.shell.runner -> surfaces.interactive_shell.runtime.subprocess_runner.task_streaming
     tools.interactive_shell.shell.runner -> surfaces.interactive_shell.ui

--- a/surfaces/cli/commands/general.py
+++ b/surfaces/cli/commands/general.py
@@ -174,8 +174,8 @@ def investigate_command(
 
     from surfaces.cli import write_json
     from surfaces.cli.investigation import run_investigation_cli, run_investigation_cli_streaming
-    from surfaces.cli.investigation.alert_templates import build_alert_template
     from surfaces.cli.investigation.payload import load_payload
+    from tools.investigation.alert_templates import build_alert_template
 
     try:
         if print_template:

--- a/surfaces/cli/investigation/__init__.py
+++ b/surfaces/cli/investigation/__init__.py
@@ -3,19 +3,11 @@
 from surfaces.cli.investigation.investigate import (
     run_investigation_cli,
     run_investigation_cli_streaming,
-    run_investigation_for_session,
-    run_investigation_for_session_background,
-    run_sample_alert_for_session,
-    run_sample_alert_for_session_background,
     stream_investigation_cli,
 )
 
 __all__ = [
     "run_investigation_cli",
     "run_investigation_cli_streaming",
-    "run_investigation_for_session_background",
-    "run_investigation_for_session",
-    "run_sample_alert_for_session_background",
-    "run_sample_alert_for_session",
     "stream_investigation_cli",
 ]

--- a/surfaces/cli/investigation/investigate.py
+++ b/surfaces/cli/investigation/investigate.py
@@ -6,75 +6,28 @@ import asyncio
 import contextlib
 import logging
 import threading
-from collections.abc import Generator, Iterator
-from typing import TYPE_CHECKING, Any, NoReturn
+from collections.abc import Generator
+from typing import Any, NoReturn
 
-from config.config import resolve_llm_settings
+from core.domain.stream import StreamEvent
 from platform.observability.tracing import traceable
 from surfaces.cli.error_mapping import reraise_cli_runtime_error
-
-if TYPE_CHECKING:
-    from core.domain.stream import StreamEvent
+from tools.investigation.session_runner import InvestigationPumpCancelled, check_llm_settings
 
 _logger = logging.getLogger(__name__)
-
-
-class _InvestigationPumpCancelled(Exception):
-    """Propagated when the async pump task was cancelled (distinct from Ctrl+C SIGINT)."""
-
 
 _SESSION_EVENT_POLL_S = 0.25
 
 
-def _check_llm_settings() -> None:
-    """Validate LLM settings early and surface misconfiguration as a structured error."""
-    from pydantic import ValidationError
-
-    from surfaces.interactive_shell.utils.error_handling.errors import OpenSREError
-
-    try:
-        settings = resolve_llm_settings()
-    except ValidationError as exc:
-        errors = exc.errors()
-        if errors:
-            ctx = errors[0].get("ctx", {})
-            original = ctx.get("error")
-            msg = str(original) if isinstance(original, Exception) else errors[0]["msg"]
-        else:
-            msg = str(exc)
-        raise OpenSREError(
-            msg,
-            suggestion="Run `opensre onboard` to configure your LLM provider and API credentials.",
-        ) from exc
-
-    provider = getattr(settings, "provider", None)
-    if not isinstance(provider, str):
-        return
-    from config.llm_auth.credentials import status as credential_status
-
-    auth_status = credential_status(provider)
-    if auth_status.configured and not auth_status.stale:
-        return
-    state = "stale" if auth_status.stale else "missing"
-    raise OpenSREError(
-        f"LLM provider '{provider}' credentials are {state}: {auth_status.detail}",
-        suggestion=(
-            f"Run `opensre auth verify {provider}` or `opensre auth login {provider}` "
-            "before starting an investigation."
-        ),
-    )
-
-
-def _reraise_investigation_failure(exc: BaseException) -> NoReturn:
+def _reraise_cli_investigation_failure(exc: BaseException) -> NoReturn:
     """Map investigation runtime failures to structured CLI errors."""
-    if isinstance(exc, _InvestigationPumpCancelled):
-        from surfaces.interactive_shell.utils.error_handling.errors import OpenSREError
+    from platform.common.errors import OpenSREError
 
+    if isinstance(exc, InvestigationPumpCancelled):
         raise OpenSREError(
             "Investigation streaming stopped before completion.",
             suggestion="The run was cancelled or closed early. Retry if you still need results.",
         ) from exc
-
     reraise_cli_runtime_error(exc)
 
 
@@ -95,8 +48,7 @@ def run_investigation_cli(
     ``investigation_metadata`` is an optional ``(alert_name, pipeline_name, severity)``
     tuple for initial state (e.g. HTTP request overrides) without mutating ``raw_alert``.
     """
-    _check_llm_settings()
-    # Import the heavy investigation runner only when execution starts.
+    check_llm_settings()
     from tools.investigation.capability import run_investigation_payload
 
     try:
@@ -106,7 +58,7 @@ def run_investigation_cli(
             investigation_metadata=investigation_metadata,
         )
     except Exception as exc:
-        _reraise_investigation_failure(exc)
+        _reraise_cli_investigation_failure(exc)
 
 
 def stream_investigation_cli(
@@ -125,11 +77,10 @@ def stream_investigation_cli(
     leaving an orphaned investigation task in flight.
     """
     import queue
-    import threading
 
     from tools.investigation.capability import astream_investigation
 
-    _check_llm_settings()
+    check_llm_settings()
 
     event_queue: queue.Queue[StreamEvent | BaseException | None] = queue.Queue()
     loop_ref: dict[str, asyncio.AbstractEventLoop] = {}
@@ -151,7 +102,7 @@ def stream_investigation_cli(
             try:
                 loop.run_until_complete(task)
             except asyncio.CancelledError:
-                event_queue.put(_InvestigationPumpCancelled())
+                event_queue.put(InvestigationPumpCancelled())
         except Exception as exc:
             event_queue.put(exc)
         finally:
@@ -167,7 +118,6 @@ def stream_investigation_cli(
         if loop is None or task is None or loop.is_closed():
             return
         with contextlib.suppress(RuntimeError):
-            # Loop may close between `is_closed()` and scheduling cancellation.
             loop.call_soon_threadsafe(task.cancel)
 
     try:
@@ -178,7 +128,7 @@ def stream_investigation_cli(
                 continue
             if isinstance(item, BaseException):
                 thread.join(timeout=5)
-                _reraise_investigation_failure(item)
+                _reraise_cli_investigation_failure(item)
             if item is None:
                 break
             yield item
@@ -210,8 +160,6 @@ def run_investigation_cli_streaming(
     try:
         final_state = renderer.render_stream(events)
     except KeyboardInterrupt:
-        # Force-close the generator so the background thread's finally block
-        # runs and the async task is cancelled before we re-raise.
         events.close()
         raise
 
@@ -227,197 +175,3 @@ def run_investigation_cli_streaming(
         "is_noise": final_state.get("is_noise", False),
         "tool_calls": final_state.get("evidence_entries", []),
     }
-
-
-def _run_session_alert_payload(
-    *,
-    raw_alert: dict[str, Any],
-    context_overrides: dict[str, Any] | None = None,
-    cancel_requested: threading.Event | None = None,
-    render: bool = True,
-) -> dict[str, Any]:
-    """Run a streaming investigation from an already-structured session alert."""
-    import queue
-
-    from surfaces.cli.ui.renderer import StreamRenderer
-    from tools.investigation.capability import astream_investigation
-
-    _check_llm_settings()
-    if context_overrides:
-        raw_alert.setdefault("annotations", {}).update(context_overrides)
-
-    event_queue: queue.Queue[StreamEvent | BaseException | None] = queue.Queue()
-    loop_ref: dict[str, asyncio.AbstractEventLoop] = {}
-    pump_task_ref: dict[str, asyncio.Task[None]] = {}
-
-    def _run_async() -> None:
-        loop = asyncio.new_event_loop()
-        loop_ref["loop"] = loop
-        try:
-
-            async def _pump() -> None:
-                async for evt in astream_investigation(
-                    raw_alert=raw_alert,
-                ):
-                    event_queue.put(evt)
-
-            task = loop.create_task(_pump())
-            pump_task_ref["task"] = task
-            try:
-                loop.run_until_complete(task)
-            except asyncio.CancelledError:
-                event_queue.put(_InvestigationPumpCancelled())
-        except Exception as exc:
-            event_queue.put(exc)
-        finally:
-            event_queue.put(None)
-            loop.close()
-
-    thread = threading.Thread(target=_run_async, daemon=True)
-    thread.start()
-
-    def _cancel_pump() -> None:
-        loop = loop_ref.get("loop")
-        task = pump_task_ref.get("task")
-        if loop is None or task is None or loop.is_closed():
-            return
-        with contextlib.suppress(RuntimeError):
-            # Loop may close between `is_closed()` and scheduling cancellation.
-            loop.call_soon_threadsafe(task.cancel)
-
-    def _events() -> Iterator[StreamEvent]:
-        try:
-            while True:
-                if cancel_requested is not None and cancel_requested.is_set():
-                    _cancel_pump()
-                    raise KeyboardInterrupt
-                try:
-                    item = event_queue.get(timeout=_SESSION_EVENT_POLL_S)
-                except queue.Empty:
-                    continue
-                if isinstance(item, BaseException):
-                    thread.join(timeout=5)
-                    _reraise_investigation_failure(item)
-                if item is None:
-                    return
-                yield item
-        finally:
-            _cancel_pump()
-
-    if render:
-        renderer = StreamRenderer(local=True)
-        try:
-            rendered_state = renderer.render_stream(_events())
-        except KeyboardInterrupt:
-            _cancel_pump()
-            raise
-        finally:
-            # Always join so unexpected exceptions from render_stream don't leak
-            # the daemon thread and leave an orphaned LLM call running.
-            thread.join(timeout=5)
-            if thread.is_alive():
-                _logger.warning(
-                    "investigation thread did not terminate within 5s after cancellation; "
-                    "an LLM call may still be in flight"
-                )
-        return dict(rendered_state)
-
-    from surfaces.interactive_shell.ui.output import reset_tracker, set_silent_tracker
-
-    set_silent_tracker()
-    renderer = StreamRenderer(local=True, display=False)
-    try:
-        return dict(renderer.render_stream(_events()))
-    except KeyboardInterrupt:
-        _cancel_pump()
-        raise
-    finally:
-        reset_tracker()
-        thread.join(timeout=5)
-        if thread.is_alive():
-            _logger.warning(
-                "investigation thread did not terminate within 5s after cancellation; "
-                "an LLM call may still be in flight"
-            )
-
-
-def run_investigation_for_session(
-    *,
-    alert_text: str,
-    context_overrides: dict[str, Any] | None = None,
-    cancel_requested: threading.Event | None = None,
-) -> dict[str, Any]:
-    """Run a streaming investigation from a free-text alert description.
-
-    Used by the REPL loop: wraps the user's text as the alert payload, runs
-    the full pipeline with live streaming, and returns the final state so
-    follow-ups and context accumulation can reference it.
-
-    KeyboardInterrupt in the main thread is forwarded to the background
-    asyncio loop as a task cancel, so Ctrl+C unwinds the in-flight remote investigation
-    run cleanly instead of leaving it orphaned.
-
-    When ``cancel_requested`` is set, the streaming loop polls it and cancels
-    the pump the same way (used by the interactive shell task table).
-
-    While this function runs, the synchronous REPL cannot process ``/cancel`` —
-    Ctrl+C remains the interactive cancel path; the event wiring exists for a
-    future non-blocking investigation driver or tooling that sets the flag.
-    """
-    raw_alert: dict[str, Any] = {"alert_name": "Interactive session", "message": alert_text}
-    return _run_session_alert_payload(
-        raw_alert=raw_alert,
-        context_overrides=context_overrides,
-        cancel_requested=cancel_requested,
-        render=True,
-    )
-
-
-def run_sample_alert_for_session(
-    *,
-    template_name: str = "generic",
-    context_overrides: dict[str, Any] | None = None,
-    cancel_requested: threading.Event | None = None,
-) -> dict[str, Any]:
-    """Run a streaming investigation for a built-in sample alert."""
-    from surfaces.cli.investigation.alert_templates import build_alert_template
-
-    return _run_session_alert_payload(
-        raw_alert=build_alert_template(template_name),
-        context_overrides=context_overrides,
-        cancel_requested=cancel_requested,
-        render=True,
-    )
-
-
-def run_investigation_for_session_background(
-    *,
-    alert_text: str,
-    context_overrides: dict[str, Any] | None = None,
-    cancel_requested: threading.Event | None = None,
-) -> dict[str, Any]:
-    """Run a non-rendering investigation for session-local background tasks."""
-    raw_alert: dict[str, Any] = {"alert_name": "Interactive session", "message": alert_text}
-    return _run_session_alert_payload(
-        raw_alert=raw_alert,
-        context_overrides=context_overrides,
-        cancel_requested=cancel_requested,
-        render=False,
-    )
-
-
-def run_sample_alert_for_session_background(
-    *,
-    template_name: str = "generic",
-    context_overrides: dict[str, Any] | None = None,
-    cancel_requested: threading.Event | None = None,
-) -> dict[str, Any]:
-    """Run a non-rendering sample-alert investigation for background tasks."""
-    from surfaces.cli.investigation.alert_templates import build_alert_template
-
-    return _run_session_alert_payload(
-        raw_alert=build_alert_template(template_name),
-        context_overrides=context_overrides,
-        cancel_requested=cancel_requested,
-        render=False,
-    )

--- a/surfaces/cli/investigation/investigate.py
+++ b/surfaces/cli/investigation/investigate.py
@@ -21,13 +21,10 @@ _SESSION_EVENT_POLL_S = 0.25
 
 def _reraise_cli_investigation_failure(exc: BaseException) -> NoReturn:
     """Map investigation runtime failures to structured CLI errors."""
-    from platform.common.errors import OpenSREError
+    from tools.investigation.session_runner import reraise_investigation_failure
 
     if isinstance(exc, InvestigationPumpCancelled):
-        raise OpenSREError(
-            "Investigation streaming stopped before completion.",
-            suggestion="The run was cancelled or closed early. Retry if you still need results.",
-        ) from exc
+        reraise_investigation_failure(exc)
     reraise_cli_runtime_error(exc)
 
 

--- a/surfaces/cli/investigation/payload.py
+++ b/surfaces/cli/investigation/payload.py
@@ -201,7 +201,7 @@ def _choose_guided_target() -> str:
 
 
 def _choose_guided_payload() -> dict[str, Any]:
-    from surfaces.cli.investigation.alert_templates import build_alert_template
+    from tools.investigation.alert_templates import build_alert_template
 
     while True:
         target = _choose_guided_target()

--- a/surfaces/interactive_shell/command_registry/investigation.py
+++ b/surfaces/interactive_shell/command_registry/investigation.py
@@ -113,7 +113,7 @@ def _prompt_investigate_path(console: Console) -> str | None:
 
 def _cmd_template(session: Session, console: Console, args: list[str]) -> bool:
     from surfaces.cli.constants import ALERT_TEMPLATE_CHOICES
-    from surfaces.cli.investigation.alert_templates import build_alert_template
+    from tools.investigation.alert_templates import build_alert_template
 
     if not args and repl_tty_interactive():
         return _interactive_template_menu(session, console)
@@ -217,11 +217,11 @@ def _cmd_investigate_file(session: Session, console: Console, args: list[str]) -
     from platform.analytics.cli import track_investigation
     from platform.analytics.source import EntrypointSource, TriggerMode
     from surfaces.cli.constants import ALERT_TEMPLATE_CHOICES
-    from surfaces.cli.investigation import (
+    from surfaces.cli.investigation.payload import resolve_alert_path
+    from surfaces.interactive_shell.runtime.investigation_adapter import (
         run_investigation_for_session,
         run_sample_alert_for_session,
     )
-    from surfaces.cli.investigation.payload import resolve_alert_path
 
     if not args and repl_tty_interactive():
         return _interactive_investigate_menu(session, console)

--- a/surfaces/interactive_shell/runtime/background/runner.py
+++ b/surfaces/interactive_shell/runtime/background/runner.py
@@ -191,7 +191,9 @@ def start_background_text_investigation(
     display_command: str = "background free-text investigation",
     investigation_target: str = "",
 ) -> str:
-    from surfaces.cli.investigation import run_investigation_for_session_background
+    from surfaces.interactive_shell.runtime.investigation_adapter import (
+        run_investigation_for_session_background,
+    )
 
     return _start_background_investigation(
         session=session,
@@ -215,7 +217,9 @@ def start_background_template_investigation(
     display_command: str,
     investigation_target: str = "",
 ) -> str:
-    from surfaces.cli.investigation import run_sample_alert_for_session_background
+    from surfaces.interactive_shell.runtime.investigation_adapter import (
+        run_sample_alert_for_session_background,
+    )
 
     return _start_background_investigation(
         session=session,

--- a/surfaces/interactive_shell/runtime/investigation_adapter.py
+++ b/surfaces/interactive_shell/runtime/investigation_adapter.py
@@ -1,0 +1,170 @@
+"""REPL adapters for session investigation streaming and action-tool launch."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Iterator
+from typing import Any
+
+from rich.console import Console
+
+from core.domain.stream import StreamEvent
+from platform.common.task_types import TaskRecord
+from surfaces.interactive_shell.ui.execution_confirm import execution_allowed
+from surfaces.interactive_shell.ui.foreground_investigation import run_foreground_investigation
+from tools.interactive_shell.shared.execution_policy import ExecutionPolicyResult
+from tools.interactive_shell.shared.investigation_launch import (
+    ForegroundInvestigationResult,
+    InvestigationLaunchPorts,
+    InvestigationLaunchSession,
+)
+from tools.investigation import session_runner
+
+
+def repl_foreground_renderer() -> session_runner.StreamRendererFn:
+    """Return a renderer that streams investigation progress to the REPL terminal."""
+    from surfaces.cli.ui.renderer import StreamRenderer
+
+    def _render(events: Iterator[StreamEvent]) -> dict[str, Any]:
+        renderer = StreamRenderer(local=True)
+        return dict(renderer.render_stream(events))
+
+    return _render
+
+
+def repl_background_renderer() -> session_runner.StreamRendererFn:
+    """Return a silent renderer for background investigations."""
+    from surfaces.cli.ui.renderer import StreamRenderer
+    from surfaces.interactive_shell.ui.output import reset_tracker, set_silent_tracker
+
+    def _render(events: Iterator[StreamEvent]) -> dict[str, Any]:
+        set_silent_tracker()
+        try:
+            renderer = StreamRenderer(local=True, display=False)
+            return dict(renderer.render_stream(events))
+        finally:
+            reset_tracker()
+
+    return _render
+
+
+def run_investigation_for_session(
+    *,
+    alert_text: str,
+    context_overrides: dict[str, Any] | None = None,
+    cancel_requested: threading.Event | None = None,
+) -> dict[str, Any]:
+    """Run a foreground streaming investigation in the REPL."""
+    return session_runner.run_investigation_for_session(
+        alert_text=alert_text,
+        context_overrides=context_overrides,
+        cancel_requested=cancel_requested,
+        render_stream=repl_foreground_renderer(),
+    )
+
+
+def run_sample_alert_for_session(
+    *,
+    template_name: str = "generic",
+    context_overrides: dict[str, Any] | None = None,
+    cancel_requested: threading.Event | None = None,
+) -> dict[str, Any]:
+    """Run a foreground sample-alert investigation in the REPL."""
+    return session_runner.run_sample_alert_for_session(
+        template_name=template_name,
+        context_overrides=context_overrides,
+        cancel_requested=cancel_requested,
+        render_stream=repl_foreground_renderer(),
+    )
+
+
+def run_investigation_for_session_background(
+    *,
+    alert_text: str,
+    context_overrides: dict[str, Any] | None = None,
+    cancel_requested: threading.Event | None = None,
+) -> dict[str, Any]:
+    """Run a silent background investigation in the REPL."""
+    return session_runner.run_investigation_for_session_background(
+        alert_text=alert_text,
+        context_overrides=context_overrides,
+        cancel_requested=cancel_requested,
+        render_stream=repl_background_renderer(),
+    )
+
+
+def run_sample_alert_for_session_background(
+    *,
+    template_name: str = "generic",
+    context_overrides: dict[str, Any] | None = None,
+    cancel_requested: threading.Event | None = None,
+) -> dict[str, Any]:
+    """Run a silent background sample-alert investigation in the REPL."""
+    return session_runner.run_sample_alert_for_session_background(
+        template_name=template_name,
+        context_overrides=context_overrides,
+        cancel_requested=cancel_requested,
+        render_stream=repl_background_renderer(),
+    )
+
+
+class ReplInvestigationLaunchPorts:
+    """Default REPL ports for investigation-style action tools."""
+
+    def execution_allowed(
+        self,
+        *,
+        policy: ExecutionPolicyResult,
+        session: InvestigationLaunchSession,
+        console: Console,
+        action_summary: str,
+        confirm_fn: Callable[[str], str] | None,
+        is_tty: bool | None,
+        action_already_listed: bool,
+    ) -> bool:
+        return execution_allowed(
+            policy,
+            session=session,  # type: ignore[arg-type]
+            console=console,
+            action_summary=action_summary,
+            confirm_fn=confirm_fn,
+            is_tty=is_tty,
+            action_already_listed=action_already_listed,
+        )
+
+    def run_foreground_investigation(
+        self,
+        *,
+        session: InvestigationLaunchSession,
+        console: Console,
+        task_command: str,
+        run: Callable[[TaskRecord], dict[str, object]],
+        exception_context: str,
+        target: str,
+    ) -> ForegroundInvestigationResult:
+        outcome = run_foreground_investigation(
+            session=session,  # type: ignore[arg-type]
+            console=console,
+            task_command=task_command,
+            run=run,
+            exception_context=exception_context,
+            target=target,
+        )
+        return ForegroundInvestigationResult(status=outcome.status)
+
+
+def repl_investigation_launch_ports() -> InvestigationLaunchPorts:
+    """Return REPL investigation launch ports for action tools."""
+    return ReplInvestigationLaunchPorts()
+
+
+__all__ = [
+    "ReplInvestigationLaunchPorts",
+    "repl_background_renderer",
+    "repl_foreground_renderer",
+    "repl_investigation_launch_ports",
+    "run_investigation_for_session",
+    "run_investigation_for_session_background",
+    "run_sample_alert_for_session",
+    "run_sample_alert_for_session_background",
+]

--- a/surfaces/interactive_shell/runtime/investigation_adapter.py
+++ b/surfaces/interactive_shell/runtime/investigation_adapter.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from rich.console import Console
 
+from core.agent_harness.session import Session
 from core.domain.stream import StreamEvent
 from platform.common.task_types import TaskRecord
 from surfaces.interactive_shell.ui.execution_confirm import execution_allowed
@@ -16,7 +17,6 @@ from tools.interactive_shell.shared.execution_policy import ExecutionPolicyResul
 from tools.interactive_shell.shared.investigation_launch import (
     ForegroundInvestigationResult,
     InvestigationLaunchPorts,
-    InvestigationLaunchSession,
 )
 from tools.investigation import session_runner
 
@@ -115,7 +115,7 @@ class ReplInvestigationLaunchPorts:
         self,
         *,
         policy: ExecutionPolicyResult,
-        session: InvestigationLaunchSession,
+        session: Session,
         console: Console,
         action_summary: str,
         confirm_fn: Callable[[str], str] | None,
@@ -124,7 +124,7 @@ class ReplInvestigationLaunchPorts:
     ) -> bool:
         return execution_allowed(
             policy,
-            session=session,  # type: ignore[arg-type]
+            session=session,
             console=console,
             action_summary=action_summary,
             confirm_fn=confirm_fn,
@@ -135,7 +135,7 @@ class ReplInvestigationLaunchPorts:
     def run_foreground_investigation(
         self,
         *,
-        session: InvestigationLaunchSession,
+        session: Session,
         console: Console,
         task_command: str,
         run: Callable[[TaskRecord], dict[str, object]],
@@ -143,7 +143,7 @@ class ReplInvestigationLaunchPorts:
         target: str,
     ) -> ForegroundInvestigationResult:
         outcome = run_foreground_investigation(
-            session=session,  # type: ignore[arg-type]
+            session=session,
             console=console,
             task_command=task_command,
             run=run,

--- a/tests/cli/test_investigate.py
+++ b/tests/cli/test_investigate.py
@@ -60,7 +60,7 @@ def test_run_investigation_cli_passes_investigation_metadata_to_runner(
             "validity_score": 0.0,
         }
 
-    monkeypatch.setattr("tools.investigation.session_runner.check_llm_settings", lambda: None)
+    monkeypatch.setattr("surfaces.cli.investigation.investigate.check_llm_settings", lambda: None)
     monkeypatch.setattr(
         "tools.investigation.capability.run_investigation_payload",
         fake_call,
@@ -91,7 +91,7 @@ def test_run_investigation_cli_shapes_agent_state(monkeypatch) -> None:
             "root_cause": "bad deploy",
         }
 
-    monkeypatch.setattr("tools.investigation.session_runner.check_llm_settings", lambda: None)
+    monkeypatch.setattr("surfaces.cli.investigation.investigate.check_llm_settings", lambda: None)
     monkeypatch.setattr(
         "tools.investigation.capability.run_investigation",
         fake_run_investigation,
@@ -129,7 +129,7 @@ def test_run_investigation_cli_evaluate_reports_skip_when_no_rubric(monkeypatch)
             "opensre_llm_eval": {},
         }
 
-    monkeypatch.setattr("tools.investigation.session_runner.check_llm_settings", lambda: None)
+    monkeypatch.setattr("surfaces.cli.investigation.investigate.check_llm_settings", lambda: None)
     monkeypatch.setattr("tools.investigation.capability.run_investigation", fake_run)
 
     result = run_investigation_cli(
@@ -181,7 +181,7 @@ def test_stream_investigation_cli_raises_queued_exception_immediately(
         yield StreamEvent("metadata", data={"run_id": "run-123"})
         raise RuntimeError("stream failed")
 
-    monkeypatch.setattr("tools.investigation.session_runner.check_llm_settings", lambda: None)
+    monkeypatch.setattr("surfaces.cli.investigation.investigate.check_llm_settings", lambda: None)
     monkeypatch.setattr(
         "tools.investigation.capability.astream_investigation",
         fake_astream_investigation,
@@ -207,7 +207,7 @@ def test_stream_investigation_cli_closes_cleanly_on_generator_close(
         # Simulate a long-running stream
         await asyncio.sleep(1000)
 
-    monkeypatch.setattr("tools.investigation.session_runner.check_llm_settings", lambda: None)
+    monkeypatch.setattr("surfaces.cli.investigation.investigate.check_llm_settings", lambda: None)
     monkeypatch.setattr(
         "tools.investigation.capability.astream_investigation",
         fake_astream_investigation,
@@ -233,7 +233,7 @@ def test_run_investigation_cli_maps_cli_auth_to_opensre_error(
             detail="Not logged in.",
         )
 
-    monkeypatch.setattr("tools.investigation.session_runner.check_llm_settings", lambda: None)
+    monkeypatch.setattr("surfaces.cli.investigation.investigate.check_llm_settings", lambda: None)
     monkeypatch.setattr("tools.investigation.capability.run_investigation", boom)
 
     with pytest.raises(OpenSREError, match="not authenticated") as exc_info:
@@ -253,7 +253,7 @@ def test_stream_investigation_cli_maps_cli_auth_to_opensre_error(
             detail="Not logged in.",
         )
 
-    monkeypatch.setattr("tools.investigation.session_runner.check_llm_settings", lambda: None)
+    monkeypatch.setattr("surfaces.cli.investigation.investigate.check_llm_settings", lambda: None)
     monkeypatch.setattr(
         "tools.investigation.capability.astream_investigation",
         fake_astream_investigation,

--- a/tests/cli/test_investigate.py
+++ b/tests/cli/test_investigate.py
@@ -60,7 +60,7 @@ def test_run_investigation_cli_passes_investigation_metadata_to_runner(
             "validity_score": 0.0,
         }
 
-    monkeypatch.setattr("surfaces.cli.investigation.investigate.resolve_llm_settings", object)
+    monkeypatch.setattr("tools.investigation.session_runner.check_llm_settings", lambda: None)
     monkeypatch.setattr(
         "tools.investigation.capability.run_investigation_payload",
         fake_call,
@@ -91,7 +91,7 @@ def test_run_investigation_cli_shapes_agent_state(monkeypatch) -> None:
             "root_cause": "bad deploy",
         }
 
-    monkeypatch.setattr("surfaces.cli.investigation.investigate.resolve_llm_settings", object)
+    monkeypatch.setattr("tools.investigation.session_runner.check_llm_settings", lambda: None)
     monkeypatch.setattr(
         "tools.investigation.capability.run_investigation",
         fake_run_investigation,
@@ -129,7 +129,7 @@ def test_run_investigation_cli_evaluate_reports_skip_when_no_rubric(monkeypatch)
             "opensre_llm_eval": {},
         }
 
-    monkeypatch.setattr("surfaces.cli.investigation.investigate.resolve_llm_settings", object)
+    monkeypatch.setattr("tools.investigation.session_runner.check_llm_settings", lambda: None)
     monkeypatch.setattr("tools.investigation.capability.run_investigation", fake_run)
 
     result = run_investigation_cli(
@@ -149,6 +149,7 @@ def test_parse_args_evaluate_flag() -> None:
 
 def test_run_investigation_cli_fails_fast_for_missing_llm_auth(monkeypatch, tmp_path) -> None:
     from config.llm_auth.credentials import CredentialStatus
+    from platform.common.errors import OpenSREError
 
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -180,7 +181,7 @@ def test_stream_investigation_cli_raises_queued_exception_immediately(
         yield StreamEvent("metadata", data={"run_id": "run-123"})
         raise RuntimeError("stream failed")
 
-    monkeypatch.setattr("surfaces.cli.investigation.investigate.resolve_llm_settings", object)
+    monkeypatch.setattr("tools.investigation.session_runner.check_llm_settings", lambda: None)
     monkeypatch.setattr(
         "tools.investigation.capability.astream_investigation",
         fake_astream_investigation,
@@ -206,7 +207,7 @@ def test_stream_investigation_cli_closes_cleanly_on_generator_close(
         # Simulate a long-running stream
         await asyncio.sleep(1000)
 
-    monkeypatch.setattr("surfaces.cli.investigation.investigate.resolve_llm_settings", object)
+    monkeypatch.setattr("tools.investigation.session_runner.check_llm_settings", lambda: None)
     monkeypatch.setattr(
         "tools.investigation.capability.astream_investigation",
         fake_astream_investigation,
@@ -232,7 +233,7 @@ def test_run_investigation_cli_maps_cli_auth_to_opensre_error(
             detail="Not logged in.",
         )
 
-    monkeypatch.setattr("surfaces.cli.investigation.investigate.resolve_llm_settings", object)
+    monkeypatch.setattr("tools.investigation.session_runner.check_llm_settings", lambda: None)
     monkeypatch.setattr("tools.investigation.capability.run_investigation", boom)
 
     with pytest.raises(OpenSREError, match="not authenticated") as exc_info:
@@ -252,7 +253,7 @@ def test_stream_investigation_cli_maps_cli_auth_to_opensre_error(
             detail="Not logged in.",
         )
 
-    monkeypatch.setattr("surfaces.cli.investigation.investigate.resolve_llm_settings", object)
+    monkeypatch.setattr("tools.investigation.session_runner.check_llm_settings", lambda: None)
     monkeypatch.setattr(
         "tools.investigation.capability.astream_investigation",
         fake_astream_investigation,

--- a/tests/core/agent/orchestration/test_agent_actions.py
+++ b/tests/core/agent/orchestration/test_agent_actions.py
@@ -623,10 +623,10 @@ def test_nitro_prompt_executes_remote_then_investigation(monkeypatch: object) ->
         return {"root_cause": "hello world handled"}
 
     monkeypatch.setattr(slash_tool, "dispatch_slash", _fake_dispatch)
-    import surfaces.cli.investigation as investigation_module
+    import surfaces.interactive_shell.runtime.investigation_adapter as investigation_adapter
 
     monkeypatch.setattr(
-        investigation_module,
+        investigation_adapter,
         "run_investigation_for_session",
         _fake_run_investigation_for_session,
     )
@@ -696,10 +696,10 @@ def test_execute_cli_actions_runs_sample_alert(monkeypatch: object) -> None:
             "is_noise": False,
         }
 
-    import surfaces.cli.investigation as investigation_module
+    import surfaces.interactive_shell.runtime.investigation_adapter as investigation_adapter
 
     monkeypatch.setattr(
-        investigation_module,
+        investigation_adapter,
         "run_sample_alert_for_session",
         _fake_run_sample_alert_for_session,
     )
@@ -742,9 +742,9 @@ def test_execute_cli_actions_sample_alert_opensre_error_marks_task_failed(
     ) -> dict[str, object]:
         raise OpenSREError("sample pipeline blocked")
 
-    import surfaces.cli.investigation as investigation_module
+    import surfaces.interactive_shell.runtime.investigation_adapter as investigation_adapter
 
-    monkeypatch.setattr(investigation_module, "run_sample_alert_for_session", _raise)
+    monkeypatch.setattr(investigation_adapter, "run_sample_alert_for_session", _raise)
 
     session = Session()
     console, _ = _capture()

--- a/tests/interactive_shell/runtime/test_background_runner.py
+++ b/tests/interactive_shell/runtime/test_background_runner.py
@@ -46,7 +46,7 @@ def test_start_background_template_investigation_assigns_fresh_investigation_id(
         return {"root_cause": "done"}
 
     monkeypatch.setattr(
-        "surfaces.cli.investigation.run_sample_alert_for_session_background",
+        "surfaces.interactive_shell.runtime.investigation_adapter.run_sample_alert_for_session_background",
         _fake_run,
     )
     monkeypatch.setattr(

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -1256,8 +1256,11 @@ class TestInvestigateFileCommand:
             captured.append(alert_text)
             return {"root_cause": "test cause"}
 
-        # Patch package re-export: slash handler does `from surfaces.cli.investigation import ...`.
-        monkeypatch.setattr("surfaces.cli.investigation.run_investigation_for_session", _fake)
+        # Patch REPL adapter used by slash handler lazy import.
+        monkeypatch.setattr(
+            "surfaces.interactive_shell.runtime.investigation_adapter.run_investigation_for_session",
+            _fake,
+        )
         session = Session()
         console, _ = _capture()
         dispatch_slash(f"/investigate {alert_file}", session, console)
@@ -1277,7 +1280,10 @@ class TestInvestigateFileCommand:
             captured.append(template_name)
             return {"root_cause": "sample cause"}
 
-        monkeypatch.setattr("surfaces.cli.investigation.run_sample_alert_for_session", _fake_sample)
+        monkeypatch.setattr(
+            "surfaces.interactive_shell.runtime.investigation_adapter.run_sample_alert_for_session",
+            _fake_sample,
+        )
 
         session = Session()
         console, _ = _capture()
@@ -1336,7 +1342,7 @@ class TestInvestigateFileCommand:
 
         monkeypatch.setattr("platform.analytics.cli.track_investigation", _fake_track)
         monkeypatch.setattr(
-            "surfaces.cli.investigation.run_sample_alert_for_session",
+            "surfaces.interactive_shell.runtime.investigation_adapter.run_sample_alert_for_session",
             lambda **_kwargs: {"root_cause": "sample cause"},
         )
 
@@ -1363,7 +1369,10 @@ class TestInvestigateFileCommand:
             calls.append(template_name)
             return {"root_cause": "template-wins"}
 
-        monkeypatch.setattr("surfaces.cli.investigation.run_sample_alert_for_session", _fake_sample)
+        monkeypatch.setattr(
+            "surfaces.interactive_shell.runtime.investigation_adapter.run_sample_alert_for_session",
+            _fake_sample,
+        )
 
         session = Session()
         console, _ = _capture()
@@ -1394,7 +1403,10 @@ class TestInvestigateFileCommand:
 
         monkeypatch.setattr(investigation_cmd, "repl_tty_interactive", lambda: True)
         monkeypatch.setattr(investigation_cmd, "repl_choose_one", lambda **_: next(picks))
-        monkeypatch.setattr("surfaces.cli.investigation.run_sample_alert_for_session", _fake_sample)
+        monkeypatch.setattr(
+            "surfaces.interactive_shell.runtime.investigation_adapter.run_sample_alert_for_session",
+            _fake_sample,
+        )
 
         session = Session()
         console, buf = _capture()
@@ -1440,7 +1452,10 @@ class TestInvestigateFileCommand:
             "_prompt_investigate_path",
             lambda _console: str(alert_file),
         )
-        monkeypatch.setattr("surfaces.cli.investigation.run_investigation_for_session", _fake)
+        monkeypatch.setattr(
+            "surfaces.interactive_shell.runtime.investigation_adapter.run_investigation_for_session",
+            _fake,
+        )
 
         session = Session()
         console, _ = _capture()
@@ -1479,7 +1494,7 @@ class TestInvestigateFileCommand:
 
         monkeypatch.setattr("platform.analytics.cli.track_investigation", _fake_track)
         monkeypatch.setattr(
-            "surfaces.cli.investigation.run_investigation_for_session",
+            "surfaces.interactive_shell.runtime.investigation_adapter.run_investigation_for_session",
             lambda **_kwargs: {"root_cause": "test cause"},
         )
         session = Session()
@@ -1512,7 +1527,10 @@ class TestInvestigateFileCommand:
                 "region": "us-east-1",
             }
 
-        monkeypatch.setattr("surfaces.cli.investigation.run_investigation_for_session", _fake)
+        monkeypatch.setattr(
+            "surfaces.interactive_shell.runtime.investigation_adapter.run_investigation_for_session",
+            _fake,
+        )
 
         session = Session()
         console, _ = _capture()
@@ -1574,7 +1592,10 @@ class TestInvestigateFileCommand:
         ) -> dict[str, object]:
             raise OpenSREError("bad config")
 
-        monkeypatch.setattr("surfaces.cli.investigation.run_investigation_for_session", _raise)
+        monkeypatch.setattr(
+            "surfaces.interactive_shell.runtime.investigation_adapter.run_investigation_for_session",
+            _raise,
+        )
         session = Session()
         console, _ = _capture()
         dispatch_slash(f"/investigate {alert_file}", session, console)

--- a/tests/tools/investigation/test_layering.py
+++ b/tests/tools/investigation/test_layering.py
@@ -25,6 +25,7 @@ _ORCHESTRATION_PIPELINE_FILES: tuple[Path, ...] = (
     Path("tools/investigation/capability.py"),
     Path("tools/investigation/state_factory.py"),
     Path("tools/investigation/streaming.py"),
+    Path("tools/investigation/session_runner.py"),
 )
 # ``cli`` is the presentation layer; same rule.
 _FORBIDDEN_PREFIXES: tuple[str, ...] = ("cli",)

--- a/tests/tools/investigation/test_session_runner.py
+++ b/tests/tools/investigation/test_session_runner.py
@@ -140,3 +140,33 @@ def test_run_investigation_for_session_background_uses_renderer(
     )
 
     assert result["status"] == "silent"
+
+
+def test_run_session_alert_payload_does_not_mutate_raw_alert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tools.investigation.session_runner.check_llm_settings",
+        lambda: None,
+    )
+
+    async def _empty_gen():
+        if False:
+            yield StreamEvent(event_type="end")
+
+    monkeypatch.setattr(
+        "tools.investigation.capability.astream_investigation",
+        lambda **_kwargs: _empty_gen(),
+    )
+
+    shared: dict[str, Any] = {"alert_name": "test", "annotations": {"keep": "yes"}}
+    original = dict(shared)
+    original["annotations"] = dict(shared["annotations"])
+
+    session_runner.run_session_alert_payload(
+        raw_alert=shared,
+        context_overrides={"add": "value"},
+        render_stream=_collecting_renderer(),
+    )
+
+    assert shared == original

--- a/tests/tools/investigation/test_session_runner.py
+++ b/tests/tools/investigation/test_session_runner.py
@@ -1,0 +1,142 @@
+"""Tests for surface-agnostic session investigation streaming."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from core.domain.stream import StreamEvent
+from tools.investigation import session_runner
+
+
+def _collecting_renderer(
+    final_state: dict[str, Any] | None = None,
+) -> session_runner.StreamRendererFn:
+    state = final_state if final_state is not None else {"root_cause": "done"}
+
+    def _render(events: Iterator[StreamEvent]) -> dict[str, Any]:
+        for _ in events:
+            pass
+        return dict(state)
+
+    return _render
+
+
+def test_run_investigation_for_session_invokes_renderer(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_astream(**_kwargs: Any):
+        async def _gen():
+            yield StreamEvent(event_type="end", data={"output": {"root_cause": "ok"}})
+
+        return _gen()
+
+    monkeypatch.setattr(
+        "tools.investigation.session_runner.check_llm_settings",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "tools.investigation.capability.astream_investigation",
+        _fake_astream,
+    )
+
+    def _render(events: Iterator[StreamEvent]) -> dict[str, Any]:
+        list(events)
+        captured["rendered"] = True
+        return {"root_cause": "ok"}
+
+    result = session_runner.run_investigation_for_session(
+        alert_text="payments failing",
+        render_stream=_render,
+    )
+
+    assert captured["rendered"] is True
+    assert result["root_cause"] == "ok"
+
+
+def test_run_session_alert_payload_cancel_requested_raises_keyboard_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cancel = threading.Event()
+
+    def _slow_astream(**_kwargs: Any):
+        async def _gen():
+            cancel.set()
+            while True:
+                yield StreamEvent(event_type="events", data={})
+                await __import__("asyncio").sleep(0.05)
+
+        return _gen()
+
+    monkeypatch.setattr(
+        "tools.investigation.session_runner.check_llm_settings",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "tools.investigation.capability.astream_investigation",
+        _slow_astream,
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        session_runner.run_session_alert_payload(
+            raw_alert={"alert_name": "test"},
+            cancel_requested=cancel,
+            render_stream=_collecting_renderer(),
+        )
+
+
+def test_run_sample_alert_for_session_uses_template(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_alert: dict[str, Any] = {}
+
+    def _fake_astream(*, raw_alert: dict[str, Any], **_kwargs: Any):
+        captured_alert.update(raw_alert)
+
+        async def _gen():
+            if False:
+                yield StreamEvent(event_type="end")
+
+        return _gen()
+
+    monkeypatch.setattr(
+        "tools.investigation.session_runner.check_llm_settings",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "tools.investigation.capability.astream_investigation",
+        _fake_astream,
+    )
+
+    session_runner.run_sample_alert_for_session(
+        template_name="generic",
+        render_stream=_collecting_renderer(),
+    )
+
+    assert captured_alert.get("pipeline_name") == "payments_etl"
+
+
+def test_run_investigation_for_session_background_uses_renderer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tools.investigation.session_runner.check_llm_settings",
+        lambda: None,
+    )
+
+    async def _empty_gen():
+        if False:
+            yield StreamEvent(event_type="end")
+
+    monkeypatch.setattr(
+        "tools.investigation.capability.astream_investigation",
+        lambda **_kwargs: _empty_gen(),
+    )
+
+    result = session_runner.run_investigation_for_session_background(
+        alert_text="background test",
+        render_stream=_collecting_renderer({"status": "silent"}),
+    )
+
+    assert result["status"] == "silent"

--- a/tools/interactive_shell/actions/investigation.py
+++ b/tools/interactive_shell/actions/investigation.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from rich.console import Console
 
+from core.agent_harness.session import Session
 from core.agent_harness.tools.tool_context import (
     ActionToolContext,
     execute_with_action_context,
@@ -15,7 +16,6 @@ from core.agent_harness.tools.tool_context import (
 )
 from core.tool_framework.registered_tool import RegisteredTool
 from platform.common.task_types import TaskRecord
-from surfaces.interactive_shell.runtime import Session
 from tools.interactive_shell.shared.investigation_launch import launch_investigation
 
 
@@ -36,9 +36,12 @@ def run_text_investigation(
     is_tty: bool | None = None,
     action_already_listed: bool = False,
 ) -> None:
-    def _run(task: TaskRecord) -> dict[str, object]:
-        from surfaces.cli.investigation import run_investigation_for_session
+    from surfaces.interactive_shell.runtime.investigation_adapter import (
+        repl_investigation_launch_ports,
+        run_investigation_for_session,
+    )
 
+    def _run(task: TaskRecord) -> dict[str, object]:
         return run_investigation_for_session(
             alert_text=alert_text,
             context_overrides=session.accumulated_context or None,
@@ -60,6 +63,7 @@ def run_text_investigation(
     launch_investigation(
         session=session,
         console=console,
+        ports=repl_investigation_launch_ports(),
         tool_type="investigation",
         action_summary=f'investigation from text "{alert_text}"',
         announce_label="investigation",

--- a/tools/interactive_shell/actions/sample_alert.py
+++ b/tools/interactive_shell/actions/sample_alert.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from rich.console import Console
 
+from core.agent_harness.session import Session
 from core.agent_harness.tools.tool_context import (
     ActionToolContext,
     execute_with_action_context,
@@ -15,7 +16,6 @@ from core.agent_harness.tools.tool_context import (
 )
 from core.tool_framework.registered_tool import RegisteredTool
 from platform.common.task_types import TaskRecord
-from surfaces.interactive_shell.runtime import Session
 from tools.interactive_shell.shared.investigation_launch import launch_investigation
 
 _SAMPLE_ALERT_TEMPLATES = ("generic",)
@@ -30,9 +30,12 @@ def run_sample_alert(
     is_tty: bool | None = None,
     action_already_listed: bool = False,
 ) -> None:
-    def _run(task: TaskRecord) -> dict[str, object]:
-        from surfaces.cli.investigation import run_sample_alert_for_session
+    from surfaces.interactive_shell.runtime.investigation_adapter import (
+        repl_investigation_launch_ports,
+        run_sample_alert_for_session,
+    )
 
+    def _run(task: TaskRecord) -> dict[str, object]:
         return run_sample_alert_for_session(
             template_name=template_name,
             context_overrides=session.accumulated_context or None,
@@ -54,6 +57,7 @@ def run_sample_alert(
     launch_investigation(
         session=session,
         console=console,
+        ports=repl_investigation_launch_ports(),
         tool_type="sample_alert",
         action_summary=f"sample alert investigation ({template_name})",
         announce_label="sample alert",

--- a/tools/interactive_shell/shared/investigation_launch.py
+++ b/tools/interactive_shell/shared/investigation_launch.py
@@ -16,6 +16,7 @@ from typing import Literal, Protocol, runtime_checkable
 from rich.console import Console
 from rich.markup import escape
 
+from core.agent_harness.session import Session
 from platform.common.task_types import TaskRecord
 from tools.interactive_shell.shared.execution_policy import (
     ExecutionPolicyResult,
@@ -33,15 +34,6 @@ class ForegroundInvestigationResult:
 
 
 @runtime_checkable
-class InvestigationLaunchSession(Protocol):
-    """Session surface required by investigation launch orchestration."""
-
-    background_mode_enabled: bool
-
-    def record(self, channel: str, value: str, *, ok: bool = True) -> None: ...
-
-
-@runtime_checkable
 class InvestigationLaunchPorts(Protocol):
     """Surface-specific hooks for gating and foreground investigation UX."""
 
@@ -49,29 +41,31 @@ class InvestigationLaunchPorts(Protocol):
         self,
         *,
         policy: ExecutionPolicyResult,
-        session: InvestigationLaunchSession,
+        session: Session,
         console: Console,
         action_summary: str,
         confirm_fn: Callable[[str], str] | None,
         is_tty: bool | None,
         action_already_listed: bool,
-    ) -> bool: ...
+    ) -> bool:
+        raise NotImplementedError
 
     def run_foreground_investigation(
         self,
         *,
-        session: InvestigationLaunchSession,
+        session: Session,
         console: Console,
         task_command: str,
         run: Callable[[TaskRecord], dict[str, object]],
         exception_context: str,
         target: str,
-    ) -> ForegroundInvestigationResult: ...
+    ) -> ForegroundInvestigationResult:
+        raise NotImplementedError
 
 
 def launch_investigation(
     *,
-    session: InvestigationLaunchSession,
+    session: Session,
     console: Console,
     ports: InvestigationLaunchPorts,
     tool_type: str,
@@ -131,6 +125,6 @@ def launch_investigation(
 __all__ = [
     "ForegroundInvestigationResult",
     "InvestigationLaunchPorts",
-    "InvestigationLaunchSession",
+    "Session",
     "launch_investigation",
 ]

--- a/tools/interactive_shell/shared/investigation_launch.py
+++ b/tools/interactive_shell/shared/investigation_launch.py
@@ -10,21 +10,70 @@ and the display/record strings).
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal, Protocol, runtime_checkable
 
 from rich.console import Console
 from rich.markup import escape
 
 from platform.common.task_types import TaskRecord
-from surfaces.interactive_shell.runtime import Session
-from surfaces.interactive_shell.ui.execution_confirm import execution_allowed
-from surfaces.interactive_shell.ui.foreground_investigation import run_foreground_investigation
-from tools.interactive_shell.shared.execution_policy import plan_foreground_tool
+from tools.interactive_shell.shared.execution_policy import (
+    ExecutionPolicyResult,
+    plan_foreground_tool,
+)
+
+ForegroundInvestigationStatus = Literal["completed", "failed", "cancelled"]
+
+
+@dataclass(frozen=True)
+class ForegroundInvestigationResult:
+    """Minimal foreground investigation outcome for launch gating."""
+
+    status: ForegroundInvestigationStatus
+
+
+@runtime_checkable
+class InvestigationLaunchSession(Protocol):
+    """Session surface required by investigation launch orchestration."""
+
+    background_mode_enabled: bool
+
+    def record(self, channel: str, value: str, *, ok: bool = True) -> None: ...
+
+
+@runtime_checkable
+class InvestigationLaunchPorts(Protocol):
+    """Surface-specific hooks for gating and foreground investigation UX."""
+
+    def execution_allowed(
+        self,
+        *,
+        policy: ExecutionPolicyResult,
+        session: InvestigationLaunchSession,
+        console: Console,
+        action_summary: str,
+        confirm_fn: Callable[[str], str] | None,
+        is_tty: bool | None,
+        action_already_listed: bool,
+    ) -> bool: ...
+
+    def run_foreground_investigation(
+        self,
+        *,
+        session: InvestigationLaunchSession,
+        console: Console,
+        task_command: str,
+        run: Callable[[TaskRecord], dict[str, object]],
+        exception_context: str,
+        target: str,
+    ) -> ForegroundInvestigationResult: ...
 
 
 def launch_investigation(
     *,
-    session: Session,
+    session: InvestigationLaunchSession,
     console: Console,
+    ports: InvestigationLaunchPorts,
     tool_type: str,
     action_summary: str,
     announce_label: str,
@@ -43,8 +92,8 @@ def launch_investigation(
     Every outcome is recorded on the ``alert`` channel keyed by ``record_value``.
     """
     plan = plan_foreground_tool(tool_type, "investigation_launch")
-    if not execution_allowed(
-        plan.policy,
+    if not ports.execution_allowed(
+        policy=plan.policy,
         session=session,
         console=console,
         action_summary=action_summary,
@@ -63,7 +112,7 @@ def launch_investigation(
         return
 
     if (
-        run_foreground_investigation(
+        ports.run_foreground_investigation(
             session=session,
             console=console,
             task_command=foreground_task_command,
@@ -79,4 +128,9 @@ def launch_investigation(
     session.record("alert", record_value)
 
 
-__all__ = ["launch_investigation"]
+__all__ = [
+    "ForegroundInvestigationResult",
+    "InvestigationLaunchPorts",
+    "InvestigationLaunchSession",
+    "launch_investigation",
+]

--- a/tools/investigation/alert_templates.py
+++ b/tools/investigation/alert_templates.py
@@ -1,4 +1,4 @@
-"""Starter alert payload templates for CLI investigations."""
+"""Starter alert payload templates for investigations."""
 
 from __future__ import annotations
 

--- a/tools/investigation/session_runner.py
+++ b/tools/investigation/session_runner.py
@@ -83,6 +83,21 @@ def reraise_investigation_failure(exc: BaseException) -> NoReturn:
     raise exc
 
 
+def _alert_payload_with_context(
+    raw_alert: dict[str, Any],
+    context_overrides: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not context_overrides:
+        return raw_alert
+    return {
+        **raw_alert,
+        "annotations": {
+            **raw_alert.get("annotations", {}),
+            **context_overrides,
+        },
+    }
+
+
 def run_session_alert_payload(
     *,
     raw_alert: dict[str, Any],
@@ -94,8 +109,7 @@ def run_session_alert_payload(
     from tools.investigation.capability import astream_investigation
 
     check_llm_settings()
-    if context_overrides:
-        raw_alert.setdefault("annotations", {}).update(context_overrides)
+    alert_payload = _alert_payload_with_context(raw_alert, context_overrides)
 
     event_queue: queue.Queue[StreamEvent | BaseException | None] = queue.Queue()
     loop_ref: dict[str, asyncio.AbstractEventLoop] = {}
@@ -108,7 +122,7 @@ def run_session_alert_payload(
 
             async def _pump() -> None:
                 async for evt in astream_investigation(
-                    raw_alert=raw_alert,
+                    raw_alert=alert_payload,
                 ):
                     event_queue.put(evt)
 

--- a/tools/investigation/session_runner.py
+++ b/tools/investigation/session_runner.py
@@ -1,0 +1,248 @@
+"""Surface-agnostic session investigation streaming orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import queue
+import threading
+from collections.abc import Callable, Iterator
+from typing import Any, NoReturn
+
+from config.config import resolve_llm_settings
+from core.domain.stream import StreamEvent
+from platform.common.errors import OpenSREError
+from tools.investigation.alert_templates import build_alert_template
+
+_logger = logging.getLogger(__name__)
+
+_SESSION_EVENT_POLL_S = 0.25
+
+StreamRendererFn = Callable[[Iterator[StreamEvent]], dict[str, Any]]
+
+
+class InvestigationPumpCancelled(Exception):
+    """Propagated when the async pump task was cancelled (distinct from Ctrl+C SIGINT)."""
+
+
+def check_llm_settings() -> None:
+    """Validate LLM settings early and surface misconfiguration as a structured error."""
+    from pydantic import ValidationError
+
+    try:
+        settings = resolve_llm_settings()
+    except ValidationError as exc:
+        errors = exc.errors()
+        if errors:
+            ctx = errors[0].get("ctx", {})
+            original = ctx.get("error")
+            msg = str(original) if isinstance(original, Exception) else errors[0]["msg"]
+        else:
+            msg = str(exc)
+        raise OpenSREError(
+            msg,
+            suggestion="Run `opensre onboard` to configure your LLM provider and API credentials.",
+        ) from exc
+
+    provider = getattr(settings, "provider", None)
+    if not isinstance(provider, str):
+        return
+    from config.llm_auth.credentials import status as credential_status
+
+    auth_status = credential_status(provider)
+    if auth_status.configured and not auth_status.stale:
+        return
+    state = "stale" if auth_status.stale else "missing"
+    raise OpenSREError(
+        f"LLM provider '{provider}' credentials are {state}: {auth_status.detail}",
+        suggestion=(
+            f"Run `opensre auth verify {provider}` or `opensre auth login {provider}` "
+            "before starting an investigation."
+        ),
+    )
+
+
+def reraise_investigation_failure(exc: BaseException) -> NoReturn:
+    """Map investigation runtime failures to structured errors."""
+    from core.llm_invoke_errors import classify_llm_invoke_failure
+
+    if isinstance(exc, InvestigationPumpCancelled):
+        raise OpenSREError(
+            "Investigation streaming stopped before completion.",
+            suggestion="The run was cancelled or closed early. Retry if you still need results.",
+        ) from exc
+
+    classified = classify_llm_invoke_failure(exc)
+    if classified is not None:
+        suggestion = (
+            "\n".join(classified.remediation_steps) if classified.remediation_steps else None
+        )
+        raise OpenSREError(classified.user_message, suggestion=suggestion) from exc
+
+    raise exc
+
+
+def run_session_alert_payload(
+    *,
+    raw_alert: dict[str, Any],
+    context_overrides: dict[str, Any] | None = None,
+    cancel_requested: threading.Event | None = None,
+    render_stream: StreamRendererFn,
+) -> dict[str, Any]:
+    """Run a streaming investigation from an already-structured session alert."""
+    from tools.investigation.capability import astream_investigation
+
+    check_llm_settings()
+    if context_overrides:
+        raw_alert.setdefault("annotations", {}).update(context_overrides)
+
+    event_queue: queue.Queue[StreamEvent | BaseException | None] = queue.Queue()
+    loop_ref: dict[str, asyncio.AbstractEventLoop] = {}
+    pump_task_ref: dict[str, asyncio.Task[None]] = {}
+
+    def _run_async() -> None:
+        loop = asyncio.new_event_loop()
+        loop_ref["loop"] = loop
+        try:
+
+            async def _pump() -> None:
+                async for evt in astream_investigation(
+                    raw_alert=raw_alert,
+                ):
+                    event_queue.put(evt)
+
+            task = loop.create_task(_pump())
+            pump_task_ref["task"] = task
+            try:
+                loop.run_until_complete(task)
+            except asyncio.CancelledError:
+                event_queue.put(InvestigationPumpCancelled())
+        except Exception as exc:
+            event_queue.put(exc)
+        finally:
+            event_queue.put(None)
+            loop.close()
+
+    thread = threading.Thread(target=_run_async, daemon=True)
+    thread.start()
+
+    def _cancel_pump() -> None:
+        loop = loop_ref.get("loop")
+        task = pump_task_ref.get("task")
+        if loop is None or task is None or loop.is_closed():
+            return
+        with contextlib.suppress(RuntimeError):
+            loop.call_soon_threadsafe(task.cancel)
+
+    def _events() -> Iterator[StreamEvent]:
+        try:
+            while True:
+                if cancel_requested is not None and cancel_requested.is_set():
+                    _cancel_pump()
+                    raise KeyboardInterrupt
+                try:
+                    item = event_queue.get(timeout=_SESSION_EVENT_POLL_S)
+                except queue.Empty:
+                    continue
+                if isinstance(item, BaseException):
+                    thread.join(timeout=5)
+                    reraise_investigation_failure(item)
+                if item is None:
+                    return
+                yield item
+        finally:
+            _cancel_pump()
+
+    try:
+        rendered_state = render_stream(_events())
+    except KeyboardInterrupt:
+        _cancel_pump()
+        raise
+    finally:
+        thread.join(timeout=5)
+        if thread.is_alive():
+            _logger.warning(
+                "investigation thread did not terminate within 5s after cancellation; "
+                "an LLM call may still be in flight"
+            )
+    return dict(rendered_state)
+
+
+def run_investigation_for_session(
+    *,
+    alert_text: str,
+    context_overrides: dict[str, Any] | None = None,
+    cancel_requested: threading.Event | None = None,
+    render_stream: StreamRendererFn,
+) -> dict[str, Any]:
+    """Run a streaming investigation from a free-text alert description."""
+    raw_alert: dict[str, Any] = {"alert_name": "Interactive session", "message": alert_text}
+    return run_session_alert_payload(
+        raw_alert=raw_alert,
+        context_overrides=context_overrides,
+        cancel_requested=cancel_requested,
+        render_stream=render_stream,
+    )
+
+
+def run_sample_alert_for_session(
+    *,
+    template_name: str = "generic",
+    context_overrides: dict[str, Any] | None = None,
+    cancel_requested: threading.Event | None = None,
+    render_stream: StreamRendererFn,
+) -> dict[str, Any]:
+    """Run a streaming investigation for a built-in sample alert."""
+    return run_session_alert_payload(
+        raw_alert=build_alert_template(template_name),
+        context_overrides=context_overrides,
+        cancel_requested=cancel_requested,
+        render_stream=render_stream,
+    )
+
+
+def run_investigation_for_session_background(
+    *,
+    alert_text: str,
+    context_overrides: dict[str, Any] | None = None,
+    cancel_requested: threading.Event | None = None,
+    render_stream: StreamRendererFn,
+) -> dict[str, Any]:
+    """Run a non-rendering investigation for session-local background tasks."""
+    raw_alert: dict[str, Any] = {"alert_name": "Interactive session", "message": alert_text}
+    return run_session_alert_payload(
+        raw_alert=raw_alert,
+        context_overrides=context_overrides,
+        cancel_requested=cancel_requested,
+        render_stream=render_stream,
+    )
+
+
+def run_sample_alert_for_session_background(
+    *,
+    template_name: str = "generic",
+    context_overrides: dict[str, Any] | None = None,
+    cancel_requested: threading.Event | None = None,
+    render_stream: StreamRendererFn,
+) -> dict[str, Any]:
+    """Run a non-rendering sample-alert investigation for background tasks."""
+    return run_session_alert_payload(
+        raw_alert=build_alert_template(template_name),
+        context_overrides=context_overrides,
+        cancel_requested=cancel_requested,
+        render_stream=render_stream,
+    )
+
+
+__all__ = [
+    "InvestigationPumpCancelled",
+    "StreamRendererFn",
+    "check_llm_settings",
+    "reraise_investigation_failure",
+    "run_investigation_for_session",
+    "run_investigation_for_session_background",
+    "run_sample_alert_for_session",
+    "run_sample_alert_for_session_background",
+    "run_session_alert_payload",
+]


### PR DESCRIPTION
This pull request refactors the CLI investigation code to simplify dependencies and improve separation of concerns. The main changes involve moving session and alert template logic out of the CLI layer, consolidating LLM settings validation, and cleaning up import rules and public APIs.

**CLI investigation refactor and dependency cleanup:**

* Removed session-based investigation and sample alert functions from `surfaces.cli.investigation`, along with their internal helpers, so this module only exposes the main CLI entrypoints (`run_investigation_cli`, `run_investigation_cli_streaming`, `stream_investigation_cli`). This reduces the public API surface and clarifies responsibility boundaries. [[1]](diffhunk://#diff-d1c4906dae36ab20e7d8bc3bb2c423a1d4ecad71aaee61609a58a253d198d9b0L6-L19) [[2]](diffhunk://#diff-c9f72fbf1accedf5e6e58addcdefca435f798cfa1d28064866ecce2de571361fL230-L423)
* Moved LLM settings validation and investigation pump cancellation logic into `tools.investigation.session_runner`, replacing the previous local implementations in the CLI. The CLI now imports and uses `check_llm_settings` and `InvestigationPumpCancelled` directly. [[1]](diffhunk://#diff-c9f72fbf1accedf5e6e58addcdefca435f798cfa1d28064866ecce2de571361fL9-L77) [[2]](diffhunk://#diff-c9f72fbf1accedf5e6e58addcdefca435f798cfa1d28064866ecce2de571361fL98-R51) [[3]](diffhunk://#diff-c9f72fbf1accedf5e6e58addcdefca435f798cfa1d28064866ecce2de571361fL154-R105)
* Updated all references to `build_alert_template` to import from `tools.investigation.alert_templates` instead of the CLI layer, ensuring a single source of truth for alert templates. [[1]](diffhunk://#diff-2366108dd8b4dabdb3bb14afd5fba8f95ab974aafebcaf1f1df2e3bfca26b88aL177-R178) [[2]](diffhunk://#diff-5071d6e993215e0d8977edfc55cb2e124951556b80d8fb0463a15fc54e4a1facL204-R204) [[3]](diffhunk://#diff-2d253bbb4ec06fbfb45d4a2080bde9672386b22782c80a3fbaa50e13792d2065L116-R116)

**Import rules and dependency enforcement:**

* Updated `.importlinter.strict` and `.github/ci/check_direct_imports.py` to reflect the new import boundaries, removing now-invalid direct imports from CLI to session/alert logic and adding new allowed import paths for the refactored structure. [[1]](diffhunk://#diff-2e5da16409883b1fe0e83df8f52f809e71c3b28feb64c5c0b8a58f308146c042L70-R76) [[2]](diffhunk://#diff-2e5da16409883b1fe0e83df8f52f809e71c3b28feb64c5c0b8a58f308146c042L92-L94) [[3]](diffhunk://#diff-4a26ec604e52d3a275a8230a7b4d10bc8bc6df247123827d5f5cf523d1bb950bL59-L62) [[4]](diffhunk://#diff-4a26ec604e52d3a275a8230a7b4d10bc8bc6df247123827d5f5cf523d1bb950bL76-L78) [[5]](diffhunk://#diff-4a26ec604e52d3a275a8230a7b4d10bc8bc6df247123827d5f5cf523d1bb950bL99-R97)

**Error handling and minor improvements:**

* Renamed and clarified error handling helpers for investigation failures, and improved cancellation and error propagation logic in streaming helpers. ([surfaces/cli/investigation/investigate.pyL109-R61](diffhunk://#diff-c9f72fbf1accedf5e6e58addcdefca435f798cfa1d28064866ecce2de571361fL109-R61), Fc3211d0L128R128, Fc3211d0L160R160)

These changes collectively streamline the CLI investigation code and clarify module boundaries, making future maintenance and testing easier.

/fix #3535 