### PR TITLE
Extract _default_llm_factory to canonical core.agent_harness.factories

### DIFF
--- a/core/agent_harness/agents/action_agent.py
+++ b/core/agent_harness/agents/action_agent.py
@@ -21,6 +21,7 @@ from typing import Any
 from core.agent import Agent
 from core.agent_harness.agent_builder import AgentConfig, build_agent
 from core.agent_harness.debug.prompt_trace import persist_turn_system_prompt
+from core.agent_harness.factories import default_llm_factory
 from core.agent_harness.models.turn_context import TurnContext
 from core.agent_harness.models.turn_results import ToolCallingTurnResult
 from core.agent_harness.ports import (
@@ -279,12 +280,6 @@ def _literal_slash_tool_call(message: str, agent_tools: list[Any]) -> ToolCall |
     )
 
 
-def _default_llm_factory() -> Any:
-    from core.llm import agent_llm_client
-
-    return agent_llm_client.get_agent_llm()
-
-
 def _build_action_agent(
     *,
     message: str,
@@ -331,9 +326,7 @@ def _build_action_agent(
         system = "Execute the explicit slash_invoke tool call."
         user_message = message
     else:
-        factory = (
-            deps.llm_factory if deps is not None and deps.llm_factory else _default_llm_factory
-        )
+        factory = deps.llm_factory if deps is not None and deps.llm_factory else default_llm_factory
         llm = factory()
         system = build_action_system_prompt(turn_ctx or TurnContext.from_session(message, session))
         user_message = build_action_user_message(message)

--- a/core/agent_harness/factories.py
+++ b/core/agent_harness/factories.py
@@ -1,0 +1,15 @@
+"""Canonical factory functions for the agent harness."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def default_llm_factory() -> Any:
+    """Return the default agent LLM client.
+
+    Uses a lazy import to avoid pulling in the full LLM stack at module load time.
+    """
+    from core.llm import agent_llm_client
+
+    return agent_llm_client.get_agent_llm()

--- a/surfaces/interactive_shell/runtime/action_turn.py
+++ b/surfaces/interactive_shell/runtime/action_turn.py
@@ -7,11 +7,11 @@ core ``run_action_agent_turn``.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
 
 from rich.console import Console
 
 from core.agent_harness.agents.action_agent import ToolCallingDeps, run_action_agent_turn
+from core.agent_harness.factories import default_llm_factory
 from core.agent_harness.models.turn_context import TurnContext
 from core.agent_harness.models.turn_results import ToolCallingTurnResult
 from core.agent_harness.ports import OutputSink
@@ -22,12 +22,6 @@ from surfaces.interactive_shell.command_registry import SLASH_COMMANDS
 from surfaces.interactive_shell.command_registry.suggestions import resolve_literal_slash_typo
 from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink
 from surfaces.interactive_shell.ui.action_rendering import ActionRenderObserver
-
-
-def _default_llm_factory() -> Any:
-    from core.llm import agent_llm_client
-
-    return agent_llm_client.get_agent_llm()
 
 
 def _action_observer_factory(
@@ -80,7 +74,7 @@ def run_action_tool_turn(
     effective_deps = (
         deps
         if deps is not None and deps.llm_factory is not None
-        else ToolCallingDeps(llm_factory=_default_llm_factory)
+        else ToolCallingDeps(llm_factory=default_llm_factory)
     )
     return run_action_agent_turn(
         message,

--- a/tests/core/agent/orchestration/test_agent_actions.py
+++ b/tests/core/agent/orchestration/test_agent_actions.py
@@ -36,7 +36,7 @@ from tools.interactive_shell.action_names import (
     ToolKind,
 )
 
-_ACTION_LLM_FACTORY_PATCH = "surfaces.interactive_shell.runtime.action_turn._default_llm_factory"
+_ACTION_LLM_FACTORY_PATCH = "surfaces.interactive_shell.runtime.action_turn.default_llm_factory"
 execute_shell_turn = shell_turn_execution.execute_shell_turn
 
 

--- a/tests/core/agent/orchestration/test_model_question_misroute.py
+++ b/tests/core/agent/orchestration/test_model_question_misroute.py
@@ -33,7 +33,7 @@ from tests.core.agent.orchestration.action_execution_test_harness import (
     tool_response,
 )
 
-_ACTION_LLM_FACTORY_PATCH = "surfaces.interactive_shell.runtime.action_turn._default_llm_factory"
+_ACTION_LLM_FACTORY_PATCH = "surfaces.interactive_shell.runtime.action_turn.default_llm_factory"
 _PROMPT = "which model is being used now?"
 
 

--- a/tests/core/runtime/test_loop.py
+++ b/tests/core/runtime/test_loop.py
@@ -135,7 +135,7 @@ def test_agent_exposes_headless_dispatch_entrypoint(monkeypatch: pytest.MonkeyPa
             yield "hello from headless"
 
     monkeypatch.setattr(
-        "core.agent_harness.agents.action_agent._default_llm_factory",
+        "core.agent_harness.agents.action_agent.default_llm_factory",
         lambda: FakeLLM(iter([AgentLLMResponse(content="", tool_calls=[], raw_content=None)])),
     )
 

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -1842,7 +1842,7 @@ class TestResumeCommand:
             raise RuntimeError("codex: quota or rate limit exceeded (exit 1)")
 
         with patch(
-            "surfaces.interactive_shell.runtime.action_turn._default_llm_factory",
+            "surfaces.interactive_shell.runtime.action_turn.default_llm_factory",
             side_effect=_raise,
         ):
             result = run_action_tool_turn("check cpu usage", session, console)

--- a/tests/interactive_shell/test_terminal_runtime_turns.py
+++ b/tests/interactive_shell/test_terminal_runtime_turns.py
@@ -266,7 +266,7 @@ def test_execute_shell_turn_nitro_prompt_executes_remote_then_investigation(
         call_order.append(f"investigation:{alert_text}")
 
     monkeypatch.setattr(
-        "surfaces.interactive_shell.runtime.action_turn._default_llm_factory",
+        "surfaces.interactive_shell.runtime.action_turn.default_llm_factory",
         lambda: FakeActionLLM(
             [
                 AgentLLMResponse(


### PR DESCRIPTION
## Problem

`_default_llm_factory` — `from core.llm import agent_llm_client; return agent_llm_client.get_agent_llm()` — was duplicated verbatim in two files:

| Location | |
| --- | --- |
| `core/agent_harness/agents/action_agent.py` | local `_default_llm_factory` |
| `surfaces/interactive_shell/runtime/action_turn.py` | identical copy |

(The issue referenced `shell_turn_execution.py`, which has since been renamed to `action_turn.py`.)

## Fix

- **New canonical module** `core/agent_harness/factories.py` with a single `default_llm_factory()`. It lives in the same `core.agent_harness` package both consumers already import from, so no new import-linter layer entries are needed.
- Dropped the leading underscore since it is now a public, importable symbol.
- Both consumers now `from core.agent_harness.factories import default_llm_factory` and the local copies are deleted.
- Removed the now-unused `from typing import Any` in `action_turn.py`.
- Updated the 5 test files that patch the factory to target the new name at each consumer site (`action_agent.default_llm_factory` for `test_loop.py`; `action_turn.default_llm_factory` for the other four), keeping patches at the consumer site per the existing convention.

## Verification

- `make lint` — clean
- `make format-check` — clean
- `make typecheck` — no issues (1082 source files)
- `make test-scope` — **1881 passed, 31 skipped**
- `uv run lint-imports --config .importlinter` — contract kept
- `grep -rn _default_llm_factory` — no references remain

Fixes #3610

🤖 Generated with [Claude Code](https://claude.com/claude-code)