### PR TITLE
fix(architecture): finish T-06 synthetic path decoupling (#3539)

### DIFF
--- a/config/synthetic_paths.py
+++ b/config/synthetic_paths.py
@@ -5,7 +5,7 @@ they live in :mod:`config` (the layered root package that everyone may depend
 on). Hosting them here lets both surface code (the CLI ``tests`` command) and
 core session state (post-synthetic-failure follow-up hinting) reference the
 same directories without ``core -> surfaces`` imports (see T-4 layering audit,
-issue #3352).
+issue #3352; harness decoupling T-06, issue #3539).
 
 The constants intentionally do not touch the file system at import time — they
 are lazy path expressions consumed by callers that check ``is_dir()`` /

--- a/core/agent_harness/session/state.py
+++ b/core/agent_harness/session/state.py
@@ -355,7 +355,7 @@ class Session:
             return
         # ``config`` is the shared layer both ``core`` and ``surfaces`` can
         # depend on; the constant used to live in ``surfaces.cli.tests.discover``
-        # but that direct edge is a T-4 layering violation (issue #3352).
+        # but that direct edge is a layering violation (T-06, issue #3539).
         try:
             from config.synthetic_paths import SYNTHETIC_SCENARIOS_DIR
         except Exception:

--- a/surfaces/cli/commands/tests.py
+++ b/surfaces/cli/commands/tests.py
@@ -274,9 +274,9 @@ def run_synthetic_suite(
     # We pre-check the data dir explicitly *and* catch a narrow
     # ``ModuleNotFoundError`` so users see one structured message regardless
     # of which failure mode their bundle produces. The data-dir path is the
-    # ``SYNTHETIC_SCENARIOS_DIR`` constant from ``discover.py`` — single
+    # ``SYNTHETIC_SCENARIOS_DIR`` constant from ``config.synthetic_paths`` — single
     # source of truth shared with ``_discover_rds_synthetic_scenarios``.
-    from surfaces.cli.tests.discover import SYNTHETIC_SCENARIOS_DIR
+    from config.synthetic_paths import SYNTHETIC_SCENARIOS_DIR
 
     if not SYNTHETIC_SCENARIOS_DIR.is_dir():
         raise _synthetic_suite_not_bundled_error()
@@ -318,7 +318,7 @@ def run_synthetic_suite(
 @click.option("--json", "output_json", is_flag=True, help="Print machine-readable JSON results.")
 def run_openclaw_synthetic_suite(scenario: str, output_json: bool) -> None:
     """Run the synthetic OpenClaw RCA suite through the fixture bridge backend."""
-    from surfaces.cli.tests.discover import OPENCLAW_SYNTHETIC_SCENARIOS_DIR
+    from config.synthetic_paths import OPENCLAW_SYNTHETIC_SCENARIOS_DIR
 
     if not OPENCLAW_SYNTHETIC_SCENARIOS_DIR.is_dir():
         raise _openclaw_synthetic_suite_not_bundled_error()

--- a/surfaces/cli/tests/discover.py
+++ b/surfaces/cli/tests/discover.py
@@ -8,27 +8,17 @@ from typing import cast
 import yaml
 from typing_extensions import TypedDict
 
-from config.synthetic_paths import (
-    CLOUDOPSBENCH_DIR,
-    OPENCLAW_SYNTHETIC_SCENARIOS_DIR,
-    RCA_DIR,
-    REPO_ROOT,
-    SYNTHETIC_SCENARIOS_DIR,
-)
+from config import synthetic_paths
 from surfaces.cli.tests.catalog import TestCatalog, TestCatalogItem, TestRequirement
 
-MAKEFILE_PATH = REPO_ROOT / "Makefile"
+MAKEFILE_PATH = synthetic_paths.REPO_ROOT / "Makefile"
 
-# Re-exported so existing callers and ``unittest.mock.patch`` targets
-# ``surfaces.cli.tests.discover.<name>`` keep working after the constants
-# moved to :mod:`config.synthetic_paths` (T-4 layering fix, issue #3352).
 __all__ = (
-    "CLOUDOPSBENCH_DIR",
     "MAKEFILE_PATH",
-    "OPENCLAW_SYNTHETIC_SCENARIOS_DIR",
-    "RCA_DIR",
-    "REPO_ROOT",
-    "SYNTHETIC_SCENARIOS_DIR",
+    "discover_cli_commands",
+    "discover_make_targets",
+    "discover_rca_files",
+    "load_test_catalog",
 )
 
 _TARGETS_TO_INDEX = (
@@ -325,13 +315,13 @@ def discover_make_targets() -> list[TestCatalogItem]:
 
 def discover_rca_files() -> list[TestCatalogItem]:
     items: list[TestCatalogItem] = []
-    if not RCA_DIR.is_dir():
+    if not synthetic_paths.RCA_DIR.is_dir():
         # ``Path.glob`` on a missing parent returns an empty iterator on
         # CPython, so this isn't a crash today — but the explicit guard
         # documents the bundled-binary contract and matches the shape of
         # the other ``discover_*`` helpers below.
         return items
-    for path in sorted(RCA_DIR.glob("*.md")):
+    for path in sorted(synthetic_paths.RCA_DIR.glob("*.md")):
         title = path.stem.replace("_", " ").title()
         first_line = path.read_text(encoding="utf-8").splitlines()[0].strip()
         if first_line.startswith("# "):
@@ -362,10 +352,10 @@ def _discover_rds_synthetic_scenarios() -> list[TestCatalogItem]:
     only meaningful when the scenarios are on disk anyway.
     """
     items: list[TestCatalogItem] = []
-    if not SYNTHETIC_SCENARIOS_DIR.is_dir():
+    if not synthetic_paths.SYNTHETIC_SCENARIOS_DIR.is_dir():
         return items
     req = TestRequirement(env_vars=("ANTHROPIC_API_KEY",))
-    for scenario_dir in sorted(SYNTHETIC_SCENARIOS_DIR.iterdir()):
+    for scenario_dir in sorted(synthetic_paths.SYNTHETIC_SCENARIOS_DIR.iterdir()):
         if not scenario_dir.is_dir() or scenario_dir.name.startswith("_"):
             continue
         scenario_id = scenario_dir.name
@@ -397,11 +387,11 @@ def _discover_rds_synthetic_scenarios() -> list[TestCatalogItem]:
 
 def _discover_openclaw_synthetic_scenarios() -> list[TestCatalogItem]:
     items: list[TestCatalogItem] = []
-    if not OPENCLAW_SYNTHETIC_SCENARIOS_DIR.is_dir():
+    if not synthetic_paths.OPENCLAW_SYNTHETIC_SCENARIOS_DIR.is_dir():
         return items
 
     requirements = TestRequirement(notes=("Configured LLM provider",))
-    for scenario_dir in sorted(OPENCLAW_SYNTHETIC_SCENARIOS_DIR.iterdir()):
+    for scenario_dir in sorted(synthetic_paths.OPENCLAW_SYNTHETIC_SCENARIOS_DIR.iterdir()):
         if not scenario_dir.is_dir() or scenario_dir.name.startswith("_"):
             continue
         scenario_id = scenario_dir.name
@@ -437,7 +427,7 @@ def _discover_openclaw_synthetic_scenarios() -> list[TestCatalogItem]:
 
 
 def _discover_cloudopsbench_suite() -> list[TestCatalogItem]:
-    benchmark_dir = CLOUDOPSBENCH_DIR / "benchmark"
+    benchmark_dir = synthetic_paths.CLOUDOPSBENCH_DIR / "benchmark"
     if not benchmark_dir.is_dir():
         return []
     return [
@@ -448,7 +438,7 @@ def _discover_cloudopsbench_suite() -> list[TestCatalogItem]:
             description="Run the downloaded Cloud-OpsBench corpus through the OpenSRE runner.",
             command=("opensre", "tests", "cloudopsbench"),
             tags=("synthetic", "cloudopsbench", "k8s", "benchmark"),
-            source_path=str(CLOUDOPSBENCH_DIR),
+            source_path=str(synthetic_paths.CLOUDOPSBENCH_DIR),
             requirements=TestRequirement(env_vars=("ANTHROPIC_API_KEY",)),
         )
     ]

--- a/surfaces/cli/tests/runner.py
+++ b/surfaces/cli/tests/runner.py
@@ -4,8 +4,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+from config.synthetic_paths import REPO_ROOT
 from surfaces.cli.tests.catalog import TestCatalogItem
-from surfaces.cli.tests.discover import REPO_ROOT, load_test_catalog
+from surfaces.cli.tests.discover import load_test_catalog
 
 
 def format_command(item: TestCatalogItem) -> str:

--- a/surfaces/cli/tests/runner.py
+++ b/surfaces/cli/tests/runner.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from config.synthetic_paths import REPO_ROOT
+from config import synthetic_paths
 from surfaces.cli.tests.catalog import TestCatalogItem
 from surfaces.cli.tests.discover import load_test_catalog
 
@@ -89,7 +89,7 @@ def run_catalog_item(
 
     result = subprocess.run(
         list(item.command),
-        cwd=working_directory or REPO_ROOT,
+        cwd=working_directory or synthetic_paths.REPO_ROOT,
         check=False,
     )
     return int(result.returncode)

--- a/tests/cli/test_cli_inventory.py
+++ b/tests/cli/test_cli_inventory.py
@@ -306,7 +306,7 @@ def test_tests_synthetic_clean_error_when_data_dir_missing(tmp_path: Path) -> No
     # Point SYNTHETIC_SCENARIOS_DIR at a path that doesn't exist so the
     # pre-check in ``run_synthetic_suite`` short-circuits to OpenSREError.
     missing = tmp_path / "missing-rds-postgres"
-    with unittest.mock.patch("surfaces.cli.tests.discover.SYNTHETIC_SCENARIOS_DIR", missing):
+    with unittest.mock.patch("config.synthetic_paths.SYNTHETIC_SCENARIOS_DIR", missing):
         result = runner.invoke(cli, ["tests", "synthetic", "--scenario", "001-replication-lag"])
 
     output = result.output or ""
@@ -339,7 +339,7 @@ def test_tests_synthetic_clean_error_when_module_not_bundled(tmp_path: Path) -> 
     (scenarios_dir / "001-replication-lag").mkdir(parents=True)
 
     with (
-        unittest.mock.patch("surfaces.cli.tests.discover.SYNTHETIC_SCENARIOS_DIR", scenarios_dir),
+        unittest.mock.patch("config.synthetic_paths.SYNTHETIC_SCENARIOS_DIR", scenarios_dir),
         unittest.mock.patch("builtins.__import__", side_effect=_fail_synthetic_import),
     ):
         result = runner.invoke(cli, ["tests", "synthetic", "--scenario", "001-replication-lag"])
@@ -370,7 +370,7 @@ def test_tests_synthetic_unrelated_module_not_found_propagates(tmp_path: Path) -
     (scenarios_dir / "001-replication-lag").mkdir(parents=True)
 
     with (
-        unittest.mock.patch("surfaces.cli.tests.discover.SYNTHETIC_SCENARIOS_DIR", scenarios_dir),
+        unittest.mock.patch("config.synthetic_paths.SYNTHETIC_SCENARIOS_DIR", scenarios_dir),
         unittest.mock.patch("builtins.__import__", side_effect=_fail_unrelated_import),
     ):
         result = runner.invoke(cli, ["tests", "synthetic", "--scenario", "001-replication-lag"])

--- a/tests/cli/test_discover.py
+++ b/tests/cli/test_discover.py
@@ -119,20 +119,19 @@ def _patch_discover_paths(
 ) -> None:
     """Helper: monkeypatch any subset of the discover module's path constants.
 
-    Reduces the ``monkeypatch.setattr("surfaces.cli.tests.discover.X", ...)`` ×4
-    repetition that tests in ``TestDiscoverGracefulOnMissingSource`` would
-    otherwise carry. Per @muddlebee's PR #952 review nit on duplicated test
-    setup."""
+    Corpus directories live in :mod:`config.synthetic_paths`; ``MAKEFILE_PATH``
+    remains discover-specific.
+    """
     if repo_root is not None:
-        monkeypatch.setattr("surfaces.cli.tests.discover.REPO_ROOT", repo_root)
+        monkeypatch.setattr("config.synthetic_paths.REPO_ROOT", repo_root)
     if makefile is not None:
         monkeypatch.setattr("surfaces.cli.tests.discover.MAKEFILE_PATH", makefile)
     if rca_dir is not None:
-        monkeypatch.setattr("surfaces.cli.tests.discover.RCA_DIR", rca_dir)
+        monkeypatch.setattr("config.synthetic_paths.RCA_DIR", rca_dir)
     if synthetic_dir is not None:
-        monkeypatch.setattr("surfaces.cli.tests.discover.SYNTHETIC_SCENARIOS_DIR", synthetic_dir)
+        monkeypatch.setattr("config.synthetic_paths.SYNTHETIC_SCENARIOS_DIR", synthetic_dir)
     if cloudopsbench_dir is not None:
-        monkeypatch.setattr("surfaces.cli.tests.discover.CLOUDOPSBENCH_DIR", cloudopsbench_dir)
+        monkeypatch.setattr("config.synthetic_paths.CLOUDOPSBENCH_DIR", cloudopsbench_dir)
 
 
 class TestDiscoverGracefulOnMissingSource:

--- a/tests/cli/test_tests_command_synthetic_flags.py
+++ b/tests/cli/test_tests_command_synthetic_flags.py
@@ -98,7 +98,7 @@ def test_tests_synthetic_cli_forwards_flags_to_run_suite_main(tmp_path: Path) ->
     fake_run_suite.main = _fake_main
 
     with (
-        unittest.mock.patch("surfaces.cli.tests.discover.SYNTHETIC_SCENARIOS_DIR", scenarios_dir),
+        unittest.mock.patch("config.synthetic_paths.SYNTHETIC_SCENARIOS_DIR", scenarios_dir),
         unittest.mock.patch.dict(
             sys.modules,
             {"tests.synthetic.rds_postgres.run_suite": fake_run_suite},
@@ -151,7 +151,7 @@ def test_tests_synthetic_cli_does_not_pass_observations_dir_when_unset(tmp_path:
     fake_run_suite.main = _fake_main
 
     with (
-        unittest.mock.patch("surfaces.cli.tests.discover.SYNTHETIC_SCENARIOS_DIR", scenarios_dir),
+        unittest.mock.patch("config.synthetic_paths.SYNTHETIC_SCENARIOS_DIR", scenarios_dir),
         unittest.mock.patch.dict(
             sys.modules,
             {"tests.synthetic.rds_postgres.run_suite": fake_run_suite},
@@ -186,7 +186,7 @@ def test_tests_synthetic_all_defaults_to_parallel_all_levels(tmp_path: Path) -> 
     fake_run_suite.main = _fake_main
 
     with (
-        unittest.mock.patch("surfaces.cli.tests.discover.SYNTHETIC_SCENARIOS_DIR", scenarios_dir),
+        unittest.mock.patch("config.synthetic_paths.SYNTHETIC_SCENARIOS_DIR", scenarios_dir),
         unittest.mock.patch.dict(
             sys.modules,
             {"tests.synthetic.rds_postgres.run_suite": fake_run_suite},
@@ -221,7 +221,7 @@ def test_tests_openclaw_synthetic_cli_forwards_flags_to_run_suite_main(tmp_path:
 
     with (
         unittest.mock.patch(
-            "surfaces.cli.tests.discover.OPENCLAW_SYNTHETIC_SCENARIOS_DIR",
+            "config.synthetic_paths.OPENCLAW_SYNTHETIC_SCENARIOS_DIR",
             scenarios_dir,
         ),
         unittest.mock.patch.dict(

--- a/tests/core/agent_harness/session/test_synthetic_observation_binding.py
+++ b/tests/core/agent_harness/session/test_synthetic_observation_binding.py
@@ -1,0 +1,48 @@
+"""Regression tests for post-synthetic-failure observation path binding."""
+
+from __future__ import annotations
+
+import unittest.mock
+from pathlib import Path
+
+from core.agent_harness.session.state import Session
+
+
+def test_suggest_synthetic_failure_follow_up_binds_observation_path(tmp_path: Path) -> None:
+    scenario_id = "001-replication-lag"
+    scenarios_root = tmp_path / "rds_postgres"
+    latest = scenarios_root / "_observations" / scenario_id / "latest.json"
+    latest.parent.mkdir(parents=True)
+    latest.write_text('{"status": "failed"}', encoding="utf-8")
+
+    session = Session()
+    with unittest.mock.patch("config.synthetic_paths.SYNTHETIC_SCENARIOS_DIR", scenarios_root):
+        session.suggest_synthetic_failure_follow_up(
+            label="opensre tests synthetic --scenario 001-replication-lag",
+        )
+
+    assert session.last_synthetic_observation_path == str(latest.resolve())
+
+
+def test_suggest_synthetic_failure_follow_up_invalid_scenario_clears_path() -> None:
+    session = Session()
+    session.last_synthetic_observation_path = "/tmp/stale.json"
+
+    session.suggest_synthetic_failure_follow_up(label="opensre tests synthetic --scenario ./evil")
+
+    assert session.last_synthetic_observation_path is None
+
+
+def test_suggest_synthetic_failure_follow_up_missing_observation_clears_path(
+    tmp_path: Path,
+) -> None:
+    scenarios_root = tmp_path / "rds_postgres"
+    scenarios_root.mkdir()
+
+    session = Session()
+    with unittest.mock.patch("config.synthetic_paths.SYNTHETIC_SCENARIOS_DIR", scenarios_root):
+        session.suggest_synthetic_failure_follow_up(
+            label="opensre tests synthetic --scenario 001-replication-lag",
+        )
+
+    assert session.last_synthetic_observation_path is None

--- a/tests/core/agent_harness/session/test_synthetic_observation_binding.py
+++ b/tests/core/agent_harness/session/test_synthetic_observation_binding.py
@@ -40,7 +40,10 @@ def test_suggest_synthetic_failure_follow_up_missing_observation_clears_path(
     scenarios_root.mkdir()
 
     session = Session()
-    with unittest.mock.patch("config.synthetic_paths.SYNTHETIC_SCENARIOS_DIR", scenarios_root):
+    with (
+        unittest.mock.patch("config.synthetic_paths.SYNTHETIC_SCENARIOS_DIR", scenarios_root),
+        unittest.mock.patch("core.agent_harness.session.state.time.sleep"),
+    ):
         session.suggest_synthetic_failure_follow_up(
             label="opensre tests synthetic --scenario 001-replication-lag",
         )


### PR DESCRIPTION
This pull request refactors how synthetic test path constants are imported and referenced throughout the codebase, centralizing their usage through the `config.synthetic_paths` module. This change further decouples the CLI and core harness layers, improves testability, and addresses layering violations. It also updates test code and documentation to match the new import paths, and adds regression tests for observation path binding after synthetic test failures.

The most important changes are:

**Refactoring and Decoupling of Path Constants:**

* All references to synthetic test path constants (e.g., `SYNTHETIC_SCENARIOS_DIR`, `OPENCLAW_SYNTHETIC_SCENARIOS_DIR`, `RCA_DIR`, `CLOUDOPSBENCH_DIR`, `REPO_ROOT`) in both CLI and core harness code have been updated to import them from `config.synthetic_paths` instead of `surfaces.cli.tests.discover`. This eliminates direct dependencies and resolves layering violations [[1]](diffhunk://#diff-f586eede4757f18a182996b0a7301c546eef9a7edaceb01d5f492b0395315d5bL11-R21) [[2]](diffhunk://#diff-d92d0f6c0d8edaf49f03f57eca995418ac9b0ee3025d6ecbc193f0e51179e069L277-R279) [[3]](diffhunk://#diff-d92d0f6c0d8edaf49f03f57eca995418ac9b0ee3025d6ecbc193f0e51179e069L321-R321) [[4]](diffhunk://#diff-b8b41e2c4efa619ab65d3b953ad1d092700aa03c22abe5e8a1bed694a545d20cL358-R358) [[5]](diffhunk://#diff-2e7641f68d07fe098e52c64612bbd278d7b8ca512e403d7bbfb49d87debb403bR7-R9).

* The `surfaces.cli.tests.discover` module no longer re-exports path constants, and all internal references to these constants are now accessed via the `synthetic_paths` module [[1]](diffhunk://#diff-f586eede4757f18a182996b0a7301c546eef9a7edaceb01d5f492b0395315d5bL11-R21) [[2]](diffhunk://#diff-f586eede4757f18a182996b0a7301c546eef9a7edaceb01d5f492b0395315d5bL328-R324) [[3]](diffhunk://#diff-f586eede4757f18a182996b0a7301c546eef9a7edaceb01d5f492b0395315d5bL365-R358) [[4]](diffhunk://#diff-f586eede4757f18a182996b0a7301c546eef9a7edaceb01d5f492b0395315d5bL400-R394) [[5]](diffhunk://#diff-f586eede4757f18a182996b0a7301c546eef9a7edaceb01d5f492b0395315d5bL440-R430) [[6]](diffhunk://#diff-f586eede4757f18a182996b0a7301c546eef9a7edaceb01d5f492b0395315d5bL451-R441).

**Test Suite and Mocking Updates:**

* All tests and test helpers that previously patched path constants in `surfaces.cli.tests.discover` now patch them in `config.synthetic_paths`, ensuring test isolation and compatibility with the refactor [[1]](diffhunk://#diff-9f168c1a271ffb9c423ccb158a49b5b4352afdbb6e7b1e032750ad9088ec39b4L309-R309) [[2]](diffhunk://#diff-9f168c1a271ffb9c423ccb158a49b5b4352afdbb6e7b1e032750ad9088ec39b4L342-R342) [[3]](diffhunk://#diff-9f168c1a271ffb9c423ccb158a49b5b4352afdbb6e7b1e032750ad9088ec39b4L373-R373) [[4]](diffhunk://#diff-d0064c025a9f187ee4354c89fce0b30732d630d0b1a07790159c53aaab404680L122-R134) [[5]](diffhunk://#diff-fb18ef0f75392c7f6c57b3b4de0356b626aef795381c07530975e824b065d44fL101-R101) [[6]](diffhunk://#diff-fb18ef0f75392c7f6c57b3b4de0356b626aef795381c07530975e824b065d44fL154-R154) [[7]](diffhunk://#diff-fb18ef0f75392c7f6c57b3b4de0356b626aef795381c07530975e824b065d44fL189-R189) [[8]](diffhunk://#diff-fb18ef0f75392c7f6c57b3b4de0356b626aef795381c07530975e824b065d44fL224-R224).

**Documentation and Comments:**

* Updated comments and docstrings throughout the codebase to reflect the new import locations and clarify the rationale behind the changes [[1]](diffhunk://#diff-a7ef39c90576b60a76a8755fcdfdedf5aa5453ab8d570d684b472141f1d99930L8-R8) [[2]](diffhunk://#diff-b8b41e2c4efa619ab65d3b953ad1d092700aa03c22abe5e8a1bed694a545d20cL358-R358) [[3]](diffhunk://#diff-d0064c025a9f187ee4354c89fce0b30732d630d0b1a07790159c53aaab404680L122-R134).

**Regression Testing:**

* Added a new regression test module, `tests/core/agent_harness/session/test_synthetic_observation_binding.py`, to verify correct binding and clearing of the last synthetic observation path after test failures.

These changes collectively improve code maintainability, enforce proper layering, and make the test harness more robust and easier to test.

/fix #3539 