### PR TITLE
test(core/agent): add unit test that AgentRunInput.from_runtime_request copies resolved_integrations

### DIFF
--- a/tests/core/agent/test_run_io.py
+++ b/tests/core/agent/test_run_io.py
@@ -57,6 +57,25 @@ def test_from_runtime_request_uses_render_system_prompt_when_callable() -> None:
     assert run_input.messages == [UserRuntimeMessage(content="hello")]
 
 
+def test_from_runtime_request_copies_resolved_integrations() -> None:
+    resolved_integrations = {"github": {"configured": True}}
+    request = _PlainRuntimeRequest(
+        system_prompt="sys",
+        active_tools=(),
+        resolved_integrations=resolved_integrations,
+        max_iterations=1,
+    )
+
+    run_input = AgentRunInput.from_runtime_request(request, llm=object())
+
+    # Mutate the source dict after construction. If `from_runtime_request`
+    # stored a reference instead of a copy, this mutation would leak into
+    # `run_input.resolved`.
+    resolved_integrations["aws"] = {"configured": True}
+
+    assert run_input.resolved == {"github": {"configured": True}}
+
+
 def test_from_runtime_request_falls_back_to_system_prompt_string() -> None:
     tool = _tool()
     request = _PlainRuntimeRequest(


### PR DESCRIPTION
## Summary
Adds the missing test coverage called out in #3732: `AgentRunInput.from_runtime_request` already defensively copies `resolved_integrations` into a new top-level dict (`resolved=dict(request.resolved_integrations or {})`), but only the `from_messages` factory had a test proving the copy behavior. `from_runtime_request` was untested.

## Change
- `tests/core/agent/test_run_io.py`: added `test_from_runtime_request_copies_resolved_integrations`, which builds a fake runtime request with a `resolved_integrations` dict, calls `from_runtime_request`, then mutates the *source* dict by adding a new top-level key. It asserts `run_input.resolved` is unaffected, which only holds if the factory stored a copy rather than a reference.

No production code changed — `core/agent/run_io.py` already implements the copy correctly; this PR only closes the test gap.

## Testing
```
uv run pytest tests/core/agent/test_run_io.py
```
The new test passes against the current implementation and would fail if the `dict(...)` copy in `from_runtime_request` were replaced with a direct reference assignment.

Closes #3732