### PR TITLE
refactor(core/agent_harness): Renamed EvidenceAgentFactory to GatherAgentFactory

### DIFF
--- a/core/agent_harness/turns/evidence_driver.py
+++ b/core/agent_harness/turns/evidence_driver.py
@@ -51,7 +51,7 @@ _MAX_PER_TOOL_CHARS = 4_000
 PersistToolCalls = Callable[[list[tuple[Any, Any]]], None]
 
 
-class EvidenceAgentFactory(Protocol):
+class GatherAgentFactory(Protocol):
     """Build the runtime :class:`Agent` for one evidence-gather turn."""
 
     def __call__(
@@ -202,7 +202,7 @@ def gather_tool_evidence(
     persist: PersistToolCalls | None = None,
     error_reporter: ErrorReporter | None = None,
     is_tty: bool | None = None,  # noqa: ARG001 — reserved for parity with answer agents
-    agent_factory: EvidenceAgentFactory | None = None,
+    agent_factory: GatherAgentFactory | None = None,
 ) -> str | None:
     """Run a bounded tool-calling loop and return collected evidence, or None.
 
@@ -267,4 +267,4 @@ def gather_tool_evidence(
     return _format_observation(result.executed)
 
 
-__all__ = ["EvidenceAgentFactory", "PersistToolCalls", "gather_tool_evidence"]
+__all__ = ["GatherAgentFactory", "PersistToolCalls", "gather_tool_evidence"]

--- a/surfaces/interactive_shell/runtime/integration_tool_gathering.py
+++ b/surfaces/interactive_shell/runtime/integration_tool_gathering.py
@@ -18,7 +18,7 @@ from rich.markup import escape
 
 from core.agent_harness.session import Session
 from core.agent_harness.turns import evidence_driver
-from core.agent_harness.turns.evidence_driver import EvidenceAgentFactory
+from core.agent_harness.turns.evidence_driver import GatherAgentFactory
 from surfaces.interactive_shell.ui import DIM
 from surfaces.interactive_shell.utils.error_handling.exception_reporting import report_exception
 from surfaces.shared.tool_labels import tool_short_label, tool_source_label
@@ -148,7 +148,7 @@ def gather_integration_tool_evidence(
     console: Console,
     *,
     is_tty: bool | None = None,
-    agent_factory: EvidenceAgentFactory | None = None,
+    agent_factory: GatherAgentFactory | None = None,
 ) -> str | None:
     """Run a bounded tool-calling loop and return collected evidence, or None.
 

--- a/tests/interactive_shell/tools/test_tool_gathering.py
+++ b/tests/interactive_shell/tools/test_tool_gathering.py
@@ -20,7 +20,7 @@ import core as runtime_module
 import core.llm.agent_llm_client as agent_llm_client
 import tools.investigation.stages.gather_evidence.tools as investigate_tools
 from core.agent_harness.session import Session
-from core.agent_harness.turns.evidence_driver import EvidenceAgentFactory
+from core.agent_harness.turns.evidence_driver import GatherAgentFactory
 from core.llm.types import ToolCall
 from surfaces.interactive_shell.runtime.integration_tool_gathering import (
     _format_gathering_progress_line,
@@ -42,7 +42,7 @@ class _DummyTool:
         self.source = source
 
 
-def _stub_agent_factory(run: _FakeRun) -> EvidenceAgentFactory:
+def _stub_agent_factory(run: _FakeRun) -> GatherAgentFactory:
     """Return a factory that runs real gather setup but stubs ``Agent.run``."""
 
     class _StubAgent:


### PR DESCRIPTION


Fixes #3735

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
Refactored `core/agent_harness/turns/evidence_driver.py` to use a more meaningful class name. I renamed the class `EvidenceAgentFactory` to `GatherAgentFactory`, including all references and the `__all__` entry.

Executed command `uv run mypy core/ && uv run pytest tests/core/agent_harness/` to verify changes.
```
(opensre) deepak@deepakdhakad:~/opensre$ uv run mypy core/ && uv run pytest tests/core/agent_harness/
mypy.ini: note: unused section(s): [mypy-kubernetes], [mypy-confluent_kafka], [mypy-confluent_kafka.*], [mypy-apscheduler], [mypy-pyfiglet]
Success: no issues found in 153 source files
.
.
====================================================== 49 passed in 1.90s =======================================================
```
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [✓] No, I wrote all the code myself

**Explain your implementation approach:**
The requirement was to rename the class, so I renamed it everywhere to ensure no stale references to the old name remain.
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [✓] I have added proper PR title and linked to the issue
- [✓] I have performed a self-review of my code
- [✓] I understand why my changes work and have tested them thoroughly
- [✓] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
