### PR TITLE
Fix AGENTS.md Telegram / watchdog paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,8 +66,8 @@ Main packages one level deeper:
 - `core/context/state/` — Shared agent runtime envelope (`AgentState`), chat slice, investigation pipeline slice contracts, `EvidenceEntry`, state-update helpers, and pure defaults.
 - `tools/` — Tool registry, decorator, base classes, per-tool packages, shared utilities, and registry helpers.
 - `core/domain/types/` — Shared typed contracts for evidence, retrieval, and tool-related payloads.
-- `platform/` — Guardrails, masking, sandbox, analytics, auth, and cross-cutting platform services (e.g. `platform/notifications/telegram_delivery.py`).
-- `tools/system/watch_dog/` — Watchdog feature: per-threshold Telegram alarm dispatch with cooldown, sitting on top of `platform/notifications/telegram_delivery.py`.
+- `platform/` — Guardrails, masking, sandbox, analytics, auth, and cross-cutting platform services (e.g. `integrations/telegram/*`).
+- `tools/system/watch_dog/` — Watchdog feature: per-threshold Telegram alarm dispatch with cooldown, sitting on top of `integrations/telegram/*`.
 - `config/webapp.py` — Web-facing application entrypoint; the `opensre` CLI is `surfaces/cli/__main__.py`.
 
 ## 2. Entry Points


### PR DESCRIPTION
Fixes #3564 

## Linked PR:-
https://github.com/Tracer-Cloud/opensre/issues/3564

#### Changes made in this PR -
AGENTS.md still referenced `platform/notifications/telegram_delivery.py` as the location of Telegram delivery logic, but that module has since moved to `integrations/telegram/*`. This PR updates the two doc references under "Main packages one level deeper" (`platform/` and `tools/system/watch_dog/` entries) so the repo map points contributors to the correct, current path instead of a stale one.

### Demo/Screenshot for feature changes and bug fixes -
Docs-only change; verified by diffing the updated section:

<img width="1212" height="385" alt="image" src="https://github.com/user-attachments/assets/fdb97e1a-9a52-486a-8aa4-625354a59d0f" />
Confirmed `integrations/telegram/` exists in the current tree and `platform/notifications/telegram_delivery.py` no longer does.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [✔️] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The problem: `AGENTS.md`'s repo-map table is a documentation aid used by contributors (and AI agents) to find where cross-cutting logic lives. It pointed at `platform/notifications/telegram_delivery.py`, a path that no longer exists after Telegram integration code was consolidated under `integrations/telegram/`. Leaving it stale would send future contributors to a dead path.

I considered either removing the specific file reference entirely or updating it to the new canonical path. I chose to update it to `integrations/telegram/*` (a glob) rather than a single exact filename, since the integration is now split across multiple files in that directory, and a glob is more resilient to future internal reorganization within the same package.

This is a two-line documentation fix — no functional code was added. The only "component" touched is the descriptive text of two bullet points in the repo map table.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
