### PR TITLE
Add auth login hint for credit exhausted errors

### DIFF
--- a/surfaces/interactive_shell/runtime/agent_presentation.py
+++ b/surfaces/interactive_shell/runtime/agent_presentation.py
@@ -98,7 +98,7 @@ async def _render_agent_presentation_transition(
             if isinstance(exc, LLMCreditExhaustedError):
                 console.print(
                     f"[{DIM}]Run /auth login (or `opensre auth login <provider>`) "
-                    f"to switch to another provider.[/]"
+                    "to switch to another provider.[/]"
                 )
         case "turn_end":
             set_prompt_suppress_fn(None)

--- a/surfaces/interactive_shell/runtime/agent_presentation.py
+++ b/surfaces/interactive_shell/runtime/agent_presentation.py
@@ -96,7 +96,10 @@ async def _render_agent_presentation_transition(
             from core.llm.llm_retry import LLMCreditExhaustedError
 
             if isinstance(exc, LLMCreditExhaustedError):
-                console.print(f"[{DIM}]Run /model to switch to another provider.[/]")
+                console.print(
+                    f"[{DIM}]Run /auth login (or `opensre auth login <provider>`) "
+                    f"to switch to another provider.[/]"
+                )
         case "turn_end":
             set_prompt_suppress_fn(None)
             if previous.show_spinner:


### PR DESCRIPTION
## Summary

Adds a `/auth login` recovery hint when a credit-exhausted error is shown in the interactive shell.

## Changes

- Replaced the previous recovery hint with a `/auth login` hint.
- Users are now guided to authenticate or switch providers using:
  - `/auth login`
  - `opensre auth login <provider>`

## Testing

- Verified the interactive shell displays the new hint when a `LLMCreditExhaustedError` is [shown.[](url)](Fixes #3739)