### PR TITLE
refactor(agent_harness): TurnPlan — one turn-wide assembly the phases read (#3683)

### DIFF
--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -161,15 +161,15 @@ class RunRecordFactory(Protocol):
 
 
 # Bound direct-answer callable (no tools):
-# ``answer(text, *, confirm_fn, is_tty, tool_observation, turn_snapshot) -> LLM-run record | None``.
+# ``answer(text, *, confirm_fn, is_tty, tool_observation, turn_plan) -> LLM-run record | None``.
 StreamAnswerFn = Callable[..., Any]
 
 # Bound evidence-gather callable:
-# ``gather(text, *, is_tty, resolved_integrations) -> str | None``.
+# ``gather(text, *, is_tty, turn_plan) -> str | None``.
 EvidenceGatherer = Callable[..., "str | None"]
 
 # Bound action tool-calling driver:
-# ``execute_actions(text, *, confirm_fn, is_tty, turn_snapshot) -> ToolCallingTurnResult``.
+# ``execute_actions(text, *, confirm_fn, is_tty, turn_plan) -> ToolCallingTurnResult``.
 ExecuteActions = Callable[..., ToolCallingTurnResult]
 
 

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -87,8 +87,19 @@ class SessionStore(Protocol):
 class ToolProvider(Protocol):
     """Supplies the action-agent tools and the per-turn tool-event observer."""
 
-    def action_tools(self, *, confirm_fn: ConfirmFn | None, is_tty: bool | None) -> list[Any]:
-        """Return the agent tools available for this turn."""
+    def action_tools(
+        self,
+        *,
+        confirm_fn: ConfirmFn | None,
+        is_tty: bool | None,
+        resolved_integrations: dict[str, Any] | None = None,
+    ) -> list[Any]:
+        """Return the agent tools available for this turn.
+
+        When ``resolved_integrations`` is supplied it is the turn's single
+        resolved-integration view (from ``TurnSnapshot``); the provider builds
+        tools from it instead of resolving again, so tools and the prompt agree.
+        """
 
     def tool_resources(self) -> dict[str, Any]:
         """Return non-serializable resources for tools that opt into runtime context."""

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -164,7 +164,8 @@ class RunRecordFactory(Protocol):
 # ``answer(text, *, confirm_fn, is_tty, tool_observation, turn_snapshot) -> LLM-run record | None``.
 StreamAnswerFn = Callable[..., Any]
 
-# Bound evidence-gather callable: ``gather(text, *, is_tty) -> str | None``.
+# Bound evidence-gather callable:
+# ``gather(text, *, is_tty, resolved_integrations) -> str | None``.
 EvidenceGatherer = Callable[..., "str | None"]
 
 # Bound action tool-calling driver:

--- a/core/agent_harness/providers/default_providers.py
+++ b/core/agent_harness/providers/default_providers.py
@@ -70,7 +70,13 @@ class DefaultToolProvider:
         self._tool_action_logger = tool_action_logger
         self._tool_context: ActionToolContext | None = None
 
-    def action_tools(self, *, confirm_fn: ConfirmFn | None, is_tty: bool | None) -> list[Any]:
+    def action_tools(
+        self,
+        *,
+        confirm_fn: ConfirmFn | None,
+        is_tty: bool | None,
+        resolved_integrations: dict[str, Any] | None = None,
+    ) -> list[Any]:
         ctx = ActionToolContext(
             session=self._session,
             console=self._console,
@@ -82,9 +88,12 @@ class DefaultToolProvider:
         self._tool_context = ctx
         if self._precomputed_action_tools is not None:
             return list(self._precomputed_action_tools)
-        return get_action_tools_from_integrations_context(
-            ctx, resolved_integrations=self._resolved_integrations()
+        resolved = (
+            resolved_integrations
+            if resolved_integrations is not None
+            else self._resolved_integrations()
         )
+        return get_action_tools_from_integrations_context(ctx, resolved_integrations=resolved)
 
     def tool_resources(self) -> dict[str, Any]:
         if self._tool_context is None:

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -216,12 +216,19 @@ def _generic_tool_result_counts(result: Any) -> tuple[int, int]:
     return executed_count, success_count
 
 
-def _resolved_integrations_for_turn(
+def _turn_resolved_integrations(
     session: SessionStore,
-    turn_snapshot: TurnSnapshot | None,
+    turn_plan: TurnPlan | None,
 ) -> dict[str, Any]:
-    if turn_snapshot is not None and turn_snapshot.resolved_integrations:
-        return dict(turn_snapshot.resolved_integrations)
+    """The turn's single resolved-integration view: from the plan, else resolve once.
+
+    ``build_turn_plan`` already resolved integrations, so the plan is trusted even
+    when the result is empty (``{}`` means "no integrations", not "unresolved").
+    Only the direct-call path with no plan (some tests, headless without a turn)
+    resolves here.
+    """
+    if turn_plan is not None:
+        return dict(turn_plan.resolved_integrations)
     return dict(resolve_and_cache_integrations(session))
 
 
@@ -288,6 +295,7 @@ def _build_action_agent(
     session: SessionStore,
     agent_tools: list[Any],
     turn_snapshot: TurnSnapshot | None,
+    resolved_integrations: dict[str, Any],
     deps: ToolCallingDeps | None,
     tool_hooks: ToolExecutionHooks | None,
     tool_resources: dict[str, Any],
@@ -337,7 +345,7 @@ def _build_action_agent(
         llm=llm,
         system=system,
         tools=tuple(agent_tools),
-        resolved_integrations=_resolved_integrations_for_turn(session, turn_snapshot),
+        resolved_integrations=resolved_integrations,
         max_iterations=_MAX_TOOL_CALLING_ITERATIONS,
         tool_resources=tool_resources,
         tool_hooks=tool_hooks,
@@ -367,12 +375,15 @@ def run_action_agent_turn(
     action tools so prompt and tools agree.
     """
     turn_snapshot = turn_plan.snapshot if turn_plan is not None else None
+    # Read the turn's resolved integrations once, so the action tools and the
+    # AgentConfig are built from the same view (single source, no re-resolve).
+    resolved_integrations = _turn_resolved_integrations(session, turn_plan)
     history_start = len(session.history)
 
     agent_tools = tools.action_tools(
         confirm_fn=confirm_fn,
         is_tty=is_tty,
-        resolved_integrations=_resolved_integrations_for_turn(session, turn_snapshot),
+        resolved_integrations=resolved_integrations,
     )
     tool_resources_provider = getattr(tools, "tool_resources", None)
     tool_resources = tool_resources_provider() if callable(tool_resources_provider) else {}
@@ -388,6 +399,7 @@ def run_action_agent_turn(
             session=session,
             agent_tools=agent_tools,
             turn_snapshot=turn_snapshot,
+            resolved_integrations=resolved_integrations,
             deps=deps,
             tool_hooks=tool_hooks,
             tool_resources=tool_resources,

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -367,7 +367,11 @@ def run_action_agent_turn(
     """
     history_start = len(session.history)
 
-    agent_tools = tools.action_tools(confirm_fn=confirm_fn, is_tty=is_tty)
+    agent_tools = tools.action_tools(
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+        resolved_integrations=_resolved_integrations_for_turn(session, turn_snapshot),
+    )
     tool_resources_provider = getattr(tools, "tool_resources", None)
     tool_resources = tool_resources_provider() if callable(tool_resources_provider) else {}
     observer = tools.observer(message=message)

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -34,6 +34,7 @@ from core.agent_harness.ports import (
 from core.agent_harness.prompts import build_action_system_prompt, build_action_user_message
 from core.agent_harness.prompts.conversation_memory import MAX_CONVERSATION_MESSAGES
 from core.agent_harness.providers.provider_models import default_llm_factory
+from core.agent_harness.turns.turn_plan import TurnPlan
 from core.events import runtime_event_callback_from_observer
 from core.execution import ToolExecutionHooks, public_tool_input
 from core.llm.types import AgentLLMResponse, ToolCall
@@ -354,17 +355,18 @@ def run_action_agent_turn(
     confirm_fn: ConfirmFn | None = None,
     is_tty: bool | None = None,
     deps: ToolCallingDeps | None = None,
-    turn_snapshot: TurnSnapshot | None = None,
+    turn_plan: TurnPlan | None = None,
     error_reporter: ErrorReporter | None = None,
     tool_hooks: ToolExecutionHooks | None = None,
 ) -> ToolCallingTurnResult:
     """Run one action tool-calling turn through the shared agent harness.
 
-    ``turn_snapshot`` is the immutable per-turn snapshot assembled at turn start.
-    When present it is used to build the action-agent system prompt so the
-    prompt reflects turn-start state rather than the live (potentially
-    mid-mutation) session.
+    ``turn_plan`` is the turn-wide assembly. Its snapshot builds the action-agent
+    system prompt so the prompt reflects turn-start state rather than the live
+    (potentially mid-mutation) session, and its resolved integrations build the
+    action tools so prompt and tools agree.
     """
+    turn_snapshot = turn_plan.snapshot if turn_plan is not None else None
     history_start = len(session.history)
 
     agent_tools = tools.action_tools(

--- a/core/agent_harness/turns/evidence_driver.py
+++ b/core/agent_harness/turns/evidence_driver.py
@@ -131,7 +131,7 @@ def _resolve_gather_integrations(
     is connected. GitHub repo scope is still applied on top.
     """
     base = (
-        resolved_integrations
+        dict(resolved_integrations)
         if resolved_integrations is not None
         else resolve_and_cache_integrations(session)
     )

--- a/core/agent_harness/turns/evidence_driver.py
+++ b/core/agent_harness/turns/evidence_driver.py
@@ -118,9 +118,23 @@ def _format_observation(executed: list[tuple[Any, Any]]) -> str:
     return _truncate("\n\n".join(blocks), _MAX_OBSERVATION_CHARS)
 
 
-def _resolve_gather_integrations(session: SessionStore, message: str) -> dict[str, Any]:
-    """Resolve integrations for one gather turn, enriching GitHub repo scope when inferred."""
-    base = resolve_and_cache_integrations(session)
+def _resolve_gather_integrations(
+    session: SessionStore,
+    message: str,
+    resolved_integrations: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve integrations for one gather turn, enriching GitHub repo scope when inferred.
+
+    ``resolved_integrations`` is the turn's already-resolved view (from
+    ``TurnSnapshot``); when supplied it is used as the base instead of resolving
+    again, so the gather phase agrees with the action prompt and tools about what
+    is connected. GitHub repo scope is still applied on top.
+    """
+    base = (
+        resolved_integrations
+        if resolved_integrations is not None
+        else resolve_and_cache_integrations(session)
+    )
     scope = infer_github_repo_scope(
         message=message,
         conversation_messages=session.cli_agent_messages,
@@ -203,6 +217,7 @@ def gather_tool_evidence(
     error_reporter: ErrorReporter | None = None,
     is_tty: bool | None = None,  # noqa: ARG001 — reserved for parity with answer agents
     agent_factory: GatherAgentFactory | None = None,
+    resolved_integrations: dict[str, Any] | None = None,
 ) -> str | None:
     """Run a bounded tool-calling loop and return collected evidence, or None.
 
@@ -217,7 +232,9 @@ def gather_tool_evidence(
         # helper, within the ``_safe_execute`` fallback boundary.
         from tools.investigation.stages.gather_evidence.tools import get_available_tools
 
-        resolved = _resolve_gather_integrations(session, message)
+        resolved = _resolve_gather_integrations(
+            session, message, resolved_integrations=resolved_integrations
+        )
         gather_tools = list(get_available_tools(resolved))
         if not _has_usable_gather_tools(gather_tools):
             return None

--- a/core/agent_harness/turns/headless_dispatch.py
+++ b/core/agent_harness/turns/headless_dispatch.py
@@ -136,8 +136,14 @@ class EmptyPromptContextProvider:
 class NullToolProvider:
     """Provides no action tools and a no-op tool-event observer."""
 
-    def action_tools(self, *, confirm_fn: ConfirmFn | None, is_tty: bool | None) -> list[Any]:
-        _ = (confirm_fn, is_tty)
+    def action_tools(
+        self,
+        *,
+        confirm_fn: ConfirmFn | None,
+        is_tty: bool | None,
+        resolved_integrations: dict[str, Any] | None = None,
+    ) -> list[Any]:
+        _ = (confirm_fn, is_tty, resolved_integrations)
         return []
 
     def tool_resources(self) -> dict[str, Any]:
@@ -279,7 +285,12 @@ def dispatch_message_to_headless_agent(
             **kwargs,  # type: ignore[arg-type]
         )
 
-    def gather(text: str, *, is_tty: bool | None = None) -> str | None:
+    def gather(
+        text: str,
+        *,
+        is_tty: bool | None = None,
+        resolved_integrations: dict[str, Any] | None = None,
+    ) -> str | None:
         if not gather_enabled:
             return None
         return gather_tool_evidence(
@@ -287,6 +298,7 @@ def dispatch_message_to_headless_agent(
             store,
             error_reporter=error_reporter,
             is_tty=is_tty,
+            resolved_integrations=resolved_integrations,
         )
 
     return run_turn(

--- a/core/agent_harness/turns/headless_dispatch.py
+++ b/core/agent_harness/turns/headless_dispatch.py
@@ -33,7 +33,6 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from core.agent_harness.models.turn_results import ShellTurnResult, ToolCallingTurnResult
-from core.agent_harness.models.turn_snapshot import TurnSnapshot
 from core.agent_harness.ports import (
     ConfirmFn,
     ErrorReporter,
@@ -54,6 +53,7 @@ from core.agent_harness.providers.default_providers import DefaultTurnAccounting
 from core.agent_harness.turns.action_driver import run_action_agent_turn
 from core.agent_harness.turns.evidence_driver import gather_tool_evidence
 from core.agent_harness.turns.orchestrator import run_turn, stream_answer
+from core.agent_harness.turns.turn_plan import TurnPlan
 from core.execution import ToolExecutionHooks
 
 
@@ -259,7 +259,7 @@ def dispatch_message_to_headless_agent(
         *,
         confirm_fn: ConfirmFn | None = None,
         is_tty: bool | None = None,
-        turn_snapshot: TurnSnapshot | None = None,
+        turn_plan: TurnPlan | None = None,
     ) -> ToolCallingTurnResult:
         return run_action_agent_turn(
             text,
@@ -268,7 +268,7 @@ def dispatch_message_to_headless_agent(
             tools=tools,
             confirm_fn=confirm_fn,
             is_tty=is_tty,
-            turn_snapshot=turn_snapshot,
+            turn_plan=turn_plan,
             error_reporter=error_reporter,
             tool_hooks=tool_hooks,
         )
@@ -289,16 +289,17 @@ def dispatch_message_to_headless_agent(
         text: str,
         *,
         is_tty: bool | None = None,
-        resolved_integrations: dict[str, Any] | None = None,
+        turn_plan: TurnPlan | None = None,
     ) -> str | None:
         if not gather_enabled:
             return None
+        resolved = turn_plan.resolved_integrations if turn_plan is not None else None
         return gather_tool_evidence(
             text,
             store,
             error_reporter=error_reporter,
             is_tty=is_tty,
-            resolved_integrations=resolved_integrations,
+            resolved_integrations=resolved,
         )
 
     return run_turn(

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -40,6 +40,7 @@ from core.agent_harness.ports import (
 from core.agent_harness.prompts import build_cli_agent_prompt_from_provider
 from core.agent_harness.prompts.conversation_memory import MAX_CONVERSATION_MESSAGES
 from core.agent_harness.session.compaction import auto_compact_if_needed
+from core.agent_harness.turns.turn_plan import TurnPlan, build_turn_plan
 from integrations.llm_cli.errors import CLITimeoutError
 
 _ASSISTANT_LABEL = "assistant"
@@ -121,7 +122,7 @@ def stream_answer(
     is_tty: bool | None = None,
     tool_observation: str | None = None,
     tool_observation_on_screen: bool = True,
-    turn_snapshot: TurnSnapshot | None = None,
+    turn_plan: TurnPlan | None = None,
 ) -> Any | None:
     """Stream one grounded conversational answer (guidance only, no tools).
 
@@ -129,16 +130,18 @@ def stream_answer(
     no ReAct loop. The **tool-calling** agent is ``core.agent.Agent`` — see
     ``core/agent_harness/AGENTS.md``.
 
-    ``turn_snapshot`` is the immutable per-turn snapshot assembled at turn start.
-    When present, snapshot fields (conversation history, integration state,
-    prior investigation, synthetic-run path) are read from it rather than from
-    the live session, so prompt construction reflects a stable turn-start view.
+    ``turn_plan`` is the turn-wide assembly built at turn start. Its snapshot
+    (conversation history, integration state, prior investigation, synthetic-run
+    path) grounds prompt construction in a stable turn-start view rather than the
+    live session.
     """
     client = reasoning.get()
     if client is None:
         return None
 
-    ctx = turn_snapshot or TurnSnapshot.from_session(message, session)
+    ctx = (
+        turn_plan.snapshot if turn_plan is not None else TurnSnapshot.from_session(message, session)
+    )
     _ = (confirm_fn, is_tty)
 
     prompt = build_cli_agent_prompt_from_provider(
@@ -228,13 +231,9 @@ def _gather_and_answer(
     gather: EvidenceGatherer,
     confirm_fn: ConfirmFn | None,
     is_tty: bool | None,
-    turn_snapshot: TurnSnapshot,
+    turn_plan: TurnPlan,
 ) -> Any | None:
-    gathered = gather(
-        text,
-        is_tty=is_tty,
-        resolved_integrations=turn_snapshot.resolved_integrations,
-    )
+    gathered = gather(text, is_tty=is_tty, turn_plan=turn_plan)
 
     # When evidence was gathered, mark it off-screen so the prompt builder
     # includes it. When nothing was gathered, omit the flag entirely so the
@@ -246,7 +245,7 @@ def _gather_and_answer(
         confirm_fn=confirm_fn,
         is_tty=is_tty,
         tool_observation=gathered or None,
-        turn_snapshot=turn_snapshot,
+        turn_plan=turn_plan,
         **on_screen,
     )
 
@@ -294,6 +293,10 @@ def run_turn(
             turn_snapshot, resolved_integrations=resolve_and_cache_integrations(session)
         )
 
+    # Assemble the turn plan once: the single object the action, gather, and
+    # answer phases read so they cannot disagree about what this turn knows.
+    turn_plan = build_turn_plan(turn_snapshot)
+
     # Clear any observation left by a prior turn so only this turn's discovery
     # output can trigger a summary pass.
     session.last_command_observation = None
@@ -305,7 +308,7 @@ def run_turn(
         text,
         confirm_fn=confirm_fn,
         is_tty=is_tty,
-        turn_snapshot=turn_snapshot,
+        turn_plan=turn_plan,
     )
     accounting.record_action_result(action_result)
 
@@ -319,7 +322,7 @@ def run_turn(
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
                 tool_observation=observation,
-                turn_snapshot=turn_snapshot,
+                turn_plan=turn_plan,
             )
         result = ShellTurnResult(
             final_intent="cli_agent_summarized",
@@ -342,7 +345,7 @@ def run_turn(
                 gather=gather,
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
-                turn_snapshot=turn_snapshot,
+                turn_plan=turn_plan,
             )
         result = ShellTurnResult(
             final_intent="cli_agent_fallback",

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -17,11 +17,10 @@ Protocols in :mod:`core.agent_harness.ports`. Nothing here imports ``interactive
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any, Literal
 
 from config.llm_reasoning_effort import apply_reasoning_effort
-from core.agent_harness.integrations.resolution import resolve_and_cache_integrations
 from core.agent_harness.models.turn_results import ShellTurnResult, ToolCallingTurnResult
 from core.agent_harness.models.turn_snapshot import TurnSnapshot
 from core.agent_harness.ports import (
@@ -283,19 +282,11 @@ def run_turn(
     # prompts reflect a consistent turn-start view rather than live session state.
     turn_snapshot = TurnSnapshot.from_session(text, session)
 
-    # Resolve integrations once, at the top of the turn, so the frozen context is
-    # the single source of truth for what this turn knows. Downstream readers
-    # (e.g. the action agent) read ``turn_snapshot.resolved_integrations`` instead of
-    # re-resolving per component. Only fill it when a runtime-request source
-    # (``select_turn_runtime_input``) hasn't already populated it.
-    if not turn_snapshot.resolved_integrations:
-        turn_snapshot = replace(
-            turn_snapshot, resolved_integrations=resolve_and_cache_integrations(session)
-        )
-
-    # Assemble the turn plan once: the single object the action, gather, and
-    # answer phases read so they cannot disagree about what this turn knows.
-    turn_plan = build_turn_plan(turn_snapshot)
+    # Assemble the turn plan once: it resolves integrations and composes the
+    # snapshot into the single object the action, gather, and answer phases read,
+    # so they cannot disagree about what this turn knows.
+    turn_plan = build_turn_plan(turn_snapshot, session)
+    turn_snapshot = turn_plan.snapshot
 
     # Clear any observation left by a prior turn so only this turn's discovery
     # output can trigger a summary pass.

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -230,7 +230,11 @@ def _gather_and_answer(
     is_tty: bool | None,
     turn_snapshot: TurnSnapshot,
 ) -> Any | None:
-    gathered = gather(text, is_tty=is_tty)
+    gathered = gather(
+        text,
+        is_tty=is_tty,
+        resolved_integrations=turn_snapshot.resolved_integrations,
+    )
 
     # When evidence was gathered, mark it off-screen so the prompt builder
     # includes it. When nothing was gathered, omit the flag entirely so the

--- a/core/agent_harness/turns/turn_plan.py
+++ b/core/agent_harness/turns/turn_plan.py
@@ -2,22 +2,25 @@
 
 Assembled once at the top of ``run_turn`` and read by the action, gather, and
 answer phases so they cannot disagree about what this turn knows. It composes the
-frozen :class:`TurnSnapshot` (the read view of session state at turn start) and
-exposes the turn's single resolved-integration view.
+frozen :class:`TurnSnapshot` (the read view of session state at turn start) with
+the turn's resolved-integration decision.
 
 The snapshot answers "what did the session look like at turn start?"; the plan
-answers "what is this turn running on?". Today the plan's decision is the
-resolved integrations; tool lists and prompts stay built by their phases (action
-tools need surface context; gather tools depend on message-time GitHub scope),
-each reading ``resolved_integrations`` here so there is one source.
+answers "what is this turn running on?". ``build_turn_plan`` owns the assembly:
+it resolves integrations once and composes them into the snapshot. Tool lists and
+prompts stay built by their phases (action tools need surface context; gather
+tools depend on message-time GitHub scope), each reading ``resolved_integrations``
+here so there is one source.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
+from core.agent_harness.integrations.resolution import resolve_and_cache_integrations
 from core.agent_harness.models.turn_snapshot import TurnSnapshot
+from core.agent_harness.ports import SessionStore
 
 
 @dataclass(frozen=True)
@@ -37,8 +40,15 @@ class TurnPlan:
         return self.snapshot.resolved_integrations
 
 
-def build_turn_plan(snapshot: TurnSnapshot) -> TurnPlan:
-    """Assemble the turn plan from the resolved snapshot (the single owner)."""
+def build_turn_plan(snapshot: TurnSnapshot, session: SessionStore) -> TurnPlan:
+    """Assemble the turn plan: resolve integrations once, then compose the snapshot.
+
+    Resolution runs only when the snapshot has not already been populated (a
+    runtime-request source can pre-fill it), so the plan is the single place that
+    decides what this turn knows about connected integrations.
+    """
+    if not snapshot.resolved_integrations:
+        snapshot = replace(snapshot, resolved_integrations=resolve_and_cache_integrations(session))
     return TurnPlan(snapshot=snapshot)
 
 

--- a/core/agent_harness/turns/turn_plan.py
+++ b/core/agent_harness/turns/turn_plan.py
@@ -1,0 +1,45 @@
+"""Turn-wide assembly: the decisions one turn runs on.
+
+Assembled once at the top of ``run_turn`` and read by the action, gather, and
+answer phases so they cannot disagree about what this turn knows. It composes the
+frozen :class:`TurnSnapshot` (the read view of session state at turn start) and
+exposes the turn's single resolved-integration view.
+
+The snapshot answers "what did the session look like at turn start?"; the plan
+answers "what is this turn running on?". Today the plan's decision is the
+resolved integrations; tool lists and prompts stay built by their phases (action
+tools need surface context; gather tools depend on message-time GitHub scope),
+each reading ``resolved_integrations`` here so there is one source.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from core.agent_harness.models.turn_snapshot import TurnSnapshot
+
+
+@dataclass(frozen=True)
+class TurnPlan:
+    """Everything one turn runs on, assembled once at ``run_turn``."""
+
+    snapshot: TurnSnapshot
+
+    @property
+    def text(self) -> str:
+        """Raw user input text for this turn."""
+        return self.snapshot.text
+
+    @property
+    def resolved_integrations(self) -> dict[str, Any]:
+        """The turn's single resolved-integration view (frozen on the snapshot)."""
+        return self.snapshot.resolved_integrations
+
+
+def build_turn_plan(snapshot: TurnSnapshot) -> TurnPlan:
+    """Assemble the turn plan from the resolved snapshot (the single owner)."""
+    return TurnPlan(snapshot=snapshot)
+
+
+__all__ = ["TurnPlan", "build_turn_plan"]

--- a/core/agent_harness/turns/turn_plan.py
+++ b/core/agent_harness/turns/turn_plan.py
@@ -46,6 +46,11 @@ def build_turn_plan(snapshot: TurnSnapshot, session: SessionStore) -> TurnPlan:
     Resolution runs only when the snapshot has not already been populated (a
     runtime-request source can pre-fill it), so the plan is the single place that
     decides what this turn knows about connected integrations.
+
+    An empty result (``{}`` — no integrations configured) is a valid resolved
+    view; downstream phases read it from the plan rather than re-checking, so the
+    resolve-once contract holds even in that case (``resolve_and_cache`` also
+    caches, so a repeat call would be a no-op regardless).
     """
     if not snapshot.resolved_integrations:
         snapshot = replace(snapshot, resolved_integrations=resolve_and_cache_integrations(session))

--- a/surfaces/interactive_shell/runtime/action_turn.py
+++ b/surfaces/interactive_shell/runtime/action_turn.py
@@ -11,12 +11,12 @@ from collections.abc import Callable
 from rich.console import Console
 
 from core.agent_harness.models.turn_results import ToolCallingTurnResult
-from core.agent_harness.models.turn_snapshot import TurnSnapshot
 from core.agent_harness.ports import OutputSink
 from core.agent_harness.providers.default_providers import DefaultErrorReporter, DefaultToolProvider
 from core.agent_harness.providers.provider_models import default_llm_factory
 from core.agent_harness.session import Session
 from core.agent_harness.turns.action_driver import ToolCallingDeps, run_action_agent_turn
+from core.agent_harness.turns.turn_plan import TurnPlan
 from core.execution import ToolExecutionHooks
 from surfaces.interactive_shell.command_registry import SLASH_COMMANDS
 from surfaces.interactive_shell.command_registry.suggestions import resolve_literal_slash_typo
@@ -62,7 +62,7 @@ def run_action_tool_turn(
     is_tty: bool | None = None,
     request_exit: Callable[[], None] | None = None,
     deps: ToolCallingDeps | None = None,
-    turn_snapshot: TurnSnapshot | None = None,
+    turn_plan: TurnPlan | None = None,
     output: OutputSink | None = None,
     tool_hooks: ToolExecutionHooks | None = None,
 ) -> ToolCallingTurnResult:
@@ -89,7 +89,7 @@ def run_action_tool_turn(
         confirm_fn=confirm_fn,
         is_tty=is_tty,
         deps=effective_deps,
-        turn_snapshot=turn_snapshot,
+        turn_plan=turn_plan,
         error_reporter=DefaultErrorReporter(),
         tool_hooks=tool_hooks,
     )

--- a/surfaces/interactive_shell/runtime/answer_turn.py
+++ b/surfaces/interactive_shell/runtime/answer_turn.py
@@ -10,7 +10,6 @@ from collections.abc import Callable
 
 from rich.console import Console
 
-from core.agent_harness.models.turn_snapshot import TurnSnapshot
 from core.agent_harness.ports import OutputSink
 from core.agent_harness.providers.default_providers import (
     DefaultErrorReporter,
@@ -21,6 +20,7 @@ from core.agent_harness.session import Session
 from core.agent_harness.turns.orchestrator import (
     stream_answer as core_stream_answer,
 )
+from core.agent_harness.turns.turn_plan import TurnPlan
 from surfaces.interactive_shell.grounding.cli_reference import shell_prompt_context_provider
 from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink
 from surfaces.interactive_shell.utils.telemetry import LlmRunInfo
@@ -35,7 +35,7 @@ def answer_shell_question(
     is_tty: bool | None = None,
     tool_observation: str | None = None,
     tool_observation_on_screen: bool = True,
-    turn_snapshot: TurnSnapshot | None = None,
+    turn_plan: TurnPlan | None = None,
     output: OutputSink | None = None,
 ) -> LlmRunInfo | None:
     """Answer one shell question through the grounded conversational assistant."""
@@ -56,7 +56,7 @@ def answer_shell_question(
         is_tty=is_tty,
         tool_observation=tool_observation,
         tool_observation_on_screen=tool_observation_on_screen,
-        turn_snapshot=turn_snapshot,
+        turn_plan=turn_plan,
     )
 
 

--- a/surfaces/interactive_shell/runtime/integration_tool_gathering.py
+++ b/surfaces/interactive_shell/runtime/integration_tool_gathering.py
@@ -102,9 +102,15 @@ def _format_gathering_progress_line(
     return f"· gathering via {safe_display}…"
 
 
-def _resolve_gather_integrations(session: Session, message: str) -> dict[str, Any]:
+def _resolve_gather_integrations(
+    session: Session,
+    message: str,
+    resolved_integrations: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Resolve gather integrations through the decoupled agent helper."""
-    return evidence_driver._resolve_gather_integrations(session, message)  # noqa: SLF001
+    return evidence_driver._resolve_gather_integrations(  # noqa: SLF001
+        session, message, resolved_integrations=resolved_integrations
+    )
 
 
 def _truncate(text: str, limit: int) -> str:
@@ -149,11 +155,14 @@ def gather_integration_tool_evidence(
     *,
     is_tty: bool | None = None,
     agent_factory: GatherAgentFactory | None = None,
+    resolved_integrations: dict[str, Any] | None = None,
 ) -> str | None:
     """Run a bounded tool-calling loop and return collected evidence, or None.
 
     Returns a formatted observation block when at least one tool was executed;
     otherwise ``None`` so the caller falls back to the normal text-only answer.
+    ``resolved_integrations`` is the turn's resolved view; it is forwarded so the
+    gather phase reuses it instead of resolving again.
     """
     tool_call_counts: dict[str, int] = {}
 
@@ -181,6 +190,7 @@ def gather_integration_tool_evidence(
         error_reporter=_ShellGatherErrorReporter(),
         is_tty=is_tty,
         agent_factory=agent_factory,
+        resolved_integrations=resolved_integrations,
     )
 
 

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -10,7 +10,7 @@ live in ``turn_seams``.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Unpack
+from typing import Any, Unpack
 
 from rich.console import Console
 
@@ -90,8 +90,15 @@ def execute_shell_turn(
         # on the plain path); AnswerKwargs types them without forcing presence.
         return _answer(t, session, console, output=resolved_output, **kwargs)
 
-    def gather_bound(t: str, *, is_tty: bool | None = None) -> str | None:
-        return _gather(t, session, console, is_tty=is_tty)
+    def gather_bound(
+        t: str,
+        *,
+        is_tty: bool | None = None,
+        resolved_integrations: dict[str, Any] | None = None,
+    ) -> str | None:
+        return _gather(
+            t, session, console, is_tty=is_tty, resolved_integrations=resolved_integrations
+        )
 
     return run_turn(
         text,

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -10,15 +10,15 @@ live in ``turn_seams``.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, Unpack
+from typing import Unpack
 
 from rich.console import Console
 
 from core.agent_harness.models.turn_results import ShellTurnResult, ToolCallingTurnResult
-from core.agent_harness.models.turn_snapshot import TurnSnapshot
 from core.agent_harness.ports import OutputSink
 from core.agent_harness.session import Session
 from core.agent_harness.turns.orchestrator import run_turn
+from core.agent_harness.turns.turn_plan import TurnPlan
 from core.execution import ToolExecutionHooks
 from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
 from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink
@@ -71,7 +71,7 @@ def execute_shell_turn(
         *,
         confirm_fn: Callable[[str], str] | None = None,
         is_tty: bool | None = None,
-        turn_snapshot: TurnSnapshot | None = None,
+        turn_plan: TurnPlan | None = None,
     ) -> ToolCallingTurnResult:
         return _execute(
             t,
@@ -80,7 +80,7 @@ def execute_shell_turn(
             confirm_fn=confirm_fn,
             is_tty=is_tty,
             request_exit=request_exit,
-            turn_snapshot=turn_snapshot,
+            turn_plan=turn_plan,
             output=resolved_output,
             tool_hooks=tool_hooks,
         )
@@ -94,11 +94,10 @@ def execute_shell_turn(
         t: str,
         *,
         is_tty: bool | None = None,
-        resolved_integrations: dict[str, Any] | None = None,
+        turn_plan: TurnPlan | None = None,
     ) -> str | None:
-        return _gather(
-            t, session, console, is_tty=is_tty, resolved_integrations=resolved_integrations
-        )
+        resolved = turn_plan.resolved_integrations if turn_plan is not None else None
+        return _gather(t, session, console, is_tty=is_tty, resolved_integrations=resolved)
 
     return run_turn(
         text,

--- a/surfaces/interactive_shell/runtime/turn_seams.py
+++ b/surfaces/interactive_shell/runtime/turn_seams.py
@@ -14,9 +14,9 @@ from typing import Any, Protocol, TypedDict
 from rich.console import Console
 
 from core.agent_harness.models.turn_results import ToolCallingTurnResult
-from core.agent_harness.models.turn_snapshot import TurnSnapshot
 from core.agent_harness.ports import OutputSink
 from core.agent_harness.session import Session
+from core.agent_harness.turns.turn_plan import TurnPlan
 from core.execution import ToolExecutionHooks
 from surfaces.interactive_shell.utils.telemetry import LlmRunInfo
 
@@ -37,7 +37,7 @@ class RunActionToolTurn(Protocol):
         confirm_fn: Callable[[str], str] | None = None,
         is_tty: bool | None = None,
         request_exit: Callable[[], None] | None = None,
-        turn_snapshot: TurnSnapshot | None = None,
+        turn_plan: TurnPlan | None = None,
         output: OutputSink | None = None,
         tool_hooks: ToolExecutionHooks | None = None,
     ) -> ToolCallingTurnResult:
@@ -70,7 +70,7 @@ class AnswerKwargs(TypedDict, total=False):
     is_tty: bool | None
     tool_observation: str | None
     tool_observation_on_screen: bool
-    turn_snapshot: TurnSnapshot | None
+    turn_plan: TurnPlan | None
 
 
 class AnswerShellQuestion(Protocol):
@@ -86,7 +86,7 @@ class AnswerShellQuestion(Protocol):
         is_tty: bool | None = None,
         tool_observation: str | None = None,
         tool_observation_on_screen: bool = True,
-        turn_snapshot: TurnSnapshot | None = None,
+        turn_plan: TurnPlan | None = None,
         output: OutputSink | None = None,
     ) -> LlmRunInfo | None:
         """Answer the question, returning the LLM run info or None."""

--- a/surfaces/interactive_shell/runtime/turn_seams.py
+++ b/surfaces/interactive_shell/runtime/turn_seams.py
@@ -9,7 +9,7 @@ checked at type-time rather than at runtime. The default adapters
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Protocol, TypedDict
+from typing import Any, Protocol, TypedDict
 
 from rich.console import Console
 
@@ -54,6 +54,7 @@ class GatherEvidence(Protocol):
         console: Console,
         *,
         is_tty: bool | None = None,
+        resolved_integrations: dict[str, Any] | None = None,
     ) -> str | None:
         """Gather evidence for the message, or return None when nothing applies."""
 

--- a/tests/core/agent/orchestration/test_agent_actions_harness.py
+++ b/tests/core/agent/orchestration/test_agent_actions_harness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+import pytest
 from rich.console import Console
 
 import tools.interactive_shell.actions.slash as slash_tool
@@ -12,6 +13,7 @@ from core.agent_harness.turns.action_driver import (
     ActionTurnPlan,
     ToolCallingDeps,
     _build_action_agent,
+    _turn_resolved_integrations,
     run_action_agent_turn,
 )
 from core.tool_framework.registered_tool import RegisteredTool
@@ -266,6 +268,7 @@ def test_build_action_agent_returns_action_turn_plan() -> None:
         session=session,
         agent_tools=[],
         turn_snapshot=None,
+        resolved_integrations={},
         deps=deps,
         tool_hooks=None,
         tool_resources={},
@@ -275,3 +278,28 @@ def test_build_action_agent_returns_action_turn_plan() -> None:
     assert isinstance(plan, ActionTurnPlan)
     assert "test message" in plan.user_message
     assert plan.agent is not None
+
+
+def test_turn_resolved_integrations_trusts_plan_without_reresolving(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With a plan present, the resolved view is read from it — never re-resolved.
+
+    Pins the single-resolve contract for the empty-integrations edge: an empty
+    ``{}`` on the plan is authoritative, not a signal to resolve again.
+    """
+    from dataclasses import replace
+
+    from core.agent_harness.models.turn_snapshot import TurnSnapshot
+    from core.agent_harness.turns.turn_plan import TurnPlan
+
+    def _must_not_run(_session: object) -> dict:
+        raise AssertionError("must not re-resolve when the plan is present")
+
+    monkeypatch.setattr(
+        "core.agent_harness.turns.action_driver.resolve_and_cache_integrations", _must_not_run
+    )
+    snapshot = replace(TurnSnapshot.from_session("q", Session()), resolved_integrations={})
+    plan = TurnPlan(snapshot=snapshot)
+
+    assert _turn_resolved_integrations(Session(), plan) == {}

--- a/tests/core/agent/orchestration/test_cross_surface_components.py
+++ b/tests/core/agent/orchestration/test_cross_surface_components.py
@@ -109,10 +109,10 @@ def test_run_turn_routes_unhandled_action_to_answer_callback() -> None:
     assert result.answered is True
 
 
-def test_run_turn_populates_resolved_integrations_on_turn_snapshot(
+def test_run_turn_builds_turn_plan_for_action_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """run_turn resolves integrations once and hands them to the action path on turn_snapshot."""
+    """run_turn resolves once and hands the action path a turn_plan carrying them."""
     resolved = {"github": {"configured": True}}
     monkeypatch.setattr(
         "core.agent_harness.turns.orchestrator.resolve_and_cache_integrations",
@@ -121,9 +121,9 @@ def test_run_turn_populates_resolved_integrations_on_turn_snapshot(
     captured: list[Any] = []
 
     def execute_actions(
-        _text: str, *, turn_snapshot: Any = None, **_kwargs: object
+        _text: str, *, turn_plan: Any = None, **_kwargs: object
     ) -> ToolCallingTurnResult:
-        captured.append(turn_snapshot)
+        captured.append(turn_plan)
         return ToolCallingTurnResult(0, 0, 0, False, False)
 
     def answer(_text: str, **_kwargs: object) -> object:
@@ -153,10 +153,10 @@ def test_run_turn_populates_resolved_integrations_on_turn_snapshot(
     assert captured[0].resolved_integrations == resolved
 
 
-def test_run_turn_passes_resolved_integrations_to_gather(
+def test_run_turn_passes_turn_plan_to_gather(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """run_turn hands the turn's resolved integrations to the gather phase (no re-resolve)."""
+    """run_turn hands the gather phase the turn_plan carrying resolved integrations (no re-resolve)."""
     resolved = {"github": {"configured": True}}
     monkeypatch.setattr(
         "core.agent_harness.turns.orchestrator.resolve_and_cache_integrations",
@@ -170,8 +170,8 @@ def test_run_turn_passes_resolved_integrations_to_gather(
     def answer(_text: str, **_kwargs: object) -> object:
         return type("Run", (), {"response_text": "answered"})()
 
-    def gather(_text: str, *, resolved_integrations: Any = None, **_kwargs: object) -> None:
-        gather_calls.append(resolved_integrations)
+    def gather(_text: str, *, turn_plan: Any = None, **_kwargs: object) -> None:
+        gather_calls.append(turn_plan.resolved_integrations if turn_plan is not None else None)
         return None
 
     class _Accounting:

--- a/tests/core/agent/orchestration/test_cross_surface_components.py
+++ b/tests/core/agent/orchestration/test_cross_surface_components.py
@@ -151,3 +151,55 @@ def test_run_turn_populates_resolved_integrations_on_turn_snapshot(
 
     assert captured, "execute_actions was never called"
     assert captured[0].resolved_integrations == resolved
+
+
+def test_action_tools_uses_passed_resolved_integrations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The turn's resolved dict is what tools are built from — no second resolve."""
+    captured: list[dict[str, Any]] = []
+
+    def _fake_build(_ctx: Any, *, resolved_integrations: dict[str, Any]) -> list[Any]:
+        captured.append(resolved_integrations)
+        return []
+
+    monkeypatch.setattr(
+        "core.agent_harness.providers.default_providers.get_action_tools_from_integrations_context",
+        _fake_build,
+    )
+    provider = DefaultToolProvider(
+        Session(storage=InMemorySessionStorage()), Console(force_terminal=False)
+    )
+    turn_resolved = {"github": {"configured": True}}
+
+    provider.action_tools(confirm_fn=None, is_tty=False, resolved_integrations=turn_resolved)
+
+    assert captured == [turn_resolved]
+
+
+def test_action_tools_falls_back_to_session_resolve_when_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting the turn's dict keeps the prior behavior: resolve from the session."""
+    captured: list[dict[str, Any]] = []
+    session_resolved = {"slack": {"configured": True}}
+
+    def _fake_build(_ctx: Any, *, resolved_integrations: dict[str, Any]) -> list[Any]:
+        captured.append(resolved_integrations)
+        return []
+
+    monkeypatch.setattr(
+        "core.agent_harness.providers.default_providers.get_action_tools_from_integrations_context",
+        _fake_build,
+    )
+    monkeypatch.setattr(
+        "core.agent_harness.integrations.resolution.resolve_and_cache_integrations",
+        lambda _session: dict(session_resolved),
+    )
+    provider = DefaultToolProvider(
+        Session(storage=InMemorySessionStorage()), Console(force_terminal=False)
+    )
+
+    provider.action_tools(confirm_fn=None, is_tty=False)
+
+    assert captured == [session_resolved]

--- a/tests/core/agent/orchestration/test_cross_surface_components.py
+++ b/tests/core/agent/orchestration/test_cross_surface_components.py
@@ -153,6 +153,47 @@ def test_run_turn_populates_resolved_integrations_on_turn_snapshot(
     assert captured[0].resolved_integrations == resolved
 
 
+def test_run_turn_passes_resolved_integrations_to_gather(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_turn hands the turn's resolved integrations to the gather phase (no re-resolve)."""
+    resolved = {"github": {"configured": True}}
+    monkeypatch.setattr(
+        "core.agent_harness.turns.orchestrator.resolve_and_cache_integrations",
+        lambda _session: resolved,
+    )
+    gather_calls: list[Any] = []
+
+    def execute_actions(_text: str, **_kwargs: object) -> ToolCallingTurnResult:
+        return ToolCallingTurnResult(0, 0, 0, False, False)
+
+    def answer(_text: str, **_kwargs: object) -> object:
+        return type("Run", (), {"response_text": "answered"})()
+
+    def gather(_text: str, *, resolved_integrations: Any = None, **_kwargs: object) -> None:
+        gather_calls.append(resolved_integrations)
+        return None
+
+    class _Accounting:
+        def record_action_result(self, _result: ToolCallingTurnResult) -> None:
+            return None
+
+        def finalize(self, result: ShellTurnResult) -> ShellTurnResult:
+            return result
+
+    session = Session(storage=InMemorySessionStorage())
+    run_turn(
+        "hi",
+        session,
+        execute_actions=execute_actions,
+        answer=answer,
+        gather=gather,
+        accounting=_Accounting(),
+    )
+
+    assert gather_calls == [resolved]
+
+
 def test_action_tools_uses_passed_resolved_integrations(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/agent/orchestration/test_cross_surface_components.py
+++ b/tests/core/agent/orchestration/test_cross_surface_components.py
@@ -115,7 +115,7 @@ def test_run_turn_builds_turn_plan_for_action_path(
     """run_turn resolves once and hands the action path a turn_plan carrying them."""
     resolved = {"github": {"configured": True}}
     monkeypatch.setattr(
-        "core.agent_harness.turns.orchestrator.resolve_and_cache_integrations",
+        "core.agent_harness.turns.turn_plan.resolve_and_cache_integrations",
         lambda _session: resolved,
     )
     captured: list[Any] = []
@@ -159,7 +159,7 @@ def test_run_turn_passes_turn_plan_to_gather(
     """run_turn hands the gather phase the turn_plan carrying resolved integrations (no re-resolve)."""
     resolved = {"github": {"configured": True}}
     monkeypatch.setattr(
-        "core.agent_harness.turns.orchestrator.resolve_and_cache_integrations",
+        "core.agent_harness.turns.turn_plan.resolve_and_cache_integrations",
         lambda _session: resolved,
     )
     gather_calls: list[Any] = []
@@ -192,6 +192,50 @@ def test_run_turn_passes_turn_plan_to_gather(
     )
 
     assert gather_calls == [resolved]
+
+
+def test_run_turn_passes_turn_plan_to_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The answer phase receives the same turn_plan (its snapshot grounds the prompt)."""
+    resolved = {"github": {"configured": True}}
+    monkeypatch.setattr(
+        "core.agent_harness.turns.turn_plan.resolve_and_cache_integrations",
+        lambda _session: resolved,
+    )
+    answer_plans: list[Any] = []
+
+    def execute_actions(_text: str, **_kwargs: object) -> ToolCallingTurnResult:
+        return ToolCallingTurnResult(0, 0, 0, False, False)
+
+    def answer(_text: str, *, turn_plan: Any = None, **_kwargs: object) -> object:
+        answer_plans.append(turn_plan)
+        return type("Run", (), {"response_text": "answered"})()
+
+    def gather(_text: str, **_kwargs: object) -> None:
+        return None
+
+    class _Accounting:
+        def record_action_result(self, _result: ToolCallingTurnResult) -> None:
+            return None
+
+        def finalize(self, result: ShellTurnResult) -> ShellTurnResult:
+            return result
+
+    session = Session(storage=InMemorySessionStorage())
+    run_turn(
+        "why is it down?",
+        session,
+        execute_actions=execute_actions,
+        answer=answer,
+        gather=gather,
+        accounting=_Accounting(),
+    )
+
+    assert answer_plans, "answer was never called"
+    assert answer_plans[0] is not None
+    assert answer_plans[0].snapshot.text == "why is it down?"
+    assert answer_plans[0].resolved_integrations == resolved
 
 
 def test_action_tools_uses_passed_resolved_integrations(

--- a/tests/core/agent_harness/test_evidence_agent.py
+++ b/tests/core/agent_harness/test_evidence_agent.py
@@ -35,7 +35,9 @@ def _session() -> Session:
 def test_tool_discovery_raise_is_swallowed(monkeypatch: Any) -> None:
     """A raise from ``get_available_tools`` must not break the turn."""
     monkeypatch.setattr(
-        evidence_agent, "_resolve_gather_integrations", lambda _session, _message: {}
+        evidence_agent,
+        "_resolve_gather_integrations",
+        lambda _session, _message, resolved_integrations=None: {},
     )
 
     def _boom(_resolved: dict[str, Any]) -> Any:
@@ -56,7 +58,7 @@ def test_tool_discovery_raise_is_swallowed(monkeypatch: Any) -> None:
 def test_integration_resolution_raise_is_swallowed(monkeypatch: Any) -> None:
     """A raise from integration resolution must not break the turn."""
 
-    def _boom(_session: Any, _message: str) -> dict[str, Any]:
+    def _boom(_session: Any, _message: str, resolved_integrations: Any = None) -> dict[str, Any]:
         raise RuntimeError("credential store unreadable")
 
     monkeypatch.setattr(evidence_agent, "_resolve_gather_integrations", _boom)
@@ -74,7 +76,9 @@ def test_integration_resolution_raise_is_swallowed(monkeypatch: Any) -> None:
 def test_no_error_reporter_still_swallows(monkeypatch: Any) -> None:
     """Even without an error reporter, a discovery raise returns None (no crash)."""
     monkeypatch.setattr(
-        evidence_agent, "_resolve_gather_integrations", lambda _session, _message: {}
+        evidence_agent,
+        "_resolve_gather_integrations",
+        lambda _session, _message, resolved_integrations=None: {},
     )
 
     def _boom(_resolved: dict[str, Any]) -> Any:
@@ -88,7 +92,9 @@ def test_no_error_reporter_still_swallows(monkeypatch: Any) -> None:
 def test_no_usable_tools_returns_none(monkeypatch: Any) -> None:
     """Empty toolset short-circuits to None without invoking the LLM."""
     monkeypatch.setattr(
-        evidence_agent, "_resolve_gather_integrations", lambda _session, _message: {}
+        evidence_agent,
+        "_resolve_gather_integrations",
+        lambda _session, _message, resolved_integrations=None: {},
     )
     monkeypatch.setattr(gather_tools, "get_available_tools", lambda _resolved: [])
 

--- a/tests/core/agent_harness/test_evidence_agent.py
+++ b/tests/core/agent_harness/test_evidence_agent.py
@@ -37,7 +37,7 @@ def test_tool_discovery_raise_is_swallowed(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         evidence_agent,
         "_resolve_gather_integrations",
-        lambda _session, _message, resolved_integrations=None: {},
+        lambda *_args, **_kwargs: {},
     )
 
     def _boom(_resolved: dict[str, Any]) -> Any:
@@ -78,7 +78,7 @@ def test_no_error_reporter_still_swallows(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         evidence_agent,
         "_resolve_gather_integrations",
-        lambda _session, _message, resolved_integrations=None: {},
+        lambda *_args, **_kwargs: {},
     )
 
     def _boom(_resolved: dict[str, Any]) -> Any:
@@ -94,7 +94,7 @@ def test_no_usable_tools_returns_none(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         evidence_agent,
         "_resolve_gather_integrations",
-        lambda _session, _message, resolved_integrations=None: {},
+        lambda *_args, **_kwargs: {},
     )
     monkeypatch.setattr(gather_tools, "get_available_tools", lambda _resolved: [])
 

--- a/tests/core/agent_harness/test_turn_plan.py
+++ b/tests/core/agent_harness/test_turn_plan.py
@@ -1,0 +1,72 @@
+"""Unit tests for the turn-wide assembly object ``TurnPlan``."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from core.agent_harness.models.turn_snapshot import TurnSnapshot
+from core.agent_harness.session import Session
+from core.agent_harness.turns.turn_plan import TurnPlan, build_turn_plan
+
+
+def _snapshot(text: str = "q", *, resolved: dict | None = None) -> TurnSnapshot:
+    snapshot = TurnSnapshot.from_session(text, Session())
+    if resolved is not None:
+        snapshot = replace(snapshot, resolved_integrations=resolved)
+    return snapshot
+
+
+def test_build_turn_plan_composes_the_snapshot() -> None:
+    snapshot = _snapshot("why did it fail?", resolved={"github": {"configured": True}})
+
+    plan = build_turn_plan(snapshot, Session())
+
+    assert isinstance(plan, TurnPlan)
+    assert plan.snapshot is snapshot
+    assert plan.text == "why did it fail?"
+
+
+def test_turn_plan_exposes_resolved_integrations_from_snapshot() -> None:
+    resolved = {"github": {"configured": True}}
+    snapshot = _snapshot(resolved=resolved)
+
+    plan = build_turn_plan(snapshot, Session())
+
+    # The plan is the single source: it reads the snapshot's resolved view, not a copy.
+    assert plan.resolved_integrations == resolved
+    assert plan.resolved_integrations is plan.snapshot.resolved_integrations
+
+
+def test_build_turn_plan_resolves_integrations_when_snapshot_has_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """build_turn_plan owns the resolve step, running it when the snapshot is empty."""
+    resolved = {"datadog": {"configured": True}}
+    monkeypatch.setattr(
+        "core.agent_harness.turns.turn_plan.resolve_and_cache_integrations",
+        lambda _session: resolved,
+    )
+
+    plan = build_turn_plan(_snapshot(), Session())
+
+    assert plan.resolved_integrations == resolved
+
+
+def test_build_turn_plan_skips_resolve_when_snapshot_already_populated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runtime-request source can pre-fill the snapshot; then no re-resolve runs."""
+
+    def _must_not_run(_session: object) -> dict:
+        raise AssertionError("resolve must not run when the snapshot is already populated")
+
+    monkeypatch.setattr(
+        "core.agent_harness.turns.turn_plan.resolve_and_cache_integrations", _must_not_run
+    )
+    resolved = {"github": {"configured": True}}
+
+    plan = build_turn_plan(_snapshot(resolved=resolved), Session())
+
+    assert plan.resolved_integrations == resolved

--- a/tests/interactive_shell/tools/test_tool_gathering.py
+++ b/tests/interactive_shell/tools/test_tool_gathering.py
@@ -302,6 +302,38 @@ def test_resolve_gather_integrations_uses_session_cache_on_follow_up() -> None:
     assert resolved["github"]["repo"] == "opensre"
 
 
+def test_resolve_gather_integrations_uses_passed_turn_view() -> None:
+    """When the turn's resolved view is supplied, it is the base — no session re-resolve."""
+    session = Session()
+    # The session cache holds a different integration than the turn resolved this turn.
+    session.resolved_integrations_cache = {"datadog": {"connection_verified": True}}
+    turn_resolved = {"slack": {"connection_verified": True}}
+
+    resolved = _resolve_gather_integrations(
+        session, "post an update", resolved_integrations=turn_resolved
+    )
+
+    assert resolved == {"slack": {"connection_verified": True}}
+
+
+def test_resolve_gather_integrations_applies_github_scope_over_passed_view() -> None:
+    """GitHub repo scope is still enriched on top of the passed turn view."""
+    session = Session()
+    session.resolved_integrations_cache = {}
+    turn_resolved = {
+        "github": {"connection_verified": True, "url": "https://api.githubcopilot.com/mcp/"}
+    }
+
+    resolved = _resolve_gather_integrations(
+        session,
+        "check github issues in https://github.com/Tracer-Cloud/opensre",
+        resolved_integrations=turn_resolved,
+    )
+
+    assert resolved["github"]["owner"] == "Tracer-Cloud"
+    assert resolved["github"]["repo"] == "opensre"
+
+
 def test_gather_enriches_github_before_selecting_tools(monkeypatch: Any) -> None:
     session = Session()
     session.resolved_integrations_cache = {


### PR DESCRIPTION
Fixes #3683

#### Describe the changes you have made in this PR -

Introduces `TurnPlan` (`core/agent_harness/turns/turn_plan.py`): the turn-wide assembly built once at the top of `run_turn` and read by the action, gather, and answer phases so they cannot disagree about what the turn knows.

`build_turn_plan(snapshot, session)` owns the assembly: it resolves integrations once and composes them onto the snapshot. `run_turn` no longer resolves inline;
`TurnSnapshot.from_session` stays a pure read view. The three phase seams (`execute_actions`, `gather`, `answer`) now carry `turn_plan` instead of a bare snapshot / loose `resolved_integrations`; each phase derives `snapshot` and reads `resolved_integrations` from the one object.

Also folds in the resolve-once slice: action tools and gather tools are built from `plan.resolved_integrations`, so prompt and tools agree (no independent re-resolve). The answer phase reads the snapshot only (it uses no tools).

Integration resolution and tool-list building were spread across the orchestrator, action driver, gather driver, and tool provider, each reading its own source — a drift class where the action prompt could describe one set of connected integrations while tools reflected another. `TurnPlan` makes one object the single source for what a turn runs on.

`TurnPlan` owns integration assembly; action and gather tools are built *from* it in their phases (action tools need surface context; gather tools need message-time GitHub scope).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
