### PR TITLE
refactor(hermes): remove investigation layer inversion

### DIFF
--- a/.github/ci/check_direct_imports.py
+++ b/.github/ci/check_direct_imports.py
@@ -89,8 +89,6 @@ _BASELINE_IGNORES: frozenset[str] = frozenset(
 # below ``surfaces/`` or making tools UI-agnostic.
 _NESTED_BASELINE_IGNORES: frozenset[str] = frozenset(
     {
-        # Hermes defers investigation pipeline import until an incident runs.
-        "integrations.hermes.investigation -> tools.investigation.capability",
         "tools.interactive_shell.actions.investigation -> surfaces.interactive_shell.runtime.background.runner",
         "tools.interactive_shell.actions.investigation -> surfaces.interactive_shell.runtime.investigation_adapter",
         "tools.interactive_shell.actions.sample_alert -> surfaces.interactive_shell.runtime.background.runner",

--- a/.importlinter.strict
+++ b/.importlinter.strict
@@ -60,8 +60,6 @@ ignore_imports =
     platform.scheduler.executor -> integrations.discord.delivery
     platform.scheduler.executor -> integrations.slack.delivery
     platform.scheduler.executor -> integrations.telegram.delivery
-    # integrations -> tools (hermes investigation bridge)
-    integrations.hermes.investigation -> tools.investigation.capability
     # surfaces -> gateway (cli gateway command)
     surfaces.cli.commands.gateway -> gateway.manager
     # tools.interactive_shell -> surfaces (T-4 debt — issue #3352)

--- a/integrations/hermes/investigation.py
+++ b/integrations/hermes/investigation.py
@@ -1,17 +1,17 @@
 """Optional bridge from Hermes incidents into the OpenSRE investigation pipeline.
 
 The :func:`run_incident_investigation` helper turns a :class:`HermesIncident`
-into a Grafana-shaped alert payload, calls
-:func:`tools.investigation.capability.run_investigation`, and extracts a
-human-readable summary from the resulting :class:`AgentState`.
+into a Grafana-shaped alert payload, calls a supplied investigation runner,
+and extracts a human-readable summary from the resulting state.
 
 The investigation pipeline is heavy (LLM calls, integration
-resolution) so this module imports it lazily — callers that never invoke
-the bridge pay no import cost.
+resolution), so the concrete investigation runner is supplied by an
+outer layer rather than imported directly by this module.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from integrations.hermes.incident import HermesIncident, LogRecord
@@ -60,21 +60,18 @@ def build_alert_from_incident(incident: HermesIncident) -> dict[str, Any]:
     }
 
 
-def run_incident_investigation(incident: HermesIncident) -> str | None:
-    """Invoke the OpenSRE investigation pipeline for ``incident``.
+def run_incident_investigation(
+    incident: HermesIncident,
+    run_investigation: Callable[[dict[str, Any]], Any],
+) -> str | None:
+    """Invoke the supplied investigation pipeline for ``incident``.
 
     Returns the resulting summary string, or ``None`` if the pipeline ran
-    successfully but produced no usable output. If :func:`run_investigation`
-    raises, the exception propagates to the caller — :class:`TelegramSink`
-    maps that to an operator-visible "attempted (failed)" marker. Heavy
-    imports are deferred so the Hermes sink can be imported in environments
-    where heavy dependencies are not installed (e.g. unit tests).
+    successfully but produced no usable output. If ``run_investigation``
+    raises, the exception propagates to the caller, where
+    :class:`TelegramSink` maps it to an operator-visible "attempted (failed)"
+    marker.
     """
-    # Imported lazily — pulling tools.investigation.capability at module import
-    # time would force every Hermes consumer to pay the pipeline import
-    # cost even when no investigation ever runs.
-    from tools.investigation.capability import run_investigation
-
     alert = build_alert_from_incident(incident)
     state = run_investigation(alert)
     return _extract_summary(state)

--- a/surfaces/cli/commands/hermes.py
+++ b/surfaces/cli/commands/hermes.py
@@ -30,6 +30,7 @@ from integrations.hermes.investigation import run_incident_investigation
 from integrations.hermes.sinks import TelegramSink
 from integrations.telegram.alarms import AlarmDispatcher
 from integrations.telegram.credentials import load_credentials_from_env
+from tools.investigation.capability import run_investigation
 
 
 @click.group(name="hermes", invoke_without_command=True)
@@ -151,7 +152,11 @@ def hermes_watch(
     dispatcher = AlarmDispatcher(creds, cooldown_seconds=cooldown_seconds)
 
     investigate_enabled = _resolve_investigate_flag(investigate)
-    bridge = run_incident_investigation if investigate_enabled else None
+    bridge = (
+        (lambda incident: run_incident_investigation(incident, run_investigation))
+        if investigate_enabled
+        else None
+    )
     telegram_sink = TelegramSink(dispatcher, investigation_bridge=bridge)
 
     correlator: IncidentCorrelator | None = None

--- a/tests/hermes/test_sinks.py
+++ b/tests/hermes/test_sinks.py
@@ -229,13 +229,12 @@ class TestSeverityRouting:
 
         dispatcher, calls = _dispatcher(monkeypatch)
 
-        def _boom(**_kwargs: Any) -> Any:
+        def _boom(_alert: dict[str, Any]) -> Any:
             raise RuntimeError("investigation pipeline exploded")
 
-        monkeypatch.setattr("tools.investigation.capability.run_investigation", _boom)
         sink = TelegramSink(
             dispatcher,
-            investigation_bridge=run_incident_investigation,
+            investigation_bridge=lambda incident: run_incident_investigation(incident, _boom),
             config=_INLINE,
         )
         sink(_incident(severity=IncidentSeverity.HIGH))


### PR DESCRIPTION
## Summary

Fixes #3541

Removes the direct dependency from `integrations.hermes.investigation` to `tools.investigation.capability` by injecting the investigation runner from an allowed surface layer.

## Changes

* Updated `run_incident_investigation()` to accept an investigation runner callback.
* Moved investigation wiring into `surfaces.cli.commands.hermes`.
* Removed the temporary layer-contract exceptions from:

  * `.importlinter.strict`
  * `.github/ci/check_direct_imports.py`
* Updated Hermes bridge tests.

## Verification

```bash
python .github/ci/check_direct_imports.py
python -m pytest tests/hermes/test_sinks.py
```

Results:

* No forbidden direct import edges found.
* 19 Hermes tests passed.
<img width="1712" height="940" alt="Ekran görüntüsü 2026-07-05 225042" src="https://github.com/user-attachments/assets/cde0c08e-9c39-41bf-81e0-81357ca56571" />
