### PR TITLE
test(jenkins): cover client error paths

### DIFF
--- a/tests/integrations/test_jenkins.py
+++ b/tests/integrations/test_jenkins.py
@@ -496,6 +496,59 @@ class TestListRunningBuilds:
         assert result["running_builds"][0]["number"] == 9
 
 
+class TestClientErrorPaths:
+    @pytest.mark.parametrize(
+        ("method_name", "args"),
+        [
+            ("list_builds", ("demo",)),
+            ("get_build_log", ("demo", 1)),
+            ("get_pipeline_stages", ("demo", 1)),
+            ("list_jobs", ()),
+            ("list_running_builds", ()),
+        ],
+    )
+    def test_client_methods_return_failure_on_timeout(
+        self,
+        method_name: str,
+        args: tuple[Any, ...],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            raise httpx.TimeoutException("jenkins timed out")
+
+        client = _client_with_handler(handler, monkeypatch)
+
+        result = getattr(client, method_name)(*args)
+
+        assert result["success"] is False
+        assert "jenkins timed out" in result["error"]
+
+    @pytest.mark.parametrize(
+        ("method_name", "args"),
+        [
+            ("list_builds", ("demo",)),
+            ("get_pipeline_stages", ("demo", 1)),
+            ("list_jobs", ()),
+            ("list_running_builds", ()),
+        ],
+    )
+    def test_json_methods_return_failure_on_invalid_json(
+        self,
+        method_name: str,
+        args: tuple[Any, ...],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b"not-json")
+
+        client = _client_with_handler(handler, monkeypatch)
+
+        result = getattr(client, method_name)(*args)
+
+        assert result["success"] is False
+        assert "expecting value" in result["error"].lower()
+
+
 class TestMakeClient:
     def test_returns_none_without_creds(self) -> None:
         assert make_jenkins_client("", api_token="") is None


### PR DESCRIPTION
## Summary

Fixes #3592

Adds mocked error-path coverage for the Jenkins client by testing timeout and invalid JSON response scenarios. These tests verify that the client fails gracefully without requiring a live Jenkins instance or credentials.

## Changes

* Added mocked timeout tests for Jenkins client methods.
* Added mocked invalid JSON response tests.
* Kept all tests isolated using `httpx.MockTransport`.
* No production code changes.

## Validation

```text
pytest tests/integrations/test_jenkins.py -q
```

Result:

* **64 passed**
* No live Jenkins credentials or external services required.
<img width="1705" height="629" alt="Ekran görüntüsü 2026-07-05 232244" src="https://github.com/user-attachments/assets/80abb067-780e-432d-a5ed-83c44643d282" />
