### PR TITLE
test(core/agent): add provider hook integration tests

### DIFF
--- a/tests/core/runtime/test_loop.py
+++ b/tests/core/runtime/test_loop.py
@@ -230,15 +230,15 @@ def test_transform_messages_hook_filters_context_sent_to_llm() -> None:
         tools=[],
         resolved_integrations={},
         max_iterations=1,
-        provider_hooks=ProviderHooks(
-            transform_messages=lambda messages: list(messages)[-1:]
-        ),
+        provider_hooks=ProviderHooks(transform_messages=lambda messages: list(messages)[-1:]),
     )
 
-    agent.run([
-        {"role": "user", "content": "first"},
-        {"role": "user", "content": "second"},
-    ])
+    agent.run(
+        [
+            {"role": "user", "content": "first"},
+            {"role": "user", "content": "second"},
+        ]
+    )
 
     assert llm.invocations == 1
     assert len(llm.seen_messages[0]) == 1

--- a/tests/core/runtime/test_loop.py
+++ b/tests/core/runtime/test_loop.py
@@ -222,6 +222,69 @@ def test_run_records_system_prompt_edited_by_before_provider_request_hook() -> N
     assert result.final_system_prompt == "sys [edited]"
 
 
+def test_transform_messages_hook_filters_context_sent_to_llm() -> None:
+    llm = FakeLLM(iter([_text_response("done")]))
+    agent = Agent(
+        llm=llm,
+        system="sys",
+        tools=[],
+        resolved_integrations={},
+        max_iterations=1,
+        provider_hooks=ProviderHooks(
+            transform_messages=lambda messages: list(messages)[-1:]
+        ),
+    )
+
+    agent.run([
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "second"},
+    ])
+
+    assert llm.invocations == 1
+    assert len(llm.seen_messages[0]) == 1
+    assert llm.seen_messages[0][0]["content"] == "second"
+
+
+def test_convert_to_llm_hook_replaces_default_message_conversion() -> None:
+    llm = FakeLLM(iter([_text_response("done")]))
+
+    def stamp(_llm: Any, messages: Any) -> list[dict[str, Any]]:
+        return [{"role": "user", "content": f"converted:{m.content}"} for m in messages]
+
+    agent = Agent(
+        llm=llm,
+        system="sys",
+        tools=[],
+        resolved_integrations={},
+        max_iterations=1,
+        provider_hooks=ProviderHooks(convert_to_llm=stamp),
+    )
+
+    agent.run([{"role": "user", "content": "hello"}])
+
+    assert llm.invocations == 1
+    assert llm.seen_messages[0][0]["content"] == "converted:hello"
+
+
+def test_after_response_hook_can_rewrite_llm_reply() -> None:
+    llm = FakeLLM(iter([_text_response("original")]))
+    agent = Agent(
+        llm=llm,
+        system="sys",
+        tools=[],
+        resolved_integrations={},
+        max_iterations=1,
+        provider_hooks=ProviderHooks(
+            after_provider_response=lambda _req, resp: replace(resp, content="rewritten")
+        ),
+    )
+
+    result = agent.run([{"role": "user", "content": "hi"}])
+
+    assert llm.invocations == 1
+    assert result.final_text == "rewritten"
+
+
 def test_one_tool_round_then_final() -> None:
     output = {"value": 42}
     llm = FakeLLM(


### PR DESCRIPTION
Fixes #3733

#### Describe the changes you have made in this PR

## Summary

Adds `Agent.run()` integration tests for the remaining provider hooks that were missing end-to-end coverage:

- `transform_messages`
- `convert_to_llm`
- `after_provider_response`

The new tests are added to `tests/core/runtime/test_loop.py` alongside the existing `before_provider_request` integration test. Each test exercises a single provider hook through a one-turn `Agent.run()` execution and verifies that its effect is observable during runtime.

This PR only adds test coverage and does not modify production behavior.

### Demo/Screenshot for feature changes and bug fixes
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/786c1a19-ae51-4359-b32d-24bd4a703f23" />

Attached is a screenshot of the relevant test suite passing.

---

## Code Understanding and AI Usage

**Did you use AI assistance?**

- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested the implementation and understand how it behaves
- [x] I have modified the AI-generated output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue requested Agent-level integration tests for provider hooks that were not previously exercised through `Agent.run()`.

I followed the existing runtime testing pattern in `tests/core/runtime/test_loop.py`, using the existing `FakeLLM` to exercise a one-turn `Agent.run()` with custom `ProviderHooks`.

Each new test focuses on a single hook and verifies its observable runtime behavior:

- `transform_messages` verifies the transformed messages are the ones sent to the LLM.
- `convert_to_llm` verifies the custom conversion replaces the default message formatting.
- `after_provider_response` verifies the modified provider response becomes the final agent output.

The implementation keeps each test isolated so failures clearly identify which provider hook regressed while remaining consistent with the existing runtime integration tests.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions