### PR TITLE
refactor(tools/investigation): tool-owned evidence normalization

### DIFF
--- a/config/alert_seed_sources.yaml
+++ b/config/alert_seed_sources.yaml
@@ -1,0 +1,65 @@
+# Auto-called before the LLM loop starts. Keep this narrower than
+# ALERT_SOURCE_TO_TOOL_SOURCES for expensive or context-dependent tools.
+grafana:
+  - grafana
+datadog:
+  - datadog
+cloudwatch:
+  - cloudwatch
+eks:
+  - eks
+alertmanager:
+  - grafana
+  - cloudwatch
+sentry:
+  - sentry
+honeycomb:
+  - honeycomb
+coralogix:
+  - coralogix
+airflow:
+  - airflow
+hermes:
+  - hermes
+kafka:
+  - kafka
+postgresql:
+  - postgresql
+mysql:
+  - mysql
+mariadb:
+  - mariadb
+mongodb:
+  - mongodb
+  - mongodb_atlas
+redis:
+  - redis
+snowflake:
+  - snowflake
+clickhouse:
+  - clickhouse
+dagster:
+  - dagster
+rabbitmq:
+  - rabbitmq
+supabase:
+  - supabase
+opensearch:
+  - opensearch
+openobserve:
+  - openobserve
+betterstack:
+  - betterstack
+azure:
+  - azure
+  - azure_sql
+splunk:
+  - splunk
+signoz:
+  - signoz
+jenkins:
+  - jenkins
+tempo:
+  - tempo
+temporal:
+  - temporal

--- a/core/domain/alerts/alert_source.py
+++ b/core/domain/alerts/alert_source.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from pathlib import Path
 from typing import Any
+
+import yaml
 
 # Maps alert_source values to integration source keys (tool `.source` field).
 # Used for broad prioritization/relevance, not automatic pre-seeding.
@@ -44,40 +47,23 @@ ALERT_SOURCE_TO_TOOL_SOURCES: dict[str, tuple[str, ...]] = {
     "temporal": ("temporal",),
 }
 
+
 # Auto-called before the LLM loop starts. Keep this narrower than
 # ALERT_SOURCE_TO_TOOL_SOURCES for expensive or context-dependent tools.
-ALERT_SOURCE_TO_SEED_TOOL_SOURCES: dict[str, tuple[str, ...]] = {
-    "grafana": ("grafana",),
-    "datadog": ("datadog",),
-    "cloudwatch": ("cloudwatch",),
-    "eks": ("eks",),
-    "alertmanager": ("grafana", "cloudwatch"),
-    "sentry": ("sentry",),
-    "honeycomb": ("honeycomb",),
-    "coralogix": ("coralogix",),
-    "airflow": ("airflow",),
-    "hermes": ("hermes",),
-    "kafka": ("kafka",),
-    "postgresql": ("postgresql",),
-    "mysql": ("mysql",),
-    "mariadb": ("mariadb",),
-    "mongodb": ("mongodb", "mongodb_atlas"),
-    "redis": ("redis",),
-    "snowflake": ("snowflake",),
-    "clickhouse": ("clickhouse",),
-    "dagster": ("dagster",),
-    "rabbitmq": ("rabbitmq",),
-    "supabase": ("supabase",),
-    "opensearch": ("opensearch",),
-    "openobserve": ("openobserve",),
-    "betterstack": ("betterstack",),
-    "azure": ("azure", "azure_sql"),
-    "splunk": ("splunk",),
-    "signoz": ("signoz",),
-    "jenkins": ("jenkins",),
-    "tempo": ("tempo",),
-    "temporal": ("temporal",),
-}
+def _load_seed_sources() -> dict[str, tuple[str, ...]]:
+    seed_yaml = Path(__file__).resolve().parents[3] / "config" / "alert_seed_sources.yaml"
+    if seed_yaml.is_file():
+        raw = yaml.safe_load(seed_yaml.read_text(encoding="utf-8"))
+        if isinstance(raw, dict):
+            return {
+                str(k): tuple(str(v) for v in val if isinstance(v, str))
+                for k, val in raw.items()
+                if isinstance(val, list)
+            }
+    return {}
+
+
+ALERT_SOURCE_TO_SEED_TOOL_SOURCES: dict[str, tuple[str, ...]] = _load_seed_sources()
 
 # Generic fallback sources: useful, but never primary when incident-specific
 # integrations match.

--- a/core/domain/alerts/alert_source.py
+++ b/core/domain/alerts/alert_source.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+import warnings
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 # Maps alert_source values to integration source keys (tool `.source` field).
 # Used for broad prioritization/relevance, not automatic pre-seeding.
@@ -51,16 +55,34 @@ ALERT_SOURCE_TO_TOOL_SOURCES: dict[str, tuple[str, ...]] = {
 # Auto-called before the LLM loop starts. Keep this narrower than
 # ALERT_SOURCE_TO_TOOL_SOURCES for expensive or context-dependent tools.
 def _load_seed_sources() -> dict[str, tuple[str, ...]]:
+    # parents[3]: core/domain/alerts/alert_source.py -> core/domain/alerts -> core/domain -> core -> repo root
     seed_yaml = Path(__file__).resolve().parents[3] / "config" / "alert_seed_sources.yaml"
-    if seed_yaml.is_file():
+    if not seed_yaml.is_file():
+        warnings.warn(
+            f"alert_seed_sources.yaml not found at {seed_yaml}; pre-seeding disabled for all alert sources.",
+            stacklevel=2,
+        )
+        return {}
+    try:
         raw = yaml.safe_load(seed_yaml.read_text(encoding="utf-8"))
-        if isinstance(raw, dict):
-            return {
-                str(k): tuple(str(v) for v in val if isinstance(v, str))
-                for k, val in raw.items()
-                if isinstance(val, list)
-            }
-    return {}
+    except (yaml.YAMLError, OSError) as exc:
+        logger.warning(
+            "Failed to load alert_seed_sources.yaml from %s: %s; pre-seeding disabled.",
+            seed_yaml,
+            exc,
+        )
+        return {}
+    if not isinstance(raw, dict):
+        warnings.warn(
+            f"alert_seed_sources.yaml at {seed_yaml} did not parse as a mapping; pre-seeding disabled.",
+            stacklevel=2,
+        )
+        return {}
+    return {
+        str(k): tuple(str(v) for v in val if isinstance(v, str))
+        for k, val in raw.items()
+        if isinstance(val, list)
+    }
 
 
 ALERT_SOURCE_TO_SEED_TOOL_SOURCES: dict[str, tuple[str, ...]] = _load_seed_sources()

--- a/core/tool_framework/registered_tool.py
+++ b/core/tool_framework/registered_tool.py
@@ -32,6 +32,12 @@ def _extract_no_params(_sources: dict[str, dict]) -> dict[str, Any]:
     return {}
 
 
+def _normalize_evidence_noop(
+    _output: dict[str, Any], _tool_input: dict[str, Any]
+) -> dict[str, Any]:
+    return {}
+
+
 def _normalize_surfaces(surfaces: Iterable[str] | None) -> tuple[ToolSurface, ...]:
     if surfaces is None:
         return _DEFAULT_SURFACES
@@ -222,6 +228,10 @@ class RegisteredTool:
     origin_module: str = ""
     origin_name: str = ""
     skill_guidance: str = ""
+    normalize_evidence: Callable[[dict[str, Any], dict[str, Any]], dict[str, Any]] = field(
+        default=_normalize_evidence_noop,
+        repr=False,
+    )
 
     def __post_init__(self) -> None:
         metadata = ToolMetadata.model_validate(
@@ -359,6 +369,8 @@ class RegisteredTool:
         approval_expiry_seconds: int | None = None,
         parallel_safe: bool | None = None,
         accepts_runtime_context: bool | None = None,
+        normalize_evidence: Callable[[dict[str, Any], dict[str, Any]], dict[str, Any]]
+        | None = None,
     ) -> RegisteredTool:
         metadata = tool.metadata()
         input_model = cast(type[BaseModel] | None, getattr(tool, "input_model", None))
@@ -439,6 +451,9 @@ class RegisteredTool:
             ),
             origin_module=tool.__class__.__module__,
             origin_name=tool.__class__.__name__,
+            normalize_evidence=normalize_evidence
+            or getattr(tool, "normalize_evidence", None)
+            or _normalize_evidence_noop,
         )
 
     @classmethod
@@ -475,6 +490,8 @@ class RegisteredTool:
         approval_expiry_seconds: int | None = None,
         parallel_safe: bool | None = None,
         accepts_runtime_context: bool | None = None,
+        normalize_evidence: Callable[[dict[str, Any], dict[str, Any]], dict[str, Any]]
+        | None = None,
     ) -> RegisteredTool:
         if source is None:
             raise ValueError("Function tools must declare a source.")
@@ -519,4 +536,5 @@ class RegisteredTool:
             accepts_runtime_context=bool(accepts_runtime_context),
             origin_module=func.__module__,
             origin_name=func.__name__,
+            normalize_evidence=normalize_evidence or _normalize_evidence_noop,
         )

--- a/core/tool_framework/tool_decorator.py
+++ b/core/tool_framework/tool_decorator.py
@@ -46,6 +46,7 @@ def tool(
     approval_expiry_seconds: int | None = None,
     parallel_safe: bool | None = None,
     accepts_runtime_context: bool | None = None,
+    normalize_evidence: Callable[[dict[str, Any], dict[str, Any]], dict[str, Any]] | None = None,
 ) -> BaseTool:
     pass
 
@@ -83,6 +84,7 @@ def tool[F: Callable[..., Any]](
     approval_expiry_seconds: int | None = None,
     parallel_safe: bool | None = None,
     accepts_runtime_context: bool | None = None,
+    normalize_evidence: Callable[[dict[str, Any], dict[str, Any]], dict[str, Any]] | None = None,
 ) -> F:
     pass
 
@@ -120,6 +122,7 @@ def tool[F: Callable[..., Any]](
     approval_expiry_seconds: int | None = None,
     parallel_safe: bool | None = None,
     accepts_runtime_context: bool | None = None,
+    normalize_evidence: Callable[[dict[str, Any], dict[str, Any]], dict[str, Any]] | None = None,
 ) -> Callable[[F], F]:
     pass
 
@@ -156,6 +159,7 @@ def tool[F: Callable[..., Any]](
     approval_expiry_seconds: int | None = None,
     parallel_safe: bool | None = None,
     accepts_runtime_context: bool | None = None,
+    normalize_evidence: Callable[[dict[str, Any], dict[str, Any]], dict[str, Any]] | None = None,
 ) -> Any:
     """Register a lightweight function tool or annotate an existing BaseTool.
 
@@ -195,6 +199,7 @@ def tool[F: Callable[..., Any]](
                 approval_expiry_seconds is not None,
                 parallel_safe is not None,
                 accepts_runtime_context is not None,
+                normalize_evidence is not None,
             ]
         )
 
@@ -266,6 +271,7 @@ def tool[F: Callable[..., Any]](
                     approval_expiry_seconds=approval_expiry_seconds,
                     parallel_safe=parallel_safe,
                     accepts_runtime_context=accepts_runtime_context,
+                    normalize_evidence=normalize_evidence,
                 ),
             )
         return target

--- a/integrations/grafana/tools/__init__.py
+++ b/integrations/grafana/tools/__init__.py
@@ -50,6 +50,12 @@ def _normalize_backend_alert_rules(raw: dict[str, Any]) -> list[dict[str, Any]]:
     return rules
 
 
+def _normalize_grafana_alert_rules_evidence(
+    output: dict[str, Any], _tool_input: dict[str, Any]
+) -> dict[str, Any]:
+    return {"grafana_alert_rules": output.get("rules", [])}
+
+
 @tool(
     name="query_grafana_alert_rules",
     display_name="Grafana alerts",
@@ -72,6 +78,7 @@ def _normalize_backend_alert_rules(raw: dict[str, Any]) -> list[dict[str, Any]]:
     },
     is_available=_query_grafana_alert_rules_available,
     extract_params=_query_grafana_alert_rules_extract_params,
+    normalize_evidence=_normalize_grafana_alert_rules_evidence,
 )
 def query_grafana_alert_rules(
     folder: str | None = None,
@@ -346,6 +353,17 @@ def _query_grafana_logs_available(sources: dict[str, dict]) -> bool:
     return _grafana_available(sources)
 
 
+def _normalize_grafana_logs_evidence(
+    output: dict[str, Any], _tool_input: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "grafana_logs": output.get("logs", []),
+        "grafana_error_logs": output.get("error_logs", []),
+        "grafana_logs_query": output.get("query", ""),
+        "grafana_logs_service": output.get("service_name", ""),
+    }
+
+
 @tool(
     name="query_grafana_logs",
     display_name="Grafana Loki",
@@ -374,6 +392,7 @@ def _query_grafana_logs_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_query_grafana_logs_available,
     extract_params=_query_grafana_logs_extract_params,
+    normalize_evidence=_normalize_grafana_logs_evidence,
 )
 def query_grafana_logs(
     service_name: str,
@@ -526,6 +545,18 @@ def _query_grafana_metrics_available(sources: dict[str, dict]) -> bool:
     return _grafana_available(sources)
 
 
+def _normalize_grafana_metrics_evidence(
+    output: dict[str, Any], tool_input: dict[str, Any]
+) -> dict[str, Any]:
+    metric_name = str(output.get("metric_name") or tool_input.get("metric_name") or "")
+    result: dict[str, Any] = {
+        "grafana_metrics": output.get("metrics", []),
+    }
+    if metric_name:
+        result["grafana_metric_results"] = {metric_name: output}
+    return result
+
+
 @tool(
     name="query_grafana_metrics",
     display_name="Grafana Mimir",
@@ -556,6 +587,7 @@ def _query_grafana_metrics_available(sources: dict[str, dict]) -> bool:
     ),
     is_available=_query_grafana_metrics_available,
     extract_params=_query_grafana_metrics_extract_params,
+    normalize_evidence=_normalize_grafana_metrics_evidence,
 )
 def query_grafana_metrics(
     metric_name: str,
@@ -633,6 +665,12 @@ def _query_grafana_service_names_available(sources: dict[str, dict]) -> bool:
     return _grafana_available(sources)
 
 
+def _normalize_grafana_service_names_evidence(
+    output: dict[str, Any], _tool_input: dict[str, Any]
+) -> dict[str, Any]:
+    return {"grafana_service_names": output.get("service_names", [])}
+
+
 @tool(
     name="query_grafana_service_names",
     source="grafana",
@@ -652,6 +690,7 @@ def _query_grafana_service_names_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_query_grafana_service_names_available,
     extract_params=_query_grafana_service_names_extract_params,
+    normalize_evidence=_normalize_grafana_service_names_evidence,
 )
 def query_grafana_service_names(
     grafana_endpoint: str | None = None,
@@ -713,6 +752,15 @@ def _query_grafana_traces_available(sources: dict[str, dict]) -> bool:
     return _grafana_available(sources)
 
 
+def _normalize_grafana_traces_evidence(
+    output: dict[str, Any], _tool_input: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "grafana_traces": output.get("traces", []),
+        "grafana_pipeline_spans": output.get("pipeline_spans", []),
+    }
+
+
 @tool(
     name="query_grafana_traces",
     display_name="Grafana Tempo",
@@ -737,6 +785,7 @@ def _query_grafana_traces_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_query_grafana_traces_available,
     extract_params=_query_grafana_traces_extract_params,
+    normalize_evidence=_normalize_grafana_traces_evidence,
 )
 def query_grafana_traces(
     service_name: str,

--- a/tests/tools/investigation/stages/gather_evidence/test_tool_evidence_normalize.py
+++ b/tests/tools/investigation/stages/gather_evidence/test_tool_evidence_normalize.py
@@ -1,0 +1,202 @@
+"""Unit tests for tool-owned evidence normalization."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from integrations.grafana.tools import (
+    _normalize_grafana_alert_rules_evidence,
+    _normalize_grafana_logs_evidence,
+    _normalize_grafana_metrics_evidence,
+    _normalize_grafana_service_names_evidence,
+    _normalize_grafana_traces_evidence,
+)
+
+
+class TestGrafanaLogsNormalize:
+    def test_extracts_logs_and_error_logs(self) -> None:
+        output = {
+            "logs": [{"message": "error occurred", "level": "ERROR"}],
+            "error_logs": [{"message": "error occurred"}],
+            "query": '{service_name="api"}',
+            "service_name": "api",
+        }
+        result = _normalize_grafana_logs_evidence(output, {})
+        assert result["grafana_logs"] == output["logs"]
+        assert result["grafana_error_logs"] == output["error_logs"]
+        assert result["grafana_logs_query"] == output["query"]
+        assert result["grafana_logs_service"] == output["service_name"]
+
+    def test_handles_empty_output(self) -> None:
+        result = _normalize_grafana_logs_evidence({}, {})
+        assert result["grafana_logs"] == []
+        assert result["grafana_error_logs"] == []
+        assert result["grafana_logs_query"] == ""
+        assert result["grafana_logs_service"] == ""
+
+
+class TestGrafanaMetricsNormalize:
+    def test_extracts_metrics_and_metric_results(self) -> None:
+        output: dict[str, Any] = {
+            "metric_name": "pipeline_runs_total",
+            "metrics": [{"value": 42}],
+        }
+        result = _normalize_grafana_metrics_evidence(output, {})
+        assert result["grafana_metrics"] == output["metrics"]
+        assert "grafana_metric_results" in result
+        assert "pipeline_runs_total" in result["grafana_metric_results"]
+        assert result["grafana_metric_results"]["pipeline_runs_total"] == output
+
+    def test_uses_input_metric_name_fallback(self) -> None:
+        output: dict[str, Any] = {"metrics": [{"value": 99}]}
+        tool_input: dict[str, Any] = {"metric_name": "cpu_usage"}
+        result = _normalize_grafana_metrics_evidence(output, tool_input)
+        assert result["grafana_metrics"] == output["metrics"]
+        assert "cpu_usage" in result["grafana_metric_results"]
+
+    def test_skips_metric_results_without_name(self) -> None:
+        output: dict[str, Any] = {"metrics": []}
+        result = _normalize_grafana_metrics_evidence(output, {})
+        assert result["grafana_metrics"] == []
+        assert "grafana_metric_results" not in result
+
+
+class TestGrafanaTracesNormalize:
+    def test_extracts_traces_and_pipeline_spans(self) -> None:
+        output: dict[str, Any] = {
+            "traces": [{"trace_id": "abc123"}],
+            "pipeline_spans": [{"span_id": "span1"}],
+        }
+        result = _normalize_grafana_traces_evidence(output, {})
+        assert result["grafana_traces"] == output["traces"]
+        assert result["grafana_pipeline_spans"] == output["pipeline_spans"]
+
+    def test_handles_empty_output(self) -> None:
+        result = _normalize_grafana_traces_evidence({}, {})
+        assert result["grafana_traces"] == []
+        assert result["grafana_pipeline_spans"] == []
+
+
+class TestGrafanaAlertRulesNormalize:
+    def test_extracts_rules(self) -> None:
+        output: dict[str, Any] = {
+            "rules": [{"name": "High CPU Alert", "state": "firing"}],
+        }
+        result = _normalize_grafana_alert_rules_evidence(output, {})
+        assert result["grafana_alert_rules"] == output["rules"]
+
+    def test_handles_empty_output(self) -> None:
+        result = _normalize_grafana_alert_rules_evidence({}, {})
+        assert result["grafana_alert_rules"] == []
+
+
+class TestGrafanaServiceNamesNormalize:
+    def test_extracts_service_names(self) -> None:
+        output: dict[str, Any] = {
+            "service_names": ["api", "worker", "web"],
+        }
+        result = _normalize_grafana_service_names_evidence(output, {})
+        assert result["grafana_service_names"] == output["service_names"]
+
+    def test_handles_empty_output(self) -> None:
+        result = _normalize_grafana_service_names_evidence({}, {})
+        assert result["grafana_service_names"] == []
+
+
+class TestMergeToolEvidence:
+    """Integration-level test of merge_tool_evidence with real RegisteredTool objects."""
+
+    def test_merges_tool_owned_evidence_keys(self) -> None:
+        from core.tool_framework.registered_tool import (
+            _always_available,
+            _extract_no_params,
+            RegisteredTool,
+        )
+        from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
+
+        tool = RegisteredTool(
+            name="query_grafana_logs",
+            description="Test tool",
+            input_schema={"type": "object", "properties": {}, "required": []},
+            source="grafana",
+            run=lambda **kw: {},
+            is_available=_always_available,
+            extract_params=_extract_no_params,
+            normalize_evidence=_normalize_grafana_logs_evidence,
+        )
+        evidence: dict[str, Any] = {}
+        output = {
+            "logs": [{"msg": "log1"}],
+            "error_logs": [{"msg": "err1"}],
+            "query": "test query",
+            "service_name": "svc",
+        }
+        merge_tool_evidence(evidence, "query_grafana_logs", output, {}, [tool])
+        assert evidence["grafana_logs"] == output["logs"]
+        assert evidence["grafana_error_logs"] == output["error_logs"]
+        assert evidence["grafana_logs_query"] == output["query"]
+        assert evidence["grafana_logs_service"] == output["service_name"]
+        assert evidence["query_grafana_logs"] == output
+
+    def test_preserves_generic_tool_output_and_tool_outputs_list(self) -> None:
+        from core.tool_framework.registered_tool import (
+            _always_available,
+            _extract_no_params,
+            RegisteredTool,
+        )
+        from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
+
+        tool = RegisteredTool(
+            name="query_grafana_logs",
+            description="Test tool",
+            input_schema={"type": "object", "properties": {}, "required": []},
+            source="grafana",
+            run=lambda **kw: {},
+            is_available=_always_available,
+            extract_params=_extract_no_params,
+            normalize_evidence=_normalize_grafana_logs_evidence,
+        )
+        evidence: dict[str, Any] = {}
+        output = {"logs": []}
+        merge_tool_evidence(evidence, "query_grafana_logs", output, {}, [tool])
+        assert evidence["query_grafana_logs"] == output
+        assert "tool_outputs" in evidence
+        assert len(evidence["tool_outputs"]) == 1
+
+    def test_noop_when_tool_not_in_list(self) -> None:
+        from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
+
+        evidence: dict[str, Any] = {}
+        output = {"logs": [{"msg": "test"}]}
+        merge_tool_evidence(evidence, "query_grafana_logs", output, {}, [])
+        assert "grafana_logs" not in evidence
+        assert evidence["query_grafana_logs"] == output
+
+    def test_accumulates_metric_results_across_calls(self) -> None:
+        from core.tool_framework.registered_tool import (
+            _always_available,
+            _extract_no_params,
+            RegisteredTool,
+        )
+        from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
+
+        tool = RegisteredTool(
+            name="query_grafana_metrics",
+            description="Test tool",
+            input_schema={"type": "object", "properties": {}, "required": []},
+            source="grafana",
+            run=lambda **kw: {},
+            is_available=_always_available,
+            extract_params=_extract_no_params,
+            normalize_evidence=_normalize_grafana_metrics_evidence,
+        )
+        evidence: dict[str, Any] = {}
+        output1: dict[str, Any] = {"metric_name": "cpu", "metrics": [{"v": 1}]}
+        output2: dict[str, Any] = {"metric_name": "mem", "metrics": [{"v": 2}]}
+        merge_tool_evidence(evidence, "query_grafana_metrics", output1, {}, [tool])
+        merge_tool_evidence(evidence, "query_grafana_metrics", output2, {}, [tool])
+        assert "cpu" in evidence["grafana_metric_results"]
+        assert "mem" in evidence["grafana_metric_results"]
+        assert len(evidence["grafana_metric_results"]) == 2

--- a/tests/tools/investigation/stages/gather_evidence/test_tool_evidence_normalize.py
+++ b/tests/tools/investigation/stages/gather_evidence/test_tool_evidence_normalize.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
 from integrations.grafana.tools import (
     _normalize_grafana_alert_rules_evidence,
     _normalize_grafana_logs_evidence,
@@ -110,9 +108,9 @@ class TestMergeToolEvidence:
 
     def test_merges_tool_owned_evidence_keys(self) -> None:
         from core.tool_framework.registered_tool import (
+            RegisteredTool,
             _always_available,
             _extract_no_params,
-            RegisteredTool,
         )
         from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
 
@@ -121,7 +119,7 @@ class TestMergeToolEvidence:
             description="Test tool",
             input_schema={"type": "object", "properties": {}, "required": []},
             source="grafana",
-            run=lambda **kw: {},
+            run=lambda **_: {},
             is_available=_always_available,
             extract_params=_extract_no_params,
             normalize_evidence=_normalize_grafana_logs_evidence,
@@ -142,9 +140,9 @@ class TestMergeToolEvidence:
 
     def test_preserves_generic_tool_output_and_tool_outputs_list(self) -> None:
         from core.tool_framework.registered_tool import (
+            RegisteredTool,
             _always_available,
             _extract_no_params,
-            RegisteredTool,
         )
         from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
 
@@ -153,7 +151,7 @@ class TestMergeToolEvidence:
             description="Test tool",
             input_schema={"type": "object", "properties": {}, "required": []},
             source="grafana",
-            run=lambda **kw: {},
+            run=lambda **_: {},
             is_available=_always_available,
             extract_params=_extract_no_params,
             normalize_evidence=_normalize_grafana_logs_evidence,
@@ -176,9 +174,9 @@ class TestMergeToolEvidence:
 
     def test_accumulates_metric_results_across_calls(self) -> None:
         from core.tool_framework.registered_tool import (
+            RegisteredTool,
             _always_available,
             _extract_no_params,
-            RegisteredTool,
         )
         from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
 
@@ -187,7 +185,7 @@ class TestMergeToolEvidence:
             description="Test tool",
             input_schema={"type": "object", "properties": {}, "required": []},
             source="grafana",
-            run=lambda **kw: {},
+            run=lambda **_: {},
             is_available=_always_available,
             extract_params=_extract_no_params,
             normalize_evidence=_normalize_grafana_metrics_evidence,

--- a/tools/investigation/stages/gather_evidence/agent.py
+++ b/tools/investigation/stages/gather_evidence/agent.py
@@ -173,7 +173,7 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
 
             for tc, output in zip(seed_calls, seed_results):
                 tool_call_cache.store(tool_call_signature(tc), output, loop_iteration=-1)
-                merge_tool_evidence(evidence, tc.name, output, tc.input)
+                merge_tool_evidence(evidence, tc.name, output, tc.input, tools)
                 evidence_entries.append(
                     EvidenceEntry(
                         key=tc.name,
@@ -291,7 +291,7 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
                 if is_dup:
                     debug_print(f"[{tc.name}] → duplicate call suppressed")
                     continue
-                merge_tool_evidence(evidence, tc.name, output, tc.input)
+                merge_tool_evidence(evidence, tc.name, output, tc.input, tools)
                 evidence_entries.append(
                     EvidenceEntry(
                         key=tc.name,

--- a/tools/investigation/stages/gather_evidence/tools.py
+++ b/tools/investigation/stages/gather_evidence/tools.py
@@ -241,8 +241,14 @@ def merge_tool_evidence(
     tool_name: str,
     output: Any,
     tool_input: dict[str, Any],
+    tools: list[RegisteredTool],
 ) -> None:
-    """Store raw tool output and the legacy report-facing evidence keys."""
+    """Store raw tool output and tool-owned evidence keys.
+
+    Tool-specific evidence keys are delegated to each tool's
+    ``normalize_evidence(output, tool_input)`` method, keeping the evidence
+    logic alongside the tool that owns it instead of in a central chain.
+    """
     evidence[tool_name] = output
     tool_outputs = evidence.setdefault("tool_outputs", [])
     if isinstance(tool_outputs, list):
@@ -257,29 +263,23 @@ def merge_tool_evidence(
     if not isinstance(output, dict):
         return
 
-    if tool_name == "query_grafana_logs":
-        evidence["grafana_logs"] = output.get("logs", [])
-        evidence["grafana_error_logs"] = output.get("error_logs", [])
-        evidence["grafana_logs_query"] = output.get("query", "")
-        evidence["grafana_logs_service"] = output.get("service_name", "")
+    tool = _find_tool(tools, tool_name)
+    if tool is None:
         return
 
-    if tool_name == "query_grafana_metrics":
-        metric_name = str(output.get("metric_name") or tool_input.get("metric_name") or "")
-        metric_results = evidence.setdefault("grafana_metric_results", {})
-        if isinstance(metric_results, dict) and metric_name:
-            metric_results[metric_name] = output
-        evidence["grafana_metrics"] = output.get("metrics", [])
+    normalized = tool.normalize_evidence(output, tool_input)
+    if not normalized:
         return
 
-    if tool_name == "query_grafana_traces":
-        evidence["grafana_traces"] = output.get("traces", [])
-        evidence["grafana_pipeline_spans"] = output.get("pipeline_spans", [])
-        return
+    for key, value in normalized.items():
+        if isinstance(value, dict) and isinstance(evidence.get(key), dict):
+            evidence[key].update(value)
+        else:
+            evidence[key] = value
 
-    if tool_name == "query_grafana_alert_rules":
-        evidence["grafana_alert_rules"] = output.get("rules", [])
-        return
 
-    if tool_name == "query_grafana_service_names":
-        evidence["grafana_service_names"] = output.get("service_names", [])
+def _find_tool(tools: list[RegisteredTool], name: str) -> RegisteredTool | None:
+    for tool in tools:
+        if tool.name == name:
+            return tool
+    return None


### PR DESCRIPTION
## Summary

Replace the central `if tool_name ==` chain in `merge_tool_evidence()` with a per-tool `normalize_evidence()` method on `RegisteredTool`.

Closes #3687

## Changes

### P1 — Tool-owned normalization
- Add `normalize_evidence(output, tool_input) -> dict` field to `RegisteredTool`
- Implement `normalize_evidence` for each of the 5 Grafana tools (logs, metrics, traces, alert_rules, service_names)
- Remove the vendor-specific `if tool_name ==` chain from `merge_tool_evidence()`
- The gather loop now calls `tool.normalize_evidence(result)` generically

### P2 — Seed policy as data
- Move `ALERT_SOURCE_TO_SEED_TOOL_SOURCES` dict to `config/alert_seed_sources.yaml`
- Load at module import time via `yaml.safe_load()`
- Existing importers continue to use the same module-level variable unchanged

### Tests
- Add 15 unit tests covering each Grafana tool's normalize function
- Test integration-level `merge_tool_evidence` with real `RegisteredTool` objects
- Test metric result accumulation across multiple calls
- No-op behavior when tool is not in the available list

## Verification

```
$ ruff check <changed files>
All checks passed!

$ mypy <changed files>
Success: no issues found in 6 source files

$ pytest tests/tools/investigation/ tests/tools/test_tool_selection_contracts.py tests/core/agent/test_tool_registry.py
96 passed

$ pytest tests/tools/investigation/stages/gather_evidence/test_tool_evidence_normalize.py
15 passed

$ pytest tests/synthetic/test_signoz_scenario.py tests/synthetic/test_tempo_scenario.py tests/synthetic/test_jenkins_scenario.py tests/synthetic/test_dagster_scenario.py tests/synthetic/test_temporal_scenario.py tests/tools/test_cloudtrail_events.py
36 passed, 17 deselected
```

### AI-assisted PR disclosure
This PR was implemented with AI assistance (Paperclip) and manually reviewed line-by-line.