### PR TITLE
refactor(agent_harness): extract headless in-memory adapters from dispatch

### DIFF
--- a/core/agent_harness/turns/headless_adapters.py
+++ b/core/agent_harness/turns/headless_adapters.py
@@ -1,3 +1,9 @@
+"""In-memory port adapters for headless agent runs.
+
+These adapters implement core.agent_harness.ports interfaces without
+external side effects (no IO, no network, no filesystem).
+"""
+
 from __future__ import annotations
 
 from collections.abc import Iterable

--- a/core/agent_harness/turns/headless_adapters.py
+++ b/core/agent_harness/turns/headless_adapters.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+from core.agent_harness.models.turn_results import (
+    ShellTurnResult,
+    ToolCallingTurnResult,
+)
+from core.agent_harness.ports import (
+    ConfirmFn,
+    ToolEventObserver,
+)
+
+
+@dataclass
+class InMemorySessionStore:
+    """List-backed :class:`core.agent_harness.ports.SessionStore` for headless runs."""
+
+    session_id: str = "headless"
+    cli_agent_messages: list[tuple[str, str]] = field(default_factory=list)
+    configured_integrations: list[str] = field(default_factory=list)
+    configured_integrations_known: bool = False
+    last_state: dict[str, Any] | None = None
+    last_synthetic_observation_path: str | None = None
+    reasoning_effort: Any | None = None
+    history: list[dict[str, Any]] = field(default_factory=list)
+    last_command_observation: str | None = None
+    resolved_integrations_cache: dict[str, Any] | None = None
+    github_repo_scope: tuple[str, str] | None = None
+    records: list[tuple[str, str, bool]] = field(default_factory=list)
+
+    def record(self, kind: str, text: str, *, ok: bool = True) -> None:
+        self.records.append((kind, text, ok))
+
+
+@dataclass
+class BufferOutputSink:
+    """Collects all output into ``lines`` / ``streamed`` for inspection."""
+
+    lines: list[str] = field(default_factory=list)
+    streamed: list[str] = field(default_factory=list)
+
+    def print(self, message: str = "") -> None:
+        self.lines.append(message)
+
+    def render_response_header(self, label: str) -> None:
+        self.lines.append(f"[{label}]")
+
+    def render_error(self, message: str) -> None:
+        self.lines.append(f"ERROR: {message}")
+
+    def stream(
+        self,
+        *,
+        label: str,
+        chunks: Iterable[str],
+        suppress_if_starts_with: str | None = None,
+    ) -> str:
+        _ = (label, suppress_if_starts_with)
+        text = "".join(str(chunk) for chunk in chunks)
+        self.streamed.append(text)
+        return text
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self.lines)
+
+
+class EmptyPromptContextProvider:
+    """Grounding provider that supplies no corpora (headless)."""
+
+    def cli_reference(self) -> str:
+        return ""
+
+    def agents_md(self) -> str:
+        return ""
+
+    def investigation_flow(self) -> str:
+        return ""
+
+    def environment_block(self) -> str:
+        return ""
+
+    def suggested_synthetic_prompt(self) -> str:
+        return ""
+
+    def log_diagnostics(self, reason: str) -> None:
+        _ = reason
+
+
+class NullToolProvider:
+    """Provides no action tools and a no-op tool-event observer."""
+
+    def action_tools(
+        self,
+        *,
+        confirm_fn: ConfirmFn | None,
+        is_tty: bool | None,
+        resolved_integrations: dict[str, Any] | None = None,
+    ) -> list[Any]:
+        _ = (confirm_fn, is_tty, resolved_integrations)
+        return []
+
+    def tool_resources(self) -> dict[str, Any]:
+        return {}
+
+    def observer(self, *, message: str) -> ToolEventObserver:
+        _ = message
+
+        def _observer(_kind: str, _data: dict[str, Any]) -> None:
+            return None
+
+        return _observer
+
+
+class NoopTurnAccounting:
+    """Records nothing and returns the result unchanged."""
+
+    def record_action_result(self, action_result: ToolCallingTurnResult) -> None:
+        _ = action_result
+
+    def finalize(self, result: ShellTurnResult) -> ShellTurnResult:
+        return result
+
+
+class NoopErrorReporter:
+    """Swallows reported exceptions (headless)."""
+
+    def report(self, exc: BaseException, *, context: str, expected: bool = False) -> None:
+        _ = (exc, context, expected)
+
+
+@dataclass
+class SimpleRunRecord:
+    """Opaque conversational-LLM run record for headless runs."""
+
+    response_text: str
+    prompt: str = ""
+    started: float = 0.0
+
+
+class SimpleRunRecordFactory:
+    """Builds :class:`SimpleRunRecord` values."""
+
+    def build(
+        self, *, client: Any, prompt: str, response_text: str, started: float
+    ) -> SimpleRunRecord:
+        _ = client
+        return SimpleRunRecord(response_text=response_text, prompt=prompt, started=started)
+
+
+@dataclass
+class StaticReasoningClientProvider:
+    """Provides a fixed reasoning client (or None to skip the assistant)."""
+
+    client: Any | None = None
+
+    def get(self) -> Any | None:
+        return self.client

--- a/core/agent_harness/turns/headless_dispatch.py
+++ b/core/agent_harness/turns/headless_dispatch.py
@@ -28,10 +28,6 @@ Example::
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-from dataclasses import dataclass, field
-from typing import Any
-
 from core.agent_harness.models.turn_results import ShellTurnResult, ToolCallingTurnResult
 from core.agent_harness.ports import (
     ConfirmFn,
@@ -41,7 +37,6 @@ from core.agent_harness.ports import (
     ReasoningClientProvider,
     RunRecordFactory,
     SessionStore,
-    ToolEventObserver,
     ToolProvider,
     TurnAccounting,
 )
@@ -52,156 +47,20 @@ from core.agent_harness.providers.default_prompt_context import (
 from core.agent_harness.providers.default_providers import DefaultTurnAccounting
 from core.agent_harness.turns.action_driver import run_action_agent_turn
 from core.agent_harness.turns.evidence_driver import gather_tool_evidence
+from core.agent_harness.turns.headless_adapters import (
+    BufferOutputSink,
+    EmptyPromptContextProvider,
+    InMemorySessionStore,
+    NoopErrorReporter,
+    NoopTurnAccounting,
+    NullToolProvider,
+    SimpleRunRecord,
+    SimpleRunRecordFactory,
+    StaticReasoningClientProvider,
+)
 from core.agent_harness.turns.orchestrator import run_turn, stream_answer
 from core.agent_harness.turns.turn_plan import TurnPlan
 from core.execution import ToolExecutionHooks
-
-
-@dataclass
-class InMemorySessionStore:
-    """List-backed :class:`core.agent_harness.ports.SessionStore` for headless runs."""
-
-    session_id: str = "headless"
-    cli_agent_messages: list[tuple[str, str]] = field(default_factory=list)
-    configured_integrations: list[str] = field(default_factory=list)
-    configured_integrations_known: bool = False
-    last_state: dict[str, Any] | None = None
-    last_synthetic_observation_path: str | None = None
-    reasoning_effort: Any | None = None
-    history: list[dict[str, Any]] = field(default_factory=list)
-    last_command_observation: str | None = None
-    resolved_integrations_cache: dict[str, Any] | None = None
-    github_repo_scope: tuple[str, str] | None = None
-    records: list[tuple[str, str, bool]] = field(default_factory=list)
-
-    def record(self, kind: str, text: str, *, ok: bool = True) -> None:
-        self.records.append((kind, text, ok))
-
-
-@dataclass
-class BufferOutputSink:
-    """Collects all output into ``lines`` / ``streamed`` for inspection."""
-
-    lines: list[str] = field(default_factory=list)
-    streamed: list[str] = field(default_factory=list)
-
-    def print(self, message: str = "") -> None:
-        self.lines.append(message)
-
-    def render_response_header(self, label: str) -> None:
-        self.lines.append(f"[{label}]")
-
-    def render_error(self, message: str) -> None:
-        self.lines.append(f"ERROR: {message}")
-
-    def stream(
-        self,
-        *,
-        label: str,
-        chunks: Iterable[str],
-        suppress_if_starts_with: str | None = None,
-    ) -> str:
-        _ = (label, suppress_if_starts_with)
-        text = "".join(str(chunk) for chunk in chunks)
-        self.streamed.append(text)
-        return text
-
-    @property
-    def text(self) -> str:
-        return "\n".join(self.lines)
-
-
-class EmptyPromptContextProvider:
-    """Grounding provider that supplies no corpora (headless)."""
-
-    def cli_reference(self) -> str:
-        return ""
-
-    def agents_md(self) -> str:
-        return ""
-
-    def investigation_flow(self) -> str:
-        return ""
-
-    def environment_block(self) -> str:
-        return ""
-
-    def suggested_synthetic_prompt(self) -> str:
-        return ""
-
-    def log_diagnostics(self, reason: str) -> None:
-        _ = reason
-
-
-class NullToolProvider:
-    """Provides no action tools and a no-op tool-event observer."""
-
-    def action_tools(
-        self,
-        *,
-        confirm_fn: ConfirmFn | None,
-        is_tty: bool | None,
-        resolved_integrations: dict[str, Any] | None = None,
-    ) -> list[Any]:
-        _ = (confirm_fn, is_tty, resolved_integrations)
-        return []
-
-    def tool_resources(self) -> dict[str, Any]:
-        return {}
-
-    def observer(self, *, message: str) -> ToolEventObserver:
-        _ = message
-
-        def _observer(_kind: str, _data: dict[str, Any]) -> None:
-            return None
-
-        return _observer
-
-
-class NoopTurnAccounting:
-    """Records nothing and returns the result unchanged."""
-
-    def record_action_result(self, action_result: ToolCallingTurnResult) -> None:
-        _ = action_result
-
-    def finalize(self, result: ShellTurnResult) -> ShellTurnResult:
-        return result
-
-
-class NoopErrorReporter:
-    """Swallows reported exceptions (headless)."""
-
-    def report(self, exc: BaseException, *, context: str, expected: bool = False) -> None:
-        _ = (exc, context, expected)
-
-
-@dataclass
-class SimpleRunRecord:
-    """Opaque conversational-LLM run record for headless runs."""
-
-    response_text: str
-    prompt: str = ""
-    started: float = 0.0
-
-
-class SimpleRunRecordFactory:
-    """Builds :class:`SimpleRunRecord` values."""
-
-    def build(
-        self, *, client: Any, prompt: str, response_text: str, started: float
-    ) -> SimpleRunRecord:
-        _ = client
-        return SimpleRunRecord(response_text=response_text, prompt=prompt, started=started)
-
-
-@dataclass
-class StaticReasoningClientProvider:
-    """Provides a fixed reasoning client (or None to skip the assistant)."""
-
-    client: Any | None = None
-
-    def get(self) -> Any | None:
-        return self.client
 
 
 def dispatch_message_to_headless_agent(


### PR DESCRIPTION
Closes #3736

## Summary
This PR refactors `core/agent_harness/turns/headless_dispatch.py` by extracting all in-memory adapter implementations into a new module `headless_adapters.py`.

The goal is to separate orchestration logic from infrastructure/test adapters while keeping full backward compatibility and zero behavior change.

## Changes

### Moved to `headless_adapters.py`
- InMemorySessionStore
- BufferOutputSink
- EmptyPromptContextProvider
- NullToolProvider
- NoopTurnAccounting
- NoopErrorReporter
- SimpleRunRecord
- SimpleRunRecordFactory
- StaticReasoningClientProvider

### Updated `headless_dispatch.py`
- Removed embedded adapter implementations
- Kept only orchestration logic in `dispatch_message_to_headless_agent`
- Imported adapters from `headless_adapters.py`
- Preserved public API via `__all__`

## Why this change
Previously, headless dispatch mixed orchestration logic with in-memory adapter implementations. This made the module harder to maintain and blurred the separation between execution logic and test infrastructure.

This refactor improves modularity and clarifies responsibilities without changing runtime behavior.

## Testing
- pytest: 115/115 tests passing
- ruff format & lint: clean