### PR TITLE
fix(core/llm): strip _opensre_* markers before provider API calls

### DIFF
--- a/core/context_budget.py
+++ b/core/context_budget.py
@@ -38,6 +38,19 @@ _PINNED_MESSAGE_KEY = "_opensre_seed"
 _DUPLICATE_RESULT_KEY = "_opensre_duplicate_result"
 
 
+def strip_internal_message_markers(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return a copy of ``messages`` without internal ``_opensre_*`` keys.
+
+    Context-budget eviction tags seed and duplicate tool exchanges with these
+    markers. They must remain on the in-memory transcript for trimming heuristics
+    but are rejected by strict provider message schemas (e.g. Anthropic).
+    """
+    return [
+        {key: value for key, value in message.items() if not key.startswith("_opensre_")}
+        for message in messages
+    ]
+
+
 @dataclass(frozen=True)
 class _ToolExchange:
     start: int

--- a/core/llm/sdk/agent_clients.py
+++ b/core/llm/sdk/agent_clients.py
@@ -13,6 +13,7 @@ import time
 from collections.abc import Callable
 from typing import Any
 
+from core.context_budget import strip_internal_message_markers
 from core.llm.llm_retry import (
     maybe_raise_credit_exhausted,
     rate_limit_sleep_seconds,
@@ -97,7 +98,7 @@ class AnthropicAgentClient:
         kwargs: dict[str, Any] = {
             "model": self._model,
             "max_tokens": self._max_tokens,
-            "messages": messages,
+            "messages": strip_internal_message_markers(messages),
         }
         if system:
             kwargs["system"] = system
@@ -329,7 +330,7 @@ class BedrockConverseAgentClient:
         from platform.guardrails.apply import apply_guardrails_to_converse_payload
         from platform.guardrails.engine import GuardrailBlockedError
 
-        converse_messages = to_converse_messages(messages)
+        converse_messages = to_converse_messages(strip_internal_message_markers(messages))
         converse_messages, system = apply_guardrails_to_converse_payload(
             messages=converse_messages,
             system=system,

--- a/core/llm/sdk/agent_clients.py
+++ b/core/llm/sdk/agent_clients.py
@@ -494,7 +494,7 @@ class OpenAIAgentClient:
             RateLimitError,
         )
 
-        msgs = list(messages)
+        msgs = strip_internal_message_markers(messages)
         if system:
             msgs = [{"role": "system", "content": system}] + msgs
 

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -250,9 +250,7 @@ def test_openai_agent_client_invoke_strips_internal_message_markers(
 
     client = OpenAIAgentClient.__new__(OpenAIAgentClient)
     client._client = types.SimpleNamespace(
-        chat=types.SimpleNamespace(
-            completions=types.SimpleNamespace(create=capture_create)
-        )
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=capture_create))
     )
     client._model = "gpt-4o"
     client._max_tokens = 1024

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -237,6 +237,50 @@ def test_anthropic_invoke_strips_internal_message_markers(
     assert messages[1]["_opensre_seed"] is True
 
 
+def test_openai_agent_client_invoke_strips_internal_message_markers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_openai(monkeypatch)
+
+    captured: dict[str, Any] = {}
+
+    def capture_create(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return _make_fake_openai_response(content="ok")
+
+    client = OpenAIAgentClient.__new__(OpenAIAgentClient)
+    client._client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=capture_create)
+        )
+    )
+    client._model = "gpt-4o"
+    client._max_tokens = 1024
+
+    messages = [
+        {"role": "user", "content": "alert"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "seed", "type": "function", "function": {"name": "n", "arguments": "{}"}},
+            ],
+            "_opensre_seed": True,
+        },
+    ]
+    client.invoke(messages=messages)
+
+    api_messages = captured["messages"]
+    assert api_messages[1] == {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": "seed", "type": "function", "function": {"name": "n", "arguments": "{}"}},
+        ],
+    }
+    assert messages[1]["_opensre_seed"] is True
+
+
 def test_anthropic_credit_balance_too_low_raises_LLMCreditExhaustedError(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -201,6 +201,42 @@ def test_anthropic_rate_limit_error_is_retried_then_raises(
     )
 
 
+def test_anthropic_invoke_strips_internal_message_markers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    captured: dict[str, Any] = {}
+
+    def capture_create(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return types.SimpleNamespace(
+            content=[types.SimpleNamespace(type="text", text="ok")],
+            usage=types.SimpleNamespace(input_tokens=1, output_tokens=1),
+        )
+
+    client = AnthropicAgentClient(model="claude-sonnet-4-6")
+    client._client = types.SimpleNamespace(messages=types.SimpleNamespace(create=capture_create))
+
+    messages = [
+        {"role": "user", "content": "alert"},
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "seed", "name": "n", "input": {}}],
+            "_opensre_seed": True,
+        },
+    ]
+    client.invoke(messages=messages)
+
+    api_messages = captured["messages"]
+    assert api_messages[1] == {
+        "role": "assistant",
+        "content": [{"type": "tool_use", "id": "seed", "name": "n", "input": {}}],
+    }
+    assert messages[1]["_opensre_seed"] is True
+
+
 def test_anthropic_credit_balance_too_low_raises_LLMCreditExhaustedError(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/test_context_budget.py
+++ b/tests/core/test_context_budget.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from core.context_budget import strip_internal_message_markers
+
+
+def test_strip_internal_message_markers_removes_opensre_keys() -> None:
+    messages = [
+        {"role": "user", "content": "alert"},
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "seed", "name": "n", "input": {}}],
+            "_opensre_seed": True,
+        },
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "seed", "content": "ok"}],
+            "_opensre_seed": True,
+            "_opensre_duplicate_result": True,
+        },
+    ]
+
+    cleaned = strip_internal_message_markers(messages)
+
+    assert cleaned[0] == messages[0]
+    assert cleaned[1] == {
+        "role": "assistant",
+        "content": [{"type": "tool_use", "id": "seed", "name": "n", "input": {}}],
+    }
+    assert cleaned[2] == {
+        "role": "user",
+        "content": [{"type": "tool_result", "tool_use_id": "seed", "content": "ok"}],
+    }
+    assert messages[1]["_opensre_seed"] is True
+    assert messages[2]["_opensre_duplicate_result"] is True
+
+
+def test_strip_internal_message_markers_preserves_other_underscore_keys() -> None:
+    messages = [{"role": "user", "content": "hi", "_custom": "keep"}]
+
+    cleaned = strip_internal_message_markers(messages)
+
+    assert cleaned == [{"role": "user", "content": "hi", "_custom": "keep"}]


### PR DESCRIPTION
## Summary
- Add `strip_internal_message_markers()` to remove internal `_opensre_*` keys from message dicts before they reach strict provider APIs
- Apply stripping in `AnthropicAgentClient.invoke()` and `BedrockConverseAgentClient.invoke()` so investigation seed/duplicate markers stay on the in-memory transcript for context-budget trimming but never leak into outbound requests
- Add regression tests covering the helper and Anthropic invoke payload shaping

Fixes #3741

## Test plan
- [x] `uv run python -m pytest tests/core/test_context_budget.py tests/core/runtime/llm/test_agent_llm_client.py::test_anthropic_invoke_strips_internal_message_markers -q`
- [x] `make lint`
- [x] `make format-check`
- [x] `make typecheck`