### PR TITLE
fix(core/llm): close remaining _opensre_* marker leak paths from #3762

### DIFF
--- a/core/llm/litellm/clients.py
+++ b/core/llm/litellm/clients.py
@@ -211,7 +211,9 @@ class LiteLLMLLMClient:
     def _build_request_kwargs(self, prompt_or_messages: Any) -> dict[str, Any]:
         from platform.guardrails.apply import apply_guardrails_to_messages
 
-        messages = normalize_messages_openai(prompt_or_messages)
+        # normalize_messages_openai already keeps only role/content, but strip explicitly
+        # so this stays safe if a future caller ever routes marked agent-history dicts here.
+        messages = strip_internal_message_markers(normalize_messages_openai(prompt_or_messages))
         messages, _ = apply_guardrails_to_messages(messages)
         kwargs: dict[str, Any] = {
             "model": self._litellm_model,

--- a/core/llm/litellm/clients.py
+++ b/core/llm/litellm/clients.py
@@ -9,6 +9,7 @@ from typing import Any
 from litellm import completion
 from pydantic import BaseModel
 
+from core.context_budget import strip_internal_message_markers
 from core.llm.openai_chat_completions import (
     AGENT_CLIENT_TIMEOUT_SEC,
     LLM_CLIENT_TIMEOUT_SEC,
@@ -92,7 +93,7 @@ class LiteLLMAgentClient:
     ) -> dict[str, Any]:
         kwargs: dict[str, Any] = {
             "model": self._litellm_model,
-            "messages": prepend_system_message(messages, system),
+            "messages": prepend_system_message(strip_internal_message_markers(messages), system),
             "max_tokens": self._max_tokens,
             "timeout": AGENT_CLIENT_TIMEOUT_SEC,
         }

--- a/core/messages/message_formatter.py
+++ b/core/messages/message_formatter.py
@@ -6,6 +6,7 @@ import json
 from collections.abc import Sequence
 from typing import Any, cast
 
+from core.context_budget import strip_internal_message_markers
 from core.llm.types import AgentLLMResponse, ToolCall
 from core.messages.runtime_message_types import (
     AppRuntimeMessage,
@@ -36,11 +37,16 @@ class MessageFormatter:
         return [_coerce_runtime_message(m) for m in messages]
 
     def to_provider_messages(self, messages: Sequence[RuntimeMessage]) -> list[ProviderMessage]:
-        """Render a RuntimeMessage sequence into provider dicts for llm.invoke."""
+        """Render a RuntimeMessage sequence into provider dicts for llm.invoke.
+
+        ``provider_payload``/``provider_payloads`` on a coerced RuntimeMessage retain
+        internal ``_opensre_*`` markers (see ``_metadata_from_provider_message``), so
+        the outbound render is stripped here rather than trusting each producer.
+        """
         result: list[ProviderMessage] = []
         for message in messages:
             result.extend(self._for_runtime_message(message))
-        return result
+        return strip_internal_message_markers(result)
 
     def assistant_from_response(self, response: AgentLLMResponse) -> ProviderMessage:
         """Build the provider assistant-message payload from an LLM response."""

--- a/tests/core/messages/test_message_formatter.py
+++ b/tests/core/messages/test_message_formatter.py
@@ -128,6 +128,20 @@ class TestToProviderMessages:
         result = bus.to_provider_messages([msg])
         assert result == [payload]
 
+    def test_normalize_then_to_provider_messages_strips_internal_markers(self) -> None:
+        """A marked dict round-tripped through normalize -> to_provider_messages must not
+        leak ``_opensre_*`` keys back out, even though provider_payload retains them."""
+        bus = MessageFormatter(_FakeLLM())
+        raw = {
+            "role": "assistant",
+            "content": "ok",
+            "_opensre_seed": True,
+        }
+        normalized = MessageFormatter.normalize([raw])
+        result = bus.to_provider_messages(normalized)
+        assert result == [{"role": "assistant", "content": "ok"}]
+        assert raw["_opensre_seed"] is True
+
     def test_tool_result_without_payloads_builds_via_llm(self) -> None:
         bus = MessageFormatter(_FakeLLM())
         tc = ToolCall(id="t1", name="foo", input={})

--- a/tests/core/runtime/llm/test_litellm_compat.py
+++ b/tests/core/runtime/llm/test_litellm_compat.py
@@ -80,6 +80,38 @@ def test_litellm_agent_client_parses_tool_calls() -> None:
     assert response.raw_content["tool_calls"] == [tool_call]
 
 
+def test_litellm_agent_client_invoke_strips_internal_message_markers() -> None:
+    captured: dict[str, Any] = {}
+
+    def completion(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _fake_response(content="ok")
+
+    client = LiteLLMAgentClient(
+        litellm_model="anthropic/claude-sonnet-4-6",
+        api_key_env="ANTHROPIC_API_KEY",
+        credential_resolver=lambda _env: "test-key",
+        completion_func=completion,
+    )
+
+    messages = [
+        {"role": "user", "content": "alert"},
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "seed", "name": "n", "input": {}}],
+            "_opensre_seed": True,
+        },
+    ]
+    client.invoke(messages)
+
+    api_messages = captured["messages"]
+    assert api_messages[1] == {
+        "role": "assistant",
+        "content": [{"type": "tool_use", "id": "seed", "name": "n", "input": {}}],
+    }
+    assert messages[1]["_opensre_seed"] is True
+
+
 def test_litellm_agent_client_emits_global_usage_hook() -> None:
     from core.llm.usage import set_usage_hook
 

--- a/tests/core/runtime/llm/test_litellm_compat.py
+++ b/tests/core/runtime/llm/test_litellm_compat.py
@@ -156,6 +156,27 @@ def test_litellm_llm_client_emits_usage_callback() -> None:
     assert usage == [("openai/groq-model", 11, 7)]
 
 
+def test_litellm_llm_client_invoke_strips_internal_message_markers() -> None:
+    captured: dict[str, Any] = {}
+
+    def completion(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _fake_response(content="ok")
+
+    client = LiteLLMLLMClient(
+        litellm_model="anthropic/claude-sonnet-4-6",
+        api_key_env="ANTHROPIC_API_KEY",
+        credential_resolver=lambda _env: "test-key",
+        completion_func=completion,
+    )
+
+    messages = [{"role": "assistant", "content": "ok", "_opensre_seed": True}]
+    client.invoke(messages)
+
+    assert captured["messages"] == [{"role": "assistant", "content": "ok"}]
+    assert messages[0]["_opensre_seed"] is True
+
+
 class NotFoundError(Exception):
     """Simulates LiteLLM/OpenAI NotFoundError by class name."""
 


### PR DESCRIPTION
## Summary
- Strip internal `_opensre_*` markers in `LiteLLMAgentClient._build_request_kwargs` (`core/llm/litellm/clients.py`), mirroring the fix already applied to the native SDK agent clients in #3761. This path is reachable whenever `OPENSRE_LLM_TRANSPORT=litellm` routes to a strict provider (e.g. Anthropic), not just Azure OpenAI — `core/llm/litellm/routing.py` has a first-class `anthropic` route through LiteLLM.
- Strip markers in `MessageFormatter.to_provider_messages()` (`core/messages/message_formatter.py`) so a `RuntimeMessage` coerced from a marked provider dict can't replay `_opensre_*` verbatim if a future caller routes investigation transcripts through `MessageFormatter`/`ReactLoop` instead of the current raw-dict path. Currently latent (no live caller hits it today), but cheap to close now.

Addresses gaps #1 (LiteLLM transport) and #3 (MessageFormatter round-trip) from #3762. Gaps #2 (OpenAI SDK) was already fixed in #3761. Gaps #4-#6 are lower-severity behavioral/policy items tracked separately in #3762.

## Test plan
- [x] Added `test_litellm_agent_client_invoke_strips_internal_message_markers` (`tests/core/runtime/llm/test_litellm_compat.py`), mirroring the existing Anthropic/OpenAI marker-strip tests.
- [x] Added `test_normalize_then_to_provider_messages_strips_internal_markers` (`tests/core/messages/test_message_formatter.py`) reproducing the round-trip leak scenario.
- [x] `make lint`, `make format-check`, `make typecheck` all pass.
- [x] `uv run python -m pytest tests/core/messages/test_message_formatter.py tests/core/runtime/llm/test_litellm_compat.py tests/core/test_context_budget.py -q` passes.
- Note: `make test-scope` on this diff surfaces 43 failures in `tests/core/agent/test_turn_scenarios.py` and `tests/core/runtime/llm/test_llm_client*.py` (live-network Azure connection errors + provider-routing assertions). Verified these are **pre-existing test-order pollution**, reproducing identically on the unmodified `main` baseline before this change — not caused by this diff.

Fixes #3762 (partially — see remaining gaps above)