### PR TITLE
fix(packaging): bundle LiteLLM data in PyInstaller binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,6 +273,7 @@ jobs:
           --noconfirm
           --collect-data surfaces.cli
           --collect-data config
+          --collect-data litellm
           --collect-submodules integrations
           --collect-submodules surfaces.interactive_shell
           --collect-submodules tools
@@ -313,6 +314,15 @@ jobs:
               ;;
           esac
           "$BINARY_PATH" -h >/dev/null
+          if [ -d "./dist/opensre/_internal" ]; then
+            LITELLM_DATA="./dist/opensre/_internal/litellm/model_prices_and_context_window_backup.json"
+          else
+            LITELLM_DATA="./dist/_internal/litellm/model_prices_and_context_window_backup.json"
+          fi
+          if [ ! -f "$LITELLM_DATA" ]; then
+            echo "LiteLLM package data missing from binary bundle: ${LITELLM_DATA}" >&2
+            exit 1
+          fi
 
       - name: Check Linux binary glibc compatibility
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,13 +314,9 @@ jobs:
               ;;
           esac
           "$BINARY_PATH" -h >/dev/null
-          if [ -d "./dist/opensre/_internal" ]; then
-            LITELLM_DATA="./dist/opensre/_internal/litellm/model_prices_and_context_window_backup.json"
-          else
-            LITELLM_DATA="./dist/_internal/litellm/model_prices_and_context_window_backup.json"
-          fi
+          LITELLM_DATA="./dist/opensre/_internal/litellm/model_prices_and_context_window_backup.json"
           if [ ! -f "$LITELLM_DATA" ]; then
-            echo "LiteLLM package data missing from binary bundle: ${LITELLM_DATA}" >&2
+            echo "LiteLLM package data missing from Unix onedir bundle: ${LITELLM_DATA}" >&2
             exit 1
           fi
 

--- a/tests/github_ci/test_release_workflow.py
+++ b/tests/github_ci/test_release_workflow.py
@@ -63,6 +63,13 @@ def test_binary_build_bundles_registry_discovered_tool_modules() -> None:
     assert "--collect-submodules integrations" in source
 
 
+def test_binary_build_collects_litellm_package_data() -> None:
+    source = _RELEASE_WORKFLOW.read_text()
+
+    assert "--collect-data litellm" in source
+    assert "model_prices_and_context_window_backup.json" in source
+
+
 def test_unix_binary_build_uses_onedir_and_pinned_ubuntu_22_runners() -> None:
     source = _RELEASE_WORKFLOW.read_text()
 

--- a/tests/packaging/test_litellm_bundle_contract.py
+++ b/tests/packaging/test_litellm_bundle_contract.py
@@ -1,0 +1,33 @@
+"""Regression tests for LiteLLM package data in frozen release binaries.
+
+Azure OpenAI and ``OPENSRE_LLM_TRANSPORT=litellm`` import ``litellm`` at runtime.
+LiteLLM reads JSON price/context files from its package directory on import; the
+release PyInstaller build must bundle them under ``_internal/litellm/`` or the
+binary crashes with ``FileNotFoundError`` (see issue #3631).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import litellm
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+# LiteLLM loads this file during import; it must be present in frozen bundles.
+_REQUIRED_LITELLM_DATA_FILE = "model_prices_and_context_window_backup.json"
+
+
+def test_litellm_package_ships_required_price_context_backup() -> None:
+    """Dev installs must still expose LiteLLM's price/context JSON (sanity check)."""
+    data_path = Path(litellm.__file__).parent / _REQUIRED_LITELLM_DATA_FILE
+    assert data_path.is_file(), f"expected LiteLLM data file at {data_path}"
+
+
+def test_release_workflow_collects_litellm_package_data() -> None:
+    """The release build must collect LiteLLM package data for frozen binaries."""
+    workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "--collect-data litellm" in workflow
+    assert "model_prices_and_context_window_backup.json" in workflow

--- a/tests/packaging/test_litellm_bundle_contract.py
+++ b/tests/packaging/test_litellm_bundle_contract.py
@@ -4,16 +4,13 @@ Azure OpenAI and ``OPENSRE_LLM_TRANSPORT=litellm`` import ``litellm`` at runtime
 LiteLLM reads JSON price/context files from its package directory on import; the
 release PyInstaller build must bundle them under ``_internal/litellm/`` or the
 binary crashes with ``FileNotFoundError`` (see issue #3631).
+
+Workflow contract assertions live in ``tests/github_ci/test_release_workflow.py``.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-
-import litellm
-
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yml"
 
 # LiteLLM loads this file during import; it must be present in frozen bundles.
 _REQUIRED_LITELLM_DATA_FILE = "model_prices_and_context_window_backup.json"
@@ -21,13 +18,7 @@ _REQUIRED_LITELLM_DATA_FILE = "model_prices_and_context_window_backup.json"
 
 def test_litellm_package_ships_required_price_context_backup() -> None:
     """Dev installs must still expose LiteLLM's price/context JSON (sanity check)."""
+    import litellm
+
     data_path = Path(litellm.__file__).parent / _REQUIRED_LITELLM_DATA_FILE
     assert data_path.is_file(), f"expected LiteLLM data file at {data_path}"
-
-
-def test_release_workflow_collects_litellm_package_data() -> None:
-    """The release build must collect LiteLLM package data for frozen binaries."""
-    workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
-
-    assert "--collect-data litellm" in workflow
-    assert "model_prices_and_context_window_backup.json" in workflow


### PR DESCRIPTION
## Summary
- Fixes #3631 — curl-installed binaries crash on Azure/LiteLLM because PyInstaller did not bundle LiteLLM package data
- Add `--collect-data litellm` to the release binary build so `model_prices_and_context_window_backup.json` lands under `_internal/litellm/`
- Add a Unix release smoke check and packaging contract tests so this cannot regress silently

## Context
LiteLLM loads its bundled model cost/context catalog at `import litellm` time (even when fetching a remote map). OpenSRE imports LiteLLM for Azure OpenAI and `OPENSRE_LLM_TRANSPORT=litellm`. Source installs via `uv sync` work; only the frozen binary was missing the JSON.

## Test plan
- [x] `uv run python -m pytest tests/packaging/test_litellm_bundle_contract.py tests/github_ci/test_release_workflow.py`
- [ ] Release workflow smoke test passes on next main-build publish (checks `_internal/litellm/model_prices_and_context_window_backup.json`)