### PR TITLE
fix(core/domain): strip _opensre_* markers from persisted agent_messages

### DIFF
--- a/core/domain/diagnosis/result.py
+++ b/core/domain/diagnosis/result.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from core.context_budget import strip_internal_message_markers
 from core.domain.diagnosis.alignment import apply_category_alignment_adjustments
 from core.domain.types.root_cause_categories import (
     HERMES_ROOT_CAUSE_CATEGORIES,
@@ -89,7 +90,10 @@ def result_to_state(result: InvestigationResult) -> dict[str, Any]:
         "investigation_recommendations": result.investigation_recommendations,
         "evidence": result.evidence,
         "evidence_entries": result.evidence_entries,
-        "agent_messages": result.agent_messages,
+        # Diagnose is the last stage to read agent_messages — the context-budget
+        # eviction markers on it (_opensre_seed, _opensre_duplicate_result) have
+        # already served their purpose and must not leak into persisted state.
+        "agent_messages": strip_internal_message_markers(result.agent_messages),
     }
 
 

--- a/tests/agent/test_result.py
+++ b/tests/agent/test_result.py
@@ -63,7 +63,7 @@ def test_result_to_state_strips_internal_markers_from_agent_messages() -> None:
         root_cause_category="disk_pressure",
         agent_messages=[
             {"role": "user", "content": "alert", "_opensre_seed": True},
-            {"role": "assistant", "content": "ok"},
+            {"role": "assistant", "content": "ok", "_opensre_duplicate_result": True},
         ],
     )
 
@@ -74,3 +74,4 @@ def test_result_to_state_strips_internal_markers_from_agent_messages() -> None:
         {"role": "assistant", "content": "ok"},
     ]
     assert result.agent_messages[0]["_opensre_seed"] is True
+    assert result.agent_messages[1]["_opensre_duplicate_result"] is True

--- a/tests/agent/test_result.py
+++ b/tests/agent/test_result.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from core.domain.diagnosis import (
+    InvestigationResult,
     build_diagnosis_schema,
     extract_last_assistant_text,
+    result_to_state,
     taxonomy_categories_for_alert_source,
 )
 
@@ -51,3 +53,24 @@ def test_hermes_taxonomy_is_scoped_to_hermes_categories() -> None:
     description = str(schema.model_fields["root_cause_category"].description)
     assert "agent_hang" in description
     assert "connection_exhaustion" not in description
+
+
+def test_result_to_state_strips_internal_markers_from_agent_messages() -> None:
+    """Diagnose is the last stage to touch agent_messages — its eviction markers
+    must not leak into the persisted investigation state."""
+    result = InvestigationResult(
+        root_cause="disk full",
+        root_cause_category="disk_pressure",
+        agent_messages=[
+            {"role": "user", "content": "alert", "_opensre_seed": True},
+            {"role": "assistant", "content": "ok"},
+        ],
+    )
+
+    state = result_to_state(result)
+
+    assert state["agent_messages"] == [
+        {"role": "user", "content": "alert"},
+        {"role": "assistant", "content": "ok"},
+    ]
+    assert result.agent_messages[0]["_opensre_seed"] is True


### PR DESCRIPTION
## Summary
- `result_to_state()` (`core/domain/diagnosis/result.py`) now strips `_opensre_*` internal markers from `InvestigationResult.agent_messages` before writing it into persisted investigation state.
- Traced the leak: `tools/investigation/stages/diagnose/node.py:68` does `result.agent_messages = messages` straight from the gather_evidence loop's marked state, and `result_to_state()` wrote that unstripped into the persisted state dict. Diagnose is the last stage to touch `agent_messages` — by the time it runs, the context-budget eviction loop is done and the `_opensre_seed`/`_opensre_duplicate_result` markers have served their purpose, so leaving them on only leaks implementation detail into session files, degraded-failure payloads, and any consumer of raw `agent_messages` JSON.

Addresses gap #6 from #3762 (the other two open gaps, #4 partial-duplicate tagging and #5 pinned-seed overflow under extreme pressure, are policy/design questions left for a separate discussion rather than mechanical fixes).

## Test plan
- [x] Added `test_result_to_state_strips_internal_markers_from_agent_messages` (`tests/agent/test_result.py`), asserting the persisted state is clean while the original `InvestigationResult.agent_messages` dict is left unmutated (markers preserved in case anything upstream still needs them before this boundary).
- [x] `make lint`, `make format-check`, `make typecheck` all pass.
- [x] `make test-cov` (escalated since `core/domain/` is shared code): 10292 passed, 43 pre-existing failures — identical set/error signatures to the pre-existing `tests/core/agent/test_turn_scenarios.py` and `tests/core/runtime/llm/test_llm_client*.py` test-order pollution documented in #3763, unrelated to this diff (reproduces on unmodified `main`).

Fixes #3762 (gap #6 of 3; #4 and #5 remain open as policy discussions)