### PR TITLE
Use shared MAX_MESSAGE_SIZE in gateway output sink (DR-07)

### DIFF
--- a/gateway/gateway_output_sink.py
+++ b/gateway/gateway_output_sink.py
@@ -10,8 +10,8 @@ from collections.abc import Iterable
 from gateway.polling.telegram_poller.client import TelegramBotClient
 from integrations.telegram.formatting import markdown_to_telegram_html
 from platform.common.truncation import truncate
+from platform.notifications.limits import MAX_MESSAGE_SIZE
 
-_MESSAGE_LIMIT = 4096
 _LOG_PREVIEW_LIMIT = 500
 logger = logging.getLogger("gateway")
 
@@ -83,7 +83,7 @@ class GatewayOutputSink:
     def _edit_preview(self, text: str) -> None:
         if not self._message_id:
             return
-        preview = truncate(text or self._status_text, _MESSAGE_LIMIT, suffix="…")
+        preview = truncate(text or self._status_text, MAX_MESSAGE_SIZE, suffix="…")
         with self._lock:
             ok, _ = self._client.edit_message_text(self._chat_id, self._message_id, preview)
             if ok:
@@ -93,7 +93,7 @@ class GatewayOutputSink:
         self._finalize(text)
 
     def _finalize(self, text: str) -> None:
-        final = truncate(text, _MESSAGE_LIMIT, suffix="…")
+        final = truncate(text, MAX_MESSAGE_SIZE, suffix="…")
         html_final = markdown_to_telegram_html(final)
         if self._message_id and self._edit_final(html_final, final):
             logger.info("outbound chat=%s text=%r", self._chat_id, _log_preview(final))


### PR DESCRIPTION
Fixes #3529

#### Describe the changes you have made in this PR -

DR-07. The gateway output sink hardcoded the `4096` message size limit as a magic number. This PR imports `MAX_MESSAGE_SIZE` from `platform.notifications.limits` and passes it directly to the sink's truncation call sites, so the limit now reads from the shared source of truth already used by the telegram, discord, and whatsapp delivery modules.

The value is unchanged (`4096`), so there is no behavior change. The existing `test_finalize_truncates_long_text` already asserts against `MAX_MESSAGE_SIZE`, so source and test now reference the same constant.

Note for maintainers: this issue is currently assigned to another contributor who has not opened a PR yet, so I picked it up since it appeared stale. Happy to defer if they are still working on it.

### Demo/Screenshot for feature changes and bug fixes -

Local CI harness (per CI.md) all green after the change:

```
make lint          -> All checks passed!
make format-check  -> 2278 files already formatted
make typecheck     -> Success: no issues found in 1122 source files
make test-scope    -> 62 passed (maps gateway/ to gateway/tests/)
```

Gateway sink tests specifically:

```
$ uv run python -m pytest gateway/tests/test_gateway_output_sink.py -q
6 passed in 1.62s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The sink defined `_MESSAGE_LIMIT = 4096`, duplicating the limit defined in `platform/notifications/limits.py`. I removed the local constant and pass the imported `MAX_MESSAGE_SIZE` directly to the two `truncate(...)` call sites (`_edit_preview` and `_finalize`), so the limit has a single source of truth with no intermediate alias. The value is identical, so the change is backward compatible with no runtime or performance impact.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
