### PR TITLE
Fix stale slash-catalog test paths

### DIFF
--- a/tests/interactive_shell/command_registry/test_slash_catalog.py
+++ b/tests/interactive_shell/command_registry/test_slash_catalog.py
@@ -21,8 +21,8 @@ def test_slash_catalog_covers_all_registered_commands() -> None:
     missing = sorted(registered - catalogued)
     stale = sorted(catalogued - registered)
     assert not missing, (
-        "Add _MCP_BY_COMMAND entries in interactive_shell/command_registry/"
-        f"slash_catalog.py for: {missing}. See interactive_shell/AGENTS.md "
+        "Add _MCP_BY_COMMAND entries in surfaces/interactive_shell/command_registry/"
+        f"slash_catalog.py for: {missing}. See surfaces/interactive_shell/AGENTS.md "
         "(Slash commands → REPL + CLI parity)."
     )
     assert not stale, (


### PR DESCRIPTION
Fixes #3572

#### Describe the changes you have made in this PR

The two assertion hints in `tests/interactive_shell/command_registry/test_slash_catalog.py` still referred to `interactive_shell/command_registry/` and `interactive_shell/AGENTS.md`. Both paths moved under `surfaces/interactive_shell/…` in the surfaces reorganisation, so the hint sent contributors to a directory that no longer exists.

Updated the two strings to the current locations. Verified the referenced paths exist:

- `surfaces/interactive_shell/command_registry/slash_catalog.py`
- `surfaces/interactive_shell/AGENTS.md`

### Demo

```
$ uv run pytest tests/interactive_shell/command_registry/test_slash_catalog.py -q
.........                                                                [100%]
9 passed, 1 warning in 7.29s
```

Lint (`ruff check`) and format (`ruff format --check`) both pass on the file.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself

**Explain your implementation approach:**

The issue is a stale-path fix in a pytest assertion message. The strings on lines 24–26 are only surfaced to a human when the `missing` assertion fires — they don't affect the pass/fail behaviour of the test. I confirmed the target paths (`surfaces/interactive_shell/command_registry/slash_catalog.py`, `surfaces/interactive_shell/AGENTS.md`) exist in the current tree before updating.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] My code follows the project's style guidelines and conventions