### PR TITLE
Fix Telegram env-var doc source paths

### DIFF
--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -249,8 +249,8 @@ All configuration options for OpenSRE can be set via environment variables. This
 | `DISCORD_APPLICATION_ID` | | Discord application ID | `integrations/_catalog_impl` |
 | `DISCORD_PUBLIC_KEY` | | Discord public key | `integrations/_catalog_impl` |
 | `DISCORD_DEFAULT_CHANNEL_ID` | | Default Discord channel | `integrations/_catalog_impl` |
-| `TELEGRAM_BOT_TOKEN` | | Telegram bot token | `platform/notifications/telegram_credentials`, `scheduler/credentials` |
-| `TELEGRAM_DEFAULT_CHAT_ID` | | Default Telegram chat ID | `platform/notifications/telegram_credentials`, `integrations/_catalog_impl` |
+| `TELEGRAM_BOT_TOKEN` | | Telegram bot token | `integrations/telegram/credentials`, `scheduler/credentials` |
+| `TELEGRAM_DEFAULT_CHAT_ID` | | Default Telegram chat ID | `integrations/telegram/credentials`, `integrations/_catalog_impl` |
 | `TWILIO_ACCOUNT_SID` | | Twilio account SID | `integrations/_catalog_impl` |
 | `TWILIO_AUTH_TOKEN` | | Twilio auth token | `integrations/_catalog_impl` |
 | `TWILIO_WHATSAPP_FROM` | | WhatsApp sender number (Twilio) | `integrations/_catalog_impl` |


### PR DESCRIPTION
Fixes #3560

#### Describe the changes you have made in this PR

The `TELEGRAM_BOT_TOKEN` and `TELEGRAM_DEFAULT_CHAT_ID` rows in `docs/configuration/environment-variables.mdx` still pointed contributors at `platform/notifications/telegram_credentials`, which no longer exists. Telegram credentials moved to `integrations/telegram/credentials.py` during the integrations consolidation.

Updated both rows to point at the current resolver:

- `integrations/telegram/credentials.py:65` reads `TELEGRAM_BOT_TOKEN`
- `integrations/telegram/credentials.py:79` reads `TELEGRAM_DEFAULT_CHAT_ID`

The second-column references (`scheduler/credentials` for the token, `integrations/_catalog_impl` for the chat ID) still resolve to real code, so I left them alone.

### Demo

Diff is the entire change:

```
-| `TELEGRAM_BOT_TOKEN` | | Telegram bot token | `platform/notifications/telegram_credentials`, `scheduler/credentials` |
-| `TELEGRAM_DEFAULT_CHAT_ID` | | Default Telegram chat ID | `platform/notifications/telegram_credentials`, `integrations/_catalog_impl` |
+| `TELEGRAM_BOT_TOKEN` | | Telegram bot token | `integrations/telegram/credentials`, `scheduler/credentials` |
+| `TELEGRAM_DEFAULT_CHAT_ID` | | Default Telegram chat ID | `integrations/telegram/credentials`, `integrations/_catalog_impl` |
```

Docs-only change, so I used the CI.md §0 shortcut (no lint/typecheck/test needed).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself

**Explain your implementation approach:**

Grep confirmed the two env vars are actually resolved in `integrations/telegram/credentials.py` (via `resolve_env_credential` and `os.getenv`). The old path `platform/notifications/telegram_credentials` does not exist. Both rows are simple markdown table cells — no logic change.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] My code follows the project's style guidelines and conventions