### PR TITLE
Use shared MAX_MESSAGE_SIZE in gateway output sink (DR-07)

### DIFF
--- a/gateway/gateway_output_sink.py
+++ b/gateway/gateway_output_sink.py
@@ -10,8 +10,8 @@ from collections.abc import Iterable
 from gateway.polling.telegram_poller.client import TelegramBotClient
 from integrations.telegram.formatting import markdown_to_telegram_html
 from platform.common.truncation import truncate
+from platform.notifications.limits import MAX_MESSAGE_SIZE
 
-_MESSAGE_LIMIT = 4096
 _LOG_PREVIEW_LIMIT = 500
 logger = logging.getLogger("gateway")
 
@@ -83,7 +83,7 @@ class GatewayOutputSink:
     def _edit_preview(self, text: str) -> None:
         if not self._message_id:
             return
-        preview = truncate(text or self._status_text, _MESSAGE_LIMIT, suffix="…")
+        preview = truncate(text or self._status_text, MAX_MESSAGE_SIZE, suffix="…")
         with self._lock:
             ok, _ = self._client.edit_message_text(self._chat_id, self._message_id, preview)
             if ok:
@@ -93,7 +93,7 @@ class GatewayOutputSink:
         self._finalize(text)
 
     def _finalize(self, text: str) -> None:
-        final = truncate(text, _MESSAGE_LIMIT, suffix="…")
+        final = truncate(text, MAX_MESSAGE_SIZE, suffix="…")
         html_final = markdown_to_telegram_html(final)
         if self._message_id and self._edit_final(html_final, final):
             logger.info("outbound chat=%s text=%r", self._chat_id, _log_preview(final))


### PR DESCRIPTION
Fixes #3529

#### Describe the changes you have made in this PR

`gateway/gateway_output_sink.py` truncated preview and final messages against a local literal `_MESSAGE_LIMIT = 4096`, duplicating `platform.notifications.limits.MAX_MESSAGE_SIZE` (already introduced by DR-06). Any future limit change would need to be made in both places.

- Import `MAX_MESSAGE_SIZE` from `platform.notifications.limits`
- Remove the local `_MESSAGE_LIMIT = 4096`
- Update both `truncate(...)` call sites in `_edit_preview` and `_finalize`

No behaviour change — the constant is numerically identical and the surrounding logic is untouched.

### Demo

Diff on the sink:

```python
-_MESSAGE_LIMIT = 4096
+from platform.notifications.limits import MAX_MESSAGE_SIZE
...
-        preview = truncate(text or self._status_text, _MESSAGE_LIMIT, suffix="…")
+        preview = truncate(text or self._status_text, MAX_MESSAGE_SIZE, suffix="…")
...
-        final = truncate(text, _MESSAGE_LIMIT, suffix="…")
+        final = truncate(text, MAX_MESSAGE_SIZE, suffix="…")
```

Verification:

```
$ uv run pytest gateway/tests/test_gateway_output_sink.py -q
......                                                                     [100%]
6 passed in 0.33s

$ uv run ruff check gateway/gateway_output_sink.py
All checks passed!

$ uv run ruff format --check gateway/gateway_output_sink.py
1 file already formatted

$ uv run mypy gateway/gateway_output_sink.py
Success: no issues found in 1 source file
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself

**Explain your implementation approach:**

DR-06 already established `platform/notifications/limits.py` with `MAX_MESSAGE_SIZE = 4096`. The gateway sink still carried its own copy under a different name. Straight de-duplication: import the shared constant, drop the private one, update the two truncation call sites. I checked `rg _MESSAGE_LIMIT` afterwards to be sure nothing else in the tree referenced the old name.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] My code follows the project's style guidelines and conventions