### PR TITLE
Remove dead [LLM provider: X] error prefix

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -564,22 +564,6 @@ def describe_llm_resolution(
     return "\n".join(lines)
 
 
-def llm_provider_error_context(
-    fallback_providers: Sequence[str] = (),
-) -> str:
-    """Return a short bracketed provider context for prefixing error messages.
-
-    Never raises — diagnostics must not mask the original error. Returns an
-    empty string when resolution itself fails so callers can fall back to the
-    raw provider error untouched.
-    """
-    try:
-        resolution = resolve_llm_settings_verbose(fallback_providers)
-    except Exception:
-        return ""
-    return f"[LLM provider: {resolution.resolved_provider}]"
-
-
 def has_credentials_for_active_llm_provider() -> bool:
     """Return prompt-safe auth availability for the configured LLM provider."""
     settings = resolve_llm_settings()

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -512,10 +512,9 @@ OpenSRE does not silently switch LLM providers when the provider in `LLM_PROVIDE
 - **`opensre auth` and `/auth status`** show prompt-safe status from environment variables, provider metadata, CLI probes, or ambient/local config.
 - **`opensre auth verify <provider>`** intentionally checks request-time credentials and refreshes metadata.
 - **`opensre config llm` and `opensre doctor`** report the configured provider plus credential status without resolving secrets.
-- **Provider errors** are prefixed with the configured provider that served the request:
+- **Provider errors** name the provider that served the request in the message itself, so you can tell at a glance which backend failed:
 
   ```
-  [LLM provider: openai]
   Missing credential for LLM provider 'openai'. Set OPENAI_API_KEY or run `opensre auth login openai`.
   ```
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,6 @@ from config.config import (
     LLMSettings,
     describe_llm_resolution,
     has_credentials_for_active_llm_provider,
-    llm_provider_error_context,
     resolve_llm_settings,
     resolve_llm_settings_verbose,
 )
@@ -366,23 +365,3 @@ def test_describe_llm_resolution_reports_missing_configured_credentials(
     assert "resolved provider   : openai" in report
     assert "credential status   : none" in report
     assert "OPENAI_API_KEY" in report
-
-
-def test_llm_provider_error_context_uses_configured_provider(monkeypatch) -> None:
-    monkeypatch.setenv("LLM_PROVIDER", "openai")
-
-    context = llm_provider_error_context()
-
-    assert context == "[LLM provider: openai]"
-
-
-def test_llm_provider_error_context_no_fallback(monkeypatch) -> None:
-    monkeypatch.setenv("LLM_PROVIDER", "openai")
-
-    assert llm_provider_error_context() == "[LLM provider: openai]"
-
-
-def test_llm_provider_error_context_never_raises(monkeypatch) -> None:
-    monkeypatch.setenv("LLM_PROVIDER", "not-a-real-provider")
-
-    assert llm_provider_error_context() == ""


### PR DESCRIPTION
Fixes #3341

#### Describe the changes you have made in this PR

The reported output — `[LLM provider: openai] Anthropic request rejected …` — was produced by `config.config.llm_provider_error_context()`, which prepended the **configured** provider from `resolve_llm_settings_verbose` rather than the **invoked** one. If OpenAI was configured but the runtime fell through to Anthropic, the prefix still said `openai` while the body was an Anthropic API error — exactly the mismatch the issue described.

The runtime path that used to attach that prefix (`llm_action_planner/llm_client.py` → `PlannerLLMError`) was replaced by the AgentTool-based planner (\"Route shell actions through AgentTools\", commit e9cea6a3), and its caller was removed. Nothing in the current tree calls `llm_provider_error_context()` — grep confirms:

```
$ rg -F "llm_provider_error_context"
config/config.py:def llm_provider_error_context(     # dead definition
tests/test_config.py: (3 orphaned unit tests)
```

Provider errors now propagate directly from the specific client with the actual provider label baked in — e.g.:

- `core/llm/transports/sdk/agent_clients.py:530` — `f"{self._provider_label} request rejected: {err}"`
- `core/llm/shared/llm_retry.py:133` — `maybe_raise_credit_exhausted(provider_name, err)` uses the client's `provider_name`

Both use the provider the failing client was constructed for, so the openai/anthropic mismatch is no longer reachable.

This PR:

1. Deletes `llm_provider_error_context` from `config/config.py`.
2. Removes its three orphaned unit tests from `tests/test_config.py`.
3. Fixes the misleading example in `docs/llm-providers.mdx` that still showed the old `[LLM provider: openai]` prefix — the current behavior is that the provider name is in the error text itself.

### Demo

Before/after for the docs example:

```diff
-- **Provider errors** are prefixed with the configured provider that served the request:
-
-  ```
-  [LLM provider: openai]
-  Missing credential for LLM provider 'openai'. Set OPENAI_API_KEY or run `opensre auth login openai`.
-  ```
+- **Provider errors** name the provider that served the request in the message itself, so you can tell at a glance which backend failed:
+
+  ```
+  Missing credential for LLM provider 'openai'. Set OPENAI_API_KEY or run `opensre auth login openai`.
+  ```
```

Verification:

```
$ rg -F "llm_provider_error_context"
$ rg -F "[LLM provider"
docs/pi-coding.mdx: [LLM providers](/llm-providers))         # normal link text
docs/interactive-shell-commands.mdx: [LLM providers](/llm-providers)
docs/interactive-shell-commands.mdx: [LLM providers](/llm-providers)
docs/interactive-shell-commands.mdx: - [LLM providers](/llm-providers)

$ uv run pytest tests/test_config.py -q
.....................................                                    [100%]
37 passed in 0.44s

$ uv run ruff check config/config.py tests/test_config.py
All checks passed!

$ uv run mypy config/config.py
Success: no issues found in 1 source file
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself

**Explain your implementation approach:**

Investigation was mostly grep-driven. `git log -S "llm_provider_error_context"` showed the introducing commit (d302abaf, `feat(llm): make provider fallback observable with accurate errors`) and its caller in `llm_action_planner/llm_client.py`. `rg -n "PlannerLLMError"` returned zero hits, and `rg -n "llm_action_planner"` — same. So the whole caller path was already gone, leaving `llm_provider_error_context` and its tests orphaned.

Two options existed: (a) re-wire the prefix at a new call site, or (b) delete the dead code. (a) is redundant — the current client-level error messages already name the provider that failed (I traced `_provider_label` and `provider_name` in `core/llm/transports/sdk/agent_clients.py` and `core/llm/shared/llm_retry.py`), so re-adding a top-level prefix would either duplicate the label or reintroduce the same drift the issue was about. (b) fits the AGENTS.md rule about not leaving compatibility-only forwarding modules after a refactor. Also updated the docs example, which still described the old behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] My code follows the project's style guidelines and conventions