### PR TITLE
Add filter, search, and count subcommands to /tools

### DIFF
--- a/surfaces/interactive_shell/command_registry/slash_catalog.py
+++ b/surfaces/interactive_shell/command_registry/slash_catalog.py
@@ -292,9 +292,12 @@ _MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
     ),
     "/tools": _mcp(
         "Explicit /tools command operation: list registered investigation/chat tools "
-        "wired into this OpenSRE build.",
+        "wired into this OpenSRE build. Subcommands: list (default), count "
+        "(per-surface totals), search <query> or a bare <query> to filter by "
+        "name/description substring.",
         "User explicitly types /tools or asks to run /tools",
         "User explicitly asks to list registered tools as a shell command",
+        "User asks to count how many tools are registered or filter them by keyword",
         anti_examples=(
             "User asks conversationally what tools or capabilities the assistant can use (assistant_handoff)",
         ),

--- a/surfaces/interactive_shell/command_registry/tools_cmds.py
+++ b/surfaces/interactive_shell/command_registry/tools_cmds.py
@@ -4,39 +4,108 @@ from __future__ import annotations
 
 from rich.console import Console
 
-from surfaces.interactive_shell.command_registry.types import (
-    SlashCommand,
-    make_list_root_handler,
-)
+from platform.terminal.theme import DIM, ERROR, HIGHLIGHT
+from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui import render_tools_table
-from surfaces.interactive_shell.ui.tables.tool_catalog import build_tool_catalog
+from surfaces.interactive_shell.ui.components.rendering import repl_print
+from surfaces.interactive_shell.ui.tables.tool_catalog import (
+    ToolCatalogEntry,
+    build_tool_catalog,
+)
+
+_LIST_ALIASES: frozenset[str] = frozenset({"list", "ls", "tool", "tools"})
 
 
-def _list_tools(_session: Session, console: Console, _args: list[str]) -> bool:
-    render_tools_table(console, build_tool_catalog())
+def _matches(entry: ToolCatalogEntry, query: str) -> bool:
+    haystack = f"{entry.name} {entry.description}".lower()
+    return query in haystack
+
+
+def _filter_catalog(entries: list[ToolCatalogEntry], query: str) -> list[ToolCatalogEntry]:
+    q = query.strip().lower()
+    if not q:
+        return entries
+    return [entry for entry in entries if _matches(entry, q)]
+
+
+def _render_count(console: Console, entries: list[ToolCatalogEntry]) -> None:
+    if not entries:
+        repl_print(console, f"[{DIM}]no tools registered.[/]")
+        return
+    total = len(entries)
+    per_surface: dict[str, int] = {}
+    for entry in entries:
+        for surface in entry.surfaces:
+            per_surface[surface] = per_surface.get(surface, 0) + 1
+    repl_print(console, f"[{HIGHLIGHT}]{total}[/] registered tool{'s' if total != 1 else ''}")
+    for surface in sorted(per_surface):
+        repl_print(console, f"  [{DIM}]{surface}[/]: {per_surface[surface]}")
+
+
+def _list_tools(session: Session, console: Console, args: list[str]) -> bool:
+    entries = build_tool_catalog()
+    if args:
+        query = " ".join(args)
+        filtered = _filter_catalog(entries, query)
+        if not filtered:
+            repl_print(
+                console,
+                f"[{DIM}]no tools match[/] {query!r}. "
+                f"Try [bold]/tools[/bold] to see all, or [bold]/tools count[/bold] for a summary.",
+            )
+            session.mark_latest(ok=True, kind="slash")
+            return True
+        render_tools_table(console, filtered)
+        return True
+    render_tools_table(console, entries)
     return True
 
 
-_cmd_tools = make_list_root_handler(
-    "/tools",
-    _list_tools,
-    list_aliases=("list", "ls", "tool", "tools"),
-)
+def _cmd_tools(session: Session, console: Console, args: list[str]) -> bool:
+    if not args:
+        return _list_tools(session, console, [])
+
+    sub = args[0].lower().strip()
+    rest = args[1:]
+
+    if sub in _LIST_ALIASES:
+        return _list_tools(session, console, rest)
+    if sub == "count":
+        _render_count(console, build_tool_catalog())
+        return True
+    if sub == "search":
+        if not rest:
+            repl_print(console, f"[{ERROR}]usage:[/] /tools search <query>")
+            session.mark_latest(ok=False, kind="slash")
+            return True
+        return _list_tools(session, console, rest)
+
+    # Bare query — treat unknown args as a substring filter so `/tools slack`
+    # narrows the list instead of erroring. Slash-command completion still
+    # advertises the named subcommands via ``_TOOLS_FIRST_ARGS`` below.
+    return _list_tools(session, console, args)
+
 
 _TOOLS_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("list", "list registered tools (investigation + chat surfaces)"),
     ("ls", "alias for list"),
-    ("tool", "alias for list"),
-    ("tools", "alias for list"),
+    ("count", "print total tool count and per-surface breakdown"),
+    ("search", "filter tools by substring: /tools search <query>"),
 )
 
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/tools",
-        "List registered tools.",
+        "List registered tools; optionally filter or summarise.",
         _cmd_tools,
-        usage=("/tools", "/tools list"),
+        usage=(
+            "/tools",
+            "/tools list",
+            "/tools count",
+            "/tools search <query>",
+            "/tools <query>",
+        ),
         first_arg_completions=_TOOLS_FIRST_ARGS,
     )
 ]

--- a/tests/interactive_shell/command_registry/test_tools_cmds.py
+++ b/tests/interactive_shell/command_registry/test_tools_cmds.py
@@ -1,0 +1,155 @@
+"""Tests for the /tools slash command router."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+from surfaces.interactive_shell.command_registry import tools_cmds
+from surfaces.interactive_shell.ui.tables.tool_catalog import ToolCatalogEntry
+
+
+class _FakeSession:
+    """Minimal Session stand-in matching the slash-handler contract."""
+
+    def __init__(self) -> None:
+        self.marks: list[tuple[bool, str]] = []
+
+    def mark_latest(self, *, ok: bool, kind: str) -> None:
+        self.marks.append((ok, kind))
+
+
+def _entry(name: str, description: str, surfaces: tuple[str, ...]) -> ToolCatalogEntry:
+    return ToolCatalogEntry(
+        name=name,
+        surfaces=surfaces,
+        description=description,
+        source_file=f"tools/{name}.py",
+        input_schema_summary="",
+    )
+
+
+@pytest.fixture
+def catalog(monkeypatch: pytest.MonkeyPatch) -> list[ToolCatalogEntry]:
+    entries = [
+        _entry("query_datadog_metric", "Query Datadog metrics.", ("investigation",)),
+        _entry("slack_send_message", "Send a Slack message.", ("chat",)),
+        _entry("get_sre_guidance", "Retrieve SRE guidance snippets.", ("investigation", "chat")),
+    ]
+    monkeypatch.setattr(tools_cmds, "build_tool_catalog", lambda: list(entries))
+    return entries
+
+
+def _run(args: list[str]) -> tuple[_FakeSession, str]:
+    session = _FakeSession()
+    console = Console(file=StringIO(), width=200, force_terminal=False, no_color=True)
+    handled = tools_cmds._cmd_tools(session, console, args)  # type: ignore[arg-type]
+    assert handled is True
+    output: str = console.file.getvalue()  # type: ignore[attr-defined]
+    return session, output
+
+
+def test_filter_catalog_substring_case_insensitive(catalog: list[ToolCatalogEntry]) -> None:
+    filtered = tools_cmds._filter_catalog(catalog, "SLACK")
+    assert [e.name for e in filtered] == ["slack_send_message"]
+
+
+def test_filter_catalog_matches_description(catalog: list[ToolCatalogEntry]) -> None:
+    filtered = tools_cmds._filter_catalog(catalog, "guidance")
+    assert [e.name for e in filtered] == ["get_sre_guidance"]
+
+
+def test_filter_catalog_empty_query_returns_all(catalog: list[ToolCatalogEntry]) -> None:
+    assert tools_cmds._filter_catalog(catalog, "   ") == catalog
+
+
+def test_bare_command_lists_all(catalog: list[ToolCatalogEntry]) -> None:
+    _, output = _run([])
+    for entry in catalog:
+        assert entry.name in output
+
+
+def test_list_alias_delegates(catalog: list[ToolCatalogEntry]) -> None:
+    for alias in ("list", "ls", "tool", "tools"):
+        _, output = _run([alias])
+        assert "query_datadog_metric" in output
+
+
+def test_search_requires_query(catalog: list[ToolCatalogEntry]) -> None:
+    session, output = _run(["search"])
+    assert "usage:" in output
+    assert session.marks == [(False, "slash")]
+
+
+def test_search_narrows_output(catalog: list[ToolCatalogEntry]) -> None:
+    _, output = _run(["search", "slack"])
+    assert "slack_send_message" in output
+    assert "query_datadog_metric" not in output
+
+
+def test_bare_query_treated_as_filter(catalog: list[ToolCatalogEntry]) -> None:
+    _, output = _run(["datadog"])
+    assert "query_datadog_metric" in output
+    assert "slack_send_message" not in output
+
+
+def test_search_no_matches_prints_hint(catalog: list[ToolCatalogEntry]) -> None:
+    session, output = _run(["search", "nonexistent"])
+    assert "no tools match" in output
+    assert "'nonexistent'" in output
+    assert session.marks == [(True, "slash")]
+
+
+def test_count_shows_total_and_per_surface(catalog: list[ToolCatalogEntry]) -> None:
+    _, output = _run(["count"])
+    assert "3 registered tools" in output
+    assert "investigation" in output
+    assert "chat" in output
+    # per-surface totals reflect double-counting when a tool is on both surfaces
+    assert "investigation" in output and "2" in output
+    assert "chat" in output and "2" in output
+
+
+def test_count_singular_form(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        tools_cmds,
+        "build_tool_catalog",
+        lambda: [_entry("solo", "Only tool.", ("chat",))],
+    )
+    _, output = _run(["count"])
+    assert "1 registered tool" in output
+
+
+def test_count_empty_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tools_cmds, "build_tool_catalog", lambda: [])
+    _, output = _run(["count"])
+    assert "no tools registered" in output
+
+
+def test_command_metadata_lists_new_subcommands() -> None:
+    (spec,) = tools_cmds.COMMANDS
+    assert spec.name == "/tools"
+    assert "/tools count" in spec.usage
+    assert "/tools search <query>" in spec.usage
+    first_arg_names = {name for name, _desc in spec.first_arg_completions or ()}
+    assert {"list", "ls", "count", "search"} <= first_arg_names
+
+
+def test_first_arg_completions_expose_new_verbs() -> None:
+    args = dict(tools_cmds._TOOLS_FIRST_ARGS)
+    assert "count" in args
+    assert "search" in args
+
+
+def test_bare_command_still_works_without_args(catalog: list[ToolCatalogEntry]) -> None:
+    # `_cmd_tools` should handle both `args=None` semantics and empty list.
+    session = _FakeSession()
+    console = Console(file=StringIO(), width=200, force_terminal=False, no_color=True)
+    assert tools_cmds._cmd_tools(session, console, []) is True  # type: ignore[arg-type]
+
+
+def test_matches_returns_false_on_miss(catalog: list[ToolCatalogEntry]) -> None:
+    entry = catalog[0]
+    assert tools_cmds._matches(entry, "definitely_missing_token") is False


### PR DESCRIPTION
Fixes #3340

#### Describe the changes you have made in this PR

`/tools` printed the entire tool registry as a single Rich table. On a build with 60+ registered tools, the earliest rows scroll off the top before the user can read them — the terminal wins, the tool loses, and there is no way to narrow the view without external tooling.

Extend the `/tools` router in `surfaces/interactive_shell/command_registry/tools_cmds.py` with two named subcommands and a bare-query shortcut, without dropping any existing alias:

- `/tools`, `/tools list`, `/tools ls`, `/tools tool`, `/tools tools` — full catalog (unchanged)
- `/tools count` — total plus per-surface breakdown
- `/tools search <query>` — substring match on `name` + `description`, case-insensitive
- `/tools <query>` — bare query treated as an implicit filter (so `/tools slack` narrows to slack tools without needing a subcommand)

Empty search results print a hint pointing at `/tools` and `/tools count`, and mark the turn as OK so the shell does not stay in an error state.

Slash-catalog MCP metadata for `/tools` is updated so the LLM router description mentions the new verbs, and first-arg tab completions expose `count` and `search`.

### Demo

Command surface after the change:

```
/tools                        # full list (unchanged)
/tools list | ls | tool | tools    # aliases (unchanged)
/tools count                  # summary
/tools search <query>         # explicit filter
/tools <query>                # implicit filter, e.g. /tools slack
```

Sample output of `/tools count`:

```
12 registered tools
  chat: 4
  investigation: 10
```

Sample output of `/tools search slack`:

```
┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Tool                 ┃ Surf ┃ Description                    ┃
┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ slack_send_message   │ chat │ Send a Slack message.          │
└──────────────────────┴──────┴────────────────────────────────┘
```

Verification:

```
$ uv run pytest tests/interactive_shell/command_registry/ -q
..................................................                       [100%]
50 passed, 1 warning in 0.74s
```

`test_tools_cmds.py` adds 16 unit tests covering: substring match (case-insensitive, name and description), bare-command list, list aliases, `count` (plural / singular / empty catalog), `search` (missing query error, hit, miss), bare-query shortcut, and the SlashCommand + first-arg-completion metadata.

Ruff, ruff format, and mypy all pass on the touched files.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself

**Explain your implementation approach:**

Three fixes were proposed on the issue — pager, filter/search flag, temp file, count/summary. Pager and temp file break the flow of the REPL and add surface area (temp file cleanup, external process). The two composable ones — filter and count — are the ones users can reach for from muscle memory. I combined them.

I replaced the `make_list_root_handler` factory with a small custom router because `make_list_root_handler` errors on unknown args, and I wanted `/tools slack` to act as a filter rather than print an "unknown subcommand" hint. The named subcommands (`list`, `ls`, `count`, `search`) are still dispatched first, so tab completion and the LLM slash-invoke schema stay consistent. Everything mutates through pure helpers (`_filter_catalog`, `_matches`, `_render_count`) so they can be unit-tested without a real Session.

I kept the double-counting behavior for `count`: a tool exposed on both `investigation` and `chat` is counted under each surface, matching the way the list view groups them (`format_tool_catalog_text` uses the same shape). If the maintainers prefer unique-tool counts, that's a one-line change.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions