### PR TITLE
Report classify failures in WhatsApp integration (SM-01)

### DIFF
--- a/integrations/whatsapp/__init__.py
+++ b/integrations/whatsapp/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import WhatsAppConfig
 
 logger = logging.getLogger(__name__)
@@ -12,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 def classify(
     credentials: dict[str, Any],
-    record_id: str,  # noqa: ARG001
+    record_id: str,
 ) -> tuple[WhatsAppConfig | None, str | None]:
     try:
         cfg = WhatsAppConfig.model_validate(
@@ -23,6 +24,7 @@ def classify(
                 "default_to": credentials.get("default_to"),
             }
         )
-    except Exception:
+    except Exception as exc:
+        report_classify_failure(exc, logger=logger, integration="whatsapp", record_id=record_id)
         return None, None
     return cfg, "whatsapp"


### PR DESCRIPTION
Fixes #3505

#### Describe the changes you have made in this PR -

SM-01. The WhatsApp `classify()` swallowed every exception with a bare `except Exception: return None, None`, so a real failure was hidden with no log or telemetry. This calls the shared `report_classify_failure` helper before returning the degraded `(None, None)`, so the failure is logged and captured to Sentry with vendor tags. `record_id` is now used, so its unused-arg `noqa` is dropped.

The return shape and validation logic are unchanged.

On approach: the issue suggested narrowing to `except ValidationError`, but the established house pattern for this exact smell is `except Exception as exc: report_classify_failure(...)`, already used by `helm` and 45 other integration classifiers and documented in `integrations/_validation_helpers.py`. I matched that pattern for consistency, since it addresses the "hides real bugs" root cause (failures are now surfaced) rather than only changing the exception type.

Note for maintainers: this issue is unassigned, so I picked it up. Happy to adjust to a literal `ValidationError` narrow if you would rather keep it as the issue text describes.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run python -m pytest tests/integrations/test_whatsapp.py -q
12 passed in 0.46s
```

Local CI harness (per CI.md) all green after the change:

```
make lint          -> All checks passed!
make format-check  -> 2278 files already formatted
make typecheck     -> Success: no issues found in 1122 source files
make test-scope    -> 2328 passed, 2 skipped
```

Before (failure vanished):

```
except Exception:
    return None, None
```

After (failure logged and captured, matching helm):

```
except Exception as exc:
    report_classify_failure(exc, logger=logger, integration="whatsapp", record_id=record_id)
    return None, None
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`classify()` builds a `WhatsAppConfig` via `model_validate` and returned `(None, None)` on any exception without recording it. I kept the degraded return, but before it I call `report_classify_failure(exc, logger=logger, integration="whatsapp", record_id=record_id)`, which logs the failure and captures it to Sentry with `integration=whatsapp` tags. I chose this over narrowing to `ValidationError` because it matches the existing pattern across the other integration classifiers (helm and 45 more) and the guidance in `integrations/_validation_helpers.py`, keeping the whole integration layer consistent. Because `record_id` is now passed to the helper, it is no longer unused, so I removed the `# noqa: ARG001`. Value and control flow of the success path are unchanged.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
