### PR TITLE
Fix: /new command now requires authorization before session rotation

### DIFF
--- a/gateway/session/enforce_inbound_telegram_message_security.py
+++ b/gateway/session/enforce_inbound_telegram_message_security.py
@@ -109,7 +109,24 @@ def enforce_inbound_telegram_message_security(
             ),
         )
 
+    result: AuthorizationResult = authorize_inbound_message(
+        policy=policy,
+        user_id=user_id,
+        chat_id=chat_id,
+        message_text=text,
+    )
+
     if text.strip().lower() == "/new":
+        if not result:
+            audit_log_inbound_message(
+                platform=MessagingPlatform.TELEGRAM.value,
+                user_id=user_id,
+                chat_id=chat_id,
+                message_hash=_message_hash(text),
+                authorized=False,
+                reason=result.reason,
+            )
+            return InboundDecision(allowed=False, reply_text=result.reason)
         audit_log_inbound_message(
             platform=MessagingPlatform.TELEGRAM.value,
             user_id=user_id,
@@ -120,12 +137,6 @@ def enforce_inbound_telegram_message_security(
         )
         return InboundDecision(allowed=True, reply_text="__ROTATE_SESSION__")
 
-    result: AuthorizationResult = authorize_inbound_message(
-        policy=policy,
-        user_id=user_id,
-        chat_id=chat_id,
-        message_text=text,
-    )
     audit_log_inbound_message(
         platform=MessagingPlatform.TELEGRAM.value,
         user_id=user_id,

--- a/gateway/tests/test_authorize.py
+++ b/gateway/tests/test_authorize.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
-
 from unittest.mock import patch
-
 import pytest
-
 from gateway.session.enforce_inbound_telegram_message_security import (
     enforce_inbound_telegram_message_security,
     persist_policy_if_needed,
 )
 from integrations.messaging_security import MessagingIdentityPolicy
-
 _SECURITY = "gateway.session.enforce_inbound_telegram_message_security"
-
-
 @pytest.fixture
 def mock_integration_store():
     with (
@@ -20,8 +14,6 @@ def mock_integration_store():
         patch(f"{_SECURITY}.upsert_instance") as upsert,
     ):
         yield upsert
-
-
 @pytest.mark.usefixtures("mock_integration_store")
 def test_help_is_not_agent_turn() -> None:
     decision = enforce_inbound_telegram_message_security(
@@ -32,8 +24,6 @@ def test_help_is_not_agent_turn() -> None:
     )
     assert decision.allowed is False
     assert "OpenSRE Telegram gateway" in decision.reply_text
-
-
 @pytest.mark.usefixtures("mock_integration_store")
 def test_unauthorized_user_gets_reason() -> None:
     decision = enforce_inbound_telegram_message_security(
@@ -44,8 +34,6 @@ def test_unauthorized_user_gets_reason() -> None:
     )
     assert decision.allowed is False
     assert decision.reply_text
-
-
 def test_pair_attempt_persists_policy(mock_integration_store: pytest.MonkeyPatch) -> None:
     policy = MessagingIdentityPolicy(
         inbound_enabled=True,
@@ -70,3 +58,24 @@ def test_pair_attempt_persists_policy(mock_integration_store: pytest.MonkeyPatch
     assert decision.persist_policy is True
     persist_policy_if_needed(decision)
     mock_integration_store.assert_called_once()
+
+@pytest.mark.usefixtures("mock_integration_store")
+def test_unauthorized_user_cannot_rotate_session() -> None:
+    decision = enforce_inbound_telegram_message_security(
+        user_id="99",
+        chat_id="99",
+        text="/new",
+        env_allowed_user_ids=["42"],
+    )
+    assert decision.allowed is False
+    assert decision.reply_text != "__ROTATE_SESSION__"
+@pytest.mark.usefixtures("mock_integration_store")
+def test_authorized_user_can_rotate_session() -> None:
+    decision = enforce_inbound_telegram_message_security(
+        user_id="42",
+        chat_id="42",
+        text="/new",
+        env_allowed_user_ids=["42"],
+    )
+    assert decision.allowed is True
+    assert decision.reply_text == "__ROTATE_SESSION__"

--- a/gateway/tests/test_authorize.py
+++ b/gateway/tests/test_authorize.py
@@ -68,6 +68,7 @@ def test_unauthorized_user_cannot_rotate_session() -> None:
         env_allowed_user_ids=["42"],
     )
     assert decision.allowed is False
+    assert decision.reply_text
     assert decision.reply_text != "__ROTATE_SESSION__"
 @pytest.mark.usefixtures("mock_integration_store")
 def test_authorized_user_can_rotate_session() -> None:


### PR DESCRIPTION
Fixes #3787 

#### Describe the changes you have made in this PR
Moved the `/new` session-rotate handler to execute after `authorize_inbound_message`
is called. Previously any unauthenticated Telegram user could send `/new` and receive
`allowed=True`, bypassing the policy check entirely and logging `authorized=True` in
the audit trail. Unauthorized users now receive the same rejection response as for
regular messages.

Added two tests covering the unauthorized and authorized `/new` paths.

Related: #2678

### Demo
Before fix: unauthorized user sends `/new` → bot replies "Started a new session."
After fix: unauthorized user sends `/new` → bot replies with rejection reason, no session rotated.
