### PR TITLE
fix: close /new auth bypass in Telegram gateway and warn on hostname HMAC fallback

### DIFF
--- a/gateway/session/enforce_inbound_telegram_message_security.py
+++ b/gateway/session/enforce_inbound_telegram_message_security.py
@@ -109,17 +109,6 @@ def enforce_inbound_telegram_message_security(
             ),
         )
 
-    if text.strip().lower() == "/new":
-        audit_log_inbound_message(
-            platform=MessagingPlatform.TELEGRAM.value,
-            user_id=user_id,
-            chat_id=chat_id,
-            message_hash=_message_hash(text),
-            authorized=True,
-            reason="session rotate",
-        )
-        return InboundDecision(allowed=True, reply_text="__ROTATE_SESSION__")
-
     result: AuthorizationResult = authorize_inbound_message(
         policy=policy,
         user_id=user_id,
@@ -134,9 +123,13 @@ def enforce_inbound_telegram_message_security(
         authorized=bool(result),
         reason=result.reason,
     )
-    if result:
-        return InboundDecision(allowed=True)
-    return InboundDecision(allowed=False, reply_text=result.reason)
+    if not result:
+        return InboundDecision(allowed=False, reply_text=result.reason)
+
+    if text.strip().lower() == "/new":
+        return InboundDecision(allowed=True, reply_text="__ROTATE_SESSION__")
+
+    return InboundDecision(allowed=True)
 
 
 def persist_policy_if_needed(decision: InboundDecision) -> None:

--- a/gateway/tests/test_authorize.py
+++ b/gateway/tests/test_authorize.py
@@ -46,6 +46,18 @@ def test_unauthorized_user_gets_reason() -> None:
     assert decision.reply_text
 
 
+@pytest.mark.usefixtures("mock_integration_store")
+def test_unauthorized_user_cannot_rotate_session() -> None:
+    decision = enforce_inbound_telegram_message_security(
+        user_id="99",
+        chat_id="99",
+        text="/new",
+        env_allowed_user_ids=["42"],
+    )
+    assert decision.allowed is False
+    assert decision.reply_text
+
+
 def test_pair_attempt_persists_policy(mock_integration_store: pytest.MonkeyPatch) -> None:
     policy = MessagingIdentityPolicy(
         inbound_enabled=True,

--- a/integrations/messaging_security.py
+++ b/integrations/messaging_security.py
@@ -137,6 +137,12 @@ def _get_hmac_key() -> bytes:
     import platform
 
     machine_id = platform.node() or "opensre-default"
+    logger.warning(
+        "OPENSRE_PAIRING_SECRET is not set; falling back to a hostname-derived "
+        "HMAC key. This key is not secret — if pairing_secret_hash leaks, an "
+        "attacker can brute-force the 6-char code space offline. "
+        "Set OPENSRE_PAIRING_SECRET in production."
+    )
     return f"opensre-pairing-{machine_id}".encode()
 
 

--- a/tests/integrations/test_messaging_security.py
+++ b/tests/integrations/test_messaging_security.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import time
+from unittest.mock import patch
+
+import pytest
 
 from integrations.messaging_security import (
     _MAX_PAIRING_ATTEMPTS,
@@ -113,6 +116,19 @@ class TestPairingCode:
         code = "ABC123"
         stored = hash_pairing_code(code)
         assert verify_pairing_code("abc123", stored) is True
+
+    def test_get_hmac_key_warns_on_fallback(self, caplog: pytest.LogCaptureFixture) -> None:
+        import os
+
+        from integrations.messaging_security import _get_hmac_key
+
+        with caplog.at_level("WARNING", logger="integrations.messaging_security"):
+            with patch.dict(os.environ, {}, clear=True):
+                os.environ.pop("OPENSRE_PAIRING_SECRET", None)
+                key = _get_hmac_key()
+        assert isinstance(key, bytes)
+        assert len(caplog.records) >= 1
+        assert "OPENSRE_PAIRING_SECRET is not set" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #3787 and #3788.

### Fix 1: Telegram  auth bypass (#3787)

**Problem:** The  command short-circuited before , allowing any unauthenticated Telegram user to rotate sessions.

**Fix:** Moved  handling after the authorization check. Unauthorized users now receive the same rejection as for regular messages.

### Fix 2: Hostname-derived HMAC fallback warning (#3788)

**Problem:** When  is not set,  silently falls back to a hostname-derived key, enabling offline brute-force if the pairing hash leaks.

**Fix:** Added  when falling back, alerting operators that the key is not secret in production.

## Changes

-  — Reordered  branch after 
-  — Added  to  fallback path
-  — Added 
-  — Added 

## Verification

- All 38 affected tests pass
- Ruff lint clean