### PR TITLE
fix(integrations/whatsapp): mark unused classify record id

### DIFF
--- a/integrations/whatsapp/__init__.py
+++ b/integrations/whatsapp/__init__.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 def classify(
     credentials: dict[str, Any],
-    record_id: str,  # noqa: ARG001
+    _record_id: str,
 ) -> tuple[WhatsAppConfig | None, str | None]:
     try:
         cfg = WhatsAppConfig.model_validate(


### PR DESCRIPTION
Fixes #3513

#### Describe the changes you have made in this PR -

`integrations/whatsapp/__init__.py` had a `classify()` parameter named `record_id` even though the function does not use it. That required a `# noqa: ARG001` suppression and made the unused argument look accidental.

This PR renames the parameter to `_record_id` and removes the suppression. The runtime behavior is unchanged: WhatsApp config validation still reads from `credentials`, and `classify()` still returns the same `(cfg, "whatsapp")` success shape.

### Demo/Screenshot for feature changes and bug fixes - 

```text
make lint          -> All checks passed!
make format-check  -> 2283 files already formatted
make typecheck     -> Success: no issues found in 1116 source files
make test-scope    -> 2329 passed, 2 skipped
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The classifier signature includes a second argument so the integration registry can pass a record identifier consistently across integrations. WhatsApp does not need that identifier because its config only comes from the credential fields. Renaming the unused parameter to `_record_id` follows the existing Python convention for intentionally unused parameters and lets us remove the `ARG001` noqa without changing behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
