### PR TITLE
fix(interactive_shell): avoid live verification in integration lists

### DIFF
--- a/core/agent_harness/grounding/docs_reference.py
+++ b/core/agent_harness/grounding/docs_reference.py
@@ -73,6 +73,7 @@ _SKIP_DIRS = frozenset(
 _MAX_PER_DOC_CHARS = 4_000
 _DEFAULT_MAX_TOTAL_CHARS = 22_000
 _DEFAULT_TOP_N = 4
+_DOCS_ROOT = REPO_ROOT / "docs"
 
 # Stopwords stripped from a user's query before scoring. Without this,
 # common verbs and articles ("how", "do", "the") would dominate the match.
@@ -368,7 +369,7 @@ class DocsReference:
 
     def discover(self, root: Path | None = None) -> list[DocPage]:
         """Walk the docs root, parse each MDX page, return them as :class:`DocPage` records."""
-        target = root if root is not None else REPO_ROOT / "docs"
+        target = root if root is not None else _DOCS_ROOT
         resolved = target.resolve() if target.exists() else target
         root_key = str(resolved)
 

--- a/core/agent_harness/session/state.py
+++ b/core/agent_harness/session/state.py
@@ -366,13 +366,14 @@ class Session:
         if not scenario_id:
             self.last_synthetic_observation_path = None
             return
-        # Shared path constant lives in config so core and surfaces stay decoupled.
+        # Shared path module lives in config so core and surfaces stay decoupled.
         try:
-            from config.constants.paths import SYNTHETIC_SCENARIOS_DIR
+            from config.constants import paths
         except Exception:
             self.last_synthetic_observation_path = None
             return
-        latest = SYNTHETIC_SCENARIOS_DIR / "_observations" / scenario_id / "latest.json"
+        synthetic_dir = paths.SYNTHETIC_SCENARIOS_DIR
+        latest = synthetic_dir / "_observations" / scenario_id / "latest.json"
         for _ in range(8):
             if latest.is_file():
                 self.last_synthetic_observation_path = str(latest.resolve())

--- a/surfaces/interactive_shell/command_registry/integrations.py
+++ b/surfaces/interactive_shell/command_registry/integrations.py
@@ -40,7 +40,7 @@ _MAX_OBSERVATION_DETAIL_CHARS = 160
 
 
 def _record_integrations_observation(session: Session, results: list[dict[str, str]]) -> None:
-    """Stash a compact text view of verification results for agent summarization.
+    """Stash a compact text view of integration rows for agent summarization.
 
     Lets the agent answer questions like "is sentry installed?" by summarizing
     what ``/integrations`` actually found, instead of leaving the user with only
@@ -265,8 +265,7 @@ def _cmd_integrations(session: Session, console: Console, args: list[str]) -> bo
 
     if sub in ("list", "ls"):
         prepare_repl_output_line()
-        with console.status(f"[{DIM}]Verifying integrations…[/]", spinner="dots"):
-            results = repl_data.load_verified_integrations()
+        results = repl_data.load_configured_integrations()
         _record_integrations_observation(session, results)
         render_integrations_table(console, results)
         return True
@@ -363,7 +362,7 @@ def _cmd_mcp(session: Session, console: Console, args: list[str]) -> bool:
     sub = (args[0].lower() if args else "list").strip()
 
     if sub in ("list", "ls"):
-        render_mcp_table(console, repl_data.load_verified_integrations())
+        render_mcp_table(console, repl_data.load_configured_integrations())
         return True
 
     if sub == "connect":

--- a/surfaces/interactive_shell/command_registry/repl_data.py
+++ b/surfaces/interactive_shell/command_registry/repl_data.py
@@ -12,9 +12,29 @@ def load_verified_integrations() -> list[dict[str, str]]:
     return verify_integrations()
 
 
+def load_configured_integrations() -> list[dict[str, str]]:
+    """Return locally configured integrations without running live verifiers."""
+    from integrations.catalog import resolve_effective_integrations
+
+    effective = resolve_effective_integrations()
+    rows: list[dict[str, str]] = []
+    for service in sorted(effective):
+        entry = effective[service]
+        source = str(entry.get("source") or "-")
+        rows.append(
+            {
+                "service": str(service),
+                "source": source,
+                "status": "configured",
+                "detail": "Run /integrations verify to check connectivity.",
+            }
+        )
+    return rows
+
+
 def configured_integration_names() -> list[str]:
     """Return configured integration service names without running verifiers."""
-    from integrations.verify import resolve_effective_integrations
+    from integrations.catalog import resolve_effective_integrations
 
     return sorted(resolve_effective_integrations())
 
@@ -42,6 +62,7 @@ def load_llm_settings() -> Any | None:
 
 __all__ = [
     "configured_integration_names",
+    "load_configured_integrations",
     "load_llm_settings",
     "load_verified_integrations",
     "verify_integration",

--- a/tests/core/agent_harness/session/test_synthetic_observation_binding.py
+++ b/tests/core/agent_harness/session/test_synthetic_observation_binding.py
@@ -10,20 +10,13 @@ from core.agent_harness.session.state import Session
 
 def test_suggest_synthetic_failure_follow_up_binds_observation_path(tmp_path: Path) -> None:
     scenario_id = "001-replication-lag"
-    latest = (
-        tmp_path
-        / "tests"
-        / "synthetic"
-        / "rds_postgres"
-        / "_observations"
-        / scenario_id
-        / "latest.json"
-    )
+    synthetic_dir = tmp_path / "tests" / "synthetic" / "rds_postgres"
+    latest = synthetic_dir / "_observations" / scenario_id / "latest.json"
     latest.parent.mkdir(parents=True)
     latest.write_text('{"status": "failed"}', encoding="utf-8")
 
     session = Session()
-    with unittest.mock.patch("config.constants.paths.REPO_ROOT", tmp_path):
+    with unittest.mock.patch("config.constants.paths.SYNTHETIC_SCENARIOS_DIR", synthetic_dir):
         session.suggest_synthetic_failure_follow_up(
             label="opensre tests synthetic --scenario 001-replication-lag",
         )
@@ -43,11 +36,12 @@ def test_suggest_synthetic_failure_follow_up_invalid_scenario_clears_path() -> N
 def test_suggest_synthetic_failure_follow_up_missing_observation_clears_path(
     tmp_path: Path,
 ) -> None:
-    (tmp_path / "tests" / "synthetic" / "rds_postgres").mkdir(parents=True)
+    synthetic_dir = tmp_path / "tests" / "synthetic" / "rds_postgres"
+    synthetic_dir.mkdir(parents=True)
 
     session = Session()
     with (
-        unittest.mock.patch("config.constants.paths.REPO_ROOT", tmp_path),
+        unittest.mock.patch("config.constants.paths.SYNTHETIC_SCENARIOS_DIR", synthetic_dir),
         unittest.mock.patch("core.agent_harness.session.state.time.sleep"),
     ):
         session.suggest_synthetic_failure_follow_up(

--- a/tests/interactive_shell/command_registry/test_repl_data.py
+++ b/tests/interactive_shell/command_registry/test_repl_data.py
@@ -5,7 +5,7 @@ from surfaces.interactive_shell.command_registry import repl_data
 
 def test_configured_integration_names_reads_catalog_without_verify(monkeypatch) -> None:
     monkeypatch.setattr(
-        "integrations.verify.resolve_effective_integrations",
+        "integrations.catalog.resolve_effective_integrations",
         lambda: {"aws": {}, "grafana": {}},
     )
     verify_calls: list[str | None] = []
@@ -15,6 +15,39 @@ def test_configured_integration_names_reads_catalog_without_verify(monkeypatch) 
     )
 
     assert repl_data.configured_integration_names() == ["aws", "grafana"]
+    assert verify_calls == []
+
+
+def test_load_configured_integrations_reads_catalog_without_verify(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "integrations.catalog.resolve_effective_integrations",
+        lambda: {
+            "aws": {"source": "env"},
+            "grafana": {"source": "store"},
+        },
+    )
+    verify_calls: list[str | None] = []
+    monkeypatch.setattr(
+        "integrations.verify.verify_integrations",
+        lambda service=None, **_kwargs: verify_calls.append(service) or [],
+    )
+
+    rows = repl_data.load_configured_integrations()
+
+    assert rows == [
+        {
+            "service": "aws",
+            "source": "env",
+            "status": "configured",
+            "detail": "Run /integrations verify to check connectivity.",
+        },
+        {
+            "service": "grafana",
+            "source": "store",
+            "status": "configured",
+            "detail": "Run /integrations verify to check connectivity.",
+        },
+    ]
     assert verify_calls == []
 
 

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -365,21 +365,21 @@ class TestSpecificListCommands:
     """Coverage for /integrations list, /mcp list, /model show, and /tools list."""
 
     _FAKE_INTEGRATIONS = [
-        {"service": "datadog", "source": "store", "status": "ok", "detail": "API ok"},
-        {"service": "slack", "source": "env", "status": "failed", "detail": "No bot token"},
-        {"service": "github", "source": "store", "status": "ok", "detail": "MCP ok"},
-        {"service": "openclaw", "source": "store", "status": "failed", "detail": "401 from server"},
+        {"service": "datadog", "source": "store", "status": "configured", "detail": "Configured"},
+        {"service": "slack", "source": "env", "status": "configured", "detail": "Configured"},
+        {"service": "github", "source": "store", "status": "configured", "detail": "Configured"},
+        {"service": "openclaw", "source": "store", "status": "configured", "detail": "Configured"},
     ]
 
-    def _patch_verify(self, monkeypatch: object) -> None:
+    def _patch_configured(self, monkeypatch: object) -> None:
         monkeypatch.setattr(
             repl_data_module,
-            "load_verified_integrations",
+            "load_configured_integrations",
             lambda: list(self._FAKE_INTEGRATIONS),
         )
 
     def test_integrations_list_includes_mcp_services(self, monkeypatch: object) -> None:
-        self._patch_verify(monkeypatch)
+        self._patch_configured(monkeypatch)
         console, buf = _capture()
         dispatch_slash("/integrations list", Session(), console)
         output = buf.getvalue()
@@ -389,7 +389,7 @@ class TestSpecificListCommands:
         assert "github" in output
 
     def test_mcp_list_shows_only_mcp_services(self, monkeypatch: object) -> None:
-        self._patch_verify(monkeypatch)
+        self._patch_configured(monkeypatch)
         console, buf = _capture()
         dispatch_slash("/mcp list", Session(), console)
         output = buf.getvalue()
@@ -439,7 +439,7 @@ class TestSpecificListCommands:
     def test_integrations_list_empty_prints_onboarding_hint(self, monkeypatch: object) -> None:
         monkeypatch.setattr(
             repl_data_module,
-            "load_verified_integrations",
+            "load_configured_integrations",
             list,  # callable returning []
         )
         console, buf = _capture()
@@ -477,21 +477,33 @@ class TestSpecificListCommands:
 
 
 class TestIntegrationsCommand:
-    _FAKE = [
+    _CONFIGURED = [
+        {"service": "datadog", "source": "env", "status": "configured", "detail": "Configured"},
+        {"service": "slack", "source": "env", "status": "configured", "detail": "Configured"},
+        {"service": "github", "source": "store", "status": "configured", "detail": "Configured"},
+    ]
+    _VERIFIED = [
         {"service": "datadog", "source": "env", "status": "ok", "detail": "ok"},
         {"service": "slack", "source": "env", "status": "missing", "detail": "no token"},
         {"service": "github", "source": "store", "status": "ok", "detail": "MCP ok"},
     ]
 
-    def _patch(self, monkeypatch: object) -> None:
+    def _patch_configured(self, monkeypatch: object) -> None:
+        monkeypatch.setattr(
+            repl_data_module,
+            "load_configured_integrations",
+            lambda: list(self._CONFIGURED),
+        )
+
+    def _patch_verified(self, monkeypatch: object) -> None:
         monkeypatch.setattr(
             repl_data_module,
             "load_verified_integrations",
-            lambda: list(self._FAKE),
+            lambda: list(self._VERIFIED),
         )
 
     def test_list_shows_all_services_including_github(self, monkeypatch: object) -> None:
-        self._patch(monkeypatch)
+        self._patch_configured(monkeypatch)
         console, buf = _capture()
         dispatch_slash("/integrations list", Session(), console)
         output = buf.getvalue()
@@ -499,13 +511,24 @@ class TestIntegrationsCommand:
         assert "github" in output
 
     def test_list_is_default_when_no_subcommand(self, monkeypatch: object) -> None:
-        self._patch(monkeypatch)
+        self._patch_configured(monkeypatch)
         console, buf = _capture()
         dispatch_slash("/integrations", Session(), console)
         assert "datadog" in buf.getvalue()
 
+    def test_list_does_not_run_live_verification(self, monkeypatch: object) -> None:
+        self._patch_configured(monkeypatch)
+        monkeypatch.setattr(
+            repl_data_module,
+            "load_verified_integrations",
+            lambda: pytest.fail("/integrations list should not verify live integrations"),
+        )
+        console, buf = _capture()
+        dispatch_slash("/integrations list", Session(), console)
+        assert "datadog" in buf.getvalue()
+
     def test_verify_reports_issues(self, monkeypatch: object) -> None:
-        self._patch(monkeypatch)
+        self._patch_verified(monkeypatch)
         console, buf = _capture()
         dispatch_slash("/integrations verify", Session(), console)
         assert "need attention" in buf.getvalue()
@@ -523,7 +546,7 @@ class TestIntegrationsCommand:
         assert "all integrations ok" in buf.getvalue()
 
     def test_verify_via_slash_command(self, monkeypatch: object) -> None:
-        self._patch(monkeypatch)
+        self._patch_verified(monkeypatch)
         console, buf = _capture()
         dispatch_slash("/verify", Session(), console)
         assert "need attention" in buf.getvalue()
@@ -612,13 +635,13 @@ class TestIntegrationsCommand:
         assert session.history[-1]["ok"] is False
 
     def test_show_missing_arg(self, monkeypatch: object) -> None:
-        self._patch(monkeypatch)
+        self._patch_configured(monkeypatch)
         console, buf = _capture()
         dispatch_slash("/integrations show", Session(), console)
         assert "usage" in buf.getvalue()
 
     def test_unknown_subcommand_prints_hint(self, monkeypatch: object) -> None:
-        self._patch(monkeypatch)
+        self._patch_configured(monkeypatch)
         console, buf = _capture()
         dispatch_slash("/integrations bogus", Session(), console)
         assert "unknown subcommand" in buf.getvalue()
@@ -658,14 +681,14 @@ class TestIntegrationsCommand:
 
 class TestMcpCommand:
     _FAKE = [
-        {"service": "github", "source": "store", "status": "ok", "detail": "MCP ok"},
-        {"service": "openclaw", "source": "store", "status": "ok", "detail": "ok"},
+        {"service": "github", "source": "store", "status": "configured", "detail": "Configured"},
+        {"service": "openclaw", "source": "store", "status": "configured", "detail": "Configured"},
     ]
 
     def _patch(self, monkeypatch: object) -> None:
         monkeypatch.setattr(
             repl_data_module,
-            "load_verified_integrations",
+            "load_configured_integrations",
             lambda: list(self._FAKE),
         )
 


### PR DESCRIPTION
Fixes #3562

#### Describe the changes you have made in this PR -

This PR fixes /integrations list and /mcp list hanging the terminal by removing live verification from list commands.

Changes:
- Added load_configured_integrations() to read locally configured integrations from integrations.catalog.
- Changed /integrations list and /mcp list to render configured rows without importing integrations.verify.
- Kept live connectivity checks on /integrations verify, /verify, and /integrations show <service>.
- Added regression coverage for the list path.

### Demo/Screenshot for feature changes and bug fixes -

Terminal demo:

verify_before False
rows 0
verify_after False

Targeted regression tests:

163 passed

---

## Code Understanding and AI Usage

Did you use AI assistance to write any part of this code?
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance

If you used AI assistance:
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

Explain your implementation approach:

The list commands were using the live verification path. I split listing from verification so list commands read local catalog data only, while /integrations verify, /verify, and /integrations show <service> still run live checks.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
