### PR TITLE
Remove dead [LLM provider: X] error prefix (screenshots included)

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -564,22 +564,6 @@ def describe_llm_resolution(
     return "\n".join(lines)
 
 
-def llm_provider_error_context(
-    fallback_providers: Sequence[str] = (),
-) -> str:
-    """Return a short bracketed provider context for prefixing error messages.
-
-    Never raises — diagnostics must not mask the original error. Returns an
-    empty string when resolution itself fails so callers can fall back to the
-    raw provider error untouched.
-    """
-    try:
-        resolution = resolve_llm_settings_verbose(fallback_providers)
-    except Exception:
-        return ""
-    return f"[LLM provider: {resolution.resolved_provider}]"
-
-
 def has_credentials_for_active_llm_provider() -> bool:
     """Return prompt-safe auth availability for the configured LLM provider."""
     settings = resolve_llm_settings()

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -512,10 +512,9 @@ OpenSRE does not silently switch LLM providers when the provider in `LLM_PROVIDE
 - **`opensre auth` and `/auth status`** show prompt-safe status from environment variables, provider metadata, CLI probes, or ambient/local config.
 - **`opensre auth verify <provider>`** intentionally checks request-time credentials and refreshes metadata.
 - **`opensre config llm` and `opensre doctor`** report the configured provider plus credential status without resolving secrets.
-- **Provider errors** are prefixed with the configured provider that served the request:
+- **Provider errors** name the provider that served the request in the message itself, so you can tell at a glance which backend failed:
 
   ```
-  [LLM provider: openai]
   Missing credential for LLM provider 'openai'. Set OPENAI_API_KEY or run `opensre auth login openai`.
   ```
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,6 @@ from config.config import (
     LLMSettings,
     describe_llm_resolution,
     has_credentials_for_active_llm_provider,
-    llm_provider_error_context,
     resolve_llm_settings,
     resolve_llm_settings_verbose,
 )
@@ -366,23 +365,3 @@ def test_describe_llm_resolution_reports_missing_configured_credentials(
     assert "resolved provider   : openai" in report
     assert "credential status   : none" in report
     assert "OPENAI_API_KEY" in report
-
-
-def test_llm_provider_error_context_uses_configured_provider(monkeypatch) -> None:
-    monkeypatch.setenv("LLM_PROVIDER", "openai")
-
-    context = llm_provider_error_context()
-
-    assert context == "[LLM provider: openai]"
-
-
-def test_llm_provider_error_context_no_fallback(monkeypatch) -> None:
-    monkeypatch.setenv("LLM_PROVIDER", "openai")
-
-    assert llm_provider_error_context() == "[LLM provider: openai]"
-
-
-def test_llm_provider_error_context_never_raises(monkeypatch) -> None:
-    monkeypatch.setenv("LLM_PROVIDER", "not-a-real-provider")
-
-    assert llm_provider_error_context() == ""


### PR DESCRIPTION
Reopens the intent of #3782, which was closed while I was gathering the visual context @Davidson3556 asked for. Same branch, same commit `6e18e230` — this PR adds real terminal screenshots up-front so reviewers do not have to re-derive them.

Fixes #3341

#### The bug the issue reported

```
[LLM provider: openai] Anthropic request rejected (HTTP 400): Error code: 400 - {
  'type': 'error',
  'error': {
    'type': 'invalid_request_error',
    'message': 'Your credit balance is too low to access the Anthropic API. ...'
  },
  'request_id': 'req_011CcXb15EXT6fF4n4eJwPSd'
}
```

Provider label `openai` prepended to an Anthropic API error.

#### Root cause — the prefix was already dead code

The bracketed `[LLM provider: X]` prefix was produced by `config.config.llm_provider_error_context()`. It called `resolve_llm_settings_verbose` to look up the **configured** provider, which is different from the **invoked** one when a fallback happens — exactly the mismatch reported.

Its only caller (`llm_action_planner/llm_client.py` → `PlannerLLMError`) was removed by the \"Route shell actions through AgentTools\" refactor (`e9cea6a3`). Nothing in the current tree calls `llm_provider_error_context()`.

#### Screenshot 1 — live runtime message today

The demo runs the same billing-exhausted body from the issue through the real production code path (`core/llm/shared/llm_retry.py`) and prints what a user would see. The label is `anthropic` — the actual invoked provider — with no bracketed `[LLM provider: openai]` prefix.

![Live runtime message](https://raw.githubusercontent.com/MugemaneBertin2001/opensre/assets/pr-3807-screenshots/pr-3807/01_live_demo.png)

The label `anthropic` comes from `self._provider_label` inside the Anthropic client at `core/llm/transports/sdk/agent_clients.py:530`:

```python
except BadRequestError as err:
    # Some providers (or proxies) surface insufficient_quota as
    # 400 — distinguish before the generic wrap.
    maybe_raise_credit_exhausted(self._provider_label, err)
    raise RuntimeError(f\"{self._provider_label} request rejected: {err}\") from err
```

`_provider_label` is set when the specific client is constructed, so it always matches the backend that failed. That's why the openai/anthropic mismatch is no longer reachable.

#### Screenshot 2 — grep evidence

Confirmation that `llm_provider_error_context` is fully removed and no runtime code prepends `[LLM provider: ...]` anymore. The remaining hits are ordinary Markdown link text (`[LLM providers](/llm-providers)`) in docs.

![Grep evidence](https://raw.githubusercontent.com/MugemaneBertin2001/opensre/assets/pr-3807-screenshots/pr-3807/02_grep_evidence.png)

#### Screenshot 3 — test suite still green

`tests/test_config.py` after removing the three orphaned tests that exercised the deleted function:

![Tests pass](https://raw.githubusercontent.com/MugemaneBertin2001/opensre/assets/pr-3807-screenshots/pr-3807/03_tests_pass.png)

#### Changes

1. Delete `llm_provider_error_context()` from `config/config.py` — unreachable dead code.
2. Delete its three orphaned unit tests from `tests/test_config.py`.
3. Fix the `docs/llm-providers.mdx` example, which still described the bracketed prefix behavior. Users following that example would file the same bug again.

#### Verification (this branch)

```
$ uv run pytest tests/test_config.py -q
37 passed in 0.42s

$ uv run ruff check config/config.py tests/test_config.py
All checks passed!

$ uv run mypy config/config.py
Success: no issues found in 1 source file
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself

**Explain your implementation approach:**

Investigation was grep-driven: `git log -S \"llm_provider_error_context\"` pointed at the introducing commit `d302abaf` and its caller `llm_action_planner/llm_client.py`. `rg -n \"llm_action_planner\"` returned zero hits — the whole caller path was gone. So either re-wire the prefix at a new call site, or delete the dead code. The current client-level errors already name the failing provider (`_provider_label`, `provider_name`), so re-wiring would either duplicate the label or reintroduce the same drift. I deleted it and also fixed the doc example that was still describing the old behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] My code follows the project's style guidelines and conventions