### PR TITLE
Auto-page /tools output when the table overflows the terminal

### DIFF
--- a/surfaces/interactive_shell/command_registry/tools_cmds.py
+++ b/surfaces/interactive_shell/command_registry/tools_cmds.py
@@ -12,9 +12,43 @@ from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui import render_tools_table
 from surfaces.interactive_shell.ui.tables.tool_catalog import build_tool_catalog
 
+# Rough vertical cost per row: the table renders with `show_lines=True`, so
+# each entry uses a content line plus a divider. Description cells often wrap,
+# so budget one extra line per entry. Header, footer, and title account for
+# the leading constant.
+_ROWS_PER_ENTRY = 3
+_TABLE_CHROME_ROWS = 4
+
+
+def _estimate_table_height(entry_count: int) -> int:
+    return _TABLE_CHROME_ROWS + entry_count * _ROWS_PER_ENTRY
+
+
+def _should_page(entry_count: int, terminal_height: int, *, is_terminal: bool) -> bool:
+    """Return True when the rendered tools table won't fit in the current terminal.
+
+    The pager is only useful on a real TTY: piped output, headless test runs,
+    and CI logs should always see the raw table so downstream tooling can
+    parse it.
+    """
+    if not is_terminal or terminal_height <= 0:
+        return False
+    return _estimate_table_height(entry_count) > terminal_height
+
 
 def _list_tools(_session: Session, console: Console, _args: list[str]) -> bool:
-    render_tools_table(console, build_tool_catalog())
+    entries = build_tool_catalog()
+    if not entries:
+        render_tools_table(console, entries)
+        return True
+    terminal_height = getattr(console.size, "height", 0) or 0
+    if _should_page(
+        len(entries), terminal_height, is_terminal=bool(getattr(console, "is_terminal", False))
+    ):
+        with console.pager(styles=True):
+            render_tools_table(console, entries)
+    else:
+        render_tools_table(console, entries)
     return True
 
 

--- a/tests/interactive_shell/command_registry/test_tools_cmds.py
+++ b/tests/interactive_shell/command_registry/test_tools_cmds.py
@@ -1,0 +1,154 @@
+"""Tests for /tools slash command pager behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+from surfaces.interactive_shell.command_registry import tools_cmds
+from surfaces.interactive_shell.ui.tables.tool_catalog import ToolCatalogEntry
+
+
+class _FakeSession:
+    def mark_latest(self, *, ok: bool, kind: str) -> None:  # pragma: no cover - unused
+        pass
+
+
+def _entry(name: str) -> ToolCatalogEntry:
+    return ToolCatalogEntry(
+        name=name,
+        surfaces=("investigation",),
+        description=f"Description for {name}.",
+        source_file=f"tools/{name}.py",
+        input_schema_summary="",
+    )
+
+
+def _catalog(size: int) -> list[ToolCatalogEntry]:
+    return [_entry(f"tool_{i}") for i in range(size)]
+
+
+# ------------------------------------------------------------------ pager decision
+
+
+def test_should_page_returns_false_when_not_terminal() -> None:
+    assert tools_cmds._should_page(500, 24, is_terminal=False) is False
+
+
+def test_should_page_returns_false_when_terminal_height_unknown() -> None:
+    assert tools_cmds._should_page(500, 0, is_terminal=True) is False
+
+
+def test_should_page_returns_false_when_output_fits() -> None:
+    # 3 entries × 3 rows/entry + 4 chrome = 13 < 40
+    assert tools_cmds._should_page(3, 40, is_terminal=True) is False
+
+
+def test_should_page_returns_true_when_output_taller_than_terminal() -> None:
+    # 30 entries × 3 rows + 4 chrome = 94 > 24
+    assert tools_cmds._should_page(30, 24, is_terminal=True) is True
+
+
+def test_estimate_table_height_is_monotonic() -> None:
+    assert tools_cmds._estimate_table_height(0) < tools_cmds._estimate_table_height(1)
+    assert tools_cmds._estimate_table_height(1) < tools_cmds._estimate_table_height(10)
+
+
+# ---------------------------------------------------------------------- rendering
+
+
+def _make_console(*, tty: bool, height: int) -> Console:
+    console = Console(file=StringIO(), width=200, force_terminal=tty, no_color=True, height=height)
+    # Rich >= 13 exposes is_terminal from force_terminal; belt-and-braces guard.
+    assert bool(console.is_terminal) is tty
+    return console
+
+
+def test_short_catalog_renders_inline_no_pager(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tools_cmds, "build_tool_catalog", lambda: _catalog(3))
+    pager_used = False
+
+    @contextmanager
+    def _fake_pager(*_args: object, **_kwargs: object) -> Iterator[None]:
+        nonlocal pager_used
+        pager_used = True
+        yield
+
+    console = _make_console(tty=True, height=40)
+    monkeypatch.setattr(console, "pager", _fake_pager)
+
+    assert tools_cmds._list_tools(_FakeSession(), console, []) is True  # type: ignore[arg-type]
+    assert pager_used is False
+    output: str = console.file.getvalue()  # type: ignore[attr-defined]
+    for entry in ("tool_0", "tool_1", "tool_2"):
+        assert entry in output
+
+
+def test_long_catalog_wraps_render_in_pager(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tools_cmds, "build_tool_catalog", lambda: _catalog(40))
+    pager_used = False
+
+    @contextmanager
+    def _fake_pager(*_args: object, **_kwargs: object) -> Iterator[None]:
+        nonlocal pager_used
+        pager_used = True
+        yield
+
+    console = _make_console(tty=True, height=24)
+    monkeypatch.setattr(console, "pager", _fake_pager)
+
+    assert tools_cmds._list_tools(_FakeSession(), console, []) is True  # type: ignore[arg-type]
+    assert pager_used is True
+
+
+def test_non_tty_never_pages_even_for_long_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tools_cmds, "build_tool_catalog", lambda: _catalog(100))
+    pager_used = False
+
+    @contextmanager
+    def _fake_pager(*_args: object, **_kwargs: object) -> Iterator[None]:
+        nonlocal pager_used
+        pager_used = True
+        yield
+
+    console = _make_console(tty=False, height=24)
+    monkeypatch.setattr(console, "pager", _fake_pager)
+
+    assert tools_cmds._list_tools(_FakeSession(), console, []) is True  # type: ignore[arg-type]
+    assert pager_used is False
+    output: str = console.file.getvalue()  # type: ignore[attr-defined]
+    assert "tool_0" in output
+    assert "tool_99" in output
+
+
+def test_empty_catalog_renders_hint_no_pager(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tools_cmds, "build_tool_catalog", lambda: [])
+    pager_used = False
+
+    @contextmanager
+    def _fake_pager(*_args: object, **_kwargs: object) -> Iterator[None]:
+        nonlocal pager_used
+        pager_used = True
+        yield
+
+    console = _make_console(tty=True, height=24)
+    monkeypatch.setattr(console, "pager", _fake_pager)
+
+    assert tools_cmds._list_tools(_FakeSession(), console, []) is True  # type: ignore[arg-type]
+    assert pager_used is False
+    # Existing "no tools registered." hint is delegated to render_tools_table.
+
+
+# ------------------------------------------------------------------------ command
+
+
+def test_command_surface_unchanged() -> None:
+    (spec,) = tools_cmds.COMMANDS
+    assert spec.name == "/tools"
+    assert spec.usage == ("/tools", "/tools list")
+    first_arg_names = {name for name, _desc in spec.first_arg_completions or ()}
+    assert first_arg_names == {"list", "ls", "tool", "tools"}


### PR DESCRIPTION
Fixes #3340. Rework of the closed #3783.

@muddlebee — you asked to \"stick to only `/tools`\", so this version drops every subcommand and adds no new tab-completions. The command surface is byte-for-byte identical to `main`:

```
/tools
/tools list
/tools ls
/tools tool
/tools tools
```

The only behavioural change is invisible until the table overflows: when the estimated table height exceeds the current terminal height, the render is wrapped in `console.pager(styles=True)` so the user gets a scrollable `less`-style view instead of losing the top of the list.

#### Threshold behaviour (live demo)

Run of the `_should_page` helper against realistic terminal sizes:

```
Table height estimate vs. terminal capacity
------------------------------------------------------------
 entries | est. rows |  terminal 24 |  terminal 60
------------------------------------------------------------
       0 |         4 |       inline |       inline
       3 |        13 |       inline |       inline
      10 |        34 |        PAGER |       inline
      20 |        64 |        PAGER |        PAGER
      40 |       124 |        PAGER |        PAGER
      60 |       184 |        PAGER |        PAGER
     100 |       304 |        PAGER |        PAGER

Guardrails (never page):
  100 entries, non-TTY (piped/CI)    -> inline
  100 entries, terminal_height == 0  -> inline
```

Under any of these conditions the code takes the inline path — same as `main` today:

- non-TTY console (pytest, piped output, CI logs, gateway sink)
- unknown `console.size.height` (== 0)
- catalog small enough to fit

#### Change footprint

- `surfaces/interactive_shell/command_registry/tools_cmds.py` — add `_estimate_table_height` + `_should_page` pure helpers, and choose `console.pager(...)` vs inline render inside `_list_tools`. Everything else — `make_list_root_handler` factory, aliases, `_TOOLS_FIRST_ARGS`, `SlashCommand` metadata — is left exactly as before.
- `tests/interactive_shell/command_registry/test_tools_cmds.py` — 10 unit tests. Six cover the pure decision helpers (TTY guard, unknown height, fit, overflow, monotonic); four exercise `_list_tools` with a stubbed pager to prove the branch actually fires (short → no pager, long → pager, non-TTY → no pager even when long, empty → no pager).

#### Verification

```
$ uv run pytest tests/interactive_shell/command_registry/ -q
............................................                             [100%]
44 passed, 1 warning in 0.92s

$ uv run ruff check surfaces/interactive_shell/command_registry/tools_cmds.py
All checks passed!

$ uv run ruff format --check
All checks passed!

$ uv run mypy surfaces/interactive_shell/command_registry/tools_cmds.py
Success: no issues found in 1 source file
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself

**Explain your implementation approach:**

Issue #3340 lists four possible fixes: pager, filter/search flag, temp file, count. My earlier attempt (#3783) added subcommands for search + count, and @muddlebee's close comment said no subcommands. The pager option is the one that fixes the truncation without changing the command surface at all — `/tools` still means what it always did, but the output no longer scrolls off when there are 60+ tools.

I kept `make_list_root_handler` (didn't replace the router this time) and only extended `_list_tools`. Threshold logic is a pure function so the tests can drive it without a real terminal. Rich's `console.pager()` falls back to plain output when `PAGER` isn't available, so no runtime regressions on unusual environments.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions