### PR TITLE
docs(surfaces): fix stale cli package path comment

### DIFF
--- a/surfaces/cli/wizard/_ui.py
+++ b/surfaces/cli/wizard/_ui.py
@@ -249,7 +249,7 @@ def _choose_model(
 ) -> str:
     """Prompt the user to pick a model from ``provider.models``.
 
-    Choices come from the curated config in ``cli/wizard/config.py``.
+    Choices come from the curated config in ``surfaces/cli/wizard/config.py``.
     A saved model that isn't in the curated list is preserved as ``current``
     so re-running the wizard never silently drops a user's prior pick, and an
     "Enter custom model ID" escape hatch is always available.


### PR DESCRIPTION
Fixes #3521

#### Describe the changes you have made in this PR -

This PR picks the `surfaces/cli` package and updates one stale docstring path in the CLI wizard UI helper.

Changed:
- `cli/wizard/config.py` -> `surfaces/cli/wizard/config.py`

No runtime behavior changes. This is a comment/docstring-only cleanup.

### Demo/Screenshot for feature changes and bug fixes -

Search evidence for the chosen package:

```text
$ rg -n 'app/' ./surfaces/cli --glob '*.py' --glob '*.md' --glob '*.mdx'
./surfaces/cli/llm_auth/providers.py:35:    "gemini": "https://aistudio.google.com/app/apikey"

$ rg -n 'cli/' ./surfaces/cli --glob '*.py' --glob '*.md' --glob '*.mdx'
./surfaces/cli/wizard/config.py:281:# Source: https://developers.openai.com/codex/cli/features (verified 2026-05-21).
./surfaces/cli/wizard/_ui.py:252:    Choices come from the curated config in ``surfaces/cli/wizard/config.py``.
```

The remaining hits are accurate and intentionally unchanged: one Gemini web URL, one OpenAI docs URL, and the corrected current `surfaces/cli/...` path.

Verification:

```text
git diff --check
make format-check
make lint
make typecheck
make test-scope
```

`make test-scope` result for the final diff: `775 passed, 1 skipped, 2 warnings`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I scoped the cleanup to one package, `surfaces/cli`, as requested in the issue. I ran the exact `rg` searches for `app/` and `cli/`, updated only the stale package-layout docstring, and left URL references that are still accurate unchanged. No functions, classes, or runtime logic were added or modified.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
