### PR TITLE
fix(gather-evidence): read incident_window since/until in prompt

### DIFF
--- a/tests/agent/test_prompt.py
+++ b/tests/agent/test_prompt.py
@@ -178,6 +178,42 @@ def test_relevant_sources_honors_explicit_context_sources() -> None:
     assert _relevant_sources(state, tools_by_source) == ["vercel"]
 
 
+def test_alert_context_includes_incident_window_since_until_keys() -> None:
+    context = format_alert_context(
+        {
+            "alert_name": "Kubernetes job failed",
+            "alert_source": "generic",
+            "pipeline_name": "kubernetes_etl_pipeline",
+            "severity": "critical",
+            "incident_window": {
+                "since": "2026-02-18T22:10:00Z",
+                "until": "2026-02-19T00:10:00Z",
+                "source": "alert.startsAt",
+                "confidence": 1.0,
+            },
+        }
+    )
+
+    assert "Incident window: 2026-02-18T22:10:00Z → 2026-02-19T00:10:00Z" in context
+
+
+def test_alert_context_accepts_legacy_incident_window_start_end_keys() -> None:
+    context = format_alert_context(
+        {
+            "alert_name": "Legacy window shape",
+            "alert_source": "generic",
+            "pipeline_name": "widgets",
+            "severity": "warning",
+            "incident_window": {
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-01T02:00:00Z",
+            },
+        }
+    )
+
+    assert "Incident window: 2026-01-01T00:00:00Z → 2026-01-01T02:00:00Z" in context
+
+
 def test_alert_context_points_to_primary_source_without_duplicating_tool_metadata() -> None:
     context = format_alert_context(
         {

--- a/tools/investigation/stages/gather_evidence/prompt.py
+++ b/tools/investigation/stages/gather_evidence/prompt.py
@@ -160,8 +160,8 @@ def _build_extra_parts(state: dict[str, Any]) -> list[str]:
 
     incident_window = state.get("incident_window")
     if isinstance(incident_window, dict):
-        start = incident_window.get("start", "")
-        end = incident_window.get("end", "")
+        start = incident_window.get("since") or incident_window.get("start") or ""
+        end = incident_window.get("until") or incident_window.get("end") or ""
         if start and end:
             parts.append(f"Incident window: {start} → {end}")
 


### PR DESCRIPTION
## Summary

Fixes #3814.

`IncidentWindow.to_dict()` serializes `since` and `until`, but the gather-evidence alert context builder only read `start` and `end`. The incident window line was therefore never included in the evidence-gathering prompt, even when the window was correctly anchored.

This aligns gather-evidence with `plan_evidence`, which already accepts both spellings.

## Changes

- Read `since`/`until` first in `_build_extra_parts`, with `start`/`end` as legacy fallback
- Add regression tests for both key shapes

## Test plan

- [x] `uv run pytest tests/agent/test_prompt.py`
- [x] `make format-check`
- [x] `make lint`
- [x] `make typecheck`