### PR TITLE
fix(delivery): align error shapes across messaging delivery modules

### DIFF
--- a/integrations/twilio/delivery.py
+++ b/integrations/twilio/delivery.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import httpx
-
 from platform.common.truncation import truncate
+from platform.notifications.delivery_errors import extract_http_error
+from platform.notifications.delivery_transport import post_form
 from platform.notifications.redaction import redact_token
 
 logger = logging.getLogger(__name__)
@@ -51,41 +51,24 @@ def post_twilio_sms(
     if status_callback:
         payload["StatusCallback"] = status_callback
 
-    try:
-        response = httpx.post(
-            url,
-            data=payload,
-            auth=(account_sid, auth_token),
-            timeout=15.0,
-            follow_redirects=False,
-        )
-    except Exception as exc:
-        error = redact_token(str(exc), auth_token)
+    response = post_form(
+        url,
+        payload,
+        auth=(account_sid, auth_token),
+        timeout=15.0,
+    )
+    if not response.ok:
+        error = redact_token(response.error, auth_token)
         logger.warning("[twilio-sms] post exception: %s", error)
         return False, error, ""
 
-    parsed: dict[str, Any] = {}
-    try:
-        raw = response.json()
-        if isinstance(raw, dict):
-            parsed = raw
-    except Exception:
-        parsed = {}
-
     if response.status_code not in (200, 201):
-        if parsed:
-            error_message = str(
-                parsed.get("message")
-                or parsed.get("error_message")
-                or f"HTTP {response.status_code}"
-            )
-        else:
-            error_message = response.text or f"HTTP {response.status_code}"
+        error_message = extract_http_error(response.data, response.status_code, response.text)
         error_message = redact_token(error_message, auth_token)
         logger.warning("[twilio-sms] post failed: %s", error_message)
         return False, error_message, ""
 
-    return True, "", str(parsed.get("sid") or "")
+    return True, "", str(response.data.get("sid") or "")
 
 
 def send_twilio_sms_report(

--- a/integrations/whatsapp/delivery.py
+++ b/integrations/whatsapp/delivery.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import httpx
-
 from platform.common.truncation import truncate
+from platform.notifications.delivery_errors import extract_http_error
+from platform.notifications.delivery_transport import post_form
 from platform.notifications.limits import MAX_MESSAGE_SIZE
 from platform.notifications.redaction import redact_token
 
@@ -37,42 +37,24 @@ def post_whatsapp_message_twilio(
         "To": twilio_to,
         "Body": text,
     }
-    try:
-        response = httpx.post(
-            url,
-            data=payload,
-            auth=(account_sid, auth_token),
-            timeout=15.0,
-            follow_redirects=False,
-        )
-    except Exception as exc:
-        error = redact_token(str(exc), auth_token)
+    response = post_form(
+        url,
+        payload,
+        auth=(account_sid, auth_token),
+        timeout=15.0,
+    )
+    if not response.ok:
+        error = redact_token(response.error, auth_token)
         logger.warning("[whatsapp] twilio post exception: %s", error)
         return False, error, ""
 
-    error_message = ""
-    parsed: dict[str, Any] = {}
-    try:
-        raw = response.json()
-        if isinstance(raw, dict):
-            parsed = raw
-    except Exception:
-        parsed = {}
-
     if response.status_code not in (200, 201):
-        if parsed:
-            error_message = str(
-                parsed.get("message")
-                or parsed.get("error_message")
-                or f"HTTP {response.status_code}"
-            )
-        else:
-            error_message = response.text or f"HTTP {response.status_code}"
+        error_message = extract_http_error(response.data, response.status_code, response.text)
         error_message = redact_token(error_message, auth_token)
         logger.warning("[whatsapp] twilio post failed: %s", error_message)
         return False, error_message, ""
 
-    message_id = str(parsed.get("sid") or "")
+    message_id = str(response.data.get("sid") or "")
     return True, "", message_id
 
 

--- a/platform/notifications/delivery_errors.py
+++ b/platform/notifications/delivery_errors.py
@@ -29,6 +29,9 @@ def extract_http_error(
     msg = data.get("message")
     if msg:
         return str(msg)
+    err_msg = data.get("error_message")
+    if err_msg:
+        return str(err_msg)
     err = data.get("error")
     if err:
         return str(err)

--- a/platform/notifications/delivery_transport.py
+++ b/platform/notifications/delivery_transport.py
@@ -72,6 +72,62 @@ class DeliveryResponse:
             object.__setattr__(self, "data", MappingProxyType(dict(self.data)))
 
 
+def post_form(
+    url: str,
+    data: dict[str, str],
+    *,
+    auth: tuple[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = 15.0,
+    follow_redirects: bool = False,
+) -> DeliveryResponse:
+    """POST ``data`` as form-encoded to ``url`` and return a normalized result.
+
+    Mirrors :func:`post_json` but sends ``application/x-www-form-urlencoded``
+    bodies with optional HTTP Basic Auth — the shape required by Twilio and
+    WhatsApp delivery endpoints.
+
+    Args:
+        url: Absolute URL to post to.
+        data: Form fields to encode in the request body.
+        auth: Optional ``(username, password)`` tuple for HTTP Basic Auth.
+        headers: Optional extra headers.
+        timeout: Request timeout in seconds. Defaults to 15s.
+        follow_redirects: Whether to follow 3xx redirects.
+
+    Returns:
+        ``DeliveryResponse`` with ``ok``, ``status_code``, ``data``,
+        ``text``, and ``error`` populated.
+    """
+    try:
+        response = httpx.post(
+            url,
+            data=data,
+            auth=auth,
+            headers=headers or {},
+            timeout=timeout,
+            follow_redirects=follow_redirects,
+        )
+    except Exception as exc:
+        return DeliveryResponse(ok=False, error=str(exc), exc_type=type(exc).__name__)
+
+    text = response.text
+    parsed_data: dict[str, Any] = {}
+    try:
+        parsed = response.json()
+        if isinstance(parsed, dict):
+            parsed_data = parsed
+    except Exception:
+        pass
+
+    return DeliveryResponse(
+        ok=True,
+        status_code=response.status_code,
+        data=parsed_data,
+        text=text,
+    )
+
+
 def post_json(
     url: str,
     payload: dict[str, Any],

--- a/platform/notifications/delivery_transport.py
+++ b/platform/notifications/delivery_transport.py
@@ -118,6 +118,7 @@ def post_form(
         if isinstance(parsed, dict):
             parsed_data = parsed
     except Exception:
+        # non-JSON body is permitted; fall through with empty data
         pass
 
     return DeliveryResponse(

--- a/tests/utils/test_delivery_errors.py
+++ b/tests/utils/test_delivery_errors.py
@@ -10,9 +10,21 @@ class TestExtractHttpError:
         result = extract_http_error({"message": "Missing Permissions"}, 403, "html")
         assert result == "Missing Permissions"
 
+    def test_falls_back_to_error_message_field(self) -> None:
+        result = extract_http_error({"error_message": "Queue overflow"}, 400, "html body")
+        assert result == "Queue overflow"
+
     def test_falls_back_to_error_field(self) -> None:
         result = extract_http_error({"error": "channel_not_found"}, 400, "html body")
         assert result == "channel_not_found"
+
+    def test_message_takes_precedence_over_error_message(self) -> None:
+        result = extract_http_error({"message": "primary", "error_message": "secondary"}, 400, "")
+        assert result == "primary"
+
+    def test_error_message_takes_precedence_over_error(self) -> None:
+        result = extract_http_error({"error_message": "twilio err", "error": "generic"}, 400, "")
+        assert result == "twilio err"
 
     def test_falls_back_to_text_when_no_error_fields(self) -> None:
         result = extract_http_error({}, 502, "<html>Bad Gateway</html>")

--- a/tests/utils/test_delivery_transport.py
+++ b/tests/utils/test_delivery_transport.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
-from platform.notifications.delivery_transport import DeliveryResponse, post_json
+from platform.notifications.delivery_transport import DeliveryResponse, post_form, post_json
 
 
 def _mock_response(status_code: int, json_body: Any = None, text: str = "") -> MagicMock:
@@ -274,3 +274,78 @@ class TestPostJsonErrorType:
         result = post_json("https://example.test", {})
         assert result.ok is True
         assert result.exc_type == ""
+
+
+class TestPostFormHappyPath:
+    """post_form sends form-encoded data with optional HTTP Basic Auth."""
+
+    def test_returns_ok_with_status_data_text(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        body = {"sid": "SM123"}
+        monkeypatch.setattr(
+            "platform.notifications.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(201, body, '{"sid":"SM123"}'),
+        )
+        result = post_form("https://api.twilio.com/test", {"To": "+1", "Body": "hi"})
+        assert result.ok is True
+        assert result.status_code == 201
+        assert result.data == body
+        assert result.error == ""
+
+    def test_passes_auth_and_data_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+
+        def _capture(url: str, **kwargs: Any) -> MagicMock:
+            captured["url"] = url
+            captured.update(kwargs)
+            return _mock_response(201, {"sid": "SM1"})
+
+        monkeypatch.setattr("platform.notifications.delivery_transport.httpx.post", _capture)
+        post_form(
+            "https://api.twilio.com/test",
+            {"To": "+1", "Body": "hi"},
+            auth=("AC1", "secret"),
+            timeout=10.0,
+        )
+        assert captured["url"] == "https://api.twilio.com/test"
+        assert captured["data"] == {"To": "+1", "Body": "hi"}
+        assert captured["auth"] == ("AC1", "secret")
+        assert captured["timeout"] == 10.0
+        assert captured["follow_redirects"] is False
+        # post_form must NOT send json=
+        assert "json" not in captured
+
+    def test_auth_none_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(
+            "platform.notifications.delivery_transport.httpx.post",
+            lambda *_a, **kw: captured.update(kw) or _mock_response(200, {}),
+        )
+        post_form("https://example.test", {"k": "v"})
+        assert captured["auth"] is None
+
+
+class TestPostFormTransportFailures:
+    """post_form must catch transport errors like post_json."""
+
+    def test_request_exception_becomes_ok_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _raise(*_a: Any, **_kw: Any) -> Any:
+            raise ConnectionError("refused")
+
+        monkeypatch.setattr("platform.notifications.delivery_transport.httpx.post", _raise)
+        result = post_form("https://example.test", {"k": "v"})
+        assert result.ok is False
+        assert result.status_code == 0
+        assert "refused" in result.error
+        assert result.exc_type == "ConnectionError"
+
+    def test_non_json_body_yields_empty_data(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "platform.notifications.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(
+                200, ValueError("not json"), text="<html>oops</html>"
+            ),
+        )
+        result = post_form("https://example.test", {})
+        assert result.ok is True
+        assert result.data == {}
+        assert result.text == "<html>oops</html>"

--- a/tests/utils/test_twilio_delivery.py
+++ b/tests/utils/test_twilio_delivery.py
@@ -7,32 +7,36 @@ from typing import Any
 import pytest
 
 from integrations.twilio.delivery import post_twilio_sms, send_twilio_sms_report
+from platform.notifications.delivery_transport import DeliveryResponse
 
 
-class _Resp:
-    def __init__(self, payload: dict[str, Any], status_code: int = 201) -> None:
-        self._payload = payload
-        self.status_code = status_code
-        self.text = ""
-
-    def json(self) -> dict[str, Any]:
-        return self._payload
+def _success_response(**kwargs: Any) -> DeliveryResponse:
+    defaults: dict[str, Any] = {"ok": True, "status_code": 201, "data": {"sid": "SM1"}}
+    defaults.update(kwargs)
+    return DeliveryResponse(**defaults)
 
 
-def _patch_post(monkeypatch: pytest.MonkeyPatch, response: _Resp) -> dict[str, Any]:
-    captured: dict[str, Any] = {}
-
-    def _fake_post(url: str, **kwargs: Any) -> _Resp:
-        captured["url"] = url
-        captured.update(kwargs)
-        return response
-
-    monkeypatch.setattr("integrations.twilio.delivery.httpx.post", _fake_post)
-    return captured
+def _error_response(**kwargs: Any) -> DeliveryResponse:
+    defaults: dict[str, Any] = {
+        "ok": True,
+        "status_code": 400,
+        "data": {"message": "Invalid 'To' parameter"},
+        "text": "Bad Request",
+    }
+    defaults.update(kwargs)
+    return DeliveryResponse(**defaults)
 
 
 def test_post_twilio_sms_success(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured = _patch_post(monkeypatch, _Resp({"sid": "SM1"}))
+    captured: dict[str, Any] = {}
+
+    def _fake_post_form(url: str, data: dict[str, str], **kwargs: Any) -> DeliveryResponse:
+        captured["url"] = url
+        captured["data"] = data
+        captured.update(kwargs)
+        return _success_response()
+
+    monkeypatch.setattr("integrations.twilio.delivery.post_form", _fake_post_form)
 
     success, error, sid = post_twilio_sms(
         to="+14155550000",
@@ -49,12 +53,19 @@ def test_post_twilio_sms_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert captured["data"]["Body"] == "ping"
     assert "MessagingServiceSid" not in captured["data"]
     assert "StatusCallback" not in captured["data"]
+    assert captured["auth"] == ("AC1", "tok")
 
 
 def test_post_twilio_sms_with_messaging_service_overrides_from(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured = _patch_post(monkeypatch, _Resp({"sid": "SM2"}))
+    captured: dict[str, Any] = {}
+
+    def _fake_post_form(url: str, data: dict[str, str], **kwargs: Any) -> DeliveryResponse:
+        captured["data"] = data
+        return _success_response(data={"sid": "SM2"})
+
+    monkeypatch.setattr("integrations.twilio.delivery.post_form", _fake_post_form)
 
     post_twilio_sms(
         to="+14155550000",
@@ -72,7 +83,13 @@ def test_post_twilio_sms_with_messaging_service_overrides_from(
 def test_post_twilio_sms_status_callback_passes_through(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured = _patch_post(monkeypatch, _Resp({"sid": "SM3"}))
+    captured: dict[str, Any] = {}
+
+    def _fake_post_form(url: str, data: dict[str, str], **kwargs: Any) -> DeliveryResponse:
+        captured["data"] = data
+        return _success_response(data={"sid": "SM3"})
+
+    monkeypatch.setattr("integrations.twilio.delivery.post_form", _fake_post_form)
 
     post_twilio_sms(
         to="+14155550000",
@@ -102,10 +119,12 @@ def test_post_twilio_sms_missing_sender_fails() -> None:
 def test_post_twilio_sms_transport_failure_redacts_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _fake_post(*_args: Any, **_kwargs: Any) -> Any:
-        raise RuntimeError("auth header tok-leak failed")
-
-    monkeypatch.setattr("integrations.twilio.delivery.httpx.post", _fake_post)
+    monkeypatch.setattr(
+        "integrations.twilio.delivery.post_form",
+        lambda *_a, **_kw: DeliveryResponse(
+            ok=False, error="auth header tok-leak failed", exc_type="RuntimeError"
+        ),
+    )
 
     success, error, sid = post_twilio_sms(
         to="+14155550000",
@@ -122,7 +141,10 @@ def test_post_twilio_sms_transport_failure_redacts_token(
 
 
 def test_post_twilio_sms_api_error_returns_message(monkeypatch: pytest.MonkeyPatch) -> None:
-    _patch_post(monkeypatch, _Resp({"message": "Invalid 'To' parameter"}, status_code=400))
+    monkeypatch.setattr(
+        "integrations.twilio.delivery.post_form",
+        lambda *_a, **_kw: _error_response(),
+    )
 
     success, error, sid = post_twilio_sms(
         to="bad",
@@ -137,8 +159,39 @@ def test_post_twilio_sms_api_error_returns_message(monkeypatch: pytest.MonkeyPat
     assert sid == ""
 
 
+def test_post_twilio_sms_api_error_message_key_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Twilio sometimes uses error_message instead of message."""
+    monkeypatch.setattr(
+        "integrations.twilio.delivery.post_form",
+        lambda *_a, **_kw: DeliveryResponse(
+            ok=True,
+            status_code=400,
+            data={"error_message": "Queue overflow"},
+            text="",
+        ),
+    )
+
+    success, error, sid = post_twilio_sms(
+        to="+14155550000",
+        text="hi",
+        account_sid="AC1",
+        auth_token="tok",
+        from_number="+14155551111",
+    )
+
+    assert success is False
+    assert "Queue overflow" in error
+    assert sid == ""
+
+
 def test_send_twilio_sms_report_truncates(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured = _patch_post(monkeypatch, _Resp({"sid": "SM6"}))
+    captured: dict[str, Any] = {}
+
+    def _fake_post_form(url: str, data: dict[str, str], **kwargs: Any) -> DeliveryResponse:
+        captured["data"] = data
+        return _success_response(data={"sid": "SM6"})
+
+    monkeypatch.setattr("integrations.twilio.delivery.post_form", _fake_post_form)
 
     send_twilio_sms_report(
         report="X" * 5000,
@@ -181,7 +234,10 @@ def test_send_twilio_sms_report_missing_sender() -> None:
 
 
 def test_send_twilio_sms_report_success_returns_sid(monkeypatch: pytest.MonkeyPatch) -> None:
-    _patch_post(monkeypatch, _Resp({"sid": "SM-OK"}))
+    monkeypatch.setattr(
+        "integrations.twilio.delivery.post_form",
+        lambda *_a, **_kw: _success_response(data={"sid": "SM-OK"}),
+    )
 
     success, error, sid = send_twilio_sms_report(
         report="investigation summary",
@@ -196,3 +252,16 @@ def test_send_twilio_sms_report_success_returns_sid(monkeypatch: pytest.MonkeyPa
     assert success is True
     assert error == ""
     assert sid == "SM-OK"
+
+
+class TestTwilioDelegatesToSharedTransport:
+    """Twilio delivery must use post_form from delivery_transport,
+    not import httpx directly."""
+
+    def test_module_does_not_import_httpx(self) -> None:
+        from integrations.twilio import delivery as twilio_delivery
+
+        assert not hasattr(twilio_delivery, "httpx"), (
+            "twilio_delivery should not import httpx directly — "
+            "it must go through delivery_transport.post_form"
+        )

--- a/tests/utils/test_whatsapp_delivery.py
+++ b/tests/utils/test_whatsapp_delivery.py
@@ -1,4 +1,4 @@
-"""Tests for utils/whatsapp_delivery.py."""
+"""Tests for integrations.whatsapp.delivery — WhatsApp via Twilio transport."""
 
 from __future__ import annotations
 
@@ -10,25 +10,36 @@ from integrations.whatsapp.delivery import (
     post_whatsapp_message_twilio,
     send_whatsapp_report,
 )
+from platform.notifications.delivery_transport import DeliveryResponse
+
+
+def _success_response(**kwargs: Any) -> DeliveryResponse:
+    defaults: dict[str, Any] = {"ok": True, "status_code": 201, "data": {"sid": "SM123"}}
+    defaults.update(kwargs)
+    return DeliveryResponse(**defaults)
+
+
+def _error_response(**kwargs: Any) -> DeliveryResponse:
+    defaults: dict[str, Any] = {
+        "ok": True,
+        "status_code": 400,
+        "data": {"message": "Invalid 'From' parameter"},
+        "text": "Bad Request",
+    }
+    defaults.update(kwargs)
+    return DeliveryResponse(**defaults)
 
 
 def test_post_whatsapp_message_twilio_success(monkeypatch: pytest.MonkeyPatch) -> None:
-    class _Resp:
-        status_code = 201
-        text = ""
-
-        @staticmethod
-        def json() -> dict[str, Any]:
-            return {"sid": "SM123"}
-
     captured: dict[str, Any] = {}
 
-    def _fake_post(url: str, **kwargs: Any) -> Any:
+    def _fake_post_form(url: str, data: dict[str, str], **kwargs: Any) -> DeliveryResponse:
         captured["url"] = url
+        captured["data"] = data
         captured.update(kwargs)
-        return _Resp()
+        return _success_response()
 
-    monkeypatch.setattr("integrations.whatsapp.delivery.httpx.post", _fake_post)
+    monkeypatch.setattr("integrations.whatsapp.delivery.post_form", _fake_post_form)
 
     success, error, message_id = post_whatsapp_message_twilio(
         to="+1234567890",
@@ -45,13 +56,16 @@ def test_post_whatsapp_message_twilio_success(monkeypatch: pytest.MonkeyPatch) -
     assert captured["data"]["From"] == "whatsapp:+14155238886"
     assert captured["data"]["To"] == "whatsapp:+1234567890"
     assert captured["data"]["Body"] == "hello"
+    assert captured["auth"] == ("AC123", "secret")
 
 
 def test_post_whatsapp_message_twilio_transport_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_post(*args: Any, **kwargs: Any) -> Any:
-        raise RuntimeError("auth header tok-leak failed")
-
-    monkeypatch.setattr("integrations.whatsapp.delivery.httpx.post", _fake_post)
+    monkeypatch.setattr(
+        "integrations.whatsapp.delivery.post_form",
+        lambda *_a, **_kw: DeliveryResponse(
+            ok=False, error="auth header tok-leak failed", exc_type="RuntimeError"
+        ),
+    )
 
     success, error, message_id = post_whatsapp_message_twilio(
         to="+123",
@@ -68,15 +82,10 @@ def test_post_whatsapp_message_twilio_transport_failure(monkeypatch: pytest.Monk
 
 
 def test_post_whatsapp_message_twilio_api_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    class _Resp:
-        status_code = 400
-        text = "Bad Request"
-
-        @staticmethod
-        def json() -> dict[str, Any]:
-            return {"message": "Invalid 'From' parameter"}
-
-    monkeypatch.setattr("integrations.whatsapp.delivery.httpx.post", lambda *_a, **_kw: _Resp())
+    monkeypatch.setattr(
+        "integrations.whatsapp.delivery.post_form",
+        lambda *_a, **_kw: _error_response(),
+    )
 
     success, error, message_id = post_whatsapp_message_twilio(
         to="+123",
@@ -91,17 +100,34 @@ def test_post_whatsapp_message_twilio_api_error(monkeypatch: pytest.MonkeyPatch)
     assert message_id == ""
 
 
-def test_send_whatsapp_report_success(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_post(
-        to: str,
-        text: str,
-        account_sid: str,
-        auth_token: str,
-        from_number: str,
-    ) -> tuple[bool, str, str]:
-        return True, "", "SM456"
+def test_post_whatsapp_message_twilio_prefixes_whatsapp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
 
-    monkeypatch.setattr("integrations.whatsapp.delivery.post_whatsapp_message_twilio", _fake_post)
+    def _fake_post_form(url: str, data: dict[str, str], **kwargs: Any) -> DeliveryResponse:
+        captured["data"] = data
+        return _success_response()
+
+    monkeypatch.setattr("integrations.whatsapp.delivery.post_form", _fake_post_form)
+
+    post_whatsapp_message_twilio(
+        to="+1234567890",
+        text="hi",
+        account_sid="AC123",
+        auth_token="tok",
+        from_number="+14155238886",
+    )
+
+    assert captured["data"]["To"] == "whatsapp:+1234567890"
+    assert captured["data"]["From"] == "whatsapp:+14155238886"
+
+
+def test_send_whatsapp_report_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "integrations.whatsapp.delivery.post_form",
+        lambda *_a, **_kw: _success_response(data={"sid": "SM456"}),
+    )
 
     success, error = send_whatsapp_report(
         report="Investigation summary",
@@ -128,20 +154,13 @@ def test_send_whatsapp_report_missing_credentials() -> None:
 
 
 def test_send_whatsapp_report_truncates_long_report(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured_text: str = ""
+    captured: dict[str, Any] = {}
 
-    def _fake_post(
-        to: str,
-        text: str,
-        account_sid: str,
-        auth_token: str,
-        from_number: str,
-    ) -> tuple[bool, str, str]:
-        nonlocal captured_text
-        captured_text = text
-        return True, "", "SM789"
+    def _fake_post_form(url: str, data: dict[str, str], **kwargs: Any) -> DeliveryResponse:
+        captured["data"] = data
+        return _success_response()
 
-    monkeypatch.setattr("integrations.whatsapp.delivery.post_whatsapp_message_twilio", _fake_post)
+    monkeypatch.setattr("integrations.whatsapp.delivery.post_form", _fake_post_form)
 
     send_whatsapp_report(
         report="X" * 5000,
@@ -153,5 +172,18 @@ def test_send_whatsapp_report_truncates_long_report(monkeypatch: pytest.MonkeyPa
         },
     )
 
-    assert len(captured_text) <= 4096
-    assert captured_text.endswith("…")
+    assert len(captured["data"]["Body"]) <= 4096
+    assert captured["data"]["Body"].endswith("…")
+
+
+class TestWhatsAppDelegatesToSharedTransport:
+    """WhatsApp delivery must use post_form from delivery_transport,
+    not import httpx directly."""
+
+    def test_module_does_not_import_httpx(self) -> None:
+        from integrations.whatsapp import delivery as whatsapp_delivery
+
+        assert not hasattr(whatsapp_delivery, "httpx"), (
+            "whatsapp_delivery should not import httpx directly — "
+            "it must go through delivery_transport.post_form"
+        )


### PR DESCRIPTION
## Summary

Refactor WhatsApp and Twilio delivery modules to use the shared `delivery_transport` foundation instead of calling `httpx` directly.

Changes:
- Add `post_form()` to `delivery_transport.py` for form-encoded POST with HTTP Basic Auth (Twilio/WhatsApp shape).
- Extend `extract_http_error()` to check `error_message` key (Twilio API).
- Migrate `integrations/whatsapp/delivery.py` to use `post_form` + `extract_http_error`.
- Migrate `integrations/twilio/delivery.py` to use `post_form` + `extract_http_error`.
- Update tests to verify shared transport delegation.
- Add transport-contract regression tests (no direct `httpx` import).

All delivery modules now share consistent:
- Transport layer (`DeliveryResponse` from `delivery_transport`).
- Error extraction (`extract_http_error` from `delivery_errors`).
- Token redaction (`redact_token` from `redaction`).
- Return shapes preserved (no public API changes).

Closes #3533  
Fixes #3533

---

#### Describe the changes you have made in this PR

WhatsApp and Twilio delivery modules were calling `httpx.post` directly with inline JSON parsing and custom error extraction, while Discord, Telegram, and Slack already used the shared `platform/notifications/delivery_transport.py` foundation. This created inconsistent error shapes across delivery modules.

**What was done:**
- Added `post_form()` to `delivery_transport.py` mirrors `post_json()` but sends form-encoded bodies with optional HTTP Basic Auth (the transport shape Twilio and WhatsApp APIs require).
- Extended `extract_http_error()` to check `error_message` (Twilio's error key) in the fallback chain: `message` → `error_message` → `error` → raw text → HTTP status.
- Rewrote `integrations/whatsapp/delivery.py` and `integrations/twilio/delivery.py` to use `post_form` + `extract_http_error` + `redact_token` from the shared foundation.
- Updated all related tests to patch the shared transport layer and added regression tests ensuring these modules never import `httpx` directly again.

---

### Demo/Screenshot for feature changes and bug fixes

All CI checks pass locally:

```bash
$ uv run python -m ruff check ... → All checks passed!
$ uv run python -m ruff format --check ... → 8 files already formatted
$ uv run python -m mypy ... → Success: no issues found in 4 source files
$ uv run python -m pytest tests/utils/ tests/integrations/test_twilio.py tests/integrations/test_whatsapp.py → 340 passed
```
<img width="1881" height="831" alt="image" src="https://github.com/user-attachments/assets/a6656309-1cb9-407f-99b8-e0a390f9163d" />
<img width="1882" height="718" alt="image" src="https://github.com/user-attachments/assets/b390da0e-c72b-46f2-8439-438bd558a601" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself  
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code.
- [x] I can explain the purpose and logic of each function/component I added.
- [x] I have tested edge cases and understand how the code handles them.
- [x] I have modified the AI output to follow this project's coding standards and conventions.

**Explain your implementation approach:**

- **Problem:** WhatsApp and Twilio delivery had divergent error handling direct `httpx` calls, inline JSON parsing, and custom error extraction logic that didn't match the shared pattern used by Discord/Telegram/Slack.
- **Alternative considered:** Could have just standardized the error extraction without changing the transport layer, but that would leave two modules still bypassing the shared transport and its immutable `DeliveryResponse` contract.
- **Why this approach:** `post_form()` is the minimal addition to the shared transport that covers the Twilio/WhatsApp form-encoded + Basic Auth pattern. It returns the same `DeliveryResponse` dataclass, so all seven delivery modules now produce identical error shapes. No public API return types were changed.
- **Key components:**
  - `post_form()` shared form-encoded transport (catches all exceptions, normalizes response).
  - `extract_http_error()` now handles `message`, `error_message`, and `error` keys (covers Twilio, Discord, Slack).
  - Transport-delegation tests assert modules don't import `httpx` directly, preventing regression.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue.
- [x] I have performed a self-review of my code.
- [x] **I can explain the purpose of every function, class, and logic block I added.**
- [x] I understand why my changes work and have tested them thoroughly.
- [x] I have considered potential edge cases and how my code handles them.
- [x] If it is a core feature, I have added thorough tests.
- [x] My code follows the project's style guidelines and conventions.