### PR TITLE
fix(interactive-shell): animate /investigate progress via prompt spinner (#3353)

### DIFF
--- a/surfaces/interactive_shell/command_registry/investigation.py
+++ b/surfaces/interactive_shell/command_registry/investigation.py
@@ -278,9 +278,6 @@ def _cmd_investigate_file(session: Session, console: Console, args: list[str]) -
                 ),
                 apply_reasoning_effort(session.reasoning_effort),
             ):
-                suppress = getattr(console, "suppress_prompt_spinner", None)
-                if callable(suppress):
-                    suppress()
                 return run_sample_alert_for_session(
                     template_name=template_name,
                     context_overrides=session.accumulated_context or None,
@@ -343,9 +340,6 @@ def _cmd_investigate_file(session: Session, console: Console, args: list[str]) -
             ),
             apply_reasoning_effort(session.reasoning_effort),
         ):
-            suppress = getattr(console, "suppress_prompt_spinner", None)
-            if callable(suppress):
-                suppress()
             return run_investigation_for_session(
                 alert_text=text,
                 context_overrides=session.accumulated_context or None,

--- a/surfaces/interactive_shell/runtime/agent_presentation.py
+++ b/surfaces/interactive_shell/runtime/agent_presentation.py
@@ -78,13 +78,10 @@ async def _render_agent_presentation_transition(
     spinner: SpinnerState,
 ) -> None:
     """Perform the terminal side effects for one presentation transition."""
-    from surfaces.interactive_shell.ui.output import set_prompt_suppress_fn
-
     match event.type:
         case "turn_start":
             if current.show_spinner:
                 spinner.start()
-                set_prompt_suppress_fn(console.suppress_prompt_spinner)
         case "turn_interrupted":
             console.print(f"[{WARNING}]· interrupted[/]")
         case "turn_error":
@@ -98,7 +95,6 @@ async def _render_agent_presentation_transition(
             if isinstance(exc, LLMCreditExhaustedError):
                 console.print(f"[{DIM}]Run /model to switch to another provider.[/]")
         case "turn_end":
-            set_prompt_suppress_fn(None)
             if previous.show_spinner:
                 spinner.stop()
             await asyncio.sleep(0.05)

--- a/surfaces/interactive_shell/runtime/background/workers.py
+++ b/surfaces/interactive_shell/runtime/background/workers.py
@@ -112,10 +112,16 @@ class BackgroundTaskManager:
         # the LLM stream is writing rapidly. This task explicitly invalidates
         # the prompt at 100 ms intervals so the braille glyph cycles smoothly.
         tick_s = 0.1
+        was_streaming = False
         while not self.state.exit_requested:
             try:
                 await asyncio.sleep(tick_s)
             except asyncio.CancelledError:
                 return
-            if self.spinner.streaming:
+            streaming = self.spinner.streaming
+            # Invalidate while streaming, plus one extra tick on the
+            # streaming->idle edge so the prompt repaints without the stale
+            # spinner/phase label instead of waiting for unrelated I/O.
+            if streaming or was_streaming:
                 self.prompt_invalidator()
+            was_streaming = streaming

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -166,6 +166,7 @@ class SpinnerState:
         self.bytes_in: int = 0
         self._frame_idx: int = 0
         self._verb: str = self._THINKING_VERBS[0]
+        self.phase: str = ""
 
     def start(self) -> None:
         self.streaming = True
@@ -173,9 +174,25 @@ class SpinnerState:
         self.bytes_in = 0
         self._frame_idx = 0
         self._verb = random.choice(self._THINKING_VERBS)
+        self.phase = ""
+
+    def set_phase(self, label: str) -> None:
+        """Animate a caller-supplied phase label instead of a thinking verb.
+
+        Investigation stages (``/investigate``) dispatch deterministically, so
+        the turn-level "thinking" spinner never starts. The progress display
+        calls this to keep the prompt spinner cycling with the active pipeline
+        stage; it can be called repeatedly to advance the phase.
+        """
+        if not self.streaming:
+            self.started_at = time.monotonic()
+            self._frame_idx = 0
+        self.streaming = True
+        self.phase = label
 
     def stop(self) -> None:
         self.streaming = False
+        self.phase = ""
 
     def toolbar_ansi(self) -> str:
         # Always return an empty string so prompt_toolkit's ConditionalContainer
@@ -210,8 +227,9 @@ class SpinnerState:
             suffix = f" ({elapsed:.0f}s · ↓ {tokens_str} tokens)"
         else:
             suffix = f" ({elapsed:.0f}s)"
+        label = self.phase or f"{self._verb}…"
         return (
-            f"{ui_theme.PROMPT_ACCENT_ANSI}{glyph} {self._verb}…{ui_theme.ANSI_RESET}"
+            f"{ui_theme.PROMPT_ACCENT_ANSI}{glyph} {label}{ui_theme.ANSI_RESET}"
             f"{ui_theme.ANSI_DIM}{suffix}  esc to cancel{ui_theme.ANSI_RESET}"
         )
 

--- a/surfaces/interactive_shell/runtime/turn_host.py
+++ b/surfaces/interactive_shell/runtime/turn_host.py
@@ -42,6 +42,7 @@ from surfaces.interactive_shell.runtime.input.actions import (
 from surfaces.interactive_shell.runtime.utils.input_policy import (
     turn_needs_exclusive_stdin,
 )
+from surfaces.interactive_shell.ui.output.console_state import set_investigation_spinner
 from surfaces.interactive_shell.ui.output.repl_progress import repl_safe_progress_scope
 from surfaces.interactive_shell.ui.streaming.console import StreamingConsole
 from surfaces.interactive_shell.utils.error_handling.exception_reporting import report_exception
@@ -78,7 +79,6 @@ async def run_agent_turn(runtime: AgentTurnRuntime, text: str) -> None:
     console = StreamingConsole(
         runtime.spinner,
         dispatch_cancel,
-        prompt_invalidator=runtime.invalidate_prompt,
         highlight=False,
         force_terminal=True,
         color_system="truecolor",
@@ -97,6 +97,9 @@ async def run_agent_turn(runtime: AgentTurnRuntime, text: str) -> None:
     exclusive_stdin = turn_needs_exclusive_stdin(text, runtime.session)
     progress_scope = contextlib.nullcontext() if exclusive_stdin else repl_safe_progress_scope()
     runtime.session.exclusive_stdin_active = exclusive_stdin
+    # Expose this turn's spinner so an investigation display can animate it with
+    # per-stage phase labels; /investigate never starts the "thinking" spinner.
+    set_investigation_spinner(runtime.spinner)
     try:
         with progress_scope:
             await _run_agent_turn_loop(
@@ -109,6 +112,7 @@ async def run_agent_turn(runtime: AgentTurnRuntime, text: str) -> None:
                 dispatch_cancel=dispatch_cancel,
             )
     finally:
+        set_investigation_spinner(None)
         runtime.session.exclusive_stdin_active = False
 
 

--- a/surfaces/interactive_shell/ui/output/__init__.py
+++ b/surfaces/interactive_shell/ui/output/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from surfaces.interactive_shell.ui.components.time_format import _fmt_timing
 from surfaces.interactive_shell.ui.output.console_state import (
     set_live_console,
-    set_prompt_suppress_fn,
     stop_display,
     unregister_live_console,
 )
@@ -49,7 +48,6 @@ __all__ = [
     "render_investigation_header",
     # Console lifecycle
     "set_live_console",
-    "set_prompt_suppress_fn",
     "stop_display",
     "unregister_live_console",
     # Tool-detail toggle

--- a/surfaces/interactive_shell/ui/output/console_state.py
+++ b/surfaces/interactive_shell/ui/output/console_state.py
@@ -9,24 +9,30 @@ from rich.console import Console
 _live_console: Console | None = None
 _active_display: Any | None = None
 _completed_footer_snapshot: tuple[str, float, str, str] | None = None
-_prompt_suppress_fn: Callable[[], None] | None = None
 _tracker_toggle_stop_fn: Callable[[], None] | None = None
-
-
-def set_prompt_suppress_fn(fn: Callable[[], None] | None) -> None:
-    """Register (or clear) the callback that hides the REPL prompt spinner."""
-    global _prompt_suppress_fn
-    _prompt_suppress_fn = fn
-
-
-def get_prompt_suppress_fn() -> Callable[[], None] | None:
-    return _prompt_suppress_fn
+_investigation_spinner: Any | None = None
 
 
 def set_tracker_toggle_stop_fn(fn: Callable[[], None] | None) -> None:
     """Register callback used to stop tracker-owned keyboard watchers."""
     global _tracker_toggle_stop_fn
     _tracker_toggle_stop_fn = fn
+
+
+def set_investigation_spinner(spinner: Any | None) -> None:
+    """Register the prompt spinner the investigation display animates.
+
+    ``/investigate`` dispatches as a literal slash command, so the turn-level
+    "thinking" spinner never starts. Registering the active turn's spinner here
+    lets ``_ReplEventLogDisplay`` drive it with per-stage phase labels
+    (``set_phase``) and stop it (``stop``) as the pipeline runs.
+    """
+    global _investigation_spinner
+    _investigation_spinner = spinner
+
+
+def get_investigation_spinner() -> Any | None:
+    return _investigation_spinner
 
 
 def _capture_footer_snapshot(display: Any) -> None:

--- a/surfaces/interactive_shell/ui/output/repl_display.py
+++ b/surfaces/interactive_shell/ui/output/repl_display.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import io
-import os
 import shutil
-import sys
 import threading
 import time
 from typing import Any
@@ -15,13 +12,12 @@ from platform.terminal.theme import BRAND, DIM, SECONDARY
 from surfaces.interactive_shell.ui.components.time_format import _elapsed_hms
 from surfaces.interactive_shell.ui.output.events import ProgressEvent
 from surfaces.interactive_shell.ui.output.labels import (
+    _node_label,
     _node_phase_label,
     build_progress_step_text,
 )
 
-_REPL_ANIM_FRAMES = ("·", "··", "···", "··")
-_REPL_ANIM_INTERVAL = 0.35
-# Timestamp + indent + trailing dot animation; keep hints on one physical row.
+# Timestamp + indent; keep append-only hint lines on one physical row.
 _HINT_LINE_OVERHEAD = 20
 
 
@@ -34,7 +30,7 @@ def _terminal_columns() -> int:
 
 
 def _fit_hint_prefix(prefix: str, *, cols: int | None = None) -> str:
-    """Truncate hint text so cursor-up animation stays on a single terminal row."""
+    """Truncate hint text so an append-only lap line stays on a single row."""
     budget = max(16, (cols if cols is not None else _terminal_columns()) - _HINT_LINE_OVERHEAD)
     if len(prefix) <= budget:
         return prefix
@@ -43,15 +39,14 @@ def _fit_hint_prefix(prefix: str, *, cols: int | None = None) -> str:
     return f"{prefix[: budget - 3]}..."
 
 
-def _stdout_is_tty() -> bool:
-    try:
-        return os.isatty(sys.stdout.fileno())
-    except (AttributeError, io.UnsupportedOperation, OSError):
-        return False
-
-
 class _ReplEventLogDisplay:
-    """Append-only investigation progress for the interactive REPL."""
+    """Append-only investigation progress for the interactive REPL.
+
+    Live animation is delegated to the prompt spinner (``SpinnerState``): raw
+    cursor-up frames cannot rewrite a row under ``patch_stdout(raw=True)``, so
+    the display prints step/lap history append-only and drives the spinner with
+    per-stage phase labels via the ``console_state`` registration.
+    """
 
     def __init__(self, model: str = "", mode: str = "local", t0: float | None = None) -> None:
         self._model = model
@@ -61,71 +56,31 @@ class _ReplEventLogDisplay:
         self._current_phase = "LOAD"
         self._lock = threading.Lock()
         self._console = Console(highlight=False)
-        self._prompt_suppressed = False
-        self._anim_stop: threading.Event | None = None
-        self._anim_thread: threading.Thread | None = None
         self._last_emitted_hint: str | None = None
 
     def stop(self) -> None:
-        from surfaces.interactive_shell.ui.output.console_state import _capture_footer_snapshot
+        from surfaces.interactive_shell.ui.output.console_state import (
+            _capture_footer_snapshot,
+            get_investigation_spinner,
+        )
 
-        self._stop_animation()
+        spinner = get_investigation_spinner()
+        if spinner is not None:
+            spinner.stop()
         _capture_footer_snapshot(self)
 
     def _emit(self, line: Text | Any) -> None:
-        self._stop_animation()
         from surfaces.interactive_shell.ui.components.choice_menu import prepare_repl_output_line
 
         prepare_repl_output_line()
         self._console.print(line)
 
-    def _stop_animation(self) -> None:
-        stop = self._anim_stop
-        if stop is not None:
-            stop.set()
-            self._anim_stop = None
-        thread = self._anim_thread
-        if thread is not None:
-            thread.join(timeout=0.3)
-            self._anim_thread = None
-
-    def _start_animation(self, prefix: str) -> None:
-        if not _stdout_is_tty():
-            return
-        fitted_prefix = _fit_hint_prefix(prefix)
-        stop = threading.Event()
-        self._anim_stop = stop
-        t0 = self._t0
-
-        def _run() -> None:
-            from platform.terminal import theme
-
-            frame_idx = 0
-            while not stop.wait(_REPL_ANIM_INTERVAL):
-                frame_idx = (frame_idx + 1) % len(_REPL_ANIM_FRAMES)
-                dots = _REPL_ANIM_FRAMES[frame_idx]
-                ts = _elapsed_hms(time.monotonic() - t0)
-                frame_str = (
-                    f"\033[A\r"
-                    f"{theme.SECONDARY_ANSI}{ts}  {theme.ANSI_RESET}"
-                    f"{theme.ANSI_DIM}      ↳  {theme.ANSI_RESET}"
-                    f"{theme.SECONDARY_ANSI}{fitted_prefix} {dots}{theme.ANSI_RESET}"
-                    f"\033[K\n"
-                )
-                if not stop.is_set():
-                    sys.stdout.write(frame_str)
-                    sys.stdout.flush()
-
-        thread = threading.Thread(target=_run, daemon=True)
-        self._anim_thread = thread
-        thread.start()
-
     def animate_hint(self, text: str) -> None:
-        """Print one compact lap-status line; no cursor-up animation in the REPL.
+        """Print one compact append-only lap-status line.
 
-        Append-only output under prompt_toolkit cannot safely rewrite rows in
-        place — the old animation thread spammed stdout and looked like hundreds
-        of repeated API/tool lines when hints wrapped.
+        The live "still working" cue is the prompt spinner (driven from
+        ``step_start``); this only records lap hints as scrollback history and
+        dedupes consecutive identical lines.
         """
         prefix = _fit_hint_prefix(text.rstrip("· \t"))
         if prefix == self._last_emitted_hint:
@@ -139,12 +94,11 @@ class _ReplEventLogDisplay:
         self._emit(t)
 
     def step_start(self, node_name: str) -> None:
-        from surfaces.interactive_shell.ui.output.console_state import get_prompt_suppress_fn
+        from surfaces.interactive_shell.ui.output.console_state import get_investigation_spinner
 
-        prompt_suppress_fn = get_prompt_suppress_fn()
-        if not self._prompt_suppressed and prompt_suppress_fn is not None:
-            self._prompt_suppressed = True
-            prompt_suppress_fn()
+        spinner = get_investigation_spinner()
+        if spinner is not None:
+            spinner.set_phase(_node_label(node_name))
         with self._lock:
             self._active_steps[node_name] = {
                 "t0": time.monotonic(),
@@ -172,7 +126,6 @@ class _ReplEventLogDisplay:
         pass
 
     def step_complete(self, node_name: str, event: ProgressEvent) -> None:
-        self._stop_animation()
         self._last_emitted_hint = None
         with self._lock:
             info = self._active_steps.pop(node_name, {})

--- a/surfaces/interactive_shell/ui/streaming/console.py
+++ b/surfaces/interactive_shell/ui/streaming/console.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sys
 import threading
-from collections.abc import Callable
 from typing import Any, Protocol
 
 from rich.console import Console
@@ -26,14 +25,11 @@ class StreamingConsole(Console):
         self,
         spinner: _PromptSpinner,
         cancel_event: threading.Event,
-        *,
-        prompt_invalidator: Callable[[], None] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self._spinner = spinner
         self._cancel_event = cancel_event
-        self._prompt_invalidator = prompt_invalidator
 
     def update_streaming_progress(self, bytes_received: int) -> None:
         self._spinner.bytes_in = bytes_received
@@ -41,14 +37,6 @@ class StreamingConsole(Console):
     @property
     def cancel_requested(self) -> bool:
         return self._cancel_event.is_set()
-
-    def suppress_prompt_spinner(self) -> None:
-        """Stop the REPL spinner before another live renderer owns the footer."""
-        if not self._spinner.streaming:
-            return
-        self._spinner.stop()
-        if self._prompt_invalidator is not None:
-            self._prompt_invalidator()
 
     def print(self, *args: Any, **kwargs: Any) -> None:
         """Reset the TTY column before each print when not streaming."""

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import re
-import time
 from typing import Any
 
 import pytest
@@ -18,6 +17,7 @@ from surfaces.interactive_shell.ui.output import (
     suppress_stdin_watchers,
     toggle_active_tool_details,
 )
+from surfaces.interactive_shell.ui.output import console_state as output_repl_console_state
 from surfaces.interactive_shell.ui.output import environment as output_environment
 from surfaces.interactive_shell.ui.output import repl_display as output_repl
 from surfaces.interactive_shell.ui.output import toggles as output_toggles
@@ -594,7 +594,7 @@ def test_repl_tracker_skips_per_tool_call_lines(
 
 
 class TestReplHintAnimation:
-    """Tests for _ReplEventLogDisplay in-place hint animation."""
+    """Tests for _ReplEventLogDisplay lap hints and prompt-spinner phase drive."""
 
     def test_fit_hint_prefix_truncates_for_narrow_terminals(self) -> None:
         long_prefix = (
@@ -609,121 +609,34 @@ class TestReplHintAnimation:
         short = "Planning investigation (lap 1/20)"
         assert output_repl._fit_hint_prefix(short, cols=80) == short
 
-    def test_animate_hint_does_not_start_animation_thread(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """REPL lap hints print once; no background cursor-up spam."""
-        monkeypatch.setattr(output_repl, "_stdout_is_tty", lambda: True)
+    def test_animate_hint_dedupes_consecutive_identical_lines(self) -> None:
+        """Lap hints print once; a repeated hint is a no-op (append-only history)."""
         display = self._make_display()
+        emitted: list[str] = []
+        display._emit = lambda line: emitted.append(line.plain)  # type: ignore[method-assign]
+        display.animate_hint("Reviewing evidence (lap 2/20) after Datadog logs")
         display.animate_hint("Reviewing evidence (lap 2/20) after Datadog logs ·")
-        assert display._anim_thread is None
-        display.animate_hint("Reviewing evidence (lap 2/20) after Datadog logs ··")
-        assert display._anim_thread is None
+        assert len(emitted) == 1
+
+    def test_step_start_drives_prompt_spinner_phase(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The display animates the prompt spinner with the active stage label."""
+        from surfaces.interactive_shell.runtime.core.state import SpinnerState
+
+        spinner = SpinnerState()
+        monkeypatch.setattr(output_repl_console_state, "_investigation_spinner", spinner)
+        display = self._make_display()
+        display._emit = lambda _line: None  # type: ignore[method-assign]
+
+        display.step_start("investigation_agent")
+        assert spinner.streaming
+        assert spinner.phase == "Investigation"
+
+        display.stop()
+        assert not spinner.streaming
+        assert spinner.phase == ""
 
     def _make_display(self) -> output_repl._ReplEventLogDisplay:
         return output_repl._ReplEventLogDisplay(t0=0.0)
-
-    class _FakeStdout:
-        def __init__(self) -> None:
-            self.writes: list[str] = []
-
-        def write(self, s: str) -> None:
-            self.writes.append(s)
-
-        def flush(self) -> None:
-            pass
-
-        def fileno(self) -> int:
-            return 1
-
-    def test_no_ansi_when_not_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Animation does not start and no \\r/ANSI codes are emitted when stdout is not a TTY."""
-        monkeypatch.setattr(output_repl, "_stdout_is_tty", lambda: False)
-        fake = self._FakeStdout()
-        monkeypatch.setattr(output_repl.sys, "stdout", fake)
-
-        display = self._make_display()
-        display._start_animation("analyzing alert")
-        time.sleep(0.1)  # give potential thread time to run
-
-        assert display._anim_thread is None, "no thread should start on non-TTY"
-        ansi_or_cr = [w for w in fake.writes if "\r" in w or "\x1b" in w]
-        assert not ansi_or_cr, f"unexpected cursor/ANSI codes in non-TTY output: {ansi_or_cr}"
-
-    def test_animation_advances_multiple_frames_over_time(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Animation thread writes multiple distinct frames over wall-clock time."""
-        monkeypatch.setattr(output_repl, "_stdout_is_tty", lambda: True)
-        monkeypatch.setattr(output_repl, "_REPL_ANIM_INTERVAL", 0.05)  # fast for tests
-        fake = self._FakeStdout()
-        monkeypatch.setattr(output_repl.sys, "stdout", fake)
-
-        display = self._make_display()
-        display._start_animation("analyzing results")
-
-        # At 0.05s per frame, 0.3s gives ≥4 frames comfortably
-        time.sleep(0.3)
-        display._stop_animation()
-
-        frame_writes = [w for w in fake.writes if "analyzing results" in w]
-        assert len(frame_writes) >= 3, (
-            f"expected ≥3 animation frames, got {len(frame_writes)}: {frame_writes}"
-        )
-        for w in frame_writes:
-            # Frames use cursor-up + carriage-return, not bare \r
-            assert "\033[A\r" in w, "each frame must use cursor-up + \\r"
-            assert "\033[K" in w, "each frame must clear trailing chars with \\033[K"
-            assert w.endswith("\n"), "each frame must end with \\n to restore cursor position"
-        # Dots must cycle — collect the unique dot suffixes seen
-        import re as _re
-
-        dot_variants = {
-            _re.search(r"(·+)\x1b", w).group(1) for w in frame_writes if _re.search(r"(·+)\x1b", w)
-        }  # type: ignore[union-attr]
-        assert len(dot_variants) >= 2, f"expected cycling dots, got only: {dot_variants}"
-
-    def test_stop_animation_joins_thread_and_resets_state(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """_stop_animation signals the thread and joins it, leaving clean state."""
-        monkeypatch.setattr(output_repl, "_stdout_is_tty", lambda: True)
-        fake = self._FakeStdout()
-        monkeypatch.setattr(output_repl.sys, "stdout", fake)
-
-        display = self._make_display()
-        display._start_animation("analyzing")
-
-        assert display._anim_thread is not None
-        assert display._anim_thread.is_alive()
-
-        display._stop_animation()
-
-        assert display._anim_thread is None
-        assert display._anim_stop is None
-
-    def test_exception_during_synthesis_stops_animation_via_finally(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Animation is guaranteed stopped even when the caller raises mid-synthesis."""
-        monkeypatch.setattr(output_repl, "_stdout_is_tty", lambda: True)
-        fake = self._FakeStdout()
-        monkeypatch.setattr(output_repl.sys, "stdout", fake)
-
-        display = self._make_display()
-        display._start_animation("analyzing results")
-        assert display._anim_thread is not None
-
-        def _synthesis_then_stop() -> None:
-            try:
-                raise RuntimeError("synthesis failed")
-            finally:
-                display._stop_animation()
-
-        with pytest.raises(RuntimeError, match="synthesis failed"):
-            _synthesis_then_stop()
-
-        assert display._anim_thread is None
 
 
 def test_active_tool_detail_toggle_uses_newest_registered_callback() -> None:

--- a/tests/interactive_shell/runtime/test_spinner_ticker.py
+++ b/tests/interactive_shell/runtime/test_spinner_ticker.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+from core.agent_harness.session import Session
+from surfaces.interactive_shell.runtime.background.workers import BackgroundTaskManager
+from surfaces.interactive_shell.runtime.core.state import ReplState, SpinnerState
+
+
+@pytest.mark.asyncio
+async def test_spinner_ticker_invalidates_once_after_streaming_stops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ticker repaints while streaming and once more on the streaming->idle edge.
+
+    Without the trailing invalidation a stopped investigation would leave the
+    last phase label rendered on the prompt until unrelated I/O redraws it.
+    """
+    state = ReplState()
+    spinner = SpinnerState()
+    calls: list[int] = []
+    manager = BackgroundTaskManager(
+        cast(Session, cast(Any, object())),
+        state,
+        spinner,
+        None,
+        lambda: calls.append(1),
+    )
+
+    ticks = 0
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(_seconds: float) -> None:
+        nonlocal ticks
+        ticks += 1
+        if ticks == 1:
+            spinner.set_phase("Investigation")  # streaming on
+        elif ticks == 3:
+            spinner.stop()  # streaming off (investigation done)
+        elif ticks >= 5:
+            state.exit_requested = True
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await manager._spinner_ticker()
+
+    # ticks 1-2 stream (2 invalidations) + one trailing edge at tick 3, then
+    # silence while idle at tick 4.
+    assert len(calls) == 3


### PR DESCRIPTION
Fixes #3353

#### Describe the changes you have made in this PR -

The `/investigate` progress indicator sat frozen while the pipeline ran. Two things caused it:

- `/investigate` is a literal slash command, so the turn-level spinner never starts (it's suppressed on purpose for deterministic commands).
- The old cursor-up dot animation can't work under `patch_stdout(raw=True)` — every frame gets rendered as a new line instead of rewriting one, which is exactly why it was disabled in an earlier PR and left as dead code.

So nothing was driving the one animation that *is* safe here: the prompt spinner, which prompt_toolkit already redraws on its refresh loop.

This wires the investigation display to that spinner. On each stage it calls `SpinnerState.set_phase(...)`, so the prompt spinner keeps cycling with the current step (`Reading alert`, `Loading integrations`, `Investigation`, `Diagnosing`, `Publishing`) instead of showing a random "thinking" verb, and it stops cleanly when the report renders.

While I was in there I deleted the dead raw-ANSI animation and the prompt-suppress seam it used to rely on (`get/set_prompt_suppress_fn`, `StreamingConsole.suppress_prompt_spinner`), since nothing calls them after this change. Net about -130 lines.

Verified locally: `make lint`, `make typecheck`, and the `tests/interactive_shell/` + `tests/cli/test_output.py` suites pass. Replaced the tests that pinned the old frozen behavior with one that checks the display drives the spinner phase and clears it on stop.

### Demo/Screenshot for feature changes and bug fixes - 


https://github.com/user-attachments/assets/3f1267e5-02b3-4685-9ae1-c20bd2ce3f2c


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The indicator looked frozen because `/investigate` never starts the normal spinner, and the raw cursor-up animation is incompatible with `patch_stdout`. I didn't want to re-add raw stdout writes, since that's what caused the original repeated-line spam. Instead I reused the spinner that already animates safely through prompt_toolkit and gave it a per-stage label.

The main pieces: `SpinnerState.set_phase` (show a stage label instead of a random verb, keep it streaming), `console_state.set_investigation_spinner` (hand the active turn's spinner to the display across the thread boundary, since the investigation runs in `asyncio.to_thread`), and `_ReplEventLogDisplay.step_start`/`stop` (set the phase per stage and stop it at the end). The turn registers/clears the spinner in `run_agent_turn`.

I considered keeping the raw animation with single-row fitting, but it fundamentally can't rewrite a row under `patch_stdout`, so I removed it rather than leave a path that can't work.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
