### PR TITLE
fix(ci): sort imports in gateway/tests/test_authorize.py to unblock Release

### DIFF
--- a/gateway/tests/test_authorize.py
+++ b/gateway/tests/test_authorize.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
+
 from unittest.mock import patch
+
 import pytest
+
 from gateway.session.enforce_inbound_telegram_message_security import (
     enforce_inbound_telegram_message_security,
     persist_policy_if_needed,
 )
 from integrations.messaging_security import MessagingIdentityPolicy
+
 _SECURITY = "gateway.session.enforce_inbound_telegram_message_security"
+
+
 @pytest.fixture
 def mock_integration_store():
     with (


### PR DESCRIPTION
## Summary

- Fixes the failing **Release** workflow on `main`. Its `verify` job runs `make lint`, whose `PYTHON_SOURCE_PATHS` includes `gateway/`, so ruff `I001` (un-sorted import block in `gateway/tests/test_authorize.py`, introduced by #3829) failed the release pipeline.
- The main **CI** `quality` job excludes `gateway/` from its lint paths (`ci.yml` `PYTHON_SOURCE_PATHS`), which is why only Release caught this.
- Minimal change: sorts the import block (adds the blank lines ruff's import sorter requires). No behavior change.

## Verification

- `uv run ruff check config core gateway integrations platform surfaces tools tests/` → **All checks passed**

Note: the separate `CI` workflow failure on the same commit was a live-LLM turn-scenario oracle flake (`314-windows-crash-multisource-query`); it is unrelated to this change and re-runs green.

Made with [Cursor](https://cursor.com)