### PR TITLE
docs: fix stale app and cli path references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,8 +97,8 @@ Notes:
 
 ### 3. Add or Update Tests
 
-- **Test Location:** New tests should be placed in the `tests/` directory, mirroring the structure of the `app/` directory (e.g., tests for `cli/` go in `tests/cli/`).
-- **No Inline Tests:** Avoid adding `*_test.py` files directly inside the `app/` directory. We are phasing out existing inline tests to keep the core logic clean.
+- **Test Location:** New tests should be placed in the `tests/` directory, mirroring the source package area when useful (e.g., tests for `surfaces/cli/` go in `tests/cli/`).
+- **No Inline Tests:** Avoid adding `*_test.py` files directly inside source packages. We are phasing out existing inline tests to keep the core logic clean.
 - Bug fixes should include a test that would have caught the bug
 - New features should have corresponding tests
 - Aim for >80% code coverage (run `make test-cov` to check)

--- a/SETUP.md
+++ b/SETUP.md
@@ -94,11 +94,13 @@ Run equivalents from the repo root (same shell where `uv` is on `PATH`). Prefer 
 uv sync --frozen --extra dev
 uv run python -m platform.analytics.install
 
-uv run ruff check app/ tests/
-uv run ruff format --check app/ tests/
-uv run mypy app/
+uv run ruff check config core gateway integrations platform surfaces tools tests/
+uv run ruff format --check config core gateway integrations platform surfaces tools tests/
+uv run mypy config core gateway integrations platform surfaces tools
 
-uv run pytest -n auto -v --cov=app --cov-report=term-missing \
+uv run pytest -n auto -v \
+  --cov=config --cov=core --cov=gateway --cov=integrations \
+  --cov=platform --cov=surfaces --cov=tools --cov-report=term-missing \
   --ignore=tests/e2e/kubernetes_local_alert_simulation \
   --ignore=tests/synthetic \
   -m "not synthetic"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -24,7 +24,7 @@ From the repo root:
 ```bash
 make lint          # ruff check
 make format-check  # ruff format --check (CI-enforced)
-make typecheck     # mypy app/
+make typecheck     # mypy config core gateway integrations platform surfaces tools
 make test-cov      # pytest + coverage (default unit suite)
 ```
 

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -178,7 +178,7 @@ All configuration options for OpenSRE can be set via environment variables. This
 | Variable | Default | Description | Module |
 |----------|---------|-------------|--------|
 | `INVESTIGATIONS_DIR` | `~/.opensre/investigations` | Directory for saved investigations | `remote/server` |
-| `OPENSRE_PROJECT_ENV_PATH` | `PROJECT_ROOT/.env` | Path to project-level `.env` file | `cli/wizard/config` |
+| `OPENSRE_PROJECT_ENV_PATH` | `PROJECT_ROOT/.env` | Path to project-level `.env` file | `surfaces/cli/wizard/config` |
 | `OPENSRE_WIZARD_STORE_PATH` | `~/.opensre/opensre.json` | Path to the local wizard/provider selection store | `config/constants` |
 
 ## Feature Flags
@@ -187,7 +187,7 @@ All configuration options for OpenSRE can be set via environment variables. This
 |----------|---------|-------------|--------|
 | `OSRE_HELM_INTEGRATION` | | Enable Helm integration (1/true/yes) | `integrations/_catalog_impl` |
 | `GITLAB_MR_WRITEBACK` | | Enable GitLab merge request writeback (`true`, `1`, `yes`) | `tools/investigation/reporting/gitlab_writeback` |
-| `OPENSRE_RELEASES_API_URL` | GitHub releases API | Override releases API endpoint | `cli/support/update` |
+| `OPENSRE_RELEASES_API_URL` | GitHub releases API | Override releases API endpoint | `surfaces/cli/lifecycle/update` |
 
 ## Integration Credentials
 

--- a/gateway/tests/test_authorize.py
+++ b/gateway/tests/test_authorize.py
@@ -20,6 +20,8 @@ def mock_integration_store():
         patch(f"{_SECURITY}.upsert_instance") as upsert,
     ):
         yield upsert
+
+
 @pytest.mark.usefixtures("mock_integration_store")
 def test_help_is_not_agent_turn() -> None:
     decision = enforce_inbound_telegram_message_security(
@@ -30,6 +32,8 @@ def test_help_is_not_agent_turn() -> None:
     )
     assert decision.allowed is False
     assert "OpenSRE Telegram gateway" in decision.reply_text
+
+
 @pytest.mark.usefixtures("mock_integration_store")
 def test_unauthorized_user_gets_reason() -> None:
     decision = enforce_inbound_telegram_message_security(
@@ -40,6 +44,8 @@ def test_unauthorized_user_gets_reason() -> None:
     )
     assert decision.allowed is False
     assert decision.reply_text
+
+
 def test_pair_attempt_persists_policy(mock_integration_store: pytest.MonkeyPatch) -> None:
     policy = MessagingIdentityPolicy(
         inbound_enabled=True,
@@ -65,6 +71,7 @@ def test_pair_attempt_persists_policy(mock_integration_store: pytest.MonkeyPatch
     persist_policy_if_needed(decision)
     mock_integration_store.assert_called_once()
 
+
 @pytest.mark.usefixtures("mock_integration_store")
 def test_unauthorized_user_cannot_rotate_session() -> None:
     decision = enforce_inbound_telegram_message_security(
@@ -76,6 +83,8 @@ def test_unauthorized_user_cannot_rotate_session() -> None:
     assert decision.allowed is False
     assert decision.reply_text
     assert decision.reply_text != "__ROTATE_SESSION__"
+
+
 @pytest.mark.usefixtures("mock_integration_store")
 def test_authorized_user_can_rotate_session() -> None:
     decision = enforce_inbound_telegram_message_security(

--- a/integrations/llm_cli/AGENTS.md
+++ b/integrations/llm_cli/AGENTS.md
@@ -33,7 +33,7 @@ Use this package when adding a new **non-interactive** LLM that shells out to a 
 1. **Adapter** — Implement `LLMCLIAdapter`: `detect()` must not raise; `build()` returns argv + optional stdin; `parse` / `explain_failure` for success and non-zero exits. Put prompt text on stdin and/or in argv as appropriate — the runner does not branch on a separate “delivery mode”; `CLIInvocation` carries what `build()` produced.
 2. **Registry** — Add an entry to `CLI_PROVIDER_REGISTRY` in `registry.py` (`adapter_factory`, `model_env_key`). The dict key must match `LLM_PROVIDER` / `ProviderOption.value` / `LLMProvider` in `config/config.py`. `resolve_llm_route` in `core/llm/factory.py` resolves registered CLI providers into a `cli_provider_registration`, and the builders in `core/llm/client_builders.py` construct the CLI-backed client automatically (no new branch for normal cases).
 3. **Config** — Add the provider literal to `LLMProvider` and validators in `config/config.py` (same string as the registry key).
-4. **Wizard (optional)** — If onboarding should offer the CLI: add a `ProviderOption` in `cli/wizard/config.py` with `credential_kind="cli"` and `adapter_factory`. `flow.py` already runs `_run_cli_llm_onboarding` for CLI providers and builds the saved-summary credential line from `provider.label` + `adapter.auth_hint`.
+4. **Wizard (optional)** — If onboarding should offer the CLI: add a `ProviderOption` in `surfaces/cli/wizard/config.py` with `credential_kind="cli"` and `adapter_factory`. `flow.py` already runs `_run_cli_llm_onboarding` for CLI providers and builds the saved-summary credential line from `provider.label` + `adapter.auth_hint`.
 5. **Typing** — Prefer `adapter_factory: Callable[[], LLMCLIAdapter]` on `ProviderOption` so wizard and client stay aligned.
 
 ## Binary resolution (recommended pattern)
@@ -159,7 +159,7 @@ CODEX_BIN=
 - Write `_classify_<name>_auth` — test against a real logged-in **and** logged-out session before merging.
 - If the CLI reads custom env vars (e.g. `GEMINI_*`), add the prefix to `_SAFE_SUBPROCESS_ENV_PREFIXES` in `subprocess_env.py`.
 - Register the provider in `registry.py` and add the same `LLM_PROVIDER` value in `config/config.py`.
-- (Optional) Add wizard onboarding option in `cli/wizard/config.py`.
+- (Optional) Add wizard onboarding option in `surfaces/cli/wizard/config.py`.
 - Add tests under `tests/integrations/llm_cli/` for detect/build/failure paths, including env forwarding.
 
 ## Tests

--- a/integrations/llm_cli/antigravity_cli.py
+++ b/integrations/llm_cli/antigravity_cli.py
@@ -244,7 +244,8 @@ class AntigravityCLIAdapter:
         # inside the REPL.
         # TODO(antigravity-cli): once agy supports ``--model`` in headless, replace
         # the ``del`` with a conditional ``argv.extend(["--model", model])`` block
-        # and lock the catalog into ``cli/wizard/config.py:ANTIGRAVITY_CLI_MODELS``.
+        # and lock the catalog into
+        # ``surfaces/cli/wizard/config.py:ANTIGRAVITY_CLI_MODELS``.
         del model, reasoning_effort
 
         binary = self._resolve_binary()

--- a/integrations/store.py
+++ b/integrations/store.py
@@ -240,7 +240,7 @@ def _record_with_flat_credentials_view(record: dict[str, Any]) -> dict[str, Any]
 
     v2 records store credentials inside ``instances[0].credentials``. Many
     existing callers (``azure_sql.py``, ``mysql.py``, ``postgresql.py``,
-    ``cli/wizard/flow.py``) read ``record["credentials"]`` directly. This
+    ``surfaces/cli/wizard/flow.py``) read ``record["credentials"]`` directly. This
     helper synthesises a top-level ``credentials`` view from the default
     (first) instance so those callers continue to work unchanged.
     """

--- a/surfaces/cli/wizard/_ui.py
+++ b/surfaces/cli/wizard/_ui.py
@@ -249,7 +249,7 @@ def _choose_model(
 ) -> str:
     """Prompt the user to pick a model from ``provider.models``.
 
-    Choices come from the curated config in ``cli/wizard/config.py``.
+    Choices come from the curated config in ``surfaces/cli/wizard/config.py``.
     A saved model that isn't in the curated list is preserved as ``current``
     so re-running the wizard never silently drops a user's prior pick, and an
     "Enter custom model ID" escape hatch is always available.

--- a/surfaces/interactive_shell/AGENTS.md
+++ b/surfaces/interactive_shell/AGENTS.md
@@ -61,7 +61,7 @@ owning area rather than adding more logic to the caller.
   - **New REPL-only slash command:** add `SlashCommand` in the owning
     `command_registry/*` module **and** `_mcp(...)` in `slash_catalog.py` (keep
     keys sorted alphabetically in `_MCP_BY_COMMAND`).
-  - **New CLI with REPL parity:** add the Click command under `cli/commands/`,
+  - **New CLI with REPL parity:** add the Click command under `surfaces/cli/commands/`,
     register a `SlashCommand` in `command_registry/cli_parity.py` (subprocess to
     `opensre …`), **and** add `_MCP_BY_COMMAND` in `slash_catalog.py` with
     `llm_description`, `use_cases`, and `anti_examples` aligned to the command’s
@@ -246,7 +246,7 @@ owning area rather than adding more logic to the caller.
 
 - Put tests under `tests/interactive_shell/`, mirroring the package area
   when useful (`orchestration/`, `ui/`, etc.). Never add tests under
-  `app/`.
+  source packages.
 - For focused changes, run the closest tests, for example:
   - `uv run python -m pytest tests/core/domain/alerts/test_inbox.py`
   - `uv run python -m pytest tests/interactive_shell/<area>/`

--- a/surfaces/interactive_shell/ui/output/__init__.py
+++ b/surfaces/interactive_shell/ui/output/__init__.py
@@ -58,7 +58,7 @@ __all__ = [
     # Output config
     "debug_print",
     "get_output_format",
-    # Semi-public helpers used by cli/ui/renderer (underscore names are
+    # Semi-public helpers used by surfaces/cli/ui/renderer (underscore names are
     # intentional — they signal "reach in carefully" rather than stable API)
     "_fmt_timing",
     "_repl_progress_active",

--- a/tests/cli/test_command_help_sync.py
+++ b/tests/cli/test_command_help_sync.py
@@ -29,5 +29,5 @@ def test_registered_commands_match_help_table() -> None:
     )
     assert not missing_from_registry, (
         f"Commands shown in the rendered help list but not registered in _COMMANDS: {missing_from_registry}. "
-        "Add the command to _COMMANDS in cli/commands/__init__.py."
+        "Add the command to _COMMANDS in surfaces/cli/commands/__init__.py."
     )

--- a/tests/cli/test_local_llm_hardware.py
+++ b/tests/cli/test_local_llm_hardware.py
@@ -1,4 +1,4 @@
-"""Unit tests for cli/wizard/local_llm/hardware.py
+"""Unit tests for surfaces/cli/wizard/local_llm/hardware.py
 
 Covers:
 - _get_total_ram_gb()   — Linux /proc/meminfo, macOS sysctl, and fallback


### PR DESCRIPTION
Fixes #3521

Supersedes closed PR #3811.

## Summary
- Updates stale `app/` and top-level `cli/` path references in contributor docs, package guidance, docstrings, and test messages to the current `surfaces/cli/` and source-package layout.
- Leaves accurate `app/` matches unchanged, including URLs, macOS `.app` paths, `slack_app`, Sentry sample paths, benchmark `app/<service>` values, and historical daily-update records.
- Applies a mechanical Ruff-format fix to `gateway/tests/test_authorize.py` because current CI formatting requires the added blank lines.

## Verification
- `git diff --check origin/main...HEAD`
- `make format-check`
- `make lint`
- `make typecheck`
- `.venv/bin/python -m pytest tests/cli/test_local_llm_hardware.py tests/cli/test_command_help_sync.py gateway/tests/test_authorize.py -q`
- `gh pr checks 3811 --repo Tracer-Cloud/opensre` showed the latest checks for the earlier PR were green before this superseding PR.

## Note
`make test-scope` escalates to the full local unit suite because the diff touches several documentation/source guidance areas. A local full-suite run reached 10617 passed / 56 skipped before failing on unrelated existing full-suite failures outside this PR scope (for example `_DOCS_ROOT`, synthetic observation binding, import-boundary basename collision, and gateway Antarctica Slack test state). The targeted checks above cover this no-runtime-behavior cleanup.