### PR TITLE
refactor(C-11): unify Telegram scheduler credential resolution via integrations/telegram/credentials.py

### DIFF
--- a/gateway/tests/test_authorize.py
+++ b/gateway/tests/test_authorize.py
@@ -20,6 +20,8 @@ def mock_integration_store():
         patch(f"{_SECURITY}.upsert_instance") as upsert,
     ):
         yield upsert
+
+
 @pytest.mark.usefixtures("mock_integration_store")
 def test_help_is_not_agent_turn() -> None:
     decision = enforce_inbound_telegram_message_security(
@@ -30,6 +32,8 @@ def test_help_is_not_agent_turn() -> None:
     )
     assert decision.allowed is False
     assert "OpenSRE Telegram gateway" in decision.reply_text
+
+
 @pytest.mark.usefixtures("mock_integration_store")
 def test_unauthorized_user_gets_reason() -> None:
     decision = enforce_inbound_telegram_message_security(
@@ -40,6 +44,8 @@ def test_unauthorized_user_gets_reason() -> None:
     )
     assert decision.allowed is False
     assert decision.reply_text
+
+
 def test_pair_attempt_persists_policy(mock_integration_store: pytest.MonkeyPatch) -> None:
     policy = MessagingIdentityPolicy(
         inbound_enabled=True,
@@ -65,6 +71,7 @@ def test_pair_attempt_persists_policy(mock_integration_store: pytest.MonkeyPatch
     persist_policy_if_needed(decision)
     mock_integration_store.assert_called_once()
 
+
 @pytest.mark.usefixtures("mock_integration_store")
 def test_unauthorized_user_cannot_rotate_session() -> None:
     decision = enforce_inbound_telegram_message_security(
@@ -76,6 +83,8 @@ def test_unauthorized_user_cannot_rotate_session() -> None:
     assert decision.allowed is False
     assert decision.reply_text
     assert decision.reply_text != "__ROTATE_SESSION__"
+
+
 @pytest.mark.usefixtures("mock_integration_store")
 def test_authorized_user_can_rotate_session() -> None:
     decision = enforce_inbound_telegram_message_security(

--- a/integrations/telegram/credentials.py
+++ b/integrations/telegram/credentials.py
@@ -48,7 +48,7 @@ def _telegram_store_config() -> dict[str, object]:
         entry = resolve_effective_integrations().get("telegram", {})
         config = entry.get("config", {}) if isinstance(entry, dict) else {}
         return config if isinstance(config, dict) else {}
-    except (ImportError, KeyError, TypeError, ValueError) as exc:
+    except (ImportError, KeyError, TypeError, ValueError, OSError, RuntimeError) as exc:
         logger.debug(
             "Failed to resolve Telegram credentials from the store: %s", exc, exc_info=True
         )

--- a/integrations/telegram/credentials.py
+++ b/integrations/telegram/credentials.py
@@ -48,8 +48,10 @@ def _telegram_store_config() -> dict[str, object]:
         entry = resolve_effective_integrations().get("telegram", {})
         config = entry.get("config", {}) if isinstance(entry, dict) else {}
         return config if isinstance(config, dict) else {}
-    except Exception:
-        logger.debug("Failed to resolve Telegram credentials from the store", exc_info=True)
+    except (ImportError, KeyError, TypeError, ValueError) as exc:
+        logger.debug(
+            "Failed to resolve Telegram credentials from the store: %s", exc, exc_info=True
+        )
         return {}
 
 
@@ -112,3 +114,19 @@ def load_credentials_from_env(
         )
 
     return TelegramCredentials(bot_token=bot_token, chat_id=chat_id)
+
+
+def resolve_telegram_bot_token(
+    task_params: dict[str, str] | None = None,
+) -> str:
+    """Resolve the Telegram bot token from task params, store, env, or keyring.
+
+    Priority: task params > store config > env var > system keyring.
+    """
+    if task_params:
+        token = task_params.get("bot_token", "").strip()
+        if token:
+            return token
+
+    store_config = _telegram_store_config()
+    return _resolve_bot_token(store_config)

--- a/platform/scheduler/credentials.py
+++ b/platform/scheduler/credentials.py
@@ -13,14 +13,20 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+try:
+    from keyring.errors import KeyringError as _KeyringError
+except ImportError:
+
+    class _KeyringError(Exception):  # type: ignore[no-redef]
+        """Fallback when keyring is not installed."""
+
+
 def resolve_telegram_credentials(task_params: dict[str, str]) -> dict[str, str]:
     """Resolve Telegram bot_token from task params, integration store, or env.
 
     Priority: task.params > integration store > environment variable.
     """
     try:
-        import keyring.errors
-
         from integrations.telegram.credentials import resolve_telegram_bot_token
 
         token = resolve_telegram_bot_token(task_params)
@@ -30,7 +36,7 @@ def resolve_telegram_credentials(task_params: dict[str, str]) -> dict[str, str]:
         KeyError,
         TypeError,
         ValueError,
-        keyring.errors.KeyringError,
+        _KeyringError,
     ) as exc:
         logger.debug("Failed to resolve Telegram credentials: %s", exc)
         return {}

--- a/platform/scheduler/credentials.py
+++ b/platform/scheduler/credentials.py
@@ -18,12 +18,22 @@ def resolve_telegram_credentials(task_params: dict[str, str]) -> dict[str, str]:
 
     Priority: task.params > integration store > environment variable.
     """
-    return _resolve_credentials(
-        task_params,
-        service="telegram",
-        credential_key="bot_token",
-        env_vars=("TELEGRAM_BOT_TOKEN",),
-    )
+    try:
+        import keyring.errors
+
+        from integrations.telegram.credentials import resolve_telegram_bot_token
+
+        token = resolve_telegram_bot_token(task_params)
+        return {"bot_token": token} if token else {}
+    except (
+        ImportError,
+        KeyError,
+        TypeError,
+        ValueError,
+        keyring.errors.KeyringError,
+    ) as exc:
+        logger.debug("Failed to resolve Telegram credentials: %s", exc)
+        return {}
 
 
 def resolve_slack_credentials(task_params: dict[str, str]) -> dict[str, str]:

--- a/tests/scheduler/test_credentials.py
+++ b/tests/scheduler/test_credentials.py
@@ -19,8 +19,8 @@ class TestTelegramCredentials:
     def test_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "from_env")
         monkeypatch.setattr(
-            "platform.scheduler.credentials._get_integration_credential",
-            lambda *_: "",
+            "integrations.telegram.credentials._telegram_store_config",
+            lambda: {},
         )
         creds = resolve_telegram_credentials({})
         assert creds == {"bot_token": "from_env"}
@@ -28,11 +28,25 @@ class TestTelegramCredentials:
     def test_empty_when_nothing_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
         monkeypatch.setattr(
-            "platform.scheduler.credentials._get_integration_credential",
-            lambda *_: "",
+            "integrations.telegram.credentials._telegram_store_config",
+            lambda: {},
         )
         creds = resolve_telegram_credentials({})
         assert creds == {}
+
+    def test_from_keyring(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+        monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "integrations.telegram.credentials._telegram_store_config",
+            lambda: {},
+        )
+        monkeypatch.setattr(
+            "keyring.get_password",
+            lambda _service, username: "from_keyring" if username == "TELEGRAM_BOT_TOKEN" else "",
+        )
+        creds = resolve_telegram_credentials({})
+        assert creds == {"bot_token": "from_keyring"}
 
 
 class TestSlackCredentials:


### PR DESCRIPTION
## Summary

Closes #3482

`platform/scheduler/credentials.resolve_telegram_credentials` duplicated 
credential-resolution logic that already existed in 
`integrations/telegram/credentials.py`. This PR removes the duplication by 
having the scheduler delegate to a new shared helper.

## Changes

- **Added** `resolve_telegram_bot_token()` in `integrations/telegram/credentials.py` — 
  a non-raising public helper that resolves the bot token with priority 
  `task_params → store → env → keyring`, returning an empty string if 
  nothing is found (instead of raising, unlike `load_credentials_from_env`).
- **Refactored** `platform/scheduler/credentials.resolve_telegram_credentials` 
  to delegate to the new helper instead of duplicating the lookup logic. 
  Preserves the scheduler's existing `{}`-on-missing contract by narrowly 
  catching the specific exceptions that can occur along this path.
- **Narrowed** exception handling in `_telegram_store_config` from a bare 
  `except Exception` to a specific exception list.
- **New capability:** the scheduler now also falls back to the system 
  keyring (via `opensre onboard`), which it did not support before — useful 
  for local scheduler runs/testing.

## Behavioral notes for reviewers

The two original implementations weren't fully equivalent:
- Scheduler returned `{}` on missing credentials; the integration's 
  `load_credentials_from_env` raises `OpenSREError`. Resolved by adding the 
  non-raising helper rather than making the scheduler swallow raised errors.
- Integration layer stripped whitespace on resolved values; scheduler did not. 
  Now consistent via the shared helper.
- Scheduler had no keyring fallback; now it does (additive, non-breaking).

## Testing

- `tests/scheduler/test_credentials.py` — updated mocks to match the new 
  delegation path; added `test_from_keyring` covering keyring-only 
  resolution (no task_params, no store config, no env var).
- `tests/scheduler/test_executor.py` — passes unchanged, confirming the 
  scheduler's calling contract is preserved.
- `make lint`, `make format-check`, `make typecheck` — all clean.
- `make verify-integrations SERVICE=telegram` — passes.

## Follow-up

C-12 (same unification for Slack/Discord) is a natural next step using the 
same pattern established here.