### PR TITLE
refactor(trello): split into config/client/verifier modules (T-18)

### DIFF
--- a/integrations/trello/__init__.py
+++ b/integrations/trello/__init__.py
@@ -1,14 +1,18 @@
 """Trello integration package."""
 
+from integrations.trello.client import (
+    create_trello_card,
+    validate_trello_connection,
+)
 from integrations.trello.config import (
     DEFAULT_TRELLO_BASE_URL,
     TrelloConfig,
-    TrelloValidationResult,
     build_trello_config,
-    create_trello_card,
     trello_config_from_env,
+)
+from integrations.trello.verifier import (
+    TrelloValidationResult,
     validate_trello_config,
-    validate_trello_connection,
 )
 
 __all__ = [

--- a/integrations/trello/client.py
+++ b/integrations/trello/client.py
@@ -1,0 +1,70 @@
+"""Trello HTTP transport and board operations."""
+
+from typing import Any
+
+import httpx
+
+from integrations.trello.config import TrelloConfig
+
+
+def _request_json(
+    config: TrelloConfig,
+    method: str,
+    path: str,
+    *,
+    params: list[tuple[str, str | int | float | bool | None]] | None = None,
+    json: dict[str, Any] | None = None,
+) -> Any:
+    request_params: list[tuple[str, str | int | float | bool | None]] = [
+        ("key", config.api_key),
+        ("token", config.token),
+    ]
+    if params:
+        request_params.extend(params)
+
+    url = f"{config.api_base_url}{path}"
+    response = httpx.request(
+        method,
+        url,
+        params=request_params,
+        json=json,
+        timeout=config.timeout_seconds,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def validate_trello_connection(
+    *,
+    config: TrelloConfig,
+) -> dict[str, Any]:
+    """Validate Trello connection with a lightweight member query."""
+    payload = _request_json(config, "GET", "/members/me")
+    return payload if isinstance(payload, dict) else {}
+
+
+def create_trello_card(
+    *,
+    config: TrelloConfig,
+    name: str,
+    desc: str,
+    list_id: str | None = None,
+) -> dict[str, Any]:
+    """Create a Trello card."""
+    target_list_id = (list_id or config.list_id).strip()
+    if not target_list_id:
+        raise ValueError("A list_id must be provided either via argument or config.")
+
+    payload = _request_json(
+        config,
+        "POST",
+        "/cards",
+        params=[
+            ("idList", target_list_id),
+        ],
+        json={
+            "name": name,
+            "desc": desc,
+        },
+    )
+    return payload if isinstance(payload, dict) else {}

--- a/integrations/trello/config.py
+++ b/integrations/trello/config.py
@@ -1,14 +1,9 @@
-import logging
+"""Trello connection settings and config builders."""
+
 import os
-from dataclasses import dataclass
 from typing import Any
 
-import httpx
 from pydantic import BaseModel, Field, field_validator
-
-from integrations._validation_helpers import report_validation_failure
-
-logger = logging.getLogger(__name__)
 
 DEFAULT_TRELLO_BASE_URL = "https://api.trello.com/1"
 
@@ -34,14 +29,6 @@ class TrelloConfig(BaseModel):
         return self.base_url.rstrip("/")
 
 
-@dataclass(frozen=True)
-class TrelloValidationResult:
-    """Result of validating a Trello integration."""
-
-    ok: bool
-    detail: str
-
-
 def build_trello_config(raw: dict[str, Any] | None) -> TrelloConfig:
     """Build a normalized Trello config object from env/store data."""
     return TrelloConfig.model_validate(raw or {})
@@ -64,93 +51,3 @@ def trello_config_from_env() -> TrelloConfig | None:
             "list_id": os.getenv("TRELLO_LIST_ID", "").strip(),
         }
     )
-
-
-def _request_json(
-    config: TrelloConfig,
-    method: str,
-    path: str,
-    *,
-    params: list[tuple[str, str | int | float | bool | None]] | None = None,
-    json: dict[str, Any] | None = None,
-) -> Any:
-    request_params: list[tuple[str, str | int | float | bool | None]] = [
-        ("key", config.api_key),
-        ("token", config.token),
-    ]
-    if params:
-        request_params.extend(params)
-
-    url = f"{config.api_base_url}{path}"
-    response = httpx.request(
-        method,
-        url,
-        params=request_params,
-        json=json,
-        timeout=config.timeout_seconds,
-    )
-    response.raise_for_status()
-    return response.json()
-
-
-def validate_trello_connection(
-    *,
-    config: TrelloConfig,
-) -> dict[str, Any]:
-    """Validate Trello connection with a lightweight member query."""
-    payload = _request_json(config, "GET", "/members/me")
-    return payload if isinstance(payload, dict) else {}
-
-
-def validate_trello_config(config: TrelloConfig) -> TrelloValidationResult:
-    """Validate Trello connectivity."""
-    if not config.api_key:
-        return TrelloValidationResult(ok=False, detail="Trello API key is required.")
-    if not config.token:
-        return TrelloValidationResult(ok=False, detail="Trello token is required.")
-
-    try:
-        member = validate_trello_connection(config=config)
-        username = member.get("username", "unknown")
-        return TrelloValidationResult(
-            ok=True,
-            detail=f"Trello connectivity successful. Authenticated as @{username}",
-        )
-    except httpx.HTTPStatusError as err:
-        detail = err.response.text.strip() or str(err)
-        return TrelloValidationResult(ok=False, detail=f"Trello validation failed: {detail}")
-    except Exception as err:
-        report_validation_failure(
-            err,
-            logger=logger,
-            integration="trello",
-            method="validate_trello_config",
-        )
-        return TrelloValidationResult(ok=False, detail=f"Trello validation failed: {err}")
-
-
-def create_trello_card(
-    *,
-    config: TrelloConfig,
-    name: str,
-    desc: str,
-    list_id: str | None = None,
-) -> dict[str, Any]:
-    """Create a Trello card."""
-    target_list_id = (list_id or config.list_id).strip()
-    if not target_list_id:
-        raise ValueError("A list_id must be provided either via argument or config.")
-
-    payload = _request_json(
-        config,
-        "POST",
-        "/cards",
-        params=[
-            ("idList", target_list_id),
-        ],
-        json={
-            "name": name,
-            "desc": desc,
-        },
-    )
-    return payload if isinstance(payload, dict) else {}

--- a/integrations/trello/verifier.py
+++ b/integrations/trello/verifier.py
@@ -1,0 +1,47 @@
+"""Trello credential and connectivity verification."""
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+import integrations.trello.client as client
+from integrations._validation_helpers import report_validation_failure
+from integrations.trello.config import TrelloConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TrelloValidationResult:
+    """Result of validating a Trello integration."""
+
+    ok: bool
+    detail: str
+
+
+def validate_trello_config(config: TrelloConfig) -> TrelloValidationResult:
+    """Validate Trello connectivity."""
+    if not config.api_key:
+        return TrelloValidationResult(ok=False, detail="Trello API key is required.")
+    if not config.token:
+        return TrelloValidationResult(ok=False, detail="Trello token is required.")
+
+    try:
+        member = client.validate_trello_connection(config=config)
+        username = member.get("username", "unknown")
+        return TrelloValidationResult(
+            ok=True,
+            detail=f"Trello connectivity successful. Authenticated as @{username}",
+        )
+    except httpx.HTTPStatusError as err:
+        detail = err.response.text.strip() or str(err)
+        return TrelloValidationResult(ok=False, detail=f"Trello validation failed: {detail}")
+    except Exception as err:
+        report_validation_failure(
+            err,
+            logger=logger,
+            integration="trello",
+            method="validate_trello_config",
+        )
+        return TrelloValidationResult(ok=False, detail=f"Trello validation failed: {err}")

--- a/tests/e2e/trello/test_orchestrator.py
+++ b/tests/e2e/trello/test_orchestrator.py
@@ -32,7 +32,7 @@ def test_trello_validation_and_card_creation_e2e(monkeypatch: pytest.MonkeyPatch
 
         raise AssertionError(f"Unexpected request: {method} {path}")
 
-    monkeypatch.setattr("integrations.trello.config._request_json", fake_request_json)
+    monkeypatch.setattr("integrations.trello.client._request_json", fake_request_json)
 
     validation = validate_trello_config(config)
     assert validation.ok is True
@@ -70,7 +70,7 @@ def test_trello_validation_failure_e2e(monkeypatch: pytest.MonkeyPatch) -> None:
             )
         raise AssertionError(f"Unexpected request: {method} {path}")
 
-    monkeypatch.setattr("integrations.trello.config._request_json", fake_request_json)
+    monkeypatch.setattr("integrations.trello.client._request_json", fake_request_json)
 
     validation = validate_trello_config(config)
     assert validation.ok is False

--- a/tests/integrations/test_trello.py
+++ b/tests/integrations/test_trello.py
@@ -74,7 +74,7 @@ def test_validate_trello_connection_success(monkeypatch: pytest.MonkeyPatch) -> 
     def fake_request_json(*_args: object, **_kwargs: object) -> dict[str, str]:
         return {"id": "member123", "username": "test_user"}
 
-    monkeypatch.setattr("integrations.trello.config._request_json", fake_request_json)
+    monkeypatch.setattr("integrations.trello.client._request_json", fake_request_json)
 
     result = validate_trello_connection(config=config)
 
@@ -106,7 +106,7 @@ def test_validate_trello_config_success(monkeypatch: pytest.MonkeyPatch) -> None
         return {"id": "member123", "username": "test_user"}
 
     monkeypatch.setattr(
-        "integrations.trello.config.validate_trello_connection",
+        "integrations.trello.client.validate_trello_connection",
         fake_validate_connection,
     )
 
@@ -130,7 +130,7 @@ def test_validate_trello_config_unauthorized(monkeypatch: pytest.MonkeyPatch) ->
         )
 
     monkeypatch.setattr(
-        "integrations.trello.config.validate_trello_connection",
+        "integrations.trello.client.validate_trello_connection",
         fake_validate_connection,
     )
 
@@ -151,7 +151,7 @@ def test_create_trello_card_success(monkeypatch: pytest.MonkeyPatch) -> None:
             "idList": _TEST_LIST_ID,
         }
 
-    monkeypatch.setattr("integrations.trello.config._request_json", fake_request_json)
+    monkeypatch.setattr("integrations.trello.client._request_json", fake_request_json)
 
     result = create_trello_card(
         config=config,
@@ -172,7 +172,7 @@ def test_create_trello_card_uses_override_list_id(monkeypatch: pytest.MonkeyPatc
         captured_kwargs.update(kwargs)
         return {"id": "card123", "idList": "override_list"}
 
-    monkeypatch.setattr("integrations.trello.config._request_json", fake_request_json)
+    monkeypatch.setattr("integrations.trello.client._request_json", fake_request_json)
 
     result = create_trello_card(
         config=config,

--- a/tests/integrations/test_validator_sentry_capture.py
+++ b/tests/integrations/test_validator_sentry_capture.py
@@ -44,7 +44,7 @@ class MigrationCase:
 CASES: tuple[MigrationCase, ...] = (
     # trello
     MigrationCase(
-        "integrations/trello/config.py",
+        "integrations/trello/verifier.py",
         "validate_trello_config",
         "trello",
         "validate_trello_config",


### PR DESCRIPTION
Part of #3551

<!-- T-18 umbrella (vendor-first completion). One vendor slice — do NOT auto-close the umbrella. -->

#### Describe the changes you have made in this PR -

Completes the vendor-first `{config, client, verifier}` layout for **trello**, which previously had everything crammed in `config.py`. Same pattern as the merged posthog slice (#3784).

- `config.py` — `TrelloConfig`, `build_trello_config`, `trello_config_from_env` (settings only)
- `client.py` — `_request_json` transport, `validate_trello_connection`, `create_trello_card`
- `verifier.py` — `TrelloValidationResult`, `validate_trello_config`
- `__init__.py` — re-exports the same public API, so every external caller (`from integrations.trello import ...`) is unchanged.

`verifier.py` imports the client submodule via `import integrations.trello.client as client` (attribute-lookup call) so it avoids a package/submodule import cycle and keeps monkeypatch semantics working.

Test wiring: repointed unit + e2e monkeypatch targets from `integrations.trello.config._request_json` / `.validate_trello_connection` to `integrations.trello.client.*`, and the `test_validator_sentry_capture` MigrationCase path to `integrations/trello/verifier.py`.

Cross-checked docs + AGENTS.md: no changes needed — the only doc reference is the `/integrations/trello` docs-site route (unchanged), and no `AGENTS.md` mentions trello. Public API, env vars, and behavior are unchanged.

### Demo/Screenshot for feature changes and bug fixes -

<!-- Attach a terminal screenshot of:
<img width="1505" height="449" alt="image" src="https://github.com/user-attachments/assets/23206cc5-361c-422f-8d30-20a3ba12dd1b" />
-->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`trello/config.py` was a monolith holding config, HTTP client, and the verifier together, so trello was one of the vendors still missing the `verifier.py` the T-1 layout expects. I split it by concern, keeping a thin `__init__` that re-exports the same names so no caller changes.

The subtle part is the tests: they monkeypatch `_request_json` and `validate_trello_connection` by string path. Cross-module patching breaks if the caller and the patched name end up in different modules, so I kept `validate_trello_connection` and `create_trello_card` beside `_request_json` in `client.py`, had `verifier.py` call `client.validate_trello_connection` via attribute lookup, and repointed the patch targets to `integrations.trello.client.*` (unit and e2e). The submodule import in `verifier.py` also avoids the package/submodule cycle the repo's SCC checker enforces.

Alternative considered: extracting only `verifier.py` and leaving the client code in `config.py` — rejected because it would leave `config.py` still doing HTTP, which is the exact SoC problem T-18 is closing.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
