### PR TITLE
fix(integrations/slack): name response body truncation limit

### DIFF
--- a/integrations/slack/delivery.py
+++ b/integrations/slack/delivery.py
@@ -14,6 +14,9 @@ from platform.observability import debug_print
 
 logger = logging.getLogger(__name__)
 
+# Limit raw HTTP response bodies included in Slack delivery log messages.
+_LOG_BODY_MAX_LEN = 200
+
 
 def _slack_bearer_headers(token: str) -> dict[str, str]:
     # Slack explicitly recommends ``charset=utf-8`` on JSON POSTs — without
@@ -337,7 +340,10 @@ def _post_via_webapp(
         debug_print(f"Slack delivery failed: {response.error}")
         return False
     if not 200 <= response.status_code < 300:
-        debug_print(f"Slack delivery failed: HTTP {response.status_code}: {response.text[:200]}")
+        debug_print(
+            "Slack delivery failed: "
+            f"HTTP {response.status_code}: {response.text[:_LOG_BODY_MAX_LEN]}"
+        )
         return False
     debug_print(f"Slack delivery triggered via NextJS /api/slack (thread_ts={thread_ts}).")
     return True
@@ -363,7 +369,8 @@ def _post_via_incoming_webhook(
         return False
     if not 200 <= response.status_code < 300:
         debug_print(
-            f"Slack incoming webhook failed: HTTP {response.status_code}: {response.text[:200]}"
+            "Slack incoming webhook failed: "
+            f"HTTP {response.status_code}: {response.text[:_LOG_BODY_MAX_LEN]}"
         )
         return False
     debug_print("Slack report posted via incoming webhook.")

--- a/tests/utils/test_slack_delivery.py
+++ b/tests/utils/test_slack_delivery.py
@@ -188,6 +188,25 @@ class TestIncomingWebhook:
             slack_delivery._post_via_incoming_webhook("hi", "https://hooks.slack.test/abc") is False
         )
 
+    def test_non_2xx_status_truncates_response_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from platform.notifications.delivery_transport import DeliveryResponse
+
+        body = "x" * (slack_delivery._LOG_BODY_MAX_LEN + 20)
+        messages: list[str] = []
+
+        def _stub_post_json(*_a: Any, **_kw: Any) -> DeliveryResponse:
+            return DeliveryResponse(ok=True, status_code=500, data={}, text=body)
+
+        monkeypatch.setattr("integrations.slack.delivery.post_json", _stub_post_json)
+        monkeypatch.setattr("integrations.slack.delivery.debug_print", messages.append)
+
+        assert (
+            slack_delivery._post_via_incoming_webhook("hi", "https://hooks.slack.test/abc") is False
+        )
+        assert messages == [
+            f"Slack incoming webhook failed: HTTP 500: {body[: slack_delivery._LOG_BODY_MAX_LEN]}"
+        ]
+
     def test_transport_exception_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def _raise(*_a: Any, **_kw: Any) -> Any:
             raise ConnectionError("refused")
@@ -248,6 +267,24 @@ class TestPostViaWebapp:
             lambda *_a, **_kw: _mock_response(500, None, "boom"),
         )
         assert slack_delivery._post_via_webapp("hi", "C1", "1.0") is False
+
+    def test_5xx_truncates_response_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from platform.notifications.delivery_transport import DeliveryResponse
+
+        body = "x" * (slack_delivery._LOG_BODY_MAX_LEN + 20)
+        messages: list[str] = []
+
+        def _stub_post_json(*_a: Any, **_kw: Any) -> DeliveryResponse:
+            return DeliveryResponse(ok=True, status_code=500, data={}, text=body)
+
+        monkeypatch.setenv("TRACER_API_URL", "https://api.tracer.test")
+        monkeypatch.setattr("integrations.slack.delivery.post_json", _stub_post_json)
+        monkeypatch.setattr("integrations.slack.delivery.debug_print", messages.append)
+
+        assert slack_delivery._post_via_webapp("hi", "C1", "1.0") is False
+        assert messages == [
+            f"Slack delivery failed: HTTP 500: {body[: slack_delivery._LOG_BODY_MAX_LEN]}"
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_slack_delivery.py
+++ b/tests/utils/test_slack_delivery.py
@@ -191,6 +191,7 @@ class TestIncomingWebhook:
     def test_non_2xx_status_truncates_response_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from platform.notifications.delivery_transport import DeliveryResponse
 
+        assert slack_delivery._LOG_BODY_MAX_LEN == 200
         body = "x" * (slack_delivery._LOG_BODY_MAX_LEN + 20)
         messages: list[str] = []
 
@@ -271,6 +272,7 @@ class TestPostViaWebapp:
     def test_5xx_truncates_response_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from platform.notifications.delivery_transport import DeliveryResponse
 
+        assert slack_delivery._LOG_BODY_MAX_LEN == 200
         body = "x" * (slack_delivery._LOG_BODY_MAX_LEN + 20)
         messages: list[str] = []
 


### PR DESCRIPTION
Fixes #3840

## Summary
- Adds `_LOG_BODY_MAX_LEN = 200` in `integrations/slack/delivery.py` for Slack delivery response-body diagnostics.
- Replaces both `response.text[:200]` slices with the named constant without changing the truncation length.
- Adds focused tests for the webapp fallback and incoming-webhook non-2xx paths to lock the truncation behavior.

## Production Readiness
- No runtime behavior change: the diagnostic body limit remains 200 characters.
- No public API, config, dependency, or delivery-flow changes.
- The prior `_ERROR_TEXT_TRUNCATE = 500` path in `platform/notifications/delivery_errors.py` is untouched.

## Verification
- `git diff --check`
- `.venv/bin/python -m pytest tests/utils/test_slack_delivery.py -q` (`41 passed`)
- `.venv/bin/python -m ruff check integrations/slack/delivery.py tests/utils/test_slack_delivery.py`
- `.venv/bin/python -m ruff format --check integrations/slack/delivery.py tests/utils/test_slack_delivery.py`
- `make format-check`
- `make lint`
- `make typecheck`
- `.venv/bin/python .github/ci/run_test_scope.py --base origin/main` (`2409 passed, 2 skipped`)

## Note
`make test-scope` uses the local `main` branch as its base in this checkout. Local `main` was stale, so I used the CI scope script directly against `origin/main`, which is the correct base for this branch.
