### PR TITLE
fix(slack): replace magic number 200 with named constant _LOG_BODY_MAX_LEN

### DIFF
--- a/integrations/slack/delivery.py
+++ b/integrations/slack/delivery.py
@@ -14,6 +14,9 @@ from platform.observability import debug_print
 
 logger = logging.getLogger(__name__)
 
+# Max length for response body excerpts in log messages
+_LOG_BODY_MAX_LEN = 200
+
 
 def _slack_bearer_headers(token: str) -> dict[str, str]:
     # Slack explicitly recommends ``charset=utf-8`` on JSON POSTs — without
@@ -337,7 +340,7 @@ def _post_via_webapp(
         debug_print(f"Slack delivery failed: {response.error}")
         return False
     if not 200 <= response.status_code < 300:
-        debug_print(f"Slack delivery failed: HTTP {response.status_code}: {response.text[:200]}")
+        debug_print(f"Slack delivery failed: HTTP {response.status_code}: {response.text[:_LOG_BODY_MAX_LEN]}")
         return False
     debug_print(f"Slack delivery triggered via NextJS /api/slack (thread_ts={thread_ts}).")
     return True
@@ -363,7 +366,7 @@ def _post_via_incoming_webhook(
         return False
     if not 200 <= response.status_code < 300:
         debug_print(
-            f"Slack incoming webhook failed: HTTP {response.status_code}: {response.text[:200]}"
+            f"Slack incoming webhook failed: HTTP {response.status_code}: {response.text[:_LOG_BODY_MAX_LEN]}"
         )
         return False
     debug_print("Slack report posted via incoming webhook.")


### PR DESCRIPTION
Closes #3840

**Changements :**
- Ajout de la constante `_LOG_BODY_MAX_LEN = 200` dans `integrations/slack/delivery.py`
- Remplacement des deux `response.text[:200]` par `response.text[:_LOG_BODY_MAX_LEN]`
- 39/39 tests OK