### PR TITLE
fix(sentry_mcp): merge duplicate imports into single block

### DIFF
--- a/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
+++ b/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
@@ -17,15 +17,11 @@ from integrations.sentry_mcp import (
     SentryMCPConfig,
     SentryMCPToolCallResult,
     build_sentry_mcp_config,
+    call_sentry_mcp_tool as invoke_sentry_mcp_tool,
     describe_sentry_mcp_error,
+    list_sentry_mcp_tools as list_sentry_mcp_server_tools,
     sentry_mcp_config_from_env,
     sentry_mcp_runtime_unavailable_reason,
-)
-from integrations.sentry_mcp import (
-    call_sentry_mcp_tool as invoke_sentry_mcp_tool,
-)
-from integrations.sentry_mcp import (
-    list_sentry_mcp_tools as list_sentry_mcp_server_tools,
 )
 
 SentryMCPParams = dict[str, object]

--- a/integrations/slack/delivery.py
+++ b/integrations/slack/delivery.py
@@ -14,6 +14,9 @@ from platform.observability import debug_print
 
 logger = logging.getLogger(__name__)
 
+# Max length for response body excerpts in log messages
+_LOG_BODY_MAX_LEN = 200
+
 
 def _slack_bearer_headers(token: str) -> dict[str, str]:
     # Slack explicitly recommends ``charset=utf-8`` on JSON POSTs — without
@@ -337,7 +340,7 @@ def _post_via_webapp(
         debug_print(f"Slack delivery failed: {response.error}")
         return False
     if not 200 <= response.status_code < 300:
-        debug_print(f"Slack delivery failed: HTTP {response.status_code}: {response.text[:200]}")
+        debug_print(f"Slack delivery failed: HTTP {response.status_code}: {response.text[:_LOG_BODY_MAX_LEN]}")
         return False
     debug_print(f"Slack delivery triggered via NextJS /api/slack (thread_ts={thread_ts}).")
     return True
@@ -363,7 +366,7 @@ def _post_via_incoming_webhook(
         return False
     if not 200 <= response.status_code < 300:
         debug_print(
-            f"Slack incoming webhook failed: HTTP {response.status_code}: {response.text[:200]}"
+            f"Slack incoming webhook failed: HTTP {response.status_code}: {response.text[:_LOG_BODY_MAX_LEN]}"
         )
         return False
     debug_print("Slack report posted via incoming webhook.")


### PR DESCRIPTION
Closes #3510

**Changements :**
- Fusion des 3 blocs `from integrations.sentry_mcp import (...)` en un seul
- 41/41 tests OK