### PR TITLE
(SM-04): Narrow classify() exception in Tempo integration

### DIFF
--- a/integrations/tempo/__init__.py
+++ b/integrations/tempo/__init__.py
@@ -15,10 +15,10 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, ValidationError
+from pydantic import Field
 
 from config.strict_config import StrictConfigModel
-from integrations._validation_helpers import report_validation_failure
+from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
 logger = logging.getLogger(__name__)
 
@@ -162,10 +162,8 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[TempoConfig |
                 "integration_id": record_id,
             }
         )
-    except ValidationError:
-        raise
-    except Exception:
-        logger.debug("TempoConfig validation failed unexpectedly", exc_info=True)
+    except Exception as exc:
+        report_classify_failure(exc, logger=logger, integration="tempo", record_id=record_id)
         return None, None
     if cfg.is_configured:
         return cfg, "tempo"

--- a/integrations/tempo/__init__.py
+++ b/integrations/tempo/__init__.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field
+from pydantic import Field, ValidationError
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_validation_failure
@@ -162,7 +162,10 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[TempoConfig |
                 "integration_id": record_id,
             }
         )
+    except ValidationError:
+        raise
     except Exception:
+        logger.debug("TempoConfig validation failed unexpectedly", exc_info=True)
         return None, None
     if cfg.is_configured:
         return cfg, "tempo"


### PR DESCRIPTION
Closes #3508

## Summary
Replace bare `except Exception` with `except ValidationError` (propagates) + `except Exception` (logged) in Tempo `classify()`.

## Tests
```
tests/integrations/test_tempo.py ................. [100%]
17 passed
```