### PR TITLE
test(hermes): extend sink/delivery coverage (#3587)

### DIFF
--- a/tests/hermes/test_correlating_sink.py
+++ b/tests/hermes/test_correlating_sink.py
@@ -1,0 +1,387 @@
+"""Multi-channel delivery tests for :class:`CorrelatingSink`.
+
+The correlator/sink logic itself (dedup, escalation, metrics, close
+semantics) is covered by ``test_correlator.py``. This module focuses on the
+*delivery* seam: a :class:`CorrelatingSink` fanning incidents out to more than
+one downstream channel, with the real vendor transports mocked.
+
+Hermes only ships a :class:`~integrations.hermes.sinks.TelegramSink` today and
+its :class:`~integrations.hermes.correlator.RouteDestination` set has no SLACK
+or DISCORD members. So, we exercise multi-channel fan-out the way a real
+deployment would wire extra channels *now*: by registering thin, test-local
+channel adapters on existing destinations and asserting each vendor transport
+is (or is not) called with the right payload.
+
+Transports mocked:
+
+* Telegram → ``integrations.telegram.alarms.post_telegram_message``
+  (reached through the production :class:`TelegramSink`/:class:`AlarmDispatcher`).
+* Slack    → ``integrations.slack.delivery.send_slack_webhook_message``.
+* Discord  → ``integrations.discord.delivery.post_discord_message``.
+
+The Slack/Discord adapters are deliberately small — just enough to prove
+routing reaches the vendor transport. They are test fixtures, not a proposal
+for production Hermes sinks.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+
+from integrations.discord import delivery as discord_delivery
+from integrations.hermes.correlating_sink import CorrelatingSink
+from integrations.hermes.correlator import IncidentCorrelator, RouteDestination
+from integrations.hermes.incident import HermesIncident, IncidentSeverity, LogLevel, LogRecord
+from integrations.hermes.sinks import TelegramSink
+from integrations.slack import delivery as slack_delivery
+from integrations.telegram.alarms import AlarmDispatcher
+from integrations.telegram.credentials import TelegramCredentials
+
+_TS = datetime(2026, 5, 12, 12, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+
+
+def _record(seconds: int = 0) -> LogRecord:
+    ts = _TS + timedelta(seconds=seconds)
+    return LogRecord(
+        timestamp=ts,
+        level=LogLevel.ERROR,
+        logger="hermes.agent",
+        message="boom",
+        raw=f"{ts.isoformat()} ERROR hermes.agent: boom",
+    )
+
+
+def _incident(
+    *,
+    rule: str = "error_severity",
+    severity: IncidentSeverity = IncidentSeverity.HIGH,
+    fingerprint: str = "fp-1",
+    title: str = "ERROR from hermes.agent",
+    seconds: int = 0,
+) -> HermesIncident:
+    return HermesIncident(
+        rule=rule,
+        severity=severity,
+        title=title,
+        detected_at=_TS + timedelta(seconds=seconds),
+        logger="hermes.agent",
+        fingerprint=fingerprint,
+        records=(_record(seconds=seconds),),
+    )
+
+
+class _Channels:
+    """Captured calls for each mocked vendor transport."""
+
+    def __init__(self) -> None:
+        self.telegram: list[dict[str, Any]] = []
+        self.slack: list[dict[str, Any]] = []
+        self.discord: list[dict[str, Any]] = []
+
+    @property
+    def counts(self) -> tuple[int, int, int]:
+        return len(self.telegram), len(self.slack), len(self.discord)
+
+
+def _mock_channels(monkeypatch: pytest.MonkeyPatch) -> _Channels:
+    """Patch all three vendor transports and record their calls."""
+    channels = _Channels()
+
+    def _fake_telegram(
+        chat_id: str,
+        text: str,
+        bot_token: str,
+        parse_mode: str = "",
+        reply_to_message_id: str = "",
+        reply_markup: dict[str, Any] | None = None,
+    ) -> tuple[bool, str, str]:
+        channels.telegram.append({"chat_id": chat_id, "text": text, "bot_token": bot_token})
+        return True, "", "1"
+
+    def _fake_slack(text: str, **kwargs: Any) -> tuple[bool, str]:
+        channels.slack.append({"text": text, "kwargs": kwargs})
+        return True, ""
+
+    def _fake_discord(
+        channel_id: str,
+        embeds: list[dict[str, Any]],
+        bot_token: str,
+        content: str = "",
+    ) -> tuple[bool, str, str]:
+        channels.discord.append({"channel_id": channel_id, "content": content, "embeds": embeds})
+        return True, "", "42"
+
+    monkeypatch.setattr("integrations.telegram.alarms.post_telegram_message", _fake_telegram)
+    monkeypatch.setattr(slack_delivery, "send_slack_webhook_message", _fake_slack)
+    monkeypatch.setattr(discord_delivery, "post_discord_message", _fake_discord)
+    return channels
+
+
+def _telegram_sink() -> TelegramSink:
+    creds = TelegramCredentials(bot_token="tok", chat_id="chat-1")
+    # cooldown 0 so dedup is driven purely by the correlator, not the dispatcher.
+    return TelegramSink(AlarmDispatcher(creds, cooldown_seconds=0.0))
+
+
+def _slack_sink() -> Any:
+    """A minimal Slack channel adapter: format + post via the vendor transport.
+
+    Resolved at call time (module attribute access) so ``monkeypatch.setattr``
+    on ``slack_delivery.send_slack_webhook_message`` is honoured.
+    """
+
+    def _sink(incident: HermesIncident) -> None:
+        text = f"[{incident.severity.value.upper()}] {incident.title} ({incident.rule})"
+        slack_delivery.send_slack_webhook_message(text, webhook_url="https://hooks.example/x")
+
+    return _sink
+
+
+def _discord_sink() -> Any:
+    def _sink(incident: HermesIncident) -> None:
+        content = f"[{incident.severity.value.upper()}] {incident.title} ({incident.rule})"
+        discord_delivery.post_discord_message(
+            channel_id="chan-1", embeds=[], bot_token="bot-tok", content=content
+        )
+
+    return _sink
+
+
+def _three_channel_sink(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    correlator: IncidentCorrelator | None = None,
+) -> tuple[CorrelatingSink, _Channels]:
+    channels = _mock_channels(monkeypatch)
+    corr = correlator if correlator is not None else IncidentCorrelator()
+    sink = CorrelatingSink(
+        correlator=corr,
+        routes={
+            RouteDestination.TELEGRAM_WITH_RCA: _telegram_sink(),
+            RouteDestination.TELEGRAM: _slack_sink(),
+            RouteDestination.PAGER: _discord_sink(),
+        },
+    )
+    return sink, channels
+
+
+# ---------------------------------------------------------------------------
+# Fan-out routing
+
+
+class TestChannelFanOut:
+    def test_rca_route_hits_only_telegram(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sink, channels = _three_channel_sink(monkeypatch)
+
+        # error_severity → TELEGRAM_WITH_RCA in the default matrix.
+        sink(_incident(rule="error_severity", severity=IncidentSeverity.HIGH))
+
+        assert channels.counts == (1, 0, 0)
+        assert "Hermes incident" in channels.telegram[0]["text"]
+
+    def test_warning_burst_route_hits_only_slack(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sink, channels = _three_channel_sink(monkeypatch)
+
+        # warning_burst → TELEGRAM (wired here to the Slack adapter).
+        sink(
+            _incident(
+                rule="warning_burst",
+                severity=IncidentSeverity.MEDIUM,
+                fingerprint="fp-warn",
+            )
+        )
+
+        assert channels.counts == (0, 1, 0)
+        assert "warning_burst" in channels.slack[0]["text"]
+        assert channels.slack[0]["kwargs"]["webhook_url"] == "https://hooks.example/x"
+
+    def test_pager_route_hits_only_discord(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sink, channels = _three_channel_sink(monkeypatch)
+
+        # crash_loop → PAGER (wired here to the Discord adapter).
+        sink(
+            _incident(
+                rule="crash_loop",
+                severity=IncidentSeverity.HIGH,
+                fingerprint="fp-crash",
+            )
+        )
+
+        assert channels.counts == (0, 0, 1)
+        assert "crash_loop" in channels.discord[0]["content"]
+
+    def test_distinct_incidents_fan_out_to_distinct_channels(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A mixed batch must land each incident on exactly its routed channel
+        and leave the others untouched."""
+        sink, channels = _three_channel_sink(monkeypatch)
+
+        sink(_incident(rule="error_severity", severity=IncidentSeverity.HIGH, fingerprint="a"))
+        sink(_incident(rule="warning_burst", severity=IncidentSeverity.MEDIUM, fingerprint="b"))
+        sink(_incident(rule="crash_loop", severity=IncidentSeverity.HIGH, fingerprint="c"))
+
+        assert channels.counts == (1, 1, 1)
+        assert sink.metrics_snapshot()["delivered"] == 3
+
+
+class TestNonDeliveringDecisions:
+    def test_dropped_incident_touches_no_channel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sink, channels = _three_channel_sink(monkeypatch)
+
+        # Unknown rule + MEDIUM severity → DROP in the fallback route.
+        sink(_incident(rule="unknown_rule", severity=IncidentSeverity.MEDIUM))
+
+        assert channels.counts == (0, 0, 0)
+        assert sink.metrics_snapshot()["dropped"] == 1
+
+    def test_suppressed_duplicate_touches_no_channel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sink, channels = _three_channel_sink(monkeypatch)
+
+        sink(_incident(fingerprint="dup", seconds=0))
+        sink(_incident(fingerprint="dup", seconds=10))  # within dedup window
+
+        assert channels.counts == (1, 0, 0)
+        snap = sink.metrics_snapshot()
+        assert snap["delivered"] == 1
+        assert snap["suppressed"] == 1
+
+    def test_unrouted_destination_touches_no_channel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A PAGER-routed incident with no PAGER handler must be counted
+        unrouted and reach none of the wired channels."""
+        channels = _mock_channels(monkeypatch)
+        corr = IncidentCorrelator()
+        sink = CorrelatingSink(
+            correlator=corr,
+            routes={
+                RouteDestination.TELEGRAM_WITH_RCA: _telegram_sink(),
+                RouteDestination.TELEGRAM: _slack_sink(),
+                # PAGER intentionally omitted.
+            },
+        )
+
+        sink(_incident(rule="crash_loop", severity=IncidentSeverity.HIGH, fingerprint="fp-x"))
+
+        assert channels.counts == (0, 0, 0)
+        assert sink.metrics_snapshot()["unrouted"] == 1
+
+    def test_default_route_catches_unregistered_destination(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        channels = _mock_channels(monkeypatch)
+        corr = IncidentCorrelator()
+        sink = CorrelatingSink(
+            correlator=corr,
+            routes={RouteDestination.TELEGRAM_WITH_RCA: _telegram_sink()},
+            default_route=_discord_sink(),
+        )
+
+        # crash_loop → PAGER, unregistered, so the default (Discord) catches it.
+        sink(_incident(rule="crash_loop", severity=IncidentSeverity.HIGH, fingerprint="fp-d"))
+
+        assert channels.counts == (0, 0, 1)
+        assert sink.metrics_snapshot()["delivered"] == 1
+
+
+class TestChannelIsolation:
+    def test_one_channel_raising_does_not_starve_the_others(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A downstream channel that raises must be isolated: its incident is
+        counted as a sink error, but incidents routed to healthy channels keep
+        flowing."""
+        channels = _mock_channels(monkeypatch)
+
+        def _boom_slack(incident: HermesIncident) -> None:
+            raise RuntimeError("slack webhook exploded")
+
+        corr = IncidentCorrelator()
+        sink = CorrelatingSink(
+            correlator=corr,
+            routes={
+                RouteDestination.TELEGRAM_WITH_RCA: _telegram_sink(),
+                RouteDestination.TELEGRAM: _boom_slack,
+            },
+        )
+
+        # Route to the broken Slack channel first…
+        sink(_incident(rule="warning_burst", severity=IncidentSeverity.MEDIUM, fingerprint="w"))
+        # …then to the healthy Telegram channel.
+        sink(_incident(rule="error_severity", severity=IncidentSeverity.HIGH, fingerprint="e"))
+
+        assert channels.counts == (1, 0, 0)  # telegram delivered, slack never captured
+        snap = sink.metrics_snapshot()
+        assert snap["sink_errors"] == 1
+        assert snap["delivered"] == 1
+
+    def test_escalated_fingerprint_reaches_downstream_transport(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Escalation must break through dedup AND carry the ':escalated'
+        fingerprint all the way to the Telegram transport so a downstream
+        AlarmDispatcher cooldown cannot re-suppress it. We assert two distinct
+        deliveries reached the wire for the same underlying event."""
+        corr = IncidentCorrelator(dedup_window_s=0, escalation_window_s=60, escalation_threshold=2)
+        channels = _mock_channels(monkeypatch)
+        # A dedicated dispatcher with a real cooldown; distinct fingerprints
+        # are what let the second (escalated) send through.
+        creds = TelegramCredentials(bot_token="tok", chat_id="chat-1")
+        telegram = TelegramSink(AlarmDispatcher(creds, cooldown_seconds=300.0))
+        sink = CorrelatingSink(
+            correlator=corr,
+            routes={
+                RouteDestination.TELEGRAM_WITH_RCA: telegram,
+                RouteDestination.PAGER: telegram,
+            },
+        )
+
+        sink(_incident(fingerprint="esc", seconds=0))  # first, plain fingerprint
+        sink(_incident(fingerprint="esc", seconds=5))  # escalates → CRITICAL → PAGER
+
+        # Both reached the transport: the cooldown did not swallow the second
+        # because its fingerprint was suffixed with ':escalated'.
+        assert len(channels.telegram) == 2
+
+
+class TestCloseFanOut:
+    def test_close_closes_every_channel_and_resets_dedup(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        channels = _mock_channels(monkeypatch)
+
+        closed: list[str] = []
+
+        class _ClosableSlack:
+            def __call__(self, incident: HermesIncident) -> None:
+                slack_delivery.send_slack_webhook_message(incident.title)
+
+            def close(self) -> None:
+                closed.append("slack")
+
+        corr = IncidentCorrelator()
+        sink = CorrelatingSink(
+            correlator=corr,
+            routes={
+                RouteDestination.TELEGRAM_WITH_RCA: _telegram_sink(),
+                RouteDestination.TELEGRAM: _ClosableSlack(),
+            },
+        )
+
+        sink(_incident(fingerprint="c", seconds=0))
+        sink(_incident(fingerprint="c", seconds=10))  # suppressed by dedup
+        assert channels.counts == (1, 0, 0)
+
+        sink.close()
+        assert closed == ["slack"]
+
+        # After close(), correlator dedup state is cleared, so the same
+        # fingerprint delivers again instead of being suppressed.
+        sink(_incident(fingerprint="c", seconds=20))
+        assert channels.counts == (2, 0, 0)

--- a/tests/hermes/test_sinks.py
+++ b/tests/hermes/test_sinks.py
@@ -11,12 +11,7 @@ import pytest
 
 from integrations.hermes.incident import HermesIncident, IncidentSeverity, LogLevel, LogRecord
 from integrations.hermes.investigation import run_incident_investigation
-from integrations.hermes.sinks import (
-    TelegramSink,
-    TelegramSinkConfig,
-    _truncate,
-    make_telegram_sink,
-)
+from integrations.hermes.sinks import TelegramSink, TelegramSinkConfig, make_telegram_sink
 from integrations.telegram.alarms import AlarmDispatcher
 from integrations.telegram.credentials import TelegramCredentials
 
@@ -596,23 +591,6 @@ class TestSummaryTruncation:
         assert "investigation summary:" not in text
         assert "investigation: attempted (no summary produced)" in text
 
-    def test_whitespace_only_summary_renders_summary_block(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A non-empty string return is treated as a SUCCESS summary: it is
-        stripped and inlined under the ``investigation summary:`` heading."""
-        dispatcher, calls = _dispatcher(monkeypatch)
-
-        def _bridge(_incident: HermesIncident) -> str | None:
-            return "   \n\t  "
-
-        sink = TelegramSink(dispatcher, investigation_bridge=_bridge, config=_INLINE)
-        sink(_incident(severity=IncidentSeverity.CRITICAL))
-
-        text = calls[0]["text"]
-        assert "investigation summary:" in text
-        assert "investigation: attempted (no summary produced)" not in text
-
     def test_summary_is_stripped_before_inlining(self, monkeypatch: pytest.MonkeyPatch) -> None:
         dispatcher, calls = _dispatcher(monkeypatch)
 
@@ -716,27 +694,40 @@ class TestRecordFormatting:
         assert "run_id:" not in calls[0]["text"]
 
 
-class TestTruncateHelper:
-    """`_truncate` underpins both record and summary trimming; its boundary
-    behaviour is worth pinning directly so a refactor can't silently change
-    where the ellipsis lands."""
+class TestTruncationBoundary:
+    """Truncation boundary behaviour, pinned through the public sink API
+    (``max_record_chars``) rather than the private ``_truncate`` helper: a
+    record exactly at the limit is untouched, one char over collapses to
+    ``limit`` chars with a trailing ellipsis."""
 
-    def test_text_at_or_under_limit_is_unchanged(self) -> None:
-        assert _truncate("hello", 5) == "hello"
-        assert _truncate("hi", 5) == "hi"
+    def test_record_exactly_at_limit_is_not_truncated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        # raw = "<iso> ERROR exact: <msg>"; pin the limit to that exact length.
+        record = _record(LogLevel.ERROR, "exact", "boundary")
+        sink = TelegramSink(dispatcher, config=TelegramSinkConfig(max_record_chars=len(record.raw)))
 
-    def test_over_limit_appends_ellipsis_and_fits(self) -> None:
-        out = _truncate("hello world", 5)
-        assert out == "hell…"
-        assert len(out) == 5
+        sink(_incident(records=(record,)))
 
-    def test_non_positive_limit_returns_text_unchanged(self) -> None:
-        assert _truncate("hello", 0) == "hello"
-        assert _truncate("hello", -3) == "hello"
+        text = calls[0]["text"]
+        assert record.raw in text
+        assert "…" not in text
 
-    def test_limit_of_one_returns_single_char_without_ellipsis(self) -> None:
-        # limit <= 1 can't fit text + ellipsis, so it hard-slices.
-        assert _truncate("hello", 1) == "h"
+    def test_record_one_over_limit_collapses_to_limit_with_ellipsis(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        record = _record(LogLevel.ERROR, "over", "boundary")
+        limit = len(record.raw) - 1
+        sink = TelegramSink(dispatcher, config=TelegramSinkConfig(max_record_chars=limit))
+
+        sink(_incident(records=(record,)))
+
+        text = calls[0]["text"]
+        assert record.raw not in text
+        # The trimmed line is exactly `limit` chars ending in the ellipsis.
+        assert record.raw[: limit - 1] + "…" in text
 
 
 class TestCloseIdempotency:

--- a/tests/hermes/test_sinks.py
+++ b/tests/hermes/test_sinks.py
@@ -11,7 +11,12 @@ import pytest
 
 from integrations.hermes.incident import HermesIncident, IncidentSeverity, LogLevel, LogRecord
 from integrations.hermes.investigation import run_incident_investigation
-from integrations.hermes.sinks import TelegramSink, TelegramSinkConfig, make_telegram_sink
+from integrations.hermes.sinks import (
+    TelegramSink,
+    TelegramSinkConfig,
+    _truncate,
+    make_telegram_sink,
+)
 from integrations.telegram.alarms import AlarmDispatcher
 from integrations.telegram.credentials import TelegramCredentials
 
@@ -473,4 +478,284 @@ class TestDispatcherIntegration:
         assert result.state.value == "sink_closed", (
             f"CancelledError should yield sink_closed, got: {result.state.value}"
         )
+        sink.close()
+
+
+class TestDeliveryTransport:
+    """The sink's only egress is ``post_telegram_message`` via
+    :class:`AlarmDispatcher`. These tests pin the transport contract: the
+    resolved credentials and parse mode must reach the wire unchanged, and a
+    failing or raising transport must never propagate out of the sink."""
+
+    def test_resolved_credentials_reach_the_transport(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = _capture_telegram(monkeypatch)
+        creds = TelegramCredentials(bot_token="secret-token", chat_id="chat-42")
+        dispatcher = AlarmDispatcher(creds, cooldown_seconds=300.0)
+        sink = TelegramSink(dispatcher)
+
+        sink(_incident())
+
+        assert len(calls) == 1
+        assert calls[0]["chat_id"] == "chat-42"
+        assert calls[0]["bot_token"] == "secret-token"
+
+    def test_html_parse_mode_is_forwarded_to_transport(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = _capture_telegram(monkeypatch)
+        creds = TelegramCredentials(bot_token="tok", chat_id="chat-1")
+        dispatcher = AlarmDispatcher(creds, cooldown_seconds=300.0, parse_mode="HTML")
+        sink = TelegramSink(dispatcher)
+
+        sink(_incident())
+
+        assert calls[0]["parse_mode"] == "HTML"
+
+    def test_default_parse_mode_is_plain(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        sink = TelegramSink(dispatcher)
+
+        sink(_incident())
+
+        assert calls[0]["parse_mode"] == ""
+
+    def test_transport_returning_failure_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``(False, error, "")`` transport result is an *expected* delivery
+        failure — the sink must swallow it, not surface it to the agent."""
+
+        def _failing_post(*_a: Any, **_kw: Any) -> tuple[bool, str, str]:
+            return False, "telegram: 502 bad gateway", ""
+
+        monkeypatch.setattr("integrations.telegram.alarms.post_telegram_message", _failing_post)
+        creds = TelegramCredentials(bot_token="tok", chat_id="chat-1")
+        dispatcher = AlarmDispatcher(creds, cooldown_seconds=300.0)
+        sink = TelegramSink(dispatcher)
+
+        # Must not raise even though delivery failed.
+        sink(_incident(severity=IncidentSeverity.HIGH))
+
+    def test_transport_raising_is_swallowed_by_sink(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A transport that *raises* (e.g. a socket error escaping the HTTP
+        layer) must not crash the sink — Hermes delivery is best-effort."""
+
+        def _raising_post(*_a: Any, **_kw: Any) -> tuple[bool, str, str]:
+            raise ConnectionError("connection reset by peer")
+
+        monkeypatch.setattr("integrations.telegram.alarms.post_telegram_message", _raising_post)
+        creds = TelegramCredentials(bot_token="tok", chat_id="chat-1")
+        dispatcher = AlarmDispatcher(creds, cooldown_seconds=300.0)
+        sink = TelegramSink(dispatcher)
+
+        # AlarmDispatcher.dispatch catches the transport exception; the sink
+        # must complete cleanly regardless.
+        sink(_incident(severity=IncidentSeverity.CRITICAL))
+
+
+class TestSummaryTruncation:
+    """A successful investigation summary is inlined into the message body but
+    must respect ``max_summary_chars`` so one verbose RCA cannot blow past the
+    Telegram limit and crowd out the incident metadata above it."""
+
+    def test_long_summary_is_truncated_with_ellipsis(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        long_summary = "root cause: " + ("y" * 5000)
+
+        def _bridge(_incident: HermesIncident) -> str | None:
+            return long_summary
+
+        sink = TelegramSink(
+            dispatcher,
+            investigation_bridge=_bridge,
+            config=TelegramSinkConfig(bridge_run_inline=True, max_summary_chars=100),
+        )
+        sink(_incident(severity=IncidentSeverity.HIGH))
+
+        text = calls[0]["text"]
+        assert "investigation summary:" in text
+        assert long_summary not in text
+        assert "…" in text
+
+    def test_empty_string_summary_is_treated_as_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty-string return is the documented ``None``-equivalent of the
+        bridge contract and must surface the EMPTY marker, not a blank block."""
+        dispatcher, calls = _dispatcher(monkeypatch)
+
+        def _bridge(_incident: HermesIncident) -> str | None:
+            return ""
+
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge, config=_INLINE)
+        sink(_incident(severity=IncidentSeverity.CRITICAL))
+
+        text = calls[0]["text"]
+        assert "investigation summary:" not in text
+        assert "investigation: attempted (no summary produced)" in text
+
+    def test_whitespace_only_summary_renders_summary_block(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-empty string return is treated as a SUCCESS summary: it is
+        stripped and inlined under the ``investigation summary:`` heading."""
+        dispatcher, calls = _dispatcher(monkeypatch)
+
+        def _bridge(_incident: HermesIncident) -> str | None:
+            return "   \n\t  "
+
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge, config=_INLINE)
+        sink(_incident(severity=IncidentSeverity.CRITICAL))
+
+        text = calls[0]["text"]
+        assert "investigation summary:" in text
+        assert "investigation: attempted (no summary produced)" not in text
+
+    def test_summary_is_stripped_before_inlining(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+
+        def _bridge(_incident: HermesIncident) -> str | None:
+            return "\n  root cause: disk full  \n"
+
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge, config=_INLINE)
+        sink(_incident(severity=IncidentSeverity.HIGH))
+
+        text = calls[0]["text"]
+        assert "investigation summary:\nroot cause: disk full" in text
+
+
+class TestSeverityGate:
+    """Only HIGH/CRITICAL run the bridge. LOW is silent (no marker at all);
+    MEDIUM carries the notify-only marker. These cases fill the gap between
+    the two already-covered severities."""
+
+    def test_low_severity_never_runs_bridge_and_emits_no_marker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        bridge_calls: list[HermesIncident] = []
+
+        def _bridge(incident: HermesIncident) -> str | None:
+            bridge_calls.append(incident)
+            return "should never run"
+
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge, config=_INLINE)
+        sink(_incident(severity=IncidentSeverity.LOW, rule="info_noise"))
+
+        assert bridge_calls == []
+        text = calls[0]["text"]
+        assert "investigation" not in text.lower()
+        assert "notify only" not in text
+
+    @pytest.mark.parametrize(
+        ("severity", "should_investigate"),
+        [
+            (IncidentSeverity.LOW, False),
+            (IncidentSeverity.MEDIUM, False),
+            (IncidentSeverity.HIGH, True),
+            (IncidentSeverity.CRITICAL, True),
+        ],
+    )
+    def test_investigation_gate_matches_severity(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        severity: IncidentSeverity,
+        should_investigate: bool,
+    ) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        bridge_calls: list[HermesIncident] = []
+
+        def _bridge(incident: HermesIncident) -> str | None:
+            bridge_calls.append(incident)
+            return "rca"
+
+        sink = TelegramSink(dispatcher, investigation_bridge=_bridge, config=_INLINE)
+        sink(_incident(severity=severity))
+
+        assert bool(bridge_calls) is should_investigate
+        assert ("investigation summary:" in calls[0]["text"]) is should_investigate
+
+
+class TestRecordFormatting:
+    """Record-block rendering edges that the operator sees directly."""
+
+    def test_no_records_omits_recent_log_records_block(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        sink = TelegramSink(dispatcher)
+
+        sink(_incident(records=()))
+
+        text = calls[0]["text"]
+        assert "recent log records:" not in text
+        # Core metadata is still present.
+        assert "Hermes incident:" in text
+
+    def test_single_omitted_record_uses_singular_wording(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        sink = TelegramSink(dispatcher, config=TelegramSinkConfig(max_inlined_records=2))
+
+        records = tuple(_record(LogLevel.ERROR, "noisy", f"line-{i}") for i in range(3))
+        sink(_incident(records=records))
+
+        text = calls[0]["text"]
+        assert "1 more record omitted" in text
+        assert "records omitted" not in text  # singular, not plural
+
+    def test_run_id_absent_omits_run_id_line(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dispatcher, calls = _dispatcher(monkeypatch)
+        sink = TelegramSink(dispatcher)
+
+        sink(_incident(run_id=None))
+
+        assert "run_id:" not in calls[0]["text"]
+
+
+class TestTruncateHelper:
+    """`_truncate` underpins both record and summary trimming; its boundary
+    behaviour is worth pinning directly so a refactor can't silently change
+    where the ellipsis lands."""
+
+    def test_text_at_or_under_limit_is_unchanged(self) -> None:
+        assert _truncate("hello", 5) == "hello"
+        assert _truncate("hi", 5) == "hi"
+
+    def test_over_limit_appends_ellipsis_and_fits(self) -> None:
+        out = _truncate("hello world", 5)
+        assert out == "hell…"
+        assert len(out) == 5
+
+    def test_non_positive_limit_returns_text_unchanged(self) -> None:
+        assert _truncate("hello", 0) == "hello"
+        assert _truncate("hello", -3) == "hello"
+
+    def test_limit_of_one_returns_single_char_without_ellipsis(self) -> None:
+        # limit <= 1 can't fit text + ellipsis, so it hard-slices.
+        assert _truncate("hello", 1) == "h"
+
+
+class TestCloseIdempotency:
+    def test_close_is_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dispatcher, _ = _dispatcher(monkeypatch)
+
+        def _bridge(_incident: HermesIncident) -> str | None:
+            return "rca"
+
+        sink = TelegramSink(
+            dispatcher,
+            investigation_bridge=_bridge,
+            config=TelegramSinkConfig(bridge_workers=1),
+        )
+        # Multiple close() calls must not raise (SIGTERM handlers may double-fire).
+        sink.close()
+        sink.close()
+
+    def test_close_without_bridge_is_safe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dispatcher, _ = _dispatcher(monkeypatch)
+        sink = TelegramSink(dispatcher)  # no bridge → no executor ever created
         sink.close()

--- a/tests/synthetic/hermes/test_multichannel_e2e.py
+++ b/tests/synthetic/hermes/test_multichannel_e2e.py
@@ -193,6 +193,33 @@ class TestMultiChannelDedup:
         assert snap["delivered"] == 1
         assert snap["suppressed"] == 1
 
+    def test_telegram_cooldown_suppresses_after_correlator_lets_both_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The pipeline has two independent suppression layers. With correlator
+        dedup disabled, both incidents are *delivered* to the Telegram sink, but
+        the AlarmDispatcher's per-fingerprint cooldown collapses them into a
+        single wire call — proving the second layer works on its own."""
+        channels = _mock_channels(monkeypatch)
+        agent, sink = _build_pipeline(
+            correlator=IncidentCorrelator(dedup_window_s=0.0),
+            telegram_cooldown_s=300.0,
+        )
+
+        agent.process(
+            [
+                "2026-05-12 00:00:00,000 ERROR backend.api: database connection refused",
+                "2026-05-12 00:00:30,000 ERROR backend.api: database connection refused",
+            ]
+        )
+
+        # Correlator suppressed nothing: both reached the sink.
+        snap = sink.metrics_snapshot()
+        assert snap["delivered"] == 2
+        assert snap["suppressed"] == 0
+        # …but the dispatcher cooldown let only the first one onto the wire.
+        assert channels.counts == (1, 0, 0)
+
 
 class TestMultiChannelEscalation:
     def test_repeated_warning_burst_escalates_and_switches_channel(

--- a/tests/synthetic/hermes/test_multichannel_e2e.py
+++ b/tests/synthetic/hermes/test_multichannel_e2e.py
@@ -1,0 +1,231 @@
+"""Synthetic end-to-end test: HermesAgent → CorrelatingSink → 3 channels.
+
+Complements ``test_telegram_dispatch.py`` (single-channel Telegram) by driving
+a realistic ``errors.log`` slice through the *full* pipeline into a
+:class:`CorrelatingSink` that fans out to three delivery channels — Telegram,
+Slack, and Discord — with every vendor transport mocked.
+
+Currently Hermes only routes to Telegram in production today, so Slack/Discord are wired here through thin test-local
+channel adapters registered on existing :class:`RouteDestination` values. The
+point of the test is the *routing + dedup + escalation* behaviour that a
+multi-channel deployment depends on, observed at the transport boundary.
+
+Rule → destination (default matrix) → channel wired in this test:
+
+* ``error_severity``/``traceback`` → ``TELEGRAM_WITH_RCA`` → Telegram
+* ``warning_burst``               → ``TELEGRAM``          → Slack adapter
+* ``disk_full``                   → ``PAGER``             → Discord adapter
+
+The log fixture is synthesized inline so the test does not depend on the
+per-scenario ``errors.log`` files (which are ``.gitignore``d).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from integrations.discord import delivery as discord_delivery
+from integrations.hermes.agent import HermesAgent
+from integrations.hermes.classifier import IncidentClassifier
+from integrations.hermes.correlating_sink import CorrelatingSink
+from integrations.hermes.correlator import IncidentCorrelator, RouteDestination
+from integrations.hermes.incident import HermesIncident
+from integrations.hermes.sinks import TelegramSink
+from integrations.slack import delivery as slack_delivery
+from integrations.telegram.alarms import AlarmDispatcher
+from integrations.telegram.credentials import TelegramCredentials
+
+pytestmark = pytest.mark.synthetic
+
+
+class _Channels:
+    def __init__(self) -> None:
+        self.telegram: list[str] = []
+        self.slack: list[str] = []
+        self.discord: list[str] = []
+
+    @property
+    def counts(self) -> tuple[int, int, int]:
+        return len(self.telegram), len(self.slack), len(self.discord)
+
+
+def _mock_channels(monkeypatch: pytest.MonkeyPatch) -> _Channels:
+    channels = _Channels()
+
+    def _fake_telegram(
+        chat_id: str,
+        text: str,
+        bot_token: str,
+        parse_mode: str = "",
+        reply_to_message_id: str = "",
+        reply_markup: dict[str, Any] | None = None,
+    ) -> tuple[bool, str, str]:
+        channels.telegram.append(text)
+        return True, "", "1"
+
+    def _fake_slack(text: str, **_kw: Any) -> tuple[bool, str]:
+        channels.slack.append(text)
+        return True, ""
+
+    def _fake_discord(
+        channel_id: str,
+        embeds: list[dict[str, Any]],
+        bot_token: str,
+        content: str = "",
+    ) -> tuple[bool, str, str]:
+        channels.discord.append(content)
+        return True, "", "42"
+
+    monkeypatch.setattr("integrations.telegram.alarms.post_telegram_message", _fake_telegram)
+    monkeypatch.setattr(slack_delivery, "send_slack_webhook_message", _fake_slack)
+    monkeypatch.setattr(discord_delivery, "post_discord_message", _fake_discord)
+    return channels
+
+
+def _slack_adapter(incident: HermesIncident) -> None:
+    text = f"[{incident.severity.value.upper()}] {incident.title} ({incident.rule})"
+    slack_delivery.send_slack_webhook_message(text, webhook_url="https://hooks.example/x")
+
+
+def _discord_adapter(incident: HermesIncident) -> None:
+    content = f"[{incident.severity.value.upper()}] {incident.title} ({incident.rule})"
+    discord_delivery.post_discord_message(
+        channel_id="chan-1", embeds=[], bot_token="bot-tok", content=content
+    )
+
+
+def _build_pipeline(
+    *,
+    correlator: IncidentCorrelator,
+    telegram_cooldown_s: float = 0.0,
+) -> tuple[HermesAgent, CorrelatingSink]:
+    creds = TelegramCredentials(bot_token="tok", chat_id="chat-1")
+    telegram = TelegramSink(AlarmDispatcher(creds, cooldown_seconds=telegram_cooldown_s))
+    sink = CorrelatingSink(
+        correlator=correlator,
+        routes={
+            RouteDestination.TELEGRAM_WITH_RCA: telegram,
+            RouteDestination.TELEGRAM: _slack_adapter,
+            RouteDestination.PAGER: _discord_adapter,
+        },
+    )
+    agent = HermesAgent(
+        sink=sink,
+        log_path="/dev/null",
+        classifier=IncidentClassifier(warning_burst_threshold=3, warning_burst_window_s=120.0),
+    )
+    return agent, sink
+
+
+# A mixed log slice covering all three channels:
+#   - 3 WARNING polling-conflict lines (same logger) → one warning_burst → Slack
+#   - 2 ERROR lines (distinct loggers)               → two error_severity → Telegram
+#   - 1 WARNING "no space left on device" line       → one disk_full     → Discord
+_MIXED_LOG = [
+    "2026-05-12 00:40:12,000 WARNING gateway.platforms.telegram: "
+    + "[Telegram] Telegram polling conflict (1/3), will retry in 10s.",
+    "2026-05-12 00:40:34,500 WARNING gateway.platforms.telegram: "
+    + "[Telegram] Telegram polling conflict (2/3), will retry in 10s.",
+    "2026-05-12 00:40:57,000 WARNING gateway.platforms.telegram: "
+    + "[Telegram] Telegram polling conflict (3/3), will retry in 10s.",
+    "2026-05-12 00:41:05,000 ERROR backend.api: database connection refused",
+    "2026-05-12 00:41:06,000 ERROR worker.queue: failed to ack message",
+    "2026-05-12 00:41:10,000 WARNING storage.writer: no space left on device",
+]
+
+
+class TestMultiChannelFanOut:
+    def test_mixed_log_routes_each_incident_to_its_channel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        channels = _mock_channels(monkeypatch)
+        agent, sink = _build_pipeline(correlator=IncidentCorrelator())
+
+        agent.process(_MIXED_LOG)
+
+        # Telegram: two distinct error_severity incidents.
+        # Slack: one warning_burst. Discord: one disk_full.
+        assert channels.counts == (2, 1, 1), (
+            f"unexpected fan-out: telegram/slack/discord = {channels.counts}"
+        )
+        assert all("Hermes incident" in t for t in channels.telegram)
+        assert "warning_burst" in channels.slack[0]
+        assert "disk_full" in channels.discord[0]
+        assert sink.metrics_snapshot()["delivered"] == 4
+
+    def test_no_channel_receives_dropped_incidents(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A benign INFO/low-severity line produces no incident and therefore
+        touches no channel — the pipeline must stay silent."""
+        channels = _mock_channels(monkeypatch)
+        agent, _ = _build_pipeline(correlator=IncidentCorrelator())
+
+        agent.process(
+            [
+                "2026-05-12 00:00:00,000 INFO backend.api: request served in 12ms",
+                "2026-05-12 00:00:01,000 DEBUG backend.api: cache hit",
+            ]
+        )
+
+        assert channels.counts == (0, 0, 0)
+
+
+class TestMultiChannelDedup:
+    def test_repeated_error_is_deduped_before_reaching_telegram(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two identical ERROR lines inside the correlator dedup window collapse
+        to a single Telegram delivery; Slack/Discord stay untouched."""
+        channels = _mock_channels(monkeypatch)
+        # Default 300s dedup window; both lines are 30s apart.
+        agent, sink = _build_pipeline(correlator=IncidentCorrelator())
+
+        agent.process(
+            [
+                "2026-05-12 00:00:00,000 ERROR backend.api: database connection refused",
+                "2026-05-12 00:00:30,000 ERROR backend.api: database connection refused",
+            ]
+        )
+
+        assert channels.counts == (1, 0, 0)
+        snap = sink.metrics_snapshot()
+        assert snap["delivered"] == 1
+        assert snap["suppressed"] == 1
+
+
+class TestMultiChannelEscalation:
+    def test_repeated_warning_burst_escalates_and_switches_channel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``warning_burst`` (MEDIUM → Slack) that repeats past the escalation
+        threshold is bumped to HIGH and, because the burst fingerprint is stable,
+        breaks through dedup. The escalated incident re-routes: MEDIUM→HIGH still
+        maps ``warning_burst`` to TELEGRAM (Slack here), so both land on Slack but
+        the second is an escalation, proving escalation crosses the sink boundary."""
+        channels = _mock_channels(monkeypatch)
+        corr = IncidentCorrelator(
+            dedup_window_s=300.0, escalation_window_s=600.0, escalation_threshold=2
+        )
+        agent, sink = _build_pipeline(correlator=corr)
+
+        # Two full bursts (3 warnings each) from the same logger → two
+        # warning_burst incidents sharing one fingerprint. The second repeat
+        # escalates and breaks through the dedup window.
+        burst = [
+            "2026-05-12 00:40:12,000 WARNING gateway.platforms.telegram: polling conflict (1/3)",
+            "2026-05-12 00:40:34,500 WARNING gateway.platforms.telegram: polling conflict (2/3)",
+            "2026-05-12 00:40:57,000 WARNING gateway.platforms.telegram: polling conflict (3/3)",
+            "2026-05-12 00:41:12,000 WARNING gateway.platforms.telegram: polling conflict (1/3)",
+            "2026-05-12 00:41:34,500 WARNING gateway.platforms.telegram: polling conflict (2/3)",
+            "2026-05-12 00:41:57,000 WARNING gateway.platforms.telegram: polling conflict (3/3)",
+        ]
+        agent.process(burst)
+
+        # First burst delivered; second escalated through dedup → 2 Slack sends.
+        assert channels.counts == (0, 2, 0)
+        snap = sink.metrics_snapshot()
+        assert snap["delivered"] == 2
+        assert snap["escalated"] == 1
+        # The escalated delivery carries the ESCALATED marker in its title.
+        assert any("ESCALATED" in t for t in channels.slack)


### PR DESCRIPTION
Extend Hermes sink/delivery tests across unit and synthetic layers with Telegram/Slack/Discord transports mocked. No production changes; integrations/hermes/investigation.py is untouched.

- test_sinks.py: transport contract (creds/parse_mode forwarding, failure and raising transport are swallowed), summary truncation/strip/empty, severity gate matrix, record-block edges, _truncate boundaries, close idempotency.
- test_correlating_sink.py (new): multi-channel fan-out via CorrelatingSink with all three vendor transports mocked behind test-local channel adapters — routing, drop/suppress/unrouted, default_route, channel isolation, escalated fingerprint reaching the wire, close fan-out.
- test_multichannel_e2e.py (new, synthetic): full HermesAgent ->
  CorrelatingSink -> {Telegram, Slack, Discord} over a mixed log slice; fan-out, dedup, and escalation observed at the transport boundary.

Fixes #3587 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Extends Hermes sink/delivery test coverage - tests only, no production changes (investigation.py untouched). Adds delivery-contract and edge-case tests to test_sinks.py, a new test_correlating_sink.py for multi-channel fan-out through CorrelatingSink with Telegram/Slack/Discord mocked, and a synthetic test_multichannel_e2e.py covering the full HermesAgent → CorrelatingSink → 3 channels pipeline (fan-out, dedup, escalation). 57 tests, all green.

### Demo/Screenshot for feature changes and bug fixes - 


https://github.com/user-attachments/assets/7a6f2d5c-8b1d-47f9-8717-18eef638acf1

<img width="1521" height="941" alt="Pasted image (38)" src="https://github.com/user-attachments/assets/770be759-21ad-4101-abe9-a579644e1edf" />

<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Kept it strictly test-only: mocked the three vendor transports (post_telegram_message, send_slack_webhook_message, post_discord_message) and asserted behavior at that boundary. Since Hermes only ships a TelegramSink, I wired Slack/Discord as thin test-local adapters on CorrelatingSink routes to exercise multi-channel fan-out without touching production, and drove the synthetic e2e through HermesAgent.process() with a realistic log slice.

<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
