### PR TITLE
fix(cloudtrail): harden LookupEvents live payload parsing so events reach the agent (#3583)

### DIFF
--- a/docs/cloudtrail_events.mdx
+++ b/docs/cloudtrail_events.mdx
@@ -42,6 +42,10 @@ CloudTrail's `LookupEvents` API accepts **only one filter attribute per call**. 
 CloudTrail returns at most 50 events per page. When more matching events exist, the response sets **`truncated: true`** and returns a **`next_token`** — pass it back via the `next_token` parameter to fetch the next page, so a busy account or wide window never silently drops events.
 </Note>
 
+<Note>
+A single event can touch more resources than the transport layer returns inline (for example `CreateTags` across a fleet). When the affected-resources list for an event is trimmed, that event carries **`resources_truncated: true`**, signalling that the real blast radius is wider than the resources shown — so a large fan-out change is never silently understated.
+</Note>
+
 ### Use cases
 
 - Finding who modified an IAM policy, role, or security group just before an incident

--- a/integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py
+++ b/integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py
@@ -58,12 +58,17 @@ def _build_lookup_attribute(
 
 def _shape_event(raw: dict[str, Any]) -> dict[str, Any]:
     """Trim a raw CloudTrail event down to the fields RCA actually needs."""
+    # Skip non-dict Resources entries: the transport sanitizer replaces the tail
+    # of an oversized list with a "... (N more items truncated)" string (one
+    # event CAN reference >MAX_LIST_ITEMS resources, e.g. CreateTags across a
+    # fleet), and degraded payloads may carry nulls.
     resources = [
         {
             "type": resource.get("ResourceType"),
             "name": resource.get("ResourceName"),
         }
         for resource in (raw.get("Resources") or [])
+        if isinstance(resource, dict)
     ]
 
     # CloudTrailEvent is a JSON string carrying the full record; pull the
@@ -74,6 +79,11 @@ def _shape_event(raw: dict[str, Any]) -> dict[str, Any]:
         try:
             parsed = json.loads(detail)
         except (ValueError, TypeError):
+            parsed = {}
+        # The record should be a JSON object, but degraded payloads can carry
+        # valid-but-non-dict JSON ("null", a bare string, a list) — treat those
+        # as "no detail" rather than crashing on .get.
+        if not isinstance(parsed, dict):
             parsed = {}
         aws_region = parsed.get("awsRegion")
         source_ip = parsed.get("sourceIPAddress")
@@ -242,7 +252,9 @@ def lookup_cloudtrail_events(
 
     data = result.get("data") or {}
     raw_events = data.get("Events") or []
-    events = [_shape_event(event) for event in raw_events]
+    # Shape only dict entries: the transport sanitizer appends a string
+    # truncation marker to oversized lists, which must not crash the parse.
+    events = [_shape_event(event) for event in raw_events if isinstance(event, dict)]
     # CloudTrail returns a NextToken when more matching events exist beyond this
     # page. Surface it so the agent knows the result is partial (and can paginate
     # via the next_token param) instead of silently treating 50 events as "all".

--- a/integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py
+++ b/integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py
@@ -61,15 +61,19 @@ def _shape_event(raw: dict[str, Any]) -> dict[str, Any]:
     # Skip non-dict Resources entries: the transport sanitizer replaces the tail
     # of an oversized list with a "... (N more items truncated)" string (one
     # event CAN reference >MAX_LIST_ITEMS resources, e.g. CreateTags across a
-    # fleet), and degraded payloads may carry nulls.
+    # fleet), and degraded payloads may carry nulls. Anything skipped is
+    # surfaced via resources_truncated so the planner knows the resource list
+    # understates the true blast radius instead of silently trusting it.
+    raw_resources = raw.get("Resources") or []
     resources = [
         {
             "type": resource.get("ResourceType"),
             "name": resource.get("ResourceName"),
         }
-        for resource in (raw.get("Resources") or [])
+        for resource in raw_resources
         if isinstance(resource, dict)
     ]
+    resources_truncated = len(resources) != len(raw_resources)
 
     # CloudTrailEvent is a JSON string carrying the full record; pull the
     # high-signal forensic fields out of it without dumping the whole blob.
@@ -108,6 +112,7 @@ def _shape_event(raw: dict[str, Any]) -> dict[str, Any]:
         "read_only": read_only,
         "access_key_id": raw.get("AccessKeyId"),
         "resources": resources,
+        "resources_truncated": resources_truncated,
         "aws_region": aws_region,
         "source_ip_address": source_ip,
         "error_code": error_code,
@@ -252,8 +257,10 @@ def lookup_cloudtrail_events(
 
     data = result.get("data") or {}
     raw_events = data.get("Events") or []
-    # Shape only dict entries: the transport sanitizer appends a string
-    # truncation marker to oversized lists, which must not crash the parse.
+    # Shape only dict entries. Defensive: the sanitizer's list-truncation marker
+    # cannot reach Events today (LookupEvents pages cap at 50 < MAX_LIST_ITEMS
+    # and the client never merges pages) — unlike per-event Resources, where it
+    # genuinely can — but degraded payloads must degrade, not crash the parse.
     events = [_shape_event(event) for event in raw_events if isinstance(event, dict)]
     # CloudTrail returns a NextToken when more matching events exist beyond this
     # page. Surface it so the agent knows the result is partial (and can paginate

--- a/integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py
+++ b/integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py
@@ -267,6 +267,12 @@ def lookup_cloudtrail_events(
     # via the next_token param) instead of silently treating 50 events as "all".
     returned_token = data.get("NextToken") or None
 
+    # NOTE: the success payload must NOT carry an "error" key. The runtime tool
+    # loop (core.execution._normalize_result) treats the mere presence of an
+    # "error" key as a failure (is_error = "error" in raw) and replaces the whole
+    # payload with {"error": ...} before the agent sees it — so a success dict
+    # with "error": None would hide every event from the investigation. Only the
+    # failure paths above set "error".
     return {
         "source": "cloudtrail",
         "available": True,
@@ -277,5 +283,4 @@ def lookup_cloudtrail_events(
         "truncated": bool(returned_token),
         "next_token": returned_token,
         "events": events,
-        "error": None,
     }

--- a/tests/fixtures/cloudtrail/lookup_events_page.json
+++ b/tests/fixtures/cloudtrail/lookup_events_page.json
@@ -1,0 +1,41 @@
+{
+  "_comment": "Realistic CloudTrail LookupEvents response page as it reaches the tool after integrations/aws/aws_sdk_client._sanitize_response (datetimes already ISO strings, ResponseMetadata stripped). Mirrors the documented LookupEvents shape: top-level Events + NextToken; each event carries EventId/EventName/ReadOnly(string!)/AccessKeyId/EventTime/EventSource/Username/Resources plus the full record serialized as the CloudTrailEvent JSON string.",
+  "Events": [
+    {
+      "EventId": "8e3c6f2b-4a1d-4c8e-9f2a-1b7d3e5a9c01",
+      "EventName": "PutRolePolicy",
+      "ReadOnly": "false",
+      "AccessKeyId": "AKIAIOSFODNN7EXAMPLE",
+      "EventTime": "2026-07-03T09:12:41+00:00",
+      "EventSource": "iam.amazonaws.com",
+      "Username": "deploy-bot",
+      "Resources": [
+        {"ResourceType": "AWS::IAM::Role", "ResourceName": "payments-service-role"}
+      ],
+      "CloudTrailEvent": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"AIDA2EXAMPLE9XLZQW\",\"arn\":\"arn:aws:iam::802096226397:user/deploy-bot\",\"accountId\":\"802096226397\",\"userName\":\"deploy-bot\"},\"eventTime\":\"2026-07-03T09:12:41Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"PutRolePolicy\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"203.0.113.24\",\"userAgent\":\"aws-cli/2.17.0\",\"requestParameters\":{\"roleName\":\"payments-service-role\",\"policyName\":\"inline-s3-write\"},\"responseElements\":null,\"requestID\":\"b4f1c9d2-8a3e-4f6b-b2d1-9c8e7a6f5d40\",\"eventID\":\"8e3c6f2b-4a1d-4c8e-9f2a-1b7d3e5a9c01\",\"readOnly\":false,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"802096226397\"}"
+    },
+    {
+      "EventId": "1f9a7c3e-6b2d-4a5f-8c1e-7d4b2a9f6e02",
+      "EventName": "DeleteSecurityGroup",
+      "ReadOnly": "false",
+      "AccessKeyId": "ASIA6EXAMPLETEMPKEY",
+      "EventTime": "2026-07-03T09:05:17+00:00",
+      "EventSource": "ec2.amazonaws.com",
+      "Username": "intern-sandbox",
+      "Resources": [
+        {"ResourceType": "AWS::EC2::SecurityGroup", "ResourceName": "sg-0a1b2c3d4e5f6a7b8"}
+      ],
+      "CloudTrailEvent": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROA4EXAMPLE:intern-sandbox\",\"arn\":\"arn:aws:sts::802096226397:assumed-role/sandbox/intern-sandbox\",\"accountId\":\"802096226397\"},\"eventTime\":\"2026-07-03T09:05:17Z\",\"eventSource\":\"ec2.amazonaws.com\",\"eventName\":\"DeleteSecurityGroup\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"198.51.100.7\",\"userAgent\":\"console.ec2.amazonaws.com\",\"errorCode\":\"Client.UnauthorizedOperation\",\"errorMessage\":\"You are not authorized to perform this operation.\",\"requestParameters\":{\"groupId\":\"sg-0a1b2c3d4e5f6a7b8\"},\"responseElements\":null,\"requestID\":\"2c7e9f1a-5d3b-4e8c-a6f2-1b9d8c7e6a51\",\"eventID\":\"1f9a7c3e-6b2d-4a5f-8c1e-7d4b2a9f6e02\",\"readOnly\":false,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"802096226397\"}"
+    },
+    {
+      "EventId": "5d2b8e4a-9c1f-4d7b-a3e6-8f5c2d1b9a03",
+      "EventName": "DescribeScalingActivities",
+      "ReadOnly": "true",
+      "EventTime": "2026-07-03T08:58:02+00:00",
+      "EventSource": "autoscaling.amazonaws.com",
+      "Resources": [],
+      "CloudTrailEvent": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AWSService\",\"invokedBy\":\"autoscaling.amazonaws.com\"},\"eventTime\":\"2026-07-03T08:58:02Z\",\"eventSource\":\"autoscaling.amazonaws.com\",\"eventName\":\"DescribeScalingActivities\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"autoscaling.amazonaws.com\",\"userAgent\":\"autoscaling.amazonaws.com\",\"requestParameters\":null,\"responseElements\":null,\"requestID\":\"7a4c1e9b-2f8d-4b6a-9e3c-5d1f8b7a2c62\",\"eventID\":\"5d2b8e4a-9c1f-4d7b-a3e6-8f5c2d1b9a03\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"802096226397\"}"
+    }
+  ],
+  "NextToken": "AAAAfR3kNzXhCq9lEXAMPLEtokenXo1v"
+}

--- a/tests/fixtures/cloudtrail/lookup_events_page.json
+++ b/tests/fixtures/cloudtrail/lookup_events_page.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Realistic CloudTrail LookupEvents response page as it reaches the tool after integrations/aws/aws_sdk_client._sanitize_response (datetimes already ISO strings, ResponseMetadata stripped). Mirrors the documented LookupEvents shape: top-level Events + NextToken; each event carries EventId/EventName/ReadOnly(string!)/AccessKeyId/EventTime/EventSource/Username/Resources plus the full record serialized as the CloudTrailEvent JSON string.",
+  "_comment": "Realistic CloudTrail LookupEvents response page as it reaches the tool after integrations/aws/aws_sdk_client._sanitize_response (datetimes already ISO strings, ResponseMetadata stripped). Mirrors the documented LookupEvents shape: top-level Events + NextToken; each event carries EventId/EventName/ReadOnly(string!)/AccessKeyId/EventTime/EventSource/Username/Resources plus the full record serialized as the CloudTrailEvent JSON string. Uses the AWS documentation account 123456789012.",
   "Events": [
     {
       "EventId": "8e3c6f2b-4a1d-4c8e-9f2a-1b7d3e5a9c01",
@@ -12,7 +12,7 @@
       "Resources": [
         {"ResourceType": "AWS::IAM::Role", "ResourceName": "payments-service-role"}
       ],
-      "CloudTrailEvent": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"AIDA2EXAMPLE9XLZQW\",\"arn\":\"arn:aws:iam::802096226397:user/deploy-bot\",\"accountId\":\"802096226397\",\"userName\":\"deploy-bot\"},\"eventTime\":\"2026-07-03T09:12:41Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"PutRolePolicy\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"203.0.113.24\",\"userAgent\":\"aws-cli/2.17.0\",\"requestParameters\":{\"roleName\":\"payments-service-role\",\"policyName\":\"inline-s3-write\"},\"responseElements\":null,\"requestID\":\"b4f1c9d2-8a3e-4f6b-b2d1-9c8e7a6f5d40\",\"eventID\":\"8e3c6f2b-4a1d-4c8e-9f2a-1b7d3e5a9c01\",\"readOnly\":false,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"802096226397\"}"
+      "CloudTrailEvent": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"AIDA2EXAMPLE9XLZQW\",\"arn\":\"arn:aws:iam::123456789012:user/deploy-bot\",\"accountId\":\"123456789012\",\"accessKeyId\":\"AKIAIOSFODNN7EXAMPLE\",\"userName\":\"deploy-bot\"},\"eventTime\":\"2026-07-03T09:12:41Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"PutRolePolicy\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"203.0.113.24\",\"userAgent\":\"aws-cli/2.17.0\",\"requestParameters\":{\"roleName\":\"payments-service-role\",\"policyName\":\"inline-s3-write\"},\"responseElements\":null,\"requestID\":\"b4f1c9d2-8a3e-4f6b-b2d1-9c8e7a6f5d40\",\"eventID\":\"8e3c6f2b-4a1d-4c8e-9f2a-1b7d3e5a9c01\",\"readOnly\":false,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"123456789012\"}"
     },
     {
       "EventId": "1f9a7c3e-6b2d-4a5f-8c1e-7d4b2a9f6e02",
@@ -25,7 +25,7 @@
       "Resources": [
         {"ResourceType": "AWS::EC2::SecurityGroup", "ResourceName": "sg-0a1b2c3d4e5f6a7b8"}
       ],
-      "CloudTrailEvent": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROA4EXAMPLE:intern-sandbox\",\"arn\":\"arn:aws:sts::802096226397:assumed-role/sandbox/intern-sandbox\",\"accountId\":\"802096226397\"},\"eventTime\":\"2026-07-03T09:05:17Z\",\"eventSource\":\"ec2.amazonaws.com\",\"eventName\":\"DeleteSecurityGroup\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"198.51.100.7\",\"userAgent\":\"console.ec2.amazonaws.com\",\"errorCode\":\"Client.UnauthorizedOperation\",\"errorMessage\":\"You are not authorized to perform this operation.\",\"requestParameters\":{\"groupId\":\"sg-0a1b2c3d4e5f6a7b8\"},\"responseElements\":null,\"requestID\":\"2c7e9f1a-5d3b-4e8c-a6f2-1b9d8c7e6a51\",\"eventID\":\"1f9a7c3e-6b2d-4a5f-8c1e-7d4b2a9f6e02\",\"readOnly\":false,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"802096226397\"}"
+      "CloudTrailEvent": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROA4EXAMPLE:intern-sandbox\",\"arn\":\"arn:aws:sts::123456789012:assumed-role/sandbox/intern-sandbox\",\"accountId\":\"123456789012\",\"accessKeyId\":\"ASIA6EXAMPLETEMPKEY\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"AROA4EXAMPLE\",\"arn\":\"arn:aws:iam::123456789012:role/sandbox\",\"accountId\":\"123456789012\",\"userName\":\"sandbox\"},\"attributes\":{\"creationDate\":\"2026-07-03T08:59:00Z\",\"mfaAuthenticated\":\"false\"}}},\"eventTime\":\"2026-07-03T09:05:17Z\",\"eventSource\":\"ec2.amazonaws.com\",\"eventName\":\"DeleteSecurityGroup\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"198.51.100.7\",\"userAgent\":\"console.ec2.amazonaws.com\",\"errorCode\":\"Client.UnauthorizedOperation\",\"errorMessage\":\"You are not authorized to perform this operation.\",\"requestParameters\":{\"groupId\":\"sg-0a1b2c3d4e5f6a7b8\"},\"responseElements\":null,\"requestID\":\"2c7e9f1a-5d3b-4e8c-a6f2-1b9d8c7e6a51\",\"eventID\":\"1f9a7c3e-6b2d-4a5f-8c1e-7d4b2a9f6e02\",\"readOnly\":false,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"123456789012\"}"
     },
     {
       "EventId": "5d2b8e4a-9c1f-4d7b-a3e6-8f5c2d1b9a03",
@@ -34,7 +34,7 @@
       "EventTime": "2026-07-03T08:58:02+00:00",
       "EventSource": "autoscaling.amazonaws.com",
       "Resources": [],
-      "CloudTrailEvent": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AWSService\",\"invokedBy\":\"autoscaling.amazonaws.com\"},\"eventTime\":\"2026-07-03T08:58:02Z\",\"eventSource\":\"autoscaling.amazonaws.com\",\"eventName\":\"DescribeScalingActivities\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"autoscaling.amazonaws.com\",\"userAgent\":\"autoscaling.amazonaws.com\",\"requestParameters\":null,\"responseElements\":null,\"requestID\":\"7a4c1e9b-2f8d-4b6a-9e3c-5d1f8b7a2c62\",\"eventID\":\"5d2b8e4a-9c1f-4d7b-a3e6-8f5c2d1b9a03\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"802096226397\"}"
+      "CloudTrailEvent": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AWSService\",\"invokedBy\":\"autoscaling.amazonaws.com\"},\"eventTime\":\"2026-07-03T08:58:02Z\",\"eventSource\":\"autoscaling.amazonaws.com\",\"eventName\":\"DescribeScalingActivities\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"autoscaling.amazonaws.com\",\"userAgent\":\"autoscaling.amazonaws.com\",\"requestParameters\":null,\"responseElements\":null,\"requestID\":\"7a4c1e9b-2f8d-4b6a-9e3c-5d1f8b7a2c62\",\"eventID\":\"5d2b8e4a-9c1f-4d7b-a3e6-8f5c2d1b9a03\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"123456789012\"}"
     }
   ],
   "NextToken": "AAAAfR3kNzXhCq9lEXAMPLEtokenXo1v"

--- a/tests/fixtures/cloudtrail/lookup_events_weird.json
+++ b/tests/fixtures/cloudtrail/lookup_events_weird.json
@@ -1,0 +1,53 @@
+{
+  "_comment": "Partial/degenerate LookupEvents payloads the parser must survive: CloudTrailEvent as valid-but-non-dict JSON (null / string / list) or invalid JSON, an event with only EventId, ReadOnly as bool / mixed-case string, a null and a _sanitize_response truncation marker inside Resources (one event CAN reference >MAX_LIST_ITEMS resources, e.g. CreateTags across a fleet), and the same marker as the final Events entry.",
+  "Events": [
+    {
+      "EventId": "weird-null-detail",
+      "EventName": "PutRolePolicy",
+      "EventSource": "iam.amazonaws.com",
+      "CloudTrailEvent": "null"
+    },
+    {
+      "EventId": "weird-string-detail",
+      "EventName": "AssumeRole",
+      "EventSource": "sts.amazonaws.com",
+      "CloudTrailEvent": "\"throttled\""
+    },
+    {
+      "EventId": "weird-list-detail",
+      "EventName": "RunInstances",
+      "EventSource": "ec2.amazonaws.com",
+      "CloudTrailEvent": "[1, 2]"
+    },
+    {
+      "EventId": "weird-invalid-json-detail",
+      "EventName": "CreateBucket",
+      "EventSource": "s3.amazonaws.com",
+      "CloudTrailEvent": "{ this is not json"
+    },
+    {
+      "EventId": "weird-bare-event"
+    },
+    {
+      "EventId": "weird-resources-mixed",
+      "EventName": "CreateTags",
+      "ReadOnly": true,
+      "EventSource": "ec2.amazonaws.com",
+      "Username": "fleet-tagger",
+      "Resources": [
+        {"ResourceType": "AWS::EC2::Instance", "ResourceName": "i-0abc123def456789a"},
+        null,
+        "... (57 more items truncated)"
+      ],
+      "CloudTrailEvent": "{\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"192.0.2.44\",\"readOnly\":false}"
+    },
+    {
+      "EventId": "weird-readonly-mixed-case",
+      "EventName": "GetCallerIdentity",
+      "ReadOnly": "True",
+      "EventSource": "sts.amazonaws.com"
+    },
+    "... (12 more items truncated)"
+  ],
+  "NextToken": "AAAAweirdPageToken"
+}

--- a/tests/fixtures/cloudtrail/lookup_events_weird.json
+++ b/tests/fixtures/cloudtrail/lookup_events_weird.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Partial/degenerate LookupEvents payloads the parser must survive: CloudTrailEvent as valid-but-non-dict JSON (null / string / list) or invalid JSON, an event with only EventId, ReadOnly as bool / mixed-case string, a null and a _sanitize_response truncation marker inside Resources (one event CAN reference >MAX_LIST_ITEMS resources, e.g. CreateTags across a fleet), and the same marker as the final Events entry.",
+  "_comment": "Partial/degenerate LookupEvents payloads the parser must survive: CloudTrailEvent as valid-but-non-dict JSON (null / string / list) or invalid JSON, an event with only EventId, ReadOnly as bool / mixed-case string, and a null plus a _sanitize_response truncation marker inside Resources — the one place the marker is genuinely reachable (a single event CAN reference >MAX_LIST_ITEMS resources, e.g. CreateTags across a fleet). Truncated lists are abbreviated here for readability; a real post-sanitizer list carries exactly MAX_LIST_ITEMS kept items before the marker. The marker as the final Events entry is a purely DEFENSIVE case: LookupEvents pages cap at 50 < MAX_LIST_ITEMS so the sanitizer cannot produce it there — it exercises non-dict-entry tolerance, not real transport behavior.",
   "Events": [
     {
       "EventId": "weird-null-detail",

--- a/tests/tools/test_cloudtrail_events.py
+++ b/tests/tools/test_cloudtrail_events.py
@@ -385,15 +385,22 @@ def test_realistic_page_shapes_every_event(mock_call) -> None:
     assert result["total_events"] == 3
     by_id = {event["event_id"]: event for event in result["events"]}
 
-    iam = by_id["8e3c6f2b-4a1d-4c8e-9f2a-1b7d3e5a9c01"]
-    assert iam["event_name"] == "PutRolePolicy"
-    assert iam["username"] == "deploy-bot"
-    assert iam["read_only"] is False
-    assert iam["access_key_id"] == "AKIAIOSFODNN7EXAMPLE"
-    assert iam["resources"] == [{"type": "AWS::IAM::Role", "name": "payments-service-role"}]
-    assert iam["aws_region"] == "us-east-1"
-    assert iam["source_ip_address"] == "203.0.113.24"
-    assert iam["error_code"] is None
+    # Full-dict equality: locks every key of the shaped-event contract,
+    # including the ISO EventTime passthrough and event_source.
+    assert by_id["8e3c6f2b-4a1d-4c8e-9f2a-1b7d3e5a9c01"] == {
+        "event_id": "8e3c6f2b-4a1d-4c8e-9f2a-1b7d3e5a9c01",
+        "event_name": "PutRolePolicy",
+        "event_time": "2026-07-03T09:12:41+00:00",
+        "event_source": "iam.amazonaws.com",
+        "username": "deploy-bot",
+        "read_only": False,
+        "access_key_id": "AKIAIOSFODNN7EXAMPLE",
+        "resources": [{"type": "AWS::IAM::Role", "name": "payments-service-role"}],
+        "resources_truncated": False,
+        "aws_region": "us-east-1",
+        "source_ip_address": "203.0.113.24",
+        "error_code": None,
+    }
 
     # A denied call surfaces its errorCode from the CloudTrailEvent record.
     denied = by_id["1f9a7c3e-6b2d-4a5f-8c1e-7d4b2a9f6e02"]
@@ -409,13 +416,7 @@ def test_realistic_page_shapes_every_event(mock_call) -> None:
     assert service["read_only"] is True
     assert service["resources"] == []
 
-
-@patch("integrations.cloudtrail.tools.cloudtrail_events_tool.execute_aws_sdk_call")
-def test_realistic_page_surfaces_pagination(mock_call) -> None:
-    mock_call.return_value = {"success": True, "data": _fixture_payload("lookup_events_page.json")}
-
-    result = lookup_cloudtrail_events()
-
+    # More matching events exist beyond this page — surfaced, not swallowed.
     assert result["truncated"] is True
     assert result["next_token"] == "AAAAfR3kNzXhCq9lEXAMPLEtokenXo1v"
 
@@ -426,10 +427,13 @@ def test_weird_page_survives_and_shapes_gracefully(mock_call) -> None:
 
     The weird fixture packs the §1 cases: CloudTrailEvent as valid-but-non-dict
     JSON (null / bare string / list) or invalid JSON, an event with only
-    EventId, ReadOnly as a real bool and as "True", a null plus a
-    _sanitize_response truncation marker inside Resources (one event CAN
-    reference >MAX_LIST_ITEMS resources, e.g. CreateTags across a fleet), and
-    the same marker as the final Events entry.
+    EventId, ReadOnly as a real bool and as "True", and a null plus a
+    _sanitize_response truncation marker inside Resources — the one place the
+    marker is genuinely reachable (a single event CAN reference >MAX_LIST_ITEMS
+    resources, e.g. CreateTags across a fleet). The marker as the final Events
+    entry is a purely defensive case (LookupEvents pages cap at 50 <
+    MAX_LIST_ITEMS, so the sanitizer cannot produce it there): it pins that
+    non-dict Events entries are tolerated, not that the transport emits them.
     """
     mock_call.return_value = {"success": True, "data": _fixture_payload("lookup_events_weird.json")}
 
@@ -456,11 +460,14 @@ def test_weird_page_survives_and_shapes_gracefully(mock_call) -> None:
     assert bare["username"] is None
     assert bare["read_only"] is None
     assert bare["resources"] == []
+    assert bare["resources_truncated"] is False
 
     # Non-dict Resources entries (null / truncation marker) are skipped; the
-    # real resource survives, and a bool ReadOnly passes through unchanged.
+    # real resource survives, a bool ReadOnly passes through unchanged, and the
+    # drop is surfaced so the planner knows the blast radius is understated.
     mixed = by_id["weird-resources-mixed"]
     assert mixed["resources"] == [{"type": "AWS::EC2::Instance", "name": "i-0abc123def456789a"}]
+    assert mixed["resources_truncated"] is True
     assert mixed["read_only"] is True
     assert mixed["aws_region"] == "eu-west-1"
 

--- a/tests/tools/test_cloudtrail_events.py
+++ b/tests/tools/test_cloudtrail_events.py
@@ -422,6 +422,30 @@ def test_realistic_page_shapes_every_event(mock_call) -> None:
 
 
 @patch("integrations.cloudtrail.tools.cloudtrail_events_tool.execute_aws_sdk_call")
+def test_success_payload_omits_error_key(mock_call) -> None:
+    """The success payload must NOT carry an "error" key.
+
+    The runtime tool loop (core.execution._normalize_result) flags a result as a
+    failure on the mere presence of an "error" key (is_error = "error" in raw) and
+    replaces the whole payload with {"error": ...} before the agent sees it. A
+    success dict with "error": None therefore hides every event from the
+    investigation — regression guard against reintroducing it.
+    """
+    mock_call.return_value = {"success": True, "data": _fixture_payload("lookup_events_page.json")}
+    result = lookup_cloudtrail_events(duration_minutes=60)
+
+    assert result["available"] is True
+    assert result["total_events"] == 3
+    assert "error" not in result
+
+    # Failure paths still carry a real message (correctly flagged as is_error).
+    mock_call.return_value = {"success": False, "error": "ThrottlingException"}
+    failed = lookup_cloudtrail_events()
+    assert failed["available"] is False
+    assert "error" in failed and failed["error"]
+
+
+@patch("integrations.cloudtrail.tools.cloudtrail_events_tool.execute_aws_sdk_call")
 def test_weird_page_survives_and_shapes_gracefully(mock_call) -> None:
     """Degenerate live payloads must degrade to partial events, never raise.
 

--- a/tests/tools/test_cloudtrail_events.py
+++ b/tests/tools/test_cloudtrail_events.py
@@ -418,3 +418,54 @@ def test_realistic_page_surfaces_pagination(mock_call) -> None:
 
     assert result["truncated"] is True
     assert result["next_token"] == "AAAAfR3kNzXhCq9lEXAMPLEtokenXo1v"
+
+
+@patch("integrations.cloudtrail.tools.cloudtrail_events_tool.execute_aws_sdk_call")
+def test_weird_page_survives_and_shapes_gracefully(mock_call) -> None:
+    """Degenerate live payloads must degrade to partial events, never raise.
+
+    The weird fixture packs the §1 cases: CloudTrailEvent as valid-but-non-dict
+    JSON (null / bare string / list) or invalid JSON, an event with only
+    EventId, ReadOnly as a real bool and as "True", a null plus a
+    _sanitize_response truncation marker inside Resources (one event CAN
+    reference >MAX_LIST_ITEMS resources, e.g. CreateTags across a fleet), and
+    the same marker as the final Events entry.
+    """
+    mock_call.return_value = {"success": True, "data": _fixture_payload("lookup_events_weird.json")}
+
+    result = lookup_cloudtrail_events()
+
+    assert result["available"] is True
+    # The trailing Events truncation marker (a str) is dropped, not shaped.
+    assert result["total_events"] == 7
+    by_id = {event["event_id"]: event for event in result["events"]}
+
+    # Valid-but-non-dict CloudTrailEvent JSON -> detail fields None, no crash.
+    for event_id in ("weird-null-detail", "weird-string-detail", "weird-list-detail"):
+        event = by_id[event_id]
+        assert event["aws_region"] is None
+        assert event["source_ip_address"] is None
+        assert event["error_code"] is None
+
+    # Invalid JSON keeps its existing graceful path.
+    assert by_id["weird-invalid-json-detail"]["aws_region"] is None
+
+    # An event carrying only EventId shapes with every other field defaulted.
+    bare = by_id["weird-bare-event"]
+    assert bare["event_name"] is None
+    assert bare["username"] is None
+    assert bare["read_only"] is None
+    assert bare["resources"] == []
+
+    # Non-dict Resources entries (null / truncation marker) are skipped; the
+    # real resource survives, and a bool ReadOnly passes through unchanged.
+    mixed = by_id["weird-resources-mixed"]
+    assert mixed["resources"] == [{"type": "AWS::EC2::Instance", "name": "i-0abc123def456789a"}]
+    assert mixed["read_only"] is True
+    assert mixed["aws_region"] == "eu-west-1"
+
+    # ReadOnly arrives with inconsistent casing in live payloads.
+    assert by_id["weird-readonly-mixed-case"]["read_only"] is True
+
+    assert result["truncated"] is True
+    assert result["next_token"] == "AAAAweirdPageToken"

--- a/tests/tools/test_cloudtrail_events.py
+++ b/tests/tools/test_cloudtrail_events.py
@@ -9,6 +9,7 @@ priority, the time-window helper, response shaping, and the synthetic
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
@@ -357,3 +358,63 @@ def test_harness_shaped_aws_source_short_circuits_off_real_aws(mock_call) -> Non
     mock_call.assert_not_called()
     assert backend.calls and backend.calls[0]["region"] == "us-east-1"
     assert result["available"] is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Live payload fixtures (#3583) — real LookupEvents response shapes
+# ─────────────────────────────────────────────────────────────────────────────
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "cloudtrail"
+
+
+def _fixture_payload(name: str) -> dict[str, Any]:
+    payload = json.loads((_FIXTURES / name).read_text(encoding="utf-8"))
+    payload.pop("_comment", None)
+    return payload
+
+
+@patch("integrations.cloudtrail.tools.cloudtrail_events_tool.execute_aws_sdk_call")
+def test_realistic_page_shapes_every_event(mock_call) -> None:
+    """A faithful LookupEvents page (mixed principals, an errored call, a
+    service event without Username) shapes into the exact per-event contract."""
+    mock_call.return_value = {"success": True, "data": _fixture_payload("lookup_events_page.json")}
+
+    result = lookup_cloudtrail_events(duration_minutes=120)
+
+    assert result["available"] is True
+    assert result["total_events"] == 3
+    by_id = {event["event_id"]: event for event in result["events"]}
+
+    iam = by_id["8e3c6f2b-4a1d-4c8e-9f2a-1b7d3e5a9c01"]
+    assert iam["event_name"] == "PutRolePolicy"
+    assert iam["username"] == "deploy-bot"
+    assert iam["read_only"] is False
+    assert iam["access_key_id"] == "AKIAIOSFODNN7EXAMPLE"
+    assert iam["resources"] == [{"type": "AWS::IAM::Role", "name": "payments-service-role"}]
+    assert iam["aws_region"] == "us-east-1"
+    assert iam["source_ip_address"] == "203.0.113.24"
+    assert iam["error_code"] is None
+
+    # A denied call surfaces its errorCode from the CloudTrailEvent record.
+    denied = by_id["1f9a7c3e-6b2d-4a5f-8c1e-7d4b2a9f6e02"]
+    assert denied["event_name"] == "DeleteSecurityGroup"
+    assert denied["error_code"] == "Client.UnauthorizedOperation"
+    assert denied["source_ip_address"] == "198.51.100.7"
+
+    # AWS service events carry no Username or AccessKeyId — shaped as None,
+    # never a KeyError, and ReadOnly "true" coerces to a real bool.
+    service = by_id["5d2b8e4a-9c1f-4d7b-a3e6-8f5c2d1b9a03"]
+    assert service["username"] is None
+    assert service["access_key_id"] is None
+    assert service["read_only"] is True
+    assert service["resources"] == []
+
+
+@patch("integrations.cloudtrail.tools.cloudtrail_events_tool.execute_aws_sdk_call")
+def test_realistic_page_surfaces_pagination(mock_call) -> None:
+    mock_call.return_value = {"success": True, "data": _fixture_payload("lookup_events_page.json")}
+
+    result = lookup_cloudtrail_events()
+
+    assert result["truncated"] is True
+    assert result["next_token"] == "AAAAfR3kNzXhCq9lEXAMPLEtokenXo1v"


### PR DESCRIPTION
Fixes #3583

#### Describe the changes you have made in this PR -

**Problem.** `lookup_cloudtrail_events` (the CloudTrail "who changed what, and when?" forensics tool) parsed the live `LookupEvents` response optimistically. Two classes of real-world payload broke it:

1. **Degenerate event shapes crashed the parser.** `_shape_event` assumed every `Resources[]` entry was a dict and that `CloudTrailEvent` (a JSON string) always decoded to an object. A `null` / bare-string / list `CloudTrailEvent`, invalid JSON, or the transport sanitizer's list-truncation marker (`"... (N more items truncated)"`) landing inside `Resources` raised `AttributeError` and failed the whole tool call.
2. **The success payload was silently discarded inside investigations.** The success return carried `"error": None`. The runtime tool loop (`core.execution._normalize_result`) treats the mere *presence* of an `"error"` key as a failure (`is_error = "error" in raw`) and replaces the payload with `{"error": ...}` before the agent sees it. Result: **every** investigation that called CloudTrail received zero events — even though the tool returned 50 when called standalone.

**Fix (minimal, test-proven).**
- Harden `_shape_event`: skip non-dict `Resources` entries, coerce a non-dict decoded `CloudTrailEvent` to `{}`, and normalise CloudTrail's string `ReadOnly` (`"true"` / `"True"`) into a real `bool`.
- Surface truncation instead of hiding it: each event now carries **`resources_truncated`**, and only dict events are shaped (`events = [_shape_event(e) for e in raw_events if isinstance(e, dict)]`) so a degraded page degrades rather than crashes.
- Remove `"error": None` from the success return so events actually reach the agent; the failure paths still set a real `"error"` message.
- Fixtures + tests: a faithful post-sanitizer `LookupEvents` page (`lookup_events_page.json`) and a degenerate-payload page (`lookup_events_weird.json`), with tests asserting exact event shaping, pagination surfacing (`truncated` / `next_token`), graceful survival of weird payloads, and a regression that a success payload never carries an `"error"` key.
- Docs: document the new `resources_truncated` signal on the CloudTrail page.

Scope is exactly what the issue asks: only `integrations/cloudtrail/tools/…`, its fixtures/tests, and its doc page — **no** changes to `core/agent_harness/` or `tools/interactive_shell/`.

**Validation.** `make lint`, `make format-check`, `make typecheck` all clean; `tests/tools/test_cloudtrail_events.py` + `tests/integrations/` → **2359 passed, 2 skipped**. Verified end to end against a live AWS account: `opensre investigate` now calls CloudTrail and produces an evidence-backed RCA (see below).

### Demo/Screenshot for feature changes and bug fixes -

Real run in a real terminal against a live AWS account (no cache/mocks) — `opensre integrations verify aws` followed by a full `opensre investigate` that calls CloudTrail and lands an evidence-backed root cause.

**▶️ Full run (GIF):**

<img width="1850" height="1322" alt="cloudtrail-demo" src="https://github.com/user-attachments/assets/9d4882e3-be31-4bd7-a6fd-7000495f1c76" />


**1️⃣ AWS integration verified — `opensre integrations verify aws`**

<img width="1850" height="1322" alt="1-verify-aws" src="https://github.com/user-attachments/assets/04e6b6a8-eeb9-41f7-8c54-e3e9d5ac0d05" />


**2️⃣ Investigation launched with the full CLI command**


<img width="1850" height="1322" alt="2-investigate-command" src="https://github.com/user-attachments/assets/7660f727-7c51-46d5-b9dc-2029c774bd85" />


**3️⃣ ReAct loop reviewing evidence after the CloudTrail lookup**

<img width="1850" height="1322" alt="3-cloudtrail-evidence" src="https://github.com/user-attachments/assets/f81b1479-dca9-4091-9fb7-2bb9e997ae5b" />


**4️⃣ Root-cause diagnosis running (validity 100%)**

<img width="1850" height="1322" alt="4-diagnose-root-cause" src="https://github.com/user-attachments/assets/8e201b32-4606-4fac-99f4-e83b3e2e0738" />

**5️⃣ Findings → Recommended Actions → Cited Evidence (`lookup cloudtrail events`) → Root cause**

<img width="1850" height="1322" alt="5-findings-rca" src="https://github.com/user-attachments/assets/3f204b36-c2c1-4275-a81f-1444f5bf9a1f" />

**6️⃣ Final RCA + feedback saved**

<img width="1850" height="1322" alt="6-feedback-saved" src="https://github.com/user-attachments/assets/edf01f3e-a4e2-43a2-b6d0-0318153dfd37" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
<!-- Please answer this honestly before submitting — tick exactly one. -->
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug surfaced while building the demo: the CloudTrail tool returned 50 events on its own but every investigation reported "no events / tool broken." Tracing the runtime tool loop showed `core.execution._normalize_result` flags a result as an error whenever an `"error"` key is *present*, regardless of value — so the success payload's `"error": None` was masking the entire event list. The smallest correct fix is to stop emitting that key on success (failure paths keep a real message). The parser hardening is driven by the actual `LookupEvents` shape: `ReadOnly` comes back as a string, `CloudTrailEvent` is a JSON string that can decode to a non-object under degraded conditions, and the transport sanitizer can drop a truncation-marker string into an oversized `Resources` list — each is covered by a fixture and a test that fails before the fix. I preferred `isinstance` guards + an explicit `resources_truncated` flag over broad `try/except` so the tool degrades transparently and the planner is told when a resource list understates blast radius.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
