### PR TITLE
fix(k8s): create etl-pipeline-sa in test_datadog before running jobs

### DIFF
--- a/tests/e2e/kubernetes/test_datadog.py
+++ b/tests/e2e/kubernetes/test_datadog.py
@@ -31,6 +31,7 @@ import urllib.request
 import uuid
 
 from tests.e2e.kubernetes.infrastructure_sdk.local import (
+    _run,
     apply_manifest,
     build_image,
     check_prerequisites,
@@ -223,8 +224,6 @@ def main() -> int:
         build_image(PIPELINE_DIR, IMAGE_TAG)
         load_image(CLUSTER_NAME, IMAGE_TAG)
         apply_manifest(NAMESPACE_MANIFEST)
-        from tests.e2e.kubernetes.infrastructure_sdk.local import _run
-
         _run(
             ["kubectl", "create", "serviceaccount", "etl-pipeline-sa", "-n", NAMESPACE],
             check=False,

--- a/tests/e2e/kubernetes/test_datadog.py
+++ b/tests/e2e/kubernetes/test_datadog.py
@@ -223,6 +223,12 @@ def main() -> int:
         build_image(PIPELINE_DIR, IMAGE_TAG)
         load_image(CLUSTER_NAME, IMAGE_TAG)
         apply_manifest(NAMESPACE_MANIFEST)
+        from tests.e2e.kubernetes.infrastructure_sdk.local import _run
+
+        _run(
+            ["kubectl", "create", "serviceaccount", "etl-pipeline-sa", "-n", NAMESPACE],
+            check=False,
+        )
         deploy_datadog_helm(DATADOG_VALUES, NAMESPACE)
 
         if not wait_for_datadog_agent(NAMESPACE):


### PR DESCRIPTION
## Summary
- Create `etl-pipeline-sa` in `test_datadog` before deploying jobs, matching `test_local.setup_cluster()`.
- Fixes `make test-k8s-datadog` timing out on `etl-extract` because the job pod never schedules without the service account.

Fixes #3866

## Test plan
- [x] `make test-k8s-datadog` completes extract → transform-error and finds `PIPELINE_ERROR` in Datadog
- [x] Local run: `TEST PASSED` after this change