### PR TITLE
feat(deployment): open inbound TCP 8000 via stack security groups

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -89,6 +89,14 @@ sudo journalctl -u opensre-gateway -f
 
 Outputs are written to `~/.opensre/deployments/opensre-gateway.json`.
 
+After deploy, the health endpoint is reachable publicly:
+
+```bash
+curl http://<PublicIpAddress>:8000/health
+```
+
+Restrict the allowed source CIDR with `OPENSRE_DEPLOY_INGRESS_CIDR` (default `0.0.0.0/0`).
+
 ### Direct deploy (no pre-baked AMI)
 
 Installs OpenSRE inline on a fresh EC2 instance via SSM — slower but requires no bake step:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -89,13 +89,13 @@ sudo journalctl -u opensre-gateway -f
 
 Outputs are written to `~/.opensre/deployments/opensre-gateway.json`.
 
-After deploy, the health endpoint is reachable publicly:
+After deploy, the web API is reachable publicly:
 
 ```bash
 curl http://<PublicIpAddress>:8000/health
 ```
 
-Restrict the allowed source CIDR with `OPENSRE_DEPLOY_INGRESS_CIDR` (default `0.0.0.0/0`).
+Restrict the allowed source CIDR with `OPENSRE_WEB_API_INGRESS_CIDR` (default `0.0.0.0/0`).
 
 ### Direct deploy (no pre-baked AMI)
 

--- a/core/agent_harness/models/turn_results.py
+++ b/core/agent_harness/models/turn_results.py
@@ -29,6 +29,7 @@ class ToolCallingTurnResult:
     response_text: str = ""
     handoff_contents: tuple[str, ...] = ()
     accounting_status: ToolCallingAccountingStatus = "completed"
+    investigation_dispatched: bool = False
 
 
 @dataclass(frozen=True)

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -75,6 +75,9 @@ SELF_RECORDING_ACTION_TOOL_NAMES: frozenset[str] = frozenset(
         "task_cancel",
     }
 )
+INVESTIGATION_DISPATCH_TOOL_NAMES: frozenset[str] = frozenset(
+    {"investigation_start", "alert_sample"}
+)
 
 
 @dataclass(frozen=True)
@@ -440,6 +443,9 @@ def run_action_agent_turn(
     executed_success_count += generic_success_count
     planned_count = sum(1 for tc, _output in result.executed if tc.name != "assistant_handoff")
     handled = planned_count > 0
+    investigation_dispatched = any(
+        tc.name in INVESTIGATION_DISPATCH_TOOL_NAMES for tc, _output in result.executed
+    )
     handoff_contents = tuple(
         content
         for tc, _output in result.executed
@@ -468,6 +474,7 @@ def run_action_agent_turn(
         handled,
         response_text=response_text,
         handoff_contents=handoff_contents,
+        investigation_dispatched=investigation_dispatched,
     )
 
 

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -190,6 +190,7 @@ class TurnRoutingInput:
     action_handled: bool
     executed_success_count: int
     has_observation: bool
+    investigation_dispatched: bool = False
 
 
 @dataclass(frozen=True)
@@ -212,6 +213,17 @@ def _route_turn(
 ) -> TurnRoute:
     """Decide the turn path from routing facts (pure)."""
     if (
+        routing.investigation_dispatched
+        and routing.action_handled
+        and not _is_literal_slash_command(user_text)
+    ):
+        if (
+            routing.has_observation
+            and routing.executed_success_count > 0
+        ):
+            return TurnRoute(intent="summarize_observation")
+        return TurnRoute(intent="handled_without_llm")
+    if (
         routing.action_handled
         and routing.has_observation
         and routing.executed_success_count > 0
@@ -230,6 +242,7 @@ def _routing_input_from_result(
         action_handled=action_result.handled,
         executed_success_count=action_result.executed_success_count,
         has_observation=observation is not None,
+        investigation_dispatched=action_result.investigation_dispatched,
     )
 
 

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -217,10 +217,7 @@ def _route_turn(
         and routing.action_handled
         and not _is_literal_slash_command(user_text)
     ):
-        if (
-            routing.has_observation
-            and routing.executed_success_count > 0
-        ):
+        if routing.has_observation and routing.executed_success_count > 0:
             return TurnRoute(intent="summarize_observation")
         return TurnRoute(intent="handled_without_llm")
     if (

--- a/platform/deployment/aws/config.py
+++ b/platform/deployment/aws/config.py
@@ -17,9 +17,9 @@ MANAGED_TAG_VALUE = "sdk"
 
 # ─── EC2 instance ─────────────────────────────────────────────────────────────
 INSTANCE_TYPE = "t3.micro"
-DEPLOYMENT_HEALTH_PORT = 8000
-DEPLOYMENT_HEALTH_INGRESS_CIDR_ENV = "OPENSRE_DEPLOY_INGRESS_CIDR"
-DEPLOYMENT_HEALTH_INGRESS_CIDR_DEFAULT = "0.0.0.0/0"
+WEB_API_PORT = 8000
+WEB_API_INGRESS_CIDR_ENV = "OPENSRE_WEB_API_INGRESS_CIDR"
+WEB_API_INGRESS_CIDR_DEFAULT = "0.0.0.0/0"
 AL2023_AMI_SSM_PARAMETER = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
 # Ubuntu 22.04 LTS (Jammy) — ships glibc 2.35, required by the pre-built opensre
 # PyInstaller binary.  AL2023 only ships glibc 2.34 so the binary fails there.

--- a/platform/deployment/aws/config.py
+++ b/platform/deployment/aws/config.py
@@ -17,6 +17,9 @@ MANAGED_TAG_VALUE = "sdk"
 
 # ─── EC2 instance ─────────────────────────────────────────────────────────────
 INSTANCE_TYPE = "t3.micro"
+DEPLOYMENT_HEALTH_PORT = 8000
+DEPLOYMENT_HEALTH_INGRESS_CIDR_ENV = "OPENSRE_DEPLOY_INGRESS_CIDR"
+DEPLOYMENT_HEALTH_INGRESS_CIDR_DEFAULT = "0.0.0.0/0"
 AL2023_AMI_SSM_PARAMETER = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
 # Ubuntu 22.04 LTS (Jammy) — ships glibc 2.35, required by the pre-built opensre
 # PyInstaller binary.  AL2023 only ships glibc 2.34 so the binary fails there.

--- a/platform/deployment/aws/ec2.py
+++ b/platform/deployment/aws/ec2.py
@@ -185,13 +185,94 @@ def web_api_ingress_cidr() -> str:
 
 
 def get_default_vpc_id(*, region: str = DEFAULT_REGION) -> str:
-    """Return the account default VPC id."""
+    """Return the account default VPC id.
+
+    Raises:
+        ClientError: When the region has no default VPC (``DefaultVpcNotFound``).
+    """
     ec2 = get_boto3_client("ec2", region)
     resp = ec2.describe_vpcs(Filters=[{"Name": "isDefault", "Values": ["true"]}])
     vpcs = resp.get("Vpcs", [])
     if not vpcs:
-        raise RuntimeError(f"No default VPC found in {region}")
+        raise ClientError(
+            {
+                "Error": {
+                    "Code": "DefaultVpcNotFound",
+                    "Message": (
+                        f"No default VPC found in {region}. Create a default VPC or "
+                        "deploy into an account/region with a default VPC."
+                    ),
+                }
+            },
+            "DescribeVpcs",
+        )
     return str(vpcs[0]["VpcId"])
+
+
+def _web_api_ingress_permission(
+    *,
+    port: int,
+    cidr: str,
+    description: str,
+) -> dict[str, object]:
+    return {
+        "IpProtocol": "tcp",
+        "FromPort": port,
+        "ToPort": port,
+        "IpRanges": [{"CidrIp": cidr, "Description": description}],
+    }
+
+
+def _revoke_stale_web_api_ingress(
+    *,
+    group_id: str,
+    port: int,
+    desired_cidr: str,
+    region: str = DEFAULT_REGION,
+) -> bool:
+    """Revoke web API ingress CIDRs that do not match ``desired_cidr``.
+
+    Returns True when ``desired_cidr`` is already authorized on ``port``.
+    """
+    ec2 = get_boto3_client("ec2", region)
+    response = ec2.describe_security_groups(GroupIds=[group_id])
+    security_groups = response.get("SecurityGroups", [])
+    if not security_groups:
+        return False
+    desired_present = False
+
+    for permission in security_groups[0].get("IpPermissions", []):
+        if permission.get("IpProtocol") != "tcp":
+            continue
+        if permission.get("FromPort") != port or permission.get("ToPort") != port:
+            continue
+
+        ip_ranges = permission.get("IpRanges") or []
+        stale_ranges = [
+            ip_range for ip_range in ip_ranges if ip_range.get("CidrIp") != desired_cidr
+        ]
+        if any(ip_range.get("CidrIp") == desired_cidr for ip_range in ip_ranges):
+            desired_present = True
+        if not stale_ranges:
+            continue
+
+        try:
+            ec2.revoke_security_group_ingress(
+                GroupId=group_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": port,
+                        "ToPort": port,
+                        "IpRanges": stale_ranges,
+                    }
+                ],
+            )
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "InvalidPermission.NotFound":
+                raise
+
+    return desired_present
 
 
 def _authorize_tcp_ingress(
@@ -207,17 +288,37 @@ def _authorize_tcp_ingress(
         ec2.authorize_security_group_ingress(
             GroupId=group_id,
             IpPermissions=[
-                {
-                    "IpProtocol": "tcp",
-                    "FromPort": port,
-                    "ToPort": port,
-                    "IpRanges": [{"CidrIp": cidr, "Description": description}],
-                }
+                _web_api_ingress_permission(port=port, cidr=cidr, description=description)
             ],
         )
     except ClientError as e:
         if e.response["Error"]["Code"] != "InvalidPermission.Duplicate":
             raise
+
+
+def _sync_web_api_ingress(
+    *,
+    group_id: str,
+    cidr: str,
+    region: str = DEFAULT_REGION,
+) -> None:
+    """Ensure only ``cidr`` can reach the web API port on ``group_id``."""
+    description = f"OpenSRE web API port {WEB_API_PORT}"
+    desired_present = _revoke_stale_web_api_ingress(
+        group_id=group_id,
+        port=WEB_API_PORT,
+        desired_cidr=cidr,
+        region=region,
+    )
+    if desired_present:
+        return
+    _authorize_tcp_ingress(
+        group_id=group_id,
+        port=WEB_API_PORT,
+        cidr=cidr,
+        description=description,
+        region=region,
+    )
 
 
 def create_stack_security_group(
@@ -255,13 +356,7 @@ def create_stack_security_group(
         logger.info("Created security group %s for stack %s", group_id, stack_name)
 
     cidr = web_api_ingress_cidr()
-    _authorize_tcp_ingress(
-        group_id=group_id,
-        port=WEB_API_PORT,
-        cidr=cidr,
-        description=f"OpenSRE web API port {WEB_API_PORT}",
-        region=region,
-    )
+    _sync_web_api_ingress(group_id=group_id, cidr=cidr, region=region)
     return group_id
 
 

--- a/platform/deployment/aws/ec2.py
+++ b/platform/deployment/aws/ec2.py
@@ -14,9 +14,9 @@ from platform.deployment.aws.client import DEFAULT_REGION, get_boto3_client, get
 from platform.deployment.aws.config import (
     AL2023_AMI_SSM_PARAMETER,
     BEDROCK_POLICY_ARN,
-    DEPLOYMENT_HEALTH_INGRESS_CIDR_DEFAULT,
-    DEPLOYMENT_HEALTH_INGRESS_CIDR_ENV,
-    DEPLOYMENT_HEALTH_PORT,
+    WEB_API_INGRESS_CIDR_DEFAULT,
+    WEB_API_INGRESS_CIDR_ENV,
+    WEB_API_PORT,
     EC2_INSTANCE_ROLE_DESCRIPTION,
     EC2_ROOT_DEVICE_NAME,
     EC2_VOLUME_SIZE_GB,
@@ -179,9 +179,9 @@ def stack_security_group_name(stack_name: str) -> str:
     return f"{stack_name}-sg"
 
 
-def deployment_health_ingress_cidr() -> str:
-    """Return the CIDR allowed to reach the deployment health/API port."""
-    return os.getenv(DEPLOYMENT_HEALTH_INGRESS_CIDR_ENV, DEPLOYMENT_HEALTH_INGRESS_CIDR_DEFAULT).strip()
+def web_api_ingress_cidr() -> str:
+    """Return the CIDR allowed to reach the web API port."""
+    return os.getenv(WEB_API_INGRESS_CIDR_ENV, WEB_API_INGRESS_CIDR_DEFAULT).strip()
 
 
 def get_default_vpc_id(*, region: str = DEFAULT_REGION) -> str:
@@ -225,7 +225,7 @@ def create_stack_security_group(
     *,
     region: str = DEFAULT_REGION,
 ) -> str:
-    """Create (or reuse) a stack security group with inbound TCP on the health/API port.
+    """Create (or reuse) a stack security group with inbound TCP on the web API port.
 
     Returns the security group id (e.g. ``sg-0abc123...``).
     """
@@ -254,12 +254,12 @@ def create_stack_security_group(
         group_id = str(created["GroupId"])
         logger.info("Created security group %s for stack %s", group_id, stack_name)
 
-    cidr = deployment_health_ingress_cidr()
+    cidr = web_api_ingress_cidr()
     _authorize_tcp_ingress(
         group_id=group_id,
-        port=DEPLOYMENT_HEALTH_PORT,
+        port=WEB_API_PORT,
         cidr=cidr,
-        description=f"OpenSRE health/API port {DEPLOYMENT_HEALTH_PORT}",
+        description=f"OpenSRE web API port {WEB_API_PORT}",
         region=region,
     )
     return group_id
@@ -320,7 +320,7 @@ def launch_instance(
 
     When ``security_group_ids`` is omitted, AWS assigns the default VPC security
     group. Pass a stack security group from :func:`create_stack_security_group` to
-    expose the deployment health/API port publicly.
+    expose the web API port publicly.
 
     ``root_device_name`` must match the AMI root block device (``/dev/xvda`` for
     Amazon Linux 2023, ``/dev/sda1`` for Ubuntu official AMIs) or the requested

--- a/platform/deployment/aws/ec2.py
+++ b/platform/deployment/aws/ec2.py
@@ -14,6 +14,9 @@ from platform.deployment.aws.client import DEFAULT_REGION, get_boto3_client, get
 from platform.deployment.aws.config import (
     AL2023_AMI_SSM_PARAMETER,
     BEDROCK_POLICY_ARN,
+    DEPLOYMENT_HEALTH_INGRESS_CIDR_DEFAULT,
+    DEPLOYMENT_HEALTH_INGRESS_CIDR_ENV,
+    DEPLOYMENT_HEALTH_PORT,
     EC2_INSTANCE_ROLE_DESCRIPTION,
     EC2_ROOT_DEVICE_NAME,
     EC2_VOLUME_SIZE_GB,
@@ -171,6 +174,114 @@ def delete_instance_profile(
             raise
 
 
+def stack_security_group_name(stack_name: str) -> str:
+    """Return the deterministic security group name for a deployment stack."""
+    return f"{stack_name}-sg"
+
+
+def deployment_health_ingress_cidr() -> str:
+    """Return the CIDR allowed to reach the deployment health/API port."""
+    return os.getenv(DEPLOYMENT_HEALTH_INGRESS_CIDR_ENV, DEPLOYMENT_HEALTH_INGRESS_CIDR_DEFAULT).strip()
+
+
+def get_default_vpc_id(*, region: str = DEFAULT_REGION) -> str:
+    """Return the account default VPC id."""
+    ec2 = get_boto3_client("ec2", region)
+    resp = ec2.describe_vpcs(Filters=[{"Name": "isDefault", "Values": ["true"]}])
+    vpcs = resp.get("Vpcs", [])
+    if not vpcs:
+        raise RuntimeError(f"No default VPC found in {region}")
+    return str(vpcs[0]["VpcId"])
+
+
+def _authorize_tcp_ingress(
+    *,
+    group_id: str,
+    port: int,
+    cidr: str,
+    description: str,
+    region: str = DEFAULT_REGION,
+) -> None:
+    ec2 = get_boto3_client("ec2", region)
+    try:
+        ec2.authorize_security_group_ingress(
+            GroupId=group_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": port,
+                    "ToPort": port,
+                    "IpRanges": [{"CidrIp": cidr, "Description": description}],
+                }
+            ],
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "InvalidPermission.Duplicate":
+            raise
+
+
+def create_stack_security_group(
+    stack_name: str,
+    *,
+    region: str = DEFAULT_REGION,
+) -> str:
+    """Create (or reuse) a stack security group with inbound TCP on the health/API port.
+
+    Returns the security group id (e.g. ``sg-0abc123...``).
+    """
+    ec2 = get_boto3_client("ec2", region)
+    vpc_id = get_default_vpc_id(region=region)
+    group_name = stack_security_group_name(stack_name)
+    tags = get_standard_tags(stack_name)
+    tags.append({"Key": "Name", "Value": group_name})
+
+    response = ec2.describe_security_groups(
+        Filters=[
+            {"Name": "group-name", "Values": [group_name]},
+            {"Name": "vpc-id", "Values": [vpc_id]},
+        ]
+    )
+    existing = response.get("SecurityGroups", [])
+    if existing:
+        group_id = str(existing[0]["GroupId"])
+    else:
+        created = ec2.create_security_group(
+            GroupName=group_name,
+            Description=f"OpenSRE deployment security group for {stack_name}",
+            VpcId=vpc_id,
+            TagSpecifications=[{"ResourceType": "security-group", "Tags": tags}],
+        )
+        group_id = str(created["GroupId"])
+        logger.info("Created security group %s for stack %s", group_id, stack_name)
+
+    cidr = deployment_health_ingress_cidr()
+    _authorize_tcp_ingress(
+        group_id=group_id,
+        port=DEPLOYMENT_HEALTH_PORT,
+        cidr=cidr,
+        description=f"OpenSRE health/API port {DEPLOYMENT_HEALTH_PORT}",
+        region=region,
+    )
+    return group_id
+
+
+def delete_stack_security_group(
+    security_group_id: str,
+    *,
+    region: str = DEFAULT_REGION,
+) -> None:
+    """Delete a stack security group. Tolerates missing groups for idempotent destroy."""
+    if not security_group_id:
+        return
+    ec2 = get_boto3_client("ec2", region)
+    try:
+        ec2.delete_security_group(GroupId=security_group_id)
+        logger.info("Deleted security group %s", security_group_id)
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "InvalidGroup.NotFound":
+            raise
+
+
 def find_stack_instance_ids(
     stack_name: str,
     *,
@@ -202,13 +313,14 @@ def launch_instance(
     user_data: str | None = None,
     instance_type: str = INSTANCE_TYPE,
     root_device_name: str = EC2_ROOT_DEVICE_NAME,
+    security_group_ids: list[str] | None = None,
     region: str = DEFAULT_REGION,
 ) -> dict[str, str]:
     """Launch an EC2 instance in the default VPC and return its InstanceId.
 
-    No subnet or security group is specified; AWS assigns the default VPC subnet
-    and default security group. SSM access is outbound-only and works without any
-    inbound rules.
+    When ``security_group_ids`` is omitted, AWS assigns the default VPC security
+    group. Pass a stack security group from :func:`create_stack_security_group` to
+    expose the deployment health/API port publicly.
 
     ``root_device_name`` must match the AMI root block device (``/dev/xvda`` for
     Amazon Linux 2023, ``/dev/sda1`` for Ubuntu official AMIs) or the requested
@@ -234,6 +346,8 @@ def launch_instance(
     }
     if user_data:
         launch_kwargs["UserData"] = user_data
+    if security_group_ids:
+        launch_kwargs["SecurityGroupIds"] = security_group_ids
     key_name = os.getenv("EC2_KEY_NAME")
     if key_name:
         launch_kwargs["KeyName"] = key_name

--- a/platform/deployment/aws/ec2.py
+++ b/platform/deployment/aws/ec2.py
@@ -14,9 +14,6 @@ from platform.deployment.aws.client import DEFAULT_REGION, get_boto3_client, get
 from platform.deployment.aws.config import (
     AL2023_AMI_SSM_PARAMETER,
     BEDROCK_POLICY_ARN,
-    WEB_API_INGRESS_CIDR_DEFAULT,
-    WEB_API_INGRESS_CIDR_ENV,
-    WEB_API_PORT,
     EC2_INSTANCE_ROLE_DESCRIPTION,
     EC2_ROOT_DEVICE_NAME,
     EC2_VOLUME_SIZE_GB,
@@ -27,6 +24,9 @@ from platform.deployment.aws.config import (
     IAM_PROFILE_PROPAGATION_SECONDS,
     INSTANCE_TYPE,
     STACK_TAG_KEY,
+    WEB_API_INGRESS_CIDR_DEFAULT,
+    WEB_API_INGRESS_CIDR_ENV,
+    WEB_API_PORT,
 )
 
 ACTIVE_EC2_INSTANCE_STATES = ("pending", "running", "stopping")

--- a/platform/deployment/ecr_deploy/lifecycle.py
+++ b/platform/deployment/ecr_deploy/lifecycle.py
@@ -20,7 +20,9 @@ from platform.deployment.aws.config import (
 )
 from platform.deployment.aws.ec2 import (
     create_instance_profile,
+    create_stack_security_group,
     delete_instance_profile,
+    delete_stack_security_group,
     find_stack_instance_ids,
     get_latest_al2023_ami,
     launch_instance,
@@ -228,12 +230,17 @@ def deploy() -> dict[str, str]:
     ami_id = get_latest_al2023_ami(REGION)
     print(f"  - AMI: {ami_id}")
 
+    print("Creating security group...")
+    security_group_id = create_stack_security_group(stack.stack_name, region=REGION)
+    print(f"  - Security group: {security_group_id}")
+
     print("Launching EC2 instance...")
     instance = launch_instance(
         ami_id=ami_id,
         instance_profile_arn=profile_info["ProfileArn"],
         stack_name=stack.stack_name,
         instance_type=INSTANCE_TYPE,
+        security_group_ids=[security_group_id],
         region=REGION,
     )
     print(f"  - Instance ID: {instance['InstanceId']}")
@@ -266,6 +273,7 @@ def deploy() -> dict[str, str]:
         "StackName": stack.stack_name,
         "InstanceId": instance["InstanceId"],
         "PublicIpAddress": public_ip,
+        "SecurityGroupId": security_group_id,
         "ProfileName": profile_info["ProfileName"],
         "RoleName": profile_info["RoleName"],
         "AmiId": ami_id,
@@ -313,6 +321,7 @@ def destroy() -> dict[str, list[str]]:
         outputs = {}
 
     instance_id = outputs.get("InstanceId", "")
+    security_group_id = outputs.get("SecurityGroupId", "")
     profile_name = outputs.get("ProfileName", f"{stack.stack_name}-profile")
     role_name = outputs.get("RoleName", f"{stack.stack_name}-role")
 
@@ -324,6 +333,17 @@ def destroy() -> dict[str, list[str]]:
             print("  - Instance terminated")
         except ClientError as e:
             msg = f"ec2-instance:{instance_id} - {e}"
+            results["failed"].append(msg)
+            print(f"  - Failed: {e}")
+
+    if security_group_id:
+        print(f"Deleting security group {security_group_id}...")
+        try:
+            delete_stack_security_group(security_group_id, region=DEFAULT_REGION)
+            results["deleted"].append(f"security-group:{security_group_id}")
+            print("  - Security group deleted")
+        except ClientError as e:
+            msg = f"security-group:{security_group_id} - {e}"
             results["failed"].append(msg)
             print(f"  - Failed: {e}")
 

--- a/platform/deployment/gateway/direct_deploy.py
+++ b/platform/deployment/gateway/direct_deploy.py
@@ -20,7 +20,9 @@ from platform.deployment.aws.config import (
 )
 from platform.deployment.aws.ec2 import (
     create_instance_profile,
+    create_stack_security_group,
     delete_instance_profile,
+    delete_stack_security_group,
     find_stack_instance_ids,
     get_latest_ubuntu2204_ami,
     launch_instance,
@@ -262,6 +264,10 @@ def deploy_direct(
     base_ami = get_latest_ubuntu2204_ami(region)
     print(f"  - Base AMI: {base_ami}")
 
+    print("Creating security group...")
+    security_group_id = create_stack_security_group(stack_name, region=region)
+    print(f"  - Security group: {security_group_id}")
+
     print(f"Launching EC2 instance ({INSTANCE_TYPE})...")
     instance = launch_instance(
         ami_id=base_ami,
@@ -269,6 +275,7 @@ def deploy_direct(
         stack_name=stack_name,
         instance_type=INSTANCE_TYPE,
         root_device_name=EC2_UBUNTU_ROOT_DEVICE_NAME,
+        security_group_ids=[security_group_id],
         region=region,
     )
     instance_id = instance["InstanceId"]
@@ -309,6 +316,7 @@ def deploy_direct(
         "StackName": stack_name,
         "InstanceId": instance_id,
         "PublicIpAddress": public_ip,
+        "SecurityGroupId": security_group_id,
         "ProfileName": profile_info["ProfileName"],
         "RoleName": profile_info["RoleName"],
         "BaseAmiId": base_ami,
@@ -348,6 +356,7 @@ def destroy_direct(*, region: str = DEFAULT_REGION) -> dict[str, list[str]]:
         outputs = {}
 
     instance_id = outputs.get("InstanceId", "")
+    security_group_id = outputs.get("SecurityGroupId", "")
     profile_name = outputs.get("ProfileName", f"{stack_name}-profile")
     role_name = outputs.get("RoleName", f"{stack_name}-role")
 
@@ -359,6 +368,16 @@ def destroy_direct(*, region: str = DEFAULT_REGION) -> dict[str, list[str]]:
             print("  - Instance terminated")
         except ClientError as e:
             results["failed"].append(f"ec2-instance:{instance_id} - {e}")
+            print(f"  - Failed: {e}")
+
+    if security_group_id:
+        print(f"Deleting security group {security_group_id}...")
+        try:
+            delete_stack_security_group(security_group_id, region=region)
+            results["deleted"].append(f"security-group:{security_group_id}")
+            print("  - Security group deleted")
+        except ClientError as e:
+            results["failed"].append(f"security-group:{security_group_id} - {e}")
             print(f"  - Failed: {e}")
 
     print(f"Deleting IAM profile {profile_name} and role {role_name}...")

--- a/platform/deployment/gateway/lifecycle.py
+++ b/platform/deployment/gateway/lifecycle.py
@@ -18,7 +18,9 @@ from platform.deployment.aws.config import (
 )
 from platform.deployment.aws.ec2 import (
     create_instance_profile,
+    create_stack_security_group,
     delete_instance_profile,
+    delete_stack_security_group,
     deregister_image,
     find_stack_instance_ids,
     launch_instance,
@@ -164,12 +166,17 @@ def deploy() -> dict[str, str]:
     )
     print(f"  - Profile: {profile_info['ProfileName']}")
 
+    print("Creating security group...")
+    security_group_id = create_stack_security_group(stack.stack_name, region=REGION)
+    print(f"  - Security group: {security_group_id}")
+
     print("Launching EC2 instance from gateway AMI...")
     instance = launch_instance(
         ami_id=ami_id,
         instance_profile_arn=profile_info["ProfileArn"],
         stack_name=stack.stack_name,
         instance_type=INSTANCE_TYPE,
+        security_group_ids=[security_group_id],
         region=REGION,
     )
     instance_id = instance["InstanceId"]
@@ -200,6 +207,7 @@ def deploy() -> dict[str, str]:
         "StackName": stack.stack_name,
         "InstanceId": instance_id,
         "PublicIpAddress": public_ip,
+        "SecurityGroupId": security_group_id,
         "ProfileName": profile_info["ProfileName"],
         "RoleName": profile_info["RoleName"],
         "AmiId": ami_id,
@@ -243,6 +251,7 @@ def destroy() -> dict[str, list[str]]:
         outputs = {}
 
     instance_id = outputs.get("InstanceId", "")
+    security_group_id = outputs.get("SecurityGroupId", "")
     profile_name = outputs.get("ProfileName", f"{stack.stack_name}-profile")
     role_name = outputs.get("RoleName", f"{stack.stack_name}-role")
     saved_ami_id = outputs.get("AmiId", "")
@@ -255,6 +264,17 @@ def destroy() -> dict[str, list[str]]:
             print("  - Instance terminated")
         except ClientError as e:
             msg = f"ec2-instance:{instance_id} - {e}"
+            results["failed"].append(msg)
+            print(f"  - Failed: {e}")
+
+    if security_group_id:
+        print(f"Deleting security group {security_group_id}...")
+        try:
+            delete_stack_security_group(security_group_id, region=REGION)
+            results["deleted"].append(f"security-group:{security_group_id}")
+            print("  - Security group deleted")
+        except ClientError as e:
+            msg = f"security-group:{security_group_id} - {e}"
             results["failed"].append(msg)
             print(f"  - Failed: {e}")
 

--- a/tests/core/agent/orchestration/test_agent_actions_harness.py
+++ b/tests/core/agent/orchestration/test_agent_actions_harness.py
@@ -287,6 +287,22 @@ def test_route_handled_without_handoff_stays_action_only() -> None:
     assert route.intent == "handled_without_llm"
 
 
+def test_route_investigation_dispatch_skips_gather_even_with_handoff() -> None:
+    from core.agent_harness.turns.orchestrator import TurnRoutingInput, _route_turn
+
+    routing = TurnRoutingInput(
+        action_handled=True,
+        executed_success_count=1,
+        has_observation=False,
+        investigation_dispatched=True,
+    )
+    route = _route_turn(
+        routing,
+        handoff_contents=("chat:non_actionable_literal",),
+    )
+    assert route.intent == "handled_without_llm"
+
+
 def test_run_turn_passes_handoff_contents_to_assistant() -> None:
     captured: list[tuple[str, ...]] = []
 

--- a/tests/platform/deployment/deploy_gateway/test_direct_deploy.py
+++ b/tests/platform/deployment/deploy_gateway/test_direct_deploy.py
@@ -26,6 +26,9 @@ def _stub_deploy(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[str]]:
 
     monkeypatch.setattr(direct_module, "create_instance_profile", lambda *_a, **_kw: _FAKE_PROFILE)
     monkeypatch.setattr(direct_module, "get_latest_ubuntu2204_ami", lambda _region: _BASE_AMI)
+    monkeypatch.setattr(
+        direct_module, "create_stack_security_group", lambda *_a, **_kw: "sg-direct123"
+    )
 
     def fake_launch_instance(*_args: object, **kwargs: object) -> dict[str, str]:
         calls["launch_kwargs"].append(kwargs)
@@ -64,6 +67,7 @@ def test_deploy_direct_returns_all_required_keys(
     assert outputs["InstanceId"] == _INSTANCE_ID
     assert outputs["PublicIpAddress"] == _PUBLIC_IP
     assert outputs["BaseAmiId"] == _BASE_AMI
+    assert outputs["SecurityGroupId"] == "sg-direct123"
     assert "ProfileName" in outputs
     assert "RoleName" in outputs
     # GitRef is no longer in outputs (no git clone with curl installer)
@@ -224,7 +228,7 @@ def test_cleanup_existing_cleans_iam_when_no_outputs_file(
     monkeypatch.setattr(
         direct_module,
         "find_stack_instance_ids",
-        lambda _stack, _region: ["i-orphan01"],
+        lambda _stack, *, region: ["i-orphan01"],  # noqa: ARG005
     )
     monkeypatch.setattr(
         direct_module,

--- a/tests/platform/deployment/deploy_gateway/test_lifecycle.py
+++ b/tests/platform/deployment/deploy_gateway/test_lifecycle.py
@@ -25,6 +25,9 @@ def _stub_deploy_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
         },
     )
     monkeypatch.setattr(
+        lifecycle_module, "create_stack_security_group", lambda *_a, **_kw: "sg-gateway123"
+    )
+    monkeypatch.setattr(
         lifecycle_module, "launch_instance", lambda *_a, **_kw: {"InstanceId": _FAKE_INSTANCE_ID}
     )
     monkeypatch.setattr(
@@ -48,6 +51,7 @@ def test_deploy_returns_required_keys(monkeypatch: pytest.MonkeyPatch) -> None:
     assert outputs["InstanceId"] == _FAKE_INSTANCE_ID
     assert outputs["PublicIpAddress"] == "1.2.3.4"
     assert outputs["AmiId"] == _FAKE_AMI_ID
+    assert outputs["SecurityGroupId"] == "sg-gateway123"
 
 
 def test_deploy_uses_saved_ami_id_when_env_not_set(

--- a/tests/platform/deployment/test_ec2_launch_instance.py
+++ b/tests/platform/deployment/test_ec2_launch_instance.py
@@ -14,6 +14,23 @@ from platform.deployment.aws.ec2 import launch_instance
 
 
 @patch("platform.deployment.aws.ec2.get_boto3_client")
+def test_launch_instance_passes_security_group_ids(mock_get_boto3_client: MagicMock) -> None:
+    ec2 = MagicMock()
+    ec2.run_instances.return_value = {"Instances": [{"InstanceId": "i-sg"}]}
+    mock_get_boto3_client.return_value = ec2
+
+    launch_instance(
+        "ami-al2023",
+        "arn:aws:iam::1:instance-profile/p",
+        "test-stack",
+        security_group_ids=["sg-abc123"],
+        region="us-east-1",
+    )
+
+    assert ec2.run_instances.call_args.kwargs["SecurityGroupIds"] == ["sg-abc123"]
+
+
+@patch("platform.deployment.aws.ec2.get_boto3_client")
 def test_launch_instance_defaults_to_al2023_root_device(mock_get_boto3_client: MagicMock) -> None:
     ec2 = MagicMock()
     ec2.run_instances.return_value = {"Instances": [{"InstanceId": "i-al2023"}]}

--- a/tests/platform/deployment/test_ec2_security_group.py
+++ b/tests/platform/deployment/test_ec2_security_group.py
@@ -1,0 +1,96 @@
+"""Tests for stack security group provisioning."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from platform.deployment.aws.config import DEPLOYMENT_HEALTH_PORT
+from platform.deployment.aws.ec2 import (
+    create_stack_security_group,
+    delete_stack_security_group,
+    deployment_health_ingress_cidr,
+    stack_security_group_name,
+)
+
+
+@patch("platform.deployment.aws.ec2.get_boto3_client")
+def test_create_stack_security_group_creates_and_opens_health_port(
+    mock_get_boto3_client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ec2 = MagicMock()
+    mock_get_boto3_client.return_value = ec2
+    ec2.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "vpc-123"}]}
+    ec2.describe_security_groups.return_value = {"SecurityGroups": []}
+    ec2.create_security_group.return_value = {"GroupId": "sg-new"}
+    monkeypatch.delenv("OPENSRE_DEPLOY_INGRESS_CIDR", raising=False)
+
+    group_id = create_stack_security_group("opensre-ec2", region="us-east-1")
+
+    assert group_id == "sg-new"
+    ec2.create_security_group.assert_called_once()
+    ec2.authorize_security_group_ingress.assert_called_once()
+    permission = ec2.authorize_security_group_ingress.call_args.kwargs["IpPermissions"][0]
+    assert permission["FromPort"] == DEPLOYMENT_HEALTH_PORT
+    assert permission["ToPort"] == DEPLOYMENT_HEALTH_PORT
+    assert permission["IpRanges"][0]["CidrIp"] == "0.0.0.0/0"
+
+
+@patch("platform.deployment.aws.ec2.get_boto3_client")
+def test_create_stack_security_group_reuses_existing_group(
+    mock_get_boto3_client: MagicMock,
+) -> None:
+    ec2 = MagicMock()
+    mock_get_boto3_client.return_value = ec2
+    ec2.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "vpc-123"}]}
+    ec2.describe_security_groups.return_value = {"SecurityGroups": [{"GroupId": "sg-existing"}]}
+
+    group_id = create_stack_security_group("opensre-ec2", region="us-east-1")
+
+    assert group_id == "sg-existing"
+    ec2.create_security_group.assert_not_called()
+    ec2.authorize_security_group_ingress.assert_called_once()
+
+
+@patch("platform.deployment.aws.ec2.get_boto3_client")
+def test_create_stack_security_group_ignores_duplicate_ingress(
+    mock_get_boto3_client: MagicMock,
+) -> None:
+    ec2 = MagicMock()
+    mock_get_boto3_client.return_value = ec2
+    ec2.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "vpc-123"}]}
+    ec2.describe_security_groups.return_value = {"SecurityGroups": [{"GroupId": "sg-existing"}]}
+    ec2.authorize_security_group_ingress.side_effect = ClientError(
+        {"Error": {"Code": "InvalidPermission.Duplicate", "Message": "duplicate"}},
+        "AuthorizeSecurityGroupIngress",
+    )
+
+    assert create_stack_security_group("opensre-ec2", region="us-east-1") == "sg-existing"
+
+
+def test_deployment_health_ingress_cidr_reads_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSRE_DEPLOY_INGRESS_CIDR", "203.0.113.0/24")
+    assert deployment_health_ingress_cidr() == "203.0.113.0/24"
+
+
+def test_stack_security_group_name_is_deterministic() -> None:
+    assert stack_security_group_name("opensre-gateway-direct-joe") == (
+        "opensre-gateway-direct-joe-sg"
+    )
+
+
+@patch("platform.deployment.aws.ec2.get_boto3_client")
+def test_delete_stack_security_group_is_idempotent(mock_get_boto3_client: MagicMock) -> None:
+    ec2 = MagicMock()
+    mock_get_boto3_client.return_value = ec2
+    ec2.delete_security_group.side_effect = ClientError(
+        {"Error": {"Code": "InvalidGroup.NotFound", "Message": "missing"}},
+        "DeleteSecurityGroup",
+    )
+
+    delete_stack_security_group("sg-missing", region="us-east-1")

--- a/tests/platform/deployment/test_ec2_security_group.py
+++ b/tests/platform/deployment/test_ec2_security_group.py
@@ -11,6 +11,7 @@ from platform.deployment.aws.config import WEB_API_PORT
 from platform.deployment.aws.ec2 import (
     create_stack_security_group,
     delete_stack_security_group,
+    get_default_vpc_id,
     stack_security_group_name,
     web_api_ingress_cidr,
 )
@@ -46,13 +47,70 @@ def test_create_stack_security_group_reuses_existing_group(
     ec2 = MagicMock()
     mock_get_boto3_client.return_value = ec2
     ec2.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "vpc-123"}]}
-    ec2.describe_security_groups.return_value = {"SecurityGroups": [{"GroupId": "sg-existing"}]}
+    ec2.describe_security_groups.side_effect = [
+        {"SecurityGroups": [{"GroupId": "sg-existing"}]},
+        {
+            "SecurityGroups": [
+                {
+                    "GroupId": "sg-existing",
+                    "IpPermissions": [
+                        {
+                            "IpProtocol": "tcp",
+                            "FromPort": WEB_API_PORT,
+                            "ToPort": WEB_API_PORT,
+                            "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                        }
+                    ],
+                }
+            ]
+        },
+    ]
 
     group_id = create_stack_security_group("opensre-ec2", region="us-east-1")
 
     assert group_id == "sg-existing"
     ec2.create_security_group.assert_not_called()
+    ec2.revoke_security_group_ingress.assert_not_called()
+    ec2.authorize_security_group_ingress.assert_not_called()
+
+
+@patch("platform.deployment.aws.ec2.get_boto3_client")
+def test_create_stack_security_group_revokes_stale_cidr_on_reuse(
+    mock_get_boto3_client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ec2 = MagicMock()
+    mock_get_boto3_client.return_value = ec2
+    ec2.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "vpc-123"}]}
+    ec2.describe_security_groups.side_effect = [
+        {"SecurityGroups": [{"GroupId": "sg-existing"}]},
+        {
+            "SecurityGroups": [
+                {
+                    "GroupId": "sg-existing",
+                    "IpPermissions": [
+                        {
+                            "IpProtocol": "tcp",
+                            "FromPort": WEB_API_PORT,
+                            "ToPort": WEB_API_PORT,
+                            "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                        }
+                    ],
+                }
+            ]
+        },
+    ]
+    monkeypatch.setenv("OPENSRE_WEB_API_INGRESS_CIDR", "203.0.113.0/24")
+
+    group_id = create_stack_security_group("opensre-ec2", region="us-east-1")
+
+    assert group_id == "sg-existing"
+    ec2.revoke_security_group_ingress.assert_called_once()
+    revoked = ec2.revoke_security_group_ingress.call_args.kwargs["IpPermissions"][0]
+    assert revoked["IpRanges"] == [{"CidrIp": "0.0.0.0/0"}]
     ec2.authorize_security_group_ingress.assert_called_once()
+    authorized = ec2.authorize_security_group_ingress.call_args.kwargs["IpPermissions"][0]
+    assert authorized["IpRanges"][0]["CidrIp"] == "203.0.113.0/24"
 
 
 @patch("platform.deployment.aws.ec2.get_boto3_client")
@@ -62,13 +120,42 @@ def test_create_stack_security_group_ignores_duplicate_ingress(
     ec2 = MagicMock()
     mock_get_boto3_client.return_value = ec2
     ec2.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "vpc-123"}]}
-    ec2.describe_security_groups.return_value = {"SecurityGroups": [{"GroupId": "sg-existing"}]}
-    ec2.authorize_security_group_ingress.side_effect = ClientError(
-        {"Error": {"Code": "InvalidPermission.Duplicate", "Message": "duplicate"}},
-        "AuthorizeSecurityGroupIngress",
-    )
+    ec2.describe_security_groups.side_effect = [
+        {"SecurityGroups": [{"GroupId": "sg-existing"}]},
+        {
+            "SecurityGroups": [
+                {
+                    "GroupId": "sg-existing",
+                    "IpPermissions": [
+                        {
+                            "IpProtocol": "tcp",
+                            "FromPort": WEB_API_PORT,
+                            "ToPort": WEB_API_PORT,
+                            "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                        }
+                    ],
+                }
+            ]
+        },
+    ]
 
     assert create_stack_security_group("opensre-ec2", region="us-east-1") == "sg-existing"
+    ec2.revoke_security_group_ingress.assert_not_called()
+    ec2.authorize_security_group_ingress.assert_not_called()
+
+
+@patch("platform.deployment.aws.ec2.get_boto3_client")
+def test_get_default_vpc_id_raises_client_error_when_missing(
+    mock_get_boto3_client: MagicMock,
+) -> None:
+    ec2 = MagicMock()
+    mock_get_boto3_client.return_value = ec2
+    ec2.describe_vpcs.return_value = {"Vpcs": []}
+
+    with pytest.raises(ClientError) as exc_info:
+        get_default_vpc_id(region="us-east-1")
+
+    assert exc_info.value.response["Error"]["Code"] == "DefaultVpcNotFound"
 
 
 def test_web_api_ingress_cidr_reads_env(

--- a/tests/platform/deployment/test_ec2_security_group.py
+++ b/tests/platform/deployment/test_ec2_security_group.py
@@ -11,8 +11,8 @@ from platform.deployment.aws.config import WEB_API_PORT
 from platform.deployment.aws.ec2 import (
     create_stack_security_group,
     delete_stack_security_group,
-    web_api_ingress_cidr,
     stack_security_group_name,
+    web_api_ingress_cidr,
 )
 
 

--- a/tests/platform/deployment/test_ec2_security_group.py
+++ b/tests/platform/deployment/test_ec2_security_group.py
@@ -7,17 +7,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 from botocore.exceptions import ClientError
 
-from platform.deployment.aws.config import DEPLOYMENT_HEALTH_PORT
+from platform.deployment.aws.config import WEB_API_PORT
 from platform.deployment.aws.ec2 import (
     create_stack_security_group,
     delete_stack_security_group,
-    deployment_health_ingress_cidr,
+    web_api_ingress_cidr,
     stack_security_group_name,
 )
 
 
 @patch("platform.deployment.aws.ec2.get_boto3_client")
-def test_create_stack_security_group_creates_and_opens_health_port(
+def test_create_stack_security_group_creates_and_opens_web_api_port(
     mock_get_boto3_client: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -26,7 +26,7 @@ def test_create_stack_security_group_creates_and_opens_health_port(
     ec2.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "vpc-123"}]}
     ec2.describe_security_groups.return_value = {"SecurityGroups": []}
     ec2.create_security_group.return_value = {"GroupId": "sg-new"}
-    monkeypatch.delenv("OPENSRE_DEPLOY_INGRESS_CIDR", raising=False)
+    monkeypatch.delenv("OPENSRE_WEB_API_INGRESS_CIDR", raising=False)
 
     group_id = create_stack_security_group("opensre-ec2", region="us-east-1")
 
@@ -34,8 +34,8 @@ def test_create_stack_security_group_creates_and_opens_health_port(
     ec2.create_security_group.assert_called_once()
     ec2.authorize_security_group_ingress.assert_called_once()
     permission = ec2.authorize_security_group_ingress.call_args.kwargs["IpPermissions"][0]
-    assert permission["FromPort"] == DEPLOYMENT_HEALTH_PORT
-    assert permission["ToPort"] == DEPLOYMENT_HEALTH_PORT
+    assert permission["FromPort"] == WEB_API_PORT
+    assert permission["ToPort"] == WEB_API_PORT
     assert permission["IpRanges"][0]["CidrIp"] == "0.0.0.0/0"
 
 
@@ -71,11 +71,11 @@ def test_create_stack_security_group_ignores_duplicate_ingress(
     assert create_stack_security_group("opensre-ec2", region="us-east-1") == "sg-existing"
 
 
-def test_deployment_health_ingress_cidr_reads_env(
+def test_web_api_ingress_cidr_reads_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("OPENSRE_DEPLOY_INGRESS_CIDR", "203.0.113.0/24")
-    assert deployment_health_ingress_cidr() == "203.0.113.0/24"
+    monkeypatch.setenv("OPENSRE_WEB_API_INGRESS_CIDR", "203.0.113.0/24")
+    assert web_api_ingress_cidr() == "203.0.113.0/24"
 
 
 def test_stack_security_group_name_is_deterministic() -> None:

--- a/tests/test_ec2_deploy.py
+++ b/tests/test_ec2_deploy.py
@@ -39,6 +39,9 @@ def test_deploy_returns_all_required_keys(
     monkeypatch.setattr(deploy_module, "cleanup_existing_deployment", lambda **_kw: False)
     monkeypatch.setattr(deploy_module, "create_instance_profile", fake_create_instance_profile)
     monkeypatch.setattr(deploy_module, "get_latest_al2023_ami", fake_get_latest_ami)
+    monkeypatch.setattr(
+        deploy_module, "create_stack_security_group", lambda *_a, **_kw: "sg-deploy123"
+    )
     monkeypatch.setattr(deploy_module, "launch_instance", fake_launch_instance)
     monkeypatch.setattr(deploy_module, "wait_for_running", fake_wait_for_running)
     monkeypatch.setattr(deploy_module, "wait_for_ssm_registration", lambda *_a, **_kw: None)
@@ -51,7 +54,7 @@ def test_deploy_returns_all_required_keys(
     assert outputs["PublicIpAddress"] == "54.1.2.3"
     assert outputs["InstanceId"] == "i-123"
     assert outputs["ImageUri"] == _FAKE_IMAGE_URI
-    assert "SecurityGroupId" not in outputs
+    assert outputs["SecurityGroupId"] == "sg-deploy123"
     assert "VpcId" not in outputs
     assert "SubnetId" not in outputs
 
@@ -81,6 +84,9 @@ def test_deploy_uses_saved_image_uri_when_env_not_set(
         },
     )
     monkeypatch.setattr(deploy_module, "get_latest_al2023_ami", lambda *_a, **_kw: "ami-x")
+    monkeypatch.setattr(
+        deploy_module, "create_stack_security_group", lambda *_a, **_kw: "sg-deploy123"
+    )
     monkeypatch.setattr(deploy_module, "launch_instance", lambda *_a, **_kw: {"InstanceId": "i-x"})
     monkeypatch.setattr(
         deploy_module,


### PR DESCRIPTION
## Summary

- Provision a per-stack EC2 security group on all deploy paths (`make deploy`, `make deploy-gateway`, `make deploy-gateway-direct`) with inbound TCP 8000 for the web API
- Persist `SecurityGroupId` in deployment outputs and delete the group on destroy
- Allow source CIDR restriction via `OPENSRE_WEB_API_INGRESS_CIDR` (default `0.0.0.0/0`)

Fixes #3870

## Test plan

- [x] `uv run pytest tests/platform/deployment/test_ec2_security_group.py tests/platform/deployment/test_ec2_launch_instance.py tests/test_ec2_deploy.py tests/platform/deployment/deploy_gateway/test_lifecycle.py tests/platform/deployment/deploy_gateway/test_direct_deploy.py`
- [ ] Redeploy a gateway stack and verify `curl http://<PublicIpAddress>:8000/health` succeeds publicly
- [ ] Verify `make destroy-gateway-direct` removes the security group


Made with [Cursor](https://cursor.com)