### PR TITLE
fix(agent): hand off instead of fabricating a delivery command when send tool is unavailable

### DIFF
--- a/core/agent_harness/prompts/action_agent_system_prompt.py
+++ b/core/agent_harness/prompts/action_agent_system_prompt.py
@@ -291,6 +291,7 @@ Other tools:
 - assistant_handoff — informational/conversational requests (docs, greetings,
   pasted alerts for analysis discussion, follow-ups, vague ops questions)
 
+Missing delivery tools: If the user asks to send, post, or notify a channel (e.g., Slack or Telegram) but the required delivery tool is NOT in your available tool list (because it is not configured), you MUST emit assistant_handoff explaining that the integration is not configured. NEVER fabricate a slash or CLI subcommand (like `/messaging send slack`) for delivery.
 Never use shell_run for OpenSRE product requests like "show integration details",
 "list connected services", "show model/provider", or docs/how-to questions.
 Those are assistant_handoff or slash/cli operations, not shell diagnostics.


### PR DESCRIPTION
Fixes #3857

Added a strict guardrail to the `action_agent_system_prompt.py` instructing the planner to emit an `assistant_handoff` if a requested delivery tool (like Slack) is not configured, rather than hallucinating a CLI subcommand. 

*Note: I have the prompt fix ready here. Let me know which test file handles the live-LLM scenarios and I would be happy to add the regression test for this as well!*