### PR TITLE
fix(smtp): report classify failures

### DIFF
--- a/integrations/smtp/__init__.py
+++ b/integrations/smtp/__init__.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
+from pydantic import ValidationError
+
+from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import SMTPIntegrationConfig
+
+logger = logging.getLogger(__name__)
 
 
 def classify(
-    credentials: dict[str, Any], _record_id: str
+    credentials: dict[str, Any], record_id: str
 ) -> tuple[SMTPIntegrationConfig | None, str | None]:
     try:
         cfg = SMTPIntegrationConfig.model_validate(
@@ -22,6 +28,10 @@ def classify(
                 "default_to": credentials.get("default_to"),
             }
         )
-    except Exception:
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="smtp", record_id=record_id)
+        return None, None
+    except Exception as exc:
+        report_classify_failure(exc, logger=logger, integration="smtp", record_id=record_id)
         return None, None
     return cfg, "smtp"

--- a/integrations/smtp/__init__.py
+++ b/integrations/smtp/__init__.py
@@ -13,6 +13,11 @@ from integrations.config_models import SMTPIntegrationConfig
 logger = logging.getLogger(__name__)
 
 
+def _smtp_validation_failure() -> ValueError:
+    """Return a non-secret exception for SMTP config validation failures."""
+    return ValueError("SMTPIntegrationConfig validation failed")
+
+
 def classify(
     credentials: dict[str, Any], record_id: str
 ) -> tuple[SMTPIntegrationConfig | None, str | None]:
@@ -28,8 +33,13 @@ def classify(
                 "default_to": credentials.get("default_to"),
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="smtp", record_id=record_id)
+    except ValidationError:
+        report_classify_failure(
+            _smtp_validation_failure(),
+            logger=logger,
+            integration="smtp",
+            record_id=record_id,
+        )
         return None, None
     except Exception as exc:
         report_classify_failure(exc, logger=logger, integration="smtp", record_id=record_id)

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -120,6 +120,7 @@ _CLASSIFY_PATCH_TARGETS: list[tuple[str, str, str]] = [
     ("victoria_logs", "integrations.victoria_logs", "VictoriaLogsIntegrationConfig"),
     ("splunk", "integrations.splunk", "SplunkIntegrationConfig"),
     ("supabase", "integrations.supabase", "build_supabase_config"),
+    ("smtp", "integrations.smtp", "SMTPIntegrationConfig"),
 ]
 
 

--- a/tests/integrations/test_smtp.py
+++ b/tests/integrations/test_smtp.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from integrations.config_models import SMTPIntegrationConfig
+from integrations.smtp import classify
 from integrations.smtp.verifier import verify_smtp as _verify_smtp
 
 
@@ -54,6 +57,27 @@ def test_verify_smtp_reports_validation_errors() -> None:
     result = _verify_smtp("local env", {"host": "smtp.example.com"})
     assert result["status"] == "missing"
     assert "from_address" in result["detail"]
+
+
+def test_classify_validation_failure_reports_without_secret_value() -> None:
+    secret = "smtp-secret-password"
+
+    with patch("integrations._validation_helpers.report_exception") as mock_report:
+        result = classify(
+            {
+                "host": "smtp.example.com",
+                "username": "mailer",
+                "password": secret,
+                "from_address": "not-an-email",
+            },
+            "smtp-record",
+        )
+
+    assert result == (None, None)
+    mock_report.assert_called_once()
+    reported_exc = mock_report.call_args.args[0]
+    assert secret not in str(reported_exc)
+    assert "SMTPIntegrationConfig validation failed" in str(reported_exc)
 
 
 def test_catalog_bootstraps_smtp_from_env(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #3507

#### Describe the changes you have made in this PR -

SMTP `classify()` previously caught every exception and returned `(None, None)` without reporting the failure. This change handles Pydantic `ValidationError` explicitly and reports both validation and unexpected classify failures through the existing `report_classify_failure` helper before preserving the existing `(None, None)` fallback behavior.

I also added SMTP to the existing classify-failure regression matrix so a forced SMTP classify failure is checked for both skip behavior and reporting.

### Demo/Screenshot for feature changes and bug fixes - 

```text
$env:OPENSRE_NO_TELEMETRY='1'; .\.venv\Scripts\python -m pytest tests\integrations\test_smtp.py -q
6 passed in 1.73s

$env:OPENSRE_NO_TELEMETRY='1'; .\.venv\Scripts\python -m pytest tests\integrations\test_catalog_silent_fallback_elimination.py -q
70 passed in 3.55s

$env:OPENSRE_NO_TELEMETRY='1'; .\.venv\Scripts\python -m ruff check integrations\smtp\__init__.py tests\integrations\test_catalog_silent_fallback_elimination.py
All checks passed!
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`classify()` builds an `SMTPIntegrationConfig` using Pydantic `model_validate`. Invalid SMTP config raises a Pydantic `ValidationError`, which is now handled explicitly and reported through the shared `report_classify_failure` helper with `integration="smtp"` and the record id. Unexpected exceptions are also reported through the same helper to match the existing integration-classifier pattern while preserving the previous caller contract of returning `(None, None)` on failure. The success path is unchanged.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.