### PR TITLE
refactor: remove RDS synthetic suite re-export shims

### DIFF
--- a/tests/synthetic/rds_postgres/AGENTS.md
+++ b/tests/synthetic/rds_postgres/AGENTS.md
@@ -17,12 +17,14 @@ from dataclasses import asdict
 from datetime import UTC, datetime
 from tests.synthetic.rds_postgres.run_suite import (
     _resolved_golden_trajectory, _trajectory_policy_for_fixture,
-    _apply_trajectory_policy_to_score, score_result,
+    _apply_trajectory_policy_to_score,
 )
 from tests.synthetic.rds_postgres.observations import (
-    build_observation, compute_trajectory_metrics, evaluate_trajectory_policy,
+    build_observation, compute_trajectory_metrics,
 )
 from tests.synthetic.rds_postgres.scenario_loader import load_all_scenarios, SUITE_DIR
+from tests.synthetic.rds_postgres.scoring import score_result
+from tests.synthetic.rds_postgres.trajectory_policy import evaluate_trajectory_policy
 
 baseline_dir = Path('tests/synthetic/rds_postgres/_baseline')
 baseline_dir.mkdir(parents=True, exist_ok=True)
@@ -69,12 +71,11 @@ uv run python -m tests.synthetic.rds_postgres.run_suite \
   --baseline-check tests/synthetic/rds_postgres/_baseline
 ```
 
-## Re-export shim policy
+## Import policy
 
-Do not add new compatibility-only re-export shims. When moving symbols, migrate
-import sites to the canonical module and delete the old path in the same change.
-Existing re-exports in `observations.py` are temporary legacy debt; remove them
-when touching that surface rather than extending the pattern.
+Import scoring symbols from ``scoring.py``, trajectory policy types from
+``trajectory_policy.py``, and orchestration helpers from ``run_suite.py``.
+Do not add compatibility-only re-export shims.
 
 ## Module layout (after all phases)
 

--- a/tests/synthetic/rds_postgres/observations.py
+++ b/tests/synthetic/rds_postgres/observations.py
@@ -13,20 +13,10 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-# Re-exported for backward compatibility — canonical definitions live in trajectory_policy.py
 from tests.synthetic.rds_postgres.trajectory_policy import (
     TrajectoryMetrics,
-    TrajectoryPolicy,
     TrajectoryPolicyResult,
-    evaluate_trajectory_policy,
 )
-
-__all__ = [
-    "TrajectoryMetrics",
-    "TrajectoryPolicy",
-    "TrajectoryPolicyResult",
-    "evaluate_trajectory_policy",
-]
 
 
 @dataclass(frozen=True)

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -3,6 +3,7 @@
 Pure scoring logic lives in scoring.py.
 Rendering/cross-axis reports live in reporting.py.
 Per-scenario observation building and Rich rendering live in observations.py.
+Trajectory policy types and evaluation live in trajectory_policy.py.
 """
 
 from __future__ import annotations
@@ -41,11 +42,8 @@ from tests.synthetic.mock_aws_backend import FixtureAWSBackend
 from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
 from tests.synthetic.mock_grafana_backend.selective_backend import SelectiveGrafanaBackend
 from tests.synthetic.rds_postgres.observations import (
-    TrajectoryPolicy,
-    TrajectoryPolicyResult,
     build_observation,
     compute_trajectory_metrics,
-    evaluate_trajectory_policy,
     render_report_to_console,
     write_observation,
 )
@@ -66,32 +64,20 @@ from tests.synthetic.rds_postgres.scenario_loader import (
     ScenarioFixture,
     load_all_scenarios,
 )
-
-# Re-export scoring symbols so existing import sites continue to work without
-# modification. Track removal in a follow-up once all sites are migrated.
 from tests.synthetic.rds_postgres.scoring import (
     FailureDetail,
     GateResult,
-    ReasoningScore,
     ScenarioScore,
-    TrajectoryScore,
     _all_required_gates_pass,
-    score_reasoning,
     score_result,
-    score_trajectory,
+)
+from tests.synthetic.rds_postgres.trajectory_policy import (
+    TrajectoryPolicy,
+    TrajectoryPolicyResult,
+    evaluate_trajectory_policy,
 )
 
 __all__ = [
-    # dataclasses
-    "FailureDetail",
-    "GateResult",
-    "ReasoningScore",
-    "ScenarioScore",
-    "TrajectoryScore",
-    # functions
-    "score_result",
-    "score_reasoning",
-    "score_trajectory",
     # orchestration
     "run_scenario",
     "run_synthetic_suite",

--- a/tests/synthetic/rds_postgres/scoring.py
+++ b/tests/synthetic/rds_postgres/scoring.py
@@ -2,9 +2,6 @@
 
 This module is free of ``app.*`` imports so scoring logic can be unit-tested
 without importing the full investigation runtime or any heavy runtime dependencies.
-
-Dataclasses and functions in this module are re-exported from run_suite.py
-for backward compatibility with existing import sites.
 """
 
 from __future__ import annotations

--- a/tests/synthetic/rds_postgres/test_evidence_sources.py
+++ b/tests/synthetic/rds_postgres/test_evidence_sources.py
@@ -273,8 +273,8 @@ def test_score_result_fails_when_pi_required_but_only_cloudwatch_present() -> No
     A scenario requiring PI evidence must fail when only CloudWatch data is available,
     even if grafana_metrics is populated.
     """
-    from tests.synthetic.rds_postgres.run_suite import score_result
     from tests.synthetic.rds_postgres.scenario_loader import SUITE_DIR, load_all_scenarios
+    from tests.synthetic.rds_postgres.scoring import score_result
 
     # Use scenario 004 (cpu-saturation-bad-query) which requires PI
     fixtures = load_all_scenarios(SUITE_DIR)

--- a/tests/synthetic/rds_postgres/test_observation_metrics.py
+++ b/tests/synthetic/rds_postgres/test_observation_metrics.py
@@ -7,11 +7,9 @@ from pathlib import Path
 from typing import Any
 
 from tests.synthetic.rds_postgres.observations import (
-    TrajectoryPolicy,
     build_observation,
     compute_trajectory_metrics,
     edit_distance,
-    evaluate_trajectory_policy,
     lcs_length,
     render_report_to_string,
     write_observation,
@@ -20,9 +18,13 @@ from tests.synthetic.rds_postgres.run_suite import (
     _apply_trajectory_policy_to_score,
     _resolved_golden_trajectory,
     _trajectory_policy_for_fixture,
-    score_result,
 )
 from tests.synthetic.rds_postgres.scenario_loader import SUITE_DIR, load_all_scenarios
+from tests.synthetic.rds_postgres.scoring import score_result
+from tests.synthetic.rds_postgres.trajectory_policy import (
+    TrajectoryPolicy,
+    evaluate_trajectory_policy,
+)
 
 
 def _sample_final_state() -> dict[str, Any]:

--- a/tests/synthetic/rds_postgres/test_suite.py
+++ b/tests/synthetic/rds_postgres/test_suite.py
@@ -7,13 +7,14 @@ from pathlib import Path
 import pytest
 
 from config.config import has_credentials_for_active_llm_provider
-from tests.synthetic.rds_postgres.run_suite import run_scenario, score_result
+from tests.synthetic.rds_postgres.run_suite import run_scenario
 from tests.synthetic.rds_postgres.scenario_loader import (
     SUITE_DIR,
     GoldenTrajectoryConfig,
     load_all_scenarios,
     load_scenario,
 )
+from tests.synthetic.rds_postgres.scoring import score_result
 from tests.synthetic.schemas import VALID_EVIDENCE_SOURCES
 
 

--- a/tests/synthetic/rds_postgres/test_suite_axis2.py
+++ b/tests/synthetic/rds_postgres/test_suite_axis2.py
@@ -30,8 +30,9 @@ import pytest
 
 from config.config import has_credentials_for_active_llm_provider
 from tests.synthetic.mock_grafana_backend.selective_backend import SelectiveGrafanaBackend
-from tests.synthetic.rds_postgres.run_suite import run_scenario, score_reasoning
+from tests.synthetic.rds_postgres.run_suite import run_scenario
 from tests.synthetic.rds_postgres.scenario_loader import load_all_scenarios
+from tests.synthetic.rds_postgres.scoring import score_reasoning
 
 _ALL_SCENARIOS = load_all_scenarios()
 _LLM_ATTEMPTS = 2

--- a/tests/synthetic/rds_postgres/test_trajectory_policy.py
+++ b/tests/synthetic/rds_postgres/test_trajectory_policy.py
@@ -314,9 +314,9 @@ def test_trajectory_policy_gate_present_on_pass() -> None:
     """Gates must contain 'trajectory_policy' with status='pass' for a passing policy."""
     from tests.synthetic.rds_postgres.run_suite import (
         _apply_trajectory_policy_to_score,
-        score_result,
     )
     from tests.synthetic.rds_postgres.scenario_loader import SUITE_DIR, load_all_scenarios
+    from tests.synthetic.rds_postgres.scoring import score_result
 
     fixture = next(iter(load_all_scenarios(SUITE_DIR)))
     final_state: dict[str, Any] = {
@@ -364,9 +364,9 @@ def test_trajectory_policy_gate_present_when_not_applicable() -> None:
     """When trajectory_policy is None, gate must be recorded as not_applicable."""
     from tests.synthetic.rds_postgres.run_suite import (
         _apply_trajectory_policy_to_score,
-        score_result,
     )
     from tests.synthetic.rds_postgres.scenario_loader import SUITE_DIR, load_all_scenarios
+    from tests.synthetic.rds_postgres.scoring import score_result
 
     fixture = next(iter(load_all_scenarios(SUITE_DIR)))
     final_state: dict[str, Any] = {
@@ -395,9 +395,9 @@ def test_trajectory_policy_failure_sets_passed_false() -> None:
     from tests.synthetic.rds_postgres.observations import compute_trajectory_metrics
     from tests.synthetic.rds_postgres.run_suite import (
         _apply_trajectory_policy_to_score,
-        score_result,
     )
     from tests.synthetic.rds_postgres.scenario_loader import SUITE_DIR, load_all_scenarios
+    from tests.synthetic.rds_postgres.scoring import score_result
 
     # Use fixture 000-healthy: it has no required evidence so a pure policy
     # failure can be isolated without noise from other failures.


### PR DESCRIPTION
## Summary

- Remove backward-compat re-exports in the RDS PostgreSQL synthetic benchmark suite.
- Callers now import from canonical modules:
  - `scoring.py` — `score_result`, `score_reasoning`, `ScenarioScore`, etc.
  - `trajectory_policy.py` — `TrajectoryPolicy`, `evaluate_trajectory_policy`, etc.
  - `observations.py` — observation builders only (`build_observation`, `compute_trajectory_metrics`, …)
  - `run_suite.py` — orchestration only (`run_scenario`, `main`, …)

## Why

Per `tests/synthetic/rds_postgres/AGENTS.md`, compatibility-only re-export shims are temporary debt. This completes the migration started in the V0.2 refactor.

## Test plan

- [x] `make lint`
- [x] `uv run python -m pytest tests/synthetic/rds_postgres/test_scoring.py tests/synthetic/rds_postgres/test_trajectory_policy.py tests/synthetic/rds_postgres/test_observation_metrics.py tests/synthetic/rds_postgres/test_observation_correlation.py tests/synthetic/rds_postgres/test_artifact_determinism.py tests/synthetic/rds_postgres/test_evidence_sources.py -q` (65 passed)