### PR TITLE
fix: register GitLab integration verifier

### DIFF
--- a/integrations/gitlab/verifier.py
+++ b/integrations/gitlab/verifier.py
@@ -1,0 +1,12 @@
+"""GitLab integration verifier."""
+
+from __future__ import annotations
+
+from integrations.gitlab import build_gitlab_config, validate_gitlab_config
+from integrations.verification import register_validation_verifier
+
+verify_gitlab = register_validation_verifier(
+    "gitlab",
+    build_config=build_gitlab_config,
+    validate_config=validate_gitlab_config,
+)

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -94,9 +94,10 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
     ),
     IntegrationSpec(
         service="gitlab",
+        has_verifier=True,
         direct_effective=True,
         setup_order=15,
-        verify_order=None,
+        verify_order=52,
     ),
     IntegrationSpec(
         service="jenkins",

--- a/tests/integrations/test_gitlab.py
+++ b/tests/integrations/test_gitlab.py
@@ -21,6 +21,7 @@ from integrations.gitlab import (
     validate_gitlab_config,
     validate_gitlab_connection,
 )
+from integrations.gitlab.verifier import verify_gitlab
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -217,6 +218,23 @@ def test_validate_gitlab_config_handles_generic_exception(
 
     assert result.ok is False
     assert "connection refused" in result.detail
+
+
+def test_verify_gitlab_wraps_validation_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _ok(*, config: GitlabConfig) -> dict[str, str]:
+        del config
+        return {"username": "gl-user"}
+
+    monkeypatch.setattr("integrations.gitlab.validate_gitlab_connection", _ok)
+
+    result = verify_gitlab("local store", {"auth_token": "test-token"})
+
+    assert result == {
+        "service": "gitlab",
+        "source": "local store",
+        "status": "passed",
+        "detail": "GitLab connectivity successful. Authenticated as @gl-user",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integrations/test_verification_registry.py
+++ b/tests/integrations/test_verification_registry.py
@@ -108,7 +108,7 @@ class TestRegistryCatalogSync:
         """Every CLI/catalog service has a registered verifier."""
         assert set(list_verifiers()) == set(SUPPORTED_VERIFY_SERVICES)
 
-    @pytest.mark.parametrize("service", ("aws", "datadog", "slack"))
+    @pytest.mark.parametrize("service", ("aws", "datadog", "gitlab", "slack"))
     def test_loader_discovers_integration_local_verifier_modules(self, service: str) -> None:
         """Verifier discovery loads ``integrations.<name>.verifier`` modules."""
         verifier = get_verifier(service)


### PR DESCRIPTION
Fixes #3882

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Added `integrations/gitlab/verifier.py` and registered it through the existing validation-verifier helper.
- Marked the GitLab integration spec as verifier-backed so `gitlab` is included in `SUPPORTED_VERIFY_SERVICES` and accepted by `opensre integrations verify gitlab`.
- Added regression coverage for the GitLab verifier wrapper and verifier auto-discovery.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

```text
$ uv run opensre integrations verify gitlab

  SERVICE    SOURCE       STATUS      DETAIL
  gitlab    local store  passed      GitLab connectivity successful. Authenticated as @marin
```

Validation run:

```text
$ uv run pytest tests/integrations/test_gitlab.py tests/integrations/test_verification_registry.py tests/integrations/test_registry.py tests/integrations/test_registry_invariants.py
75 passed in 0.64s

$ make lint
All checks passed!

$ make format-check
2359 files already formatted

$ make typecheck
Success: no issues found in 1165 source files
```

Additional checks:

```text
$ uv run python .github/ci/run_test_scope.py --base origin/main
5 failed, 2365 passed, 2 skipped
```

The scoped integration suite failures were unrelated Codex OAuth callback tests expecting `302`/`400`/`200` but receiving `503`.

```text
$ make verify-integrations
```

This failed on the local Redis integration (`unknown command HELLO`) while GitLab passed in the same run.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

GitLab already had normalized config building and `validate_gitlab_config()` connectivity logic. The missing piece was the verifier-registry entrypoint that `integrations._verifiers_loader` can discover. This PR adds the minimal `integrations/gitlab/verifier.py` wrapper using the same `register_validation_verifier` pattern as other validation-backed integrations, then marks the GitLab registry spec with `has_verifier=True` and a deterministic `verify_order`.

I chose this over duplicating GitLab connectivity code because the existing validation helper already produces the expected verifier contract and keeps config parsing in the canonical GitLab integration module.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
