### PR TITLE
Fix GitLab integration verification

### DIFF
--- a/docs/gitlab.mdx
+++ b/docs/gitlab.mdx
@@ -53,6 +53,12 @@ The wizard validates your token by calling the GitLab API and writes the followi
 | `GITLAB_ACCESS_TOKEN` | Token used for all GitLab API calls |
 | `GITLAB_BASE_URL` | API base URL (defaults to `https://gitlab.com/api/v4`) |
 
+Verify the saved credentials:
+
+```bash
+opensre integrations verify gitlab
+```
+
 ---
 
 ## What the Agent Can Do

--- a/integrations/gitlab/verifier.py
+++ b/integrations/gitlab/verifier.py
@@ -1,0 +1,28 @@
+"""GitLab integration verifier."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from integrations.gitlab import build_gitlab_config, validate_gitlab_config
+from integrations.verification import register_verifier, result
+
+
+@register_verifier("gitlab")
+def verify_gitlab(source: str, config: dict[str, Any]) -> dict[str, str]:
+    """Validate GitLab credentials through the shared GitLab config probe."""
+    try:
+        normalized_config = build_gitlab_config(config)
+    except Exception as exc:
+        return result("gitlab", source, "missing", str(exc))
+
+    validation_result = validate_gitlab_config(normalized_config)
+    if not normalized_config.auth_token:
+        return result("gitlab", source, "missing", validation_result.detail)
+
+    return result(
+        "gitlab",
+        source,
+        "passed" if validation_result.ok else "failed",
+        validation_result.detail,
+    )

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -94,9 +94,10 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
     ),
     IntegrationSpec(
         service="gitlab",
+        has_verifier=True,
         direct_effective=True,
         setup_order=15,
-        verify_order=None,
+        verify_order=52,
     ),
     IntegrationSpec(
         service="jenkins",

--- a/tests/cli/test_integrations.py
+++ b/tests/cli/test_integrations.py
@@ -68,6 +68,25 @@ def test_integrations_setup_accepts_vercel() -> None:
     mock_capture.assert_not_called()
 
 
+def test_integrations_setup_accepts_gitlab() -> None:
+    runner = CliRunner()
+
+    with (
+        patch("surfaces.cli.commands.integrations.capture_integration_setup_started"),
+        patch("surfaces.cli.commands.integrations.capture_integration_setup_completed"),
+        patch("surfaces.cli.commands.integrations.capture_integration_verified") as mock_capture,
+        patch("integrations.cli.cmd_setup") as mock_setup,
+        patch("integrations.cli.cmd_verify", return_value=0) as mock_verify,
+    ):
+        mock_setup.return_value = "gitlab"
+        result = runner.invoke(cli, ["integrations", "setup", "gitlab"])
+
+    assert result.exit_code == 0
+    mock_setup.assert_called_once_with("gitlab")
+    mock_verify.assert_called_once_with("gitlab")
+    mock_capture.assert_called_once_with("gitlab")
+
+
 def test_integrations_setup_accepts_openclaw() -> None:
     runner = CliRunner()
 
@@ -302,6 +321,23 @@ def test_integrations_verify_accepts_github() -> None:
     mock_capture.assert_called_once_with("github")
 
 
+def test_integrations_verify_accepts_gitlab() -> None:
+    runner = CliRunner()
+
+    with (
+        patch("surfaces.cli.commands.integrations.capture_integration_verified") as mock_capture,
+        patch("integrations.cli.cmd_verify", return_value=0) as mock_verify,
+    ):
+        result = runner.invoke(cli, ["integrations", "verify", "gitlab"])
+
+    assert result.exit_code == 0
+    mock_verify.assert_called_once_with(
+        "gitlab",
+        send_slack_test=False,
+    )
+    mock_capture.assert_called_once_with("gitlab")
+
+
 def test_integrations_verify_accepts_openclaw() -> None:
     runner = CliRunner()
 
@@ -393,6 +429,12 @@ def test_verify_services_includes_previously_missing_integrations() -> None:
         "supabase",
     }
     assert previously_missing <= set(VERIFY_SERVICES)
+
+
+def test_verify_services_includes_gitlab() -> None:
+    # #3882: GitLab had setup/catalog/tool support but no verifier, so Click
+    # rejected `opensre integrations verify gitlab` before dispatch.
+    assert "gitlab" in VERIFY_SERVICES
 
 
 def test_setup_services_includes_previously_missing_integrations() -> None:

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -72,6 +72,12 @@ def test_registry_preserves_aliases_and_special_case_buckets() -> None:
     assert "bitbucket" not in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES
 
 
+def test_gitlab_is_setup_and_verify_capable() -> None:
+    assert "gitlab" in SUPPORTED_SETUP_SERVICES
+    assert "gitlab" in SUPPORTED_VERIFY_SERVICES
+    assert "gitlab" in list_verifiers()
+
+
 def test_resolve_management_service_maps_posthog_to_posthog_mcp() -> None:
     # The bare `posthog` integration has no interactive setup/verify flow, so
     # management commands should treat "posthog" as the PostHog MCP integration.

--- a/tests/integrations/test_verify.py
+++ b/tests/integrations/test_verify.py
@@ -9,6 +9,7 @@ from integrations.aws.verifier import verify_aws as _verify_aws
 from integrations.coralogix.verifier import verify_coralogix as _verify_coralogix
 from integrations.datadog.verifier import verify_datadog as _verify_datadog
 from integrations.github.verifier import verify_github as _verify_github
+from integrations.gitlab.verifier import verify_gitlab as _verify_gitlab
 from integrations.grafana.verifier import verify_grafana as _verify_grafana
 from integrations.honeycomb.verifier import verify_honeycomb as _verify_honeycomb
 from integrations.sentry.verifier import verify_sentry as _verify_sentry
@@ -540,6 +541,90 @@ def test_verify_github_reports_credential_less_store_record_as_missing() -> None
     assert verdict["service"] == "github"
     assert verdict["status"] == "missing"
     assert "without an auth token" in verdict["detail"]
+
+
+def test_verify_gitlab_passes_with_user_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_httpx_request(
+        method: str,
+        url: str,
+        *_args: Any,
+        headers: dict[str, str],
+        **_kwargs: Any,
+    ) -> _FakeResponse:
+        assert method == "GET"
+        assert url == "https://gitlab.example.com/api/v4/user"
+        assert headers["Authorization"] == "Bearer glpat_test"
+        return _FakeResponse({"username": "opensre-user"})
+
+    monkeypatch.setattr("integrations.gitlab.httpx.request", _fake_httpx_request)
+
+    result = _verify_gitlab(
+        "local env",
+        {
+            "base_url": "https://gitlab.example.com/api/v4",
+            "auth_token": "glpat_test",
+        },
+    )
+
+    assert result["service"] == "gitlab"
+    assert result["status"] == "passed"
+    assert "@opensre-user" in result["detail"]
+
+
+def test_verify_gitlab_reports_missing_token_without_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fail_request(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("GitLab verifier should not call the API without a token")
+
+    monkeypatch.setattr("integrations.gitlab.httpx.request", _fail_request)
+
+    result = _verify_gitlab("local store", {"base_url": "https://gitlab.example.com/api/v4"})
+
+    assert result["service"] == "gitlab"
+    assert result["status"] == "missing"
+    assert "auth token is required" in result["detail"].lower()
+
+
+def test_verify_integrations_dispatches_to_gitlab(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_httpx_request(
+        method: str,
+        url: str,
+        *_args: Any,
+        headers: dict[str, str],
+        **_kwargs: Any,
+    ) -> _FakeResponse:
+        assert method == "GET"
+        assert url == "https://gitlab.example.com/api/v4/user"
+        assert headers["Authorization"] == "Bearer glpat_store"
+        return _FakeResponse({"username": "store-user"})
+
+    monkeypatch.setattr("integrations.gitlab.httpx.request", _fake_httpx_request)
+    monkeypatch.setattr(
+        "integrations.catalog.load_integrations",
+        lambda: [
+            {
+                "id": "gitlab-local",
+                "service": "gitlab",
+                "status": "active",
+                "credentials": {
+                    "base_url": "https://gitlab.example.com/api/v4",
+                    "auth_token": "glpat_store",
+                },
+            }
+        ],
+    )
+
+    results = verify_integrations("gitlab")
+
+    assert results == [
+        {
+            "service": "gitlab",
+            "source": "local store",
+            "status": "passed",
+            "detail": "GitLab connectivity successful. Authenticated as @store-user",
+        }
+    ]
 
 
 def test_verify_sentry_passes_with_valid_config(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #3882

## Summary
- add a GitLab verifier registered through the integration verifier loader
- mark gitlab as verify-capable in the integration registry with a stable verify order
- add registry, dispatch, and Click-facing CLI regression tests for integrations verify gitlab
- document the GitLab verify command

## Tests
- uv run python -m ruff check config core gateway integrations platform surfaces tools tests
- uv run python -m ruff format --check config core gateway integrations platform surfaces tools tests
- uv run python -m mypy config core gateway integrations platform surfaces tools
- uv run python -m pytest tests/integrations/test_registry.py tests/integrations/test_registry_invariants.py tests/integrations/test_verification_registry.py tests/integrations/test_verify.py tests/cli/test_integrations.py
- uv run opensre integrations verify gitlab with an empty temp home: reaches verifier path and returns expected missing status

## Local test-scope note
- uv run python .github/ci/run_test_scope.py --base main ran 2,396 scoped tests on Windows: 2,391 passed, 3 skipped, 2 failed in files untouched by this PR:
  - 	ests/integrations/git/test_local.py::test_changed_paths_handles_quoted_filenames (Windows Unicode path decoding)
  - 	ests/integrations/llm_cli/test_codex_oauth.py::test_codex_auth_payload_and_write_auth_shape (Windows file mode reports o666 instead of POSIX o600)