### PR TITLE
fix(observability): guard POSIX-only resource import for Windows

### DIFF
--- a/platform/observability/trace/process_stats.py
+++ b/platform/observability/trace/process_stats.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import gc
-import resource
 import sys
 import threading
 from typing import Any
+
+try:
+    import resource
+except ImportError:  # ``resource`` is POSIX-only; absent on Windows.
+    resource = None  # type: ignore[assignment]
 
 #: Cap thread rows embedded in a turn-boundary snapshot (ATM thread map).
 _MAX_THREADS_IN_SNAPSHOT = 40
@@ -28,11 +32,18 @@ def _normalize_rss_mb(ru_maxrss: int) -> float:
 
 
 def sample_resource_snapshot() -> dict[str, Any]:
-    """RSS + GC generation counts (cheap; safe on turn boundaries)."""
-    rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    """RSS + GC generation counts (cheap; safe on turn boundaries).
+
+    ``rss_mb`` is ``None`` on platforms without the POSIX ``resource``
+    module (Windows); the GC counts stay cross-platform.
+    """
     gen0, gen1, gen2 = gc.get_count()
+    rss_mb: float | None = None
+    if resource is not None:
+        ru_maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        rss_mb = _normalize_rss_mb(ru_maxrss)
     return {
-        "rss_mb": _normalize_rss_mb(rss_kb),
+        "rss_mb": rss_mb,
         "gc_gen0": gen0,
         "gc_gen1": gen1,
         "gc_gen2": gen2,


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

`platform/observability/trace/process_stats.py` (added in the #3886 observability span refactor) imports the **POSIX-only `resource` module at module scope** for a single `getrusage` RSS reading.

That module is not import-isolated: `platform/observability/trace/spans.py` imports `sample_turn_boundary_stats` from it at module scope, and `spans.py` is imported eagerly by `core/execution.py`, `core/agent/react_loop.py`, the `core/agent_harness/turns/*` drivers, and `gateway/turn_handler.py`. On Windows — a platform documented as supported in `SETUP.md` — this raises `ModuleNotFoundError: No module named 'resource'` **at import time**, crashing the CLI, REPL, and gateway before they can start.

This PR guards the import and skips only the RSS reading when `resource` is unavailable: `sample_resource_snapshot()` returns `rss_mb=None` on such platforms while the cross-platform GC generation counts are unaffected. POSIX behavior (and the macOS-vs-Linux `ru_maxrss` unit normalization) is unchanged.

`psutil` (used for process stats elsewhere) is intentionally **not** used here, to keep it confined to the fleet-monitoring probe module as enforced by `tests/fleet_monitoring/test_probe.py::test_psutil_is_not_imported_outside_probe_module`.

### Demo/Screenshot for feature changes and bug fixes -

Simulating a platform without the `resource` module (`import resource` forced to raise, as on Windows):

**Before (current `main`)** — crashes at import:
```
CRASH at import: No module named 'resource'
  File ".../process_stats.py", line 6, in <module>
    import resource
ModuleNotFoundError: No module named 'resource'
```

**After (this PR)** — imports cleanly, degrades gracefully:
```
import OK on simulated Windows (no `resource`)
snapshot: {'rss_mb': None, 'gc_gen0': 963, 'gc_gen1': 7, 'gc_gen2': 0}
```

POSIX unchanged (macOS): `{'rss_mb': 17.06, 'gc_gen0': 362, 'gc_gen1': 7, 'gc_gen2': 0}`

Local CI: `make lint`, `make format-check`, `make typecheck` clean; `make test-cov` passes (10,724 passed; the one unrelated failure is an environment-dependent Copilot CLI adapter test that also fails on unmodified `main` because the `copilot` binary is installed on this machine).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: a POSIX-only stdlib import (`resource`) sits at module scope in a file that is transitively imported by every entry point, so any platform lacking `resource` (Windows) fails to start. The fix has to keep the module importable everywhere while preserving the existing RSS metric where it is available.

I considered two alternatives: (1) reading RSS via `psutil`, which is already a dependency and cross-platform — rejected because an import-boundary test deliberately confines `psutil` to `tools/system/fleet_monitoring/probe.py`, and I did not want to widen that surface; (2) moving `import resource` into the function body — this fixes the import-time crash but still raises on every call on Windows. I chose a guarded top-level import with graceful degradation: `rss_mb` becomes `None` when `resource` is absent, and the GC counts (which are cross-platform) are always returned. This keeps the metric intact on POSIX, never raises on Windows, and touches nothing outside the one file.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions