### PR TITLE
ci: add importlinter check to quality job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Import graph
         run: uv run python .github/ci/check_imports.py --strict
 
+      - name: Import boundaries
+        run: uv run lint-imports
+
   test:
     name: test (${{ matrix.shard }})
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,10 @@ jobs:
       - name: Import graph
         run: uv run python .github/ci/check_imports.py --strict
 
+      # Full layered contracts (.importlinter.strict), not the minimal default
+      # .importlinter config used by ``make check-imports``.
       - name: Import boundaries
-        run: uv run lint-imports
+        run: uv run lint-imports --config .importlinter.strict
 
   test:
     name: test (${{ matrix.shard }})


### PR DESCRIPTION
Wires up the existing `.importlinter` config as a CI gate so import boundary violations are caught before merge.