### PR TITLE
fix(core/execution): flag tool failure on truthy error, not key presence (#3889)

### DIFF
--- a/core/execution.py
+++ b/core/execution.py
@@ -325,7 +325,10 @@ def _requires_sequential_execution(
 def _normalize_result(raw: Any, *, tool_name: str) -> ToolExecutionResult:
     if isinstance(raw, ToolExecutionResult):
         return raw
-    is_error = isinstance(raw, dict) and "error" in raw
+    # Flag failure on a truthy "error", not the mere presence of the key: a
+    # success payload carrying "error": None must reach the agent, not be
+    # replaced with {"error": "None"}. Matches bedrock_converse's convention.
+    is_error = isinstance(raw, dict) and bool(raw.get("error"))
     content = _content_from_payload(raw)
     if is_error:
         content = str(raw.get("error", content))

--- a/tests/core/runtime/test_tool_execution_contract.py
+++ b/tests/core/runtime/test_tool_execution_contract.py
@@ -76,6 +76,27 @@ def test_execute_tool_calls_validates_arguments_before_execution() -> None:
     ]
 
 
+def test_success_payload_with_error_none_reaches_agent() -> None:
+    """A success dict carrying ``"error": None`` must reach the agent unchanged,
+    not be flagged as a failure on the mere presence of the key (#3889)."""
+    payload = {"available": True, "events": [{"id": 1}], "error": None}
+
+    result = execute_tool_calls([_call()], [_tool(execute=lambda _a, _c: payload)], {})[0]
+
+    assert result.is_error is False
+    assert result.details == payload
+    # compat_payload returns the full payload for old call sites, not {"error": ...}.
+    assert execute_tools([_call()], [_tool(execute=lambda _a, _c: payload)], {}) == [payload]
+
+
+def test_truthy_error_still_flagged_as_failure() -> None:
+    """A real error message is still surfaced as a failure (#3889)."""
+    result = execute_tool_calls([_call()], [_tool(execute=lambda _a, _c: {"error": "boom"})], {})[0]
+
+    assert result.is_error is True
+    assert result.content == "boom"
+
+
 def test_before_hook_can_block_with_structured_result() -> None:
     def before(_request: ToolExecutionRequest) -> BeforeToolCallResult:
         return BeforeToolCallResult(blocked=True, reason="blocked", details={"policy": "deny"})


### PR DESCRIPTION
Fixes #3889

#### Describe the changes you have made in this PR -

The runtime tool loop flagged a tool result as a failure whenever an `"error"` key was present in the returned dict, regardless of its value:

```python
# core/execution.py
is_error = isinstance(raw, dict) and "error" in raw
```

So a tool that returns `{"available": True, ..., "error": None}` on success got `is_error=True`, and the result was serialized to the LLM as `{"error": "None"}` with the real payload discarded. The agent saw nothing.

This surfaced in #3859: CloudTrail returned 50 events standalone but every investigation saw zero, because its success dict carried `"error": None`. That PR fixed CloudTrail by dropping the key. The root cause is in `_normalize_result`, and the same shape ships from several other tools (EKS, RDS, EC2, groundcover, fix_sentry_issue).

**Fix.** Flag failure on a truthy `"error"`, not the mere presence of the key — the convention already used in `core/llm/transports/sdk/bedrock_converse.py`:

```python
is_error = isinstance(raw, dict) and bool(raw.get("error"))
```

One shared change repairs every affected tool at once and keeps existing `"error": None` keys harmless (fully backward compatible), so no per-tool churn is needed. It also corrects a related latent case: telegram/twilio/helm success paths that returned `"error": ""` were being mis-flagged as failures too.

Regression tests added at the runtime layer: a success dict with `"error": None` reaches the agent unchanged, and a truthy `"error"` is still surfaced as a failure.

### Demo/Screenshot for feature changes and bug fixes -
main
<img width="852" height="71" alt="image" src="https://github.com/user-attachments/assets/17affa69-7eff-4b7b-b5a5-9925c4797529" />

current branch
<img width="838" height="97" alt="image" src="https://github.com/user-attachments/assets/686273f6-9509-498a-963a-d2ba2a2fa407" />

**Validation.** `make lint`, `make format-check`, `make typecheck` clean. `make test-cov`: 10668 passed (3 pre-existing/environmental failures unrelated to this change: a stale local `core/context` dir, terminal-theme colors, a locally installed `copilot` binary).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is a presence-vs-truthiness check in the shared tool-result normalizer. Fixing it at `_normalize_result` (rather than stripping `"error": None` tool by tool) repairs every affected tool with one change and avoids churning ~11 files plus their tests. `bool(raw.get("error"))` matches the existing bedrock_converse convention, so a real error message still flags `is_error` while a `None`/empty value does not. Tests exercise the runtime path end to end via `execute_tools`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
