### PR TITLE
test(llm_cli): isolate copilot binary-not-found test from real installs (#3895)

### DIFF
--- a/tests/integrations/llm_cli/test_copilot_adapter.py
+++ b/tests/integrations/llm_cli/test_copilot_adapter.py
@@ -366,6 +366,13 @@ def test_detect_when_binary_not_found(
     _mock_which: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _clean_copilot_env(monkeypatch)
+    # resolve_cli_binary falls back to known install dirs (e.g. /opt/homebrew/bin)
+    # after the PATH lookup. Mocking shutil.which alone still finds a real copilot
+    # install on a dev machine, so force nothing to resolve as runnable — this also
+    # overrides the autouse fixture that treats real fallback paths as runnable.
+    import integrations.llm_cli.binary_resolver as br
+
+    monkeypatch.setattr(br, "is_runnable_binary", lambda _path: False)
     probe = CopilotAdapter().detect()
     assert probe.installed is False
     assert probe.logged_in is None


### PR DESCRIPTION
Fixes #3895

#### Describe the changes you have made in this PR -

`tests/integrations/llm_cli/test_copilot_adapter.py::test_detect_when_binary_not_found` simulated "binary not found" by mocking only the PATH lookup (`shutil.which → None`). But `resolve_cli_binary` resolves in three steps — env override, `shutil.which`, then **fallback install dirs** (e.g. `/opt/homebrew/bin`) checked via `is_runnable_binary`. On a dev machine with the `copilot` CLI installed in a fallback dir, `detect()` still found it, so the test failed:

```text
assert probe.installed is False
E   AssertionError: assert True is False
E    +  where True = CLIProbe(installed=True, version='1.0.43', bin_path='/opt/homebrew/bin/copilot', ...).installed
```

It passed in CI only because CI runners don't have `copilot` installed.

The product behavior is correct (fallback dirs are how real installs are found) — this is a test-isolation gap. The fix forces `is_runnable_binary` to `False` in this one test so nothing resolves, which also overrides the autouse fixture that treats real fallback paths as runnable. No product code changes.

### Demo/Screenshot for feature changes and bug fixes -

On a machine with copilot installed via Homebrew (`/opt/homebrew/bin/copilot`):

```text
# BEFORE
FAILED tests/integrations/llm_cli/test_copilot_adapter.py::test_detect_when_binary_not_found
  assert True is False  (bin_path='/opt/homebrew/bin/copilot')

# AFTER
29 passed
```

`ruff check` and `ruff format --check` clean on the file.

#### Related (out of scope)

Several sibling adapter tests use the same `shutil.which → None`-only pattern for "binary not found" (`test_claude_code_adapter.py`, `test_opencode_adapter.py`, `test_codex_adapter.py`, `test_antigravity_cli_adapter.py`, `test_gemini_cli_adapter.py`, `test_grok_cli_adapter.py`). They pass today only because the matching CLI isn't installed. Noted in #3895 as a follow-up (a shared `simulate_binary_not_found` helper).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The test under-mocked binary resolution: `resolve_cli_binary` has a fallback-dir step that `shutil.which` mocking doesn't cover. Forcing `is_runnable_binary → False` (via monkeypatch, matching the file's idiom and overriding its autouse fixture) makes the test truly exercise the binary-absent path regardless of what's installed on the machine. Product code is untouched.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
