### PR TITLE
fix(ci): drop stale tests/github path from cli-runtime shard (#3899)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,6 @@ jobs:
               tests/delivery
               tests/sandbox
               tests/hermes
-              tests/github
           - os: ubuntu-latest
             shard: integrations-and-misc
             pytest_paths: >-


### PR DESCRIPTION
Fixes #3899

#### Describe the changes you have made in this PR -

The `test (cli-runtime)` shard fails on every PR based on current `main`:

```text
2 workers [0 items]
============================ no tests ran in ~1s =============================
##[error]Process completed with exit code 5.
```

**Root cause.** `ci.yml`'s `cli-runtime` shard listed `tests/github` in `pytest_paths`. That directory was removed in `0caeed43 (chore: rm redundant tests)` — its tests now live in `tests/tools/test_github_*`, `tests/integrations/test_github_*`, and `tests/github_ci/` — but the shard path was never updated. Under `-n auto` (xdist), pytest treats a nonexistent path as "0 items collected" and exits 5, so one stale path zeroes out the whole shard. It only passes locally when a leftover `tests/github/` (e.g. `__pycache__`) still exists in the working tree; on CI's clean checkout it doesn't.

Confirmed locally: `pytest -n auto tests/cli tests/DOES_NOT_EXIST` → `collected 0 items`. This is why pre-regression fork PRs (#3859, #3877) passed cli-runtime while later PRs (#3893, #3897) fail identically.

**Fix.** Drop the stale `tests/github` entry. No coverage is lost — those tests already run in `tools-runtime` (`tests/tools`) and `integrations-and-misc` (`tests/integrations`, `tests/github_ci`).

### Demo/Screenshot for feature changes and bug fixes -

With the local `tests/github` leftover removed (matching CI's clean checkout), collecting the shard's paths:

```text
# BEFORE (with tests/github in the list)
pytest -n auto <cli-runtime paths incl. tests/github>
  -> 2 workers [0 items] ... no tests ran ... exit 5

# AFTER (tests/github removed)
pytest -n auto <cli-runtime paths>
  -> 3255/3286 tests collected (31 deselected)
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Traced the shard's `exit 5` to a single nonexistent path (`tests/github`) that xdist turns into a zero-collection for the entire shard. Confirmed the path was deleted in `0caeed43` and that its tests are already covered by the `tools-runtime` and `integrations-and-misc` shards, so removing the stale entry restores the shard without dropping coverage.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
