### PR TITLE
fix(session): stop trace spans from rescanning the session file

### DIFF
--- a/core/agent_harness/session/persistence/jsonl_storage.py
+++ b/core/agent_harness/session/persistence/jsonl_storage.py
@@ -289,7 +289,14 @@ class JsonlSessionStorage:
             records = self._read_records(path)
             if not records:
                 return
-            if records[-1].get("type") == "leaf":
+            # Ignore trailing side-channel trace_span rows when checking for an
+            # existing leaf, so a span written after a leaf can't slip a second
+            # leaf past this guard (consistent with _current_leaf_id's skip).
+            last_meaningful = next(
+                (rec for rec in reversed(records) if rec.get("type") != "trace_span"),
+                None,
+            )
+            if last_meaningful is not None and last_meaningful.get("type") == "leaf":
                 return
             if not self._has_turns(records):
                 path.unlink(missing_ok=True)

--- a/core/agent_harness/session/persistence/jsonl_storage.py
+++ b/core/agent_harness/session/persistence/jsonl_storage.py
@@ -354,7 +354,17 @@ class JsonlSessionStorage:
             if not path.exists():
                 return ""
             entry_id = _new_id()
-            parent = parent_id if parent_id is not None else self._current_leaf_id(path)
+            # ``trace_span`` rows are side-channel telemetry (ATM / debug) and
+            # never join the conversation parent chain, so they skip the leaf
+            # lookup every other append pays. They are emitted once per LLM and
+            # per tool call, so resolving the leaf here would re-read the whole
+            # session file on every span -- O(n) per span, O(n^2) per session.
+            if parent_id is not None:
+                parent = parent_id
+            elif entry_type == "trace_span":
+                parent = None
+            else:
+                parent = self._current_leaf_id(path)
             record = {
                 "id": entry_id,
                 "parent_id": parent,
@@ -383,6 +393,10 @@ class JsonlSessionStorage:
         for rec in reversed(records):
             if rec.get("type") == "leaf":
                 return str(rec.get("parent_id") or "") or None
+            # Side-channel telemetry, not a tree node: a ``trace_span`` must
+            # never become the parent of the next real entry.
+            if rec.get("type") == "trace_span":
+                continue
             if rec.get("type") != "session":
                 return str(rec.get("id") or "") or None
         return None

--- a/tests/interactive_shell/sessions/test_store.py
+++ b/tests/interactive_shell/sessions/test_store.py
@@ -313,6 +313,23 @@ def test_flush_writes_session_end(tmp_path: Path) -> None:
     assert leaf["investigation_turns"] == 1
 
 
+def test_flush_is_idempotent_after_trailing_trace_span(tmp_path: Path) -> None:
+    """A side-channel trace_span written after a leaf must not let a second leaf
+    slip past flush()'s idempotency guard."""
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "q1")
+        SessionStore.flush(session)
+        SessionStore.append_trace_span(
+            session.session_id, span_kind="tool", name="late", duration_ms=1
+        )
+        SessionStore.flush(session)
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    assert [r["type"] for r in records].count("leaf") == 1
+
+
 def test_flush_counts_cli_agent_turns_as_chat(tmp_path: Path) -> None:
     """Chat turns recorded as kind='cli_agent' must count as chat_turns."""
     session = _make_session()

--- a/tests/platform/observability/test_session_trace.py
+++ b/tests/platform/observability/test_session_trace.py
@@ -402,3 +402,48 @@ def test_set_session_trace_sink_none_restores_noop() -> None:
     set_session_trace_sink(None)
     assert not is_session_trace_active()
     assert isinstance(get_session_trace_sink(), NoopSessionTraceSink)
+
+
+def test_trace_span_append_skips_leaf_scan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A trace_span is side-channel: appending one must not read the session
+    file to resolve a leaf (the source of the per-span O(n) rescan)."""
+    session_id = "sess-trace-perf"
+    monkeypatch.setattr(
+        "core.agent_harness.session.persistence.jsonl_storage.session_path",
+        lambda sid: tmp_path / f"{sid}.jsonl",
+    )
+    path = _seed_session_jsonl(tmp_path, session_id)
+    storage = JsonlSessionStorage()
+    storage.append_message(session_id, role="user", content="hi")
+
+    calls = {"n": 0}
+    original = JsonlSessionStorage._read_records
+
+    def _counting_read(p: Path) -> list[dict[str, Any]]:
+        calls["n"] += 1
+        return original(p)
+
+    monkeypatch.setattr(JsonlSessionStorage, "_read_records", staticmethod(_counting_read))
+    storage.append_trace_span(session_id, span_kind="tool", name="probe", duration_ms=1)
+    assert calls["n"] == 0, "trace_span append should not re-read the session file"
+    assert path.read_text(encoding="utf-8").strip().splitlines()[-1].find('"trace_span"') != -1
+
+
+def test_trace_span_never_becomes_conversation_parent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A message appended after a trace_span must chain to the previous real
+    entry, not onto the telemetry span."""
+    session_id = "sess-trace-chain"
+    monkeypatch.setattr(
+        "core.agent_harness.session.persistence.jsonl_storage.session_path",
+        lambda sid: tmp_path / f"{sid}.jsonl",
+    )
+    _seed_session_jsonl(tmp_path, session_id)
+    storage = JsonlSessionStorage()
+    user_id = storage.append_message(session_id, role="user", content="hi")
+    storage.append_trace_span(session_id, span_kind="llm", name="invoke", duration_ms=2)
+    assistant_id = storage.append_message(session_id, role="assistant", content="hello")
+
+    records = {r["id"]: r for r in storage._read_records(tmp_path / f"{session_id}.jsonl")}
+    assert records[assistant_id]["parent_id"] == user_id

--- a/tests/platform/observability/test_session_trace.py
+++ b/tests/platform/observability/test_session_trace.py
@@ -426,7 +426,7 @@ def test_trace_span_append_skips_leaf_scan(tmp_path: Path, monkeypatch: pytest.M
     monkeypatch.setattr(JsonlSessionStorage, "_read_records", staticmethod(_counting_read))
     storage.append_trace_span(session_id, span_kind="tool", name="probe", duration_ms=1)
     assert calls["n"] == 0, "trace_span append should not re-read the session file"
-    assert path.read_text(encoding="utf-8").strip().splitlines()[-1].find('"trace_span"') != -1
+    assert '"trace_span"' in path.read_text(encoding="utf-8").strip().splitlines()[-1]
 
 
 def test_trace_span_never_becomes_conversation_parent(


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

The session-trace span port (#3886 / #3890) wraps every LLM invoke (`llm_span`) and every tool execution (`tool_span`) and writes a `trace_span` record through `JsonlSessionStorage`. Those helpers pass no `parent_id`, so each append falls into `_append_entry`'s fallback and calls `_current_leaf_id`, which reads and JSON-parses the **entire session file** to find the current leaf.

Because a span fires once per LLM call and once per tool call, this makes turn latency scale with session length: **O(n) per span, O(n^2) over a session's life** — and it's on by default for every interactive-shell session (`runtime/context.py` registers a JSONL trace sink unconditionally).

`trace_span` rows are side-channel telemetry (ATM / debug); they do not belong in the conversation parent chain. This PR:

1. Skips the leaf lookup when appending a `trace_span` (`_append_entry`), so a span never triggers a file read.
2. Skips `trace_span` rows in `_current_leaf_id`, so a span can never become the parent of the next real entry.

Change (2) also fixes a **latent correctness issue**: because spans are emitted mid-turn — before the turn's message is appended to the same file — the next real message was chaining its `parent_id` onto a telemetry span instead of the previous message.

### Demo/Screenshot for feature changes and bug fixes -

Appending 50 `trace_span` records (a normal turn with many LLM/tool calls), counting full session-file reads, and checking the parent of the message that follows:

**Before (current `main`):**
```
50 trace_span appends -> 50 full-file reads
assistant message parent type = 'trace_span'   (conversation chain polluted)
```

**After (this PR):**
```
50 trace_span appends -> 0 full-file reads
assistant message parent type = 'message'      (chains to the previous real entry)
```

Adds two regression tests in `tests/platform/observability/test_session_trace.py`:
- `test_trace_span_append_skips_leaf_scan` — a `trace_span` append performs zero file reads.
- `test_trace_span_never_becomes_conversation_parent` — a message appended after a span chains to the prior real entry.

Local CI: `make lint`, `make format-check`, `make typecheck` clean; `make test-cov` passes (10,662 passed; the one unrelated failure is an environment-dependent Copilot CLI adapter test that also fails on unmodified `main` because the `copilot` binary is installed on this machine).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: `trace_span` records are written into the same append-only JSONL file as conversation entries, and every append without an explicit `parent_id` resolves the leaf by re-reading the whole file. Spans are the highest-frequency writer (per LLM call, per tool call), so they dominate this cost, and they also shouldn't be part of the conversation tree at all.

I considered caching the last-appended entry id on the storage instance to make leaf resolution O(1). I rejected that as the primary fix: the leaf rule has to skip `leaf`/`session` (and now `trace_span`) record types, so a naive "last id" cache would be subtly wrong, and it adds mutable state to a class that is otherwise stateless per call. The narrower, correct fix is to recognize that a `trace_span` is side-channel telemetry: it neither needs a parent nor should it be one. So I skip the leaf lookup for `trace_span` appends and exclude `trace_span` from `_current_leaf_id`. This removes the per-span file read entirely and keeps the conversation chain pointing only at real entries. The pre-existing per-message leaf resolution (far lower frequency) is intentionally left unchanged to keep the diff scoped to the regression.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions