### PR TITLE
fix(execution): propagate context so parallel tool calls emit spans

### DIFF
--- a/core/execution.py
+++ b/core/execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextvars
 import json
 import logging
 from collections.abc import Callable, Sequence
@@ -140,7 +141,12 @@ def execute_tool_calls(
     try:
         with ThreadPoolExecutor(max_workers=min(_TOOL_EXECUTOR_WORKERS, len(tool_calls))) as pool:
             for i, tc in enumerate(tool_calls):
-                submitted[pool.submit(_call, tc)] = i
+                # Run each call inside a copy of the submitting thread's context
+                # so contextvars (notably the session-trace binding read by
+                # tool_span) propagate into the worker thread. Without this,
+                # parallel tool calls emit no trace spans. Mirrors the
+                # copy_context().run pattern in tools/investigation/capability.py.
+                submitted[pool.submit(contextvars.copy_context().run, _call, tc)] = i
             for fut in as_completed(submitted):
                 try:
                     results[submitted[fut]] = fut.result()

--- a/tests/core/runtime/test_tool_execution_contract.py
+++ b/tests/core/runtime/test_tool_execution_contract.py
@@ -713,3 +713,30 @@ def test_execute_tool_calls_span_marks_tool_error_and_exception(
         assert by_name["hard"]["status"] == "error"
     finally:
         set_session_trace_sink(NoopSessionTraceSink())
+
+
+def test_parallel_tool_calls_emit_spans_in_worker_threads(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: a multi-tool batch runs in ThreadPoolExecutor workers that do
+    not inherit contextvars, so tool_span saw no bound trace session and emitted
+    nothing. The executor must propagate the submitting context to each worker."""
+    from platform.observability.trace.spans import (
+        NoopSessionTraceSink,
+        bind_session_trace,
+        set_session_trace_sink,
+    )
+
+    session_id = "sess-parallel-spans"
+    path = _activate_tool_trace(tmp_path, monkeypatch, session_id)
+    try:
+        calls = [_call("echo", "a"), _call("echo2", "b")]
+        tools = [_tool("echo"), _tool("echo2")]
+        with bind_session_trace(session_id):
+            results = execute_tool_calls(calls, tools, {})
+        assert all(not r.is_error for r in results)
+        spans = _tool_spans_from(path)
+        assert {s["name"] for s in spans} == {"echo", "echo2"}
+        assert all(s["status"] == "ok" for s in spans)
+    finally:
+        set_session_trace_sink(NoopSessionTraceSink())


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

`execute_tool_calls` wraps each call in `tool_span`, which resolves the active session-trace binding from a contextvar (`bind_session_trace`). On the **parallel** path the calls run in `ThreadPoolExecutor` worker threads, and those workers do **not** inherit the submitting thread's contextvars. So the trace binding is unset inside the worker, `tool_span` → `emit_span` short-circuits on the empty session id, and **every tool that runs in parallel produces no trace span** — silently losing tool-level observability for the common multi-tool turn.

The single-tool / forced-sequential path runs on the calling thread, so it was unaffected — which is why the existing span tests (all single-call) stayed green and masked the gap.

Fix: submit each call through `contextvars.copy_context().run`, so the worker executes inside a copy of the submitting thread's context. This is the same pattern already used for the background pipeline thread in `tools/investigation/capability.py`:

```python
threading.Thread(target=contextvars.copy_context().run, args=(_run_pipeline,), daemon=True)
```

### Demo/Screenshot for feature changes and bug fixes -

New regression test `test_parallel_tool_calls_emit_spans_in_worker_threads` runs a two-tool parallel batch under a bound trace session and asserts one span per tool. Verified it fails without the fix and passes with it:

```
# with the fix
1 passed

# with the fix reverted (pool.submit(_call, tc))
1 failed
tests/core/runtime/test_tool_execution_contract.py::test_parallel_tool_calls_emit_spans_in_worker_threads
# -> only 0 tool spans recorded; expected {'echo', 'echo2'}
```

Local CI: `make lint`, `make format-check`, `make typecheck` clean; `make test-cov` passes (10,661 passed; the one unrelated failure is an environment-dependent Copilot CLI adapter test that also fails on unmodified `main` because the `copilot` binary is installed on this machine).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is a contextvar-propagation gap specific to the thread-pool path. `tool_span` depends on the session-trace contextvar set by `bind_session_trace` on the calling thread; `ThreadPoolExecutor` workers start with a fresh (empty) context, so the binding is invisible there and spans silently drop.

I considered passing the session id explicitly into `tool_span` (`session_id=current_trace_session_id()` captured before submit). That works for the trace binding alone, but it only patches the one contextvar this bug exposed and would leave any other context-dependent behavior in the tool call still running without the caller's context. Copying the whole context with `contextvars.copy_context().run` is both the minimal change at the submit site and the more correct one — it propagates the entire context, and it's the pattern the codebase already uses for its other worker thread. `copy_context()` is evaluated on the submitting thread at submit time, so each task captures the binding that is active then. The regression test drives the actual parallel path (two parallel-safe tools) rather than asserting on the executor internals, so it guards the observable behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions