### PR TITLE
fix(interactive-shell): don't mask REPL errors in alert listener

### DIFF
--- a/surfaces/interactive_shell/controller.py
+++ b/surfaces/interactive_shell/controller.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import os
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.patch_stdout import patch_stdout
@@ -79,29 +79,37 @@ def _alert_listener(
         yield None
         return
 
-    from gateway.web_server import WebAppServerHandle, serve_webapp_in_thread
+    from gateway.web_server import serve_webapp_in_thread
 
+    # Acquire the listener's resources under one stack so that only a *startup*
+    # failure is handled here. The yield stays OUTSIDE this except: if it were
+    # inside, an exception raised by the REPL body would be caught as a "could
+    # not start" failure and trigger a second yield -- which makes
+    # @contextmanager raise "generator didn't stop after throw()" and masks the
+    # real error. The token env var must remain set across the yield (the
+    # webapp reads it per request), so the stack stays open until the body ends.
     inbox: _alert_inbox.AlertInbox | None = None
-    handle: WebAppServerHandle | None = None
+    resources = ExitStack()
     try:
         inbox = _alert_inbox.AlertInbox()
         _alert_inbox.set_current_inbox(inbox)
-        with _alert_listener_token(cfg.alert_listener_token):
-            handle = serve_webapp_in_thread(
-                host=cfg.alert_listener_host,
-                port=cfg.alert_listener_port,
-            )
-            console.print(f"[{DIM}]listening for alerts on http://{handle.bound_address}/alerts[/]")
-            try:
-                yield inbox
-            finally:
-                if handle is not None:
-                    handle.stop()
-                _alert_inbox.set_current_inbox(None)
+        resources.callback(_alert_inbox.set_current_inbox, None)
+        resources.enter_context(_alert_listener_token(cfg.alert_listener_token))
+        handle = serve_webapp_in_thread(
+            host=cfg.alert_listener_host,
+            port=cfg.alert_listener_port,
+        )
+        resources.callback(handle.stop)
+        bound_address = handle.bound_address
     except Exception as exc:
         log.warning("Alert listener could not start: %s — continuing without it.", exc)
-        _alert_inbox.set_current_inbox(None)
+        resources.close()
         yield None
+        return
+
+    with resources:
+        console.print(f"[{DIM}]listening for alerts on http://{bound_address}/alerts[/]")
+        yield inbox
 
 
 def _resolve_runtime_context(

--- a/tests/interactive_shell/test_alert_listener.py
+++ b/tests/interactive_shell/test_alert_listener.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from unittest.mock import MagicMock
 
+import pytest
 from rich.console import Console
 
 from config.repl_config import ReplConfig
@@ -55,3 +56,55 @@ def test_alert_listener_clears_token_when_unconfigured(monkeypatch) -> None:
         assert captured == [None]
 
     assert os.environ.get("OPENSRE_ALERT_LISTENER_TOKEN") == "stale"
+
+
+def test_alert_listener_propagates_body_exception_without_masking(monkeypatch) -> None:
+    """A failure in the REPL body (inside the `with`) must propagate unchanged,
+    not be swallowed and re-yielded as a "could not start" failure (which makes
+    @contextmanager raise "generator didn't stop after throw()")."""
+    os.environ.pop("OPENSRE_ALERT_LISTENER_TOKEN", None)
+    handle = MagicMock()
+    handle.bound_address = "127.0.0.1:8765"
+
+    def _fake_serve(**_kwargs: object) -> MagicMock:
+        return handle
+
+    monkeypatch.setattr("gateway.web_server.serve_webapp_in_thread", _fake_serve)
+    from core.domain.alerts import inbox as _alert_inbox
+
+    cfg = ReplConfig(alert_listener_enabled=True, alert_listener_token="tok")
+
+    class _BodyError(RuntimeError):
+        pass
+
+    with (
+        pytest.raises(_BodyError, match="boom"),
+        _alert_listener(cfg, Console(force_terminal=False)) as inbox,
+    ):
+        assert inbox is not None
+        raise _BodyError("boom")
+
+    # cleanup still ran: server stopped, inbox cleared, token restored
+    handle.stop.assert_called_once()
+    assert _alert_inbox.get_current_inbox() is None
+    assert os.environ.get("OPENSRE_ALERT_LISTENER_TOKEN") is None
+
+
+def test_alert_listener_degrades_to_none_when_startup_fails(monkeypatch) -> None:
+    """A startup failure yields None and does not crash the REPL, and restores
+    the token env var."""
+    os.environ.pop("OPENSRE_ALERT_LISTENER_TOKEN", None)
+
+    def _boom_serve(**_kwargs: object) -> MagicMock:
+        raise OSError("port in use")
+
+    monkeypatch.setattr("gateway.web_server.serve_webapp_in_thread", _boom_serve)
+    from core.domain.alerts import inbox as _alert_inbox
+
+    cfg = ReplConfig(alert_listener_enabled=True, alert_listener_token="tok")
+
+    with _alert_listener(cfg, Console(force_terminal=False)) as inbox:
+        assert inbox is None
+
+    assert _alert_inbox.get_current_inbox() is None
+    assert os.environ.get("OPENSRE_ALERT_LISTENER_TOKEN") is None

--- a/tests/interactive_shell/test_alert_listener.py
+++ b/tests/interactive_shell/test_alert_listener.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 from unittest.mock import MagicMock
 
-import pytest
 from rich.console import Console
 
 from config.repl_config import ReplConfig
@@ -77,14 +76,20 @@ def test_alert_listener_propagates_body_exception_without_masking(monkeypatch) -
     class _BodyError(RuntimeError):
         pass
 
-    with (
-        pytest.raises(_BodyError, match="boom"),
-        _alert_listener(cfg, Console(force_terminal=False)) as inbox,
-    ):
-        assert inbox is not None
-        raise _BodyError("boom")
+    # Explicit try/except (rather than pytest.raises) so the assertions after
+    # the block are unambiguously reachable to static analysis.
+    raised: _BodyError | None = None
+    try:
+        with _alert_listener(cfg, Console(force_terminal=False)) as inbox:
+            assert inbox is not None
+            raise _BodyError("boom")
+    except _BodyError as exc:
+        raised = exc
 
-    # cleanup still ran: server stopped, inbox cleared, token restored
+    # The body's own exception propagated unchanged (not masked by a
+    # RuntimeError from a second yield), and cleanup still ran.
+    assert raised is not None
+    assert str(raised) == "boom"
     handle.stop.assert_called_once()
     assert _alert_inbox.get_current_inbox() is None
     assert os.environ.get("OPENSRE_ALERT_LISTENER_TOKEN") is None


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

`_alert_listener` (`surfaces/interactive_shell/controller.py`) is a `@contextmanager` that wrapped its `yield inbox` **inside the same `try/except` that guards listener startup**:

```python
try:
    ...
    with _alert_listener_token(...):
        handle = serve_webapp_in_thread(...)
        try:
            yield inbox        # body runs here
        finally:
            handle.stop(); set_current_inbox(None)
except Exception as exc:       # <-- also catches exceptions from the body
    log.warning("Alert listener could not start: ...", exc)
    set_current_inbox(None)
    yield None                 # <-- second yield
```

When the REPL body inside `with _alert_listener(...)` raises, `@contextmanager` throws that exception back in at `yield inbox`. It then propagates to the outer `except`, which (a) logs a misleading *"Alert listener could not start"* even though it started fine, and (b) runs a **second `yield`**. A second yield after an exception makes contextlib raise `RuntimeError("generator didn't stop after throw()")` — so the REPL body's real error is masked and replaced with a confusing one.

Fix: restructure with `contextlib.ExitStack`. Acquire the inbox, token, and web server under the stack and catch only **startup** failures (which still degrade gracefully to `yield None`). Once startup succeeds, `yield` outside that `except` with the stack held open, so:
- a body exception propagates unchanged, and
- cleanup (stop server, clear inbox, restore token env) still runs via the stack.

The token env var must stay set across the yield because the webapp reads `OPENSRE_ALERT_LISTENER_TOKEN` per request (`gateway/webapp.py:97`), so the stack is what keeps it open for the serving lifetime.

### Demo/Screenshot for feature changes and bug fixes -

New regression tests in `tests/interactive_shell/test_alert_listener.py`:
- `test_alert_listener_propagates_body_exception_without_masking` — raising inside the `with` block propagates the original exception, and cleanup still runs (server stopped, inbox cleared, token restored).
- `test_alert_listener_degrades_to_none_when_startup_fails` — a `serve_webapp_in_thread` failure yields `None` without crashing.

Verified the first fails before this change and passes after:
```
# before the fix
FAILED ...test_alert_listener_propagates_body_exception_without_masking
# (the RuntimeError from the double-yield replaces the body's exception)

# after the fix
4 passed
```

Local CI: `make lint`, `make format-check`, `make typecheck` clean; `make test-cov` passes (10,662 passed; the one unrelated failure is an environment-dependent Copilot CLI adapter test that also fails on unmodified `main` because the `copilot` binary is installed on this machine).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The root cause is a `@contextmanager` control-flow error: the `yield` sat inside the `except` that was meant to catch only startup failures, so exceptions from the managed body were misrouted into the startup handler and triggered an illegal second yield.

The constraint that shapes the fix: the token env var has to remain set for the whole serving window (the webapp reads it per request), so I can't simply exit the token context after startup. I considered manually calling `__enter__`/`__exit__` on the token context manager to span the yield, but that is exactly the error-prone bookkeeping `ExitStack` exists to remove. `ExitStack` lets me register the token context and the server/inbox teardown during the guarded startup, catch only startup exceptions there, and then yield with the stack still open so the body runs with everything held and unwinds cleanly on exit (including on a body exception). Teardown is registered so the server is stopped before the inbox is cleared. The two tests pin both paths — the previously-broken body-exception path and the already-working startup-failure path — so the behavior can't regress in either direction.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions