### PR TITLE
fix(whatsapp): narrow broad except in classify to ValidationError

### DIFF
--- a/integrations/whatsapp/__init__.py
+++ b/integrations/whatsapp/__init__.py
@@ -28,6 +28,7 @@ def classify(
     except ValidationError:
         return None, None
     except Exception:
-        logger.debug("Unexpected error validating WhatsApp config", exc_info=True)
+        logger.exception("Unexpected error validating WhatsApp config")
         return None, None
+    
     return cfg, "whatsapp"

--- a/integrations/whatsapp/__init__.py
+++ b/integrations/whatsapp/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations.config_models import WhatsAppConfig
 
 logger = logging.getLogger(__name__)
@@ -23,6 +25,9 @@ def classify(
                 "default_to": credentials.get("default_to"),
             }
         )
+    except ValidationError:
+        return None, None
     except Exception:
+        logger.debug("Unexpected error validating WhatsApp config", exc_info=True)
         return None, None
     return cfg, "whatsapp"

--- a/integrations/whatsapp/__init__.py
+++ b/integrations/whatsapp/__init__.py
@@ -30,5 +30,4 @@ def classify(
     except Exception:
         logger.exception("Unexpected error validating WhatsApp config")
         return None, None
-    
     return cfg, "whatsapp"


### PR DESCRIPTION

Fixes #3505

The 'classify' function in 'integrations/whatsapp/__init__.py' used a bare 'except Exception: return None, None' around 'WhatsAppConfig.model_validate(...)', which silently swallowed both expected validation failures and any unexpected bugs (e.g. a TypeError from a bad credentials shape), making real errors invisible.

Split the exception handling into two cases:
- 'except ValidationError' (from pydantic) for expected validation failures - same behaviour as before, returns (None, None).
- 'except Exception' as a fallback for genuinely unexpected errors - now logged via `logger.debug(..., exc_info=True)` before returning (None, None), so unexpected bugs surface in logs instead of being silently hidden.

No change to the return tuple shape or validation rules - only the exception handling was narrowed/split.

Fixes #3505

(SM-01): Narrow classify() exception in WhatsApp integration

The 'classify' function in 'integrations/whatsapp/__init__.py' used a bare 'except Exception: return None, None' around 'WhatsAppConfig.model_validate(...)', which silently swallowed both expected validation failures and any unexpected bugs (e.g. a TypeError from a bad credentials shape), making real errors invisible.

Split the exception handling into two cases:
- 'except ValidationError' (from pydantic) for expected validation failures - same behavior as before, returns (None, None).
- 'except Exception' as a fallback for genuinely unexpected errors - now logged via `logger.debug(..., exc_info=True)` before returning (None, None), so unexpected bugs surface in logs instead of being silently hidden.

No change to the return tuple shape or validation rules - only the exception handling was narrowed/split.

### Demo/Screenshot for feature changes and bug fixes - 
- =================================== test session starts ===================================
platform linux -- Python 3.13.14, pytest-9.0.3, pluggy-1.6.0
rootdir: /workspaces/opensre
configfile: pytest.ini
plugins: cov-7.1.0, anyio-4.13.0
collected 12 items                                                                        

tests/integrations/test_whatsapp.py ............                                    [100%]

================================== slowest 20 durations ===================================
7.16s setup    tests/integrations/test_whatsapp.py::test_whatsapp_config_validates_required_fields

(19 durations < 0.005s hidden.  Use -vv to show these durations.)
=================================== 12 passed in 12.88s ===================================

- (.venv-devcontainer) vscode@codespaces-2a9d70:/workspaces/opensre$ make lint
.venv/bin/python -m ruff check config core gateway integrations platform surfaces tools tests/
All checks passed!

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
