### PR TITLE
fix(importlinter): register scheduler->telegram credentials layer edge

### DIFF
--- a/.importlinter.strict
+++ b/.importlinter.strict
@@ -33,6 +33,7 @@ ignore_imports =
     platform.analytics.cli -> integrations.github.identity
     platform.observability.errors.sentry -> integrations.llm_cli.errors
     platform.scheduler.credentials -> integrations.catalog
+    platform.scheduler.credentials -> integrations.telegram.credentials
     platform.scheduler.executor -> integrations.discord.delivery
     platform.scheduler.executor -> integrations.slack.delivery
     platform.scheduler.executor -> integrations.telegram.delivery


### PR DESCRIPTION
## Summary

`main`'s `quality` job is currently red on the **import-graph** step (the `OpenSRE package layers (transitive)` contract):

```
platform is not allowed to import integrations:
  platform.scheduler.credentials -> integrations.telegram.credentials
```

This edge was introduced by #3837 (`refactor(C-11): unify Telegram scheduler credential resolution`), which made `platform/scheduler/credentials.py` import `integrations.telegram.credentials` but did not register the new `platform -> integrations` edge in `.importlinter.strict`. That PR merged while its `quality` check was failing, so `main` has been failing this contract for every PR since.

This registers the edge in `ignore_imports` alongside its sibling scheduler debt entries (e.g. the already-present `platform.scheduler.credentials -> integrations.catalog`), matching how the other accepted `platform -> integrations` scheduler edges are tracked as T-4 debt.

Note: this is a debt registration, not an architectural fix — the proper long-term fix is to stop `platform/scheduler` reaching directly into `integrations/` (invert via a port), to be burned down with the other entries in that section.

## Test plan

- [x] `uv run python .github/ci/check_imports.py --strict` → all 3 import checks pass
- [x] `ruff check` → clean
- [x] `ruff format --check` → clean

Made with [Cursor](https://cursor.com)