### PR TITLE
(SM-02): Narrow classify() exception in Twilio integration

### DIFF
--- a/integrations/twilio/__init__.py
+++ b/integrations/twilio/__init__.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
+from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import TwilioIntegrationConfig
 
 logger = logging.getLogger(__name__)
@@ -22,6 +25,9 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except Exception:
+    except ValidationError:
+        return None, None
+    except Exception as exc:
+        report_classify_failure(exc, logger=logger, integration="twilio", record_id=record_id)
         return None, None
     return cfg, "twilio"


### PR DESCRIPTION
## Summary

Narrows the bare `except Exception` in the `twilio` `classify()`
function (or helper) so real validation failures (`pydantic.ValidationError`)
stay a clean "not configured" result, while any other unexpected
exception is now reported through the existing
`integrations._validation_helpers.report_classify_failure` helper
(same pattern already used by ~40 other integrations in this repo)
instead of being silently swallowed.

Closes #3506

## Type of change

- [x] CI classifier logic

## Safety checklist

- [x] No secrets or raw private logs added
- [x] No new network access without explicit opt-in
- [x] No write action without dry-run and human approval
- [x] No bounty claiming or mass-commenting behavior

## Tests

Commands run:

```
python -m ruff check integrations/twilio/__init__.py
python -m pytest tests/integrations/test_twilio.py -q
```

Return tuple/value shape is unchanged; only the except clause and
logging/reporting behavior changed.