### PR TITLE
(SM-18): Narrow classify() exception in SigNoz integration

### DIFF
--- a/integrations/signoz/__init__.py
+++ b/integrations/signoz/__init__.py
@@ -12,10 +12,10 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field
+from pydantic import Field, ValidationError
 
 from config.strict_config import StrictConfigModel
-from integrations._validation_helpers import report_validation_failure
+from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +148,10 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[SigNozConfig 
                 "integration_id": record_id,
             }
         )
-    except Exception:
+    except ValidationError:
+        return None, None
+    except Exception as exc:
+        report_classify_failure(exc, logger=logger, integration="signoz", record_id=record_id)
         return None, None
     if cfg.is_configured:
         return cfg, "signoz"


### PR DESCRIPTION
## Summary

Narrows the bare `except Exception` in the `signoz` `classify()`
function (or helper) so real validation failures (`pydantic.ValidationError`)
stay a clean "not configured" result, while any other unexpected
exception is now reported through the existing
`integrations._validation_helpers.report_classify_failure` helper
(same pattern already used by ~40 other integrations in this repo)
instead of being silently swallowed.

Closes #3522

## Type of change

- [x] CI classifier logic

## Safety checklist

- [x] No secrets or raw private logs added
- [x] No new network access without explicit opt-in
- [x] No write action without dry-run and human approval
- [x] No bounty claiming or mass-commenting behavior

## Tests

Commands run:

```
python -m ruff check integrations/signoz/__init__.py
python -m pytest tests/integrations/test_signoz.py tests/tools/test_signoz_tools.py -q
```

Return tuple/value shape is unchanged; only the except clause and
logging/reporting behavior changed.