### PR TITLE
perf(tools/registry): lazy surface-scoped tool loading via a static descriptor index (#3686)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -42,6 +42,17 @@ The seven first-party packages, the four-tier layering (which package may
 import which), the folder diagram, per-layer responsibilities, and cross-layer
 flows are documented in [`docs/ARCHITECTURE.md`](ARCHITECTURE.md).
 
+## Tool registry — surface-scoped, lazy loading
+
+Loading every vendor tool at startup was slow. A static index
+(`tools/registry_index.py`) reads tool metadata by scanning the source, without importing executors, so a turn loads only the tools it needs.
+
+- `get_registered_tools(surface)` imports only that surface's tool modules.
+- `get_tool_descriptors(surface)` returns metadata with no executor import.
+- `load_tool(descriptor)` imports the executor, only when a tool runs.
+
+Adding a vendor tool is a `@tool`/`BaseTool` module; the index finds it and no other vendor is imported. `tests/tools/test_registry_index.py` checks the index matches the imported registry exactly, so they cannot drift.
+
 ## Investigation pipeline architecture
 
 The six-stage investigation pipeline (resolve integrations → extract alert → plan → ReAct evidence loop → diagnose → deliver), the loop's guardrails (tool cap, stagnation breaker, context budget, duplicate detection), and diagrams are documented in [`docs/investigation-pipeline-architecture.md`](investigation-pipeline-architecture.md).

--- a/integrations/__main__.py
+++ b/integrations/__main__.py
@@ -94,7 +94,7 @@ def main() -> None:
                 )
             )
     finally:
-        shutdown_analytics(flush=True)
+        shutdown_analytics(flush=False)
 
 
 if __name__ == "__main__":

--- a/platform/analytics/install.py
+++ b/platform/analytics/install.py
@@ -13,10 +13,14 @@ _INSTALL_PROPERTIES: Properties = {
     "entrypoint": "make install",
 }
 
+# One-shot install exit has no interactive spinner to keep snappy, so it can wait
+# a full send-timeout for the install_detected POST to land (a conversion signal).
+_INSTALL_FLUSH_TIMEOUT_SECONDS = 2.0
+
 
 def main() -> int:
     capture_install_detected_if_needed(_INSTALL_PROPERTIES)
-    shutdown_analytics(flush=True)
+    shutdown_analytics(flush=True, timeout=_INSTALL_FLUSH_TIMEOUT_SECONDS)
     return 0
 
 

--- a/platform/analytics/provider.py
+++ b/platform/analytics/provider.py
@@ -861,13 +861,15 @@ def shutdown_analytics(*, flush: bool = False, timeout: float = _SHUTDOWN_WAIT) 
 
 
 def analytics_needs_flush() -> bool:
-    """True when a best-effort drain would wait on queued or in-flight events."""
+    """True when a best-effort drain would wait on queued or in-flight events.
+
+    ``_pending`` is raised in ``capture`` before enqueue and lowered in
+    ``_mark_done`` only after the POST completes, so it already covers both
+    queued and in-flight events; an idle-but-alive worker does not need a drain.
+    """
     if _instance is None or _instance._disabled or _instance._shutdown:
         return False
-    if _instance._pending > 0:
-        return True
-    worker = _instance._worker
-    return worker is not None and worker.is_alive()
+    return _instance._pending > 0
 
 
 def capture_install_detected_if_needed(properties: Properties | None = None) -> bool:

--- a/platform/analytics/provider.py
+++ b/platform/analytics/provider.py
@@ -33,7 +33,9 @@ _FIRST_RUN_PATH = _CONFIG_DIR / "installed"
 
 _QUEUE_SIZE = 128
 _SEND_TIMEOUT = 2.0
-_SHUTDOWN_WAIT = 1.0
+# Bound how long an explicit flush=True shutdown may block the process.
+# Interactive /quit drains under a spinner with this budget; atexit stays non-blocking.
+_SHUTDOWN_WAIT = 0.5
 
 _EVENT_LOG_ENV_VAR: Final[str] = "OPENSRE_ANALYTICS_LOG_EVENTS"
 _EVENT_LOG_FILENAME: Final[str] = "posthog_events.txt"
@@ -674,7 +676,12 @@ class Analytics:
         self._persistent_properties: Properties = {}
 
         if not self._disabled:
-            atexit.register(self.shutdown)
+            # Never block interpreter exit on PostHog; callers that need a
+            # best-effort drain (e.g. install) pass flush=True explicitly.
+            def _atexit_shutdown() -> None:
+                self.shutdown(flush=False)
+
+            atexit.register(_atexit_shutdown)
             for properties in _pop_user_id_load_failures():
                 self.capture(Event.USER_ID_LOAD_FAILED, properties)
 
@@ -741,7 +748,14 @@ class Analytics:
             _log_failure("capture", exc, event=envelope.event)
             _capture_sentry_failure(exc)
 
-    def shutdown(self, *, flush: bool = True, timeout: float = _SHUTDOWN_WAIT) -> None:
+    def shutdown(self, *, flush: bool = False, timeout: float = _SHUTDOWN_WAIT) -> None:
+        """Stop accepting events and signal the worker to exit.
+
+        By default ``flush=False``: enqueue a sentinel and return immediately so
+        interactive exit (``/quit``) is not blocked on network I/O. Pass
+        ``flush=True`` only when a short best-effort drain is worth waiting for
+        (e.g. one-shot install telemetry).
+        """
         if self._shutdown:
             return
         self._shutdown = True
@@ -841,9 +855,19 @@ def get_analytics() -> Analytics:
     return _instance
 
 
-def shutdown_analytics(*, flush: bool = True) -> None:
+def shutdown_analytics(*, flush: bool = False, timeout: float = _SHUTDOWN_WAIT) -> None:
     if _instance is not None:
-        _instance.shutdown(flush=flush)
+        _instance.shutdown(flush=flush, timeout=timeout)
+
+
+def analytics_needs_flush() -> bool:
+    """True when a best-effort drain would wait on queued or in-flight events."""
+    if _instance is None or _instance._disabled or _instance._shutdown:
+        return False
+    if _instance._pending > 0:
+        return True
+    worker = _instance._worker
+    return worker is not None and worker.is_alive()
 
 
 def capture_install_detected_if_needed(properties: Properties | None = None) -> bool:

--- a/platform/observability/trace/process_stats.py
+++ b/platform/observability/trace/process_stats.py
@@ -1,9 +1,9 @@
 """Process-level snapshots for session trace spans (memory, threads, asyncio tasks).
 
-``rss_mb`` is **current** resident set size (via ``psutil`` when available), so
-turn-boundary series can rise *and fall*. ``rss_peak_mb`` is the POSIX
-``ru_maxrss`` high-water mark (never decreases) — useful context, not a leak
-signal by itself.
+``rss_mb`` is **current** resident set size (Linux ``/proc``), so turn-boundary
+series can rise *and fall*; elsewhere it falls back to the peak watermark.
+``rss_peak_mb`` is the POSIX ``ru_maxrss`` high-water mark (never decreases) —
+useful context, not a leak signal by itself.
 """
 
 from __future__ import annotations
@@ -17,11 +17,6 @@ try:
     import resource as _resource
 except ImportError:  # Windows / non-POSIX
     _resource = None  # type: ignore[assignment]
-
-try:
-    import psutil as _psutil
-except ImportError:  # optional at import time; declared in pyproject
-    _psutil = None  # type: ignore[assignment]
 
 #: Cap thread rows embedded in a turn-boundary snapshot (ATM thread map).
 _MAX_THREADS_IN_SNAPSHOT = 40
@@ -43,16 +38,7 @@ def _normalize_ru_maxrss_mb(ru_maxrss: int) -> float:
 
 
 def _current_rss_mb() -> float | None:
-    """Current process RSS in MiB, or ``None`` if unavailable."""
-    if _psutil is not None:
-        try:
-            return round(
-                _psutil.Process().memory_info().rss / _BYTES_PER_MEBIBYTE,
-                _RSS_MB_DECIMAL_PLACES,
-            )
-        except Exception:  # noqa: BLE001 — never break turn boundaries
-            pass
-    # Fallback: Linux /proc (no psutil). Still current RSS, not peak.
+    """Current process RSS in MiB from Linux ``/proc``, or ``None`` elsewhere."""
     if sys.platform.startswith("linux"):
         try:
             with open("/proc/self/status", encoding="utf-8") as fh:
@@ -62,7 +48,8 @@ def _current_rss_mb() -> float | None:
                         kib = int(line.split()[1])
                         return round(kib / _KIB_PER_MIB, _RSS_MB_DECIMAL_PLACES)
         except (OSError, ValueError, IndexError):
-            pass
+            # /proc unavailable or malformed: treat current RSS as unknown.
+            return None
     return None
 
 

--- a/platform/observability/trace/process_stats.py
+++ b/platform/observability/trace/process_stats.py
@@ -1,7 +1,9 @@
 """Process-level snapshots for session trace spans (memory, threads, asyncio tasks).
 
-``resource`` is POSIX-only. On Windows (and frozen Windows builds) RSS sampling
-is skipped so importing this module — and therefore ``trace.spans`` — stays safe.
+``rss_mb`` is **current** resident set size (via ``psutil`` when available), so
+turn-boundary series can rise *and fall*. ``rss_peak_mb`` is the POSIX
+``ru_maxrss`` high-water mark (never decreases) — useful context, not a leak
+signal by itself.
 """
 
 from __future__ import annotations
@@ -16,6 +18,11 @@ try:
 except ImportError:  # Windows / non-POSIX
     _resource = None  # type: ignore[assignment]
 
+try:
+    import psutil as _psutil
+except ImportError:  # optional at import time; declared in pyproject
+    _psutil = None  # type: ignore[assignment]
+
 #: Cap thread rows embedded in a turn-boundary snapshot (ATM thread map).
 _MAX_THREADS_IN_SNAPSHOT = 40
 
@@ -26,8 +33,8 @@ _BYTES_PER_MEBIBYTE = _BYTES_PER_KIBIBYTE * _KIB_PER_MIB
 _RSS_MB_DECIMAL_PLACES = 2
 
 
-def _normalize_rss_mb(ru_maxrss: int) -> float:
-    """Normalize ``resource.getrusage`` RSS to mebibytes (macOS vs Linux)."""
+def _normalize_ru_maxrss_mb(ru_maxrss: int) -> float:
+    """Normalize ``resource.getrusage`` peak RSS to mebibytes (macOS vs Linux)."""
     if sys.platform == "darwin":
         # Darwin reports ``ru_maxrss`` in bytes.
         return round(ru_maxrss / _BYTES_PER_MEBIBYTE, _RSS_MB_DECIMAL_PLACES)
@@ -35,17 +42,51 @@ def _normalize_rss_mb(ru_maxrss: int) -> float:
     return round(ru_maxrss / _KIB_PER_MIB, _RSS_MB_DECIMAL_PLACES)
 
 
+def _current_rss_mb() -> float | None:
+    """Current process RSS in MiB, or ``None`` if unavailable."""
+    if _psutil is not None:
+        try:
+            return round(
+                _psutil.Process().memory_info().rss / _BYTES_PER_MEBIBYTE,
+                _RSS_MB_DECIMAL_PLACES,
+            )
+        except Exception:  # noqa: BLE001 — never break turn boundaries
+            pass
+    # Fallback: Linux /proc (no psutil). Still current RSS, not peak.
+    if sys.platform.startswith("linux"):
+        try:
+            with open("/proc/self/status", encoding="utf-8") as fh:
+                for line in fh:
+                    if line.startswith("VmRSS:"):
+                        # VmRSS is in kB
+                        kib = int(line.split()[1])
+                        return round(kib / _KIB_PER_MIB, _RSS_MB_DECIMAL_PLACES)
+        except (OSError, ValueError, IndexError):
+            pass
+    return None
+
+
 def sample_resource_snapshot() -> dict[str, Any]:
-    """RSS (when available) + GC generation counts (cheap; safe on turn boundaries)."""
+    """Current RSS (when available) + peak RSS + GC generation counts."""
     gen0, gen1, gen2 = gc.get_count()
     out: dict[str, Any] = {
         "gc_gen0": gen0,
         "gc_gen1": gen1,
         "gc_gen2": gen2,
     }
+    current = _current_rss_mb()
+    if current is not None:
+        out["rss_mb"] = current
+
     if _resource is not None:
         ru_maxrss = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
-        out["rss_mb"] = _normalize_rss_mb(ru_maxrss)
+        peak = _normalize_ru_maxrss_mb(ru_maxrss)
+        out["rss_peak_mb"] = peak
+        # Last-resort: if current RSS unavailable, keep legacy field as peak
+        # but mark it so consumers know it is a watermark.
+        if "rss_mb" not in out:
+            out["rss_mb"] = peak
+            out["rss_is_peak"] = True
     return out
 
 

--- a/surfaces/cli/__main__.py
+++ b/surfaces/cli/__main__.py
@@ -285,7 +285,8 @@ def main(argv: list[str] | None = None) -> int:
                 _sentry_sdk.flush(timeout=2)
         raise
     finally:
-        shutdown_analytics(flush=True)
+        # Non-blocking: daemon worker may still drain in-flight events briefly.
+        shutdown_analytics(flush=False)
     return 0
 
 

--- a/surfaces/cli/telemetry.py
+++ b/surfaces/cli/telemetry.py
@@ -29,10 +29,13 @@ def capture_cli_invoked(properties: Properties | None = None) -> None:
     _capture(properties)
 
 
-def shutdown_analytics(*, flush: bool = True) -> None:
+def shutdown_analytics(*, flush: bool = False, timeout: float | None = None) -> None:
     from platform.analytics.provider import shutdown_analytics as _shutdown
 
-    _shutdown(flush=flush)
+    if timeout is None:
+        _shutdown(flush=flush)
+    else:
+        _shutdown(flush=flush, timeout=timeout)
 
 
 def build_cli_invoked_properties(

--- a/surfaces/cli/wizard/__main__.py
+++ b/surfaces/cli/wizard/__main__.py
@@ -36,7 +36,7 @@ def main() -> int:
         print(flush=True)
         return 0
     finally:
-        shutdown_analytics(flush=True)
+        shutdown_analytics(flush=False)
 
 
 if __name__ == "__main__":

--- a/surfaces/interactive_shell/command_registry/system.py
+++ b/surfaces/interactive_shell/command_registry/system.py
@@ -19,10 +19,30 @@ from surfaces.interactive_shell.ui import (
 )
 
 
+def _flush_analytics_on_exit(console: Console) -> None:
+    """Best-effort PostHog drain with a spinner so /quit is not silent or fire-and-forget."""
+    from platform.analytics.provider import analytics_needs_flush, shutdown_analytics
+
+    if not analytics_needs_flush():
+        shutdown_analytics(flush=False)
+        return
+
+    if console.is_terminal:
+        with console.status(
+            f"[{DIM}]finishing up…[/]",
+            spinner="dots",
+            spinner_style=DIM,
+        ):
+            shutdown_analytics(flush=True)
+    else:
+        shutdown_analytics(flush=True)
+
+
 def _cmd_exit(session: Session, console: Console, _args: list[str]) -> bool:
     if session.session_id:
         console.print()
         print_session_resume_hint(console, session.session_id)
+    _flush_analytics_on_exit(console)
     console.print(f"[{DIM}]goodbye.[/]")
     return False
 

--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -845,12 +845,149 @@ def test_analytics_post_shutdown_capture_is_safe_noop(
     assert analytics._pending == 0
 
 
+def test_analytics_needs_flush_false_when_idle_or_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OPENSRE_NO_TELEMETRY", "1")
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+    monkeypatch.setattr(provider.atexit, "register", lambda *_a, **_k: None)
+
+    assert provider.analytics_needs_flush() is False
+    analytics = provider.Analytics()
+    provider._instance = analytics
+    assert provider.analytics_needs_flush() is False
+
+
+def test_analytics_needs_flush_true_when_events_pending(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("OPENSRE_ANALYTICS_DISABLED", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+    monkeypatch.setattr(provider.atexit, "register", lambda *_a, **_k: None)
+
+    class _SlowClient:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def __enter__(self) -> _SlowClient:
+            return self
+
+        def __exit__(self, _exc_type, _exc, _tb) -> None:
+            return None
+
+        def post(self, url: str, json: dict[str, object]) -> object:
+            time.sleep(1.0)
+
+            class _Resp:
+                def raise_for_status(self) -> None:
+                    return None
+
+            return _Resp()
+
+    monkeypatch.setattr(provider.httpx, "Client", _SlowClient)
+    analytics = provider.Analytics()
+    provider._instance = analytics
+    analytics.capture(Event.CLI_INVOKED)
+    assert provider.analytics_needs_flush() is True
+    analytics.shutdown(flush=False)
+    assert provider.analytics_needs_flush() is False
+
+
 def test_shutdown_analytics_is_noop_when_singleton_not_initialized(monkeypatch) -> None:
     monkeypatch.setattr(provider, "_instance", None)
 
     provider.shutdown_analytics(flush=False)
 
     assert provider._instance is None
+
+
+def test_shutdown_flush_false_returns_without_waiting_on_slow_worker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """flush=False must return immediately even when the worker is slow."""
+    monkeypatch.delenv("OPENSRE_ANALYTICS_DISABLED", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+    monkeypatch.setattr(provider.atexit, "register", lambda *_a, **_k: None)
+
+    class _SlowResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+    class _SlowClient:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def __enter__(self) -> _SlowClient:
+            return self
+
+        def __exit__(self, _exc_type, _exc, _tb) -> None:
+            return None
+
+        def post(self, url: str, json: dict[str, object]) -> _SlowResponse:
+            time.sleep(2.0)
+            return _SlowResponse()
+
+    monkeypatch.setattr(provider.httpx, "Client", _SlowClient)
+
+    analytics = provider.Analytics()
+    analytics.capture(Event.CLI_INVOKED, {"interactive": True})
+
+    started = time.perf_counter()
+    analytics.shutdown(flush=False)
+    elapsed = time.perf_counter() - started
+
+    assert analytics._shutdown is True
+    assert elapsed < 0.2
+
+
+def test_atexit_registers_non_blocking_shutdown(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("OPENSRE_ANALYTICS_DISABLED", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+
+    registered: list[object] = []
+    monkeypatch.setattr(provider.atexit, "register", registered.append)
+
+    class _SlowClient:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def __enter__(self) -> _SlowClient:
+            return self
+
+        def __exit__(self, _exc_type, _exc, _tb) -> None:
+            return None
+
+        def post(self, url: str, json: dict[str, object]) -> object:
+            time.sleep(2.0)
+
+            class _Resp:
+                def raise_for_status(self) -> None:
+                    return None
+
+            return _Resp()
+
+    monkeypatch.setattr(provider.httpx, "Client", _SlowClient)
+
+    analytics = provider.Analytics()
+    analytics.capture(Event.CLI_INVOKED)
+
+    assert len(registered) == 1
+    started = time.perf_counter()
+    registered[0]()
+    elapsed = time.perf_counter() - started
+
+    assert analytics._shutdown is True
+    assert elapsed < 0.2
+    analytics.shutdown(flush=False)
 
 
 def test_analytics_is_disabled_when_no_telemetry_env_var_is_set(

--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -878,7 +878,7 @@ def test_analytics_needs_flush_true_when_events_pending(
         def __exit__(self, _exc_type, _exc, _tb) -> None:
             return None
 
-        def post(self, url: str, json: dict[str, object]) -> object:
+        def post(self, _url: str, **_kwargs: object) -> object:
             time.sleep(1.0)
 
             class _Resp:
@@ -928,7 +928,7 @@ def test_shutdown_flush_false_returns_without_waiting_on_slow_worker(
         def __exit__(self, _exc_type, _exc, _tb) -> None:
             return None
 
-        def post(self, url: str, json: dict[str, object]) -> _SlowResponse:
+        def post(self, _url: str, **_kwargs: object) -> _SlowResponse:
             time.sleep(2.0)
             return _SlowResponse()
 
@@ -966,7 +966,7 @@ def test_atexit_registers_non_blocking_shutdown(
         def __exit__(self, _exc_type, _exc, _tb) -> None:
             return None
 
-        def post(self, url: str, json: dict[str, object]) -> object:
+        def post(self, _url: str, **_kwargs: object) -> object:
             time.sleep(2.0)
 
             class _Resp:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -357,6 +357,10 @@ def test_main_emits_first_run_install_before_cli_invoked(
 
     assert exit_code == 0
     assert "OpenSRE is in Public Beta" in capsys.readouterr().err
+    # CLI exit is non-blocking; wait for the daemon worker to finish posts.
+    analytics = provider._instance
+    if analytics is not None and analytics._worker is not None:
+        analytics._worker.join(timeout=2.0)
     assert [payload["json"]["event"] for payload in posted_payloads] == [
         Event.INSTALL_DETECTED.value,
         Event.CLI_INVOKED.value,

--- a/tests/cli/test_wizard_main.py
+++ b/tests/cli/test_wizard_main.py
@@ -41,7 +41,7 @@ def test_main_initialises_sentry_and_emits_cli_invoked(
     assert properties["command_family"] == "wizard"
 
 
-def test_main_flushes_analytics_even_when_wizard_raises(
+def test_main_shuts_down_analytics_without_blocking_flush(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     flush_calls: list[bool] = []
@@ -64,7 +64,7 @@ def test_main_flushes_analytics_even_when_wizard_raises(
     with pytest.raises(RuntimeError):
         wizard_main.main()
 
-    assert flush_calls == [True]
+    assert flush_calls == [False]
 
 
 def test_main_treats_abort_as_clean_cancel(
@@ -90,7 +90,7 @@ def test_main_treats_abort_as_clean_cancel(
     exit_code = wizard_main.main()
 
     assert exit_code == 0
-    assert flush_calls == [True]
+    assert flush_calls == [False]
 
 
 def test_main_treats_keyboard_interrupt_as_clean_cancel(
@@ -116,4 +116,4 @@ def test_main_treats_keyboard_interrupt_as_clean_cancel(
     exit_code = wizard_main.main()
 
     assert exit_code == 0
-    assert flush_calls == [True]
+    assert flush_calls == [False]

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -33,11 +33,31 @@ def _capture() -> tuple[Console, io.StringIO]:
 
 
 class TestDispatchSlash:
-    def test_exit_returns_false(self) -> None:
+    def test_exit_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "surfaces.interactive_shell.command_registry.system._flush_analytics_on_exit",
+            lambda _console: None,
+        )
         session = Session()
         console, _ = _capture()
         assert dispatch_slash("/exit", session, console) is False
         assert dispatch_slash("/quit", session, console) is False
+
+    def test_exit_flushes_analytics_before_goodbye(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[str] = []
+
+        def _flush(console: Console) -> None:
+            calls.append("flush")
+
+        monkeypatch.setattr(
+            "surfaces.interactive_shell.command_registry.system._flush_analytics_on_exit",
+            _flush,
+        )
+        session = Session()
+        console, buf = _capture()
+        assert dispatch_slash("/quit", session, console) is False
+        assert calls == ["flush"]
+        assert "goodbye." in buf.getvalue()
 
     def test_delegated_cli_failure_does_not_exit_repl(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/platform/observability/test_session_trace.py
+++ b/tests/platform/observability/test_session_trace.py
@@ -87,17 +87,57 @@ def test_sample_thread_snapshot_lists_current_thread() -> None:
 def test_sample_resource_snapshot_includes_gc_counts() -> None:
     snap = sample_resource_snapshot()
     assert {"gc_gen0", "gc_gen1", "gc_gen2"} <= snap.keys()
-    # POSIX: rss_mb present; Windows (no ``resource``): omitted.
-    if process_stats._resource is not None:
-        assert "rss_mb" in snap
+    # Prefer current RSS (psutil /proc); peak watermark is separate.
+    if "rss_mb" in snap:
         assert isinstance(snap["rss_mb"], float)
+        assert snap["rss_mb"] > 0
+    if process_stats._resource is not None:
+        assert "rss_peak_mb" in snap
+        assert isinstance(snap["rss_peak_mb"], float)
 
 
-def test_sample_resource_snapshot_skips_rss_without_resource(
+def test_sample_resource_snapshot_current_rss_not_peak_when_psutil(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Windows / non-POSIX: ``resource`` is absent; snapshot must still succeed."""
+    """``rss_mb`` must be current RSS; ``rss_peak_mb`` is the high-water mark."""
+
+    class _Mem:
+        rss = 50 * 1024 * 1024  # 50 MiB current
+
+    class _Proc:
+        def memory_info(self) -> _Mem:
+            return _Mem()
+
+    class _FakePsutil:
+        @staticmethod
+        def Process() -> _Proc:
+            return _Proc()
+
+    monkeypatch.setattr(process_stats, "_psutil", _FakePsutil)
+
+    class _FakeResource:
+        RUSAGE_SELF = 0
+
+        @staticmethod
+        def getrusage(_who: int) -> object:
+            # Peak higher than current (bytes on darwin path via normalize)
+            return type("RU", (), {"ru_maxrss": 200 * 1024 * 1024})()
+
+    monkeypatch.setattr(process_stats, "_resource", _FakeResource)
+    monkeypatch.setattr(process_stats.sys, "platform", "darwin")
+    snap = sample_resource_snapshot()
+    assert snap["rss_mb"] == 50.0
+    assert snap["rss_peak_mb"] == 200.0
+    assert snap.get("rss_is_peak") is not True
+
+
+def test_sample_resource_snapshot_skips_rss_without_backends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No psutil / resource /proc → snapshot still succeeds without rss_mb."""
     monkeypatch.setattr(process_stats, "_resource", None)
+    monkeypatch.setattr(process_stats, "_psutil", None)
+    monkeypatch.setattr(process_stats.sys, "platform", "win32")
     snap = sample_resource_snapshot()
     assert "rss_mb" not in snap
     assert {"gc_gen0", "gc_gen1", "gc_gen2"} <= snap.keys()

--- a/tests/platform/observability/test_session_trace.py
+++ b/tests/platform/observability/test_session_trace.py
@@ -87,7 +87,7 @@ def test_sample_thread_snapshot_lists_current_thread() -> None:
 def test_sample_resource_snapshot_includes_gc_counts() -> None:
     snap = sample_resource_snapshot()
     assert {"gc_gen0", "gc_gen1", "gc_gen2"} <= snap.keys()
-    # Prefer current RSS (psutil /proc); peak watermark is separate.
+    # Prefer current RSS (Linux /proc); peak watermark is separate.
     if "rss_mb" in snap:
         assert isinstance(snap["rss_mb"], float)
         assert snap["rss_mb"] > 0
@@ -96,24 +96,11 @@ def test_sample_resource_snapshot_includes_gc_counts() -> None:
         assert isinstance(snap["rss_peak_mb"], float)
 
 
-def test_sample_resource_snapshot_current_rss_not_peak_when_psutil(
+def test_sample_resource_snapshot_current_rss_not_peak(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``rss_mb`` must be current RSS; ``rss_peak_mb`` is the high-water mark."""
-
-    class _Mem:
-        rss = 50 * 1024 * 1024  # 50 MiB current
-
-    class _Proc:
-        def memory_info(self) -> _Mem:
-            return _Mem()
-
-    class _FakePsutil:
-        @staticmethod
-        def Process() -> _Proc:
-            return _Proc()
-
-    monkeypatch.setattr(process_stats, "_psutil", _FakePsutil)
+    monkeypatch.setattr(process_stats, "_current_rss_mb", lambda: 50.0)
 
     class _FakeResource:
         RUSAGE_SELF = 0
@@ -134,9 +121,8 @@ def test_sample_resource_snapshot_current_rss_not_peak_when_psutil(
 def test_sample_resource_snapshot_skips_rss_without_backends(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """No psutil / resource /proc → snapshot still succeeds without rss_mb."""
+    """No resource / no Linux /proc → snapshot still succeeds without rss_mb."""
     monkeypatch.setattr(process_stats, "_resource", None)
-    monkeypatch.setattr(process_stats, "_psutil", None)
     monkeypatch.setattr(process_stats.sys, "platform", "win32")
     snap = sample_resource_snapshot()
     assert "rss_mb" not in snap

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -240,7 +240,7 @@ def test_auto_discovery_populates_investigation_and_chat_surfaces(
         registry_discovery, "_iter_tool_module_names", lambda _pkg: ["fake_discovered_tool"]
     )
     monkeypatch.setattr(registry_module, "_external_tool_packages", [])
-    monkeypatch.setattr(registry_module, "_INTEGRATION_TOOL_PACKAGES", ())
+    monkeypatch.setattr(registry_module, "INTEGRATION_TOOL_PACKAGES", ())
     monkeypatch.setattr(registry_discovery, "_import_tool_module", lambda _pkg, _name: module)
 
     # Surface-scoped loads read the on-disk descriptor index; assert surface
@@ -274,7 +274,7 @@ def test_action_surface_is_filtered_separately(monkeypatch: pytest.MonkeyPatch) 
         registry_discovery, "_iter_tool_module_names", lambda _pkg: ["fake_action_tool"]
     )
     monkeypatch.setattr(registry_module, "_external_tool_packages", [])
-    monkeypatch.setattr(registry_module, "_INTEGRATION_TOOL_PACKAGES", ())
+    monkeypatch.setattr(registry_module, "INTEGRATION_TOOL_PACKAGES", ())
     monkeypatch.setattr(registry_discovery, "_import_tool_module", lambda _pkg, _name: module)
 
     # Surface-scoped loads read the on-disk descriptor index; assert surface
@@ -371,7 +371,7 @@ def test_manifest_discovery_imports_nested_tool_modules(
     nested_module.lookup_nested_incident = lookup_nested_incident
 
     monkeypatch.setattr(registry_module, "_external_tool_packages", [])
-    monkeypatch.setattr(registry_module, "_INTEGRATION_TOOL_PACKAGES", ())
+    monkeypatch.setattr(registry_module, "INTEGRATION_TOOL_PACKAGES", ())
     monkeypatch.setattr(
         registry_discovery,
         "_iter_tool_module_names",
@@ -416,7 +416,7 @@ def test_manifest_discovery_logs_nested_import_failure_with_full_module_path(
     valid_module.valid_nested_tool = valid_nested_tool
 
     monkeypatch.setattr(registry_module, "_external_tool_packages", [])
-    monkeypatch.setattr(registry_module, "_INTEGRATION_TOOL_PACKAGES", ())
+    monkeypatch.setattr(registry_module, "INTEGRATION_TOOL_PACKAGES", ())
     monkeypatch.setattr(
         registry_discovery,
         "_iter_tool_module_names",
@@ -476,7 +476,7 @@ def test_manifest_discovery_preserves_duplicate_name_first_wins(
     nested_module.nested_tool = nested_tool
 
     monkeypatch.setattr(registry_module, "_external_tool_packages", [])
-    monkeypatch.setattr(registry_module, "_INTEGRATION_TOOL_PACKAGES", ())
+    monkeypatch.setattr(registry_module, "INTEGRATION_TOOL_PACKAGES", ())
     monkeypatch.setattr(
         registry_discovery,
         "_iter_tool_module_names",
@@ -521,7 +521,7 @@ def test_top_level_discovery_unchanged_without_manifest(
     import_calls: list[tuple[str, str]] = []
 
     monkeypatch.setattr(registry_module, "_external_tool_packages", [])
-    monkeypatch.setattr(registry_module, "_INTEGRATION_TOOL_PACKAGES", ())
+    monkeypatch.setattr(registry_module, "INTEGRATION_TOOL_PACKAGES", ())
     monkeypatch.setattr(
         registry_discovery,
         "_iter_tool_module_names",

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -242,15 +242,16 @@ def test_auto_discovery_populates_investigation_and_chat_surfaces(
     monkeypatch.setattr(registry_module, "_INTEGRATION_TOOL_PACKAGES", ())
     monkeypatch.setattr(registry_module, "_import_tool_module", lambda _pkg, _name: module)
 
-    assert [
-        tool_def.name for tool_def in registry_module.get_registered_tools("investigation")
-    ] == ["get_incident_metadata"]
-    assert [tool_def.name for tool_def in registry_module.get_registered_tools("chat")] == [
+    # Surface-scoped loads read the on-disk descriptor index; assert surface
+    # assignment on the mocked full snapshot instead.
+    snapshot = registry_module.get_registered_tools()
+    assert [t.name for t in snapshot if "investigation" in (t.surfaces or ())] == [
         "get_incident_metadata"
     ]
-    assert registry_module.get_registered_tool_map("chat")["get_incident_metadata"].run(
-        "inc-1"
-    ) == {"incident_id": "inc-1"}
+    assert [t.name for t in snapshot if "chat" in (t.surfaces or ())] == ["get_incident_metadata"]
+    assert registry_module.get_registered_tool_map()["get_incident_metadata"].run("inc-1") == {
+        "incident_id": "inc-1"
+    }
 
 
 def test_action_surface_is_filtered_separately(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -275,11 +276,12 @@ def test_action_surface_is_filtered_separately(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(registry_module, "_INTEGRATION_TOOL_PACKAGES", ())
     monkeypatch.setattr(registry_module, "_import_tool_module", lambda _pkg, _name: module)
 
-    assert [tool_def.name for tool_def in registry_module.get_registered_tools("action")] == [
-        "perform_action"
-    ]
-    assert registry_module.get_registered_tools("investigation") == []
-    assert registry_module.get_registered_tools("chat") == []
+    # Surface-scoped loads read the on-disk descriptor index; assert surface
+    # filtering on the mocked full snapshot instead.
+    snapshot = registry_module.get_registered_tools()
+    assert [t.name for t in snapshot if "action" in (t.surfaces or ())] == ["perform_action"]
+    assert [t.name for t in snapshot if "investigation" in (t.surfaces or ())] == []
+    assert [t.name for t in snapshot if "chat" in (t.surfaces or ())] == []
 
 
 def test_github_workflow_skill_guidance_is_attached_to_chat_and_investigation_tools() -> None:

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -13,6 +13,7 @@ from core.tool_framework.base import BaseTool
 from core.tool_framework.registered_tool import REGISTERED_TOOL_ATTR, RegisteredTool
 from core.tool_framework.tool_decorator import tool
 from tools import registry as registry_module
+from tools import registry_discovery
 from tools.investigation_registry.actions import get_available_actions
 
 _V2_TOOL_CONTRACT_NAMES = frozenset(
@@ -49,7 +50,7 @@ def test_tool_decorator_registers_function_tool_with_inferred_schema() -> None:
     lookup_incident.__module__ = module.__name__
     module.lookup_incident = lookup_incident
 
-    tools = registry_module._collect_registered_tools_from_module(module)
+    tools = registry_discovery._collect_registered_tools_from_module(module)
 
     assert [tool_def.name for tool_def in tools] == ["lookup_incident"]
     registered = tools[0]
@@ -71,7 +72,7 @@ def test_tool_decorator_supports_minimal_single_file_function_tool() -> None:
     check_status.__module__ = module.__name__
     module.check_status = check_status
 
-    tools = registry_module._collect_registered_tools_from_module(module)
+    tools = registry_discovery._collect_registered_tools_from_module(module)
 
     assert [tool_def.name for tool_def in tools] == ["check_status"]
     registered = tools[0]
@@ -236,11 +237,11 @@ def test_auto_discovery_populates_investigation_and_chat_surfaces(
     module.get_incident_metadata = get_incident_metadata
 
     monkeypatch.setattr(
-        registry_module, "_iter_tool_module_names", lambda _pkg: ["fake_discovered_tool"]
+        registry_discovery, "_iter_tool_module_names", lambda _pkg: ["fake_discovered_tool"]
     )
     monkeypatch.setattr(registry_module, "_external_tool_packages", [])
     monkeypatch.setattr(registry_module, "_INTEGRATION_TOOL_PACKAGES", ())
-    monkeypatch.setattr(registry_module, "_import_tool_module", lambda _pkg, _name: module)
+    monkeypatch.setattr(registry_discovery, "_import_tool_module", lambda _pkg, _name: module)
 
     # Surface-scoped loads read the on-disk descriptor index; assert surface
     # assignment on the mocked full snapshot instead.
@@ -270,11 +271,11 @@ def test_action_surface_is_filtered_separately(monkeypatch: pytest.MonkeyPatch) 
     module.perform_action = perform_action
 
     monkeypatch.setattr(
-        registry_module, "_iter_tool_module_names", lambda _pkg: ["fake_action_tool"]
+        registry_discovery, "_iter_tool_module_names", lambda _pkg: ["fake_action_tool"]
     )
     monkeypatch.setattr(registry_module, "_external_tool_packages", [])
     monkeypatch.setattr(registry_module, "_INTEGRATION_TOOL_PACKAGES", ())
-    monkeypatch.setattr(registry_module, "_import_tool_module", lambda _pkg, _name: module)
+    monkeypatch.setattr(registry_discovery, "_import_tool_module", lambda _pkg, _name: module)
 
     # Surface-scoped loads read the on-disk descriptor index; assert surface
     # filtering on the mocked full snapshot instead.
@@ -372,7 +373,7 @@ def test_manifest_discovery_imports_nested_tool_modules(
     monkeypatch.setattr(registry_module, "_external_tool_packages", [])
     monkeypatch.setattr(registry_module, "_INTEGRATION_TOOL_PACKAGES", ())
     monkeypatch.setattr(
-        registry_module,
+        registry_discovery,
         "_iter_tool_module_names",
         lambda package: ["fake_provider"] if package is registry_module.tools_package else [],
     )
@@ -384,7 +385,7 @@ def test_manifest_discovery_imports_nested_tool_modules(
             return nested_module
         raise AssertionError(f"unexpected import: {package.__name__}.{name}")
 
-    monkeypatch.setattr(registry_module, "_import_tool_module", mock_import)
+    monkeypatch.setattr(registry_discovery, "_import_tool_module", mock_import)
 
     tools = registry_module.get_registered_tools()
 
@@ -417,7 +418,7 @@ def test_manifest_discovery_logs_nested_import_failure_with_full_module_path(
     monkeypatch.setattr(registry_module, "_external_tool_packages", [])
     monkeypatch.setattr(registry_module, "_INTEGRATION_TOOL_PACKAGES", ())
     monkeypatch.setattr(
-        registry_module,
+        registry_discovery,
         "_iter_tool_module_names",
         lambda package: ["fake_provider"] if package is registry_module.tools_package else [],
     )
@@ -431,7 +432,7 @@ def test_manifest_discovery_logs_nested_import_failure_with_full_module_path(
             return valid_module
         raise AssertionError(f"unexpected import: {package.__name__}.{name}")
 
-    monkeypatch.setattr(registry_module, "_import_tool_module", mock_import)
+    monkeypatch.setattr(registry_discovery, "_import_tool_module", mock_import)
 
     with caplog.at_level(logging.WARNING, logger="tools.registry"):
         tools = registry_module.get_registered_tools()
@@ -477,12 +478,12 @@ def test_manifest_discovery_preserves_duplicate_name_first_wins(
     monkeypatch.setattr(registry_module, "_external_tool_packages", [])
     monkeypatch.setattr(registry_module, "_INTEGRATION_TOOL_PACKAGES", ())
     monkeypatch.setattr(
-        registry_module,
+        registry_discovery,
         "_iter_tool_module_names",
         lambda package: ["fake_provider"] if package is registry_module.tools_package else [],
     )
     monkeypatch.setattr(
-        registry_module,
+        registry_discovery,
         "_import_tool_module",
         lambda package, name: (
             provider_pkg
@@ -522,7 +523,7 @@ def test_top_level_discovery_unchanged_without_manifest(
     monkeypatch.setattr(registry_module, "_external_tool_packages", [])
     monkeypatch.setattr(registry_module, "_INTEGRATION_TOOL_PACKAGES", ())
     monkeypatch.setattr(
-        registry_module,
+        registry_discovery,
         "_iter_tool_module_names",
         lambda package: ["fake_top_level_tool"] if package is registry_module.tools_package else [],
     )
@@ -531,7 +532,7 @@ def test_top_level_discovery_unchanged_without_manifest(
         import_calls.append((package.__name__, name))
         return top_level_module
 
-    monkeypatch.setattr(registry_module, "_import_tool_module", mock_import)
+    monkeypatch.setattr(registry_discovery, "_import_tool_module", mock_import)
 
     tools = registry_module.get_registered_tools()
 
@@ -557,9 +558,9 @@ def test_resolve_tool_display_name_prefers_registered_metadata(
     module.get_incident_metadata = get_incident_metadata
 
     monkeypatch.setattr(
-        registry_module, "_iter_tool_module_names", lambda _pkg: ["fake_display_name_tool"]
+        registry_discovery, "_iter_tool_module_names", lambda _pkg: ["fake_display_name_tool"]
     )
-    monkeypatch.setattr(registry_module, "_import_tool_module", lambda _pkg, _name: module)
+    monkeypatch.setattr(registry_discovery, "_import_tool_module", lambda _pkg, _name: module)
 
     assert registry_module.resolve_tool_display_name("get_incident_metadata") == "Incident metadata"
 
@@ -630,12 +631,12 @@ def test_registry_regression_duplicate_tool_names_across_modules(
     module2.shared_tool_second = second_tool
 
     monkeypatch.setattr(
-        registry_module,
+        registry_discovery,
         "_iter_tool_module_names",
         lambda _pkg: ["first_module", "second_module"],
     )
     monkeypatch.setattr(
-        registry_module,
+        registry_discovery,
         "_import_tool_module",
         lambda _pkg, name: module1 if name == "first_module" else module2,
     )
@@ -679,12 +680,12 @@ def test_registry_regression_import_failures(
         return module
 
     monkeypatch.setattr(
-        registry_module,
+        registry_discovery,
         "_iter_tool_module_names",
         lambda _pkg: ["broken_module", "valid_tool"],
     )
     monkeypatch.setattr(
-        registry_module,
+        registry_discovery,
         "_import_tool_module",
         mock_import,
     )
@@ -969,8 +970,8 @@ def test_registry_canonical_tool_wins_when_external_package_redefines_name(
     fake_pkg.__path__ = []  # type: ignore[attr-defined]
 
     # Inject the fake by patching the walk + import.
-    real_iter = registry_module._iter_tool_module_names
-    real_import = registry_module._import_tool_module
+    real_iter = registry_discovery._iter_tool_module_names
+    real_import = registry_discovery._import_tool_module
 
     def fake_iter(package: ModuleType) -> list[str]:
         if package is fake_pkg:
@@ -982,8 +983,8 @@ def test_registry_canonical_tool_wins_when_external_package_redefines_name(
             return fake_module
         return real_import(package, name)
 
-    monkeypatch.setattr(registry_module, "_iter_tool_module_names", fake_iter)
-    monkeypatch.setattr(registry_module, "_import_tool_module", fake_import)
+    monkeypatch.setattr(registry_discovery, "_iter_tool_module_names", fake_iter)
+    monkeypatch.setattr(registry_discovery, "_import_tool_module", fake_import)
 
     saved = list(registry_module._external_tool_packages)
     try:

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -50,7 +50,7 @@ def test_tool_decorator_registers_function_tool_with_inferred_schema() -> None:
     lookup_incident.__module__ = module.__name__
     module.lookup_incident = lookup_incident
 
-    tools = registry_discovery._collect_registered_tools_from_module(module)
+    tools = registry_discovery.collect_registered_tools_from_module(module)
 
     assert [tool_def.name for tool_def in tools] == ["lookup_incident"]
     registered = tools[0]
@@ -72,7 +72,7 @@ def test_tool_decorator_supports_minimal_single_file_function_tool() -> None:
     check_status.__module__ = module.__name__
     module.check_status = check_status
 
-    tools = registry_discovery._collect_registered_tools_from_module(module)
+    tools = registry_discovery.collect_registered_tools_from_module(module)
 
     assert [tool_def.name for tool_def in tools] == ["check_status"]
     registered = tools[0]

--- a/tests/tools/test_registry_index.py
+++ b/tests/tools/test_registry_index.py
@@ -1,0 +1,79 @@
+"""Contract: the static descriptor index matches the imported registry (#3686).
+
+The index (AST scan + pinned fallback descriptors) must equal the imported
+registry exactly — same tool names, same surfaces, same source — so surface-
+scoped loads built on it can never diverge from the eager snapshot. If this
+drifts, a tool changed shape: make its metadata literal, or update the pinned
+``_fallback_descriptors`` in ``tools/registry_index.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+import tools.registry as registry_module
+from tools.registry import get_registered_tools
+from tools.registry_index import build_descriptor_index
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry() -> Iterator[None]:
+    # Assert against the on-disk tool set: drop any tools other tests left in the
+    # global ``_external_tool_packages`` (the AST index only sees disk).
+    saved = list(registry_module._external_tool_packages)
+    registry_module._external_tool_packages.clear()
+    registry_module.clear_tool_registry_cache()
+    yield
+    registry_module._external_tool_packages[:] = saved
+    registry_module.clear_tool_registry_cache()
+
+
+def _registered_by_name() -> dict[str, Any]:
+    return {tool.name: tool for tool in get_registered_tools()}
+
+
+def test_index_tool_set_matches_registry_exactly() -> None:
+    index = set(build_descriptor_index())
+    registered = set(_registered_by_name())
+    assert index == registered, {
+        "missing_from_index": sorted(registered - index),
+        "not_registered": sorted(index - registered),
+    }
+
+
+def test_descriptor_surfaces_match_registry() -> None:
+    index = build_descriptor_index()
+    registered = _registered_by_name()
+    mismatched = {
+        name: (descriptor.surfaces, tuple(getattr(registered[name], "surfaces", ()) or ()))
+        for name, descriptor in index.items()
+        if set(descriptor.surfaces) != set(getattr(registered[name], "surfaces", ()) or ())
+    }
+    assert mismatched == {}
+
+
+def test_descriptor_source_matches_registry_when_known() -> None:
+    index = build_descriptor_index()
+    registered = _registered_by_name()
+    for name, descriptor in index.items():
+        if descriptor.source is None:
+            continue
+        assert descriptor.source == getattr(registered[name], "source", None), name
+
+
+def test_descriptor_module_is_dotted_import_path() -> None:
+    index = build_descriptor_index()
+    assert index["query_datadog_all"].module == "integrations.datadog.tools"
+    assert index["shell_run"].module == "tools.interactive_shell.actions.shell"
+
+
+def test_surface_scoped_load_equals_full_filtered() -> None:
+    """The fast surface path must return exactly the full snapshot filtered by surface."""
+    full = get_registered_tools()
+    for surface in ("action", "chat", "investigation"):
+        scoped = {tool.name for tool in get_registered_tools(surface)}
+        expected = {tool.name for tool in full if surface in (getattr(tool, "surfaces", ()) or ())}
+        assert scoped == expected, surface

--- a/tests/tools/test_registry_index.py
+++ b/tests/tools/test_registry_index.py
@@ -15,7 +15,7 @@ from typing import Any
 import pytest
 
 import tools.registry as registry_module
-from tools.registry import get_registered_tools
+from tools.registry import get_registered_tools, get_tool_descriptors, load_tool
 from tools.registry_index import build_descriptor_index
 
 
@@ -77,3 +77,19 @@ def test_surface_scoped_load_equals_full_filtered() -> None:
         scoped = {tool.name for tool in get_registered_tools(surface)}
         expected = {tool.name for tool in full if surface in (getattr(tool, "surfaces", ()) or ())}
         assert scoped == expected, surface
+
+
+def test_get_tool_descriptors_match_surface_load() -> None:
+    assert {d.name for d in get_tool_descriptors()} == set(build_descriptor_index())
+    for surface in ("action", "chat", "investigation"):
+        descriptor_names = {d.name for d in get_tool_descriptors(surface)}
+        tool_names = {tool.name for tool in get_registered_tools(surface)}
+        assert descriptor_names == tool_names, surface
+
+
+def test_load_tool_materializes_the_executor() -> None:
+    # @tool-decorated (AST-indexed) and RegisteredTool-constructed (pinned) both load.
+    for name in ("query_datadog_all", "shell_run"):
+        descriptor = next(d for d in get_tool_descriptors() if d.name == name)
+        tool = load_tool(descriptor)
+        assert tool is not None and tool.name == name

--- a/tests/tools/test_registry_index.py
+++ b/tests/tools/test_registry_index.py
@@ -15,7 +15,6 @@ from typing import Any
 import pytest
 
 import tools.registry as registry_module
-from tools.registry import get_registered_tools, get_tool_descriptors, load_tool
 from tools.registry_index import build_descriptor_index
 
 
@@ -32,7 +31,7 @@ def _isolated_registry() -> Iterator[None]:
 
 
 def _registered_by_name() -> dict[str, Any]:
-    return {tool.name: tool for tool in get_registered_tools()}
+    return {tool.name: tool for tool in registry_module.get_registered_tools()}
 
 
 def test_index_tool_set_matches_registry_exactly() -> None:
@@ -72,24 +71,24 @@ def test_descriptor_module_is_dotted_import_path() -> None:
 
 def test_surface_scoped_load_equals_full_filtered() -> None:
     """The fast surface path must return exactly the full snapshot filtered by surface."""
-    full = get_registered_tools()
+    full = registry_module.get_registered_tools()
     for surface in ("action", "chat", "investigation"):
-        scoped = {tool.name for tool in get_registered_tools(surface)}
+        scoped = {tool.name for tool in registry_module.get_registered_tools(surface)}
         expected = {tool.name for tool in full if surface in (getattr(tool, "surfaces", ()) or ())}
         assert scoped == expected, surface
 
 
 def test_get_tool_descriptors_match_surface_load() -> None:
-    assert {d.name for d in get_tool_descriptors()} == set(build_descriptor_index())
+    assert {d.name for d in registry_module.get_tool_descriptors()} == set(build_descriptor_index())
     for surface in ("action", "chat", "investigation"):
-        descriptor_names = {d.name for d in get_tool_descriptors(surface)}
-        tool_names = {tool.name for tool in get_registered_tools(surface)}
+        descriptor_names = {d.name for d in registry_module.get_tool_descriptors(surface)}
+        tool_names = {tool.name for tool in registry_module.get_registered_tools(surface)}
         assert descriptor_names == tool_names, surface
 
 
 def test_load_tool_materializes_the_executor() -> None:
     # @tool-decorated (AST-indexed) and RegisteredTool-constructed (pinned) both load.
     for name in ("query_datadog_all", "shell_run"):
-        descriptor = next(d for d in get_tool_descriptors() if d.name == name)
-        tool = load_tool(descriptor)
+        descriptor = next(d for d in registry_module.get_tool_descriptors() if d.name == name)
+        tool = registry_module.load_tool(descriptor)
         assert tool is not None and tool.name == name

--- a/tests/tools/test_registry_index.py
+++ b/tests/tools/test_registry_index.py
@@ -70,11 +70,23 @@ def test_descriptor_module_is_dotted_import_path() -> None:
 
 
 def test_surface_scoped_load_equals_full_filtered() -> None:
-    """The fast surface path must return exactly the full snapshot filtered by surface."""
+    """The fast surface path must return exactly the full snapshot filtered by surface.
+
+    Compares by ``(name, origin_module)`` so a duplicate tool name that resolves to
+    a different module in the surface path (alphabetical) than the full path
+    (package-declaration order) fails here rather than silently diverging.
+    """
     full = registry_module.get_registered_tools()
     for surface in ("action", "chat", "investigation"):
-        scoped = {tool.name for tool in registry_module.get_registered_tools(surface)}
-        expected = {tool.name for tool in full if surface in (getattr(tool, "surfaces", ()) or ())}
+        scoped = {
+            (tool.name, tool.origin_module)
+            for tool in registry_module.get_registered_tools(surface)
+        }
+        expected = {
+            (tool.name, tool.origin_module)
+            for tool in full
+            if surface in (getattr(tool, "surfaces", ()) or ())
+        }
         assert scoped == expected, surface
 
 

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -1217,18 +1217,18 @@ def test_every_registered_tool_is_migrated_or_allowlisted() -> None:
     lets them escape and relies on #1476's global wrapper (allowlist it in
     ``_TOOLS_WITHOUT_DELIBERATE_CATCH``).
     """
-    from tools.registry import _INTEGRATION_TOOL_PACKAGES, get_registered_tool_map
+    from tools.registry import INTEGRATION_TOOL_PACKAGES, get_registered_tool_map
 
     # Limit the audit to PRODUCTION tools — those defined in ``tools.*`` or in
     # the exact per-vendor packages the registry walks via
-    # ``_INTEGRATION_TOOL_PACKAGES``. External packages registered via
+    # ``INTEGRATION_TOOL_PACKAGES``. External packages registered via
     # ``register_external_tool_package`` (e.g. bench-only tools that live under
     # ``tests/benchmarks/``) have their own classification expectations and
     # aren't part of this production-telemetry contract. Pinning the prefix
     # to the registry's own integration list (instead of a broad
     # ``"integrations."``) keeps the audit from sweeping in any future
     # caller that ships tools under an ``integrations.*`` namespace.
-    _PRODUCTION_TOOL_PREFIXES = ("tools.", *_INTEGRATION_TOOL_PACKAGES)
+    _PRODUCTION_TOOL_PREFIXES = ("tools.", *INTEGRATION_TOOL_PACKAGES)
     registered = {
         name
         for name, tool in get_registered_tool_map().items()

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -178,9 +178,9 @@ def get_tool_descriptors(surface: ToolSurface | None = None) -> list[ToolDescrip
     """
     from tools.registry_index import build_descriptor_index
 
-    descriptors = build_descriptor_index().values()
+    descriptors = list(build_descriptor_index().values())
     if surface is not None:
-        descriptors = [d for d in descriptors if surface in d.surfaces]  # type: ignore[assignment]
+        descriptors = [d for d in descriptors if surface in d.surfaces]
     return sorted(descriptors, key=lambda descriptor: descriptor.name)
 
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -307,12 +307,20 @@ def _with_skill_guidance(tool: RegisteredTool, guidance: str) -> RegisteredTool:
     )
 
 
-def _apply_skill_guidance(tools_by_name: dict[str, RegisteredTool]) -> None:
-    known_tool_names = frozenset(tools_by_name)
+def _apply_skill_guidance(
+    tools_by_name: dict[str, RegisteredTool],
+    *,
+    known_tool_names: frozenset[str] | None = None,
+) -> None:
+    # Diagnostics validate against the full tool set (a surface load holds only a
+    # subset); guidance still attaches only to tools present in ``tools_by_name``.
+    diagnostic_names = (
+        known_tool_names if known_tool_names is not None else frozenset(tools_by_name)
+    )
     guidance_by_tool: dict[str, list[str]] = {}
 
     for skill_path in _skill_guidance_files():
-        result = load_tool_skill_guidance(skill_path, known_tool_names=known_tool_names)
+        result = load_tool_skill_guidance(skill_path, known_tool_names=diagnostic_names)
         for diagnostic in result.diagnostics:
             logger.warning(
                 "[tools] Skill guidance %s (%s): %s",
@@ -384,16 +392,53 @@ def _load_registry_tool_map() -> dict[str, RegisteredTool]:
     return {tool.name: tool for tool in _load_registry_snapshot()}
 
 
+@lru_cache(maxsize=8)
+def _load_surface_snapshot(surface: str) -> tuple[RegisteredTool, ...]:
+    """Import only the modules that statically declare a tool for ``surface``.
+
+    Resolved from the descriptor index so a surface load never imports the other
+    surfaces' vendor executors (see #3686). Runtime-registered external packages
+    are already imported, so they are collected directly. Equivalent to the full
+    snapshot filtered by ``surface`` (pinned by the registry-index contract test).
+    """
+    from tools.registry_index import build_descriptor_index
+
+    index = build_descriptor_index()
+    modules = sorted({d.module for d in index.values() if surface in d.surfaces})
+    tools_by_name: dict[str, RegisteredTool] = {}
+    for dotted in modules:
+        try:
+            module = importlib.import_module(dotted)
+        except Exception as exc:
+            logger.warning("[tools] Skipping %s for surface %r: %s", dotted, surface, exc)
+            continue
+        for tool in _collect_registered_tools_from_module(module):
+            if surface in tool.surfaces:
+                tools_by_name.setdefault(tool.name, tool)
+
+    for package in _external_tool_packages:
+        for module in _iter_discovered_tool_modules(package):
+            for tool in _collect_registered_tools_from_module(module):
+                if surface in tool.surfaces:
+                    tools_by_name.setdefault(tool.name, tool)
+
+    _apply_skill_guidance(tools_by_name, known_tool_names=frozenset(index))
+    return tuple(sorted(tools_by_name.values(), key=lambda tool: tool.name))
+
+
 def clear_tool_registry_cache() -> None:
     _load_registry_snapshot.cache_clear()
     _load_registry_tool_map.cache_clear()
+    _load_surface_snapshot.cache_clear()
+    from tools.registry_index import clear_descriptor_index_cache
+
+    clear_descriptor_index_cache()
 
 
 def get_registered_tools(surface: ToolSurface | None = None) -> list[RegisteredTool]:
-    tools = list(_load_registry_snapshot())
     if surface is None:
-        return tools
-    return [tool for tool in tools if surface in tool.surfaces]
+        return list(_load_registry_snapshot())
+    return list(_load_surface_snapshot(surface))
 
 
 def get_registered_tool_map(surface: ToolSurface | None = None) -> dict[str, RegisteredTool]:

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -19,10 +19,10 @@ import tools as tools_package
 from core.tool_framework.registered_tool import RegisteredTool, ToolSurface
 from tools.registry_discovery import (
     INTEGRATION_TOOL_PACKAGES,
-    _collect_registered_tools_from_module,
-    _iter_discovered_tool_modules,
+    collect_registered_tools_from_module,
+    iter_discovered_tool_modules,
 )
-from tools.registry_skill_guidance import _apply_skill_guidance
+from tools.registry_skill_guidance import apply_skill_guidance
 
 if TYPE_CHECKING:
     from tools.registry_index import ToolDescriptor
@@ -96,9 +96,9 @@ def _load_registry_snapshot() -> tuple[RegisteredTool, ...]:
         modules_to_scan: list[ModuleType] = []
         if id(package) in integration_module_ids:
             modules_to_scan.append(package)
-        modules_to_scan.extend(_iter_discovered_tool_modules(package))
+        modules_to_scan.extend(iter_discovered_tool_modules(package))
         for module in modules_to_scan:
-            for tool in _collect_registered_tools_from_module(module):
+            for tool in collect_registered_tools_from_module(module):
                 if tool.name in tools_by_name:
                     logger.warning(
                         "[tools] Duplicate tool name '%s' across modules; keeping first definition",
@@ -107,7 +107,7 @@ def _load_registry_snapshot() -> tuple[RegisteredTool, ...]:
                     continue
                 tools_by_name[tool.name] = tool
 
-    _apply_skill_guidance(tools_by_name)
+    apply_skill_guidance(tools_by_name)
     return tuple(sorted(tools_by_name.values(), key=lambda tool: tool.name))
 
 
@@ -136,17 +136,17 @@ def _load_surface_snapshot(surface: str) -> tuple[RegisteredTool, ...]:
         except Exception as exc:
             logger.warning("[tools] Skipping %s for surface %r: %s", dotted, surface, exc)
             continue
-        for tool in _collect_registered_tools_from_module(module):
+        for tool in collect_registered_tools_from_module(module):
             if surface in tool.surfaces:
                 tools_by_name.setdefault(tool.name, tool)
 
     for package in _external_tool_packages:
-        for module in _iter_discovered_tool_modules(package):
-            for tool in _collect_registered_tools_from_module(module):
+        for module in iter_discovered_tool_modules(package):
+            for tool in collect_registered_tools_from_module(module):
                 if surface in tool.surfaces:
                     tools_by_name.setdefault(tool.name, tool)
 
-    _apply_skill_guidance(tools_by_name, known_tool_names=frozenset(index))
+    apply_skill_guidance(tools_by_name, known_tool_names=frozenset(index))
     return tuple(sorted(tools_by_name.values(), key=lambda tool: tool.name))
 
 
@@ -196,7 +196,7 @@ def load_tool(descriptor: ToolDescriptor) -> RegisteredTool | None:
             "[tools] Failed to load %r from %s: %s", descriptor.name, descriptor.module, exc
         )
         return None
-    for tool in _collect_registered_tools_from_module(module):
+    for tool in collect_registered_tools_from_module(module):
         if tool.name == descriptor.name:
             return tool
     return None

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -1,118 +1,33 @@
-"""Canonical tool registry shared by investigation and chat surfaces."""
+"""Canonical tool registry shared by investigation and chat surfaces.
+
+Facade over tool discovery (:mod:`tools.registry_discovery`), the static
+descriptor index (:mod:`tools.registry_index`), and skill-guidance attachment
+(:mod:`tools.registry_skill_guidance`): it owns the cached snapshots, the public
+lookup API, and the ``ToolRegistry`` port.
+"""
 
 from __future__ import annotations
 
 import importlib
-import inspect
 import logging
-import pkgutil
 import threading
-from dataclasses import replace
 from functools import lru_cache
-from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING
 
 import tools as tools_package
-from config.constants.paths import REPO_ROOT
-from core.tool_framework.base import BaseTool
-from core.tool_framework.registered_tool import REGISTERED_TOOL_ATTR, RegisteredTool, ToolSurface
-from core.tool_framework.skill_guidance import format_tool_skill_guidance, load_tool_skill_guidance
+from core.tool_framework.registered_tool import RegisteredTool, ToolSurface
+from tools.registry_discovery import (
+    _INTEGRATION_TOOL_PACKAGES,
+    _collect_registered_tools_from_module,
+    _iter_discovered_tool_modules,
+)
+from tools.registry_skill_guidance import _apply_skill_guidance
 
 if TYPE_CHECKING:
     from tools.registry_index import ToolDescriptor
 
-# Per-vendor tool packages — when a vendor consolidates its tool code under
-# ``integrations/<vendor>/tools/``, list the dotted package path here so the
-# registry walks it alongside the canonical ``tools/`` package. New vendors get
-# one entry each as they migrate.
-#
-# The external extension point (:func:`register_external_tool_package`) is
-# separate; it's for plugin-style callers that ship tool packages outside of
-# opensre's own codebase.
-_INTEGRATION_TOOL_PACKAGES: tuple[str, ...] = (
-    "integrations.alertmanager.tools",
-    "integrations.argocd.tools",
-    "integrations.aws.tools",
-    "integrations.aws_lambda.tools",
-    "integrations.azure.tools",
-    "integrations.azure_sql.tools",
-    "integrations.betterstack.tools",
-    "integrations.bitbucket.tools",
-    "integrations.clickhouse.tools",
-    "integrations.cloudtrail.tools",
-    "integrations.cloudwatch.tools",
-    "integrations.coralogix.tools",
-    "integrations.dagster.tools",
-    "integrations.datadog.tools",
-    "integrations.ec2.tools",
-    "integrations.eks.tools",
-    "integrations.elasticsearch.tools",
-    "integrations.elb.tools",
-    "integrations.github.tools",
-    "integrations.gitlab.tools",
-    "integrations.google_docs.tools",
-    "integrations.grafana.tools",
-    "integrations.groundcover.tools",
-    "integrations.helm.tools",
-    "integrations.hermes.tools",
-    "integrations.honeycomb.tools",
-    "integrations.incident_io.tools",
-    "integrations.jenkins.tools",
-    "integrations.jira.tools",
-    "integrations.kafka.tools",
-    "integrations.mariadb.tools",
-    "integrations.mongodb.tools",
-    "integrations.mongodb_atlas.tools",
-    "integrations.mysql.tools",
-    "integrations.openclaw.tools",
-    "integrations.openobserve.tools",
-    "integrations.opensearch.tools",
-    "integrations.opsgenie.tools",
-    "integrations.pagerduty.tools",
-    "integrations.posthog_mcp.tools",
-    "integrations.postgresql.tools",
-    "integrations.prefect.tools",
-    "integrations.rabbitmq.tools",
-    "integrations.rds.tools",
-    "integrations.redis.tools",
-    "integrations.s3.tools",
-    "integrations.sentry.tools",
-    "integrations.sentry_mcp.tools",
-    "integrations.signoz.tools",
-    "integrations.snowflake.tools",
-    "integrations.splunk.tools",
-    "integrations.supabase.tools",
-    "integrations.telegram.tools",
-    "integrations.tempo.tools",
-    "integrations.temporal.tools",
-    "integrations.tracer.tools",
-    "integrations.twilio.tools",
-    "integrations.vercel.tools",
-    "integrations.victoria_logs.tools",
-    "integrations.x_mcp.tools",
-)
-
 logger = logging.getLogger(__name__)
-
-_SKIP_MODULE_NAMES = {
-    "__pycache__",
-    "investigation_registry",
-    "registry",
-}
-_TOOL_MODULES_ATTR = "TOOL_MODULES"
-_MAX_TOOL_SKILL_GUIDANCE_CHARS = 2400
-
-
-def _skill_guidance_files() -> tuple[Path, ...]:
-    """Return explicit and package-local SKILL.md files attached at registry load."""
-
-    explicit = (REPO_ROOT / "integrations" / "github" / "tools" / "workflow" / "SKILL.md",)
-    discovered = sorted(
-        (REPO_ROOT / "tools" / "system" / "python_execution_tool" / "skills").glob("*/SKILL.md")
-    )
-    return (*explicit, *discovered)
-
 
 # Extension point: callers outside ``tools.*`` can register additional
 # tool packages by calling :func:`register_external_tool_package`.
@@ -149,201 +64,6 @@ def register_external_tool_package(package: ModuleType) -> None:
             return
         _external_tool_packages.append(package)
         clear_tool_registry_cache()
-
-
-def _iter_tool_module_names(package: ModuleType) -> list[str]:
-    module_names: list[str] = []
-    for module_info in pkgutil.iter_modules(package.__path__):
-        if module_info.name in _SKIP_MODULE_NAMES:
-            continue
-        if module_info.name.startswith("_") or module_info.name.endswith("_test"):
-            continue
-        module_names.append(module_info.name)
-    return sorted(module_names)
-
-
-def _import_tool_module(package: ModuleType, module_name: str) -> ModuleType:
-    return importlib.import_module(_qualify_tool_module_name(package, module_name))
-
-
-def _qualify_tool_module_name(package: ModuleType, module_name: str) -> str:
-    if module_name == package.__name__ or module_name.startswith(f"{package.__name__}."):
-        return module_name
-    return f"{package.__name__}.{module_name}"
-
-
-def _iter_manifest_tool_module_names(module: ModuleType) -> tuple[str, ...]:
-    manifest = getattr(module, _TOOL_MODULES_ATTR, ())
-    if manifest is None:
-        return ()
-    if isinstance(manifest, str):
-        logger.warning(
-            "[tools] Ignoring %s.%s because it must be an iterable of module names, not a string",
-            module.__name__,
-            _TOOL_MODULES_ATTR,
-        )
-        return ()
-
-    try:
-        module_names = tuple(manifest)
-    except TypeError:
-        logger.warning(
-            "[tools] Ignoring %s.%s because it is not iterable",
-            module.__name__,
-            _TOOL_MODULES_ATTR,
-        )
-        return ()
-
-    valid_module_names: list[str] = []
-    for module_name in module_names:
-        if not isinstance(module_name, str) or not module_name:
-            logger.warning(
-                "[tools] Ignoring invalid %s entry on %s: %r",
-                _TOOL_MODULES_ATTR,
-                module.__name__,
-                module_name,
-            )
-            continue
-        valid_module_names.append(module_name)
-    return tuple(valid_module_names)
-
-
-def _import_tool_module_or_none(package: ModuleType, module_name: str) -> ModuleType | None:
-    full_module_name = _qualify_tool_module_name(package, module_name)
-    try:
-        return _import_tool_module(package, module_name)
-    except ModuleNotFoundError as exc:
-        logger.warning("[tools] Skipping %s: %s", full_module_name, exc)
-        return None
-    except Exception as exc:
-        logger.warning(
-            "[tools] Skipping %s due to import failure: %s",
-            full_module_name,
-            exc,
-            exc_info=True,
-        )
-        return None
-
-
-def _iter_discovered_tool_modules(package: ModuleType) -> list[ModuleType]:
-    modules: list[ModuleType] = []
-    for module_name in _iter_tool_module_names(package):
-        module = _import_tool_module_or_none(package, module_name)
-        if module is None:
-            continue
-        modules.append(module)
-
-        for manifest_module_name in _iter_manifest_tool_module_names(module):
-            manifest_module = _import_tool_module_or_none(module, manifest_module_name)
-            if manifest_module is not None:
-                modules.append(manifest_module)
-
-    return modules
-
-
-def _candidate_belongs_to_module(candidate: object, module_name: str) -> bool:
-    if isinstance(candidate, RegisteredTool):
-        return (candidate.origin_module or getattr(candidate.run, "__module__", "")) == module_name
-    if isinstance(candidate, BaseTool):
-        return candidate.__class__.__module__ == module_name
-    return getattr(candidate, "__module__", None) == module_name
-
-
-def _registered_tool_from_candidate(candidate: object) -> RegisteredTool | None:
-    if isinstance(candidate, RegisteredTool):
-        if not candidate.origin_module or not candidate.origin_name:
-            return replace(
-                candidate,
-                origin_module=candidate.origin_module or getattr(candidate.run, "__module__", ""),
-                origin_name=candidate.origin_name or getattr(candidate.run, "__name__", ""),
-            )
-        return candidate
-
-    registered = getattr(candidate, REGISTERED_TOOL_ATTR, None)
-    if isinstance(registered, RegisteredTool):
-        return registered
-
-    if isinstance(candidate, BaseTool):
-        return RegisteredTool.from_base_tool(candidate)
-
-    return None
-
-
-def _collect_registered_tools_from_module(module: ModuleType) -> list[RegisteredTool]:
-    tools_by_name: dict[str, RegisteredTool] = {}
-    seen_candidate_ids: set[int] = set()
-
-    for _, candidate in inspect.getmembers(module):
-        if not _candidate_belongs_to_module(candidate, module.__name__):
-            continue
-        candidate_id = id(candidate)
-        if candidate_id in seen_candidate_ids:
-            continue
-        seen_candidate_ids.add(candidate_id)
-        registered = _registered_tool_from_candidate(candidate)
-        if registered is None:
-            continue
-        if registered.name in tools_by_name:
-            logger.warning(
-                "[tools] Duplicate tool name '%s' in module %s; keeping first definition",
-                registered.name,
-                module.__name__,
-            )
-            continue
-        tools_by_name[registered.name] = registered
-
-    return sorted(tools_by_name.values(), key=lambda tool: tool.name)
-
-
-def _truncate_skill_guidance(text: str) -> str:
-    if len(text) <= _MAX_TOOL_SKILL_GUIDANCE_CHARS:
-        return text
-    return text[: _MAX_TOOL_SKILL_GUIDANCE_CHARS - 3].rstrip() + "..."
-
-
-def _with_skill_guidance(tool: RegisteredTool, guidance: str) -> RegisteredTool:
-    if not guidance:
-        return tool
-    return replace(
-        tool,
-        description=f"{tool.description}\n\nWorkflow guidance:\n{guidance}",
-        skill_guidance=guidance,
-    )
-
-
-def _apply_skill_guidance(
-    tools_by_name: dict[str, RegisteredTool],
-    *,
-    known_tool_names: frozenset[str] | None = None,
-) -> None:
-    # Diagnostics validate against the full tool set (a surface load holds only a
-    # subset); guidance still attaches only to tools present in ``tools_by_name``.
-    diagnostic_names = (
-        known_tool_names if known_tool_names is not None else frozenset(tools_by_name)
-    )
-    guidance_by_tool: dict[str, list[str]] = {}
-
-    for skill_path in _skill_guidance_files():
-        result = load_tool_skill_guidance(skill_path, known_tool_names=diagnostic_names)
-        for diagnostic in result.diagnostics:
-            logger.warning(
-                "[tools] Skill guidance %s (%s): %s",
-                diagnostic.path,
-                diagnostic.code,
-                diagnostic.message,
-            )
-        skill = result.skill
-        if skill is None or skill.disable_model_invocation:
-            continue
-        guidance = format_tool_skill_guidance(skill)
-        for tool_name in skill.tool_names:
-            if tool_name not in tools_by_name:
-                continue
-            guidance_by_tool.setdefault(tool_name, []).append(guidance)
-
-    for tool_name, guidances in guidance_by_tool.items():
-        combined = _truncate_skill_guidance("\n\n".join(guidances))
-        tools_by_name[tool_name] = _with_skill_guidance(tools_by_name[tool_name], combined)
 
 
 @lru_cache(maxsize=1)
@@ -401,9 +121,9 @@ def _load_surface_snapshot(surface: str) -> tuple[RegisteredTool, ...]:
     """Import only the modules that statically declare a tool for ``surface``.
 
     Resolved from the descriptor index so a surface load never imports the other
-    surfaces' vendor executors (see #3686). Runtime-registered external packages
-    are already imported, so they are collected directly. Equivalent to the full
-    snapshot filtered by ``surface`` (pinned by the registry-index contract test).
+    surfaces' vendor executors. Runtime-registered external packages are already
+    imported, so they are collected directly. Equivalent to the full snapshot
+    filtered by ``surface`` (pinned by the registry-index contract test).
     """
     from tools.registry_index import build_descriptor_index
 
@@ -453,8 +173,8 @@ def get_registered_tool_map(surface: ToolSurface | None = None) -> dict[str, Reg
 
 def get_tool_descriptors(surface: ToolSurface | None = None) -> list[ToolDescriptor]:
     """Cheap tool metadata for ``surface`` — reads the static index, imports no
-    executor (see #3686). Use for listing/availability; call :func:`load_tool`
-    to materialize an executor only when a tool must run.
+    executor. Use for listing/availability; call :func:`load_tool` to materialize
+    an executor only when a tool must run.
     """
     from tools.registry_index import build_descriptor_index
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -11,12 +11,16 @@ from dataclasses import replace
 from functools import lru_cache
 from pathlib import Path
 from types import ModuleType
+from typing import TYPE_CHECKING
 
 import tools as tools_package
 from config.constants.paths import REPO_ROOT
 from core.tool_framework.base import BaseTool
 from core.tool_framework.registered_tool import REGISTERED_TOOL_ATTR, RegisteredTool, ToolSurface
 from core.tool_framework.skill_guidance import format_tool_skill_guidance, load_tool_skill_guidance
+
+if TYPE_CHECKING:
+    from tools.registry_index import ToolDescriptor
 
 # Per-vendor tool packages — when a vendor consolidates its tool code under
 # ``integrations/<vendor>/tools/``, list the dotted package path here so the
@@ -445,6 +449,37 @@ def get_registered_tool_map(surface: ToolSurface | None = None) -> dict[str, Reg
     if surface is None:
         return dict(_load_registry_tool_map())
     return {tool.name: tool for tool in get_registered_tools(surface)}
+
+
+def get_tool_descriptors(surface: ToolSurface | None = None) -> list[ToolDescriptor]:
+    """Cheap tool metadata for ``surface`` — reads the static index, imports no
+    executor (see #3686). Use for listing/availability; call :func:`load_tool`
+    to materialize an executor only when a tool must run.
+    """
+    from tools.registry_index import build_descriptor_index
+
+    descriptors = build_descriptor_index().values()
+    if surface is not None:
+        descriptors = [d for d in descriptors if surface in d.surfaces]  # type: ignore[assignment]
+    return sorted(descriptors, key=lambda descriptor: descriptor.name)
+
+
+def load_tool(descriptor: ToolDescriptor) -> RegisteredTool | None:
+    """Import a descriptor's module and return its executor — the lazy step.
+
+    Returns ``None`` if the module fails to import or no longer defines the tool.
+    """
+    try:
+        module = importlib.import_module(descriptor.module)
+    except Exception as exc:
+        logger.warning(
+            "[tools] Failed to load %r from %s: %s", descriptor.name, descriptor.module, exc
+        )
+        return None
+    for tool in _collect_registered_tools_from_module(module):
+        if tool.name == descriptor.name:
+            return tool
+    return None
 
 
 class RegisteredToolRegistry:

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 import tools as tools_package
 from core.tool_framework.registered_tool import RegisteredTool, ToolSurface
 from tools.registry_discovery import (
-    _INTEGRATION_TOOL_PACKAGES,
+    INTEGRATION_TOOL_PACKAGES,
     _collect_registered_tools_from_module,
     _iter_discovered_tool_modules,
 )
@@ -74,7 +74,7 @@ def _load_registry_snapshot() -> tuple[RegisteredTool, ...]:
     # packages, then any externally-registered packages in registration order.
     # First definition of a given tool name wins; duplicates are logged and skipped.
     integration_packages: list[ModuleType] = []
-    for dotted in _INTEGRATION_TOOL_PACKAGES:
+    for dotted in INTEGRATION_TOOL_PACKAGES:
         try:
             integration_packages.append(importlib.import_module(dotted))
         except ImportError as exc:

--- a/tools/registry_discovery.py
+++ b/tools/registry_discovery.py
@@ -170,7 +170,7 @@ def _import_tool_module_or_none(package: ModuleType, module_name: str) -> Module
         return None
 
 
-def _iter_discovered_tool_modules(package: ModuleType) -> list[ModuleType]:
+def iter_discovered_tool_modules(package: ModuleType) -> list[ModuleType]:
     modules: list[ModuleType] = []
     for module_name in _iter_tool_module_names(package):
         module = _import_tool_module_or_none(package, module_name)
@@ -214,7 +214,7 @@ def _registered_tool_from_candidate(candidate: object) -> RegisteredTool | None:
     return None
 
 
-def _collect_registered_tools_from_module(module: ModuleType) -> list[RegisteredTool]:
+def collect_registered_tools_from_module(module: ModuleType) -> list[RegisteredTool]:
     tools_by_name: dict[str, RegisteredTool] = {}
     seen_candidate_ids: set[int] = set()
 

--- a/tools/registry_discovery.py
+++ b/tools/registry_discovery.py
@@ -1,0 +1,240 @@
+"""Tool discovery — walk tool packages and extract RegisteredTool objects.
+
+The canonical ``tools/`` tree and each per-vendor ``integrations/<vendor>/tools``
+package are walked here; the registry facade (:mod:`tools.registry`) caches the
+result. Kept separate so both the facade and the static descriptor index
+(:mod:`tools.registry_index`) share ``_INTEGRATION_TOOL_PACKAGES`` without a
+circular import.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import logging
+import pkgutil
+from dataclasses import replace
+from types import ModuleType
+
+from core.tool_framework.base import BaseTool
+from core.tool_framework.registered_tool import REGISTERED_TOOL_ATTR, RegisteredTool
+
+logger = logging.getLogger(__name__)
+
+# Per-vendor tool packages — when a vendor consolidates its tool code under
+# ``integrations/<vendor>/tools/``, list the dotted package path here so the
+# registry walks it alongside the canonical ``tools/`` package. New vendors get
+# one entry each as they migrate.
+_INTEGRATION_TOOL_PACKAGES: tuple[str, ...] = (
+    "integrations.alertmanager.tools",
+    "integrations.argocd.tools",
+    "integrations.aws.tools",
+    "integrations.aws_lambda.tools",
+    "integrations.azure.tools",
+    "integrations.azure_sql.tools",
+    "integrations.betterstack.tools",
+    "integrations.bitbucket.tools",
+    "integrations.clickhouse.tools",
+    "integrations.cloudtrail.tools",
+    "integrations.cloudwatch.tools",
+    "integrations.coralogix.tools",
+    "integrations.dagster.tools",
+    "integrations.datadog.tools",
+    "integrations.ec2.tools",
+    "integrations.eks.tools",
+    "integrations.elasticsearch.tools",
+    "integrations.elb.tools",
+    "integrations.github.tools",
+    "integrations.gitlab.tools",
+    "integrations.google_docs.tools",
+    "integrations.grafana.tools",
+    "integrations.groundcover.tools",
+    "integrations.helm.tools",
+    "integrations.hermes.tools",
+    "integrations.honeycomb.tools",
+    "integrations.incident_io.tools",
+    "integrations.jenkins.tools",
+    "integrations.jira.tools",
+    "integrations.kafka.tools",
+    "integrations.mariadb.tools",
+    "integrations.mongodb.tools",
+    "integrations.mongodb_atlas.tools",
+    "integrations.mysql.tools",
+    "integrations.openclaw.tools",
+    "integrations.openobserve.tools",
+    "integrations.opensearch.tools",
+    "integrations.opsgenie.tools",
+    "integrations.pagerduty.tools",
+    "integrations.posthog_mcp.tools",
+    "integrations.postgresql.tools",
+    "integrations.prefect.tools",
+    "integrations.rabbitmq.tools",
+    "integrations.rds.tools",
+    "integrations.redis.tools",
+    "integrations.s3.tools",
+    "integrations.sentry.tools",
+    "integrations.sentry_mcp.tools",
+    "integrations.signoz.tools",
+    "integrations.snowflake.tools",
+    "integrations.splunk.tools",
+    "integrations.supabase.tools",
+    "integrations.telegram.tools",
+    "integrations.tempo.tools",
+    "integrations.temporal.tools",
+    "integrations.tracer.tools",
+    "integrations.twilio.tools",
+    "integrations.vercel.tools",
+    "integrations.victoria_logs.tools",
+    "integrations.x_mcp.tools",
+)
+
+_SKIP_MODULE_NAMES = {
+    "__pycache__",
+    "investigation_registry",
+    "registry",
+}
+_TOOL_MODULES_ATTR = "TOOL_MODULES"
+
+
+def _iter_tool_module_names(package: ModuleType) -> list[str]:
+    module_names: list[str] = []
+    for module_info in pkgutil.iter_modules(package.__path__):
+        if module_info.name in _SKIP_MODULE_NAMES:
+            continue
+        if module_info.name.startswith("_") or module_info.name.endswith("_test"):
+            continue
+        module_names.append(module_info.name)
+    return sorted(module_names)
+
+
+def _import_tool_module(package: ModuleType, module_name: str) -> ModuleType:
+    return importlib.import_module(_qualify_tool_module_name(package, module_name))
+
+
+def _qualify_tool_module_name(package: ModuleType, module_name: str) -> str:
+    if module_name == package.__name__ or module_name.startswith(f"{package.__name__}."):
+        return module_name
+    return f"{package.__name__}.{module_name}"
+
+
+def _iter_manifest_tool_module_names(module: ModuleType) -> tuple[str, ...]:
+    manifest = getattr(module, _TOOL_MODULES_ATTR, ())
+    if manifest is None:
+        return ()
+    if isinstance(manifest, str):
+        logger.warning(
+            "[tools] Ignoring %s.%s because it must be an iterable of module names, not a string",
+            module.__name__,
+            _TOOL_MODULES_ATTR,
+        )
+        return ()
+
+    try:
+        module_names = tuple(manifest)
+    except TypeError:
+        logger.warning(
+            "[tools] Ignoring %s.%s because it is not iterable",
+            module.__name__,
+            _TOOL_MODULES_ATTR,
+        )
+        return ()
+
+    valid_module_names: list[str] = []
+    for module_name in module_names:
+        if not isinstance(module_name, str) or not module_name:
+            logger.warning(
+                "[tools] Ignoring invalid %s entry on %s: %r",
+                _TOOL_MODULES_ATTR,
+                module.__name__,
+                module_name,
+            )
+            continue
+        valid_module_names.append(module_name)
+    return tuple(valid_module_names)
+
+
+def _import_tool_module_or_none(package: ModuleType, module_name: str) -> ModuleType | None:
+    full_module_name = _qualify_tool_module_name(package, module_name)
+    try:
+        return _import_tool_module(package, module_name)
+    except ModuleNotFoundError as exc:
+        logger.warning("[tools] Skipping %s: %s", full_module_name, exc)
+        return None
+    except Exception as exc:
+        logger.warning(
+            "[tools] Skipping %s due to import failure: %s",
+            full_module_name,
+            exc,
+            exc_info=True,
+        )
+        return None
+
+
+def _iter_discovered_tool_modules(package: ModuleType) -> list[ModuleType]:
+    modules: list[ModuleType] = []
+    for module_name in _iter_tool_module_names(package):
+        module = _import_tool_module_or_none(package, module_name)
+        if module is None:
+            continue
+        modules.append(module)
+
+        for manifest_module_name in _iter_manifest_tool_module_names(module):
+            manifest_module = _import_tool_module_or_none(module, manifest_module_name)
+            if manifest_module is not None:
+                modules.append(manifest_module)
+
+    return modules
+
+
+def _candidate_belongs_to_module(candidate: object, module_name: str) -> bool:
+    if isinstance(candidate, RegisteredTool):
+        return (candidate.origin_module or getattr(candidate.run, "__module__", "")) == module_name
+    if isinstance(candidate, BaseTool):
+        return candidate.__class__.__module__ == module_name
+    return getattr(candidate, "__module__", None) == module_name
+
+
+def _registered_tool_from_candidate(candidate: object) -> RegisteredTool | None:
+    if isinstance(candidate, RegisteredTool):
+        if not candidate.origin_module or not candidate.origin_name:
+            return replace(
+                candidate,
+                origin_module=candidate.origin_module or getattr(candidate.run, "__module__", ""),
+                origin_name=candidate.origin_name or getattr(candidate.run, "__name__", ""),
+            )
+        return candidate
+
+    registered = getattr(candidate, REGISTERED_TOOL_ATTR, None)
+    if isinstance(registered, RegisteredTool):
+        return registered
+
+    if isinstance(candidate, BaseTool):
+        return RegisteredTool.from_base_tool(candidate)
+
+    return None
+
+
+def _collect_registered_tools_from_module(module: ModuleType) -> list[RegisteredTool]:
+    tools_by_name: dict[str, RegisteredTool] = {}
+    seen_candidate_ids: set[int] = set()
+
+    for _, candidate in inspect.getmembers(module):
+        if not _candidate_belongs_to_module(candidate, module.__name__):
+            continue
+        candidate_id = id(candidate)
+        if candidate_id in seen_candidate_ids:
+            continue
+        seen_candidate_ids.add(candidate_id)
+        registered = _registered_tool_from_candidate(candidate)
+        if registered is None:
+            continue
+        if registered.name in tools_by_name:
+            logger.warning(
+                "[tools] Duplicate tool name '%s' in module %s; keeping first definition",
+                registered.name,
+                module.__name__,
+            )
+            continue
+        tools_by_name[registered.name] = registered
+
+    return sorted(tools_by_name.values(), key=lambda tool: tool.name)

--- a/tools/registry_discovery.py
+++ b/tools/registry_discovery.py
@@ -3,7 +3,7 @@
 The canonical ``tools/`` tree and each per-vendor ``integrations/<vendor>/tools``
 package are walked here; the registry facade (:mod:`tools.registry`) caches the
 result. Kept separate so both the facade and the static descriptor index
-(:mod:`tools.registry_index`) share ``_INTEGRATION_TOOL_PACKAGES`` without a
+(:mod:`tools.registry_index`) share ``INTEGRATION_TOOL_PACKAGES`` without a
 circular import.
 """
 
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 # ``integrations/<vendor>/tools/``, list the dotted package path here so the
 # registry walks it alongside the canonical ``tools/`` package. New vendors get
 # one entry each as they migrate.
-_INTEGRATION_TOOL_PACKAGES: tuple[str, ...] = (
+INTEGRATION_TOOL_PACKAGES: tuple[str, ...] = (
     "integrations.alertmanager.tools",
     "integrations.argocd.tools",
     "integrations.aws.tools",

--- a/tools/registry_index.py
+++ b/tools/registry_index.py
@@ -198,8 +198,16 @@ def _module_dotted(path: Path) -> str:
 
 def _descriptors_in_file(path: Path) -> list[ToolDescriptor]:
     try:
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    except (SyntaxError, UnicodeDecodeError):
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+    # Skip the AST parse for files that can't declare a tool. The
+    # ``index == registry`` contract test guarantees this never drops a tool.
+    if "@tool" not in text and "BaseTool" not in text:
+        return []
+    try:
+        tree = ast.parse(text, filename=str(path))
+    except SyntaxError:
         return []
     module = _module_dotted(path)
     descriptors: list[ToolDescriptor] = []

--- a/tools/registry_index.py
+++ b/tools/registry_index.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from config.constants.paths import REPO_ROOT
 from core.tool_framework.registry_metadata import normalize_surfaces
-from tools.registry_discovery import _INTEGRATION_TOOL_PACKAGES
+from tools.registry_discovery import INTEGRATION_TOOL_PACKAGES
 
 _SKIP_FILE_SUFFIXES = ("_test.py",)
 _TOOL_DECORATOR_NAME = "tool"
@@ -244,7 +244,7 @@ def _descriptors_in_file(path: Path) -> list[ToolDescriptor]:
 
 def _scan_roots() -> list[Path]:
     roots = [REPO_ROOT / "tools"]
-    for dotted in _INTEGRATION_TOOL_PACKAGES:
+    for dotted in INTEGRATION_TOOL_PACKAGES:
         directory = REPO_ROOT / Path(*dotted.split("."))
         if directory.is_dir():
             roots.append(directory)

--- a/tools/registry_index.py
+++ b/tools/registry_index.py
@@ -1,0 +1,270 @@
+"""Static tool descriptor index — metadata without importing executors (#3686).
+
+The registry's ``_load_registry_snapshot`` imports every vendor tool module (and
+its SDK) to read each tool's metadata, which costs ~1.5s at startup. This module
+reads the same metadata (name, surfaces, source, display name, and the dotted
+module to import for execution) by AST-scanning the tool source files — no
+executor imports. Surface-scoped loads and lazy execution build on it.
+
+Tools whose metadata cannot be read statically (re-exported ``RegisteredTool``
+objects, runtime-registered packages) are not in the index; the registry imports
+those the existing way. ``tests/tools/test_registry_index.py`` pins that gap.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+from config.constants.paths import REPO_ROOT
+from core.tool_framework.registry_metadata import normalize_surfaces
+from tools.registry import _INTEGRATION_TOOL_PACKAGES
+
+_SKIP_FILE_SUFFIXES = ("_test.py",)
+_TOOL_DECORATOR_NAME = "tool"
+
+
+@dataclass(frozen=True, slots=True)
+class ToolDescriptor:
+    """Cheap tool metadata read without importing the executor module."""
+
+    name: str
+    surfaces: tuple[str, ...]
+    source: str | None
+    display_name: str | None
+    module: str
+
+
+# Tools the AST scan cannot read: built via ``RegisteredTool(...)`` construction
+# (the interactive-shell action tools) or with a non-literal ``surfaces=`` constant
+# (slack/telegram). Pinned here so the index is complete; ``test_registry_index``
+# asserts every entry matches the imported registry, so drift fails loudly.
+def _fallback_descriptors() -> tuple[ToolDescriptor, ...]:
+    return (
+        ToolDescriptor(
+            "alert_sample",
+            ("action",),
+            "interactive_shell",
+            None,
+            "tools.interactive_shell.actions.sample_alert",
+        ),
+        ToolDescriptor(
+            "assistant_handoff",
+            ("action",),
+            "interactive_shell",
+            None,
+            "tools.interactive_shell.actions.assistant_handoff",
+        ),
+        ToolDescriptor(
+            "cli_exec",
+            ("action",),
+            "interactive_shell",
+            None,
+            "tools.interactive_shell.actions.cli_command",
+        ),
+        ToolDescriptor(
+            "code_implement",
+            ("action",),
+            "interactive_shell",
+            None,
+            "tools.interactive_shell.actions.implementation",
+        ),
+        ToolDescriptor(
+            "fix_sentry_issue_start",
+            ("action",),
+            "interactive_shell",
+            None,
+            "tools.interactive_shell.actions.sentry_fix",
+        ),
+        ToolDescriptor(
+            "investigation_start",
+            ("action",),
+            "interactive_shell",
+            None,
+            "tools.interactive_shell.actions.investigation",
+        ),
+        ToolDescriptor(
+            "llm_set_provider",
+            ("action",),
+            "interactive_shell",
+            None,
+            "tools.interactive_shell.actions.llm_provider",
+        ),
+        ToolDescriptor(
+            "shell_run",
+            ("action",),
+            "interactive_shell",
+            None,
+            "tools.interactive_shell.actions.shell",
+        ),
+        ToolDescriptor(
+            "slack_send_message",
+            ("investigation", "chat", "action"),
+            "slack",
+            None,
+            "tools.slack_send_message_tool.tool",
+        ),
+        ToolDescriptor(
+            "slash_invoke",
+            ("action",),
+            "interactive_shell",
+            None,
+            "tools.interactive_shell.actions.slash",
+        ),
+        ToolDescriptor(
+            "synthetic_run",
+            ("action",),
+            "interactive_shell",
+            None,
+            "tools.interactive_shell.actions.synthetic",
+        ),
+        ToolDescriptor(
+            "task_cancel",
+            ("action",),
+            "interactive_shell",
+            None,
+            "tools.interactive_shell.actions.task_cancel",
+        ),
+        ToolDescriptor(
+            "telegram_send_message",
+            ("investigation", "chat", "action"),
+            "telegram",
+            None,
+            "integrations.telegram.tools.telegram_send_message_tool.tool",
+        ),
+    )
+
+
+def _string_constant(node: ast.expr | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _string_tuple(node: ast.expr | None) -> tuple[str, ...] | None:
+    if isinstance(node, ast.Tuple | ast.List):
+        values = [_string_constant(el) for el in node.elts]
+        if all(v is not None for v in values):
+            return tuple(v for v in values if v is not None)
+    return None
+
+
+def _keyword(call: ast.Call, key: str) -> ast.expr | None:
+    for kw in call.keywords:
+        if kw.arg == key:
+            return kw.value
+    return None
+
+
+def _is_tool_decorator(dec: ast.expr) -> bool:
+    call = dec.func if isinstance(dec, ast.Call) else dec
+    if isinstance(call, ast.Name):
+        return call.id == _TOOL_DECORATOR_NAME
+    if isinstance(call, ast.Attribute):
+        return call.attr == _TOOL_DECORATOR_NAME
+    return False
+
+
+def _is_base_tool_class(cls: ast.ClassDef) -> bool:
+    for base in cls.bases:
+        if isinstance(base, ast.Name) and base.id == "BaseTool":
+            return True
+        if isinstance(base, ast.Attribute) and base.attr == "BaseTool":
+            return True
+    return False
+
+
+def _class_attr(cls: ast.ClassDef, key: str) -> ast.expr | None:
+    for node in cls.body:
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.target.id == key and node.value is not None:
+                return node.value
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == key:
+                    return node.value
+    return None
+
+
+def _module_dotted(path: Path) -> str:
+    relative = path.relative_to(REPO_ROOT).with_suffix("")
+    parts = list(relative.parts)
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _descriptors_in_file(path: Path) -> list[ToolDescriptor]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+    module = _module_dotted(path)
+    descriptors: list[ToolDescriptor] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            for dec in node.decorator_list:
+                if isinstance(dec, ast.Call) and _is_tool_decorator(dec):
+                    name = _string_constant(_keyword(dec, "name")) or node.name
+                    descriptors.append(
+                        ToolDescriptor(
+                            name=name,
+                            surfaces=normalize_surfaces(_string_tuple(_keyword(dec, "surfaces"))),
+                            source=_string_constant(_keyword(dec, "source")),
+                            display_name=_string_constant(_keyword(dec, "display_name")),
+                            module=module,
+                        )
+                    )
+        elif isinstance(node, ast.ClassDef) and _is_base_tool_class(node):
+            class_name = _string_constant(_class_attr(node, "name"))
+            if class_name is None:
+                continue
+            descriptors.append(
+                ToolDescriptor(
+                    name=class_name,
+                    surfaces=normalize_surfaces(_string_tuple(_class_attr(node, "surfaces"))),
+                    source=_string_constant(_class_attr(node, "source")),
+                    display_name=_string_constant(_class_attr(node, "display_name")),
+                    module=module,
+                )
+            )
+    return descriptors
+
+
+def _scan_roots() -> list[Path]:
+    roots = [REPO_ROOT / "tools"]
+    for dotted in _INTEGRATION_TOOL_PACKAGES:
+        directory = REPO_ROOT / Path(*dotted.split("."))
+        if directory.is_dir():
+            roots.append(directory)
+    return roots
+
+
+@lru_cache(maxsize=1)
+def build_descriptor_index() -> dict[str, ToolDescriptor]:
+    """Map tool name -> descriptor, first definition wins (registry order)."""
+    index: dict[str, ToolDescriptor] = {}
+    for root in _scan_roots():
+        for path in sorted(root.rglob("*.py")):
+            if "__pycache__" in path.parts or path.name.endswith(_SKIP_FILE_SUFFIXES):
+                continue
+            for descriptor in _descriptors_in_file(path):
+                index.setdefault(descriptor.name, descriptor)
+    # Pinned descriptors override (slack/telegram surfaces) or add (action tools).
+    for descriptor in _fallback_descriptors():
+        index[descriptor.name] = descriptor
+    return index
+
+
+def clear_descriptor_index_cache() -> None:
+    build_descriptor_index.cache_clear()
+
+
+__all__ = [
+    "ToolDescriptor",
+    "build_descriptor_index",
+    "clear_descriptor_index_cache",
+]

--- a/tools/registry_index.py
+++ b/tools/registry_index.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from config.constants.paths import REPO_ROOT
 from core.tool_framework.registry_metadata import normalize_surfaces
-from tools.registry import _INTEGRATION_TOOL_PACKAGES
+from tools.registry_discovery import _INTEGRATION_TOOL_PACKAGES
 
 _SKIP_FILE_SUFFIXES = ("_test.py",)
 _TOOL_DECORATOR_NAME = "tool"

--- a/tools/registry_skill_guidance.py
+++ b/tools/registry_skill_guidance.py
@@ -1,6 +1,6 @@
 """Attach SKILL.md workflow guidance to discovered tools.
 
-The registry facade (:mod:`tools.registry`) calls :func:`_apply_skill_guidance`
+The registry facade (:mod:`tools.registry`) calls :func:`apply_skill_guidance`
 after collecting tools so a tool's description carries the workflow guidance the
 matching SKILL.md declares for it.
 """
@@ -46,7 +46,7 @@ def _with_skill_guidance(tool: RegisteredTool, guidance: str) -> RegisteredTool:
     )
 
 
-def _apply_skill_guidance(
+def apply_skill_guidance(
     tools_by_name: dict[str, RegisteredTool],
     *,
     known_tool_names: frozenset[str] | None = None,

--- a/tools/registry_skill_guidance.py
+++ b/tools/registry_skill_guidance.py
@@ -1,0 +1,81 @@
+"""Attach SKILL.md workflow guidance to discovered tools.
+
+The registry facade (:mod:`tools.registry`) calls :func:`_apply_skill_guidance`
+after collecting tools so a tool's description carries the workflow guidance the
+matching SKILL.md declares for it.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+from pathlib import Path
+
+from config.constants.paths import REPO_ROOT
+from core.tool_framework.registered_tool import RegisteredTool
+from core.tool_framework.skill_guidance import format_tool_skill_guidance, load_tool_skill_guidance
+
+logger = logging.getLogger(__name__)
+
+_MAX_TOOL_SKILL_GUIDANCE_CHARS = 2400
+
+
+def _skill_guidance_files() -> tuple[Path, ...]:
+    """Return explicit and package-local SKILL.md files attached at registry load."""
+
+    explicit = (REPO_ROOT / "integrations" / "github" / "tools" / "workflow" / "SKILL.md",)
+    discovered = sorted(
+        (REPO_ROOT / "tools" / "system" / "python_execution_tool" / "skills").glob("*/SKILL.md")
+    )
+    return (*explicit, *discovered)
+
+
+def _truncate_skill_guidance(text: str) -> str:
+    if len(text) <= _MAX_TOOL_SKILL_GUIDANCE_CHARS:
+        return text
+    return text[: _MAX_TOOL_SKILL_GUIDANCE_CHARS - 3].rstrip() + "..."
+
+
+def _with_skill_guidance(tool: RegisteredTool, guidance: str) -> RegisteredTool:
+    if not guidance:
+        return tool
+    return replace(
+        tool,
+        description=f"{tool.description}\n\nWorkflow guidance:\n{guidance}",
+        skill_guidance=guidance,
+    )
+
+
+def _apply_skill_guidance(
+    tools_by_name: dict[str, RegisteredTool],
+    *,
+    known_tool_names: frozenset[str] | None = None,
+) -> None:
+    # Diagnostics validate against the full tool set (a surface load holds only a
+    # subset); guidance still attaches only to tools present in ``tools_by_name``.
+    diagnostic_names = (
+        known_tool_names if known_tool_names is not None else frozenset(tools_by_name)
+    )
+    guidance_by_tool: dict[str, list[str]] = {}
+
+    for skill_path in _skill_guidance_files():
+        result = load_tool_skill_guidance(skill_path, known_tool_names=diagnostic_names)
+        for diagnostic in result.diagnostics:
+            logger.warning(
+                "[tools] Skill guidance %s (%s): %s",
+                diagnostic.path,
+                diagnostic.code,
+                diagnostic.message,
+            )
+        skill = result.skill
+        if skill is None or skill.disable_model_invocation:
+            continue
+        guidance = format_tool_skill_guidance(skill)
+        for tool_name in skill.tool_names:
+            if tool_name not in tools_by_name:
+                continue
+            guidance_by_tool.setdefault(tool_name, []).append(guidance)
+
+    for tool_name, guidances in guidance_by_tool.items():
+        combined = _truncate_skill_guidance("\n\n".join(guidances))
+        tools_by_name[tool_name] = _with_skill_guidance(tools_by_name[tool_name], combined)


### PR DESCRIPTION
Fixes #3686 

#### Describe the changes you have made in this PR -

The tool registry read every tool's metadata by importing every vendor tool module (and its SDK) on the first `get_registered_tools()` call — ~1.5s, and the dominant chunk of the ~2s startup target (#3361). This makes that lazy: a static descriptor index carries tool metadata without importing executors, so a turn loads only the tools for its surface and imports an executor only when a tool runs.

- **Static descriptor index** (`tools/registry_index.py`): AST-scans the tool  source for `@tool`/`BaseTool` literal metadata — no executor imports, no vendor SDKs. Produces `ToolDescriptor(name, surfaces, source, display_name, module)` for all 233 tools. 13 tools that build via `RegisteredTool(...)` or a non-literal `surfaces=` are pinned as fallback descriptors. A substring prefilter skips parsing files that can't declare a tool.

- **Surface-scoped loads** (`tools/registry.py`): `get_registered_tools(surface)` resolves the surface's modules from the index and imports only those (plus any runtime-registered external packages), instead of all 60 vendor packages. `surface=None` still returns the full eager snapshot. Fixed `_apply_skill_guidance` so a surface subset no longer emits false "tool not registered" warnings.

- **Descriptor seam** (P3): `get_tool_descriptors(surface)` returns import-free metadata (listing/availability); `load_tool(descriptor)` imports the module and returns the executor only when a tool must run. `ToolDescriptor` is the cheap metadata type; `RegisteredTool` stays the materialized executor. Adding a vendor is now a `@tool` module that auto-indexes — no import of any other vendor.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
