### PR TITLE
fix(posthog_mcp): merge duplicate imports into single block

### DIFF
--- a/integrations/posthog_mcp/tools/posthog_mcp_tool/__init__.py
+++ b/integrations/posthog_mcp/tools/posthog_mcp_tool/__init__.py
@@ -17,15 +17,11 @@ from integrations.posthog_mcp import (
     PostHogMCPConfig,
     PostHogMCPToolCallResult,
     build_posthog_mcp_config,
+    call_posthog_mcp_tool as invoke_posthog_mcp_tool,
     describe_posthog_mcp_error,
+    list_posthog_mcp_tools as list_posthog_mcp_server_tools,
     posthog_mcp_config_from_env,
     posthog_mcp_runtime_unavailable_reason,
-)
-from integrations.posthog_mcp import (
-    call_posthog_mcp_tool as invoke_posthog_mcp_tool,
-)
-from integrations.posthog_mcp import (
-    list_posthog_mcp_tools as list_posthog_mcp_server_tools,
 )
 
 PostHogMCPParams = dict[str, object]


### PR DESCRIPTION
Fixes #3509

#### Describe the changes you have made in this PR -
The file had 3 separate import statements from the same module (integrations.posthog_mcp), which is a duplicate-imports code smell - noisy to read and typically the result of incremental edits over time rather than an intentional pattern. Combined all imported names into a single from integrations.posthog_mcp import (...) block, sorted alphabetically (uppercase classes first, then lowercase functions/aliases by their original pre-as name). No behaviour changes - purely a cosmetic import consolidation.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have modified the AI output to follow this project's coding standards and conventions

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
