### PR TITLE
fix(gateway): restore POST /investigate REST API endpoint

### DIFF
--- a/docs/deployment.mdx
+++ b/docs/deployment.mdx
@@ -70,22 +70,24 @@ Use the built-in gateway command when you want a local HTTP server for investiga
 
 | Command | What it does |
 | --- | --- |
-| `uv run opensre gateway` | Starts the local gateway on `127.0.0.1:2024`. |
-| `uv run opensre gateway --host 0.0.0.0 --port 8080` | Binds the gateway to a custom host/port. |
-| `uv run opensre gateway --api-key local-dev-key` | Enables API key auth for non-exempt routes. |
-| `uv run opensre gateway --investigations-dir ./investigations` | Writes investigation reports to a custom directory. |
+| `uv run opensre gateway start` | Starts the gateway daemon in the background (web app, Telegram chat, task scheduler). |
+| `uv run opensre gateway start --foreground` | Runs the gateway attached to this terminal. |
+| `uv run opensre gateway stop` | Stops the background daemon. |
+| `uv run opensre gateway status` | Shows daemon and component status. |
+
+The web app binds `0.0.0.0` on the port from the `PORT` environment variable
+(default `8000`).
 
 Quick local checks:
 
 ```bash
-curl http://127.0.0.1:2024/ok
-curl http://127.0.0.1:2024/version
+curl http://127.0.0.1:8000/ok
 ```
 
 Example investigation request:
 
 ```bash
-curl -X POST http://127.0.0.1:2024/investigate \
+curl -X POST http://127.0.0.1:8000/investigate \
   -H "Content-Type: application/json" \
   -d '{
     "raw_alert": {
@@ -97,12 +99,13 @@ curl -X POST http://127.0.0.1:2024/investigate \
   }'
 ```
 
-When `--api-key` is set, include it for protected endpoints:
+By default, `/investigate` (like `/alerts`) accepts only loopback callers. Set
+`OPENSRE_ALERT_LISTENER_TOKEN` to allow remote callers with a bearer token:
 
 ```bash
-curl -X POST http://127.0.0.1:2024/investigate \
+curl -X POST http://127.0.0.1:8000/investigate \
   -H "Content-Type: application/json" \
-  -H "X-API-Key: local-dev-key" \
+  -H "Authorization: Bearer $OPENSRE_ALERT_LISTENER_TOKEN" \
   -d '{"raw_alert":{"alert_name":"test"}}'
 ```
 

--- a/gateway/tests/test_webapp_investigate.py
+++ b/gateway/tests/test_webapp_investigate.py
@@ -1,0 +1,141 @@
+"""Tests for the ``POST /investigate`` endpoint on the gateway web app."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway import webapp
+
+_LOOPBACK = ("127.0.0.1", 40000)
+_REMOTE = ("203.0.113.9", 40000)
+
+
+@pytest.fixture(autouse=True)
+def _no_token(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.delenv("OPENSRE_ALERT_LISTENER_TOKEN", raising=False)
+    yield
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(webapp.app, client=_LOOPBACK)
+
+
+def _fake_payload() -> dict[str, Any]:
+    return {
+        "report": "Root cause identified.",
+        "problem_md": "## Problem\nOrders pipeline timed out.",
+        "root_cause": "Timeout calling downstream service.",
+        "is_noise": False,
+        "validity_score": 0.9,
+        "tool_calls": [{"key": "logs", "tool_name": "hermes_logs", "data": {}}],
+    }
+
+
+def test_investigate_runs_pipeline_and_returns_report(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_run_investigation_payload(
+        *, raw_alert: Any, investigation_metadata: Any = None, **_: Any
+    ) -> dict[str, Any]:
+        captured["raw_alert"] = raw_alert
+        captured["investigation_metadata"] = investigation_metadata
+        return _fake_payload()
+
+    monkeypatch.setattr(webapp, "run_investigation_payload", _fake_run_investigation_payload)
+
+    resp = client.post(
+        "/investigate",
+        json={
+            "raw_alert": {"message": "Orders pipeline failed with timeout."},
+            "alert_name": "etl-daily-orders-failure",
+            "pipeline_name": "etl_daily_orders",
+            "severity": "critical",
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["report"] == "Root cause identified."
+    assert body["root_cause"] == "Timeout calling downstream service."
+    assert body["is_noise"] is False
+    assert captured["raw_alert"] == {"message": "Orders pipeline failed with timeout."}
+    assert captured["investigation_metadata"] == (
+        "etl-daily-orders-failure",
+        "etl_daily_orders",
+        "critical",
+    )
+
+
+def test_investigate_resolves_metadata_from_raw_alert_when_overrides_missing(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_run_investigation_payload(
+        *, investigation_metadata: Any = None, **_: Any
+    ) -> dict[str, Any]:
+        captured["investigation_metadata"] = investigation_metadata
+        return _fake_payload()
+
+    monkeypatch.setattr(webapp, "run_investigation_payload", _fake_run_investigation_payload)
+
+    resp = client.post(
+        "/investigate",
+        json={"raw_alert": {"alert_name": "High CPU", "severity": "warning"}},
+    )
+
+    assert resp.status_code == 200
+    assert captured["investigation_metadata"] == ("High CPU", "unknown", "warning")
+
+
+def test_investigate_missing_raw_alert_returns_422(client: TestClient) -> None:
+    resp = client.post("/investigate", json={"alert_name": "x"})
+    assert resp.status_code == 422
+
+
+def test_investigate_pipeline_failure_returns_503(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    def _boom(**_: Any) -> dict[str, Any]:
+        raise RuntimeError("llm unavailable")
+
+    monkeypatch.setattr(webapp, "run_investigation_payload", _boom)
+
+    resp = client.post("/investigate", json={"raw_alert": {"alert_name": "x"}})
+
+    assert resp.status_code == 503
+    assert "llm unavailable" in resp.json()["error"]
+
+
+def test_investigate_non_loopback_without_token_returns_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(webapp, "run_investigation_payload", lambda **_: _fake_payload())
+    remote = TestClient(webapp.app, client=_REMOTE)
+
+    resp = remote.post("/investigate", json={"raw_alert": {"alert_name": "x"}})
+
+    assert resp.status_code == 403
+
+
+def test_investigate_token_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_ALERT_LISTENER_TOKEN", "sekret")
+    monkeypatch.setattr(webapp, "run_investigation_payload", lambda **_: _fake_payload())
+    remote = TestClient(webapp.app, client=_REMOTE)
+
+    assert remote.post("/investigate", json={"raw_alert": {"alert_name": "x"}}).status_code == 401
+    assert (
+        remote.post(
+            "/investigate",
+            json={"raw_alert": {"alert_name": "x"}},
+            headers={"Authorization": "Bearer sekret"},
+        ).status_code
+        == 200
+    )

--- a/gateway/tests/test_webapp_investigate.py
+++ b/gateway/tests/test_webapp_investigate.py
@@ -100,18 +100,37 @@ def test_investigate_missing_raw_alert_returns_422(client: TestClient) -> None:
     assert resp.status_code == 422
 
 
-def test_investigate_pipeline_failure_returns_503(
+def test_investigate_pipeline_failure_returns_503_without_leaking_exception_text(
     monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:
     def _boom(**_: Any) -> dict[str, Any]:
-        raise RuntimeError("llm unavailable")
+        raise RuntimeError("llm unavailable at s3://internal-bucket/creds.json")
 
     monkeypatch.setattr(webapp, "run_investigation_payload", _boom)
 
     resp = client.post("/investigate", json={"raw_alert": {"alert_name": "x"}})
 
     assert resp.status_code == 503
-    assert "llm unavailable" in resp.json()["error"]
+    body = resp.json()
+    assert body["error"] == "investigation failed: RuntimeError"
+    assert "llm unavailable" not in body["error"]
+    assert "s3://internal-bucket" not in body["error"]
+
+
+def test_investigate_malformed_pipeline_result_returns_503(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    """A result dict that fails InvestigateResponse validation is caught too."""
+
+    def _malformed(**_: Any) -> dict[str, Any]:
+        return {"report": None, "problem_md": "p", "root_cause": "c"}
+
+    monkeypatch.setattr(webapp, "run_investigation_payload", _malformed)
+
+    resp = client.post("/investigate", json={"raw_alert": {"alert_name": "x"}})
+
+    assert resp.status_code == 503
+    assert resp.json()["error"] == "investigation failed: ValidationError"
 
 
 def test_investigate_non_loopback_without_token_returns_403(

--- a/gateway/webapp.py
+++ b/gateway/webapp.py
@@ -1,10 +1,11 @@
-"""The gateway's single FastAPI app: health probes plus alert intake.
+"""The gateway's single FastAPI app: health probes, alert intake, investigations.
 
 Every HTTP endpoint OpenSRE serves lives here, on one port — ``/`` ``/health``
-``/ok`` (health probes), ``/healthz`` (liveness), and ``POST /alerts`` (external
-alert pushes into the process-wide :class:`AlertInbox`). Hosted by the gateway
-daemon and the interactive shell via :mod:`gateway.web_server`, or standalone
-via ``uvicorn gateway.webapp:app``.
+``/ok`` (health probes), ``/healthz`` (liveness), ``POST /alerts`` (external
+alert pushes into the process-wide :class:`AlertInbox`), and ``POST /investigate``
+(run an investigation synchronously and return the RCA report). Hosted by the
+gateway daemon and the interactive shell via :mod:`gateway.web_server`, or
+standalone via ``uvicorn gateway.webapp:app``.
 """
 
 from __future__ import annotations
@@ -31,7 +32,11 @@ from core.domain.alerts.inbox import (
 
 ensure_project_platform_package()
 
-from platform.observability.errors.sentry import init_sentry  # noqa: E402
+from platform.observability.errors.sentry import capture_exception, init_sentry  # noqa: E402
+from tools.investigation.capability import (  # noqa: E402
+    resolve_investigation_context,
+    run_investigation_payload,
+)
 
 init_sentry(entrypoint="webapp")
 
@@ -92,8 +97,12 @@ def _alert_inbox() -> AlertInbox:
     return inbox
 
 
-def _alert_auth_error(request: Request) -> JSONResponse | None:
-    """Bearer-token auth when configured; otherwise loopback callers only."""
+def _gateway_auth_error(request: Request) -> JSONResponse | None:
+    """Bearer-token auth when configured; otherwise loopback callers only.
+
+    Shared by every mutating gateway route (``/alerts``, ``/investigate``) since
+    they sit behind the same trust boundary: local callers or a configured token.
+    """
     token = os.environ.get("OPENSRE_ALERT_LISTENER_TOKEN")
     if token:
         supplied = request.headers.get("authorization", "")
@@ -104,14 +113,14 @@ def _alert_auth_error(request: Request) -> JSONResponse | None:
     if client_host in _LOOPBACK_HOSTS:
         return None
     return JSONResponse(
-        {"error": "set OPENSRE_ALERT_LISTENER_TOKEN to accept non-loopback alerts"},
+        {"error": "set OPENSRE_ALERT_LISTENER_TOKEN to accept non-loopback callers"},
         status_code=403,
     )
 
 
 @app.post("/alerts")
 async def receive_alert(request: Request) -> JSONResponse:
-    if (auth_error := _alert_auth_error(request)) is not None:
+    if (auth_error := _gateway_auth_error(request)) is not None:
         return auth_error
 
     try:
@@ -148,3 +157,52 @@ async def receive_alert(request: Request) -> JSONResponse:
         payload["dropped"] = inbox.dropped
         payload["warning"] = "inbox full, oldest alert dropped"
     return JSONResponse(payload, status_code=202)
+
+
+class InvestigateRequest(BaseModel):
+    raw_alert: dict[str, Any]
+    alert_name: str | None = None
+    pipeline_name: str | None = None
+    severity: str | None = None
+
+
+class InvestigateResponse(BaseModel):
+    report: str
+    problem_md: str
+    root_cause: str
+    is_noise: bool = False
+    validity_score: float = 0.0
+    tool_calls: list[dict[str, Any]] | None = None
+
+
+@app.post("/investigate", response_model=InvestigateResponse)
+def investigate(req: InvestigateRequest, request: Request) -> InvestigateResponse | JSONResponse:
+    """Run an investigation synchronously and return the RCA report.
+
+    Lets external systems (CI pipelines, custom webhooks, chat integrations
+    without a native tool) trigger the same investigation pipeline the CLI and
+    interactive shell use, over HTTP. FastAPI runs this sync handler in a
+    threadpool, so a long investigation does not block ``/health`` or ``/alerts``.
+    """
+    if (auth_error := _gateway_auth_error(request)) is not None:
+        return auth_error
+
+    investigation_metadata = resolve_investigation_context(
+        raw_alert=req.raw_alert,
+        alert_name=req.alert_name,
+        pipeline_name=req.pipeline_name,
+        severity=req.severity,
+    )
+    try:
+        result = run_investigation_payload(
+            raw_alert=req.raw_alert,
+            investigation_metadata=investigation_metadata,
+        )
+    except Exception as exc:
+        capture_exception(exc, context="gateway.webapp.investigate")
+        return JSONResponse(
+            {"error": f"{type(exc).__name__}: {exc}"},
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    return InvestigateResponse(**result)

--- a/gateway/webapp.py
+++ b/gateway/webapp.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hmac
 import json
+import logging
 import os
 from datetime import UTC, datetime
 from typing import Any
@@ -39,6 +40,8 @@ from tools.investigation.capability import (  # noqa: E402
 )
 
 init_sentry(entrypoint="webapp")
+
+logger = logging.getLogger(__name__)
 
 # Cap on POST body size accepted from any caller (authed or not). Realistic
 # alert payloads top out around 50 KB, so 1 MiB is ~20× headroom.
@@ -198,11 +201,16 @@ def investigate(req: InvestigateRequest, request: Request) -> InvestigateRespons
             raw_alert=req.raw_alert,
             investigation_metadata=investigation_metadata,
         )
+        return InvestigateResponse(**result)
     except Exception as exc:
+        # Full detail (which may include internal paths, stack context, or
+        # upstream error bodies) goes to logs/Sentry only. The HTTP response
+        # carries just the exception type so it stays actionable without
+        # exposing internals to the caller (CodeQL: information exposure
+        # through an exception).
+        logger.exception("Investigation failed")
         capture_exception(exc, context="gateway.webapp.investigate")
         return JSONResponse(
-            {"error": f"{type(exc).__name__}: {exc}"},
+            {"error": f"investigation failed: {type(exc).__name__}"},
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
-
-    return InvestigateResponse(**result)


### PR DESCRIPTION
Fixes #3842

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

The `/investigate` REST endpoint was lost when `infra/deployment/remote/server.py` — a standalone FastAPI app that also bundled unrelated Discord bot, Vercel deployment poller, and EC2 IMDS metadata code — was deleted in a prior "infra folder cleanup" commit.

This PR restores just the `/investigate` endpoint, not the legacy infrastructure it used to be bundled with:

- Adds `POST /investigate` to `gateway/webapp.py`, the app's single current FastAPI surface (alongside the existing `/health`, `/ok`, `/healthz`, `POST /alerts`). It runs an investigation synchronously and returns the RCA report.
- Reuses `tools.investigation.capability.run_investigation_payload` — the same headless runner the CLI already calls — so pipeline behavior is identical across surfaces, and the change respects the `gateway`/`surfaces` import-boundary rule (gateway must not import from `surfaces`, which is how the old code was previously wired and why it couldn't just be copy-pasted back).
- Accepts the same parameters as before: `raw_alert`, `alert_name`, `pipeline_name`, `severity`.
- Reuses the existing gateway auth boundary (loopback-only by default, or `OPENSRE_ALERT_LISTENER_TOKEN` bearer token for remote callers) — the same trust boundary `POST /alerts` already uses. Generalized the internal auth helper (`_alert_auth_error` → `_gateway_auth_error`) since it now guards two routes.
- Fixes `docs/deployment.mdx`, which already documented `/investigate` but with a stale `--host/--port/--api-key`/`X-API-Key` CLI contract that doesn't exist in the current `opensre gateway start` command — updated to match the real CLI and the actual bearer-token auth.
- **Follow-up commit addressing review feedback:** guarded `InvestigateResponse(**result)` construction inside the same `try/except` as the pipeline call (Greptile: a malformed pipeline result could raise an unguarded Pydantic `ValidationError`), and stopped returning raw exception text to HTTP callers — the response now carries only the exception type name, with full detail going to logs/Sentry server-side only (CodeQL: information exposure through an exception).

Out of scope (not required by the issue's acceptance criteria, and would reintroduce dead/legacy functionality): the Discord slash-command integration, the Vercel deployment poller, EC2 IMDS instance metadata, deep health checks, and `.md` report persistence (`/investigations` list/get) that lived in the old `infra/deployment/remote/server.py`. None of that infrastructure exists in the current codebase anymore.

### Demo/Screenshot for feature changes and bug fixes -
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

Started a real `uvicorn` gateway process via `gateway.web_server.serve_webapp_in_thread` (not just `TestClient` mocks) and hit it with real HTTP requests:

```
$ curl http://127.0.0.1:39045/health
{"ok":true,"version":"0.1","llm_configured":true,"env":"development"}

$ curl -X POST http://127.0.0.1:39045/investigate   # missing raw_alert
422 {"detail":[{"type":"missing","loc":["body","raw_alert"],"msg":"Field required","input":{"alert_name":"x"}}]}
```

Full test run:

```
$ uv run pytest gateway/tests -q
======================== 117 passed, 1 warning in 7.05s =========================
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: `/investigate` was removed as collateral damage of an infra cleanup that deleted a much bigger legacy file it happened to live in. The fix isn't "restore the old file" — most of that file (Discord bot, Vercel poller, EC2 IMDS) is dead code with no current callers, and re-adding it would violate the current Tier-1 import-boundary rules (`gateway` and `surfaces` must not import each other) that didn't exist when the old server was written.

Alternative considered: resurrect `infra/deployment/remote/server.py` wholesale. Rejected — it imports directly from `surfaces.cli` and `surfaces.interactive_shell`, which is now a forbidden cross-surface import, and it reintroduces several unrelated, currently-unused integrations (Discord, Vercel, IMDS) the issue never asked for.

Chosen approach: add `POST /investigate` directly to `gateway/webapp.py`, the app's one current FastAPI surface, and have it call `tools.investigation.capability.run_investigation_payload` — a Tier-2 helper already explicitly documented as "the headless counterpart used by surfaces that do not render a live terminal stream (HTTP server, MCP, integration webhooks)." This keeps the endpoint's behavior byte-for-byte consistent with what the CLI already produces, without adding a new code path to maintain.

Key pieces:
- `InvestigateRequest`/`InvestigateResponse` — Pydantic models mirroring the old endpoint's request shape and the payload `run_investigation_payload` already returns.
- `_gateway_auth_error` (renamed from `_alert_auth_error`) — the same loopback-or-bearer-token check `/alerts` already used, now shared by both mutating routes since they sit behind the same trust boundary.
- Error handling — after review feedback, both the pipeline call and the response-model construction are wrapped in one `try/except`, exceptions are logged and sent to Sentry server-side, and the client only sees the exception type name (not the message), to avoid leaking internal detail through an HTTP error body.

Edge cases tested: missing `raw_alert` (422), pipeline exceptions (503, with exception text confirmed absent from the response body), a malformed pipeline result that fails response validation (503, not an unguarded 500), metadata resolution falling back to `raw_alert` fields when overrides are omitted, and the full 401/403/200 auth matrix (loopback vs. remote, with/without token).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.