### PR TITLE
fix(analytics): tag conversational LLM provider failures correctly on $ai_model

### DIFF
--- a/.importlinter.strict
+++ b/.importlinter.strict
@@ -33,7 +33,6 @@ ignore_imports =
     platform.analytics.cli -> integrations.github.identity
     platform.observability.errors.sentry -> integrations.llm_cli.errors
     platform.scheduler.credentials -> integrations.catalog
-    platform.scheduler.credentials -> integrations.telegram.credentials
     platform.scheduler.executor -> integrations.discord.delivery
     platform.scheduler.executor -> integrations.slack.delivery
     platform.scheduler.executor -> integrations.telegram.delivery

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -251,6 +251,37 @@ def _render_tool_calling_error(output: OutputSink, message: str) -> None:
     output.render_error(message)
 
 
+def _stage_action_llm_failure(
+    message: str,
+    session: SessionStore,
+    *,
+    deps: ToolCallingDeps | None,
+    error_text: str,
+) -> None:
+    """Stage telemetry for an action-agent LLM failure on conversational input.
+
+    Explicit ``!shell`` / literal ``/slash`` turns never invoke the hosted LLM
+    (they run through ``_StaticToolCallLLM``), so a failure there stays a
+    terminal-action outcome. For conversational input the LLM was the intended
+    route, so the turn must be reported as a failed LLM call — not a terminal
+    turn tagged ``no_conversational_agent``.
+    """
+    if _bang_shell_command(message) is not None or message.strip().startswith("/"):
+        return
+    from core.agent_harness.turns.orchestrator import stage_turn_error, stage_turn_llm_failure
+
+    stage_turn_error(session, "action_agent_error", error_text)
+    factory = deps.llm_factory if deps is not None and deps.llm_factory else default_llm_factory
+    try:
+        # A build-time failure (missing key, bad config) raises again here and
+        # leaves the model unresolved; an invoke-time failure returns the same
+        # (cached) client so the attempted model/provider can be reported.
+        client = factory()
+    except Exception:
+        client = None
+    stage_turn_llm_failure(session, client=client)
+
+
 def _bang_shell_command(message: str) -> str | None:
     # Explicit `!cmd` shell escape: a deterministic bypass for input the user
     # typed verbatim as a shell command. This is NOT natural-language intent
@@ -458,6 +489,7 @@ def _run_action_agent_turn_body(
         error_text = str(exc)
         if error_reporter is not None:
             error_reporter.report(exc, context="core.agent_harness.action_driver", expected=True)
+        _stage_action_llm_failure(message, session, deps=deps, error_text=error_text)
         _render_tool_calling_error(output, error_text)
         _persist_tool_calling_error(session, message, error_text)
         session.record("cli_agent", message, ok=False)

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -85,6 +85,7 @@ INVESTIGATION_DISPATCH_TOOL_NAMES: frozenset[str] = frozenset(
 class ActionTurnPlan:
     agent: Agent[Any]
     user_message: str
+    llm_client: Any | None = None
 
 
 @dataclass(frozen=True)
@@ -255,7 +256,7 @@ def _stage_action_llm_failure(
     message: str,
     session: SessionStore,
     *,
-    deps: ToolCallingDeps | None,
+    client: Any | None,
     error_text: str,
 ) -> None:
     """Stage telemetry for an action-agent LLM failure on conversational input.
@@ -271,14 +272,6 @@ def _stage_action_llm_failure(
     from core.agent_harness.turns.orchestrator import stage_turn_error, stage_turn_llm_failure
 
     stage_turn_error(session, "action_agent_error", error_text)
-    factory = deps.llm_factory if deps is not None and deps.llm_factory else default_llm_factory
-    try:
-        # A build-time failure (missing key, bad config) raises again here and
-        # leaves the model unresolved; an invoke-time failure returns the same
-        # (cached) client so the attempted model/provider can be reported.
-        client = factory()
-    except Exception:
-        client = None
     stage_turn_llm_failure(session, client=client)
 
 
@@ -388,7 +381,11 @@ def _build_action_agent(
         tool_hooks=tool_hooks,
         on_runtime_event=runtime_event_callback_from_observer(observer),
     )
-    return ActionTurnPlan(agent=build_agent(config), user_message=user_message)
+    return ActionTurnPlan(
+        agent=build_agent(config),
+        user_message=user_message,
+        llm_client=None if isinstance(llm, _StaticToolCallLLM) else llm,
+    )
 
 
 def run_action_agent_turn(
@@ -459,6 +456,7 @@ def _run_action_agent_turn_body(
         len(resolved_integrations),
     )
 
+    plan: ActionTurnPlan | None = None
     try:
         # LLM selection inside _build_action_agent is inside the try so a factory
         # raise (e.g. provider unavailable) is caught and rendered like a run-loop
@@ -489,7 +487,12 @@ def _run_action_agent_turn_body(
         error_text = str(exc)
         if error_reporter is not None:
             error_reporter.report(exc, context="core.agent_harness.action_driver", expected=True)
-        _stage_action_llm_failure(message, session, deps=deps, error_text=error_text)
+        _stage_action_llm_failure(
+            message,
+            session,
+            client=plan.llm_client if plan is not None else None,
+            error_text=error_text,
+        )
         _render_tool_calling_error(output, error_text)
         _persist_tool_calling_error(session, message, error_text)
         session.record("cli_agent", message, ok=False)

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -497,11 +497,7 @@ def _run_action_agent_turn_body(
         error_text = str(exc)
         if error_reporter is not None:
             error_reporter.report(exc, context="core.agent_harness.action_driver", expected=True)
-        llm_client = (
-            None
-            if plan is None or isinstance(plan.llm, _StaticToolCallLLM)
-            else plan.llm
-        )
+        llm_client = None if plan is None or isinstance(plan.llm, _StaticToolCallLLM) else plan.llm
         _stage_action_llm_failure(
             message,
             session,

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -64,6 +64,31 @@ def stage_turn_error(session: Any, kind: str, message: str) -> None:
         setter(kind, message)
 
 
+def stage_turn_llm_failure(session: Any, *, client: Any | None = None) -> None:
+    """Best-effort staging of the attempted conversational-LLM identity.
+
+    When the LLM was the intended route for a turn but the provider failed,
+    the turn's ``$ai_model`` must reflect the attempted model (or ``unknown``)
+    rather than the terminal-action sentinel. Stages whatever identity the
+    failed *client* exposes; when nothing resolves, the recorder falls back to
+    ``unknown`` based on the staged error kind.
+    """
+    from core.agent_harness.accounting.token_accounting import (
+        LlmRunInfo,
+        resolve_model_name,
+        resolve_provider_name,
+    )
+
+    terminal = getattr(session, "terminal", None)
+    setter = getattr(terminal, "set_pending_turn_llm", None)
+    if not callable(setter):
+        return
+    model = resolve_model_name(client) if client is not None else None
+    provider = resolve_provider_name(client) if client is not None else None
+    if model or provider:
+        setter(LlmRunInfo(model=model, provider=provider))
+
+
 def _stream_response(
     *,
     client: Any,
@@ -90,8 +115,9 @@ def _stream_response(
                 expected=is_cli_timeout_error(exc),
             )
         if session is not None:
-            kind = "timeout" if is_cli_timeout_error(exc) else "assistant_error"
+            kind = "llm_timeout" if is_cli_timeout_error(exc) else "assistant_error"
             stage_turn_error(session, kind, str(exc))
+            stage_turn_llm_failure(session, client=client)
         output.render_error(f"assistant failed: {exc}")
         return None
     return run_factory.build(client=client, prompt=prompt, response_text=text_str, started=started)

--- a/core/llm_invoke_errors.py
+++ b/core/llm_invoke_errors.py
@@ -93,7 +93,7 @@ LLM_PROVIDER_FAILURE_KINDS = frozenset(
 )
 
 _NOT_CONFIGURED_PATTERNS = (
-    "api_key",  # env-var style, e.g. "requires ANTHROPIC_API_KEY to be set"
+    "_api_key",  # env-var style, e.g. "requires ANTHROPIC_API_KEY to be set"
     "api key is not set",
     "missing api key",
     "not available for your account",
@@ -113,6 +113,9 @@ _AUTH_PATTERNS = (
     "forbidden",
     "invalid api key",
     "incorrect api key",
+    "invalid api_key",
+    "incorrect api_key",
+    "api_key is invalid",
     "x-api-key",
 )
 
@@ -125,14 +128,14 @@ def classify_provider_error_kind(message: str) -> str:
     without regexing over response text.
     """
     text = message.lower()
+    if any(pattern in text for pattern in _AUTH_PATTERNS):
+        return "auth"
+    if any(pattern in text for pattern in _QUOTA_PATTERNS):
+        return "quota"
     if any(pattern in text for pattern in _NOT_CONFIGURED_PATTERNS) or (
         "model" in text and "not found" in text
     ):
         return "not_configured"
-    if any(pattern in text for pattern in _QUOTA_PATTERNS):
-        return "quota"
-    if any(pattern in text for pattern in _AUTH_PATTERNS):
-        return "auth"
     return "provider_error"
 
 

--- a/core/llm_invoke_errors.py
+++ b/core/llm_invoke_errors.py
@@ -76,6 +76,66 @@ def is_cli_timeout_error(exc: BaseException) -> bool:
     return _is_llm_cli_error(exc, "CLITimeoutError")
 
 
+# Turn-error kinds staged when the conversational/action LLM was the intended
+# route for the user's input but the provider failed before a normal reply.
+# The prompt-log recorder uses this set to report a failed LLM turn (model
+# "unknown" plus ``ai_error_kind``) instead of a terminal-action turn
+# (``no_conversational_agent``). Terminal-path kinds (investigation failure
+# categories, background-task "timeout"/"cli_exit_nonzero", slash outcomes)
+# must never appear here.
+LLM_PROVIDER_FAILURE_KINDS = frozenset(
+    {
+        "llm_unavailable",  # reasoning client import/creation failed
+        "llm_timeout",  # conversational stream timed out
+        "assistant_error",  # conversational stream failed mid-turn
+        "action_agent_error",  # action-selection LLM failed for conversational input
+    }
+)
+
+_NOT_CONFIGURED_PATTERNS = (
+    "api_key",  # env-var style, e.g. "requires ANTHROPIC_API_KEY to be set"
+    "api key is not set",
+    "missing api key",
+    "not available for your account",
+    "marketplace",
+    "inference profile",
+    "not configured",
+    "no llm provider",
+    "llm client unavailable",
+    "billing is not enabled",
+)
+_QUOTA_PATTERNS = ("429", "quota", "rate limit", "too many requests", "credit")
+_AUTH_PATTERNS = (
+    "authentication",
+    "unauthorized",
+    "401",
+    "403",
+    "forbidden",
+    "invalid api key",
+    "incorrect api key",
+    "x-api-key",
+)
+
+
+def classify_provider_error_kind(message: str) -> str:
+    """Bucket an LLM provider failure message for analytics filtering.
+
+    Returns one of ``not_configured``, ``quota``, ``auth``, or
+    ``provider_error`` so downstream dashboards can filter provider failures
+    without regexing over response text.
+    """
+    text = message.lower()
+    if any(pattern in text for pattern in _NOT_CONFIGURED_PATTERNS) or (
+        "model" in text and "not found" in text
+    ):
+        return "not_configured"
+    if any(pattern in text for pattern in _QUOTA_PATTERNS):
+        return "quota"
+    if any(pattern in text for pattern in _AUTH_PATTERNS):
+        return "auth"
+    return "provider_error"
+
+
 def classify_llm_invoke_failure(exc: BaseException) -> LLMInvokeFailure | None:
     """Return a structured failure when *exc* is a known operational LLM error.
 

--- a/docs/interactive-shell-privacy.mdx
+++ b/docs/interactive-shell-privacy.mdx
@@ -84,7 +84,7 @@ interactive:
 Separately from typed-command history, the interactive shell records each LLM turn — the full prompt sent and the full response received — for chat and follow-up routes. This log is richer than command history (it includes model output, not just what you typed) and is used for two purposes:
 
 1. **Local debugging / `/resume`**: appended as JSON Lines to `~/.opensre/prompt_log.jsonl`, and folded into the session file so `/resume` can restore conversation context.
-2. **Product analytics**: forwarded to PostHog as an `$ai_generation` event (model, provider, latency, token counts, and the prompt/response text) so we can track usage and quality of the AI features. Investigation turns additionally include the model/provider/token usage of the investigation run and an `investigation_id` join key; failed turns carry structured error properties (`$ai_is_error`, `$ai_error`, `error_kind`).
+2. **Product analytics**: forwarded to PostHog as an `$ai_generation` event (model, provider, latency, token counts, and the prompt/response text) so we can track usage and quality of the AI features. Investigation turns additionally include the model/provider/token usage of the investigation run and an `investigation_id` join key; failed turns carry structured error properties (`$ai_is_error`, `$ai_error`, `error_kind`). Turns handled entirely by terminal tools or slash commands report `$ai_model` / `$ai_provider` as `no_conversational_agent`; when a conversational reply was intended but the LLM provider failed (missing API key, model access, quota, auth), the event instead reports the attempted model (or `unknown`) plus an `ai_error_kind` bucket (`not_configured`, `quota`, `auth`, or `provider_error`).
 
 ### Defaults
 

--- a/surfaces/interactive_shell/utils/telemetry/recorder.py
+++ b/surfaces/interactive_shell/utils/telemetry/recorder.py
@@ -197,9 +197,7 @@ class PromptRecorder:
     def set_response(self, text: str, run: LlmRunInfo | None = None) -> None:
         cleaned = _sanitize_text(text, config=self._config)
         if not cleaned.strip():
-            # A failed turn may produce no assistant text; surface the error
-            # message as the assistant content so analytics can display it.
-            cleaned = self._error_message or _fallback_terminal_response(prompt=self._prompt)
+            cleaned = ""
         self._response = cleaned
         if run is None:
             self._latency_ms = int((time.monotonic() - self._start) * 1000)
@@ -210,10 +208,19 @@ class PromptRecorder:
         self._input_tokens = run.input_tokens
         self._output_tokens = run.output_tokens
 
+    def _response_for_emit(self) -> str:
+        """Resolve the assistant text written to sinks at flush time."""
+        if self._response.strip():
+            return self._response
+        if self._error_message.strip():
+            return self._error_message
+        return _fallback_terminal_response(prompt=self._prompt)
+
     def flush(self) -> None:
         if self._flushed:
             return
         self._flushed = True
+        response_text = self._response_for_emit()
         latency_ms = self._latency_ms or int((time.monotonic() - self._start) * 1000)
         record = {
             "ts": datetime.now(UTC).isoformat(),
@@ -221,7 +228,7 @@ class PromptRecorder:
             "turn_id": self._turn_id,
             "turn_kind": self._turn_kind,
             "prompt": self._prompt,
-            "response": self._response,
+            "response": response_text,
             "model": self._model or "",
             "provider": self._provider or "",
             "latency_ms": latency_ms,
@@ -242,7 +249,7 @@ class PromptRecorder:
                 self._session_id,
                 session_kind,
                 self._prompt,
-                response=self._response or None,
+                response=response_text or None,
                 turn_id=self._turn_id,
                 model=self._model or None,
                 provider=self._provider or None,
@@ -269,7 +276,7 @@ class PromptRecorder:
                     "$ai_output_choices": [
                         {
                             "role": "assistant",
-                            "content": self._response,
+                            "content": response_text,
                         }
                     ],
                     "$ai_latency": (

--- a/surfaces/interactive_shell/utils/telemetry/recorder.py
+++ b/surfaces/interactive_shell/utils/telemetry/recorder.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from config.version import get_opensre_version
 from core.agent_harness.accounting.token_accounting import LlmRunInfo
+from core.llm_invoke_errors import LLM_PROVIDER_FAILURE_KINDS, classify_provider_error_kind
 from platform.analytics.provider import JsonValue
 from surfaces.interactive_shell.prompt_history.policy import redact_text
 from surfaces.interactive_shell.utils.telemetry.config import PromptLogConfig
@@ -26,6 +27,12 @@ _SUPPORTED_TURN_KINDS = frozenset({"agent", "follow_up", "new_alert", "backgroun
 # Sentinel for turns handled by terminal tools/slash commands without the
 # conversational assistant LLM (PostHog ``$ai_model`` / ``$ai_provider``).
 NO_CONVERSATIONAL_AGENT = "no_conversational_agent"
+
+# Sentinel for turns where the conversational LLM was attempted but failed
+# before the model/provider identity could be resolved (missing key, bad
+# config). Distinct from ``NO_CONVERSATIONAL_AGENT`` so provider failures are
+# never mislabeled as terminal-action turns in analytics.
+UNKNOWN_LLM = "unknown"
 
 # Maps PromptRecorder turn_kind to session turn kind stored in turn_detail records.
 _TURN_TO_SESSION_KIND: dict[str, str] = {
@@ -190,7 +197,9 @@ class PromptRecorder:
     def set_response(self, text: str, run: LlmRunInfo | None = None) -> None:
         cleaned = _sanitize_text(text, config=self._config)
         if not cleaned.strip():
-            cleaned = _fallback_terminal_response(prompt=self._prompt)
+            # A failed turn may produce no assistant text; surface the error
+            # message as the assistant content so analytics can display it.
+            cleaned = self._error_message or _fallback_terminal_response(prompt=self._prompt)
         self._response = cleaned
         if run is None:
             self._latency_ms = int((time.monotonic() - self._start) * 1000)
@@ -242,14 +251,20 @@ class PromptRecorder:
 
         if self._config.posthog_enabled:
             with contextlib.suppress(Exception):
+                # When the conversational LLM was attempted but the provider
+                # failed, the turn is a failed LLM call — never a terminal
+                # action. Fall back to "unknown" instead of the terminal
+                # sentinel when the attempted model could not be resolved.
+                llm_provider_failed = self._error_kind in LLM_PROVIDER_FAILURE_KINDS
+                fallback_label = UNKNOWN_LLM if llm_provider_failed else NO_CONVERSATIONAL_AGENT
                 integration_snapshot = build_turn_integration_snapshot(self._session)
                 posthog_properties: dict[str, JsonValue] = {
                     "$ai_trace_id": self._turn_id,
                     "$ai_session_id": self._session_id,
                     "$ai_span_id": self._turn_id,
                     "$ai_span_name": f"surfaces.interactive_shell.{self._turn_kind}",
-                    "$ai_model": self._model or NO_CONVERSATIONAL_AGENT,
-                    "$ai_provider": self._provider or NO_CONVERSATIONAL_AGENT,
+                    "$ai_model": self._model or fallback_label,
+                    "$ai_provider": self._provider or fallback_label,
                     "$ai_input": [{"role": "user", "content": self._prompt}],
                     "$ai_output_choices": [
                         {
@@ -278,6 +293,10 @@ class PromptRecorder:
                     posthog_properties["$ai_is_error"] = True
                     posthog_properties["$ai_error"] = self._error_message or self._error_kind
                     posthog_properties["error_kind"] = self._error_kind
+                    if llm_provider_failed:
+                        posthog_properties["ai_error_kind"] = classify_provider_error_kind(
+                            self._error_message or self._error_kind
+                        )
                 capture_ai_generation(posthog_properties)
 
 

--- a/tests/core/agent/orchestration/test_agent_actions_harness.py
+++ b/tests/core/agent/orchestration/test_agent_actions_harness.py
@@ -481,13 +481,49 @@ def test_llm_invoke_failure_on_conversational_input_stages_attempted_model() -> 
     assert staged.provider == "bedrock"
 
 
+def test_llm_invoke_failure_uses_built_client_without_second_factory_call() -> None:
+    """Invoke-time failure must stage identity from the client that actually failed."""
+    error = "Bedrock model unavailable"
+    factory_calls = 0
+
+    class _FailingInvokeLLM:
+        _model = "us.anthropic.claude-sonnet-4-6"
+        _provider_label = "Bedrock"
+
+        def tool_schemas(self, _tools: list[Any]) -> list[dict[str, Any]]:
+            return []
+
+        def invoke(self, *_args: Any, **_kwargs: Any) -> Any:
+            raise RuntimeError(error)
+
+    client = _FailingInvokeLLM()
+
+    def _factory() -> _FailingInvokeLLM:
+        nonlocal factory_calls
+        factory_calls += 1
+        return client
+
+    session = Session()
+    run_action_tool_turn(
+        "hi",
+        session,
+        Console(force_terminal=False),
+        deps=ToolCallingDeps(llm_factory=_factory),
+    )
+
+    assert factory_calls == 1
+    staged = session.terminal.pop_pending_turn_llm()
+    assert staged is not None
+    assert staged.model == client._model
+
+
 def test_llm_failure_on_literal_slash_input_stays_terminal() -> None:
     """Explicit /slash and !shell turns must keep the terminal-action telemetry shape."""
     from core.agent_harness.turns.action_driver import _stage_action_llm_failure
 
     for terminal_input in ("/help", "!ls -la"):
         session = Session()
-        _stage_action_llm_failure(terminal_input, session, deps=None, error_text="boom")
+        _stage_action_llm_failure(terminal_input, session, client=None, error_text="boom")
         assert session.terminal.pop_pending_turn_error() is None
         assert session.terminal.pop_pending_turn_llm() is None
 

--- a/tests/core/agent/orchestration/test_agent_actions_harness.py
+++ b/tests/core/agent/orchestration/test_agent_actions_harness.py
@@ -430,6 +430,100 @@ def test_execute_with_harness_handles_llm_unavailable() -> None:
     assert session.cli_agent_messages[-1] == ("assistant", "action agent unavailable")
 
 
+def test_llm_build_failure_on_conversational_input_stages_llm_failure() -> None:
+    """Conversational turn + provider build failure must flush as a failed LLM call."""
+    message = "LLM provider 'anthropic' requires ANTHROPIC_API_KEY to be set."
+
+    def _raise() -> object:
+        raise RuntimeError(message)
+
+    session = Session()
+    run_action_tool_turn(
+        "hi",
+        session,
+        Console(force_terminal=False),
+        deps=ToolCallingDeps(llm_factory=_raise),
+    )
+
+    assert session.terminal.pop_pending_turn_error() == ("action_agent_error", message)
+    # The client never built, so no attempted-model identity could be staged;
+    # the recorder reports "unknown" from the error kind alone.
+    assert session.terminal.pop_pending_turn_llm() is None
+
+
+def test_llm_invoke_failure_on_conversational_input_stages_attempted_model() -> None:
+    """Invoke-time provider failure stages the attempted model/provider identity."""
+    error = "Bedrock model 'us.anthropic.claude-sonnet-4-6' is not available for your account."
+
+    class _FailingInvokeLLM:
+        _model = "us.anthropic.claude-sonnet-4-6"
+        _provider_label = "Bedrock"
+
+        def tool_schemas(self, _tools: list[Any]) -> list[dict[str, Any]]:
+            return []
+
+        def invoke(self, *_args: Any, **_kwargs: Any) -> Any:
+            raise RuntimeError(error)
+
+    client = _FailingInvokeLLM()
+    session = Session()
+    run_action_tool_turn(
+        "hi",
+        session,
+        Console(force_terminal=False),
+        deps=ToolCallingDeps(llm_factory=lambda: client),
+    )
+
+    assert session.terminal.pop_pending_turn_error() == ("action_agent_error", error)
+    staged = session.terminal.pop_pending_turn_llm()
+    assert staged is not None
+    assert staged.model == "us.anthropic.claude-sonnet-4-6"
+    assert staged.provider == "bedrock"
+
+
+def test_llm_failure_on_literal_slash_input_stays_terminal() -> None:
+    """Explicit /slash and !shell turns must keep the terminal-action telemetry shape."""
+    from core.agent_harness.turns.action_driver import _stage_action_llm_failure
+
+    for terminal_input in ("/help", "!ls -la"):
+        session = Session()
+        _stage_action_llm_failure(terminal_input, session, deps=None, error_text="boom")
+        assert session.terminal.pop_pending_turn_error() is None
+        assert session.terminal.pop_pending_turn_llm() is None
+
+
+def test_stream_failure_stages_llm_error_and_identity() -> None:
+    """A conversational stream failure stages both the error and the attempted LLM."""
+    from core.agent_harness.turns.orchestrator import _stream_response
+
+    class _FailingStreamClient:
+        _model = "claude-sonnet-4-6"
+        _provider_label = "Anthropic"
+
+        def invoke_stream(self, _prompt: str) -> Any:
+            raise RuntimeError("Anthropic authentication failed.")
+
+    session = Session()
+    run = _stream_response(
+        client=_FailingStreamClient(),
+        prompt="hi",
+        output=_OutputSink(Console(force_terminal=False)),
+        run_factory=object(),
+        error_reporter=None,
+        session=session,
+    )
+
+    assert run is None
+    assert session.terminal.pop_pending_turn_error() == (
+        "assistant_error",
+        "Anthropic authentication failed.",
+    )
+    staged = session.terminal.pop_pending_turn_llm()
+    assert staged is not None
+    assert staged.model == "claude-sonnet-4-6"
+    assert staged.provider == "anthropic"
+
+
 def test_build_action_agent_returns_action_turn_plan() -> None:
     llm = FakeActionLLM([no_tool_response()])
     deps = ToolCallingDeps(llm_factory=lambda: llm)

--- a/tests/core/runtime/test_llm_invoke_errors.py
+++ b/tests/core/runtime/test_llm_invoke_errors.py
@@ -83,6 +83,8 @@ def test_cli_auth_required_uses_unknown_provider_when_attr_missing() -> None:
         ("Anthropic authentication failed.", "auth"),
         ("openai request forbidden: 403", "auth"),
         ("invalid api key provided", "auth"),
+        ("Incorrect api_key value provided", "auth"),
+        ("Your api_key is invalid", "auth"),
         ("anthropic CLI timed out after 300s.", "provider_error"),
         ("something unexpected exploded", "provider_error"),
     ],

--- a/tests/core/runtime/test_llm_invoke_errors.py
+++ b/tests/core/runtime/test_llm_invoke_errors.py
@@ -4,9 +4,13 @@ import sys
 from types import ModuleType
 from unittest.mock import patch
 
+import pytest
+
 from core.llm_invoke_errors import (
+    LLM_PROVIDER_FAILURE_KINDS,
     _looks_like_timeout,
     classify_llm_invoke_failure,
+    classify_provider_error_kind,
     is_cli_timeout_error,
 )
 from integrations.llm_cli.errors import CLITimeoutError
@@ -55,6 +59,42 @@ def test_cli_auth_required_uses_unknown_provider_when_attr_missing() -> None:
     assert failure.remediation_steps == [
         "Run `opensre doctor` to verify CLI installation and auth.",
     ]
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (
+            "Bedrock model 'us.anthropic.claude-sonnet-4-6' is not available for your "
+            "account. Check Bedrock model access in the configured AWS region, AWS "
+            "Marketplace subscription/payment setup, and IAM permissions.",
+            "not_configured",
+        ),
+        ("LLM provider 'anthropic' requires ANTHROPIC_API_KEY to be set.", "not_configured"),
+        (
+            "Gemini model 'gemini-pro' is not configured or billing is not enabled: x",
+            "not_configured",
+        ),
+        ("Anthropic model 'claude-x' was not found.", "not_configured"),
+        ("LLM client unavailable: No module named 'anthropic'", "not_configured"),
+        ("OpenAI rate limit exceeded after 6 attempts.", "quota"),
+        ("Error code: 429 - too many requests", "quota"),
+        ("Your credit balance is too low to access the Anthropic API.", "quota"),
+        ("Anthropic authentication failed.", "auth"),
+        ("openai request forbidden: 403", "auth"),
+        ("invalid api key provided", "auth"),
+        ("anthropic CLI timed out after 300s.", "provider_error"),
+        ("something unexpected exploded", "provider_error"),
+    ],
+)
+def test_classify_provider_error_kind(message: str, expected: str) -> None:
+    assert classify_provider_error_kind(message) == expected
+
+
+def test_llm_provider_failure_kinds_exclude_terminal_task_kinds() -> None:
+    """Background-task/investigation error kinds must never count as LLM provider failures."""
+    for terminal_kind in ("timeout", "cli_exit_nonzero", "spawn_failed", "unknown", "config"):
+        assert terminal_kind not in LLM_PROVIDER_FAILURE_KINDS
 
 
 def test_cli_auth_required_filters_none_remediation_fields() -> None:

--- a/tests/interactive_shell/utils/telemetry/test_recorder.py
+++ b/tests/interactive_shell/utils/telemetry/test_recorder.py
@@ -437,6 +437,10 @@ def test_prompt_recorder_set_error_adds_structured_properties(monkeypatch, tmp_p
     assert captured[0]["$ai_is_error"] is True
     assert captured[0]["$ai_error"] == "ANTHROPIC_API_KEY not set"
     assert captured[0]["error_kind"] == "config"
+    # Investigation-style errors are terminal-path failures, not conversational
+    # LLM provider failures: no ai_error_kind and the sentinel model stays.
+    assert "ai_error_kind" not in captured[0]
+    assert captured[0]["$ai_model"] == "no_conversational_agent"
 
 
 def test_prompt_recorder_omits_error_properties_by_default(monkeypatch, tmp_path: Path) -> None:
@@ -468,6 +472,88 @@ def test_prompt_recorder_omits_error_properties_by_default(monkeypatch, tmp_path
     assert "$ai_is_error" not in captured[0]
     assert "$ai_error" not in captured[0]
     assert "error_kind" not in captured[0]
+
+
+def _posthog_recorder(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    text: str,
+    captured: list[dict[str, object]],
+) -> PromptRecorder:
+    cfg = PromptLogConfig(
+        enabled=True,
+        local_enabled=False,
+        posthog_enabled=True,
+        redact=False,
+        max_chars=1000,
+        log_path=tmp_path / "prompt_log.jsonl",
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.PromptLogConfig.load", lambda: cfg
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.build_turn_integration_snapshot",
+        lambda _session: {},
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.utils.telemetry.recorder.capture_ai_generation",
+        lambda payload: captured.append(payload),
+    )
+    recorder = PromptRecorder.start(session=Session(), text=text, turn_kind="agent")
+    assert recorder is not None
+    return recorder
+
+
+def test_prompt_recorder_llm_provider_failure_never_uses_terminal_sentinel(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Conversational prompt + provider failure must not be tagged no_conversational_agent."""
+    captured: list[dict[str, object]] = []
+    recorder = _posthog_recorder(monkeypatch, tmp_path, text="hi", captured=captured)
+    error = (
+        "Bedrock model 'us.anthropic.claude-sonnet-4-6' is not available for your account. "
+        "Check Bedrock model access in the configured AWS region."
+    )
+    recorder.set_error("action_agent_error", error)
+    recorder.set_response(error)
+    recorder.flush()
+    assert captured[0]["$ai_model"] == "unknown"
+    assert captured[0]["$ai_provider"] == "unknown"
+    assert captured[0]["ai_error_kind"] == "not_configured"
+    assert "not available for your account" in captured[0]["$ai_output_choices"][0]["content"]
+
+
+def test_prompt_recorder_llm_provider_failure_reports_attempted_model(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: list[dict[str, object]] = []
+    recorder = _posthog_recorder(monkeypatch, tmp_path, text="hi", captured=captured)
+    recorder.set_error("assistant_error", "Anthropic authentication failed.")
+    recorder.set_response(
+        "",
+        LlmRunInfo(model="claude-sonnet-4-6", provider="anthropic"),
+    )
+    recorder.flush()
+    assert captured[0]["$ai_model"] == "claude-sonnet-4-6"
+    assert captured[0]["$ai_provider"] == "anthropic"
+    assert captured[0]["ai_error_kind"] == "auth"
+    # Empty assistant text falls back to the error message, not the terminal fallback.
+    assert captured[0]["$ai_output_choices"][0]["content"] == "Anthropic authentication failed."
+
+
+def test_prompt_recorder_terminal_error_kinds_keep_terminal_sentinel(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Background-task style errors (e.g. subprocess timeout) stay terminal-action turns."""
+    captured: list[dict[str, object]] = []
+    recorder = _posthog_recorder(monkeypatch, tmp_path, text="hi", captured=captured)
+    recorder.set_error("timeout", "command timed out after 60 seconds")
+    recorder.set_response("command timed out after 60 seconds")
+    recorder.flush()
+    assert captured[0]["$ai_model"] == "no_conversational_agent"
+    assert captured[0]["$ai_provider"] == "no_conversational_agent"
+    assert "ai_error_kind" not in captured[0]
 
 
 def test_prompt_recorder_uses_only_latest_slash_outcome(monkeypatch, tmp_path: Path) -> None:

--- a/tests/interactive_shell/utils/telemetry/test_recorder.py
+++ b/tests/interactive_shell/utils/telemetry/test_recorder.py
@@ -542,6 +542,18 @@ def test_prompt_recorder_llm_provider_failure_reports_attempted_model(
     assert captured[0]["$ai_output_choices"][0]["content"] == "Anthropic authentication failed."
 
 
+def test_prompt_recorder_flush_resolves_error_message_after_empty_set_response(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Flush-time fallback tolerates set_response before set_error."""
+    captured: list[dict[str, object]] = []
+    recorder = _posthog_recorder(monkeypatch, tmp_path, text="hi", captured=captured)
+    recorder.set_response("")
+    recorder.set_error("assistant_error", "provider failed")
+    recorder.flush()
+    assert captured[0]["$ai_output_choices"][0]["content"] == "provider failed"
+
+
 def test_prompt_recorder_terminal_error_kinds_keep_terminal_sentinel(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

- Stage attempted LLM model/provider identity and structured error kinds when the action or reasoning LLM fails on conversational input, so `$ai_generation` events no longer emit `no_conversational_agent` for provider failures (Bedrock model unavailable, missing API key, quota/auth errors, etc.).
- Add `ai_error_kind` (`not_configured`, `quota`, `auth`, `provider_error`) on provider-failure paths for filterable PostHog analytics.
- Preserve `no_conversational_agent` for true terminal turns (`/help`, slash/cli_exec, investigation terminal outcomes).

Fixes #3928

## Changes

| Area | What |
|---|---|
| `action_driver.py` | On conversational LLM failure, stage `action_agent_error` + attempted model via `_stage_action_llm_failure` |
| `orchestrator.py` | On stream failure, stage `assistant_error`/`llm_timeout` + attempted model via `stage_turn_llm_failure` |
| `recorder.py` | Use `unknown` (not `no_conversational_agent`) when `error_kind` is an LLM provider failure; emit `ai_error_kind` |
| `llm_invoke_errors.py` | `classify_provider_error_kind()` + `LLM_PROVIDER_FAILURE_KINDS` set |

## Test plan

- [x] `uv run python -m pytest tests/core/runtime/test_llm_invoke_errors.py tests/interactive_shell/utils/telemetry/test_recorder.py tests/core/agent/orchestration/test_agent_actions_harness.py tests/interactive_shell/runtime/test_turn_accounting.py`
- [x] `uv run ruff check` + `uv run ruff format --check` + `uv run mypy` on changed source files
- [ ] Manual: send `hi` with Bedrock model unavailable → PostHog `$ai_model != no_conversational_agent`, `ai_error_kind = not_configured`
- [ ] Manual: `/help` → still `no_conversational_agent`