### PR TITLE
fix(gateway): authenticate and cap body before parsing POST /investigate

### DIFF
--- a/gateway/tests/test_webapp_investigate.py
+++ b/gateway/tests/test_webapp_investigate.py
@@ -158,3 +158,42 @@ def test_investigate_token_auth(monkeypatch: pytest.MonkeyPatch) -> None:
         ).status_code
         == 200
     )
+
+
+def test_investigate_body_over_cap_returns_413(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    """A body larger than the cap is rejected before the pipeline runs."""
+    monkeypatch.setattr(webapp, "MAX_ALERT_BODY_BYTES", 100)
+    called = False
+
+    def _should_not_run(**_: Any) -> dict[str, Any]:
+        nonlocal called
+        called = True
+        return _fake_payload()
+
+    monkeypatch.setattr(webapp, "run_investigation_payload", _should_not_run)
+
+    resp = client.post("/investigate", json={"raw_alert": {"blob": "x" * 500}})
+
+    assert resp.status_code == 413
+    assert called is False
+
+
+def test_investigate_auth_runs_before_body_parse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unauthenticated caller is rejected by auth *before* the body is parsed.
+
+    A remote caller sending an invalid body must get 403 (auth), not 422 (body
+    validation). With the body bound as a Pydantic parameter the framework
+    parsed and rejected it (422) before the handler's auth check ever ran --
+    the pre-auth parse this fix closes.
+    """
+    monkeypatch.setattr(webapp, "run_investigation_payload", lambda **_: _fake_payload())
+    remote = TestClient(webapp.app, client=_REMOTE)
+
+    # Body is missing the required raw_alert field.
+    resp = remote.post("/investigate", json={"alert_name": "x"})
+
+    assert resp.status_code == 403

--- a/gateway/tests/test_webapp_investigate.py
+++ b/gateway/tests/test_webapp_investigate.py
@@ -197,3 +197,41 @@ def test_investigate_auth_runs_before_body_parse(
     resp = remote.post("/investigate", json={"alert_name": "x"})
 
     assert resp.status_code == 403
+
+
+def test_investigate_malformed_json_returns_400(client: TestClient) -> None:
+    """Malformed JSON is a decode error (400), distinct from a schema violation (422)."""
+    resp = client.post(
+        "/investigate",
+        content=b"{not valid json",
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == 400
+
+
+def test_investigate_chunked_over_cap_returns_413(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    """A chunked body (no Content-Length) over the cap is caught by the
+    post-read len(body) guard, not just the Content-Length header check."""
+    monkeypatch.setattr(webapp, "MAX_ALERT_BODY_BYTES", 100)
+    called = False
+
+    def _should_not_run(**_: Any) -> dict[str, Any]:
+        nonlocal called
+        called = True
+        return _fake_payload()
+
+    monkeypatch.setattr(webapp, "run_investigation_payload", _should_not_run)
+
+    def _chunks() -> Iterator[bytes]:
+        # A generator body makes httpx use chunked transfer encoding, so no
+        # Content-Length header is sent and the first guard is bypassed.
+        yield b'{"raw_alert": {"blob": "'
+        yield b"x" * 500
+        yield b'"}}'
+
+    resp = client.post("/investigate", content=_chunks())
+
+    assert resp.status_code == 413
+    assert called is False

--- a/gateway/webapp.py
+++ b/gateway/webapp.py
@@ -210,8 +210,14 @@ async def investigate(request: Request) -> InvestigateResponse | JSONResponse:
     if len(body) > MAX_ALERT_BODY_BYTES:
         return JSONResponse({"error": "payload too large"}, status_code=413)
 
+    # Split decode from validation so malformed JSON returns 400 and a
+    # well-formed body that violates the schema returns 422, matching /alerts.
     try:
-        req = InvestigateRequest.model_validate_json(body)
+        data = json.loads(body)
+    except ValueError:
+        return JSONResponse({"error": "invalid json"}, status_code=400)
+    try:
+        req = InvestigateRequest.model_validate(data)
     except ValidationError:
         return JSONResponse({"error": "invalid request"}, status_code=422)
 

--- a/gateway/webapp.py
+++ b/gateway/webapp.py
@@ -10,6 +10,7 @@ standalone via ``uvicorn gateway.webapp:app``.
 
 from __future__ import annotations
 
+import functools
 import hmac
 import json
 import logging
@@ -17,6 +18,7 @@ import os
 from datetime import UTC, datetime
 from typing import Any
 
+import anyio
 from fastapi import FastAPI, Request, Response, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ValidationError
@@ -179,16 +181,39 @@ class InvestigateResponse(BaseModel):
 
 
 @app.post("/investigate", response_model=InvestigateResponse)
-def investigate(req: InvestigateRequest, request: Request) -> InvestigateResponse | JSONResponse:
+async def investigate(request: Request) -> InvestigateResponse | JSONResponse:
     """Run an investigation synchronously and return the RCA report.
 
     Lets external systems (CI pipelines, custom webhooks, chat integrations
     without a native tool) trigger the same investigation pipeline the CLI and
-    interactive shell use, over HTTP. FastAPI runs this sync handler in a
-    threadpool, so a long investigation does not block ``/health`` or ``/alerts``.
+    interactive shell use, over HTTP. The blocking pipeline is offloaded to a
+    worker thread so it does not block the event loop / ``/health``.
+
+    The body is read manually (not via a Pydantic parameter) so authentication
+    and the size cap run *before* the request body is buffered and parsed --
+    otherwise an unauthenticated caller could force parsing of an arbitrarily
+    large body. Mirrors ``/alerts``.
     """
     if (auth_error := _gateway_auth_error(request)) is not None:
         return auth_error
+
+    try:
+        declared_length = int(request.headers.get("content-length", 0))
+    except ValueError:
+        return JSONResponse({"error": "invalid Content-Length"}, status_code=400)
+    if declared_length < 0:
+        return JSONResponse({"error": "invalid Content-Length"}, status_code=400)
+    if declared_length > MAX_ALERT_BODY_BYTES:
+        return JSONResponse({"error": "payload too large"}, status_code=413)
+
+    body = await request.body()
+    if len(body) > MAX_ALERT_BODY_BYTES:
+        return JSONResponse({"error": "payload too large"}, status_code=413)
+
+    try:
+        req = InvestigateRequest.model_validate_json(body)
+    except ValidationError:
+        return JSONResponse({"error": "invalid request"}, status_code=422)
 
     investigation_metadata = resolve_investigation_context(
         raw_alert=req.raw_alert,
@@ -197,9 +222,12 @@ def investigate(req: InvestigateRequest, request: Request) -> InvestigateRespons
         severity=req.severity,
     )
     try:
-        result = run_investigation_payload(
-            raw_alert=req.raw_alert,
-            investigation_metadata=investigation_metadata,
+        result = await anyio.to_thread.run_sync(
+            functools.partial(
+                run_investigation_payload,
+                raw_alert=req.raw_alert,
+                investigation_metadata=investigation_metadata,
+            )
         )
         return InvestigateResponse(**result)
     except Exception as exc:


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

The restored `POST /investigate` (#3926) bound the request body as a Pydantic parameter:

```python
def investigate(req: InvestigateRequest, request: Request) -> ...:
    if (auth_error := _gateway_auth_error(request)) is not None:
        return auth_error
```

Because `req` is a body-bound parameter, Starlette **buffers and JSON-parses the entire body during parameter resolution — before the handler runs**, so `_gateway_auth_error` executes only *after* the full parse, and there is no body-size limit anywhere on the route. In the non-loopback + `OPENSRE_ALERT_LISTENER_TOKEN` deployment this endpoint is built for, an **unauthenticated** caller can force full buffering/parsing of an arbitrarily large body ahead of the 401/403 — a pre-auth memory/CPU DoS.

The sibling `POST /alerts` already does this correctly: auth first, then a `Content-Length` check, then a 1 MiB (`MAX_ALERT_BODY_BYTES`) cap on the buffered body, then parse.

This PR makes `/investigate` mirror `/alerts`:
1. Take the raw `Request` (no Pydantic body parameter).
2. `_gateway_auth_error(request)` first.
3. `Content-Length` check, then `await request.body()` with the `MAX_ALERT_BODY_BYTES` cap.
4. Parse `InvestigateRequest` from the bytes (`ValidationError` -> 422).

The handler is now `async`; the blocking pipeline is offloaded via `anyio.to_thread.run_sync(functools.partial(run_investigation_payload, ...))`, so it still does not block the event loop or `/health`.

### Demo/Screenshot for feature changes and bug fixes -

Two new tests in `gateway/tests/test_webapp_investigate.py`:
- `test_investigate_body_over_cap_returns_413` — with the cap lowered, an over-cap body returns **413** and the pipeline is never invoked.
- `test_investigate_auth_runs_before_body_parse` — a remote unauthenticated caller sending an **invalid** body gets **403** (auth), not 422 (body validation) — proving auth precedes the parse.

Verified both fail against the pre-fix handler and pass after:
```
# before the fix (Pydantic-param handler)
FAILED test_investigate_body_over_cap_returns_413            # no cap -> 200
FAILED test_investigate_auth_runs_before_body_parse          # parse-first -> 422, not 403

# after the fix
9 passed   (7 existing + 2 new)
```

Local CI: `make lint`, `make format-check`, `make typecheck` clean; `make test-cov` passes (10,781 passed).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The root cause is that a Pydantic body parameter moves body buffering + parsing *ahead* of the handler body, so no in-handler auth or size check can precede it. The fix therefore has to drop the body parameter and read the body manually, which is exactly what `/alerts` does — so I mirrored it rather than inventing a new shape, reusing `MAX_ALERT_BODY_BYTES` and the same Content-Length/`len(body)` two-step (the second guards chunked requests with no declared length).

Reading the body requires `await`, so the handler becomes `async`. A naive async handler would then run the long synchronous pipeline directly on the event loop and block `/health` — worse than before. I offload it with `anyio.to_thread.run_sync` (anyio is already a FastAPI dependency), preserving the original "runs off the event loop" property. I considered a Starlette body-size middleware instead, but that would cap size without moving the parse after auth (the Pydantic param would still parse first), so it doesn't close the actual ordering bug. A dedicated bounded executor to also isolate `/investigate` from `/health` under heavy concurrency is a reasonable follow-up but is a separate capacity-tuning decision, so I kept this PR to the security fix.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions