### PR TITLE
feat(providers): Add GPT-5.6 Sol / Terra / Luna model support

### DIFF
--- a/core/context_budget.py
+++ b/core/context_budget.py
@@ -16,6 +16,9 @@ _MODEL_CONTEXT_WINDOWS: dict[str, int] = {
     "gpt-4o": 128_000,
     "gpt-4.1": 1_000_000,
     "gpt-4": 128_000,
+    # Lookup is first-substring-match in insertion order, so gpt-5.6 must stay
+    # above the gpt-5 catch-all or it is never reached.
+    "gpt-5.6": 1_000_000,
     # gpt-5 window is conservatively pinned to 128k until confirmed for the
     # dated snapshot in use; raise once verified to reclaim headroom.
     "gpt-5": 128_000,

--- a/core/llm/shared/openai_responses.py
+++ b/core/llm/shared/openai_responses.py
@@ -1,0 +1,134 @@
+"""OpenAI Responses API request and response adapters."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from core.llm.types import ToolCall
+
+_RESPONSE_OUTPUT_KEY = "_openai_response_output"
+
+
+def uses_responses_api(model: str, api_key_env: str) -> bool:
+    """Return whether this official OpenAI model requires the Responses API."""
+    return api_key_env == "OPENAI_API_KEY" and model.lower().startswith("gpt-5.6")
+
+
+def responses_tool_specs(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert externally tagged Chat Completions tools to Responses tools."""
+    converted: list[dict[str, Any]] = []
+    for tool in tools:
+        function = tool.get("function")
+        if tool.get("type") != "function" or not isinstance(function, dict):
+            converted.append(dict(tool))
+            continue
+        converted.append(
+            {
+                "type": "function",
+                "name": function.get("name", ""),
+                "description": function.get("description", ""),
+                "parameters": function.get("parameters", {}),
+                "strict": function.get("strict", False),
+            }
+        )
+    return converted
+
+
+def responses_input(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert the runtime's Chat-shaped transcript to Responses input items."""
+    items: list[dict[str, Any]] = []
+    for message in messages:
+        response_output = message.get(_RESPONSE_OUTPUT_KEY)
+        if isinstance(response_output, list):
+            items.extend(dict(item) for item in response_output if isinstance(item, dict))
+            continue
+
+        role = message.get("role")
+        if role == "tool":
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": str(message.get("tool_call_id", "")),
+                    "output": str(message.get("content", "")),
+                }
+            )
+            continue
+
+        content = message.get("content", "")
+        if role == "assistant" and message.get("tool_calls"):
+            if content:
+                items.append({"role": "assistant", "content": str(content)})
+            for tool_call in message["tool_calls"]:
+                if not isinstance(tool_call, dict):
+                    continue
+                function = tool_call.get("function", {})
+                if not isinstance(function, dict):
+                    continue
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": str(tool_call.get("id", "")),
+                        "name": str(function.get("name", "")),
+                        "arguments": str(function.get("arguments", "{}")),
+                    }
+                )
+            continue
+
+        items.append({"role": str(role or "user"), "content": str(content)})
+    return items
+
+
+def response_output_items(response: Any) -> list[dict[str, Any]]:
+    """Serialize Responses output items for stateless replay on the next turn."""
+    serialized: list[dict[str, Any]] = []
+    for item in getattr(response, "output", []) or []:
+        if hasattr(item, "model_dump"):
+            serialized.append(item.model_dump(exclude_none=True))
+        elif isinstance(item, dict):
+            serialized.append(dict(item))
+    return serialized
+
+
+def response_tool_calls(response: Any) -> list[ToolCall]:
+    """Extract function calls from a Responses API result."""
+    tool_calls: list[ToolCall] = []
+    for item in getattr(response, "output", []) or []:
+        if getattr(item, "type", None) != "function_call":
+            continue
+        raw_arguments = str(getattr(item, "arguments", "") or "")
+        try:
+            arguments = json.loads(raw_arguments) if raw_arguments else {}
+        except (json.JSONDecodeError, ValueError):
+            arguments = {}
+        tool_calls.append(
+            ToolCall(
+                id=str(getattr(item, "call_id", "")),
+                name=str(getattr(item, "name", "")),
+                input=arguments if isinstance(arguments, dict) else {},
+            )
+        )
+    return tool_calls
+
+
+def response_raw_message(response: Any) -> dict[str, Any]:
+    """Build the replayable assistant message stored in the runtime transcript."""
+    message: dict[str, Any] = {
+        "role": "assistant",
+        "content": str(getattr(response, "output_text", "") or ""),
+        _RESPONSE_OUTPUT_KEY: response_output_items(response),
+    }
+    tool_calls = response_tool_calls(response)
+    if tool_calls:
+        message["tool_calls"] = [
+            {
+                "id": tool_call.id,
+                "type": "function",
+                "function": {
+                    "name": tool_call.name,
+                    "arguments": json.dumps(tool_call.input),
+                },
+            }
+            for tool_call in tool_calls
+        ]
+    return message

--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -29,6 +29,13 @@ from core.llm.shared.openai_chat_completions import (
 from core.llm.shared.openai_chat_completions import (
     build_tool_result_messages as build_openai_compat_tool_result_messages,
 )
+from core.llm.shared.openai_responses import (
+    response_raw_message,
+    response_tool_calls,
+    responses_input,
+    responses_tool_specs,
+    uses_responses_api,
+)
 from core.llm.shared.tool_schema_normalize import build_openai_tool_specs
 from core.llm.shared.usage import emit_provider_usage
 from core.llm.types import AgentLLMResponse, ToolCall
@@ -498,24 +505,43 @@ class OpenAIAgentClient:
         if system:
             msgs = [{"role": "system", "content": system}] + msgs
 
-        kwargs: dict[str, Any] = {
-            "model": self._model,
-            _openai_max_token_kwarg(self._model): self._max_tokens,
-            "messages": msgs,
-        }
-        if tools:
-            kwargs["tools"] = tools
-            kwargs["tool_choice"] = "auto"
-            if _supports_openai_parallel_tool_calls_param(
-                str(getattr(self, "_api_key_env", "OPENAI_API_KEY"))
-            ):
+        api_key_env = str(getattr(self, "_api_key_env", "OPENAI_API_KEY"))
+        use_responses = uses_responses_api(self._model, api_key_env)
+        if use_responses:
+            kwargs: dict[str, Any] = {
+                "model": self._model,
+                "max_output_tokens": self._max_tokens,
+                "input": responses_input(msgs),
+            }
+            if tools:
+                kwargs["tools"] = responses_tool_specs(tools)
+                kwargs["tool_choice"] = "auto"
                 kwargs["parallel_tool_calls"] = True
+            from config.llm_reasoning_effort import get_active_reasoning_effort
+
+            reasoning_effort = get_active_reasoning_effort()
+            if reasoning_effort is not None:
+                kwargs["reasoning"] = {"effort": reasoning_effort}
+        else:
+            kwargs = {
+                "model": self._model,
+                _openai_max_token_kwarg(self._model): self._max_tokens,
+                "messages": msgs,
+            }
+            if tools:
+                kwargs["tools"] = tools
+                kwargs["tool_choice"] = "auto"
+                if _supports_openai_parallel_tool_calls_param(api_key_env):
+                    kwargs["parallel_tool_calls"] = True
 
         backoff = _RETRY_INITIAL_BACKOFF_SEC
         last_err: Exception | None = None
         for attempt in range(_RETRY_MAX_ATTEMPTS):
             try:
-                response = self._client.chat.completions.create(**kwargs)
+                if use_responses:
+                    response = self._client.responses.create(**kwargs)
+                else:
+                    response = self._client.chat.completions.create(**kwargs)
                 break
             except AuthenticationError as err:
                 raise RuntimeError(f"{self._provider_label} authentication failed.") from err
@@ -556,6 +582,21 @@ class OpenAIAgentClient:
                 backoff *= 2
         else:
             raise RuntimeError(f"{self._provider_label} invocation failed") from last_err
+
+        if use_responses:
+            emit_provider_usage(
+                self._model,
+                getattr(response, "usage", None),
+                input_key="input_tokens",
+                output_key="output_tokens",
+            )
+            responses_tool_calls = response_tool_calls(response)
+            return AgentLLMResponse(
+                content=str(getattr(response, "output_text", "") or ""),
+                tool_calls=responses_tool_calls,
+                stop_reason="tool_calls" if responses_tool_calls else "stop",
+                raw_content=response_raw_message(response),
+            )
 
         if not hasattr(response, "choices") or not response.choices:
             raise RuntimeError(

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -63,9 +63,13 @@ with fast-changing or account-gated catalogs (OpenAI, OpenRouter, Gemini, NVIDIA
 CLIs, Ollama, and DeepSeek) also accept custom model IDs:
 
 ```bash
-/model set openai gpt-5.5
+/model set openai gpt-5.6-sol
+/model set openai gpt-5.6-terra --toolcall-model gpt-5.6-luna
 /model set openai gpt-5.5 --toolcall-model gpt-5.4-mini
 ```
+
+The GPT-5.6 family has three tiers: `gpt-5.6-sol` (flagship), `gpt-5.6-terra` (balanced),
+and `gpt-5.6-luna` (cost-efficient). The bare `gpt-5.6` alias is routed to Sol by OpenAI.
 
 Override the default model for a slot via env vars:
 
@@ -210,7 +214,7 @@ In the REPL, switch provider or deployment like any other API provider:
 /model set azure-openai gpt-5.4-mini --toolcall-model gpt-5.4-nano
 ```
 
-Common deployment names in the onboarding picker include `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5-mini`, `gpt-4.1`, and `o3-mini`. Use custom names when your Azure deployment names differ (`allow_custom_models` is enabled).
+Common deployment names in the onboarding picker include `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5-mini`, `gpt-4.1`, and `o3-mini`. Use custom names when your Azure deployment names differ (`allow_custom_models` is enabled).
 
 ### OpenRouter
 

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -110,6 +110,10 @@ When `OPENSRE_LLM_TRANSPORT=litellm` (or when using `LLM_PROVIDER=azure-openai`)
 | `ollama` | OpenAI-compatible SDK | `openai/<model>` + `${OLLAMA_HOST}/v1` | Opt-in |
 | `azure-openai` | — | `azure/<deployment>` | **Always** via LiteLLM |
 
+The native OpenAI SDK transport uses the Responses API for GPT-5.6 agent tool calls, including
+replaying reasoning and function-call items between tool steps. Older OpenAI models and
+OpenAI-compatible providers continue to use Chat Completions.
+
 For providers beyond this list, LiteLLM supports [100+ backends](https://docs.litellm.ai/docs/providers). OpenSRE only wires the slugs above today — use one of them, or open an issue if you need another first-class provider.
 
 ## Login and secret storage

--- a/surfaces/cli/wizard/config.py
+++ b/surfaces/cli/wizard/config.py
@@ -120,6 +120,9 @@ ANTHROPIC_MODELS = (
 # provider uses Chat Completions, while Codex models require a different API path.
 OPENAI_MODELS = (
     ModelOption(value=OPENAI_REASONING_MODEL, label="GPT-5.4 mini"),
+    ModelOption(value="gpt-5.6-sol", label="GPT-5.6 Sol — flagship"),
+    ModelOption(value="gpt-5.6-terra", label="GPT-5.6 Terra — balanced"),
+    ModelOption(value="gpt-5.6-luna", label="GPT-5.6 Luna — cost-efficient"),
     ModelOption(value="gpt-5.5", label="GPT-5.5"),
     ModelOption(value="gpt-5.4", label="GPT-5.4"),
     ModelOption(value="gpt-5.4-nano", label="GPT-5.4 nano"),
@@ -128,6 +131,9 @@ OPENAI_MODELS = (
 # Source: https://openrouter.ai/api/v1/models
 OPENROUTER_MODELS = (
     ModelOption(value=OPENROUTER_REASONING_MODEL, label="OpenRouter Auto (smart routing)"),
+    ModelOption(value="openai/gpt-5.6-sol", label="GPT-5.6 Sol (via OpenRouter)"),
+    ModelOption(value="openai/gpt-5.6-terra", label="GPT-5.6 Terra (via OpenRouter)"),
+    ModelOption(value="openai/gpt-5.6-luna", label="GPT-5.6 Luna (via OpenRouter)"),
     ModelOption(value="openai/gpt-5.5", label="GPT-5.5 (via OpenRouter)"),
     ModelOption(value="anthropic/claude-opus-4.7", label="Claude Opus 4.7 (via OpenRouter)"),
     ModelOption(value="anthropic/claude-sonnet-4.6", label="Claude Sonnet 4.6 (via OpenRouter)"),
@@ -201,6 +207,9 @@ GROQ_MODELS = (
 # Source: https://learn.microsoft.com/en-us/azure/ai-foundry/model-inference/concepts/models
 AZURE_OPENAI_MODELS = (
     ModelOption(value=AZURE_OPENAI_REASONING_MODEL, label="gpt-5.4-mini deployment"),
+    ModelOption(value="gpt-5.6-sol", label="gpt-5.6-sol deployment"),
+    ModelOption(value="gpt-5.6-terra", label="gpt-5.6-terra deployment"),
+    ModelOption(value="gpt-5.6-luna", label="gpt-5.6-luna deployment"),
     ModelOption(value="gpt-5.5", label="gpt-5.5 deployment"),
     ModelOption(value="gpt-5.4", label="gpt-5.4 deployment"),
     ModelOption(value="gpt-5.4-nano", label="gpt-5.4-nano deployment"),
@@ -285,7 +294,10 @@ CODEX_MODELS = (
         value="",
         label="CLI default (no -m; use Codex configured model)",
     ),
-    ModelOption(value="gpt-5.5", label="gpt-5.5 — newest frontier coding"),
+    ModelOption(value="gpt-5.6-sol", label="gpt-5.6-sol — newest frontier coding"),
+    ModelOption(value="gpt-5.6-terra", label="gpt-5.6-terra — balanced"),
+    ModelOption(value="gpt-5.6-luna", label="gpt-5.6-luna — fast, cost-efficient"),
+    ModelOption(value="gpt-5.5", label="gpt-5.5 — frontier coding"),
     ModelOption(value="gpt-5.4", label="gpt-5.4 — fallback default"),
     ModelOption(value="gpt-5.4-mini", label="gpt-5.4-mini — fast, cost-efficient"),
     ModelOption(value="gpt-5.3-codex", label="gpt-5.3-codex — coding-optimized"),

--- a/tests/cli/test_model_persistence_scenarios.py
+++ b/tests/cli/test_model_persistence_scenarios.py
@@ -271,3 +271,26 @@ class TestReplModelPersistence:
         assert "unknown model for anthropic" in buf.getvalue()
         assert not persistence_paths["env"].exists()
         assert not persistence_paths["store"].exists()
+
+    @pytest.mark.parametrize("model", ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])
+    def test_model_set_accepts_and_persists_gpt56_tiers(
+        self,
+        model: str,
+        persistence_paths: dict[str, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # #3931 acceptance criterion: ``/model set openai gpt-5.6-<tier>``
+        # is accepted and persists. openai sets ``allow_custom_models``, so
+        # this already held before the quick-picks landed; the test pins it
+        # against a future tightening of the allowlist.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+        console, buf = _capture()
+        dispatch_slash(f"/model set openai {model}", Session(), console)
+
+        assert "unknown model" not in buf.getvalue()
+        assert f"OPENAI_REASONING_MODEL={model}" in persistence_paths["env"].read_text(
+            encoding="utf-8"
+        )
+        stored = wizard_store.load_local_config(persistence_paths["store"])
+        assert stored["targets"]["local"]["model"] == model

--- a/tests/cli/wizard/test_model_selection.py
+++ b/tests/cli/wizard/test_model_selection.py
@@ -104,3 +104,36 @@ def test_choose_model_works_for_cli_provider(monkeypatch: pytest.MonkeyPatch) ->
     model = _ui._choose_model(provider, default="")
 
     assert model == "gpt-5.4"
+
+
+class TestGpt56CatalogPresence:
+    """The onboarding picker must offer Sol / Terra / Luna (#3931)."""
+
+    @pytest.mark.parametrize("model", ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])
+    def test_openai_picker_lists_every_tier(self, model: str) -> None:
+        values = {option.value for option in PROVIDER_BY_VALUE["openai"].models}
+        assert model in values
+
+    @pytest.mark.parametrize("model", ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])
+    def test_azure_picker_lists_every_tier(self, model: str) -> None:
+        values = {option.value for option in PROVIDER_BY_VALUE["azure-openai"].models}
+        assert model in values
+
+    def test_openrouter_picker_uses_namespaced_ids(self) -> None:
+        values = {option.value for option in PROVIDER_BY_VALUE["openrouter"].models}
+        assert "openai/gpt-5.6-sol" in values
+
+    def test_codex_picker_lists_sol(self) -> None:
+        values = {option.value for option in PROVIDER_BY_VALUE["codex"].models}
+        assert "gpt-5.6-sol" in values
+
+    def test_openai_default_model_is_unchanged(self) -> None:
+        # #3931 explicitly does not re-point defaults; adding quick-picks
+        # must not promote a GPT-5.6 tier to the default slot.
+        assert PROVIDER_BY_VALUE["openai"].default_model == "gpt-5.4-mini"
+
+    def test_openai_picker_selects_sol(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = PROVIDER_BY_VALUE["openai"]
+        _wire_prompts(monkeypatch, select_values=["gpt-5.6-sol"])
+
+        assert _ui._choose_model(provider, default="") == "gpt-5.6-sol"

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -598,6 +598,112 @@ def test_openai_agent_client_enables_parallel_tool_calls_for_openai(
     assert captured["parallel_tool_calls"] is True
 
 
+def test_openai_gpt_5_6_agent_uses_responses_api_and_replays_reasoning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_openai(monkeypatch)
+    monkeypatch.setenv("OPENSRE_REASONING_EFFORT", "high")
+    captured: list[dict[str, Any]] = []
+
+    reasoning = types.SimpleNamespace(
+        type="reasoning",
+        model_dump=lambda **_: {"id": "rs_1", "type": "reasoning", "summary": []},
+    )
+    function_call = types.SimpleNamespace(
+        type="function_call",
+        call_id="call_1",
+        name="get_logs",
+        arguments='{"service":"api"}',
+        model_dump=lambda **_: {
+            "id": "fc_1",
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "get_logs",
+            "arguments": '{"service":"api"}',
+        },
+    )
+    first_response = types.SimpleNamespace(
+        output=[reasoning, function_call],
+        output_text="",
+        usage=None,
+    )
+    final_response = types.SimpleNamespace(
+        output=[],
+        output_text="done",
+        usage=None,
+    )
+
+    def responses_create(**kwargs: Any) -> object:
+        captured.append(kwargs)
+        return first_response if len(captured) == 1 else final_response
+
+    client = OpenAIAgentClient.__new__(OpenAIAgentClient)
+    client._client = types.SimpleNamespace(
+        responses=types.SimpleNamespace(create=responses_create),
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(
+                create=lambda **_: pytest.fail("GPT-5.6 must not use Chat Completions")
+            )
+        ),
+    )
+    client._model = "gpt-5.6"
+    client._max_tokens = 4096
+    client._api_key_env = "OPENAI_API_KEY"
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_logs",
+                "description": "Fetch logs",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    first = client.invoke(
+        messages=[{"role": "user", "content": "check the api"}],
+        tools=tools,
+    )
+    second = client.invoke(
+        messages=[
+            {"role": "user", "content": "check the api"},
+            first.raw_content,
+            {"role": "tool", "tool_call_id": "call_1", "content": '{"ok":true}'},
+        ],
+        tools=tools,
+    )
+
+    assert first.tool_calls[0].id == "call_1"
+    assert first.tool_calls[0].input == {"service": "api"}
+    assert second.content == "done"
+    assert captured[0]["max_output_tokens"] == 4096
+    assert captured[0]["reasoning"] == {"effort": "high"}
+    assert captured[0]["tools"] == [
+        {
+            "type": "function",
+            "name": "get_logs",
+            "description": "Fetch logs",
+            "parameters": {"type": "object", "properties": {}},
+            "strict": False,
+        }
+    ]
+    assert captured[1]["input"][1:3] == [
+        {"id": "rs_1", "type": "reasoning", "summary": []},
+        {
+            "id": "fc_1",
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "get_logs",
+            "arguments": '{"service":"api"}',
+        },
+    ]
+    assert captured[1]["input"][3] == {
+        "type": "function_call_output",
+        "call_id": "call_1",
+        "output": '{"ok":true}',
+    }
+
+
 def test_openai_agent_client_omits_parallel_tool_calls_for_compat_provider(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/test_context_budget.py
+++ b/tests/core/test_context_budget.py
@@ -1,6 +1,33 @@
 from __future__ import annotations
 
-from core.context_budget import strip_internal_message_markers
+from core.context_budget import context_budget_ceiling_for_model, strip_internal_message_markers
+
+
+class TestGpt56ContextWindow:
+    """GPT-5.6 ships a 1M-token window, unlike the 128k-pinned gpt-5 family (#3931)."""
+
+    def test_sol_reclaims_the_million_token_window(self) -> None:
+        # 1_000_000 window - 16_000 response headroom.
+        assert context_budget_ceiling_for_model("gpt-5.6-sol") == 984_000
+
+    def test_all_tiers_share_the_family_window(self) -> None:
+        sol = context_budget_ceiling_for_model("gpt-5.6-sol")
+        assert context_budget_ceiling_for_model("gpt-5.6-terra") == sol
+        assert context_budget_ceiling_for_model("gpt-5.6-luna") == sol
+        assert context_budget_ceiling_for_model("gpt-5.6") == sol
+
+    def test_gpt56_is_not_shadowed_by_the_gpt5_catch_all(self) -> None:
+        # ``_MODEL_CONTEXT_WINDOWS`` is matched by substring in insertion
+        # order with a break, so moving the ``gpt-5.6`` key below ``gpt-5``
+        # would silently pin 5.6 back to 128k. Nothing else would fail.
+        assert context_budget_ceiling_for_model("gpt-5.6-sol") > context_budget_ceiling_for_model(
+            "gpt-5.5"
+        )
+
+    def test_older_gpt5_models_keep_their_conservative_pin(self) -> None:
+        # 128_000 window - 16_000 response headroom.
+        assert context_budget_ceiling_for_model("gpt-5.5") == 112_000
+        assert context_budget_ceiling_for_model("gpt-5") == 112_000
 
 
 def test_strip_internal_message_markers_removes_opensre_keys() -> None:

--- a/tests/fleet_monitoring/test_pricing.py
+++ b/tests/fleet_monitoring/test_pricing.py
@@ -63,6 +63,68 @@ class TestUsdPerTokenBlended:
         assert opus_4_1 is not None
 
 
+class TestGpt56Family:
+    """GPT-5.6 Sol / Terra / Luna (#3931).
+
+    Rates from https://developers.openai.com/api/docs/pricing (GA 2026-07-09),
+    per 1M tokens: sol 5/30, terra 2.50/15, luna 1/6. Cached input is 90% off.
+    """
+
+    @pytest.mark.parametrize(
+        ("model", "input_usd_per_million", "output_usd_per_million"),
+        [
+            ("gpt-5.6-sol", 5.00, 30.00),
+            ("gpt-5.6-terra", 2.50, 15.00),
+            ("gpt-5.6-luna", 1.00, 6.00),
+        ],
+    )
+    def test_published_rates(
+        self, model: str, input_usd_per_million: float, output_usd_per_million: float
+    ) -> None:
+        price = MODEL_PRICES[model]
+        assert price.usd_per_input_token == pytest.approx(input_usd_per_million / 1e6)
+        assert price.usd_per_output_token == pytest.approx(output_usd_per_million / 1e6)
+        # Cached input reads are 90% off uncached input.
+        assert price.usd_per_cache_read_input_token == pytest.approx(
+            input_usd_per_million / 1e6 * 0.10
+        )
+
+    def test_sol_is_not_priced_as_base_gpt5(self) -> None:
+        # The regression this whole entry exists to prevent: before #3931,
+        # ``gpt-5.6-sol`` matched the ``gpt-5`` family catch-all and was
+        # silently billed at the base gpt-5 rate (1.25/10) — a 4x
+        # under-report on the flagship, with no error and no ``-`` cell.
+        assert usd_per_token_blended("gpt-5.6-sol") != usd_per_token_blended("gpt-5")
+
+    def test_tiers_are_distinctly_priced(self) -> None:
+        # Each tier must resolve to its own rate rather than collapsing
+        # onto a sibling via the shared ``gpt-5.6`` prefix.
+        sol = usd_per_token_blended("gpt-5.6-sol")
+        terra = usd_per_token_blended("gpt-5.6-terra")
+        luna = usd_per_token_blended("gpt-5.6-luna")
+        assert sol is not None and terra is not None and luna is not None
+        assert sol > terra > luna
+
+    def test_bare_alias_resolves_to_sol(self) -> None:
+        # OpenAI routes the bare ``gpt-5.6`` alias to Sol server-side, so
+        # billing it as anything else would mis-report real spend.
+        assert usd_per_token_blended("gpt-5.6") == usd_per_token_blended("gpt-5.6-sol")
+        assert normalize_model_name("gpt-5.6") == "gpt-5.6-sol"
+
+    def test_unknown_tier_suffix_does_not_borrow_sol_rate(self) -> None:
+        # ``gpt-5.6-terra-preview`` must land on terra, not on Sol via the
+        # shorter ``gpt-5.6`` alias prefix. This is what the per-tier
+        # family rows buy us over a single alias row.
+        assert usd_per_token_blended("gpt-5.6-terra-preview") == usd_per_token_blended(
+            "gpt-5.6-terra"
+        )
+
+    def test_openai_provider_prefix_resolves(self) -> None:
+        # OpenRouter-style ids (``openai/gpt-5.6-sol``) are stripped to the
+        # bare model before lookup.
+        assert usd_per_token_blended("openai/gpt-5.6-sol") == usd_per_token_blended("gpt-5.6-sol")
+
+
 class TestUsdPerHour:
     def test_zero_tokens_per_min_is_zero_cost(self) -> None:
         # An idle agent costs $0/hr — the cell shows ``$0.00``, not

--- a/tools/system/fleet_monitoring/pricing.py
+++ b/tools/system/fleet_monitoring/pricing.py
@@ -197,6 +197,9 @@ MODEL_PRICES: dict[str, ModelPrice] = {
     "gpt-5.4-pro": _price(30.00, 180.00),
     "gpt-5.5": _price(5.00, 30.00, cache_read_usd_per_million=0.50),
     "gpt-5.5-pro": _price(30.00, 180.00),
+    "gpt-5.6-luna": _price(1.00, 6.00, cache_read_usd_per_million=0.10),
+    "gpt-5.6-sol": _price(5.00, 30.00, cache_read_usd_per_million=0.50),
+    "gpt-5.6-terra": _price(2.50, 15.00, cache_read_usd_per_million=0.25),
     "o3": _price(2.00, 8.00, cache_read_usd_per_million=0.50),
     "o3-deep-research": _price(10.00, 40.00, cache_read_usd_per_million=2.50),
     "o3-mini": _price(1.10, 4.40, cache_read_usd_per_million=0.55),
@@ -223,6 +226,12 @@ _UNSORTED_FAMILY_FALLBACKS: tuple[tuple[str, str], ...] = (
     ("gpt-5.1-codex-max", "gpt-5.1-codex-max"),
     ("gpt-5.1-codex", "gpt-5.1-codex"),
     ("gpt-5-codex", "gpt-5-codex"),
+    ("gpt-5.6-terra", "gpt-5.6-terra"),
+    ("gpt-5.6-luna", "gpt-5.6-luna"),
+    ("gpt-5.6-sol", "gpt-5.6-sol"),
+    # OpenAI routes the bare `gpt-5.6` alias to Sol server-side. The three
+    # rows above are longer prefixes, so they still win for terra/luna.
+    ("gpt-5.6", "gpt-5.6-sol"),
     ("gpt-5.5-pro", "gpt-5.5-pro"),
     ("gpt-5.5", "gpt-5.5"),
     ("gpt-5.4-mini", "gpt-5.4-mini"),


### PR DESCRIPTION
Fixes #3931 

#### Describe the changes you have made in this PR -

# Research notes — #3931: Add GPT-5.6 Sol / Terra / Luna support

## Summary

Adds `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` across fleet pricing, the onboarding
pickers, context budgeting, and docs.

The headline change is not "three new model IDs." It is a **silent 4× cost under-report**:
`gpt-5.6-sol` already resolved in the pricing table — to the wrong price — and nothing failed
loudly enough for anyone to notice.

## Why this needed verification first

GPT-5.6 was announced 2026-07-09, one day before this work started, and postdates the
assistant knowledge cutoff used to draft the change. Every model ID and price below was
confirmed against primary sources before any code was written, rather than recalled.

That check was not ceremonial. The ticket's pricing table lists Sol at $5/$30 and Terra at
$2.50/$15 — byte-identical to the `gpt-5.5` and `gpt-5.4` rows already in
`tools/system/fleet_monitoring/pricing.py`. That is exactly the fingerprint of numbers copied
from adjacent rows. The duplication turned out to be genuine and explainable (OpenAI priced
Terra at half of GPT-5.5, and Sol inherited GPT-5.5's price point), but it was worth
confirming before hardcoding six rates into a cost-reporting path.

### Sources

| Claim | Source |
|---|---|
| GA date, three-tier family, tier roles | [OpenAI: GPT-5.6](https://openai.com/index/gpt-5-6/), [Previewing GPT-5.6 Sol](https://openai.com/index/previewing-gpt-5-6-sol/) |
| Per-1M rates: sol 5/30, terra 2.50/15, luna 1/6 | [OpenAI API pricing](https://developers.openai.com/api/docs/pricing) |
| Cached input is 90% off uncached | [OpenAI API pricing](https://developers.openai.com/api/docs/pricing) |
| Bare `gpt-5.6` alias routes to Sol server-side | [gpt-5.6-sol model docs](https://developers.openai.com/api/docs/models/gpt-5.6-sol) |
| ~1M-token context window | [gpt-5.6-sol model docs](https://developers.openai.com/api/docs/models/gpt-5.6-sol) |
| Azure availability | [Azure AI Foundry catalog](https://ai.azure.com/catalog/models/gpt-5.6-sol) |
| OpenRouter availability | [OpenRouter: openai/gpt-5.6-sol](https://openrouter.ai/openai/gpt-5.6-sol) |
| Codex availability | [OpenAI GA post](https://openai.com/index/gpt-5-6/) ("across ChatGPT, Codex, and the OpenAI API") |
| OpenCode Zen availability | [OpenCode Zen docs](https://opencode.ai/docs/zen/) — **not listed; deliberately excluded** |

## Findings that changed the implementation

Reading the code surfaced four things the ticket did not describe correctly.

### 1. The real bug: Sol was silently billed at base `gpt-5` rates

The ticket frames fleet pricing as "resolves for all three variants." It already *resolved*.
`_lookup_price` falls through to a `("gpt-5", "gpt-5")` catch-all prefix, so `gpt-5.6-sol`
matched and was priced at **$1.25/$10 instead of $5/$30**. No exception, no `-` cell on the
dashboard, just a 4× under-report on the flagship model.

This is why the pricing change carries an explicit regression test
(`test_sol_is_not_priced_as_base_gpt5`) rather than only asserting the new rates.

### 2. No client-side alias machinery was needed

The ticket asks for "the `gpt-5.6` alias that routes to Sol." OpenAI performs that routing
server-side, so API calls with the bare alias already work. It only needed to *price*
correctly. That is one fallback row, not a new short-name→specific-ID resolution layer — and
this repo has no such hook to extend, so inventing one would have been a meaningful
architectural addition smuggled in under a "add three models" ticket.

### 3. Per-tier fallback rows are load-bearing, not redundant boilerplate

`_FAMILY_FALLBACKS` is sorted longest-prefix-first. Mapping the alias with
`("gpt-5.6", "gpt-5.6-sol")` alone would mean an unrecognized suffix like
`gpt-5.6-terra-preview` matches the shorter `gpt-5.6` prefix and gets billed at **Sol**
rates. The explicit `gpt-5.6-terra` / `-luna` / `-sol` rows shadow the alias correctly.
Covered by `test_unknown_tier_suffix_does_not_borrow_sol_rate`.

Pointing the alias at the `gpt-5.6-sol` canonical (rather than adding a duplicate
`MODEL_PRICES["gpt-5.6"]` row) keeps one price in one place and has a side benefit:
`normalize_model_name("gpt-5.6")` now returns `"gpt-5.6-sol"`, so the fleet dashboard groups
alias traffic with Sol instead of splitting it across two rows.

### 4. An unlisted file: `core/context_budget.py`

Not in the ticket's scope list. It pinned every `gpt-5*` model to a 128k window, with a
standing comment: *"conservatively pinned to 128k until confirmed; raise once verified to
reclaim headroom."* Sol ships ~1M. GPT-5.6 users were getting 12% of their context window.

The lookup is a first-substring-match in **dict insertion order** with a `break`, so
`"gpt-5.6"` must sit *above* the `"gpt-5"` catch-all or it is never reached. That ordering is
invisible to a reader and a future alphabetizing edit would silently revert it, so it has both
a comment and a dedicated test (`test_gpt56_is_not_shadowed_by_the_gpt5_catch_all`).

`1_000_000` is used rather than the ~1.05M some trackers report — it matches the existing
`"gpt-4.1": 1_000_000` precedent in the same dict and errs toward trimming early.

## Scope decisions

**Defaults are untouched.** Per the ticket, `OPENAI_REASONING_MODEL` and every `default_model=`
stay at `gpt-5.4-mini`. `test_openai_default_model_is_unchanged` pins this so a future
quick-pick reshuffle cannot promote a GPT-5.6 tier into the default slot.

**Four of five pickers.** `surfaces/cli/wizard/config.py` holds five model pickers. OpenAI,
Azure, Codex, and OpenRouter each had GPT-5.6 availability confirmed against a primary source
(see table above). **OpenCode Zen was left alone** — no source lists GPT-5.6 in its curated
catalog, and adding `opencode/gpt-5.6-sol` would ship a model ID that 404s for users. Easy to
add in a follow-up once OpenCode publishes support.

**One acceptance criterion was already met.** `/model set openai gpt-5.6-sol` was always
accepted: the `openai` provider sets `allow_custom_models=True`, so `_is_model_allowed` takes
any non-empty ID. There was no allowlist to widen. The added test pins the behavior against a
future tightening rather than fixing a bug that did not exist.

## Known gap, deliberately not addressed

`ModelPrice` has no tiered-rate support, so GPT-5.6's **long-context pricing** (Sol rises to
$10/$45 above the threshold) and its **1.25× cache-write rate** are not modeled. Fleet will
under-report on very large prompts. This gap is pre-existing and affects every model in the
table; reshaping `ModelPrice` under a "add three models" ticket would be the wrong place for
it. Worth its own issue.

## Verification

Observed resolution after the change:

```
gpt-5.6-sol      -> gpt-5.6-sol      in=$  5.00/M out=$ 30.00/M cache=$ 0.50/M ctx_ceiling=984,000
gpt-5.6-terra    -> gpt-5.6-terra    in=$  2.50/M out=$ 15.00/M cache=$ 0.25/M ctx_ceiling=984,000
gpt-5.6-luna     -> gpt-5.6-luna     in=$  1.00/M out=$  6.00/M cache=$ 0.10/M ctx_ceiling=984,000
gpt-5.6          -> gpt-5.6-sol      in=$  5.00/M out=$ 30.00/M cache=$ 0.50/M ctx_ceiling=984,000
gpt-5            -> gpt-5            in=$  1.25/M out=$ 10.00/M cache=$ 0.12/M ctx_ceiling=112,000
```

The alias collapses to Sol; each tier holds its own rate; `gpt-5` is unaffected.

Full pre-push gate per [CI.md](../CI.md) — `make test-cov` is required because this touches
`core/`:

| Command | Result |
|---|---|
| `make lint` | All checks passed |
| `make format-check` | 2377 files already formatted |
| `make typecheck` | Success: no issues found in 1175 source files |
| `make test-cov` | 10771 passed, 57 skipped |

## Files changed

| File | Change |
|---|---|
| `tools/system/fleet_monitoring/pricing.py` | 3 `MODEL_PRICES` rows + 4 `_FAMILY_FALLBACKS` rows (3 tiers + alias→Sol) |
| `core/context_budget.py` | `gpt-5.6` → 1M window, ordered above the `gpt-5` catch-all |
| `surfaces/cli/wizard/config.py` | Sol/Terra/Luna in the OpenAI, Azure, Codex, OpenRouter pickers |
| `docs/llm-providers.mdx` | `/model set` examples, tier explainer, Azure deployment-name list |
| `tests/fleet_monitoring/test_pricing.py` | Rates, alias→Sol, tier distinctness, suffix-shadowing, base-`gpt-5` regression guard |
| `tests/core/test_context_budget.py` | 1M ceiling, ordering guard, older `gpt-5` pin preserved |
| `tests/cli/wizard/test_model_selection.py` | Catalog presence per picker, defaults-unchanged guard |
| `tests/cli/test_model_persistence_scenarios.py` | `/model set openai gpt-5.6-<tier>` accepted and persisted |

No `docs/docs.json` entry is needed — no new page was added.


### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

<img width="1034" height="780" alt="Screenshot 2026-07-10 at 13 47 44" src="https://github.com/user-attachments/assets/65654863-6c4b-46a3-9092-691bab939633" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
What problem does your code solve?

OpenAI released the GPT-5.6 family (Sol, Terra, Luna) on 2026-07-09, and OpenSRE didn't know about it. Beyond just missing them from the onboarding menus, fleet monitoring was actively reporting wrong costs: gpt-5.6-sol fell through to the generic gpt-5 pricing entry and got billed at $1.25/$10 instead of $5/$30. Nothing errored — the dashboard just quietly showed a number that was 4× too low. This adds the three models to the pricing table, the wizard pickers, and the docs, and fixes the mispricing.

What alternative approaches did you consider?

For the bare gpt-5.6 alias, I looked at adding a short-name → full-ID resolution layer so the client could expand it to gpt-5.6-sol. I dropped that after checking OpenAI's docs: they do that routing on their end, so the API call already works. All the alias needed was to resolve to the right price, which is one fallback row. Building a resolver would have added machinery this repo doesn't otherwise have.

I also considered giving the alias its own price entry, but that duplicates Sol's rates in two places. Pointing it at the gpt-5.6-sol canonical keeps one source of truth and makes the dashboard group alias traffic under Sol.

On scope: I could have added the models to all five wizard pickers. I checked each vendor and only found confirmation for OpenAI, Azure, OpenRouter, and Codex. OpenCode Zen doesn't list GPT-5.6, so I left it out rather than ship an ID that 404s.

Why did you choose this specific implementation?

It follows the patterns already in the files. MODEL_PRICES plus per-tier _FAMILY_FALLBACKS rows is exactly how gpt-5.5 and gpt-5.4 are wired. The per-tier rows aren't redundant: fallbacks match longest-prefix-first, so without an explicit gpt-5.6-terra row, something like gpt-5.6-terra-preview would match the shorter gpt-5.6 prefix and get billed at Sol's rate.

I kept defaults unchanged, as the issue asked, and added a test that pins them so a future reshuffle of the quick-pick list can't accidentally promote a GPT-5.6 tier into the default slot.

What are the key functions/components?

MODEL_PRICES / _FAMILY_FALLBACKS in pricing.py — the rate table and the prefix rules that resolve an unknown model ID onto a known family. _lookup_price tries an exact match first, then longest-prefix.
_MODEL_CONTEXT_WINDOWS in context_budget.py — maps a model to its context window. It's substring-matched in dict insertion order with a break, so the new gpt-5.6 key has to sit above the gpt-5 catch-all or it's never reached. That ordering is invisible to a reader, so it has a comment and its own test.
OPENAI_MODELS and friends in wizard/config.py — the curated quick-pick menus. These are UX lists, not an allowlist: openai sets allow_custom_models=True, so /model set openai gpt-5.6-sol was always accepted. I added a test to pin that rather than "fix" a bug that didn't exist.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

## Follow-up: GPT-5.6 tool transport

GPT-5.6 function tools are now routed through OpenAI's Responses API instead of Chat Completions. The adapter converts tool schemas, preserves reasoning and function-call output items between ReAct iterations, forwards the active reasoning effort in the Responses shape, and leaves older OpenAI models plus OpenAI-compatible providers on Chat Completions.

Additional files:
- `core/llm/shared/openai_responses.py`
- `core/llm/transports/sdk/agent_clients.py`
- `tests/core/runtime/llm/test_agent_llm_client.py`

Additional verification:
- `make lint` — passed
- `make typecheck` — passed
- 97 focused transport/message/context-budget tests — passed
- Live GPT-5.6 response with function tools — passed
- Live function-call → tool-output → final-response replay — passed

The full test suite was not rerun for this follow-up at the maintainer's request; PR CI provides the full matrix.