### PR TITLE
fix(investigation): preserve stream errors on deferred import failure

### DIFF
--- a/tests/tools/investigation/test_streaming_loop_metrics.py
+++ b/tests/tools/investigation/test_streaming_loop_metrics.py
@@ -73,3 +73,28 @@ def test_main_thread_bridge_binds_metrics_from_wrapped_stream_failure() -> None:
         assert bound_loop_metrics() == (4, 20)
     finally:
         reset_investigation_loop_metrics(scope_token)
+
+
+
+@pytest.mark.anyio
+async def test_astream_deferred_import_failure_is_wrapped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def failing_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tools.investigation.stages.gather_evidence":
+            raise ImportError("simulated deferred import failure")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", failing_import)
+
+    with pytest.raises(InvestigationPipelineStreamError) as exc_info:
+        async for _ in astream_investigation("alert text"):
+            pass
+
+    wrapped = exc_info.value
+    assert isinstance(wrapped.cause, ImportError)
+    assert str(wrapped.cause) == "simulated deferred import failure"

--- a/tools/investigation/capability.py
+++ b/tools/investigation/capability.py
@@ -297,6 +297,9 @@ async def astream_investigation(
             )
 
     def _run_pipeline() -> None:
+        state = initial
+        loop_count = 0
+        iteration_cap = None
         try:
             from core.state.updates import apply_state_updates
             from platform.analytics.investigation_loop import loop_metrics_from_state
@@ -307,7 +310,7 @@ async def astream_investigation(
             from tools.investigation.stages.plan_evidence import plan_actions
             from tools.investigation.stages.resolve_integrations import resolve_integrations
 
-            state = initial
+
 
             # --- resolve_integrations ---
             _put(_make_node_event("on_chain_start", "resolve_integrations", {}))
@@ -463,7 +466,8 @@ async def astream_investigation(
             )
 
         except Exception as exc:
-            loop_count, iteration_cap = loop_metrics_from_state(state)
+            if "loop_metrics_from_state" in locals():
+                loop_count, iteration_cap = loop_metrics_from_state(state)
             _capture_exception_once(exc, context="pipeline.astream_investigation")
             with contextlib.suppress(RuntimeError):
                 loop.call_soon_threadsafe(


### PR DESCRIPTION
Fixes #3941

#### Describe the changes you have made in this PR -

`astream_investigation`'s background `_run_pipeline` could silently swallow investigation failures when a deferred stage import failed.

Previously, the exception handler immediately attempted to resolve loop metrics:

```python
loop_count, iteration_cap = loop_metrics_from_state(state)
```

However, both `state` and `loop_metrics_from_state` were only available after the deferred imports inside the `try` block. If one of those deferred imports failed, the exception handler itself would raise before it could capture the original exception or enqueue an `InvestigationPipelineStreamError`. As a result, the streaming consumer received only the end-of-stream sentinel and the investigation appeared to complete successfully, while the original exception was lost.

This PR fixes the regression by:

- Initializing `state` and default loop metric values before entering the `try` block.
- Guarding loop metric extraction when `loop_metrics_from_state` is unavailable because a deferred import failed.
- Preserving the original exception by wrapping it in `InvestigationPipelineStreamError` instead of allowing the exception handler itself to fail.

Additionally, this PR adds a regression test that simulates a deferred stage import failure and verifies that the original exception is surfaced correctly to the streaming consumer.

### Demo/Screenshot for feature changes and bug fixes -

Regression test:

```text
uv run pytest tests/tools/investigation/test_streaming_loop_metrics.py

============================= test session starts =============================
...
collected 3 items

tests/tools/investigation/test_streaming_loop_metrics.py ...          [100%]

============================== 3 passed ==============================
```

The newly added regression test verifies that:

- A deferred stage import failure no longer causes the exception handler to fail.
- The streaming consumer receives an `InvestigationPipelineStreamError`.
- The wrapped exception preserves the original `ImportError`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The regression occurred because `_run_pipeline`'s exception handler depended on values that might never be initialized if a deferred stage import failed. In that scenario, the handler itself raised before it could capture and propagate the original pipeline exception.

To fix this, I initialized the handler's required state (`state`) and default loop metric values before entering the `try` block while keeping the deferred stage imports unchanged. The exception handler now safely attempts to compute loop metrics only when the helper is available, allowing it to consistently capture the original exception and wrap it in `InvestigationPipelineStreamError`.

To prevent regressions, I added a test that monkeypatches Python's import mechanism to simulate a deferred stage import failure. The test verifies that the streaming consumer receives an `InvestigationPipelineStreamError` whose cause is the original `ImportError`, rather than silently completing the stream.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions