### PR TITLE
fix(agent): session runtime metadata skips sandbox subprocess (#3946)

### DIFF
--- a/config/runtime_metadata.py
+++ b/config/runtime_metadata.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -46,26 +47,62 @@ def _resolve_gitdir(candidate: Path) -> Path | None:
     return None
 
 
-def _find_gitdir() -> Path | None:
-    """Walk up from this file to the enclosing repo's git directory."""
+@dataclass(frozen=True)
+class _GitLayout:
+    """Per-worktree gitdir plus the shared common gitdir.
+
+    In a standard checkout the two are the same directory. In a linked worktree
+    (``git worktree add``), ``HEAD`` is per-worktree but ``refs/``, ``packed-refs``,
+    and tags live in the primary repo's gitdir named by the worktree's
+    ``commondir`` marker file.
+    """
+
+    gitdir: Path
+    commondir: Path
+
+
+def _resolve_commondir(gitdir: Path) -> Path:
+    """Return the shared common gitdir for ``gitdir``.
+
+    Standard checkouts have no ``commondir`` marker; the gitdir is its own
+    common dir. Linked worktrees carry a ``commondir`` file with a path
+    (relative to the per-worktree gitdir) to the primary repo's gitdir.
+    """
+    marker = gitdir / "commondir"
+    if not marker.is_file():
+        return gitdir
+    try:
+        content = marker.read_text(encoding="utf-8").strip()
+    except OSError:
+        return gitdir
+    if not content:
+        return gitdir
+    target = Path(content)
+    if not target.is_absolute():
+        target = (gitdir / target).resolve()
+    return target if target.is_dir() else gitdir
+
+
+def _find_git_layout() -> _GitLayout | None:
+    """Walk up from this file to the enclosing repo's git layout."""
     here = Path(__file__).resolve().parent
     while here.parent != here:
         gitdir = _resolve_gitdir(here / ".git")
         if gitdir is not None:
-            return gitdir
+            return _GitLayout(gitdir=gitdir, commondir=_resolve_commondir(gitdir))
         here = here.parent
     return None
 
 
-def _read_packed_refs(gitdir: Path) -> dict[str, str]:
-    """Parse ``<gitdir>/packed-refs`` into a ``{ref_name: sha}`` map.
+def _read_packed_refs(commondir: Path) -> dict[str, str]:
+    """Parse ``<commondir>/packed-refs`` into a ``{ref_name: sha}`` map.
 
     After ``git pack-refs`` the loose files under ``refs/`` disappear and both
     branch heads and tag refs live only here. Peeled tag lines (``^<sha>``) are
     ignored: the non-peeled line already holds the tag object's sha which is
     enough for a build marker.
     """
-    packed = gitdir / "packed-refs"
+    packed = commondir / "packed-refs"
     if not packed.is_file():
         return {}
     refs: dict[str, str] = {}
@@ -83,23 +120,28 @@ def _read_packed_refs(gitdir: Path) -> dict[str, str]:
     return refs
 
 
-def _read_git_head_sha(gitdir: Path) -> str | None:
-    """Short SHA the working tree currently points at, or ``None``.
+def _read_ref_sha(layout: _GitLayout, ref_name: str) -> str | None:
+    """Resolve ``ref_name`` (e.g. ``refs/heads/main``) via loose files + packed-refs.
 
-    Reads loose refs first; falls back to ``packed-refs`` if the branch was
-    packed (loose file is gone).
+    Per-worktree refs (bisect/HEAD-like) may live under the worktree gitdir,
+    so it's tried first; branches and tags live in the commondir.
     """
-    head_file = gitdir / "HEAD"
+    for base in (layout.gitdir, layout.commondir):
+        loose = base / ref_name
+        if loose.is_file():
+            return loose.read_text(encoding="utf-8").strip() or None
+    return _read_packed_refs(layout.commondir).get(ref_name)
+
+
+def _read_git_head_sha(layout: _GitLayout) -> str | None:
+    """Short SHA the working tree currently points at, or ``None``."""
+    head_file = layout.gitdir / "HEAD"
     if not head_file.is_file():
         return None
     head = head_file.read_text(encoding="utf-8").strip()
     if not head.startswith("ref: "):
         return head[:7] or None
-    ref_name = head[len("ref: ") :].strip()
-    ref_path = gitdir / ref_name
-    if ref_path.is_file():
-        return ref_path.read_text(encoding="utf-8").strip()[:7] or None
-    sha = _read_packed_refs(gitdir).get(ref_name)
+    sha = _read_ref_sha(layout, head[len("ref: ") :].strip())
     return sha[:7] if sha else None
 
 
@@ -116,22 +158,22 @@ def _release_tag_sort_key(name: str) -> tuple[int, ...] | None:
         return None
 
 
-def _iter_release_tag_names(gitdir: Path) -> set[str]:
+def _iter_release_tag_names(commondir: Path) -> set[str]:
     """Release tag names, from loose refs and from ``packed-refs`` combined."""
     names: set[str] = set()
-    tags_dir = gitdir / "refs" / "tags"
+    tags_dir = commondir / "refs" / "tags"
     if tags_dir.is_dir():
         names.update(entry.name for entry in tags_dir.iterdir())
-    for ref_name in _read_packed_refs(gitdir):
+    for ref_name in _read_packed_refs(commondir):
         if ref_name.startswith("refs/tags/"):
             names.add(ref_name[len("refs/tags/") :])
     return names
 
 
-def _read_latest_release_tag(gitdir: Path) -> str | None:
+def _read_latest_release_tag(commondir: Path) -> str | None:
     """Highest release tag (loose + packed) by numeric ordering."""
     ranked: list[tuple[tuple[int, ...], str]] = []
-    for name in _iter_release_tag_names(gitdir):
+    for name in _iter_release_tag_names(commondir):
         if not _RELEASE_TAG_PATTERN.match(name):
             continue
         key = _release_tag_sort_key(name)
@@ -145,11 +187,11 @@ def _read_latest_release_tag(gitdir: Path) -> str | None:
 
 def _detect_build_info() -> str:
     """Human-readable build marker: ``""`` for wheels, ``dev, <tag> @ <sha>`` for checkouts."""
-    gitdir = _find_gitdir()
-    if gitdir is None:
+    layout = _find_git_layout()
+    if layout is None:
         return ""
-    tag = _read_latest_release_tag(gitdir)
-    sha = _read_git_head_sha(gitdir)
+    tag = _read_latest_release_tag(layout.commondir)
+    sha = _read_git_head_sha(layout)
     if tag and sha:
         return f"dev, {tag} @ {sha}"
     if tag:

--- a/config/runtime_metadata.py
+++ b/config/runtime_metadata.py
@@ -21,49 +21,104 @@ RUNTIME_INPUTS_KEY = "opensre_runtime"
 _RELEASE_TAG_PATTERN = re.compile(r"^v\d+\.\d+(\.\d+){2,}$")
 
 
-def _repo_root_from_here() -> Path | None:
-    """Walk up from this file looking for a ``.git`` directory.
+def _resolve_gitdir(candidate: Path) -> Path | None:
+    """Resolve a candidate ``.git`` entry to the actual git directory.
+
+    In a normal checkout ``.git`` is a directory. In a linked worktree or a
+    submodule ``.git`` is a *file* containing a ``gitdir: <absolute path>``
+    line pointing to the real git dir under the primary repo. Both shapes
+    need to work so build metadata surfaces correctly for worktree devs too.
+    """
+    if candidate.is_dir():
+        return candidate
+    if candidate.is_file():
+        try:
+            content = candidate.read_text(encoding="utf-8")
+        except OSError:
+            return None
+        for line in content.splitlines():
+            line = line.strip()
+            if line.startswith("gitdir:"):
+                target = Path(line[len("gitdir:") :].strip())
+                if not target.is_absolute():
+                    target = (candidate.parent / target).resolve()
+                if target.is_dir():
+                    return target
+                return None
+    return None
+
+
+def _repo_root_from_here() -> tuple[Path, Path] | None:
+    """Walk up from this file looking for a ``.git`` directory or file.
 
     Filesystem-only — no subprocess. Used to enrich metadata when opensre is
     imported from a git checkout (local dev). Returns ``None`` in installed
     wheels where ``.git`` doesn't exist alongside the package.
+
+    Returns a tuple of ``(worktree_root, gitdir)`` — the worktree root is
+    where ``.git`` lives (a checkout or a linked worktree); the gitdir is the
+    resolved directory that actually contains ``HEAD``, ``refs/``, etc. Under
+    a normal checkout the two point at the same physical directory
+    (``<repo>/.git``); under a linked worktree they differ.
     """
     here = Path(__file__).resolve().parent
     while here.parent != here:
-        if (here / ".git").is_dir():
-            return here
+        gitdir = _resolve_gitdir(here / ".git")
+        if gitdir is not None:
+            return here, gitdir
         here = here.parent
     return None
 
 
-def _read_git_head_sha(repo: Path) -> str | None:
+def _read_git_head_sha(gitdir: Path) -> str | None:
     """Return the short SHA the working tree currently points at, or None."""
-    head_file = repo / ".git" / "HEAD"
+    head_file = gitdir / "HEAD"
     if not head_file.is_file():
         return None
     head = head_file.read_text(encoding="utf-8").strip()
     if head.startswith("ref: "):
-        ref_path = repo / ".git" / head[5:].strip()
+        ref_path = gitdir / head[5:].strip()
         if ref_path.is_file():
             return ref_path.read_text(encoding="utf-8").strip()[:7] or None
         return None
     return head[:7] or None
 
 
-def _read_latest_release_tag(repo: Path) -> str | None:
-    """Return the highest-sorted release tag (v0.1.YYYY.M.D shape) present.
+def _release_tag_sort_key(name: str) -> tuple[int, ...]:
+    """Return a tuple sort key for a release tag like ``v0.1.2026.9.30``.
 
-    Filesystem-only: reads ``.git/refs/tags/``. Sorts lexicographically —
-    correct for the date-suffixed tag shape opensre uses.
+    Sorts by (major, minor, year, month, day...) numerically so
+    ``v0.1.2026.10.1`` correctly outranks ``v0.1.2026.9.30`` — a naive
+    lexicographic sort would pick the older tag because ``'9' > '1'`` as
+    ASCII, flipping September-30 above October-1.
     """
-    tags_dir = repo / ".git" / "refs" / "tags"
+    parts = name.removeprefix("v").split(".")
+    numeric: list[int] = []
+    for part in parts:
+        try:
+            numeric.append(int(part))
+        except ValueError:
+            # Any non-numeric component (unexpected for this tag shape) sorts
+            # this tag below any tag whose components are all-numeric.
+            return ()
+    return tuple(numeric)
+
+
+def _read_latest_release_tag(gitdir: Path) -> str | None:
+    """Return the highest release tag (``v0.1.YYYY.M.D`` shape) present.
+
+    Filesystem-only: reads ``<gitdir>/refs/tags/``. Sorts using a numeric
+    tuple key so month/day boundary crossings (e.g. ``9.30`` vs ``10.1``)
+    order correctly, unlike lexicographic sort.
+    """
+    tags_dir = gitdir / "refs" / "tags"
     if not tags_dir.is_dir():
         return None
-    matches = sorted(
-        (t.name for t in tags_dir.iterdir() if _RELEASE_TAG_PATTERN.match(t.name)),
-        reverse=True,
-    )
-    return matches[0] if matches else None
+    candidates = [t.name for t in tags_dir.iterdir() if _RELEASE_TAG_PATTERN.match(t.name)]
+    if not candidates:
+        return None
+    candidates.sort(key=_release_tag_sort_key, reverse=True)
+    return candidates[0]
 
 
 def _detect_build_info() -> str:
@@ -76,11 +131,12 @@ def _detect_build_info() -> str:
       so the LLM can quote the latest tag AND the current SHA without shelling
       out. Both are filesystem reads only.
     """
-    repo = _repo_root_from_here()
-    if repo is None:
+    located = _repo_root_from_here()
+    if located is None:
         return ""
-    latest_tag = _read_latest_release_tag(repo)
-    sha = _read_git_head_sha(repo)
+    _, gitdir = located
+    latest_tag = _read_latest_release_tag(gitdir)
+    sha = _read_git_head_sha(gitdir)
     if latest_tag and sha:
         return f"dev, {latest_tag} @ {sha}"
     if latest_tag:

--- a/config/runtime_metadata.py
+++ b/config/runtime_metadata.py
@@ -1,0 +1,130 @@
+"""Safe read-only runtime metadata for sessions and sandboxed agent tools.
+
+Populated at session init so agents can answer introspection questions
+(e.g. OpenSRE version) without shelling out. Subprocess remains blocked in
+the Python execution sandbox; this is the preferred alternative.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from config.config import get_environment
+from config.version import get_opensre_version
+
+# Reserved key merged into ``execute_python_code`` inputs (never overwrite user keys).
+RUNTIME_INPUTS_KEY = "opensre_runtime"
+
+_RELEASE_TAG_PATTERN = re.compile(r"^v\d+\.\d+(\.\d+){2,}$")
+
+
+def _repo_root_from_here() -> Path | None:
+    """Walk up from this file looking for a ``.git`` directory.
+
+    Filesystem-only — no subprocess. Used to enrich metadata when opensre is
+    imported from a git checkout (local dev). Returns ``None`` in installed
+    wheels where ``.git`` doesn't exist alongside the package.
+    """
+    here = Path(__file__).resolve().parent
+    while here.parent != here:
+        if (here / ".git").is_dir():
+            return here
+        here = here.parent
+    return None
+
+
+def _read_git_head_sha(repo: Path) -> str | None:
+    """Return the short SHA the working tree currently points at, or None."""
+    head_file = repo / ".git" / "HEAD"
+    if not head_file.is_file():
+        return None
+    head = head_file.read_text(encoding="utf-8").strip()
+    if head.startswith("ref: "):
+        ref_path = repo / ".git" / head[5:].strip()
+        if ref_path.is_file():
+            return ref_path.read_text(encoding="utf-8").strip()[:7] or None
+        return None
+    return head[:7] or None
+
+
+def _read_latest_release_tag(repo: Path) -> str | None:
+    """Return the highest-sorted release tag (v0.1.YYYY.M.D shape) present.
+
+    Filesystem-only: reads ``.git/refs/tags/``. Sorts lexicographically —
+    correct for the date-suffixed tag shape opensre uses.
+    """
+    tags_dir = repo / ".git" / "refs" / "tags"
+    if not tags_dir.is_dir():
+        return None
+    matches = sorted(
+        (t.name for t in tags_dir.iterdir() if _RELEASE_TAG_PATTERN.match(t.name)),
+        reverse=True,
+    )
+    return matches[0] if matches else None
+
+
+def _detect_build_info() -> str:
+    """Return a human-readable build marker for the running process.
+
+    - Installed wheel (no ``.git`` present): returns ``""`` — the caller
+      relies on ``opensre_version`` alone (already the full release version
+      because ``sync_release_version.py`` stamped ``pyproject.toml`` at build).
+    - Git checkout (local dev): returns e.g. ``"dev, v0.1.2026.7.11 @ abc1234"``
+      so the LLM can quote the latest tag AND the current SHA without shelling
+      out. Both are filesystem reads only.
+    """
+    repo = _repo_root_from_here()
+    if repo is None:
+        return ""
+    latest_tag = _read_latest_release_tag(repo)
+    sha = _read_git_head_sha(repo)
+    if latest_tag and sha:
+        return f"dev, {latest_tag} @ {sha}"
+    if latest_tag:
+        return f"dev, {latest_tag}"
+    if sha:
+        return f"dev, @ {sha}"
+    return "dev"
+
+
+def build_runtime_metadata() -> dict[str, Any]:
+    """Return JSON-serializable read-only runtime facts for the current process.
+
+    Keys are stable for prompts and sandbox ``inputs``:
+    - ``opensre_version`` — installed/package version via ``importlib.metadata``
+    - ``opensre_build`` — build marker: empty in released wheels (version is
+      already the full release), or ``"dev, v0.1.YYYY.M.D @ SHA"`` in a git
+      checkout so the LLM can answer "which build" in local dev.
+    - ``runtime_env`` — ``OPENSRE_ENV`` or app environment (development/production)
+    """
+    env_override = (os.environ.get("OPENSRE_ENV") or "").strip()
+    return {
+        "opensre_version": get_opensre_version(),
+        "opensre_build": _detect_build_info(),
+        "runtime_env": env_override or get_environment().value,
+    }
+
+
+def merge_runtime_into_inputs(
+    inputs: dict[str, Any] | None,
+    *,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Copy ``inputs`` and inject runtime metadata under :data:`RUNTIME_INPUTS_KEY`.
+
+    Does not overwrite an existing ``opensre_runtime`` key supplied by the caller.
+    """
+    merged: dict[str, Any] = dict(inputs or {})
+    if RUNTIME_INPUTS_KEY not in merged:
+        merged[RUNTIME_INPUTS_KEY] = dict(metadata or build_runtime_metadata())
+    return merged
+
+
+__all__ = [
+    "RUNTIME_INPUTS_KEY",
+    "build_runtime_metadata",
+    "merge_runtime_into_inputs",
+]

--- a/config/runtime_metadata.py
+++ b/config/runtime_metadata.py
@@ -22,139 +22,152 @@ _RELEASE_TAG_PATTERN = re.compile(r"^v\d+\.\d+(\.\d+){2,}$")
 
 
 def _resolve_gitdir(candidate: Path) -> Path | None:
-    """Resolve a candidate ``.git`` entry to the actual git directory.
+    """Return the git directory for ``candidate`` (``.git``), or ``None``.
 
-    In a normal checkout ``.git`` is a directory. In a linked worktree or a
-    submodule ``.git`` is a *file* containing a ``gitdir: <absolute path>``
-    line pointing to the real git dir under the primary repo. Both shapes
-    need to work so build metadata surfaces correctly for worktree devs too.
+    Handles both a normal checkout (``.git`` is a directory) and a linked
+    worktree / submodule (``.git`` is a file with a ``gitdir: <path>`` line).
     """
     if candidate.is_dir():
         return candidate
-    if candidate.is_file():
-        try:
-            content = candidate.read_text(encoding="utf-8")
-        except OSError:
-            return None
-        for line in content.splitlines():
-            line = line.strip()
-            if line.startswith("gitdir:"):
-                target = Path(line[len("gitdir:") :].strip())
-                if not target.is_absolute():
-                    target = (candidate.parent / target).resolve()
-                if target.is_dir():
-                    return target
-                return None
+    if not candidate.is_file():
+        return None
+    try:
+        content = candidate.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("gitdir:"):
+            continue
+        target = Path(stripped[len("gitdir:") :].strip())
+        if not target.is_absolute():
+            target = (candidate.parent / target).resolve()
+        return target if target.is_dir() else None
     return None
 
 
-def _repo_root_from_here() -> tuple[Path, Path] | None:
-    """Walk up from this file looking for a ``.git`` directory or file.
-
-    Filesystem-only — no subprocess. Used to enrich metadata when opensre is
-    imported from a git checkout (local dev). Returns ``None`` in installed
-    wheels where ``.git`` doesn't exist alongside the package.
-
-    Returns a tuple of ``(worktree_root, gitdir)`` — the worktree root is
-    where ``.git`` lives (a checkout or a linked worktree); the gitdir is the
-    resolved directory that actually contains ``HEAD``, ``refs/``, etc. Under
-    a normal checkout the two point at the same physical directory
-    (``<repo>/.git``); under a linked worktree they differ.
-    """
+def _find_gitdir() -> Path | None:
+    """Walk up from this file to the enclosing repo's git directory."""
     here = Path(__file__).resolve().parent
     while here.parent != here:
         gitdir = _resolve_gitdir(here / ".git")
         if gitdir is not None:
-            return here, gitdir
+            return gitdir
         here = here.parent
     return None
 
 
+def _read_packed_refs(gitdir: Path) -> dict[str, str]:
+    """Parse ``<gitdir>/packed-refs`` into a ``{ref_name: sha}`` map.
+
+    After ``git pack-refs`` the loose files under ``refs/`` disappear and both
+    branch heads and tag refs live only here. Peeled tag lines (``^<sha>``) are
+    ignored: the non-peeled line already holds the tag object's sha which is
+    enough for a build marker.
+    """
+    packed = gitdir / "packed-refs"
+    if not packed.is_file():
+        return {}
+    refs: dict[str, str] = {}
+    try:
+        content = packed.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line or line.startswith(("#", "^")):
+            continue
+        sha, _, name = line.partition(" ")
+        if sha and name:
+            refs[name] = sha
+    return refs
+
+
 def _read_git_head_sha(gitdir: Path) -> str | None:
-    """Return the short SHA the working tree currently points at, or None."""
+    """Short SHA the working tree currently points at, or ``None``.
+
+    Reads loose refs first; falls back to ``packed-refs`` if the branch was
+    packed (loose file is gone).
+    """
     head_file = gitdir / "HEAD"
     if not head_file.is_file():
         return None
     head = head_file.read_text(encoding="utf-8").strip()
-    if head.startswith("ref: "):
-        ref_path = gitdir / head[5:].strip()
-        if ref_path.is_file():
-            return ref_path.read_text(encoding="utf-8").strip()[:7] or None
-        return None
-    return head[:7] or None
+    if not head.startswith("ref: "):
+        return head[:7] or None
+    ref_name = head[len("ref: ") :].strip()
+    ref_path = gitdir / ref_name
+    if ref_path.is_file():
+        return ref_path.read_text(encoding="utf-8").strip()[:7] or None
+    sha = _read_packed_refs(gitdir).get(ref_name)
+    return sha[:7] if sha else None
 
 
-def _release_tag_sort_key(name: str) -> tuple[int, ...]:
-    """Return a tuple sort key for a release tag like ``v0.1.2026.9.30``.
+def _release_tag_sort_key(name: str) -> tuple[int, ...] | None:
+    """Numeric tuple for a ``v0.1.YYYY.M.D`` tag; ``None`` if not all-numeric.
 
-    Sorts by (major, minor, year, month, day...) numerically so
-    ``v0.1.2026.10.1`` correctly outranks ``v0.1.2026.9.30`` — a naive
-    lexicographic sort would pick the older tag because ``'9' > '1'`` as
-    ASCII, flipping September-30 above October-1.
+    Numeric sort so ``v0.1.2026.10.1`` outranks ``v0.1.2026.9.30`` — a
+    lexicographic sort would pick the older tag because ``'9' > '1'`` as ASCII.
     """
     parts = name.removeprefix("v").split(".")
-    numeric: list[int] = []
-    for part in parts:
-        try:
-            numeric.append(int(part))
-        except ValueError:
-            # Any non-numeric component (unexpected for this tag shape) sorts
-            # this tag below any tag whose components are all-numeric.
-            return ()
-    return tuple(numeric)
+    try:
+        return tuple(int(part) for part in parts)
+    except ValueError:
+        return None
+
+
+def _iter_release_tag_names(gitdir: Path) -> set[str]:
+    """Release tag names, from loose refs and from ``packed-refs`` combined."""
+    names: set[str] = set()
+    tags_dir = gitdir / "refs" / "tags"
+    if tags_dir.is_dir():
+        names.update(entry.name for entry in tags_dir.iterdir())
+    for ref_name in _read_packed_refs(gitdir):
+        if ref_name.startswith("refs/tags/"):
+            names.add(ref_name[len("refs/tags/") :])
+    return names
 
 
 def _read_latest_release_tag(gitdir: Path) -> str | None:
-    """Return the highest release tag (``v0.1.YYYY.M.D`` shape) present.
-
-    Filesystem-only: reads ``<gitdir>/refs/tags/``. Sorts using a numeric
-    tuple key so month/day boundary crossings (e.g. ``9.30`` vs ``10.1``)
-    order correctly, unlike lexicographic sort.
-    """
-    tags_dir = gitdir / "refs" / "tags"
-    if not tags_dir.is_dir():
+    """Highest release tag (loose + packed) by numeric ordering."""
+    ranked: list[tuple[tuple[int, ...], str]] = []
+    for name in _iter_release_tag_names(gitdir):
+        if not _RELEASE_TAG_PATTERN.match(name):
+            continue
+        key = _release_tag_sort_key(name)
+        if key is not None:
+            ranked.append((key, name))
+    if not ranked:
         return None
-    candidates = [t.name for t in tags_dir.iterdir() if _RELEASE_TAG_PATTERN.match(t.name)]
-    if not candidates:
-        return None
-    candidates.sort(key=_release_tag_sort_key, reverse=True)
-    return candidates[0]
+    ranked.sort(reverse=True)
+    return ranked[0][1]
 
 
 def _detect_build_info() -> str:
-    """Return a human-readable build marker for the running process.
-
-    - Installed wheel (no ``.git`` present): returns ``""`` — the caller
-      relies on ``opensre_version`` alone (already the full release version
-      because ``sync_release_version.py`` stamped ``pyproject.toml`` at build).
-    - Git checkout (local dev): returns e.g. ``"dev, v0.1.2026.7.11 @ abc1234"``
-      so the LLM can quote the latest tag AND the current SHA without shelling
-      out. Both are filesystem reads only.
-    """
-    located = _repo_root_from_here()
-    if located is None:
+    """Human-readable build marker: ``""`` for wheels, ``dev, <tag> @ <sha>`` for checkouts."""
+    gitdir = _find_gitdir()
+    if gitdir is None:
         return ""
-    _, gitdir = located
-    latest_tag = _read_latest_release_tag(gitdir)
+    tag = _read_latest_release_tag(gitdir)
     sha = _read_git_head_sha(gitdir)
-    if latest_tag and sha:
-        return f"dev, {latest_tag} @ {sha}"
-    if latest_tag:
-        return f"dev, {latest_tag}"
+    if tag and sha:
+        return f"dev, {tag} @ {sha}"
+    if tag:
+        return f"dev, {tag}"
     if sha:
         return f"dev, @ {sha}"
     return "dev"
 
 
 def build_runtime_metadata() -> dict[str, Any]:
-    """Return JSON-serializable read-only runtime facts for the current process.
+    """JSON-serializable read-only runtime facts for the current process.
 
     Keys are stable for prompts and sandbox ``inputs``:
-    - ``opensre_version`` — installed/package version via ``importlib.metadata``
-    - ``opensre_build`` — build marker: empty in released wheels (version is
-      already the full release), or ``"dev, v0.1.YYYY.M.D @ SHA"`` in a git
-      checkout so the LLM can answer "which build" in local dev.
-    - ``runtime_env`` — ``OPENSRE_ENV`` or app environment (development/production)
+
+    - ``opensre_version`` — package version via ``importlib.metadata``.
+    - ``opensre_build`` — ``""`` in released wheels; ``dev, v0.1.YYYY.M.D @ SHA``
+      in a git checkout so the LLM can quote the exact build in local dev.
+    - ``runtime_env`` — ``OPENSRE_ENV`` env var, else the app environment name.
     """
     env_override = (os.environ.get("OPENSRE_ENV") or "").strip()
     return {
@@ -171,7 +184,7 @@ def merge_runtime_into_inputs(
 ) -> dict[str, Any]:
     """Copy ``inputs`` and inject runtime metadata under :data:`RUNTIME_INPUTS_KEY`.
 
-    Does not overwrite an existing ``opensre_runtime`` key supplied by the caller.
+    Never overwrites an existing ``opensre_runtime`` key supplied by the caller.
     """
     merged: dict[str, Any] = dict(inputs or {})
     if RUNTIME_INPUTS_KEY not in merged:

--- a/core/agent_harness/prompts/assistant_agent_prompt.py
+++ b/core/agent_harness/prompts/assistant_agent_prompt.py
@@ -70,6 +70,9 @@ def build_environment_block(
     reasoning_model: str | None = None,
     toolcall_model: str | None = None,
     llm_settings_available: bool | None = None,
+    opensre_version: str | None = None,
+    opensre_build: str | None = None,
+    runtime_env: str | None = None,
 ) -> str:
     """Render shell-state facts so the assistant can answer directly.
 
@@ -109,6 +112,27 @@ def build_environment_block(
             "Active LLM settings are unavailable in this session. If the user asks "
             "which model/provider is being used, say the settings could not be read "
             "instead of guessing or telling them to run another command."
+        )
+
+    version = (opensre_version or "").strip()
+    build_marker = (opensre_build or "").strip()
+    env_name = (runtime_env or "").strip()
+    if version or env_name:
+        runtime_bits: list[str] = []
+        if version:
+            version_display = f"{version} ({build_marker})" if build_marker else version
+            runtime_bits.append(f"OpenSRE version is {version_display}")
+        if env_name:
+            runtime_bits.append(f"runtime environment is {env_name}")
+        facts.append(
+            "Runtime facts (quote the strings below EXACTLY when asked; do not "
+            "paraphrase them into other field names): "
+            + "; ".join(runtime_bits)
+            + ". When the user asks which OpenSRE version is running, reply with the "
+            "full version string above verbatim — including any parenthetical suffix. "
+            "Do NOT invent field names, values, or numbers not present above. Do NOT "
+            "shell out, call `opensre --version`, or use subprocess — the Python "
+            "execution sandbox blocks process spawning."
         )
 
     if not facts:

--- a/core/agent_harness/prompts/assistant_agent_prompt.py
+++ b/core/agent_harness/prompts/assistant_agent_prompt.py
@@ -62,6 +62,40 @@ def build_handoff_guidance_block(handoff_contents: tuple[str, ...]) -> str:
     return "".join(blocks)
 
 
+def _render_runtime_facts(
+    opensre_version: str | None,
+    opensre_build: str | None,
+    runtime_env: str | None,
+) -> str:
+    """Runtime section of the environment block, or ``""`` when nothing to say.
+
+    Phrased for quote-verbatim recall: earlier prompt wording ("including the
+    build marker if present") caused the LLM to treat "build marker" as a slot
+    name and hallucinate a value like ``0`` when the marker was empty.
+    """
+    version = (opensre_version or "").strip()
+    build_marker = (opensre_build or "").strip()
+    env_name = (runtime_env or "").strip()
+    if not version and not env_name:
+        return ""
+    bits: list[str] = []
+    if version:
+        display = f"{version} ({build_marker})" if build_marker else version
+        bits.append(f"OpenSRE version is {display}")
+    if env_name:
+        bits.append(f"runtime environment is {env_name}")
+    return (
+        "Runtime facts (quote the strings below EXACTLY when asked; do not "
+        "paraphrase them into other field names): "
+        + "; ".join(bits)
+        + ". When the user asks which OpenSRE version is running, reply with the "
+        "full version string above verbatim — including any parenthetical suffix. "
+        "Do NOT invent field names, values, or numbers not present above. Do NOT "
+        "shell out, call `opensre --version`, or use subprocess — the Python "
+        "execution sandbox blocks process spawning."
+    )
+
+
 def build_environment_block(
     *,
     integrations: tuple[str, ...],
@@ -114,26 +148,9 @@ def build_environment_block(
             "instead of guessing or telling them to run another command."
         )
 
-    version = (opensre_version or "").strip()
-    build_marker = (opensre_build or "").strip()
-    env_name = (runtime_env or "").strip()
-    if version or env_name:
-        runtime_bits: list[str] = []
-        if version:
-            version_display = f"{version} ({build_marker})" if build_marker else version
-            runtime_bits.append(f"OpenSRE version is {version_display}")
-        if env_name:
-            runtime_bits.append(f"runtime environment is {env_name}")
-        facts.append(
-            "Runtime facts (quote the strings below EXACTLY when asked; do not "
-            "paraphrase them into other field names): "
-            + "; ".join(runtime_bits)
-            + ". When the user asks which OpenSRE version is running, reply with the "
-            "full version string above verbatim — including any parenthetical suffix. "
-            "Do NOT invent field names, values, or numbers not present above. Do NOT "
-            "shell out, call `opensre --version`, or use subprocess — the Python "
-            "execution sandbox blocks process spawning."
-        )
+    runtime_fact = _render_runtime_facts(opensre_version, opensre_build, runtime_env)
+    if runtime_fact:
+        facts.append(runtime_fact)
 
     if not facts:
         return ""

--- a/core/agent_harness/prompts/prompt_context.py
+++ b/core/agent_harness/prompts/prompt_context.py
@@ -10,6 +10,7 @@ from core.agent_harness.grounding.investigation_flow_reference import (
 )
 from core.agent_harness.llm_resolution import resolve_provider_models
 from core.agent_harness.prompts import build_environment_block
+from platform.observability.trace.spans import component_span
 
 
 def load_llm_settings() -> Any | None:
@@ -49,25 +50,37 @@ class DefaultPromptContextProvider:
         return build_investigation_flow_reference_text()
 
     def environment_block(self) -> str:
-        settings = load_llm_settings()
-        llm_provider: str | None = None
-        reasoning_model: str | None = None
-        toolcall_model: str | None = None
-        llm_settings_available = settings is not None
-        if settings is not None:
-            llm_provider = str(getattr(settings, "provider", "") or "unknown")
-            try:
-                reasoning_model, toolcall_model = resolve_provider_models(settings, llm_provider)
-            except Exception:
-                llm_settings_available = False
-        return build_environment_block(
-            integrations=tuple(self._session.configured_integrations),
-            known=self._session.configured_integrations_known,
-            llm_provider=llm_provider,
-            reasoning_model=reasoning_model,
-            toolcall_model=toolcall_model,
-            llm_settings_available=llm_settings_available,
-        )
+        sid = getattr(self._session, "session_id", None)
+        with component_span("runtime_metadata:env_block", session_id=sid):
+            settings = load_llm_settings()
+            llm_provider: str | None = None
+            reasoning_model: str | None = None
+            toolcall_model: str | None = None
+            llm_settings_available = settings is not None
+            if settings is not None:
+                llm_provider = str(getattr(settings, "provider", "") or "unknown")
+                try:
+                    reasoning_model, toolcall_model = resolve_provider_models(
+                        settings, llm_provider
+                    )
+                except Exception:
+                    llm_settings_available = False
+            runtime = getattr(self._session, "runtime_metadata", None)
+            if not isinstance(runtime, dict) or not runtime:
+                from config.runtime_metadata import build_runtime_metadata
+
+                runtime = build_runtime_metadata()
+            return build_environment_block(
+                integrations=tuple(self._session.configured_integrations),
+                known=self._session.configured_integrations_known,
+                llm_provider=llm_provider,
+                reasoning_model=reasoning_model,
+                toolcall_model=toolcall_model,
+                llm_settings_available=llm_settings_available,
+                opensre_version=str(runtime.get("opensre_version") or ""),
+                opensre_build=str(runtime.get("opensre_build") or ""),
+                runtime_env=str(runtime.get("runtime_env") or ""),
+            )
 
     def suggested_synthetic_prompt(self) -> str:
         return SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST

--- a/core/agent_harness/session/integration_resolution.py
+++ b/core/agent_harness/session/integration_resolution.py
@@ -48,14 +48,7 @@ def has_resolved_integrations(cache: dict[str, Any] | None) -> bool:
 
 
 def has_only_underscore_prefixed_keys(cache: dict[str, Any] | None) -> bool:
-    """Return True when every cache key starts with an underscore.
-
-    Used to distinguish a cache holding only internal book-keeping entries
-    (``_``-prefixed) from one that has resolved integration configs. The name
-    was previously ``has_only_runtime_metadata`` which invited confusion with
-    session ``runtime_metadata`` (an unrelated concept from #3946); renamed
-    to describe what the check actually does.
-    """
+    """True when every cache key starts with ``_`` (book-keeping only, no configs)."""
     if not cache:
         return False
     return all(str(key).startswith("_") for key in cache)

--- a/core/agent_harness/session/integration_resolution.py
+++ b/core/agent_harness/session/integration_resolution.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 __all__ = [
     "IntegrationResolutionResult",
     "IntegrationState",
-    "has_only_runtime_metadata",
+    "has_only_underscore_prefixed_keys",
     "has_resolved_integrations",
     "merge_resolved_integrations",
     "resolve_and_cache_integrations",
@@ -47,8 +47,15 @@ def has_resolved_integrations(cache: dict[str, Any] | None) -> bool:
     return any(not str(key).startswith("_") for key in cache)
 
 
-def has_only_runtime_metadata(cache: dict[str, Any] | None) -> bool:
-    """Return True when the cache holds only runtime metadata keys."""
+def has_only_underscore_prefixed_keys(cache: dict[str, Any] | None) -> bool:
+    """Return True when every cache key starts with an underscore.
+
+    Used to distinguish a cache holding only internal book-keeping entries
+    (``_``-prefixed) from one that has resolved integration configs. The name
+    was previously ``has_only_runtime_metadata`` which invited confusion with
+    session ``runtime_metadata`` (an unrelated concept from #3946); renamed
+    to describe what the check actually does.
+    """
     if not cache:
         return False
     return all(str(key).startswith("_") for key in cache)
@@ -67,7 +74,7 @@ def merge_resolved_integrations(
 def _has_usable_cache(cache: dict[str, Any] | None) -> bool:
     """True when a cache holds resolved configs and need not be re-resolved."""
     return cache is not None and (
-        has_resolved_integrations(cache) or not has_only_runtime_metadata(cache)
+        has_resolved_integrations(cache) or not has_only_underscore_prefixed_keys(cache)
     )
 
 
@@ -134,7 +141,7 @@ class IntegrationState:
         resolution raced store/env hydration. Failures leave the cache unset.
         """
         cached = self.resolved_cache
-        if cached is not None and not has_only_runtime_metadata(cached):
+        if cached is not None and not has_only_underscore_prefixed_keys(cached):
             return
         if generation is None:
             with self._warm_lock:
@@ -152,7 +159,7 @@ class IntegrationState:
         with self._warm_lock:
             if generation != self._warm_generation:
                 return
-            if self.resolved_cache is not None and not has_only_runtime_metadata(
+            if self.resolved_cache is not None and not has_only_underscore_prefixed_keys(
                 self.resolved_cache
             ):
                 return

--- a/core/agent_harness/session/lifecycle.py
+++ b/core/agent_harness/session/lifecycle.py
@@ -41,6 +41,7 @@ from core.agent_harness.session.persistence.ports import SessionRepo, SessionSto
 # re-export SessionManager without a circular import.
 from core.agent_harness.session.session_core import SessionCore
 from platform.common.task_registry import TaskRegistry
+from platform.observability.trace.spans import component_span
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +103,9 @@ class SessionManager:
         """
         if persistent_tasks:
             session.task_registry = TaskRegistry.persistent()
+        # Safe read-only facts (version/env) so agents never need subprocess introspection.
+        with component_span("runtime_metadata:bootstrap", session_id=session.session_id):
+            session.refresh_runtime_metadata()
         if hydrate_integrations:
             session.hydrate_configured_integrations()
         if warm_integrations:

--- a/core/agent_harness/session/session_core.py
+++ b/core/agent_harness/session/session_core.py
@@ -99,6 +99,10 @@ class SessionCore:
     """Reusable infra context — service names, clusters, regions — learned from
     earlier investigations that should seed future ones."""
 
+    runtime_metadata: dict[str, Any] = field(default_factory=dict)
+    """Safe read-only process facts (version, env, feature flags) for agent prompts
+    and sandboxed tools — populated at session bootstrap, never via subprocess."""
+
     reasoning_effort: ReasoningEffortChoice | None = None
     """Session-scoped reasoning effort preference for REPL-driven LLM calls."""
 
@@ -267,6 +271,12 @@ class SessionCore:
     def github_repo_scope(self, value: tuple[str, str] | None) -> None:
         self.integrations.github_repo_scope = value
 
+    def refresh_runtime_metadata(self) -> None:
+        """Inject safe read-only process metadata (version/env) without subprocess."""
+        from config.runtime_metadata import build_runtime_metadata
+
+        self.runtime_metadata = build_runtime_metadata()
+
     def hydrate_configured_integrations(self) -> None:
         """Load configured integration names (env + local store); metadata-only."""
         self.integrations.hydrate()
@@ -314,6 +324,8 @@ class SessionCore:
         self.accumulated_context.clear()
         self.tokens.reset()
         self.agent.clear()
+        # Re-inject process metadata after wipe so /new and /resume keep version facts.
+        self.refresh_runtime_metadata()
         # Keep persisted cross-session task history on disk intact.
         # /new is session-scoped, so swap in a fresh in-memory registry
         # that reuses the same backing store (if any) so /tasks still shows history.

--- a/core/agent_harness/session/session_core.py
+++ b/core/agent_harness/session/session_core.py
@@ -100,8 +100,7 @@ class SessionCore:
     earlier investigations that should seed future ones."""
 
     runtime_metadata: dict[str, Any] = field(default_factory=dict)
-    """Safe read-only process facts (version, env, feature flags) for agent prompts
-    and sandboxed tools — populated at session bootstrap, never via subprocess."""
+    """Read-only process facts (version, build, env) exposed to prompts and sandboxed tools."""
 
     reasoning_effort: ReasoningEffortChoice | None = None
     """Session-scoped reasoning effort preference for REPL-driven LLM calls."""
@@ -272,7 +271,7 @@ class SessionCore:
         self.integrations.github_repo_scope = value
 
     def refresh_runtime_metadata(self) -> None:
-        """Inject safe read-only process metadata (version/env) without subprocess."""
+        """Repopulate :attr:`runtime_metadata` from current process facts."""
         from config.runtime_metadata import build_runtime_metadata
 
         self.runtime_metadata = build_runtime_metadata()
@@ -324,7 +323,6 @@ class SessionCore:
         self.accumulated_context.clear()
         self.tokens.reset()
         self.agent.clear()
-        # Re-inject process metadata after wipe so /new and /resume keep version facts.
         self.refresh_runtime_metadata()
         # Keep persisted cross-session task history on disk intact.
         # /new is session-scoped, so swap in a fresh in-memory registry

--- a/tests/config/test_runtime_metadata.py
+++ b/tests/config/test_runtime_metadata.py
@@ -6,8 +6,12 @@ from types import SimpleNamespace
 
 import pytest
 
+from pathlib import Path
+
 from config.runtime_metadata import (
     RUNTIME_INPUTS_KEY,
+    _read_latest_release_tag,
+    _resolve_gitdir,
     build_runtime_metadata,
     merge_runtime_into_inputs,
 )
@@ -127,6 +131,35 @@ def test_environment_block_instructs_verbatim_quoting_not_field_names() -> None:
     assert "verbatim" in block
     assert "Do NOT invent field names" in block
     assert "build marker" not in block, "the 'build marker' phrase was a hallucination sink"
+
+
+def test_resolve_gitdir_follows_linked_worktree_pointer_file(tmp_path: Path) -> None:
+    """Linked worktrees (and submodules) store ``.git`` as a *file* that points
+    at the real gitdir under the primary repo. Build metadata must resolve
+    through it instead of returning ``None``."""
+    real_gitdir = tmp_path / "primary" / ".git" / "worktrees" / "wt1"
+    real_gitdir.mkdir(parents=True)
+    pointer = tmp_path / "wt" / ".git"
+    pointer.parent.mkdir(parents=True)
+    pointer.write_text(f"gitdir: {real_gitdir}\n", encoding="utf-8")
+    assert _resolve_gitdir(pointer) == real_gitdir
+
+
+def test_resolve_gitdir_returns_none_for_pointer_to_missing_dir(tmp_path: Path) -> None:
+    pointer = tmp_path / ".git"
+    pointer.write_text("gitdir: /does/not/exist\n", encoding="utf-8")
+    assert _resolve_gitdir(pointer) is None
+
+
+def test_latest_release_tag_sorts_numerically_not_lexicographically(tmp_path: Path) -> None:
+    """``v0.1.YYYY.M.D`` uses non-padded month/day, so a lexicographic sort
+    would pick ``v0.1.2026.9.30`` over the later ``v0.1.2026.10.1`` (because
+    ``'9' > '1'`` as ASCII). Regression guard: numeric tuple sort."""
+    tags_dir = tmp_path / "refs" / "tags"
+    tags_dir.mkdir(parents=True)
+    for name in ("v0.1.2026.9.30", "v0.1.2026.10.1", "v0.1.2026.7.11"):
+        (tags_dir / name).write_text("sha\n", encoding="utf-8")
+    assert _read_latest_release_tag(tmp_path) == "v0.1.2026.10.1"
 
 
 def test_python_tool_reports_version_via_injected_runtime_inputs() -> None:

--- a/tests/config/test_runtime_metadata.py
+++ b/tests/config/test_runtime_metadata.py
@@ -1,4 +1,4 @@
-"""Tests for session runtime metadata injection (#3946)."""
+"""Tests for session runtime metadata injection."""
 
 from __future__ import annotations
 

--- a/tests/config/test_runtime_metadata.py
+++ b/tests/config/test_runtime_metadata.py
@@ -1,0 +1,154 @@
+"""Tests for session runtime metadata injection (#3946)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from config.runtime_metadata import (
+    RUNTIME_INPUTS_KEY,
+    build_runtime_metadata,
+    merge_runtime_into_inputs,
+)
+from config.version import get_opensre_version
+from core.agent_harness.prompts.assistant_agent_prompt import build_environment_block
+from core.agent_harness.session import InMemorySessionStorage, SessionCore, SessionManager
+from tools.system.python_execution_tool import execute_python_code
+
+
+@pytest.fixture(autouse=True)
+def _no_real_integration_bootstrap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(SessionCore, "warm_resolved_integrations", lambda _self, **_k: None)
+    monkeypatch.setattr(SessionCore, "hydrate_configured_integrations", lambda _self: None)
+
+
+def test_build_runtime_metadata_uses_importlib_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_ENV", "staging")
+    meta = build_runtime_metadata()
+    assert meta["opensre_version"] == get_opensre_version()
+    assert meta["runtime_env"] == "staging"
+    # opensre_build is populated in git checkouts (dev), empty in installed wheels.
+    # Just assert the key exists and is a string — the value varies by env.
+    assert isinstance(meta["opensre_build"], str)
+
+
+def test_build_runtime_metadata_populates_build_marker_in_git_checkout() -> None:
+    """In a git checkout (this test tree), opensre_build should include a SHA
+    or release tag so the LLM can quote a precise build identifier without
+    shelling out. The exact string varies with head, but must be non-empty."""
+    meta = build_runtime_metadata()
+    # This test runs from the opensre checkout, so .git exists → build marker
+    # is populated. If someone ever runs the test suite from an installed
+    # wheel, this test would need adjusting.
+    assert meta["opensre_build"], "opensre_build should be populated in a git checkout"
+    assert meta["opensre_build"].startswith("dev"), meta["opensre_build"]
+
+
+def test_merge_runtime_into_inputs_does_not_overwrite_caller_key() -> None:
+    custom = {"opensre_version": "custom"}
+    merged = merge_runtime_into_inputs({"x": 1, RUNTIME_INPUTS_KEY: custom})
+    assert merged["x"] == 1
+    assert merged[RUNTIME_INPUTS_KEY] == custom
+
+
+def test_session_bootstrap_populates_runtime_metadata() -> None:
+    manager = SessionManager(
+        storage=InMemorySessionStorage(),
+        repo=SimpleNamespace(load_session=lambda _sid: None),
+    )
+    session = manager.create(hydrate_integrations=False, persistent_tasks=False, open_storage=False)
+    assert session.runtime_metadata["opensre_version"] == get_opensre_version()
+    assert "runtime_env" in session.runtime_metadata
+    assert "opensre_build" in session.runtime_metadata
+
+
+def test_session_clear_repopulates_runtime_metadata() -> None:
+    session = SessionCore()
+    session.refresh_runtime_metadata()
+    session.runtime_metadata = {}
+    session.clear(rotate_identity=False)
+    assert session.runtime_metadata["opensre_version"] == get_opensre_version()
+
+
+def test_environment_block_includes_version_without_subprocess_hint() -> None:
+    block = build_environment_block(
+        integrations=(),
+        known=False,
+        opensre_version="9.9.9",
+        runtime_env="development",
+    )
+    assert "OpenSRE version is 9.9.9" in block
+    assert "runtime environment is development" in block
+    assert "opensre --version" in block
+    assert "subprocess" in block.lower()
+
+
+def test_environment_block_renders_build_marker_when_provided() -> None:
+    """In a git checkout the runtime metadata carries an opensre_build marker;
+    the env block should render it inline with the version so the LLM can
+    quote both parts."""
+    block = build_environment_block(
+        integrations=(),
+        known=False,
+        opensre_version="0.1",
+        opensre_build="dev, v0.1.2026.7.11 @ abc1234",
+        runtime_env="development",
+    )
+    assert "OpenSRE version is 0.1 (dev, v0.1.2026.7.11 @ abc1234)" in block
+
+
+def test_environment_block_omits_build_parens_when_marker_empty() -> None:
+    """Released wheels report opensre_build=''; version renders bare."""
+    block = build_environment_block(
+        integrations=(),
+        known=False,
+        opensre_version="0.1.2026.7.11",
+        opensre_build="",
+        runtime_env="production",
+    )
+    assert "OpenSRE version is 0.1.2026.7.11" in block
+    assert "()" not in block
+
+
+def test_environment_block_instructs_verbatim_quoting_not_field_names() -> None:
+    """Regression guard: an earlier version of the prompt said 'including the
+    build marker if present', which caused the LLM to treat 'build marker' as
+    a field name and hallucinate a value like '0' when the slot was empty. The
+    prompt now instructs verbatim quoting and explicitly forbids inventing field
+    names or numbers not in the block."""
+    block = build_environment_block(
+        integrations=(),
+        known=False,
+        opensre_version="0.1",
+        opensre_build="dev, v0.1.2026.7.11 @ abc1234",
+        runtime_env="development",
+    )
+    assert "verbatim" in block
+    assert "Do NOT invent field names" in block
+    assert "build marker" not in block, "the 'build marker' phrase was a hallucination sink"
+
+
+def test_python_tool_reports_version_via_injected_runtime_inputs() -> None:
+    result = execute_python_code.run(
+        code="print(inputs['opensre_runtime']['opensre_version'])",
+    )
+    assert result["success"] is True
+    assert get_opensre_version() in result["stdout"]
+    assert RUNTIME_INPUTS_KEY in result["inputs"]
+
+
+def test_python_tool_reports_version_via_importlib_metadata() -> None:
+    result = execute_python_code.run(
+        code=("import importlib.metadata as m\nprint(m.version('opensre'))\n"),
+    )
+    assert result["success"] is True
+    assert get_opensre_version() in result["stdout"]
+
+
+def test_python_tool_still_blocks_subprocess_version_check() -> None:
+    result = execute_python_code.run(
+        code="import subprocess; subprocess.run(['opensre', '--version'])",
+    )
+    assert result["success"] is False
+    assert "PermissionError" in result["stderr"] or "PermissionError" in result["stdout"]

--- a/tests/config/test_runtime_metadata.py
+++ b/tests/config/test_runtime_metadata.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
-from pathlib import Path
-
 from config.runtime_metadata import (
     RUNTIME_INPUTS_KEY,
+    _read_git_head_sha,
     _read_latest_release_tag,
     _resolve_gitdir,
     build_runtime_metadata,
@@ -149,6 +149,31 @@ def test_resolve_gitdir_returns_none_for_pointer_to_missing_dir(tmp_path: Path) 
     pointer = tmp_path / ".git"
     pointer.write_text("gitdir: /does/not/exist\n", encoding="utf-8")
     assert _resolve_gitdir(pointer) is None
+
+
+def test_latest_release_tag_reads_packed_refs_when_loose_missing(tmp_path: Path) -> None:
+    """After ``git pack-refs`` there is no ``refs/tags/<name>`` file — the tag
+    lives only in ``packed-refs``. Build metadata must fall back so packed
+    repos still surface a build marker."""
+    (tmp_path / "packed-refs").write_text(
+        "# pack-refs with: peeled fully-peeled sorted \n"
+        "abc1234abc1234abc1234abc1234abc1234abcd refs/tags/v0.1.2026.7.11\n"
+        "def5678def5678def5678def5678def5678def56 refs/heads/main\n",
+        encoding="utf-8",
+    )
+    assert _read_latest_release_tag(tmp_path) == "v0.1.2026.7.11"
+
+
+def test_head_sha_reads_packed_refs_when_loose_ref_missing(tmp_path: Path) -> None:
+    """A packed branch has no loose ``refs/heads/<name>`` file; the sha is in
+    ``packed-refs``. Falling through instead of following packed-refs would
+    drop the SHA from the build marker."""
+    (tmp_path / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    (tmp_path / "packed-refs").write_text(
+        "abc1234abc1234abc1234abc1234abc1234abcd refs/heads/main\n",
+        encoding="utf-8",
+    )
+    assert _read_git_head_sha(tmp_path) == "abc1234"
 
 
 def test_latest_release_tag_sorts_numerically_not_lexicographically(tmp_path: Path) -> None:

--- a/tests/config/test_runtime_metadata.py
+++ b/tests/config/test_runtime_metadata.py
@@ -9,6 +9,7 @@ import pytest
 
 from config.runtime_metadata import (
     RUNTIME_INPUTS_KEY,
+    _GitLayout,
     _read_git_head_sha,
     _read_latest_release_tag,
     _resolve_gitdir,
@@ -173,7 +174,37 @@ def test_head_sha_reads_packed_refs_when_loose_ref_missing(tmp_path: Path) -> No
         "abc1234abc1234abc1234abc1234abc1234abcd refs/heads/main\n",
         encoding="utf-8",
     )
-    assert _read_git_head_sha(tmp_path) == "abc1234"
+    layout = _GitLayout(gitdir=tmp_path, commondir=tmp_path)
+    assert _read_git_head_sha(layout) == "abc1234"
+
+
+def test_head_sha_resolves_branch_from_commondir_in_linked_worktree(tmp_path: Path) -> None:
+    """In a linked worktree ``HEAD`` sits in the per-worktree gitdir but the
+    branch ref lives in the shared commondir. Reading only the per-worktree
+    gitdir would miss the sha and drop it from the build marker."""
+    commondir = tmp_path / "primary" / ".git"
+    (commondir / "refs" / "heads").mkdir(parents=True)
+    (commondir / "refs" / "heads" / "main").write_text(
+        "abc1234abc1234abc1234abc1234abc1234abcd\n", encoding="utf-8"
+    )
+    per_worktree = commondir / "worktrees" / "wt1"
+    per_worktree.mkdir(parents=True)
+    (per_worktree / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+    layout = _GitLayout(gitdir=per_worktree, commondir=commondir)
+    assert _read_git_head_sha(layout) == "abc1234"
+
+
+def test_latest_release_tag_reads_from_commondir_in_linked_worktree(tmp_path: Path) -> None:
+    """Tags are a shared ref: only the commondir's ``refs/tags/`` sees them.
+    A worktree-local read would return ``None`` and drop the tag from the
+    build marker."""
+    commondir = tmp_path / "primary" / ".git"
+    tags_dir = commondir / "refs" / "tags"
+    tags_dir.mkdir(parents=True)
+    (tags_dir / "v0.1.2026.7.11").write_text("sha\n", encoding="utf-8")
+
+    assert _read_latest_release_tag(commondir) == "v0.1.2026.7.11"
 
 
 def test_latest_release_tag_sorts_numerically_not_lexicographically(tmp_path: Path) -> None:

--- a/tests/config/test_runtime_metadata_perf.py
+++ b/tests/config/test_runtime_metadata_perf.py
@@ -1,0 +1,127 @@
+"""Perf regression guards for session runtime metadata (#3946).
+
+Each test times its target N times, uses the median (robust to jitter), and
+asserts a generous upper bound calibrated at ~10-100x the measured Darwin
+arm64 baseline so slow CI runners don't flake.
+
+Baseline (Darwin arm64, Python 3.14.3, n=500):
+- session dict lookup       ~0.0001 ms
+- importlib.metadata.version ~0.56 ms
+- build_runtime_metadata     ~0.58 ms
+- build_environment_block    ~0.0016 ms
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import statistics
+import time
+from collections.abc import Callable
+
+import pytest
+
+from config.runtime_metadata import build_runtime_metadata
+from core.agent_harness.prompts.assistant_agent_prompt import build_environment_block
+
+_RUNS = 200
+
+
+def _time_median_ms(fn: Callable[[], object]) -> float:
+    """Median wall-time per call in milliseconds. Warmup + N samples."""
+    for _ in range(5):
+        fn()
+    samples = []
+    for _ in range(_RUNS):
+        t0 = time.perf_counter_ns()
+        fn()
+        samples.append((time.perf_counter_ns() - t0) / 1_000_000.0)
+    return statistics.median(samples)
+
+
+def test_session_dict_lookup_stays_under_10us() -> None:
+    """The steady-state path: agent reads pre-built dict during prompt build.
+
+    Baseline ~0.0001 ms; 100x buffer = 0.01 ms = 10 µs. Anything above suggests
+    the field type changed (e.g. lazy accessor, computed property) — regression.
+    """
+    metadata = build_runtime_metadata()
+    median_ms = _time_median_ms(lambda: metadata.get("opensre_version"))
+    print(f"\n  session dict lookup: {median_ms * 1000:.2f} µs")
+    assert median_ms < 0.01, f"regression: {median_ms} ms > 0.01 ms threshold"
+
+
+def test_importlib_version_lookup_stays_under_5ms() -> None:
+    """The fallback path used inside the sandbox when session inputs aren't wired.
+
+    Baseline ~0.56 ms; ~10x buffer = 5 ms. If this breaches, importlib's package
+    resolution has slowed (dependency count, entry-point registration, etc).
+    """
+    median_ms = _time_median_ms(lambda: importlib.metadata.version("opensre"))
+    print(f"\n  importlib.metadata.version: {median_ms:.2f} ms")
+    assert median_ms < 5.0, f"regression: {median_ms} ms > 5 ms threshold"
+
+
+def test_build_runtime_metadata_stays_under_5ms() -> None:
+    """The one-time bootstrap cost at session init / /new / /resume.
+
+    Baseline ~0.58 ms; ~10x buffer = 5 ms. If this breaches, someone added an
+    expensive call to build_runtime_metadata — undermines the "cheap to call
+    per session" invariant.
+    """
+    median_ms = _time_median_ms(build_runtime_metadata)
+    print(f"\n  build_runtime_metadata: {median_ms:.2f} ms")
+    assert median_ms < 5.0, f"regression: {median_ms} ms > 5 ms threshold"
+
+
+def test_environment_block_render_stays_under_1ms() -> None:
+    """The per-turn cost of rendering the version fact into the LLM prompt.
+
+    Baseline ~0.0016 ms; 500x buffer = 1 ms. This runs per prompt build so
+    even sub-millisecond overhead matters.
+    """
+    metadata = build_runtime_metadata()
+
+    def _run() -> str:
+        return build_environment_block(
+            integrations=("github",),
+            known=True,
+            llm_provider="openai",
+            reasoning_model="gpt-5.4-mini",
+            toolcall_model="gpt-5.4-mini",
+            llm_settings_available=True,
+            opensre_version=str(metadata.get("opensre_version") or ""),
+            runtime_env=str(metadata.get("runtime_env") or ""),
+        )
+
+    median_ms = _time_median_ms(_run)
+    print(f"\n  build_environment_block: {median_ms * 1000:.2f} µs")
+    assert median_ms < 1.0, f"regression: {median_ms} ms > 1 ms threshold"
+
+
+@pytest.mark.parametrize("_i", range(3))
+def test_baseline_stability(_i: int) -> None:
+    """Run the whole quartet 3x to smoke-test flakiness under jitter.
+
+    If any of the individual tests flake more than 1 in 3 under CI jitter, the
+    threshold is too tight and should be relaxed. All four asserts inline here.
+    """
+    metadata = build_runtime_metadata()
+
+    dict_ms = _time_median_ms(lambda: metadata.get("opensre_version"))
+    imp_ms = _time_median_ms(lambda: importlib.metadata.version("opensre"))
+    build_ms = _time_median_ms(build_runtime_metadata)
+
+    def _env() -> str:
+        return build_environment_block(
+            integrations=(),
+            known=False,
+            opensre_version=str(metadata.get("opensre_version") or ""),
+            runtime_env=str(metadata.get("runtime_env") or ""),
+        )
+
+    env_ms = _time_median_ms(_env)
+
+    assert dict_ms < 0.01, f"dict {dict_ms} ms"
+    assert imp_ms < 5.0, f"importlib {imp_ms} ms"
+    assert build_ms < 5.0, f"build {build_ms} ms"
+    assert env_ms < 1.0, f"env {env_ms} ms"

--- a/tests/core/agent_harness/session/test_session_characterization.py
+++ b/tests/core/agent_harness/session/test_session_characterization.py
@@ -34,6 +34,7 @@ _CORE_FIELDS = (
     "task_registry",
     "agent",
     "grounding",
+    "runtime_metadata",
     "_ACCUMULATED_KEYS",
 )
 

--- a/tests/core/agent_harness/test_session_manager.py
+++ b/tests/core/agent_harness/test_session_manager.py
@@ -127,6 +127,7 @@ def test_bootstrap_sets_persistent_task_registry() -> None:
     before = session.task_registry
     _manager().bootstrap(session)
     assert session.task_registry is not before
+    assert session.runtime_metadata.get("opensre_version")
 
 
 def test_created_session_persists_through_manager_storage() -> None:

--- a/tests/interactive_shell/session/test_session_facets.py
+++ b/tests/interactive_shell/session/test_session_facets.py
@@ -16,7 +16,7 @@ from core.domain.alerts.inbox import IncomingAlert
 from surfaces.interactive_shell.session.session import Session
 
 # Core fields are inherited from SessionCore; the shell adds these two facets.
-_CORE_FIELD_COUNT = 18
+_CORE_FIELD_COUNT = 19
 _FACET_FIELDS = ("alerts", "terminal")
 
 

--- a/tests/tools/test_python_execution_tool.py
+++ b/tests/tools/test_python_execution_tool.py
@@ -57,7 +57,9 @@ class TestPythonExecutionToolExecution:
         )
         assert result["success"] is True
         assert "Tracer-Cloud/opensre" in result["stdout"]
-        assert result["inputs"] == {"owner": "Tracer-Cloud", "repo": "opensre"}
+        assert result["inputs"]["owner"] == "Tracer-Cloud"
+        assert result["inputs"]["repo"] == "opensre"
+        assert "opensre_runtime" in result["inputs"]
 
     def test_failure_returns_non_zero_exit_code(self) -> None:
         result = execute_python_code.run(code="raise RuntimeError('boom')")

--- a/tools/system/python_execution_tool/__init__.py
+++ b/tools/system/python_execution_tool/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool_framework.base import BaseTool
+from platform.observability.trace.spans import component_span
 from tools.system.python_execution_tool.credentials import execution_env, github_extract_params
 from tools.system.python_execution_tool.runner import run_python_execution
 
@@ -21,17 +22,22 @@ class PythonExecutionTool(BaseTool):
     description = (
         "Execute generated Python code in a restricted subprocess, capture stdout, stderr, "
         "exceptions, and timeout state, and return the result to the agent. Network access is "
-        "blocked by default; opt in only for approved API-backed analysis. When workflow "
-        "guidance lists skills, read each skill description and follow the one that matches "
-        "the user's request."
+        "blocked by default; opt in only for approved API-backed analysis. Subprocess spawning "
+        "is always blocked — for OpenSRE version/runtime facts use "
+        "`inputs['opensre_runtime']` (injected automatically) or "
+        "`importlib.metadata.version('opensre')`, never `opensre --version` or "
+        "`subprocess`. When workflow guidance lists skills, read each skill description and "
+        "follow the one that matches the user's request."
     )
     use_cases = [
         "Compute metrics or summaries from structured evidence already in context",
         "Run a small API-backed calculation with approved credentials",
         "Parse logs or JSON payloads when a direct tool result needs post-processing",
+        "Read OpenSRE version via inputs['opensre_runtime'] or importlib.metadata",
     ]
     anti_examples = [
         "Changing local files or shelling out to other processes",
+        "Calling opensre --version / subprocess / os.system (blocked by sandbox)",
         "Long-running jobs, crawlers, or broad external scans",
         "Accessing credentials not explicitly provided by configured integrations or env vars",
     ]
@@ -46,7 +52,8 @@ class PythonExecutionTool(BaseTool):
                 "type": "object",
                 "description": (
                     "Optional JSON-serializable values injected into the script as the "
-                    "`inputs` global."
+                    "`inputs` global. OpenSRE always merges `opensre_runtime` "
+                    "(version, runtime_env, feature_flags) unless you already set that key."
                 ),
                 "nullable": True,
             },
@@ -95,16 +102,29 @@ class PythonExecutionTool(BaseTool):
         timeout: int | None = None,
         allow_network: bool | None = None,
         github_token: str | None = None,
+        runtime_metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        env, credentials_available = execution_env(github_token=github_token)
-        return run_python_execution(
-            code=code,
-            inputs=inputs,
-            timeout=timeout,
-            env=env,
-            allow_network=bool(allow_network),
-            credentials_available=credentials_available,
-        )
+        """Execute ``code`` in the sandbox with runtime metadata injected.
+
+        ``runtime_metadata`` — when the caller has a session with a pre-built
+        ``runtime_metadata`` dict (e.g. ``SessionCore.runtime_metadata``),
+        passing it here avoids re-running ``build_runtime_metadata()`` per tool
+        call. When ``None`` (default) the merge helper builds a fresh dict —
+        preserving the pre-#3946 behavior. Callers that thread session down
+        (T-2c follow-up) can pass ``session.runtime_metadata`` directly.
+        """
+        from config.runtime_metadata import merge_runtime_into_inputs
+
+        with component_span("runtime_metadata:sandbox"):
+            env, credentials_available = execution_env(github_token=github_token)
+            return run_python_execution(
+                code=code,
+                inputs=merge_runtime_into_inputs(inputs, metadata=runtime_metadata),
+                timeout=timeout,
+                env=env,
+                allow_network=bool(allow_network),
+                credentials_available=credentials_available,
+            )
 
 
 execute_python_code = PythonExecutionTool()


### PR DESCRIPTION
Fixes #3946 

#### Describe the changes you have made in this PR -

The Python execution sandbox blocks all `subprocess` calls as a security boundary. When users asked common introspection questions ("what version are you?", "what environment am I in?"), the agent's default answer path was
`opensre --version` inside the sandbox — which fails with `PermissionError`. The LLM then either burned 1-2 recovery turns explaining the failure or answered "blocked by sandbox permissions" and gave up.

Fix: populate a `runtime_metadata` dict on `SessionCore` at bootstrap using process-native APIs (`importlib.metadata` + `os.environ` + filesystem read of `.git/`). Thread it into the assistant system prompt and into `execute_python_code` inputs so the agent answers from context — no subprocess needed. The sandbox boundary is unchanged; subprocess remains blocked.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
