### PR TITLE
fix(wizard): persist Ollama host where the runtime reads it (#3291)

### DIFF
--- a/surfaces/cli/wizard/_ui.py
+++ b/surfaces/cli/wizard/_ui.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import cast
@@ -121,6 +122,7 @@ def _local_defaults() -> dict[str, str | bool | None]:
         local.get("api_key_env"), api_key_provider.api_key_env if api_key_provider else ""
     )
     is_cli = bool(raw_provider_option and raw_provider_option.credential_kind == "cli")
+    is_host = bool(api_key_provider and api_key_provider.credential_kind == "host")
     is_oauth_backend = bool(raw_provider_value and raw_provider_value != provider_value)
     raw_auth_method = local.get("auth_method")
     auth_method = (
@@ -136,7 +138,15 @@ def _local_defaults() -> dict[str, str | bool | None]:
         "auth_method": auth_method,
         "model": _string_value(local.get("model")),
         "api_key_env": api_key_env,
-        "has_api_key": True if is_cli else bool(api_key_env and has_llm_api_key(api_key_env)),
+        # A ``host`` credential (e.g. the Ollama host) is only real when the
+        # runtime can see it — the environment — never the keyring.
+        "has_api_key": True
+        if is_cli
+        else (
+            bool(api_key_env and os.getenv(api_key_env, "").strip())
+            if is_host
+            else bool(api_key_env and has_llm_api_key(api_key_env))
+        ),
         "legacy_api_key": _string_value(local.get("api_key")),
     }
 

--- a/surfaces/cli/wizard/env_sync.py
+++ b/surfaces/cli/wizard/env_sync.py
@@ -334,6 +334,11 @@ def sync_provider_env(
             active_non_secret.add(provider.endpoint_env)
         if provider.api_version_env:
             active_non_secret.add(provider.api_version_env)
+    # A ``host`` credential (e.g. the Ollama host) is non-secret runtime config
+    # that the wizard persists to ``.env`` — keep it as an active key so this
+    # sync does not strip it back out in the same wizard run (see #3291).
+    if provider.credential_kind == "host" and provider.api_key_env:
+        active_non_secret.add(provider.api_key_env)
     keys_to_remove -= active_non_secret
 
     lines = _remove_keys(existing, keys_to_remove)

--- a/surfaces/cli/wizard/flow.py
+++ b/surfaces/cli/wizard/flow.py
@@ -831,7 +831,11 @@ def run_wizard(_argv: list[str] | None = None) -> int:
             ):
                 has_api_key = bool(defaults["has_api_key"])
                 legacy_api_key = str(defaults["legacy_api_key"] or "").strip()
-                if not has_api_key and legacy_api_key:
+                # A ``host`` credential (e.g. the Ollama host) is not a secret api key: never
+                # migrate a stale legacy ``api_key`` value into it — that would leak a
+                # secret-shaped value into .env and point the runtime at a bogus host. Fall
+                # through to the host prompt instead (#3291).
+                if not has_api_key and legacy_api_key and provider.credential_kind != "host":
                     if not _persist_llm_credential(provider, legacy_api_key):
                         return 1
                     has_api_key = True

--- a/surfaces/cli/wizard/flow.py
+++ b/surfaces/cli/wizard/flow.py
@@ -224,6 +224,21 @@ def _credential_prompt_label(provider: ProviderOption) -> str:
     return provider.label
 
 
+def _persist_llm_credential(provider: ProviderOption, value: str) -> bool:
+    """Persist one prompted credential where the runtime will actually read it.
+
+    ``credential_kind == "host"`` values (e.g. the Ollama host URL) are plain
+    runtime configuration, not secrets: the runtime resolves them from the
+    environment only, never the keyring, so they belong in the project ``.env``.
+    Everything else keeps the keyring path.
+    """
+    if provider.credential_kind == "host":
+        sync_env_values({provider.api_key_env: value})
+        os.environ[provider.api_key_env] = value
+        return True
+    return _persist_llm_api_key(provider.api_key_env, value)
+
+
 def _azure_openai_endpoint_env(provider: ProviderOption) -> dict[str, str]:
     """Return Azure endpoint env vars, using the default API version when unset."""
     from core.llm.providers.azure_openai import resolve_azure_openai_api_version
@@ -796,7 +811,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                 except KeyboardInterrupt:
                     _console.print(f"\n[{WARNING}]Setup cancelled.[/]")
                     return 1
-                if not _persist_llm_api_key(provider.api_key_env, api_key):
+                if not _persist_llm_credential(provider, api_key):
                     return 1
                 azure_env = _ensure_azure_openai_endpoint_settings(provider)
                 if azure_env is None:
@@ -817,7 +832,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                 has_api_key = bool(defaults["has_api_key"])
                 legacy_api_key = str(defaults["legacy_api_key"] or "").strip()
                 if not has_api_key and legacy_api_key:
-                    if not _persist_llm_api_key(provider.api_key_env, legacy_api_key):
+                    if not _persist_llm_credential(provider, legacy_api_key):
                         return 1
                     has_api_key = True
                 if not has_api_key:
@@ -835,7 +850,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                     except KeyboardInterrupt:
                         _console.print(f"\n[{WARNING}]Setup cancelled.[/]")
                         return 1
-                    if not _persist_llm_api_key(provider.api_key_env, api_key):
+                    if not _persist_llm_credential(provider, api_key):
                         return 1
             azure_env = _ensure_azure_openai_endpoint_settings(provider)
             if azure_env is None:

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -103,6 +103,33 @@ def test_sync_provider_env_updates_provider_specific_keys(tmp_path, monkeypatch)
     assert "OPENAI_MODEL=gpt-5-mini\n" in content
 
 
+def test_sync_provider_env_preserves_host_credential(tmp_path, monkeypatch) -> None:
+    """#3291: the wizard writes the Ollama host to .env, then calls sync_provider_env
+    in the same run. A host credential is non-secret runtime config, so it must
+    survive that sync — otherwise OLLAMA_HOST is stripped from both .env and the
+    environment and the custom host is silently lost again."""
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("OLLAMA_MODEL", raising=False)
+    monkeypatch.setenv("OLLAMA_HOST", "http://10.0.0.5:11434")
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "OLLAMA_HOST=http://10.0.0.5:11434\nLLM_PROVIDER=ollama\n",
+        encoding="utf-8",
+    )
+
+    sync_provider_env(
+        provider=PROVIDER_BY_VALUE["ollama"],
+        model="llama3.1",
+        env_path=env_path,
+    )
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "OLLAMA_HOST=http://10.0.0.5:11434\n" in content  # kept in .env
+    assert os.environ["OLLAMA_HOST"] == "http://10.0.0.5:11434"  # kept in runtime env
+    assert "LLM_PROVIDER=ollama\n" in content
+    assert "OLLAMA_MODEL=llama3.1\n" in content
+
+
 def test_sync_provider_env_strips_integration_fallback_secrets(tmp_path, monkeypatch) -> None:
     monkeypatch.delenv("LLM_PROVIDER", raising=False)
     monkeypatch.delenv("OPENAI_REASONING_MODEL", raising=False)

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -2369,3 +2369,59 @@ def test_run_wizard_telegram_retries_on_validation_failure(monkeypatch, tmp_path
     assert validation_call_count == 2
     assert saved_integrations[0][0] == "telegram"
     assert saved_integrations[0][1]["credentials"]["bot_token"] == "123:GOOD"
+
+
+def test_persist_llm_credential_host_kind_writes_env_not_keyring(monkeypatch, tmp_path) -> None:
+    """#3291: a host credential lands where the runtime reads it (.env), never the keyring."""
+    from surfaces.cli.wizard.config import PROVIDER_BY_VALUE
+
+    synced: dict[str, str] = {}
+    monkeypatch.setattr(
+        flow, "sync_env_values", lambda values: synced.update(values) or tmp_path / ".env"
+    )
+    keyring_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        flow,
+        "_persist_llm_api_key",
+        lambda env, val: keyring_calls.append((env, val)) or True,
+    )
+    monkeypatch.setenv("OLLAMA_HOST", "sentinel-before")
+
+    assert flow._persist_llm_credential(PROVIDER_BY_VALUE["ollama"], "http://10.0.0.5:11434")
+
+    assert synced == {"OLLAMA_HOST": "http://10.0.0.5:11434"}
+    assert keyring_calls == []
+    assert os.environ["OLLAMA_HOST"] == "http://10.0.0.5:11434"
+
+
+def test_persist_llm_credential_secret_kind_keeps_keyring(monkeypatch, tmp_path) -> None:
+    from surfaces.cli.wizard.config import PROVIDER_BY_VALUE
+
+    monkeypatch.setattr(
+        flow, "sync_env_values", lambda _values: pytest.fail("secret must not hit .env")
+    )
+    keyring_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        flow,
+        "_persist_llm_api_key",
+        lambda env, val: keyring_calls.append((env, val)) or True,
+    )
+
+    assert flow._persist_llm_credential(PROVIDER_BY_VALUE["anthropic"], "sk-test")
+
+    assert keyring_calls == [("ANTHROPIC_API_KEY", "sk-test")]
+
+
+def test_local_defaults_host_kind_ignores_stale_keyring_entry(monkeypatch, tmp_path) -> None:
+    """#3291 trap half: a keyring-only host must NOT read as configured — the runtime
+    cannot see it, so the wizard must re-prompt instead of skipping."""
+    store = tmp_path / "opensre.json"
+    store.write_text(json.dumps({"targets": {"local": {"provider": "ollama"}}}))
+    monkeypatch.setattr(_ui, "get_store_path", lambda: store)
+    monkeypatch.setattr(_ui, "has_llm_api_key", lambda _env: True)  # stale keyring entry
+
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    assert _ui._local_defaults()["has_api_key"] is False
+
+    monkeypatch.setenv("OLLAMA_HOST", "http://10.0.0.5:11434")
+    assert _ui._local_defaults()["has_api_key"] is True

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -2425,3 +2425,67 @@ def test_local_defaults_host_kind_ignores_stale_keyring_entry(monkeypatch, tmp_p
 
     monkeypatch.setenv("OLLAMA_HOST", "http://10.0.0.5:11434")
     assert _ui._local_defaults()["has_api_key"] is True
+
+
+def test_run_wizard_host_kind_does_not_migrate_legacy_api_key(monkeypatch, tmp_path) -> None:
+    """#3291 (Greptile P1): a saved Ollama config carrying a stale legacy ``api_key`` must NOT
+    have that value migrated into ``OLLAMA_HOST`` — a host is not a secret api key, and writing a
+    secret-shaped legacy value to ``.env`` would both leak it in plaintext and point the runtime
+    at a bogus host. The wizard must fall through to the host-URL prompt instead."""
+    store = tmp_path / "opensre.json"
+    store.write_text(
+        json.dumps(
+            {
+                "targets": {
+                    "local": {
+                        "provider": "ollama",
+                        "model": "llama3.1",
+                        "auth_method": "api_key",
+                        "api_key": "sk-stale-legacy-secret",
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(_ui, "get_store_path", lambda: store)
+    monkeypatch.setattr(flow, "get_store_path", lambda: store)
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    monkeypatch.setattr(flow, "probe_local_target", lambda _p: ProbeResult("local", True, "ok"))
+
+    def _mock_select(*_args, **_kwargs):  # quickstart setup mode
+        m = MagicMock()
+        m.ask.return_value = "quickstart"
+        return m
+
+    def _mock_confirm(*_args, **_kwargs):  # "Change provider?" -> No: keep the saved ollama
+        m = MagicMock()
+        m.ask.return_value = False
+        return m
+
+    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
+
+    prompted: list[str] = []
+
+    def _fake_prompt(label, *_args, **_kwargs):
+        prompted.append(label)
+        return "http://10.0.0.9:11434"  # the host the user actually enters
+
+    monkeypatch.setattr(flow, "_prompt_value", _fake_prompt)
+
+    persisted: list[tuple[str, str]] = []
+
+    def _fake_persist(provider, value):
+        persisted.append((provider.value, value))
+        return False  # stop the wizard right after the credential decision
+
+    monkeypatch.setattr(flow, "_persist_llm_credential", _fake_persist)
+
+    exit_code = flow.run_wizard()
+
+    # The stale legacy api_key was never routed into OLLAMA_HOST; the wizard prompted for the
+    # host and would persist the entered value, not the legacy secret.
+    assert prompted, "a host-kind provider must fall through to the host-URL prompt"
+    assert ("ollama", "sk-stale-legacy-secret") not in persisted
+    assert persisted == [("ollama", "http://10.0.0.9:11434")]
+    assert exit_code == 1  # _fake_persist returned False to short-circuit the run


### PR DESCRIPTION
Fixes #3291

#### Describe the changes you have made in this PR

A custom Ollama host entered in the onboarding wizard was written to the system
keyring, but every runtime consumer reads `OLLAMA_HOST` from the **environment** —
so the custom host was silently ignored (OpenSRE fell back to `localhost:11434`)
and trapped: the keyring entry made the wizard skip the re-prompt on the next run.

A `host` credential is non-secret runtime configuration, so this treats it as the
environment value it is, end to end:

1. **Persist to `.env` + `os.environ`, not the keyring** — a new
   `_persist_llm_credential` routes `credential_kind == "host"` through
   `sync_env_values`; secret credentials keep the keyring path unchanged.
2. **Survive the same-run provider sync** — `sync_provider_env` deliberately
   strips every provider's API-key env line (secrets live in the keyring), and
   Ollama's `api_key_env` *is* `OLLAMA_HOST`, so the host was collateral damage
   later in the same wizard run. It now keeps the active provider's `host` key as
   a non-secret active key (mirroring how the Azure endpoint is preserved), so
   the host is no longer stripped from `.env` and the environment.
3. **Env-based "already configured" check** — `_local_defaults` derives a host
   credential's presence from the environment, so a stale keyring-only entry no
   longer suppresses the re-prompt (which previously defaulted the host back to
   localhost).

The runtime read paths (`config/config.py`, `config/llm_auth/credentials.py`)
already read `OLLAMA_HOST` from the environment and are unchanged — this aligns
the wizard's persistence with the documented `export OLLAMA_HOST=...` behavior.

### Demo: end-to-end screencast

![opensre#3291 custom Ollama host, before vs after](https://raw.githubusercontent.com/Ourbando/opensre/demo-assets/opensre-3291-demo.gif)

The real onboarding wizard, run on the pre-fix commit and then on this fix (same steps, same host):

- **Before:** enter a custom Ollama host. `opensre config` resolves `localhost:11434` (the host was written to the keyring, which the runtime never reads), and a real `opensre investigate` never reaches it (the stub host stays silent).
- **After:** same steps. `.env` keeps `OLLAMA_HOST`, `opensre config` resolves the custom host, and `opensre investigate` actually connects to it.

Reproduce: `opensre onboard` with a custom Ollama host, then check `opensre config`. Without this fix it resolves `localhost:11434`; with it, your host.

#### Regression test (red/green)

Without the `sync_provider_env` fix, the host is stripped in the same wizard run:

```
$ pytest -k preserves_host_credential
    assert "OLLAMA_HOST=http://10.0.0.5:11434\n" in content
E   AssertionError: assert 'OLLAMA_HOST=http://10.0.0.5:11434\n' in
                            'LLM_PROVIDER=ollama\nOLLAMA_MODEL=llama3.1\n'
1 failed
```

With the fix, the whole wizard + model-persistence surface passes:

```
$ pytest tests/cli/wizard/test_env_sync.py tests/cli/wizard/test_flow.py \
         tests/cli/test_model_persistence_scenarios.py
107 passed
```

`ruff check`, `ruff format --check`, and `mypy` are clean on all changed files.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

🔏 Corroboration — a signed, re-runnable receipt for this contribution (measured PR state · CI · diff · green tests, then signed): https://gist.github.com/Ourbando/f2cc5e9315cc7c31be3df51fc0498171 — verify with stock OpenSSH (`ssh-keygen -Y verify`, zero installs); any tampered byte is refused.

**Explain your implementation approach:**

The bug is a persistence/read mismatch: the wizard treated the Ollama host like an
API key (keyring), but the host is keyless runtime config the runtime only reads
from the environment. I considered teaching the runtime to also read the keyring,
but that spreads a secret-store dependency across every consumer for a non-secret
value and contradicts the documented env-based behavior — so instead the host is
routed to `.env`/`os.environ`, keeping one source of truth. The non-obvious part
is `sync_provider_env`: it intentionally removes every provider's API-key line
because secrets belong in the keyring, and since Ollama's `api_key_env` slot is
`OLLAMA_HOST`, a correct persist in step 1 was undone moments later in the same
run. Keeping the active `host` key as a non-secret active key fixes that, and a
regression test pins the behavior so it can't silently regress again.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

