### PR TITLE
fix(interactive_shell): stop masking REPL errors when alert listener is active (#3940)

### DIFF
--- a/surfaces/interactive_shell/controller.py
+++ b/surfaces/interactive_shell/controller.py
@@ -99,6 +99,7 @@ def _alert_listener(
             stack.callback(handle.stop)
         except Exception as exc:
             log.warning("Alert listener could not start: %s — continuing without it.", exc)
+            stack.close()
             yield None
             return
 

--- a/surfaces/interactive_shell/controller.py
+++ b/surfaces/interactive_shell/controller.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import os
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.patch_stdout import patch_stdout
@@ -79,29 +79,31 @@ def _alert_listener(
         yield None
         return
 
-    from gateway.web_server import WebAppServerHandle, serve_webapp_in_thread
+    from gateway.web_server import serve_webapp_in_thread
 
-    inbox: _alert_inbox.AlertInbox | None = None
-    handle: WebAppServerHandle | None = None
-    try:
-        inbox = _alert_inbox.AlertInbox()
-        _alert_inbox.set_current_inbox(inbox)
-        with _alert_listener_token(cfg.alert_listener_token):
+    inbox = _alert_inbox.AlertInbox()
+    with ExitStack() as stack:
+        try:
+            # Bring-up only. This ``except`` must not see exceptions from the
+            # REPL body that runs during ``yield inbox``: a body error caught
+            # here would be mislogged as "could not start", and the following
+            # ``yield None`` would make ``@contextmanager`` raise "generator
+            # didn't stop after throw()", masking the real error (#3940).
+            _alert_inbox.set_current_inbox(inbox)
+            stack.callback(_alert_inbox.set_current_inbox, None)
+            stack.enter_context(_alert_listener_token(cfg.alert_listener_token))
             handle = serve_webapp_in_thread(
                 host=cfg.alert_listener_host,
                 port=cfg.alert_listener_port,
             )
-            console.print(f"[{DIM}]listening for alerts on http://{handle.bound_address}/alerts[/]")
-            try:
-                yield inbox
-            finally:
-                if handle is not None:
-                    handle.stop()
-                _alert_inbox.set_current_inbox(None)
-    except Exception as exc:
-        log.warning("Alert listener could not start: %s — continuing without it.", exc)
-        _alert_inbox.set_current_inbox(None)
-        yield None
+            stack.callback(handle.stop)
+        except Exception as exc:
+            log.warning("Alert listener could not start: %s — continuing without it.", exc)
+            yield None
+            return
+
+        console.print(f"[{DIM}]listening for alerts on http://{handle.bound_address}/alerts[/]")
+        yield inbox
 
 
 def _resolve_runtime_context(

--- a/tests/interactive_shell/test_alert_listener.py
+++ b/tests/interactive_shell/test_alert_listener.py
@@ -9,6 +9,7 @@ import pytest
 from rich.console import Console
 
 from config.repl_config import ReplConfig
+from core.domain.alerts import inbox as _alert_inbox
 from surfaces.interactive_shell.controller import _alert_listener
 
 
@@ -100,3 +101,23 @@ def test_startup_failure_yields_none_without_masking(monkeypatch) -> None:
 
     with _alert_listener(cfg, Console(force_terminal=False)) as inbox:
         assert inbox is None
+
+
+def test_startup_failure_clears_global_inbox_before_body_runs(monkeypatch) -> None:
+    """Regression: on the startup-failure fallback path, the listener's
+    partially-acquired resources (the process-wide current inbox, in
+    particular) must be torn down *before* the REPL body runs with
+    ``inbox=None`` — otherwise ``get_current_inbox()`` would still return the
+    never-started listener's inbox while callers were told there is none."""
+
+    def _boom(**_kwargs: object) -> MagicMock:
+        raise OSError("port already in use")
+
+    monkeypatch.setattr("gateway.web_server.serve_webapp_in_thread", _boom)
+    cfg = ReplConfig(alert_listener_enabled=True, alert_listener_token="tok")
+
+    with _alert_listener(cfg, Console(force_terminal=False)) as inbox:
+        assert inbox is None
+        assert _alert_inbox.get_current_inbox() is None
+
+    assert _alert_inbox.get_current_inbox() is None

--- a/tests/interactive_shell/test_alert_listener.py
+++ b/tests/interactive_shell/test_alert_listener.py
@@ -5,10 +5,17 @@ from __future__ import annotations
 import os
 from unittest.mock import MagicMock
 
+import pytest
 from rich.console import Console
 
 from config.repl_config import ReplConfig
 from surfaces.interactive_shell.controller import _alert_listener
+
+
+def _fake_serve_handle(**_kwargs: object) -> MagicMock:
+    handle = MagicMock()
+    handle.bound_address = "127.0.0.1:8765"
+    return handle
 
 
 def test_alert_listener_replaces_stale_process_token(monkeypatch) -> None:
@@ -55,3 +62,41 @@ def test_alert_listener_clears_token_when_unconfigured(monkeypatch) -> None:
         assert captured == [None]
 
     assert os.environ.get("OPENSRE_ALERT_LISTENER_TOKEN") == "stale"
+
+
+class _ReplBodyError(Exception):
+    """Stand-in for a real error raised inside the REPL turn body."""
+
+
+def test_repl_body_error_propagates_unchanged(monkeypatch) -> None:
+    """Regression for #3940: an exception from the REPL body while the alert
+    listener is active must propagate unchanged, not be masked as
+    ``RuntimeError('generator didn't stop after throw()')`` by the listener's
+    startup ``except``."""
+    handle = _fake_serve_handle()
+    monkeypatch.setattr("gateway.web_server.serve_webapp_in_thread", lambda **_k: handle)
+    cfg = ReplConfig(alert_listener_enabled=True, alert_listener_token="tok")
+
+    with (
+        pytest.raises(_ReplBodyError, match="real repl error"),
+        _alert_listener(cfg, Console(force_terminal=False)) as inbox,
+    ):
+        assert inbox is not None
+        raise _ReplBodyError("real repl error")
+
+    # Cleanup still runs on the body-error path (listener is torn down).
+    handle.stop.assert_called_once()
+
+
+def test_startup_failure_yields_none_without_masking(monkeypatch) -> None:
+    """A genuine listener bring-up failure still degrades gracefully: the
+    context manager yields ``None`` and does not raise."""
+
+    def _boom(**_kwargs: object) -> MagicMock:
+        raise OSError("port already in use")
+
+    monkeypatch.setattr("gateway.web_server.serve_webapp_in_thread", _boom)
+    cfg = ReplConfig(alert_listener_enabled=True, alert_listener_token="tok")
+
+    with _alert_listener(cfg, Console(force_terminal=False)) as inbox:
+        assert inbox is None


### PR DESCRIPTION
Fixes #3940

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

`_alert_listener` in `surfaces/interactive_shell/controller.py` is a `@contextmanager` that starts the alert-listener web server, then yields control to the REPL body, then tears it down. Its `try/except Exception` was meant to guard startup only, but `yield inbox` sat inside that same `try` block. When the REPL body raised, the exception resumed at the `yield`, so it was caught by the startup `except`, logged as "Alert listener could not start", and then a second `yield None` ran. That made `contextlib` raise `RuntimeError("generator didn't stop after throw()")`, replacing the real REPL error.

This PR restructures `_alert_listener` around `contextlib.ExitStack`. The `try/except` now wraps bring-up only (set current inbox, install alert token, start server thread), cleanup is registered as stack callbacks, and `yield inbox` moves outside the `try/except`. A REPL-body exception now propagates unchanged. Cleanup (`handle.stop()`, clearing the inbox, restoring the token) still runs via the `ExitStack`. A genuine bring-up failure still yields `None`.

Also removed an import (`WebAppServerHandle`) no longer needed after the restructure.

### Demo/Screenshot for feature changes and bug fixes -

Before (main), a REPL-body exception is masked:

```
$ uv run python -m pytest tests/interactive_shell/test_alert_listener.py::test_repl_body_error_propagates_unchanged -v
...
E   RuntimeError: generator didn't stop after throw()
WARNING  surfaces.interactive_shell.controller:controller.py:102 Alert listener could not start: real repl error, continuing without it.
============================== 1 failed in 3.46s ==============================
```

After (this branch), the real exception propagates and the full suite passes:

```
$ uv run python -m pytest tests/interactive_shell/test_alert_listener.py -v
tests/interactive_shell/test_alert_listener.py::test_alert_listener_replaces_stale_process_token PASSED [ 25%]
tests/interactive_shell/test_alert_listener.py::test_alert_listener_clears_token_when_unconfigured PASSED [ 50%]
tests/interactive_shell/test_alert_listener.py::test_repl_body_error_propagates_unchanged PASSED [ 75%]
tests/interactive_shell/test_alert_listener.py::test_startup_failure_yields_none_without_masking PASSED [100%]
============================== 4 passed in 3.69s ==============================
```

`make lint`, `make format-check`, and `make typecheck` are clean on the changed files.

`make test-cov` (full suite) does not complete within 10 minutes in my local Windows environment; the run reached 98 percent with a single unrelated failure, `tests/fleet_monitoring/test_probe.py::test_probe_returns_nonzero_cpu_for_busy_process`. I confirmed this failure is pre-existing on `main` (reproduces identically with this branch's two changed files reverted) and is a CPU-sampling timing assertion unrelated to the interactive shell. The scoped, directly relevant suite (`tests/interactive_shell/`) passes in full: 4 passed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is a `@contextmanager` pitfall: code after `yield` inside a `try/except` catches exceptions raised from the `with` block's body, not only exceptions raised before the `yield`. The fix separates the two concerns. `ExitStack` was chosen over nested `try/finally` because it registers cleanup incrementally as each resource is acquired, so a failure partway through bring-up tears down only what was actually acquired, in reverse order. The `try/except` now wraps bring-up only; `yield inbox` is placed after it but still inside the `with ExitStack() as stack:` block, so cleanup still runs on any exit path through the stack's own `__exit__`.

Alternative considered: keep the nested `try/finally` and move `yield` out of the `except`-guarded region. This would work but scales poorly if a third bring-up step is added later. `ExitStack` keeps ordering and partial-failure cleanup correct without hand-nested blocks.

Edge cases tested: a REPL-body exception while the listener is running (propagates unchanged, cleanup still runs), a genuine startup failure (yields `None`, does not raise), and the two pre-existing token-management tests (stale token replaced or cleared) to confirm no regression.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
