### PR TITLE
fix(execution): propagate contextvars to parallel tool-call threads (#3939)

### DIFF
--- a/core/execution.py
+++ b/core/execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextvars
 import json
 import logging
 from collections.abc import Callable, Sequence
@@ -140,7 +141,12 @@ def execute_tool_calls(
     try:
         with ThreadPoolExecutor(max_workers=min(_TOOL_EXECUTOR_WORKERS, len(tool_calls))) as pool:
             for i, tc in enumerate(tool_calls):
-                submitted[pool.submit(_call, tc)] = i
+                # Copy the caller's context so ContextVar bindings (session
+                # trace) reach the pool worker; ThreadPoolExecutor threads are
+                # reused across submissions and otherwise start with an empty
+                # context, which silently drops tool trace spans (#3939).
+                ctx = contextvars.copy_context()
+                submitted[pool.submit(ctx.run, _call, tc)] = i
             for fut in as_completed(submitted):
                 try:
                     results[submitted[fut]] = fut.result()

--- a/tests/core/runtime/test_tool_execution_contract.py
+++ b/tests/core/runtime/test_tool_execution_contract.py
@@ -21,6 +21,11 @@ from core.llm.types import AgentLLMResponse, ToolCall
 from core.provider import ProviderHooks, ProviderRequest
 from core.tool_framework.registered_tool import RegisteredTool
 from core.types import AgentTool, AgentToolContext
+from platform.observability.trace.spans import (
+    NoopSessionTraceSink,
+    bind_session_trace,
+    set_session_trace_sink,
+)
 
 
 def _schema(required: list[str] | None = None) -> dict[str, Any]:
@@ -279,6 +284,59 @@ def test_parallel_batch_preserves_provider_order() -> None:
     results = execute_tool_calls(calls, tools, {})
 
     assert [result.details for result in results] == [{"order": 2}, {"order": 1}]
+
+
+class _RecordingTraceSink:
+    """Minimal in-memory session-trace sink for asserting emitted spans."""
+
+    def __init__(self) -> None:
+        self.spans: list[dict[str, Any]] = []
+
+    def emit(
+        self,
+        session_id: str,
+        *,
+        span_kind: str,
+        name: str,
+        status: str = "ok",
+        duration_ms: int | None = None,
+        attributes: dict[str, Any] | None = None,
+        parent_id: str | None = None,
+    ) -> str:
+        del status, duration_ms, parent_id
+        self.spans.append(
+            {
+                "session_id": session_id,
+                "span_kind": span_kind,
+                "name": name,
+                "attributes": attributes or {},
+            }
+        )
+        return str(len(self.spans))
+
+
+def test_parallel_tool_calls_emit_tool_trace_spans() -> None:
+    """Regression for #3939: tool calls dispatched via the ThreadPoolExecutor
+    branch must still emit a ``tool`` trace span each, matching the
+    single-tool path. Pool workers previously started with an empty
+    ``contextvars`` context, so the ``bind_session_trace`` binding set on the
+    calling thread never reached ``tool_span``/``timed_span``, and every
+    parallel tool call silently produced zero spans."""
+    sink = _RecordingTraceSink()
+    set_session_trace_sink(sink)  # type: ignore[arg-type]
+    try:
+        tools = [_tool("first"), _tool("second")]
+        calls = [_call("first", "a"), _call("second", "b")]
+
+        with bind_session_trace("sess-3939"):
+            results = execute_tool_calls(calls, tools, {})
+    finally:
+        set_session_trace_sink(NoopSessionTraceSink())
+
+    assert [r.is_error for r in results] == [False, False]
+    tool_spans = [s for s in sink.spans if s["span_kind"] == "tool"]
+    assert sorted(s["name"] for s in tool_spans) == ["first", "second"]
+    assert all(s["session_id"] == "sess-3939" for s in tool_spans)
 
 
 def _registered_echo(name: str, *, parallel_safe: bool = True) -> RegisteredTool:


### PR DESCRIPTION
Fixes #3939

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

`execute_tool_calls` in `core/execution.py` dispatches 2+ parallel-safe tool calls to a `ThreadPoolExecutor` via `pool.submit(_call, tc)`. `_call` enters `tool_span(...)`, which resolves the active session id from a `contextvars.ContextVar` bound earlier on the calling thread by `bind_session_trace`. Pool worker threads are reused across submissions and start with an empty `contextvars` context, so that binding is invisible inside the worker. `tool_span`/`timed_span` read an unset session id and silently return without emitting anything. Every tool call dispatched on the parallel path produced zero `tool` trace spans; only the single-tool or forced-sequential path (which runs on the calling thread, context intact) traced correctly.

This PR copies the caller's context per submission and runs `_call` through it: `ctx = contextvars.copy_context(); pool.submit(ctx.run, _call, tc)`. This mirrors an existing, correct use of the same pattern elsewhere in the codebase (`tools/investigation/capability.py`, which uses `contextvars.copy_context().run` as a thread target for the same reason: propagating the session-trace binding into a new thread).

This supersedes the previously closed PR #3905, which addressed the same root cause; that attempt is referenced in the issue body.

### Demo/Screenshot for feature changes and bug fixes -

Before (main), a 2-tool parallel batch emits zero `tool` spans:

```
$ uv run python -m pytest tests/core/runtime/test_tool_execution_contract.py::test_parallel_tool_calls_emit_tool_trace_spans -v
...
E       assert [] == ['first', 'second']
FAILED tests/core/runtime/test_tool_execution_contract.py::test_parallel_tool_calls_emit_tool_trace_spans
```

After (this branch), spans are emitted for both parallel calls and the full contract suite passes:

```
$ uv run python -m pytest tests/core/runtime/test_tool_execution_contract.py -v
...
25 passed in 2.30s
```

Broader scope also verified, per this repo's rule that `core/` changes require `make test-cov` and `make typecheck`:

```
$ uv run python -m pytest tests/core/ tests/platform/observability/ -q
1283 passed, 30 skipped in 36.63s
```

`make lint`, `make format-check`, and `make typecheck` are clean on the changed files.

`make test-cov` (full suite) does not complete within 10 minutes in my local Windows environment. The run reached 99 percent; the last event before the timeout was an xdist worker crash (`[gw5] node down: Not properly terminated`) on `tests/interactive_shell/ui/test_feedback.py::test_run_select_returns_highlighted_choice_on_enter`, a Unix terminal raw-mode test unrelated to this change. In isolation that single test hangs indefinitely on this machine and never completes, confirming it is a pre-existing, environment-specific issue rather than a regression from this diff. The scoped, directly relevant suites (`tests/core/`, `tests/platform/observability/`) pass in full: 1283 passed, 30 skipped.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is a `contextvars` propagation gap: `ContextVar` state is thread-local by design, and a `ThreadPoolExecutor` worker thread does not inherit the submitting thread's context automatically. `contextvars.copy_context()` snapshots the calling thread's context at submission time; `ctx.run(fn, *args)` executes `fn` inside that snapshot on whichever thread picks up the task, giving the worker the same `ContextVar` values (in this case, the session-trace binding) the caller had.

The copy is taken once per submission, inside the loop, rather than once for the whole batch. Each `ToolCall` is independent, and this keeps the isolation semantics simple: a `ContextVar.set()` performed inside one tool's execution (if any tool ever does this) cannot leak into a sibling call's copy, since `Context.run` executes in an isolated copy and does not mutate the caller's context or other copies. A single shared copy would still work correctly for the read-only session-trace binding here, but per-submission copies keep the isolation guarantee general rather than relying on the current call graph never mutating context vars.

Alternative considered: wrapping the whole `with ThreadPoolExecutor(...) as pool:` block in a single `contextvars.copy_context().run(...)`, similar to the `capability.py` thread-target pattern. This does not fit here because `execute_tool_calls` submits multiple independent tasks to a pool rather than starting one dedicated thread, so the fix is applied at the `pool.submit` call site instead.

Edge cases tested: a 2-tool parallel batch emits a `tool` span per call, with the correct session id on each; the existing parallel-order test still passes unmodified.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
