### PR TITLE
fix(packaging): resolve tiktoken plugin discovery in frozen builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,6 +275,8 @@ jobs:
           --collect-data config
           --copy-metadata opensre
           --collect-data litellm
+          --hidden-import tiktoken_ext
+          --hidden-import tiktoken_ext.openai_public
           --collect-submodules integrations
           --collect-submodules surfaces.interactive_shell
           --collect-submodules tools

--- a/core/llm/transports/litellm/clients.py
+++ b/core/llm/transports/litellm/clients.py
@@ -6,11 +6,17 @@ import logging
 from collections.abc import Callable, Iterator
 from typing import Any
 
-from litellm import completion
-from pydantic import BaseModel
+from core.llm.transports.litellm.frozen_tiktoken_bootstrap import (
+    ensure_tiktoken_encodings_discoverable,
+)
 
-from core.context_budget import strip_internal_message_markers
-from core.llm.shared.openai_chat_completions import (
+ensure_tiktoken_encodings_discoverable()
+
+from litellm import completion  # noqa: E402
+from pydantic import BaseModel  # noqa: E402
+
+from core.context_budget import strip_internal_message_markers  # noqa: E402
+from core.llm.shared.openai_chat_completions import (  # noqa: E402
     AGENT_CLIENT_TIMEOUT_SEC,
     LLM_CLIENT_TIMEOUT_SEC,
     agent_response_from_completion,
@@ -24,9 +30,9 @@ from core.llm.shared.openai_chat_completions import (
     prepend_system_message,
     stream_with_litellm_retries,
 )
-from core.llm.shared.structured_output import StructuredOutputClient
-from core.llm.shared.tool_schema_normalize import build_openai_tool_specs
-from core.llm.types import AgentLLMResponse, LLMResponse, ToolCall
+from core.llm.shared.structured_output import StructuredOutputClient  # noqa: E402
+from core.llm.shared.tool_schema_normalize import build_openai_tool_specs  # noqa: E402
+from core.llm.types import AgentLLMResponse, LLMResponse, ToolCall  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/core/llm/transports/litellm/frozen_tiktoken_bootstrap.py
+++ b/core/llm/transports/litellm/frozen_tiktoken_bootstrap.py
@@ -1,0 +1,31 @@
+"""Bootstrap tiktoken plugin discovery for PyInstaller-frozen builds.
+
+``litellm`` imports ``tiktoken`` at module load time and immediately calls
+``tiktoken.get_encoding("cl100k_base")``. ``tiktoken`` finds that encoding by
+walking the ``tiktoken_ext`` namespace package with ``pkgutil.iter_modules``
+and importing whatever submodules it finds there. That directory walk only
+sees loose files on disk, so it comes back empty inside a frozen binary even
+when ``tiktoken_ext.openai_public`` (tiktoken's one shipped plugin) is bundled
+into the archive as a hidden import — the frozen ``from litellm import
+completion`` then raises ``ValueError: Unknown encoding cl100k_base`` with
+``Plugins found: []`` (see issue #3631). Importing the plugin module directly
+sidesteps the broken directory walk while still going through tiktoken's own
+registration path.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def ensure_tiktoken_encodings_discoverable() -> None:
+    """Make tiktoken find its bundled plugin when running as a frozen binary."""
+    if not getattr(sys, "frozen", False):
+        return
+
+    import tiktoken.registry as registry
+
+    def _direct_plugin_modules() -> tuple[str, ...]:
+        return ("tiktoken_ext.openai_public",)
+
+    registry._available_plugin_modules = _direct_plugin_modules  # type: ignore[assignment]

--- a/tests/packaging/test_frozen_tiktoken_bootstrap.py
+++ b/tests/packaging/test_frozen_tiktoken_bootstrap.py
@@ -1,0 +1,82 @@
+"""Regression tests for the frozen-binary tiktoken plugin discovery bootstrap.
+
+``litellm`` imports ``tiktoken`` at module load time and calls
+``tiktoken.get_encoding("cl100k_base")`` immediately. tiktoken discovers that
+encoding by walking the ``tiktoken_ext`` namespace package with
+``pkgutil.iter_modules``, which only sees loose files on disk and finds
+nothing in a PyInstaller frozen build -- crashing with ``ValueError: Unknown
+encoding cl100k_base`` (``Plugins found: []``, see issue #3631). These tests
+guard the bootstrap that bypasses the broken directory walk in frozen builds.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import tiktoken.registry as registry
+
+from core.llm.transports.litellm.frozen_tiktoken_bootstrap import (
+    ensure_tiktoken_encodings_discoverable,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+
+@pytest.fixture(autouse=True)
+def _reset_tiktoken_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate each test from tiktoken's process-wide plugin/encoding caches."""
+    monkeypatch.setattr(registry, "ENCODING_CONSTRUCTORS", None)
+    monkeypatch.setattr(registry, "ENCODINGS", {})
+
+
+def _simulate_broken_frozen_plugin_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reproduce the frozen-build failure: the namespace-package walk finds nothing."""
+    monkeypatch.setattr(registry, "_available_plugin_modules", lambda: ())
+
+
+def test_non_frozen_build_leaves_discovery_untouched(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Outside a frozen build the bootstrap must be a no-op."""
+    monkeypatch.delattr(sys, "frozen", raising=False)
+    original = registry._available_plugin_modules
+
+    ensure_tiktoken_encodings_discoverable()
+
+    assert registry._available_plugin_modules is original
+
+
+def test_frozen_build_without_bootstrap_reproduces_reported_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Confirms the failure mode this bootstrap exists to fix (issue #3631)."""
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    _simulate_broken_frozen_plugin_scan(monkeypatch)
+
+    with pytest.raises(ValueError, match="Unknown encoding cl100k_base"):
+        registry.get_encoding("cl100k_base")
+
+
+def test_frozen_build_bootstrap_resolves_encoding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With the bootstrap applied, the frozen build must resolve the encoding."""
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    _simulate_broken_frozen_plugin_scan(monkeypatch)
+
+    ensure_tiktoken_encodings_discoverable()
+    encoding = registry.get_encoding("cl100k_base")
+
+    assert encoding.name == "cl100k_base"
+
+
+def test_release_workflow_bundles_tiktoken_plugin() -> None:
+    """The release build must hidden-import tiktoken's plugin module.
+
+    Ties the bootstrap's direct-import target to the PyInstaller build command
+    so renaming or dropping the hidden-import fails fast instead of only
+    surfacing as a release-time binary crash.
+    """
+    workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "tiktoken_ext.openai_public" in workflow
+    assert "tiktoken_ext" in workflow


### PR DESCRIPTION
Fixes #3631

#### Describe the changes you have made in this PR -

The curl installer (`install.opensre.com`) ships a PyInstaller frozen binary. After the earlier fix in #3771 (bundling LiteLLM's price/context JSON), users on `OPENSRE_LLM_TRANSPORT=litellm` (e.g. Azure OpenAI) still hit a crash on `opensre investigate`:

```
ValueError: Unknown encoding cl100k_base.
Plugins found: []
```

`litellm` imports `tiktoken` at module load and calls `tiktoken.get_encoding("cl100k_base")` immediately. `tiktoken` discovers that encoding by walking the `tiktoken_ext` namespace package with `pkgutil.iter_modules`, which only sees loose files on disk — inside a frozen binary it comes back empty (`Plugins found: []`) even when `tiktoken_ext.openai_public` (tiktoken's one shipped plugin) is present in the archive.

Fix, mirroring the existing frozen-build-shim pattern in `platform/__init__.py` / `config/platform_bootstrap.py`:
1. `core/llm/transports/litellm/frozen_tiktoken_bootstrap.py` — when running as a frozen binary (`sys.frozen`), replaces tiktoken's plugin-discovery function with one that imports `tiktoken_ext.openai_public` directly, bypassing the broken directory walk. No-op outside frozen builds.
2. `core/llm/transports/litellm/clients.py` — calls the bootstrap before `from litellm import completion` (the only litellm import site), since that's where the crash originates.
3. `.github/workflows/release.yml` — hidden-imports `tiktoken_ext` / `tiktoken_ext.openai_public` in the release PyInstaller build so the module is actually bundled (necessary for the direct import in step 1 to succeed).
4. `tests/packaging/test_frozen_tiktoken_bootstrap.py` — reproduces the exact reported failure mode (stubbed plugin scan → `ValueError: Unknown encoding cl100k_base`), proves the bootstrap fixes it, confirms non-frozen behavior is untouched, and pins the workflow's hidden-import strings so a future rename fails fast instead of only surfacing as a release-time crash.

### Demo/Screenshot for feature changes and bug fixes -

Simulated the frozen-binary failure mode locally (can't build the full PyInstaller binary here) by setting `sys.frozen = True` and stubbing tiktoken's plugin scan to return `[]`, matching the reported traceback exactly:

```
>>> registry.get_encoding("cl100k_base")   # before bootstrap runs
ValueError: Unknown encoding cl100k_base.
Plugins found: ()
tiktoken version: 0.13.0 ...

>>> ensure_tiktoken_encodings_discoverable(); registry.get_encoding("cl100k_base")
OK: cl100k_base 100277
```

New regression test passes:
```
tests/packaging/test_frozen_tiktoken_bootstrap.py::test_non_frozen_build_leaves_discovery_untouched PASSED
tests/packaging/test_frozen_tiktoken_bootstrap.py::test_frozen_build_without_bootstrap_reproduces_reported_crash PASSED
tests/packaging/test_frozen_tiktoken_bootstrap.py::test_frozen_build_bootstrap_resolves_encoding PASSED
tests/packaging/test_frozen_tiktoken_bootstrap.py::test_release_workflow_bundles_tiktoken_plugin PASSED
```

`make lint`, `make format-check`, `make typecheck` all pass. `make test-scope` shows the same 46 pre-existing failures as on `main` (verified via `git stash`), all unrelated to this change (live-LLM network tests failing against a stray local `.env`, plus one unrelated `core.context` leftover-module test) — no new failures introduced.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The crash traceback pointed directly at `tiktoken/registry.py`'s `get_encoding`, which raises with a `Plugins found: []` diagnostic when its `pkgutil.iter_modules`-based plugin scan of the `tiktoken_ext` namespace package finds nothing — that's the exact signature in the reported error. PyInstaller freezes modules into an archive rather than laying them out as loose files, so a filesystem directory walk over a namespace package's `__path__` finds nothing at runtime, regardless of whether the module was bundled.

I considered patching tiktoken itself or vendoring a fork, but that adds an unnecessary dependency fork for a one-line-cause bug. Instead I bypass only the broken discovery step: `tiktoken_ext.openai_public` is tiktoken's only shipped plugin, so once it's bundled via `--hidden-import` (making it directly importable inside the frozen archive, which does work — only the *scan* is broken, not direct imports), swapping tiktoken's private `_available_plugin_modules` function for one that returns that module name directly lets the rest of tiktoken's existing, unmodified registration logic run as normal. This is guarded behind `sys.frozen` so it's a no-op for every non-frozen dev/CI/test environment, and it matches the project's existing convention (see `platform/__init__.py`) for working around PyInstaller-specific import quirks with a small, targeted bootstrap rather than a broad workaround.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
