### PR TITLE
fix(jsonl_storage): O(n²) trace_span perf and parent-chain corruption

### DIFF
--- a/core/agent_harness/session/persistence/jsonl_storage.py
+++ b/core/agent_harness/session/persistence/jsonl_storage.py
@@ -354,7 +354,12 @@ class JsonlSessionStorage:
             if not path.exists():
                 return ""
             entry_id = _new_id()
-            parent = parent_id if parent_id is not None else self._current_leaf_id(path)
+            if parent_id is not None:
+                parent = parent_id
+            elif self._is_diagnostic_type(entry_type):
+                parent = None
+            else:
+                parent = self._current_leaf_id(path)
             record = {
                 "id": entry_id,
                 "parent_id": parent,
@@ -378,12 +383,18 @@ class JsonlSessionStorage:
                     records.append(rec)
         return records
 
+    @staticmethod
+    def _is_diagnostic_type(entry_type: str) -> bool:
+        """Return True for sidecar entry types that must not participate in the
+        session parent-chain or trigger expensive leaf lookups."""
+        return entry_type in ("trace_span",)
+
     def _current_leaf_id(self, path: Path) -> str | None:
         records = self._read_records(path)
         for rec in reversed(records):
             if rec.get("type") == "leaf":
                 return str(rec.get("parent_id") or "") or None
-            if rec.get("type") != "session":
+            if rec.get("type") not in ("session", "trace_span"):
                 return str(rec.get("id") or "") or None
         return None
 


### PR DESCRIPTION
Fixes #3938

#### Describe the changes you have made in this PR -

Two bugs in `JsonlSessionStorage`:

1. **Parent-chain corruption**: `_current_leaf_id()` returned `trace_span` entries as the current leaf, making diagnostic records the parent of subsequent session entries — corrupting the navigation tree.

2. **O(n²) performance**: `_append_entry()` called `_current_leaf_id()` on every write, even for `trace_span` appends. Each span write triggered a full file re-read + JSON parse, making span-heavy sessions quadratic.

### Fix

- Added `_is_diagnostic_type()` static method to gate sidecar entry types
- `_current_leaf_id()` now skips `trace_span` alongside `session` entries
- `_append_entry()` skips `_current_leaf_id()` for diagnostic types, setting `parent_id: null` instead

### Demo

All existing tests pass (132 passed, 1 skipped — live REPL test):

```
132 passed, 1 skipped in 4.79s
```

Ruff lint: All checks passed
Mypy: No issues found

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The fix targets two interacting bugs in `JsonlSessionStorage`:

- **`_current_leaf_id()`** scans records in reverse to find the most recent non-`session` entry as the `parent_id` for new records. `trace_span` entries were not excluded, so they would incorrectly become parents of subsequent real entries (turns, tool calls, etc.), corrupting the session tree.

- **`_append_entry()`** unconditionally called `_current_leaf_id()` before every append. For `trace_span` entries — which are fire-and-forget diagnostic records — this meant re-reading and re-parsing the entire JSONL file each time, even though the span doesn't need a parent in the session hierarchy.

The fix introduces `_is_diagnostic_type()` as a single gating point for sidecar entry types. `_current_leaf_id()` skips diagnostic types alongside `session`. `_append_entry()` bypasses the leaf lookup for diagnostic types entirely, setting `parent_id: null`.

The alternative considered was passing an explicit `parent_id` from callers, but that would require threading it through the `JsonlSessionTraceSink` and span-creation call stack — more invasive and error-prone. A storage-layer gate is cleaner and keeps the span sink stateless.

Key design decisions:
- `_is_diagnostic_type` is a `@staticmethod` — no instance state needed
- The skip list in `_current_leaf_id` uses `not in ("session", "trace_span")` — extensible, just add types to the tuple
- Diagnostic records get `parent_id: null` in JSON — semantically correct (they are session-level orphans, not leaves)

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
