### PR TITLE
feat(tools): add model_spend_tool for spend and burn-rate estimation (3231-model-spend-tool)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -105,6 +105,7 @@
               "interactive-shell-privacy",
               "sessions",
               "fleet",
+              "model_spend_tool",
               "cron",
               "closed-loop-learning",
               "multi-instance-integrations"

--- a/docs/model_spend_tool.mdx
+++ b/docs/model_spend_tool.mdx
@@ -1,0 +1,76 @@
+---
+title: Model Spend Tool
+description: Estimate AI spend and projected burn rate from token usage.
+---
+
+The model spend tool turns per-model token usage into a USD cost estimate and a projected
+hourly burn rate. It is a pure calculator: estimates come only from token counts and OpenSRE's
+local price table — it never calls a provider billing API and never claims your live credit balance.
+
+Unknown models are reported as **unpriced** (never silently costed at `$0`), so a missing rate is
+obvious rather than hidden.
+
+## Tools
+
+| Tool | What it does |
+|------|--------------|
+| `estimate_model_spend` | Estimate total USD from per-model token usage, broken down by model, token bucket, and cost per investigation lap. |
+| `summarize_model_burn_rate` | Project hourly burn (`$/hr`) from a per-minute token sample, or from run totals plus elapsed seconds. |
+
+Both are available in investigation and chat surfaces.
+
+## `estimate_model_spend`
+
+Inputs:
+
+- `token_usage_by_model` (required) — map of model name → token buckets (`input_tokens`,
+  `output_tokens`, and optional `cached_input_tokens`, `cache_read_input_tokens`,
+  `cache_creation_input_tokens`).
+- `laps` (optional) — investigation loop iterations, used to derive cost per lap.
+- `run_label` (optional) — a label echoed back in the result.
+- `price_overrides` (optional) — per-model `input_usd_per_million` / `output_usd_per_million`
+  overrides for custom or unlisted models.
+
+Example:
+
+```json
+{
+  "token_usage_by_model": {
+    "claude-sonnet-4-6": { "input_tokens": 120000, "output_tokens": 18000 }
+  },
+  "laps": 12
+}
+```
+
+Returns the total USD, a `by_model` breakdown (with `cost_by_bucket`), aggregate `cost_by_bucket`,
+`usd_per_lap`, and any `unpriced_models`.
+
+## `summarize_model_burn_rate`
+
+Inputs:
+
+- `token_usage_by_model` (required) — same shape as above.
+- `elapsed_seconds` (optional) — when set, the usage is treated as **totals** observed over that
+  window and normalized to per-minute before projecting to an hour. When omitted, the usage is
+  treated as a **per-minute** sample.
+- `run_label`, `price_overrides` — as above.
+
+Example (project burn from a 2-minute run's totals):
+
+```json
+{
+  "token_usage_by_model": {
+    "claude-sonnet-4-6": { "input_tokens": 40000, "output_tokens": 6000 }
+  },
+  "elapsed_seconds": 120
+}
+```
+
+Returns `total_usd_per_hour` and a per-model breakdown.
+
+## Notes
+
+- Estimates use OpenSRE's local price table; rates are periodically re-verified and the result
+  includes a `rates_verified_at` date.
+- Cache-bucket rates are cheaper than fresh input. If your token source only reports input/output,
+  estimates that omit cache buckets will run slightly high.

--- a/tests/tools/test_model_spend_tool.py
+++ b/tests/tools/test_model_spend_tool.py
@@ -1,0 +1,156 @@
+"""Tests for model_spend_tool (issue #3231)."""
+
+from __future__ import annotations
+
+from tests.tools.conftest import BaseToolContract
+from tools.system.fleet_monitoring.meters import TokenUsage
+from tools.system.fleet_monitoring.pricing import usd_for_usage
+from tools.system.model_spend_tool import estimate_model_spend, summarize_model_burn_rate
+
+_KNOWN = "claude-sonnet-4-6"
+_UNKNOWN = "totally-made-up-model-xyz"
+
+
+class TestEstimateModelSpendContract(BaseToolContract):
+    def get_tool_under_test(self):  # type: ignore[no-untyped-def]
+        return estimate_model_spend.__opensre_registered_tool__
+
+
+class TestSummarizeBurnRateContract(BaseToolContract):
+    def get_tool_under_test(self):  # type: ignore[no-untyped-def]
+        return summarize_model_burn_rate.__opensre_registered_tool__
+
+
+def test_known_model_pricing_matches_price_table() -> None:
+    result = estimate_model_spend({_KNOWN: {"input_tokens": 1000, "output_tokens": 500}})
+    expected = usd_for_usage(TokenUsage(input_tokens=1000, output_tokens=500), _KNOWN)
+    assert expected is not None
+    assert result["priced"] is True
+    assert result["total_usd"] == round(float(expected), 6)
+    assert result["by_model"][0]["model"] == _KNOWN
+    assert result["by_model"][0]["priced"] is True
+
+
+def test_unknown_model_is_unpriced_not_zero() -> None:
+    result = estimate_model_spend({_UNKNOWN: {"input_tokens": 1000}})
+    assert result["priced"] is False
+    assert result["total_usd"] == 0.0
+    assert result["unpriced_models"] == [_UNKNOWN]
+    assert result["by_model"][0]["priced"] is False
+    assert result["by_model"][0]["usd"] is None
+
+
+def test_bucket_costs_sum_to_model_total() -> None:
+    usage = {
+        "input_tokens": 2000,
+        "output_tokens": 800,
+        "cache_read_input_tokens": 500,
+        "cache_creation_input_tokens": 100,
+    }
+    entry = estimate_model_spend({_KNOWN: usage})["by_model"][0]
+    assert round(sum(entry["cost_by_bucket"].values()), 6) == entry["usd"]
+
+
+def test_usd_per_lap_divides_total_by_laps() -> None:
+    result = estimate_model_spend({_KNOWN: {"input_tokens": 1000, "output_tokens": 500}}, laps=5)
+    assert result["laps"] == 5
+    assert result["usd_per_lap"] == round(result["total_usd"] / 5, 6)
+
+
+def test_usd_per_lap_none_when_laps_zero_or_missing() -> None:
+    assert estimate_model_spend({_KNOWN: {"input_tokens": 1000}}, laps=0)["usd_per_lap"] is None
+    assert estimate_model_spend({_KNOWN: {"input_tokens": 1000}})["usd_per_lap"] is None
+
+
+def test_price_override_prices_unknown_model() -> None:
+    # 1M input tokens at an overridden $2/1M input rate = $2.00.
+    result = estimate_model_spend(
+        {"custom-model": {"input_tokens": 1_000_000, "output_tokens": 0}},
+        price_overrides={
+            "custom-model": {"input_usd_per_million": 2.0, "output_usd_per_million": 8.0}
+        },
+    )
+    assert result["priced"] is True
+    assert result["total_usd"] == 2.0
+
+
+def test_multiple_models_aggregate_only_priced() -> None:
+    mixed = estimate_model_spend(
+        {
+            _KNOWN: {"input_tokens": 1000, "output_tokens": 500},
+            _UNKNOWN: {"input_tokens": 1000},
+        }
+    )
+    known_only = estimate_model_spend({_KNOWN: {"input_tokens": 1000, "output_tokens": 500}})
+    assert mixed["total_usd"] == known_only["total_usd"]
+    assert _UNKNOWN in mixed["unpriced_models"]
+    assert len(mixed["by_model"]) == 2
+
+
+def test_burn_rate_per_minute_projection() -> None:
+    result = summarize_model_burn_rate({_KNOWN: {"input_tokens": 1000, "output_tokens": 500}})
+    per_min_cost = usd_for_usage(TokenUsage(input_tokens=1000, output_tokens=500), _KNOWN)
+    assert per_min_cost is not None
+    assert result["usage_interpreted_as"] == "per_minute"
+    assert result["total_usd_per_hour"] == round(float(per_min_cost) * 60.0, 6)
+
+
+def test_burn_rate_from_totals_over_elapsed_seconds() -> None:
+    # 120s window -> per-minute halves the totals; $/hr = per-min cost * 60.
+    result = summarize_model_burn_rate(
+        {_KNOWN: {"input_tokens": 1000, "output_tokens": 500}}, elapsed_seconds=120.0
+    )
+    expected = usd_for_usage(TokenUsage(input_tokens=500, output_tokens=250), _KNOWN)
+    assert expected is not None
+    assert result["usage_interpreted_as"] == "totals_over_elapsed_seconds"
+    assert result["total_usd_per_hour"] == round(float(expected) * 60.0, 6)
+
+
+def test_burn_rate_unknown_model_unpriced() -> None:
+    result = summarize_model_burn_rate({_UNKNOWN: {"input_tokens": 1000}})
+    assert result["priced"] is False
+    assert result["unpriced_models"] == [_UNKNOWN]
+
+
+def test_bool_token_value_is_not_counted() -> None:
+    # isinstance(True, int) is True, so a stray boolean must not add a token
+    # (mirrors meters.safe_int). Otherwise "input_tokens": true would cost money.
+    result = estimate_model_spend({_KNOWN: {"input_tokens": True, "output_tokens": 500}})
+    assert result["by_model"][0]["tokens"]["input_tokens"] == 0.0
+    expected = usd_for_usage(TokenUsage(output_tokens=500), _KNOWN)
+    assert expected is not None
+    assert result["total_usd"] == round(float(expected), 6)
+
+
+def test_non_numeric_string_token_value_falls_back_to_zero() -> None:
+    # A non-numeric string must not raise; it is treated as zero tokens.
+    result = estimate_model_spend({_KNOWN: {"input_tokens": "1,000", "output_tokens": 500}})
+    assert result["by_model"][0]["tokens"]["input_tokens"] == 0.0
+    # A clean numeric string is still parsed.
+    parsed = estimate_model_spend({_KNOWN: {"input_tokens": "1000"}})
+    assert parsed["by_model"][0]["tokens"]["input_tokens"] == 1000.0
+
+
+def test_non_mapping_usage_value_does_not_crash() -> None:
+    # A bare total (a common LLM shorthand) is not a bucket dict; it must be
+    # tolerated as empty usage rather than raising AttributeError mid-batch.
+    result = estimate_model_spend({_KNOWN: 50000})  # type: ignore[dict-item]
+    assert result["by_model"][0]["tokens"]["input_tokens"] == 0.0
+    assert result["total_usd"] == 0.0
+
+
+def test_non_positive_elapsed_seconds_is_consistent_per_minute() -> None:
+    # A zero/negative window cannot be projected: fall back to per-minute and
+    # report elapsed_seconds as null so the output is never self-contradictory.
+    for bad in (0.0, -30.0):
+        result = summarize_model_burn_rate({_KNOWN: {"input_tokens": 1000}}, elapsed_seconds=bad)
+        assert result["usage_interpreted_as"] == "per_minute"
+        assert result["elapsed_seconds"] is None
+    baseline = summarize_model_burn_rate({_KNOWN: {"input_tokens": 1000}})
+    zero = summarize_model_burn_rate({_KNOWN: {"input_tokens": 1000}}, elapsed_seconds=0.0)
+    assert zero["total_usd_per_hour"] == baseline["total_usd_per_hour"]
+
+
+def test_tool_sources_are_knowledge() -> None:
+    for fn in (estimate_model_spend, summarize_model_burn_rate):
+        assert fn.__opensre_registered_tool__.source == "knowledge"

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -1005,6 +1005,9 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         "describe_rds_events",
         "describe_rds_instance",
         "ec2_instances_by_tag",
+        # model_spend_tool calculators are pure (tokens x local price table); they
+        # let unexpected errors escape to the global #1476 wrapper.
+        "estimate_model_spend",
         "execute_aws_operation",
         "execute_github_issue_mutation",
         "execute_python_code",
@@ -1191,6 +1194,7 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         "slash_invoke",
         "summarize_community_followups",
         "summarize_github_pr_status",
+        "summarize_model_burn_rate",
         "synthetic_run",
         "task_cancel",
         # Temporal tools use try/finally only (to close the client); the client

--- a/tools/system/__init__.py
+++ b/tools/system/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 TOOL_MODULES = (
     "fleet_monitoring",
+    "model_spend_tool",
     "python_execution_tool",
     "sre_guidance_tool",
     "watch_dog",

--- a/tools/system/model_spend_tool/__init__.py
+++ b/tools/system/model_spend_tool/__init__.py
@@ -1,0 +1,138 @@
+"""Model spend + burn-rate estimation tools (issue #3231).
+
+Pure calculators over token/model/lap metadata that reuse the fleet-monitoring
+price table. They never call a provider billing API — estimates come only from
+tokens x the local price table, and unknown models are surfaced as unpriced.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.tool_framework.tool_decorator import tool
+from tools.system.model_spend_tool.estimation import estimate_spend, summarize_burn_rate
+
+_TOKEN_USAGE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "Map of model name -> token buckets. Provide at least input_tokens and "
+        "output_tokens; cache buckets are optional but improve accuracy."
+    ),
+    "additionalProperties": {
+        "type": "object",
+        "properties": {
+            "input_tokens": {"type": "number"},
+            "output_tokens": {"type": "number"},
+            "cached_input_tokens": {"type": "number"},
+            "cache_read_input_tokens": {"type": "number"},
+            "cache_creation_input_tokens": {"type": "number"},
+        },
+    },
+}
+
+_PRICE_OVERRIDES_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Optional per-model rate overrides, in USD per 1M tokens.",
+    "additionalProperties": {
+        "type": "object",
+        "properties": {
+            "input_usd_per_million": {"type": "number"},
+            "output_usd_per_million": {"type": "number"},
+        },
+    },
+}
+
+
+def _no_state_params(_sources: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    # Inputs are supplied by the caller/planner, not drawn from evidence state.
+    return {}
+
+
+@tool(
+    name="estimate_model_spend",
+    display_name="Model spend estimate",
+    source="knowledge",
+    description="Estimate AI spend (USD) from per-model token usage, with a per-lap breakdown.",
+    use_cases=[
+        "Estimating the USD cost of a benchmark or investigation run from token usage",
+        "Explaining cost drivers: model choice, token buckets, and cost per investigation lap",
+        "Comparing spend across models for the same workload",
+    ],
+    tags=("safe", "fast", "no-credentials"),
+    surfaces=("investigation", "chat"),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "token_usage_by_model": _TOKEN_USAGE_SCHEMA,
+            "laps": {
+                "type": "integer",
+                "description": "Investigation loop iterations, used to derive cost per lap.",
+            },
+            "run_label": {"type": "string", "description": "Optional label for the run."},
+            "price_overrides": _PRICE_OVERRIDES_SCHEMA,
+        },
+        "required": ["token_usage_by_model"],
+    },
+    extract_params=_no_state_params,
+)
+def estimate_model_spend(
+    token_usage_by_model: dict[str, Any],
+    laps: int | None = None,
+    run_label: str | None = None,
+    price_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Estimate USD spend from per-model token usage."""
+    return estimate_spend(
+        token_usage_by_model,
+        laps=laps,
+        run_label=run_label,
+        price_overrides=price_overrides,
+    )
+
+
+@tool(
+    name="summarize_model_burn_rate",
+    display_name="Model burn rate",
+    source="knowledge",
+    description="Project hourly AI burn ($/hr) from per-model token usage.",
+    use_cases=[
+        "Projecting $/hr burn from a per-minute token sample",
+        "Projecting hourly burn from run totals plus elapsed wall-clock seconds",
+        "Flagging which model dominates ongoing spend",
+    ],
+    tags=("safe", "fast", "no-credentials"),
+    surfaces=("investigation", "chat"),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "token_usage_by_model": _TOKEN_USAGE_SCHEMA,
+            "elapsed_seconds": {
+                "type": "number",
+                "description": (
+                    "If set, token usage is treated as totals over this window and "
+                    "normalized to per-minute before projecting to an hour."
+                ),
+            },
+            "run_label": {"type": "string", "description": "Optional label for the run."},
+            "price_overrides": _PRICE_OVERRIDES_SCHEMA,
+        },
+        "required": ["token_usage_by_model"],
+    },
+    extract_params=_no_state_params,
+)
+def summarize_model_burn_rate(
+    token_usage_by_model: dict[str, Any],
+    elapsed_seconds: float | None = None,
+    run_label: str | None = None,
+    price_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Project hourly burn from per-model token usage."""
+    return summarize_burn_rate(
+        token_usage_by_model,
+        elapsed_seconds=elapsed_seconds,
+        run_label=run_label,
+        price_overrides=price_overrides,
+    )
+
+
+__all__ = ["estimate_model_spend", "summarize_model_burn_rate"]

--- a/tools/system/model_spend_tool/estimation.py
+++ b/tools/system/model_spend_tool/estimation.py
@@ -1,0 +1,238 @@
+"""Pure cost / burn-rate estimation over token usage — no external calls.
+
+Reuses the fleet-monitoring price table (``tools.system.fleet_monitoring.pricing``)
+so estimates stay consistent with the rest of the codebase. Estimates come only
+from tokens x the local price table; this never claims a live provider credit
+balance (there is no billing API in the repo). Unknown models are surfaced as
+``priced: false`` rather than silently costed at zero.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools.system.fleet_monitoring.meters import TokenUsage
+from tools.system.fleet_monitoring.pricing import (
+    RATES_VERIFIED_AT,
+    PriceOverride,
+    normalize_model_name,
+    usd_for_usage,
+    usd_per_hour_for_usage,
+)
+
+_BUCKET_KEYS = ("input", "cached_input", "output", "cache_read", "cache_creation")
+
+
+def _token_usage_from_mapping(raw: Any) -> TokenUsage:
+    """Build a clamped :class:`TokenUsage` from a loose token-bucket dict.
+
+    Tolerant of malformed input: a non-mapping value is treated as empty usage,
+    and each bucket is coerced defensively (``bool`` and non-numeric strings
+    become zero, so a stray ``"input_tokens": true`` never adds a token).
+    """
+    data = raw if isinstance(raw, dict) else {}
+
+    def _num(key: str) -> float:
+        value = data.get(key)
+        if value is None or isinstance(value, bool):
+            return 0.0
+        if not isinstance(value, (int, float)):
+            try:
+                value = float(value)
+            except (TypeError, ValueError):
+                return 0.0
+        return float(value) if value > 0 else 0.0
+
+    return TokenUsage(
+        input_tokens=_num("input_tokens"),
+        output_tokens=_num("output_tokens"),
+        cached_input_tokens=_num("cached_input_tokens"),
+        cache_read_input_tokens=_num("cache_read_input_tokens"),
+        cache_creation_input_tokens=_num("cache_creation_input_tokens"),
+    ).clamped()
+
+
+def _price_override_from_mapping(raw: dict[str, Any] | None) -> PriceOverride | None:
+    if not raw:
+        return None
+    inp = raw.get("input_usd_per_million")
+    out = raw.get("output_usd_per_million")
+    if inp is None and out is None:
+        return None
+    return PriceOverride(
+        input_usd_per_million=None if inp is None else float(inp),
+        output_usd_per_million=None if out is None else float(out),
+    )
+
+
+def _bucket_costs(
+    usage: TokenUsage, model: str, override: PriceOverride | None
+) -> dict[str, float] | None:
+    """Per-bucket USD for one model, or ``None`` when the model has no price.
+
+    ``usd_for_usage`` is linear in each bucket, so a single-bucket
+    :class:`TokenUsage` yields exactly that bucket's cost. This reuses the
+    shared price table instead of duplicating rate math, and the buckets sum
+    to the model total.
+    """
+    cached = min(usage.cached_input_tokens, usage.input_tokens)
+    non_cached_input = usage.input_tokens - cached
+    parts: dict[str, float | None] = {
+        "input": usd_for_usage(TokenUsage(input_tokens=non_cached_input), model, override),
+        "cached_input": usd_for_usage(
+            TokenUsage(input_tokens=cached, cached_input_tokens=cached), model, override
+        ),
+        "output": usd_for_usage(TokenUsage(output_tokens=usage.output_tokens), model, override),
+        "cache_read": usd_for_usage(
+            TokenUsage(cache_read_input_tokens=usage.cache_read_input_tokens), model, override
+        ),
+        "cache_creation": usd_for_usage(
+            TokenUsage(cache_creation_input_tokens=usage.cache_creation_input_tokens),
+            model,
+            override,
+        ),
+    }
+    result: dict[str, float] = {}
+    for key in _BUCKET_KEYS:
+        value = parts[key]
+        if value is None:
+            return None
+        result[key] = float(value)
+    return result
+
+
+def _tokens_dict(usage: TokenUsage) -> dict[str, float]:
+    return {
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
+        "cached_input_tokens": usage.cached_input_tokens,
+        "cache_read_input_tokens": usage.cache_read_input_tokens,
+        "cache_creation_input_tokens": usage.cache_creation_input_tokens,
+    }
+
+
+def estimate_spend(
+    token_usage_by_model: dict[str, Any],
+    *,
+    laps: int | None = None,
+    run_label: str | None = None,
+    price_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Estimate total USD spend from per-model token usage.
+
+    Returns a breakdown by model, by token bucket, and (when ``laps`` is
+    provided) a cost-per-lap driver. Unknown models are listed under
+    ``unpriced_models`` and never contribute to the total.
+    """
+    overrides = price_overrides or {}
+    by_model: list[dict[str, Any]] = []
+    unpriced: list[str] = []
+    total_usd = 0.0
+    priced_any = False
+    bucket_totals = dict.fromkeys(_BUCKET_KEYS, 0.0)
+
+    for model, raw_usage in token_usage_by_model.items():
+        usage = _token_usage_from_mapping(raw_usage or {})
+        override = _price_override_from_mapping(overrides.get(model))
+        usd = usd_for_usage(usage, model, override)
+        entry: dict[str, Any] = {
+            "model": model,
+            "normalized_model": normalize_model_name(model),
+            "priced": usd is not None,
+            "usd": None if usd is None else round(float(usd), 6),
+            "tokens": _tokens_dict(usage),
+        }
+        if usd is None:
+            unpriced.append(model)
+        else:
+            priced_any = True
+            total_usd += float(usd)
+            buckets = _bucket_costs(usage, model, override)
+            if buckets is not None:
+                entry["cost_by_bucket"] = {k: round(v, 6) for k, v in buckets.items()}
+                for key, value in buckets.items():
+                    bucket_totals[key] += value
+        by_model.append(entry)
+
+    usd_per_lap = None
+    if laps is not None and laps > 0 and priced_any:
+        usd_per_lap = round(total_usd / laps, 6)
+
+    return {
+        "run_label": run_label,
+        "rates_verified_at": RATES_VERIFIED_AT,
+        "priced": priced_any,
+        "total_usd": round(total_usd, 6),
+        "laps": laps,
+        "usd_per_lap": usd_per_lap,
+        "cost_by_bucket": {k: round(v, 6) for k, v in bucket_totals.items()},
+        "by_model": by_model,
+        "unpriced_models": unpriced,
+        "note": (
+            f"Estimated from tokens x local price table (verified {RATES_VERIFIED_AT}); "
+            "does not reflect a live provider credit balance."
+        ),
+    }
+
+
+def summarize_burn_rate(
+    token_usage_by_model: dict[str, Any],
+    *,
+    elapsed_seconds: float | None = None,
+    run_label: str | None = None,
+    price_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Project hourly burn ($/hr) from per-model token usage.
+
+    When ``elapsed_seconds`` is given, ``token_usage_by_model`` is treated as
+    totals observed over that window and normalized to per-minute before
+    projecting to an hour. Otherwise the usage is treated as a per-minute
+    sample (matching ``usd_per_hour_for_usage``).
+    """
+    overrides = price_overrides or {}
+    by_model: list[dict[str, Any]] = []
+    unpriced: list[str] = []
+    total_usd_per_hour = 0.0
+    priced_any = False
+
+    # A non-positive window can't be projected; fall back to per-minute and report it as null.
+    effective_elapsed = (
+        elapsed_seconds if (elapsed_seconds is not None and elapsed_seconds > 0) else None
+    )
+    scale = 60.0 / effective_elapsed if effective_elapsed is not None else None
+
+    for model, raw_usage in token_usage_by_model.items():
+        usage = _token_usage_from_mapping(raw_usage or {})
+        per_minute = usage.scaled(scale) if scale is not None else usage
+        override = _price_override_from_mapping(overrides.get(model))
+        usd_per_hour = usd_per_hour_for_usage(per_minute, model, override)
+        entry = {
+            "model": model,
+            "normalized_model": normalize_model_name(model),
+            "priced": usd_per_hour is not None,
+            "usd_per_hour": None if usd_per_hour is None else round(float(usd_per_hour), 6),
+        }
+        if usd_per_hour is None:
+            unpriced.append(model)
+        else:
+            priced_any = True
+            total_usd_per_hour += float(usd_per_hour)
+        by_model.append(entry)
+
+    return {
+        "run_label": run_label,
+        "rates_verified_at": RATES_VERIFIED_AT,
+        "priced": priced_any,
+        "elapsed_seconds": effective_elapsed,
+        "usage_interpreted_as": ("per_minute" if scale is None else "totals_over_elapsed_seconds"),
+        "total_usd_per_hour": round(total_usd_per_hour, 6),
+        "by_model": by_model,
+        "unpriced_models": unpriced,
+        "note": (
+            "Projected burn from tokens x local price table; does not reflect a "
+            "live provider credit balance."
+        ),
+    }
+
+
+__all__ = ["estimate_spend", "summarize_burn_rate"]


### PR DESCRIPTION
Adds `tools/system/model_spend_tool` with two agent/chat tools that estimate AI cost from token/model/lap metadata, reusing the fleet-monitoring price table:

- **`estimate_model_spend`**: total USD from per-model token usage, broken down by model, by token bucket, and by cost-per-investigation-lap.
- **`summarize_model_burn_rate`**: projected `$/hr` from a per-minute sample, or from run totals plus elapsed seconds.

Pure calculators: estimates come only from tokens × the local price table, so there is no live billing-API call and unknown models are surfaced as **unpriced** (never silently costed at zero). Per-model price overrides are supported for custom or unlisted models.

Registers the package in `tools/system`, classifies both tools in the telemetry error-coverage allowlist (they let exceptions escape to the global wrapper), adds `docs/model_spend_tool.mdx` to the nav, and covers pricing, unknown-model fallback, bucket-sum, per-lap, burn-rate, overrides, and malformed-input handling in tests.

Fixes #3231

#### Describe the changes you have made in this PR -

New leaf tool package `tools/system/model_spend_tool/` (function-based, mirroring `sre_guidance_tool`):

- `estimation.py` — pure calculation: `estimate_spend`, `summarize_burn_rate`, and helpers.
- `__init__.py` — the two `@tool(source="knowledge", surfaces=("investigation", "chat"))` entrypoints.

| Tool | What it does |
|------|--------------|
| `estimate_model_spend` | Total USD from per-model token usage → `by_model`, per-`cost_by_bucket`, and `usd_per_lap`. |
| `summarize_model_burn_rate` | Projects `$/hr` from a per-minute sample, or from run totals + `elapsed_seconds`. |

Design notes:
- **Reuses the existing price table** (`tools/system/fleet_monitoring/pricing.py`: `usd_for_usage`, `normalize_model_name`, `PriceOverride`, `RATES_VERIFIED_AT`) and `meters.TokenUsage` — **no rate math or dependency duplication**.
- **Token buckets, not a scalar** — input/output/cache buckets are priced separately (output's higher rate is respected). Per-bucket USD is derived by isolating each bucket through the shared pricer, so the buckets provably **sum to the model total** (tested).
- **Unknown models → `priced: false` + `unpriced_models`**, never costed at `$0`.
- **`laps`** → `usd_per_lap = total_usd / laps` (guarded for `laps > 0`).
- **Robust to malformed input** — a bare/stringified total, a non-numeric string, or a boolean (`isinstance(True, int)` is `True`) is coerced defensively to zero tokens rather than crashing or adding phantom cost; a non-positive `elapsed_seconds` falls back to the per-minute interpretation and reports `elapsed_seconds: null` so the result is never self-contradictory.

Files: new `model_spend_tool/{__init__.py, estimation.py}`; registered in `tools/system/__init__.py`; user docs `docs/model_spend_tool.mdx` + nav in `docs/docs.json`; tests `tests/tools/test_model_spend_tool.py`; both tools classified in `tests/tools/test_telemetry.py`.

### Demo/Screenshot for feature changes and bug fixes -

```
### estimate_model_spend — a 12-lap investigation on claude-sonnet-4-6
{
  "priced": true,
  "total_usd": 0.63,
  "laps": 12,
  "usd_per_lap": 0.0525,
  "cost_by_bucket": { "input": 0.36, "output": 0.27, ... },
  "by_model": [ { "model": "claude-sonnet-4-6", "usd": 0.63, ... } ],
  "unpriced_models": [],
  "note": "Estimated from tokens x local price table (verified 2026-05-17); does not reflect a live provider credit balance."
}

### estimate_model_spend — unknown model is surfaced, not costed at $0
{
  "priced": false,
  "total_usd": 0.0,
  "by_model": [ { "model": "some-unlisted-model", "priced": false, "usd": null } ],
  "unpriced_models": [ "some-unlisted-model" ]
}

### summarize_model_burn_rate — projected from a 120s run's totals
{
  "priced": true,
  "elapsed_seconds": 120,
  "usage_interpreted_as": "totals_over_elapsed_seconds",
  "total_usd_per_hour": 6.3,
  "by_model": [ { "model": "claude-sonnet-4-6", "usd_per_hour": 6.3 } ]
}
```

All checks green locally: `make lint` · `make format-check` · `make typecheck` (1180 files) · `make test-cov`. The tool's own suite (27 tests) covers known-model pricing vs the table, unknown→unpriced, per-bucket sum == model total, per-lap math, burn-rate (per-minute and totals+elapsed), price overrides, malformed/boolean/stringified inputs, and non-positive `elapsed_seconds` — plus the shared `BaseToolContract` for both tools.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: OpenSRE could run investigations and benchmarks but had no first-class way to answer "what did that cost, and what is it burning per hour?" The pricing math already existed inside `fleet_monitoring`, but it wasn't reachable as an agent tool for arbitrary per-model token usage.

I considered (a) a per-provider billing-API integration and (b) a pure calculator over the price table OpenSRE already maintains. I chose (b): it's deterministic, needs no credentials, works offline, and stays truthful about what it is (an estimate, not a live balance). The main risk of a token-based estimator is quietly reporting `$0` for a model it doesn't recognize, so unknown models are marked `priced: false` and listed in `unpriced_models` rather than costed at zero.

Key components:
- `estimation.py` holds the pure functions `estimate_spend` and `summarize_burn_rate` plus helpers. Per-bucket cost is derived by pricing each token bucket in isolation through the shared `usd_for_usage`, so bucket costs always reconcile to the model total and no rate constant is duplicated.
- `__init__.py` is a thin registry entrypoint exposing the two `@tool`s with their input schemas; `extract_params` returns `{}` because inputs come from the caller/planner, not evidence state.
- `summarize_burn_rate` treats usage as a per-minute sample by default, or — when `elapsed_seconds` is given — as totals over that window, normalized to per-minute then projected to an hour.

I also hardened the input path after a self-review: token values are coerced defensively (booleans and non-numeric strings become zero, not phantom tokens or crashes), and a non-positive `elapsed_seconds` degrades to the documented per-minute default with a self-consistent response. Everything is verified through the test suite (27 tool tests + the telemetry classification test), and I confirmed both tools are discovered on the investigation and chat surfaces.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions