### PR TITLE
fix(agent): inject Python, kubectl, tools, time, and PID as session metadata (#3950)

### DIFF
--- a/config/runtime_metadata.py
+++ b/config/runtime_metadata.py
@@ -7,8 +7,12 @@ the Python execution sandbox; this is the preferred alternative.
 
 from __future__ import annotations
 
+import datetime as _dt
 import os
 import re
+import shutil
+import sys
+import time as _time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -201,22 +205,115 @@ def _detect_build_info() -> str:
     return "dev"
 
 
-def build_runtime_metadata() -> dict[str, Any]:
-    """JSON-serializable read-only runtime facts for the current process.
+# Monotonic snapshot at import — anchor for uptime deltas that resist wall-clock skew.
+_PROCESS_START_MONOTONIC = _time.monotonic()
 
-    Keys are stable for prompts and sandbox ``inputs``:
+# Tools the LLM commonly reflex-shells for. Presence-only surfaces so the agent
+# can answer without invoking ``--version``, which the sandbox blocks.
+_TOOLS_TO_PROBE = ("kubectl", "helm", "docker", "git", "python", "python3")
+
+
+_LOCALTIME_LINK = Path("/etc/localtime")
+
+
+def _local_tz_name() -> str:
+    """Best-effort local timezone name — IANA (``Europe/Berlin``) when possible.
+
+    Reads the ``/etc/localtime`` symlink target on macOS/Linux — the standard
+    way the OS advertises which zone it's set to. Falls back to
+    ``time.tzname`` short codes (``CET``, ``BST``) if the symlink can't be
+    resolved (Windows, unusual OS config), and finally to ``UTC``.
+    """
+    try:
+        if _LOCALTIME_LINK.is_symlink():
+            target = os.readlink(_LOCALTIME_LINK)
+            marker = "zoneinfo/"
+            idx = target.rfind(marker)
+            if idx >= 0:
+                iana = target[idx + len(marker) :]
+                if iana:
+                    return iana
+    except OSError:
+        pass
+    return _time.tzname[0] if _time.tzname else "UTC"
+
+
+def _python_version_string() -> str:
+    """Interpreter version as ``major.minor.patch`` from :mod:`sys` (no subprocess)."""
+    info = sys.version_info
+    return f"{info.major}.{info.minor}.{info.micro}"
+
+
+def _installed_tools() -> dict[str, str]:
+    """Map each probed tool name to its ``PATH`` location (empty if absent).
+
+    :func:`shutil.which` walks ``PATH`` in pure Python — no subprocess. Version
+    strings would require invoking the binary and are intentionally omitted;
+    presence is what the agent needs to stop reflex-shelling for ``--version``.
+    """
+    return {tool: shutil.which(tool) or "" for tool in _TOOLS_TO_PROBE}
+
+
+def _kubeconfig_path() -> str:
+    """Effective ``kubeconfig`` path from env, or the default under ``~/.kube``.
+
+    Kept as a session-static fact so the agent can answer "which cluster
+    config is loaded" without shelling to ``kubectl config view``.
+    """
+    override = (os.environ.get("KUBECONFIG") or "").strip()
+    if override:
+        # ``KUBECONFIG`` may be a ``:``-separated list; the first entry wins.
+        first = override.split(os.pathsep, 1)[0]
+        if first:
+            return first
+    default = Path.home() / ".kube" / "config"
+    return str(default) if default.is_file() else ""
+
+
+def build_runtime_metadata() -> dict[str, Any]:
+    """Session-lifetime read-only runtime facts.
+
+    Keys are stable for prompts and sandbox ``inputs`` and safe to cache at
+    session bootstrap (nothing here changes turn to turn):
 
     - ``opensre_version`` — package version via ``importlib.metadata``.
     - ``opensre_build`` — ``""`` in released wheels; ``dev, v0.1.YYYY.M.D @ SHA``
       in a git checkout so the LLM can quote the exact build in local dev.
     - ``runtime_env`` — ``OPENSRE_ENV`` env var, else the app environment name.
+    - ``tz_name`` — local timezone name (rarely changes mid-session).
+    - ``python_version`` — interpreter version from :data:`sys.version_info`.
+    - ``pid`` / ``ppid`` — this process and its parent from :mod:`os`.
+    - ``tools`` — probed tool paths (``kubectl``, ``helm``, ``docker``, ``git``, …).
+    - ``kubeconfig`` — effective kubeconfig path (``KUBECONFIG`` or ``~/.kube/config``).
+
+    Live values that must NOT be cached (current time, uptime) come from
+    :func:`capture_runtime_facts` at each render/sandbox call.
     """
     env_override = (os.environ.get("OPENSRE_ENV") or "").strip()
     return {
         "opensre_version": get_opensre_version(),
         "opensre_build": _detect_build_info(),
         "runtime_env": env_override or get_environment().value,
+        "tz_name": _local_tz_name(),
+        "python_version": _python_version_string(),
+        "pid": os.getpid(),
+        "ppid": os.getppid(),
+        "tools": _installed_tools(),
+        "kubeconfig": _kubeconfig_path(),
     }
+
+
+def capture_runtime_facts(*, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Session metadata plus fresh live facts (current time, uptime).
+
+    Read once per prompt render or sandbox invocation so time doesn't lie. Pass
+    ``metadata`` (typically ``session.runtime_metadata``) to avoid re-running
+    the git+importlib probe every call.
+    """
+    facts = dict(metadata or build_runtime_metadata())
+    facts["now_iso"] = _dt.datetime.now().astimezone().isoformat(timespec="seconds")
+    facts["uptime_seconds"] = round(_time.monotonic() - _PROCESS_START_MONOTONIC, 3)
+    return facts
 
 
 def merge_runtime_into_inputs(
@@ -224,18 +321,21 @@ def merge_runtime_into_inputs(
     *,
     metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Copy ``inputs`` and inject runtime metadata under :data:`RUNTIME_INPUTS_KEY`.
+    """Copy ``inputs`` and inject runtime facts under :data:`RUNTIME_INPUTS_KEY`.
 
     Never overwrites an existing ``opensre_runtime`` key supplied by the caller.
+    Facts are captured live via :func:`capture_runtime_facts` so ``now_iso`` is
+    fresh for each sandbox invocation.
     """
     merged: dict[str, Any] = dict(inputs or {})
     if RUNTIME_INPUTS_KEY not in merged:
-        merged[RUNTIME_INPUTS_KEY] = dict(metadata or build_runtime_metadata())
+        merged[RUNTIME_INPUTS_KEY] = capture_runtime_facts(metadata=metadata)
     return merged
 
 
 __all__ = [
     "RUNTIME_INPUTS_KEY",
     "build_runtime_metadata",
+    "capture_runtime_facts",
     "merge_runtime_into_inputs",
 ]

--- a/config/runtime_metadata.py
+++ b/config/runtime_metadata.py
@@ -234,6 +234,7 @@ def _local_tz_name() -> str:
                 if iana:
                     return iana
     except OSError:
+        # Unreadable /etc/localtime: fall back to time.tzname/UTC below.
         pass
     return _time.tzname[0] if _time.tzname else "UTC"
 

--- a/core/agent_harness/prompts/assistant_agent_prompt.py
+++ b/core/agent_harness/prompts/assistant_agent_prompt.py
@@ -66,6 +66,14 @@ def _render_runtime_facts(
     opensre_version: str | None,
     opensre_build: str | None,
     runtime_env: str | None,
+    now_iso: str | None,
+    tz_name: str | None,
+    python_version: str | None,
+    pid: int | None,
+    ppid: int | None,
+    uptime_seconds: float | None,
+    installed_tools: dict[str, str] | None,
+    kubeconfig: str | None,
 ) -> str:
     """Runtime section of the environment block, or ``""`` when nothing to say.
 
@@ -76,7 +84,12 @@ def _render_runtime_facts(
     version = (opensre_version or "").strip()
     build_marker = (opensre_build or "").strip()
     env_name = (runtime_env or "").strip()
-    if not version and not env_name:
+    now = (now_iso or "").strip()
+    tz = (tz_name or "").strip()
+    py = (python_version or "").strip()
+    kubecfg = (kubeconfig or "").strip()
+    present_tools = sorted(name for name, path in (installed_tools or {}).items() if path)
+    if not (version or env_name or now or py or pid or present_tools):
         return ""
     bits: list[str] = []
     if version:
@@ -84,15 +97,36 @@ def _render_runtime_facts(
         bits.append(f"OpenSRE version is {display}")
     if env_name:
         bits.append(f"runtime environment is {env_name}")
+    if now:
+        bits.append(f"current time is {now}")
+    if tz:
+        bits.append(f"local timezone is {tz}")
+    if uptime_seconds is not None and uptime_seconds >= 0:
+        bits.append(f"process uptime is {uptime_seconds} seconds")
+    if py:
+        bits.append(f"Python interpreter version is {py}")
+    if pid:
+        parent = f", parent {ppid}" if ppid else ""
+        bits.append(f"process id is {pid}{parent}")
+    if present_tools:
+        bits.append(f"installed tools on PATH are {', '.join(present_tools)}")
+    if kubecfg:
+        bits.append(f"kubeconfig path is {kubecfg}")
     return (
         "Runtime facts (quote the strings below EXACTLY when asked; do not "
         "paraphrase them into other field names): "
         + "; ".join(bits)
         + ". When the user asks which OpenSRE version is running, reply with the "
         "full version string above verbatim — including any parenthetical suffix. "
+        "When the user asks for the current date, time, day of the week, or "
+        "timezone, answer from the strings above — do NOT guess a date/time from "
+        "your training data. When the user asks for the Python version, process "
+        "id, parent process id, uptime, kubeconfig path, or which tools are "
+        "installed, answer from the strings above — do NOT run `python --version`, "
+        "`kubectl version`, `which`, `ps`, `date`, `uptime`, or `opensre --version`. "
         "Do NOT invent field names, values, or numbers not present above. Do NOT "
-        "shell out, call `opensre --version`, or use subprocess — the Python "
-        "execution sandbox blocks process spawning."
+        "shell out or use subprocess — the Python execution sandbox blocks process "
+        "spawning; use `inputs['opensre_runtime']` inside the sandbox instead."
     )
 
 
@@ -107,6 +141,14 @@ def build_environment_block(
     opensre_version: str | None = None,
     opensre_build: str | None = None,
     runtime_env: str | None = None,
+    now_iso: str | None = None,
+    tz_name: str | None = None,
+    python_version: str | None = None,
+    pid: int | None = None,
+    ppid: int | None = None,
+    uptime_seconds: float | None = None,
+    installed_tools: dict[str, str] | None = None,
+    kubeconfig: str | None = None,
 ) -> str:
     """Render shell-state facts so the assistant can answer directly.
 
@@ -148,7 +190,19 @@ def build_environment_block(
             "instead of guessing or telling them to run another command."
         )
 
-    runtime_fact = _render_runtime_facts(opensre_version, opensre_build, runtime_env)
+    runtime_fact = _render_runtime_facts(
+        opensre_version,
+        opensre_build,
+        runtime_env,
+        now_iso,
+        tz_name,
+        python_version,
+        pid,
+        ppid,
+        uptime_seconds,
+        installed_tools,
+        kubeconfig,
+    )
     if runtime_fact:
         facts.append(runtime_fact)
 

--- a/core/agent_harness/prompts/prompt_context.py
+++ b/core/agent_harness/prompts/prompt_context.py
@@ -65,11 +65,16 @@ class DefaultPromptContextProvider:
                     )
                 except Exception:
                     llm_settings_available = False
-            runtime = getattr(self._session, "runtime_metadata", None)
-            if not isinstance(runtime, dict) or not runtime:
-                from config.runtime_metadata import build_runtime_metadata
+            from config.runtime_metadata import capture_runtime_facts
 
-                runtime = build_runtime_metadata()
+            cached = getattr(self._session, "runtime_metadata", None)
+            runtime = capture_runtime_facts(
+                metadata=cached if isinstance(cached, dict) and cached else None
+            )
+            tools = runtime.get("tools")
+            pid = runtime.get("pid")
+            ppid = runtime.get("ppid")
+            uptime = runtime.get("uptime_seconds")
             return build_environment_block(
                 integrations=tuple(self._session.configured_integrations),
                 known=self._session.configured_integrations_known,
@@ -80,6 +85,14 @@ class DefaultPromptContextProvider:
                 opensre_version=str(runtime.get("opensre_version") or ""),
                 opensre_build=str(runtime.get("opensre_build") or ""),
                 runtime_env=str(runtime.get("runtime_env") or ""),
+                now_iso=str(runtime.get("now_iso") or ""),
+                tz_name=str(runtime.get("tz_name") or ""),
+                python_version=str(runtime.get("python_version") or ""),
+                pid=pid if isinstance(pid, int) else None,
+                ppid=ppid if isinstance(ppid, int) else None,
+                uptime_seconds=float(uptime) if isinstance(uptime, (int, float)) else None,
+                installed_tools=tools if isinstance(tools, dict) else None,
+                kubeconfig=str(runtime.get("kubeconfig") or ""),
             )
 
     def suggested_synthetic_prompt(self) -> str:

--- a/tests/config/test_runtime_metadata.py
+++ b/tests/config/test_runtime_metadata.py
@@ -239,11 +239,12 @@ def test_environment_block_renders_python_process_and_tools_facts() -> None:
     assert "installed tools on PATH are git, kubectl" in block, block
     assert "helm" not in block  # not-present tools are filtered
     assert "kubeconfig path is /home/me/.kube/config" in block
-    # Anti-guess instruction names the actual shell commands the LLM would reach for.
-    assert "python --version" in block
-    assert "kubectl version" in block
-    assert "which" in block
-    assert "ps" in block
+    # Anti-guess instruction names the actual shell commands the LLM would reach
+    # for, in backticked form so a stray substring can't satisfy the check.
+    assert "`python --version`" in block
+    assert "`kubectl version`" in block
+    assert "`which`" in block
+    assert "`ps`" in block
 
 
 def test_environment_block_omits_installed_tools_line_when_none_present() -> None:

--- a/tests/config/test_runtime_metadata.py
+++ b/tests/config/test_runtime_metadata.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from config import runtime_metadata as runtime_metadata_module
 from config.runtime_metadata import (
     RUNTIME_INPUTS_KEY,
     _GitLayout,
+    _local_tz_name,
     _read_git_head_sha,
     _read_latest_release_tag,
     _resolve_gitdir,
     build_runtime_metadata,
+    capture_runtime_facts,
     merge_runtime_into_inputs,
 )
 from config.version import get_opensre_version
@@ -36,6 +40,115 @@ def test_build_runtime_metadata_uses_importlib_version(monkeypatch: pytest.Monke
     # opensre_build is populated in git checkouts (dev), empty in installed wheels.
     # Just assert the key exists and is a string — the value varies by env.
     assert isinstance(meta["opensre_build"], str)
+    # tz_name is OS-dependent but always present.
+    assert isinstance(meta["tz_name"], str) and meta["tz_name"]
+
+
+def test_build_runtime_metadata_populates_process_and_python_facts() -> None:
+    """Session-init facts asked in #3950: python version, PID, PPID, tools
+    manifest, kubeconfig — all pure-Python, none via subprocess."""
+    import sys as _sys
+
+    meta = build_runtime_metadata()
+    assert meta["python_version"] == (
+        f"{_sys.version_info.major}.{_sys.version_info.minor}.{_sys.version_info.micro}"
+    )
+    assert meta["pid"] == os.getpid()
+    assert meta["ppid"] == os.getppid()
+    assert isinstance(meta["tools"], dict)
+    # Python itself must be on PATH (we're running under it right now).
+    assert meta["tools"]["python"] or meta["tools"]["python3"], meta["tools"]
+    assert isinstance(meta["kubeconfig"], str)
+
+
+def test_build_runtime_metadata_reflects_kubeconfig_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``KUBECONFIG`` env var wins over the default under ``~/.kube/config``."""
+    override = tmp_path / "mycluster.yaml"
+    override.write_text("apiVersion: v1\n", encoding="utf-8")
+    monkeypatch.setenv("KUBECONFIG", str(override))
+    assert build_runtime_metadata()["kubeconfig"] == str(override)
+
+
+def test_build_runtime_metadata_kubeconfig_takes_first_of_colon_separated(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``KUBECONFIG`` may hold multiple paths joined by ``os.pathsep``; the
+    first is the merged base and is what we report."""
+    first = tmp_path / "a.yaml"
+    second = tmp_path / "b.yaml"
+    first.write_text("", encoding="utf-8")
+    second.write_text("", encoding="utf-8")
+    monkeypatch.setenv("KUBECONFIG", f"{first}{os.pathsep}{second}")
+    assert build_runtime_metadata()["kubeconfig"] == str(first)
+
+
+def test_build_runtime_metadata_does_not_include_live_now_iso() -> None:
+    """``now_iso`` must NOT live on the session-cached metadata: caching it at
+    bootstrap would make the LLM report a stale clock every turn."""
+    meta = build_runtime_metadata()
+    assert "now_iso" not in meta
+
+
+def test_capture_runtime_facts_adds_fresh_now_iso() -> None:
+    meta = build_runtime_metadata()
+    facts = capture_runtime_facts(metadata=meta)
+    assert facts["opensre_version"] == meta["opensre_version"]
+    assert facts["tz_name"] == meta["tz_name"]
+    assert facts["now_iso"], "now_iso should always be populated"
+    # ISO 8601 with offset (e.g. 2026-07-11T14:30:12+02:00 or ...Z-form).
+    assert "T" in facts["now_iso"]
+
+
+def test_local_tz_name_reads_iana_from_localtime_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The IANA name (``Europe/Berlin``) is much clearer to the LLM than the
+    OS short code (``CEST``/``BST``), which is ambiguous across regions.
+    Reading ``/etc/localtime``'s symlink target is the standard way to get it."""
+    zonefile = tmp_path / "usr" / "share" / "zoneinfo" / "Europe" / "Berlin"
+    zonefile.parent.mkdir(parents=True)
+    zonefile.write_bytes(b"")
+    fake_link = tmp_path / "localtime"
+    os.symlink(zonefile, fake_link)
+    monkeypatch.setattr(runtime_metadata_module, "_LOCALTIME_LINK", fake_link)
+    assert _local_tz_name() == "Europe/Berlin"
+
+
+def test_capture_runtime_facts_populates_uptime_seconds() -> None:
+    """Uptime is a live fact — it must be present on the captured facts, not
+    on the session-cached metadata (which would freeze it at bootstrap)."""
+    meta = build_runtime_metadata()
+    assert "uptime_seconds" not in meta
+    facts = capture_runtime_facts(metadata=meta)
+    assert isinstance(facts["uptime_seconds"], float)
+    assert facts["uptime_seconds"] >= 0.0
+
+
+def test_capture_runtime_facts_uptime_grows_over_time() -> None:
+    """Uptime is monotonic — a later capture must be >= an earlier one, and
+    grow by roughly the elapsed sleep. Regression guard against accidentally
+    caching a snapshot in metadata."""
+    import time as _t
+
+    first = capture_runtime_facts()["uptime_seconds"]
+    _t.sleep(0.05)
+    second = capture_runtime_facts()["uptime_seconds"]
+    assert second > first
+    assert second - first >= 0.04
+
+
+def test_capture_runtime_facts_refreshes_now_between_calls() -> None:
+    """Live time slot must actually be live — two calls one second apart
+    should differ. Regression guard against accidentally caching now_iso on
+    the session metadata."""
+    import time as _t
+
+    first = capture_runtime_facts()["now_iso"]
+    _t.sleep(1.05)
+    second = capture_runtime_facts()["now_iso"]
+    assert first != second
 
 
 def test_build_runtime_metadata_populates_build_marker_in_git_checkout() -> None:
@@ -87,6 +200,76 @@ def test_environment_block_includes_version_without_subprocess_hint() -> None:
     assert "runtime environment is development" in block
     assert "opensre --version" in block
     assert "subprocess" in block.lower()
+
+
+def test_environment_block_renders_current_time_and_timezone() -> None:
+    """Time slot must land in the prompt as a quotable string with an anti-
+    guessing instruction — the same shape that stopped the version being
+    hallucinated from training data."""
+    block = build_environment_block(
+        integrations=(),
+        known=False,
+        opensre_version="0.1",
+        now_iso="2026-07-11T14:30:12+02:00",
+        tz_name="Europe/Berlin",
+    )
+    assert "current time is 2026-07-11T14:30:12+02:00" in block
+    assert "local timezone is Europe/Berlin" in block
+    assert "do NOT guess a date/time" in block.replace("Do NOT", "do NOT")
+
+
+def test_environment_block_renders_python_process_and_tools_facts() -> None:
+    """All the #3950 facts must land in the block as verbatim-quotable strings,
+    each with a corresponding "do not shell out" instruction that names the
+    reflex command the LLM would otherwise reach for."""
+    block = build_environment_block(
+        integrations=(),
+        known=False,
+        opensre_version="0.1",
+        python_version="3.12.4",
+        pid=12345,
+        ppid=6789,
+        uptime_seconds=42.5,
+        installed_tools={"kubectl": "/usr/local/bin/kubectl", "helm": "", "git": "/usr/bin/git"},
+        kubeconfig="/home/me/.kube/config",
+    )
+    assert "Python interpreter version is 3.12.4" in block
+    assert "process id is 12345, parent 6789" in block
+    assert "process uptime is 42.5 seconds" in block
+    assert "installed tools on PATH are git, kubectl" in block, block
+    assert "helm" not in block  # not-present tools are filtered
+    assert "kubeconfig path is /home/me/.kube/config" in block
+    # Anti-guess instruction names the actual shell commands the LLM would reach for.
+    assert "python --version" in block
+    assert "kubectl version" in block
+    assert "which" in block
+    assert "ps" in block
+
+
+def test_environment_block_omits_installed_tools_line_when_none_present() -> None:
+    """When every probed tool is absent, the block must not render an
+    empty ``installed tools on PATH are `` line."""
+    block = build_environment_block(
+        integrations=(),
+        known=False,
+        opensre_version="0.1",
+        installed_tools={"kubectl": "", "helm": "", "git": ""},
+    )
+    assert "installed tools on PATH" not in block
+
+
+def test_environment_block_omits_time_when_slot_empty() -> None:
+    """Released wheels or pathological callers may pass no time; the block
+    must not render an empty ``current time is`` line in that case."""
+    block = build_environment_block(
+        integrations=(),
+        known=False,
+        opensre_version="0.1",
+        now_iso="",
+        tz_name="",
+    )
+    assert "current time is" not in block
+    assert "local timezone is" not in block
 
 
 def test_environment_block_renders_build_marker_when_provided() -> None:
@@ -225,6 +408,46 @@ def test_python_tool_reports_version_via_injected_runtime_inputs() -> None:
     assert result["success"] is True
     assert get_opensre_version() in result["stdout"]
     assert RUNTIME_INPUTS_KEY in result["inputs"]
+
+
+def test_python_tool_reports_current_time_via_injected_runtime_inputs() -> None:
+    """Sandbox path should surface a fresh ``now_iso`` (not a bootstrap
+    snapshot) so scripts asking for the current time never see a stale value."""
+    result = execute_python_code.run(
+        code="print(inputs['opensre_runtime']['now_iso'])",
+    )
+    assert result["success"] is True
+    stdout = result["stdout"].strip()
+    assert stdout, "now_iso should be non-empty"
+    assert "T" in stdout, f"expected ISO 8601 datetime, got {stdout!r}"
+
+
+def test_python_tool_reports_process_and_python_facts_via_injected_runtime_inputs() -> None:
+    """The #3950 replacement path: a script asking for python version, PID,
+    parent PID, uptime, kubeconfig, or the installed tools list should read
+    them from ``inputs['opensre_runtime']`` — no ``subprocess`` needed."""
+    result = execute_python_code.run(
+        code=(
+            "import json\n"
+            "runtime = inputs['opensre_runtime']\n"
+            "print(json.dumps({\n"
+            "    'py': runtime['python_version'],\n"
+            "    'pid': runtime['pid'],\n"
+            "    'ppid': runtime['ppid'],\n"
+            "    'uptime': runtime['uptime_seconds'],\n"
+            "    'kubeconfig': runtime['kubeconfig'],\n"
+            "    'tools': sorted(k for k, v in runtime['tools'].items() if v),\n"
+            "}))\n"
+        ),
+    )
+    assert result["success"] is True, result
+    import json as _json
+
+    payload = _json.loads(result["stdout"].strip())
+    assert payload["pid"] == os.getpid()
+    assert payload["py"].count(".") == 2
+    assert isinstance(payload["uptime"], (int, float))
+    assert payload["uptime"] >= 0.0
 
 
 def test_python_tool_reports_version_via_importlib_metadata() -> None:

--- a/tools/system/python_execution_tool/__init__.py
+++ b/tools/system/python_execution_tool/__init__.py
@@ -38,8 +38,10 @@ class PythonExecutionTool(BaseTool):
     ]
     anti_examples = [
         "Changing local files or shelling out to other processes",
-        "Calling opensre --version, python --version, kubectl version, which, ps, date, uptime "
-        "(all blocked by the sandbox)",
+        (
+            "Calling opensre --version, python --version, kubectl version, which, ps, "
+            "date, uptime (all blocked by the sandbox)"
+        ),
         "Long-running jobs, crawlers, or broad external scans",
         "Accessing credentials not explicitly provided by configured integrations or env vars",
     ]

--- a/tools/system/python_execution_tool/__init__.py
+++ b/tools/system/python_execution_tool/__init__.py
@@ -23,21 +23,23 @@ class PythonExecutionTool(BaseTool):
         "Execute generated Python code in a restricted subprocess, capture stdout, stderr, "
         "exceptions, and timeout state, and return the result to the agent. Network access is "
         "blocked by default; opt in only for approved API-backed analysis. Subprocess spawning "
-        "is always blocked — for OpenSRE version/runtime facts use "
-        "`inputs['opensre_runtime']` (injected automatically) or "
-        "`importlib.metadata.version('opensre')`, never `opensre --version` or "
-        "`subprocess`. When workflow guidance lists skills, read each skill description and "
-        "follow the one that matches the user's request."
+        "is always blocked — for runtime facts (OpenSRE version, current time, uptime, PID, "
+        "Python interpreter version, kubeconfig path, installed tools like kubectl/helm/docker/git) "
+        "read `inputs['opensre_runtime']` (injected automatically). Never run "
+        "`opensre --version`, `python --version`, `kubectl version`, `which`, `ps`, `date`, "
+        "`uptime`, or any other `subprocess` call. When workflow guidance lists skills, read "
+        "each skill description and follow the one that matches the user's request."
     )
     use_cases = [
         "Compute metrics or summaries from structured evidence already in context",
         "Run a small API-backed calculation with approved credentials",
         "Parse logs or JSON payloads when a direct tool result needs post-processing",
-        "Read OpenSRE version via inputs['opensre_runtime'] or importlib.metadata",
+        "Read runtime facts (version, time, uptime, PID, kubeconfig, tools) via inputs['opensre_runtime']",
     ]
     anti_examples = [
         "Changing local files or shelling out to other processes",
-        "Calling opensre --version / subprocess / os.system (blocked by sandbox)",
+        "Calling opensre --version, python --version, kubectl version, which, ps, date, uptime "
+        "(all blocked by the sandbox)",
         "Long-running jobs, crawlers, or broad external scans",
         "Accessing credentials not explicitly provided by configured integrations or env vars",
     ]
@@ -52,8 +54,11 @@ class PythonExecutionTool(BaseTool):
                 "type": "object",
                 "description": (
                     "Optional JSON-serializable values injected into the script as the "
-                    "`inputs` global. OpenSRE always merges `opensre_runtime` "
-                    "(version, runtime_env, feature_flags) unless you already set that key."
+                    "`inputs` global. OpenSRE always merges `opensre_runtime` under this "
+                    "key with: opensre_version, opensre_build, runtime_env, tz_name, "
+                    "now_iso, uptime_seconds, python_version, pid, ppid, tools "
+                    "(dict of tool name → PATH), and kubeconfig. Skipped if you already "
+                    "set the `opensre_runtime` key yourself."
                 ),
                 "nullable": True,
             },


### PR DESCRIPTION
Fixes #3950 

#### Describe the changes you have made in this PR -

Agent introspection questions (Python version, current time, PID, installed tools, kubeconfig) trigger subprocess calls that the Python execution sandbox blocks, so the agent either fails with `PermissionError` or invents an answer. Follow-up to #3946, which fixed the same failure mode for the OpenSRE version.

Extends the session runtime metadata pattern from #3946 with pure-Python facts,
split by lifetime:

**Cached at session bootstrap** (`SessionCore.runtime_metadata`):
- `python_version` — from `sys.version_info`
- `pid` / `ppid` — from `os.getpid()` / `os.getppid()`
- `tools` — PATH locations of kubectl, helm, docker, git, python, python3 via
  `shutil.which` (pure Python, no subprocess)
- `kubeconfig` — `KUBECONFIG` env var (first entry of a colon-separated list)
  or `~/.kube/config` when present
- `tz_name` — IANA timezone read from the `/etc/localtime` symlink, falling
  back to `time.tzname`

**Captured fresh per prompt render / sandbox call** (`capture_runtime_facts`):
- `now_iso` — current wall-clock time with offset
- `uptime_seconds` — from `time.monotonic()`, so it survives clock skew

Caching time at bootstrap would make the agent report a stale clock every
turn, hence the split.

All facts flow to both consumers:
- the assistant system prompt (environment block), with explicit instructions to quote values verbatim, not to guess dates/times from training data, and not to run `python --version`, `kubectl version`, `which`, `ps`, `date`, `uptime`, or `opensre --version`
- the sandbox as `inputs['opensre_runtime']`, advertised in the `execute_python_code` tool description

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
