### PR TITLE
fix(integrations): log classify failures with exc_info on Exception only

### DIFF
--- a/integrations/airflow/config.py
+++ b/integrations/airflow/config.py
@@ -9,7 +9,7 @@ from typing import Any
 from urllib.parse import quote
 
 import httpx
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -336,9 +336,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="airflow", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying airflow config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="airflow", record_id=record_id)

--- a/integrations/airflow/config.py
+++ b/integrations/airflow/config.py
@@ -9,7 +9,7 @@ from typing import Any
 from urllib.parse import quote
 
 import httpx
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -336,7 +336,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="airflow", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying airflow config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="airflow", record_id=record_id)
         return None, None
     if cfg.is_configured:

--- a/integrations/alertmanager/__init__.py
+++ b/integrations/alertmanager/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import AlertmanagerIntegrationConfig
 
@@ -24,7 +26,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="alertmanager", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying alertmanager config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="alertmanager", record_id=record_id)
         return None, None
     if cfg.base_url:

--- a/integrations/alertmanager/__init__.py
+++ b/integrations/alertmanager/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import AlertmanagerIntegrationConfig
 
@@ -26,9 +24,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="alertmanager", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying alertmanager config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="alertmanager", record_id=record_id)

--- a/integrations/argocd/__init__.py
+++ b/integrations/argocd/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import ArgoCDIntegrationConfig
 
@@ -29,7 +31,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="argocd", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying argocd config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="argocd", record_id=record_id)
         return None, None
     if cfg.base_url and (cfg.bearer_token or (cfg.username and cfg.password)):

--- a/integrations/argocd/__init__.py
+++ b/integrations/argocd/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import ArgoCDIntegrationConfig
 
@@ -31,9 +29,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="argocd", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying argocd config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="argocd", record_id=record_id)

--- a/integrations/aws/__init__.py
+++ b/integrations/aws/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import AWSIntegrationConfig
 
@@ -28,6 +30,10 @@ def classify(
         }
     try:
         return AWSIntegrationConfig.model_validate(raw), "aws"
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="aws", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying aws config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="aws", record_id=record_id)
         return None, None

--- a/integrations/aws/__init__.py
+++ b/integrations/aws/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import AWSIntegrationConfig
 
@@ -30,9 +28,6 @@ def classify(
         }
     try:
         return AWSIntegrationConfig.model_validate(raw), "aws"
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="aws", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying aws config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="aws", record_id=record_id)

--- a/integrations/azure/__init__.py
+++ b/integrations/azure/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import AzureIntegrationConfig
 
@@ -28,9 +26,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="azure", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying azure config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="azure", record_id=record_id)

--- a/integrations/azure/__init__.py
+++ b/integrations/azure/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import AzureIntegrationConfig
 
@@ -26,7 +28,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="azure", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying azure config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="azure", record_id=record_id)
         return None, None
     if cfg.workspace_id and cfg.access_token:

--- a/integrations/azure_sql/__init__.py
+++ b/integrations/azure_sql/__init__.py
@@ -17,7 +17,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -671,9 +671,6 @@ def classify(
                 "encrypt": credentials.get("encrypt", True),
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="azure_sql", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying azure_sql config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="azure_sql", record_id=record_id)

--- a/integrations/azure_sql/__init__.py
+++ b/integrations/azure_sql/__init__.py
@@ -17,7 +17,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -671,7 +671,11 @@ def classify(
                 "encrypt": credentials.get("encrypt", True),
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="azure_sql", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying azure_sql config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="azure_sql", record_id=record_id)
         return None, None
     if cfg.server and cfg.database:

--- a/integrations/betterstack/__init__.py
+++ b/integrations/betterstack/__init__.py
@@ -25,7 +25,7 @@ from datetime import datetime
 from typing import Any
 
 import httpx
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -462,9 +462,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="betterstack", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying betterstack config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="betterstack", record_id=record_id)

--- a/integrations/betterstack/__init__.py
+++ b/integrations/betterstack/__init__.py
@@ -25,7 +25,7 @@ from datetime import datetime
 from typing import Any
 
 import httpx
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -462,7 +462,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="betterstack", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying betterstack config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="betterstack", record_id=record_id)
         return None, None
     if cfg.query_endpoint and cfg.username:

--- a/integrations/bitbucket/__init__.py
+++ b/integrations/bitbucket/__init__.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import (
@@ -291,9 +291,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="bitbucket", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying bitbucket config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="bitbucket", record_id=record_id)

--- a/integrations/bitbucket/__init__.py
+++ b/integrations/bitbucket/__init__.py
@@ -13,10 +13,13 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from config.strict_config import StrictConfigModel
-from integrations._validation_helpers import report_validation_failure
+from integrations._validation_helpers import (
+    report_classify_failure,
+    report_validation_failure,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -288,7 +291,12 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except Exception:
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="bitbucket", record_id=record_id)
+        return None, None
+    except Exception as exc:
+        logger.warning("unexpected error classifying bitbucket config", exc_info=True)
+        report_classify_failure(exc, logger=logger, integration="bitbucket", record_id=record_id)
         return None, None
     if cfg.workspace:
         return cfg, "bitbucket"

--- a/integrations/coralogix/__init__.py
+++ b/integrations/coralogix/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import CoralogixIntegrationConfig
 
@@ -26,9 +24,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="coralogix", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying coralogix config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="coralogix", record_id=record_id)

--- a/integrations/coralogix/__init__.py
+++ b/integrations/coralogix/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import CoralogixIntegrationConfig
 
@@ -24,7 +26,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="coralogix", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying coralogix config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="coralogix", record_id=record_id)
         return None, None
     if cfg.api_key:

--- a/integrations/dagster/__init__.py
+++ b/integrations/dagster/__init__.py
@@ -13,8 +13,6 @@ from collections import deque
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from pydantic import ValidationError
-
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure
 
@@ -324,9 +322,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="dagster", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying dagster config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="dagster", record_id=record_id)

--- a/integrations/dagster/__init__.py
+++ b/integrations/dagster/__init__.py
@@ -13,6 +13,8 @@ from collections import deque
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from pydantic import ValidationError
+
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure
 
@@ -322,7 +324,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="dagster", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying dagster config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="dagster", record_id=record_id)
         return None, None
     if cfg.endpoint:

--- a/integrations/datadog/__init__.py
+++ b/integrations/datadog/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import DatadogIntegrationConfig
 
@@ -25,9 +23,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="datadog", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying datadog config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="datadog", record_id=record_id)

--- a/integrations/datadog/__init__.py
+++ b/integrations/datadog/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import DatadogIntegrationConfig
 
@@ -23,7 +25,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="datadog", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying datadog config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="datadog", record_id=record_id)
         return None, None
     if cfg.api_key and cfg.app_key:

--- a/integrations/discord/__init__.py
+++ b/integrations/discord/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import DiscordBotConfig
 
@@ -25,7 +27,11 @@ def classify(
                 "default_channel_id": credentials.get("default_channel_id"),
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="discord", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying discord config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="discord", record_id=record_id)
         return None, None
     return cfg, "discord"

--- a/integrations/discord/__init__.py
+++ b/integrations/discord/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import DiscordBotConfig
 
@@ -27,9 +25,6 @@ def classify(
                 "default_channel_id": credentials.get("default_channel_id"),
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="discord", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying discord config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="discord", record_id=record_id)

--- a/integrations/github/mcp.py
+++ b/integrations/github/mcp.py
@@ -21,7 +21,7 @@ import httpx
 from mcp import ClientSession, StdioServerParameters, types  # type: ignore[import-not-found]
 from mcp.client.sse import sse_client  # type: ignore[import-not-found]
 from mcp.client.stdio import stdio_client  # type: ignore[import-not-found]
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, ValidationError, field_validator, model_validator
 from rich.console import Console, Group
 from rich.panel import Panel
 from rich.table import Table
@@ -1405,7 +1405,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="github", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying github config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="github", record_id=record_id)
         return None, None
     return cfg, "github"

--- a/integrations/github/mcp.py
+++ b/integrations/github/mcp.py
@@ -21,7 +21,7 @@ import httpx
 from mcp import ClientSession, StdioServerParameters, types  # type: ignore[import-not-found]
 from mcp.client.sse import sse_client  # type: ignore[import-not-found]
 from mcp.client.stdio import stdio_client  # type: ignore[import-not-found]
-from pydantic import Field, ValidationError, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 from rich.console import Console, Group
 from rich.panel import Panel
 from rich.table import Table
@@ -1405,9 +1405,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="github", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying github config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="github", record_id=record_id)

--- a/integrations/gitlab/__init__.py
+++ b/integrations/gitlab/__init__.py
@@ -9,7 +9,7 @@ from typing import Any
 from urllib.parse import quote
 
 import httpx
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -254,7 +254,11 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[GitlabConfig 
                 "auth_token": credentials.get("auth_token", ""),
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="gitlab", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying gitlab config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="gitlab", record_id=record_id)
         return None, None
     return cfg, "gitlab"

--- a/integrations/gitlab/__init__.py
+++ b/integrations/gitlab/__init__.py
@@ -9,7 +9,7 @@ from typing import Any
 from urllib.parse import quote
 
 import httpx
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -254,9 +254,6 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[GitlabConfig 
                 "auth_token": credentials.get("auth_token", ""),
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="gitlab", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying gitlab config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="gitlab", record_id=record_id)

--- a/integrations/grafana/__init__.py
+++ b/integrations/grafana/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import GrafanaIntegrationConfig
 
@@ -24,7 +26,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="grafana", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying grafana config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="grafana", record_id=record_id)
         return None, None
     if not cfg.endpoint:

--- a/integrations/grafana/__init__.py
+++ b/integrations/grafana/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import GrafanaIntegrationConfig
 
@@ -26,9 +24,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="grafana", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying grafana config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="grafana", record_id=record_id)

--- a/integrations/groundcover/__init__.py
+++ b/integrations/groundcover/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import GroundcoverIntegrationConfig
 
@@ -25,7 +27,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="groundcover", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying groundcover config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="groundcover", record_id=record_id)
         return None, None
     if cfg.api_key:

--- a/integrations/groundcover/__init__.py
+++ b/integrations/groundcover/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import GroundcoverIntegrationConfig
 
@@ -27,9 +25,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="groundcover", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying groundcover config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="groundcover", record_id=record_id)

--- a/integrations/helm/__init__.py
+++ b/integrations/helm/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import HelmIntegrationConfig
 
@@ -28,7 +30,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="helm", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying helm config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="helm", record_id=record_id)
         return None, None
     return cfg, "helm"

--- a/integrations/helm/__init__.py
+++ b/integrations/helm/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import HelmIntegrationConfig
 
@@ -30,9 +28,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="helm", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying helm config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="helm", record_id=record_id)

--- a/integrations/honeycomb/__init__.py
+++ b/integrations/honeycomb/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import HoneycombIntegrationConfig
 
@@ -23,7 +25,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="honeycomb", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying honeycomb config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="honeycomb", record_id=record_id)
         return None, None
     if cfg.api_key:

--- a/integrations/honeycomb/__init__.py
+++ b/integrations/honeycomb/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import HoneycombIntegrationConfig
 
@@ -25,9 +23,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="honeycomb", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying honeycomb config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="honeycomb", record_id=record_id)

--- a/integrations/incident_io/__init__.py
+++ b/integrations/incident_io/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import IncidentIoIntegrationConfig
 
@@ -24,9 +22,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="incident_io", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying incident_io config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="incident_io", record_id=record_id)

--- a/integrations/incident_io/__init__.py
+++ b/integrations/incident_io/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import IncidentIoIntegrationConfig
 
@@ -22,7 +24,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="incident_io", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying incident_io config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="incident_io", record_id=record_id)
         return None, None
     if cfg.api_key:

--- a/integrations/jenkins/__init__.py
+++ b/integrations/jenkins/__init__.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -140,9 +140,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="jenkins", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying jenkins config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="jenkins", record_id=record_id)

--- a/integrations/jenkins/__init__.py
+++ b/integrations/jenkins/__init__.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -140,7 +140,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="jenkins", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying jenkins config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="jenkins", record_id=record_id)
         return None, None
     if cfg.is_configured:

--- a/integrations/jira/__init__.py
+++ b/integrations/jira/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import JiraIntegrationConfig
 
@@ -24,7 +26,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="jira", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying jira config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="jira", record_id=record_id)
         return None, None
     if cfg.base_url and cfg.email and cfg.api_token:

--- a/integrations/jira/__init__.py
+++ b/integrations/jira/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import JiraIntegrationConfig
 
@@ -26,9 +24,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="jira", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying jira config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="jira", record_id=record_id)

--- a/integrations/mariadb/__init__.py
+++ b/integrations/mariadb/__init__.py
@@ -12,7 +12,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from integrations._relational import RelationalConfigBase, env_bool, env_str
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -474,9 +474,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="mariadb", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying mariadb config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="mariadb", record_id=record_id)

--- a/integrations/mariadb/__init__.py
+++ b/integrations/mariadb/__init__.py
@@ -12,7 +12,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from integrations._relational import RelationalConfigBase, env_bool, env_str
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -474,7 +474,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="mariadb", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying mariadb config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="mariadb", record_id=record_id)
         return None, None
     if cfg.host and cfg.database:

--- a/integrations/mongodb/__init__.py
+++ b/integrations/mongodb/__init__.py
@@ -12,7 +12,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -477,7 +477,11 @@ def classify(
                 "tls": credentials.get("tls", True),
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="mongodb", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying mongodb config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="mongodb", record_id=record_id)
         return None, None
     if cfg.connection_string:

--- a/integrations/mongodb/__init__.py
+++ b/integrations/mongodb/__init__.py
@@ -12,7 +12,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -477,9 +477,6 @@ def classify(
                 "tls": credentials.get("tls", True),
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="mongodb", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying mongodb config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="mongodb", record_id=record_id)

--- a/integrations/mongodb_atlas/__init__.py
+++ b/integrations/mongodb_atlas/__init__.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -574,11 +574,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(
-            exc, logger=logger, integration="mongodb_atlas", record_id=record_id
-        )
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying mongodb_atlas config", exc_info=True)
         report_classify_failure(

--- a/integrations/mongodb_atlas/__init__.py
+++ b/integrations/mongodb_atlas/__init__.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -574,7 +574,13 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(
+            exc, logger=logger, integration="mongodb_atlas", record_id=record_id
+        )
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying mongodb_atlas config", exc_info=True)
         report_classify_failure(
             exc, logger=logger, integration="mongodb_atlas", record_id=record_id
         )

--- a/integrations/mysql/__init__.py
+++ b/integrations/mysql/__init__.py
@@ -12,7 +12,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from integrations._relational import (
     RelationalConfigBase,
@@ -649,9 +649,6 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[MySQLConfig |
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="mysql", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying mysql config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="mysql", record_id=record_id)

--- a/integrations/mysql/__init__.py
+++ b/integrations/mysql/__init__.py
@@ -12,7 +12,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from integrations._relational import (
     RelationalConfigBase,
@@ -649,7 +649,11 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[MySQLConfig |
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="mysql", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying mysql config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="mysql", record_id=record_id)
         return None, None
     if cfg.host and cfg.database:

--- a/integrations/openclaw/__init__.py
+++ b/integrations/openclaw/__init__.py
@@ -29,7 +29,7 @@ import httpx
 from mcp import ClientSession, StdioServerParameters, types  # type: ignore[import-not-found]
 from mcp.client.sse import sse_client  # type: ignore[import-not-found]
 from mcp.client.stdio import stdio_client  # type: ignore[import-not-found]
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, ValidationError, field_validator, model_validator
 from typing_extensions import TypedDict
 
 from config.strict_config import StrictConfigModel
@@ -642,7 +642,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="openclaw", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying openclaw config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="openclaw", record_id=record_id)
         return None, None
     if cfg.is_configured:

--- a/integrations/openclaw/__init__.py
+++ b/integrations/openclaw/__init__.py
@@ -29,7 +29,7 @@ import httpx
 from mcp import ClientSession, StdioServerParameters, types  # type: ignore[import-not-found]
 from mcp.client.sse import sse_client  # type: ignore[import-not-found]
 from mcp.client.stdio import stdio_client  # type: ignore[import-not-found]
-from pydantic import Field, ValidationError, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 from typing_extensions import TypedDict
 
 from config.strict_config import StrictConfigModel
@@ -642,9 +642,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="openclaw", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying openclaw config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="openclaw", record_id=record_id)

--- a/integrations/openobserve/__init__.py
+++ b/integrations/openobserve/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import OpenObserveIntegrationConfig
 
@@ -29,9 +27,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="openobserve", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying openobserve config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="openobserve", record_id=record_id)

--- a/integrations/openobserve/__init__.py
+++ b/integrations/openobserve/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import OpenObserveIntegrationConfig
 
@@ -27,7 +29,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="openobserve", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying openobserve config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="openobserve", record_id=record_id)
         return None, None
     if cfg.base_url and (cfg.api_token or (cfg.username and cfg.password)):

--- a/integrations/opensearch/__init__.py
+++ b/integrations/opensearch/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import OpenSearchIntegrationConfig
 
@@ -28,9 +26,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="opensearch", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying opensearch config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="opensearch", record_id=record_id)

--- a/integrations/opensearch/__init__.py
+++ b/integrations/opensearch/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import OpenSearchIntegrationConfig
 
@@ -26,7 +28,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="opensearch", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying opensearch config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="opensearch", record_id=record_id)
         return None, None
     if cfg.url:

--- a/integrations/opsgenie/__init__.py
+++ b/integrations/opsgenie/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import OpsGenieIntegrationConfig
 
@@ -24,9 +22,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="opsgenie", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying opsgenie config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="opsgenie", record_id=record_id)

--- a/integrations/opsgenie/__init__.py
+++ b/integrations/opsgenie/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import OpsGenieIntegrationConfig
 
@@ -22,7 +24,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="opsgenie", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying opsgenie config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="opsgenie", record_id=record_id)
         return None, None
     if cfg.api_key:

--- a/integrations/pagerduty/__init__.py
+++ b/integrations/pagerduty/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import PagerDutyIntegrationConfig
 
@@ -22,7 +24,11 @@ def classify(
         if credentials.get("base_url"):
             raw["base_url"] = credentials["base_url"]
         cfg = PagerDutyIntegrationConfig.model_validate(raw)
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="pagerduty", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying pagerduty config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="pagerduty", record_id=record_id)
         return None, None
     if cfg.api_key:

--- a/integrations/pagerduty/__init__.py
+++ b/integrations/pagerduty/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import PagerDutyIntegrationConfig
 
@@ -24,9 +22,6 @@ def classify(
         if credentials.get("base_url"):
             raw["base_url"] = credentials["base_url"]
         cfg = PagerDutyIntegrationConfig.model_validate(raw)
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="pagerduty", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying pagerduty config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="pagerduty", record_id=record_id)

--- a/integrations/postgresql/__init__.py
+++ b/integrations/postgresql/__init__.py
@@ -12,7 +12,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from integrations._relational import (
     RelationalConfigBase,
@@ -820,9 +820,6 @@ def classify(
                 "ssl_mode": credentials.get("ssl_mode", "prefer"),
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="postgresql", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying postgresql config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="postgresql", record_id=record_id)

--- a/integrations/postgresql/__init__.py
+++ b/integrations/postgresql/__init__.py
@@ -12,7 +12,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from integrations._relational import (
     RelationalConfigBase,
@@ -820,7 +820,11 @@ def classify(
                 "ssl_mode": credentials.get("ssl_mode", "prefer"),
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="postgresql", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying postgresql config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="postgresql", record_id=record_id)
         return None, None
     if cfg.host and cfg.database:

--- a/integrations/posthog_mcp/__init__.py
+++ b/integrations/posthog_mcp/__init__.py
@@ -36,7 +36,7 @@ import httpx
 from mcp import ClientSession, StdioServerParameters, types  # type: ignore[import-not-found]
 from mcp.client.sse import sse_client  # type: ignore[import-not-found]
 from mcp.client.stdio import stdio_client  # type: ignore[import-not-found]
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, ValidationError, field_validator, model_validator
 from typing_extensions import TypedDict
 
 from config.strict_config import StrictConfigModel
@@ -557,7 +557,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="posthog_mcp", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying posthog_mcp config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="posthog_mcp", record_id=record_id)
         return None, None
     if cfg.is_configured:

--- a/integrations/posthog_mcp/__init__.py
+++ b/integrations/posthog_mcp/__init__.py
@@ -36,7 +36,7 @@ import httpx
 from mcp import ClientSession, StdioServerParameters, types  # type: ignore[import-not-found]
 from mcp.client.sse import sse_client  # type: ignore[import-not-found]
 from mcp.client.stdio import stdio_client  # type: ignore[import-not-found]
-from pydantic import Field, ValidationError, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 from typing_extensions import TypedDict
 
 from config.strict_config import StrictConfigModel
@@ -557,9 +557,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="posthog_mcp", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying posthog_mcp config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="posthog_mcp", record_id=record_id)

--- a/integrations/prefect/__init__.py
+++ b/integrations/prefect/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import PrefectIntegrationConfig
 
@@ -32,7 +34,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="prefect", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying prefect config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="prefect", record_id=record_id)
         return None, None
     return cfg, "prefect"

--- a/integrations/prefect/__init__.py
+++ b/integrations/prefect/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import PrefectIntegrationConfig
 
@@ -34,9 +32,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="prefect", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying prefect config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="prefect", record_id=record_id)

--- a/integrations/rabbitmq/__init__.py
+++ b/integrations/rabbitmq/__init__.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -572,7 +572,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="rabbitmq", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying rabbitmq config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="rabbitmq", record_id=record_id)
         return None, None
     if cfg.host and cfg.username:

--- a/integrations/rabbitmq/__init__.py
+++ b/integrations/rabbitmq/__init__.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -572,9 +572,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="rabbitmq", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying rabbitmq config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="rabbitmq", record_id=record_id)

--- a/integrations/rds/__init__.py
+++ b/integrations/rds/__init__.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from config.strict_config import StrictConfigModel
 from integrations._relational import env_str
 from integrations._validation_helpers import report_classify_failure
@@ -96,9 +94,6 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[RDSConfig | N
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="rds", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying rds config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="rds", record_id=record_id)

--- a/integrations/rds/__init__.py
+++ b/integrations/rds/__init__.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from config.strict_config import StrictConfigModel
 from integrations._relational import env_str
 from integrations._validation_helpers import report_classify_failure
@@ -94,7 +96,11 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[RDSConfig | N
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="rds", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying rds config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="rds", record_id=record_id)
         return None, None
     if cfg.is_configured:

--- a/integrations/redis/__init__.py
+++ b/integrations/redis/__init__.py
@@ -13,7 +13,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -701,7 +701,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="redis", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying redis config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="redis", record_id=record_id)
         return None, None
     if cfg.host:

--- a/integrations/redis/__init__.py
+++ b/integrations/redis/__init__.py
@@ -13,7 +13,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -701,9 +701,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="redis", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying redis config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="redis", record_id=record_id)

--- a/integrations/sentry/__init__.py
+++ b/integrations/sentry/__init__.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -355,9 +355,6 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[SentryConfig 
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="sentry", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying sentry config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="sentry", record_id=record_id)

--- a/integrations/sentry/__init__.py
+++ b/integrations/sentry/__init__.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -355,7 +355,11 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[SentryConfig 
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="sentry", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying sentry config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="sentry", record_id=record_id)
         return None, None
     if cfg.organization_slug and cfg.auth_token:

--- a/integrations/sentry_mcp/__init__.py
+++ b/integrations/sentry_mcp/__init__.py
@@ -35,7 +35,7 @@ import httpx
 from mcp import ClientSession, StdioServerParameters, types  # type: ignore[import-not-found]
 from mcp.client.sse import sse_client  # type: ignore[import-not-found]
 from mcp.client.stdio import stdio_client  # type: ignore[import-not-found]
-from pydantic import Field, ValidationError, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 from typing_extensions import TypedDict
 
 from config.strict_config import StrictConfigModel
@@ -523,9 +523,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="sentry_mcp", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying sentry_mcp config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="sentry_mcp", record_id=record_id)

--- a/integrations/sentry_mcp/__init__.py
+++ b/integrations/sentry_mcp/__init__.py
@@ -35,7 +35,7 @@ import httpx
 from mcp import ClientSession, StdioServerParameters, types  # type: ignore[import-not-found]
 from mcp.client.sse import sse_client  # type: ignore[import-not-found]
 from mcp.client.stdio import stdio_client  # type: ignore[import-not-found]
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, ValidationError, field_validator, model_validator
 from typing_extensions import TypedDict
 
 from config.strict_config import StrictConfigModel
@@ -523,7 +523,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="sentry_mcp", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying sentry_mcp config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="sentry_mcp", record_id=record_id)
         return None, None
     if cfg.is_configured:

--- a/integrations/signoz/__init__.py
+++ b/integrations/signoz/__init__.py
@@ -12,10 +12,13 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field
+from pydantic import Field, ValidationError
 
 from config.strict_config import StrictConfigModel
-from integrations._validation_helpers import report_validation_failure
+from integrations._validation_helpers import (
+    report_classify_failure,
+    report_validation_failure,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +151,12 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[SigNozConfig 
                 "integration_id": record_id,
             }
         )
-    except Exception:
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="signoz", record_id=record_id)
+        return None, None
+    except Exception as exc:
+        logger.warning("unexpected error classifying signoz config", exc_info=True)
+        report_classify_failure(exc, logger=logger, integration="signoz", record_id=record_id)
         return None, None
     if cfg.is_configured:
         return cfg, "signoz"

--- a/integrations/signoz/__init__.py
+++ b/integrations/signoz/__init__.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, ValidationError
+from pydantic import Field
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import (
@@ -151,9 +151,6 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[SigNozConfig 
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="signoz", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying signoz config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="signoz", record_id=record_id)

--- a/integrations/smtp/__init__.py
+++ b/integrations/smtp/__init__.py
@@ -42,6 +42,7 @@ def classify(
         )
         return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying smtp config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="smtp", record_id=record_id)
         return None, None
     return cfg, "smtp"

--- a/integrations/snowflake/__init__.py
+++ b/integrations/snowflake/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import SnowflakeIntegrationConfig
 
@@ -31,7 +33,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="snowflake", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying snowflake config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="snowflake", record_id=record_id)
         return None, None
     if cfg.account_identifier and cfg.token:

--- a/integrations/snowflake/__init__.py
+++ b/integrations/snowflake/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import SnowflakeIntegrationConfig
 
@@ -33,9 +31,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="snowflake", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying snowflake config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="snowflake", record_id=record_id)

--- a/integrations/splunk/__init__.py
+++ b/integrations/splunk/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import SplunkIntegrationConfig
 
@@ -25,7 +27,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="splunk", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying splunk config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="splunk", record_id=record_id)
         return None, None
     if cfg.base_url and cfg.token:

--- a/integrations/splunk/__init__.py
+++ b/integrations/splunk/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import SplunkIntegrationConfig
 
@@ -27,9 +25,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="splunk", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying splunk config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="splunk", record_id=record_id)

--- a/integrations/supabase/__init__.py
+++ b/integrations/supabase/__init__.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
 
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure
@@ -317,7 +317,11 @@ def classify(
                 "service_key": credentials.get("service_key", ""),
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="supabase", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying supabase config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="supabase", record_id=record_id)
         return None, None
     if cfg.is_configured:

--- a/integrations/supabase/__init__.py
+++ b/integrations/supabase/__init__.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
 
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure
@@ -317,9 +317,6 @@ def classify(
                 "service_key": credentials.get("service_key", ""),
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="supabase", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying supabase config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="supabase", record_id=record_id)

--- a/integrations/telegram/__init__.py
+++ b/integrations/telegram/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import TelegramBotConfig
 
@@ -23,7 +25,11 @@ def classify(
                 "default_chat_id": credentials.get("default_chat_id"),
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="telegram", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying telegram config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="telegram", record_id=record_id)
         return None, None
     return cfg, "telegram"

--- a/integrations/telegram/__init__.py
+++ b/integrations/telegram/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import TelegramBotConfig
 
@@ -25,9 +23,6 @@ def classify(
                 "default_chat_id": credentials.get("default_chat_id"),
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="telegram", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying telegram config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="telegram", record_id=record_id)

--- a/integrations/tempo/__init__.py
+++ b/integrations/tempo/__init__.py
@@ -15,10 +15,13 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field
+from pydantic import Field, ValidationError
 
 from config.strict_config import StrictConfigModel
-from integrations._validation_helpers import report_validation_failure
+from integrations._validation_helpers import (
+    report_classify_failure,
+    report_validation_failure,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +165,12 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[TempoConfig |
                 "integration_id": record_id,
             }
         )
-    except Exception:
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="tempo", record_id=record_id)
+        return None, None
+    except Exception as exc:
+        logger.warning("unexpected error classifying tempo config", exc_info=True)
+        report_classify_failure(exc, logger=logger, integration="tempo", record_id=record_id)
         return None, None
     if cfg.is_configured:
         return cfg, "tempo"

--- a/integrations/tempo/__init__.py
+++ b/integrations/tempo/__init__.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, ValidationError
+from pydantic import Field
 
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import (
@@ -165,9 +165,6 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[TempoConfig |
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="tempo", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying tempo config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="tempo", record_id=record_id)

--- a/integrations/temporal/__init__.py
+++ b/integrations/temporal/__init__.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.temporal.client import TemporalConfig
 
@@ -39,9 +37,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="temporal", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying temporal config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="temporal", record_id=record_id)

--- a/integrations/temporal/__init__.py
+++ b/integrations/temporal/__init__.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.temporal.client import TemporalConfig
 
@@ -37,7 +39,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="temporal", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying temporal config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="temporal", record_id=record_id)
         return None, None
     if cfg.base_url and cfg.namespace:

--- a/integrations/twilio/__init__.py
+++ b/integrations/twilio/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import TwilioIntegrationConfig
 
@@ -25,9 +23,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="twilio", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying twilio config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="twilio", record_id=record_id)

--- a/integrations/twilio/__init__.py
+++ b/integrations/twilio/__init__.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
+from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import TwilioIntegrationConfig
 
 logger = logging.getLogger(__name__)
@@ -22,6 +25,11 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except Exception:
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="twilio", record_id=record_id)
+        return None, None
+    except Exception as exc:
+        logger.warning("unexpected error classifying twilio config", exc_info=True)
+        report_classify_failure(exc, logger=logger, integration="twilio", record_id=record_id)
         return None, None
     return cfg, "twilio"

--- a/integrations/vercel/__init__.py
+++ b/integrations/vercel/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.vercel.client import VercelConfig
 
@@ -22,9 +20,6 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[VercelConfig 
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="vercel", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying vercel config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="vercel", record_id=record_id)

--- a/integrations/vercel/__init__.py
+++ b/integrations/vercel/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.vercel.client import VercelConfig
 
@@ -20,7 +22,11 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[VercelConfig 
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="vercel", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying vercel config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="vercel", record_id=record_id)
         return None, None
     if cfg.api_token:

--- a/integrations/victoria_logs/__init__.py
+++ b/integrations/victoria_logs/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import VictoriaLogsIntegrationConfig
 
@@ -24,11 +22,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(
-            exc, logger=logger, integration="victoria_logs", record_id=record_id
-        )
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying victoria_logs config", exc_info=True)
         report_classify_failure(

--- a/integrations/victoria_logs/__init__.py
+++ b/integrations/victoria_logs/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import VictoriaLogsIntegrationConfig
 
@@ -22,7 +24,13 @@ def classify(
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(
+            exc, logger=logger, integration="victoria_logs", record_id=record_id
+        )
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying victoria_logs config", exc_info=True)
         report_classify_failure(
             exc, logger=logger, integration="victoria_logs", record_id=record_id
         )

--- a/integrations/whatsapp/__init__.py
+++ b/integrations/whatsapp/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import WhatsAppConfig
 
 logger = logging.getLogger(__name__)
@@ -14,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def classify(
     credentials: dict[str, Any],
-    _record_id: str,
+    record_id: str,
 ) -> tuple[WhatsAppConfig | None, str | None]:
     try:
         cfg = WhatsAppConfig.model_validate(
@@ -25,9 +26,11 @@ def classify(
                 "default_to": credentials.get("default_to"),
             }
         )
-    except ValidationError:
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="whatsapp", record_id=record_id)
         return None, None
-    except Exception:
-        logger.exception("Unexpected error validating WhatsApp config")
+    except Exception as exc:
+        logger.warning("unexpected error classifying whatsapp config", exc_info=True)
+        report_classify_failure(exc, logger=logger, integration="whatsapp", record_id=record_id)
         return None, None
     return cfg, "whatsapp"

--- a/integrations/whatsapp/__init__.py
+++ b/integrations/whatsapp/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import WhatsAppConfig
 
@@ -26,9 +24,6 @@ def classify(
                 "default_to": credentials.get("default_to"),
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="whatsapp", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying whatsapp config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="whatsapp", record_id=record_id)

--- a/integrations/x_mcp/__init__.py
+++ b/integrations/x_mcp/__init__.py
@@ -41,7 +41,7 @@ import httpx
 from mcp import ClientSession, StdioServerParameters, types  # type: ignore[import-not-found]
 from mcp.client.sse import sse_client  # type: ignore[import-not-found]
 from mcp.client.stdio import stdio_client  # type: ignore[import-not-found]
-from pydantic import Field, ValidationError, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 from typing_extensions import TypedDict
 
 from config.strict_config import StrictConfigModel
@@ -519,9 +519,6 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[XMCPConfig | 
                 "integration_id": record_id,
             }
         )
-    except ValidationError as exc:
-        report_classify_failure(exc, logger=logger, integration="x_mcp", record_id=record_id)
-        return None, None
     except Exception as exc:
         logger.warning("unexpected error classifying x_mcp config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="x_mcp", record_id=record_id)

--- a/integrations/x_mcp/__init__.py
+++ b/integrations/x_mcp/__init__.py
@@ -41,7 +41,7 @@ import httpx
 from mcp import ClientSession, StdioServerParameters, types  # type: ignore[import-not-found]
 from mcp.client.sse import sse_client  # type: ignore[import-not-found]
 from mcp.client.stdio import stdio_client  # type: ignore[import-not-found]
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, ValidationError, field_validator, model_validator
 from typing_extensions import TypedDict
 
 from config.strict_config import StrictConfigModel
@@ -519,7 +519,11 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[XMCPConfig | 
                 "integration_id": record_id,
             }
         )
+    except ValidationError as exc:
+        report_classify_failure(exc, logger=logger, integration="x_mcp", record_id=record_id)
+        return None, None
     except Exception as exc:
+        logger.warning("unexpected error classifying x_mcp config", exc_info=True)
         report_classify_failure(exc, logger=logger, integration="x_mcp", record_id=record_id)
         return None, None
     if cfg.is_configured:


### PR DESCRIPTION
Fixes #3522

#### Describe the changes you have made in this PR -

Apply SM-18 classify error handling to the remaining 51 vendor `classify()` functions using the **maintainer-approved pattern** (addresses feedback on closed #3880 and #3966):

- **One** `except Exception` handler — not separate `ValidationError` + `Exception` (duplicate handlers rejected by @muddlebee)
- Add `logger.warning(..., exc_info=True)` before `report_classify_failure` on unexpected errors
- Return shape unchanged: `(None, None)` on failure
- **SMTP exception:** keeps separate `ValidationError` branch because it reports `_smtp_validation_failure()` (not the raw exception — avoids leaking secrets)

### Demo/Screenshot for feature changes and bug fixes -

**Demo recording:**

https://github.com/Codenuclei/opensre/releases/download/sm18-demo-2026-07-13/Recording.2026-07-13.112952.mp4

```text
$ sed -n '15,30p' integrations/datadog/__init__.py
    except Exception as exc:
        logger.warning("unexpected error classifying datadog config", exc_info=True)
        report_classify_failure(exc, logger=logger, integration="datadog", record_id=record_id)
        return None, None

$ make lint && make format-check && make typecheck
All checks passed!
2371 files already formatted
Success: no issues found in 1173 source files

$ pytest tests/integrations/ -q -k 'classify or validation'
294 passed, 2258 deselected in 8.87s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`ValidationError` is a subclass of `Exception`, so a separate `except ValidationError` block that calls the same `report_classify_failure` + `return None, None` is redundant. The actual fix per @Davidson3556 is adding `logger.warning(..., exc_info=True)` to the existing `except Exception` branch. SMTP keeps a distinct `ValidationError` handler because it substitutes a sanitized `ValueError` instead of the raw pydantic error.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
