### PR TITLE
fix(tempo): report classify failures

### DIFF
--- a/integrations/tempo/__init__.py
+++ b/integrations/tempo/__init__.py
@@ -15,10 +15,10 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field
+from pydantic import Field, ValidationError
 
 from config.strict_config import StrictConfigModel
-from integrations._validation_helpers import report_validation_failure
+from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +71,11 @@ class TempoValidationResult:
 def build_tempo_config(raw: dict[str, Any] | None) -> TempoConfig:
     """Build a normalized Tempo config object from env/store data."""
     return TempoConfig.model_validate(raw or {})
+
+
+def _tempo_validation_failure() -> ValueError:
+    """Return a non-secret exception for Tempo config validation failures."""
+    return ValueError("TempoConfig validation failed")
 
 
 def tempo_config_from_env() -> TempoConfig | None:
@@ -162,7 +167,16 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[TempoConfig |
                 "integration_id": record_id,
             }
         )
-    except Exception:
+    except ValidationError:
+        report_classify_failure(
+            _tempo_validation_failure(),
+            logger=logger,
+            integration="tempo",
+            record_id=record_id,
+        )
+        return None, None
+    except Exception as exc:
+        report_classify_failure(exc, logger=logger, integration="tempo", record_id=record_id)
         return None, None
     if cfg.is_configured:
         return cfg, "tempo"

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -121,6 +121,7 @@ _CLASSIFY_PATCH_TARGETS: list[tuple[str, str, str]] = [
     ("splunk", "integrations.splunk", "SplunkIntegrationConfig"),
     ("supabase", "integrations.supabase", "build_supabase_config"),
     ("smtp", "integrations.smtp", "SMTPIntegrationConfig"),
+    ("tempo", "integrations.tempo", "build_tempo_config"),
 ]
 
 

--- a/tests/integrations/test_tempo.py
+++ b/tests/integrations/test_tempo.py
@@ -1,9 +1,12 @@
 """Unit tests for the Grafana Tempo integration module."""
 
+from unittest.mock import patch
+
 from integrations.catalog import load_env_integrations
 from integrations.tempo import (
     TempoConfig,
     build_tempo_config,
+    classify,
     tempo_config_from_env,
     tempo_extract_params,
     validate_tempo_config,
@@ -50,6 +53,29 @@ class TestBuildTempoConfig:
 
     def test_from_none(self) -> None:
         assert build_tempo_config(None).is_configured is False
+
+
+class TestTempoClassify:
+    def test_validation_failure_reports_without_secret_values(self) -> None:
+        api_key = "tempo-secret-api-key"
+        password = "tempo-secret-password"
+        with patch("integrations._validation_helpers.report_exception") as mock_report:
+            result = classify(
+                {
+                    "url": object(),
+                    "api_key": api_key,
+                    "username": "tempo-user",
+                    "password": password,
+                },
+                "tempo-record",
+            )
+
+        assert result == (None, None)
+        mock_report.assert_called_once()
+        reported_exc = mock_report.call_args.args[0]
+        assert api_key not in str(reported_exc)
+        assert password not in str(reported_exc)
+        assert "TempoConfig validation failed" in str(reported_exc)
 
 
 class TestTempoConfigFromEnv:


### PR DESCRIPTION
Fixes #3508

#### Describe the changes you have made in this PR -
- Reports Tempo classify validation failures through the shared classify-failure helper.
- Uses a generic non-secret validation error for Tempo config validation failures.
- Keeps the existing `(None, None)` fallback behavior for unclassified Tempo records.
- Adds Tempo coverage to the shared silent-fallback test matrix.

### Demo/Screenshot for feature changes and bug fixes -
Tested locally:

```text
OPENSRE_NO_TELEMETRY=1 python -m pytest tests/integrations/test_tempo.py -q
18 passed

OPENSRE_NO_TELEMETRY=1 python -m pytest tests/integrations/test_catalog_silent_fallback_elimination.py -q
71 passed

python -m ruff check integrations/tempo/__init__.py tests/integrations/test_tempo.py tests/integrations/test_catalog_silent_fallback_elimination.py
All checks passed
```