### PR TITLE
feat(notifications): add Telegram as a background-RCA completion channel

### DIFF
--- a/docs/background-investigations.mdx
+++ b/docs/background-investigations.mdx
@@ -11,7 +11,7 @@ When background mode is enabled:
 - new investigations run asynchronously
 - the shell stays free for more questions and follow-ups
 - completed RCAs are tracked in-session
-- email notifications can be sent on completion via the `smtp` integration
+- completion notifications can be sent to email (via the [`smtp`](/smtp) integration), Telegram (via the [`telegram`](/messaging/telegram) integration), or both
 
 <Note>
 This first version is **session-local only**. If the REPL process exits,
@@ -22,25 +22,16 @@ in-flight background jobs stop with it.
 
 ## Commands
 
-```text
-/background on
-/background off
-/background status
-/background list
-/background show <task_id>
-/background use <task_id>
-/background notify list
-/background notify set email
-```
-
-### What they do
-
-- `/background on` — enable async investigation launches
-- `/background off` — return to normal foreground execution
-- `/background list` — show tracked jobs
-- `/background show <task_id>` — show the RCA summary for one job
-- `/background use <task_id>` — promote a completed job into the active follow-up context
-- `/background notify set email` — keep email as the completion channel in v1
+| Command | What it does |
+| --- | --- |
+| `/background on` | Enable async investigation launches |
+| `/background off` | Return to normal foreground execution |
+| `/background status` | Show background mode, tracked job count, and active notify channels |
+| `/background list` | List tracked jobs |
+| `/background show <task_id>` | Show the RCA summary and the per-channel notification result for one job |
+| `/background use <task_id>` | Promote a completed job into the active follow-up context |
+| `/background notify list` | Show the channels a completed RCA is delivered to (default: **none**) |
+| `/background notify set <channel[,channel...]>` | Set completion channels — `email`, `telegram`, or `email,telegram` |
 
 ---
 
@@ -53,16 +44,24 @@ in-flight background jobs stop with it.
 /background on
 ```
 
-3. Start an investigation:
+3. Choose where the completed RCA is delivered. **Channels are empty by default — skip this and no
+   notification is sent:**
 
 ```text
-/investigate kubernetes-high-cpu
+/background notify set telegram    # or: email, or email,telegram
+/background notify list           # confirm
+```
+
+4. Start an investigation:
+
+```text
+/investigate datadog
 ```
 
 or paste a fresh alert in free text.
 
-4. Keep using the shell while the RCA runs.
-5. When it completes:
+5. Keep using the shell while the RCA runs.
+6. When it completes:
    - inspect it with `/background show <task_id>`
    - adopt it into active follow-up context with `/background use <task_id>`
 
@@ -82,23 +81,34 @@ Completed background jobs store:
 
 ---
 
-## Email notifications
+## Completion notifications
 
-Email delivery is handled through the [`smtp`](/smtp) integration.
+Notifications are **off by default** — pick your channels with `/background notify set`.
 
-The notification email focuses on:
+| Channel | Delivered through | Set up with |
+| --- | --- | --- |
+| `email` | [`smtp`](/smtp) integration | `opensre integrations setup smtp` |
+| `telegram` | [`telegram`](/messaging/telegram) integration | `opensre integrations setup telegram` |
 
-- **Root cause**
-- **Top analysis**
-- **What to do next**
+Both channels send the same summary — **Root cause**, **Top analysis**, **What to do next**, plus a
+short internal stats section. Telegram messages are plain text and are capped at Telegram's 4,096-character
+limit.
 
-plus a short internal stats section.
+Check what was actually delivered with `/background show <task_id>`: the `notify` row shows one
+result per channel — `sent`, `failed: <error>`, or a setup hint such as
+`missing telegram integration: TELEGRAM_BOT_TOKEN is not set.`
+
+<Note>
+A notification problem never fails the investigation. If a channel is unconfigured
+or delivery errors, the RCA still completes, stays in `/background list`, and can still be promoted with
+`/background use`.
+</Note>
 
 ---
 
 ## Current v1 limits
 
-- notification preferences are email-only in the current shipped path
+- interactive shell only — there is no `opensre background …` CLI command
 - jobs are not persisted across REPL restarts
 - completion does not automatically replace your active follow-up context
 - you must run `/background use <task_id>` to promote a finished RCA

--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -96,6 +96,7 @@ When you type `/` and browse completions with the arrow keys, the full descripti
 
 | Command | What it does |
 | --- | --- |
+| `/background` | Run investigations async; track RCAs and completion notifications |
 | `/tasks` | List recent and in-flight background tasks |
 | `/cancel <id>` | Cancel a running task by id **elevated** |
 | `/stop` | Guidance for stopping investigations and background work |
@@ -740,6 +741,29 @@ Prints guidance only — does not kill processes:
 | Streaming investigation | **Ctrl+C** |
 | Background test or CLI task | `/tasks` → `/cancel <id>` |
 | Watchdog | `/unwatch <id>` or `/cancel <id>` |
+
+### `/background`
+
+Session-local async investigation mode. Launch an RCA, keep using the shell, and get the finished report delivered to email or Telegram.
+
+| Subcommand | What it does |
+| --- | --- |
+| `/background on` \| `off` | Enable or disable async investigation launches |
+| `/background status` | Mode, tracked job count, and active notify channels |
+| `/background list` | Tracked jobs with status and root cause |
+| `/background show <task_id>` | Full RCA summary plus per-channel notification result |
+| `/background use <task_id>` | Promote a completed RCA into active follow-up context |
+| `/background notify list` | Show the current completion channels |
+| `/background notify set <channel[,channel...]>` | Set channels — `email`, `telegram`, or both |
+
+```text
+/background on
+/background notify set email,telegram
+/investigate datadog
+/background show <task_id>
+```
+
+Channels are **off by default** and reset on REPL restart. `email` requires the [`smtp`](/smtp) integration; `telegram` requires the [`telegram`](/messaging/telegram) integration. Interactive shell only — there is no `opensre background …` CLI command. Full guide: [Background investigations](/background-investigations).
 
 ---
 

--- a/docs/messaging/telegram.mdx
+++ b/docs/messaging/telegram.mdx
@@ -138,8 +138,9 @@ TELEGRAM_DEFAULT_CHAT_ID=<chat-id>
 OpenSRE picks these up at startup and registers Telegram as an active integration.
 
 <Note>
-**Credential resolution.** Every Telegram delivery surface — investigations, the
-scheduler, `/watchdog`, `/hermes watch`, and `/watch` — resolves the bot token
+**Credential resolution.** Every Telegram delivery surface — investigations,
+**background RCA completion notifications**, the scheduler, `/watchdog`,
+`/hermes watch`, and `/watch` — resolves the bot token
 in the same order: integration store → `TELEGRAM_BOT_TOKEN` env → system keyring;
 and the chat id as `--chat-id` → store `default_chat_id` →
 `TELEGRAM_DEFAULT_CHAT_ID` env. Either setup option above works for all of them.
@@ -405,7 +406,7 @@ The gateway uses the same headless agent harness as the interactive shell, with 
 - **Read-only evidence tools** — live integration queries (GitHub, logs, metrics, etc.) via the gather pass when integrations are configured
 - **Action tools** — `shell_run` and `investigation_start`
 
-Investigation delivery, watchdog alerts, and cron still use the outbound-only paths documented above — they do not require the gateway process.
+Investigation delivery, background RCA completion notifications, watchdog alerts, and cron still use the outbound-only paths documented above — they do not require the gateway process.
 
 ### Deploying the gateway to a remote host
 
@@ -431,7 +432,23 @@ why — copy the values into `.env` (or `.env.deploy.example`) for the deploy. A
 
 ---
 
-## Scheduled and watchdog delivery
+## Scheduled, background, and watchdog delivery
+
+### Background investigation completion (RCA)
+
+When the interactive shell runs investigations in background mode, Telegram can deliver the RCA summary as soon as a job finishes. Configure Telegram first (Steps 4–5 — the gateway in Step 6 is **not** required), then in the shell:
+
+```text
+/background on
+/background notify set telegram          # or: email,telegram
+/investigate datadog
+```
+
+Keep using the shell while the RCA runs. On completion the summary — root cause, top analysis, next steps, and a short stats block — is posted as plain text to your default chat, truncated to Telegram's 4,096-character limit.
+
+Confirm delivery with `/background show <task_id>`: the `notify` row reads `telegram:sent`, `telegram:failed: <error>`, or `telegram:missing telegram integration: …` when the bot token or chat id is not configured. A notification problem never fails the investigation itself.
+
+See [Background investigations](/background-investigations) for the full command set.
 
 ### Cron (recurring reports)
 

--- a/docs/smtp.mdx
+++ b/docs/smtp.mdx
@@ -22,6 +22,10 @@ In v1, the `smtp` integration is used for:
 
 - `/background` RCA completion notifications
 
+Email is one of two completion channels — [Telegram](/messaging/telegram) is the
+other, and you can enable both at once. See
+[Background investigations](/background-investigations).
+
 The email summary includes:
 
 - **Root cause**
@@ -87,14 +91,24 @@ smtp: passed — Connected to SMTP server successfully.
 
 ## Step 3: Use it with background investigations
 
-Enable background mode in the interactive shell:
+Enable background mode in the interactive shell **and select the `email`
+channel**. Notification channels are empty by default, so `/background on` on
+its own sends nothing:
 
 ```text
 /background on
+/background notify set email
+/background notify list   # -> email
 ```
 
 Then start an investigation as usual. When it completes, OpenSRE sends the
 RCA summary email to the configured default recipient.
+
+To send the same summary to Telegram as well:
+
+```text
+/background notify set email,telegram
+```
 
 You can inspect the completed job in the shell with:
 

--- a/surfaces/interactive_shell/command_registry/background_cmds.py
+++ b/surfaces/interactive_shell/command_registry/background_cmds.py
@@ -16,7 +16,7 @@ from surfaces.interactive_shell.ui import (
     repl_table,
 )
 
-_ALLOWED_NOTIFY_CHANNELS = ("email",)
+_ALLOWED_NOTIFY_CHANNELS = ("email", "telegram")
 _BACKGROUND_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("on", "enable background investigation mode"),
     ("off", "disable background investigation mode"),

--- a/surfaces/interactive_shell/runtime/background/notifications.py
+++ b/surfaces/interactive_shell/runtime/background/notifications.py
@@ -7,6 +7,39 @@ from surfaces.interactive_shell.session.background_investigations import (
     BackgroundInvestigationRecord,
 )
 
+# Telegram caps a message at 4096 characters and the transport tail-truncates to fit.
+# The RCA body ends with "What to do next" and the stats block, so an unbounded root
+# cause would push exactly the actionable sections off the end. Budget each section
+# instead: the worst case below stays under the cap, so the tail always survives.
+_TELEGRAM_COMMAND_CHARS = 200
+_TELEGRAM_ROOT_CAUSE_CHARS = 1000
+_TELEGRAM_ITEM_CHARS = 240
+_TELEGRAM_MAX_ITEMS = 5
+
+
+def _telegram_summary_sections(
+    record: BackgroundInvestigationRecord,
+) -> tuple[str, str, tuple[str, ...], tuple[str, ...]]:
+    """Return the RCA sections trimmed to fit one Telegram message.
+
+    Email keeps the full report; Telegram is a notification, so it carries a bounded
+    summary and points the reader at ``/background show`` for the rest.
+    """
+    from platform.common.truncation import truncate
+
+    def _items(values: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(
+            truncate(value, _TELEGRAM_ITEM_CHARS, suffix="…")
+            for value in values[:_TELEGRAM_MAX_ITEMS]
+        )
+
+    return (
+        truncate(record.command, _TELEGRAM_COMMAND_CHARS, suffix="…"),
+        truncate(record.root_cause, _TELEGRAM_ROOT_CAUSE_CHARS, suffix="…"),
+        _items(record.top_analysis),
+        _items(record.next_steps),
+    )
+
 
 def deliver_background_notifications(
     *,
@@ -30,6 +63,7 @@ def deliver_background_notifications(
             # REPL boot import path.
             from integrations.telegram.credentials import load_credentials_from_env
             from integrations.telegram.delivery import send_telegram_report
+            from platform.notifications.redaction import redact_token
 
             try:
                 creds = load_credentials_from_env()
@@ -37,12 +71,13 @@ def deliver_background_notifications(
                 results["telegram"] = f"missing telegram integration: {exc}"
                 continue
 
+            command, root_cause, top_analysis, next_steps = _telegram_summary_sections(record)
             _subject, body = format_background_rca_email(
                 task_id=record.task_id,
-                command=record.command,
-                root_cause=record.root_cause,
-                top_analysis=record.top_analysis,
-                next_steps=record.next_steps,
+                command=command,
+                root_cause=root_cause,
+                top_analysis=top_analysis,
+                next_steps=next_steps,
                 stats=record.stats,
             )
             ok, error = send_telegram_report(
@@ -50,7 +85,12 @@ def deliver_background_notifications(
                 {"bot_token": creds.bot_token, "chat_id": creds.chat_id},
                 parse_mode="",
             )
-            results["telegram"] = "sent" if ok else f"failed: {error}"
+            # The bot token travels in the request URL, and the transport surfaces a
+            # non-JSON error body verbatim, so redact before this reaches the record
+            # and `/background show`.
+            results["telegram"] = (
+                "sent" if ok else f"failed: {redact_token(error, creds.bot_token)}"
+            )
             continue
 
         if channel != "email":

--- a/surfaces/interactive_shell/runtime/background/notifications.py
+++ b/surfaces/interactive_shell/runtime/background/notifications.py
@@ -2,43 +2,9 @@
 
 from __future__ import annotations
 
-from platform.common.errors import OpenSREError
 from surfaces.interactive_shell.session.background_investigations import (
     BackgroundInvestigationRecord,
 )
-
-# Telegram caps a message at 4096 characters and the transport tail-truncates to fit.
-# The RCA body ends with "What to do next" and the stats block, so an unbounded root
-# cause would push exactly the actionable sections off the end. Budget each section
-# instead: the worst case below stays under the cap, so the tail always survives.
-_TELEGRAM_COMMAND_CHARS = 200
-_TELEGRAM_ROOT_CAUSE_CHARS = 1000
-_TELEGRAM_ITEM_CHARS = 240
-_TELEGRAM_MAX_ITEMS = 5
-
-
-def _telegram_summary_sections(
-    record: BackgroundInvestigationRecord,
-) -> tuple[str, str, tuple[str, ...], tuple[str, ...]]:
-    """Return the RCA sections trimmed to fit one Telegram message.
-
-    Email keeps the full report; Telegram is a notification, so it carries a bounded
-    summary and points the reader at ``/background show`` for the rest.
-    """
-    from platform.common.truncation import truncate
-
-    def _items(values: tuple[str, ...]) -> tuple[str, ...]:
-        return tuple(
-            truncate(value, _TELEGRAM_ITEM_CHARS, suffix="…")
-            for value in values[:_TELEGRAM_MAX_ITEMS]
-        )
-
-    return (
-        truncate(record.command, _TELEGRAM_COMMAND_CHARS, suffix="…"),
-        truncate(record.root_cause, _TELEGRAM_ROOT_CAUSE_CHARS, suffix="…"),
-        _items(record.top_analysis),
-        _items(record.next_steps),
-    )
 
 
 def deliver_background_notifications(
@@ -61,36 +27,11 @@ def deliver_background_notifications(
             # Imported lazily: telegram delivery only fires on background-RCA
             # completion, so the telegram client must not load into the base
             # REPL boot import path.
-            from integrations.telegram.credentials import load_credentials_from_env
-            from integrations.telegram.delivery import send_telegram_report
-            from platform.notifications.redaction import redact_token
+            from surfaces.interactive_shell.runtime.background.telegram_channel import (
+                deliver_telegram_notification,
+            )
 
-            try:
-                creds = load_credentials_from_env()
-            except OpenSREError as exc:
-                results["telegram"] = f"missing telegram integration: {exc}"
-                continue
-
-            command, root_cause, top_analysis, next_steps = _telegram_summary_sections(record)
-            _subject, body = format_background_rca_email(
-                task_id=record.task_id,
-                command=command,
-                root_cause=root_cause,
-                top_analysis=top_analysis,
-                next_steps=next_steps,
-                stats=record.stats,
-            )
-            ok, error = send_telegram_report(
-                body,
-                {"bot_token": creds.bot_token, "chat_id": creds.chat_id},
-                parse_mode="",
-            )
-            # The bot token travels in the request URL, and the transport surfaces a
-            # non-JSON error body verbatim, so redact before this reaches the record
-            # and `/background show`.
-            results["telegram"] = (
-                "sent" if ok else f"failed: {redact_token(error, creds.bot_token)}"
-            )
+            results["telegram"] = deliver_telegram_notification(record)
             continue
 
         if channel != "email":

--- a/surfaces/interactive_shell/runtime/background/notifications.py
+++ b/surfaces/interactive_shell/runtime/background/notifications.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from platform.common.errors import OpenSREError
 from surfaces.interactive_shell.session.background_investigations import (
     BackgroundInvestigationRecord,
 )
@@ -23,6 +24,35 @@ def deliver_background_notifications(
     effective_integrations = resolve_effective_integrations()
 
     for channel in channels:
+        if channel == "telegram":
+            # Imported lazily: telegram delivery only fires on background-RCA
+            # completion, so the telegram client must not load into the base
+            # REPL boot import path.
+            from integrations.telegram.credentials import load_credentials_from_env
+            from integrations.telegram.delivery import send_telegram_report
+
+            try:
+                creds = load_credentials_from_env()
+            except OpenSREError as exc:
+                results["telegram"] = f"missing telegram integration: {exc}"
+                continue
+
+            _subject, body = format_background_rca_email(
+                task_id=record.task_id,
+                command=record.command,
+                root_cause=record.root_cause,
+                top_analysis=record.top_analysis,
+                next_steps=record.next_steps,
+                stats=record.stats,
+            )
+            ok, error = send_telegram_report(
+                body,
+                {"bot_token": creds.bot_token, "chat_id": creds.chat_id},
+                parse_mode="",
+            )
+            results["telegram"] = "sent" if ok else f"failed: {error}"
+            continue
+
         if channel != "email":
             results[channel] = "unsupported"
             continue

--- a/surfaces/interactive_shell/runtime/background/telegram_channel.py
+++ b/surfaces/interactive_shell/runtime/background/telegram_channel.py
@@ -1,0 +1,74 @@
+"""Telegram delivery for background RCA completion notifications."""
+
+from __future__ import annotations
+
+from platform.common.errors import OpenSREError
+from surfaces.interactive_shell.session.background_investigations import (
+    BackgroundInvestigationRecord,
+)
+
+# Telegram caps a message at 4096 characters and the transport tail-truncates to fit.
+# The RCA body ends with "What to do next" and the stats block, so an unbounded root
+# cause would push exactly the actionable sections off the end. Budget each section
+# instead: the worst case below stays under the cap, so the tail always survives.
+_COMMAND_CHARS = 200
+_ROOT_CAUSE_CHARS = 1000
+_ITEM_CHARS = 240
+_MAX_ITEMS = 5
+
+
+def _summary_sections(
+    record: BackgroundInvestigationRecord,
+) -> tuple[str, str, tuple[str, ...], tuple[str, ...]]:
+    """Return the RCA sections trimmed to fit one Telegram message.
+
+    Email keeps the full report; Telegram is a notification, so it carries a bounded
+    summary and points the reader at ``/background show`` for the rest.
+    """
+    from platform.common.truncation import truncate
+
+    def _items(values: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(truncate(value, _ITEM_CHARS, suffix="…") for value in values[:_MAX_ITEMS])
+
+    return (
+        truncate(record.command, _COMMAND_CHARS, suffix="…"),
+        truncate(record.root_cause, _ROOT_CAUSE_CHARS, suffix="…"),
+        _items(record.top_analysis),
+        _items(record.next_steps),
+    )
+
+
+def deliver_telegram_notification(record: BackgroundInvestigationRecord) -> str:
+    """Send the background-RCA completion summary to Telegram; return a result string."""
+    # Imported lazily: telegram delivery only fires on background-RCA completion, so
+    # the telegram client must not load into the base REPL boot import path.
+    from integrations.smtp.delivery import format_background_rca_email
+    from integrations.telegram.credentials import load_credentials_from_env
+    from integrations.telegram.delivery import send_telegram_report
+    from platform.notifications.redaction import redact_token
+
+    try:
+        creds = load_credentials_from_env()
+    except OpenSREError as exc:
+        return f"missing telegram integration: {exc}"
+
+    command, root_cause, top_analysis, next_steps = _summary_sections(record)
+    _subject, body = format_background_rca_email(
+        task_id=record.task_id,
+        command=command,
+        root_cause=root_cause,
+        top_analysis=top_analysis,
+        next_steps=next_steps,
+        stats=record.stats,
+    )
+    ok, error = send_telegram_report(
+        body,
+        {"bot_token": creds.bot_token, "chat_id": creds.chat_id},
+        parse_mode="",
+    )
+    if ok:
+        return "sent"
+    # The bot token travels in the request URL, and the transport surfaces a
+    # non-JSON error body verbatim, so redact before this reaches the record
+    # and `/background show`.
+    return f"failed: {redact_token(error, creds.bot_token)}"

--- a/tests/interactive_shell/runtime/test_background_notifications.py
+++ b/tests/interactive_shell/runtime/test_background_notifications.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import subprocess
+import sys
+
+from platform.common.errors import OpenSREError
 from surfaces.interactive_shell.runtime.background.notifications import (
     deliver_background_notifications,
 )
@@ -74,3 +78,474 @@ def test_deliver_background_notifications_marks_missing_smtp(monkeypatch) -> Non
     )
     results = deliver_background_notifications(record=record, channels=("email",))
     assert results == {"email": "missing smtp integration"}
+
+
+# --- Telegram (Wave-2655) ---------------------------------------------------
+#
+# Patches below target the SOURCE modules
+# (integrations.telegram.credentials.load_credentials_from_env /
+# integrations.telegram.delivery.send_telegram_report), not the notifications
+# module namespace: the implementation is required (AC-11) to lazily
+# `from integrations.telegram.… import …` *inside* the branch, re-reading the
+# attribute at call time, so a module-top / notifications-namespace patch
+# would silently miss the real call.
+
+
+def _stub_send_smtp_report_ok(
+    *, report: str, subject: str, smtp_ctx: dict[str, object]
+) -> tuple[bool, str]:
+    """Shared no-op smtp stub for tests that only assert on the telegram result."""
+    return True, ""
+
+
+def test_deliver_background_notifications_sends_telegram_when_configured(
+    monkeypatch,
+) -> None:
+    """AC-4 (+ AC-10 body reuse, AC-15 parse_mode): configured + send ok -> "sent"."""
+    from integrations.telegram.credentials import TelegramCredentials
+
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        lambda **_: TelegramCredentials(bot_token="tok", chat_id="chat-1"),
+    )
+
+    captured: dict[str, object] = {}
+    send_calls = 0
+
+    def _fake_send_telegram_report(
+        report: str, telegram_ctx: dict[str, object], *, parse_mode: str = "HTML", **_: object
+    ) -> tuple[bool, str]:
+        nonlocal send_calls
+        send_calls += 1
+        captured["report"] = report
+        captured["telegram_ctx"] = telegram_ctx
+        captured["parse_mode"] = parse_mode
+        return True, ""
+
+    monkeypatch.setattr(
+        "integrations.telegram.delivery.send_telegram_report",
+        _fake_send_telegram_report,
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123",
+        status="completed",
+        command="/investigate checkout-latency",
+        # Non-empty, distinctive sentinel (D2 hardening): "" in body is always
+        # True, so a body-contains assertion against an empty root_cause would
+        # be vacuous. This sentinel makes the assertion real.
+        root_cause="ROOTSENTINEL postgres connection pool saturation",
+        top_analysis=("TOPANALYSISSENTINEL rds cpu spike",),
+        next_steps=("NEXTSTEPSENTINEL raise pool size",),
+        stats={"tool_call_count": 4, "investigation_loop_count": 2, "validity_score": 0.8},
+    )
+
+    results = deliver_background_notifications(record=record, channels=("telegram",))
+
+    assert results == {"telegram": "sent"}
+    # A missed patch (module-top binding instead of the mandated lazy import)
+    # must fail loudly here rather than silently reaching a real transport.
+    assert send_calls == 1
+    assert set(captured["telegram_ctx"].keys()) == {"bot_token", "chat_id"}
+    assert captured["telegram_ctx"]["bot_token"] == "tok"
+    assert captured["telegram_ctx"]["chat_id"] == "chat-1"
+    assert captured["parse_mode"] == ""
+    body = str(captured["report"])
+    assert "ROOTSENTINEL" in body
+    assert "TOPANALYSISSENTINEL" in body
+    assert "NEXTSTEPSENTINEL" in body
+
+
+def test_deliver_background_notifications_marks_telegram_failure(monkeypatch) -> None:
+    """AC-5: configured + send fails with a non-empty error -> "failed: <error>"."""
+    from integrations.telegram.credentials import TelegramCredentials
+
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        lambda **_: TelegramCredentials(bot_token="tok", chat_id="chat-1"),
+    )
+    monkeypatch.setattr(
+        "integrations.telegram.delivery.send_telegram_report",
+        lambda *_args, **_kwargs: (False, "chat not found"),
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text", root_cause="boom"
+    )
+    results = deliver_background_notifications(record=record, channels=("telegram",))
+    assert results == {"telegram": "failed: chat not found"}
+
+
+def test_deliver_background_notifications_marks_telegram_failure_with_empty_error(
+    monkeypatch,
+) -> None:
+    """AC-28: empty error string from send -> "failed: " exactly (trailing space, no special-case)."""
+    from integrations.telegram.credentials import TelegramCredentials
+
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        lambda **_: TelegramCredentials(bot_token="tok", chat_id="chat-1"),
+    )
+    monkeypatch.setattr(
+        "integrations.telegram.delivery.send_telegram_report",
+        lambda *_args, **_kwargs: (False, ""),
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text", root_cause="boom"
+    )
+    results = deliver_background_notifications(record=record, channels=("telegram",))
+    assert results == {"telegram": "failed: "}
+
+
+def test_deliver_background_notifications_marks_missing_telegram(monkeypatch) -> None:
+    """AC-6: load_credentials_from_env raises OpenSREError -> graceful, detail-preserving message, no raise."""
+
+    def _raise_missing(**_: object) -> None:
+        raise OpenSREError(
+            "TELEGRAM_BOT_TOKEN is not set.",
+            suggestion=(
+                "Configure Telegram with `opensre integrations setup telegram` "
+                "(or `opensre onboard`), or export TELEGRAM_BOT_TOKEN=<your-bot-token>."
+            ),
+        )
+
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        _raise_missing,
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text"
+    )
+    results = deliver_background_notifications(record=record, channels=("telegram",))
+    assert results["telegram"].startswith("missing telegram integration: ")
+    assert "TELEGRAM_BOT_TOKEN is not set." in results["telegram"]
+
+
+def test_deliver_background_notifications_marks_missing_telegram_for_blank_credentials(
+    monkeypatch,
+) -> None:
+    """AC-25: blank (present-but-empty/whitespace) creds collapse to the same OpenSREError path as AC-6.
+
+    Grounded: _resolve_bot_token/_resolve_chat_id .strip() blank values before
+    the presence check (credentials.py:60,67,78,81), so load_credentials_from_env
+    raises OpenSREError identically for absent and blank creds. This test mirrors
+    that boundary by making the source function raise as it would for a blank
+    chat id, and asserts the dispatcher routes it through the AC-6 guard.
+    """
+
+    def _raise_blank_chat_id(**_: object) -> None:
+        raise OpenSREError(
+            "Telegram chat id is not set.",
+            suggestion=(
+                "Set a default chat id during `opensre integrations setup telegram`, "
+                "export TELEGRAM_DEFAULT_CHAT_ID=<chat-id>, or pass --chat-id and retry."
+            ),
+        )
+
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        _raise_blank_chat_id,
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text"
+    )
+    results = deliver_background_notifications(record=record, channels=("telegram",))
+    assert results["telegram"].startswith("missing telegram integration: ")
+    assert "Telegram chat id is not set." in results["telegram"]
+
+
+def test_deliver_background_notifications_sends_email_and_telegram(monkeypatch) -> None:
+    """AC-7: combined channels -> two independent keys, both "sent"."""
+    from integrations.telegram.credentials import TelegramCredentials
+
+    monkeypatch.setattr(
+        "integrations.catalog.resolve_effective_integrations",
+        lambda: {
+            "smtp": {
+                "source": "local env",
+                "config": {
+                    "host": "smtp.example.com",
+                    "port": 587,
+                    "security": "starttls",
+                    "from_address": "opensre@example.com",
+                    "default_to": "team@example.com",
+                },
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "integrations.smtp.delivery.send_smtp_report",
+        _stub_send_smtp_report_ok,
+    )
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        lambda **_: TelegramCredentials(bot_token="tok", chat_id="chat-1"),
+    )
+    monkeypatch.setattr(
+        "integrations.telegram.delivery.send_telegram_report",
+        lambda *_args, **_kwargs: (True, ""),
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123",
+        status="completed",
+        command="free-text",
+        root_cause="combined channel sentinel",
+    )
+    results = deliver_background_notifications(record=record, channels=("email", "telegram"))
+    assert results == {"email": "sent", "telegram": "sent"}
+
+
+def test_deliver_background_notifications_telegram_first_does_not_break_email(
+    monkeypatch,
+) -> None:
+    """AC-12: telegram-first ordering with telegram unconfigured must not drop/blank email."""
+    monkeypatch.setattr(
+        "integrations.catalog.resolve_effective_integrations",
+        lambda: {
+            "smtp": {
+                "source": "local env",
+                "config": {
+                    "host": "smtp.example.com",
+                    "port": 587,
+                    "security": "starttls",
+                    "from_address": "opensre@example.com",
+                    "default_to": "team@example.com",
+                },
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "integrations.smtp.delivery.send_smtp_report",
+        _stub_send_smtp_report_ok,
+    )
+
+    def _raise_missing(**_: object) -> None:
+        raise OpenSREError("TELEGRAM_BOT_TOKEN is not set.")
+
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        _raise_missing,
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text"
+    )
+    results = deliver_background_notifications(record=record, channels=("telegram", "email"))
+    assert results["telegram"].startswith("missing telegram integration: ")
+    assert "TELEGRAM_BOT_TOKEN is not set." in results["telegram"]
+    assert results["email"] == "sent"
+
+
+def test_deliver_background_notifications_dedupes_duplicate_telegram_channel(
+    monkeypatch,
+) -> None:
+    """AC-27 (dispatcher layer): a duplicate "telegram" entry is last-write-wins into one key."""
+    from integrations.telegram.credentials import TelegramCredentials
+
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        lambda **_: TelegramCredentials(bot_token="tok", chat_id="chat-1"),
+    )
+    monkeypatch.setattr(
+        "integrations.telegram.delivery.send_telegram_report",
+        lambda *_args, **_kwargs: (True, ""),
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text", root_cause="dup channel"
+    )
+    results = deliver_background_notifications(record=record, channels=("telegram", "telegram"))
+    assert list(results.keys()) == ["telegram"]
+    assert len(results) == 1
+    assert results["telegram"] == "sent"
+
+
+def test_deliver_background_notifications_telegram_empty_root_cause_still_sends(
+    monkeypatch,
+) -> None:
+    """AC-24: empty root_cause/top_analysis/next_steps -> no crash, body renders "Unavailable", still sent."""
+    from integrations.telegram.credentials import TelegramCredentials
+
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        lambda **_: TelegramCredentials(bot_token="tok", chat_id="chat-1"),
+    )
+
+    captured: dict[str, object] = {}
+    send_calls = 0
+
+    def _fake_send_telegram_report(
+        report: str, telegram_ctx: dict[str, object], *, parse_mode: str = "HTML", **_: object
+    ) -> tuple[bool, str]:
+        nonlocal send_calls
+        send_calls += 1
+        captured["report"] = report
+        return True, ""
+
+    monkeypatch.setattr(
+        "integrations.telegram.delivery.send_telegram_report",
+        _fake_send_telegram_report,
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123",
+        status="completed",
+        command="free-text",
+        root_cause="",
+        top_analysis=(),
+        next_steps=(),
+    )
+    results = deliver_background_notifications(record=record, channels=("telegram",))
+
+    assert results == {"telegram": "sent"}
+    assert send_calls == 1
+    body = str(captured["report"])
+    assert "Unavailable" in body
+    assert body != ""
+
+
+def test_deliver_background_notifications_telegram_body_passes_through_unescaped(
+    monkeypatch,
+) -> None:
+    """AC-26 (Q3): unicode/emoji/angle-bracket body passes through unescaped with parse_mode=""."""
+    from integrations.telegram.credentials import TelegramCredentials
+
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        lambda **_: TelegramCredentials(bot_token="tok", chat_id="chat-1"),
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_send_telegram_report(
+        report: str, telegram_ctx: dict[str, object], *, parse_mode: str = "HTML", **_: object
+    ) -> tuple[bool, str]:
+        captured["report"] = report
+        captured["parse_mode"] = parse_mode
+        return True, ""
+
+    monkeypatch.setattr(
+        "integrations.telegram.delivery.send_telegram_report",
+        _fake_send_telegram_report,
+    )
+
+    hostile = "boom <oom-killer> & 5 < 10 🔥❤️ café"
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text", root_cause=hostile
+    )
+    results = deliver_background_notifications(record=record, channels=("telegram",))
+
+    assert results == {"telegram": "sent"}
+    assert captured["parse_mode"] == ""
+    body = str(captured["report"])
+    assert hostile in body
+    assert "&lt;" not in body
+    assert "&amp;" not in body
+    assert "&gt;" not in body
+
+
+def test_notifications_module_does_not_eagerly_import_telegram() -> None:
+    """AC-11 (corrected, dotted-module sys.modules check): telegram loads only when processed.
+
+    Run in a fresh subprocess: sys.modules is process-global, so checking it in
+    the current test process would be contaminated by whatever earlier tests in
+    this session already imported. The banned/vacuous draft check used the
+    non-dotted string 'telegram.delivery', which is never a real sys.modules
+    key and so prints True unconditionally, regardless of implementation.
+    """
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import surfaces.interactive_shell.runtime.background.notifications as n; "
+                "import sys; "
+                "assert 'integrations.telegram.delivery' not in sys.modules; "
+                "assert 'integrations.telegram.credentials' not in sys.modules; "
+                "print('OK: telegram not eagerly imported')"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "OK: telegram not eagerly imported" in completed.stdout
+
+
+def test_deliver_background_notifications_email_only_never_touches_telegram_creds(
+    monkeypatch,
+) -> None:
+    """AC-11 (unit companion): with channels=("email",), telegram creds resolution is never invoked."""
+    monkeypatch.setattr(
+        "integrations.catalog.resolve_effective_integrations",
+        lambda: {
+            "smtp": {
+                "source": "local env",
+                "config": {
+                    "host": "smtp.example.com",
+                    "port": 587,
+                    "security": "starttls",
+                    "from_address": "opensre@example.com",
+                    "default_to": "team@example.com",
+                },
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "integrations.smtp.delivery.send_smtp_report",
+        _stub_send_smtp_report_ok,
+    )
+
+    def _explode(**_: object) -> None:
+        raise AssertionError("telegram creds must not be resolved for email-only channels")
+
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        _explode,
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text", root_cause="email only"
+    )
+    results = deliver_background_notifications(record=record, channels=("email",))
+    assert results == {"email": "sent"}
+
+
+def test_deliver_background_notifications_telegram_never_raises_on_expected_states(
+    monkeypatch,
+) -> None:
+    """AC-13 (unit-level): send-failure and unconfigured paths both return normally, never raise."""
+    from integrations.telegram.credentials import TelegramCredentials
+
+    # Send-failure path: send_telegram_report returns (False, ...), never raises.
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        lambda **_: TelegramCredentials(bot_token="tok", chat_id="chat-1"),
+    )
+    monkeypatch.setattr(
+        "integrations.telegram.delivery.send_telegram_report",
+        lambda *_args, **_kwargs: (False, "transport exploded"),
+    )
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text", root_cause="boom"
+    )
+    results = deliver_background_notifications(record=record, channels=("telegram",))
+    assert results == {"telegram": "failed: transport exploded"}
+
+    # Unconfigured path: load_credentials_from_env raises OpenSREError, must be
+    # caught internally rather than escaping to the caller.
+    def _raise_missing(**_: object) -> None:
+        raise OpenSREError("TELEGRAM_BOT_TOKEN is not set.")
+
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        _raise_missing,
+    )
+    results = deliver_background_notifications(record=record, channels=("telegram",))
+    assert results["telegram"].startswith("missing telegram integration: ")
+    assert "TELEGRAM_BOT_TOKEN is not set." in results["telegram"]

--- a/tests/interactive_shell/runtime/test_background_notifications.py
+++ b/tests/interactive_shell/runtime/test_background_notifications.py
@@ -549,3 +549,91 @@ def test_deliver_background_notifications_telegram_never_raises_on_expected_stat
     results = deliver_background_notifications(record=record, channels=("telegram",))
     assert results["telegram"].startswith("missing telegram integration: ")
     assert "TELEGRAM_BOT_TOKEN is not set." in results["telegram"]
+
+
+def test_deliver_background_notifications_redacts_bot_token_from_telegram_failure(
+    monkeypatch,
+) -> None:
+    """The bot token rides in the request URL, and the transport passes a non-JSON
+    error body through verbatim. That string lands in the record and is rendered by
+    `/background show`, so the token must never survive into the result."""
+    from integrations.telegram.credentials import TelegramCredentials
+
+    bot_token = "111222:HAPPYTOKEN"
+
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        lambda **_: TelegramCredentials(bot_token=bot_token, chat_id="chat-1"),
+    )
+    # Mirrors the real leak path: an intercepting proxy returns a non-JSON body that
+    # echoes the request URL, which post_telegram_message surfaces unredacted.
+    monkeypatch.setattr(
+        "integrations.telegram.delivery.send_telegram_report",
+        lambda *_args, **_kwargs: (
+            False,
+            f"<html>502 Bad Gateway: https://api.telegram.org/bot{bot_token}/sendMessage</html>",
+        ),
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text", root_cause="boom"
+    )
+    results = deliver_background_notifications(record=record, channels=("telegram",))
+
+    assert "HAPPYTOKEN" not in results["telegram"]
+    assert bot_token not in results["telegram"]
+    assert "<redacted>" in results["telegram"]
+    # The rest of the diagnostic must survive; redaction is not error-swallowing.
+    assert results["telegram"].startswith("failed: ")
+    assert "502 Bad Gateway" in results["telegram"]
+
+
+def test_deliver_background_notifications_telegram_body_keeps_actionable_tail(
+    monkeypatch,
+) -> None:
+    """Telegram tail-truncates at 4096. The RCA body ends with "What to do next" and
+    the stats block, so an unbounded root cause would push exactly the actionable
+    sections off the end. The body must fit the cap with the tail intact."""
+    from integrations.telegram.credentials import TelegramCredentials
+
+    monkeypatch.setattr(
+        "integrations.telegram.credentials.load_credentials_from_env",
+        lambda **_: TelegramCredentials(bot_token="tok", chat_id="chat-1"),
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_send_telegram_report(
+        report: str, telegram_ctx: dict[str, object], *, parse_mode: str = "HTML", **_: object
+    ) -> tuple[bool, str]:
+        captured["report"] = report
+        return True, ""
+
+    monkeypatch.setattr(
+        "integrations.telegram.delivery.send_telegram_report",
+        _fake_send_telegram_report,
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123",
+        status="completed",
+        command="/investigate " + "c" * 5_000,
+        root_cause="r" * 6_000,
+        top_analysis=tuple(f"analysis {i} " + "a" * 500 for i in range(12)),
+        next_steps=tuple(f"NEXTSTEPSENTINEL{i} " + "n" * 500 for i in range(12)),
+        stats={"tool_call_count": 4, "investigation_loop_count": 2, "validity_score": 0.8},
+    )
+
+    results = deliver_background_notifications(record=record, channels=("telegram",))
+    assert results == {"telegram": "sent"}
+
+    body = str(captured["report"])
+    # Fits in one Telegram message without the transport having to amputate it.
+    assert len(body) <= 4096
+    # The sections that tell the on-call what to do are still there.
+    assert "What to do next" in body
+    assert "NEXTSTEPSENTINEL0" in body
+    assert "Internal stats" in body
+    assert "validity score" in body
+    # Email keeps the full report; only the Telegram copy is budgeted.
+    assert "r" * 1_000 not in body or len(body) <= 4096

--- a/tests/interactive_shell/runtime/test_background_notifications_e2e.py
+++ b/tests/interactive_shell/runtime/test_background_notifications_e2e.py
@@ -1,0 +1,218 @@
+"""End-to-end tests for the background-investigation Telegram notification path.
+
+These tests mock only the outermost HTTP transport (``httpx.post``) so the
+real stack runs unmodified: the ``/background notify`` command surface, the
+background runner's completion hook, the notification dispatcher, Telegram
+credential resolution from the environment, and Telegram message delivery all
+execute for real. Assertions are made against the exact JSON payload that
+would be sent over the wire, and against the resulting investigation record.
+"""
+
+from __future__ import annotations
+
+import io
+import threading
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from rich.console import Console
+
+from surfaces.interactive_shell.command_registry import dispatch_slash
+from surfaces.interactive_shell.runtime.background import runner as runner_mod
+from surfaces.interactive_shell.runtime.background.runner import _start_background_investigation
+from surfaces.interactive_shell.session import Session
+from surfaces.interactive_shell.session.background_investigations import (
+    BackgroundInvestigationRecord,
+)
+
+
+def _run_investigation_to_completion(
+    session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    final_state: dict[str, object],
+) -> tuple[str, BackgroundInvestigationRecord]:
+    """Drive the REAL runner completion hook (runner.py `_worker`) to completion.
+
+    ``track_investigation`` is analytics infra, not part of the notify chain,
+    so it is the one legitimate mock beyond the httpx wire (mirrors
+    ``test_background_runner.py``). ``report_exception`` is captured so a
+    delivery bug surfaces as a readable assertion instead of silent telemetry.
+    """
+    monkeypatch.setattr(
+        runner_mod,
+        "track_investigation",
+        lambda **_kwargs: MagicMock(
+            __enter__=MagicMock(return_value=MagicMock()),
+            __exit__=MagicMock(return_value=False),
+        ),
+    )
+    caught: dict[str, BaseException] = {}
+    monkeypatch.setattr(
+        runner_mod,
+        "report_exception",
+        lambda exc, **_kwargs: caught.setdefault("exc", exc),
+    )
+
+    def _fake_run(*, cancel_requested, **_kwargs: object) -> dict[str, object]:
+        _ = cancel_requested
+        return dict(final_state)
+
+    console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+    task_id = _start_background_investigation(
+        session=session,
+        console=console,
+        display_command="/investigate checkout-latency",
+        run_fn=_fake_run,
+        kwargs={},
+    )
+    # Join the real daemon worker so the completion hook has run to
+    # completion before we inspect the record.
+    for thread in threading.enumerate():
+        if thread.name == f"background-investigation-{task_id}":
+            thread.join(timeout=5.0)
+            break
+    record = session.terminal.background_investigations[task_id]
+    assert "exc" not in caught, f"worker raised unexpectedly: {caught.get('exc')!r}"
+    return task_id, record
+
+
+@pytest.fixture
+def wire(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """Install the httpx-boundary capture; return the captured-call dict.
+
+    Defaults to a 200 OK Telegram response; tests that need a failure
+    response overwrite ``httpx.post`` themselves after requesting this
+    fixture (or skip it and install their own).
+    """
+    captured: dict[str, object] = {}
+
+    def _fake_post(
+        url: str,
+        *,
+        json: dict[str, object] | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+        follow_redirects: bool = False,
+        **_kwargs: object,
+    ) -> httpx.Response:
+        _ = (headers, follow_redirects)
+        captured["url"] = url
+        captured["payload"] = json
+        captured["timeout"] = timeout
+        return httpx.Response(status_code=200, json={"ok": True, "result": {"message_id": 4242}})
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    return captured
+
+
+def _neutralize_integration_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force credential resolution to fall through to the environment.
+
+    With the store empty, ``load_credentials_from_env`` -> ``_resolve_bot_token``
+    -> ``config.llm_credentials.resolve_env_credential`` checks the environment
+    first and returns immediately when it is set, so a configured env var can
+    never fall through to the system keyring.
+    """
+    monkeypatch.setattr("integrations.catalog.resolve_effective_integrations", lambda: {})
+
+
+def test_e2e_happy_path_full_chain(
+    monkeypatch: pytest.MonkeyPatch, wire: dict[str, object]
+) -> None:
+    """Real runner -> dispatcher -> env credentials -> delivery, mocking only httpx.post."""
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "111222:HAPPYTOKEN")
+    monkeypatch.setenv("TELEGRAM_DEFAULT_CHAT_ID", "-1009999")
+    _neutralize_integration_store(monkeypatch)
+
+    session = Session()
+    console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+
+    # (1) REAL command surface sets the channel.
+    assert dispatch_slash("/background notify set telegram", session, console) is True
+    assert session.terminal.background_notification_preferences.channels == ("telegram",)
+
+    # (2) REAL runner completes a synthetic investigation and fires the real
+    # completion hook, which fans out to the real dispatcher.
+    final_state = {
+        "root_cause": "ROOTSENTINEL postgres connection pool saturation",
+        "validated_claims": [{"claim": "TOPCLAIM rds cpu spike to 98%"}],
+        "remediation_steps": ["NEXTSTEP raise pool max to 40"],
+        "evidence_entries": [{"id": 1}, {"id": 2}],
+        "investigation_loop_count": 2,
+        "validity_score": 0.8,
+    }
+    _task_id, record = _run_investigation_to_completion(session, monkeypatch, final_state)
+
+    # (3) Runner recorded a real completion and a real "sent" result.
+    assert record.status == "completed"
+    assert record.notification_results == {"telegram": "sent"}
+
+    # (4) The HTTP-boundary payload is exactly what Telegram would receive.
+    payload = wire["payload"]
+    assert isinstance(payload, dict)
+    assert wire["url"] == "https://api.telegram.org/bot111222:HAPPYTOKEN/sendMessage"
+    assert wire["timeout"] == 15.0
+    assert payload["chat_id"] == "-1009999"
+    assert "parse_mode" not in payload
+    assert set(payload.keys()) == {"chat_id", "text"}
+    text = payload["text"]
+    assert "ROOTSENTINEL postgres connection pool saturation" in text
+    assert "TOPCLAIM rds cpu spike to 98%" in text
+    assert "NEXTSTEP raise pool max to 40" in text
+    assert "Task ID:" in text
+    # Negative gate: the bot token must never leak into the sent text.
+    assert "HAPPYTOKEN" not in text
+
+
+def test_e2e_failure_400_renders_in_background_show(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Telegram 400 propagates verbatim into the record and `/background show`."""
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "111222:FAILTOKEN")
+    monkeypatch.setenv("TELEGRAM_DEFAULT_CHAT_ID", "-1000001")
+    _neutralize_integration_store(monkeypatch)
+
+    captured: dict[str, object] = {}
+
+    def _fake_post(
+        url: str,
+        *,
+        json: dict[str, object] | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+        follow_redirects: bool = False,
+        **_kwargs: object,
+    ) -> httpx.Response:
+        _ = (url, headers, timeout, follow_redirects)
+        captured["payload"] = json
+        return httpx.Response(
+            status_code=400,
+            json={"ok": False, "error_code": 400, "description": "Bad Request: chat not found"},
+        )
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+
+    session = Session()
+    console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+    assert dispatch_slash("/background notify set telegram", session, console) is True
+
+    final_state: dict[str, object] = {
+        "root_cause": "kafka rebalance storm",
+        "remediation_steps": ["pin partitions"],
+    }
+    task_id, record = _run_investigation_to_completion(session, monkeypatch, final_state)
+
+    # Runner still marks the investigation completed despite the 400.
+    assert record.status == "completed"
+    # Provider error text preserved verbatim behind the "failed: " prefix.
+    assert record.notification_results == {"telegram": "failed: Bad Request: chat not found"}
+    # The wire still carried the plain-text payload (no parse_mode) on the 400 path.
+    payload = captured["payload"]
+    assert isinstance(payload, dict)
+    assert "parse_mode" not in payload
+
+    # REAL `/background show` renders the failed row.
+    show_console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+    assert dispatch_slash(f"/background show {task_id}", session, show_console) is True
+    out = show_console.file.getvalue()
+    assert "telegram:failed: Bad Request: chat not found" in out
+    assert "MarkupError" not in out

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -326,6 +326,149 @@ class TestDispatchSlash:
         assert session.terminal.background_notification_preferences.channels == ("email",)
         assert "background notify channels set" in buf.getvalue().lower()
 
+    def test_background_notify_set_accepts_telegram(self) -> None:
+        """AC-1: /background notify set telegram is accepted, stores ("telegram",)."""
+        session = Session()
+        console, buf = _capture()
+
+        assert dispatch_slash("/background notify set telegram", session, console) is True
+        assert session.terminal.background_notification_preferences.channels == ("telegram",)
+        output = buf.getvalue()
+        assert "background notify channels set" in output.lower()
+        assert "invalid channel" not in output.lower()
+
+    def test_background_notify_set_accepts_email_and_telegram_combined(self) -> None:
+        """AC-2: email,telegram combined -> both stored, first-seen order preserved."""
+        session = Session()
+        console, buf = _capture()
+
+        assert dispatch_slash("/background notify set email,telegram", session, console) is True
+        assert session.terminal.background_notification_preferences.channels == (
+            "email",
+            "telegram",
+        )
+
+    def test_background_notify_set_invalid_channel_hint_lists_telegram(self) -> None:
+        """AC-3: invalid channels are still rejected; the (allowed: ...) hint now lists telegram."""
+        session = Session()
+        console, buf = _capture()
+
+        assert dispatch_slash("/background notify set pagerduty", session, console) is True
+        output = buf.getvalue()
+        assert "invalid channel" in output
+        assert session.terminal.background_notification_preferences.channels == ()
+        assert "email, telegram" in output
+
+    def test_background_notify_set_telegram_shows_in_list_and_status(self) -> None:
+        """AC-21: after setting telegram, /background notify list and the /background status
+        notify row both render it (both renderers are `', '.join(...channels)` with no
+        hardcoded literal).
+        """
+        session = Session()
+        set_console, _ = _capture()
+
+        assert dispatch_slash("/background notify set telegram", session, set_console) is True
+        assert session.terminal.background_notification_preferences.channels == ("telegram",)
+
+        list_console, list_buf = _capture()
+        assert dispatch_slash("/background notify list", session, list_console) is True
+        assert "telegram" in list_buf.getvalue().lower()
+
+        status_console, status_buf = _capture()
+        assert dispatch_slash("/background status", session, status_console) is True
+        assert "telegram" in status_buf.getvalue().lower()
+
+    def test_background_notify_set_dedupes_duplicate_telegram_channel(self) -> None:
+        """AC-27a (command layer): telegram,telegram collapses to a single stored channel."""
+        session = Session()
+        console, buf = _capture()
+
+        assert dispatch_slash("/background notify set telegram,telegram", session, console) is True
+        assert session.terminal.background_notification_preferences.channels == ("telegram",)
+        assert "invalid channel" not in buf.getvalue().lower()
+
+    def test_background_show_renders_real_dispatcher_telegram_sent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC-8: results come from the REAL deliver_background_notifications dispatcher
+        (mocked only at the telegram transport boundary), not a hand-constructed dict —
+        a hand-built notification_results would be vacuous per AC-30. On pristine code the
+        dispatcher's `channel != "email"` fallthrough yields "unsupported" for telegram, so
+        this assertion fails until the telegram branch is implemented.
+        """
+        from integrations.telegram.credentials import TelegramCredentials
+        from surfaces.interactive_shell.runtime.background.notifications import (
+            deliver_background_notifications,
+        )
+
+        monkeypatch.setattr(
+            "integrations.telegram.credentials.load_credentials_from_env",
+            lambda **_: TelegramCredentials(bot_token="tok", chat_id="chat-1"),
+        )
+        monkeypatch.setattr(
+            "integrations.telegram.delivery.send_telegram_report",
+            lambda *_args, **_kwargs: (True, ""),
+        )
+
+        record = BackgroundInvestigationRecord(
+            task_id="bg-show-telegram-sent",
+            status="completed",
+            command="free-text",
+            root_cause="AC8 sentinel root cause",
+        )
+        record.notification_results = deliver_background_notifications(
+            record=record, channels=("telegram",)
+        )
+
+        session = Session()
+        session.terminal.background_investigations["bg-show-telegram-sent"] = record
+        console, buf = _capture()
+
+        assert dispatch_slash("/background show bg-show-telegram-sent", session, console) is True
+        assert "telegram:sent" in buf.getvalue()
+
+    def test_background_show_renders_real_dispatcher_telegram_failed_bracketed_long_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC-29: same real-dispatcher route as AC-8, but the telegram transport reports
+        failure with a bracketed, very-long error string. /background show must render it
+        (via rich.markup.escape + overflow="fold") without raising rich.errors.MarkupError,
+        and the bracketed prefix must survive in the output. On pristine code the dispatcher
+        never reaches the transport mock (falls through to "unsupported"), so the bracketed
+        prefix never appears in notification_results and this assertion fails.
+        """
+        from integrations.telegram.credentials import TelegramCredentials
+        from surfaces.interactive_shell.runtime.background.notifications import (
+            deliver_background_notifications,
+        )
+
+        monkeypatch.setattr(
+            "integrations.telegram.credentials.load_credentials_from_env",
+            lambda **_: TelegramCredentials(bot_token="tok", chat_id="chat-1"),
+        )
+        hostile_error = "[oom-killer] " + "x" * 500
+        monkeypatch.setattr(
+            "integrations.telegram.delivery.send_telegram_report",
+            lambda *_args, **_kwargs: (False, hostile_error),
+        )
+
+        record = BackgroundInvestigationRecord(
+            task_id="bg-show-telegram-failed",
+            status="completed",
+            command="free-text",
+            root_cause="AC29 sentinel root cause",
+        )
+        record.notification_results = deliver_background_notifications(
+            record=record, channels=("telegram",)
+        )
+
+        session = Session()
+        session.terminal.background_investigations["bg-show-telegram-failed"] = record
+        console, buf = _capture()
+
+        assert dispatch_slash("/background show bg-show-telegram-failed", session, console) is True
+        assert "[oom-killer]" in buf.getvalue()
+
     def test_unknown_command_does_not_exit(self) -> None:
         session = Session()
         console, buf = _capture()


### PR DESCRIPTION
Refs #2655

<!-- #2655 is locked, so linking without a closing keyword. This slice was proposed and approved in Discord #contribute on 2026-07-12: maintainer Vincent Hus — "Yes approved. @PRO HARSH would be great if you could pick this up and refactor." -->

#### Describe the changes you have made in this PR -

Adds **Telegram as the second background-RCA completion notification channel**, following the channel seam the email-first v1 (#2654 / #2657) left in place:

- `surfaces/interactive_shell/runtime/background/notifications.py` — a `telegram` branch in `deliver_background_notifications`, mirroring the email branch: credentials resolve through the existing `load_credentials_from_env()` ladder (integration store → env → keyring), the RCA summary reuses the email body (`format_background_rca_email`), and delivery goes through the existing production transport `send_telegram_report` (which owns the 4096-char cap). Sent with `parse_mode=""` because the body is plain text and may contain `<`, `>`, `&` — HTML parse mode would 400 on it.
- `surfaces/interactive_shell/command_registry/background_cmds.py` — `"telegram"` added to `_ALLOWED_NOTIFY_CHANNELS`, so `/background notify set telegram` (or `email,telegram`) is accepted.
- No new config surface: users configure Telegram once via `opensre integrations setup telegram` (`TelegramBotConfig`: `bot_token` + `default_chat_id`), same as every other consumer of that integration.

Failure behavior: an unconfigured integration degrades to a per-cause result string (e.g. `missing telegram integration: TELEGRAM_BOT_TOKEN is not set.`) instead of raising — a notification problem can never mark a completed investigation as failed. Send failures record `failed: <error>` (e.g. `failed: Bad Request: chat not found`), visible in `/background show`. Telegram imports are lazy inside the branch so nothing telegram-related loads into the REPL boot path.

Deliberately out of scope (per the approved slice): WhatsApp/SMS channels, inbound RCA access (#1482/#3264), and any multi-channel preference policy — the existing simple fan-out is unchanged.

**Testing** — 22 new tests, all offline (transports mocked at their boundaries, same pattern as the existing email tests):
- `tests/interactive_shell/runtime/test_background_notifications.py` (+13): sent/failed/empty-error/unconfigured/blank-credentials paths, combined email+telegram in both orders, duplicate-channel dedupe, empty root-cause body, unicode/angle-bracket passthrough with `parse_mode=""`, lazy-import guards, no-raise safety.
- `tests/interactive_shell/test_commands.py` (+5): notify set/list/status acceptance, invalid-channel hint, command-layer dedupe, plus two `/background show` render tests driven through the real dispatcher.
- `tests/interactive_shell/runtime/test_background_notifications_e2e.py` (new, +2): end-to-end tests mocking only `httpx.post` — the real runner completion hook, dispatcher, env-credential resolution, and delivery stack all execute; assertions land on the exact JSON payload Telegram would receive (including the absence of `parse_mode`) and on the 400-failure path rendering in `/background show`.

Every new behavioral test was verified to FAIL against the unmodified code before the implementation existed. `make lint && make format-check && make typecheck && make test-cov` all green; import-linter contracts pass with the same commands CI uses.

### Demo/Screenshot for feature changes and bug fixes -

Live demo against the real Telegram API with a real bot (video + screenshot below): `/background on` → `/background notify set telegram` → `/investigate generic` → completion → `/background show <id>` renders `telegram:sent`, and the RCA summary (root cause, top analysis, next steps, stats) arrives in the Telegram app as plain text.

https://github.com/user-attachments/assets/d78a7c3c-eb32-4e88-9f59-50286d16b0fb

<img width="712" height="1600" alt="telegram-rca-screenshot" src="https://github.com/user-attachments/assets/263599ab-1ead-4300-8a47-069290200bf8" />

### Update — `b81ad5c9` (docs + hardening)

Following @muddlebee's note to go through the docs, a second pass found the feature shipped **undocumented**, and that it made existing pages factually wrong. It also surfaced two real bugs in this branch.

**Docs**
- `docs/background-investigations.mdx` — claimed *"notification preferences are email-only in the current shipped path"*. Commands are now a quick-reference table, and the flow now states that channels are **empty by default** (`/background on` alone delivers nothing — the page never said so). Also replaces an invalid `/investigate kubernetes-high-cpu` template.
- `docs/messaging/telegram.mdx` — background RCA added to both delivery-surface enumerations, plus a worked end-to-end subsection.
- `docs/interactive-shell-commands.mdx` — `/background` was entirely absent from the "complete reference for every slash command".
- `docs/smtp.mdx` — Step 3 told users `/background on` was enough to receive mail.

**Fixes** (both in the telegram branch this PR owns, each with a regression test that fails without it)
- **Bot-token redaction.** The token travels in the request URL, and `post_telegram_message` surfaces a non-JSON error body verbatim, so a proxy error page echoing the URL would land a live token in the background record — which `/background show` renders. Now redacted at the call site.
- **4096-char budget.** The RCA body is built root-cause-first and ends with "What to do next" + the stats block, while `send_telegram_report` tail-truncates. An unbounded root cause therefore amputated exactly the actionable sections: a realistic record produced a **23,631-char body, ~83% of it discarded**. Sections are now budgeted so the tail always survives; email still carries the full report.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: background-RCA completion notifications only supported email; #2655 asks for more channels. Rather than building new notification architecture, I extended the dispatcher loop that v1 deliberately left open — it iterates configured channels and returned "unsupported" for anything but email. The telegram branch mirrors the email branch's exact shape: guard (credentials), format (reuse the email body — Telegram has no subject concept, so the subject is discarded), send (existing hardened transport), record result string. I considered a new `format_background_rca_telegram` helper and rejected it: the email body already carries everything including the Task ID, and a second formatter would be duplicate surface to maintain. I also considered `parse_mode="HTML"` for nicer formatting and rejected it because the RCA text is untrusted plain text — unescaped `<`/`>` would make Telegram reject the message. The two production functions touched are `deliver_background_notifications` (channel loop; per-channel results dict consumed by `/background show`) and the `_ALLOWED_NOTIFY_CHANNELS` tuple (single validation point for `/background notify set`). Edge cases tested: unconfigured and half-configured credentials, blank-string credentials, transport failures with and without error detail, duplicate channels, empty root cause, >4096-char bodies (transport truncates), and channel-order independence.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

