### PR TITLE
fix(helm): log unexpected client validation failures

### DIFF
--- a/integrations/helm/helpers.py
+++ b/integrations/helm/helpers.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+from pydantic import ValidationError
 
 from integrations.config_models import HelmIntegrationConfig
 from integrations.helm.client import HelmClient
+
+logger = logging.getLogger(__name__)
 
 
 def helm_client_for_run(
@@ -25,7 +30,10 @@ def helm_client_for_run(
                 "integration_id": integration_id or "",
             }
         )
+    except ValidationError:
+        return None
     except Exception:
+        logger.debug("helm_client_for_run failed unexpectedly", exc_info=True)
         return None
     return HelmClient(cfg)
 

--- a/tests/integrations/helm/test_helpers.py
+++ b/tests/integrations/helm/test_helpers.py
@@ -1,0 +1,52 @@
+"""Tests for shared Helm integration helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from integrations.config_models import HelmIntegrationConfig
+from integrations.helm import helpers
+from integrations.helm.client import HelmClient
+
+
+def _helm_validation_error() -> ValidationError:
+    with pytest.raises(ValidationError) as exc_info:
+        HelmIntegrationConfig.model_validate({"unexpected_field": "value"})
+    return exc_info.value
+
+
+def test_helm_client_for_run_builds_client_for_valid_config() -> None:
+    client = helpers.helm_client_for_run(integration_id="helm-test")
+
+    assert isinstance(client, HelmClient)
+
+
+def test_helm_client_for_run_returns_none_for_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    validate = MagicMock(side_effect=_helm_validation_error())
+    debug_log = MagicMock()
+    monkeypatch.setattr(helpers.HelmIntegrationConfig, "model_validate", validate)
+    monkeypatch.setattr(helpers.logger, "debug", debug_log)
+
+    assert helpers.helm_client_for_run() is None
+    debug_log.assert_not_called()
+
+
+def test_helm_client_for_run_logs_unexpected_validation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error = RuntimeError("unexpected validation failure")
+    validate = MagicMock(side_effect=error)
+    debug_log = MagicMock()
+    monkeypatch.setattr(helpers.HelmIntegrationConfig, "model_validate", validate)
+    monkeypatch.setattr(helpers.logger, "debug", debug_log)
+
+    assert helpers.helm_client_for_run() is None
+    debug_log.assert_called_once_with(
+        "helm_client_for_run failed unexpectedly",
+        exc_info=True,
+    )


### PR DESCRIPTION
Fixes #3515

#### Describe the changes you have made in this PR -

- Catch Pydantic `ValidationError` separately when building `HelmIntegrationConfig`, preserving the existing `None` result for invalid configuration.
- Log unexpected validation failures at debug level with `exc_info=True` before returning `None`, so real defects are diagnosable without changing caller behavior.
- Add focused tests for the valid-client path, expected validation failures, and unexpected exception logging.

The public function signature, successful return path, and unavailable-client behavior remain unchanged.

### Demo/Screenshot for feature changes and bug fixes -

```console
$ make lint
All checks passed!

$ make format-check
2399 files already formatted

$ make typecheck
Success: no issues found in 1186 source files

$ .venv/bin/python .github/ci/run_test_scope.py --base origin/main
20 passed

$ .venv/bin/python -m pytest tests/integrations -k helm -q
28 passed, 2529 deselected
```

The live `make verify-integrations SERVICE=helm` probe reports `missing` on this development machine because no Helm executable or local Helm integration is configured; no live cluster is required for this exception-handling change.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The helper previously treated every exception from Pydantic validation as an expected invalid configuration and silently returned `None`. The implementation now distinguishes the expected `ValidationError` path from unexpected exceptions. Expected invalid configuration keeps the same caller-visible behavior, while unexpected failures include traceback context in debug logs. Focused tests pin all three branches without invoking Helm or changing external integration behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Maintainers may modify the pull request branch if needed.