### PR TITLE
Fix/sm 18 discord classify validation error

### DIFF
--- a/integrations/discord/__init__.py
+++ b/integrations/discord/__init__.py
@@ -5,10 +5,17 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import DiscordBotConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _discord_validation_failure() -> ValueError:
+    """Return a non-secret exception for Discord config validation failures."""
+    return ValueError("DiscordBotConfig validation failed")
 
 
 def classify(
@@ -25,6 +32,14 @@ def classify(
                 "default_channel_id": credentials.get("default_channel_id"),
             }
         )
+    except ValidationError:
+        report_classify_failure(
+            _discord_validation_failure(),
+            logger=logger,
+            integration="discord",
+            record_id=record_id,
+        )
+        return None, None
     except Exception as exc:
         report_classify_failure(exc, logger=logger, integration="discord", record_id=record_id)
         return None, None

--- a/tests/integrations/test_discord.py
+++ b/tests/integrations/test_discord.py
@@ -4,7 +4,11 @@ import sys
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import patch
 
+from pydantic import ValidationError
+
+from integrations.discord import classify
 from integrations.discord.verifier import verify_discord
 
 
@@ -101,33 +105,27 @@ def test_verify_discord_accepts_token_when_client_run_succeeds(monkeypatch: Any)
     assert result["status"] == "passed"
 
 
-def test_classify_validation_error_returns_none_and_reports(monkeypatch: Any) -> None:
-    """SM-18: ValidationError in Discord classify() returns (None, None) and
-    reports a sanitized error (no secret field values) via report_classify_failure."""
-    from unittest.mock import patch
+def test_classify_validation_error_returns_none_and_reports() -> None:
+    """SM-18: a real ValidationError in Discord classify() returns (None, None)
+    and reports the sanitized wrapper (no secret field values) to Sentry.
 
-    from pydantic import ValidationError
-
-    from integrations.discord import classify
-
-    # Force model_validate to raise ValidationError
-    def _raise_validation_error(*args: Any, **kwargs: Any) -> None:
-        raise ValidationError.from_exception_data(
-            title="DiscordBotConfig",
-            line_errors=[],
-        )
-
-    monkeypatch.setattr(
-        "integrations.discord.DiscordBotConfig.model_validate",
-        _raise_validation_error,
-    )
+    Pydantic v2 embeds the failing field's ``input_value`` in the
+    ValidationError string, so forwarding the raw error would leak secrets. Here
+    an invalid ``public_key`` triggers validation, and we assert its value never
+    reaches ``report_classify_failure``.
+    """
+    secret_value = "leaked-non-hex-secret"
 
     with patch("integrations.discord.report_classify_failure") as mock_report:
-        result = classify({"bot_token": "some-token"}, record_id="rec-discord")
+        result = classify(
+            {"bot_token": "some-token", "public_key": secret_value},
+            record_id="rec-discord",
+        )
 
     assert result == (None, None)
     assert mock_report.call_count == 1
     exc_arg = mock_report.call_args.args[0]
-    # Must be the safe wrapper, not the raw ValidationError
-    assert isinstance(exc_arg, ValueError)
-    assert "DiscordBotConfig validation failed" in str(exc_arg)
+    # Must be the safe wrapper, not the raw ValidationError (a ValueError subclass).
+    assert not isinstance(exc_arg, ValidationError)
+    assert str(exc_arg) == "DiscordBotConfig validation failed"
+    assert secret_value not in str(exc_arg)

--- a/tests/integrations/test_discord.py
+++ b/tests/integrations/test_discord.py
@@ -99,3 +99,35 @@ def test_verify_discord_accepts_token_when_client_run_succeeds(monkeypatch: Any)
 
     assert tokens == ["token"]
     assert result["status"] == "passed"
+
+
+def test_classify_validation_error_returns_none_and_reports(monkeypatch: Any) -> None:
+    """SM-18: ValidationError in Discord classify() returns (None, None) and
+    reports a sanitized error (no secret field values) via report_classify_failure."""
+    from unittest.mock import patch
+
+    from pydantic import ValidationError
+
+    from integrations.discord import classify
+
+    # Force model_validate to raise ValidationError
+    def _raise_validation_error(*args: Any, **kwargs: Any) -> None:
+        raise ValidationError.from_exception_data(
+            title="DiscordBotConfig",
+            line_errors=[],
+        )
+
+    monkeypatch.setattr(
+        "integrations.discord.DiscordBotConfig.model_validate",
+        _raise_validation_error,
+    )
+
+    with patch("integrations.discord.report_classify_failure") as mock_report:
+        result = classify({"bot_token": "some-token"}, record_id="rec-discord")
+
+    assert result == (None, None)
+    assert mock_report.call_count == 1
+    exc_arg = mock_report.call_args.args[0]
+    # Must be the safe wrapper, not the raw ValidationError
+    assert isinstance(exc_arg, ValueError)
+    assert "DiscordBotConfig validation failed" in str(exc_arg)


### PR DESCRIPTION
Refs #3522

## Description

Apply the SM-01 pattern to the Discord vendor `classify()` in `integrations/discord/__init__.py`:

- Catch `pydantic.ValidationError` specifically instead of letting it fall through the broad `except Exception`
- Wrap the ValidationError in a safe `ValueError("DiscordBotConfig validation failed")` before calling `report_classify_failure` — preserves observability without leaking secret field values into Sentry
- Keep the broad `except Exception` for truly unexpected failures
- Return shapes unchanged

Matches the `smtp` classifier pattern (the most complete analogue in this codebase).

## Testing

- `pytest tests/integrations/test_discord.py` — all 5 tests pass
- `pytest tests/integrations/test_catalog_silent_fallback_elimination.py` — all 70 tests pass (including the Discord-specific parametrized cases)
- `ruff check` passes
- `mypy` passes

---

## Code Understanding and AI Usage

- [x] Yes, I used AI assistance (continue below)
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Implementation approach:** Added a `_discord_validation_failure()` helper that returns a generic `ValueError` (no secret fields). The `except ValidationError` block calls `report_classify_failure` with this safe wrapper, matching the existing `smtp` classifier. This narrows the broad `except Exception` while preserving Sentry observability for config validation failures.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] My code follows the project's style guidelines and conventions
