### PR TITLE
refactor(integrations): centralize ValidationError sanitization in report helpers

### DIFF
--- a/integrations/_validation_helpers.py
+++ b/integrations/_validation_helpers.py
@@ -11,7 +11,23 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from platform.observability.errors.boundary import report_exception
+
+
+def _sentry_safe(exc: BaseException) -> BaseException:
+    """Return an exception safe to capture, stripping secret field values.
+
+    A pydantic ``ValidationError`` string embeds each failing field's raw
+    ``input_value`` — which can be a secret (bot token, password, API key).
+    Replace it with a non-secret ``ValueError`` keyed on the model name so the
+    failure signal reaches Sentry without the leaked value. All other
+    exceptions pass through unchanged.
+    """
+    if isinstance(exc, ValidationError):
+        return ValueError(f"{exc.title} validation failed")
+    return exc
 
 
 def report_validation_failure(
@@ -46,7 +62,7 @@ def report_validation_failure(
             ``True`` only when the local traceback genuinely aids debugging.
     """
     report_exception(
-        exc,
+        _sentry_safe(exc),
         logger=logger,
         message=f"[{integration}] {method} validation failed",
         severity=severity,
@@ -70,7 +86,7 @@ def report_classify_failure(
 ) -> None:
     """Log + Sentry-capture a classify failure for an integration record."""
     report_exception(
-        exc,
+        _sentry_safe(exc),
         logger=logger,
         message=f"classify_failed: integration={integration} record_id={record_id}",
         severity="warning",

--- a/integrations/discord/__init__.py
+++ b/integrations/discord/__init__.py
@@ -5,17 +5,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import DiscordBotConfig
 
 logger = logging.getLogger(__name__)
-
-
-def _discord_validation_failure() -> ValueError:
-    """Return a non-secret exception for Discord config validation failures."""
-    return ValueError("DiscordBotConfig validation failed")
 
 
 def classify(
@@ -32,14 +25,6 @@ def classify(
                 "default_channel_id": credentials.get("default_channel_id"),
             }
         )
-    except ValidationError:
-        report_classify_failure(
-            _discord_validation_failure(),
-            logger=logger,
-            integration="discord",
-            record_id=record_id,
-        )
-        return None, None
     except Exception as exc:
         report_classify_failure(exc, logger=logger, integration="discord", record_id=record_id)
         return None, None

--- a/integrations/smtp/__init__.py
+++ b/integrations/smtp/__init__.py
@@ -5,17 +5,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import SMTPIntegrationConfig
 
 logger = logging.getLogger(__name__)
-
-
-def _smtp_validation_failure() -> ValueError:
-    """Return a non-secret exception for SMTP config validation failures."""
-    return ValueError("SMTPIntegrationConfig validation failed")
 
 
 def classify(
@@ -33,14 +26,6 @@ def classify(
                 "default_to": credentials.get("default_to"),
             }
         )
-    except ValidationError:
-        report_classify_failure(
-            _smtp_validation_failure(),
-            logger=logger,
-            integration="smtp",
-            record_id=record_id,
-        )
-        return None, None
     except Exception as exc:
         report_classify_failure(exc, logger=logger, integration="smtp", record_id=record_id)
         return None, None

--- a/tests/integrations/test_discord.py
+++ b/tests/integrations/test_discord.py
@@ -6,8 +6,6 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
-from pydantic import ValidationError
-
 from integrations.discord import classify
 from integrations.discord.verifier import verify_discord
 
@@ -105,27 +103,24 @@ def test_verify_discord_accepts_token_when_client_run_succeeds(monkeypatch: Any)
     assert result["status"] == "passed"
 
 
-def test_classify_validation_error_returns_none_and_reports() -> None:
+def test_classify_validation_failure_reports_without_secret_value() -> None:
     """SM-18: a real ValidationError in Discord classify() returns (None, None)
-    and reports the sanitized wrapper (no secret field values) to Sentry.
+    and the exception reaching Sentry carries no secret field value.
 
     Pydantic v2 embeds the failing field's ``input_value`` in the
-    ValidationError string, so forwarding the raw error would leak secrets. Here
-    an invalid ``public_key`` triggers validation, and we assert its value never
-    reaches ``report_classify_failure``.
+    ValidationError string, so an invalid ``public_key`` here would leak its
+    value; the shared reporter sanitizes it to a model-name-only ValueError.
     """
     secret_value = "leaked-non-hex-secret"
 
-    with patch("integrations.discord.report_classify_failure") as mock_report:
+    with patch("integrations._validation_helpers.report_exception") as mock_report:
         result = classify(
             {"bot_token": "some-token", "public_key": secret_value},
             record_id="rec-discord",
         )
 
     assert result == (None, None)
-    assert mock_report.call_count == 1
-    exc_arg = mock_report.call_args.args[0]
-    # Must be the safe wrapper, not the raw ValidationError (a ValueError subclass).
-    assert not isinstance(exc_arg, ValidationError)
-    assert str(exc_arg) == "DiscordBotConfig validation failed"
-    assert secret_value not in str(exc_arg)
+    mock_report.assert_called_once()
+    reported_exc = mock_report.call_args.args[0]
+    assert secret_value not in str(reported_exc)
+    assert "DiscordBotConfig validation failed" in str(reported_exc)

--- a/tests/integrations/test_validation_helpers.py
+++ b/tests/integrations/test_validation_helpers.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import logging
 from unittest.mock import MagicMock, patch
 
-from integrations._validation_helpers import report_validation_failure
+from pydantic import ValidationError
+
+from integrations._validation_helpers import (
+    report_classify_failure,
+    report_validation_failure,
+)
+from integrations.config_models import DiscordBotConfig
 
 
 def _mock_logger() -> MagicMock:
@@ -121,3 +127,50 @@ class TestReportValidationFailure:
             )
         mock_cap.assert_called_once()
         assert mock_cap.call_args[0][0] is exc
+
+
+def _validation_error_with_secret(secret: str) -> ValidationError:
+    """Build a real pydantic ValidationError whose string embeds ``secret``."""
+    try:
+        DiscordBotConfig.model_validate({"bot_token": "ok", "public_key": secret})
+    except ValidationError as exc:
+        assert secret in str(exc), "test premise: pydantic embeds the input value"
+        return exc
+    raise AssertionError("expected ValidationError")
+
+
+class TestSentrySafeSanitization:
+    """ValidationError strings embed secret field values; both reporters must
+    replace them with a model-name-only ValueError before capture."""
+
+    def test_classify_failure_sanitizes_validation_error(self) -> None:
+        secret = "leaked-non-hex-secret"
+        exc = _validation_error_with_secret(secret)
+        with patch("integrations._validation_helpers.report_exception") as mock_report:
+            report_classify_failure(
+                exc, logger=_mock_logger(), integration="discord", record_id="rec-1"
+            )
+        reported = mock_report.call_args.args[0]
+        assert not isinstance(reported, ValidationError)
+        assert str(reported) == "DiscordBotConfig validation failed"
+        assert secret not in str(reported)
+
+    def test_validation_failure_sanitizes_validation_error(self) -> None:
+        secret = "leaked-non-hex-secret"
+        exc = _validation_error_with_secret(secret)
+        with patch("integrations._validation_helpers.report_exception") as mock_report:
+            report_validation_failure(
+                exc, logger=_mock_logger(), integration="discord", method="classify"
+            )
+        reported = mock_report.call_args.args[0]
+        assert not isinstance(reported, ValidationError)
+        assert str(reported) == "DiscordBotConfig validation failed"
+        assert secret not in str(reported)
+
+    def test_non_validation_error_passes_through_unchanged(self) -> None:
+        exc = RuntimeError("boom")
+        with patch("integrations._validation_helpers.report_exception") as mock_report:
+            report_classify_failure(
+                exc, logger=_mock_logger(), integration="discord", record_id="rec-1"
+            )
+        assert mock_report.call_args.args[0] is exc


### PR DESCRIPTION
Refs #3522

#### Describe the changes you have made in this PR -

Follow-up to #3994. muddlebee flagged that the per-vendor `except ValidationError`
block looked like duplicated exception handling. It wasn't quite duplication — the
branch passed a *sanitized* ValueError because pydantic embeds the failing field's
raw `input_value` (a secret: bot token, password) into the ValidationError string,
so a plain `except Exception` would forward that to Sentry and leak it.

Rather than collapse to a bare `except Exception` (which reintroduces the leak),
this centralizes the sanitization:

- Add `_sentry_safe()` in `integrations/_validation_helpers.py`: if the exception
  is a pydantic `ValidationError`, replace it with `ValueError(f"{exc.title} validation
  failed")` (title is just the model class name, no field values). All other
  exceptions pass through unchanged.
- Apply it inside both `report_classify_failure` and `report_validation_failure`.
- Delete the per-vendor `_discord_validation_failure()` / `_smtp_validation_failure()`
  helpers and their `except ValidationError` blocks — the plain `except Exception`
  path is now leak-safe.

Net effect: every vendor is protected (not just discord/smtp), one source of truth,
production code nets -14 lines. Message parity preserved (`exc.title` yields the same
"DiscordBotConfig validation failed" / "SMTPIntegrationConfig validation failed").

### Demo/Screenshot for feature changes and bug fixes -

Feeding a secret through both classifiers and capturing what reaches Sentry:

<img width="1071" height="800" alt="image" src="https://github.com/user-attachments/assets/8630aaba-4ec2-4bfc-9456-711efa74aab8" />

Verification:
- `pytest tests/integrations/` — 2584 passed, 2 skipped
- `ruff check` / `ruff format --check` — clean
- `mypy` — no issues

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: pydantic ValidationError stringifies with the failing field's raw
input value, so any site that forwards it to Sentry leaks secrets. #3994 fixed
this per-vendor with a hand-rolled sanitizing helper, which duplicated the pattern.
I moved the sanitization to the one shared choke point every classifier already
calls (`report_classify_failure`), keyed on `ValidationError.title` so the model
name is preserved without any field values. Considered collapsing to a single
`except Exception` per vendor, but that drops the sanitization; centralizing keeps
it while removing the duplication and covering all vendors.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
