### PR TITLE
fix(integrations): centralize ValidationError safety in report_classify_failure

### DIFF
--- a/integrations/_validation_helpers.py
+++ b/integrations/_validation_helpers.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from platform.observability.errors.boundary import report_exception
 
 
@@ -68,7 +70,17 @@ def report_classify_failure(
     integration: str,
     record_id: str,
 ) -> None:
-    """Log + Sentry-capture a classify failure for an integration record."""
+    """Log + Sentry-capture a classify failure for an integration record.
+
+    ``pydantic.ValidationError`` renders the raw invalid field value (often a
+    secret, e.g. a token or password) inline in its message via
+    ``input_value=...``. Sentry's ``before_send`` hook scrubs that pattern from
+    captured events, but this function also logs locally with ``exc_info``,
+    which bypasses the Sentry scrubber entirely. Swap in a message-only
+    ``ValueError`` so no call site has to do this itself.
+    """
+    if isinstance(exc, ValidationError):
+        exc = ValueError(f"{integration} config validation failed")
     report_exception(
         exc,
         logger=logger,

--- a/integrations/_validation_helpers.py
+++ b/integrations/_validation_helpers.py
@@ -78,9 +78,16 @@ def report_classify_failure(
     captured events, but this function also logs locally with ``exc_info``,
     which bypasses the Sentry scrubber entirely. Swap in a message-only
     ``ValueError`` so no call site has to do this itself.
+
+    The wrapper reuses the original exception's ``__traceback__`` (but not
+    ``__cause__`` — chaining would print the raw ``ValidationError`` text as
+    part of the chain in local logs, defeating the swap above) so logs and
+    Sentry still point at the vendor model/field that actually failed.
     """
     if isinstance(exc, ValidationError):
-        exc = ValueError(f"{integration} config validation failed")
+        safe_exc = ValueError(f"{integration} config validation failed")
+        safe_exc.__traceback__ = exc.__traceback__
+        exc = safe_exc
     report_exception(
         exc,
         logger=logger,

--- a/integrations/bitbucket/__init__.py
+++ b/integrations/bitbucket/__init__.py
@@ -16,7 +16,7 @@ import httpx
 from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
-from integrations._validation_helpers import report_validation_failure
+from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
 logger = logging.getLogger(__name__)
 
@@ -288,7 +288,8 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except Exception:
+    except Exception as exc:
+        report_classify_failure(exc, logger=logger, integration="bitbucket", record_id=record_id)
         return None, None
     if cfg.workspace:
         return cfg, "bitbucket"

--- a/integrations/discord/__init__.py
+++ b/integrations/discord/__init__.py
@@ -5,17 +5,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import DiscordBotConfig
 
 logger = logging.getLogger(__name__)
-
-
-def _discord_validation_failure() -> ValueError:
-    """Return a non-secret exception for Discord config validation failures."""
-    return ValueError("DiscordBotConfig validation failed")
 
 
 def classify(
@@ -32,14 +25,6 @@ def classify(
                 "default_channel_id": credentials.get("default_channel_id"),
             }
         )
-    except ValidationError:
-        report_classify_failure(
-            _discord_validation_failure(),
-            logger=logger,
-            integration="discord",
-            record_id=record_id,
-        )
-        return None, None
     except Exception as exc:
         report_classify_failure(exc, logger=logger, integration="discord", record_id=record_id)
         return None, None

--- a/integrations/signoz/__init__.py
+++ b/integrations/signoz/__init__.py
@@ -15,7 +15,7 @@ import httpx
 from pydantic import Field
 
 from config.strict_config import StrictConfigModel
-from integrations._validation_helpers import report_validation_failure
+from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +148,8 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[SigNozConfig 
                 "integration_id": record_id,
             }
         )
-    except Exception:
+    except Exception as exc:
+        report_classify_failure(exc, logger=logger, integration="signoz", record_id=record_id)
         return None, None
     if cfg.is_configured:
         return cfg, "signoz"

--- a/integrations/smtp/__init__.py
+++ b/integrations/smtp/__init__.py
@@ -5,17 +5,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import SMTPIntegrationConfig
 
 logger = logging.getLogger(__name__)
-
-
-def _smtp_validation_failure() -> ValueError:
-    """Return a non-secret exception for SMTP config validation failures."""
-    return ValueError("SMTPIntegrationConfig validation failed")
 
 
 def classify(
@@ -33,14 +26,6 @@ def classify(
                 "default_to": credentials.get("default_to"),
             }
         )
-    except ValidationError:
-        report_classify_failure(
-            _smtp_validation_failure(),
-            logger=logger,
-            integration="smtp",
-            record_id=record_id,
-        )
-        return None, None
     except Exception as exc:
         report_classify_failure(exc, logger=logger, integration="smtp", record_id=record_id)
         return None, None

--- a/integrations/tempo/__init__.py
+++ b/integrations/tempo/__init__.py
@@ -18,7 +18,7 @@ import httpx
 from pydantic import Field
 
 from config.strict_config import StrictConfigModel
-from integrations._validation_helpers import report_validation_failure
+from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +162,8 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[TempoConfig |
                 "integration_id": record_id,
             }
         )
-    except Exception:
+    except Exception as exc:
+        report_classify_failure(exc, logger=logger, integration="tempo", record_id=record_id)
         return None, None
     if cfg.is_configured:
         return cfg, "tempo"

--- a/integrations/twilio/__init__.py
+++ b/integrations/twilio/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import TwilioIntegrationConfig
 
@@ -25,8 +23,6 @@ def classify(
                 "integration_id": record_id,
             }
         )
-    except ValidationError:
-        return None, None
     except Exception as exc:
         report_classify_failure(exc, logger=logger, integration="twilio", record_id=record_id)
         return None, None

--- a/integrations/whatsapp/__init__.py
+++ b/integrations/whatsapp/__init__.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
+from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import WhatsAppConfig
 
 logger = logging.getLogger(__name__)
@@ -14,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 def classify(
     credentials: dict[str, Any],
-    _record_id: str,
+    record_id: str,
 ) -> tuple[WhatsAppConfig | None, str | None]:
     try:
         cfg = WhatsAppConfig.model_validate(
@@ -25,9 +24,7 @@ def classify(
                 "default_to": credentials.get("default_to"),
             }
         )
-    except ValidationError:
-        return None, None
-    except Exception:
-        logger.exception("Unexpected error validating WhatsApp config")
+    except Exception as exc:
+        report_classify_failure(exc, logger=logger, integration="whatsapp", record_id=record_id)
         return None, None
     return cfg, "whatsapp"

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -4,7 +4,11 @@ Three patterns previously dropped exceptions to ``(None, None)``, ``pass``,
 or ``logger.debug(..., exc_info=True)`` with no Sentry trace:
 
   A. ``_classify_service_instance`` per-vendor ``try/except Exception``
-     blocks (33 sites covering grafana .. supabase).
+     blocks (38 sites covering grafana .. whatsapp; bitbucket/signoz/tempo/
+     twilio/whatsapp were fixed in a later pass — see
+     ``integrations._validation_helpers.report_classify_failure``, which now
+     centrally wraps ``pydantic.ValidationError`` so no vendor classifier has
+     to duplicate that guard itself).
   B. ``load_env_integrations`` argocd + helm ``except Exception: pass``.
   C. ``load_env_integrations`` debug-only env loaders (incident_io,
      openclaw, mariadb, rabbitmq, rds, betterstack, alertmanager,
@@ -121,6 +125,15 @@ _CLASSIFY_PATCH_TARGETS: list[tuple[str, str, str]] = [
     ("splunk", "integrations.splunk", "SplunkIntegrationConfig"),
     ("supabase", "integrations.supabase", "build_supabase_config"),
     ("smtp", "integrations.smtp", "SMTPIntegrationConfig"),
+    # Previously silent or partially-reported (bitbucket/signoz/tempo dropped to
+    # (None, None) with no report at all; twilio/whatsapp swallowed ValidationError
+    # specifically). All five now route through report_classify_failure like every
+    # other vendor above.
+    ("bitbucket", "integrations.bitbucket", "BitbucketConfig"),
+    ("signoz", "integrations.signoz", "build_signoz_config"),
+    ("tempo", "integrations.tempo", "build_tempo_config"),
+    ("twilio", "integrations.twilio", "TwilioIntegrationConfig"),
+    ("whatsapp", "integrations.whatsapp", "WhatsAppConfig"),
 ]
 
 

--- a/tests/integrations/test_discord.py
+++ b/tests/integrations/test_discord.py
@@ -107,16 +107,18 @@ def test_verify_discord_accepts_token_when_client_run_succeeds(monkeypatch: Any)
 
 def test_classify_validation_error_returns_none_and_reports() -> None:
     """SM-18: a real ValidationError in Discord classify() returns (None, None)
-    and reports the sanitized wrapper (no secret field values) to Sentry.
+    and reports a sanitized wrapper (no secret field values) to Sentry.
 
     Pydantic v2 embeds the failing field's ``input_value`` in the
-    ValidationError string, so forwarding the raw error would leak secrets. Here
-    an invalid ``public_key`` triggers validation, and we assert its value never
-    reaches ``report_classify_failure``.
+    ValidationError string, so forwarding the raw error would leak secrets.
+    Discord's classify() passes the exception straight through to
+    ``report_classify_failure`` (integrations._validation_helpers), which is
+    responsible for the swap — assert on what actually reaches
+    ``report_exception``, one layer past the mocked-out call in older tests.
     """
     secret_value = "leaked-non-hex-secret"
 
-    with patch("integrations.discord.report_classify_failure") as mock_report:
+    with patch("integrations._validation_helpers.report_exception") as mock_report:
         result = classify(
             {"bot_token": "some-token", "public_key": secret_value},
             record_id="rec-discord",
@@ -127,5 +129,5 @@ def test_classify_validation_error_returns_none_and_reports() -> None:
     exc_arg = mock_report.call_args.args[0]
     # Must be the safe wrapper, not the raw ValidationError (a ValueError subclass).
     assert not isinstance(exc_arg, ValidationError)
-    assert str(exc_arg) == "DiscordBotConfig validation failed"
+    assert str(exc_arg) == "discord config validation failed"
     assert secret_value not in str(exc_arg)

--- a/tests/integrations/test_smtp.py
+++ b/tests/integrations/test_smtp.py
@@ -77,7 +77,7 @@ def test_classify_validation_failure_reports_without_secret_value() -> None:
     mock_report.assert_called_once()
     reported_exc = mock_report.call_args.args[0]
     assert secret not in str(reported_exc)
-    assert "SMTPIntegrationConfig validation failed" in str(reported_exc)
+    assert "smtp config validation failed" in str(reported_exc)
 
 
 def test_catalog_bootstraps_smtp_from_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/integrations/test_validation_helpers.py
+++ b/tests/integrations/test_validation_helpers.py
@@ -177,6 +177,8 @@ class TestReportClassifyFailure:
             _SecretConfig.model_validate({"api_token": "x", "port": "not-a-number"})
         except ValidationError as exc:
             validation_error = exc
+        else:
+            raise AssertionError("expected ValidationError")
 
         with patch("platform.observability.errors.boundary.capture_exception"):
             report_classify_failure(

--- a/tests/integrations/test_validation_helpers.py
+++ b/tests/integrations/test_validation_helpers.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import logging
 from unittest.mock import MagicMock, patch
 
-from integrations._validation_helpers import report_validation_failure
+from pydantic import BaseModel, ValidationError
+
+from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
 
 def _mock_logger() -> MagicMock:
@@ -121,3 +123,73 @@ class TestReportValidationFailure:
             )
         mock_cap.assert_called_once()
         assert mock_cap.call_args[0][0] is exc
+
+
+class _SecretConfig(BaseModel):
+    api_token: str
+    port: int
+
+
+class TestReportClassifyFailure:
+    def test_validation_error_is_wrapped_before_reporting(self) -> None:
+        """pydantic renders the raw invalid input inline (``input_value=...``).
+
+        ``report_exception`` logs with ``exc_info``, which bypasses the Sentry
+        ``before_send`` scrubber entirely (that hook only sees the Sentry
+        event, not the local log line) — so the swap must happen before the
+        exception is ever logged, not just before it's captured.
+        """
+        secret_value = "leaked-secret-token"
+        mock_log = _mock_logger()
+        try:
+            _SecretConfig.model_validate({"api_token": secret_value, "port": "not-a-number"})
+        except ValidationError as exc:
+            validation_error = exc
+        else:
+            raise AssertionError("expected ValidationError")
+
+        with patch("platform.observability.errors.boundary.capture_exception") as mock_cap:
+            report_classify_failure(
+                validation_error,
+                logger=mock_log,
+                integration="widget",
+                record_id="rec-1",
+            )
+
+        logged_exc = mock_log.warning.call_args.kwargs["exc_info"]
+        assert not isinstance(logged_exc, ValidationError)
+        assert secret_value not in str(logged_exc)
+        assert str(logged_exc) == "widget config validation failed"
+
+        captured_exc = mock_cap.call_args[0][0]
+        assert not isinstance(captured_exc, ValidationError)
+        assert secret_value not in str(captured_exc)
+
+    def test_non_validation_error_passes_through_unchanged(self) -> None:
+        mock_log = _mock_logger()
+        exc = RuntimeError("boom")
+        with patch("platform.observability.errors.boundary.capture_exception") as mock_cap:
+            report_classify_failure(
+                exc,
+                logger=mock_log,
+                integration="widget",
+                record_id="rec-1",
+            )
+        assert mock_log.warning.call_args.kwargs["exc_info"] is exc
+        assert mock_cap.call_args[0][0] is exc
+
+    def test_tags_have_expected_shape(self) -> None:
+        mock_log = _mock_logger()
+        with patch("platform.observability.errors.boundary.capture_exception") as mock_cap:
+            report_classify_failure(
+                RuntimeError("boom"),
+                logger=mock_log,
+                integration="widget",
+                record_id="rec-1",
+            )
+        extra = mock_cap.call_args[1]["extra"]
+        assert extra["tag.surface"] == "integration"
+        assert extra["tag.component"] == "integrations"
+        assert extra["tag.integration"] == "widget"
+        assert extra["tag.event"] == "classify_failed"
+        assert extra["record_id"] == "rec-1"

--- a/tests/integrations/test_validation_helpers.py
+++ b/tests/integrations/test_validation_helpers.py
@@ -165,6 +165,32 @@ class TestReportClassifyFailure:
         assert not isinstance(captured_exc, ValidationError)
         assert secret_value not in str(captured_exc)
 
+    def test_validation_error_wrapper_keeps_original_traceback(self) -> None:
+        """The wrapper must not drop the traceback pointing at the failing
+        vendor model/validator, or logs/Sentry become undebuggable — but it
+        must not use ``raise ... from`` chaining either, since that would
+        print the raw ``ValidationError`` text (with the secret) as part of
+        the exception chain when the local log formats it.
+        """
+        mock_log = _mock_logger()
+        try:
+            _SecretConfig.model_validate({"api_token": "x", "port": "not-a-number"})
+        except ValidationError as exc:
+            validation_error = exc
+
+        with patch("platform.observability.errors.boundary.capture_exception"):
+            report_classify_failure(
+                validation_error,
+                logger=mock_log,
+                integration="widget",
+                record_id="rec-1",
+            )
+
+        logged_exc = mock_log.warning.call_args.kwargs["exc_info"]
+        assert logged_exc.__traceback__ is validation_error.__traceback__
+        assert logged_exc.__cause__ is None
+        assert logged_exc.__context__ is None
+
     def test_non_validation_error_passes_through_unchanged(self) -> None:
         mock_log = _mock_logger()
         exc = RuntimeError("boom")


### PR DESCRIPTION
Fixes #1554

#### Describe the changes you have made in this PR -

Follow-up to #3994. That PR hand-wrapped `pydantic.ValidationError` in Discord's `classify()` before reporting it, to keep the raw secret field value pydantic embeds inline (`input_value=...`) out of Sentry. Auditing the other 47 vendor `classify()` functions turned up three inconsistencies in the same family:

- `smtp` had the same hand-rolled wrap as discord (duplicated, not shared).
- `twilio` and `whatsapp` caught `ValidationError` separately and silently returned `(None, None)` with **no** reporting at all — a config typo produces zero signal.
- `bitbucket`, `signoz`, `tempo` (issue #1554) don't special-case `ValidationError` at all — they swallow *every* classify exception silently, no logging, no Sentry.

Rather than re-duplicate the discord/smtp wrapper into 5 more files, I moved the swap into `report_classify_failure` itself (`integrations/_validation_helpers.py`), so every one of the ~44 vendor classifiers that already call it gets the protection automatically, with nothing to duplicate. Also found the wrap has to happen before the exception is *logged*, not just before Sentry capture: `report_exception` logs locally with `exc_info=exc`, and that log line bypasses Sentry's `before_send` scrubber entirely (which only sees the outgoing Sentry event) — so a raw `ValidationError` would still print the secret to local logs/terminal even though Sentry itself already scrubs `input_value=` patterns.

Changes:
- `integrations/_validation_helpers.py`: `report_classify_failure` now swaps `ValidationError` for a generic `ValueError(f"{integration} config validation failed")` before logging/reporting.
- `discord`, `smtp`: removed the now-redundant per-vendor `_xxx_validation_failure()` helpers and the separate `except ValidationError` branch; collapsed to the same single `except Exception` every other vendor uses.
- `twilio`, `whatsapp`: same collapse — these now actually report to Sentry on validation failure instead of swallowing it silently (`whatsapp`'s unused `_record_id` param is now used).
- `bitbucket`, `signoz`, `tempo`: wired their previously-silent `except Exception: return None, None` through `report_classify_failure`, matching every other vendor classifier.

### Demo/Screenshot for feature changes and bug fixes -

Targeted test run (validation-helper unit tests + all touched vendor classifiers):

```
$ uv run python -m pytest tests/integrations/test_validation_helpers.py tests/integrations/test_discord.py \
    tests/integrations/test_catalog_silent_fallback_elimination.py tests/integrations/test_smtp.py \
    tests/integrations/test_twilio.py tests/integrations/test_whatsapp.py tests/integrations/test_bitbucket.py \
    tests/integrations/test_signoz.py tests/integrations/test_tempo.py -q

tests/integrations/test_validation_helpers.py ...........                [  6%]
tests/integrations/test_discord.py ......                                [ 10%]
tests/integrations/test_catalog_silent_fallback_elimination.py ......... [ 15%]
..................................................................       [ 54%]
tests/integrations/test_smtp.py .......                                  [ 58%]
tests/integrations/test_twilio.py ...............                        [ 67%]
tests/integrations/test_whatsapp.py ............                         [ 74%]
tests/integrations/test_bitbucket.py ............                        [ 81%]
tests/integrations/test_signoz.py ..............                         [ 89%]
tests/integrations/test_tempo.py .................                       [100%]
169 passed in 1.05s
```

`make lint`, `make format-check`, `make typecheck` all pass.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Started from a question about why #3994 duplicated ValidationError-handling logic between discord and smtp. Traced the pattern to all 48 `classify()` functions in `integrations/`, and found the security rationale behind the wrap holds (raw pydantic `ValidationError` text embeds secret field values) but the mitigation was scattered, inconsistent, and in most vendors missing entirely — including three (bitbucket/signoz/tempo) that don't report classify failures to Sentry at all. Verified the Sentry-side scrubber in `platform/observability/errors/sentry.py` (`_scrub_exception_value`/`_PYDANTIC_INPUT_RE`) only covers the outgoing Sentry event, not the local `logger.warning(..., exc_info=exc)` call in `report_exception`, which is what actually motivated centralizing the fix in `report_classify_failure` rather than relying on the existing Sentry scrubber alone. Extended `tests/integrations/test_catalog_silent_fallback_elimination.py`'s `_CLASSIFY_PATCH_TARGETS` to cover the five newly-fixed vendors, added a `TestReportClassifyFailure` class in `test_validation_helpers.py` asserting the secret never reaches either the logged `exc_info` or the Sentry-captured exception, and updated `test_discord.py`/`test_smtp.py` assertions to match the new (integration-name-based, not model-class-name-based) message text.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.