### PR TITLE
Cache uv virtualenv across CI jobs to cut redundant dependency syncs

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -1,0 +1,32 @@
+name: Setup Python environment
+description: >-
+  Install uv, set up Python, and restore/create a cached uv-managed
+  virtualenv keyed by OS + Python version + uv.lock hash, so jobs stop
+  re-running a full ``uv sync`` from a cold environment on every run.
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v8.1.0
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          pyproject.toml
+          uv.lock
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
+
+    - name: Cache virtualenv
+      id: venv-cache
+      uses: actions/cache@v4
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-py3.13-${{ hashFiles('uv.lock') }}
+
+    - name: Install dependencies
+      shell: bash
+      run: uv sync --frozen --extra dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,38 +71,25 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: uv sync --frozen --extra dev
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-python-env
 
       - name: Lint
-        run: uv run python -m ruff check $PYTHON_SOURCE_PATHS tests/
+        run: uv run --no-sync python -m ruff check $PYTHON_SOURCE_PATHS tests/
 
       - name: Format check
-        run: uv run python -m ruff format --check $PYTHON_SOURCE_PATHS tests/
+        run: uv run --no-sync python -m ruff format --check $PYTHON_SOURCE_PATHS tests/
 
       - name: Typecheck
-        run: uv run python -m mypy $PYTHON_SOURCE_PATHS
+        run: uv run --no-sync python -m mypy $PYTHON_SOURCE_PATHS
 
       - name: Import graph
-        run: uv run python .github/ci/check_imports.py --strict
+        run: uv run --no-sync python .github/ci/check_imports.py --strict
 
       # Full layered contracts (.importlinter.strict), not the minimal default
       # .importlinter config used by ``make check-imports``.
       - name: Import boundaries
-        run: uv run lint-imports --config .importlinter.strict
+        run: uv run --no-sync lint-imports --config .importlinter.strict
 
   test:
     name: test (${{ matrix.shard }})
@@ -201,21 +188,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: uv sync --frozen --extra dev
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-python-env
 
       - name: Validate pytest marker
         env:
@@ -243,7 +217,7 @@ jobs:
         # A ``run: |`` + ``\`` rewrite can drop/split those paths and yield
         # ``N workers [0 items]`` even when the marker is correct.
         run: >
-          uv run python -m pytest -n auto -v
+          uv run --no-sync python -m pytest -n auto -v
           ${{ matrix.pytest_paths }}
           --cov=config
           --cov=core
@@ -284,21 +258,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: uv sync --frozen --extra dev
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-python-env
 
       - name: Download shard coverage artifacts
         uses: actions/download-artifact@v4
@@ -309,8 +270,8 @@ jobs:
 
       - name: Combine coverage and build report
         run: |
-          uv run python -m coverage combine .
-          uv run python -m coverage html
+          uv run --no-sync python -m coverage combine .
+          uv run --no-sync python -m coverage html
 
       - name: Upload combined coverage
         uses: actions/upload-artifact@v4
@@ -340,28 +301,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: uv sync --frozen --extra dev
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-python-env
 
       - name: Run Kubernetes tests
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
-        run: uv run python -m tests.e2e.kubernetes.test_local
+        run: uv run --no-sync python -m tests.e2e.kubernetes.test_local
 
   should-run-thorough:
     runs-on: ubuntu-latest
@@ -437,21 +385,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: uv sync --frozen --extra dev
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-python-env
 
       - name: Install tracer CLI
         run: |
@@ -464,5 +399,5 @@ jobs:
         timeout-minutes: 2
 
       - name: Run test
-        run: uv run ${{ matrix.command }}
+        run: uv run --no-sync ${{ matrix.command }}
         timeout-minutes: 30


### PR DESCRIPTION

-  then runs uv sync --frozen --extra dev once against that cache.
- Replaced the repeated three-step setup in all 6 jobs of ci.yml with a single uses: ./.github/actions/setup-python-env step.
- Switched the downstream uv run invocations in those jobs to uv run --no-sync, since the environment is already validated by the composite action and each step no longer needs to re-check the lock file.

Net effect: on a warm cache (unchanged uv.lock), every job restores its virtualenv from cache instead of reinstalling dependencies, and per-step uv run calls skip the sync check — addressing the ≥15% CI time reduction and ≥70% warm cache-hit target described in #1359.

Demo/Screenshot for feature changes and bug fixes -
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->

<!-- Do not add code diff here -->

Both changed YAML files were validated locally with python3 -c "import yaml; yaml.safe_load(...)" (parses cleanly). I have not yet observed a live GitHub Actions run of this workflow (no CI trigger available outside of opening this PR) — first-run cache-miss timing and warm-run cache-hit timing should be checked from the Actions tab once this is up, and I'm happy to iterate on the cache key or restore-keys if the hit rate doesn't land in range.
⸻
Code Understanding and AI Usage

Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

If you used AI assistance:
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

Explain your implementation approach:

I worked through this with Claude (Anthropic's coding assistant): I identified issue #1359 and directed the approach, and the diff was written and reviewed jointly — Claude drafted the composite action and workflow edits, and I reviewed the resulting diff line by line before it went up.

- Problem: every CI job independently re-ran uv's full dependency sync from scratch, which is the single biggest duplicated cost across the 6 jobs in ci.yml (they all install the identical uv.lock-pinned environment).
- Alternatives considered: relying only on setup-uv's built-in enable-cache (already present) — but that only caches uv's package/wheel cache, not the assembled .venv, so every job still pays the cost of rebuilding the virtualenv from those cached wheels. Caching .venv directly, keyed on lock-file hash, skips that rebuild entirely on a hit.
- Why this implementation: a composite action was the natural way to de-duplicate the identical 3-step setup block that was copy-pasted across all 6 jobs, and it's the natural place to add the actions/cache step alongside it. uv run --no-sync on the per-step commands avoids uv re-checking the lock file on every single invocation within a job, now that the composite action has already validated the env once.
- Testing status: YAML validity is confirmed locally; the actual cache hit-rate and timing improvement can only be observed once this runs in GitHub Actions, since there's no local equivalent of the hosted runner cache. I'll be watching the first few CI runs on this PR to confirm the cache behaves as expected and will adjust (e.g. cache key granularity, restore-keys fallback) if not.
⸻
Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work; full validation is limited to YAML parsing locally, real cache behavior will be confirmed once Actions runs this PR (see note above)
- [ ] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
⸻
Note: Please check Allow edits from maintainers if you would like us to assist in the PR.