### PR TITLE
fix(agent): wire docs grounding into the assistant prompt (#3933)

### DIFF
--- a/core/agent_harness/grounding/docs_reference.py
+++ b/core/agent_harness/grounding/docs_reference.py
@@ -323,15 +323,21 @@ def find_relevant_docs(
     pages: list[DocPage],
     *,
     top_n: int = _DEFAULT_TOP_N,
+    min_score: int = 1,
 ) -> list[DocPage]:
     """Return up to ``top_n`` docs most relevant to ``query``, ranked by overlap.
 
-    Returns an empty list if the query has no useful tokens or no pages match.
+    Only pages scoring at least ``min_score`` are returned. The default of 1
+    keeps every positive match; callers that ground an LLM prompt pass a higher
+    floor so a weak keyword overlap (a single body token, or a slug collision
+    like "center" matching "cost-center-mapping") does not inject an unrelated
+    page. Returns an empty list if the query has no useful tokens or nothing
+    clears the floor.
     """
     qt = _query_tokens(query)
     if not qt:
         return []
-    scored = [(s, p) for p in pages for s in [_score(qt, p)] if s > 0]
+    scored = [(s, p) for p in pages for s in [_score(qt, p)] if s >= min_score]
     scored.sort(key=lambda item: (-item[0], item[1].relpath))
     return [page for _, page in scored[:top_n]]
 
@@ -396,10 +402,11 @@ class DocsReference:
         pages: list[DocPage] | None = None,
         *,
         top_n: int = _DEFAULT_TOP_N,
+        min_score: int = 1,
     ) -> list[DocPage]:
         """Return up to ``top_n`` docs most relevant to ``query``."""
         candidates = pages if pages is not None else self.discover()
-        return find_relevant_docs(query, candidates, top_n=top_n)
+        return find_relevant_docs(query, candidates, top_n=top_n, min_score=min_score)
 
     def build_text(
         self,
@@ -408,21 +415,28 @@ class DocsReference:
         top_n: int = _DEFAULT_TOP_N,
         max_chars: int = _DEFAULT_MAX_TOTAL_CHARS,
         root: Path | None = None,
+        min_score: int = 1,
     ) -> str:
         """Assemble a docs reference block for LLM grounding.
 
-        Includes the top-N most relevant pages (with body excerpts) followed by
-        a compact index of all discovered pages. Returns ``""`` when no docs
-        are available so callers can detect that and adjust the prompt. ``root``
-        defaults to the repository ``docs/`` directory.
+        Includes the top-N pages scoring at least ``min_score`` (with body
+        excerpts), followed by a compact index of all discovered pages so the
+        LLM can point at siblings. Returns ``""`` when no docs are available, or
+        when nothing clears ``min_score``, so a query that no page strongly
+        matches contributes no grounding rather than injecting an unrelated
+        excerpt. ``root`` defaults to the repository ``docs/`` directory.
         """
         pages = self.discover(root)
         if not pages:
             return ""
 
-        parts: list[str] = []
-        relevant = self.find_relevant(query, pages, top_n=top_n) if query else []
+        relevant = (
+            self.find_relevant(query, pages, top_n=top_n, min_score=min_score) if query else []
+        )
+        if not relevant:
+            return ""
 
+        parts: list[str] = []
         for page in relevant:
             parts.append(f"=== docs/{page.relpath} (title: {page.title}) ===\n")
             parts.append(excerpt(page.body, _MAX_PER_DOC_CHARS))

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -143,6 +143,9 @@ class PromptContextProvider(Protocol):
     def agents_md(self) -> str:
         raise NotImplementedError
 
+    def docs(self, query: str) -> str:
+        raise NotImplementedError
+
     def investigation_flow(self) -> str:
         raise NotImplementedError
 

--- a/core/agent_harness/prompts/assistant.py
+++ b/core/agent_harness/prompts/assistant.py
@@ -35,6 +35,9 @@ class AssistantPromptContextProvider(Protocol):
     def agents_md(self) -> str:
         raise NotImplementedError
 
+    def docs(self, query: str) -> str:
+        raise NotImplementedError
+
     def investigation_flow(self) -> str:
         raise NotImplementedError
 
@@ -52,6 +55,7 @@ def build_assistant_system_prompt(
     reference: str,
     history: str,
     agents_md: str = "",
+    docs: str = "",
     investigation_flow: str = "",
     prior_investigation: str = "",
     prior_action_facts: str = "",
@@ -62,6 +66,7 @@ def build_assistant_system_prompt(
         reference,
         history,
         agents_md=agents_md,
+        docs=docs,
         investigation_flow=investigation_flow,
         prior_investigation=prior_investigation,
         prior_action_facts=prior_action_facts,
@@ -224,6 +229,7 @@ def build_cli_agent_prompt_from_provider(
         prompts.cli_reference(),
         format_recent_conversation(list(turn_snapshot.conversation_messages)),
         agents_md=prompts.agents_md(),
+        docs=prompts.docs(message),
         investigation_flow=prompts.investigation_flow(),
         prior_investigation=(
             _summarize_last_state(turn_snapshot.last_state)

--- a/core/agent_harness/prompts/assistant_agent_prompt.py
+++ b/core/agent_harness/prompts/assistant_agent_prompt.py
@@ -146,6 +146,7 @@ def _build_system_prompt(
     reference: str,
     history: str,
     agents_md: str = "",
+    docs: str = "",
     investigation_flow: str = "",
     prior_investigation: str = "",
     prior_action_facts: str = "",
@@ -153,6 +154,16 @@ def _build_system_prompt(
 ) -> str:
     """Build the system prompt for one assistant turn."""
     repo_map_block = f"--- Repo map (AGENTS.md) ---\n{agents_md}\n\n" if agents_md else ""
+    docs_block = (
+        "--- Documentation reference (docs/) ---\n"
+        "Relevant OpenSRE documentation pages for this question. When answering "
+        "how to configure or set up something, use these to give the complete "
+        "procedure — including steps that happen outside OpenSRE (creating "
+        "accounts, API keys, bots, OAuth apps, finding IDs) — not just the "
+        f"in-tool command. Do not invent steps beyond what these pages state.\n{docs}\n\n"
+        if docs
+        else ""
+    )
     investigation_flow_block = (
         f"--- Investigation flow reference ---\n{investigation_flow}\n\n"
         if investigation_flow
@@ -216,6 +227,7 @@ def _build_system_prompt(
         f"{_TERMINOLOGY_RULE}\n{_MARKDOWN_RULE}\n\n"
         f"{environment}"
         f"--- CLI reference ---\n{reference}\n\n"
+        f"{docs_block}"
         f"{investigation_flow_block}"
         f"{prior_investigation_block}"
         f"{prior_action_facts_block}"

--- a/core/agent_harness/prompts/prompt_context.py
+++ b/core/agent_harness/prompts/prompt_context.py
@@ -46,6 +46,9 @@ class DefaultPromptContextProvider:
     def agents_md(self) -> str:
         return str(self._session.grounding.agents_md.build_text())
 
+    def docs(self, query: str) -> str:
+        return str(self._session.grounding.docs.build_text(query))
+
     def investigation_flow(self) -> str:
         return build_investigation_flow_reference_text()
 

--- a/core/agent_harness/prompts/prompt_context.py
+++ b/core/agent_harness/prompts/prompt_context.py
@@ -12,6 +12,13 @@ from core.agent_harness.llm_resolution import resolve_provider_models
 from core.agent_harness.prompts import build_environment_block
 from platform.observability.trace.spans import component_span
 
+# Minimum retrieval score for a docs page to ground an assistant answer. A
+# genuine setup/config question scores ~30 on its page (slug + exact-slug +
+# title + heading hits); incidental single-token overlap scores ~1-4. A floor
+# of 8 requires at least a slug/title-level signal, so unrelated pages are
+# dropped rather than injected as excerpts.
+_DOCS_RELEVANCE_FLOOR = 8
+
 
 def load_llm_settings() -> Any | None:
     """Best-effort LLM settings load for prompt environment grounding."""
@@ -47,7 +54,12 @@ class DefaultPromptContextProvider:
         return str(self._session.grounding.agents_md.build_text())
 
     def docs(self, query: str) -> str:
-        return str(self._session.grounding.docs.build_text(query))
+        # Only ground on a docs page the question strongly points at. A real
+        # setup question ("how do I set up telegram?") scores ~30 on its page;
+        # this floor drops incidental keyword overlap (e.g. "center a div"
+        # colliding with cost-center-mapping) so unrelated pages never leak into
+        # the answer. Below the floor the block is omitted entirely.
+        return str(self._session.grounding.docs.build_text(query, min_score=_DOCS_RELEVANCE_FLOOR))
 
     def investigation_flow(self) -> str:
         return build_investigation_flow_reference_text()

--- a/core/agent_harness/turns/headless_adapters.py
+++ b/core/agent_harness/turns/headless_adapters.py
@@ -84,6 +84,10 @@ class EmptyPromptContextProvider:
     def agents_md(self) -> str:
         return ""
 
+    def docs(self, query: str) -> str:
+        _ = query
+        return ""
+
     def investigation_flow(self) -> str:
         return ""
 

--- a/surfaces/interactive_shell/grounding/cli_reference.py
+++ b/surfaces/interactive_shell/grounding/cli_reference.py
@@ -336,6 +336,9 @@ class ShellPromptContextProvider:
     def agents_md(self) -> str:
         return self._base.agents_md()
 
+    def docs(self, query: str) -> str:
+        return self._base.docs(query)
+
     def investigation_flow(self) -> str:
         return self._base.investigation_flow()
 

--- a/tests/core/agent/orchestration/test_action_prompt.py
+++ b/tests/core/agent/orchestration/test_action_prompt.py
@@ -297,6 +297,10 @@ class _FakePrompts:
     def agents_md(self) -> str:
         return ""
 
+    def docs(self, query: str) -> str:
+        _ = query
+        return ""
+
     def investigation_flow(self) -> str:
         return ""
 
@@ -339,3 +343,47 @@ def test_local_llama_handoff_injects_setup_guidance_into_assistant_prompt() -> N
     assert "opensre onboard local_llm" in prompt
     assert "/onboard local_llm" in prompt
     assert "/model set ollama" in prompt
+
+
+class _FakePromptsWithDocs(_FakePrompts):
+    """Provider that echoes the retrieval query so the wiring can be asserted."""
+
+    def __init__(self) -> None:
+        self.docs_query: str | None = None
+
+    def docs(self, query: str) -> str:
+        self.docs_query = query
+        return "=== docs/messaging/telegram.mdx ===\nCreate a bot with @BotFather"
+
+
+def test_docs_grounding_reaches_assistant_prompt() -> None:
+    """The user's question is retrieved against docs and injected into the prompt.
+
+    Locks the wiring the harness-move refactor severed: a procedural setup
+    question must carry its documentation page into the LLM grounding so the
+    assistant answers with the out-of-tool steps instead of improvising.
+    """
+    message = "how do I set up the telegram bot?"
+    turn_snapshot = TurnSnapshot(
+        text=message,
+        conversation_messages=(),
+        configured_integrations=(),
+        configured_integrations_known=True,
+        last_state=None,
+        last_synthetic_observation_path=None,
+        reasoning_effort=None,
+    )
+    prompts = _FakePromptsWithDocs()
+
+    prompt = build_cli_agent_prompt_from_provider(
+        message=message,
+        prompts=prompts,
+        tool_observation=None,
+        tool_observation_on_screen=True,
+        turn_snapshot=turn_snapshot,
+    )
+
+    assert prompts.docs_query == message
+    assert "--- Documentation reference (docs/) ---" in prompt
+    assert "docs/messaging/telegram.mdx" in prompt
+    assert "@BotFather" in prompt

--- a/tests/core/agent/prompts/test_prompt_characterization.py
+++ b/tests/core/agent/prompts/test_prompt_characterization.py
@@ -64,6 +64,9 @@ class _StubPromptContextProvider:
     def agents_md(self) -> str:
         return _AGENTS_MD_TEXT
 
+    def docs(self, query: str) -> str:  # noqa: ARG002 - stub
+        return ""
+
     def investigation_flow(self) -> str:
         return build_investigation_flow_reference_text()
 

--- a/tests/interactive_shell/references/test_docs_reference.py
+++ b/tests/interactive_shell/references/test_docs_reference.py
@@ -146,6 +146,22 @@ class TestFindRelevantDocs:
         results = find_relevant_docs("install configure deploy investigate", pages, top_n=2)
         assert len(results) <= 2
 
+    def test_min_score_floor_excludes_weak_matches(self, tmp_path: Path) -> None:
+        """A page whose only match is a single body token is kept at the default
+        floor but dropped once the caller raises ``min_score`` — the knob the
+        assistant provider uses so weak keyword overlap does not ground an
+        answer."""
+        _write_doc(
+            tmp_path,
+            "notes.mdx",
+            "# Notes\n\nWe briefly mention masking in this note.\n",
+        )
+        pages = DocsReference().discover(tmp_path)
+        # Default floor (1) keeps the weak single-token match.
+        assert [p.slug for p in find_relevant_docs("masking", pages)] == ["notes"]
+        # A higher floor drops it entirely.
+        assert find_relevant_docs("masking", pages, min_score=5) == []
+
     def test_nested_page_with_weak_match_is_not_dropped_by_depth(self, tmp_path: Path) -> None:
         """A page whose only match is a single body token, nested deep enough
         that the depth penalty equals or exceeds its raw score, must still
@@ -185,6 +201,18 @@ class TestBuildDocsReferenceText:
         # can suggest other relevant pages even when one ranked highest.
         assert "docs index" in text
         assert "deployment.mdx" in text
+
+    def test_omits_block_when_nothing_clears_floor(self, tmp_path: Path) -> None:
+        # A query no page strongly matches must contribute no grounding at all,
+        # rather than injecting an unrelated excerpt or a bare page index.
+        _seed_docs(tmp_path)
+        assert DocsReference().build_text("bake sourdough bread", root=tmp_path, min_score=8) == ""
+
+    def test_strong_match_survives_floor(self, tmp_path: Path) -> None:
+        _seed_docs(tmp_path)
+        text = DocsReference().build_text("how do I configure Datadog?", root=tmp_path, min_score=8)
+        assert "datadog.mdx" in text
+        assert "API Key" in text
 
     def test_truncates_to_max_chars(self, tmp_path: Path) -> None:
         _seed_docs(tmp_path)


### PR DESCRIPTION
Fixes #3933

#### Describe the changes you have made in this PR -

The docs retrieval engine (`DocsReference`) was already built, cached, and threaded into every session, but its output never reached the LLM. The assistant prompt only assembled the CLI reference and AGENTS.md, so "how do I set up X" questions got answered from model memory instead of the `docs/` pages. That is why setup answers skipped the steps that happen outside OpenSRE (creating the bot in BotFather, finding a `chat_id` via `getUpdates`, and so on), which is the gap #3933 describes.

`docs.build_text()` was wired up in #3180 and later dropped by the harness-move refactor. The engine survived; its consumer did not. This reconnects it:

- adds `docs(query)` to the two prompt-context providers and both provider protocols
- passes the user's message as the retrieval query
- injects the matched pages as a documentation reference block, omitted when empty so non-doc turns stay byte-identical (the prompt characterization snapshot is unchanged)

A regression test asserts the query reaches `docs()` and the retrieved page lands in the assembled prompt, so it cannot get silently severed again.

### Demo/Screenshot for feature changes and bug fixes -

Same question the issue quotes, before and after, driven against a live Anthropic model through the interactive shell.

Before (fix stashed): "That prompts you for the bot token (from @BotFather) and default chat ID." Vague, jumps straight to the command, no `getUpdates`, no chat_id retrieval.
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/23930aac-92ba-415f-bc69-63d767e05da4" />


After: a complete procedure pulled from `docs/messaging/telegram.mdx`:

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/4b83d68f-3e47-4a85-ae52-614188f4f091" />
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/0bd35e2f-cf71-4498-bf22-5d91e1306cbd" />


The `getUpdates` mechanism and the exact token format come from the docs page, not model memory, which is the proof the grounding is being used.

Verification: `make typecheck`, `make lint`, `make format-check` clean; `make test-scope` 2459 passed / 32 skipped; prompt characterization snapshot unchanged.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is a severed wire, not a missing feature, so the fix reconnects the existing engine rather than adding anything new. I traced the assistant prompt assembly in `assistant.py`, found `docs.build_text()` was never called in the answer path, and confirmed through git history that it used to be (removed during the harness-move refactor). I added `docs(query)` next to the existing `agents_md()` / `cli_reference()` provider methods, and passed the user message (already handed to the prompt builder) as the retrieval query. The docs block sits right after the CLI reference and drops out when empty, which keeps every non-doc turn identical and leaves the golden snapshot untouched. I also considered a hardcoded per-integration URL map in the CLI setup flow, but that only helps the non-interactive path and leaves the assistant improvising, so I went with the root-cause fix that covers every integration at once.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
