### PR TITLE
fix(grafana): cast datasource JSON to satisfy mypy

### DIFF
--- a/integrations/grafana/verifier.py
+++ b/integrations/grafana/verifier.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import requests
 
@@ -22,7 +22,7 @@ def _discover_datasources(config: GrafanaIntegrationConfig) -> list[Any] | str:
     try:
         response = requests.get(url, headers=config.auth_headers, timeout=10)
         response.raise_for_status()
-        return response.json()
+        return cast(list[Any], response.json())
     except requests.HTTPError as exc:
         status = exc.response.status_code if exc.response is not None else "unknown"
         body = ""


### PR DESCRIPTION
## Summary
- Fix mypy `no-any-return` in `integrations/grafana/verifier.py` by casting `response.json()` to `list[Any]`
- Unblocks the `quality` job on main CI (typecheck was the only failing step)

## Test plan
- [x] `make typecheck`
- [x] `make lint`
- [x] `make format-check`
- [x] `uv run pytest tests/integrations/test_verify.py`