### PR TITLE
docs: remove dead `fargate/` link from platform/deployment README

### DIFF
--- a/platform/deployment/README.md
+++ b/platform/deployment/README.md
@@ -8,7 +8,6 @@ AWS EC2 deployment and shared provisioning primitives for OpenSRE.
 | --- | --- |
 | [`aws/`](aws/) | Shared AWS SDK primitives (`client`, `config`, VPC/SG, EC2/IAM, ECR, SSM). |
 | [`ecr_deploy/`](ecr_deploy/) | Docker/ECR EC2 provisioning: `opensre-web` + `opensre-gateway` on one instance. |
-| [`fargate/`](fargate/) | ECS Fargate + RDS layout (plan/dry-run; apply not implemented yet). |
 | [`gateway/`](gateway/) | AMI + systemd deployment path for the messaging gateway (Telegram and/or Slack; no Docker/ECR). See [gateway/README.md](gateway/README.md). |
 | `install-proxy/` | Install proxy utility (Cloudflare Worker). |
 

--- a/platform/deployment/README.md
+++ b/platform/deployment/README.md
@@ -8,6 +8,7 @@ AWS EC2 deployment and shared provisioning primitives for OpenSRE.
 | --- | --- |
 | [`aws/`](aws/) | Shared AWS SDK primitives (`client`, `config`, VPC/SG, EC2/IAM, ECR, SSM). |
 | [`ecr_deploy/`](ecr_deploy/) | Docker/ECR EC2 provisioning: `opensre-web` + `opensre-gateway` on one instance. |
+| [`infra/terraform/`](../../infra/terraform/) | ECS Fargate backend (web API + Slack gateway) via Terraform. Plan by default; `make deploy-fargate-apply` to apply. |
 | [`gateway/`](gateway/) | AMI + systemd deployment path for the messaging gateway (Telegram and/or Slack; no Docker/ECR). See [gateway/README.md](gateway/README.md). |
 | `install-proxy/` | Install proxy utility (Cloudflare Worker). |
 


### PR DESCRIPTION
Fixes #4033

#### Describe the changes you have made in this PR -

Removes the stale `fargate/` row from the "What's here" table in `platform/deployment/README.md`. That row linked to a `fargate/` sub-directory that does not exist in `platform/deployment/`, so the relative link 404s when the README renders on GitHub. The other four rows (`aws/`, `ecr_deploy/`, `gateway/`, `install-proxy/`) all point to real directories and are unchanged.

### Demo/Screenshot for feature changes and bug fixes -

The link target does not exist (GitHub Contents API returns 404):

```
$ gh api repos/Tracer-Cloud/opensre/contents/platform/deployment/fargate
{"message":"Not Found","status":"404"}
```

The path also has no commit history — the directory was never committed at that location. The real Fargate infrastructure lives under `tests/benchmarks/cloudopsbench/infra/` (benchmark infra), which is already linked correctly further down the same README, so this is a stale inventory entry rather than a moved directory.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: a docs table advertised a directory (`platform/deployment/fargate/`) that isn't in the repo, producing a dead relative link on GitHub. I verified it was genuinely missing (Contents API 404 + no commit history for the path) rather than renamed, and confirmed the four remaining rows resolve. I considered repointing the link to the existing Fargate Terraform under `tests/benchmarks/cloudopsbench/infra/`, but that is benchmark infra with a different purpose (and it is already linked elsewhere in this file), so repointing would be misleading. Removing the single dead row is the honest, minimal fix. No code paths are affected — this is documentation only.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
