### PR TITLE
feat(fleet_monitoring): migrate model pricing to litellm's price table

### DIFF
--- a/tests/fleet_monitoring/test_pricing.py
+++ b/tests/fleet_monitoring/test_pricing.py
@@ -70,6 +70,15 @@ class TestUsdPerTokenBlended:
         expected = 0.7 * entry["input_cost_per_token"] + 0.3 * entry["output_cost_per_token"]
         assert usd_per_token_blended("claude-sonnet-4-5") == pytest.approx(expected)
 
+    def test_local_snapshot_loads_a_substantial_table(self) -> None:
+        # Startup-time smoke guard: if litellm's packaged JSON file is ever
+        # missing/unreadable, _litellm_local_cost_map degrades to an empty
+        # dict rather than crashing the always-on sampler (see its
+        # docstring) — but that failure mode must be loud in CI, not silent.
+        from tools.system.fleet_monitoring.pricing import _litellm_local_cost_map
+
+        assert len(_litellm_local_cost_map()) > 1000
+
 
 class TestGpt56Family:
     """GPT-5.6 Sol / Terra / Luna (#3931) — the confirmed litellm gap.

--- a/tests/fleet_monitoring/test_pricing.py
+++ b/tests/fleet_monitoring/test_pricing.py
@@ -1,4 +1,4 @@
-"""Tests for the model pricing table and $/hr computation (#2023)."""
+"""Tests for the model pricing table and $/hr computation (#2023, #4035)."""
 
 from __future__ import annotations
 
@@ -8,7 +8,6 @@ import pytest
 
 from tools.system.fleet_monitoring.meters import TokenUsage
 from tools.system.fleet_monitoring.pricing import (
-    MODEL_PRICES,
     PriceOverride,
     normalize_model_name,
     usd_for_usage,
@@ -20,7 +19,8 @@ from tools.system.fleet_monitoring.pricing import (
 
 class TestUsdPerTokenBlended:
     def test_known_claude_model(self) -> None:
-        # claude-sonnet-4-5: 3 USD/M input, 15 USD/M output, 70/30 blend.
+        # claude-sonnet-4-5 (litellm's model_cost table): 3 USD/M input,
+        # 15 USD/M output, 70/30 blend.
         # Expected: 0.7 * 3e-6 + 0.3 * 15e-6 = 2.1e-6 + 4.5e-6 = 6.6e-6.
         rate = usd_per_token_blended("claude-sonnet-4-5")
         assert rate is not None
@@ -44,30 +44,39 @@ class TestUsdPerTokenBlended:
         assert usd_per_token_blended(None) is None
 
     def test_dated_suffix_falls_back_to_family(self) -> None:
-        # ``claude-sonnet-4-5-20251015`` (date-suffixed id from a
-        # future release that we have not added explicitly to the
-        # table) should still resolve via the family prefix.
+        # ``claude-sonnet-4-5-20251015`` (a future release id litellm's
+        # bundled table does not have yet) resolves via the bare family
+        # alias, which litellm does carry.
         rate = usd_per_token_blended("claude-sonnet-4-5-20251015")
         assert rate == usd_per_token_blended("claude-sonnet-4-5")
 
-    def test_family_prefix_does_not_collide_with_shorter_family(self) -> None:
-        # ``claude-opus-4-1`` must NOT match the ``claude-opus-4``
-        # family before the longer ``claude-opus-4-1`` entry — the
-        # opus-4-1 rate would otherwise be misread as opus-4.
-        opus_4 = usd_per_token_blended("claude-opus-4")
+    def test_dated_sibling_does_not_collide_with_shorter_family(self) -> None:
+        # ``claude-opus-4-1`` must resolve to its own rate rather than
+        # collapsing onto an unrelated, older sibling in the same family.
+        opus_4_20250514 = usd_per_token_blended("claude-opus-4-20250514")
         opus_4_1 = usd_per_token_blended("claude-opus-4-1")
-        # Both happen to be the same today; the regression we guard
-        # against is a future opus-4-1 with different rates getting
-        # silently shadowed by a generic ``claude-opus-4`` rule.
-        assert opus_4 is not None
+        assert opus_4_20250514 is not None
         assert opus_4_1 is not None
+
+    def test_price_matches_litellm_local_snapshot_directly(self) -> None:
+        # Regression guard that this is actually wired to litellm's *local*
+        # snapshot — not a hardcoded number that happens to agree with it
+        # today, and not the shared ``litellm.model_cost`` global (which can
+        # diverge from the local snapshot after a live fetch elsewhere in
+        # the process; see the module docstring).
+        from tools.system.fleet_monitoring.pricing import _litellm_local_cost_map
+
+        entry = _litellm_local_cost_map()["claude-sonnet-4-5"]
+        expected = 0.7 * entry["input_cost_per_token"] + 0.3 * entry["output_cost_per_token"]
+        assert usd_per_token_blended("claude-sonnet-4-5") == pytest.approx(expected)
 
 
 class TestGpt56Family:
-    """GPT-5.6 Sol / Terra / Luna (#3931).
+    """GPT-5.6 Sol / Terra / Luna (#3931) — the confirmed litellm gap.
 
-    Rates from https://developers.openai.com/api/docs/pricing (GA 2026-07-09),
-    per 1M tokens: sol 5/30, terra 2.50/15, luna 1/6. Cached input is 90% off.
+    litellm's bundled table doesn't have this family yet (GA'd 2026-07-09).
+    Rates from https://developers.openai.com/api/docs/pricing, per 1M
+    tokens: sol 5/30, terra 2.50/15, luna 1/6. Cached input is 90% off.
     """
 
     @pytest.mark.parametrize(
@@ -81,7 +90,9 @@ class TestGpt56Family:
     def test_published_rates(
         self, model: str, input_usd_per_million: float, output_usd_per_million: float
     ) -> None:
-        price = MODEL_PRICES[model]
+        from tools.system.fleet_monitoring.pricing import _LOCAL_MODEL_PRICES
+
+        price = _LOCAL_MODEL_PRICES[model]
         assert price.usd_per_input_token == pytest.approx(input_usd_per_million / 1e6)
         assert price.usd_per_output_token == pytest.approx(output_usd_per_million / 1e6)
         # Cached input reads are 90% off uncached input.
@@ -218,36 +229,48 @@ class TestNormalizeModelName:
     def test_at_default_variant_resolves_to_base(self) -> None:
         assert normalize_model_name("claude-sonnet-4-5@default") == "claude-sonnet-4-5"
 
+    def test_legacy_direct_api_id_normalizes_to_itself(self) -> None:
+        # claude-3-5-sonnet-20241022 is the confirmed litellm gap (only
+        # present under Bedrock-routed keys upstream) — covered by the
+        # local override table, and must still normalize cleanly.
+        assert normalize_model_name("claude-3-5-sonnet-20241022") == "claude-3-5-sonnet-20241022"
+
 
 class TestFamilyFallbackCoherence:
-    """Drift guards on ``_FAMILY_FALLBACKS`` ↔ ``MODEL_PRICES``."""
+    """Drift guards on ``_LOCAL_FAMILY_FALLBACKS`` ↔ ``_LOCAL_MODEL_PRICES``."""
 
     def test_family_fallbacks_are_longest_prefix_first(self) -> None:
-        from tools.system.fleet_monitoring.pricing import _FAMILY_FALLBACKS
+        from tools.system.fleet_monitoring.pricing import _LOCAL_FAMILY_FALLBACKS
 
-        lengths = [len(prefix) for prefix, _canonical_id in _FAMILY_FALLBACKS]
+        lengths = [len(prefix) for prefix, _canonical_id in _LOCAL_FAMILY_FALLBACKS]
         assert lengths == sorted(lengths, reverse=True)
 
     def test_every_family_fallback_canonical_id_has_a_price(self) -> None:
-        # Without this guard, a typo in ``_FAMILY_FALLBACKS``'s
+        # Without this guard, a typo in ``_LOCAL_FAMILY_FALLBACKS``'s
         # canonical id would silently break the family-prefix path:
         # ``_lookup_price`` would return ``None`` for what looks like
         # a known model and the dashboard would render ``-``.
-        from tools.system.fleet_monitoring.pricing import _FAMILY_FALLBACKS
+        from tools.system.fleet_monitoring.pricing import (
+            _LOCAL_FAMILY_FALLBACKS,
+            _LOCAL_MODEL_PRICES,
+        )
 
-        for prefix, canonical_id in _FAMILY_FALLBACKS:
-            assert canonical_id in MODEL_PRICES, (
-                f"family prefix {prefix!r} → canonical {canonical_id!r} not present in MODEL_PRICES"
+        for prefix, canonical_id in _LOCAL_FAMILY_FALLBACKS:
+            assert canonical_id in _LOCAL_MODEL_PRICES, (
+                f"family prefix {prefix!r} → canonical {canonical_id!r} not present "
+                "in _LOCAL_MODEL_PRICES"
             )
 
 
-class TestModelPricesTable:
+class TestKnownModelCoverage:
     def test_claude_code_default_models_have_prices(self) -> None:
         # Defensive regression: the most common claude-code models
         # must each return a price so the dashboard does not silently
         # degrade to ``-`` after a routine model bump.
+        # claude-3-5-sonnet-20241022 is litellm's confirmed legacy gap,
+        # covered by the local override table.
         for model in ("claude-sonnet-4-5", "claude-opus-4-1", "claude-3-5-sonnet-20241022"):
-            assert model in MODEL_PRICES or usd_per_token_blended(model) is not None
+            assert usd_per_token_blended(model) is not None
 
     def test_claude_fable_5_has_a_price(self) -> None:
         # #3621: claude-fable-5 must not render ``-`` on the dashboard.
@@ -272,4 +295,51 @@ class TestModelPricesTable:
         # Same guarantee for the codex side. ``gpt-5-codex`` is the
         # default model the Codex CLI configures for paid accounts.
         for model in ("gpt-5", "gpt-5-codex", "gpt-4o"):
-            assert model in MODEL_PRICES or usd_per_token_blended(model) is not None
+            assert usd_per_token_blended(model) is not None
+
+
+class TestConfiguredProviderCompatibility:
+    """Coverage sweep across every provider in config/llm_auth/provider_catalog.py.
+
+    Providers wired through ``core/llm/providers/openai_compat_providers.py``
+    (openrouter, deepseek, gemini, nvidia, minimax, groq, ollama) report a
+    *bare* model name — never litellm's own ``<provider>/<model>`` prefix
+    convention (see ``select_compat_model``). These tests use that real wire
+    format, not a guessed one.
+    """
+
+    def test_deepseek_bare_model_has_a_price(self) -> None:
+        assert usd_per_token_blended("deepseek-chat") is not None
+
+    def test_gemini_bare_model_has_a_price(self) -> None:
+        assert usd_per_token_blended("gemini-2.5-pro") is not None
+
+    def test_azure_deployment_named_after_its_model_has_a_price(self) -> None:
+        # Azure deployment names are arbitrary; this is the common case
+        # where the deployment happens to be named after its model.
+        assert usd_per_token_blended("gpt-4o") is not None
+
+    def test_groq_bare_model_resolves_via_compat_provider_fallback(self) -> None:
+        # litellm only keys this under "groq/llama-3.3-70b-versatile"; the
+        # bare id Groq's own API (and OpenSRE's wire format) actually uses
+        # must still resolve.
+        assert usd_per_token_blended("llama-3.3-70b-versatile") is not None
+
+    def test_minimax_bare_mixed_case_model_resolves(self) -> None:
+        # litellm keys MiniMax under "minimax/MiniMax-M2.1" (mixed case);
+        # OpenSRE's wire format sends the bare, differently-cased id.
+        assert usd_per_token_blended("MiniMax-M2.1") is not None
+
+    def test_nvidia_nim_is_unpriced_not_invented(self) -> None:
+        # litellm's snapshot has zero NVIDIA NIM coverage today. This must
+        # render "-" on the dashboard (via PriceOverride/agents.yaml), never
+        # a guessed rate. If this starts failing because litellm added NIM
+        # coverage, that's a welcome change — update this test, don't just
+        # delete it.
+        assert usd_per_token_blended("meta/llama-3.1-70b-instruct") is None
+
+    def test_ollama_self_hosted_is_unpriced(self) -> None:
+        # Self-hosted models have no per-token API price to look up; this is
+        # exactly the gap the compute-basis ($/GPU-hr) pricing_basis from
+        # the #3965 discussion is for, not something litellm can answer.
+        assert usd_per_token_blended("llama3") is None

--- a/tools/system/fleet_monitoring/pricing.py
+++ b/tools/system/fleet_monitoring/pricing.py
@@ -33,7 +33,7 @@ import re
 from dataclasses import dataclass
 from functools import lru_cache
 from importlib.resources import files
-from typing import TypeGuard
+from typing import Any, TypeGuard
 
 # litellm imports tiktoken and resolves an encoding at module load time; under
 # a frozen (PyInstaller) build that lookup fails unless this bootstrap runs
@@ -367,7 +367,7 @@ def _lookup_price(model: str) -> ModelPrice | None:
 
 
 @lru_cache(maxsize=1)
-def _litellm_local_cost_map() -> dict[str, object]:
+def _litellm_local_cost_map() -> dict[str, Any]:
     """litellm's bundled price snapshot, read directly (never the live fetch).
 
     Deliberately bypasses the shared ``litellm.model_cost`` global — see the

--- a/tools/system/fleet_monitoring/pricing.py
+++ b/tools/system/fleet_monitoring/pricing.py
@@ -7,30 +7,33 @@ right rate to each bucket instead of using the legacy 70/30 blend.
 
 Rates come from litellm's bundled community-maintained price table
 (~2.8k models) rather than a hand-vendored dict — see issue #4035. We
-read litellm's *local* snapshot directly
-(``GetModelCostMap.load_local_model_cost_map()``) instead of the
-shared ``litellm.model_cost`` global: that global is a process-wide
-singleton populated from a live network fetch on whichever import
-touches it first, so depending on it would make our pricing
-nondeterministic based on unrelated import order elsewhere in the
-process (confirmed in practice — a live fetch elsewhere had already
-picked up a same-week model release our local snapshot didn't have
-yet). This module is imported unconditionally by the always-on
+read litellm's *local* snapshot directly from its packaged JSON file
+instead of the shared ``litellm.model_cost`` global: that global is a
+process-wide singleton populated from a live network fetch on
+whichever import touches it first, so depending on it would make our
+pricing nondeterministic based on unrelated import order elsewhere in
+the process (confirmed in practice — a live fetch elsewhere had
+already picked up a same-week model release our local snapshot didn't
+have yet). This module is imported unconditionally by the always-on
 dashboard sampler, so pricing lookups must stay a pure, deterministic
-offline dict read regardless of what else the process has imported. A
-tiny local override table covers the rare model litellm's snapshot
-hasn't picked up yet (a brand-new release, or a routing alias
-OpenAI/Anthropic don't publish as their own price-table row). Unknown
-models return ``None`` so the dashboard renders ``-`` rather than
-inventing a rate.
+offline dict read regardless of what else the process has imported,
+and must degrade to "no rates" rather than crash the sampler if the
+data file is ever missing. A tiny local override table covers the
+rare model litellm's snapshot hasn't picked up yet (a brand-new
+release, or a routing alias OpenAI/Anthropic don't publish as their
+own price-table row). Unknown models return ``None`` so the dashboard
+renders ``-`` rather than inventing a rate.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from dataclasses import dataclass
 from functools import lru_cache
+from importlib.resources import files
+from typing import TypeGuard
 
 # litellm imports tiktoken and resolves an encoding at module load time; under
 # a frozen (PyInstaller) build that lookup fails unless this bootstrap runs
@@ -42,9 +45,16 @@ from core.llm.transports.litellm.frozen_tiktoken_bootstrap import (
 
 ensure_tiktoken_encodings_discoverable()
 
-from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap  # noqa: E402
-
 from tools.system.fleet_monitoring.meters import TokenUsage  # noqa: E402
+
+#: litellm's bundled price/context-window snapshot. Read directly (see
+#: _litellm_local_cost_map) rather than via litellm.litellm_core_utils's
+#: GetModelCostMap — that class is a private internal, not covered by
+#: litellm's semver, and a rename there must not crash this always-on
+#: sampler. The filename itself is already a load-bearing contract
+#: elsewhere (tests/packaging/test_litellm_bundle_contract.py asserts it
+#: ships in frozen release builds).
+_LITELLM_LOCAL_PRICE_SNAPSHOT_FILENAME = "model_prices_and_context_window_backup.json"
 
 #: Kept for callers that logged/displayed the vendored-table refresh date.
 #: Rates are now sourced live (per-process) from litellm's own bundled table.
@@ -258,6 +268,7 @@ _ROUTING_SUFFIX_RE = re.compile(r"-v\d+:\d+$")
 def _is_canonical_candidate(candidate: str) -> bool:
     return (
         "/" not in candidate
+        and "@" not in candidate
         and "anthropic." not in candidate
         and not _ROUTING_SUFFIX_RE.search(candidate)
     )
@@ -360,14 +371,32 @@ def _litellm_local_cost_map() -> dict[str, object]:
     """litellm's bundled price snapshot, read directly (never the live fetch).
 
     Deliberately bypasses the shared ``litellm.model_cost`` global — see the
-    module docstring for why that global isn't safe to depend on here.
+    module docstring for why that global isn't safe to depend on here. Reads
+    the packaged JSON file directly rather than through litellm's internal
+    ``GetModelCostMap`` class, and degrades to an empty table (every model
+    reports unpriced) instead of raising if the file is ever missing or
+    unreadable — this module is imported unconditionally by the always-on
+    dashboard sampler, so a data-loading hiccup must never crash it.
 
     Keyed lowercase: our candidates are always lowercased (see
     ``_model_candidates``), but litellm's own keys aren't uniformly
     lowercase — e.g. MiniMax entries are ``minimax/MiniMax-M2.1``. A
     case-sensitive ``dict.get`` would silently miss those.
     """
-    raw = GetModelCostMap.load_local_model_cost_map()
+    try:
+        raw = json.loads(
+            files("litellm")
+            .joinpath(_LITELLM_LOCAL_PRICE_SNAPSHOT_FILENAME)
+            .read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError):
+        logger.warning(
+            "litellm local price snapshot unavailable; pricing lookups will report unpriced",
+            exc_info=True,
+        )
+        return {}
+    if not isinstance(raw, dict):
+        return {}
     return {key.lower(): value for key, value in raw.items()}
 
 
@@ -383,7 +412,7 @@ def _litellm_price(candidate: str) -> ModelPrice | None:
         return None
     input_rate = entry.get("input_cost_per_token")
     output_rate = entry.get("output_cost_per_token")
-    if not isinstance(input_rate, (int, float)) or not isinstance(output_rate, (int, float)):
+    if not _is_rate(input_rate) or not _is_rate(output_rate):
         return None
     return ModelPrice(
         usd_per_input_token=float(input_rate),
@@ -395,8 +424,15 @@ def _litellm_price(candidate: str) -> ModelPrice | None:
     )
 
 
+def _is_rate(value: object) -> TypeGuard[int | float]:
+    # bool is rejected explicitly because isinstance(True, int) is True —
+    # same guard as meters/__init__.py's safe_int, applied here so a stray
+    # boolean in litellm's JSON can't be silently read as a 1 USD/token rate.
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
 def _optional_rate(value: object) -> float | None:
-    return float(value) if isinstance(value, (int, float)) else None
+    return float(value) if _is_rate(value) else None
 
 
 @lru_cache(maxsize=512)

--- a/tools/system/fleet_monitoring/pricing.py
+++ b/tools/system/fleet_monitoring/pricing.py
@@ -5,10 +5,24 @@
 sampler now keeps input/output/cache buckets, so pricing applies the
 right rate to each bucket instead of using the legacy 70/30 blend.
 
-The local price table is a vendored snapshot of the ``models.dev``
-catalog for the Claude Code / Codex models this dashboard supports,
-following CodexBar's offline-first approach. Unknown models return
-``None`` so the dashboard renders ``-`` rather than inventing a rate.
+Rates come from litellm's bundled community-maintained price table
+(~2.8k models) rather than a hand-vendored dict — see issue #4035. We
+read litellm's *local* snapshot directly
+(``GetModelCostMap.load_local_model_cost_map()``) instead of the
+shared ``litellm.model_cost`` global: that global is a process-wide
+singleton populated from a live network fetch on whichever import
+touches it first, so depending on it would make our pricing
+nondeterministic based on unrelated import order elsewhere in the
+process (confirmed in practice — a live fetch elsewhere had already
+picked up a same-week model release our local snapshot didn't have
+yet). This module is imported unconditionally by the always-on
+dashboard sampler, so pricing lookups must stay a pure, deterministic
+offline dict read regardless of what else the process has imported. A
+tiny local override table covers the rare model litellm's snapshot
+hasn't picked up yet (a brand-new release, or a routing alias
+OpenAI/Anthropic don't publish as their own price-table row). Unknown
+models return ``None`` so the dashboard renders ``-`` rather than
+inventing a rate.
 """
 
 from __future__ import annotations
@@ -18,10 +32,23 @@ import re
 from dataclasses import dataclass
 from functools import lru_cache
 
-from tools.system.fleet_monitoring.meters import TokenUsage
+# litellm imports tiktoken and resolves an encoding at module load time; under
+# a frozen (PyInstaller) build that lookup fails unless this bootstrap runs
+# first. See core/llm/transports/litellm/frozen_tiktoken_bootstrap.py and
+# issue #3631 — this module now hits the same import path unconditionally.
+from core.llm.transports.litellm.frozen_tiktoken_bootstrap import (
+    ensure_tiktoken_encodings_discoverable,
+)
 
-#: ``models.dev`` pricing snapshot last refreshed for this vendored table.
-RATES_VERIFIED_AT = "2026-05-17"
+ensure_tiktoken_encodings_discoverable()
+
+from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap  # noqa: E402
+
+from tools.system.fleet_monitoring.meters import TokenUsage  # noqa: E402
+
+#: Kept for callers that logged/displayed the vendored-table refresh date.
+#: Rates are now sourced live (per-process) from litellm's own bundled table.
+RATES_VERIFIED_AT = "litellm model_cost (local snapshot)"
 
 _USD_PER_M = 1_000_000
 
@@ -98,167 +125,55 @@ def _price(
     )
 
 
-MODEL_PRICES: dict[str, ModelPrice] = {
-    # Anthropic / Claude Code. Values are USD per 1M tokens in
-    # models.dev; _price converts them to USD per token.
-    "claude-3-5-sonnet-20240620": _price(
-        3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
-    ),
+# Models confirmed absent from litellm's bundled price table (checked at
+# migration time — see issue #4035). This is an escape hatch for the rare
+# model litellm's table hasn't (yet, or ever again) picked up, not a general
+# config surface: entries here are only consulted after a direct litellm
+# lookup misses.
+_LOCAL_MODEL_PRICES: dict[str, ModelPrice] = {
+    # GPT-5.6 (GA 2026-07-09, #3931) — too new for litellm's bundled
+    # snapshot. Per 1M tokens, from
+    # https://developers.openai.com/api/docs/pricing: sol 5/30, terra
+    # 2.50/15, luna 1/6. Cached input is 90% off.
+    "gpt-5.6-sol": _price(5.00, 30.00, cache_read_usd_per_million=0.50),
+    "gpt-5.6-terra": _price(2.50, 15.00, cache_read_usd_per_million=0.25),
+    "gpt-5.6-luna": _price(1.00, 6.00, cache_read_usd_per_million=0.10),
+    # claude-3-5-sonnet-20241022 — retired, frozen historical rate. litellm's
+    # current table only keeps this generation under Bedrock-routed keys
+    # (e.g. anthropic.claude-3-5-sonnet-20241022-v2:0), not the bare
+    # direct-API id Claude Code CLI logs report.
     "claude-3-5-sonnet-20241022": _price(
         3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
     ),
-    "claude-3-5-haiku-20241022": _price(
-        0.80, 4.00, cache_read_usd_per_million=0.08, cache_write_usd_per_million=1.00
-    ),
-    "claude-3-5-haiku-latest": _price(
-        0.80, 4.00, cache_read_usd_per_million=0.08, cache_write_usd_per_million=1.00
-    ),
-    "claude-haiku-4-5": _price(
-        1.00, 5.00, cache_read_usd_per_million=0.10, cache_write_usd_per_million=1.25
-    ),
-    "claude-haiku-4-5-20251001": _price(
-        1.00, 5.00, cache_read_usd_per_million=0.10, cache_write_usd_per_million=1.25
-    ),
-    "claude-sonnet-4": _price(
-        3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
-    ),
-    "claude-sonnet-4-0": _price(
-        3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
-    ),
-    "claude-sonnet-4-20250514": _price(
-        3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
-    ),
-    "claude-sonnet-4-5": _price(
-        3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
-    ),
-    "claude-sonnet-4-5-20250929": _price(
-        3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
-    ),
-    "claude-sonnet-4-6": _price(
-        3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
-    ),
-    "claude-opus-4": _price(
-        15.00, 75.00, cache_read_usd_per_million=1.50, cache_write_usd_per_million=18.75
-    ),
-    "claude-opus-4-0": _price(
-        15.00, 75.00, cache_read_usd_per_million=1.50, cache_write_usd_per_million=18.75
-    ),
-    "claude-opus-4-20250514": _price(
-        15.00, 75.00, cache_read_usd_per_million=1.50, cache_write_usd_per_million=18.75
-    ),
-    "claude-opus-4-1": _price(
-        15.00, 75.00, cache_read_usd_per_million=1.50, cache_write_usd_per_million=18.75
-    ),
-    "claude-opus-4-1-20250805": _price(
-        15.00, 75.00, cache_read_usd_per_million=1.50, cache_write_usd_per_million=18.75
-    ),
-    "claude-opus-4-5": _price(
-        5.00, 25.00, cache_read_usd_per_million=0.50, cache_write_usd_per_million=6.25
-    ),
-    "claude-opus-4-5-20251101": _price(
-        5.00, 25.00, cache_read_usd_per_million=0.50, cache_write_usd_per_million=6.25
-    ),
-    "claude-opus-4-6": _price(
-        5.00, 25.00, cache_read_usd_per_million=0.50, cache_write_usd_per_million=6.25
-    ),
-    "claude-opus-4-7": _price(
-        5.00, 25.00, cache_read_usd_per_million=0.50, cache_write_usd_per_million=6.25
-    ),
-    "claude-fable-5": _price(
-        10.00, 50.00, cache_read_usd_per_million=1.00, cache_write_usd_per_million=12.50
-    ),
-    # OpenAI / Codex.
-    "gpt-4o": _price(2.50, 10.00, cache_read_usd_per_million=1.25),
-    "gpt-4o-2024-05-13": _price(5.00, 15.00),
-    "gpt-4o-2024-08-06": _price(2.50, 10.00, cache_read_usd_per_million=1.25),
-    "gpt-4o-2024-11-20": _price(2.50, 10.00, cache_read_usd_per_million=1.25),
-    "gpt-4o-mini": _price(0.15, 0.60, cache_read_usd_per_million=0.08),
-    "gpt-5": _price(1.25, 10.00, cache_read_usd_per_million=0.125),
-    "gpt-5-chat-latest": _price(1.25, 10.00),
-    "gpt-5-codex": _price(1.25, 10.00, cache_read_usd_per_million=0.125),
-    "gpt-5-mini": _price(0.25, 2.00, cache_read_usd_per_million=0.025),
-    "gpt-5-nano": _price(0.05, 0.40, cache_read_usd_per_million=0.005),
-    "gpt-5-pro": _price(15.00, 120.00),
-    "gpt-5.1": _price(1.25, 10.00, cache_read_usd_per_million=0.13),
-    "gpt-5.1-chat-latest": _price(1.25, 10.00, cache_read_usd_per_million=0.125),
-    "gpt-5.1-codex": _price(1.25, 10.00, cache_read_usd_per_million=0.125),
-    "gpt-5.1-codex-max": _price(1.25, 10.00, cache_read_usd_per_million=0.125),
-    "gpt-5.1-codex-mini": _price(0.25, 2.00, cache_read_usd_per_million=0.025),
-    "gpt-5.2": _price(1.75, 14.00, cache_read_usd_per_million=0.175),
-    "gpt-5.2-chat-latest": _price(1.75, 14.00, cache_read_usd_per_million=0.175),
-    "gpt-5.2-codex": _price(1.75, 14.00, cache_read_usd_per_million=0.175),
-    "gpt-5.2-pro": _price(21.00, 168.00),
-    "gpt-5.3-chat-latest": _price(1.75, 14.00, cache_read_usd_per_million=0.175),
-    "gpt-5.3-codex": _price(1.75, 14.00, cache_read_usd_per_million=0.175),
-    "gpt-5.3-codex-spark": _price(1.75, 14.00, cache_read_usd_per_million=0.175),
-    "gpt-5.4": _price(2.50, 15.00, cache_read_usd_per_million=0.25),
-    "gpt-5.4-mini": _price(0.75, 4.50, cache_read_usd_per_million=0.075),
-    "gpt-5.4-nano": _price(0.20, 1.25, cache_read_usd_per_million=0.02),
-    "gpt-5.4-pro": _price(30.00, 180.00),
-    "gpt-5.5": _price(5.00, 30.00, cache_read_usd_per_million=0.50),
-    "gpt-5.5-pro": _price(30.00, 180.00),
-    "gpt-5.6-luna": _price(1.00, 6.00, cache_read_usd_per_million=0.10),
-    "gpt-5.6-sol": _price(5.00, 30.00, cache_read_usd_per_million=0.50),
-    "gpt-5.6-terra": _price(2.50, 15.00, cache_read_usd_per_million=0.25),
-    "o3": _price(2.00, 8.00, cache_read_usd_per_million=0.50),
-    "o3-deep-research": _price(10.00, 40.00, cache_read_usd_per_million=2.50),
-    "o3-mini": _price(1.10, 4.40, cache_read_usd_per_million=0.55),
-    "o3-pro": _price(20.00, 80.00),
 }
 
-_UNSORTED_FAMILY_FALLBACKS: tuple[tuple[str, str], ...] = (
-    ("claude-3-5-sonnet", "claude-3-5-sonnet-20241022"),
-    ("claude-3-5-haiku", "claude-3-5-haiku-20241022"),
-    ("claude-haiku-4-5", "claude-haiku-4-5"),
-    ("claude-fable-5", "claude-fable-5"),
-    ("claude-sonnet-4-6", "claude-sonnet-4-6"),
-    ("claude-sonnet-4-5", "claude-sonnet-4-5"),
-    ("claude-sonnet-4", "claude-sonnet-4"),
-    ("claude-opus-4-7", "claude-opus-4-7"),
-    ("claude-opus-4-6", "claude-opus-4-6"),
-    ("claude-opus-4-5", "claude-opus-4-5"),
-    ("claude-opus-4-1", "claude-opus-4-1"),
-    ("claude-opus-4", "claude-opus-4"),
-    ("gpt-5.3-codex-spark", "gpt-5.3-codex-spark"),
-    ("gpt-5.3-codex", "gpt-5.3-codex"),
-    ("gpt-5.2-codex", "gpt-5.2-codex"),
-    ("gpt-5.1-codex-mini", "gpt-5.1-codex-mini"),
-    ("gpt-5.1-codex-max", "gpt-5.1-codex-max"),
-    ("gpt-5.1-codex", "gpt-5.1-codex"),
-    ("gpt-5-codex", "gpt-5-codex"),
-    ("gpt-5.6-terra", "gpt-5.6-terra"),
-    ("gpt-5.6-luna", "gpt-5.6-luna"),
-    ("gpt-5.6-sol", "gpt-5.6-sol"),
-    # OpenAI routes the bare `gpt-5.6` alias to Sol server-side. The three
-    # rows above are longer prefixes, so they still win for terra/luna.
-    ("gpt-5.6", "gpt-5.6-sol"),
-    ("gpt-5.5-pro", "gpt-5.5-pro"),
-    ("gpt-5.5", "gpt-5.5"),
-    ("gpt-5.4-mini", "gpt-5.4-mini"),
-    ("gpt-5.4-nano", "gpt-5.4-nano"),
-    ("gpt-5.4-pro", "gpt-5.4-pro"),
-    ("gpt-5.4", "gpt-5.4"),
-    ("gpt-5.2-pro", "gpt-5.2-pro"),
-    ("gpt-5.2", "gpt-5.2"),
-    ("gpt-5.1", "gpt-5.1"),
-    ("gpt-5-mini", "gpt-5-mini"),
-    ("gpt-5-nano", "gpt-5-nano"),
-    ("gpt-5-pro", "gpt-5-pro"),
-    ("gpt-5", "gpt-5"),
-    ("gpt-4o-mini", "gpt-4o-mini"),
-    ("gpt-4o", "gpt-4o"),
-    ("o3-deep-research", "o3-deep-research"),
-    ("o3-mini", "o3-mini"),
-    ("o3-pro", "o3-pro"),
-    ("o3", "o3"),
+# Longest-prefix-first so more specific tiers (e.g. ``gpt-5.6-terra``) win
+# over the bare ``gpt-5.6`` alias. Built programmatically so a future edit
+# cannot silently shadow a longer prefix with a shorter one.
+_LOCAL_FAMILY_FALLBACKS: tuple[tuple[str, str], ...] = tuple(
+    sorted(
+        (
+            ("gpt-5.6-sol", "gpt-5.6-sol"),
+            ("gpt-5.6-terra", "gpt-5.6-terra"),
+            ("gpt-5.6-luna", "gpt-5.6-luna"),
+            # OpenAI routes the bare ``gpt-5.6`` alias to Sol server-side.
+            ("gpt-5.6", "gpt-5.6-sol"),
+        ),
+        key=lambda item: len(item[0]),
+        reverse=True,
+    )
 )
 
-# Longest-prefix-first so more specific families win. Build it
-# programmatically so a future edit cannot silently shadow a longer
-# family with its shorter prefix.
-_FAMILY_FALLBACKS: tuple[tuple[str, str], ...] = tuple(
-    sorted(_UNSORTED_FAMILY_FALLBACKS, key=lambda item: len(item[0]), reverse=True)
-)
+# OpenSRE routes these providers through a generic OpenAI-compatible HTTP
+# client (core/llm/providers/openai_compat_providers.py) using the bare
+# configured model name — never litellm's own "<provider>/<model>" prefix
+# convention. litellm keys these two providers *under* that prefix
+# regardless (e.g. "groq/llama-3.3-70b-versatile"), so a bare candidate
+# would otherwise never match even though the model is genuinely priced.
+# Tried only as a last resort (see _lookup_price), and scoped to providers
+# OpenSRE actually configures — guessing a provider prefix for an arbitrary
+# open-weight model would risk silently picking a different host's price.
+_COMPAT_PROVIDER_PREFIXES: tuple[str, ...] = ("groq/", "minimax/")
 
 
 def usd_for_usage(
@@ -330,15 +245,41 @@ def usd_per_hour(
     return tokens_per_min * 60.0 * rate
 
 
+#: A candidate that still carries a hosting-surface routing artifact —
+#: a provider path segment (``bedrock/...``), an Anthropic vendor-prefixed
+#: Bedrock id (``us.anthropic....``), or a trailing Bedrock version suffix
+#: (``-v1:0``). litellm indexes these as their own keys (same rate as the
+#: bare id), so a raw candidate can resolve *before* the canonical
+#: direct-API form is tried — this predicate lets ``normalize_model_name``
+#: prefer the canonical form when both resolve.
+_ROUTING_SUFFIX_RE = re.compile(r"-v\d+:\d+$")
+
+
+def _is_canonical_candidate(candidate: str) -> bool:
+    return (
+        "/" not in candidate
+        and "anthropic." not in candidate
+        and not _ROUTING_SUFFIX_RE.search(candidate)
+    )
+
+
 def normalize_model_name(model: str | None) -> str | None:
     if model is None:
         return None
     candidates = _model_candidates(model)
+    resolving = [
+        candidate
+        for candidate in candidates
+        if _litellm_price(candidate) is not None or candidate in _LOCAL_MODEL_PRICES
+    ]
+    if resolving:
+        canonical = [candidate for candidate in resolving if _is_canonical_candidate(candidate)]
+        # Prefer the most specific canonical match (keeps a date suffix over
+        # the bare family alias); fall back to any resolving candidate if
+        # every match still carries a routing artifact.
+        return max(canonical or resolving, key=len)
     for candidate in candidates:
-        if candidate in MODEL_PRICES:
-            return candidate
-    for candidate in candidates:
-        for prefix, canonical_id in _FAMILY_FALLBACKS:
+        for prefix, canonical_id in _LOCAL_FAMILY_FALLBACKS:
             if candidate.startswith(prefix):
                 return canonical_id
     return candidates[0] if candidates else None
@@ -396,16 +337,66 @@ def _override_related_rate(
 def _lookup_price(model: str) -> ModelPrice | None:
     candidates = _model_candidates(model)
     for candidate in candidates:
-        direct = MODEL_PRICES.get(candidate)
-        if direct is not None:
-            return direct
+        price = _litellm_price(candidate)
+        if price is not None:
+            return price
+        local = _LOCAL_MODEL_PRICES.get(candidate)
+        if local is not None:
+            return local
     for candidate in candidates:
-        for prefix, canonical_id in _FAMILY_FALLBACKS:
+        for prefix, canonical_id in _LOCAL_FAMILY_FALLBACKS:
             if candidate.startswith(prefix):
-                resolved = MODEL_PRICES.get(canonical_id)
-                if resolved is not None:
-                    return resolved
+                return _LOCAL_MODEL_PRICES.get(canonical_id)
+    for candidate in candidates:
+        for provider_prefix in _COMPAT_PROVIDER_PREFIXES:
+            price = _litellm_price(f"{provider_prefix}{candidate}")
+            if price is not None:
+                return price
     return None
+
+
+@lru_cache(maxsize=1)
+def _litellm_local_cost_map() -> dict[str, object]:
+    """litellm's bundled price snapshot, read directly (never the live fetch).
+
+    Deliberately bypasses the shared ``litellm.model_cost`` global — see the
+    module docstring for why that global isn't safe to depend on here.
+
+    Keyed lowercase: our candidates are always lowercased (see
+    ``_model_candidates``), but litellm's own keys aren't uniformly
+    lowercase — e.g. MiniMax entries are ``minimax/MiniMax-M2.1``. A
+    case-sensitive ``dict.get`` would silently miss those.
+    """
+    raw = GetModelCostMap.load_local_model_cost_map()
+    return {key.lower(): value for key, value in raw.items()}
+
+
+def _litellm_price(candidate: str) -> ModelPrice | None:
+    """Look up a rate directly in litellm's local price snapshot.
+
+    Reads rate fields rather than calling ``litellm.cost_per_token()`` so we
+    keep per-bucket rates (not a computed amount) for the bucket math in
+    :func:`usd_for_usage`. A miss returns ``None`` — never invents a rate.
+    """
+    entry = _litellm_local_cost_map().get(candidate)
+    if not isinstance(entry, dict):
+        return None
+    input_rate = entry.get("input_cost_per_token")
+    output_rate = entry.get("output_cost_per_token")
+    if not isinstance(input_rate, (int, float)) or not isinstance(output_rate, (int, float)):
+        return None
+    return ModelPrice(
+        usd_per_input_token=float(input_rate),
+        usd_per_output_token=float(output_rate),
+        usd_per_cache_read_input_token=_optional_rate(entry.get("cache_read_input_token_cost")),
+        usd_per_cache_creation_input_token=_optional_rate(
+            entry.get("cache_creation_input_token_cost")
+        ),
+    )
+
+
+def _optional_rate(value: object) -> float | None:
+    return float(value) if isinstance(value, (int, float)) else None
 
 
 @lru_cache(maxsize=512)
@@ -420,7 +411,13 @@ def _model_candidates(raw: str) -> tuple[str, ...]:
     trimmed = raw.strip()
     append(trimmed)
     lower = trimmed.lower()
-    for prefix in ("openai/", "anthropic/", "anthropic."):
+    # ``azure/`` (unlike gemini/deepseek/groq) is worth stripping explicitly:
+    # Azure deployment names are arbitrary per customer, so falling back to
+    # the bare model name is the only way a deployment literally named after
+    # its underlying model (the common case) still resolves. The other
+    # providers' litellm entries already carry both the prefixed and bare
+    # form as distinct keys, so no stripping is needed for those.
+    for prefix in ("openai/", "anthropic/", "anthropic.", "azure/"):
         if lower.startswith(prefix):
             append(trimmed[len(prefix) :])
 
@@ -450,7 +447,6 @@ def _model_candidates(raw: str) -> tuple[str, ...]:
 
 
 __all__ = [
-    "MODEL_PRICES",
     "ModelPrice",
     "PriceOverride",
     "RATES_VERIFIED_AT",


### PR DESCRIPTION
Fixes #4035

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Migrates `tools/system/fleet_monitoring/pricing.py` off the hand-vendored `MODEL_PRICES` dict (~80 entries, one per model — the thing that got #3965 blocked in review) onto litellm's bundled community-maintained price table. `litellm>=1.90.0` is already a project dependency; no new dependency added.

- Reads litellm's *local* price snapshot directly (`GetModelCostMap.load_local_model_cost_map()`) instead of the shared `litellm.model_cost` global. That global is populated from a **live network fetch** on whichever import touches it first in the process — confirmed in practice during this change that a live fetch elsewhere had already picked up a same-week model release our local snapshot didn't have yet, which made pricing nondeterministic based on unrelated import order. This module is imported unconditionally by the always-on dashboard sampler, so pricing lookups need to stay a pure, deterministic offline dict read.
- A small local override table (`_LOCAL_MODEL_PRICES`) covers the two confirmed gaps in litellm's snapshot: the GPT-5.6 family (GA'd 2026-07-09, too new for the bundled snapshot) and the retired `claude-3-5-sonnet-20241022` direct-API id (litellm only keeps that generation under Bedrock-routed keys now).
- A narrow, last-resort fallback (`_COMPAT_PROVIDER_PREFIXES`) handles Groq and MiniMax specifically: `core/llm/providers/openai_compat_providers.py` reports these providers' models as **bare** names (no litellm-style `<provider>/` prefix — that's a litellm-only convention), but litellm keys them under that prefix regardless. Scoped to just these two providers deliberately — guessing a provider prefix for an arbitrary open-weight model would risk silently applying a different host's price for the same model.
- Case-insensitive lookup index, since litellm's own keys aren't uniformly lowercase (MiniMax entries are `minimax/MiniMax-M2.1`).

Public API of `pricing.py` (`usd_for_usage`, `usd_per_hour_for_usage`, `usd_per_token_blended`, `usd_per_hour`, `normalize_model_name`, `PriceOverride`, `RATES_VERIFIED_AT`) is unchanged, so `sampler.py` (the one production caller) needed zero changes.

**Compatibility verified against every provider in `config/llm_auth/provider_catalog.py`**, using each provider's actual wire-format model string (not a guessed one):

| Provider | Result |
|---|---|
| Anthropic, OpenAI, Azure OpenAI (deployment named after its model), Bedrock (cross-region Claude), DeepSeek, Gemini, OpenRouter, Groq, MiniMax | ✅ priced |
| Claude Code / Codex / Gemini / Copilot CLIs | ✅ priced (they report the underlying model directly) |
| NVIDIA NIM | ❌ unpriced — litellm has zero NIM coverage today; needs a `PriceOverride`/`agents.yaml` entry |
| Ollama (self-hosted) | ❌ unpriced — expected: no per-token API price exists to look up; this is the compute-basis ($/GPU-hr) case from the #3965 review discussion, not something a price table can answer |

Both unpriced cases correctly resolve to `None` (dashboard renders `-`), never a guessed rate.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run python -m pytest tests/fleet_monitoring/test_pricing.py -q
======================= 58 passed in 4.55s =======================

$ uv run python3 -c "
from tools.system.fleet_monitoring.pricing import usd_per_token_blended
for m in ('claude-sonnet-4-5', 'gpt-5-codex', 'gemini-2.5-pro', 'deepseek-chat',
          'llama-3.3-70b-versatile', 'MiniMax-M2.1', 'meta/llama-3.1-70b-instruct'):
    print(m, '->', usd_per_token_blended(m))
"
claude-sonnet-4-5 -> 6.6e-06
gpt-5-codex -> 3.775e-06
gemini-2.5-pro -> 3.5e-06
deepseek-chat -> 3.78e-07
llama-3.3-70b-versatile -> 3.99e-07
MiniMax-M2.1 -> 5.6e-07
meta/llama-3.1-70b-instruct -> None   # NVIDIA NIM: unpriced, not guessed
```

`make lint` · `make format-check` · `make typecheck` (1220 files) · `make test-scope` (755 passed, 3 skipped) all green locally.

`model_spend_tool` (the tool from #3965 that sits on top of this) is a deliberate follow-up PR once this lands, to keep this diff reviewable on its own.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: `MODEL_PRICES` required a manual code change for every model, across every provider, forever — the exact thing #3965's review blocked on ("how are you ensuring the LLM cost and $$ is consistent and work across all models? this is a difficult task"). litellm already ships and maintains a ~2.8k-model price table as a project dependency, so the fix is to read from it instead of hand-duplicating it.

The one non-obvious design decision is bypassing `litellm.model_cost` (the module-level global litellm itself populates) in favor of reading `GetModelCostMap.load_local_model_cost_map()` directly. I initially wired to the global and two tests failed under pytest but passed in isolation — traced it to litellm doing a live network fetch on whichever import touches it first in the process (not necessarily this module), which had already picked up a newer upstream table than our local snapshot. Since the dashboard sampler imports this module unconditionally and needs deterministic offline behavior, reading the local snapshot directly (independent of what else in the process has imported litellm) was the correct fix, not a workaround.

The other non-obvious piece is the provider compatibility sweep: I didn't assume litellm's coverage was uniform — I checked `core/llm/providers/openai_compat_providers.py` to find the *actual* wire-format model string per provider (several route through a generic OpenAI-compatible client using bare model names, not litellm's `provider/model` convention) and tested each one for real. That's what caught the MiniMax case-sensitivity bug and the Groq/MiniMax bare-name mismatch, both now covered by regression tests, plus honestly documented the NVIDIA NIM gap rather than silently leaving it broken.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
