### PR TITLE
Feat/4035 pricing litellm and spend tool

### DIFF
--- a/core/llm/transports/litellm/clients.py
+++ b/core/llm/transports/litellm/clients.py
@@ -9,8 +9,12 @@ from typing import Any
 from core.llm.transports.litellm.frozen_tiktoken_bootstrap import (
     ensure_tiktoken_encodings_discoverable,
 )
+from core.llm.transports.litellm.local_cost_map_bootstrap import (
+    ensure_local_model_cost_map,
+)
 
 ensure_tiktoken_encodings_discoverable()
+ensure_local_model_cost_map()
 
 from litellm import completion  # noqa: E402
 from pydantic import BaseModel  # noqa: E402

--- a/core/llm/transports/litellm/local_cost_map_bootstrap.py
+++ b/core/llm/transports/litellm/local_cost_map_bootstrap.py
@@ -1,0 +1,29 @@
+"""Keep LiteLLM's import-time price-map load offline (no network fetch).
+
+On import, ``litellm`` populates its ``litellm.model_cost`` global via
+``get_model_cost_map(url=...)`` — a live ``httpx.get`` against a GitHub-hosted
+price map unless ``LITELLM_LOCAL_MODEL_COST_MAP`` is ``"true"``. ``litellm`` is
+now imported unconditionally (the always-on dashboard sampler reaches it through
+``tools/system/fleet_monitoring/pricing.py``), so an un-pinned import would do a
+network round-trip at startup.
+
+``pricing.py`` reads LiteLLM's bundled JSON snapshot *directly* for its rates and
+does not depend on that global, so this is purely an optimization: calling
+:func:`ensure_local_model_cost_map` before the first ``import litellm`` avoids
+the wasted fetch. ``setdefault`` lets an operator opt back into the remote map
+with ``LITELLM_LOCAL_MODEL_COST_MAP=false``.
+"""
+
+from __future__ import annotations
+
+import os
+
+_ENV_VAR = "LITELLM_LOCAL_MODEL_COST_MAP"
+
+
+def ensure_local_model_cost_map() -> None:
+    """Pin LiteLLM's import-time cost-map load to offline (idempotent).
+
+    Must run before the first ``import litellm`` in the process to take effect.
+    """
+    os.environ.setdefault(_ENV_VAR, "True")

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -106,6 +106,7 @@
               "interactive-shell-privacy",
               "sessions",
               "fleet",
+              "model_spend_tool",
               "cron",
               "closed-loop-learning",
               "multi-instance-integrations"

--- a/docs/model_spend_tool.mdx
+++ b/docs/model_spend_tool.mdx
@@ -76,3 +76,7 @@ Returns `total_usd_per_hour` and a per-model breakdown.
   date, which reflects that local fallback table.
 - Cache-bucket rates are cheaper than fresh input. If your token source only reports input/output,
   estimates that omit cache buckets will run slightly high.
+- `price_overrides` for a model **not** in the price table must include **both** `input_usd_per_million`
+  and `output_usd_per_million`. A single rate cannot price an otherwise-unknown model, so it stays
+  unpriced (surfaced in `unpriced_models`) rather than guessed. A known model can be overridden on
+  one side only.

--- a/docs/model_spend_tool.mdx
+++ b/docs/model_spend_tool.mdx
@@ -1,0 +1,78 @@
+---
+title: Model Spend Tool
+description: Estimate AI spend and projected burn rate from token usage.
+---
+
+The model spend tool turns per-model token usage into a USD cost estimate and a projected
+hourly burn rate. It is a pure calculator: estimates come only from token counts and LiteLLM's
+community-maintained cost table (with a small local fallback) — it never calls a provider billing
+API and never claims your live credit balance.
+
+Unknown models are reported as **unpriced** (never silently costed at `$0`), so a missing rate is
+obvious rather than hidden.
+
+## Tools
+
+| Tool | What it does |
+|------|--------------|
+| `estimate_model_spend` | Estimate total USD from per-model token usage, broken down by model, token bucket, and cost per investigation lap. |
+| `summarize_model_burn_rate` | Project hourly burn (`$/hr`) from a per-minute token sample, or from run totals plus elapsed seconds. |
+
+Both are available in investigation and chat surfaces.
+
+## `estimate_model_spend`
+
+Inputs:
+
+- `token_usage_by_model` (required) — map of model name → token buckets (`input_tokens`,
+  `output_tokens`, and optional `cached_input_tokens`, `cache_read_input_tokens`,
+  `cache_creation_input_tokens`).
+- `laps` (optional) — investigation loop iterations, used to derive cost per lap.
+- `run_label` (optional) — a label echoed back in the result.
+- `price_overrides` (optional) — per-model `input_usd_per_million` / `output_usd_per_million`
+  overrides for custom or unlisted models.
+
+Example:
+
+```json
+{
+  "token_usage_by_model": {
+    "claude-sonnet-4-6": { "input_tokens": 120000, "output_tokens": 18000 }
+  },
+  "laps": 12
+}
+```
+
+Returns the total USD, a `by_model` breakdown (with `cost_by_bucket`), aggregate `cost_by_bucket`,
+`usd_per_lap`, and any `unpriced_models`.
+
+## `summarize_model_burn_rate`
+
+Inputs:
+
+- `token_usage_by_model` (required) — same shape as above.
+- `elapsed_seconds` (optional) — when set, the usage is treated as **totals** observed over that
+  window and normalized to per-minute before projecting to an hour. When omitted, the usage is
+  treated as a **per-minute** sample.
+- `run_label`, `price_overrides` — as above.
+
+Example (project burn from a 2-minute run's totals):
+
+```json
+{
+  "token_usage_by_model": {
+    "claude-sonnet-4-6": { "input_tokens": 40000, "output_tokens": 6000 }
+  },
+  "elapsed_seconds": 120
+}
+```
+
+Returns `total_usd_per_hour` and a per-model breakdown.
+
+## Notes
+
+- Estimates use LiteLLM's cost table (refreshed with each pinned `litellm` release), falling back to
+  a small local table for ids LiteLLM does not yet carry. The result includes a `rates_verified_at`
+  date, which reflects that local fallback table.
+- Cache-bucket rates are cheaper than fresh input. If your token source only reports input/output,
+  estimates that omit cache buckets will run slightly high.

--- a/tests/fleet_monitoring/test_pricing.py
+++ b/tests/fleet_monitoring/test_pricing.py
@@ -273,3 +273,134 @@ class TestModelPricesTable:
         # default model the Codex CLI configures for paid accounts.
         for model in ("gpt-5", "gpt-5-codex", "gpt-4o"):
             assert model in MODEL_PRICES or usd_per_token_blended(model) is not None
+
+
+class TestLiteLLMPricingSource:
+    """Migration to LiteLLM's cost table (#4035)."""
+
+    def test_cost_map_is_pinned_offline(self) -> None:
+        # The always-on sampler imports this module, so LiteLLM's map must be
+        # pinned to its bundled snapshot — no HTTP fetch at import.
+        import os
+
+        assert os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP") == "True"
+
+    def test_local_table_holds_only_ids_litellm_lacks(self) -> None:
+        # Reconciliation guard: nothing in the local fallback may also be
+        # priced by LiteLLM, or we'd be hand-maintaining a duplicate. If this
+        # fails after a ``litellm`` bump, delete the now-covered id(s).
+        from tools.system.fleet_monitoring.pricing import _litellm_price
+
+        dupes = [model for model in MODEL_PRICES if _litellm_price(model) is not None]
+        assert dupes == [], f"remove ids now covered by LiteLLM: {dupes}"
+
+    @pytest.mark.parametrize(
+        ("model", "input_per_m", "output_per_m"),
+        [
+            ("claude-sonnet-4-5", 3.0, 15.0),
+            ("claude-haiku-4-5", 1.0, 5.0),
+            ("claude-opus-4-5", 5.0, 25.0),
+            ("gpt-4o", 2.5, 10.0),
+        ],
+    )
+    def test_real_models_priced_from_litellm_at_expected_rates(
+        self, model: str, input_per_m: float, output_per_m: float
+    ) -> None:
+        # These ids are NOT in the local table — they must resolve via LiteLLM,
+        # at the rates the hand-vendored table used to carry (behavior-preserving).
+        from tools.system.fleet_monitoring.pricing import _litellm_price
+
+        assert model not in MODEL_PRICES
+        price = _litellm_price(model)
+        assert price is not None
+        assert price.usd_per_input_token == pytest.approx(input_per_m / 1e6)
+        assert price.usd_per_output_token == pytest.approx(output_per_m / 1e6)
+
+    def test_sonnet_45_cost_is_behavior_preserving(self) -> None:
+        # 1000 in / 500 out on sonnet-4.5 was $0.0105 before the migration.
+        usage = TokenUsage(input_tokens=1000, output_tokens=500)
+        assert usd_for_usage(usage, "claude-sonnet-4-5") == pytest.approx(0.0105)
+
+    def test_bedrock_prefixed_id_is_priced(self) -> None:
+        # Bedrock reports ``us.anthropic.…-v1:0`` ids; they must resolve, not ``-``.
+        usage = TokenUsage(input_tokens=1000, output_tokens=500)
+        cost = usd_for_usage(usage, "us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+        assert cost is not None and cost > 0
+
+    def test_snapshot_read_failure_is_cached_and_falls_back_never_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A missing/unreadable bundled snapshot (e.g. absent from a frozen
+        # build) must degrade to the local table (and unpriced for snapshot-only
+        # ids) — never a crash, never a fake $0 — and be cached so the always-on
+        # sampler does not re-attempt the read on every tick.
+        from tools.system.fleet_monitoring import pricing
+
+        attempts = {"read": 0}
+
+        def _boom(*_args: object, **_kwargs: object) -> object:
+            attempts["read"] += 1
+            raise FileNotFoundError("snapshot missing")
+
+        monkeypatch.setattr(pricing, "_litellm_cost_map", None)
+        monkeypatch.setattr(pricing, "files", _boom)
+
+        usage = TokenUsage(input_tokens=1000, output_tokens=500)
+        assert usd_for_usage(usage, "gpt-5.6-sol") == pytest.approx(0.02)  # local fallback
+        assert usd_for_usage(usage, "gpt-4o") is None  # snapshot-only → unpriced
+        # Failure cached to {}, so the read was attempted at most once.
+        assert pricing._litellm_cost_map == {}
+        assert attempts["read"] == 1
+
+    def test_priced_from_local_snapshot_not_the_global(self) -> None:
+        # Guard that pricing reads litellm's *local* snapshot directly rather
+        # than the process-wide litellm.model_cost global (which a live fetch
+        # elsewhere can diverge). The blended rate must match the local file.
+        from tools.system.fleet_monitoring.pricing import _litellm_local_cost_map
+
+        entry = _litellm_local_cost_map()["claude-sonnet-4-5"]
+        expected = 0.7 * entry["input_cost_per_token"] + 0.3 * entry["output_cost_per_token"]
+        assert usd_per_token_blended("claude-sonnet-4-5") == pytest.approx(expected)
+
+    def test_local_snapshot_loads_a_substantial_table(self) -> None:
+        # Smoke guard: if litellm's packaged JSON is missing, the read degrades
+        # to {} rather than crashing — but that must be loud in CI, not silent.
+        from tools.system.fleet_monitoring.pricing import _litellm_local_cost_map
+
+        assert len(_litellm_local_cost_map()) > 1000
+
+
+class TestConfiguredProviderCompatibility:
+    """Coverage across providers wired in config, using real wire-format ids.
+
+    Providers routed through ``core/llm/providers/openai_compat_providers.py``
+    (deepseek, gemini, minimax, groq, …) report a *bare* model id, never
+    litellm's ``<provider>/<model>`` convention. These use that real wire
+    format, not a guessed one.
+    """
+
+    def test_deepseek_bare_model_has_a_price(self) -> None:
+        assert usd_per_token_blended("deepseek-chat") is not None
+
+    def test_gemini_bare_model_has_a_price(self) -> None:
+        assert usd_per_token_blended("gemini-2.5-pro") is not None
+
+    def test_groq_bare_model_resolves_via_compat_prefix(self) -> None:
+        # litellm only keys this under "groq/llama-3.3-70b-versatile"; the bare
+        # id Groq's API (and OpenSRE's wire format) uses must still resolve.
+        assert usd_per_token_blended("llama-3.3-70b-versatile") is not None
+
+    def test_minimax_mixed_case_bare_model_resolves(self) -> None:
+        # litellm keys MiniMax under "minimax/MiniMax-M2.1" (mixed case);
+        # OpenSRE sends the bare, differently-cased id.
+        assert usd_per_token_blended("MiniMax-M2.1") is not None
+
+    def test_nvidia_nim_is_unpriced_not_invented(self) -> None:
+        # litellm's snapshot has no NVIDIA NIM coverage today; it must render
+        # "-" (via PriceOverride/agents.yaml), never a guessed rate. If litellm
+        # adds coverage, update this test — don't just delete it.
+        assert usd_per_token_blended("meta/llama-3.1-70b-instruct") is None
+
+    def test_ollama_self_hosted_is_unpriced(self) -> None:
+        # Self-hosted models have no per-token API price to look up.
+        assert usd_per_token_blended("llama3") is None

--- a/tests/packaging/test_litellm_bundle_contract.py
+++ b/tests/packaging/test_litellm_bundle_contract.py
@@ -1,11 +1,14 @@
 """Regression tests for LiteLLM package data in frozen release binaries.
 
-Azure OpenAI and ``OPENSRE_LLM_TRANSPORT=litellm`` import ``litellm`` at runtime.
-LiteLLM reads JSON price/context files from its package directory on import; the
-release PyInstaller build must bundle them under ``_internal/litellm/`` or the
-binary crashes with ``FileNotFoundError`` (see issue #3631).
-
-Workflow contract assertions live in ``tests/github_ci/test_release_workflow.py``.
+``litellm`` is imported unconditionally now that
+``tools/system/fleet_monitoring/pricing.py`` sources model rates from
+``litellm.model_cost`` (#4035) — the always-on dashboard sampler imports it, on
+top of the Azure OpenAI / ``OPENSRE_LLM_TRANSPORT=litellm`` transport paths.
+LiteLLM reads JSON price/context files from its package directory on import, and
+``pricing.py`` reads its ``model_prices_and_context_window_backup.json`` for the
+offline cost map; the release PyInstaller build must bundle them under
+``_internal/litellm/`` (via ``--collect-data litellm``) or the binary crashes
+with ``FileNotFoundError`` (see issue #3631).
 """
 
 from __future__ import annotations

--- a/tests/tools/test_model_spend_tool.py
+++ b/tests/tools/test_model_spend_tool.py
@@ -1,0 +1,173 @@
+"""Tests for model_spend_tool (issue #3231)."""
+
+from __future__ import annotations
+
+from tests.tools.conftest import BaseToolContract
+from tools.system.fleet_monitoring.meters import TokenUsage
+from tools.system.fleet_monitoring.pricing import usd_for_usage
+from tools.system.model_spend_tool import estimate_model_spend, summarize_model_burn_rate
+
+_KNOWN = "claude-sonnet-4-6"
+_UNKNOWN = "totally-made-up-model-xyz"
+
+
+class TestEstimateModelSpendContract(BaseToolContract):
+    def get_tool_under_test(self):  # type: ignore[no-untyped-def]
+        return estimate_model_spend.__opensre_registered_tool__
+
+
+class TestSummarizeBurnRateContract(BaseToolContract):
+    def get_tool_under_test(self):  # type: ignore[no-untyped-def]
+        return summarize_model_burn_rate.__opensre_registered_tool__
+
+
+def test_known_model_pricing_matches_price_table() -> None:
+    result = estimate_model_spend({_KNOWN: {"input_tokens": 1000, "output_tokens": 500}})
+    expected = usd_for_usage(TokenUsage(input_tokens=1000, output_tokens=500), _KNOWN)
+    assert expected is not None
+    assert result["priced"] is True
+    assert result["total_usd"] == round(float(expected), 6)
+    assert result["by_model"][0]["model"] == _KNOWN
+    assert result["by_model"][0]["priced"] is True
+
+
+def test_unknown_model_is_unpriced_not_zero() -> None:
+    result = estimate_model_spend({_UNKNOWN: {"input_tokens": 1000}})
+    assert result["priced"] is False
+    assert result["total_usd"] == 0.0
+    assert result["unpriced_models"] == [_UNKNOWN]
+    assert result["by_model"][0]["priced"] is False
+    assert result["by_model"][0]["usd"] is None
+
+
+def test_bucket_costs_sum_to_model_total() -> None:
+    usage = {
+        "input_tokens": 2000,
+        "output_tokens": 800,
+        "cache_read_input_tokens": 500,
+        "cache_creation_input_tokens": 100,
+    }
+    entry = estimate_model_spend({_KNOWN: usage})["by_model"][0]
+    assert round(sum(entry["cost_by_bucket"].values()), 6) == entry["usd"]
+
+
+def test_usd_per_lap_divides_total_by_laps() -> None:
+    result = estimate_model_spend({_KNOWN: {"input_tokens": 1000, "output_tokens": 500}}, laps=5)
+    assert result["laps"] == 5
+    assert result["usd_per_lap"] == round(result["total_usd"] / 5, 6)
+
+
+def test_usd_per_lap_none_when_laps_zero_or_missing() -> None:
+    assert estimate_model_spend({_KNOWN: {"input_tokens": 1000}}, laps=0)["usd_per_lap"] is None
+    assert estimate_model_spend({_KNOWN: {"input_tokens": 1000}})["usd_per_lap"] is None
+
+
+def test_price_override_prices_unknown_model() -> None:
+    # 1M input tokens at an overridden $2/1M input rate = $2.00.
+    result = estimate_model_spend(
+        {"custom-model": {"input_tokens": 1_000_000, "output_tokens": 0}},
+        price_overrides={
+            "custom-model": {"input_usd_per_million": 2.0, "output_usd_per_million": 8.0}
+        },
+    )
+    assert result["priced"] is True
+    assert result["total_usd"] == 2.0
+
+
+def test_malformed_price_override_does_not_crash() -> None:
+    # An LLM caller may violate the schema; a non-numeric override rate must
+    # degrade to "no override" rather than raising ValueError.
+    result = estimate_model_spend(
+        {"custom-model": {"input_tokens": 1_000_000, "output_tokens": 0}},
+        price_overrides={
+            "custom-model": {
+                "input_usd_per_million": "not-a-number",
+                "output_usd_per_million": None,
+            }
+        },
+    )
+    # Override discarded → unknown model stays unpriced (never a crash, never $0).
+    assert result["priced"] is False
+    assert "custom-model" in result["unpriced_models"]
+
+
+def test_multiple_models_aggregate_only_priced() -> None:
+    mixed = estimate_model_spend(
+        {
+            _KNOWN: {"input_tokens": 1000, "output_tokens": 500},
+            _UNKNOWN: {"input_tokens": 1000},
+        }
+    )
+    known_only = estimate_model_spend({_KNOWN: {"input_tokens": 1000, "output_tokens": 500}})
+    assert mixed["total_usd"] == known_only["total_usd"]
+    assert _UNKNOWN in mixed["unpriced_models"]
+    assert len(mixed["by_model"]) == 2
+
+
+def test_burn_rate_per_minute_projection() -> None:
+    result = summarize_model_burn_rate({_KNOWN: {"input_tokens": 1000, "output_tokens": 500}})
+    per_min_cost = usd_for_usage(TokenUsage(input_tokens=1000, output_tokens=500), _KNOWN)
+    assert per_min_cost is not None
+    assert result["usage_interpreted_as"] == "per_minute"
+    assert result["total_usd_per_hour"] == round(float(per_min_cost) * 60.0, 6)
+
+
+def test_burn_rate_from_totals_over_elapsed_seconds() -> None:
+    # 120s window -> per-minute halves the totals; $/hr = per-min cost * 60.
+    result = summarize_model_burn_rate(
+        {_KNOWN: {"input_tokens": 1000, "output_tokens": 500}}, elapsed_seconds=120.0
+    )
+    expected = usd_for_usage(TokenUsage(input_tokens=500, output_tokens=250), _KNOWN)
+    assert expected is not None
+    assert result["usage_interpreted_as"] == "totals_over_elapsed_seconds"
+    assert result["total_usd_per_hour"] == round(float(expected) * 60.0, 6)
+
+
+def test_burn_rate_unknown_model_unpriced() -> None:
+    result = summarize_model_burn_rate({_UNKNOWN: {"input_tokens": 1000}})
+    assert result["priced"] is False
+    assert result["unpriced_models"] == [_UNKNOWN]
+
+
+def test_bool_token_value_is_not_counted() -> None:
+    # isinstance(True, int) is True, so a stray boolean must not add a token
+    # (mirrors meters.safe_int). Otherwise "input_tokens": true would cost money.
+    result = estimate_model_spend({_KNOWN: {"input_tokens": True, "output_tokens": 500}})
+    assert result["by_model"][0]["tokens"]["input_tokens"] == 0.0
+    expected = usd_for_usage(TokenUsage(output_tokens=500), _KNOWN)
+    assert expected is not None
+    assert result["total_usd"] == round(float(expected), 6)
+
+
+def test_non_numeric_string_token_value_falls_back_to_zero() -> None:
+    # A non-numeric string must not raise; it is treated as zero tokens.
+    result = estimate_model_spend({_KNOWN: {"input_tokens": "1,000", "output_tokens": 500}})
+    assert result["by_model"][0]["tokens"]["input_tokens"] == 0.0
+    # A clean numeric string is still parsed.
+    parsed = estimate_model_spend({_KNOWN: {"input_tokens": "1000"}})
+    assert parsed["by_model"][0]["tokens"]["input_tokens"] == 1000.0
+
+
+def test_non_mapping_usage_value_does_not_crash() -> None:
+    # A bare total (a common LLM shorthand) is not a bucket dict; it must be
+    # tolerated as empty usage rather than raising AttributeError mid-batch.
+    result = estimate_model_spend({_KNOWN: 50000})  # type: ignore[dict-item]
+    assert result["by_model"][0]["tokens"]["input_tokens"] == 0.0
+    assert result["total_usd"] == 0.0
+
+
+def test_non_positive_elapsed_seconds_is_consistent_per_minute() -> None:
+    # A zero/negative window cannot be projected: fall back to per-minute and
+    # report elapsed_seconds as null so the output is never self-contradictory.
+    for bad in (0.0, -30.0):
+        result = summarize_model_burn_rate({_KNOWN: {"input_tokens": 1000}}, elapsed_seconds=bad)
+        assert result["usage_interpreted_as"] == "per_minute"
+        assert result["elapsed_seconds"] is None
+    baseline = summarize_model_burn_rate({_KNOWN: {"input_tokens": 1000}})
+    zero = summarize_model_burn_rate({_KNOWN: {"input_tokens": 1000}}, elapsed_seconds=0.0)
+    assert zero["total_usd_per_hour"] == baseline["total_usd_per_hour"]
+
+
+def test_tool_sources_are_knowledge() -> None:
+    for fn in (estimate_model_spend, summarize_model_burn_rate):
+        assert fn.__opensre_registered_tool__.source == "knowledge"

--- a/tests/tools/test_model_spend_tool.py
+++ b/tests/tools/test_model_spend_tool.py
@@ -51,6 +51,23 @@ def test_bucket_costs_sum_to_model_total() -> None:
     assert round(sum(entry["cost_by_bucket"].values()), 6) == entry["usd"]
 
 
+def test_cached_input_bucket_charges_only_cache_rate_and_sums() -> None:
+    # cached_input_tokens is a discounted SUBSET of input_tokens (Codex-style):
+    # the cached slice must be charged at the cache rate only (not the full input
+    # rate on top), and per-bucket costs must still sum to the model total.
+    usage = {"input_tokens": 2000, "output_tokens": 800, "cached_input_tokens": 500}
+    entry = estimate_model_spend({_KNOWN: usage})["by_model"][0]
+    buckets = entry["cost_by_bucket"]
+    assert buckets["cached_input"] > 0.0  # the cached branch is exercised
+    assert round(sum(buckets.values()), 6) == entry["usd"]
+    # The whole-usage total must match usd_for_usage directly (cached charged once).
+    expected = usd_for_usage(
+        TokenUsage(input_tokens=2000, output_tokens=800, cached_input_tokens=500), _KNOWN
+    )
+    assert expected is not None
+    assert entry["usd"] == round(float(expected), 6)
+
+
 def test_usd_per_lap_divides_total_by_laps() -> None:
     result = estimate_model_spend({_KNOWN: {"input_tokens": 1000, "output_tokens": 500}}, laps=5)
     assert result["laps"] == 5
@@ -89,6 +106,26 @@ def test_malformed_price_override_does_not_crash() -> None:
     # Override discarded → unknown model stays unpriced (never a crash, never $0).
     assert result["priced"] is False
     assert "custom-model" in result["unpriced_models"]
+
+
+def test_partial_override_on_unknown_model_stays_unpriced() -> None:
+    # A single rate cannot price an otherwise-unknown model (there is no base
+    # rate to fill the other side), so it stays unpriced and is surfaced in
+    # unpriced_models rather than guessed. The schema documents this contract.
+    result = estimate_model_spend(
+        {"custom-model": {"input_tokens": 1_000_000, "output_tokens": 1_000_000}},
+        price_overrides={"custom-model": {"input_usd_per_million": 2.0}},
+    )
+    assert result["priced"] is False
+    assert "custom-model" in result["unpriced_models"]
+    # Both rates for the same unknown model DO price it.
+    both = estimate_model_spend(
+        {"custom-model": {"input_tokens": 1_000_000, "output_tokens": 0}},
+        price_overrides={
+            "custom-model": {"input_usd_per_million": 2.0, "output_usd_per_million": 8.0}
+        },
+    )
+    assert both["priced"] is True and both["total_usd"] == 2.0
 
 
 def test_multiple_models_aggregate_only_priced() -> None:

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -1010,6 +1010,9 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         "describe_rds_events",
         "describe_rds_instance",
         "ec2_instances_by_tag",
+        # model_spend_tool calculators are pure (tokens x rate table); they
+        # let unexpected errors escape to the global #1476 wrapper.
+        "estimate_model_spend",
         "execute_aws_operation",
         "execute_github_issue_mutation",
         "execute_python_code",
@@ -1203,6 +1206,7 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         "slash_invoke",
         "summarize_community_followups",
         "summarize_github_pr_status",
+        "summarize_model_burn_rate",
         "synthetic_run",
         "task_cancel",
         # Temporal tools use try/finally only (to close the client); the client

--- a/tools/system/__init__.py
+++ b/tools/system/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 TOOL_MODULES = (
     "fleet_monitoring",
+    "model_spend_tool",
     "python_execution_tool",
     "sre_guidance_tool",
     "watch_dog",

--- a/tools/system/fleet_monitoring/pricing.py
+++ b/tools/system/fleet_monitoring/pricing.py
@@ -2,25 +2,54 @@
 
 ``$/hr`` is a *projected hourly burn rate* derived from the trailing
 60 s usage window, not the actual spend over the last hour. The
-sampler now keeps input/output/cache buckets, so pricing applies the
-right rate to each bucket instead of using the legacy 70/30 blend.
+sampler keeps input/output/cache buckets, so pricing applies the right
+rate to each bucket instead of using the legacy 70/30 blend.
 
-The local price table is a vendored snapshot of the ``models.dev``
-catalog for the Claude Code / Codex models this dashboard supports,
-following CodexBar's offline-first approach. Unknown models return
-``None`` so the dashboard renders ``-`` rather than inventing a rate.
+Rates come primarily from **LiteLLM's community-maintained cost table**
+(``litellm.model_cost``, ~2.8k models), pinned to the snapshot bundled
+inside the ``litellm`` package so lookups stay offline (see
+:func:`~core.llm.transports.litellm.local_cost_map_bootstrap.ensure_local_model_cost_map`).
+:data:`MODEL_PRICES` is now a small fallback table for the handful of
+model ids LiteLLM's bundled map does not yet carry. Unknown models
+return ``None`` so the dashboard renders ``-`` rather than inventing a
+rate.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass
 from functools import lru_cache
+from importlib.resources import files
+from typing import TypeGuard
 
-from tools.system.fleet_monitoring.meters import TokenUsage
+from core.llm.transports.litellm.frozen_tiktoken_bootstrap import (
+    ensure_tiktoken_encodings_discoverable,
+)
+from core.llm.transports.litellm.local_cost_map_bootstrap import (
+    ensure_local_model_cost_map,
+)
 
-#: ``models.dev`` pricing snapshot last refreshed for this vendored table.
+# Set LITELLM_LOCAL_MODEL_COST_MAP before any ``import litellm`` so litellm's
+# own import-time price-map load stays offline (no network fetch). We still read
+# the snapshot file directly for import-order-independent determinism (see
+# _litellm_local_cost_map); this only avoids the wasted fetch when we import
+# first. Kept ahead of the sibling import below for the same reason.
+ensure_local_model_cost_map()
+
+from tools.system.fleet_monitoring.meters import TokenUsage  # noqa: E402
+
+#: litellm's bundled price/context snapshot, read directly rather than via the
+#: process-wide ``litellm.model_cost`` global (see _litellm_local_cost_map). The
+#: filename is already a load-bearing contract — tests/packaging/
+#: test_litellm_bundle_contract.py asserts it ships in frozen builds.
+_LITELLM_PRICE_SNAPSHOT_FILENAME = "model_prices_and_context_window_backup.json"
+
+#: Verification date for the local fallback table only. Primary rates come from
+#: litellm's bundled snapshot.
 RATES_VERIFIED_AT = "2026-05-17"
 
 _USD_PER_M = 1_000_000
@@ -98,9 +127,13 @@ def _price(
     )
 
 
+#: Fallback rates for model ids that LiteLLM's bundled snapshot does not carry
+#: (values are USD per 1M tokens; ``_price`` converts to per-token). Everything
+#: else is priced from that snapshot — see :func:`_litellm_price`. Keep this
+#: list minimal: an id belongs here only while confirmed absent from the pinned
+#: LiteLLM release (guarded by a reconciliation test). Re-verify on a bump.
 MODEL_PRICES: dict[str, ModelPrice] = {
-    # Anthropic / Claude Code. Values are USD per 1M tokens in
-    # models.dev; _price converts them to USD per token.
+    # Legacy Claude 3.5 snapshots (dropped from LiteLLM's current map).
     "claude-3-5-sonnet-20240620": _price(
         3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
     ),
@@ -113,28 +146,11 @@ MODEL_PRICES: dict[str, ModelPrice] = {
     "claude-3-5-haiku-latest": _price(
         0.80, 4.00, cache_read_usd_per_million=0.08, cache_write_usd_per_million=1.00
     ),
-    "claude-haiku-4-5": _price(
-        1.00, 5.00, cache_read_usd_per_million=0.10, cache_write_usd_per_million=1.25
-    ),
-    "claude-haiku-4-5-20251001": _price(
-        1.00, 5.00, cache_read_usd_per_million=0.10, cache_write_usd_per_million=1.25
-    ),
+    # Bare Anthropic aliases LiteLLM only keys under Bedrock-prefixed ids.
     "claude-sonnet-4": _price(
         3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
     ),
     "claude-sonnet-4-0": _price(
-        3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
-    ),
-    "claude-sonnet-4-20250514": _price(
-        3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
-    ),
-    "claude-sonnet-4-5": _price(
-        3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
-    ),
-    "claude-sonnet-4-5-20250929": _price(
-        3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
-    ),
-    "claude-sonnet-4-6": _price(
         3.00, 15.00, cache_read_usd_per_million=0.30, cache_write_usd_per_million=3.75
     ),
     "claude-opus-4": _price(
@@ -143,114 +159,28 @@ MODEL_PRICES: dict[str, ModelPrice] = {
     "claude-opus-4-0": _price(
         15.00, 75.00, cache_read_usd_per_million=1.50, cache_write_usd_per_million=18.75
     ),
-    "claude-opus-4-20250514": _price(
-        15.00, 75.00, cache_read_usd_per_million=1.50, cache_write_usd_per_million=18.75
-    ),
-    "claude-opus-4-1": _price(
-        15.00, 75.00, cache_read_usd_per_million=1.50, cache_write_usd_per_million=18.75
-    ),
-    "claude-opus-4-1-20250805": _price(
-        15.00, 75.00, cache_read_usd_per_million=1.50, cache_write_usd_per_million=18.75
-    ),
-    "claude-opus-4-5": _price(
-        5.00, 25.00, cache_read_usd_per_million=0.50, cache_write_usd_per_million=6.25
-    ),
-    "claude-opus-4-5-20251101": _price(
-        5.00, 25.00, cache_read_usd_per_million=0.50, cache_write_usd_per_million=6.25
-    ),
-    "claude-opus-4-6": _price(
-        5.00, 25.00, cache_read_usd_per_million=0.50, cache_write_usd_per_million=6.25
-    ),
-    "claude-opus-4-7": _price(
-        5.00, 25.00, cache_read_usd_per_million=0.50, cache_write_usd_per_million=6.25
-    ),
-    "claude-fable-5": _price(
-        10.00, 50.00, cache_read_usd_per_million=1.00, cache_write_usd_per_million=12.50
-    ),
-    # OpenAI / Codex.
-    "gpt-4o": _price(2.50, 10.00, cache_read_usd_per_million=1.25),
-    "gpt-4o-2024-05-13": _price(5.00, 15.00),
-    "gpt-4o-2024-08-06": _price(2.50, 10.00, cache_read_usd_per_million=1.25),
-    "gpt-4o-2024-11-20": _price(2.50, 10.00, cache_read_usd_per_million=1.25),
-    "gpt-4o-mini": _price(0.15, 0.60, cache_read_usd_per_million=0.08),
-    "gpt-5": _price(1.25, 10.00, cache_read_usd_per_million=0.125),
-    "gpt-5-chat-latest": _price(1.25, 10.00),
-    "gpt-5-codex": _price(1.25, 10.00, cache_read_usd_per_million=0.125),
-    "gpt-5-mini": _price(0.25, 2.00, cache_read_usd_per_million=0.025),
-    "gpt-5-nano": _price(0.05, 0.40, cache_read_usd_per_million=0.005),
-    "gpt-5-pro": _price(15.00, 120.00),
-    "gpt-5.1": _price(1.25, 10.00, cache_read_usd_per_million=0.13),
-    "gpt-5.1-chat-latest": _price(1.25, 10.00, cache_read_usd_per_million=0.125),
-    "gpt-5.1-codex": _price(1.25, 10.00, cache_read_usd_per_million=0.125),
-    "gpt-5.1-codex-max": _price(1.25, 10.00, cache_read_usd_per_million=0.125),
-    "gpt-5.1-codex-mini": _price(0.25, 2.00, cache_read_usd_per_million=0.025),
-    "gpt-5.2": _price(1.75, 14.00, cache_read_usd_per_million=0.175),
-    "gpt-5.2-chat-latest": _price(1.75, 14.00, cache_read_usd_per_million=0.175),
-    "gpt-5.2-codex": _price(1.75, 14.00, cache_read_usd_per_million=0.175),
-    "gpt-5.2-pro": _price(21.00, 168.00),
-    "gpt-5.3-chat-latest": _price(1.75, 14.00, cache_read_usd_per_million=0.175),
-    "gpt-5.3-codex": _price(1.75, 14.00, cache_read_usd_per_million=0.175),
+    # Recently GA'd models LiteLLM's bundled snapshot has not caught up on.
     "gpt-5.3-codex-spark": _price(1.75, 14.00, cache_read_usd_per_million=0.175),
-    "gpt-5.4": _price(2.50, 15.00, cache_read_usd_per_million=0.25),
-    "gpt-5.4-mini": _price(0.75, 4.50, cache_read_usd_per_million=0.075),
-    "gpt-5.4-nano": _price(0.20, 1.25, cache_read_usd_per_million=0.02),
-    "gpt-5.4-pro": _price(30.00, 180.00),
-    "gpt-5.5": _price(5.00, 30.00, cache_read_usd_per_million=0.50),
-    "gpt-5.5-pro": _price(30.00, 180.00),
     "gpt-5.6-luna": _price(1.00, 6.00, cache_read_usd_per_million=0.10),
     "gpt-5.6-sol": _price(5.00, 30.00, cache_read_usd_per_million=0.50),
     "gpt-5.6-terra": _price(2.50, 15.00, cache_read_usd_per_million=0.25),
-    "o3": _price(2.00, 8.00, cache_read_usd_per_million=0.50),
-    "o3-deep-research": _price(10.00, 40.00, cache_read_usd_per_million=2.50),
-    "o3-mini": _price(1.10, 4.40, cache_read_usd_per_million=0.55),
-    "o3-pro": _price(20.00, 80.00),
 }
 
+# Only bare aliases whose *exact* id is not itself a key here. Deliberately
+# NO broad ``claude-sonnet-4`` / ``claude-opus-4`` prefixes: those would
+# collapse newer, differently-priced variants (e.g. ``claude-opus-4-5`` at
+# 5/25) onto a legacy bare rate. Newer variants are priced by LiteLLM; only
+# the bare legacy ids remain, and they resolve by direct lookup.
 _UNSORTED_FAMILY_FALLBACKS: tuple[tuple[str, str], ...] = (
     ("claude-3-5-sonnet", "claude-3-5-sonnet-20241022"),
     ("claude-3-5-haiku", "claude-3-5-haiku-20241022"),
-    ("claude-haiku-4-5", "claude-haiku-4-5"),
-    ("claude-fable-5", "claude-fable-5"),
-    ("claude-sonnet-4-6", "claude-sonnet-4-6"),
-    ("claude-sonnet-4-5", "claude-sonnet-4-5"),
-    ("claude-sonnet-4", "claude-sonnet-4"),
-    ("claude-opus-4-7", "claude-opus-4-7"),
-    ("claude-opus-4-6", "claude-opus-4-6"),
-    ("claude-opus-4-5", "claude-opus-4-5"),
-    ("claude-opus-4-1", "claude-opus-4-1"),
-    ("claude-opus-4", "claude-opus-4"),
-    ("gpt-5.3-codex-spark", "gpt-5.3-codex-spark"),
-    ("gpt-5.3-codex", "gpt-5.3-codex"),
-    ("gpt-5.2-codex", "gpt-5.2-codex"),
-    ("gpt-5.1-codex-mini", "gpt-5.1-codex-mini"),
-    ("gpt-5.1-codex-max", "gpt-5.1-codex-max"),
-    ("gpt-5.1-codex", "gpt-5.1-codex"),
-    ("gpt-5-codex", "gpt-5-codex"),
+    # Per-tier rows so a suffixed variant (e.g. ``gpt-5.6-terra-preview``)
+    # lands on its own tier, not on the shorter ``gpt-5.6`` → Sol alias.
     ("gpt-5.6-terra", "gpt-5.6-terra"),
     ("gpt-5.6-luna", "gpt-5.6-luna"),
     ("gpt-5.6-sol", "gpt-5.6-sol"),
-    # OpenAI routes the bare `gpt-5.6` alias to Sol server-side. The three
-    # rows above are longer prefixes, so they still win for terra/luna.
+    # OpenAI routes the bare `gpt-5.6` alias to Sol server-side.
     ("gpt-5.6", "gpt-5.6-sol"),
-    ("gpt-5.5-pro", "gpt-5.5-pro"),
-    ("gpt-5.5", "gpt-5.5"),
-    ("gpt-5.4-mini", "gpt-5.4-mini"),
-    ("gpt-5.4-nano", "gpt-5.4-nano"),
-    ("gpt-5.4-pro", "gpt-5.4-pro"),
-    ("gpt-5.4", "gpt-5.4"),
-    ("gpt-5.2-pro", "gpt-5.2-pro"),
-    ("gpt-5.2", "gpt-5.2"),
-    ("gpt-5.1", "gpt-5.1"),
-    ("gpt-5-mini", "gpt-5-mini"),
-    ("gpt-5-nano", "gpt-5-nano"),
-    ("gpt-5-pro", "gpt-5-pro"),
-    ("gpt-5", "gpt-5"),
-    ("gpt-4o-mini", "gpt-4o-mini"),
-    ("gpt-4o", "gpt-4o"),
-    ("o3-deep-research", "o3-deep-research"),
-    ("o3-mini", "o3-mini"),
-    ("o3-pro", "o3-pro"),
-    ("o3", "o3"),
 )
 
 # Longest-prefix-first so more specific families win. Build it
@@ -331,6 +261,13 @@ def usd_per_hour(
 
 
 def normalize_model_name(model: str | None) -> str | None:
+    """Return a clean canonical id for ``model`` for display and lookup.
+
+    Prefers an id a price source recognizes: an exact local-table key, then the
+    first non-vendor-qualified candidate LiteLLM prices (so a Bedrock id like
+    ``us.anthropic.claude-sonnet-4-5-…-v1:0`` reduces to ``claude-sonnet-4-5``),
+    then a family-prefix canonical, else the cleanest candidate.
+    """
     if model is None:
         return None
     candidates = _model_candidates(model)
@@ -338,9 +275,15 @@ def normalize_model_name(model: str | None) -> str | None:
         if candidate in MODEL_PRICES:
             return candidate
     for candidate in candidates:
+        if _is_clean_id(candidate) and _litellm_prices_bare(candidate):
+            return candidate
+    for candidate in candidates:
         for prefix, canonical_id in _FAMILY_FALLBACKS:
             if candidate.startswith(prefix):
                 return canonical_id
+    for candidate in candidates:
+        if _is_clean_id(candidate):
+            return candidate
     return candidates[0] if candidates else None
 
 
@@ -394,6 +337,10 @@ def _override_related_rate(
 
 
 def _lookup_price(model: str) -> ModelPrice | None:
+    litellm_price = _litellm_price(model)
+    if litellm_price is not None:
+        return litellm_price
+
     candidates = _model_candidates(model)
     for candidate in candidates:
         direct = MODEL_PRICES.get(candidate)
@@ -405,6 +352,153 @@ def _lookup_price(model: str) -> ModelPrice | None:
                 resolved = MODEL_PRICES.get(canonical_id)
                 if resolved is not None:
                     return resolved
+    return None
+
+
+#: Prefixes LiteLLM keys the same model under: bare, provider-namespaced, and
+#: Bedrock/region-prefixed. Probed in order against each normalized candidate.
+_LITELLM_KEY_PREFIXES: tuple[str, ...] = (
+    "",
+    "anthropic/",
+    "anthropic.",
+    "us.anthropic.",
+    "eu.anthropic.",
+    "openai/",
+)
+
+#: Providers that report a *bare* model id (via openai_compat_providers) while
+#: LiteLLM only keys them under ``<provider>/``. Probed as a last resort after a
+#: bare miss — kept narrow deliberately: guessing a prefix for an arbitrary
+#: open-weight model risks applying a different host's price for the same name.
+_COMPAT_PROVIDER_PREFIXES: tuple[str, ...] = ("groq/", "minimax/")
+
+#: Case-folded snapshot (``lower(key) -> entry``). ``None`` until first read;
+#: ``{}`` if the snapshot is unavailable, so lookups stop retrying the read.
+_litellm_cost_map: dict[str, dict] | None = None
+
+
+def _is_number(value: object) -> TypeGuard[float]:
+    """True for a real int/float rate — ``bool`` is rejected (``True`` is an int)."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+#: A candidate that is not a clean canonical display id: a provider/region
+#: namespace (``openai/…``, ``anthropic.…``, ``us.anthropic.…``), a Bedrock
+#: version marker (``-v1:0``), or an ``@`` variant tag.
+_NOT_CLEAN_ID = re.compile(r"^([a-z0-9-]+\.)?anthropic\.|/|-v\d+:\d+$|@")
+
+
+def _is_clean_id(candidate: str) -> bool:
+    return not _NOT_CLEAN_ID.search(candidate)
+
+
+def _litellm_local_cost_map() -> dict[str, dict]:
+    """Return LiteLLM's bundled price snapshot, case-folded (``lower(key) -> entry``).
+
+    Reads LiteLLM's packaged ``model_prices_and_context_window_backup.json``
+    directly rather than the process-wide ``litellm.model_cost`` global: that
+    global is populated by a live network fetch on whichever import touches it
+    first, so depending on it would make pricing depend on unrelated import
+    order elsewhere in the process. Reading the file is deterministic and
+    offline. Keys are lower-cased because LiteLLM's own keys are not uniformly
+    cased (e.g. ``minimax/MiniMax-M2.1``).
+
+    Never raises: a missing/unreadable file or non-dict payload is cached as
+    ``{}`` so the always-on sampler stops re-attempting the read on every tick.
+    """
+    global _litellm_cost_map
+    if _litellm_cost_map is None:
+        try:
+            ensure_tiktoken_encodings_discoverable()
+            raw = json.loads(
+                files("litellm")
+                .joinpath(_LITELLM_PRICE_SNAPSHOT_FILENAME)
+                .read_text(encoding="utf-8")
+            )
+            _litellm_cost_map = (
+                {k.lower(): v for k, v in raw.items() if isinstance(v, dict)}
+                if isinstance(raw, dict)
+                else {}
+            )
+        except Exception:  # noqa: BLE001 - defensive: missing/renamed snapshot
+            logger.debug("litellm price snapshot unavailable; disabling it", exc_info=True)
+            _litellm_cost_map = {}
+    return _litellm_cost_map
+
+
+def warm_cost_map() -> None:
+    """Eagerly load LiteLLM's price snapshot, paying the one-time ``import litellm``.
+
+    Call this off the UI/render thread (e.g. from the sampler's background loop)
+    so the first ``$/hr`` price lookup does not pay the import cost synchronously
+    on the interactive-shell render path.
+    """
+    _litellm_local_cost_map()
+
+
+def _priced_entry(entry: object) -> TypeGuard[dict]:
+    """True if ``entry`` is a LiteLLM row carrying both input and output rates."""
+    return (
+        isinstance(entry, dict)
+        and _is_number(entry.get("input_cost_per_token"))
+        and _is_number(entry.get("output_cost_per_token"))
+    )
+
+
+def _litellm_prices_bare(candidate: str) -> bool:
+    """True if LiteLLM prices ``candidate`` under any of its keying conventions.
+
+    Requires both input and output rates, matching :func:`_litellm_price`'s
+    notion of "priced" so ``normalize_model_name`` never canonicalizes onto an
+    id ``usd_for_usage`` then treats as unpriced.
+    """
+    cost_map = _litellm_local_cost_map()
+    return any(
+        _priced_entry(cost_map.get(prefix + candidate))
+        for prefix in (*_LITELLM_KEY_PREFIXES, *_COMPAT_PROVIDER_PREFIXES)
+    )
+
+
+def _litellm_candidates(model: str) -> Iterator[str]:
+    """Yield candidate snapshot keys for ``model`` (lower-cased) without repeats.
+
+    Primary keying conventions first; the narrow compat-provider prefixes only
+    after, so a bare hit always wins over a guessed ``<provider>/`` match.
+    """
+    seen: set[str] = set()
+    bases = _model_candidates(model)
+    for prefixes in (_LITELLM_KEY_PREFIXES, _COMPAT_PROVIDER_PREFIXES):
+        for base in bases:
+            for prefix in prefixes:
+                key = prefix + base
+                if key not in seen:
+                    seen.add(key)
+                    yield key
+
+
+def _litellm_price(model: str) -> ModelPrice | None:
+    """Build a :class:`ModelPrice` from LiteLLM's snapshot, or ``None`` on miss.
+
+    A miss (or the snapshot being unavailable, in which case the map is empty)
+    returns ``None`` so the caller falls back to :data:`MODEL_PRICES` and
+    ultimately to unpriced — never a fabricated ``$0``.
+    """
+    cost_map = _litellm_local_cost_map()
+    for key in _litellm_candidates(model):
+        entry = cost_map.get(key)
+        if not _priced_entry(entry):
+            continue
+        cache_read = entry.get("cache_read_input_token_cost")
+        cache_creation = entry.get("cache_creation_input_token_cost")
+        return ModelPrice(
+            usd_per_input_token=float(entry["input_cost_per_token"]),
+            usd_per_output_token=float(entry["output_cost_per_token"]),
+            usd_per_cached_input_token=(float(cache_read) if _is_number(cache_read) else None),
+            usd_per_cache_read_input_token=(float(cache_read) if _is_number(cache_read) else None),
+            usd_per_cache_creation_input_token=(
+                float(cache_creation) if _is_number(cache_creation) else None
+            ),
+        )
     return None
 
 
@@ -459,4 +553,5 @@ __all__ = [
     "usd_per_hour",
     "usd_per_hour_for_usage",
     "usd_per_token_blended",
+    "warm_cost_map",
 ]

--- a/tools/system/fleet_monitoring/pricing.py
+++ b/tools/system/fleet_monitoring/pricing.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import threading
 from collections.abc import Iterator
 from dataclasses import dataclass
 from functools import lru_cache
@@ -374,7 +375,10 @@ _COMPAT_PROVIDER_PREFIXES: tuple[str, ...] = ("groq/", "minimax/")
 
 #: Case-folded snapshot (``lower(key) -> entry``). ``None`` until first read;
 #: ``{}`` if the snapshot is unavailable, so lookups stop retrying the read.
+#: Guarded by ``_litellm_cost_map_lock`` because the sampler warms it on a
+#: background thread while the render thread may read it concurrently.
 _litellm_cost_map: dict[str, dict] | None = None
+_litellm_cost_map_lock = threading.Lock()
 
 
 def _is_number(value: object) -> TypeGuard[float]:
@@ -405,24 +409,30 @@ def _litellm_local_cost_map() -> dict[str, dict]:
 
     Never raises: a missing/unreadable file or non-dict payload is cached as
     ``{}`` so the always-on sampler stops re-attempting the read on every tick.
+    Thread-safe (double-checked lock) so concurrent warm/render callers load the
+    ~800 KB snapshot at most once, incl. under free-threaded CPython (PEP 703).
     """
     global _litellm_cost_map
-    if _litellm_cost_map is None:
-        try:
-            ensure_tiktoken_encodings_discoverable()
-            raw = json.loads(
-                files("litellm")
-                .joinpath(_LITELLM_PRICE_SNAPSHOT_FILENAME)
-                .read_text(encoding="utf-8")
-            )
-            _litellm_cost_map = (
-                {k.lower(): v for k, v in raw.items() if isinstance(v, dict)}
-                if isinstance(raw, dict)
-                else {}
-            )
-        except Exception:  # noqa: BLE001 - defensive: missing/renamed snapshot
-            logger.debug("litellm price snapshot unavailable; disabling it", exc_info=True)
-            _litellm_cost_map = {}
+    cached = _litellm_cost_map
+    if cached is not None:
+        return cached
+    with _litellm_cost_map_lock:
+        if _litellm_cost_map is None:
+            try:
+                ensure_tiktoken_encodings_discoverable()
+                raw = json.loads(
+                    files("litellm")
+                    .joinpath(_LITELLM_PRICE_SNAPSHOT_FILENAME)
+                    .read_text(encoding="utf-8")
+                )
+                _litellm_cost_map = (
+                    {k.lower(): v for k, v in raw.items() if isinstance(v, dict)}
+                    if isinstance(raw, dict)
+                    else {}
+                )
+            except Exception:  # noqa: BLE001 - defensive: missing/renamed snapshot
+                logger.debug("litellm price snapshot unavailable; disabling it", exc_info=True)
+                _litellm_cost_map = {}
     return _litellm_cost_map
 
 

--- a/tools/system/fleet_monitoring/sampler.py
+++ b/tools/system/fleet_monitoring/sampler.py
@@ -25,6 +25,7 @@ from tools.system.fleet_monitoring.pricing import (
     PriceOverride,
     normalize_model_name,
     usd_per_hour_for_usage,
+    warm_cost_map,
 )
 from tools.system.fleet_monitoring.probe import ProcessSnapshot, env_value_for_pid, probe
 from tools.system.fleet_monitoring.providers import provider_for
@@ -73,6 +74,13 @@ def get_usd_per_hour(pid: int) -> float | None:
 
 
 async def _sampler_loop(interval: float) -> None:
+    # Pay the one-time ``import litellm`` for the price map here, off the
+    # interactive-shell render thread, so the first ``/fleet`` $/hr lookup is
+    # a warm dict read rather than a ~1s synchronous import.
+    try:
+        await asyncio.get_running_loop().run_in_executor(None, warm_cost_map)
+    except Exception:
+        logger.debug("pricing cost-map warm-up failed", exc_info=True)
     while True:
         registry = AgentRegistry()
         agents = _records_for_tick(registry)

--- a/tools/system/model_spend_tool/__init__.py
+++ b/tools/system/model_spend_tool/__init__.py
@@ -1,8 +1,9 @@
 """Model spend + burn-rate estimation tools (issue #3231).
 
 Pure calculators over token/model/lap metadata that reuse the fleet-monitoring
-price table. They never call a provider billing API — estimates come only from
-tokens x the local price table, and unknown models are surfaced as unpriced.
+pricer (LiteLLM's cost table, with a small local fallback). They never call a
+provider billing API — estimates come only from tokens x that rate table, and
+unknown models are surfaced as unpriced.
 """
 
 from __future__ import annotations
@@ -32,7 +33,13 @@ _TOKEN_USAGE_SCHEMA: dict[str, Any] = {
 
 _PRICE_OVERRIDES_SCHEMA: dict[str, Any] = {
     "type": "object",
-    "description": "Optional per-model rate overrides, in USD per 1M tokens.",
+    "description": (
+        "Optional per-model rate overrides, in USD per 1M tokens. For a model "
+        "that is NOT in the price table, provide BOTH input_usd_per_million and "
+        "output_usd_per_million: a partial override cannot price an otherwise "
+        "unknown model, so it stays unpriced (listed in unpriced_models). For a "
+        "known model, either rate may be given on its own."
+    ),
     "additionalProperties": {
         "type": "object",
         "properties": {

--- a/tools/system/model_spend_tool/__init__.py
+++ b/tools/system/model_spend_tool/__init__.py
@@ -1,0 +1,138 @@
+"""Model spend + burn-rate estimation tools (issue #3231).
+
+Pure calculators over token/model/lap metadata that reuse the fleet-monitoring
+price table. They never call a provider billing API — estimates come only from
+tokens x the local price table, and unknown models are surfaced as unpriced.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.tool_framework.tool_decorator import tool
+from tools.system.model_spend_tool.estimation import estimate_spend, summarize_burn_rate
+
+_TOKEN_USAGE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "Map of model name -> token buckets. Provide at least input_tokens and "
+        "output_tokens; cache buckets are optional but improve accuracy."
+    ),
+    "additionalProperties": {
+        "type": "object",
+        "properties": {
+            "input_tokens": {"type": "number"},
+            "output_tokens": {"type": "number"},
+            "cached_input_tokens": {"type": "number"},
+            "cache_read_input_tokens": {"type": "number"},
+            "cache_creation_input_tokens": {"type": "number"},
+        },
+    },
+}
+
+_PRICE_OVERRIDES_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Optional per-model rate overrides, in USD per 1M tokens.",
+    "additionalProperties": {
+        "type": "object",
+        "properties": {
+            "input_usd_per_million": {"type": "number"},
+            "output_usd_per_million": {"type": "number"},
+        },
+    },
+}
+
+
+def _no_state_params(_sources: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    # Inputs are supplied by the caller/planner, not drawn from evidence state.
+    return {}
+
+
+@tool(
+    name="estimate_model_spend",
+    display_name="Model spend estimate",
+    source="knowledge",
+    description="Estimate AI spend (USD) from per-model token usage, with a per-lap breakdown.",
+    use_cases=[
+        "Estimating the USD cost of a benchmark or investigation run from token usage",
+        "Explaining cost drivers: model choice, token buckets, and cost per investigation lap",
+        "Comparing spend across models for the same workload",
+    ],
+    tags=("safe", "fast", "no-credentials"),
+    surfaces=("investigation", "chat"),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "token_usage_by_model": _TOKEN_USAGE_SCHEMA,
+            "laps": {
+                "type": "integer",
+                "description": "Investigation loop iterations, used to derive cost per lap.",
+            },
+            "run_label": {"type": "string", "description": "Optional label for the run."},
+            "price_overrides": _PRICE_OVERRIDES_SCHEMA,
+        },
+        "required": ["token_usage_by_model"],
+    },
+    extract_params=_no_state_params,
+)
+def estimate_model_spend(
+    token_usage_by_model: dict[str, Any],
+    laps: int | None = None,
+    run_label: str | None = None,
+    price_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Estimate USD spend from per-model token usage."""
+    return estimate_spend(
+        token_usage_by_model,
+        laps=laps,
+        run_label=run_label,
+        price_overrides=price_overrides,
+    )
+
+
+@tool(
+    name="summarize_model_burn_rate",
+    display_name="Model burn rate",
+    source="knowledge",
+    description="Project hourly AI burn ($/hr) from per-model token usage.",
+    use_cases=[
+        "Projecting $/hr burn from a per-minute token sample",
+        "Projecting hourly burn from run totals plus elapsed wall-clock seconds",
+        "Flagging which model dominates ongoing spend",
+    ],
+    tags=("safe", "fast", "no-credentials"),
+    surfaces=("investigation", "chat"),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "token_usage_by_model": _TOKEN_USAGE_SCHEMA,
+            "elapsed_seconds": {
+                "type": "number",
+                "description": (
+                    "If set, token usage is treated as totals over this window and "
+                    "normalized to per-minute before projecting to an hour."
+                ),
+            },
+            "run_label": {"type": "string", "description": "Optional label for the run."},
+            "price_overrides": _PRICE_OVERRIDES_SCHEMA,
+        },
+        "required": ["token_usage_by_model"],
+    },
+    extract_params=_no_state_params,
+)
+def summarize_model_burn_rate(
+    token_usage_by_model: dict[str, Any],
+    elapsed_seconds: float | None = None,
+    run_label: str | None = None,
+    price_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Project hourly burn from per-model token usage."""
+    return summarize_burn_rate(
+        token_usage_by_model,
+        elapsed_seconds=elapsed_seconds,
+        run_label=run_label,
+        price_overrides=price_overrides,
+    )
+
+
+__all__ = ["estimate_model_spend", "summarize_model_burn_rate"]

--- a/tools/system/model_spend_tool/estimation.py
+++ b/tools/system/model_spend_tool/estimation.py
@@ -1,0 +1,253 @@
+"""Pure cost / burn-rate estimation over token usage — no external calls.
+
+Reuses the fleet-monitoring pricer (``tools.system.fleet_monitoring.pricing``),
+which sources rates from LiteLLM's community-maintained cost table (with a small
+local fallback), so estimates stay consistent with the rest of the codebase.
+Estimates come only from tokens x that rate table; this never claims a live
+provider credit balance (there is no billing API in the repo). Unknown models
+are surfaced as ``priced: false`` rather than silently costed at zero.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools.system.fleet_monitoring.meters import TokenUsage
+from tools.system.fleet_monitoring.pricing import (
+    RATES_VERIFIED_AT,
+    PriceOverride,
+    normalize_model_name,
+    usd_for_usage,
+    usd_per_hour_for_usage,
+)
+
+_BUCKET_KEYS = ("input", "cached_input", "output", "cache_read", "cache_creation")
+
+
+def _token_usage_from_mapping(raw: Any) -> TokenUsage:
+    """Build a clamped :class:`TokenUsage` from a loose token-bucket dict.
+
+    Tolerant of malformed input: a non-mapping value is treated as empty usage,
+    and each bucket is coerced defensively (``bool`` and non-numeric strings
+    become zero, so a stray ``"input_tokens": true`` never adds a token).
+    """
+    data = raw if isinstance(raw, dict) else {}
+
+    def _num(key: str) -> float:
+        value = data.get(key)
+        if value is None or isinstance(value, bool):
+            return 0.0
+        if not isinstance(value, (int, float)):
+            try:
+                value = float(value)
+            except (TypeError, ValueError):
+                return 0.0
+        return float(value) if value > 0 else 0.0
+
+    return TokenUsage(
+        input_tokens=_num("input_tokens"),
+        output_tokens=_num("output_tokens"),
+        cached_input_tokens=_num("cached_input_tokens"),
+        cache_read_input_tokens=_num("cache_read_input_tokens"),
+        cache_creation_input_tokens=_num("cache_creation_input_tokens"),
+    ).clamped()
+
+
+def _override_rate(value: Any) -> float | None:
+    """Coerce a loose override rate to a positive float, or ``None``.
+
+    Mirrors the defensive coercion in :func:`_token_usage_from_mapping`: a
+    ``bool``, non-numeric string, or negative value degrades to ``None`` rather
+    than crashing on a schema-violating override from an LLM caller.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, float)):
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            return None
+    return float(value) if value >= 0 else None
+
+
+def _price_override_from_mapping(raw: dict[str, Any] | None) -> PriceOverride | None:
+    if not raw:
+        return None
+    inp = _override_rate(raw.get("input_usd_per_million"))
+    out = _override_rate(raw.get("output_usd_per_million"))
+    if inp is None and out is None:
+        return None
+    return PriceOverride(input_usd_per_million=inp, output_usd_per_million=out)
+
+
+def _bucket_costs(
+    usage: TokenUsage, model: str, override: PriceOverride | None
+) -> dict[str, float] | None:
+    """Per-bucket USD for one model, or ``None`` when the model has no price.
+
+    ``usd_for_usage`` is linear in each bucket, so a single-bucket
+    :class:`TokenUsage` yields exactly that bucket's cost. This reuses the
+    shared price table instead of duplicating rate math, and the buckets sum
+    to the model total.
+    """
+    cached = min(usage.cached_input_tokens, usage.input_tokens)
+    non_cached_input = usage.input_tokens - cached
+    parts: dict[str, float | None] = {
+        "input": usd_for_usage(TokenUsage(input_tokens=non_cached_input), model, override),
+        "cached_input": usd_for_usage(
+            TokenUsage(input_tokens=cached, cached_input_tokens=cached), model, override
+        ),
+        "output": usd_for_usage(TokenUsage(output_tokens=usage.output_tokens), model, override),
+        "cache_read": usd_for_usage(
+            TokenUsage(cache_read_input_tokens=usage.cache_read_input_tokens), model, override
+        ),
+        "cache_creation": usd_for_usage(
+            TokenUsage(cache_creation_input_tokens=usage.cache_creation_input_tokens),
+            model,
+            override,
+        ),
+    }
+    result: dict[str, float] = {}
+    for key in _BUCKET_KEYS:
+        value = parts[key]
+        if value is None:
+            return None
+        result[key] = float(value)
+    return result
+
+
+def _tokens_dict(usage: TokenUsage) -> dict[str, float]:
+    return {
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
+        "cached_input_tokens": usage.cached_input_tokens,
+        "cache_read_input_tokens": usage.cache_read_input_tokens,
+        "cache_creation_input_tokens": usage.cache_creation_input_tokens,
+    }
+
+
+def estimate_spend(
+    token_usage_by_model: dict[str, Any],
+    *,
+    laps: int | None = None,
+    run_label: str | None = None,
+    price_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Estimate total USD spend from per-model token usage.
+
+    Returns a breakdown by model, by token bucket, and (when ``laps`` is
+    provided) a cost-per-lap driver. Unknown models are listed under
+    ``unpriced_models`` and never contribute to the total.
+    """
+    overrides = price_overrides or {}
+    by_model: list[dict[str, Any]] = []
+    unpriced: list[str] = []
+    total_usd = 0.0
+    priced_any = False
+    bucket_totals = dict.fromkeys(_BUCKET_KEYS, 0.0)
+
+    for model, raw_usage in token_usage_by_model.items():
+        usage = _token_usage_from_mapping(raw_usage or {})
+        override = _price_override_from_mapping(overrides.get(model))
+        usd = usd_for_usage(usage, model, override)
+        entry: dict[str, Any] = {
+            "model": model,
+            "normalized_model": normalize_model_name(model),
+            "priced": usd is not None,
+            "usd": None if usd is None else round(float(usd), 6),
+            "tokens": _tokens_dict(usage),
+        }
+        if usd is None:
+            unpriced.append(model)
+        else:
+            priced_any = True
+            total_usd += float(usd)
+            buckets = _bucket_costs(usage, model, override)
+            if buckets is not None:
+                entry["cost_by_bucket"] = {k: round(v, 6) for k, v in buckets.items()}
+                for key, value in buckets.items():
+                    bucket_totals[key] += value
+        by_model.append(entry)
+
+    usd_per_lap = None
+    if laps is not None and laps > 0 and priced_any:
+        usd_per_lap = round(total_usd / laps, 6)
+
+    return {
+        "run_label": run_label,
+        "rates_verified_at": RATES_VERIFIED_AT,
+        "priced": priced_any,
+        "total_usd": round(total_usd, 6),
+        "laps": laps,
+        "usd_per_lap": usd_per_lap,
+        "cost_by_bucket": {k: round(v, 6) for k, v in bucket_totals.items()},
+        "by_model": by_model,
+        "unpriced_models": unpriced,
+        "note": (
+            "Estimated from tokens x LiteLLM's cost table (local fallback verified "
+            f"{RATES_VERIFIED_AT}); does not reflect a live provider credit balance."
+        ),
+    }
+
+
+def summarize_burn_rate(
+    token_usage_by_model: dict[str, Any],
+    *,
+    elapsed_seconds: float | None = None,
+    run_label: str | None = None,
+    price_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Project hourly burn ($/hr) from per-model token usage.
+
+    When ``elapsed_seconds`` is given, ``token_usage_by_model`` is treated as
+    totals observed over that window and normalized to per-minute before
+    projecting to an hour. Otherwise the usage is treated as a per-minute
+    sample (matching ``usd_per_hour_for_usage``).
+    """
+    overrides = price_overrides or {}
+    by_model: list[dict[str, Any]] = []
+    unpriced: list[str] = []
+    total_usd_per_hour = 0.0
+    priced_any = False
+
+    # A non-positive window can't be projected; fall back to per-minute and report it as null.
+    effective_elapsed = (
+        elapsed_seconds if (elapsed_seconds is not None and elapsed_seconds > 0) else None
+    )
+    scale = 60.0 / effective_elapsed if effective_elapsed is not None else None
+
+    for model, raw_usage in token_usage_by_model.items():
+        usage = _token_usage_from_mapping(raw_usage or {})
+        per_minute = usage.scaled(scale) if scale is not None else usage
+        override = _price_override_from_mapping(overrides.get(model))
+        usd_per_hour = usd_per_hour_for_usage(per_minute, model, override)
+        entry = {
+            "model": model,
+            "normalized_model": normalize_model_name(model),
+            "priced": usd_per_hour is not None,
+            "usd_per_hour": None if usd_per_hour is None else round(float(usd_per_hour), 6),
+        }
+        if usd_per_hour is None:
+            unpriced.append(model)
+        else:
+            priced_any = True
+            total_usd_per_hour += float(usd_per_hour)
+        by_model.append(entry)
+
+    return {
+        "run_label": run_label,
+        "rates_verified_at": RATES_VERIFIED_AT,
+        "priced": priced_any,
+        "elapsed_seconds": effective_elapsed,
+        "usage_interpreted_as": ("per_minute" if scale is None else "totals_over_elapsed_seconds"),
+        "total_usd_per_hour": round(total_usd_per_hour, 6),
+        "by_model": by_model,
+        "unpriced_models": unpriced,
+        "note": (
+            "Projected burn from tokens x LiteLLM's cost table; does not reflect a "
+            "live provider credit balance."
+        ),
+    }
+
+
+__all__ = ["estimate_spend", "summarize_burn_rate"]


### PR DESCRIPTION

Implements **both halves of #4035**: (1) migrate `tools/system/fleet_monitoring/pricing.py` off the hand-vendored `MODEL_PRICES` dict onto LiteLLM's bundled community-maintained price table, and (2) reintroduce `model_spend_tool` (from the closed #3965) on top of the migrated pricer. `litellm>=1.90.0` is already a project dependency; no new dependency is added.

Fixes #4035 · follows #3965 / #3231.

> **Relationship to #4047 (transparent):** @muddlebee's #4047 migrates `pricing.py` in parallel, and this PR **deliberately adopts its two best ideas** — the deterministic *direct read of LiteLLM's local snapshot* (not the network-fetchable `litellm.model_cost` global) and the *Groq/MiniMax bare-name + case-insensitive* compatibility handling. On top of that, this PR also does what #4047 does not: reintroduces `model_spend_tool` (the second half of #4035), warms the import off the render thread, and adds failure-caching / override hardening. **Happy to split** — if you'd rather land your `pricing.py` in #4047, I'll rebase this to just the `model_spend_tool` half on top of it. Credit for the local-snapshot-read and compat approach is yours.

#### Describe the changes you have made in this PR -

**1. `pricing.py` → LiteLLM's local snapshot (deterministic, offline)**

- Reads LiteLLM's bundled `model_prices_and_context_window_backup.json` **directly** via `importlib.resources`, rather than the process-wide `litellm.model_cost` global — that global is populated by a live network fetch on whichever import touches it first, so depending on it makes pricing nondeterministic based on unrelated import order. The always-on dashboard sampler imports this module, so lookups must be a pure, deterministic offline read.
- Also sets `LITELLM_LOCAL_MODEL_COST_MAP` before any `import litellm` (via a tiny bootstrap), so the wasted network fetch is avoided entirely when we're the first importer — determinism from the direct read, *and* no wasted fetch.
- **Case-folded** index + a narrow `_COMPAT_PROVIDER_PREFIXES` (`groq/`, `minimax/`) probed only after a bare miss, so bare/mixed-case wire-format ids (`llama-3.3-70b-versatile`, `MiniMax-M2.1`) resolve. Scoped to those two deliberately — guessing a prefix for an arbitrary open-weight model would risk applying a different host's price.
- A **12-id local fallback** (`MODEL_PRICES`) covers only the models the bundled snapshot lacks — the GPT-5.6 family (GA'd 2026-07-09), the retired `claude-3-5-*` direct-API ids, and bare `claude-sonnet-4`/`claude-opus-4` aliases LiteLLM only keys under Bedrock ids. A reconciliation test asserts every entry is genuinely absent from the snapshot, so the table can never re-grow into a hand-maintained duplicate.
- **Warms the snapshot off the sampler's background thread** so the first `/fleet` render doesn't pay the one-time `import litellm` synchronously; degrades to an empty map (cached) if the snapshot is ever missing, never crashing the always-on sampler; `normalize_model_name` is LiteLLM-aware so Bedrock ids still display cleanly.
- Public API (`usd_for_usage`, `usd_per_hour_for_usage`, `usd_per_token_blended`, `usd_per_hour`, `normalize_model_name`, `PriceOverride`, `RATES_VERIFIED_AT`) is **unchanged** → `sampler.py` needs no changes.

**2. Reintroduce `model_spend_tool`**

- `estimate_model_spend` (total USD by model / bucket / lap) and `summarize_model_burn_rate` (projected `$/hr`) — pure calculators over the migrated pricer. Unknown models are surfaced as **unpriced** (never `$0`); booleans, non-numeric strings, non-mapping usage, and non-numeric price overrides all degrade defensively rather than crash.
- Registered under `tools/system`, both tools classified in the telemetry allowlist, `docs/model_spend_tool.mdx` + nav added.

**Compatibility swept across every provider in `config/llm_auth/provider_catalog.py`** using each provider's real wire-format id (Anthropic/OpenAI/Azure/Bedrock resolve; Groq/MiniMax/DeepSeek/Gemini resolve via the compat path; NVIDIA NIM and Ollama stay **unpriced**, never invented).

### Demo/Screenshot for feature changes and bug fixes -

```
satviksawhney@Satviks-MacBook-Pro opensre % uv run python -m pytest tests/fleet_monitoring/test_pricing.py -q
================================================== test session starts ===================================================
platform darwin -- Python 3.13.2, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/satviksawhney/Downloads/OpenSource/opensre
configfile: pytest.ini
plugins: cov-7.1.0, xdist-3.8.0, asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 53 items                                                                                                       

tests/fleet_monitoring/test_pricing.py .....................................................                       [100%]

================================================== slowest 20 durations ==================================================
1.09s call     tests/fleet_monitoring/test_pricing.py::TestUsdPerTokenBlended::test_known_claude_model
0.46s setup    tests/fleet_monitoring/test_pricing.py::TestUsdPerTokenBlended::test_known_claude_model

(18 durations < 0.005s hidden.  Use -vv to show these durations.)
=================================================== 53 passed in 1.62s ===================================================
satviksawhney@Satviks-MacBook-Pro opensre % uv run python3 -c "
from tools.system.fleet_monitoring.pricing import usd_per_token_blended
for m in ('claude-sonnet-4-5', 'gpt-5-codex', 'gemini-2.5-pro', 'deepseek-chat',
          'llama-3.3-70b-versatile', 'MiniMax-M2.1', 'meta/llama-3.1-70b-instruct'):
    print(m, '->', usd_per_token_blended(m))
"
claude-sonnet-4-5 -> 6.5999999999999995e-06
gpt-5-codex -> 3.875e-06
gemini-2.5-pro -> 3.875e-06
deepseek-chat -> 3.22e-07
llama-3.3-70b-versatile -> 6.499999999999999e-07
MiniMax-M2.1 -> 5.699999999999999e-07
meta/llama-3.1-70b-instruct -> None
```
```
### pricing.py — same rate, now sourced from LiteLLM's local snapshot
usd_for_usage(TokenUsage(input_tokens=1000, output_tokens=500), "claude-sonnet-4-5")  ->  0.0105   # unchanged
usd_for_usage(..., "gpt-4o")                                                            ->  0.0075   # from litellm
usd_for_usage(..., "llama-3.3-70b-versatile")  # groq bare id  -> priced (compat prefix)
usd_for_usage(..., "MiniMax-M2.1")             # mixed-case     -> priced (case-insensitive)
usd_for_usage(..., "meta/llama-3.1-70b-instruct")  # NVIDIA NIM -> None (unpriced, not invented)

### estimate_model_spend — unknown model surfaced, not costed at $0
{ "priced": false, "total_usd": 0.0,
  "by_model": [ { "model": "some-unlisted-model", "priced": false, "usd": null } ],
  "unpriced_models": [ "some-unlisted-model" ] }

### summarize_model_burn_rate — projected from a 120s run's totals
{ "priced": true, "elapsed_seconds": 120, "usage_interpreted_as": "totals_over_elapsed_seconds",
  "total_usd_per_hour": 6.3 }
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The pricing migration is the direction I proposed on the #3965 review before #4035 existed. The key correctness concern is determinism: `litellm.model_cost` is a process-wide global filled by a live fetch on first import, so a value that depends on it changes with unrelated import order. I read LiteLLM's bundled JSON snapshot directly (deterministic, offline) and additionally pin `LITELLM_LOCAL_MODEL_COST_MAP` to avoid the wasted fetch. Rates are extracted into the existing `ModelPrice` shape and run through the already-tested `usd_for_usage` bucket formula, so the migration is behavior-preserving (verified: 46/58 of the old table's ids match the snapshot exactly, 0 conflicts; the rest are the local fallback). Provider coverage is handled with a case-folded index and a narrow Groq/MiniMax bare-name fallback; everything unknown stays unpriced. `model_spend_tool` rides the migrated pricer unchanged and hardens all malformed-input paths. All of this was cross-checked against a full provider sweep and an adversarial self-review (import-order safety, failure-caching, first-render import cost).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

All checks green locally: `make lint` · `make format-check` · `make typecheck` (1251 files) · `make test-scope` (11,355 passed; the single failure is a pre-existing, unrelated sentry-summary skill-length test that also fails on `main`). Pricing suite covers behavior-preservation, the local-snapshot source, provider compatibility, Bedrock/case-insensitive resolution, reconciliation drift, failure-degrades-to-fallback, and the `model_spend_tool` calculators.

@greptile review