### PR TITLE
docs: remove dead fargate/ link from platform/deployment README

### DIFF
--- a/platform/deployment/README.md
+++ b/platform/deployment/README.md
@@ -8,7 +8,6 @@ AWS EC2 deployment and shared provisioning primitives for OpenSRE.
 | --- | --- |
 | [`aws/`](aws/) | Shared AWS SDK primitives (`client`, `config`, VPC/SG, EC2/IAM, ECR, SSM). |
 | [`ecr_deploy/`](ecr_deploy/) | Docker/ECR EC2 provisioning: `opensre-web` + `opensre-gateway` on one instance. |
-| [`fargate/`](fargate/) | ECS Fargate + RDS layout (plan/dry-run; apply not implemented yet). |
 | [`gateway/`](gateway/) | AMI + systemd deployment path for the messaging gateway (Telegram and/or Slack; no Docker/ECR). See [gateway/README.md](gateway/README.md). |
 | `install-proxy/` | Install proxy utility (Cloudflare Worker). |
 


### PR DESCRIPTION
## Summary
- The "What's here" table in `platform/deployment/README.md` listed a `fargate/` sub-directory that was never committed to this repo, so the relative link 404s.
- The other four rows (`aws/`, `ecr_deploy/`, `gateway/`, `install-proxy/`) all resolve; only `fargate/` was dead.
- Actual Fargate infra lives under `tests/benchmarks/cloudopsbench/infra/`, which is already linked correctly lower in the same file.

## Fix
Removed the stale `fargate/` inventory row.

Fixes #4033