### PR TITLE
fix(interactive-shell): align /integrations table with plain CLI status colors, connected-first sorting

### DIFF
--- a/surfaces/interactive_shell/ui/tables/tables.py
+++ b/surfaces/interactive_shell/ui/tables/tables.py
@@ -17,6 +17,10 @@ from platform.terminal.theme import (
     BOLD_BRAND,
     DIM,
     ERROR,
+    GLYPH_BULLET,
+    GLYPH_ERROR,
+    GLYPH_SUCCESS,
+    GLYPH_WARNING,
     HIGHLIGHT,
     WARNING,
 )
@@ -39,10 +43,22 @@ def status_style(status: str) -> str:
     return {
         "ok": HIGHLIGHT,
         "configured": HIGHLIGHT,
-        "missing": DIM,
-        "failed": WARNING,
+        "passed": HIGHLIGHT,
+        "missing": WARNING,
+        "failed": ERROR,
         "error": ERROR,
     }.get(status, DIM)
+
+
+def status_glyph(status: str) -> str:
+    return {
+        "ok": GLYPH_SUCCESS,
+        "configured": GLYPH_SUCCESS,
+        "passed": GLYPH_SUCCESS,
+        "missing": GLYPH_WARNING,
+        "failed": GLYPH_ERROR,
+        "error": GLYPH_ERROR,
+    }.get(status, GLYPH_BULLET)
 
 
 # ---------------------------------------------------------------------------
@@ -131,13 +147,24 @@ def _integration_row(r: dict[str, str]) -> tuple[str | Text, ...]:
     return (
         r.get("service", "?"),
         r.get("source", "?"),
-        Text(st, style=status_style(st)),
+        Text(f"{status_glyph(st)} {st}", style=status_style(st)),
         r.get("detail", ""),
     )
 
 
+_CONNECTED_STATUSES = frozenset({"ok", "configured", "passed"})
+
+
 def render_integrations_table(console: Console, results: list[dict[str, str]]) -> None:
-    rows = sorted(results, key=lambda r: r.get("service", ""))
+    # Connected integrations first (so the few a user has actually set up
+    # aren't buried among 50+ "missing" rows), alphabetical within each group.
+    rows = sorted(
+        results,
+        key=lambda r: (
+            r.get("status") not in _CONNECTED_STATUSES,
+            r.get("service", ""),
+        ),
+    )
     if not rows:
         repl_print(
             console, f"[{DIM}]no integrations configured.  try `opensre onboard` to add one.[/]"

--- a/surfaces/interactive_shell/ui/tables/tables.py
+++ b/surfaces/interactive_shell/ui/tables/tables.py
@@ -147,7 +147,7 @@ def _integration_row(r: dict[str, str]) -> tuple[str | Text, ...]:
     return (
         r.get("service", "?"),
         r.get("source", "?"),
-        Text(f"{status_glyph(st)} {st}", style=status_style(st)),
+        Text(st, style=status_style(st)),
         r.get("detail", ""),
     )
 


### PR DESCRIPTION

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
- Fixed a pre-existing mismatch: status_style() had no case for
  "passed" (the actual status verify_integrations() returns) and
  missing/failed colors were swapped relative to the CLI's convention.
  Now: passed=green, missing=yellow, failed=red.
- render_integrations_table() now sorts connected/passed integrations
  first, alphabetical within each group, instead of pure alphabetical -
  so a user's few configured integrations aren't buried among 50+
  unconfigured ones.



---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
