### PR TITLE
feat(sentry): uptime watch — notify on downtime transitions (#4032)

### DIFF
--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -129,7 +129,7 @@ These commands delegate to the same Click CLI you would run outside the REPL.
 | `/remote` | Connect to and operate remote deployed agents |
 | `/config` | Show or edit `~/.opensre/config.yml` |
 | `/cron` | Manage scheduled delivery jobs |
-| `/sentry` | Schedule automated Sentry morning digests (Telegram or Slack required) |
+| `/sentry` | Schedule automated Sentry morning digests or uptime watches (Telegram or Slack required) |
 | `/messaging` | Telegram pairing and allowlist |
 | `/hermes` | Hermes log tailing and incident escalation |
 | `/guardrails` | Sensitive-information guardrail rules |
@@ -947,9 +947,15 @@ Scheduled investigation or report delivery. See [Cron](/cron).
 /sentry digest schedule add --cron "0 8 * * *" --provider telegram --chat-id <id>
 /sentry digest schedule run <id>
 /sentry digest schedule remove <id>
+/sentry uptime check
+/sentry uptime watch list
+/sentry uptime watch add --cron "*/5 * * * *" --provider telegram --chat-id <id>
+/sentry uptime watch run <id>
+/sentry uptime watch remove <id>
 ```
 
-Automated Sentry morning digest delivery (#10). Requires Sentry plus Telegram or Slack configured for the chosen provider. See [Sentry](/sentry).
+Automated Sentry morning digest delivery (#10) and uptime watch notifications (#4032).
+Requires Sentry plus Telegram or Slack configured for the chosen provider. See [Sentry](/sentry).
 
 ### `/messaging`
 

--- a/docs/sentry.mdx
+++ b/docs/sentry.mdx
@@ -8,7 +8,9 @@ OpenSRE queries Sentry to retrieve recent issues, error events, and stack traces
 ## Prerequisites
 
 - Sentry account with at least one organization
-- Auth token with `event:read` scope
+- Auth token with `event:read` scope (Issues lookup)
+- For uptime watching: also `alerts:read` (or `org:read`) so
+  `opensre sentry uptime` can list monitors
 
 ## Setup
 
@@ -35,7 +37,7 @@ SENTRY_STATS_PERIOD=24h                # optional, issue search time window
 | Variable | Default | Description |
 | --- | --- | --- |
 | `SENTRY_ORG_SLUG` | — | **Required.** Your Sentry organization slug |
-| `SENTRY_AUTH_TOKEN` | — | **Required.** Sentry auth token with `event:read` |
+| `SENTRY_AUTH_TOKEN` | — | **Required.** Sentry auth token with `event:read` (add `alerts:read` for uptime watch) |
 | `SENTRY_URL` | `https://sentry.io` | Override for self-hosted Sentry |
 | `SENTRY_PROJECT_SLUG` | — | Scope queries to a specific project |
 | `SENTRY_STATS_PERIOD` | `24h` | Time window for issue searches (e.g. `24h`, `14d`, `90d`) |
@@ -74,7 +76,7 @@ almost always the time window or a `SENTRY_PROJECT_SLUG` scope — not a cap of 
 
 1. In Sentry, go to **Settings** → **Developer Settings** → **Organization Tokens**
 2. Click **Create New Token**
-3. Enable the `event:read` scope
+3. Enable the `event:read` scope (and `alerts:read` if you use uptime watch)
 4. Copy the token
 
 **Alternative: Internal Integration**
@@ -144,6 +146,38 @@ The count reflects issues seen in the last 7 days (capped at 100, shown as
 `100+` when it saturates). Use a search (e.g. `search_sentry_issues` during an
 investigation) to enumerate the full issue set over a custom window.
 </Note>
+
+## Uptime watch (downtime notifications)
+
+Poll Sentry **uptime monitors** (Alerts / Uptime — not the Issues digest) and
+ping Slack or Telegram only when a monitor transitions to **down** or
+**recovered**. Quiet polls deliver nothing. This is separate from the morning
+Issues digest (`sentry-summary` / Feature #10).
+
+| Command | What it does |
+| --- | --- |
+| `opensre sentry uptime check` | List current uptime monitor health once |
+| `opensre sentry uptime watch add` | Schedule polling (default every 5 minutes) |
+| `opensre sentry uptime watch list` | List uptime watch schedules |
+| `opensre sentry uptime watch run TASK_ID` | Run a watch tick now (may notify) |
+| `opensre sentry uptime watch remove TASK_ID` | Remove a watch schedule |
+
+Example — poll every 5 minutes and ping Slack on transitions:
+
+```bash
+opensre sentry uptime watch add \
+  --cron "*/5 * * * *" \
+  --tz UTC \
+  --provider slack \
+  --chat-id C0123ABCD
+```
+
+Requires `alerts:read` (or equivalent) on the Sentry token. The agent tool
+`list_sentry_uptime_alerts` exposes the same monitor list in chat/investigation.
+
+Follow-ups (not in v1): inbound Sentry webhooks, auto-remediation attempts, and
+a morning-digest section summarizing yesterday's uptime transitions.
+
 ## Telemetry knobs
 
 | Variable | Default | Description |
@@ -179,7 +213,7 @@ command exits non-zero without sending anything.
 
 | Symptom | Fix |
 | --- | --- |
-| **403 Forbidden** | Ensure the token has `event:read` scope |
+| **403 Forbidden** | Ensure the token has `event:read`; for uptime watch also `alerts:read` |
 | **Organization not found** | Verify `SENTRY_ORG_SLUG` matches the slug in your Sentry URL |
 | **Connection refused** | Check `SENTRY_URL` for self-hosted instances |
 | **No issues returned** | Normal if no issues exist in the time window — check `SENTRY_PROJECT_SLUG` |

--- a/integrations/scheduled_agent_bootstrap.py
+++ b/integrations/scheduled_agent_bootstrap.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 from integrations.github.pr_sweep_runner import run_github_pr_sweep
 from integrations.sentry.morning_digest_runner import run_sentry_morning_digest
+from integrations.sentry.uptime import run_uptime_watch_tick
 from platform.scheduler.agent_runner import AgentPayload, register_agent_runner
 
 
 def run_scheduled_agent_digest(payload: AgentPayload) -> str:
-    """Route by ``payload['source']`` to Sentry digest or GitHub PR sweep."""
+    """Route by ``payload['source']`` to Sentry digest, uptime watch, or GitHub PR sweep."""
     source = str(payload.get("source") or "")
+    if "uptime_watch" in source:
+        return run_uptime_watch_tick(
+            task_id=str(payload.get("task_id") or "cli"),
+            project_slug=str(payload.get("project_slug") or "").strip(),
+        )
     if "github_pr" in source:
         return run_github_pr_sweep(payload)
     return run_sentry_morning_digest(payload)

--- a/integrations/sentry/__init__.py
+++ b/integrations/sentry/__init__.py
@@ -115,7 +115,10 @@ def get_sentry_auth_recommendations() -> dict[str, str]:
         "where_to_create": "Settings > Developer Settings > Organization Tokens",
         "fallback_token_type": "Internal Integration",
         "fallback_where_to_create": "Settings > Developer Settings > Internal Integrations",
-        "required_scope_hint": "Issue and event lookup requires an auth token with event:read access.",
+        "required_scope_hint": (
+            "Issue and event lookup requires event:read. "
+            "Uptime monitor watching (opensre sentry uptime) also needs alerts:read."
+        ),
     }
 
 

--- a/integrations/sentry/tools/sentry_list_uptime_alerts_tool/__init__.py
+++ b/integrations/sentry/tools/sentry_list_uptime_alerts_tool/__init__.py
@@ -4,14 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-import httpx
-
 from core.tool_framework.telemetry import report_run_error
 from core.tool_framework.tool_decorator import tool
 from integrations.sentry import (
     SentryConfig,
     build_sentry_config,
-    describe_sentry_api_error,
     sentry_config_from_env,
 )
 from integrations.sentry.uptime import list_sentry_uptime_monitors
@@ -75,6 +72,7 @@ def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         },
         "required": ["organization_slug", "sentry_token"],
     },
+    injected_params=("organization_slug", "sentry_token", "sentry_url", "project_slug"),
     is_available=_sentry_available,
     extract_params=_extract_params,
     surfaces=("investigation", "chat"),
@@ -88,31 +86,52 @@ def list_sentry_uptime_alerts(
     """Return normalized Sentry uptime monitor health."""
     config = _resolve_config(sentry_url, organization_slug, sentry_token, project_slug)
     if config is None:
-        return {"error": "Sentry organization_slug and auth token are required."}
+        return {
+            "source": "sentry",
+            "available": False,
+            "error": "Sentry organization_slug and auth token are required.",
+            "monitors": [],
+        }
 
     try:
         monitors = list_sentry_uptime_monitors(config=config)
     except RuntimeError as err:
-        return {"error": str(err)}
-    except httpx.HTTPStatusError as err:
+        # HTTP failures are wrapped as RuntimeError by list_sentry_uptime_monitors.
         report_run_error(
             err,
             tool_name="list_sentry_uptime_alerts",
-            integration="sentry",
+            source="sentry",
+            component="integrations.sentry.tools.sentry_list_uptime_alerts_tool",
+            method="list_sentry_uptime_monitors",
+            severity="warning",
+            extras={"organization_slug": config.organization_slug},
         )
         return {
-            "error": describe_sentry_api_error(err, project_slug=config.project_slug),
+            "source": "sentry",
+            "available": False,
+            "error": str(err),
+            "monitors": [],
         }
     except Exception as err:
         report_run_error(
             err,
             tool_name="list_sentry_uptime_alerts",
-            integration="sentry",
+            source="sentry",
+            component="integrations.sentry.tools.sentry_list_uptime_alerts_tool",
+            method="list_sentry_uptime_monitors",
+            extras={"organization_slug": config.organization_slug},
         )
-        return {"error": f"Failed to list Sentry uptime monitors: {err}"}
+        return {
+            "source": "sentry",
+            "available": False,
+            "error": f"Failed to list Sentry uptime monitors: {err}",
+            "monitors": [],
+        }
 
     down = [m for m in monitors if m.health == "down"]
     return {
+        "source": "sentry",
+        "available": True,
         "monitor_count": len(monitors),
         "down_count": len(down),
         "monitors": [

--- a/integrations/sentry/tools/sentry_list_uptime_alerts_tool/__init__.py
+++ b/integrations/sentry/tools/sentry_list_uptime_alerts_tool/__init__.py
@@ -1,0 +1,131 @@
+"""List Sentry uptime monitors for investigations and chat."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from core.tool_framework.telemetry import report_run_error
+from core.tool_framework.tool_decorator import tool
+from integrations.sentry import (
+    SentryConfig,
+    build_sentry_config,
+    describe_sentry_api_error,
+    sentry_config_from_env,
+)
+from integrations.sentry.uptime import list_sentry_uptime_monitors
+
+
+def _resolve_config(
+    sentry_url: str | None,
+    organization_slug: str | None,
+    sentry_token: str | None,
+    project_slug: str | None = None,
+) -> SentryConfig | None:
+    env_config = sentry_config_from_env()
+    config = build_sentry_config(
+        {
+            "base_url": sentry_url or (env_config.base_url if env_config else ""),
+            "organization_slug": organization_slug
+            or (env_config.organization_slug if env_config else ""),
+            "auth_token": sentry_token or (env_config.auth_token if env_config else ""),
+            "project_slug": project_slug or (env_config.project_slug if env_config else ""),
+        }
+    )
+    if not config.organization_slug or not config.auth_token:
+        return None
+    return config
+
+
+def _sentry_available(sources: dict[str, dict]) -> bool:
+    return bool(sources.get("sentry", {}).get("connection_verified"))
+
+
+def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:
+    sentry = sources["sentry"]
+    return {
+        "organization_slug": sentry.get("organization_slug", ""),
+        "sentry_token": sentry.get("sentry_token") or sentry.get("auth_token", ""),
+        "sentry_url": sentry.get("sentry_url") or sentry.get("base_url") or "https://sentry.io",
+        "project_slug": sentry.get("project_slug", ""),
+    }
+
+
+@tool(
+    name="list_sentry_uptime_alerts",
+    source="sentry",
+    description=(
+        "List Sentry uptime monitors and their current health (up/down). "
+        "Use for downtime/alerts status — not for clustering error Issues."
+    ),
+    use_cases=[
+        "Checking which domains or URLs are currently down in Sentry uptime",
+        "Confirming whether a critical downtime alert is still firing",
+        "Listing uptime monitors before or after a recovery",
+    ],
+    requires=["organization_slug", "sentry_token"],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "organization_slug": {"type": "string"},
+            "sentry_token": {"type": "string"},
+            "sentry_url": {"type": "string", "default": ""},
+            "project_slug": {"type": "string", "default": ""},
+        },
+        "required": ["organization_slug", "sentry_token"],
+    },
+    is_available=_sentry_available,
+    extract_params=_extract_params,
+    surfaces=("investigation", "chat"),
+)
+def list_sentry_uptime_alerts(
+    organization_slug: str,
+    sentry_token: str,
+    sentry_url: str = "",
+    project_slug: str = "",
+) -> dict[str, Any]:
+    """Return normalized Sentry uptime monitor health."""
+    config = _resolve_config(sentry_url, organization_slug, sentry_token, project_slug)
+    if config is None:
+        return {"error": "Sentry organization_slug and auth token are required."}
+
+    try:
+        monitors = list_sentry_uptime_monitors(config=config)
+    except RuntimeError as err:
+        return {"error": str(err)}
+    except httpx.HTTPStatusError as err:
+        report_run_error(
+            err,
+            tool_name="list_sentry_uptime_alerts",
+            integration="sentry",
+        )
+        return {
+            "error": describe_sentry_api_error(err, project_slug=config.project_slug),
+        }
+    except Exception as err:
+        report_run_error(
+            err,
+            tool_name="list_sentry_uptime_alerts",
+            integration="sentry",
+        )
+        return {"error": f"Failed to list Sentry uptime monitors: {err}"}
+
+    down = [m for m in monitors if m.health == "down"]
+    return {
+        "monitor_count": len(monitors),
+        "down_count": len(down),
+        "monitors": [
+            {
+                "id": m.id,
+                "name": m.name,
+                "url": m.url,
+                "project_slug": m.project_slug,
+                "health": m.health,
+                "uptime_status": m.uptime_status,
+                "status": m.status,
+                "severity": "critical" if m.health == "down" else "ok",
+            }
+            for m in monitors
+        ],
+    }

--- a/integrations/sentry/uptime.py
+++ b/integrations/sentry/uptime.py
@@ -70,24 +70,41 @@ class WatchState:
     open_incidents: set[str] = field(default_factory=set)
 
 
+def _store_credentials(store: dict[str, Any]) -> dict[str, Any]:
+    """Extract Sentry credentials from an integration store record.
+
+    Store shape is ``{credentials: {...}}`` (optionally with ``instances``),
+    not a top-level ``config`` dict.
+    """
+    creds = store.get("credentials")
+    if isinstance(creds, dict) and creds:
+        return creds
+    instances = store.get("instances")
+    if isinstance(instances, list):
+        for instance in instances:
+            if not isinstance(instance, dict):
+                continue
+            nested = instance.get("credentials")
+            if isinstance(nested, dict) and nested:
+                return nested
+    # Legacy / test shapes
+    nested_config = store.get("config")
+    if isinstance(nested_config, dict) and nested_config:
+        return nested_config
+    return store
+
+
 def resolve_sentry_config(*, project_slug: str = "") -> SentryConfig | None:
     """Resolve Sentry REST config from env, then the integration store."""
     env_config = sentry_config_from_env()
     store = get_integration("sentry") or {}
-    raw_config = store.get("config")
-    store_config: dict[str, Any]
-    if isinstance(raw_config, dict):
-        store_config = raw_config
-    elif isinstance(store, dict):
-        store_config = store
-    else:
-        store_config = {}
+    store_config = _store_credentials(store if isinstance(store, dict) else {})
 
     organization_slug = (env_config.organization_slug if env_config else "") or str(
         store_config.get("organization_slug") or ""
     ).strip()
     auth_token = (env_config.auth_token if env_config else "") or str(
-        store_config.get("auth_token") or ""
+        store_config.get("auth_token") or store_config.get("sentry_token") or ""
     ).strip()
     if not organization_slug or not auth_token:
         return None
@@ -101,7 +118,11 @@ def resolve_sentry_config(*, project_slug: str = "") -> SentryConfig | None:
         {
             "base_url": (
                 (env_config.base_url if env_config else "")
-                or str(store_config.get("base_url") or "https://sentry.io").strip()
+                or str(
+                    store_config.get("base_url")
+                    or store_config.get("sentry_url")
+                    or "https://sentry.io"
+                ).strip()
                 or "https://sentry.io"
             ),
             "organization_slug": organization_slug,

--- a/integrations/sentry/uptime.py
+++ b/integrations/sentry/uptime.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
@@ -61,11 +62,26 @@ class UptimeTransition:
     monitor: UptimeMonitor
 
 
+@dataclass
+class WatchState:
+    """Persisted per-task watch snapshot."""
+
+    health: dict[str, MonitorHealth] = field(default_factory=dict)
+    open_incidents: set[str] = field(default_factory=set)
+
+
 def resolve_sentry_config(*, project_slug: str = "") -> SentryConfig | None:
     """Resolve Sentry REST config from env, then the integration store."""
     env_config = sentry_config_from_env()
     store = get_integration("sentry") or {}
-    store_config = store.get("config") if isinstance(store.get("config"), dict) else store
+    raw_config = store.get("config")
+    store_config: dict[str, Any]
+    if isinstance(raw_config, dict):
+        store_config = raw_config
+    elif isinstance(store, dict):
+        store_config = store
+    else:
+        store_config = {}
 
     organization_slug = (env_config.organization_slug if env_config else "") or str(
         store_config.get("organization_slug") or ""
@@ -161,52 +177,65 @@ def list_sentry_uptime_monitors(*, config: SentryConfig) -> list[UptimeMonitor]:
     return monitors
 
 
-def health_snapshot(monitors: list[UptimeMonitor]) -> dict[str, MonitorHealth]:
-    """Map monitor id → health for persistence."""
-    return {monitor.id: monitor.health for monitor in monitors}
+def health_snapshot(
+    monitors: list[UptimeMonitor],
+    *,
+    previous: dict[str, MonitorHealth] | None = None,
+) -> dict[str, MonitorHealth]:
+    """Map monitor id → health for persistence.
+
+    Unknown samples do not clobber a known prior value so a transient
+    ``down → unknown → up`` sequence still recovers cleanly.
+    """
+    prior = previous or {}
+    out: dict[str, MonitorHealth] = {}
+    for monitor in monitors:
+        if monitor.health == "unknown" and prior.get(monitor.id) in ("up", "down"):
+            out[monitor.id] = prior[monitor.id]
+        else:
+            out[monitor.id] = monitor.health
+    return out
 
 
 def detect_uptime_transitions(
     previous: dict[str, MonitorHealth],
     monitors: list[UptimeMonitor],
     *,
+    open_incidents: set[str] | None = None,
     notify_initial_down: bool = True,
-) -> list[UptimeTransition]:
-    """Return DOWN / RECOVERED transitions versus *previous* snapshot.
+) -> tuple[list[UptimeTransition], set[str]]:
+    """Return DOWN / RECOVERED transitions and the updated open-incident set.
 
-    First poll (empty *previous*): optionally emit DOWN for currently-failed
-    monitors so existing outages are not silent until the next flip.
+    Recovery is keyed off *open_incidents*, not only the prior health value, so
+    ``down → unknown → up`` still emits RECOVERED.
     """
     transitions: list[UptimeTransition] = []
+    open_set = set(open_incidents or ())
     by_id = {monitor.id: monitor for monitor in monitors}
 
-    if not previous:
+    if not previous and not open_set:
         if notify_initial_down:
             for monitor in monitors:
                 if monitor.health == "down":
                     transitions.append(UptimeTransition(kind="down", monitor=monitor))
-        return transitions
+                    open_set.add(monitor.id)
+        return transitions, open_set
 
-    for monitor_id, monitor in by_id.items():
-        prior = previous.get(monitor_id)
-        if prior is None:
-            if monitor.health == "down":
-                transitions.append(UptimeTransition(kind="down", monitor=monitor))
-            continue
-        if prior != "down" and monitor.health == "down":
+    for monitor in by_id.values():
+        if monitor.health == "down" and monitor.id not in open_set:
             transitions.append(UptimeTransition(kind="down", monitor=monitor))
-        elif prior == "down" and monitor.health == "up":
+            open_set.add(monitor.id)
+        elif monitor.health == "up" and monitor.id in open_set:
             transitions.append(UptimeTransition(kind="recovered", monitor=monitor))
+            open_set.discard(monitor.id)
+        # unknown: leave open_incidents unchanged
 
-    for monitor_id, prior in previous.items():
+    for monitor_id in list(open_set):
         if monitor_id in by_id:
             continue
-        # Monitor disappeared from the API — if it was down, treat as recovered
-        # only when we no longer observe it as failing (cannot confirm up).
-        if prior == "down":
-            logger.info("Previously down uptime monitor %s no longer listed", monitor_id)
+        logger.info("Previously open uptime incident %s no longer listed", monitor_id)
 
-    return transitions
+    return transitions, open_set
 
 
 def format_uptime_transition_message(transitions: list[UptimeTransition]) -> str:
@@ -234,38 +263,47 @@ def load_watch_state(
     task_id: str,
     *,
     path: Path | None = None,
-) -> dict[str, MonitorHealth]:
-    """Load prior health snapshot for a scheduled watch task."""
+) -> WatchState:
+    """Load prior health snapshot and open incidents for a watch task."""
     store_path = path or _state_path()
     if not store_path.exists():
-        return {}
+        return WatchState()
     try:
         raw = json.loads(store_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         logger.warning("Failed to read uptime watch state: %s", exc)
-        return {}
+        return WatchState()
     if not isinstance(raw, dict):
-        return {}
+        return WatchState()
     entry = raw.get(task_id)
     if not isinstance(entry, dict):
-        return {}
+        return WatchState()
+
+    health: dict[str, MonitorHealth] = {}
     snapshot = entry.get("health")
-    if not isinstance(snapshot, dict):
-        return {}
-    out: dict[str, MonitorHealth] = {}
-    for key, value in snapshot.items():
-        if value in ("up", "down", "unknown"):
-            out[str(key)] = value  # type: ignore[assignment]
-    return out
+    if isinstance(snapshot, dict):
+        for key, value in snapshot.items():
+            if value in ("up", "down", "unknown"):
+                health[str(key)] = value  # type: ignore[assignment]
+
+    open_incidents: set[str] = set()
+    incidents = entry.get("open_incidents")
+    if isinstance(incidents, list):
+        open_incidents = {str(item) for item in incidents if str(item).strip()}
+    else:
+        # Back-compat: reconstruct open incidents from down snapshots.
+        open_incidents = {mid for mid, status in health.items() if status == "down"}
+
+    return WatchState(health=health, open_incidents=open_incidents)
 
 
 def save_watch_state(
     task_id: str,
-    health: dict[str, MonitorHealth],
+    state: WatchState,
     *,
     path: Path | None = None,
 ) -> None:
-    """Persist health snapshot for a scheduled watch task."""
+    """Persist watch state atomically (temp file + replace)."""
     store_path = path or _state_path()
     store_path.parent.mkdir(parents=True, exist_ok=True)
     existing: dict[str, Any] = {}
@@ -276,8 +314,14 @@ def save_watch_state(
                 existing = loaded
         except (OSError, json.JSONDecodeError):
             existing = {}
-    existing[task_id] = {"health": health}
-    store_path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    existing[task_id] = {
+        "health": state.health,
+        "open_incidents": sorted(state.open_incidents),
+    }
+    payload = json.dumps(existing, indent=2, sort_keys=True) + "\n"
+    tmp_path = store_path.with_suffix(store_path.suffix + f".{os.getpid()}.tmp")
+    tmp_path.write_text(payload, encoding="utf-8")
+    tmp_path.replace(store_path)
 
 
 def run_uptime_watch_tick(
@@ -297,18 +341,24 @@ def run_uptime_watch_tick(
 
     monitors = list_sentry_uptime_monitors(config=config)
     previous = load_watch_state(task_id, path=state_path)
-    transitions = detect_uptime_transitions(
-        previous,
+    transitions, open_incidents = detect_uptime_transitions(
+        previous.health,
         monitors,
+        open_incidents=previous.open_incidents,
         notify_initial_down=notify_initial_down,
     )
-    save_watch_state(task_id, health_snapshot(monitors), path=state_path)
+    next_state = WatchState(
+        health=health_snapshot(monitors, previous=previous.health),
+        open_incidents=open_incidents,
+    )
+    save_watch_state(task_id, next_state, path=state_path)
     return format_uptime_transition_message(transitions)
 
 
 __all__ = [
     "UptimeMonitor",
     "UptimeTransition",
+    "WatchState",
     "detect_uptime_transitions",
     "format_uptime_transition_message",
     "health_snapshot",

--- a/integrations/sentry/uptime.py
+++ b/integrations/sentry/uptime.py
@@ -276,6 +276,26 @@ def format_uptime_transition_message(transitions: list[UptimeTransition]) -> str
     return "\n".join(lines)
 
 
+def format_uptime_watch_active_message(
+    *,
+    task_id: str,
+    cron: str,
+    timezone: str,
+    project_slug: str = "",
+) -> str:
+    """One-shot confirmation when a watch schedule is created."""
+    scope = (
+        f"Sentry project `{project_slug}`" if project_slug.strip() else "all Sentry uptime monitors"
+    )
+    return (
+        "Sentry uptime watch is **active**.\n"
+        f"OpenSRE will poll {scope} on schedule `{cron}` ({timezone}) "
+        "and ping this chat when a monitor goes **down** or **recovers**.\n"
+        "Quiet polls (no change) send nothing.\n"
+        f"Task id: `{task_id}`"
+    )
+
+
 def _state_path() -> Path:
     return OPENSRE_HOME_DIR / "sentry_uptime_watch_state.json"
 
@@ -382,6 +402,7 @@ __all__ = [
     "WatchState",
     "detect_uptime_transitions",
     "format_uptime_transition_message",
+    "format_uptime_watch_active_message",
     "health_snapshot",
     "list_sentry_uptime_monitors",
     "load_watch_state",

--- a/integrations/sentry/uptime.py
+++ b/integrations/sentry/uptime.py
@@ -1,0 +1,321 @@
+"""Sentry uptime monitor polling, state transitions, and notify messages.
+
+v1 for #4032: REST poll of organization uptime monitors + DOWN/RECOVERED
+transition messages. No skill, no remediation, no morning-report section.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import httpx
+
+from config.constants import OPENSRE_HOME_DIR
+from integrations.sentry import (
+    SentryConfig,
+    _request_json,
+    build_sentry_config,
+    describe_sentry_api_error,
+    sentry_config_from_env,
+)
+from integrations.store import get_integration
+
+logger = logging.getLogger(__name__)
+
+# Sentry UptimeStatus IntEnum: OK=1, FAILED=2
+_UPTIME_STATUS_OK = 1
+_UPTIME_STATUS_FAILED = 2
+
+MonitorHealth = Literal["up", "down", "unknown"]
+TransitionKind = Literal["down", "recovered"]
+
+_ALERTS_READ_HINT = (
+    "Uptime monitor listing requires a Sentry auth token with alerts:read "
+    "(or org:read). The Issues-only event:read scope is not enough — update "
+    "the token scopes and re-run `opensre integrations setup` / verify sentry."
+)
+
+
+@dataclass(frozen=True)
+class UptimeMonitor:
+    """Normalized Sentry uptime monitor row."""
+
+    id: str
+    name: str
+    url: str
+    project_slug: str
+    health: MonitorHealth
+    uptime_status: int | None
+    status: str
+
+
+@dataclass(frozen=True)
+class UptimeTransition:
+    """A health transition worth notifying about."""
+
+    kind: TransitionKind
+    monitor: UptimeMonitor
+
+
+def resolve_sentry_config(*, project_slug: str = "") -> SentryConfig | None:
+    """Resolve Sentry REST config from env, then the integration store."""
+    env_config = sentry_config_from_env()
+    store = get_integration("sentry") or {}
+    store_config = store.get("config") if isinstance(store.get("config"), dict) else store
+
+    organization_slug = (env_config.organization_slug if env_config else "") or str(
+        store_config.get("organization_slug") or ""
+    ).strip()
+    auth_token = (env_config.auth_token if env_config else "") or str(
+        store_config.get("auth_token") or ""
+    ).strip()
+    if not organization_slug or not auth_token:
+        return None
+
+    slug = (
+        project_slug.strip()
+        or (env_config.project_slug if env_config else "")
+        or str(store_config.get("project_slug") or "").strip()
+    )
+    return build_sentry_config(
+        {
+            "base_url": (
+                (env_config.base_url if env_config else "")
+                or str(store_config.get("base_url") or "https://sentry.io").strip()
+                or "https://sentry.io"
+            ),
+            "organization_slug": organization_slug,
+            "auth_token": auth_token,
+            "project_slug": slug,
+        }
+    )
+
+
+def _normalize_health(uptime_status: Any) -> MonitorHealth:
+    try:
+        value = int(uptime_status)
+    except (TypeError, ValueError):
+        return "unknown"
+    if value == _UPTIME_STATUS_FAILED:
+        return "down"
+    if value == _UPTIME_STATUS_OK:
+        return "up"
+    return "unknown"
+
+
+def normalize_uptime_monitor(raw: dict[str, Any]) -> UptimeMonitor | None:
+    """Normalize one Sentry uptime detector payload."""
+    monitor_id = str(raw.get("id") or "").strip()
+    if not monitor_id:
+        return None
+    uptime_status = raw.get("uptimeStatus", raw.get("uptime_status"))
+    return UptimeMonitor(
+        id=monitor_id,
+        name=str(raw.get("name") or "").strip() or f"uptime-{monitor_id}",
+        url=str(raw.get("url") or "").strip(),
+        project_slug=str(raw.get("projectSlug") or raw.get("project_slug") or "").strip(),
+        health=_normalize_health(uptime_status),
+        uptime_status=(
+            int(uptime_status)
+            if isinstance(uptime_status, int)
+            or (isinstance(uptime_status, str) and uptime_status.isdigit())
+            else None
+        ),
+        status=str(raw.get("status") or "").strip() or "unknown",
+    )
+
+
+def list_sentry_uptime_monitors(*, config: SentryConfig) -> list[UptimeMonitor]:
+    """List organization uptime monitors via REST.
+
+    Endpoint: ``GET /api/0/organizations/{org}/uptime/``
+    """
+    path = f"/api/0/organizations/{config.organization_slug}/uptime/"
+    params: list[tuple[str, str | int | float | bool | None]] = []
+    if config.project_slug:
+        params.append(("project", config.project_slug))
+
+    try:
+        payload = _request_json(config, "GET", path, params=params or None)
+    except httpx.HTTPStatusError as err:
+        detail = describe_sentry_api_error(
+            err,
+            project_slug=config.project_slug,
+        )
+        if err.response.status_code == 403:
+            detail = f"{detail} {_ALERTS_READ_HINT}"
+        raise RuntimeError(detail) from err
+
+    rows = payload if isinstance(payload, list) else []
+    monitors: list[UptimeMonitor] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        normalized = normalize_uptime_monitor(row)
+        if normalized is not None:
+            monitors.append(normalized)
+    return monitors
+
+
+def health_snapshot(monitors: list[UptimeMonitor]) -> dict[str, MonitorHealth]:
+    """Map monitor id → health for persistence."""
+    return {monitor.id: monitor.health for monitor in monitors}
+
+
+def detect_uptime_transitions(
+    previous: dict[str, MonitorHealth],
+    monitors: list[UptimeMonitor],
+    *,
+    notify_initial_down: bool = True,
+) -> list[UptimeTransition]:
+    """Return DOWN / RECOVERED transitions versus *previous* snapshot.
+
+    First poll (empty *previous*): optionally emit DOWN for currently-failed
+    monitors so existing outages are not silent until the next flip.
+    """
+    transitions: list[UptimeTransition] = []
+    by_id = {monitor.id: monitor for monitor in monitors}
+
+    if not previous:
+        if notify_initial_down:
+            for monitor in monitors:
+                if monitor.health == "down":
+                    transitions.append(UptimeTransition(kind="down", monitor=monitor))
+        return transitions
+
+    for monitor_id, monitor in by_id.items():
+        prior = previous.get(monitor_id)
+        if prior is None:
+            if monitor.health == "down":
+                transitions.append(UptimeTransition(kind="down", monitor=monitor))
+            continue
+        if prior != "down" and monitor.health == "down":
+            transitions.append(UptimeTransition(kind="down", monitor=monitor))
+        elif prior == "down" and monitor.health == "up":
+            transitions.append(UptimeTransition(kind="recovered", monitor=monitor))
+
+    for monitor_id, prior in previous.items():
+        if monitor_id in by_id:
+            continue
+        # Monitor disappeared from the API — if it was down, treat as recovered
+        # only when we no longer observe it as failing (cannot confirm up).
+        if prior == "down":
+            logger.info("Previously down uptime monitor %s no longer listed", monitor_id)
+
+    return transitions
+
+
+def format_uptime_transition_message(transitions: list[UptimeTransition]) -> str:
+    """Format a plain-text notify body for delivery providers."""
+    if not transitions:
+        return ""
+
+    lines = ["Sentry uptime watch"]
+    for transition in transitions:
+        monitor = transition.monitor
+        target = monitor.url or monitor.name
+        project = f" [{monitor.project_slug}]" if monitor.project_slug else ""
+        if transition.kind == "down":
+            lines.append(f"CRITICAL downtime{project}: {monitor.name} — {target}")
+        else:
+            lines.append(f"RECOVERED{project}: {monitor.name} — {target}")
+    return "\n".join(lines)
+
+
+def _state_path() -> Path:
+    return OPENSRE_HOME_DIR / "sentry_uptime_watch_state.json"
+
+
+def load_watch_state(
+    task_id: str,
+    *,
+    path: Path | None = None,
+) -> dict[str, MonitorHealth]:
+    """Load prior health snapshot for a scheduled watch task."""
+    store_path = path or _state_path()
+    if not store_path.exists():
+        return {}
+    try:
+        raw = json.loads(store_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to read uptime watch state: %s", exc)
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    entry = raw.get(task_id)
+    if not isinstance(entry, dict):
+        return {}
+    snapshot = entry.get("health")
+    if not isinstance(snapshot, dict):
+        return {}
+    out: dict[str, MonitorHealth] = {}
+    for key, value in snapshot.items():
+        if value in ("up", "down", "unknown"):
+            out[str(key)] = value  # type: ignore[assignment]
+    return out
+
+
+def save_watch_state(
+    task_id: str,
+    health: dict[str, MonitorHealth],
+    *,
+    path: Path | None = None,
+) -> None:
+    """Persist health snapshot for a scheduled watch task."""
+    store_path = path or _state_path()
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    existing: dict[str, Any] = {}
+    if store_path.exists():
+        try:
+            loaded = json.loads(store_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                existing = loaded
+        except (OSError, json.JSONDecodeError):
+            existing = {}
+    existing[task_id] = {"health": health}
+    store_path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run_uptime_watch_tick(
+    *,
+    task_id: str,
+    project_slug: str = "",
+    state_path: Path | None = None,
+    notify_initial_down: bool = True,
+) -> str:
+    """Poll uptime monitors and return a notify message (empty if quiet)."""
+    config = resolve_sentry_config(project_slug=project_slug)
+    if config is None:
+        raise RuntimeError(
+            "Sentry is not configured. Run `opensre integrations setup` and verify "
+            "with `opensre integrations verify sentry`."
+        )
+
+    monitors = list_sentry_uptime_monitors(config=config)
+    previous = load_watch_state(task_id, path=state_path)
+    transitions = detect_uptime_transitions(
+        previous,
+        monitors,
+        notify_initial_down=notify_initial_down,
+    )
+    save_watch_state(task_id, health_snapshot(monitors), path=state_path)
+    return format_uptime_transition_message(transitions)
+
+
+__all__ = [
+    "UptimeMonitor",
+    "UptimeTransition",
+    "detect_uptime_transitions",
+    "format_uptime_transition_message",
+    "health_snapshot",
+    "list_sentry_uptime_monitors",
+    "load_watch_state",
+    "normalize_uptime_monitor",
+    "resolve_sentry_config",
+    "run_uptime_watch_tick",
+    "save_watch_state",
+]

--- a/platform/scheduler/executor.py
+++ b/platform/scheduler/executor.py
@@ -269,4 +269,13 @@ def _emit_analytics(task: ScheduledTask, status: TaskStatus, error: str = "") ->
         logger.debug("Failed to emit analytics for task %s", task.id, exc_info=True)
 
 
-__all__ = ["execute_task"]
+def deliver_scheduled_message(task: ScheduledTask, message: str) -> tuple[bool, str, str]:
+    """Deliver an ad-hoc message using the task's configured provider/chat.
+
+    Used for one-shot notices (e.g. uptime watch activation) outside a cron tick.
+    Returns ``(ok, error, message_id)``.
+    """
+    return _deliver(task, message)
+
+
+__all__ = ["deliver_scheduled_message", "execute_task"]

--- a/platform/scheduler/executor.py
+++ b/platform/scheduler/executor.py
@@ -58,6 +58,19 @@ def execute_task(
         _record_failure(task, fire_time, f"Message build error: {type(exc).__name__}")
         return False
 
+    # Quiet ticks (e.g. uptime watch with no transitions) skip delivery.
+    if not message.strip():
+        complete_run(
+            task.id,
+            fire_time,
+            status=TaskStatus.SUCCESS,
+            posted_message_id="",
+            provider=task.provider.value,
+        )
+        _emit_analytics(task, TaskStatus.SUCCESS)
+        logger.info("Task %s produced no message; delivery skipped", task.id)
+        return True
+
     # Deliver to the configured provider
     ok, error, message_id = _deliver(task, message)
 

--- a/platform/scheduler/tasks.py
+++ b/platform/scheduler/tasks.py
@@ -39,6 +39,7 @@ def build_message(task: ScheduledTask) -> str:
         TaskKind.SYNTHETIC_RUN: _build_synthetic_run,
         TaskKind.CUSTOM_INVESTIGATION: _build_custom_investigation,
         TaskKind.SENTRY_MORNING_DIGEST: _build_sentry_morning_digest,
+        TaskKind.SENTRY_UPTIME_WATCH: _build_sentry_uptime_watch,
         TaskKind.GITHUB_PR_SWEEP: _build_github_pr_sweep,
     }
     builder = builders.get(task.kind)
@@ -203,6 +204,23 @@ def _build_sentry_morning_digest(task: ScheduledTask) -> str:
         logger.error("Sentry morning digest failed for task %s: %s", task.id, exc)
         raise RuntimeError(
             f"Sentry morning digest failed for task {task.id}. Check logs for details."
+        ) from exc
+
+
+def _build_sentry_uptime_watch(task: ScheduledTask) -> str:
+    """Poll Sentry uptime monitors; return a notify body only on transitions.
+
+    Quiet ticks return an empty string so the executor skips delivery (#4032 v1).
+    """
+    from integrations.sentry.uptime import run_uptime_watch_tick
+
+    try:
+        project_slug = str(task.params.get("project_slug") or "").strip()
+        return run_uptime_watch_tick(task_id=task.id, project_slug=project_slug)
+    except Exception as exc:
+        logger.error("Sentry uptime watch failed for task %s: %s", task.id, exc)
+        raise RuntimeError(
+            f"Sentry uptime watch failed for task {task.id}. Check logs for details."
         ) from exc
 
 

--- a/platform/scheduler/tasks.py
+++ b/platform/scheduler/tasks.py
@@ -211,12 +211,17 @@ def _build_sentry_uptime_watch(task: ScheduledTask) -> str:
     """Poll Sentry uptime monitors; return a notify body only on transitions.
 
     Quiet ticks return an empty string so the executor skips delivery (#4032 v1).
+    Implemented via the agent-runner port so ``platform`` does not import
+    ``integrations`` (layering).
     """
-    from integrations.sentry.uptime import run_uptime_watch_tick
-
     try:
-        project_slug = str(task.params.get("project_slug") or "").strip()
-        return run_uptime_watch_tick(task_id=task.id, project_slug=project_slug)
+        safe_params = {k: v for k, v in task.params.items() if k not in _CREDENTIAL_KEYS}
+        payload = {
+            **safe_params,
+            "source": "scheduled_sentry_uptime_watch",
+            "task_id": task.id,
+        }
+        return invoke_agent_runner(payload)
     except Exception as exc:
         logger.error("Sentry uptime watch failed for task %s: %s", task.id, exc)
         raise RuntimeError(

--- a/platform/scheduler/types.py
+++ b/platform/scheduler/types.py
@@ -18,6 +18,7 @@ class TaskKind(StrEnum):
     SYNTHETIC_RUN = "synthetic_run"
     CUSTOM_INVESTIGATION = "custom_investigation"
     SENTRY_MORNING_DIGEST = "sentry_morning_digest"
+    SENTRY_UPTIME_WATCH = "sentry_uptime_watch"
     GITHUB_PR_SWEEP = "github_pr_sweep"
 
 

--- a/surfaces/cli/commands/sentry_digest.py
+++ b/surfaces/cli/commands/sentry_digest.py
@@ -171,6 +171,21 @@ def sentry_uptime_watch_add(
     if params:
         _console.print(f"  Project: {params['project_slug']}")
 
+    from integrations.sentry.uptime import format_uptime_watch_active_message
+    from platform.scheduler.executor import deliver_scheduled_message
+
+    active_message = format_uptime_watch_active_message(
+        task_id=added.id,
+        cron=added.cron,
+        timezone=added.timezone,
+        project_slug=params.get("project_slug", ""),
+    )
+    ok, error, _message_id = deliver_scheduled_message(added, active_message)
+    if ok:
+        _console.print("[green]Activation notice sent to chat.[/green]")
+    else:
+        _console.print(f"[yellow]Watch scheduled, but activation notice failed: {error}[/yellow]")
+
 
 @sentry_uptime_watch_command.command(name="list")
 def sentry_uptime_watch_list() -> None:

--- a/surfaces/cli/commands/sentry_digest.py
+++ b/surfaces/cli/commands/sentry_digest.py
@@ -159,7 +159,9 @@ def sentry_uptime_watch_add(
         timezone=timezone,
         provider=Provider(provider),
         chat_id=chat_id,
-        window_hours=1,
+        # Unused by the uptime watcher (poll is point-in-time); keep 0 so
+        # operators aren't misled into thinking a lookback window applies.
+        window_hours=0,
         params=params,
     )
     added = add_task(task)

--- a/surfaces/cli/commands/sentry_digest.py
+++ b/surfaces/cli/commands/sentry_digest.py
@@ -38,6 +38,219 @@ def sentry_digest_command() -> None:
     """Run or schedule the Sentry morning digest (#10)."""
 
 
+@sentry_command.group(name="uptime")
+def sentry_uptime_command() -> None:
+    """Poll Sentry uptime monitors and notify on downtime transitions (#4032)."""
+
+
+@sentry_uptime_command.command(name="check")
+@click.option(
+    "--project",
+    "project_slug",
+    type=str,
+    default="",
+    help="Optional Sentry project slug to scope the listing.",
+)
+def sentry_uptime_check(project_slug: str) -> None:
+    """List current Sentry uptime monitor health (no notification)."""
+    from integrations.sentry.uptime import list_sentry_uptime_monitors, resolve_sentry_config
+
+    config = resolve_sentry_config(project_slug=project_slug)
+    if config is None:
+        _console.print(
+            "[red]Sentry is not configured.[/red] Run `opensre integrations setup` and verify "
+            "with `opensre integrations verify sentry`."
+        )
+        raise SystemExit(1)
+
+    try:
+        monitors = list_sentry_uptime_monitors(config=config)
+    except Exception as exc:
+        _console.print(f"[red]Sentry uptime check failed: {exc}[/red]")
+        raise SystemExit(1) from exc
+
+    if not monitors:
+        _console.print("[dim]No Sentry uptime monitors found.[/dim]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Health")
+    table.add_column("Name")
+    table.add_column("URL")
+    table.add_column("Project")
+    for monitor in monitors:
+        health_style = "red" if monitor.health == "down" else "green"
+        table.add_row(
+            f"[{health_style}]{monitor.health}[/{health_style}]",
+            monitor.name,
+            monitor.url or "—",
+            monitor.project_slug or "—",
+        )
+    _console.print(table)
+
+
+@sentry_uptime_command.group(name="watch")
+def sentry_uptime_watch_command() -> None:
+    """Schedule polling that pings Slack/Telegram on uptime transitions."""
+
+
+@sentry_uptime_watch_command.command(name="add")
+@click.option(
+    "--cron",
+    "cron_expr",
+    type=str,
+    default="*/5 * * * *",
+    show_default=True,
+    help="Cron expression (5 fields). Prefer a short interval for downtime pings.",
+)
+@click.option(
+    "--tz",
+    "timezone",
+    type=str,
+    default="UTC",
+    show_default=True,
+    help="IANA timezone for the schedule.",
+)
+@click.option(
+    "--provider",
+    type=click.Choice(["telegram", "slack"], case_sensitive=False),
+    required=True,
+    help="Messaging provider for delivery.",
+)
+@click.option(
+    "--chat-id",
+    type=str,
+    required=True,
+    help="Chat/channel ID for the target provider.",
+)
+@click.option(
+    "--project",
+    "project_slug",
+    type=str,
+    default="",
+    help="Optional Sentry project slug to scope the watch.",
+)
+def sentry_uptime_watch_add(
+    cron_expr: str,
+    timezone: str,
+    provider: str,
+    chat_id: str,
+    project_slug: str,
+) -> None:
+    """Schedule Sentry uptime watch delivery (notify only on transitions)."""
+    from integrations.sentry.digest_prerequisites import (
+        require_digest_delivery_provider,
+        require_sentry_integration,
+    )
+    from platform.scheduler.store import add_task
+    from platform.scheduler.types import Provider, ScheduledTask, TaskKind
+
+    require_sentry_integration()
+    require_digest_delivery_provider(provider)
+    _validate_cron_and_timezone(cron_expr, timezone)
+
+    params: dict[str, str] = {}
+    if project_slug.strip():
+        params["project_slug"] = project_slug.strip()
+
+    task = ScheduledTask(
+        kind=TaskKind.SENTRY_UPTIME_WATCH,
+        cron=cron_expr,
+        timezone=timezone,
+        provider=Provider(provider),
+        chat_id=chat_id,
+        window_hours=1,
+        params=params,
+    )
+    added = add_task(task)
+    _console.print(f"[green]Sentry uptime watch task {added.id} created.[/green]")
+    _console.print(f"  Cron: {added.cron}  TZ: {added.timezone}")
+    _console.print(f"  Provider: {added.provider.value}  Chat: {added.chat_id}")
+    if params:
+        _console.print(f"  Project: {params['project_slug']}")
+
+
+@sentry_uptime_watch_command.command(name="list")
+def sentry_uptime_watch_list() -> None:
+    """List scheduled Sentry uptime watch tasks."""
+    from platform.scheduler.store import list_tasks
+    from platform.scheduler.types import TaskKind
+
+    tasks = [task for task in list_tasks() if task.kind == TaskKind.SENTRY_UPTIME_WATCH]
+    if not tasks:
+        _console.print("[dim]No Sentry uptime watch schedules configured.[/dim]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("ID", style="cyan")
+    table.add_column("Cron")
+    table.add_column("TZ")
+    table.add_column("Provider")
+    table.add_column("Chat")
+    table.add_column("Project")
+    table.add_column("Enabled")
+    table.add_column("Last run")
+
+    for task in tasks:
+        project = task.params.get("project_slug", "—")
+        table.add_row(
+            task.display_id(),
+            task.cron,
+            task.timezone,
+            task.provider.value,
+            task.chat_id,
+            project or "—",
+            "✓" if task.enabled else "✗",
+            task.last_run or "—",
+        )
+    _console.print(table)
+
+
+@sentry_uptime_watch_command.command(name="remove")
+@click.argument("task_id")
+def sentry_uptime_watch_remove(task_id: str) -> None:
+    """Remove a scheduled Sentry uptime watch task."""
+    from platform.scheduler.store import get_task, remove_task
+    from platform.scheduler.types import TaskKind
+
+    task = get_task(task_id)
+    if task is None or task.kind != TaskKind.SENTRY_UPTIME_WATCH:
+        _console.print(f"[red]Error: Sentry uptime watch task {task_id} not found.[/red]")
+        raise SystemExit(1)
+
+    if remove_task(task_id):
+        _console.print(f"[green]Task {task_id} removed.[/green]")
+    else:
+        _console.print(f"[red]Error: task {task_id} not found.[/red]")
+        raise SystemExit(1)
+
+
+@sentry_uptime_watch_command.command(name="run")
+@click.argument("task_id")
+def sentry_uptime_watch_run(task_id: str) -> None:
+    """Run a scheduled Sentry uptime watch task immediately."""
+    from integrations.sentry.digest_prerequisites import require_digest_delivery_provider
+    from platform.scheduler.runner import run_task_now
+    from platform.scheduler.store import get_task
+    from platform.scheduler.types import TaskKind
+
+    _install_scheduler_runners()
+    task = get_task(task_id)
+    if task is None or task.kind != TaskKind.SENTRY_UPTIME_WATCH:
+        _console.print(f"[red]Error: Sentry uptime watch task {task_id} not found.[/red]")
+        raise SystemExit(1)
+
+    require_digest_delivery_provider(task.provider.value)
+
+    _console.print(f"Running Sentry uptime watch task {task_id}...")
+    success = run_task_now(task_id)
+    if success:
+        _console.print("[green]Done.[/green]")
+    else:
+        _console.print("[red]Task execution failed. Check logs for details.[/red]")
+        raise SystemExit(1)
+
+
 @sentry_digest_command.command(name="run")
 @click.option(
     "--project",

--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -459,7 +459,7 @@ COMMANDS: list[SlashCommand] = [
     ),
     SlashCommand(
         "/sentry",
-        "Schedule and run automated Sentry morning digests.",
+        "Schedule and run automated Sentry morning digests or uptime watches.",
         _cmd_sentry,
         usage=(
             "/sentry digest run",
@@ -467,6 +467,11 @@ COMMANDS: list[SlashCommand] = [
             "/sentry digest schedule add",
             "/sentry digest schedule run <id>",
             "/sentry digest schedule remove <id>",
+            "/sentry uptime check",
+            "/sentry uptime watch list",
+            "/sentry uptime watch add",
+            "/sentry uptime watch run <id>",
+            "/sentry uptime watch remove <id>",
         ),
     ),
     SlashCommand(

--- a/surfaces/interactive_shell/command_registry/slash_catalog.py
+++ b/surfaces/interactive_shell/command_registry/slash_catalog.py
@@ -106,10 +106,13 @@ _MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
         anti_examples=("User asks about one-off messaging without a schedule (use /messaging)",),
     ),
     "/sentry": _mcp(
-        "Schedule and run automated Sentry morning digests (requires Telegram or Slack). "
-        "Subcommands: digest run, digest schedule list|add|run|remove.",
+        "Schedule and run automated Sentry morning digests or uptime watches "
+        "(requires Telegram or Slack). "
+        "Subcommands: digest run, digest schedule list|add|run|remove, "
+        "uptime check, uptime watch list|add|run|remove.",
         "User asks to schedule or automate a Sentry morning digest delivery",
         "User asks to list or run configured Sentry digest schedules",
+        "User asks to poll Sentry uptime monitors or watch for downtime",
         anti_examples=(
             "User wants an on-demand Sentry summary in chat (ask naturally; skill handles it)",
             "User asks about Sentry integration setup only (use /integrations)",

--- a/tests/cli/test_sentry_digest.py
+++ b/tests/cli/test_sentry_digest.py
@@ -37,6 +37,53 @@ def test_schedule_add_requires_delivery_provider(monkeypatch) -> None:
     assert "Telegram is not configured" in result.output
 
 
+def test_uptime_watch_add_sends_activation_notice(monkeypatch, tmp_path) -> None:
+    runner = CliRunner()
+    monkeypatch.setattr(
+        "integrations.sentry.digest_prerequisites.configured_integration_services",
+        lambda: ("sentry", "telegram"),
+    )
+    monkeypatch.setattr(
+        "integrations.sentry.digest_prerequisites.delivery_provider_ready",
+        lambda _provider: True,
+    )
+    monkeypatch.setattr(
+        "platform.scheduler.store._default_store_path",
+        lambda: tmp_path / "tasks.json",
+    )
+    delivered: list[str] = []
+
+    def _fake_deliver(task, message: str):
+        delivered.append(message)
+        return True, "", "1"
+
+    monkeypatch.setattr(
+        "platform.scheduler.executor.deliver_scheduled_message",
+        _fake_deliver,
+    )
+
+    result = runner.invoke(
+        sentry_command,
+        [
+            "uptime",
+            "watch",
+            "add",
+            "--cron",
+            "*/5 * * * *",
+            "--provider",
+            "telegram",
+            "--chat-id",
+            "8117261725",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Activation notice sent" in result.output
+    assert delivered
+    assert "active" in delivered[0].lower()
+    assert "down" in delivered[0].lower()
+
+
 def test_uptime_watch_add_requires_sentry(monkeypatch) -> None:
     runner = CliRunner()
     monkeypatch.setattr(

--- a/tests/cli/test_sentry_digest.py
+++ b/tests/cli/test_sentry_digest.py
@@ -37,6 +37,32 @@ def test_schedule_add_requires_delivery_provider(monkeypatch) -> None:
     assert "Telegram is not configured" in result.output
 
 
+def test_uptime_watch_add_requires_sentry(monkeypatch) -> None:
+    runner = CliRunner()
+    monkeypatch.setattr(
+        "integrations.sentry.digest_prerequisites.configured_integration_services",
+        lambda: ("telegram",),
+    )
+
+    result = runner.invoke(
+        sentry_command,
+        [
+            "uptime",
+            "watch",
+            "add",
+            "--cron",
+            "*/5 * * * *",
+            "--provider",
+            "telegram",
+            "--chat-id",
+            "-100",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Sentry is not configured" in result.output
+
+
 def test_schedule_add_requires_sentry(monkeypatch) -> None:
     runner = CliRunner()
     monkeypatch.setattr(

--- a/tests/integrations/sentry/test_uptime.py
+++ b/tests/integrations/sentry/test_uptime.py
@@ -10,6 +10,7 @@ import pytest
 from integrations.sentry import SentryConfig
 from integrations.sentry.uptime import (
     UptimeMonitor,
+    WatchState,
     detect_uptime_transitions,
     format_uptime_transition_message,
     health_snapshot,
@@ -28,7 +29,7 @@ def _monitor(
     url: str = "https://example.com",
     name: str = "example",
 ) -> UptimeMonitor:
-    status = 2 if health == "down" else 1
+    status = 2 if health == "down" else 1 if health == "up" else None
     return UptimeMonitor(
         id=monitor_id,
         name=name,
@@ -60,31 +61,73 @@ def test_detect_transitions_initial_down_and_recovery() -> None:
     down = _monitor("1", health="down")
     up = _monitor("1", health="up")
 
-    initial = detect_uptime_transitions({}, [down], notify_initial_down=True)
+    initial, open_set = detect_uptime_transitions({}, [down], notify_initial_down=True)
     assert len(initial) == 1
     assert initial[0].kind == "down"
+    assert open_set == {"1"}
 
-    recovered = detect_uptime_transitions({"1": "down"}, [up])
+    recovered, open_after = detect_uptime_transitions(
+        {"1": "down"},
+        [up],
+        open_incidents={"1"},
+    )
     assert len(recovered) == 1
     assert recovered[0].kind == "recovered"
+    assert open_after == set()
 
-    quiet = detect_uptime_transitions({"1": "up"}, [up])
+    quiet, open_quiet = detect_uptime_transitions({"1": "up"}, [up], open_incidents=set())
     assert quiet == []
+    assert open_quiet == set()
+
+
+def test_detect_transitions_recovers_after_unknown() -> None:
+    """down → unknown → up must still emit RECOVERED (Greptile P1)."""
+    unknown = _monitor("1", health="unknown")
+    up = _monitor("1", health="up")
+
+    transitions, open_set = detect_uptime_transitions(
+        {"1": "down"},
+        [unknown],
+        open_incidents={"1"},
+    )
+    assert transitions == []
+    assert open_set == {"1"}
+
+    recovered, open_after = detect_uptime_transitions(
+        {"1": "down"},
+        [up],
+        open_incidents=open_set,
+    )
+    assert len(recovered) == 1
+    assert recovered[0].kind == "recovered"
+    assert open_after == set()
+
+
+def test_health_snapshot_preserves_known_over_unknown() -> None:
+    unknown = _monitor("1", health="unknown")
+    assert health_snapshot([unknown], previous={"1": "down"}) == {"1": "down"}
 
 
 def test_format_message_marks_critical_downtime() -> None:
-    transitions = detect_uptime_transitions({}, [_monitor("1", health="down", name="api")])
+    transitions, _ = detect_uptime_transitions({}, [_monitor("1", health="down", name="api")])
     message = format_uptime_transition_message(transitions)
     assert "CRITICAL downtime" in message
     assert "api" in message
     assert format_uptime_transition_message([]) == ""
 
 
-def test_watch_state_roundtrip(tmp_path: Path) -> None:
+def test_watch_state_roundtrip_atomic(tmp_path: Path) -> None:
     path = tmp_path / "state.json"
-    save_watch_state("task-a", {"1": "down", "2": "up"}, path=path)
-    assert load_watch_state("task-a", path=path) == {"1": "down", "2": "up"}
-    assert load_watch_state("missing", path=path) == {}
+    save_watch_state(
+        "task-a",
+        WatchState(health={"1": "down", "2": "up"}, open_incidents={"1"}),
+        path=path,
+    )
+    loaded = load_watch_state("task-a", path=path)
+    assert loaded.health == {"1": "down", "2": "up"}
+    assert loaded.open_incidents == {"1"}
+    assert load_watch_state("missing", path=path).health == {}
+    assert not list(tmp_path.glob("*.tmp"))
 
 
 def test_list_sentry_uptime_monitors_parses_payload(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/integrations/sentry/test_uptime.py
+++ b/tests/integrations/sentry/test_uptime.py
@@ -179,6 +179,29 @@ def test_list_sentry_uptime_monitors_403_includes_alerts_hint(
         list_sentry_uptime_monitors(config=config)
 
 
+def test_resolve_sentry_config_reads_store_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("integrations.sentry.uptime.sentry_config_from_env", lambda: None)
+    monkeypatch.setattr(
+        "integrations.sentry.uptime.get_integration",
+        lambda _service: {
+            "service": "sentry",
+            "credentials": {
+                "base_url": "https://sentry.io",
+                "organization_slug": "tracer-30",
+                "auth_token": "sntrys_test",
+                "project_slug": "python",
+            },
+        },
+    )
+    from integrations.sentry.uptime import resolve_sentry_config
+
+    config = resolve_sentry_config()
+    assert config is not None
+    assert config.organization_slug == "tracer-30"
+    assert config.auth_token == "sntrys_test"
+    assert config.project_slug == "python"
+
+
 def test_run_uptime_watch_tick_notifies_then_quiets(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/integrations/sentry/test_uptime.py
+++ b/tests/integrations/sentry/test_uptime.py
@@ -108,6 +108,21 @@ def test_health_snapshot_preserves_known_over_unknown() -> None:
     assert health_snapshot([unknown], previous={"1": "down"}) == {"1": "down"}
 
 
+def test_format_uptime_watch_active_message() -> None:
+    from integrations.sentry.uptime import format_uptime_watch_active_message
+
+    message = format_uptime_watch_active_message(
+        task_id="abc123",
+        cron="*/5 * * * *",
+        timezone="UTC",
+        project_slug="marketing-website",
+    )
+    assert "active" in message.lower()
+    assert "down" in message.lower()
+    assert "abc123" in message
+    assert "marketing-website" in message
+
+
 def test_format_message_marks_critical_downtime() -> None:
     transitions, _ = detect_uptime_transitions({}, [_monitor("1", health="down", name="api")])
     message = format_uptime_transition_message(transitions)

--- a/tests/integrations/sentry/test_uptime.py
+++ b/tests/integrations/sentry/test_uptime.py
@@ -1,0 +1,157 @@
+"""Unit tests for Sentry uptime watch helpers (#4032)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from integrations.sentry import SentryConfig
+from integrations.sentry.uptime import (
+    UptimeMonitor,
+    detect_uptime_transitions,
+    format_uptime_transition_message,
+    health_snapshot,
+    list_sentry_uptime_monitors,
+    load_watch_state,
+    normalize_uptime_monitor,
+    run_uptime_watch_tick,
+    save_watch_state,
+)
+
+
+def _monitor(
+    monitor_id: str,
+    *,
+    health: str = "up",
+    url: str = "https://example.com",
+    name: str = "example",
+) -> UptimeMonitor:
+    status = 2 if health == "down" else 1
+    return UptimeMonitor(
+        id=monitor_id,
+        name=name,
+        url=url,
+        project_slug="tracer-30",
+        health=health,  # type: ignore[arg-type]
+        uptime_status=status,
+        status="active",
+    )
+
+
+def test_normalize_uptime_monitor_maps_failed_status() -> None:
+    monitor = normalize_uptime_monitor(
+        {
+            "id": "99",
+            "name": "docs",
+            "url": "https://docs.example.com",
+            "projectSlug": "web",
+            "uptimeStatus": 2,
+            "status": "active",
+        }
+    )
+    assert monitor is not None
+    assert monitor.health == "down"
+    assert monitor.project_slug == "web"
+
+
+def test_detect_transitions_initial_down_and_recovery() -> None:
+    down = _monitor("1", health="down")
+    up = _monitor("1", health="up")
+
+    initial = detect_uptime_transitions({}, [down], notify_initial_down=True)
+    assert len(initial) == 1
+    assert initial[0].kind == "down"
+
+    recovered = detect_uptime_transitions({"1": "down"}, [up])
+    assert len(recovered) == 1
+    assert recovered[0].kind == "recovered"
+
+    quiet = detect_uptime_transitions({"1": "up"}, [up])
+    assert quiet == []
+
+
+def test_format_message_marks_critical_downtime() -> None:
+    transitions = detect_uptime_transitions({}, [_monitor("1", health="down", name="api")])
+    message = format_uptime_transition_message(transitions)
+    assert "CRITICAL downtime" in message
+    assert "api" in message
+    assert format_uptime_transition_message([]) == ""
+
+
+def test_watch_state_roundtrip(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    save_watch_state("task-a", {"1": "down", "2": "up"}, path=path)
+    assert load_watch_state("task-a", path=path) == {"1": "down", "2": "up"}
+    assert load_watch_state("missing", path=path) == {}
+
+
+def test_list_sentry_uptime_monitors_parses_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_request(
+        config: SentryConfig,
+        method: str,
+        path: str,
+        *,
+        params: list | None = None,
+    ) -> list[dict]:
+        assert method == "GET"
+        assert path.endswith("/uptime/")
+        assert ("project", "web") in (params or [])
+        return [
+            {
+                "id": "7",
+                "name": "homepage",
+                "url": "https://example.com",
+                "projectSlug": "web",
+                "uptimeStatus": 1,
+                "status": "active",
+            }
+        ]
+
+    monkeypatch.setattr("integrations.sentry.uptime._request_json", _fake_request)
+    config = SentryConfig(
+        organization_slug="acme",
+        auth_token="token",
+        project_slug="web",
+    )
+    monitors = list_sentry_uptime_monitors(config=config)
+    assert len(monitors) == 1
+    assert monitors[0].health == "up"
+    assert health_snapshot(monitors) == {"7": "up"}
+
+
+def test_list_sentry_uptime_monitors_403_includes_alerts_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = httpx.Request("GET", "https://sentry.io/api/0/organizations/acme/uptime/")
+    response = httpx.Response(403, request=request, text='{"detail":"forbidden"}')
+
+    def _raise(*_args: object, **_kwargs: object) -> None:
+        raise httpx.HTTPStatusError("forbidden", request=request, response=response)
+
+    monkeypatch.setattr("integrations.sentry.uptime._request_json", _raise)
+    config = SentryConfig(organization_slug="acme", auth_token="token")
+    with pytest.raises(RuntimeError, match="alerts:read"):
+        list_sentry_uptime_monitors(config=config)
+
+
+def test_run_uptime_watch_tick_notifies_then_quiets(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state_path = tmp_path / "state.json"
+    config = SentryConfig(organization_slug="acme", auth_token="token")
+    monkeypatch.setattr(
+        "integrations.sentry.uptime.resolve_sentry_config",
+        lambda **_kwargs: config,
+    )
+    monkeypatch.setattr(
+        "integrations.sentry.uptime.list_sentry_uptime_monitors",
+        lambda **_kwargs: [_monitor("1", health="down", name="api")],
+    )
+
+    first = run_uptime_watch_tick(task_id="t1", state_path=state_path)
+    assert "CRITICAL downtime" in first
+    second = run_uptime_watch_tick(task_id="t1", state_path=state_path)
+    assert second == ""

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -180,3 +180,21 @@ class TestExecutor:
 
         assert result is False
         mock_deliver.assert_called_once()
+
+    def test_empty_message_skips_delivery(self) -> None:
+        task = ScheduledTask(
+            id="test_quiet_uptime",
+            kind=TaskKind.SENTRY_UPTIME_WATCH,
+            cron="*/5 * * * *",
+            provider=Provider.SLACK,
+            chat_id="C123",
+        )
+
+        with (
+            patch("platform.scheduler.executor.build_message", return_value=""),
+            patch("platform.scheduler.executor._deliver_slack") as mock_deliver,
+        ):
+            result = execute_task(task, "2026-01-01T09:00")
+
+        assert result is True
+        mock_deliver.assert_not_called()

--- a/tests/scheduler/test_github_pr_sweep.py
+++ b/tests/scheduler/test_github_pr_sweep.py
@@ -45,8 +45,6 @@ def test_scheduled_agent_routes_github(monkeypatch) -> None:
     assert run_scheduled_agent_digest({"source": "scheduled_github_pr_sweep"}) == "gh"
     assert run_scheduled_agent_digest({"source": "scheduled_sentry_morning_digest"}) == "sentry"
     assert (
-        run_scheduled_agent_digest(
-            {"source": "scheduled_sentry_uptime_watch", "task_id": "t1"}
-        )
+        run_scheduled_agent_digest({"source": "scheduled_sentry_uptime_watch", "task_id": "t1"})
         == "uptime"
     )

--- a/tests/scheduler/test_github_pr_sweep.py
+++ b/tests/scheduler/test_github_pr_sweep.py
@@ -38,5 +38,15 @@ def test_scheduled_agent_routes_github(monkeypatch) -> None:
         "integrations.scheduled_agent_bootstrap.run_sentry_morning_digest",
         lambda _payload: "sentry",
     )
+    monkeypatch.setattr(
+        "integrations.scheduled_agent_bootstrap.run_uptime_watch_tick",
+        lambda **_kwargs: "uptime",
+    )
     assert run_scheduled_agent_digest({"source": "scheduled_github_pr_sweep"}) == "gh"
     assert run_scheduled_agent_digest({"source": "scheduled_sentry_morning_digest"}) == "sentry"
+    assert (
+        run_scheduled_agent_digest(
+            {"source": "scheduled_sentry_uptime_watch", "task_id": "t1"}
+        )
+        == "uptime"
+    )

--- a/tests/scheduler/test_tasks.py
+++ b/tests/scheduler/test_tasks.py
@@ -229,3 +229,24 @@ class TestMessageBuilders:
 
         with pytest.raises(RuntimeError, match="Sentry morning digest failed"):
             tasks_mod.build_message(task)
+
+    def test_sentry_uptime_watch_uses_tick_helper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        task = ScheduledTask(
+            id="uptime1",
+            kind=TaskKind.SENTRY_UPTIME_WATCH,
+            cron="*/5 * * * *",
+            provider=Provider.SLACK,
+            chat_id="C123",
+            params={"project_slug": "api"},
+        )
+        captured: dict[str, object] = {}
+
+        def _mock_tick(*, task_id: str, project_slug: str = "") -> str:
+            captured["task_id"] = task_id
+            captured["project_slug"] = project_slug
+            return "CRITICAL downtime: api"
+
+        monkeypatch.setattr("integrations.sentry.uptime.run_uptime_watch_tick", _mock_tick)
+        msg = tasks_mod.build_message(task)
+        assert msg == "CRITICAL downtime: api"
+        assert captured == {"task_id": "uptime1", "project_slug": "api"}

--- a/tests/scheduler/test_tasks.py
+++ b/tests/scheduler/test_tasks.py
@@ -230,7 +230,9 @@ class TestMessageBuilders:
         with pytest.raises(RuntimeError, match="Sentry morning digest failed"):
             tasks_mod.build_message(task)
 
-    def test_sentry_uptime_watch_uses_tick_helper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_sentry_uptime_watch_uses_agent_runner_port(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         task = ScheduledTask(
             id="uptime1",
             kind=TaskKind.SENTRY_UPTIME_WATCH,
@@ -241,12 +243,13 @@ class TestMessageBuilders:
         )
         captured: dict[str, object] = {}
 
-        def _mock_tick(*, task_id: str, project_slug: str = "") -> str:
-            captured["task_id"] = task_id
-            captured["project_slug"] = project_slug
+        def _mock_agent_runner(payload: dict[str, object]) -> str:
+            captured.update(payload)
             return "CRITICAL downtime: api"
 
-        monkeypatch.setattr("integrations.sentry.uptime.run_uptime_watch_tick", _mock_tick)
+        monkeypatch.setattr("platform.scheduler.tasks.invoke_agent_runner", _mock_agent_runner)
         msg = tasks_mod.build_message(task)
         assert msg == "CRITICAL downtime: api"
-        assert captured == {"task_id": "uptime1", "project_slug": "api"}
+        assert captured["source"] == "scheduled_sentry_uptime_watch"
+        assert captured["task_id"] == "uptime1"
+        assert captured["project_slug"] == "api"

--- a/tests/scheduler/test_types.py
+++ b/tests/scheduler/test_types.py
@@ -52,6 +52,7 @@ class TestScheduledTask:
         assert TaskKind.SYNTHETIC_RUN == "synthetic_run"
         assert TaskKind.CUSTOM_INVESTIGATION == "custom_investigation"
         assert TaskKind.SENTRY_MORNING_DIGEST == "sentry_morning_digest"
+        assert TaskKind.SENTRY_UPTIME_WATCH == "sentry_uptime_watch"
 
     def test_all_providers(self) -> None:
         assert Provider.TELEGRAM == "telegram"

--- a/tests/tools/test_sentry_list_uptime_alerts_tool.py
+++ b/tests/tools/test_sentry_list_uptime_alerts_tool.py
@@ -27,6 +27,7 @@ def test_list_sentry_uptime_alerts_returns_normalized_rows(monkeypatch) -> None:
     )
 
     result = list_sentry_uptime_alerts(organization_slug="acme", sentry_token="tok")
+    assert result["available"] is True
     assert result["down_count"] == 1
     assert result["monitors"][0]["severity"] == "critical"
     assert result["monitors"][0]["health"] == "down"
@@ -38,4 +39,5 @@ def test_list_sentry_uptime_alerts_missing_creds(monkeypatch) -> None:
         lambda: None,
     )
     result = list_sentry_uptime_alerts(organization_slug="", sentry_token="")
+    assert result["available"] is False
     assert "error" in result

--- a/tests/tools/test_sentry_list_uptime_alerts_tool.py
+++ b/tests/tools/test_sentry_list_uptime_alerts_tool.py
@@ -1,0 +1,41 @@
+"""Tests for list_sentry_uptime_alerts tool."""
+
+from __future__ import annotations
+
+from integrations.sentry.tools.sentry_list_uptime_alerts_tool import list_sentry_uptime_alerts
+from integrations.sentry.uptime import UptimeMonitor
+
+
+def test_list_sentry_uptime_alerts_returns_normalized_rows(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "integrations.sentry.tools.sentry_list_uptime_alerts_tool._resolve_config",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "integrations.sentry.tools.sentry_list_uptime_alerts_tool.list_sentry_uptime_monitors",
+        lambda **_kwargs: [
+            UptimeMonitor(
+                id="1",
+                name="api",
+                url="https://api.example.com",
+                project_slug="web",
+                health="down",
+                uptime_status=2,
+                status="active",
+            )
+        ],
+    )
+
+    result = list_sentry_uptime_alerts(organization_slug="acme", sentry_token="tok")
+    assert result["down_count"] == 1
+    assert result["monitors"][0]["severity"] == "critical"
+    assert result["monitors"][0]["health"] == "down"
+
+
+def test_list_sentry_uptime_alerts_missing_creds(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "integrations.sentry.tools.sentry_list_uptime_alerts_tool.sentry_config_from_env",
+        lambda: None,
+    )
+    result = list_sentry_uptime_alerts(organization_slug="", sentry_token="")
+    assert "error" in result

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -1150,6 +1150,7 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         "list_jenkins_running_builds",
         "list_s3_objects",
         "list_sentry_issue_events",
+        "list_sentry_uptime_alerts",
         "llm_set_provider",
         "lookup_cloudtrail_events",
         "opsgenie_alert_detail",


### PR DESCRIPTION
Fixes #4032

## Summary

- Minimal v1 for Sentry **uptime monitor** watching (separate from Issues / `sentry-summary`).
- Poll `GET /api/0/organizations/{org}/uptime/` on a schedule; ping Slack/Telegram **only** on DOWN / RECOVERED transitions (quiet ticks skip delivery).
- Agent tool `list_sentry_uptime_alerts` for chat/investigation observation.
- CLI: `opensre sentry uptime check` and `opensre sentry uptime watch …` (reuses digest delivery prerequisites).
- Token may need `alerts:read` beyond Issues-only `event:read` — documented with a clear 403 hint.

## Demo / how to try

```bash
opensre integrations verify sentry   # ensure token can list uptime (alerts:read)
opensre sentry uptime check
opensre sentry uptime watch add \
  --cron "*/5 * * * *" \
  --provider slack \
  --chat-id C…   # or telegram + chat id
opensre sentry uptime watch run <task_id>
```

## Follow-ups (explicitly out of v1 — do not close as "done" for these)

Per [issue decisions](https://github.com/Tracer-Cloud/opensre/issues/4032#issuecomment-4980271944):

1. **Webhook trigger (option C):** inbound Sentry webhook / gateway path so we wake on failure without waiting for the next poll tick.
2. **Concrete remediation:** after notify, attempt to bring the monitored target back up and ping the user with that attempt report.
3. **Morning report alerts section:** extend the morning digest so it includes yesterday's uptime/alert history (fired / recovered / still down) as a **separate section** from Issues/`sentry-summary` — composer addition, not folding into the Issues skill.

## Non-goals in this PR

- No new skill (`sentry-summary` unchanged)
- No auto-remediation / investigation handoff on DOWN
- No MCP-based polling (REST contract only)

## Test plan

- [x] `uv run pytest tests/integrations/sentry/test_uptime.py tests/tools/test_sentry_list_uptime_alerts_tool.py tests/scheduler/test_tasks.py tests/scheduler/test_executor.py tests/cli/test_sentry_digest.py tests/interactive_shell/command_registry/test_slash_catalog.py tests/tools/test_telemetry.py::test_every_registered_tool_is_migrated_or_allowlisted`
- [ ] Live: `opensre sentry uptime check` against an org with a failing uptime monitor
- [ ] Live: schedule watch → take domain down → receive CRITICAL ping → recover → receive RECOVERED ping

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Reuse the existing scheduler delivery path (same as morning digest) with a new `TaskKind.SENTRY_UPTIME_WATCH` that builds a message only on health transitions. Core logic lives in `integrations/sentry/uptime.py` (list + normalize + state file + format). Executor skips empty messages so quiet polls do not spam chat. Agent visibility is a thin REST tool, not a skill.