### PR TITLE
feat(interactive-shell): set up Telegram from a pasted token via a gated action tool (#3933)

### DIFF
--- a/.importlinter.strict
+++ b/.importlinter.strict
@@ -43,6 +43,8 @@ ignore_imports =
     surfaces.interactive_shell.command_registry.gateway_cmds -> gateway.runtime.daemon
     surfaces.interactive_shell.controller -> gateway.http.web_server
     # tools -> integrations (T-4 debt — vendor tools / reporting)
+    tools.interactive_shell.actions.configure_telegram -> integrations.store
+    tools.interactive_shell.actions.configure_telegram -> integrations.telegram.verifier
     tools.community_followup_tool -> integrations.github.client
     tools.community_followup_tool -> integrations.github.helpers
     tools.community_followup_tool -> integrations.github.tools.workflow

--- a/.importlinter.strict
+++ b/.importlinter.strict
@@ -43,8 +43,7 @@ ignore_imports =
     surfaces.interactive_shell.command_registry.gateway_cmds -> gateway.runtime.daemon
     surfaces.interactive_shell.controller -> gateway.http.web_server
     # tools -> integrations (T-4 debt — vendor tools / reporting)
-    tools.interactive_shell.actions.configure_telegram -> integrations.store
-    tools.interactive_shell.actions.configure_telegram -> integrations.telegram.verifier
+    tools.interactive_shell.actions.configure_telegram -> integrations.setup_flow
     tools.community_followup_tool -> integrations.github.client
     tools.community_followup_tool -> integrations.github.helpers
     tools.community_followup_tool -> integrations.github.tools.workflow

--- a/integrations/setup_flow.py
+++ b/integrations/setup_flow.py
@@ -1,0 +1,193 @@
+"""Surface-agnostic integration setup: merge, validate, then persist.
+
+Setting up an integration is the same work regardless of where the values come
+from — the onboarding wizard collects them with interactive prompts, while the
+interactive-shell action tool receives them from a user message the agent
+parsed. Only the *collection* differs, so this module owns everything after it:
+merging over the stored record, running the vendor's verifier, persisting, and
+reporting the advisory a vendor wants shown on success.
+
+Keeping it here (``integrations/``) rather than in the wizard lets both the
+``surfaces/`` wizard and the ``tools/`` action tool share one implementation
+without either reaching across layers. Validation is delegated to the existing
+per-vendor verifier registry, so a vendor that can already be verified needs
+only a :class:`IntegrationSetupSpec` to become settable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from integrations.store import get_integration, upsert_integration
+from integrations.verification import get_verifier
+
+_REDACTED = "<redacted>"
+
+
+@dataclass(frozen=True)
+class SetupField:
+    """One credential a vendor needs, and how it should be handled."""
+
+    name: str
+    description: str
+    required: bool = False
+    # Secret values are scrubbed from any text shown to the user or the model:
+    # verifier failures often quote the request URL, which embeds the token.
+    secret: bool = False
+    env_var: str | None = None
+
+
+@dataclass(frozen=True)
+class IntegrationSetupSpec:
+    """What a vendor needs to be configured, independent of how it's collected."""
+
+    service: str
+    fields: tuple[SetupField, ...]
+    # Advisory shown after a successful save — e.g. the integration is valid but
+    # cannot deliver yet. Returns None when there is nothing to say.
+    warn: Callable[[dict[str, Any]], str | None] | None = None
+
+
+@dataclass(frozen=True)
+class SetupOutcome:
+    """Result of a setup attempt. ``saved`` is False whenever ``ok`` is False."""
+
+    ok: bool
+    detail: str
+    saved: bool = False
+    warning: str | None = None
+
+
+def _telegram_warning(values: dict[str, Any]) -> str | None:
+    if values.get("default_chat_id"):
+        return None
+    return (
+        "No default chat ID set — Hermes, watchdog, and scheduled deliveries "
+        "need TELEGRAM_DEFAULT_CHAT_ID to send messages."
+    )
+
+
+_SPECS: dict[str, IntegrationSetupSpec] = {}
+
+
+def register_setup_spec(spec: IntegrationSetupSpec) -> None:
+    """Make ``spec.service`` configurable through :func:`apply_setup`."""
+    _SPECS[spec.service] = spec
+
+
+def get_setup_spec(service: str) -> IntegrationSetupSpec | None:
+    return _SPECS.get(service)
+
+
+def settable_services() -> tuple[str, ...]:
+    """Services that can be configured from collected values, sorted."""
+    return tuple(sorted(_SPECS))
+
+
+register_setup_spec(
+    IntegrationSetupSpec(
+        service="telegram",
+        fields=(
+            SetupField(
+                name="bot_token",
+                description=(
+                    "Bot HTTP API token from @BotFather, in the form <numeric-id>:<secret>."
+                ),
+                required=True,
+                secret=True,
+                env_var="TELEGRAM_BOT_TOKEN",
+            ),
+            SetupField(
+                name="default_chat_id",
+                description="Default delivery destination; required for delivery to work.",
+                env_var="TELEGRAM_DEFAULT_CHAT_ID",
+            ),
+        ),
+        warn=_telegram_warning,
+    )
+)
+
+
+def _stored_credentials(service: str) -> dict[str, Any]:
+    record = get_integration(service)
+    if not record:
+        return {}
+    credentials = record.get("credentials")
+    return dict(credentials) if isinstance(credentials, dict) else {}
+
+
+def _merge(spec: IntegrationSetupSpec, values: dict[str, Any]) -> dict[str, Any]:
+    """Overlay supplied values on the stored record, ignoring blanks.
+
+    Merging (rather than replacing) means setting only one field — pasting a
+    fresh token, say — keeps the rest of the record, so a previously configured
+    ``default_chat_id`` is not silently dropped.
+    """
+    known = {field.name for field in spec.fields}
+    supplied = {
+        name: str(value).strip()
+        for name, value in values.items()
+        if name in known and str(value or "").strip()
+    }
+    return {**_stored_credentials(spec.service), **supplied}
+
+
+def _redact(text: str, spec: IntegrationSetupSpec, credentials: dict[str, Any]) -> str:
+    """Scrub secret values out of user- and model-facing text."""
+    for field in spec.fields:
+        if not field.secret:
+            continue
+        secret = str(credentials.get(field.name) or "")
+        if secret:
+            text = text.replace(secret, _REDACTED)
+    return text
+
+
+def apply_setup(service: str, values: dict[str, Any]) -> SetupOutcome:
+    """Configure ``service`` from ``values``, verifying before anything is saved.
+
+    Values are merged over the stored record, checked for required fields, and
+    validated by the vendor's verifier. Nothing is persisted unless verification
+    passes, so a typo cannot overwrite a working integration.
+    """
+    spec = get_setup_spec(service)
+    if spec is None:
+        return SetupOutcome(ok=False, detail=f"{service} cannot be configured this way.")
+
+    # Check the inputs before priming the verifier registry: that walk imports
+    # every vendor module, which is wasted work for an incomplete request.
+    credentials = _merge(spec, values)
+    missing = [f.name for f in spec.fields if f.required and not credentials.get(f.name)]
+    if missing:
+        return SetupOutcome(ok=False, detail=f"Missing required: {', '.join(missing)}.")
+
+    # Verifiers register themselves on import, so prime the registry rather than
+    # relying on the caller having imported the vendor module. Idempotent.
+    from integrations._verifiers_loader import register_all_verifiers
+
+    register_all_verifiers()
+    verifier = get_verifier(service)
+    if verifier is None:
+        return SetupOutcome(ok=False, detail=f"No verifier is registered for {service}.")
+
+    result = verifier("setup", credentials)
+    detail = _redact(result.get("detail", ""), spec, credentials)
+    if result.get("status") != "passed":
+        return SetupOutcome(ok=False, detail=detail)
+
+    upsert_integration(service, {"credentials": credentials})
+    warning = spec.warn(credentials) if spec.warn else None
+    return SetupOutcome(ok=True, detail=detail, saved=True, warning=warning)
+
+
+__all__ = [
+    "IntegrationSetupSpec",
+    "SetupField",
+    "SetupOutcome",
+    "apply_setup",
+    "get_setup_spec",
+    "register_setup_spec",
+    "settable_services",
+]

--- a/tests/integrations/test_setup_flow.py
+++ b/tests/integrations/test_setup_flow.py
@@ -1,0 +1,134 @@
+"""Tests for the shared integration setup flow.
+
+This is the logic both the onboarding wizard and the interactive-shell action
+tool rely on, so the invariants here are the ones that matter regardless of how
+values were collected: nothing is persisted unless the vendor's verifier passes,
+supplying one field does not discard the rest of the stored record, and secrets
+never survive into text shown to a user or a model.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from integrations.setup_flow import (
+    apply_setup,
+    get_setup_spec,
+    settable_services,
+)
+
+_STORED = "integrations.setup_flow._stored_credentials"
+_VERIFIER = "integrations.setup_flow.get_verifier"
+_UPSERT = "integrations.setup_flow.upsert_integration"
+_TOKEN = "123456789:AAExampleSecretTokenValue"
+
+
+def _verifier(status: str, detail: str = "") -> Any:
+    return lambda _source, _config: {"status": status, "detail": detail}
+
+
+def test_telegram_is_settable_and_declares_its_fields() -> None:
+    assert "telegram" in settable_services()
+    spec = get_setup_spec("telegram")
+    assert spec is not None
+    fields = {f.name: f for f in spec.fields}
+    assert fields["bot_token"].required is True
+    assert fields["bot_token"].secret is True
+    # Optional, but delivery does not work without it — hence the advisory.
+    assert fields["default_chat_id"].required is False
+
+
+def test_unknown_service_is_rejected() -> None:
+    outcome = apply_setup("not_a_service", {"token": "x"})
+    assert outcome.ok is False
+    assert outcome.saved is False
+
+
+def test_missing_required_field_is_reported_before_any_verification() -> None:
+    with (
+        patch(_STORED, return_value={}),
+        patch(_VERIFIER) as verifier,
+        patch(_UPSERT) as upsert,
+    ):
+        outcome = apply_setup("telegram", {"default_chat_id": "-100"})
+    assert outcome.ok is False
+    assert "bot_token" in outcome.detail
+    verifier.assert_not_called()
+    upsert.assert_not_called()
+
+
+def test_nothing_is_persisted_when_verification_fails() -> None:
+    with (
+        patch(_STORED, return_value={}),
+        patch(_VERIFIER, return_value=_verifier("failed", "Unauthorized.")),
+        patch(_UPSERT) as upsert,
+    ):
+        outcome = apply_setup("telegram", {"bot_token": _TOKEN})
+    assert outcome.ok is False
+    assert outcome.saved is False
+    upsert.assert_not_called()
+
+
+def test_secret_is_redacted_from_verifier_detail() -> None:
+    """Verifier failures quote the request URL, which embeds the bot token."""
+    detail = f"Telegram API check failed: 401 for https://api.telegram.org/bot{_TOKEN}/getMe"
+    with (
+        patch(_STORED, return_value={}),
+        patch(_VERIFIER, return_value=_verifier("failed", detail)),
+        patch(_UPSERT),
+    ):
+        outcome = apply_setup("telegram", {"bot_token": _TOKEN})
+    assert _TOKEN not in outcome.detail
+    assert "<redacted>" in outcome.detail
+
+
+def test_supplying_one_field_keeps_the_rest_of_the_stored_record() -> None:
+    """Pasting a fresh token must not drop an already-configured chat id."""
+    stored = {"bot_token": "old-token", "default_chat_id": "-1001234567890"}
+    with (
+        patch(_STORED, return_value=stored),
+        patch(_VERIFIER, return_value=_verifier("passed", "Connected.")),
+        patch(_UPSERT) as upsert,
+    ):
+        outcome = apply_setup("telegram", {"bot_token": "new-token"})
+    assert outcome.ok is True
+    upsert.assert_called_once_with(
+        "telegram",
+        {"credentials": {"bot_token": "new-token", "default_chat_id": "-1001234567890"}},
+    )
+
+
+def test_blank_values_do_not_overwrite_stored_credentials() -> None:
+    stored = {"bot_token": "kept", "default_chat_id": "-100"}
+    with (
+        patch(_STORED, return_value=stored),
+        patch(_VERIFIER, return_value=_verifier("passed", "Connected.")),
+        patch(_UPSERT) as upsert,
+    ):
+        apply_setup("telegram", {"bot_token": "kept", "default_chat_id": "   "})
+    assert upsert.call_args[0][1]["credentials"]["default_chat_id"] == "-100"
+
+
+def test_setup_without_a_chat_id_warns_that_delivery_will_not_work() -> None:
+    with (
+        patch(_STORED, return_value={}),
+        patch(_VERIFIER, return_value=_verifier("passed", "Connected.")),
+        patch(_UPSERT),
+    ):
+        outcome = apply_setup("telegram", {"bot_token": _TOKEN})
+    assert outcome.ok is True
+    assert outcome.warning is not None
+    assert "TELEGRAM_DEFAULT_CHAT_ID" in outcome.warning
+
+
+def test_no_warning_once_a_chat_id_is_configured() -> None:
+    with (
+        patch(_STORED, return_value={}),
+        patch(_VERIFIER, return_value=_verifier("passed", "Connected.")),
+        patch(_UPSERT),
+    ):
+        outcome = apply_setup(
+            "telegram", {"bot_token": _TOKEN, "default_chat_id": "-1001234567890"}
+        )
+    assert outcome.warning is None

--- a/tests/integrations/test_vendor_first_layout.py
+++ b/tests/integrations/test_vendor_first_layout.py
@@ -35,6 +35,7 @@ ALLOWED_FLAT_MODULES = frozenset(
         "registry.py",
         "scheduled_agent_bootstrap.py",
         "selectors.py",
+        "setup_flow.py",
         "store.py",
         "verify.py",
     }

--- a/tests/tools/test_configure_telegram_action.py
+++ b/tests/tools/test_configure_telegram_action.py
@@ -1,0 +1,96 @@
+"""Tests for the interactive-shell 'configure telegram' action tool.
+
+Covers: token validation before persistence, that a valid token is saved (and
+the secret is never echoed, even on the failure path), and optional chat id. The
+action LLM's decision to call this tool with a pasted token is a live concern
+exercised via ReplDriver, not here.
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock, patch
+
+from rich.console import Console
+
+import tools.interactive_shell.actions.configure_telegram as configure_telegram
+from core.agent_harness.tools.tool_context import ActionToolContext
+
+_VERIFY = "integrations.telegram.verifier.verify_telegram"
+_UPSERT = "integrations.store.upsert_integration"
+_TOKEN = "123456789:AAExampleSecretTokenValue"
+
+
+def _ctx() -> tuple[ActionToolContext, io.StringIO]:
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, highlight=False, width=200)
+    return ActionToolContext(session=MagicMock(), console=console), buf
+
+
+def test_missing_token_is_not_handled() -> None:
+    ctx, _ = _ctx()
+    with patch(_UPSERT) as upsert:
+        result = configure_telegram.execute_configure_telegram_tool({"bot_token": "  "}, ctx)
+    assert result["ok"] is False
+    assert result["error"] == "missing_bot_token"
+    upsert.assert_not_called()
+
+
+def test_invalid_token_reports_error_and_does_not_save() -> None:
+    ctx, buf = _ctx()
+    with (
+        patch(
+            _VERIFY,
+            # The verifier's failure detail can embed the token (via the request URL);
+            # the tool must redact it before showing the user.
+            return_value={
+                "status": "failed",
+                "detail": f"Telegram API check failed: 401 for https://api.telegram.org/bot{_TOKEN}/getMe",
+            },
+        ),
+        patch(_UPSERT) as upsert,
+    ):
+        result = configure_telegram.execute_configure_telegram_tool({"bot_token": _TOKEN}, ctx)
+    assert result["ok"] is False
+    upsert.assert_not_called()
+    assert "failed" in buf.getvalue().lower()
+    # The token must never be surfaced, even on the failure path.
+    assert _TOKEN not in buf.getvalue()
+    assert _TOKEN not in result["error"]
+
+
+def test_valid_token_verifies_then_saves_without_echoing_secret() -> None:
+    ctx, buf = _ctx()
+    with (
+        patch(
+            _VERIFY,
+            return_value={"status": "passed", "detail": "Connected to Telegram bot @acme_bot."},
+        ),
+        patch(_UPSERT) as upsert,
+    ):
+        result = configure_telegram.execute_configure_telegram_tool({"bot_token": _TOKEN}, ctx)
+
+    assert result["ok"] is True
+    upsert.assert_called_once_with("telegram", {"credentials": {"bot_token": _TOKEN}})
+    out = buf.getvalue()
+    assert "@acme_bot" in out
+    # The secret must never be printed back to the user.
+    assert _TOKEN not in out
+
+
+def test_optional_chat_id_is_persisted() -> None:
+    ctx, _ = _ctx()
+    with (
+        patch(
+            _VERIFY,
+            return_value={"status": "passed", "detail": "Connected to Telegram bot @b."},
+        ),
+        patch(_UPSERT) as upsert,
+    ):
+        configure_telegram.execute_configure_telegram_tool(
+            {"bot_token": _TOKEN, "chat_id": "-1001234567890"}, ctx
+        )
+    upsert.assert_called_once_with(
+        "telegram",
+        {"credentials": {"bot_token": _TOKEN, "default_chat_id": "-1001234567890"}},
+    )

--- a/tests/tools/test_configure_telegram_action.py
+++ b/tests/tools/test_configure_telegram_action.py
@@ -1,9 +1,14 @@
 """Tests for the interactive-shell 'configure telegram' action tool.
 
-Covers: token validation before persistence, that a valid token is saved (and
-the secret is never echoed, even on the failure path), and optional chat id. The
-action LLM's decision to call this tool with a pasted token is a live concern
-exercised via ReplDriver, not here.
+The tool is an adapter: it turns the agent's arguments into a call to the shared
+:func:`integrations.setup_flow.apply_setup` and renders the outcome. These tests
+cover that adapter contract — argument pass-through, the failure and success
+renderings, the delivery advisory, and that the token is never echoed. Merging,
+verification, and redaction belong to the shared flow and are tested in
+``tests/integrations/test_setup_flow.py``.
+
+The action LLM's decision to call this tool with a pasted token is a live
+concern exercised via ReplDriver, not here.
 """
 
 from __future__ import annotations
@@ -15,9 +20,9 @@ from rich.console import Console
 
 import tools.interactive_shell.actions.configure_telegram as configure_telegram
 from core.agent_harness.tools.tool_context import ActionToolContext
+from integrations.setup_flow import SetupOutcome
 
-_VERIFY = "integrations.telegram.verifier.verify_telegram"
-_UPSERT = "integrations.store.upsert_integration"
+_APPLY = "integrations.setup_flow.apply_setup"
 _TOKEN = "123456789:AAExampleSecretTokenValue"
 
 
@@ -29,68 +34,55 @@ def _ctx() -> tuple[ActionToolContext, io.StringIO]:
 
 def test_missing_token_is_not_handled() -> None:
     ctx, _ = _ctx()
-    with patch(_UPSERT) as upsert:
+    with patch(_APPLY) as apply_setup:
         result = configure_telegram.execute_configure_telegram_tool({"bot_token": "  "}, ctx)
     assert result["ok"] is False
     assert result["error"] == "missing_bot_token"
-    upsert.assert_not_called()
+    apply_setup.assert_not_called()
 
 
-def test_invalid_token_reports_error_and_does_not_save() -> None:
-    ctx, buf = _ctx()
-    with (
-        patch(
-            _VERIFY,
-            # The verifier's failure detail can embed the token (via the request URL);
-            # the tool must redact it before showing the user.
-            return_value={
-                "status": "failed",
-                "detail": f"Telegram API check failed: 401 for https://api.telegram.org/bot{_TOKEN}/getMe",
-            },
-        ),
-        patch(_UPSERT) as upsert,
-    ):
-        result = configure_telegram.execute_configure_telegram_tool({"bot_token": _TOKEN}, ctx)
-    assert result["ok"] is False
-    upsert.assert_not_called()
-    assert "failed" in buf.getvalue().lower()
-    # The token must never be surfaced, even on the failure path.
-    assert _TOKEN not in buf.getvalue()
-    assert _TOKEN not in result["error"]
-
-
-def test_valid_token_verifies_then_saves_without_echoing_secret() -> None:
-    ctx, buf = _ctx()
-    with (
-        patch(
-            _VERIFY,
-            return_value={"status": "passed", "detail": "Connected to Telegram bot @acme_bot."},
-        ),
-        patch(_UPSERT) as upsert,
-    ):
-        result = configure_telegram.execute_configure_telegram_tool({"bot_token": _TOKEN}, ctx)
-
-    assert result["ok"] is True
-    upsert.assert_called_once_with("telegram", {"credentials": {"bot_token": _TOKEN}})
-    out = buf.getvalue()
-    assert "@acme_bot" in out
-    # The secret must never be printed back to the user.
-    assert _TOKEN not in out
-
-
-def test_optional_chat_id_is_persisted() -> None:
+def test_supplied_values_are_forwarded_to_the_shared_flow() -> None:
     ctx, _ = _ctx()
-    with (
-        patch(
-            _VERIFY,
-            return_value={"status": "passed", "detail": "Connected to Telegram bot @b."},
-        ),
-        patch(_UPSERT) as upsert,
-    ):
+    with patch(
+        _APPLY, return_value=SetupOutcome(ok=True, detail="Connected.", saved=True)
+    ) as apply_setup:
         configure_telegram.execute_configure_telegram_tool(
             {"bot_token": _TOKEN, "chat_id": "-1001234567890"}, ctx
         )
-    upsert.assert_called_once_with(
-        "telegram",
-        {"credentials": {"bot_token": _TOKEN, "default_chat_id": "-1001234567890"}},
+    apply_setup.assert_called_once_with(
+        "telegram", {"bot_token": _TOKEN, "default_chat_id": "-1001234567890"}
     )
+
+
+def test_failed_setup_reports_the_reason_without_echoing_the_token() -> None:
+    ctx, buf = _ctx()
+    with patch(_APPLY, return_value=SetupOutcome(ok=False, detail="Unauthorized.")):
+        result = configure_telegram.execute_configure_telegram_tool({"bot_token": _TOKEN}, ctx)
+    assert result["ok"] is False
+    assert result["error"] == "Unauthorized."
+    out = buf.getvalue()
+    assert "failed" in out.lower()
+    assert _TOKEN not in out
+
+
+def test_successful_setup_reports_the_bot_without_echoing_the_token() -> None:
+    ctx, buf = _ctx()
+    outcome = SetupOutcome(ok=True, detail="Connected to Telegram bot @acme_bot.", saved=True)
+    with patch(_APPLY, return_value=outcome):
+        result = configure_telegram.execute_configure_telegram_tool({"bot_token": _TOKEN}, ctx)
+    assert result["ok"] is True
+    out = buf.getvalue()
+    assert "@acme_bot" in out
+    assert _TOKEN not in out
+
+
+def test_delivery_advisory_is_surfaced_on_success() -> None:
+    """A token-only setup verifies, but cannot deliver until a chat id is set."""
+    ctx, buf = _ctx()
+    outcome = SetupOutcome(
+        ok=True, detail="Connected.", saved=True, warning="No default chat ID set."
+    )
+    with patch(_APPLY, return_value=outcome):
+        result = configure_telegram.execute_configure_telegram_tool({"bot_token": _TOKEN}, ctx)
+    assert result["warning"] == "No default chat ID set."
+    assert "No default chat ID set." in buf.getvalue()

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -1007,6 +1007,7 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         "check_s3_marker",
         "cli_exec",
         "code_implement",
+        "configure_telegram",
         "describe_rds_events",
         "describe_rds_instance",
         "ec2_instances_by_tag",

--- a/tools/interactive_shell/__init__.py
+++ b/tools/interactive_shell/__init__.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 TOOL_MODULES = (
     "actions.assistant_handoff",
     "actions.cli_command",
+    "actions.configure_telegram",
     "actions.implementation",
     "actions.investigation",
     "actions.llm_provider",

--- a/tools/interactive_shell/action_names.py
+++ b/tools/interactive_shell/action_names.py
@@ -16,6 +16,7 @@ ToolKind = Literal[
     "implementation",
     "llm_provider",
     "assistant_handoff",
+    "configure_telegram",
 ]
 
 TOOL_KIND_TO_NAME: dict[ToolKind, str] = {
@@ -30,6 +31,7 @@ TOOL_KIND_TO_NAME: dict[ToolKind, str] = {
     "implementation": "code_implement",
     "llm_provider": "llm_set_provider",
     "assistant_handoff": "assistant_handoff",
+    "configure_telegram": "configure_telegram",
 }
 
 __all__ = ["TOOL_KIND_TO_NAME", "ToolKind"]

--- a/tools/interactive_shell/actions/configure_telegram.py
+++ b/tools/interactive_shell/actions/configure_telegram.py
@@ -2,10 +2,14 @@
 
 The action agent selects this tool when a user pastes a Telegram bot token and
 asks to set up / connect / enable Telegram, and extracts the token (and an
-optional chat id) into the tool arguments. It validates the token against the
-Telegram Bot API and, on success, saves the integration — so the user does not
-have to re-enter the token in the interactive `/integrations setup telegram`
-wizard.
+optional chat id) into the tool arguments — so the user does not have to
+re-enter the token in the interactive `/integrations setup telegram` wizard.
+
+Everything after collecting those values (merging over the stored record,
+verifying, persisting, and the "configured but cannot deliver" advisory) is
+delegated to :func:`integrations.setup_flow.apply_setup`, which the onboarding
+wizard drives with prompt-collected values. This module is only the adapter
+between the agent's arguments and that shared flow.
 
 Selection is the action agent's job via normal tool-calling; there is no
 keyword/regex detection of tokens here (see ``tools/interactive_shell/AGENTS.md``).
@@ -35,33 +39,28 @@ def execute_configure_telegram_tool(args: dict[str, Any], ctx: ActionToolContext
         ctx.console.print("[yellow]No Telegram bot token provided.[/]")
         return {"ok": False, "error": "missing_bot_token"}
 
-    # Validate the token against the Telegram Bot API before persisting anything,
-    # so a typo or revoked token fails with a reason instead of saving junk. Uses
-    # the integration-layer verifier (tools may depend on integrations, not on
-    # surfaces).
-    from integrations.telegram.verifier import verify_telegram
+    # The shared setup flow merges over the stored record, verifies, and only
+    # then persists — so a token-only paste keeps an existing default_chat_id, a
+    # bad token cannot overwrite a working integration, and the secret is
+    # redacted out of anything shown back.
+    from integrations.setup_flow import apply_setup
 
     ctx.console.print("[dim]Validating Telegram bot token…[/]")
-    outcome = verify_telegram("setup", {"bot_token": bot_token})
-    # The verifier's failure detail can embed the token (it includes the request
-    # URL, which contains ``/bot<token>/``). Redact it so the secret is never
-    # surfaced back to the user or the model.
-    detail = outcome["detail"].replace(bot_token, "<token>")
-    if outcome["status"] != "passed":
-        ctx.console.print(f"[red]Telegram setup failed: {escape(detail)}[/]")
-        return {"ok": False, "error": detail}
+    outcome = apply_setup("telegram", {"bot_token": bot_token, "default_chat_id": chat_id})
+    if not outcome.ok:
+        ctx.console.print(f"[red]Telegram setup failed: {escape(outcome.detail)}[/]")
+        return {"ok": False, "error": outcome.detail}
 
-    from integrations.store import upsert_integration
-
-    credentials: dict[str, Any] = {"bot_token": bot_token}
-    if chat_id:
-        credentials["default_chat_id"] = chat_id
-    upsert_integration("telegram", {"credentials": credentials})
-
-    # Never echo the token back; the verifier's detail names the bot, not the secret.
-    ctx.console.print(f"[green]✓ {escape(detail)} Saved to the integration store.[/]")
+    ctx.console.print(f"[green]✓ {escape(outcome.detail)} Saved to the integration store.[/]")
+    if outcome.warning:
+        ctx.console.print(f"[yellow]{escape(outcome.warning)}[/]")
     ctx.session.record("configure_telegram", "telegram", ok=True)
-    return {"ok": True, "detail": detail, "chat_id_set": bool(chat_id)}
+    return {
+        "ok": True,
+        "detail": outcome.detail,
+        "warning": outcome.warning,
+        "chat_id_set": bool(chat_id),
+    }
 
 
 def run_configure_telegram(*, bot_token: str, chat_id: str = "", context: Any) -> dict[str, Any]:

--- a/tools/interactive_shell/actions/configure_telegram.py
+++ b/tools/interactive_shell/actions/configure_telegram.py
@@ -1,0 +1,107 @@
+"""Configure the Telegram integration from a bot token provided in chat.
+
+The action agent selects this tool when a user pastes a Telegram bot token and
+asks to set up / connect / enable Telegram, and extracts the token (and an
+optional chat id) into the tool arguments. It validates the token against the
+Telegram Bot API and, on success, saves the integration — so the user does not
+have to re-enter the token in the interactive `/integrations setup telegram`
+wizard.
+
+Selection is the action agent's job via normal tool-calling; there is no
+keyword/regex detection of tokens here (see ``tools/interactive_shell/AGENTS.md``).
+The tool stays UI-agnostic — it validates and persists, leaving any confirmation
+UX to the surface — matching the other action tools (e.g. ``sentry_fix``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.markup import escape
+
+from core.agent_harness.tools.tool_context import (
+    ActionToolContext,
+    execute_with_action_context,
+    object_schema,
+    string_property,
+)
+from core.tool_framework.registered_tool import RegisteredTool
+
+
+def execute_configure_telegram_tool(args: dict[str, Any], ctx: ActionToolContext) -> dict[str, Any]:
+    bot_token = str(args.get("bot_token", "")).strip()
+    chat_id = str(args.get("chat_id", "")).strip()
+    if not bot_token:
+        ctx.console.print("[yellow]No Telegram bot token provided.[/]")
+        return {"ok": False, "error": "missing_bot_token"}
+
+    # Validate the token against the Telegram Bot API before persisting anything,
+    # so a typo or revoked token fails with a reason instead of saving junk. Uses
+    # the integration-layer verifier (tools may depend on integrations, not on
+    # surfaces).
+    from integrations.telegram.verifier import verify_telegram
+
+    ctx.console.print("[dim]Validating Telegram bot token…[/]")
+    outcome = verify_telegram("setup", {"bot_token": bot_token})
+    # The verifier's failure detail can embed the token (it includes the request
+    # URL, which contains ``/bot<token>/``). Redact it so the secret is never
+    # surfaced back to the user or the model.
+    detail = outcome["detail"].replace(bot_token, "<token>")
+    if outcome["status"] != "passed":
+        ctx.console.print(f"[red]Telegram setup failed: {escape(detail)}[/]")
+        return {"ok": False, "error": detail}
+
+    from integrations.store import upsert_integration
+
+    credentials: dict[str, Any] = {"bot_token": bot_token}
+    if chat_id:
+        credentials["default_chat_id"] = chat_id
+    upsert_integration("telegram", {"credentials": credentials})
+
+    # Never echo the token back; the verifier's detail names the bot, not the secret.
+    ctx.console.print(f"[green]✓ {escape(detail)} Saved to the integration store.[/]")
+    ctx.session.record("configure_telegram", "telegram", ok=True)
+    return {"ok": True, "detail": detail, "chat_id_set": bool(chat_id)}
+
+
+def run_configure_telegram(*, bot_token: str, chat_id: str = "", context: Any) -> dict[str, Any]:
+    return execute_with_action_context(
+        {"bot_token": bot_token, "chat_id": chat_id},
+        context,
+        execute_configure_telegram_tool,
+    )
+
+
+configure_telegram_tool = RegisteredTool(
+    name="configure_telegram",
+    description=(
+        "Set up the Telegram integration from a bot token the user pasted in chat: "
+        "validate the token against the Telegram API and, if valid, save it (plus an "
+        "optional default chat id). Use when the user provides a Telegram bot token and "
+        "asks to set up, connect, or enable Telegram. Do not use for sending messages, "
+        "and do not invent a token — only call this with a token the user supplied."
+    ),
+    input_schema=object_schema(
+        properties={
+            "bot_token": string_property(
+                description=(
+                    "Telegram bot HTTP API token from BotFather, in the form "
+                    "<numeric-id>:<secret>. Only pass a value the user actually provided."
+                ),
+                min_length=1,
+            ),
+            "chat_id": string_property(
+                description="Optional default chat id to deliver messages to.",
+            ),
+        },
+        required=("bot_token",),
+    ),
+    source="interactive_shell",
+    surfaces=("action",),
+    parallel_safe=False,
+    accepts_runtime_context=True,
+    run=run_configure_telegram,
+)
+
+
+__all__ = ["configure_telegram_tool", "execute_configure_telegram_tool"]

--- a/tools/registry_index.py
+++ b/tools/registry_index.py
@@ -72,6 +72,13 @@ def _fallback_descriptors() -> tuple[ToolDescriptor, ...]:
             "tools.interactive_shell.actions.implementation",
         ),
         ToolDescriptor(
+            "configure_telegram",
+            ("action",),
+            "interactive_shell",
+            None,
+            "tools.interactive_shell.actions.configure_telegram",
+        ),
+        ToolDescriptor(
             "fix_sentry_issue_start",
             ("action",),
             "interactive_shell",


### PR DESCRIPTION
Fixes #3933

#### Describe the changes you have made in this PR -

Follow-up to the docs-grounding PR (#4021), addressing muddlebee's point: when a user pastes a Telegram bot token in the REPL and asks to set it up, the agent should just do it.

Before this, the agent could only launch the interactive `/integrations setup telegram` wizard, which then re-prompts for the token — so pasting it in chat didn't help. This adds a `configure_telegram` action tool. Given a bot token (and optional chat id) the action agent pulled out of the message, it validates the token against the Telegram Bot API and, on success, saves the integration. The token is never printed back.

How it fits the existing patterns:

- Selection is the action agent's job through normal tool-calling — there is no keyword or regex detection of tokens (per `tools/interactive_shell/AGENTS.md`).
- The tool stays UI-agnostic: it validates and persists with no `surfaces`/UI imports, matching the other action tools (`sentry_fix`, `sample_alert`) after the #4065 runtime-ports refactor. It is a `tools -> integrations` dependency only.
- It validates before it persists, using the integration-layer verifier (`integrations.telegram.verifier.verify_telegram`), so a bad token fails with a reason instead of saving junk. The verifier's failure detail can embed the token (via the request URL), so the token is redacted before it's shown, on success or failure.
- A new action tool has to be registered in three places or a contract test fails: `registry_index.py` fallback descriptors, the `TOOL_MODULES` manifest, and `action_names.py`. It is also classified in the telemetry coverage allowlist.

### Demo/Screenshot for feature changes and bug fixes -

Live end-to-end run in the REPL. I pasted a fake bot token and asked the agent to set up Telegram; the action agent picked the new `configure_telegram` tool on its own, validated the token against the real Telegram Bot API, and reported the failure with a reason:

<img width="1196" height="461" alt="image" src="https://github.com/user-attachments/assets/b660e667-b410-480f-975f-f1d37f3726bd" />
<img width="2330" height="1094" alt="image" src="https://github.com/user-attachments/assets/779137ae-0887-4bb3-ba23-257fd07a8f38" />

That is muddlebee's flow — paste token → agent verifies → error + reason — with a real LLM selecting the tool (not the old wizard) and a real Telegram API call. The success path (valid token → saved, token never echoed) is covered by the unit tests, since I don't have a real bot token to put in a public PR.

Verification: `make typecheck` clean (1249 files), `make lint` / `make format-check` clean, `make test-scope` 2648 passed / 1 skipped.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I first checked whether this already worked, both by driving the live REPL (it just relaunched the wizard) and by reading the code (every Telegram setup path was `questionary`-interactive, and there was no action tool for integration setup). The tool validates before it persists — using the integration-layer verifier `integrations.telegram.verifier.verify_telegram` — so a bad token fails with a reason instead of saving junk, and the token is redacted from the verifier's detail so it's never printed. The tool stays UI-agnostic (no `surfaces` imports), matching the other action tools like `sentry_fix` after the #4065 runtime-ports refactor, rather than reaching into surfaces for a confirmation gate. The main non-obvious work was registration: the registry has a static descriptor index plus a module manifest, and there are contract tests that fail loudly if a new tool is missing from either — I hit two of them and wired the tool into all the required places. I kept the tool Telegram-specific rather than a generic "configure integration" tool, since Telegram is the reference case and each integration has a different credential shape; generalizing can come later.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

