### PR TITLE
fix: resolve open CodeQL scanning findings

### DIFF
--- a/gateway/slack/thread_history.py
+++ b/gateway/slack/thread_history.py
@@ -18,7 +18,6 @@ from integrations.slack.bot_api import (
 
 logger = logging.getLogger(__name__)
 
-_WANT_ME_TO_RE = re.compile(r"(?i)want\s+me\s+to\s*:")
 _ASSISTANT_SHAPE_RE = re.compile(
     r"(?i)(?:\*\*)?I found:(?:\*\*)?|(?:\*\*)?Want me to:(?:\*\*)?|"
     r"(?:\*\*)?Here's what that looks like:(?:\*\*)?"

--- a/surfaces/interactive_shell/runtime/action_turn.py
+++ b/surfaces/interactive_shell/runtime/action_turn.py
@@ -21,6 +21,7 @@ from core.execution import ToolExecutionHooks
 from surfaces.interactive_shell.command_registry import SLASH_COMMANDS
 from surfaces.interactive_shell.command_registry.suggestions import resolve_literal_slash_typo
 from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink
+from surfaces.interactive_shell.runtime.background import runner as background_runner
 from surfaces.interactive_shell.runtime.investigation_adapter import (
     repl_investigation_launch_ports,
 )
@@ -38,6 +39,7 @@ from surfaces.interactive_shell.runtime.task_cancel_adapter import (
 )
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui.action_rendering import ActionRenderObserver
+from tools.interactive_shell.shared.investigation_launch import InvestigationLaunchPorts
 
 
 def _complete_literal_slash_typo_turn(
@@ -77,6 +79,13 @@ def _subprocess_presenter_factory(
     )
 
 
+def _investigation_ports_factory() -> InvestigationLaunchPorts:
+    return repl_investigation_launch_ports(
+        start_background_text=background_runner.start_background_text_investigation,
+        start_background_sample=background_runner.start_background_template_investigation,
+    )
+
+
 def run_action_tool_turn(
     message: str,
     session: Session,
@@ -112,7 +121,7 @@ def run_action_tool_turn(
                 session=session, console=console, message=msg
             ),
             subprocess_presenter_factory=_subprocess_presenter_factory,
-            investigation_ports_factory=repl_investigation_launch_ports,
+            investigation_ports_factory=_investigation_ports_factory,
             llm_provider_ports_factory=repl_llm_provider_ports,
             task_cancel_ports_factory=repl_task_cancel_ports,
             slash_ports_factory=repl_slash_ports,

--- a/surfaces/interactive_shell/runtime/investigation_adapter.py
+++ b/surfaces/interactive_shell/runtime/investigation_adapter.py
@@ -33,7 +33,8 @@ class BackgroundTextLauncher(Protocol):
         session: Session,
         console: Console,
         display_command: str,
-    ) -> str: ...
+    ) -> str:
+        raise NotImplementedError
 
 
 class BackgroundSampleLauncher(Protocol):
@@ -46,7 +47,8 @@ class BackgroundSampleLauncher(Protocol):
         session: Session,
         console: Console,
         display_command: str,
-    ) -> str: ...
+    ) -> str:
+        raise NotImplementedError
 
 
 def repl_foreground_renderer() -> session_runner.StreamRendererFn:

--- a/surfaces/interactive_shell/runtime/investigation_adapter.py
+++ b/surfaces/interactive_shell/runtime/investigation_adapter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import threading
 from collections.abc import Callable, Iterator
-from typing import Any, cast
+from typing import Any, Protocol, cast
 
 from rich.console import Console
 
@@ -21,6 +21,32 @@ from tools.interactive_shell.shared.investigation_launch import (
     InvestigationSession,
 )
 from tools.investigation import session_runner
+
+
+class BackgroundTextLauncher(Protocol):
+    """Callable contract for starting a background text investigation."""
+
+    def __call__(
+        self,
+        *,
+        alert_text: str,
+        session: Session,
+        console: Console,
+        display_command: str,
+    ) -> str: ...
+
+
+class BackgroundSampleLauncher(Protocol):
+    """Callable contract for starting a background sample investigation."""
+
+    def __call__(
+        self,
+        *,
+        template_name: str,
+        session: Session,
+        console: Console,
+        display_command: str,
+    ) -> str: ...
 
 
 def repl_foreground_renderer() -> session_runner.StreamRendererFn:
@@ -113,6 +139,15 @@ def run_sample_alert_for_session_background(
 class ReplInvestigationLaunchPorts:
     """Default REPL ports for investigation-style action tools."""
 
+    def __init__(
+        self,
+        *,
+        start_background_text: BackgroundTextLauncher,
+        start_background_sample: BackgroundSampleLauncher,
+    ) -> None:
+        self._start_background_text = start_background_text
+        self._start_background_sample = start_background_sample
+
     def execution_allowed(
         self,
         *,
@@ -171,11 +206,7 @@ class ReplInvestigationLaunchPorts:
         console: Console,
         display_command: str,
     ) -> None:
-        from surfaces.interactive_shell.runtime.background.runner import (
-            start_background_text_investigation,
-        )
-
-        start_background_text_investigation(
+        self._start_background_text(
             alert_text=alert_text,
             session=cast(Session, session),
             console=console,
@@ -190,11 +221,7 @@ class ReplInvestigationLaunchPorts:
         console: Console,
         display_command: str,
     ) -> None:
-        from surfaces.interactive_shell.runtime.background.runner import (
-            start_background_template_investigation,
-        )
-
-        start_background_template_investigation(
+        self._start_background_sample(
             template_name=template_name,
             session=cast(Session, session),
             console=console,
@@ -222,9 +249,16 @@ class ReplInvestigationLaunchPorts:
         return ForegroundInvestigationResult(status=outcome.status)
 
 
-def repl_investigation_launch_ports() -> InvestigationLaunchPorts:
+def repl_investigation_launch_ports(
+    *,
+    start_background_text: BackgroundTextLauncher,
+    start_background_sample: BackgroundSampleLauncher,
+) -> InvestigationLaunchPorts:
     """Return REPL investigation launch ports for action tools."""
-    return ReplInvestigationLaunchPorts()
+    return ReplInvestigationLaunchPorts(
+        start_background_text=start_background_text,
+        start_background_sample=start_background_sample,
+    )
 
 
 __all__ = [

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -454,9 +454,7 @@ def test_shell_completer_investigate_includes_template_hints() -> None:
     assert any(c.text == "splunk" for c in completions)
 
 
-def test_run_text_investigation_uses_background_launcher_when_mode_enabled(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_run_text_investigation_uses_background_launcher_when_mode_enabled() -> None:
     from rich.console import Console
 
     from tools.interactive_shell.actions.investigation import (
@@ -476,10 +474,15 @@ def test_run_text_investigation_uses_background_launcher_when_mode_enabled(
         launches.append((alert_text, display_command))
         return "bg123"
 
-    monkeypatch.setattr(
-        "surfaces.interactive_shell.runtime.background.runner.start_background_text_investigation",
-        _fake_start_background_text_investigation,
-    )
+    def _unexpected_sample_launcher(
+        *,
+        template_name: str,
+        session: Session,
+        console: Console,
+        display_command: str,
+    ) -> str:
+        _ = (template_name, session, console, display_command)
+        raise AssertionError("sample launcher should not run")
 
     session = Session()
     session.terminal.background_mode_enabled = True
@@ -489,7 +492,10 @@ def test_run_text_investigation_uses_background_launcher_when_mode_enabled(
         "High CPU alert",
         session,
         console,
-        ports=repl_investigation_launch_ports(),
+        ports=repl_investigation_launch_ports(
+            start_background_text=_fake_start_background_text_investigation,
+            start_background_sample=_unexpected_sample_launcher,
+        ),
     )
 
     assert launches == [("High CPU alert", "background free-text investigation")]

--- a/tests/tools/test_architecture_issue_tool.py
+++ b/tests/tools/test_architecture_issue_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -116,7 +117,7 @@ def test_architecture_save_observations_tool_uses_explicit_session(
 ) -> None:
     monkeypatch.setattr(
         "tools.architecture_issue_tool.tool.save_architecture_observations",
-        lambda **kwargs: save_architecture_observations(**kwargs, home_dir=tmp_path),
+        partial(save_architecture_observations, home_dir=tmp_path),
     )
     result = architecture_save_observations(
         repo_name="opensre",
@@ -142,7 +143,7 @@ def test_architecture_save_observations_tool_reads_session_from_context(
 
     monkeypatch.setattr(
         "tools.architecture_issue_tool.tool.save_architecture_observations",
-        lambda **kwargs: save_architecture_observations(**kwargs, home_dir=tmp_path),
+        partial(save_architecture_observations, home_dir=tmp_path),
     )
     session = SimpleNamespace(session_id="ctx-session-id")
     context = AgentToolContext(


### PR DESCRIPTION
Resolves the open CodeQL findings:
- https://github.com/Tracer-Cloud/opensre/security/code-scanning/1877
- https://github.com/Tracer-Cloud/opensre/security/code-scanning/1878
- https://github.com/Tracer-Cloud/opensre/security/code-scanning/1879
- https://github.com/Tracer-Cloud/opensre/security/code-scanning/1880
- https://github.com/Tracer-Cloud/opensre/security/code-scanning/1873
- https://github.com/Tracer-Cloud/opensre/security/code-scanning/1850
- https://github.com/Tracer-Cloud/opensre/security/code-scanning/1851

#### Describe the changes you have made in this PR -

- Break the cyclic dependency between the REPL investigation adapter and background runner by injecting launcher callables at the action-turn composition root.
- Remove an unused Slack thread-history regex.
- Replace two unnecessary test lambdas with `functools.partial`.
- Update the background-launch regression test to exercise dependency injection directly.

### Demo/Screenshot for feature changes and bug fixes -

Validation:
- `make lint` — passed
- `make format-check` — passed
- `make typecheck` — passed
- `make check-imports` — passed
- Focused regression suite — 311 passed

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The import cycle existed because the background runner lazily imported investigation run functions while the investigation adapter lazily imported the background launchers. The adapter now receives typed launcher callables, and `action_turn.py` wires the concrete runner functions at the composition boundary. This preserves module ownership while removing the reverse dependency. The remaining findings were direct dead-code/test-cleanup changes.

---

## Checklist before requesting a review
- [x] I have added a proper PR title and linked the code-scanning alerts
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Made with [Cursor](https://cursor.com)