### PR TITLE
fix(scheduler): resolve Slack bot_token from Socket Mode setup for digest delivery

### DIFF
--- a/platform/scheduler/credentials.py
+++ b/platform/scheduler/credentials.py
@@ -67,12 +67,24 @@ def resolve_slack_credentials(task_params: dict[str, str]) -> dict[str, str]:
     if webhook:
         return webhook
 
-    return _resolve_credentials(
+    access_token = _resolve_credentials(
         {},
         service="slack",
         credential_key="access_token",
         env_vars=("SLACK_BOT_TOKEN", "SLACK_ACCESS_TOKEN"),
     )
+    if access_token:
+        return access_token
+
+    # Slack Socket Mode setup stores the bot token under "bot_token"
+    # (integrations/cli.py), not "access_token". An xoxb- bot token is a
+    # valid bearer credential for chat.postMessage, so surface it under the
+    # access_token key the delivery path expects.
+    bot_token = _get_integration_credential("slack", "bot_token")
+    if bot_token:
+        return {"access_token": bot_token}
+
+    return {}
 
 
 def resolve_discord_credentials(task_params: dict[str, str]) -> dict[str, str]:

--- a/tests/integrations/sentry/test_digest_delivery.py
+++ b/tests/integrations/sentry/test_digest_delivery.py
@@ -40,6 +40,24 @@ class TestDigestDeliveryReadiness:
         assert slack_delivery_ready() is True
         assert delivery_provider_ready("slack") is True
 
+    def test_slack_ready_with_only_bot_token_stored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Socket Mode setup stores only bot_token (no webhook, no env var)."""
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("SLACK_ACCESS_TOKEN", raising=False)
+
+        def fake_get_credential(service: str, key: str) -> str:
+            if service == "slack" and key == "bot_token":
+                return "xoxb-socket-mode"
+            return ""
+
+        monkeypatch.setattr(
+            "platform.scheduler.credentials._get_integration_credential",
+            fake_get_credential,
+        )
+        assert slack_delivery_ready() is True
+        assert delivery_provider_ready(Provider.SLACK) is True
+
     def test_none_ready(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
             "integrations.sentry.digest_delivery.resolve_telegram_credentials",

--- a/tests/scheduler/test_credentials.py
+++ b/tests/scheduler/test_credentials.py
@@ -103,6 +103,24 @@ class TestSlackCredentials:
         creds = resolve_slack_credentials({})
         assert creds == {}
 
+    def test_from_store_bot_token_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Socket Mode setup stores the token under bot_token, not access_token."""
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("SLACK_ACCESS_TOKEN", raising=False)
+
+        def fake_get_credential(service: str, key: str) -> str:
+            if service == "slack" and key == "bot_token":
+                return "xoxb-from-store"
+            return ""
+
+        monkeypatch.setattr(
+            "platform.scheduler.credentials._get_integration_credential",
+            fake_get_credential,
+        )
+        creds = resolve_slack_credentials({})
+        assert creds == {"access_token": "xoxb-from-store"}
+
 
 class TestDiscordCredentials:
     def test_from_params(self) -> None:


### PR DESCRIPTION
Fixes #4019

Socket Mode setup stores Slack token under `bot_token`
(integrations/cli.py), but `resolve_slack_credentials` only checked
`access_token`, so digest schedule/delivery rejected valid Socket Mode
configs unless SLACK_BOT_TOKEN was also set in env.

Fix: fall back to store's `bot_token` when `access_token` lookup misses,
surfaced as `{"access_token": ...}` since delivery just needs bearer token.

Added regression test `test_from_store_bot_token_fallback` in
tests/scheduler/test_credentials.py.