### PR TITLE
fix(gateway): remove stale app.entrypoints imports after folder restructure

### DIFF
--- a/gateway/main.py
+++ b/gateway/main.py
@@ -7,7 +7,7 @@ Delegates to :func:`gateway.runtime.manager.main`.
 
 from __future__ import annotations
 
-from app.entrypoints.gateway import main
+from gateway.runtime.manager import main
 
 __all__ = ["main"]
 

--- a/gateway/runtime/slash_ports.py
+++ b/gateway/runtime/slash_ports.py
@@ -1,0 +1,16 @@
+"""Gateway slash-runtime composition helpers."""
+
+from __future__ import annotations
+
+from surfaces.interactive_shell.runtime.slash_adapter import (
+    SlashPorts,
+    headless_slash_ports,
+)
+
+
+def gateway_slash_ports_factory() -> SlashPorts:
+    """Build slash runtime ports for non-interactive gateway turns."""
+    return headless_slash_ports()
+
+
+__all__ = ["gateway_slash_ports_factory"]

--- a/gateway/tests/runtime/test_slash_routing.py
+++ b/gateway/tests/runtime/test_slash_routing.py
@@ -10,10 +10,10 @@ from unittest.mock import MagicMock
 import pytest
 from rich.console import Console
 
-from app.entrypoints.gateway_slash import gateway_slash_ports_factory
 from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStorage
 from core.agent_harness.tools.action_tools import get_action_tool
+from gateway.runtime.slash_ports import gateway_slash_ports_factory
 from gateway.runtime.turn_handler import GatewayTurnHandler
 from tests.core.agent.orchestration.cross_surface_parity_harness import RecordingGatewaySink
 

--- a/gateway/tests/test_main.py
+++ b/gateway/tests/test_main.py
@@ -20,4 +20,4 @@ def test_gateway_main_module_exports_main() -> None:
     import gateway.main as entry
 
     assert callable(entry.main)
-    assert entry.main.__module__ == "app.entrypoints.gateway"
+    assert entry.main.__module__ == "gateway.runtime.manager"


### PR DESCRIPTION
## Summary

The gateway restructure (#3997) moved code into `gateway/runtime/` and `gateway/http/` but left three files importing from the old `app/entrypoints/` path, breaking the release workflow binary build (PyInstaller fails to resolve `app.entrypoints`) and any `python -m gateway.main` invocation:

| File | Broken import | Fix |
|------|--------------|-----|
| `gateway/main.py` | `from app.entrypoints.gateway import main` | `from gateway.runtime.manager import main` |
| `gateway/tests/runtime/test_slash_routing.py` | `from app.entrypoints.gateway_slash import gateway_slash_ports_factory` | `from gateway.runtime.slash_ports import gateway_slash_ports_factory` |
| `gateway/tests/test_main.py` | `assert entry.main.__module__ == "app.entrypoints.gateway"` | updated to `"gateway.runtime.manager"` |

`gateway_slash_ports_factory` is extracted into `gateway/runtime/slash_ports.py` — one thin function that wraps `headless_slash_ports()` from the interactive-shell runtime, keeping it alongside the rest of the gateway runtime package.

## Test plan

- [x] `make lint` — clean
- [x] `uv run pytest gateway/tests/test_main.py gateway/tests/runtime/test_slash_routing.py -v` — 9/9 passed

Closes #3566