### PR TITLE
fix(agent): preserve earlier turns via a running summary instead of dropping them

### DIFF
--- a/core/agent_harness/prompts/conversation_memory.py
+++ b/core/agent_harness/prompts/conversation_memory.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import re
 
-MAX_CONVERSATION_TURNS = 12
-MAX_CONVERSATION_MESSAGES = MAX_CONVERSATION_TURNS * 2
+# Canonical home for the window constants is core.state.agent_state; re-exported
+# here (see __all__) so prompt/turn builders keep a single import point.
+from core.state.agent_state import MAX_CONVERSATION_MESSAGES, MAX_CONVERSATION_TURNS
 
 NO_HISTORY_PLACEHOLDER = "(no prior messages in this CLI thread)"
 _ACTION_FACT_MARKERS = (
@@ -168,3 +169,13 @@ def format_prior_action_facts(
         rendered.append(chunk)
         remaining -= len(chunk) + 2
     return "\n\n".join(rendered)
+
+
+__all__ = [
+    "MAX_CONVERSATION_MESSAGES",
+    "MAX_CONVERSATION_TURNS",
+    "NO_HISTORY_PLACEHOLDER",
+    "expand_affirmative_follow_up",
+    "format_prior_action_facts",
+    "format_recent_conversation",
+]

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -41,7 +41,10 @@ from core.agent_harness.prompts.conversation_memory import (
     expand_affirmative_follow_up,
 )
 from core.agent_harness.session.terminal_access import agent_turn_executed_slashes
-from core.agent_harness.turns.transcript_compaction import auto_compact_if_needed
+from core.agent_harness.turns.transcript_compaction import (
+    auto_compact_if_needed,
+    fold_overflow_into_summary,
+)
 from core.agent_harness.turns.turn_plan import TurnPlan, build_turn_plan
 from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
@@ -129,8 +132,9 @@ def _stream_response(
 def _record_answer_turn(session: SessionStore, message: str, assistant_text: str) -> None:
     session.cli_agent_messages.append(("user", message))
     session.cli_agent_messages.append(("assistant", assistant_text))
-    if len(session.cli_agent_messages) > MAX_CONVERSATION_MESSAGES:
-        session.cli_agent_messages[:] = session.cli_agent_messages[-MAX_CONVERSATION_MESSAGES:]
+    session.cli_agent_messages[:] = fold_overflow_into_summary(
+        session.cli_agent_messages, max_messages=MAX_CONVERSATION_MESSAGES
+    )
 
 
 def _record_action_only_turn(session: SessionStore, message: str, assistant_text: str) -> None:

--- a/core/agent_harness/turns/transcript_compaction.py
+++ b/core/agent_harness/turns/transcript_compaction.py
@@ -119,9 +119,18 @@ def fold_overflow_into_summary(
     overflow = body[:-keep]
     recent = body[-keep:]
 
-    folded = deterministic_summary(overflow)
-    combined = f"{prior_summary}\n{folded}".strip() if prior_summary else folded
-    return [("assistant", f"{_SUMMARY_PREFIX}{combined[:_SUMMARY_MAX_CHARS]}"), *recent]
+    folded = deterministic_summary(overflow)[:_SUMMARY_MAX_CHARS]
+    if prior_summary:
+        # Keep the newest fold intact, then fill the rest of the budget with the
+        # earliest summarized context. Plain head-truncation would freeze once
+        # full and silently drop fresh overflow; plain tail-truncation would
+        # drop the original anchor context the summary exists to preserve.
+        head_room = _SUMMARY_MAX_CHARS - len(folded) - 1
+        head = prior_summary[:head_room].rstrip() if head_room > 0 else ""
+        combined = f"{head}\n{folded}".strip() if head else folded
+    else:
+        combined = folded
+    return [("assistant", f"{_SUMMARY_PREFIX}{combined}"), *recent]
 
 
 def deterministic_summary(messages: list[tuple[str, str]]) -> str:

--- a/core/agent_harness/turns/transcript_compaction.py
+++ b/core/agent_harness/turns/transcript_compaction.py
@@ -113,7 +113,9 @@ def fold_overflow_into_summary(
     prior_summary = messages[0][1][len(_SUMMARY_PREFIX) :] if head_is_summary else ""
     body = messages[1:] if head_is_summary else list(messages)
 
-    keep = max(max_messages - 1, 1)  # reserve one slot for the summary
+    # Reserve one slot for the summary, and keep an even count so the retained
+    # tail always starts on a user turn rather than orphaning an assistant reply.
+    keep = max((max_messages - 1) // 2 * 2, 2)
     if len(body) <= keep:
         return messages
     overflow = body[:-keep]

--- a/core/agent_harness/turns/transcript_compaction.py
+++ b/core/agent_harness/turns/transcript_compaction.py
@@ -9,6 +9,7 @@ from typing import Any
 DEFAULT_AUTO_COMPACTION_CHARS = 48_000
 _KEEP_RECENT_MESSAGES = 8
 _SUMMARY_MAX_CHARS = 6_000
+_SUMMARY_PREFIX = "Session summary:\n"
 
 
 @dataclass(frozen=True)
@@ -60,7 +61,7 @@ def compact_session_branch(
     kept = messages[-_KEEP_RECENT_MESSAGES:]
     compacted = messages[:-_KEEP_RECENT_MESSAGES]
     final_summary = summary or deterministic_summary(compacted)
-    session.agent.messages = [("assistant", f"Session summary:\n{final_summary}"), *kept]
+    session.agent.messages = [("assistant", f"{_SUMMARY_PREFIX}{final_summary}"), *kept]
     after_chars = _message_chars(list(session.agent.messages))
     session.storage.append_compaction(
         session.session_id,
@@ -87,6 +88,40 @@ def auto_compact_if_needed(
     if not should_compact(session, threshold_chars=threshold_chars):
         return None
     return compact_session_branch(session)
+
+
+def fold_overflow_into_summary(
+    messages: list[tuple[str, str]],
+    *,
+    max_messages: int,
+) -> list[tuple[str, str]]:
+    """Fold turns beyond the window into a leading running summary.
+
+    The end-of-turn trim used to drop the oldest turns outright, so anything past
+    the window vanished with no trace. Instead, summarize the overflow into a
+    single leading ``Session summary:`` message and keep the most recent turns
+    verbatim, so early context survives inside the window.
+
+    Works on a bare message list (not a persisted session) so both the live
+    ``Session`` and headless stores share one behavior. Extends an existing
+    leading summary rather than nesting a new one, keeping it a running summary.
+    """
+    if max_messages < 1 or len(messages) <= max_messages:
+        return messages
+
+    head_is_summary = messages[0][0] == "assistant" and messages[0][1].startswith(_SUMMARY_PREFIX)
+    prior_summary = messages[0][1][len(_SUMMARY_PREFIX) :] if head_is_summary else ""
+    body = messages[1:] if head_is_summary else list(messages)
+
+    keep = max(max_messages - 1, 1)  # reserve one slot for the summary
+    if len(body) <= keep:
+        return messages
+    overflow = body[:-keep]
+    recent = body[-keep:]
+
+    folded = deterministic_summary(overflow)
+    combined = f"{prior_summary}\n{folded}".strip() if prior_summary else folded
+    return [("assistant", f"{_SUMMARY_PREFIX}{combined[:_SUMMARY_MAX_CHARS]}"), *recent]
 
 
 def deterministic_summary(messages: list[tuple[str, str]]) -> str:
@@ -131,5 +166,6 @@ __all__ = [
     "auto_compact_if_needed",
     "compact_session_branch",
     "deterministic_summary",
+    "fold_overflow_into_summary",
     "should_compact",
 ]

--- a/tests/core/agent_harness/test_transcript_compaction.py
+++ b/tests/core/agent_harness/test_transcript_compaction.py
@@ -1,0 +1,46 @@
+"""Tests for folding conversation overflow into a running summary."""
+
+from __future__ import annotations
+
+from core.agent_harness.turns.transcript_compaction import fold_overflow_into_summary
+
+_SUMMARY_PREFIX = "Session summary:\n"
+
+
+def _turns(count: int, *, start: int = 1) -> list[tuple[str, str]]:
+    messages: list[tuple[str, str]] = []
+    for i in range(start, start + count):
+        messages.append(("user", f"Turn {i} question"))
+        messages.append(("assistant", f"Turn {i} answer"))
+    return messages
+
+
+def test_noop_when_within_window() -> None:
+    messages = _turns(3)  # 6 messages
+    assert fold_overflow_into_summary(messages, max_messages=24) == messages
+
+
+def test_early_fact_survives_in_leading_summary() -> None:
+    messages = [("user", "My cluster is named prod-eu-42."), ("assistant", "Noted.")]
+    messages += _turns(13, start=2)  # push well past the window
+
+    folded = fold_overflow_into_summary(messages, max_messages=24)
+
+    assert len(folded) <= 24
+    # The oldest turn is gone from the verbatim tail but preserved in the summary.
+    assert folded[0][0] == "assistant"
+    assert folded[0][1].startswith(_SUMMARY_PREFIX)
+    assert "prod-eu-42" in folded[0][1]
+
+
+def test_extends_existing_summary_without_nesting() -> None:
+    messages = [("assistant", f"{_SUMMARY_PREFIX}older context here")]
+    messages += _turns(20)
+
+    folded = fold_overflow_into_summary(messages, max_messages=24)
+
+    # Still exactly one leading summary, and prior summary text is retained.
+    assert folded[0][1].startswith(_SUMMARY_PREFIX)
+    assert folded[0][1].count(_SUMMARY_PREFIX) == 1
+    assert "older context here" in folded[0][1]
+    assert sum(1 for role, text in folded if text.startswith(_SUMMARY_PREFIX)) == 1

--- a/tests/core/agent_harness/test_transcript_compaction.py
+++ b/tests/core/agent_harness/test_transcript_compaction.py
@@ -48,6 +48,16 @@ def test_extends_existing_summary_without_nesting() -> None:
     assert sum(1 for role, text in folded if text.startswith(_SUMMARY_PREFIX)) == 1
 
 
+def test_retained_tail_stays_turn_aligned() -> None:
+    # keep must be even, so the verbatim tail after the summary never starts on
+    # an orphaned assistant reply (a split user/assistant turn).
+    folded = fold_overflow_into_summary(_turns(20), max_messages=24)
+
+    tail = folded[1:]  # drop the leading summary
+    assert tail[0][0] == "user"
+    assert [role for role, _ in tail] == ["user", "assistant"] * (len(tail) // 2)
+
+
 def test_full_summary_keeps_newest_overflow_and_anchor() -> None:
     # A prior summary already at the char budget must not freeze: fresh overflow
     # still lands, and the earliest anchor context is not fully evicted.

--- a/tests/core/agent_harness/test_transcript_compaction.py
+++ b/tests/core/agent_harness/test_transcript_compaction.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from core.agent_harness.turns.transcript_compaction import fold_overflow_into_summary
-
-_SUMMARY_PREFIX = "Session summary:\n"
+from core.agent_harness.turns.transcript_compaction import (
+    _SUMMARY_MAX_CHARS,
+    _SUMMARY_PREFIX,
+    fold_overflow_into_summary,
+)
 
 
 def _turns(count: int, *, start: int = 1) -> list[tuple[str, str]]:
@@ -44,3 +46,21 @@ def test_extends_existing_summary_without_nesting() -> None:
     assert folded[0][1].count(_SUMMARY_PREFIX) == 1
     assert "older context here" in folded[0][1]
     assert sum(1 for role, text in folded if text.startswith(_SUMMARY_PREFIX)) == 1
+
+
+def test_full_summary_keeps_newest_overflow_and_anchor() -> None:
+    # A prior summary already at the char budget must not freeze: fresh overflow
+    # still lands, and the earliest anchor context is not fully evicted.
+    anchor = "ANCHOR-cluster-prod-eu-42"
+    prior = anchor + " " + ("x" * _SUMMARY_MAX_CHARS)
+    messages = [("assistant", f"{_SUMMARY_PREFIX}{prior}")]
+    messages += [("user", "NEWEST-overflow-marker question"), ("assistant", "answer")]
+    messages += _turns(24)
+
+    folded = fold_overflow_into_summary(messages, max_messages=24)
+
+    summary = folded[0][1]
+    assert summary.startswith(_SUMMARY_PREFIX)
+    assert len(summary) <= len(_SUMMARY_PREFIX) + _SUMMARY_MAX_CHARS
+    assert "NEWEST-overflow-marker" in summary  # fresh overflow retained
+    assert anchor in summary  # earliest anchor retained


### PR DESCRIPTION
Fixes #4085

#### Describe the changes you have made in this PR -

The end-of-turn recorder hard-deleted conversation history beyond the 24-message window with no summary, so the agent forgot facts stated more than ~12 turns earlier. The compaction "safety net" almost never engaged because its 48k-char threshold sits above what 24 short messages hold (see #4085 for the verified analysis).

This folds overflow into a leading running summary instead of dropping it:

- `transcript_compaction.py` — new `fold_overflow_into_summary()`. Summarizes turns beyond the window into a single leading `Session summary:` message and keeps the most recent turns verbatim. Works on a bare message list (not a persisted session) so the live `Session` and headless stores share one behavior, and extends an existing leading summary rather than nesting a new one. Reuses the existing `deterministic_summary`; adds a shared `_SUMMARY_PREFIX` constant.
- `orchestrator.py` — `_record_answer_turn` now folds instead of hard-slicing.
- `conversation_memory.py` — deduped `MAX_CONVERSATION_TURNS` / `MAX_CONVERSATION_MESSAGES`, which were defined twice; canonical definition now lives in `core/state/agent_state.py`, re-exported here via `__all__`.

Deferred to a follow-up (noted on #4085): swapping the deterministic excerpt summary for an LLM-generated one. That is a larger, separately-reviewable change.

### Demo/Screenshot for feature changes and bug fixes -

Driving the real production code path (`_record_answer_turn` + `format_recent_conversation`) across 14 turns — turn 1 states a fact, then 13 ordinary turns.

**Before** (on `main`) — the turn-1 fact is dropped; the model's history starts at turn 3, so the result is `FORGOTTEN`:

<img width="718" height="224" alt="before: FORGOTTEN on main" src="https://github.com/user-attachments/assets/04bf9da1-aa04-40c6-9bf8-05a4d10c64dd" />

**After** (this branch) — the fact survives inside the leading running summary, still within the 24-message window, so the result is `REMEMBERED`:

<img width="843" height="163" alt="after: REMEMBERED on the fix branch" src="https://github.com/user-attachments/assets/9aa4f99a-73e3-4181-b69e-49800fb16c63" />

Full checks: `make lint`, `make format-check`, `make typecheck` all pass; `make test-cov` — **11486 passed, 27 skipped**.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is that two history mechanisms — a hard 24-message cap at turn end and a 48k-char compaction at turn start — are calibrated so the cap always wins and deletes old turns with no trace. I first confirmed the truncated list is the *only* conversational memory the model sees (each turn sends just the current user message plus a system-prompt history block rendered from that list), so a dropped turn is unrecoverable. Rather than raise the cap (which only delays the problem) or lower the compaction threshold (which risks over-summarizing), I made the turn-end trim summarize overflow into a running summary that stays in the window, so the two mechanisms become complementary. I put the helper on the bare message list so it works for both the live and headless session stores, and reused the existing deterministic summary to keep the change small. Edge cases covered by tests: no-op under the window, an early fact surviving in the summary, and extending an existing summary without nesting.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

