### PR TITLE
chore: remove verified unused private helpers

### DIFF
--- a/integrations/grafana/tools/__init__.py
+++ b/integrations/grafana/tools/__init__.py
@@ -272,11 +272,6 @@ from platform.common.evidence_compaction import summarize_counts
 from platform.common.log_compaction import build_error_taxonomy, deduplicate_logs
 
 
-def _map_pipeline_to_service_name(pipeline_name: str) -> str:
-    """Pass pipeline name through as the Grafana service name."""
-    return pipeline_name
-
-
 def _resolve_grafana_client(
     grafana_endpoint: str | None = None,
     grafana_api_key: str | None = None,

--- a/integrations/vercel/client.py
+++ b/integrations/vercel/client.py
@@ -33,12 +33,6 @@ _RUNTIME_LOGS_READ_ATTEMPTS = 3
 _RUNTIME_LOGS_READ_TIMEOUT_DEFAULT = 600.0
 
 
-def _scrub_log_fragment(value: object) -> str:
-    """Make user-controlled strings safe for single-line log records (avoid log injection)."""
-    text = str(value)
-    return text.replace("\r", "\\r").replace("\n", "\\n")
-
-
 def _safe_vercel_path_segment(raw: str) -> str | None:
     cleaned = (raw or "").strip()
     if not cleaned or len(cleaned) > _MAX_VERCEL_PATH_SEGMENT_LEN:

--- a/platform/__init__.py
+++ b/platform/__init__.py
@@ -45,14 +45,6 @@ def _candidate_stdlib_platform_paths() -> list[Path]:
     return candidates
 
 
-def _is_frozen() -> bool:
-    """Check if running in a PyInstaller frozen build."""
-    return getattr(sys, "frozen", False)
-
-
-_REENTRANCY_GUARD = "_opensre_platform_loading"
-
-
 def _load_stdlib_platform():
     """Load the genuine stdlib ``platform`` module.
 

--- a/surfaces/cli/ui/renderer/formatting.py
+++ b/surfaces/cli/ui/renderer/formatting.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import math
-import re
 from collections.abc import Sequence
 from typing import Any
 
@@ -53,67 +52,6 @@ def investigation_llm_progress_hint(
     if iteration == 0:
         return f"Planning investigation ({cap}){tools_clause}"
     return f"Reviewing evidence ({cap}){tools_clause}"
-
-
-def _clean_markdown_line(line: str) -> str:
-    """Strip both bulleted lists (•, ●, -, —, *) and numbered lists (e.g. 1., 2))."""
-    stripped = line.strip()
-    prev = ""
-    while stripped != prev:
-        prev = stripped
-        stripped = re.sub(r"^[-•●—]\s+", "", stripped)
-        # Markdown ``* item`` list marker only — not ``*Italic Section:*`` headings.
-        stripped = re.sub(r"^\*\s+", "", stripped)
-        stripped = re.sub(r"^\d+[.)]\s+", "", stripped)
-    return stripped
-
-
-def _normalized_report_heading_inner(line: str) -> str:
-    """Normalize LLM report lines for heading keyword matching."""
-    s = line.strip()
-    while s.startswith("#"):
-        s = s[1:].strip()
-    if s.startswith("**"):
-        core = s[2:]
-        if core.endswith("**:"):
-            core = core[:-3]
-        elif core.endswith("**"):
-            core = core[:-2]
-        return core.strip()
-    if len(s) >= 2 and s.startswith("[") and s.endswith("]") and ":" not in s:
-        return s[1:-1].strip()
-    if (
-        len(s) >= 3
-        and s.startswith("*")
-        and s.endswith("*")
-        and not s.startswith("* ")
-        and "**" not in s
-    ):
-        inner = s[1:-1].strip()
-        if ":" in inner or len(inner.split()) >= 3:
-            return inner
-    return s.strip()
-
-
-def _report_line_looks_like_heading(line: str, *, inner: str) -> bool:
-    """True if the line uses a heading-like structure (not prose)."""
-    stripped = line.strip()
-    if stripped.startswith("#"):
-        return True
-    is_bracket = (
-        stripped.startswith("[") and stripped.rstrip().endswith("]") and ":" not in stripped
-    )
-    is_bold_md = stripped.startswith("**") and (stripped.endswith("**") or stripped.endswith("**:"))
-    wrapped_ast = (
-        len(stripped) >= 3
-        and stripped.startswith("*")
-        and stripped.endswith("*")
-        and not stripped.startswith("* ")
-        and "**" not in stripped
-        and (":" in stripped[1:-1] or len(stripped[1:-1].strip().split()) >= 3)
-    )
-    shouty = inner.isupper() and len(inner.replace(" ", "")) >= 8 and len(inner.split()) <= 14
-    return bool(is_bracket or is_bold_md or wrapped_ast or shouty)
 
 
 def _validity_score_percent(score: Any) -> str | None:

--- a/surfaces/cli/ui/renderer/terminal.py
+++ b/surfaces/cli/ui/renderer/terminal.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Any
 
-from platform.terminal.theme import BRAND
 from surfaces.cli.ui.renderer.constants import _BOLD, _CYAN, _DIM, _RESET
 from surfaces.interactive_shell.ui.output import get_output_format
 
@@ -18,27 +16,6 @@ def _print_connection_banner() -> None:
         )
     else:
         print("\n  Remote Investigation  streaming from deployed agent\n")
-    sys.stdout.flush()
-
-
-def _print_section(title: str, content: str, console: Any | None = None) -> None:
-    if get_output_format() == "rich":
-        from rich.console import Console
-        from rich.markdown import Markdown
-        from rich.padding import Padding
-        from rich.rule import Rule
-
-        from platform.terminal.theme import MARKDOWN_THEME
-
-        c = console or Console(highlight=False)
-        c.print()
-        c.print(Rule(f"[bold] {title} [/]", style=BRAND, align="left"))
-        with c.use_theme(MARKDOWN_THEME):
-            c.print(Padding(Markdown(content.strip(), code_theme="ansi_dark"), (1, 2)))
-    else:
-        print(f"\n  {title}")
-        for line in content.strip().splitlines():
-            print(f"  {line}")
     sys.stdout.flush()
 
 


### PR DESCRIPTION
Remove eight private helpers that had zero references anywhere in the repo (including tests). This is a dead-code-only cleanup — no behavior changes.

Removed symbols:
- `surfaces/cli/ui/renderer/formatting.py`: `_clean_markdown_line`, `_normalized_report_heading_inner`, `_report_line_looks_like_heading` (and unused `import re`)
- `surfaces/cli/ui/renderer/terminal.py`: `_print_section` (and unused `Any` / `BRAND` imports)
- `integrations/vercel/client.py`: `_scrub_log_fragment`
- `integrations/grafana/tools/__init__.py`: `_map_pipeline_to_service_name`
- `platform/__init__.py`: `_is_frozen`, `_REENTRANCY_GUARD`

