### PR TITLE
feat(gateway): Slack gateway liveness heartbeat + non-root image; remove Slack backend infra from repo

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -27,7 +27,7 @@ Copy [`.env.deploy.example`](.env.deploy.example) and export the required variab
 | `TELEGRAM_ALLOWED_USERS` | Recommended | Gateway pairing gate |
 | `LLM_PROVIDER` + API key | Yes | Both containers |
 
-`SLACK_*` variables are ignored by the EC2 deploy (validation warns) — Slack is deployed and operated separately, not from this repo.x
+`SLACK_*` variables are ignored by the EC2 deploy (validation warns) — Slack is deployed and operated separately, not from this repo.
 
 ```bash
 # Step 1 — build and push Docker image to ECR (run once per code change):

--- a/platform/deployment/README.md
+++ b/platform/deployment/README.md
@@ -58,7 +58,7 @@ Copy [`.env.deploy.example`](../../.env.deploy.example) to `.env` in the repo ro
 | `EC2_KEY_NAME` | No | Optional SSH debug key pair |
 
 `SLACK_*` variables are ignored by the EC2 deploy (warning at validation) —
-deploy Slack with Terraform instead.
+Slack is deployed and operated separately, not from this repo.
 
 ### What `make deploy` creates
 

--- a/platform/deployment/ecr_deploy/instance.py
+++ b/platform/deployment/ecr_deploy/instance.py
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 _ENV_DIR = "/etc/opensre"
 # Slack keys stay listed defensively: the EC2 deploy no longer collects them,
 # but if one arrives via OPENSRE_DEPLOY_EXTRA_ENV_KEYS it must never reach the
-# public web container. Slack itself deploys via Terraform only
-# (a separate Terraform module).
+# public web container. Slack itself is deployed and operated separately, not
+# from this repo.
 _GATEWAY_ONLY_ENV_KEYS = frozenset(
     {
         "TELEGRAM_BOT_TOKEN",

--- a/platform/deployment/ecr_deploy/prep.py
+++ b/platform/deployment/ecr_deploy/prep.py
@@ -25,7 +25,7 @@ _MISSING_LABELS: dict[str, str] = {
 }
 _WARNING_LABELS: dict[str, str] = {
     "telegram_users": "Telegram allowed-users configuration (recommended)",
-    "slack_on_ec2": "Slack deploys via Terraform only (a separate Terraform module)",
+    "slack_on_ec2": "Slack is deployed and operated separately, not from this repo",
     "llm_provider_ec2": "LLM provider may not work inside EC2 containers",
 }
 

--- a/platform/deployment/gateway/README.md
+++ b/platform/deployment/gateway/README.md
@@ -1,8 +1,7 @@
 # `platform/deployment/gateway/`
 
 AMI + systemd deployment path for the OpenSRE **Telegram** gateway (long
-polling). Slack deploys via Terraform only, in the
-a separate Terraform module.
+polling). Slack is deployed and operated separately, not from this repo.
 
 This path is an alternative to the main Docker/ECR web+gateway deploy.
 It runs the gateway process directly on the EC2 host as a systemd service,
@@ -55,8 +54,7 @@ Copy [`.env.deploy.example`](../../../.env.deploy.example) and set
 | `TELEGRAM_ALLOWED_USERS` | Recommended | Gateway pairing gate |
 
 `SLACK_*` variables are ignored by this deploy path (validation warns) — Slack
-runs on Fargate via the
-a separate Terraform module.
+is deployed and operated separately, not from this repo.
 
 | `LLM_PROVIDER` + API key | Yes | Gateway service |
 | `OPENSRE_GATEWAY_GIT_REF` | No | Git ref to bake (default: local HEAD SHA) |

--- a/tests/deployment/ec2/conftest.py
+++ b/tests/deployment/ec2/conftest.py
@@ -1,8 +1,8 @@
 """Fixtures for EC2 deployment tests (web + gateway on one instance).
 
 These tests require AWS credentials and a Telegram bot token and should be
-skipped in CI. The EC2 deploy is Telegram-only — Slack deploys via Terraform
-(a separate Terraform module). Run manually with:
+skipped in CI. The EC2 deploy is Telegram-only — Slack is deployed and operated
+separately, not from this repo. Run manually with:
 pytest tests/deployment/ec2/ -v -s
 """
 

--- a/tests/platform/deployment/test_deploy_env_validation.py
+++ b/tests/platform/deployment/test_deploy_env_validation.py
@@ -25,7 +25,7 @@ def test_validate_deploy_env_rejects_slack_only(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Slack deploys via Terraform only — an EC2 deploy without Telegram fails."""
+    """Slack is deployed separately — an EC2 deploy without Telegram fails."""
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "key")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
     monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
@@ -43,7 +43,7 @@ def test_validate_deploy_env_rejects_slack_only(
 
     output = capsys.readouterr().out
     assert "MISSING: TELEGRAM_BOT_TOKEN" in output
-    assert "Slack deploys via Terraform only" in output
+    assert "Slack is deployed and operated separately" in output
 
 
 def test_validate_deploy_env_lists_missing_required_vars(
@@ -95,7 +95,7 @@ def test_validate_deploy_env_warns_that_slack_vars_are_ignored(
     prep.validate_deploy_env()
     output = capsys.readouterr().out
     assert "WARN: SLACK_BOT_TOKEN / SLACK_APP_TOKEN — ignored by the EC2 deploy" in output
-    assert "Slack deploys via Terraform only" in output
+    assert "Slack is deployed and operated separately" in output
 
 
 def test_validate_deploy_env_allows_bedrock_without_api_key(


### PR DESCRIPTION
Updated docs and comments: slack infra is in a separate repo