### PR TITLE
fix(azure): clarify deployment-not-found failures

### DIFF
--- a/core/llm/provider_errors.py
+++ b/core/llm/provider_errors.py
@@ -1,0 +1,26 @@
+"""Structured failures raised at hosted LLM provider boundaries."""
+
+from __future__ import annotations
+
+
+class LLMResourceNotFoundError(RuntimeError):
+    """A configured provider resource, such as a model or deployment, was not found."""
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        provider_label: str | None = None,
+        resource_kind: str,
+        resource_name: str,
+        detail: str | None = None,
+    ) -> None:
+        self.provider = provider
+        self.provider_label = provider_label or provider
+        self.resource_kind = resource_kind
+        self.resource_name = resource_name
+        default_detail = f"{self.provider_label} {resource_kind} '{resource_name}' was not found."
+        super().__init__(detail or default_detail)
+
+
+__all__ = ["LLMResourceNotFoundError"]

--- a/core/llm/providers/azure_openai.py
+++ b/core/llm/providers/azure_openai.py
@@ -57,6 +57,24 @@ def azure_openai_endpoint_configured() -> bool:
     return bool(base)
 
 
+def azure_openai_deployment_not_found_detail(
+    *,
+    deployment: str,
+) -> str:
+    """Build a pure user-facing hint for a missing Azure deployment."""
+    deployment_name = deployment.removeprefix("azure/").strip() or deployment
+    message = (
+        "Azure OpenAI deployment "
+        f"'{deployment_name}' was not found. "
+        "AZURE_OPENAI_*_MODEL must be the deployment name from your Azure resource, "
+        "not a model ID returned by GET /openai/models."
+    )
+    return (
+        message + " Find the deployment name in Azure AI Foundry or list it through "
+        "the Azure Resource Manager API."
+    )
+
+
 def resolve_azure_openai_request_kwargs(settings: Any, *, model_type: ModelType) -> dict[str, str]:
     """Resolve LiteLLM request fields for Azure OpenAI from runtime settings."""
     base_url = normalize_azure_openai_base_url(str(getattr(settings, "azure_openai_base_url", "")))
@@ -81,6 +99,7 @@ __all__ = [
     "AZURE_OPENAI_API_VERSION_ENV",
     "AZURE_OPENAI_BASE_URL_ENV",
     "AZURE_OPENAI_PROVIDER",
+    "azure_openai_deployment_not_found_detail",
     "azure_openai_endpoint_configured",
     "azure_openai_litellm_model",
     "is_azure_openai_provider",

--- a/core/llm/shared/openai_chat_completions.py
+++ b/core/llm/shared/openai_chat_completions.py
@@ -7,6 +7,7 @@ import time
 from collections.abc import Callable, Iterator
 from typing import Any
 
+from core.llm.provider_errors import LLMResourceNotFoundError
 from core.llm.shared.llm_retry import (
     extract_retry_after_seconds,
     maybe_raise_credit_exhausted,
@@ -222,7 +223,11 @@ def invoke_with_litellm_agent_retries(
     kwargs: dict[str, Any],
     *,
     provider_name: str,
+    provider_id: str | None = None,
     model: str,
+    resource_kind: str = "model",
+    resource_name: str | None = None,
+    resource_not_found_detail: str | None = None,
 ) -> Any:
     backoff = _RETRY_INITIAL_BACKOFF_SEC
     last_err: Exception | None = None
@@ -233,7 +238,13 @@ def invoke_with_litellm_agent_retries(
             if is_exception_named(err, "AuthenticationError"):
                 raise RuntimeError(f"{provider_name} authentication failed.") from err
             if is_exception_named(err, "NotFoundError"):
-                raise RuntimeError(f"{provider_name} model '{model}' not found.") from err
+                raise LLMResourceNotFoundError(
+                    provider=provider_id or provider_name,
+                    provider_label=provider_name,
+                    resource_kind=resource_kind,
+                    resource_name=resource_name or model,
+                    detail=resource_not_found_detail,
+                ) from err
             if is_exception_named(err, "PermissionDeniedError"):
                 raise RuntimeError(f"{provider_name} request forbidden: {err}") from err
             if is_exception_named(err, "BadRequestError"):
@@ -269,9 +280,13 @@ def invoke_with_litellm_llm_retries(
     kwargs: dict[str, Any],
     *,
     provider_label: str,
+    provider_id: str | None = None,
     api_key_env: str,
     model: str,
     on_model_fallback: Callable[[], dict[str, Any] | None],
+    resource_kind: str = "model",
+    resource_name: str | None = None,
+    resource_not_found_detail: str | None = None,
 ) -> Any:
     from platform.guardrails.engine import GuardrailBlockedError
 
@@ -292,9 +307,12 @@ def invoke_with_litellm_llm_retries(
                 if rebuilt is not None:
                     kwargs = rebuilt
                     continue
-                raise RuntimeError(
-                    f"{provider_label} model '{model}' was not found. "
-                    "Check your configured model name or endpoint."
+                raise LLMResourceNotFoundError(
+                    provider=provider_id or provider_label,
+                    provider_label=provider_label,
+                    resource_kind=resource_kind,
+                    resource_name=resource_name or model,
+                    detail=resource_not_found_detail,
                 ) from err
             if is_exception_named(err, "BadRequestError"):
                 message = str(getattr(err, "message", err))
@@ -336,9 +354,13 @@ def stream_with_litellm_retries(
     kwargs: dict[str, Any],
     *,
     provider_label: str,
+    provider_id: str | None = None,
     api_key_env: str,
     model: str,
     on_model_fallback: Callable[[], dict[str, Any] | None],
+    resource_kind: str = "model",
+    resource_name: str | None = None,
+    resource_not_found_detail: str | None = None,
 ) -> Iterator[str]:
     from platform.guardrails.engine import GuardrailBlockedError
 
@@ -367,9 +389,12 @@ def stream_with_litellm_retries(
                 if rebuilt is not None:
                     kwargs = rebuilt
                     continue
-                raise RuntimeError(
-                    f"{provider_label} model '{model}' was not found. "
-                    "Check your configured model name or endpoint."
+                raise LLMResourceNotFoundError(
+                    provider=provider_id or provider_label,
+                    provider_label=provider_label,
+                    resource_kind=resource_kind,
+                    resource_name=resource_name or model,
+                    detail=resource_not_found_detail,
                 ) from err
             if is_exception_named(err, "BadRequestError"):
                 message = str(getattr(err, "message", err))

--- a/core/llm/transports/litellm/clients.py
+++ b/core/llm/transports/litellm/clients.py
@@ -56,6 +56,11 @@ class LiteLLMAgentClient:
         api_key_env: str | None = None,
         api_key_default: str = "",
         temperature: float | None = None,
+        provider_id: str | None = None,
+        provider_label: str = "LiteLLM",
+        not_found_resource_kind: str = "model",
+        not_found_resource_name: str | None = None,
+        not_found_detail: str | None = None,
         credential_resolver: Callable[[str], str] | None = None,
         completion_func: Callable[..., Any] | None = None,
     ) -> None:
@@ -66,6 +71,11 @@ class LiteLLMAgentClient:
         self._api_key_env = api_key_env
         self._api_key_default = api_key_default
         self._temperature = temperature
+        self._provider_id = provider_id
+        self.provider_name = provider_label
+        self._not_found_resource_kind = not_found_resource_kind
+        self._not_found_resource_name = not_found_resource_name
+        self._not_found_detail = not_found_detail
         self._credential_resolver = credential_resolver
         self._completion_func = completion_func
 
@@ -129,7 +139,11 @@ class LiteLLMAgentClient:
             self._completion,
             kwargs,
             provider_name=self.provider_name,
+            provider_id=self._provider_id,
             model=self._litellm_model,
+            resource_kind=self._not_found_resource_kind,
+            resource_name=self._not_found_resource_name,
+            resource_not_found_detail=self._not_found_detail,
         )
         return agent_response_from_completion(
             response,
@@ -156,6 +170,11 @@ class LiteLLMLLMClient:
         api_version: str | None = None,
         api_key_env: str | None = None,
         api_key_default: str = "",
+        provider_id: str | None = None,
+        provider_label: str | None = None,
+        not_found_resource_kind: str = "model",
+        not_found_resource_name: str | None = None,
+        not_found_detail: str | None = None,
         credential_resolver: Callable[[str], str] | None = None,
         completion_func: Callable[..., Any] | None = None,
         usage_callback: Callable[[str, int | None, int | None], object] | None = None,
@@ -169,12 +188,16 @@ class LiteLLMLLMClient:
         self._api_version = api_version
         self._api_key_env = api_key_env
         self._api_key_default = api_key_default
+        self._provider_id = provider_id
         self._credential_resolver = credential_resolver
         self._completion_func = completion_func
         self._usage_callback = usage_callback
         self._bound_tools: list[dict[str, Any]] = []
         label = (api_key_env or "").removesuffix("_API_KEY").replace("_", " ").title()
-        self._provider_label = label or "LiteLLM"
+        self._provider_label = provider_label or label or "LiteLLM"
+        self._not_found_resource_kind = not_found_resource_kind
+        self._not_found_resource_name = not_found_resource_name
+        self._not_found_detail = not_found_detail
 
     def with_config(self, **_kwargs: Any) -> LiteLLMLLMClient:
         return self
@@ -251,9 +274,13 @@ class LiteLLMLLMClient:
             self._completion,
             self._build_request_kwargs(prompt_or_messages),
             provider_label=self._provider_label,
+            provider_id=self._provider_id,
             api_key_env=self._api_key_env or "",
             model=self._litellm_model,
             on_model_fallback=lambda: self._rebuild_after_model_fallback(prompt_or_messages),
+            resource_kind=self._not_found_resource_kind,
+            resource_name=self._not_found_resource_name,
+            resource_not_found_detail=self._not_found_detail,
         )
         return llm_response_from_completion(
             response,
@@ -267,7 +294,11 @@ class LiteLLMLLMClient:
             self._completion,
             self._build_request_kwargs(prompt_or_messages),
             provider_label=self._provider_label,
+            provider_id=self._provider_id,
             api_key_env=self._api_key_env or "",
             model=self._litellm_model,
             on_model_fallback=lambda: self._rebuild_after_model_fallback(prompt_or_messages),
+            resource_kind=self._not_found_resource_kind,
+            resource_name=self._not_found_resource_name,
+            resource_not_found_detail=self._not_found_detail,
         )

--- a/core/llm/transports/litellm/routing.py
+++ b/core/llm/transports/litellm/routing.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.llm.providers.azure_openai import (
+    azure_openai_deployment_not_found_detail,
     is_azure_openai_provider,
     resolve_azure_openai_request_kwargs,
 )
@@ -51,6 +52,13 @@ def build_litellm_agent_client(settings: Any, provider: str) -> LiteLLMAgentClie
             api_base=azure["api_base"],
             api_version=azure["api_version"],
             api_key_env=azure["api_key_env"],
+            provider_id="azure-openai",
+            provider_label="Azure OpenAI",
+            not_found_resource_kind="deployment",
+            not_found_resource_name=azure["litellm_model"].removeprefix("azure/"),
+            not_found_detail=azure_openai_deployment_not_found_detail(
+                deployment=azure["litellm_model"]
+            ),
         )
 
     if is_openai_compat_provider(provider):
@@ -119,6 +127,13 @@ def build_litellm_llm_client(
             api_base=azure["api_base"],
             api_version=azure["api_version"],
             api_key_env=azure["api_key_env"],
+            provider_id="azure-openai",
+            provider_label="Azure OpenAI",
+            not_found_resource_kind="deployment",
+            not_found_resource_name=azure["litellm_model"].removeprefix("azure/"),
+            not_found_detail=azure_openai_deployment_not_found_detail(
+                deployment=azure["litellm_model"]
+            ),
             usage_callback=usage_callback,
         )
 

--- a/core/llm_invoke_errors.py
+++ b/core/llm_invoke_errors.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from core.llm.provider_errors import LLMResourceNotFoundError
+
 
 @dataclass(frozen=True)
 class LLMInvokeFailure:
@@ -133,7 +135,7 @@ def classify_provider_error_kind(message: str) -> str:
     if any(pattern in text for pattern in _QUOTA_PATTERNS):
         return "quota"
     if any(pattern in text for pattern in _NOT_CONFIGURED_PATTERNS) or (
-        "model" in text and "not found" in text
+        ("model" in text or "deployment" in text) and "not found" in text
     ):
         return "not_configured"
     return "provider_error"
@@ -204,6 +206,34 @@ def classify_llm_invoke_failure(exc: BaseException) -> LLMInvokeFailure | None:
 
     err_msg = str(exc).lower()
     raw = str(exc)
+
+    if isinstance(exc, LLMResourceNotFoundError):
+        if exc.provider == "azure-openai" and exc.resource_kind == "deployment":
+            from core.llm.providers.azure_openai import (
+                azure_openai_deployment_not_found_detail,
+            )
+
+            return LLMInvokeFailure(
+                user_message=(
+                    raw
+                    if "GET /openai/models" in raw
+                    else azure_openai_deployment_not_found_detail(deployment=exc.resource_name)
+                ),
+                tracker_message="Failed: Deployment not found",
+                remediation_steps=[
+                    "Set AZURE_OPENAI_*_MODEL to an Azure deployment name.",
+                    "Do not copy model IDs from GET /openai/models.",
+                    "Verify AZURE_OPENAI_BASE_URL points at the resource containing the deployment.",
+                ],
+            )
+        return LLMInvokeFailure(
+            user_message=raw,
+            tracker_message="Failed: Model not found",
+            remediation_steps=[
+                "Verify the configured model name and endpoint.",
+                "Confirm the model is available to this provider account.",
+            ],
+        )
 
     if ("model" in err_msg and "not found" in err_msg) or "404" in err_msg:
         if "anthropic" in err_msg and "was not found" in err_msg:

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -186,7 +186,11 @@ Uses the OpenAI SDK. Reasoning models (`o1`, `o3`, `o4`, `gpt-5*`) automatically
 
 ### Azure OpenAI
 
-Azure OpenAI routes through LiteLLM. Model env vars hold **deployment names** from your Azure resource, not public OpenAI model IDs.
+Azure OpenAI routes through LiteLLM. Model env vars hold **deployment names** from your
+Azure resource, not public OpenAI model IDs. `GET /openai/models` only shows models
+available to the resource; seeing `gpt-4.1` there does not mean a deployment named
+`gpt-4.1` exists. Use the deployment name shown in Azure AI Foundry (for example,
+`prod-gpt-4-1`).
 
 ```bash
 export LLM_PROVIDER=azure-openai
@@ -198,9 +202,9 @@ export AZURE_OPENAI_API_KEY=...
 # export AZURE_OPENAI_API_VERSION=2024-10-21
 
 # Deployment names (must exist in your Azure resource):
-export AZURE_OPENAI_REASONING_MODEL=gpt-5.4-mini
-export AZURE_OPENAI_TOOLCALL_MODEL=gpt-5.4-mini
-export AZURE_OPENAI_CLASSIFICATION_MODEL=gpt-5.4-mini
+export AZURE_OPENAI_REASONING_MODEL=prod-gpt-4-1
+export AZURE_OPENAI_TOOLCALL_MODEL=prod-gpt-4-1
+export AZURE_OPENAI_CLASSIFICATION_MODEL=prod-gpt-4-1
 ```
 
 Quick setup:
@@ -214,11 +218,13 @@ Onboarding asks only for your **resource URL**, **API key**, and **reasoning dep
 In the REPL, switch provider or deployment like any other API provider:
 
 ```bash
-/model set azure-openai gpt-5.4-mini
-/model set azure-openai gpt-5.4-mini --toolcall-model gpt-5.4-nano
+/model set azure-openai prod-gpt-4-1
+/model set azure-openai prod-gpt-4-1 --toolcall-model=fast-gpt-4-1-mini
 ```
 
-Common deployment names in the onboarding picker include `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5-mini`, `gpt-4.1`, and `o3-mini`. Use custom names when your Azure deployment names differ (`allow_custom_models` is enabled).
+Azure deployment names are user-defined and can differ from their underlying model IDs.
+The onboarding picker contains common same-as-model examples for convenience, but use the
+custom-name option whenever your deployment has another name.
 
 ### OpenRouter
 

--- a/surfaces/cli/wizard/validation.py
+++ b/surfaces/cli/wizard/validation.py
@@ -89,7 +89,11 @@ def _check_azure_openai(
     api_version: str,
 ) -> ValidationResult:
     """Validate Azure OpenAI credentials with a tiny chat completion."""
-    from core.llm.providers.azure_openai import normalize_azure_openai_base_url
+    from core.llm.providers.azure_openai import (
+        azure_openai_deployment_not_found_detail,
+        normalize_azure_openai_base_url,
+        resolve_azure_openai_api_version,
+    )
 
     normalized_base = normalize_azure_openai_base_url(base_url)
     if not normalized_base:
@@ -97,7 +101,6 @@ def _check_azure_openai(
             ok=False,
             detail="Azure OpenAI resource URL is missing. Set AZURE_OPENAI_BASE_URL.",
         )
-    from core.llm.providers.azure_openai import resolve_azure_openai_api_version
 
     resolved_api_version = resolve_azure_openai_api_version(api_version)
 
@@ -128,6 +131,14 @@ def _check_azure_openai(
     except openai_auth_error:
         return ValidationResult(ok=False, detail="Azure OpenAI rejected the API key.")
     except Exception as err:
+        err_text = str(err).lower()
+        if getattr(err, "status_code", None) == 404 or (
+            "not found" in err_text and "deployment" in err_text
+        ):
+            return ValidationResult(
+                ok=False,
+                detail=azure_openai_deployment_not_found_detail(deployment=model),
+            )
         return ValidationResult(ok=False, detail=f"Validation request failed: {err}")
 
 

--- a/tests/cli/wizard/test_validation.py
+++ b/tests/cli/wizard/test_validation.py
@@ -173,6 +173,27 @@ def test_validate_provider_credentials_returns_success_for_valid_openai_key(monk
     assert result.sample_response == "OpenSRE ready"
 
 
+def test_validate_azure_openai_reports_deployment_name_mismatch(monkeypatch) -> None:
+    error = RuntimeError("DeploymentNotFound: deployment does not exist")
+    error.status_code = 404  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        "surfaces.cli.wizard.validation.OpenAI",
+        lambda **_kwargs: _FakeOpenAIClient(error),
+    )
+    monkeypatch.setenv("AZURE_OPENAI_BASE_URL", "https://example.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-10-21")
+
+    result = validate_provider_credentials(
+        provider=PROVIDER_BY_VALUE["azure-openai"],
+        api_key="test-key",
+        model="gpt-4.1",
+    )
+
+    assert result.ok is False
+    assert "deployment 'gpt-4.1' was not found" in result.detail
+    assert "not a model ID returned by GET /openai/models" in result.detail
+
+
 def test_get_provider_base_url_deepseek() -> None:
     from config.config import DEEPSEEK_BASE_URL
 

--- a/tests/core/runtime/llm/test_azure_openai_helpers.py
+++ b/tests/core/runtime/llm/test_azure_openai_helpers.py
@@ -1,0 +1,52 @@
+"""Azure OpenAI helper tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.llm.provider_errors import LLMResourceNotFoundError
+from core.llm.providers.azure_openai import azure_openai_deployment_not_found_detail
+from core.llm.shared.openai_chat_completions import invoke_with_litellm_agent_retries
+
+
+class NotFoundError(Exception):
+    pass
+
+
+def test_azure_openai_deployment_not_found_detail_explains_model_id_mismatch() -> None:
+    detail = azure_openai_deployment_not_found_detail(deployment="gpt-4.1")
+
+    assert "deployment 'gpt-4.1' was not found" in detail
+    assert "not a model ID" in detail
+    assert "Azure Resource Manager API" in detail
+
+
+def test_invoke_with_litellm_agent_retries_raises_structured_resource_error() -> None:
+    def completion(**_kwargs: object) -> None:
+        raise NotFoundError("deployment not found")
+
+    with pytest.raises(LLMResourceNotFoundError) as exc_info:
+        invoke_with_litellm_agent_retries(
+            completion,
+            {
+                "model": "azure/gpt-4.1",
+                "messages": [{"role": "user", "content": "hi"}],
+                "api_base": "https://example.openai.azure.com",
+                "api_version": "2024-10-21",
+                "api_key": "test-key",
+            },
+            provider_name="Azure OpenAI",
+            provider_id="azure-openai",
+            model="azure/gpt-4.1",
+            resource_kind="deployment",
+            resource_name="gpt-4.1",
+            resource_not_found_detail=azure_openai_deployment_not_found_detail(
+                deployment="gpt-4.1"
+            ),
+        )
+
+    assert exc_info.value.provider == "azure-openai"
+    assert exc_info.value.provider_label == "Azure OpenAI"
+    assert exc_info.value.resource_kind == "deployment"
+    assert exc_info.value.resource_name == "gpt-4.1"
+    assert "not a model ID returned by GET /openai/models" in str(exc_info.value)

--- a/tests/core/runtime/llm/test_azure_openai_routing.py
+++ b/tests/core/runtime/llm/test_azure_openai_routing.py
@@ -29,6 +29,12 @@ def test_build_litellm_agent_client_for_azure_openai() -> None:
     assert client._api_base == "https://example.openai.azure.com"
     assert client._api_version == "2024-10-21"
     assert client._api_key_env == "AZURE_OPENAI_API_KEY"
+    assert client._provider_id == "azure-openai"
+    assert client.provider_name == "Azure OpenAI"
+    assert client._not_found_resource_kind == "deployment"
+    assert client._not_found_resource_name == "gpt-5.4-mini"
+    assert client._not_found_detail is not None
+    assert "not a model ID returned by GET /openai/models" in client._not_found_detail
 
 
 def test_build_litellm_llm_client_for_azure_openai() -> None:
@@ -43,6 +49,12 @@ def test_build_litellm_llm_client_for_azure_openai() -> None:
     assert client._api_base == "https://example.openai.azure.com"
     assert client._api_version == "2024-10-21"
     assert client._model_fallback == "azure/gpt-5.4-nano"
+    assert client._provider_id == "azure-openai"
+    assert client._provider_label == "Azure OpenAI"
+    assert client._not_found_resource_kind == "deployment"
+    assert client._not_found_resource_name == "gpt-5.4-mini"
+    assert client._not_found_detail is not None
+    assert "not a model ID returned by GET /openai/models" in client._not_found_detail
 
 
 def test_azure_openai_requires_base_url_in_settings() -> None:

--- a/tests/core/runtime/test_llm_invoke_errors.py
+++ b/tests/core/runtime/test_llm_invoke_errors.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from core.llm.provider_errors import LLMResourceNotFoundError
 from core.llm_invoke_errors import (
     LLM_PROVIDER_FAILURE_KINDS,
     _looks_like_timeout,
@@ -43,6 +44,22 @@ def test_classify_returns_none_for_credit_exhausted_so_it_propagates() -> None:
 
     err = LLMCreditExhaustedError("OpenAI credit exhausted: insufficient_quota")
     assert classify_llm_invoke_failure(err) is None
+
+
+def test_classify_azure_deployment_not_found_uses_deployment_guidance() -> None:
+    failure = classify_llm_invoke_failure(
+        LLMResourceNotFoundError(
+            provider="azure-openai",
+            provider_label="Azure OpenAI",
+            resource_kind="deployment",
+            resource_name="gpt-4.1",
+        )
+    )
+
+    assert failure is not None
+    assert "deployment 'gpt-4.1' was not found" in failure.user_message
+    assert "not a model ID returned by GET /openai/models" in failure.user_message
+    assert failure.tracker_message == "Failed: Deployment not found"
 
 
 def test_cli_auth_required_uses_unknown_provider_when_attr_missing() -> None:


### PR DESCRIPTION
Fixes #4101

#### Describe the changes you have made in this PR -

- Distinguish Azure OpenAI deployment names from model IDs in onboarding, runtime failures, and docs.
- Add a typed `LLMResourceNotFoundError` so provider adapters can supply specific guidance without adding provider network calls to shared retry paths.
- Route Azure LiteLLM clients with stable provider/resource metadata across agent, reasoning, and streaming calls.
- Classify missing Azure deployments with actionable remediation while preserving generic model-not-found behavior for other providers.
- Add regression coverage for routing, retry translation, onboarding validation, and failure classification.

### Demo/Screenshot for feature changes and bug fixes -

```text
$ uv run pytest tests/core/runtime/llm/test_azure_openai_helpers.py tests/core/runtime/llm/test_azure_openai_routing.py tests/core/runtime/llm/test_litellm_compat.py tests/core/runtime/test_llm_invoke_errors.py tests/cli/wizard/test_validation.py -q
44 passed in 5.03s
```

A missing deployment now reports that `AZURE_OPENAI_*_MODEL` must contain the Azure deployment name and explicitly warns that `GET /openai/models` returns model IDs, not deployment names.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The report was caused by conflating Azure model IDs with user-defined deployment names. The existing LiteLLM routing already passed the deployment correctly, so changing request routing or querying Azure during every 404 would add failure-path latency without fixing the configuration.

This implementation introduces a structured provider/resource-not-found exception. The Azure routing adapter supplies deployment-specific metadata and a pure diagnostic message; shared retries only translate LiteLLM's error into that exception. Onboarding and investigation classification consume the same guidance without network I/O. Live deployment discovery was considered but rejected because deployment enumeration uses Azure Resource Manager credentials and should be an explicit future diagnostic, not an inference retry side effect.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Verification:
- `make lint`
- `make format-check`
- `make typecheck`
- Targeted Azure/LiteLLM/wizard regressions: 44 passed
- `make test-cov` was started but stopped after 25 minutes when it entered unrelated live Grok CLI planner scenarios; PR CI will run the repository matrix.