### PR TITLE
feat(deploy): tag ECR images by git SHA (+ latest) for reproducible, rollback-able deploys

### DIFF
--- a/platform/deployment/aws/ecr.py
+++ b/platform/deployment/aws/ecr.py
@@ -81,8 +81,13 @@ def build_and_push(
     build_args: dict[str, str] | None = None,
     region: str = DEFAULT_REGION,
     context_dir: Path | None = None,
+    extra_tags: tuple[str, ...] = (),
 ) -> str:
-    """Build a Docker image and push it to ECR. Returns the full image URI."""
+    """Build a Docker image and push it to ECR. Returns the full image URI.
+
+    ``extra_tags`` are pushed as additional tags of the same image (one build,
+    N tags) — e.g. a moving ``latest`` alongside an immutable git-SHA tag.
+    """
     docker_login(region)
 
     if dockerfile_path.is_file():
@@ -115,6 +120,11 @@ def build_and_push(
 
     subprocess.run(cmd, check=True)
     subprocess.run(["docker", "push", full_uri], check=True)
+
+    for extra_tag in extra_tags:
+        extra_uri = f"{repository_uri}:{extra_tag}"
+        subprocess.run(["docker", "tag", full_uri, extra_uri], check=True)
+        subprocess.run(["docker", "push", extra_uri], check=True)
 
     return full_uri
 

--- a/platform/deployment/ecr_deploy/lifecycle.py
+++ b/platform/deployment/ecr_deploy/lifecycle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import subprocess
 import time
 
 from botocore.exceptions import ClientError
@@ -123,15 +124,43 @@ def _resolve_image_uri() -> str:
     )
 
 
+def _image_tag() -> str:
+    """Git-pinned image tag: ``sha-<short-sha>``, ``-dirty`` when uncommitted.
+
+    Prod deploys pin this tag (``:latest`` is rejected there), so it must
+    identify the exact source: a build from a dirty working tree is marked
+    ``-dirty`` and can never masquerade as a reproducible release.
+    """
+    short_sha = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    dirty = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return f"sha-{short_sha}-dirty" if dirty else f"sha-{short_sha}"
+
+
 def build_image() -> str:
     """Build the Docker image and push it to ECR.
 
-    Saves the resulting image URI locally so subsequent ``make deploy`` calls
+    One build, two tags: an immutable-by-convention ``sha-<git-sha>`` (what
+    prod deploys pin; rollback is redeploying the previous SHA) plus a moving
+    ``latest`` for dev convenience.
+
+    Saves the SHA-tagged image URI locally so subsequent ``make deploy`` calls
     can reuse it without rebuilding. Run this once per code change, then call
     ``make deploy`` as many times as needed.
 
     Returns:
-        The full ECR image URI (e.g. ``123….dkr.ecr.us-east-1.amazonaws.com/opensre:latest``).
+        The full ECR image URI (e.g. ``123….dkr.ecr.us-east-1.amazonaws.com/opensre:sha-abc1234``).
     """
     assert_deploy_account(REGION)
     stack = get_stack()
@@ -145,14 +174,16 @@ def build_image() -> str:
     repo = ecr.create_repository(stack.ecr_repo_name, stack.stack_name, REGION)
     print(f"  - Repository: {repo['uri']}")
 
-    print("Building and pushing Docker image...")
+    tag = _image_tag()
+    print(f"Building and pushing Docker image ({tag} + {ECR_DEFAULT_IMAGE_TAG})...")
     image_uri = ecr.build_and_push(
         dockerfile_path=DOCKERFILE,
         repository_uri=repo["uri"],
-        tag=ECR_DEFAULT_IMAGE_TAG,
+        tag=tag,
         platform=ECR_DOCKER_PLATFORM,
         context_dir=REPO_ROOT,
         region=REGION,
+        extra_tags=(ECR_DEFAULT_IMAGE_TAG,),
     )
     save_image_uri(image_uri)
 

--- a/tests/platform/deployment/test_image_build.py
+++ b/tests/platform/deployment/test_image_build.py
@@ -54,6 +54,35 @@ def test_resolve_image_uri_fails_fast_when_nothing_available(
         deploy_module._resolve_image_uri()
 
 
+# ── _image_tag ────────────────────────────────────────────────────────────────
+
+
+class _FakeCompleted:
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+
+
+def _fake_git(sha: str, porcelain: str):  # noqa: ANN202 - test helper
+    def run(cmd: list[str], **_kw: object) -> _FakeCompleted:
+        if cmd[:3] == ["git", "rev-parse", "--short"]:
+            return _FakeCompleted(sha + "\n")
+        if cmd[:2] == ["git", "status"]:
+            return _FakeCompleted(porcelain)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    return run
+
+
+def test_image_tag_clean_tree_is_sha_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(deploy_module.subprocess, "run", _fake_git("abc1234", ""))
+    assert deploy_module._image_tag() == "sha-abc1234"
+
+
+def test_image_tag_dirty_tree_is_marked(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(deploy_module.subprocess, "run", _fake_git("abc1234", " M file.py\n"))
+    assert deploy_module._image_tag() == "sha-abc1234-dirty"
+
+
 # ── build_image ───────────────────────────────────────────────────────────────
 
 
@@ -74,9 +103,36 @@ def test_build_image_saves_uri_and_returns_it(
         "build_and_push",
         lambda *_a, **_kw: _FAKE_URI,
     )
+    monkeypatch.setattr(deploy_module, "_image_tag", lambda: "sha-abc1234")
 
     result = deploy_module.build_image()
 
     assert result == _FAKE_URI
     assert uri_file.exists()
     assert uri_file.read_text().strip() == _FAKE_URI
+
+
+def test_build_image_pushes_sha_tag_with_latest_alias(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pytest.TempPathFactory,
+) -> None:
+    monkeypatch.setattr(stack_module, "_IMAGE_URI_FILE", tmp_path / "image-uri.txt")
+    monkeypatch.setattr(
+        deploy_module.ecr,
+        "create_repository",
+        lambda *_a, **_kw: {"uri": "123456789012.dkr.ecr.us-east-1.amazonaws.com/opensre"},
+    )
+    monkeypatch.setattr(deploy_module, "_image_tag", lambda: "sha-abc1234")
+
+    captured: dict[str, object] = {}
+
+    def fake_build_and_push(*_a: object, **kw: object) -> str:
+        captured.update(kw)
+        return _FAKE_URI
+
+    monkeypatch.setattr(deploy_module.ecr, "build_and_push", fake_build_and_push)
+
+    deploy_module.build_image()
+
+    assert captured["tag"] == "sha-abc1234"
+    assert captured["extra_tags"] == ("latest",)


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

make build-image now produces an immutable sha-<git-sha> tag alongside a moving latest, from a single build — so prod deploys can pin an exact, reproducible source and roll back by redeploying a previous SHA.

Changes

- platform/deployment/aws/ecr.py — build_and_push gains an extra_tags param: one build, N tags. After building and pushing the primary tag it re-tags and pushes each extra (e.g. latest alongside the SHA tag) — no rebuild.

- platform/deployment/ecr_deploy/lifecycle.py — new _image_tag() derives sha-<short-sha> from git, marking -dirty when the working tree is uncommitted so a non-reproducible build can never masquerade as a release. build_image() now pushes the SHA tag as primary + latest as an extra, and saves the SHA-tagged URI locally for make deploy reuse.

- tests/platform/deployment/test_image_build.py (new) — covers clean-tree sha-<sha>, dirty-tree -dirty marking, and that build_image pushes the SHA tag with the latest alias.
Why: the deploy story needs a stable, source-identifiable image reference. :latest is fine for dev convenience but unsafe for prod (it moves); pinning sha-<git-sha> makes each deploy traceable to an exact commit and makes rollback a redeploy of the prior SHA. The -dirty suffix prevents an uncommitted local build from being mistaken for a reproducible one.
