### PR TITLE
fix(shell): record /mcp unknown subcommand as a failed turn

### DIFF
--- a/surfaces/interactive_shell/command_registry/integrations.py
+++ b/surfaces/interactive_shell/command_registry/integrations.py
@@ -413,10 +413,12 @@ def _cmd_mcp(session: Session, console: Console, args: list[str]) -> bool:
     if sub == "disconnect":
         return _handle_remove(session, console, args[1] if len(args) > 1 else None)
 
-    console.print(
+    repl_print(
+        console,
         f"[{ERROR}]unknown subcommand:[/] {escape(sub)}  "
-        "(try [bold]/mcp list[/bold], [bold]/mcp connect[/bold], or [bold]/mcp disconnect[/bold])"
+        "(try [bold]/mcp list[/bold], [bold]/mcp connect[/bold], or [bold]/mcp disconnect[/bold])",
     )
+    session.mark_latest(ok=False, kind="slash")
     return True
 
 

--- a/tests/interactive_shell/command_registry/test_suggestions.py
+++ b/tests/interactive_shell/command_registry/test_suggestions.py
@@ -77,6 +77,22 @@ def test_dispatch_invalid_subcommand_is_handled_by_command_handler(
     assert resolve_literal_slash_typo("/integrations bogus", SLASH_COMMANDS) is None
 
 
+@pytest.mark.parametrize("command_line", ["/integrations bogus", "/mcp bogus"])
+def test_dispatch_unknown_subcommand_records_turn_as_failed(
+    monkeypatch: pytest.MonkeyPatch,
+    command_line: str,
+) -> None:
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.integrations.repl_data.load_verified_integrations",
+        lambda: [],
+    )
+    session = Session()
+    console, buf = _capture()
+    assert dispatch_slash(command_line, session, console, is_tty=False) is True
+    assert "unknown subcommand" in buf.getvalue().lower()
+    assert session.history[-1]["ok"] is False
+
+
 def test_subcommand_hints_ignores_usage_placeholders() -> None:
     resume = SLASH_COMMANDS["/resume"]
     assert subcommand_hints(resume) == ()


### PR DESCRIPTION
Fixes #3345 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

`/mcp <unknown-subcommand>` printed the correct error but still recorded the turn as successful, while `/integrations <unknown-subcommand>` correctly recorded it as failed. That meant failed `/mcp` commands showed up wrong in session history and slash analytics. This change makes `/mcp` match `/integrations` — it prints through `repl_print` and marks the turn as failed — and adds a regression test covering both commands.


### Demo/Screenshot for feature changes and bug fixes - 

<img width="1395" height="972" alt="image" src="https://github.com/user-attachments/assets/9e31e3d5-0741-4e72-8b88-9e55e48e9bf0" />


<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I first reproduce the issue by running them through the real dispatcher, and found they all already print proper guidance, only `/mcp` was inconsistent. Rather than add a new pattern, I mirrored what `_cmd_integrations` already does for the identical case: print through `repl_print` (which resets the TTY column and is safe after an inline menu) and call `session.mark_latest(ok=False, kind="slash")`. The test is parametrized over both `/integrations bogus` and `/mcp bogus` so the two handlers can't drift apart again. I confirmed the test actually catches the bug by stashing the fix and watching only the `/mcp` case fail, and verified the live output still renders correctly in a real TTY using ReplDriver.


<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
