### PR TITLE
fix(interactive-shell): stream /update live instead of buffering it

### DIFF
--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -134,10 +134,8 @@ def run_cli_command(
                     f"[{ERROR}]CLI command exited with non-zero code {captured_result.returncode}[/]"
                 )
         else:
-            interactive_result = (
-                subprocess.run(cmd, check=False, timeout=subprocess_timeout, env=child_env)
-                if subprocess_timeout is not None
-                else subprocess.run(cmd, check=False, env=child_env)
+            interactive_result = subprocess.run(
+                cmd, check=False, timeout=subprocess_timeout, env=child_env
             )
             exit_code = interactive_result.returncode
             # The child wrote straight to the terminal, bypassing Rich, so Rich has no

--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -134,10 +134,10 @@ def run_cli_command(
                     f"[{ERROR}]CLI command exited with non-zero code {captured_result.returncode}[/]"
                 )
         else:
-            interactive_result = (
-                subprocess.run(cmd, check=False, timeout=subprocess_timeout, env=child_env)
-                if subprocess_timeout is not None
-                else subprocess.run(cmd, check=False, env=child_env)
+            # timeout=None is a no-op for subprocess.run, so this covers both the
+            # timed (/update) and untimed (/onboard) interactive callers.
+            interactive_result = subprocess.run(
+                cmd, check=False, timeout=subprocess_timeout, env=child_env
             )
             exit_code = interactive_result.returncode
             # The child wrote straight to the terminal, bypassing Rich, so Rich has no
@@ -157,6 +157,9 @@ def run_cli_command(
         console.print(f"[{ERROR}]error:[/] CLI command timed out")
     except KeyboardInterrupt:
         exit_code = None
+        # Same cursor hazard as the normal-exit path: Ctrl+C can land mid-line while
+        # a streamed child is mid-redraw of its own progress bar.
+        prepare_repl_output_line()
         console.print(f"[{DIM}]CLI command cancelled (Ctrl+C).[/]")
     except Exception as exc:
         exit_code = None

--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -152,6 +152,11 @@ def run_cli_command(
                 )
     except subprocess.TimeoutExpired as exc:
         exit_code = None
+        # Same cursor hazard as the normal-exit and KeyboardInterrupt paths, and the
+        # most likely one to actually hit it: the timeout exists specifically to
+        # kill a hung install script, i.e. a streamed child mid-redraw of its own
+        # progress bar.
+        prepare_repl_output_line()
         print_command_output(console, _decode_subprocess_stream(exc.stdout))
         print_command_output(console, _decode_subprocess_stream(exc.stderr), style=ERROR)
         console.print(f"[{ERROR}]error:[/] CLI command timed out")

--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -134,8 +134,10 @@ def run_cli_command(
                     f"[{ERROR}]CLI command exited with non-zero code {captured_result.returncode}[/]"
                 )
         else:
-            interactive_result = subprocess.run(
-                cmd, check=False, timeout=subprocess_timeout, env=child_env
+            interactive_result = (
+                subprocess.run(cmd, check=False, timeout=subprocess_timeout, env=child_env)
+                if subprocess_timeout is not None
+                else subprocess.run(cmd, check=False, env=child_env)
             )
             exit_code = interactive_result.returncode
             # The child wrote straight to the terminal, bypassing Rich, so Rich has no

--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -26,6 +26,7 @@ from surfaces.interactive_shell.runtime.subprocess_runner import (
     start_background_cli_task,
 )
 from surfaces.interactive_shell.ui import DIM, ERROR, print_command_output
+from surfaces.interactive_shell.ui.components.choice_menu import prepare_repl_output_line
 from surfaces.interactive_shell.utils.telemetry.turn_outcome import format_wizard_cli_outcome
 
 _UPDATE_SUBPROCESS_TIMEOUT_SECONDS = 300
@@ -76,15 +77,19 @@ def run_cli_command(
     ``subprocess_timeout`` caps how long ``subprocess.run`` waits before raising
     :class:`~subprocess.TimeoutExpired`. Interactive flows use ``None`` so the
     child can prompt as long as needed; callers that hit the network without a
-    TTY (like ``opensre update``) pass a bounded timeout.
+    guaranteed response (like ``opensre update``) pass a bounded timeout. The
+    timeout applies whether or not output is captured — it no longer forces
+    capture, so a long-running network command can still stream live to the
+    real TTY (e.g. the install script's own progress output during an update)
+    while still being killed if it hangs.
 
     ``capture_output`` (default ``False``) makes the helper capture stdout/stderr
-    and replay them through ``console`` even without a timeout. Set this for
-    non-interactive delegated commands (e.g. ``opensre tests list``) so their
-    output appears inside the REPL buffer instead of bypassing ``console.print``
-    via the child's inherited stdout FD. Interactive commands like ``onboard``
-    must leave this ``False`` so the child's prompts stay attached to the real
-    TTY. Capture is also enabled automatically whenever a timeout is set.
+    and replay them through ``console``. Set this for non-interactive delegated
+    commands (e.g. ``opensre tests list``) so their output appears inside the
+    REPL buffer instead of bypassing ``console.print`` via the child's inherited
+    stdout FD. Interactive commands, and commands whose child prints its own
+    terminal-aware progress UI (``onboard``, ``update``), must leave this
+    ``False`` so the child's output stays attached to the real TTY.
 
     **Return value:** Reports subprocess success for headless/gateway sessions
     (``session`` with no terminal facet) so slash analytics can show failure.
@@ -99,7 +104,7 @@ def run_cli_command(
     console.print()
     cmd = build_opensre_cli_argv(args)
     headless = session is not None and session_terminal(session) is None
-    should_capture = capture_output or subprocess_timeout is not None or headless
+    should_capture = capture_output or headless
     if headless and subprocess_timeout is None:
         subprocess_timeout = _HEADLESS_CLI_SUBPROCESS_TIMEOUT_SECONDS
     child_env = os.environ.copy()
@@ -129,8 +134,18 @@ def run_cli_command(
                     f"[{ERROR}]CLI command exited with non-zero code {captured_result.returncode}[/]"
                 )
         else:
-            interactive_result = subprocess.run(cmd, check=False, env=child_env)
+            interactive_result = (
+                subprocess.run(cmd, check=False, timeout=subprocess_timeout, env=child_env)
+                if subprocess_timeout is not None
+                else subprocess.run(cmd, check=False, env=child_env)
+            )
             exit_code = interactive_result.returncode
+            # The child wrote straight to the terminal, bypassing Rich, so Rich has no
+            # idea where the cursor ended up (e.g. mid-line after a \r-redrawn progress
+            # bar). Force a fresh line before resuming Rich output, or the blank line
+            # below just terminates the child's last line instead of being a real gap.
+            prepare_repl_output_line()
+            console.print()
             if interactive_result.returncode != 0:
                 console.print(
                     f"[{ERROR}]CLI command exited with non-zero code {interactive_result.returncode}[/]"

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -101,13 +101,9 @@ class TestDispatchSlash:
             *,
             check: bool,
             timeout: float | None,
-            capture_output: bool,
-            text: bool,
-            encoding: str,
-            errors: str,
             env: dict[str, str],
         ) -> subprocess.CompletedProcess[str]:
-            del check, capture_output, text, encoding, errors, env
+            del check, env
             assert timeout == m._UPDATE_SUBPROCESS_TIMEOUT_SECONDS
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout or 0.0)
 
@@ -2441,10 +2437,17 @@ class TestSlashValidatorFunctions:
 class TestRunCliCommand:
     """Regression: captured subprocess output must survive REPL prompt redraw."""
 
-    def test_timed_delegate_replays_stdout_through_console(
+    def test_timed_delegate_streams_to_the_real_terminal_without_buffering(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        """A timeout alone must not force output capture.
+
+        /update sets ``subprocess_timeout`` as a hang safety net, not to request
+        buffering. Forcing capture here would swallow the install script's own
+        live progress until the whole subprocess exits; letting it inherit the
+        real TTY (like /onboard already does) keeps that progress visible live.
+        """
         from surfaces.interactive_shell.command_registry import cli_parity as m
 
         def _fake_run(
@@ -2452,28 +2455,18 @@ class TestRunCliCommand:
             *,
             check: bool,
             timeout: float | None,
-            capture_output: bool,
-            text: bool,
-            encoding: str,
-            errors: str,
             env: dict[str, str],
         ) -> subprocess.CompletedProcess[str]:
-            del check, timeout, text, encoding, errors
-            assert capture_output is True
+            del check
+            assert timeout == 30.0
             assert env["OPENSRE_PARENT_INTERACTIVE_SHELL"] == "1"
             assert cmd[:3] == [sys.executable, "-m", "surfaces.cli"]
             assert cmd[3:] == ["update"]
-            return subprocess.CompletedProcess(
-                cmd,
-                0,
-                stdout="  opensre 1.0.0 is already up to date.\n",
-                stderr="",
-            )
+            return subprocess.CompletedProcess(cmd, 0)
 
         monkeypatch.setattr(m.subprocess, "run", _fake_run)
-        console, buf = _capture()
+        console, _buf = _capture()
         assert m.run_cli_command(console, ["update"], subprocess_timeout=30.0) is True
-        assert "already up to date" in buf.getvalue()
 
     def test_config_delegate_captures_output(
         self,

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -2665,9 +2665,10 @@ class TestRunCliCommand:
             cmd: list[str],
             *,
             check: bool,
+            timeout: float | None = None,
             env: dict[str, str],
         ) -> subprocess.CompletedProcess[str]:
-            del check
+            del check, timeout
             assert env["OPENSRE_PARENT_INTERACTIVE_SHELL"] == "1"
             captured.append(cmd)
             return subprocess.CompletedProcess(cmd, 0)
@@ -2701,9 +2702,10 @@ class TestRunCliCommand:
             cmd: list[str],
             *,
             check: bool,
+            timeout: float | None = None,
             env: dict[str, str],
         ) -> subprocess.CompletedProcess[str]:
-            del check
+            del check, timeout
             assert env["OPENSRE_PARENT_INTERACTIVE_SHELL"] == "1"
             captured.append(cmd)
             return subprocess.CompletedProcess(cmd, 0)
@@ -2726,9 +2728,10 @@ class TestRunCliCommand:
             cmd: list[str],
             *,
             check: bool,
+            timeout: float | None = None,
             env: dict[str, str],
         ) -> subprocess.CompletedProcess[str]:
-            del check
+            del check, timeout
             captured_envs.append(env)
             return subprocess.CompletedProcess(cmd, 0)
 


### PR DESCRIPTION
Fixes #4111 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
run_cli_command tied "has a timeout" to "must fully buffer output until the subprocess exits," so /update (which sets a timeout as a hang safety net) looked frozen for as long as the install script it shells out to took to run -- nothing appeared until the whole thing finished. Decouple the timeout from capture so /update streams to the real TTY like /onboard already does: the install script detects a real terminal and shows its own native spinner/step progress and before/after version lines live, instead of everything appearing at once at the end.

Also reset the TTY column and add a blank line after the child exits -- it wrote straight to the terminal bypassing Rich, so Rich doesn't know where the cursor landed (e.g. mid-line after a \r-redrawn progress bar); without this the trailing blank line just closes off the child's last line instead of being a real visual gap.

Updates two tests in test_commands.py that pinned the old (buggy) forced-capture behavior for /update specifically.


### Demo/Screenshot for feature changes and bug fixes - 

<img width="1512" height="508" alt="fixed :update prompt" src="https://github.com/user-attachments/assets/66ad2aa1-5cf1-410a-8b0f-4a72ed67e67e" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
