### PR TITLE
refactor: remove confirmed dead code and unused helpers

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -212,14 +212,6 @@ def get_llm_provider_api_key_env(provider: str | None = None) -> str | None:
     return LLM_PROVIDER_API_KEY_ENVS.get(provider_name)
 
 
-def get_llm_provider_api_key(provider: str | None = None) -> tuple[str | None, str]:
-    """Return an env API key only; Keychain reads are request-scoped now."""
-    env_var = get_llm_provider_api_key_env(provider)
-    if env_var is None:
-        return None, ""
-    return env_var, os.getenv(env_var, "").strip()
-
-
 def _llm_api_key_payload(provider: str) -> dict[str, str]:
     """Return no secrets; runtime resolves credentials request-time."""
     _ = provider

--- a/config/grafana_cloud.py
+++ b/config/grafana_cloud.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any
 from urllib.parse import urlparse
-
-from opentelemetry.sdk.resources import Resource
 
 DEFAULT_INSTANCE_URL = "https://tracerbio.grafana.net"
 DEFAULT_LOKI_UID = "grafanacloud-logs"
@@ -55,28 +52,6 @@ def get_account_instance_url(account_id: str) -> str:
     return get_env(f"GRAFANA_{account_id.upper()}_INSTANCE_URL", "")
 
 
-def get_account_datasource_uids(account_id: str) -> tuple[str, str, str]:
-    load_env()
-    if account_id == "tracerbio":
-        return get_datasource_uids()
-    prefix = f"GRAFANA_{account_id.upper()}"
-    loki_uid = _get_env(f"{prefix}_LOKI_DATASOURCE_UID", DEFAULT_LOKI_UID)
-    tempo_uid = _get_env(f"{prefix}_TEMPO_DATASOURCE_UID", DEFAULT_TEMPO_UID)
-    mimir_uid = _get_env(f"{prefix}_MIMIR_DATASOURCE_UID", DEFAULT_MIMIR_UID)
-    return loki_uid, tempo_uid, mimir_uid
-
-
-def list_account_ids() -> list[str]:
-    load_env()
-    accounts = {"tracerbio"}
-    for key in os.environ:
-        if key.startswith("GRAFANA_") and key.endswith("_READ_TOKEN"):
-            account_id = key[len("GRAFANA_") : -len("_READ_TOKEN")].lower()
-            if account_id:
-                accounts.add(account_id)
-    return sorted(accounts)
-
-
 def get_grafana_read_token() -> str:
     return get_env("GRAFANA_READ_TOKEN", "")
 
@@ -101,10 +76,6 @@ def get_otlp_auth_header() -> str:
     return get_env("GCLOUD_OTLP_AUTH_HEADER", "")
 
 
-def get_otel_protocol() -> str:
-    return get_env("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
-
-
 def get_effective_otlp_endpoint() -> str:
     load_env()
     return _get_env("OTEL_EXPORTER_OTLP_ENDPOINT") or _get_env("GCLOUD_OTLP_ENDPOINT", "")
@@ -114,39 +85,12 @@ def get_otel_exporter_otlp_protocol(default: str = "grpc") -> str:
     return get_env("OTEL_EXPORTER_OTLP_PROTOCOL", default)
 
 
-def get_otel_exporter_otlp_metrics_protocol(default: str = "grpc") -> str:
-    load_env()
-    return _get_env(
-        "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
-        _get_env("OTEL_EXPORTER_OTLP_PROTOCOL", default),
-    )
-
-
 def get_otel_exporter_otlp_endpoint(default: str = "") -> str:
     return get_env("OTEL_EXPORTER_OTLP_ENDPOINT", default)
 
 
-def get_otel_exporter_otlp_metrics_endpoint(default: str = "") -> str:
-    return get_env("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", default)
-
-
 def get_otel_exporter_otlp_headers(default: str = "") -> str:
     return get_env("OTEL_EXPORTER_OTLP_HEADERS", default)
-
-
-def get_aws_lambda_function_name(default: str = "") -> str:
-    return get_env("AWS_LAMBDA_FUNCTION_NAME", default)
-
-
-def parse_otel_headers(headers_str: str | None = None) -> dict[str, str]:
-    headers_raw = headers_str if headers_str is not None else get_otel_exporter_otlp_headers()
-    headers: dict[str, str] = {}
-    if headers_raw:
-        for pair in headers_raw.split(","):
-            if "=" in pair:
-                key, value = pair.split("=", 1)
-                headers[key.strip()] = value.strip()
-    return headers
 
 
 def get_hosted_logs_id() -> str:
@@ -165,18 +109,6 @@ def get_hosted_metrics_url() -> str:
     return get_env("GCLOUD_HOSTED_METRICS_URL", "")
 
 
-def get_hosted_traces_id() -> str:
-    return get_env("GCLOUD_HOSTED_TRACES_ID", "")
-
-
-def get_hosted_traces_url() -> str:
-    load_env()
-    traces_url = _get_env("GCLOUD_HOSTED_TRACES_URL_TEMPO") or _get_env(
-        "GCLOUD_HOSTED_TRACES_URL", ""
-    )
-    return traces_url
-
-
 def get_rw_api_key() -> str:
     return get_env("GCLOUD_RW_API_KEY", "")
 
@@ -189,11 +121,6 @@ def _is_grafana_hostname(endpoint: str) -> bool:
         or hostname == "grafana.com"
         or hostname.endswith(".grafana.com")
     )
-
-
-def is_grafana_otlp_endpoint(value: str | None = None) -> bool:
-    endpoint = value if value is not None else get_effective_otlp_endpoint()
-    return _is_grafana_hostname(endpoint)
 
 
 def configure_grafana_cloud(env_file: Path | str | None = None) -> None:
@@ -261,10 +188,3 @@ def validate_grafana_cloud_config() -> bool:
                 f"Grafana Cloud endpoint detected but missing env vars: {', '.join(missing)}"
             )
     return True
-
-
-def build_resource(service_name: str, extra_attributes: dict[str, Any] | None) -> Resource:
-    attributes: dict[str, Any] = {"service.name": service_name}
-    if extra_attributes:
-        attributes.update(extra_attributes)
-    return Resource.create(attributes)

--- a/core/agent_harness/session/persistence/jsonl_repo.py
+++ b/core/agent_harness/session/persistence/jsonl_repo.py
@@ -181,10 +181,6 @@ class JsonlSessionRepo:
         record, count = self.lookup_investigation(investigation_id_prefix)
         return record if count == 1 else None
 
-    def count_investigation_prefix_matches(self, prefix: str) -> int:
-        _, count = self.lookup_investigation(prefix)
-        return count
-
     @staticmethod
     def _summary(
         path: Path, header: dict[str, Any], entries: list[dict[str, Any]]

--- a/core/agent_harness/session/persistence/jsonl_storage.py
+++ b/core/agent_harness/session/persistence/jsonl_storage.py
@@ -157,36 +157,6 @@ class JsonlSessionStorage:
             {"tool": tool, "update": update, "tool_call_id": tool_call_id},
         )
 
-    def append_model_change(
-        self,
-        session_id: str,
-        *,
-        provider: str | None = None,
-        model: str | None = None,
-        reasoning_effort: str | None = None,
-    ) -> str:
-        return self._append_entry(
-            session_id,
-            "model_change",
-            {
-                "provider": provider,
-                "model": model,
-                "reasoning_effort": reasoning_effort,
-            },
-        )
-
-    def append_active_tools_change(
-        self,
-        session_id: str,
-        *,
-        active_tools: list[str],
-    ) -> str:
-        return self._append_entry(
-            session_id,
-            "active_tools_change",
-            {"active_tools": list(active_tools)},
-        )
-
     def append_compaction(
         self,
         session_id: str,
@@ -210,9 +180,6 @@ class JsonlSessionStorage:
                 "after_tokens": after_tokens,
             },
         )
-
-    def append_label(self, session_id: str, *, label: str) -> str:
-        return self._append_entry(session_id, "label", {"label": label})
 
     def append_custom_message(
         self,
@@ -335,11 +302,6 @@ class JsonlSessionStorage:
         # V2 session files are append-only; reopening just means future entries
         # continue from the current leaf.
         return
-
-    def current_leaf_id(self, session_id: str) -> str | None:
-        with contextlib.suppress(Exception):
-            return self._current_leaf_id(session_path(session_id))
-        return None
 
     def _append_entry(
         self,

--- a/core/agent_harness/session/persistence/ports.py
+++ b/core/agent_harness/session/persistence/ports.py
@@ -129,6 +129,3 @@ class SessionRepo(Protocol):
 
     def load_investigation(self, prefix: str) -> dict[str, Any] | None:
         raise NotImplementedError
-
-    def count_investigation_prefix_matches(self, prefix: str) -> int:
-        raise NotImplementedError

--- a/core/llm/transports/litellm/clients.py
+++ b/core/llm/transports/litellm/clients.py
@@ -172,7 +172,6 @@ class LiteLLMLLMClient:
         self._credential_resolver = credential_resolver
         self._completion_func = completion_func
         self._usage_callback = usage_callback
-        self._bound_tools: list[dict[str, Any]] = []
         label = (api_key_env or "").removesuffix("_API_KEY").replace("_", " ").title()
         self._provider_label = label or "LiteLLM"
 
@@ -181,10 +180,6 @@ class LiteLLMLLMClient:
 
     def with_structured_output(self, model: type[BaseModel]) -> StructuredOutputClient:
         return StructuredOutputClient(self, model)
-
-    def bind_tools(self, tools: list[dict[str, Any]]) -> LiteLLMLLMClient:
-        self._bound_tools = [dict(item) for item in tools]
-        return self
 
     def _completion(self, **kwargs: Any) -> Any:
         if self._completion_func is not None:
@@ -236,9 +231,6 @@ class LiteLLMLLMClient:
             kwargs["api_version"] = self._api_version
         if self._temperature is not None:
             kwargs["temperature"] = self._temperature
-        if self._bound_tools:
-            kwargs["tools"] = self._bound_tools
-            kwargs["tool_choice"] = "auto"
         return kwargs
 
     def _rebuild_after_model_fallback(self, prompt_or_messages: Any) -> dict[str, Any] | None:
@@ -258,7 +250,7 @@ class LiteLLMLLMClient:
         return llm_response_from_completion(
             response,
             model=self._litellm_model,
-            bound_tools=bool(self._bound_tools),
+            bound_tools=False,
             usage_emit=self._usage_callback,
         )
 

--- a/core/llm/transports/sdk/llm_clients.py
+++ b/core/llm/transports/sdk/llm_clients.py
@@ -5,7 +5,6 @@ These handle reasoning, classification, and structured-output tiers.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import time
@@ -182,17 +181,12 @@ class LLMClient:
         self._model = model
         self._max_tokens = max_tokens
         self._temperature = temperature
-        self._bound_tools: list[dict[str, Any]] = []
 
     def with_config(self, **_kwargs) -> LLMClient:
         return self
 
     def with_structured_output(self, model: type[BaseModel]) -> StructuredOutputClient:
         return StructuredOutputClient(self, model)
-
-    def bind_tools(self, tools: list[dict[str, Any]]) -> LLMClient:
-        self._bound_tools = [dict(item) for item in tools]
-        return self
 
     def _ensure_client(self) -> None:
         api_key = provider_credentials.resolve_llm_api_key("ANTHROPIC_API_KEY")
@@ -226,8 +220,6 @@ class LLMClient:
             kwargs["system"] = system
         if self._temperature is not None:
             kwargs["temperature"] = self._temperature
-        if self._bound_tools:
-            kwargs["tools"] = self._bound_tools
         return kwargs
 
     def invoke(self, prompt_or_messages: Any) -> LLMResponse:
@@ -264,27 +256,7 @@ class LLMClient:
         else:
             raise RuntimeError("LLM invocation failed without a concrete error") from last_err
 
-        if self._bound_tools:
-            tool_calls: list[dict[str, Any]] = []
-            text_parts: list[str] = []
-            for block in getattr(response, "content", []):
-                block_type = getattr(block, "type", None)
-                if block_type == "text":
-                    text_parts.append(str(getattr(block, "text", "")))
-                elif block_type == "tool_use":
-                    tool_calls.append(
-                        {
-                            "name": str(getattr(block, "name", "")),
-                            "arguments": getattr(block, "input", {}),
-                        }
-                    )
-            if tool_calls:
-                payload = {"tool_calls": tool_calls, "text": "".join(text_parts).strip()}
-                content = json.dumps(payload, ensure_ascii=True)
-            else:
-                content = "".join(text_parts).strip() or _extract_text(response)
-        else:
-            content = _extract_text(response)
+        content = _extract_text(response)
         usage = getattr(response, "usage", None)
         return llm_response_with_usage(
             content,
@@ -355,7 +327,6 @@ class BedrockLLMClient:
         self._model = model
         self._max_tokens = max_tokens
         self._temperature = temperature
-        self._bound_tools: list[dict[str, Any]] = []
         self._use_anthropic = is_anthropic_bedrock_model(model)
         self._aws_region = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-east-1"))
 
@@ -373,10 +344,6 @@ class BedrockLLMClient:
 
     def with_structured_output(self, model: type[BaseModel]) -> StructuredOutputClient:
         return StructuredOutputClient(self, model)
-
-    def bind_tools(self, tools: list[dict[str, Any]]) -> BedrockLLMClient:
-        self._bound_tools = [dict(item) for item in tools]
-        return self
 
     def _invoke_anthropic(self, prompt_or_messages: Any) -> LLMResponse:
         """Invoke via AnthropicBedrock SDK (Claude models only)."""
@@ -397,8 +364,6 @@ class BedrockLLMClient:
             kwargs["system"] = system
         if self._temperature is not None:
             kwargs["temperature"] = self._temperature
-        if self._bound_tools:
-            kwargs["tools"] = self._bound_tools
 
         backoff_seconds = _RETRY_INITIAL_BACKOFF_SEC
         max_attempts = _RETRY_MAX_ATTEMPTS
@@ -454,27 +419,7 @@ class BedrockLLMClient:
         else:
             raise RuntimeError("Bedrock invocation failed without a concrete error") from last_err
 
-        if self._bound_tools:
-            tool_calls: list[dict[str, Any]] = []
-            text_parts: list[str] = []
-            for block in getattr(response, "content", []):
-                block_type = getattr(block, "type", None)
-                if block_type == "text":
-                    text_parts.append(str(getattr(block, "text", "")))
-                elif block_type == "tool_use":
-                    tool_calls.append(
-                        {
-                            "name": str(getattr(block, "name", "")),
-                            "arguments": getattr(block, "input", {}),
-                        }
-                    )
-            if tool_calls:
-                payload = {"tool_calls": tool_calls, "text": "".join(text_parts).strip()}
-                content = json.dumps(payload, ensure_ascii=True)
-            else:
-                content = "".join(text_parts).strip() or _extract_text(response)
-        else:
-            content = _extract_text(response)
+        content = _extract_text(response)
         usage = getattr(response, "usage", None)
         return llm_response_with_usage(
             content,
@@ -644,7 +589,6 @@ class OpenAILLMClient:
         self._model_fallback = fallback if fallback and fallback != model else None
         self._max_tokens = max_tokens
         self._temperature = temperature
-        self._bound_tools: list[dict[str, Any]] = []
 
     def _activate_model_fallback(self) -> bool:
         """Switch to the configured fallback model once and report it."""
@@ -674,10 +618,6 @@ class OpenAILLMClient:
 
     def with_structured_output(self, model: type[BaseModel]) -> StructuredOutputClient:
         return StructuredOutputClient(self, model)
-
-    def bind_tools(self, tools: list[dict[str, Any]]) -> OpenAILLMClient:
-        self._bound_tools = [dict(item) for item in tools]
-        return self
 
     def _ensure_client(self) -> OpenAI:
         api_key = (
@@ -721,9 +661,6 @@ class OpenAILLMClient:
             kwargs["reasoning_effort"] = reasoning_effort
         if self._temperature is not None:
             kwargs["temperature"] = self._temperature
-        if self._bound_tools:
-            kwargs["tools"] = self._bound_tools
-            kwargs["tool_choice"] = "auto"
         return kwargs
 
     def invoke(self, prompt_or_messages: Any) -> LLMResponse:
@@ -813,25 +750,7 @@ class OpenAILLMClient:
         if not response.choices:
             raise RuntimeError("OpenAI API returned an empty choices list")
         message = response.choices[0].message
-        if self._bound_tools:
-            tool_calls_raw = getattr(message, "tool_calls", None) or []
-            if tool_calls_raw:
-                tool_calls: list[dict[str, Any]] = []
-                for call in tool_calls_raw:
-                    function = getattr(call, "function", None)
-                    name = str(getattr(function, "name", ""))
-                    raw_args = str(getattr(function, "arguments", "") or "")
-                    try:
-                        parsed_args = json.loads(raw_args) if raw_args else {}
-                    except (json.JSONDecodeError, ValueError):
-                        parsed_args = {}
-                    tool_calls.append({"name": name, "arguments": parsed_args})
-                payload = {"tool_calls": tool_calls, "text": (message.content or "").strip()}
-                content = json.dumps(payload, ensure_ascii=True)
-            else:
-                content = (message.content or "").strip()
-        else:
-            content = message.content or ""
+        content = message.content or ""
         usage = getattr(response, "usage", None)
         return llm_response_with_usage(
             content.strip(),

--- a/core/state/agent_state.py
+++ b/core/state/agent_state.py
@@ -50,9 +50,6 @@ class MutableAgentState:
         self._messages.append(("assistant", assistant_message))
         self._trim_messages()
 
-    def record_failure(self, user_message: str, error_text: str) -> None:
-        self.record_turn(user_message, error_text)
-
     def reset_observation(self) -> None:
         self._last_observation = None
 

--- a/integrations/groundcover/client.py
+++ b/integrations/groundcover/client.py
@@ -39,25 +39,6 @@ _DEFAULT_SSE_READ_TIMEOUT = 120.0
 # read-only/idempotent, but we keep the retry budget tiny to fail fast.
 _MAX_CONNECT_RETRIES = 1
 
-# Public, read-only MCP tools OpenSRE depends on. Verification asserts these
-# exist so the provider fails closed if the token sees a narrower surface.
-EXPECTED_PUBLIC_TOOLS: tuple[str, ...] = (
-    "list_workspaces",
-    "get_gcql_reference",
-    "query_logs",
-    "query_traces",
-    "query_events",
-    "query_entities",
-    "query_issues",
-    "query_apm",
-    "query_metrics",
-    "query_monitors",
-    "search_logs_metadata",
-    "search_traces_metadata",
-    "search_events_metadata",
-    "search_metrics_metadata",
-)
-
 # Tools that must exist for verification to pass. We require the core discovery
 # surface; per-signal tools can vary slightly by deployment version.
 _REQUIRED_VERIFY_TOOLS: tuple[str, ...] = ("list_workspaces", "get_gcql_reference")

--- a/integrations/llm_cli/runner.py
+++ b/integrations/llm_cli/runner.py
@@ -113,9 +113,6 @@ class CLIBackedLLMClient:
         """JSON-schema prompt + parse; same contract as API `StructuredOutputClient`."""
         return StructuredOutputClient(self, model)
 
-    def bind_tools(self, _tools: list[Any]) -> CLIBackedLLMClient:
-        return self
-
     def invoke(self, prompt_or_messages: Any) -> LLMResponse:
         # max_tokens / model_type are stored for API parity but ignored here:
         # CLI adapters (e.g. codex exec) do not expose a scriptable token limit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,9 +169,6 @@ paths = [
   "surfaces",
   "tools",
 ]
-exclude = [
-  "tools/simple_tools.py",          # explicitly skipped by the registry
-]
 ignore_decorators = [
   "@*.command",          # Click / Typer subcommands
   "@*.group",

--- a/tests/core/state/test_import_boundaries.py
+++ b/tests/core/state/test_import_boundaries.py
@@ -63,7 +63,7 @@ def test_old_core_domain_state_import_path_is_removed() -> None:
     old_state_module = ".".join(("core", "domain", "state"))
     offenders: list[str] = []
     for path in tracked_python_files(str(root)):
-        if _is_ignored_scan_path(path, root):
+        if _is_ignored_scan_path(path, root) or not path.is_file():
             continue
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for node in ast.walk(tree):

--- a/tools/investigation/tool.py
+++ b/tools/investigation/tool.py
@@ -1,7 +1,0 @@
-"""Tool-facing entrypoint for the composite investigation capability."""
-
-from __future__ import annotations
-
-from tools.investigation import run_investigation_tool
-
-__all__ = ["run_investigation_tool"]


### PR DESCRIPTION
Removes ~260 lines of confirmed dead code identified via vulture and full-repo reference scans. Every deleted symbol had zero callers in production and tests, and was not loaded through dynamic registration paths (tool registry, verifier loader, lazy exports).

- Delete `tools/investigation/tool.py` (unused forwarding module; canonical entry is `tools/investigation/__init__.py`)
- Remove unused `EXPECTED_PUBLIC_TOOLS` from `integrations/groundcover/client.py`
- Drop obsolete `tools/simple_tools.py` vulture exclude from `pyproject.toml`
- Remove unused `get_llm_provider_api_key()` from `config/config.py`
- Remove 11 unused Grafana Cloud helpers from `config/grafana_cloud.py` (`list_account_ids`, `build_resource`, OTLP/metrics helpers, etc.)
- Remove unused JSONL storage methods: `append_model_change`, `append_active_tools_change`, `append_label`, `current_leaf_id`
- Remove redundant `count_investigation_prefix_matches` from `SessionRepo` protocol and `JsonlSessionRepo` (callers use `lookup_investigation`)
- Remove unused `MutableAgentState.record_failure()`
- Remove never-called `bind_tools` methods and unreachable `_bound_tools` branches from SDK, LiteLLM, and CLI LLM clients

