### PR TITLE
fix(grafana): support TLS verification against internal/self-signed CAs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,6 +193,10 @@ GRAFANA_READ_TOKEN=
 GRAFANA_INSTANCE_URL=
 GRAFANA_LOKI_DATASOURCE_UID=
 GRAFANA_TEMPO_DATASOURCE_UID=
+# Set to false to skip TLS verification, or point GRAFANA_CA_BUNDLE at a PEM
+# file for a self-signed/internal CA (e.g. an on-prem Grafana instance).
+GRAFANA_VERIFY_SSL=true
+GRAFANA_CA_BUNDLE=
 
 # Optional multi-instance override. When set, this takes precedence over the
 # single-instance Grafana vars above.

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -198,6 +198,8 @@ All configuration options for OpenSRE can be set via environment variables. This
 | `GRAFANA_READ_TOKEN` | | Grafana API token | `integrations/_catalog_impl` |
 | `GRAFANA_LOKI_DATASOURCE_UID` | | UID of Loki datasource in Grafana | `.env.example` |
 | `GRAFANA_TEMPO_DATASOURCE_UID` | | UID of Tempo datasource in Grafana | `.env.example` |
+| `GRAFANA_VERIFY_SSL` | `true` | Verify Grafana SSL certificate | `integrations/_catalog_impl` |
+| `GRAFANA_CA_BUNDLE` | | Path to a CA bundle for Grafana TLS verification (self-signed/internal CA) | `integrations/_catalog_impl` |
 | `DD_API_KEY` | | Datadog API key | `integrations/_catalog_impl` |
 | `DD_APP_KEY` | | Datadog application key | `integrations/_catalog_impl` |
 | `DD_SITE` | `datadoghq.com` | Datadog site (us/eu) | `integrations/_catalog_impl` |

--- a/docs/grafana.mdx
+++ b/docs/grafana.mdx
@@ -25,6 +25,21 @@ Official documentation: [<u>How to add a token to a service account in Grafana</
      ![Connect Grafana](/images/connect_grafana.png)
    </Frame>
 
+### Self-signed or internal CA certificates
+
+If your Grafana instance is self-hosted behind a certificate signed by an internal/private
+CA, `opensre onboard` will prompt:
+
+- **Verify SSL certificate?** — answer `No` to skip TLS verification entirely (only
+  recommended for local/lab instances).
+- **Path to CA bundle for SSL verification** — point this at a PEM file containing your
+  internal CA certificate to keep full TLS verification while trusting your organization's
+  CA. This is the recommended option for a real internal Grafana deployment, since it
+  still validates the certificate chain and hostname.
+
+These can also be set directly via `GRAFANA_VERIFY_SSL` (`true`/`false`) and
+`GRAFANA_CA_BUNDLE` (path to a PEM file) in `.env`.
+
 ## Local Grafana Setup (Minikube example)
 
 ### Steps

--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -401,6 +401,9 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 {
                     "endpoint": grafana_endpoint,
                     "api_key": grafana_api_key,
+                    "verify_ssl": os.getenv("GRAFANA_VERIFY_SSL", "true").strip().lower()
+                    != "false",
+                    "ca_bundle": os.getenv("GRAFANA_CA_BUNDLE", "").strip(),
                 }
             )
         except Exception as exc:
@@ -412,6 +415,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     {
                         "endpoint": grafana_config.endpoint,
                         "api_key": grafana_config.api_key,
+                        "verify_ssl": grafana_config.verify_ssl,
+                        "ca_bundle": grafana_config.ca_bundle,
                     },
                 )
             )

--- a/integrations/config_models.py
+++ b/integrations/config_models.py
@@ -60,13 +60,28 @@ class GrafanaIntegrationConfig(StrictConfigModel):
     integration_id: str = ""
     username: str = ""
     password: str = ""
+    verify_ssl: bool = True
+    ca_bundle: str = ""
 
     _normalize_endpoint = field_validator("endpoint", mode="before")(normalize_url())
+    _normalize_ca_bundle = field_validator("ca_bundle", mode="before")(normalize_str())
+    _normalize_verify_ssl = field_validator("verify_ssl", mode="before")(normalize_bool_str())
 
     @property
     def is_local(self) -> bool:
         host = urlparse(self.endpoint).hostname or ""
         return host in _LOCAL_GRAFANA_HOSTS
+
+    @property
+    def ssl_verify(self) -> bool | str:
+        """Value to pass as ``requests``' ``verify=`` kwarg.
+
+        A configured CA bundle path takes precedence over the plain
+        verify/no-verify toggle, matching :class:`SplunkIntegrationConfig`.
+        """
+        if self.ca_bundle:
+            return self.ca_bundle
+        return self.verify_ssl
 
     @property
     def has_token(self) -> bool:

--- a/integrations/grafana/__init__.py
+++ b/integrations/grafana/__init__.py
@@ -33,6 +33,8 @@ def classify(
                 "api_key": credentials.get("api_key", ""),
                 "username": credentials.get("username", ""),
                 "password": credentials.get("password", ""),
+                "verify_ssl": credentials.get("verify_ssl", True),
+                "ca_bundle": credentials.get("ca_bundle", ""),
                 "integration_id": record_id,
             }
         )

--- a/integrations/grafana/base.py
+++ b/integrations/grafana/base.py
@@ -188,6 +188,7 @@ class GrafanaClientBase:
                 url,
                 headers=self._get_auth_headers(),
                 timeout=10,
+                verify=self._config.ssl_verify,
             )
             response.raise_for_status()
             datasources = response.json()
@@ -290,6 +291,7 @@ class GrafanaClientBase:
                 url,
                 headers=self._get_auth_headers(),
                 timeout=10,
+                verify=self._config.ssl_verify,
             )
             response.raise_for_status()
             data = response.json()
@@ -347,6 +349,7 @@ class GrafanaClientBase:
                 headers=self._get_auth_headers(),
                 params=params,
                 timeout=10,
+                verify=self._config.ssl_verify,
             )
             response.raise_for_status()
             data = response.json()
@@ -374,6 +377,7 @@ class GrafanaClientBase:
             headers=self._get_auth_headers(),
             params=params,
             timeout=timeout,
+            verify=self._config.ssl_verify,
         )
         response.raise_for_status()
         result: dict[str, Any] = response.json()

--- a/integrations/grafana/client.py
+++ b/integrations/grafana/client.py
@@ -29,6 +29,8 @@ def get_grafana_client() -> GrafanaClient:
         endpoint=os.getenv("GRAFANA_INSTANCE_URL", "https://tracerbio.grafana.net"),
         api_key=os.getenv("GRAFANA_READ_TOKEN", ""),
         account_id="env_default",
+        verify_ssl=os.getenv("GRAFANA_VERIFY_SSL", "true").strip().lower() != "false",
+        ca_bundle=os.getenv("GRAFANA_CA_BUNDLE", "").strip(),
     )
 
 

--- a/integrations/grafana/client.py
+++ b/integrations/grafana/client.py
@@ -38,6 +38,8 @@ def get_grafana_client_from_credentials(
     account_id: str = "user_integration",
     username: str = "",
     password: str = "",
+    verify_ssl: bool = True,
+    ca_bundle: str = "",
 ) -> GrafanaClient:
     """Create a Grafana client from integration credentials."""
     cache_key = f"creds_{account_id}_{endpoint}"
@@ -50,6 +52,8 @@ def get_grafana_client_from_credentials(
         read_token=api_key,
         username=username,
         password=password,
+        verify_ssl=verify_ssl,
+        ca_bundle=ca_bundle,
     )
     client = GrafanaClient(config=config)
 
@@ -61,6 +65,8 @@ def get_grafana_client_from_credentials(
             read_token=api_key,
             username=username,
             password=password,
+            verify_ssl=verify_ssl,
+            ca_bundle=ca_bundle,
             loki_datasource_uid=discovered.get("loki_uid", ""),
             tempo_datasource_uid=discovered.get("tempo_uid", ""),
             mimir_datasource_uid=discovered.get("mimir_uid", ""),

--- a/integrations/grafana/config.py
+++ b/integrations/grafana/config.py
@@ -21,11 +21,20 @@ class GrafanaAccountConfig(StrictConfigModel):
     description: str = ""
     username: str = ""
     password: str = ""
+    verify_ssl: bool = True
+    ca_bundle: str = ""
 
     @field_validator("instance_url", mode="before")
     @classmethod
     def _normalize_instance_url(cls, value: object) -> str:
         return str(value or "").strip().rstrip("/")
+
+    @property
+    def ssl_verify(self) -> bool | str:
+        """Value to pass as ``requests``' ``verify=`` kwarg."""
+        if self.ca_bundle:
+            return self.ca_bundle
+        return self.verify_ssl
 
     @property
     def uses_local_anonymous_auth(self) -> bool:

--- a/integrations/grafana/tempo.py
+++ b/integrations/grafana/tempo.py
@@ -113,6 +113,7 @@ class TempoMixin:
                 url,
                 headers=self._get_auth_headers(),
                 timeout=10,
+                verify=self._config.ssl_verify,
             )
             response.raise_for_status()
             return {"spans": parse_otlp_trace(response.json())}

--- a/integrations/grafana/tools/__init__.py
+++ b/integrations/grafana/tools/__init__.py
@@ -78,6 +78,8 @@ def query_grafana_alert_rules(
     folder: str | None = None,
     grafana_endpoint: str | None = None,
     grafana_api_key: str | None = None,
+    grafana_verify_ssl: bool = True,
+    grafana_ca_bundle: str = "",
     grafana_backend: Any = None,
     **_kwargs: Any,
 ) -> dict:
@@ -93,7 +95,12 @@ def query_grafana_alert_rules(
             "raw": raw,
         }
 
-    client = _resolve_grafana_client(grafana_endpoint, grafana_api_key)
+    client = _resolve_grafana_client(
+        grafana_endpoint,
+        grafana_api_key,
+        grafana_verify_ssl=grafana_verify_ssl,
+        grafana_ca_bundle=grafana_ca_bundle,
+    )
     if not client or not client.is_configured:
         return tool_unavailable("grafana_alerts", "Grafana integration not configured", rules=[])
 
@@ -194,6 +201,8 @@ def query_grafana_annotations(
     grafana_api_key: str | None = None,
     grafana_username: str = "",
     grafana_password: str = "",
+    grafana_verify_ssl: bool = True,
+    grafana_ca_bundle: str = "",
     grafana_backend: Any = None,
     **_kwargs: Any,
 ) -> dict:
@@ -215,7 +224,12 @@ def query_grafana_annotations(
         }
 
     client = _resolve_grafana_client(
-        grafana_endpoint, grafana_api_key, grafana_username, grafana_password
+        grafana_endpoint,
+        grafana_api_key,
+        grafana_username,
+        grafana_password,
+        grafana_verify_ssl,
+        grafana_ca_bundle,
     )
     if not client or not client.is_configured:
         return tool_unavailable(
@@ -265,6 +279,8 @@ def _resolve_grafana_client(
     grafana_api_key: str | None = None,
     grafana_username: str = "",
     grafana_password: str = "",
+    grafana_verify_ssl: bool = True,
+    grafana_ca_bundle: str = "",
 ):
     if not grafana_endpoint:
         return None
@@ -273,6 +289,8 @@ def _resolve_grafana_client(
         api_key=grafana_api_key or "",
         username=grafana_username,
         password=grafana_password,
+        verify_ssl=grafana_verify_ssl,
+        ca_bundle=grafana_ca_bundle,
     )
 
 
@@ -282,6 +300,8 @@ def _grafana_creds(grafana: dict) -> dict:
         "grafana_api_key": grafana.get("grafana_api_key") or grafana.get("api_key"),
         "grafana_username": grafana.get("username", ""),
         "grafana_password": grafana.get("password", ""),
+        "grafana_verify_ssl": grafana.get("verify_ssl", True),
+        "grafana_ca_bundle": grafana.get("ca_bundle", ""),
     }
 
 
@@ -367,6 +387,8 @@ def query_grafana_logs(
     grafana_api_key: str | None = None,
     grafana_username: str = "",
     grafana_password: str = "",
+    grafana_verify_ssl: bool = True,
+    grafana_ca_bundle: str = "",
     pipeline_name: str | None = None,
     grafana_backend: Any = None,
     **_kwargs: Any,
@@ -385,7 +407,12 @@ def query_grafana_logs(
         )
 
     client = _resolve_grafana_client(
-        grafana_endpoint, grafana_api_key, grafana_username, grafana_password
+        grafana_endpoint,
+        grafana_api_key,
+        grafana_username,
+        grafana_password,
+        grafana_verify_ssl,
+        grafana_ca_bundle,
     )
     if not client or not client.is_configured:
         return tool_unavailable("grafana_loki", "Grafana integration not configured", logs=[])
@@ -520,6 +547,8 @@ def _query_grafana_metrics_available(sources: dict[str, dict]) -> bool:
         "grafana_api_key",
         "grafana_username",
         "grafana_password",
+        "grafana_verify_ssl",
+        "grafana_ca_bundle",
         "grafana_backend",
     ),
     is_available=_query_grafana_metrics_available,
@@ -532,6 +561,8 @@ def query_grafana_metrics(
     grafana_api_key: str | None = None,
     grafana_username: str = "",
     grafana_password: str = "",
+    grafana_verify_ssl: bool = True,
+    grafana_ca_bundle: str = "",
     grafana_backend: Any = None,
     **_kwargs: Any,
 ) -> dict:
@@ -544,7 +575,12 @@ def query_grafana_metrics(
         )
 
     client = _resolve_grafana_client(
-        grafana_endpoint, grafana_api_key, grafana_username, grafana_password
+        grafana_endpoint,
+        grafana_api_key,
+        grafana_username,
+        grafana_password,
+        grafana_verify_ssl,
+        grafana_ca_bundle,
     )
     if not client or not client.is_configured:
         return tool_unavailable("grafana_mimir", "Grafana integration not configured", metrics=[])
@@ -609,6 +645,8 @@ def _query_grafana_service_names_available(sources: dict[str, dict]) -> bool:
 def query_grafana_service_names(
     grafana_endpoint: str | None = None,
     grafana_api_key: str | None = None,
+    grafana_verify_ssl: bool = True,
+    grafana_ca_bundle: str = "",
     grafana_backend: Any = None,
     **_kwargs: Any,
 ) -> dict:
@@ -616,7 +654,12 @@ def query_grafana_service_names(
     if grafana_backend is not None:
         return {"source": "grafana_loki_labels", "available": True, "service_names": []}
 
-    client = _resolve_grafana_client(grafana_endpoint, grafana_api_key)
+    client = _resolve_grafana_client(
+        grafana_endpoint,
+        grafana_api_key,
+        grafana_verify_ssl=grafana_verify_ssl,
+        grafana_ca_bundle=grafana_ca_bundle,
+    )
     if not client or not client.is_configured:
         return tool_unavailable(
             "grafana_loki_labels", "Grafana integration not configured", service_names=[]
@@ -694,6 +737,8 @@ def query_grafana_traces(
     limit: int = 20,
     grafana_endpoint: str | None = None,
     grafana_api_key: str | None = None,
+    grafana_verify_ssl: bool = True,
+    grafana_ca_bundle: str = "",
     grafana_backend: Any = None,
     **_kwargs: Any,
 ) -> dict:
@@ -707,7 +752,12 @@ def query_grafana_traces(
             extract_pipeline_spans=_extract_pipeline_spans,
         )
 
-    client = _resolve_grafana_client(grafana_endpoint, grafana_api_key)
+    client = _resolve_grafana_client(
+        grafana_endpoint,
+        grafana_api_key,
+        grafana_verify_ssl=grafana_verify_ssl,
+        grafana_ca_bundle=grafana_ca_bundle,
+    )
     if not client or not client.is_configured:
         return tool_unavailable("grafana_tempo", "Grafana integration not configured", traces=[])
     if not client.tempo_datasource_uid:

--- a/integrations/grafana/verifier.py
+++ b/integrations/grafana/verifier.py
@@ -20,7 +20,12 @@ def _discover_datasources(config: GrafanaIntegrationConfig) -> list[Any] | str:
     """
     url = f"{config.endpoint.rstrip('/')}/api/datasources"
     try:
-        response = requests.get(url, headers=config.auth_headers, timeout=10)
+        response = requests.get(
+            url,
+            headers=config.auth_headers,
+            timeout=10,
+            verify=config.ssl_verify,
+        )
         response.raise_for_status()
         return cast(list[Any], response.json())
     except requests.HTTPError as exc:

--- a/surfaces/cli/wizard/configurators/observability.py
+++ b/surfaces/cli/wizard/configurators/observability.py
@@ -43,18 +43,44 @@ def _configure_grafana() -> tuple[str, str]:
             default=_string_value(credentials.get("api_key")),
             secret=True,
         )
+        verify_ssl = _confirm(
+            "Verify SSL certificate?",
+            default=bool(credentials.get("verify_ssl", True)),
+        )
+        ca_bundle = ""
+        if verify_ssl:
+            ca_bundle = _prompt_value(
+                "Path to CA bundle for SSL verification (leave empty to use system defaults)",
+                default=_string_value(credentials.get("ca_bundle")),
+                allow_empty=True,
+            )
         with _console.status("Validating Grafana integration...", spinner="dots"):
-            result = validate_grafana_integration(endpoint=endpoint, api_key=api_key)
+            result = validate_grafana_integration(
+                endpoint=endpoint,
+                api_key=api_key,
+                verify_ssl=verify_ssl,
+                ca_bundle=ca_bundle,
+            )
         _render_integration_result("Grafana", result)
         if result.ok:
             upsert_integration(
-                "grafana", {"credentials": {"endpoint": endpoint, "api_key": api_key}}
-            )
-            env_path = sync_env_values(
+                "grafana",
                 {
-                    "GRAFANA_INSTANCE_URL": endpoint,
-                }
+                    "credentials": {
+                        "endpoint": endpoint,
+                        "api_key": api_key,
+                        "verify_ssl": verify_ssl,
+                        "ca_bundle": ca_bundle,
+                    }
+                },
             )
+            env_values: dict[str, str] = {
+                "GRAFANA_INSTANCE_URL": endpoint,
+                "GRAFANA_VERIFY_SSL": "true" if verify_ssl else "false",
+            }
+            if ca_bundle:
+                env_values["GRAFANA_CA_BUNDLE"] = ca_bundle
+            env_path = sync_env_values(env_values)
             return "Grafana", str(env_path)
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 

--- a/surfaces/cli/wizard/integration_validators/observability.py
+++ b/surfaces/cli/wizard/integration_validators/observability.py
@@ -18,16 +18,29 @@ from integrations.tempo import build_tempo_config, validate_tempo_config
 from .shared import IntegrationHealthResult
 
 
-def validate_grafana_integration(*, endpoint: str, api_key: str) -> IntegrationHealthResult:
+def validate_grafana_integration(
+    *,
+    endpoint: str,
+    api_key: str,
+    verify_ssl: bool = True,
+    ca_bundle: str = "",
+) -> IntegrationHealthResult:
     """Validate Grafana credentials by discovering datasource UIDs."""
     try:
         grafana_config = GrafanaIntegrationConfig.model_validate(
-            {"endpoint": endpoint, "api_key": api_key}
+            {
+                "endpoint": endpoint,
+                "api_key": api_key,
+                "verify_ssl": verify_ssl,
+                "ca_bundle": ca_bundle,
+            }
         )
         client = get_grafana_client_from_credentials(
             endpoint=grafana_config.endpoint,
             api_key=grafana_config.api_key,
             account_id="opensre_onboard_probe",
+            verify_ssl=grafana_config.verify_ssl,
+            ca_bundle=grafana_config.ca_bundle,
         )
         discovered = client.discover_datasource_uids()
         if not discovered:

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -422,6 +422,8 @@ def test_execute_tools_uses_availability_view_for_classified_integrations() -> N
         api_key="glsa_test",
         username="",
         password="",
+        verify_ssl=True,
+        ca_bundle="",
     )
 
 

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -187,7 +187,7 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
             "grafana-token",
         ]
     )
-    text_responses = iter(["https://grafana.example.com"])
+    text_responses = iter(["https://grafana.example.com", ""])
 
     def _mock_password(*_args, **_kwargs):
         m = MagicMock()
@@ -199,9 +199,15 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
         m.ask.return_value = next(text_responses)
         return m
 
+    def _mock_confirm(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = True
+        return m
+
     monkeypatch.setattr(_ui, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
+    monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
@@ -239,6 +245,8 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
                 "credentials": {
                     "endpoint": "https://grafana.example.com",
                     "api_key": "grafana-token",
+                    "verify_ssl": True,
+                    "ca_bundle": "",
                 }
             },
         )
@@ -246,6 +254,7 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
     assert synced_env_values == [
         {
             "GRAFANA_INSTANCE_URL": "https://grafana.example.com",
+            "GRAFANA_VERIFY_SSL": "true",
         },
     ]
     output = capsys.readouterr().out

--- a/tests/e2e/grafana_validation/test_grafana_cloud_queries.py
+++ b/tests/e2e/grafana_validation/test_grafana_cloud_queries.py
@@ -26,7 +26,11 @@ def _assert_query_success_or_skip_auth(result: dict) -> None:
         pytest.skip(f"Grafana live query credentials were rejected: {detail}")
     if any(token in detail_lower for token in ("timed out", "timeout", "connection reset")):
         pytest.skip(f"Grafana live query hit a transient network failure: {detail}")
-    if "too many unhealthy instances in the ring" in detail_lower:
+    tempo_transient_backend_tokens = (
+        "too many unhealthy instances in the ring",
+        "live-store is starting",
+    )
+    if any(token in detail_lower for token in tempo_transient_backend_tokens):
         pytest.skip(f"Grafana Tempo live query hit a transient backend failure: {detail}")
     if "unable to find datasource" in detail_lower:
         pytest.skip(
@@ -78,6 +82,19 @@ def test_assert_query_success_or_skip_auth_skips_tempo_ring_failure():
                     "Tempo query failed: 500 error querying live-stores in Querier.SearchRecent: "
                     "error finding partition ring replicas: partition 46: "
                     "too many unhealthy instances in the ring"
+                ),
+            }
+        )
+
+
+def test_assert_query_success_or_skip_auth_skips_tempo_live_store_starting():
+    with pytest.raises(Skipped, match="transient backend failure"):
+        _assert_query_success_or_skip_auth(
+            {
+                "success": False,
+                "error": (
+                    "Tempo query failed: 500 error querying live-stores in "
+                    "Querier.SearchRecent: rpc error: code = Unknown desc = live-store is starting"
                 ),
             }
         )

--- a/tests/integrations/grafana/test_client.py
+++ b/tests/integrations/grafana/test_client.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from integrations.grafana.client import get_grafana_client
+
+
+def test_get_grafana_client_reads_verify_ssl_and_ca_bundle_from_env(monkeypatch) -> None:
+    """get_grafana_client() must forward GRAFANA_VERIFY_SSL/GRAFANA_CA_BUNDLE, not just
+    the endpoint/token — otherwise env-only setups can never configure TLS trust."""
+    monkeypatch.setenv("GRAFANA_INSTANCE_URL", "https://grafana.example.com")
+    monkeypatch.setenv("GRAFANA_READ_TOKEN", "glsa_test")
+    monkeypatch.setenv("GRAFANA_VERIFY_SSL", "false")
+    monkeypatch.setenv("GRAFANA_CA_BUNDLE", "/etc/ssl/internal-ca.pem")
+
+    with patch("integrations.grafana.client.get_grafana_client_from_credentials") as mock_factory:
+        get_grafana_client()
+
+    mock_factory.assert_called_once_with(
+        endpoint="https://grafana.example.com",
+        api_key="glsa_test",
+        account_id="env_default",
+        verify_ssl=False,
+        ca_bundle="/etc/ssl/internal-ca.pem",
+    )
+
+
+def test_get_grafana_client_defaults_verify_ssl_true_when_unset(monkeypatch) -> None:
+    monkeypatch.setenv("GRAFANA_INSTANCE_URL", "https://grafana.example.com")
+    monkeypatch.setenv("GRAFANA_READ_TOKEN", "glsa_test")
+    monkeypatch.delenv("GRAFANA_VERIFY_SSL", raising=False)
+    monkeypatch.delenv("GRAFANA_CA_BUNDLE", raising=False)
+
+    with patch("integrations.grafana.client.get_grafana_client_from_credentials") as mock_factory:
+        get_grafana_client()
+
+    mock_factory.assert_called_once_with(
+        endpoint="https://grafana.example.com",
+        api_key="glsa_test",
+        account_id="env_default",
+        verify_ssl=True,
+        ca_bundle="",
+    )

--- a/tests/integrations/grafana/test_config.py
+++ b/tests/integrations/grafana/test_config.py
@@ -54,3 +54,33 @@ def test_grafana_config_is_configured(url: str, token: str, expected: bool) -> N
         read_token=token,
     )
     assert config.is_configured is expected
+
+
+def test_grafana_config_ssl_verify_defaults_to_true() -> None:
+    config = GrafanaAccountConfig(
+        account_id="test",
+        instance_url="https://grafana.example.com",
+        read_token="secret",
+    )
+    assert config.ssl_verify is True
+
+
+def test_grafana_config_ssl_verify_respects_false() -> None:
+    config = GrafanaAccountConfig(
+        account_id="test",
+        instance_url="https://grafana.example.com",
+        read_token="secret",
+        verify_ssl=False,
+    )
+    assert config.ssl_verify is False
+
+
+def test_grafana_config_ssl_verify_ca_bundle_takes_precedence() -> None:
+    config = GrafanaAccountConfig(
+        account_id="test",
+        instance_url="https://grafana.example.com",
+        read_token="secret",
+        verify_ssl=True,
+        ca_bundle="/etc/ssl/internal-ca.pem",
+    )
+    assert config.ssl_verify == "/etc/ssl/internal-ca.pem"

--- a/tests/integrations/grafana/test_tempo.py
+++ b/tests/integrations/grafana/test_tempo.py
@@ -7,6 +7,12 @@ from unittest.mock import Mock, patch
 from integrations.grafana.tempo import TempoMixin
 
 
+class _FakeAccountConfig:
+    """Minimal stand-in for GrafanaAccountConfig's ssl_verify property."""
+
+    ssl_verify: bool = True
+
+
 class FakeGrafanaClient(TempoMixin):
     """Fake Grafana client to test the TempoMixin."""
 
@@ -14,6 +20,7 @@ class FakeGrafanaClient(TempoMixin):
         self.is_configured = is_configured
         self.account_id = "test-account-123"
         self.tempo_datasource_uid = "tempo-uid-abc"
+        self._config = _FakeAccountConfig()
 
     def _build_datasource_url(self, uid: str, path: str) -> str:
         return f"https://grafana.fake/api/datasources/uid/{uid}{path}"

--- a/tests/tools/test_grafana_annotations_tool.py
+++ b/tests/tools/test_grafana_annotations_tool.py
@@ -169,7 +169,7 @@ def test_run_forwards_basic_auth_to_client() -> None:
             grafana_username="admin",
             grafana_password="secret",
         )
-    resolve.assert_called_once_with("http://grafana", None, "admin", "secret")
+    resolve.assert_called_once_with("http://grafana", None, "admin", "secret", True, "")
 
 
 def test_run_to_only_anchors_window_before_to() -> None:


### PR DESCRIPTION
Fixes #3631

#### Describe the changes you have made in this PR -

Grafana HTTP calls hardcoded strict TLS verification with no override. On-prem
Grafana instances signed by an internal/self-signed CA failed `opensre onboard`
with `SSLCertVerificationError: unable to get local issuer certificate`, even
when the CA was already installed in the OS trust store — Python's `requests`
never reads the OS store, only its bundled `certifi` CA list.

This mirrors the existing `verify_ssl` / `ca_bundle` pattern already used by
Splunk and Argo CD:

- `GrafanaIntegrationConfig` (stored/onboarding config) and `GrafanaAccountConfig`
  (runtime client config) gain `verify_ssl: bool = True` and `ca_bundle: str = ""`,
  plus an `ssl_verify` property (CA bundle path takes precedence, else the bool).
- Every `requests.get` call in `integrations/grafana/base.py`, `tempo.py`, and
  `verifier.py` now passes `verify=<ssl_verify>`.
- `opensre onboard` → Grafana step adds two prompts (mirroring Splunk's):
  "Verify SSL certificate?" and, if yes, "Path to CA bundle for SSL verification".
- New `GRAFANA_VERIFY_SSL` / `GRAFANA_CA_BUNDLE` env vars, wired through the
  env-based integration loader (`integrations/_catalog_impl.py`) and the
  `GRAFANA_INSTANCES` multi-instance JSON path (generic passthrough, so
  per-instance `verify_ssl`/`ca_bundle` works for free).
- Threaded through the 6 Grafana investigation tools
  (`integrations/grafana/tools/__init__.py`) via `_resolve_grafana_client`
  and `_grafana_creds`, so real investigations (not just onboarding) pick up
  the setting.

Default (`verify_ssl=True`, `ca_bundle=""`) reproduces today's exact behavior,
so this is purely additive/opt-in — existing configs are unaffected.

### Demo/Screenshot for feature changes and bug fixes -

Reproduced the reported bug and verified the fix against a local self-signed
HTTPS server standing in for an on-prem Grafana instance, using the real
`integrations/grafana/verifier.py` code path:

```
1) default (no ca_bundle) -> Datasource discovery failed: could not reach https://localhost:8443
   (... SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify
   failed: self-signed certificate (_ssl.c:1081)')) ...)
2) ca_bundle set -> [{'uid': 'loki1', 'name': 'logs-prod', 'type': 'loki', 'isDefault': True}]
3) verify_ssl=False -> [{'uid': 'loki1', 'name': 'logs-prod', 'type': 'loki', 'isDefault': True}]
ALL OK
```

(1) reproduces the exact error class from the issue. (2) is the recommended
fix — full TLS verification stays on, trusting the org's CA. (3) is the
explicit bypass escape hatch for local/lab instances.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

A user reported that on-prem Grafana behind a self-signed/internal CA fails
TLS verification during onboarding, with no way to configure trust. The root
cause is that `requests` never consults the OS trust store, and this repo's
Grafana client never passed a `verify=` override at all. Splunk and Argo CD
had already solved this exact problem with a `verify_ssl`/`ca_bundle` pair on
their config models, so I extended that same pattern to Grafana rather than
inventing a new mechanism — keeping the config surface, onboarding UX, and env
var naming consistent across integrations. The alternative (telling users to
set the global `REQUESTS_CA_BUNDLE` env var) was rejected because it would
also relax TLS checks for every other integration and the LLM provider calls
in the same process, not just Grafana.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.