### PR TITLE
fix(azure-openai): discover deployments during onboarding

### DIFF
--- a/core/llm/providers/azure_openai.py
+++ b/core/llm/providers/azure_openai.py
@@ -74,7 +74,9 @@ def azure_deployments_list_curl_command(*, api_version: str = "") -> str:
 def is_azure_deployment_lookup_error(error: Exception) -> bool:
     """Return whether *error* likely indicates a missing Azure deployment."""
     message = str(error).lower()
-    return "404" in message or "not found" in message or "deployment" in message
+    return "404" in message or (
+        "not found" in message and ("deployment" in message or "azure" in message)
+    )
 
 
 def is_azure_openai_failure_message(message: str) -> bool:
@@ -131,9 +133,9 @@ def list_azure_openai_deployments(
             timeout=30.0,
         )
         response.raise_for_status()
+        payload = response.json()
     except Exception:
         return []
-    payload = response.json()
     deployments: list[str] = []
     for item in payload.get("data", []):
         if not isinstance(item, dict):

--- a/core/llm/providers/azure_openai.py
+++ b/core/llm/providers/azure_openai.py
@@ -35,6 +35,12 @@ def select_azure_openai_model(settings: Any, model_type: ModelType) -> str:
     return str(getattr(settings, attr))
 
 
+def azure_openai_deployment_name(value: str) -> str:
+    """Return the Azure deployment name without the LiteLLM ``azure/`` prefix."""
+    name = value.strip()
+    return name.removeprefix("azure/")
+
+
 def azure_openai_litellm_model(deployment: str) -> str:
     """Build the LiteLLM model string for an Azure deployment name."""
     name = deployment.strip()
@@ -43,12 +49,112 @@ def azure_openai_litellm_model(deployment: str) -> str:
     return f"azure/{name}"
 
 
+def is_azure_litellm_model(model: str) -> bool:
+    """Return whether *model* is a LiteLLM Azure OpenAI model string."""
+    return model.strip().startswith("azure/")
+
+
 def resolve_azure_openai_api_version(value: str = "") -> str:
     """Return the configured Azure API version, falling back to the OpenSRE default."""
     from config.config import DEFAULT_AZURE_OPENAI_API_VERSION
 
     version = (value or os.getenv(AZURE_OPENAI_API_VERSION_ENV, "")).strip()
     return version or DEFAULT_AZURE_OPENAI_API_VERSION
+
+
+def azure_deployments_list_curl_command(*, api_version: str = "") -> str:
+    """Return a shell command that lists deployments in the configured resource."""
+    resolved_api_version = resolve_azure_openai_api_version(api_version)
+    return (
+        'curl -H "api-key: $AZURE_OPENAI_API_KEY" '
+        f'"$AZURE_OPENAI_BASE_URL/openai/deployments?api-version={resolved_api_version}"'
+    )
+
+
+def is_azure_deployment_lookup_error(error: Exception) -> bool:
+    """Return whether *error* likely indicates a missing Azure deployment."""
+    message = str(error).lower()
+    return "404" in message or "not found" in message or "deployment" in message
+
+
+def is_azure_openai_failure_message(message: str) -> bool:
+    """Return whether a user-facing failure message refers to Azure deployments."""
+    text = message.lower()
+    return (
+        "azure openai deployment" in text
+        or "azure/gpt" in text
+        or ("deployment" in text and "azure" in text)
+    )
+
+
+def format_azure_deployment_not_found_message(deployment: str) -> str:
+    """Build guidance when an Azure deployment name cannot be resolved."""
+    name = azure_openai_deployment_name(deployment)
+    return (
+        f"Azure OpenAI deployment '{name}' was not found. "
+        "Set AZURE_OPENAI_*_MODEL to your deployment name from the Azure portal "
+        "(not a model ID from /openai/models). "
+        f"List deployments with: {azure_deployments_list_curl_command()}"
+    )
+
+
+def azure_deployment_not_found_remediation_steps() -> list[str]:
+    """Return investigation remediation steps for Azure deployment 404s."""
+    return [
+        (
+            "Set AZURE_OPENAI_*_MODEL to your deployment name from the Azure portal, "
+            "not a model ID from /openai/models."
+        ),
+        f"List deployments: {azure_deployments_list_curl_command()}",
+        "Create or rename the deployment in Azure AI Foundry if needed.",
+    ]
+
+
+def list_azure_openai_deployments(
+    *,
+    base_url: str,
+    api_key: str,
+    api_version: str = "",
+) -> list[str]:
+    """Return deployment IDs configured in an Azure OpenAI resource."""
+    import httpx
+
+    normalized_base = normalize_azure_openai_base_url(base_url)
+    if not normalized_base or not api_key.strip():
+        return []
+    resolved_api_version = resolve_azure_openai_api_version(api_version)
+    url = f"{normalized_base}/openai/deployments?api-version={resolved_api_version}"
+    try:
+        response = httpx.get(
+            url,
+            headers={"api-key": api_key.strip()},
+            timeout=30.0,
+        )
+        response.raise_for_status()
+    except Exception:
+        return []
+    payload = response.json()
+    deployments: list[str] = []
+    for item in payload.get("data", []):
+        if not isinstance(item, dict):
+            continue
+        deployment_id = str(item.get("id", "")).strip()
+        if deployment_id:
+            deployments.append(deployment_id)
+    return deployments
+
+
+def discover_azure_openai_deployments_from_env() -> list[str]:
+    """Return deployment IDs from the configured Azure OpenAI resource."""
+    from config.llm_credentials import resolve_llm_api_key
+
+    base_url = os.getenv(AZURE_OPENAI_BASE_URL_ENV, "")
+    api_key = resolve_llm_api_key(AZURE_OPENAI_API_KEY_ENV) or ""
+    return list_azure_openai_deployments(
+        base_url=base_url,
+        api_key=api_key,
+        api_version=resolve_azure_openai_api_version(),
+    )
 
 
 def azure_openai_endpoint_configured() -> bool:
@@ -81,9 +187,18 @@ __all__ = [
     "AZURE_OPENAI_API_VERSION_ENV",
     "AZURE_OPENAI_BASE_URL_ENV",
     "AZURE_OPENAI_PROVIDER",
+    "azure_deployment_not_found_remediation_steps",
+    "azure_deployments_list_curl_command",
+    "azure_openai_deployment_name",
     "azure_openai_endpoint_configured",
     "azure_openai_litellm_model",
+    "discover_azure_openai_deployments_from_env",
+    "format_azure_deployment_not_found_message",
+    "is_azure_deployment_lookup_error",
+    "is_azure_litellm_model",
+    "is_azure_openai_failure_message",
     "is_azure_openai_provider",
+    "list_azure_openai_deployments",
     "normalize_azure_openai_base_url",
     "resolve_azure_openai_api_version",
     "resolve_azure_openai_request_kwargs",

--- a/core/llm/shared/openai_chat_completions.py
+++ b/core/llm/shared/openai_chat_completions.py
@@ -217,6 +217,20 @@ def is_exception_named(err: BaseException, *names: str) -> bool:
     return type(err).__name__ in names
 
 
+def _litellm_not_found_message(*, provider_label: str, model: str) -> str:
+    from core.llm.providers.azure_openai import (
+        format_azure_deployment_not_found_message,
+        is_azure_litellm_model,
+    )
+
+    if is_azure_litellm_model(model):
+        return format_azure_deployment_not_found_message(model)
+    return (
+        f"{provider_label} model '{model}' was not found. "
+        "Check your configured model name or endpoint."
+    )
+
+
 def invoke_with_litellm_agent_retries(
     completion_fn: Callable[..., Any],
     kwargs: dict[str, Any],
@@ -233,6 +247,12 @@ def invoke_with_litellm_agent_retries(
             if is_exception_named(err, "AuthenticationError"):
                 raise RuntimeError(f"{provider_name} authentication failed.") from err
             if is_exception_named(err, "NotFoundError"):
+                from core.llm.providers.azure_openai import is_azure_litellm_model
+
+                if is_azure_litellm_model(model):
+                    raise RuntimeError(
+                        _litellm_not_found_message(provider_label=provider_name, model=model)
+                    ) from err
                 raise RuntimeError(f"{provider_name} model '{model}' not found.") from err
             if is_exception_named(err, "PermissionDeniedError"):
                 raise RuntimeError(f"{provider_name} request forbidden: {err}") from err
@@ -293,8 +313,7 @@ def invoke_with_litellm_llm_retries(
                     kwargs = rebuilt
                     continue
                 raise RuntimeError(
-                    f"{provider_label} model '{model}' was not found. "
-                    "Check your configured model name or endpoint."
+                    _litellm_not_found_message(provider_label=provider_label, model=model)
                 ) from err
             if is_exception_named(err, "BadRequestError"):
                 message = str(getattr(err, "message", err))
@@ -368,8 +387,7 @@ def stream_with_litellm_retries(
                     kwargs = rebuilt
                     continue
                 raise RuntimeError(
-                    f"{provider_label} model '{model}' was not found. "
-                    "Check your configured model name or endpoint."
+                    _litellm_not_found_message(provider_label=provider_label, model=model)
                 ) from err
             if is_exception_named(err, "BadRequestError"):
                 message = str(getattr(err, "message", err))

--- a/core/llm/shared/openai_chat_completions.py
+++ b/core/llm/shared/openai_chat_completions.py
@@ -247,13 +247,9 @@ def invoke_with_litellm_agent_retries(
             if is_exception_named(err, "AuthenticationError"):
                 raise RuntimeError(f"{provider_name} authentication failed.") from err
             if is_exception_named(err, "NotFoundError"):
-                from core.llm.providers.azure_openai import is_azure_litellm_model
-
-                if is_azure_litellm_model(model):
-                    raise RuntimeError(
-                        _litellm_not_found_message(provider_label=provider_name, model=model)
-                    ) from err
-                raise RuntimeError(f"{provider_name} model '{model}' not found.") from err
+                raise RuntimeError(
+                    _litellm_not_found_message(provider_label=provider_name, model=model)
+                ) from err
             if is_exception_named(err, "PermissionDeniedError"):
                 raise RuntimeError(f"{provider_name} request forbidden: {err}") from err
             if is_exception_named(err, "BadRequestError"):

--- a/core/llm_invoke_errors.py
+++ b/core/llm_invoke_errors.py
@@ -206,6 +206,11 @@ def classify_llm_invoke_failure(exc: BaseException) -> LLMInvokeFailure | None:
     raw = str(exc)
 
     if ("model" in err_msg and "not found" in err_msg) or "404" in err_msg:
+        from core.llm.providers.azure_openai import (
+            azure_deployment_not_found_remediation_steps,
+            is_azure_openai_failure_message,
+        )
+
         if "anthropic" in err_msg and "was not found" in err_msg:
             return LLMInvokeFailure(
                 user_message=raw.strip()
@@ -218,6 +223,13 @@ def classify_llm_invoke_failure(exc: BaseException) -> LLMInvokeFailure | None:
                     ),
                     "Confirm the model ID is valid for your Anthropic account.",
                 ],
+            )
+        if "azure openai deployment" in err_msg or is_azure_openai_failure_message(raw):
+            return LLMInvokeFailure(
+                user_message=raw.strip()
+                or "The configured Azure OpenAI deployment was not found (404).",
+                tracker_message="Failed: Azure deployment not found",
+                remediation_steps=azure_deployment_not_found_remediation_steps(),
             )
         return LLMInvokeFailure(
             user_message=(

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -209,7 +209,7 @@ Quick setup:
 opensre onboard   # choose Azure OpenAI; paste resource URL, API key, deployment
 ```
 
-Onboarding asks only for your **resource URL**, **API key**, and **reasoning deployment name**. OpenSRE sets `AZURE_OPENAI_API_VERSION=2024-10-21` and `OPENSRE_LLM_TRANSPORT=litellm` automatically unless you override them in `.env`.
+Onboarding asks for your **resource URL**, **API key**, then lists **deployments** from that resource for you to pick. OpenSRE sets `AZURE_OPENAI_API_VERSION=2024-10-21` and `OPENSRE_LLM_TRANSPORT=litellm` automatically unless you override them in `.env`.
 
 In the REPL, switch provider or deployment like any other API provider:
 
@@ -218,7 +218,7 @@ In the REPL, switch provider or deployment like any other API provider:
 /model set azure-openai gpt-5.4-mini --toolcall-model gpt-5.4-nano
 ```
 
-Common deployment names in the onboarding picker include `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5-mini`, `gpt-4.1`, and `o3-mini`. Use custom names when your Azure deployment names differ (`allow_custom_models` is enabled).
+If deployment discovery fails during onboarding, enter the deployment name manually — it must match a deployment in your Azure resource, not a model ID from `/openai/models`.
 
 ### OpenRouter
 

--- a/surfaces/cli/wizard/azure_openai.py
+++ b/surfaces/cli/wizard/azure_openai.py
@@ -79,6 +79,7 @@ def ensure_endpoint_settings(provider: ProviderOption) -> dict[str, str] | None:
 def choose_azure_deployment(
     *,
     default: str | None,
+    model_env: str = "AZURE_OPENAI_REASONING_MODEL",
     back_on_cancel: bool = False,
 ) -> str:
     """Prompt for an Azure OpenAI deployment name from the user's resource."""
@@ -92,7 +93,7 @@ def choose_azure_deployment(
             "Enter the deployment name from the Azure portal.[/]"
         )
         return _prompt_value(
-            "Azure OpenAI deployment name (AZURE_OPENAI_REASONING_MODEL)",
+            f"Azure OpenAI deployment name ({model_env})",
             default=resolved_default,
             allow_empty=False,
             back_on_cancel=back_on_cancel,
@@ -125,7 +126,7 @@ def choose_azure_deployment(
         return selection
 
     return _prompt_value(
-        "Custom Azure OpenAI deployment name (AZURE_OPENAI_REASONING_MODEL)",
+        f"Custom Azure OpenAI deployment name ({model_env})",
         default=resolved_default,
         allow_empty=False,
         back_on_cancel=back_on_cancel,
@@ -142,7 +143,11 @@ def choose_provider_model(
 ) -> str:
     """Prompt for a model or Azure deployment after provider credentials are set."""
     if is_azure_openai_provider(provider.value):
-        return choose_azure_deployment(default=default, back_on_cancel=back_on_cancel)
+        return choose_azure_deployment(
+            default=default,
+            model_env=model_provider.model_env,
+            back_on_cancel=back_on_cancel,
+        )
     return _choose_model(
         model_provider,
         default=default,

--- a/surfaces/cli/wizard/azure_openai.py
+++ b/surfaces/cli/wizard/azure_openai.py
@@ -1,0 +1,231 @@
+"""Azure OpenAI wizard helpers: endpoint setup, deployment picker, validation."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from core.llm.providers.azure_openai import (
+    discover_azure_openai_deployments_from_env,
+    format_azure_deployment_not_found_message,
+    is_azure_deployment_lookup_error,
+    is_azure_openai_provider,
+    list_azure_openai_deployments,
+    normalize_azure_openai_base_url,
+    resolve_azure_openai_api_version,
+)
+from platform.terminal.theme import ERROR, WARNING
+from surfaces.cli.wizard._ui import (
+    _CUSTOM_MODEL_SENTINEL,
+    Choice,
+    WizardBack,
+    _choose,
+    _choose_model,
+    _console,
+    _prompt_value,
+    _step,
+)
+
+if TYPE_CHECKING:
+    from surfaces.cli.wizard.config import ProviderOption
+    from surfaces.cli.wizard.validation import ValidationResult
+
+
+def endpoint_env(provider: ProviderOption) -> dict[str, str]:
+    """Return Azure endpoint env vars, using the default API version when unset."""
+    return {
+        provider.endpoint_env: os.getenv(provider.endpoint_env, "").strip(),
+        provider.api_version_env: resolve_azure_openai_api_version(),
+    }
+
+
+def prompt_endpoint_settings(provider: ProviderOption) -> dict[str, str] | None:
+    """Collect Azure OpenAI resource URL during onboarding."""
+    if not provider.endpoint_env or not provider.api_version_env:
+        return {}
+
+    _step("Azure endpoint")
+    try:
+        base_url = _prompt_value(
+            f"Azure OpenAI resource URL ({provider.endpoint_env})",
+            default=os.getenv(provider.endpoint_env, provider.credential_default),
+            secret=False,
+            back_on_cancel=True,
+        )
+    except WizardBack:
+        return None
+
+    normalized_base = normalize_azure_openai_base_url(base_url)
+    if not normalized_base:
+        _console.print(f"[{ERROR}]Azure OpenAI resource URL is required.[/]")
+        return None
+    return {
+        provider.endpoint_env: normalized_base,
+        provider.api_version_env: resolve_azure_openai_api_version(),
+    }
+
+
+def ensure_endpoint_settings(provider: ProviderOption) -> dict[str, str] | None:
+    """Return Azure endpoint env vars, prompting when missing."""
+    from core.llm.providers.azure_openai import azure_openai_endpoint_configured
+
+    if not is_azure_openai_provider(provider.value):
+        return {}
+    if azure_openai_endpoint_configured():
+        return endpoint_env(provider)
+    return prompt_endpoint_settings(provider)
+
+
+def choose_azure_deployment(
+    *,
+    default: str | None,
+    back_on_cancel: bool = False,
+) -> str:
+    """Prompt for an Azure OpenAI deployment name from the user's resource."""
+    _step("Deployment")
+
+    resolved_default = (default or "").strip()
+    deployments = discover_azure_openai_deployments_from_env()
+    if not deployments:
+        _console.print(
+            f"[{WARNING}]Could not list deployments from your Azure resource. "
+            "Enter the deployment name from the Azure portal.[/]"
+        )
+        return _prompt_value(
+            "Azure OpenAI deployment name (AZURE_OPENAI_REASONING_MODEL)",
+            default=resolved_default,
+            allow_empty=False,
+            back_on_cancel=back_on_cancel,
+        )
+
+    deployment_choices = [
+        Choice(value=deployment, label=deployment, hint="deployment") for deployment in deployments
+    ]
+    extra_choices: list[Choice] = []
+    if resolved_default and resolved_default not in deployments:
+        extra_choices.append(Choice(value=resolved_default, label=resolved_default, hint="current"))
+
+    custom_choice = Choice(
+        value=_CUSTOM_MODEL_SENTINEL,
+        label="Enter custom deployment name",
+        hint="type deployment name from Azure portal",
+    )
+    choices = deployment_choices + extra_choices + [custom_choice]
+    default_value = resolved_default or deployments[0]
+    if default_value and not any(choice.value == default_value for choice in choices):
+        default_value = deployments[0]
+
+    selection = _choose(
+        "Choose Azure OpenAI deployment",
+        choices,
+        default=default_value or None,
+        back_on_cancel=back_on_cancel,
+    )
+    if selection != _CUSTOM_MODEL_SENTINEL:
+        return selection
+
+    return _prompt_value(
+        "Custom Azure OpenAI deployment name (AZURE_OPENAI_REASONING_MODEL)",
+        default=resolved_default,
+        allow_empty=False,
+        back_on_cancel=back_on_cancel,
+    )
+
+
+def choose_provider_model(
+    provider: ProviderOption,
+    model_provider: ProviderOption,
+    *,
+    default: str | None,
+    prompt_label: str | None = None,
+    back_on_cancel: bool = False,
+) -> str:
+    """Prompt for a model or Azure deployment after provider credentials are set."""
+    if is_azure_openai_provider(provider.value):
+        return choose_azure_deployment(default=default, back_on_cancel=back_on_cancel)
+    return _choose_model(
+        model_provider,
+        default=default,
+        prompt_label=prompt_label,
+        back_on_cancel=back_on_cancel,
+    )
+
+
+def format_validation_failure(
+    *,
+    deployment: str,
+    base_url: str,
+    api_key: str,
+    api_version: str,
+    error: Exception,
+) -> str:
+    """Explain Azure validation failures, listing deployments when possible."""
+    if not is_azure_deployment_lookup_error(error):
+        return f"Validation request failed: {error}"
+
+    detail = format_azure_deployment_not_found_message(deployment)
+    available = list_azure_openai_deployments(
+        base_url=base_url,
+        api_key=api_key,
+        api_version=api_version,
+    )
+    if available:
+        detail += f" Available deployments: {', '.join(available)}"
+    return detail
+
+
+def validate_credentials(
+    *,
+    api_key: str,
+    deployment: str,
+    base_url: str,
+    api_version: str,
+) -> ValidationResult:
+    """Validate Azure OpenAI credentials with a tiny chat completion."""
+    from surfaces.cli.wizard.validation import ValidationResult, _load_openai_client
+
+    normalized_base = normalize_azure_openai_base_url(base_url)
+    if not normalized_base:
+        return ValidationResult(
+            ok=False,
+            detail="Azure OpenAI resource URL is missing. Set AZURE_OPENAI_BASE_URL.",
+        )
+
+    resolved_api_version = resolve_azure_openai_api_version(api_version)
+    openai_client_cls, openai_auth_error = _load_openai_client()
+    azure_base = f"{normalized_base}/openai/deployments/{deployment}"
+    try:
+        client = openai_client_cls(
+            api_key=api_key,
+            base_url=azure_base,
+            default_query={"api-version": resolved_api_version},
+            timeout=30.0,
+        )
+        request_kwargs: dict[str, object] = {
+            "model": deployment,
+            "messages": [{"role": "user", "content": "Reply with exactly: OpenSRE ready"}],
+        }
+        if deployment.startswith(("o1", "o3", "o4", "gpt-5")):
+            request_kwargs["max_completion_tokens"] = 24
+        else:
+            request_kwargs["max_tokens"] = 24
+        response = client.chat.completions.create(**request_kwargs)
+        sample_text = (response.choices[0].message.content or "").strip()
+        return ValidationResult(
+            ok=True,
+            detail="Azure OpenAI API key validated.",
+            sample_response=sample_text,
+        )
+    except openai_auth_error:
+        return ValidationResult(ok=False, detail="Azure OpenAI rejected the API key.")
+    except Exception as err:
+        return ValidationResult(
+            ok=False,
+            detail=format_validation_failure(
+                deployment=deployment,
+                base_url=base_url,
+                api_key=api_key,
+                api_version=api_version,
+                error=err,
+            ),
+        )

--- a/surfaces/cli/wizard/config.py
+++ b/surfaces/cli/wizard/config.py
@@ -203,23 +203,6 @@ GROQ_MODELS = (
     ModelOption(value="meta-llama/llama-4-scout-17b-16e-instruct", label="Llama 4 Scout 17B"),
 )
 
-# Azure OpenAI model values are deployment names in your resource.
-# Source: https://learn.microsoft.com/en-us/azure/ai-foundry/model-inference/concepts/models
-AZURE_OPENAI_MODELS = (
-    ModelOption(value=AZURE_OPENAI_REASONING_MODEL, label="gpt-5.4-mini deployment"),
-    ModelOption(value="gpt-5.6-sol", label="gpt-5.6-sol deployment"),
-    ModelOption(value="gpt-5.6-terra", label="gpt-5.6-terra deployment"),
-    ModelOption(value="gpt-5.6-luna", label="gpt-5.6-luna deployment"),
-    ModelOption(value="gpt-5.5", label="gpt-5.5 deployment"),
-    ModelOption(value="gpt-5.4", label="gpt-5.4 deployment"),
-    ModelOption(value="gpt-5.4-nano", label="gpt-5.4-nano deployment"),
-    ModelOption(value="gpt-5-mini", label="gpt-5-mini deployment"),
-    ModelOption(value="gpt-5", label="gpt-5 deployment"),
-    ModelOption(value="gpt-4.1", label="gpt-4.1 deployment"),
-    ModelOption(value="gpt-4.1-mini", label="gpt-4.1-mini deployment"),
-    ModelOption(value="o3-mini", label="o3-mini deployment"),
-)
-
 BEDROCK_MODELS = (
     ModelOption(
         value=BEDROCK_REASONING_MODEL,
@@ -715,7 +698,7 @@ SUPPORTED_PROVIDERS = (
         api_key_env="AZURE_OPENAI_API_KEY",
         model_env="AZURE_OPENAI_REASONING_MODEL",
         default_model=AZURE_OPENAI_REASONING_MODEL,
-        models=AZURE_OPENAI_MODELS,
+        models=(),
         legacy_model_env="AZURE_OPENAI_MODEL",
         toolcall_model_env="AZURE_OPENAI_TOOLCALL_MODEL",
         classification_model_env="AZURE_OPENAI_CLASSIFICATION_MODEL",

--- a/surfaces/cli/wizard/flow.py
+++ b/surfaces/cli/wizard/flow.py
@@ -38,7 +38,6 @@ from surfaces.cli.wizard._ui import (
     Choice,
     WizardBack,
     _choose,
-    _choose_model,
     _confirm,
     _console,
     _local_defaults,
@@ -50,6 +49,12 @@ from surfaces.cli.wizard._ui import (
     _select_target_for_advanced,
     _step,
     _step_header,
+)
+from surfaces.cli.wizard.azure_openai import (
+    choose_provider_model,
+)
+from surfaces.cli.wizard.azure_openai import (
+    ensure_endpoint_settings as ensure_azure_openai_endpoint_settings,
 )
 from surfaces.cli.wizard.config import PROVIDER_BY_VALUE, SUPPORTED_PROVIDERS, ProviderOption
 from surfaces.cli.wizard.configurators.github import (
@@ -239,58 +244,6 @@ def _persist_llm_credential(provider: ProviderOption, value: str) -> bool:
         os.environ[provider.api_key_env] = value
         return True
     return _persist_llm_api_key(provider.api_key_env, value)
-
-
-def _azure_openai_endpoint_env(provider: ProviderOption) -> dict[str, str]:
-    """Return Azure endpoint env vars, using the default API version when unset."""
-    from core.llm.providers.azure_openai import resolve_azure_openai_api_version
-
-    return {
-        provider.endpoint_env: os.getenv(provider.endpoint_env, "").strip(),
-        provider.api_version_env: resolve_azure_openai_api_version(),
-    }
-
-
-def _prompt_azure_openai_endpoint_settings(provider: ProviderOption) -> dict[str, str] | None:
-    """Collect Azure OpenAI resource URL during onboarding."""
-    from core.llm.providers.azure_openai import (
-        normalize_azure_openai_base_url,
-        resolve_azure_openai_api_version,
-    )
-
-    if not provider.endpoint_env or not provider.api_version_env:
-        return {}
-
-    _step("Azure endpoint")
-    try:
-        base_url = _prompt_value(
-            f"Azure OpenAI resource URL ({provider.endpoint_env})",
-            default=os.getenv(provider.endpoint_env, provider.credential_default),
-            secret=False,
-            back_on_cancel=True,
-        )
-    except WizardBack:
-        return None
-
-    normalized_base = normalize_azure_openai_base_url(base_url)
-    if not normalized_base:
-        _console.print(f"[{ERROR}]Azure OpenAI resource URL is required.[/]")
-        return None
-    return {
-        provider.endpoint_env: normalized_base,
-        provider.api_version_env: resolve_azure_openai_api_version(),
-    }
-
-
-def _ensure_azure_openai_endpoint_settings(provider: ProviderOption) -> dict[str, str] | None:
-    """Return Azure endpoint env vars, prompting when missing."""
-    from core.llm.providers.azure_openai import azure_openai_endpoint_configured
-
-    if provider.value != "azure-openai":
-        return {}
-    if azure_openai_endpoint_configured():
-        return _azure_openai_endpoint_env(provider)
-    return _prompt_azure_openai_endpoint_settings(provider)
 
 
 def _subscription_login_command(
@@ -815,7 +768,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                     return 1
                 if not _persist_llm_credential(provider, api_key):
                     return 1
-                azure_env = _ensure_azure_openai_endpoint_settings(provider)
+                azure_env = ensure_azure_openai_endpoint_settings(provider)
                 if azure_env is None:
                     force_repick = True
                     continue
@@ -858,7 +811,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                         return 1
                     if not _persist_llm_credential(provider, api_key):
                         return 1
-            azure_env = _ensure_azure_openai_endpoint_settings(provider)
+            azure_env = ensure_azure_openai_endpoint_settings(provider)
             if azure_env is None:
                 force_repick = True
                 continue
@@ -867,7 +820,8 @@ def run_wizard(_argv: list[str] | None = None) -> int:
 
         if change_provider:
             try:
-                model = _choose_model(
+                model = choose_provider_model(
+                    provider,
                     model_provider,
                     default=model,
                     prompt_label=(
@@ -880,11 +834,12 @@ def run_wizard(_argv: list[str] | None = None) -> int:
             except WizardBack:
                 force_repick = True
                 continue
-        elif model_provider.models:
+        elif model_provider.models or provider.value == "azure-openai":
             current_display = model or "CLI default"
             _console.print(f"[{SECONDARY}]current model  {current_display}[/]")
             if _confirm("Change model?", default=False):
-                model = _choose_model(
+                model = choose_provider_model(
+                    provider,
                     model_provider,
                     default=model,
                     prompt_label=(

--- a/surfaces/cli/wizard/validation.py
+++ b/surfaces/cli/wizard/validation.py
@@ -81,56 +81,6 @@ def _provider_validation_label(provider: ProviderOption) -> str:
     return provider.label
 
 
-def _check_azure_openai(
-    *,
-    api_key: str,
-    model: str,
-    base_url: str,
-    api_version: str,
-) -> ValidationResult:
-    """Validate Azure OpenAI credentials with a tiny chat completion."""
-    from core.llm.providers.azure_openai import normalize_azure_openai_base_url
-
-    normalized_base = normalize_azure_openai_base_url(base_url)
-    if not normalized_base:
-        return ValidationResult(
-            ok=False,
-            detail="Azure OpenAI resource URL is missing. Set AZURE_OPENAI_BASE_URL.",
-        )
-    from core.llm.providers.azure_openai import resolve_azure_openai_api_version
-
-    resolved_api_version = resolve_azure_openai_api_version(api_version)
-
-    openai_client_cls, openai_auth_error = _load_openai_client()
-    azure_base = f"{normalized_base}/openai/deployments/{model}"
-    try:
-        client = openai_client_cls(
-            api_key=api_key,
-            base_url=azure_base,
-            default_query={"api-version": resolved_api_version},
-            timeout=30.0,
-        )
-        request_kwargs: dict[str, object] = {
-            "model": model,
-            "messages": [{"role": "user", "content": "Reply with exactly: OpenSRE ready"}],
-        }
-        if model.startswith(("o1", "o3", "o4", "gpt-5")):
-            request_kwargs["max_completion_tokens"] = 24
-        else:
-            request_kwargs["max_tokens"] = 24
-        response = client.chat.completions.create(**request_kwargs)
-        sample_text = (response.choices[0].message.content or "").strip()
-        return ValidationResult(
-            ok=True,
-            detail="Azure OpenAI API key validated.",
-            sample_response=sample_text,
-        )
-    except openai_auth_error:
-        return ValidationResult(ok=False, detail="Azure OpenAI rejected the API key.")
-    except Exception as err:
-        return ValidationResult(ok=False, detail=f"Validation request failed: {err}")
-
-
 def _check_ollama(host: str, model: str) -> ValidationResult:
     """Check Ollama server connectivity and verify model responds to inference."""
     import httpx
@@ -191,9 +141,13 @@ def validate_provider_credentials(
         return _check_ollama(host=api_key, model=model)
 
     if provider.value == "azure-openai":
-        return _check_azure_openai(
+        from surfaces.cli.wizard.azure_openai import (
+            validate_credentials as validate_azure_credentials,
+        )
+
+        return validate_azure_credentials(
             api_key=api_key,
-            model=model,
+            deployment=model,
             base_url=os.getenv(provider.endpoint_env, "").strip(),
             api_version=os.getenv(provider.api_version_env, "").strip(),
         )

--- a/tests/cli/wizard/test_azure_openai_wizard.py
+++ b/tests/cli/wizard/test_azure_openai_wizard.py
@@ -1,0 +1,81 @@
+"""Tests for Azure OpenAI wizard onboarding helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from surfaces.cli.wizard import _ui, azure_openai
+
+
+def test_choose_azure_deployment_lists_resource_deployments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        azure_openai,
+        "discover_azure_openai_deployments_from_env",
+        lambda: ["gpt-4.1", "my-custom-deployment"],
+    )
+
+    captured: dict[str, list[str]] = {}
+
+    def _mock_select(_prompt: str, choices: list[Any], **_kwargs: Any) -> Any:
+        captured["values"] = [choice.value for choice in choices]
+        m = MagicMock()
+        m.ask.return_value = "gpt-4.1"
+        return m
+
+    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+
+    deployment = azure_openai.choose_azure_deployment(default="")
+
+    assert deployment == "gpt-4.1"
+    assert captured["values"][:2] == ["gpt-4.1", "my-custom-deployment"]
+    assert captured["values"][-1] == _ui._CUSTOM_MODEL_SENTINEL
+
+
+def test_choose_azure_deployment_prompts_manual_entry_when_discovery_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(azure_openai, "discover_azure_openai_deployments_from_env", lambda: [])
+    monkeypatch.setattr(
+        azure_openai,
+        "_prompt_value",
+        lambda *_args, **_kwargs: "manual-deployment",
+    )
+
+    deployment = azure_openai.choose_azure_deployment(default="")
+
+    assert deployment == "manual-deployment"
+
+
+def test_format_validation_failure_lists_deployments(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        azure_openai,
+        "list_azure_openai_deployments",
+        lambda **_kwargs: ["gpt-4.1-mini"],
+    )
+
+    detail = azure_openai.format_validation_failure(
+        deployment="gpt-4.1",
+        base_url="https://example.openai.azure.com",
+        api_key="test-key",
+        api_version="2024-10-21",
+        error=RuntimeError("Error code: 404 - DeploymentNotFound"),
+    )
+
+    assert "deployment 'gpt-4.1'" in detail
+    assert "Available deployments: gpt-4.1-mini" in detail
+
+
+def test_format_validation_failure_passthrough_for_other_errors() -> None:
+    detail = azure_openai.format_validation_failure(
+        deployment="gpt-4.1",
+        base_url="https://example.openai.azure.com",
+        api_key="test-key",
+        api_version="2024-10-21",
+        error=RuntimeError("connection reset"),
+    )
+    assert detail == "Validation request failed: connection reset"

--- a/tests/cli/wizard/test_model_selection.py
+++ b/tests/cli/wizard/test_model_selection.py
@@ -114,10 +114,8 @@ class TestGpt56CatalogPresence:
         values = {option.value for option in PROVIDER_BY_VALUE["openai"].models}
         assert model in values
 
-    @pytest.mark.parametrize("model", ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])
-    def test_azure_picker_lists_every_tier(self, model: str) -> None:
-        values = {option.value for option in PROVIDER_BY_VALUE["azure-openai"].models}
-        assert model in values
+    def test_azure_provider_has_no_static_model_picker(self) -> None:
+        assert PROVIDER_BY_VALUE["azure-openai"].models == ()
 
     def test_openrouter_picker_uses_namespaced_ids(self) -> None:
         values = {option.value for option in PROVIDER_BY_VALUE["openrouter"].models}

--- a/tests/cli/wizard/test_validation.py
+++ b/tests/cli/wizard/test_validation.py
@@ -173,6 +173,28 @@ def test_validate_provider_credentials_returns_success_for_valid_openai_key(monk
     assert result.sample_response == "OpenSRE ready"
 
 
+def test_validate_provider_credentials_azure_not_found_lists_deployments(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "surfaces.cli.wizard.validation.OpenAI",
+        lambda **_kwargs: _FakeOpenAIClient(RuntimeError("Error code: 404 - DeploymentNotFound")),
+    )
+    monkeypatch.setattr(
+        "surfaces.cli.wizard.azure_openai.list_azure_openai_deployments",
+        lambda **_kwargs: ["gpt-4.1-mini"],
+    )
+    monkeypatch.setenv("AZURE_OPENAI_BASE_URL", "https://example.openai.azure.com")
+
+    result = validate_provider_credentials(
+        provider=PROVIDER_BY_VALUE["azure-openai"],
+        api_key="good-key",
+        model="gpt-4.1",
+    )
+
+    assert result.ok is False
+    assert "deployment 'gpt-4.1'" in result.detail
+    assert "Available deployments: gpt-4.1-mini" in result.detail
+
+
 def test_get_provider_base_url_deepseek() -> None:
     from config.config import DEEPSEEK_BASE_URL
 

--- a/tests/core/runtime/llm/test_azure_openai_helpers.py
+++ b/tests/core/runtime/llm/test_azure_openai_helpers.py
@@ -1,0 +1,89 @@
+"""Azure OpenAI provider helper tests."""
+
+from __future__ import annotations
+
+from core.llm.providers.azure_openai import (
+    azure_deployments_list_curl_command,
+    azure_openai_deployment_name,
+    azure_openai_litellm_model,
+    discover_azure_openai_deployments_from_env,
+    format_azure_deployment_not_found_message,
+    is_azure_deployment_lookup_error,
+    is_azure_litellm_model,
+    is_azure_openai_failure_message,
+    list_azure_openai_deployments,
+)
+
+
+def test_azure_openai_litellm_model_adds_prefix() -> None:
+    assert azure_openai_litellm_model("gpt-4.1") == "azure/gpt-4.1"
+    assert azure_openai_litellm_model("azure/gpt-4.1") == "azure/gpt-4.1"
+
+
+def test_azure_openai_deployment_name_strips_prefix() -> None:
+    assert azure_openai_deployment_name("azure/gpt-4.1") == "gpt-4.1"
+    assert azure_openai_deployment_name("gpt-4.1") == "gpt-4.1"
+
+
+def test_is_azure_litellm_model() -> None:
+    assert is_azure_litellm_model("azure/gpt-4.1") is True
+    assert is_azure_litellm_model("gpt-4.1") is False
+
+
+def test_is_azure_deployment_lookup_error() -> None:
+    assert is_azure_deployment_lookup_error(RuntimeError("Error code: 404")) is True
+    assert is_azure_deployment_lookup_error(RuntimeError("connection reset")) is False
+
+
+def test_is_azure_openai_failure_message() -> None:
+    assert (
+        is_azure_openai_failure_message("Azure OpenAI deployment 'gpt-4.1' was not found.") is True
+    )
+    assert is_azure_openai_failure_message("OpenAI model 'gpt-4' was not found.") is False
+
+
+def test_azure_deployments_list_curl_command_uses_default_api_version() -> None:
+    command = azure_deployments_list_curl_command()
+    assert "api-version=2024-10-21" in command
+    assert "$AZURE_OPENAI_BASE_URL/openai/deployments" in command
+
+
+def test_format_azure_deployment_not_found_message_mentions_deployment() -> None:
+    message = format_azure_deployment_not_found_message("azure/gpt-4.1")
+    assert "deployment 'gpt-4.1'" in message
+    assert "/openai/models" in message
+    assert "/openai/deployments" in message
+
+
+def test_list_azure_openai_deployments_parses_response(monkeypatch) -> None:
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {"data": [{"id": "gpt-4.1"}, {"id": "my-custom-name"}]}
+
+    monkeypatch.setattr(
+        "httpx.get",
+        lambda *_args, **_kwargs: _FakeResponse(),
+    )
+
+    deployments = list_azure_openai_deployments(
+        base_url="https://example.openai.azure.com",
+        api_key="test-key",
+    )
+    assert deployments == ["gpt-4.1", "my-custom-name"]
+
+
+def test_discover_azure_openai_deployments_from_env(monkeypatch) -> None:
+    monkeypatch.setenv("AZURE_OPENAI_BASE_URL", "https://example.openai.azure.com")
+    monkeypatch.setattr(
+        "config.llm_credentials.resolve_llm_api_key",
+        lambda _env: "test-key",
+    )
+    monkeypatch.setattr(
+        "core.llm.providers.azure_openai.list_azure_openai_deployments",
+        lambda **_kwargs: ["gpt-4.1-mini"],
+    )
+
+    assert discover_azure_openai_deployments_from_env() == ["gpt-4.1-mini"]

--- a/tests/core/runtime/llm/test_litellm_compat.py
+++ b/tests/core/runtime/llm/test_litellm_compat.py
@@ -210,6 +210,31 @@ def test_litellm_llm_client_invoke_stream_not_found_raises_without_retry(monkeyp
     assert sleeps == []
 
 
+def test_litellm_llm_client_invoke_stream_azure_not_found_mentions_deployment(
+    monkeypatch,
+) -> None:
+    attempts: list[bool] = []
+
+    def completion(**_kwargs: Any) -> Any:
+        attempts.append(True)
+        raise NotFoundError("deployment not found")
+
+    monkeypatch.setattr("core.llm.shared.openai_chat_completions.time.sleep", lambda _s: None)
+
+    client = LiteLLMLLMClient(
+        litellm_model="azure/gpt-4.1",
+        api_base="https://example.openai.azure.com",
+        api_key_env="AZURE_OPENAI_API_KEY",
+        credential_resolver=lambda _env: "key",
+        completion_func=completion,
+    )
+
+    with pytest.raises(RuntimeError, match="Azure OpenAI deployment 'gpt-4.1' was not found"):
+        list(client.invoke_stream("hi"))
+
+    assert len(attempts) == 1
+
+
 def test_litellm_llm_client_invoke_stream_retries_before_emit(monkeypatch) -> None:
     """Transient failure before any chunk is yielded should retry."""
     attempts: list[bool] = []


### PR DESCRIPTION
Fixes #3631

#### Describe the changes you have made in this PR -

- Add `surfaces/cli/wizard/azure_openai.py` to own Azure onboarding: endpoint setup, live deployment picker, and credential validation
- Remove the static `AZURE_OPENAI_MODELS` picker; onboarding now calls `/openai/deployments` after URL + API key are collected
- Clarify Azure 404 errors: deployment name vs model ID from `/openai/models`, with curl hint and available-deployment listing on validation failure
- Refactor runtime helpers in `core/llm/providers/azure_openai.py` (curl hint, lookup-error detection, remediation steps)
- Add unit tests for wizard picker, validation, LiteLLM routing, and error classification

### Demo/Screenshot for feature changes and bug fixes - 

Terminal flow (mocked in tests):

```
Azure endpoint → API key → [GET /openai/deployments] → Choose deployment → validate
```

If discovery fails, wizard falls back to manual deployment name entry with guidance.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Azure OpenAI uses **deployment names**, not model IDs from `/openai/models`. Users were setting `AZURE_OPENAI_*_MODEL=gpt-4.1` based on the models API and getting 404s because no deployment with that name existed.

Split responsibilities by layer: wizard UI in `surfaces/cli/wizard/azure_openai.py`, runtime/LiteLLM routing in `core/llm/providers/azure_openai.py`. Onboarding fetches deployments dynamically after credentials are set; runtime errors now explain the deployment vs model ID distinction instead of showing a generic "LiteLLM model 'azure/gpt-4.1' not found."

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.