### PR TITLE
feat(analytics): A/B test forced vs skippable GitHub first-launch sign-in

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -142,6 +142,8 @@ On the first interactive launch (all platforms, except CI/CD and test harnesses)
 
 Every gate exposure emits `github_login_prompted` with `github_gate_variant`. Outcomes are `github_login_completed`, `github_login_skipped` (control only), or `github_login_abandoned` (forced drop-off). The variant is also stamped as a persistent event property so later REPL events break down by cohort. On success OpenSRE sets `github_username` as a PostHog **person property** (via `$identify`/`$set`, which forces `$process_person_profile: True` for that one event — this is the only intentional PII OpenSRE sends). A configured GitHub integration suppresses re-prompting on later launches.
 
+Because bucketing is local and does not call PostHog feature flags, PostHog's built-in experiment exposure chart will not populate automatically. Configure `github_login_prompted` as the custom exposure event and use `github_gate_variant` as the breakdown/filter for funnels and trends.
+
 The existing kill-switches still apply: `OPENSRE_NO_TELEMETRY` / `DO_NOT_TRACK` make analytics calls no-ops, but the login itself still runs. Set `OPENSRE_SKIP_GITHUB_LOGIN=1` to bypass the login gate entirely (also auto-bypassed in CI — `CI=true`, `GITHUB_ACTIONS=true` — and in pytest).
 
 ### Kill-switch matrix

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -133,9 +133,16 @@ A random install ID is stored under `~/.opensre/anonymous_id`. PostHog `distinct
 
 ### First-launch GitHub login
 
-On the first interactive launch (all platforms, except CI/CD and test harnesses), OpenSRE requires a GitHub device-flow sign-in before the REPL prompt. On success it sets `github_username` as a PostHog **person property** (via `$identify`/`$set`, which forces `$process_person_profile: True` for that one event — this is the only intentional PII OpenSRE sends) and emits a `github_login_completed` event. A configured GitHub integration suppresses re-prompting on later launches.
+On the first interactive launch (all platforms, except CI/CD and test harnesses), OpenSRE runs a GitHub device-flow sign-in gate before the REPL prompt. Installs are split offline into an A/B experiment via sticky bucketing on `~/.opensre/anonymous_id`:
 
-The existing kill-switches still apply: `OPENSRE_NO_TELEMETRY` / `DO_NOT_TRACK` make the `$identify` and `github_login_completed` calls no-ops, but the login itself still runs. Set `OPENSRE_SKIP_GITHUB_LOGIN=1` to bypass the login gate entirely (also auto-bypassed in CI — `CI=true`, `GITHUB_ACTIONS=true` — and in pytest).
+| Variant | Behavior | How to force locally |
+| --- | --- | --- |
+| `control` | Skip allowed (menu + Escape defer the gate) | `OPENSRE_GITHUB_GATE_VARIANT=control` |
+| `forced` | Skip removed; abandoning the gate aborts startup | `OPENSRE_GITHUB_GATE_VARIANT=forced` |
+
+Every gate exposure emits `github_login_prompted` with `github_gate_variant`. Outcomes are `github_login_completed`, `github_login_skipped` (control only), or `github_login_abandoned` (forced drop-off). The variant is also stamped as a persistent event property so later REPL events break down by cohort. On success OpenSRE sets `github_username` as a PostHog **person property** (via `$identify`/`$set`, which forces `$process_person_profile: True` for that one event — this is the only intentional PII OpenSRE sends). A configured GitHub integration suppresses re-prompting on later launches.
+
+The existing kill-switches still apply: `OPENSRE_NO_TELEMETRY` / `DO_NOT_TRACK` make analytics calls no-ops, but the login itself still runs. Set `OPENSRE_SKIP_GITHUB_LOGIN=1` to bypass the login gate entirely (also auto-bypassed in CI — `CI=true`, `GITHUB_ACTIONS=true` — and in pytest).
 
 ### Kill-switch matrix
 

--- a/platform/analytics/cli.py
+++ b/platform/analytics/cli.py
@@ -819,7 +819,7 @@ def capture_github_login_abandoned(*, variant: str, reason: str) -> None:
 
 def capture_github_login_completed(username: str, *, variant: str | None = None) -> None:
     properties: Properties = {"github_username": username}
-    if variant:
+    if variant is not None:
         properties["github_gate_variant"] = variant
     _capture(Event.GITHUB_LOGIN_COMPLETED, properties)
 

--- a/platform/analytics/cli.py
+++ b/platform/analytics/cli.py
@@ -8,6 +8,7 @@ from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
+from hashlib import sha256
 from typing import TYPE_CHECKING, Final
 from uuid import uuid4
 
@@ -760,8 +761,67 @@ def identify_github_username(username: str) -> None:
         capture_exception(exc)
 
 
-def capture_github_login_completed(username: str) -> None:
-    _capture(Event.GITHUB_LOGIN_COMPLETED, {"github_username": username})
+GITHUB_GATE_EXPERIMENT: Final[str] = "github_gate_v1"
+GITHUB_GATE_VARIANT_CONTROL: Final[str] = "control"
+GITHUB_GATE_VARIANT_FORCED: Final[str] = "forced"
+_GITHUB_GATE_VARIANTS: Final[frozenset[str]] = frozenset(
+    {GITHUB_GATE_VARIANT_CONTROL, GITHUB_GATE_VARIANT_FORCED}
+)
+GITHUB_GATE_VARIANT_ENV: Final[str] = "OPENSRE_GITHUB_GATE_VARIANT"
+
+
+def assign_github_gate_variant(anonymous_id: str) -> str:
+    """Deterministically assign ``control`` (skip allowed) or ``forced`` (no skip).
+
+    Buckets on the install anonymous id so the variant is sticky without a
+    PostHog feature-flag round-trip. Override with ``OPENSRE_GITHUB_GATE_VARIANT``.
+    """
+    digest = sha256(f"{GITHUB_GATE_EXPERIMENT}:{anonymous_id}".encode()).hexdigest()
+    return (
+        GITHUB_GATE_VARIANT_FORCED if int(digest[:8], 16) % 2 == 0 else GITHUB_GATE_VARIANT_CONTROL
+    )
+
+
+def resolve_github_gate_variant() -> str:
+    """Resolve the GitHub login-gate experiment variant for this install."""
+    override = os.getenv(GITHUB_GATE_VARIANT_ENV, "").strip().lower()
+    if override in _GITHUB_GATE_VARIANTS:
+        return override
+    from platform.analytics.provider import get_anonymous_id
+
+    return assign_github_gate_variant(get_anonymous_id())
+
+
+def stamp_github_gate_variant(variant: str) -> None:
+    """Persist ``github_gate_variant`` on every subsequent analytics event."""
+    if variant not in _GITHUB_GATE_VARIANTS:
+        return
+    try:
+        get_analytics().set_persistent_property("github_gate_variant", variant)
+    except Exception as exc:
+        capture_exception(exc)
+
+
+def capture_github_login_prompted(*, variant: str) -> None:
+    _capture(Event.GITHUB_LOGIN_PROMPTED, {"github_gate_variant": variant})
+
+
+def capture_github_login_skipped(*, variant: str) -> None:
+    _capture(Event.GITHUB_LOGIN_SKIPPED, {"github_gate_variant": variant})
+
+
+def capture_github_login_abandoned(*, variant: str, reason: str) -> None:
+    _capture(
+        Event.GITHUB_LOGIN_ABANDONED,
+        {"github_gate_variant": variant, "reason": reason},
+    )
+
+
+def capture_github_login_completed(username: str, *, variant: str | None = None) -> None:
+    properties: Properties = {"github_username": username}
+    if variant:
+        properties["github_gate_variant"] = variant
+    _capture(Event.GITHUB_LOGIN_COMPLETED, properties)
 
 
 def capture_tests_picker_opened() -> None:

--- a/platform/analytics/events.py
+++ b/platform/analytics/events.py
@@ -13,7 +13,10 @@ class Event(StrEnum):
     USER_ID_LOAD_FAILED = "user_id_load_failed"
     SENTRY_INIT_SKIPPED = "sentry_init_skipped"
 
-    # GitHub first-launch login
+    # GitHub first-launch login (A/B: control allows skip, forced does not)
+    GITHUB_LOGIN_PROMPTED = "github_login_prompted"
+    GITHUB_LOGIN_SKIPPED = "github_login_skipped"
+    GITHUB_LOGIN_ABANDONED = "github_login_abandoned"
     GITHUB_LOGIN_COMPLETED = "github_login_completed"
 
     # Onboarding

--- a/platform/analytics/provider.py
+++ b/platform/analytics/provider.py
@@ -848,6 +848,16 @@ class Analytics:
 _instance: Analytics | None = None
 
 
+def get_anonymous_id() -> str:
+    """Return the stable install-scoped analytics distinct id.
+
+    Used for offline experiment bucketing (no PostHog ``/decide`` call) so
+    variants stay sticky per install without a blocking network round-trip at
+    startup.
+    """
+    return _get_or_create_anonymous_id()
+
+
 def get_analytics() -> Analytics:
     global _instance
     if _instance is None:

--- a/surfaces/interactive_shell/runtime/startup/first_launch_github.py
+++ b/surfaces/interactive_shell/runtime/startup/first_launch_github.py
@@ -1,10 +1,17 @@
 """First-launch GitHub login gate.
 
 On the first interactive launch of ``opensre`` (all platforms), the user is
-prompted to sign in to GitHub via device flow unless they skip, are in CI/CD, a
-test harness, or a non-interactive session. The sign-in runs the hosted GitHub
-MCP setup, persists the integration, and propagates the authenticated GitHub
-username to PostHog.
+prompted to sign in to GitHub via device flow unless they are in CI/CD, a test
+harness, or a non-interactive session.
+
+An offline A/B test splits installs into:
+
+* ``control`` — skip is allowed (menu choice + Escape during wait defer the gate)
+* ``forced`` — skip is removed; abandoning the gate aborts REPL startup
+
+Variant assignment is sticky per install anonymous id (see
+``platform.analytics.cli.resolve_github_gate_variant``). Override with
+``OPENSRE_GITHUB_GATE_VARIANT=control|forced`` for local testing.
 
 Escape hatch: ``OPENSRE_SKIP_GITHUB_LOGIN=1`` bypasses the gate so a GitHub
 outage or a disabled device flow can never permanently lock anyone out. The gate
@@ -22,7 +29,15 @@ from rich.console import Console
 from rich.markup import escape
 
 from config.repl_config import read_github_login_deferred, write_github_login_deferred
-from platform.analytics.cli import capture_github_login_completed
+from platform.analytics.cli import (
+    GITHUB_GATE_VARIANT_CONTROL,
+    capture_github_login_abandoned,
+    capture_github_login_completed,
+    capture_github_login_prompted,
+    capture_github_login_skipped,
+    resolve_github_gate_variant,
+    stamp_github_gate_variant,
+)
 from platform.analytics.source import is_test_run
 from platform.terminal.theme import DEVICE_CODE
 from surfaces.interactive_shell.ui import repl_tty_interactive
@@ -89,28 +104,34 @@ def clear_github_login_deferral() -> None:
     write_github_login_deferred(False)
 
 
-def _propagate_username(username: str) -> None:
+def _propagate_username(username: str, *, variant: str) -> None:
     if not username:
         return
     # ``authenticate_and_configure_github`` already calls identify_github_username;
     # only emit the one-time login lifecycle event here.
-    capture_github_login_completed(username)
+    capture_github_login_completed(username, variant=variant)
 
 
-def _print_intro(console: Console) -> None:
+def _print_intro(console: Console, *, allow_skip: bool) -> None:
     console.print()
     console.print("[bold]Connect GitHub to get started[/bold]")
     console.print(
         "OpenSRE needs read access to your GitHub repositories to investigate "
         "incidents against your source. Sign in once with your browser."
     )
-    console.print(
-        "[dim](Escape to skip for now, or set "
-        f"{_SKIP_ENV_VAR}=1 if GitHub sign-in is unavailable.)[/dim]"
-    )
+    if allow_skip:
+        console.print(
+            "[dim](Escape to skip for now, or set "
+            f"{_SKIP_ENV_VAR}=1 if GitHub sign-in is unavailable.)[/dim]"
+        )
+    else:
+        console.print(
+            "[dim](Sign-in is required to continue. Set "
+            f"{_SKIP_ENV_VAR}=1 only if GitHub sign-in is unavailable.)[/dim]"
+        )
 
 
-def _show_device_code(console: Console, code: object) -> None:
+def _show_device_code(console: Console, code: object, *, allow_skip: bool) -> None:
     from integrations.github.mcp_oauth import GitHubDeviceCode
 
     if not isinstance(code, GitHubDeviceCode):
@@ -122,9 +143,12 @@ def _show_device_code(console: Console, code: object) -> None:
     console.print(f"  2. Enter this one-time code when GitHub asks: [{DEVICE_CODE}]{user_code}[/]")
     console.print("  3. Approve the request for OpenSRE.")
     console.print()
-    console.print(
-        "  [dim]Waiting for you to approve in the browser… (Escape or Ctrl-C to skip)[/dim]"
-    )
+    if allow_skip:
+        console.print(
+            "  [dim]Waiting for you to approve in the browser… (Escape or Ctrl-C to skip)[/dim]"
+        )
+    else:
+        console.print("  [dim]Waiting for you to approve in the browser…[/dim]")
 
 
 def _print_skip_guidance(console: Console) -> None:
@@ -132,6 +156,15 @@ def _print_skip_guidance(console: Console) -> None:
     console.print(
         "[dim]Skipped GitHub sign-in. Connect later with "
         "[bold]/integrations setup[/bold] or [bold]/mcp connect github[/bold].[/dim]"
+    )
+
+
+def _print_forced_abort_guidance(console: Console) -> None:
+    console.print()
+    console.print(
+        "GitHub sign-in is required to continue. "
+        f"Set [bold]{_SKIP_ENV_VAR}=1[/bold] only if sign-in is unavailable, "
+        "then relaunch [bold]opensre[/bold]."
     )
 
 
@@ -181,8 +214,15 @@ def _sleep_until_or_cancel(seconds: float) -> None:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_attrs)  # type: ignore[attr-defined]
 
 
-def _offer_github_login(_console: Console) -> bool:
-    """Return True when the user wants to start browser sign-in."""
+def _offer_github_login(_console: Console, *, allow_skip: bool) -> bool:
+    """Return True when the user wants to start browser sign-in.
+
+    When ``allow_skip`` is False (forced variant), there is no skip choice — the
+    gate proceeds straight into device-flow sign-in.
+    """
+    if not allow_skip:
+        return True
+
     import questionary
 
     try:
@@ -216,18 +256,21 @@ def _ask_retry(_console: Console) -> bool:
     return bool(answer)
 
 
-def _attempt_login(console: Console) -> str:
+def _attempt_login(console: Console, *, allow_skip: bool, variant: str) -> str:
     """Run one login attempt. Returns ``"success"``, ``"failed"``, or ``"skipped"``."""
     from integrations.github.login import authenticate_and_configure_github
     from integrations.github.mcp_oauth import GitHubDeviceFlowError
 
     try:
         result = authenticate_and_configure_github(
-            on_prompt=lambda code: _show_device_code(console, code),
+            on_prompt=lambda code: _show_device_code(console, code, allow_skip=allow_skip),
             poll_sleep=_sleep_until_or_cancel,
         )
     except (EOFError, KeyboardInterrupt):
-        console.print("\nSkipped GitHub sign-in.")
+        if allow_skip:
+            console.print("\nSkipped GitHub sign-in.")
+        else:
+            console.print("\nGitHub sign-in cancelled.")
         return "skipped"
     except GitHubDeviceFlowError as err:
         console.print(f"[yellow]GitHub sign-in is unavailable:[/yellow] {err}")
@@ -241,7 +284,7 @@ def _attempt_login(console: Console) -> str:
         # Persisting the GitHub integration (done inside
         # ``authenticate_and_configure_github``) is what suppresses the gate on
         # subsequent launches — there is no separate completion marker to write.
-        _propagate_username(result.username)
+        _propagate_username(result.username, variant=variant)
         who = f"@{result.username}" if result.username else "your GitHub account"
         console.print(f"[bold]Connected.[/bold] Signed in as {who}.")
         return "success"
@@ -253,28 +296,49 @@ def _attempt_login(console: Console) -> str:
 def require_github_login_on_first_launch(console: Console | None = None) -> bool:
     """Run the first-launch GitHub login prompt.
 
-    Returns True when the caller should proceed into the REPL (login succeeded or
-    the user skipped), and False only when startup must abort.
+    Returns True when the caller should proceed into the REPL (login succeeded, or
+    the user skipped in the ``control`` variant), and False when startup must abort
+    (forced-variant abandonment / decline).
     """
     con = console or Console(highlight=False)
-    _print_intro(con)
-    if not _offer_github_login(con):
+    variant = resolve_github_gate_variant()
+    stamp_github_gate_variant(variant)
+    allow_skip = variant == GITHUB_GATE_VARIANT_CONTROL
+    capture_github_login_prompted(variant=variant)
+    _print_intro(con, allow_skip=allow_skip)
+
+    if allow_skip and not _offer_github_login(con, allow_skip=True):
+        capture_github_login_skipped(variant=variant)
         _defer_github_login()
         _print_skip_guidance(con)
         return True
 
+    if not allow_skip:
+        # Forced: no menu — go straight into device flow.
+        _offer_github_login(con, allow_skip=False)
+
     while True:
-        outcome = _attempt_login(con)
+        outcome = _attempt_login(con, allow_skip=allow_skip, variant=variant)
         if outcome == "success":
             return True
         if outcome == "skipped":
-            _defer_github_login()
-            _print_skip_guidance(con)
-            return True
+            if allow_skip:
+                capture_github_login_skipped(variant=variant)
+                _defer_github_login()
+                _print_skip_guidance(con)
+                return True
+            capture_github_login_abandoned(variant=variant, reason="cancelled")
+            _print_forced_abort_guidance(con)
+            return False
         if not _ask_retry(con):
-            _defer_github_login()
-            _print_skip_guidance(con)
-            return True
+            if allow_skip:
+                capture_github_login_skipped(variant=variant)
+                _defer_github_login()
+                _print_skip_guidance(con)
+                return True
+            capture_github_login_abandoned(variant=variant, reason="declined_retry")
+            _print_forced_abort_guidance(con)
+            return False
 
 
 def require_startup_github_login(console: Console) -> bool:

--- a/surfaces/interactive_shell/runtime/startup/first_launch_github.py
+++ b/surfaces/interactive_shell/runtime/startup/first_launch_github.py
@@ -46,6 +46,9 @@ _SKIP_ENV_VAR = "OPENSRE_SKIP_GITHUB_LOGIN"
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
 _SIGN_IN_CHOICE = "sign_in"
 _SKIP_CHOICE = "skip"
+_RETRY_CHOICE = "retry"
+_DECLINE_RETRY_CHOICE = "declined_retry"
+_CANCEL_RETRY_CHOICE = "cancelled"
 
 
 def _skip_requested() -> bool:
@@ -244,16 +247,16 @@ def _offer_github_login(_console: Console, *, allow_skip: bool) -> bool:
     return bool(choice == _SIGN_IN_CHOICE)
 
 
-def _ask_retry(_console: Console) -> bool:
+def _ask_retry(_console: Console) -> str:
     import questionary
 
     try:
         answer = questionary.confirm("Try GitHub sign-in again?", default=True).ask()
     except (EOFError, KeyboardInterrupt):
-        return False
+        return _CANCEL_RETRY_CHOICE
     if answer is None:
-        return False
-    return bool(answer)
+        return _CANCEL_RETRY_CHOICE
+    return _RETRY_CHOICE if answer else _DECLINE_RETRY_CHOICE
 
 
 def _attempt_login(console: Console, *, allow_skip: bool, variant: str) -> str:
@@ -313,10 +316,6 @@ def require_github_login_on_first_launch(console: Console | None = None) -> bool
         _print_skip_guidance(con)
         return True
 
-    if not allow_skip:
-        # Forced: no menu — go straight into device flow.
-        _offer_github_login(con, allow_skip=False)
-
     while True:
         outcome = _attempt_login(con, allow_skip=allow_skip, variant=variant)
         if outcome == "success":
@@ -330,13 +329,14 @@ def require_github_login_on_first_launch(console: Console | None = None) -> bool
             capture_github_login_abandoned(variant=variant, reason="cancelled")
             _print_forced_abort_guidance(con)
             return False
-        if not _ask_retry(con):
+        retry_decision = _ask_retry(con)
+        if retry_decision != _RETRY_CHOICE:
             if allow_skip:
                 capture_github_login_skipped(variant=variant)
                 _defer_github_login()
                 _print_skip_guidance(con)
                 return True
-            capture_github_login_abandoned(variant=variant, reason="declined_retry")
+            capture_github_login_abandoned(variant=variant, reason=retry_decision)
             _print_forced_abort_guidance(con)
             return False
 

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -142,11 +142,55 @@ def test_capture_github_login_completed(monkeypatch: pytest.MonkeyPatch) -> None
     stub = _StubAnalytics()
     monkeypatch.setattr(cli, "get_analytics", lambda: stub)
 
-    cli.capture_github_login_completed("octocat")
+    cli.capture_github_login_completed("octocat", variant="forced")
 
     assert stub.events == [
-        (Event.GITHUB_LOGIN_COMPLETED, {"github_username": "octocat"}),
+        (
+            Event.GITHUB_LOGIN_COMPLETED,
+            {"github_username": "octocat", "github_gate_variant": "forced"},
+        ),
     ]
+
+
+def test_assign_github_gate_variant_is_deterministic() -> None:
+    a = cli.assign_github_gate_variant("11111111-2222-3333-4444-555555555555")
+    b = cli.assign_github_gate_variant("11111111-2222-3333-4444-555555555555")
+    c = cli.assign_github_gate_variant("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+    assert a == b
+    assert a in {cli.GITHUB_GATE_VARIANT_CONTROL, cli.GITHUB_GATE_VARIANT_FORCED}
+    # Different ids should usually split; assert both variants exist across a sample.
+    variants = {
+        cli.assign_github_gate_variant(f"00000000-0000-0000-0000-{i:012d}") for i in range(40)
+    }
+    assert variants == {cli.GITHUB_GATE_VARIANT_CONTROL, cli.GITHUB_GATE_VARIANT_FORCED}
+    assert c in variants
+
+
+def test_resolve_github_gate_variant_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "forced")
+    assert cli.resolve_github_gate_variant() == "forced"
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
+    assert cli.resolve_github_gate_variant() == "control"
+
+
+def test_capture_github_login_lifecycle_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubAnalytics()
+    monkeypatch.setattr(cli, "get_analytics", lambda: stub)
+
+    cli.capture_github_login_prompted(variant="control")
+    cli.capture_github_login_skipped(variant="control")
+    cli.capture_github_login_abandoned(variant="forced", reason="cancelled")
+    cli.stamp_github_gate_variant("forced")
+
+    assert stub.events == [
+        (Event.GITHUB_LOGIN_PROMPTED, {"github_gate_variant": "control"}),
+        (Event.GITHUB_LOGIN_SKIPPED, {"github_gate_variant": "control"}),
+        (
+            Event.GITHUB_LOGIN_ABANDONED,
+            {"github_gate_variant": "forced", "reason": "cancelled"},
+        ),
+    ]
+    assert stub.persistent_properties == {"github_gate_variant": "forced"}
 
 
 def test_build_cli_invoked_properties_includes_full_command_path() -> None:

--- a/tests/interactive_shell/runtime/test_first_launch_github.py
+++ b/tests/interactive_shell/runtime/test_first_launch_github.py
@@ -225,7 +225,7 @@ def test_orchestrator_failure_then_decline_retry_skips_in_control(
         "authenticate_and_configure_github",
         lambda **_kwargs: GitHubLoginResult(ok=False, detail="cannot verify"),
     )
-    monkeypatch.setattr(flg, "_ask_retry", lambda _console: False)
+    monkeypatch.setattr(flg, "_ask_retry", lambda _console: "declined_retry")
     deferred: list[bool] = []
     monkeypatch.setattr(flg, "write_github_login_deferred", deferred.append)
     monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
@@ -272,7 +272,7 @@ def test_orchestrator_forced_decline_retry_aborts_startup(
         "authenticate_and_configure_github",
         lambda **_kwargs: GitHubLoginResult(ok=False, detail="cannot verify"),
     )
-    monkeypatch.setattr(flg, "_ask_retry", lambda _console: False)
+    monkeypatch.setattr(flg, "_ask_retry", lambda _console: "declined_retry")
     abandoned: list[tuple[str, str]] = []
     deferred: list[bool] = []
     monkeypatch.setattr(flg, "write_github_login_deferred", deferred.append)
@@ -289,6 +289,31 @@ def test_orchestrator_forced_decline_retry_aborts_startup(
     assert proceed is False
     assert deferred == []
     assert abandoned == [("forced", "declined_retry")]
+
+
+def test_orchestrator_forced_cancel_retry_aborts_startup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "forced")
+    monkeypatch.setattr(
+        github_login_mod,
+        "authenticate_and_configure_github",
+        lambda **_kwargs: GitHubLoginResult(ok=False, detail="cannot verify"),
+    )
+    monkeypatch.setattr(flg, "_ask_retry", lambda _console: "cancelled")
+    abandoned: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_abandoned",
+        lambda *, variant, reason: abandoned.append((variant, reason)),
+    )
+    monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
+    monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
+
+    proceed = flg.require_github_login_on_first_launch(_console())
+
+    assert proceed is False
+    assert abandoned == [("forced", "cancelled")]
 
 
 def test_orchestrator_forced_success_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -326,7 +351,7 @@ def test_orchestrator_retries_until_success(monkeypatch: pytest.MonkeyPatch) -> 
         return GitHubLoginResult(ok=True, username="octocat", detail="OK")
 
     monkeypatch.setattr(github_login_mod, "authenticate_and_configure_github", _login)
-    monkeypatch.setattr(flg, "_ask_retry", lambda _console: True)
+    monkeypatch.setattr(flg, "_ask_retry", lambda _console: "retry")
     monkeypatch.setattr(flg, "capture_github_login_completed", lambda _username, **_kwargs: None)
     monkeypatch.setattr(flg, "clear_github_login_deferral", lambda: None)
     monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)

--- a/tests/interactive_shell/runtime/test_first_launch_github.py
+++ b/tests/interactive_shell/runtime/test_first_launch_github.py
@@ -140,44 +140,64 @@ def test_device_code_prompt_highlights_user_code(monkeypatch: pytest.MonkeyPatch
         interval=5,
     )
 
-    flg._show_device_code(_terminal_console(output), code)
+    flg._show_device_code(_terminal_console(output), code, allow_skip=True)
 
     rendered = output.getvalue()
     assert f"{ui_theme.DEVICE_CODE_ANSI}WXYZ-1234" in rendered
 
 
 def test_orchestrator_success_proceeds_and_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(flg, "_offer_github_login", lambda _console: True)
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: True)
     monkeypatch.setattr(
         github_login_mod,
         "authenticate_and_configure_github",
         lambda **_kwargs: GitHubLoginResult(ok=True, username="octocat", detail="OK"),
     )
-    completed: list[str] = []
-    monkeypatch.setattr(flg, "capture_github_login_completed", completed.append)
+    completed: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_completed",
+        lambda username, *, variant=None: completed.append((username, variant)),
+    )
     cleared: list[bool] = []
     monkeypatch.setattr(flg, "clear_github_login_deferral", lambda: cleared.append(True))
+    monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
+    monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
 
     proceed = flg.require_github_login_on_first_launch(_console())
 
     assert proceed is True
-    assert completed == ["octocat"]
+    assert completed == [("octocat", "control")]
     assert cleared == [True]
 
 
-def test_orchestrator_skip_at_menu_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(flg, "_offer_github_login", lambda _console: False)
+def test_orchestrator_skip_at_menu_proceeds_in_control(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: False)
     deferred: list[bool] = []
+    skipped: list[str] = []
     monkeypatch.setattr(flg, "write_github_login_deferred", deferred.append)
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_skipped",
+        lambda *, variant: skipped.append(variant),
+    )
+    monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
+    monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
 
     proceed = flg.require_github_login_on_first_launch(_console())
 
     assert proceed is True
     assert deferred == [True]
+    assert skipped == ["control"]
 
 
-def test_orchestrator_escape_during_wait_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(flg, "_offer_github_login", lambda _console: True)
+def test_orchestrator_escape_during_wait_proceeds_in_control(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: True)
 
     def _raise_cancel(**_kwargs: object) -> GitHubLoginResult:
         raise KeyboardInterrupt
@@ -185,6 +205,9 @@ def test_orchestrator_escape_during_wait_proceeds(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(github_login_mod, "authenticate_and_configure_github", _raise_cancel)
     deferred: list[bool] = []
     monkeypatch.setattr(flg, "write_github_login_deferred", deferred.append)
+    monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
+    monkeypatch.setattr(flg, "capture_github_login_skipped", lambda **_kwargs: None)
+    monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
 
     proceed = flg.require_github_login_on_first_launch(_console())
 
@@ -192,8 +215,11 @@ def test_orchestrator_escape_during_wait_proceeds(monkeypatch: pytest.MonkeyPatc
     assert deferred == [True]
 
 
-def test_orchestrator_failure_then_decline_retry_skips(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(flg, "_offer_github_login", lambda _console: True)
+def test_orchestrator_failure_then_decline_retry_skips_in_control(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: True)
     monkeypatch.setattr(
         github_login_mod,
         "authenticate_and_configure_github",
@@ -202,6 +228,9 @@ def test_orchestrator_failure_then_decline_retry_skips(monkeypatch: pytest.Monke
     monkeypatch.setattr(flg, "_ask_retry", lambda _console: False)
     deferred: list[bool] = []
     monkeypatch.setattr(flg, "write_github_login_deferred", deferred.append)
+    monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
+    monkeypatch.setattr(flg, "capture_github_login_skipped", lambda **_kwargs: None)
+    monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
 
     proceed = flg.require_github_login_on_first_launch(_console())
 
@@ -209,8 +238,85 @@ def test_orchestrator_failure_then_decline_retry_skips(monkeypatch: pytest.Monke
     assert deferred == [True]
 
 
+def test_orchestrator_forced_cancel_aborts_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "forced")
+
+    def _raise_cancel(**_kwargs: object) -> GitHubLoginResult:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(github_login_mod, "authenticate_and_configure_github", _raise_cancel)
+    abandoned: list[tuple[str, str]] = []
+    deferred: list[bool] = []
+    monkeypatch.setattr(flg, "write_github_login_deferred", deferred.append)
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_abandoned",
+        lambda *, variant, reason: abandoned.append((variant, reason)),
+    )
+    monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
+    monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
+
+    proceed = flg.require_github_login_on_first_launch(_console())
+
+    assert proceed is False
+    assert deferred == []
+    assert abandoned == [("forced", "cancelled")]
+
+
+def test_orchestrator_forced_decline_retry_aborts_startup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "forced")
+    monkeypatch.setattr(
+        github_login_mod,
+        "authenticate_and_configure_github",
+        lambda **_kwargs: GitHubLoginResult(ok=False, detail="cannot verify"),
+    )
+    monkeypatch.setattr(flg, "_ask_retry", lambda _console: False)
+    abandoned: list[tuple[str, str]] = []
+    deferred: list[bool] = []
+    monkeypatch.setattr(flg, "write_github_login_deferred", deferred.append)
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_abandoned",
+        lambda *, variant, reason: abandoned.append((variant, reason)),
+    )
+    monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
+    monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
+
+    proceed = flg.require_github_login_on_first_launch(_console())
+
+    assert proceed is False
+    assert deferred == []
+    assert abandoned == [("forced", "declined_retry")]
+
+
+def test_orchestrator_forced_success_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "forced")
+    monkeypatch.setattr(
+        github_login_mod,
+        "authenticate_and_configure_github",
+        lambda **_kwargs: GitHubLoginResult(ok=True, username="octocat", detail="OK"),
+    )
+    completed: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_completed",
+        lambda username, *, variant=None: completed.append((username, variant)),
+    )
+    monkeypatch.setattr(flg, "clear_github_login_deferral", lambda: None)
+    monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
+    monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
+
+    proceed = flg.require_github_login_on_first_launch(_console())
+
+    assert proceed is True
+    assert completed == [("octocat", "forced")]
+
+
 def test_orchestrator_retries_until_success(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(flg, "_offer_github_login", lambda _console: True)
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: True)
     calls = {"n": 0}
 
     def _login(**_kwargs: object) -> GitHubLoginResult:
@@ -221,8 +327,10 @@ def test_orchestrator_retries_until_success(monkeypatch: pytest.MonkeyPatch) -> 
 
     monkeypatch.setattr(github_login_mod, "authenticate_and_configure_github", _login)
     monkeypatch.setattr(flg, "_ask_retry", lambda _console: True)
-    monkeypatch.setattr(flg, "capture_github_login_completed", lambda _username: None)
+    monkeypatch.setattr(flg, "capture_github_login_completed", lambda _username, **_kwargs: None)
     monkeypatch.setattr(flg, "clear_github_login_deferral", lambda: None)
+    monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
+    monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
 
     proceed = flg.require_github_login_on_first_launch(_console())
 


### PR DESCRIPTION
Fixes #4120

#### Describe the changes you have made in this PR -

Adds an offline A/B test on the first-launch GitHub sign-in gate:

- **`control`** — current UX with Skip for now / Escape deferral into the REPL
- **`forced`** — no skip; cancelling or declining retry aborts startup

Sticky bucketing uses the install `anonymous_id` (override with `OPENSRE_GITHUB_GATE_VARIANT`). New PostHog events (`github_login_prompted`, `github_login_skipped`, `github_login_abandoned`) plus `github_gate_variant` on completed + as a persistent property so cohorts are filterable in PostHog. Safety bypasses (`OPENSRE_SKIP_GITHUB_LOGIN`, CI/test/non-TTY) are unchanged.

### Demo/Screenshot for feature changes and bug fixes -

```bash
# Control: skip still available
OPENSRE_GITHUB_GATE_VARIANT=control opensre

# Forced: no skip; cancel aborts REPL
OPENSRE_GITHUB_GATE_VARIANT=forced opensre
```

Unit coverage: `tests/interactive_shell/runtime/test_first_launch_github.py`, `tests/analytics/test_cli.py` (52 passed locally).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

We need to measure whether removing voluntary skip increases GitHub connect rate more than it hurts activation. PostHog capture here has no `/decide` feature-flag path, so the experiment buckets offline on `anonymous_id` and stamps `github_gate_variant` on events. Control keeps deferral; forced returns `False` from the gate on abandon so `main.run_repl` exits. Instrumentation fires `github_login_prompted` at exposure and outcome events for skip/abandon/complete.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

## Test plan
- [x] `OPENSRE_GITHUB_GATE_VARIANT=control` shows Skip and Escape defers into REPL
- [x] `OPENSRE_GITHUB_GATE_VARIANT=forced` has no Skip; Ctrl-C / decline retry exits without REPL
- [x] Successful login in both variants emits `github_login_completed` with `github_gate_variant`
- [ ] PostHog: filter/break down by `properties.github_gate_variant`
- [x] `OPENSRE_SKIP_GITHUB_LOGIN=1` still bypasses the gate
- [x] `uv run python -m pytest tests/interactive_shell/runtime/test_first_launch_github.py tests/analytics/test_cli.py -q`

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.