### PR TITLE
fix(release): sync Homebrew tap when release tag already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -575,7 +575,6 @@ jobs:
             -d "$payload" "$DISCORD_WEBHOOK_URL_UPDATE"
 
       - name: Sync Homebrew tap formula
-        if: steps.github_release.outputs.created == 'true'
         continue-on-error: true
         env:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Run **Sync Homebrew tap formula** on every stable `publish-release` job, not only when `Create GitHub release` creates a new tag.
- Fixes [#4124](https://github.com/Tracer-Cloud/opensre/issues/4124) case where a green release re-run skipped the tap because `v0.1.YYYY.M.D` already existed.

## Test plan
- [x] Triggered Release workflow on this branch (release channel): https://github.com/Tracer-Cloud/opensre/actions/runs/29601852415
- [ ] Confirm **Sync Homebrew tap formula** runs (not skipped) when the GitHub release already exists
- [ ] Confirm `Tracer-Cloud/homebrew-tap` shows updated formula or “already up to date” in logs

## AI usage
- PR prepared with AI assistance (Cursor); change is a one-line workflow gate removal validated against Actions run logs for run 29600968880.