### PR TITLE
fix(telegram): redact bot token from verifier and wizard validator errors

### DIFF
--- a/docs/messaging/telegram.mdx
+++ b/docs/messaging/telegram.mdx
@@ -527,11 +527,7 @@ See [Hermes](/hermes) for log tailing and incident classification setup.
 
 **`Telegram API check failed: 401 Client Error: Unauthorized for url: …`**
 
-The bot token is invalid or has been revoked. Generate a new one in BotFather (`/mybots → your bot → API Token → Revoke current token`) and update `.env`.
-
-<Warning>
-The verifier currently does not redact secrets from this error: the `for url:` portion of the message includes the bot token (Telegram's API endpoint embeds the token in the path). Redact the token before sharing this error in bug reports or chat. The verifier-side redaction fix is tracked separately from the wizard work — file a new issue if one does not yet exist.
-</Warning>
+The bot token is invalid or has been revoked. Generate a new one in BotFather (`/mybots → your bot → API Token → Revoke current token`) and update `.env`. The `for url:` portion of the message shows the token as `<redacted>` — Telegram's API endpoint embeds the token in the path, so the verifier scrubs it before surfacing the error.
 
 ### Errors that only surface during delivery
 

--- a/integrations/telegram/verifier.py
+++ b/integrations/telegram/verifier.py
@@ -7,6 +7,7 @@ from typing import Any
 import requests
 
 from integrations.verification import register_verifier, result
+from platform.notifications.redaction import redact_token
 
 
 @register_verifier("telegram")
@@ -20,7 +21,12 @@ def verify_telegram(source: str, config: dict[str, Any]) -> dict[str, str]:
         response.raise_for_status()
         payload = response.json()
     except Exception as exc:
-        return result("telegram", source, "failed", f"Telegram API check failed: {exc}")
+        # requests embeds the full URL — which contains the bot token — in
+        # HTTPError/ConnectionError messages (e.g. "401 ... for url:
+        # https://api.telegram.org/bot<token>/getMe"), so the token must be
+        # redacted before the detail reaches the verify output.
+        safe_error = redact_token(str(exc), bot_token)
+        return result("telegram", source, "failed", f"Telegram API check failed: {safe_error}")
 
     if not payload.get("ok"):
         return result(

--- a/surfaces/cli/wizard/integration_validators/http_probe_validators.py
+++ b/surfaces/cli/wizard/integration_validators/http_probe_validators.py
@@ -6,6 +6,7 @@ import httpx
 
 from integrations.config_models import SlackWebhookConfig
 from platform.common.url_validation import validate_https_or_loopback_http_url
+from platform.notifications.redaction import redact_token
 
 from .shared import IntegrationHealthResult
 
@@ -261,16 +262,21 @@ def validate_telegram_bot(*, bot_token: str) -> IntegrationHealthResult:
     try:
         resp = httpx.get(f"https://api.telegram.org/bot{token}/getMe", timeout=10)
     except httpx.RequestError as err:
-        return IntegrationHealthResult(ok=False, detail=f"Telegram API unreachable: {err}")
+        # httpx embeds the request URL — which contains the bot token — in
+        # transport error messages, so redact before surfacing the detail.
+        safe_error = redact_token(str(err), token)
+        return IntegrationHealthResult(ok=False, detail=f"Telegram API unreachable: {safe_error}")
     except Exception as err:
-        return IntegrationHealthResult(ok=False, detail=f"Telegram API check failed: {err}")
+        safe_error = redact_token(str(err), token)
+        return IntegrationHealthResult(ok=False, detail=f"Telegram API check failed: {safe_error}")
 
     try:
         payload = resp.json()
     except Exception as err:
+        safe_error = redact_token(str(err), token)
         return IntegrationHealthResult(
             ok=False,
-            detail=f"Telegram API check failed: HTTP {resp.status_code} ({err}).",
+            detail=f"Telegram API check failed: HTTP {resp.status_code} ({safe_error}).",
         )
 
     if not payload.get("ok"):

--- a/tests/cli/wizard/test_integration_health.py
+++ b/tests/cli/wizard/test_integration_health.py
@@ -703,6 +703,28 @@ def test_validate_telegram_bot_network_error(monkeypatch: pytest.MonkeyPatch) ->
     assert "unreachable" in result.detail.lower()
 
 
+def test_validate_telegram_bot_network_error_redacts_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """httpx embeds the request URL — which carries the bot token — in
+    transport error messages; the validator must redact it (CWE-209)."""
+    import httpx as _httpx
+
+    token = "123456:SECRET-TOKEN-ABC"
+
+    def _raise(*_a: object, **_kw: object) -> None:
+        raise _httpx.ConnectError(
+            f"[Errno 8] nodename nor servname provided for "
+            f"https://api.telegram.org/bot{token}/getMe"
+        )
+
+    monkeypatch.setattr("httpx.get", _raise)
+    result = validate_telegram_bot(bot_token=token)
+    assert result.ok is False
+    assert token not in result.detail
+    assert "<redacted>" in result.detail
+
+
 def test_validate_betterstack_integration_succeeds(monkeypatch) -> None:
     monkeypatch.setattr(
         "surfaces.cli.wizard.integration_validators.alerting.validate_betterstack_config",

--- a/tests/integrations/test_verify.py
+++ b/tests/integrations/test_verify.py
@@ -228,6 +228,24 @@ def test_verify_telegram_api_not_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "unauthorized" in result["detail"].lower()
 
 
+def test_verify_telegram_exception_redacts_bot_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """requests embeds the getMe URL — which carries the bot token — in
+    HTTPError messages; the verifier must redact it before surfacing the
+    detail (CWE-209)."""
+    token = "123456:SECRET-TOKEN-ABC"
+
+    def _raise(*_a: Any, **_kw: Any) -> None:
+        raise Exception(
+            f"401 Client Error: Unauthorized for url: https://api.telegram.org/bot{token}/getMe"
+        )
+
+    monkeypatch.setattr("integrations.telegram.verifier.requests.get", _raise)
+    result = _verify_telegram("local store", {"bot_token": token})
+    assert result["status"] == "failed"
+    assert token not in result["detail"]
+    assert "<redacted>" in result["detail"]
+
+
 def test_verify_slack_send_test_posts_to_webhook(monkeypatch: pytest.MonkeyPatch) -> None:
     """End-to-end: ``verify_integrations("slack", send_slack_test=True)`` must
     actually deliver the test message through the verifier's HTTP path.


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

Telegram's Bot API embeds the token in the request URL (`api.telegram.org/bot<token>/getMe`), so `requests`/`httpx` exception messages include the full token in the output of `opensre integrations verify telegram` and in the onboarding wizard's live validation (CWE-209 — information exposure through an exception, one of the footguns called out in AGENTS.md). Anyone pasting verify output into a bug report or chat would leak their credential. The Telegram docs page even carried a warning about this and asked for the fix to be filed.

Changes:
- `integrations/telegram/verifier.py` — redact the token from the exception message with the existing `platform.notifications.redaction.redact_token` helper (the same one the Telegram/Discord delivery paths already use) before it reaches the verify detail.
- `surfaces/cli/wizard/integration_validators/http_probe_validators.py` — same redaction on the three error paths of `validate_telegram_bot`.
- Regression tests in `tests/integrations/test_verify.py` and `tests/cli/wizard/test_integration_health.py` asserting the token never appears in the surfaced detail and `<redacted>` does.
- `docs/messaging/telegram.mdx` — remove the now-obsolete warning that documented the leak.

No behavior change besides the message content: status/flow are identical.

**Testing** — `make lint`, `make format-check`, `make typecheck` pass; affected suites (`tests/integrations/test_verify.py`, `tests/cli/wizard/test_integration_health.py`) pass (82 tests). Reproduced live against the real Telegram API with a fake token (screenshot below).

### Demo/Screenshot for feature changes and bug fixes -

Before (main) vs after (this branch), same command with a fake token:

<img width="1544" height="778" alt="CleanShot 2026-07-17 at 22 40 40@2x" src="https://github.com/user-attachments/assets/36f8f12e-b10c-405c-975b-d368efc58442" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Unlike Discord or Rocket.Chat (token in headers), Telegram authenticates via the URL path, so any HTTP-library exception that embeds the request URL leaks the credential. Both leak sites already know the token (it is their input), so the minimal safe fix is redacting the exact token substring from `str(exc)` with the shared `redact_token` helper right before formatting the user-facing message — no new abstractions, same pattern the delivery modules already follow. I considered regex-based scrubbing (like `_BOT_TOKEN_RE` in `integrations/telegram/delivery.py`) but exact-substring redaction is sufficient and simpler when the token is in hand; the regex exists for log records where it is not.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions