### PR TITLE
feat(shell): add Rocket.Chat background RCA notification channel

### DIFF
--- a/docs/background-investigations.mdx
+++ b/docs/background-investigations.mdx
@@ -11,7 +11,7 @@ When background mode is enabled:
 - new investigations run asynchronously
 - the shell stays free for more questions and follow-ups
 - completed RCAs are tracked in-session
-- completion notifications can be sent to email (via the [`smtp`](/smtp) integration), Telegram (via the [`telegram`](/messaging/telegram) integration), or both
+- completion notifications can be sent to email (via the [`smtp`](/smtp) integration), Telegram (via the [`telegram`](/messaging/telegram) integration), Rocket.Chat (via the [`rocketchat`](/messaging/rocketchat) integration), or any combination
 
 <Note>
 This first version is **session-local only**. If the REPL process exits,
@@ -31,7 +31,7 @@ in-flight background jobs stop with it.
 | `/background show <task_id>` | Show the RCA summary and the per-channel notification result for one job |
 | `/background use <task_id>` | Promote a completed job into the active follow-up context |
 | `/background notify list` | Show the channels a completed RCA is delivered to (default: **none**) |
-| `/background notify set <channel[,channel...]>` | Set completion channels — `email`, `telegram`, or `email,telegram` |
+| `/background notify set <channel[,channel...]>` | Set completion channels — `email`, `telegram`, `rocketchat`, or a comma-separated combination |
 
 ---
 
@@ -48,7 +48,7 @@ in-flight background jobs stop with it.
    notification is sent:**
 
 ```text
-/background notify set telegram    # or: email, or email,telegram
+/background notify set telegram    # or: email, rocketchat, or email,telegram
 /background notify list           # confirm
 ```
 
@@ -89,9 +89,10 @@ Notifications are **off by default** — pick your channels with `/background no
 | --- | --- | --- |
 | `email` | [`smtp`](/smtp) integration | `opensre integrations setup smtp` |
 | `telegram` | [`telegram`](/messaging/telegram) integration | `opensre integrations setup telegram` |
+| `rocketchat` | [`rocketchat`](/messaging/rocketchat) integration | `opensre integrations setup rocketchat` |
 
-Both channels send the same summary — **Root cause**, **Top analysis**, **What to do next**, plus a
-short internal stats section. Telegram messages are plain text and are capped at Telegram's 4,096-character
+All channels send the same summary — **Root cause**, **Top analysis**, **What to do next**, plus a
+short internal stats section. Telegram and Rocket.Chat messages are plain text and are capped at the 4,096-character
 limit.
 
 Check what was actually delivered with `/background show <task_id>`: the `notify` row shows one

--- a/docs/messaging/rocketchat.mdx
+++ b/docs/messaging/rocketchat.mdx
@@ -156,6 +156,24 @@ Findings should appear in the configured channel as a message with an attachment
 
 ---
 
+## Background RCA completion notifications
+
+When the interactive shell runs investigations in background mode, Rocket.Chat can deliver the RCA summary as soon as a job finishes. Configure the integration first, then in the shell:
+
+```text
+/background on
+/background notify set rocketchat          # or: email,rocketchat
+/investigate datadog
+```
+
+On completion the summary — root cause, top analysis, next steps, and a short stats block — is posted as plain text, capped at 4,096 characters. Token mode posts to the configured `default_channel`; webhook-only setups deliver to the webhook's fixed destination.
+
+Confirm delivery with `/background show <task_id>`: the `notify` row reads `rocketchat:sent`, `rocketchat:failed: <error>`, or `rocketchat:missing rocketchat integration: …` when neither token credentials (with a default channel) nor a webhook is configured. A notification problem never fails the investigation itself.
+
+See [Background investigations](/background-investigations) for the full command set.
+
+---
+
 ## Troubleshooting
 
 `/integrations verify rocketchat` only calls `/api/v1/me`, so it surfaces credential errors but cannot detect channel-routing problems. Delivery-time errors only show up when an investigation actually posts; they appear in OpenSRE logs as `[rocketchat] post message failed: <error>`.

--- a/surfaces/interactive_shell/command_registry/background_cmds.py
+++ b/surfaces/interactive_shell/command_registry/background_cmds.py
@@ -16,7 +16,7 @@ from surfaces.interactive_shell.ui import (
     repl_table,
 )
 
-_ALLOWED_NOTIFY_CHANNELS = ("email", "telegram")
+_ALLOWED_NOTIFY_CHANNELS = ("email", "telegram", "rocketchat")
 _BACKGROUND_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("on", "enable background investigation mode"),
     ("off", "disable background investigation mode"),

--- a/surfaces/interactive_shell/runtime/background/notifications.py
+++ b/surfaces/interactive_shell/runtime/background/notifications.py
@@ -34,6 +34,15 @@ def deliver_background_notifications(
             results["telegram"] = deliver_telegram_notification(record)
             continue
 
+        if channel == "rocketchat":
+            # Imported lazily for the same reason as the telegram channel.
+            from surfaces.interactive_shell.runtime.background.rocketchat_channel import (
+                deliver_rocketchat_notification,
+            )
+
+            results["rocketchat"] = deliver_rocketchat_notification(record)
+            continue
+
         if channel != "email":
             results[channel] = "unsupported"
             continue

--- a/surfaces/interactive_shell/runtime/background/rca_summary.py
+++ b/surfaces/interactive_shell/runtime/background/rca_summary.py
@@ -1,0 +1,39 @@
+"""Bounded RCA summary sections for chat-notification channels.
+
+Chat platforms cap a message at 4096 characters and the transports
+tail-truncate to fit. The RCA body ends with "What to do next" and the stats
+block, so an unbounded root cause would push exactly the actionable sections
+off the end. Budget each section instead: the worst case below stays under
+the cap, so the tail always survives.
+
+Email keeps the full report; chat channels carry this bounded summary and
+point the reader at ``/background show`` for the rest.
+"""
+
+from __future__ import annotations
+
+from surfaces.interactive_shell.session.background_investigations import (
+    BackgroundInvestigationRecord,
+)
+
+_COMMAND_CHARS = 200
+_ROOT_CAUSE_CHARS = 1000
+_ITEM_CHARS = 240
+_MAX_ITEMS = 5
+
+
+def summary_sections(
+    record: BackgroundInvestigationRecord,
+) -> tuple[str, str, tuple[str, ...], tuple[str, ...]]:
+    """Return the RCA sections trimmed to fit one chat message."""
+    from platform.common.truncation import truncate
+
+    def _items(values: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(truncate(value, _ITEM_CHARS, suffix="…") for value in values[:_MAX_ITEMS])
+
+    return (
+        truncate(record.command, _COMMAND_CHARS, suffix="…"),
+        truncate(record.root_cause, _ROOT_CAUSE_CHARS, suffix="…"),
+        _items(record.top_analysis),
+        _items(record.next_steps),
+    )

--- a/surfaces/interactive_shell/runtime/background/rocketchat_channel.py
+++ b/surfaces/interactive_shell/runtime/background/rocketchat_channel.py
@@ -64,6 +64,11 @@ def deliver_rocketchat_notification(record: BackgroundInvestigationRecord) -> st
             return "sent"
         return f"failed: {redact_token(error, webhook_url)}"
     if has_pat:
+        # Deliberately no webhook fallback here even when one is configured:
+        # token credentials say the user works in channel-targeting mode, so a
+        # missing default_channel is a configuration gap to surface, not a
+        # license to deliver to the webhook's fixed destination (same rule as
+        # the rocketchat_send_message tool and the cron provider).
         return (
             "missing rocketchat integration: no default_channel configured "
             "(set ROCKETCHAT_DEFAULT_CHANNEL or re-run setup)."

--- a/surfaces/interactive_shell/runtime/background/rocketchat_channel.py
+++ b/surfaces/interactive_shell/runtime/background/rocketchat_channel.py
@@ -1,0 +1,74 @@
+"""Rocket.Chat delivery for background RCA completion notifications."""
+
+from __future__ import annotations
+
+from surfaces.interactive_shell.runtime.background.rca_summary import summary_sections
+from surfaces.interactive_shell.session.background_investigations import (
+    BackgroundInvestigationRecord,
+)
+
+
+def deliver_rocketchat_notification(record: BackgroundInvestigationRecord) -> str:
+    """Send the background-RCA completion summary to Rocket.Chat; return a result string.
+
+    Token credentials with a configured ``default_channel`` are preferred;
+    the incoming webhook (fixed destination) is the fallback when token
+    credentials are absent — the same routing rule as the
+    ``rocketchat_send_message`` tool.
+    """
+    # Imported lazily: rocketchat delivery only fires on background-RCA completion,
+    # so the rocketchat client must not load into the base REPL boot import path.
+    from integrations.catalog import resolve_effective_integrations
+    from integrations.rocketchat.delivery import (
+        post_rocketchat_message,
+        post_rocketchat_webhook,
+    )
+    from integrations.smtp.delivery import format_background_rca_email
+    from platform.notifications.redaction import redact_token
+
+    entry = resolve_effective_integrations().get("rocketchat") or {}
+    config = entry.get("config") if isinstance(entry, dict) else None
+    if not isinstance(config, dict) or not config:
+        return "missing rocketchat integration: Rocket.Chat is not configured."
+
+    server_url = str(config.get("server_url") or "")
+    auth_token = str(config.get("auth_token") or "")
+    user_id = str(config.get("user_id") or "")
+    webhook_url = str(config.get("webhook_url") or "")
+    channel = str(config.get("default_channel") or "")
+    has_pat = bool(server_url and auth_token and user_id)
+
+    command, root_cause, top_analysis, next_steps = summary_sections(record)
+    _subject, body = format_background_rca_email(
+        task_id=record.task_id,
+        command=command,
+        root_cause=root_cause,
+        top_analysis=top_analysis,
+        next_steps=next_steps,
+        stats=record.stats,
+    )
+
+    if has_pat and channel:
+        ok, error, _message_id = post_rocketchat_message(
+            server_url, channel, body, auth_token, user_id
+        )
+        if ok:
+            return "sent"
+        # Delivery errors may echo transport detail; the token is redacted by
+        # the delivery helper, but redact again at this boundary since the
+        # string lands in the record and `/background show`.
+        return f"failed: {redact_token(error, auth_token)}"
+    if not has_pat and webhook_url:
+        ok, error = post_rocketchat_webhook(webhook_url, body)
+        if ok:
+            return "sent"
+        return f"failed: {redact_token(error, webhook_url)}"
+    if has_pat:
+        return (
+            "missing rocketchat integration: no default_channel configured "
+            "(set ROCKETCHAT_DEFAULT_CHANNEL or re-run setup)."
+        )
+    return (
+        "missing rocketchat integration: configure token credentials "
+        "(server_url, auth_token, user_id) or an incoming webhook."
+    )

--- a/surfaces/interactive_shell/runtime/background/telegram_channel.py
+++ b/surfaces/interactive_shell/runtime/background/telegram_channel.py
@@ -3,39 +3,10 @@
 from __future__ import annotations
 
 from platform.common.errors import OpenSREError
+from surfaces.interactive_shell.runtime.background.rca_summary import summary_sections
 from surfaces.interactive_shell.session.background_investigations import (
     BackgroundInvestigationRecord,
 )
-
-# Telegram caps a message at 4096 characters and the transport tail-truncates to fit.
-# The RCA body ends with "What to do next" and the stats block, so an unbounded root
-# cause would push exactly the actionable sections off the end. Budget each section
-# instead: the worst case below stays under the cap, so the tail always survives.
-_COMMAND_CHARS = 200
-_ROOT_CAUSE_CHARS = 1000
-_ITEM_CHARS = 240
-_MAX_ITEMS = 5
-
-
-def _summary_sections(
-    record: BackgroundInvestigationRecord,
-) -> tuple[str, str, tuple[str, ...], tuple[str, ...]]:
-    """Return the RCA sections trimmed to fit one Telegram message.
-
-    Email keeps the full report; Telegram is a notification, so it carries a bounded
-    summary and points the reader at ``/background show`` for the rest.
-    """
-    from platform.common.truncation import truncate
-
-    def _items(values: tuple[str, ...]) -> tuple[str, ...]:
-        return tuple(truncate(value, _ITEM_CHARS, suffix="…") for value in values[:_MAX_ITEMS])
-
-    return (
-        truncate(record.command, _COMMAND_CHARS, suffix="…"),
-        truncate(record.root_cause, _ROOT_CAUSE_CHARS, suffix="…"),
-        _items(record.top_analysis),
-        _items(record.next_steps),
-    )
 
 
 def deliver_telegram_notification(record: BackgroundInvestigationRecord) -> str:
@@ -52,7 +23,7 @@ def deliver_telegram_notification(record: BackgroundInvestigationRecord) -> str:
     except OpenSREError as exc:
         return f"missing telegram integration: {exc}"
 
-    command, root_cause, top_analysis, next_steps = _summary_sections(record)
+    command, root_cause, top_analysis, next_steps = summary_sections(record)
     _subject, body = format_background_rca_email(
         task_id=record.task_id,
         command=command,

--- a/tests/interactive_shell/runtime/test_background_notifications.py
+++ b/tests/interactive_shell/runtime/test_background_notifications.py
@@ -448,6 +448,234 @@ def test_deliver_background_notifications_telegram_body_passes_through_unescaped
     assert "&gt;" not in body
 
 
+# --- Rocket.Chat -------------------------------------------------------------
+#
+# Same patching rule as the telegram cases: patch the SOURCE modules, because
+# the implementation lazily imports inside the branch.
+
+_ROCKETCHAT_PAT_ENTRY = {
+    "rocketchat": {
+        "source": "local env",
+        "config": {
+            "server_url": "https://chat.example.com",
+            "auth_token": "tok",
+            "user_id": "u1",
+            "default_channel": "#incidents",
+            "webhook_url": "",
+        },
+    }
+}
+
+_ROCKETCHAT_WEBHOOK_ENTRY = {
+    "rocketchat": {
+        "source": "local env",
+        "config": {
+            "server_url": "",
+            "auth_token": "",
+            "user_id": "",
+            "default_channel": None,
+            "webhook_url": "https://chat.example.com/hooks/abc/def",
+        },
+    }
+}
+
+
+def test_deliver_background_notifications_sends_rocketchat_via_token(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "integrations.catalog.resolve_effective_integrations",
+        lambda: dict(_ROCKETCHAT_PAT_ENTRY),
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_post(
+        server_url: str, channel: str, text: str, auth_token: str, user_id: str
+    ) -> tuple[bool, str, str]:
+        captured.update(server_url=server_url, channel=channel, text=text)
+        return True, "", "m-1"
+
+    monkeypatch.setattr(
+        "integrations.rocketchat.delivery.post_rocketchat_message",
+        _fake_post,
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123",
+        status="completed",
+        command="/investigate checkout-latency",
+        root_cause="ROOTSENTINEL postgres connection pool saturation",
+        top_analysis=("TOPANALYSISSENTINEL rds cpu spike",),
+        next_steps=("NEXTSTEPSENTINEL raise pool size",),
+        stats={"tool_call_count": 4, "investigation_loop_count": 2, "validity_score": 0.8},
+    )
+
+    results = deliver_background_notifications(record=record, channels=("rocketchat",))
+
+    assert results == {"rocketchat": "sent"}
+    assert captured["server_url"] == "https://chat.example.com"
+    assert captured["channel"] == "#incidents"
+    body = str(captured["text"])
+    assert "ROOTSENTINEL" in body
+    assert "NEXTSTEPSENTINEL" in body
+
+
+def test_deliver_background_notifications_sends_rocketchat_via_webhook_when_no_pat(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "integrations.catalog.resolve_effective_integrations",
+        lambda: dict(_ROCKETCHAT_WEBHOOK_ENTRY),
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_webhook(webhook_url: str, text: str) -> tuple[bool, str]:
+        captured.update(webhook_url=webhook_url, text=text)
+        return True, ""
+
+    monkeypatch.setattr(
+        "integrations.rocketchat.delivery.post_rocketchat_webhook",
+        _fake_webhook,
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text", root_cause="boom"
+    )
+    results = deliver_background_notifications(record=record, channels=("rocketchat",))
+
+    assert results == {"rocketchat": "sent"}
+    assert captured["webhook_url"] == "https://chat.example.com/hooks/abc/def"
+
+
+def test_deliver_background_notifications_marks_missing_rocketchat(monkeypatch) -> None:
+    monkeypatch.setattr("integrations.catalog.resolve_effective_integrations", lambda: {})
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text"
+    )
+    results = deliver_background_notifications(record=record, channels=("rocketchat",))
+    assert results["rocketchat"].startswith("missing rocketchat integration: ")
+
+
+def test_deliver_background_notifications_marks_rocketchat_missing_channel(
+    monkeypatch,
+) -> None:
+    """Token credentials without a default_channel cannot pick a destination."""
+    entry = {
+        "rocketchat": {
+            "source": "local env",
+            "config": {
+                **_ROCKETCHAT_PAT_ENTRY["rocketchat"]["config"],
+                "default_channel": None,
+            },
+        }
+    }
+    monkeypatch.setattr(
+        "integrations.catalog.resolve_effective_integrations",
+        lambda: entry,
+    )
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text"
+    )
+    results = deliver_background_notifications(record=record, channels=("rocketchat",))
+    assert results["rocketchat"].startswith("missing rocketchat integration: ")
+    assert "default_channel" in results["rocketchat"]
+
+
+def test_deliver_background_notifications_redacts_rocketchat_token_from_failure(
+    monkeypatch,
+) -> None:
+    """Failure detail lands in the record and `/background show` — the token must
+    never survive into the result, mirroring the telegram redaction contract."""
+    auth_token = "RC-HAPPYTOKEN"
+    entry = {
+        "rocketchat": {
+            "source": "local env",
+            "config": {
+                **_ROCKETCHAT_PAT_ENTRY["rocketchat"]["config"],
+                "auth_token": auth_token,
+            },
+        }
+    }
+    monkeypatch.setattr(
+        "integrations.catalog.resolve_effective_integrations",
+        lambda: entry,
+    )
+    monkeypatch.setattr(
+        "integrations.rocketchat.delivery.post_rocketchat_message",
+        lambda *_args, **_kwargs: (False, f"502 Bad Gateway echoing {auth_token}", ""),
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text", root_cause="boom"
+    )
+    results = deliver_background_notifications(record=record, channels=("rocketchat",))
+
+    assert auth_token not in results["rocketchat"]
+    assert "<redacted>" in results["rocketchat"]
+    assert results["rocketchat"].startswith("failed: ")
+    assert "502 Bad Gateway" in results["rocketchat"]
+
+
+def test_deliver_background_notifications_rocketchat_body_keeps_actionable_tail(
+    monkeypatch,
+) -> None:
+    """Same 4096 budget rule as telegram: the actionable tail must survive."""
+    monkeypatch.setattr(
+        "integrations.catalog.resolve_effective_integrations",
+        lambda: dict(_ROCKETCHAT_PAT_ENTRY),
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_post(*args: object, **_kwargs: object) -> tuple[bool, str, str]:
+        captured["text"] = args[2]
+        return True, "", "m-1"
+
+    monkeypatch.setattr(
+        "integrations.rocketchat.delivery.post_rocketchat_message",
+        _fake_post,
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123",
+        status="completed",
+        command="/investigate " + "c" * 5_000,
+        root_cause="r" * 6_000,
+        top_analysis=tuple(f"analysis {i} " + "a" * 500 for i in range(12)),
+        next_steps=tuple(f"NEXTSTEPSENTINEL{i} " + "n" * 500 for i in range(12)),
+        stats={"tool_call_count": 4, "investigation_loop_count": 2, "validity_score": 0.8},
+    )
+
+    results = deliver_background_notifications(record=record, channels=("rocketchat",))
+    assert results == {"rocketchat": "sent"}
+
+    body = str(captured["text"])
+    assert len(body) <= 4096
+    assert "What to do next" in body
+    assert "NEXTSTEPSENTINEL0" in body
+
+
+def test_notifications_module_does_not_eagerly_import_rocketchat() -> None:
+    """Rocket.Chat loads only when its channel is processed (same rule as telegram)."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import surfaces.interactive_shell.runtime.background.notifications as n; "
+                "import sys; "
+                "assert 'integrations.rocketchat.delivery' not in sys.modules; "
+                "print('OK: rocketchat not eagerly imported')"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "OK: rocketchat not eagerly imported" in completed.stdout
+
+
 def test_notifications_module_does_not_eagerly_import_telegram() -> None:
     """AC-11 (corrected, dotted-module sys.modules check): telegram loads only when processed.
 

--- a/tests/interactive_shell/runtime/test_background_notifications.py
+++ b/tests/interactive_shell/runtime/test_background_notifications.py
@@ -581,6 +581,47 @@ def test_deliver_background_notifications_marks_rocketchat_missing_channel(
     assert "default_channel" in results["rocketchat"]
 
 
+def test_deliver_background_notifications_pat_without_channel_never_falls_back_to_webhook(
+    monkeypatch,
+) -> None:
+    """Mixed config: full token credentials + webhook + no default_channel.
+
+    Token credentials mean channel-targeting mode, so the missing
+    default_channel is surfaced as a configuration gap — the webhook's fixed
+    destination is deliberately NOT used as a silent fallback (same routing
+    rule as the rocketchat_send_message tool and the cron provider).
+    """
+    entry = {
+        "rocketchat": {
+            "source": "local env",
+            "config": {
+                **_ROCKETCHAT_PAT_ENTRY["rocketchat"]["config"],
+                "default_channel": None,
+                "webhook_url": "https://chat.example.com/hooks/abc/def",
+            },
+        }
+    }
+    monkeypatch.setattr(
+        "integrations.catalog.resolve_effective_integrations",
+        lambda: entry,
+    )
+
+    def _explode_webhook(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("webhook must not be used as a fallback when PAT is configured")
+
+    monkeypatch.setattr(
+        "integrations.rocketchat.delivery.post_rocketchat_webhook",
+        _explode_webhook,
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text"
+    )
+    results = deliver_background_notifications(record=record, channels=("rocketchat",))
+    assert results["rocketchat"].startswith("missing rocketchat integration: ")
+    assert "default_channel" in results["rocketchat"]
+
+
 def test_deliver_background_notifications_redacts_rocketchat_token_from_failure(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
Fixes #4131

#### Describe the changes you have made in this PR

Adds **`rocketchat`** to the background-investigation notification channels (`/background notify set rocketchat`), so a completed background RCA posts its summary to Rocket.Chat the moment the job finishes — completing the notification parity for the integration shipped in #4114 (see also #4129 tool / #4130 cron).

- `rocketchat_channel.py` next to `telegram_channel.py`: token credentials + configured `default_channel` preferred; incoming webhook (fixed destination) as the fallback only when token credentials are absent — the same routing rule the `rocketchat_send_message` tool and the cron provider follow.
- The 4,096-char summary budget (root cause / top analysis / next steps with the **actionable tail preserved**) is extracted from the Telegram channel into a shared `rca_summary` module; the Telegram channel now imports it with no behavior change.
- Lazy imports keep the Rocket.Chat client out of the base REPL boot path (same AC-11 contract the Telegram channel is tested for, including the fresh-subprocess eager-import guard).
- Failure detail redacts the auth token / webhook URL before landing in the record and `/background show`.
- Docs: background-investigations channels table/examples + a section on the Rocket.Chat messaging page.

**Testing** — `make lint`, `make format-check`, `make typecheck`, and `make check-layers-strict` pass; `tests/interactive_shell/` passes (1319 tests). New coverage mirrors the Telegram channel suite: sent via token, sent via webhook-only, missing integration, token-without-default_channel, failure-detail redaction, 4,096 actionable-tail budget, and the eager-import subprocess guard. Verified end-to-end against a real Rocket.Chat workspace: `/background on` → `/background notify set rocketchat` → background investigation → `rocketchat:sent` in `/background show` and the RCA summary delivered to the channel (screenshots below).

### Demo/Screenshot for feature changes and bug fixes -

<img width="3436" height="1728" alt="CleanShot 2026-07-18 at 00 46 38@2x" src="https://github.com/user-attachments/assets/f21d24fc-2b81-4c50-ba42-f53edc2ff01f" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Completing the notification surface for the integration (#4114 delivery, #4129 tool, #4130 cron). The background-notification seam is clean, one module per channel plus a dispatcher branch with mandated lazy imports, so the natural shape was a `rocketchat_channel.py` sibling of `telegram_channel.py`.

Two decisions worth noting. First, instead of copying Telegram's private `_summary_sections` budgeting into the new channel, I extracted it into a shared `rca_summary` module both channels import: the 4,096-char cap with the actionable tail preserved is a channel-agnostic rule, and duplicating it would let the two copies drift. Second, destination routing reuses the rule established across this series (and hardened by the #4129 review): a configured `default_channel` with token credentials is the explicit destination; the webhook is only used when token credentials are absent, because its destination is fixed at creation time, and token-without-channel returns a clear `missing…` result rather than silently falling back.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions