### PR TITLE
fix(integrations): resolve messaging secrets via env then keyring

### DIFF
--- a/config/llm_auth/credentials.py
+++ b/config/llm_auth/credentials.py
@@ -341,9 +341,9 @@ def resolve_api_key_env_for_request(env_var: str) -> str:
     for provider, provider_env in API_KEY_PROVIDER_ENVS.items():
         if provider_env == normalized:
             return resolve_for_request(provider).api_key
-    from config.llm_keyring import resolve_llm_api_key
+    from config.llm_credentials import resolve_env_credential
 
-    return resolve_llm_api_key(normalized)
+    return resolve_env_credential(normalized)
 
 
 def save_api_key(provider: str, value: str, *, detail: str | None = None) -> None:
@@ -351,9 +351,9 @@ def save_api_key(provider: str, value: str, *, detail: str | None = None) -> Non
     spec = require_provider_spec(provider)
     if not spec.uses_open_sre_api_key:
         raise ValueError(f"{spec.value} does not use an OpenSRE-managed API key")
-    from config.llm_keyring import save_llm_api_key
+    from config.llm_keyring import save_keyring_secret
 
-    save_llm_api_key(spec.api_key_env, value)
+    save_keyring_secret(spec.api_key_env, value)
     save_provider_auth_record(
         provider=spec.value,
         auth_name=spec.value,
@@ -370,9 +370,9 @@ def delete(provider: str) -> None:
     """Delete OpenSRE-managed provider auth metadata and API key when applicable."""
     spec = require_provider_spec(provider)
     if spec.uses_open_sre_api_key:
-        from config.llm_keyring import delete_llm_api_key
+        from config.llm_keyring import delete_keyring_secret
 
-        delete_llm_api_key(spec.api_key_env)
+        delete_keyring_secret(spec.api_key_env)
     delete_provider_auth_record(spec.value)
 
 
@@ -444,7 +444,7 @@ def has_llm_api_key(env_var: str) -> bool:
     from config.llm_keyring import (
         keyring_is_disabled,
         macos_keychain_item_exists,
-        resolve_llm_api_key,
+        resolve_keyring_secret,
     )
 
     if has_api_key_env_status(env_var):
@@ -458,7 +458,7 @@ def has_llm_api_key(env_var: str) -> bool:
     item_exists = macos_keychain_item_exists(env_var)
     if item_exists is not None:
         return item_exists
-    return bool(resolve_llm_api_key(env_var))
+    return bool(resolve_keyring_secret(env_var))
 
 
 __all__ = [

--- a/config/llm_credentials.py
+++ b/config/llm_credentials.py
@@ -1,34 +1,34 @@
-"""Secure local storage helpers for LLM credentials."""
+"""Secure local storage helpers for OpenSRE secrets (LLM keys and integrations)."""
 
 from __future__ import annotations
 
 import os
 
 from config.llm_keyring import (
-    delete_llm_api_key,
+    delete_keyring_secret,
     delete_llm_credential_record,
     get_keyring_setup_instructions,
-    resolve_llm_api_key,
+    resolve_keyring_secret,
     resolve_llm_credential_record,
-    save_llm_api_key,
+    save_keyring_secret,
     save_llm_credential_record,
 )
 
 __all__ = [
-    "delete_llm_api_key",
+    "delete_keyring_secret",
     "delete_llm_credential_record",
     "get_keyring_setup_instructions",
     "resolve_env_credential",
-    "resolve_llm_api_key",
+    "resolve_keyring_secret",
     "resolve_llm_credential_record",
-    "save_llm_api_key",
+    "save_keyring_secret",
     "save_llm_credential_record",
 ]
 
 
 def resolve_env_credential(env_var: str, *, default: str = "") -> str:
-    """Resolve a credential from env first, then the local keychain."""
+    """Resolve a credential from process env first, then the OS keyring."""
     env_value = os.getenv(env_var, default).strip()
     if env_value:
         return env_value
-    return resolve_llm_api_key(env_var)
+    return resolve_keyring_secret(env_var)

--- a/config/llm_keyring.py
+++ b/config/llm_keyring.py
@@ -83,12 +83,15 @@ def resolve_keyring_secret(env_var: str) -> str:
 
     Prefer :func:`config.llm_credentials.resolve_env_credential` when callers
     should also honor a process-env value.
+
+    Backend init failures (e.g. SecretService raising bare ``RuntimeError`` when
+    D-Bus is unset) are treated as miss — catalog/env loaders must not abort.
     """
     if keyring_is_disabled():
         return ""
     try:
         return read_keychain_secret(env_var)
-    except keyring.errors.KeyringError:
+    except (keyring.errors.KeyringError, RuntimeError, OSError):
         return ""
 
 

--- a/config/llm_keyring.py
+++ b/config/llm_keyring.py
@@ -1,4 +1,10 @@
-"""Low-level keyring storage for LLM credentials and auth metadata."""
+"""Low-level OS keyring storage for OpenSRE secrets.
+
+Historically named for LLM API keys; the same store backs integration secrets
+(``TELEGRAM_BOT_TOKEN``, ``ROCKETCHAT_AUTH_TOKEN``, etc.) via
+``save_keyring_secret`` / ``resolve_env_credential``. The keyring service id
+remains ``opensre.llm`` so existing entries keep resolving.
+"""
 
 from __future__ import annotations
 
@@ -66,17 +72,18 @@ def read_keychain_secret(env_var: str) -> str:
 
     Callers that must tell "genuinely absent" apart from "keychain backend
     could not be reached right now" (e.g. deciding whether to persist a
-    credential as stale) should use this instead of ``resolve_llm_api_key``,
+    credential as stale) should use this instead of ``resolve_keyring_secret``,
     which collapses both cases to ``""``.
     """
     return (keyring.get_password(_KEYRING_SERVICE, env_var) or "").strip()
 
 
-def resolve_llm_api_key(env_var: str) -> str:
-    """Resolve an LLM API key from env first, then the local keychain."""
-    env_value = os.getenv(env_var, "").strip()
-    if env_value:
-        return env_value
+def resolve_keyring_secret(env_var: str) -> str:
+    """Read a secret from the OS keyring only (empty if missing/disabled/error).
+
+    Prefer :func:`config.llm_credentials.resolve_env_credential` when callers
+    should also honor a process-env value.
+    """
     if keyring_is_disabled():
         return ""
     try:
@@ -132,11 +139,11 @@ def get_keyring_setup_instructions(env_var: str) -> tuple[str, ...]:
     )
 
 
-def save_llm_api_key(env_var: str, value: str) -> None:
-    """Persist an LLM API key in the user's system keychain."""
+def save_keyring_secret(env_var: str, value: str) -> None:
+    """Persist a secret in the user's system keychain under ``env_var``."""
     normalized = value.strip()
     if not normalized:
-        delete_llm_api_key(env_var)
+        delete_keyring_secret(env_var)
         return
     if keyring_is_disabled():
         raise RuntimeError("Secure local credential storage is disabled on this machine.")
@@ -148,8 +155,8 @@ def save_llm_api_key(env_var: str, value: str) -> None:
         ) from exc
 
 
-def delete_llm_api_key(env_var: str) -> None:
-    """Remove an LLM API key from the user's system keychain if present."""
+def delete_keyring_secret(env_var: str) -> None:
+    """Remove a secret from the user's system keychain if present."""
     if keyring_is_disabled():
         return
     try:

--- a/core/llm/providers/azure_openai.py
+++ b/core/llm/providers/azure_openai.py
@@ -148,10 +148,10 @@ def list_azure_openai_deployments(
 
 def discover_azure_openai_deployments_from_env() -> list[str]:
     """Return deployment IDs from the configured Azure OpenAI resource."""
-    from config.llm_credentials import resolve_llm_api_key
+    from config.llm_credentials import resolve_env_credential
 
     base_url = os.getenv(AZURE_OPENAI_BASE_URL_ENV, "")
-    api_key = resolve_llm_api_key(AZURE_OPENAI_API_KEY_ENV) or ""
+    api_key = resolve_env_credential(AZURE_OPENAI_API_KEY_ENV) or ""
     return list_azure_openai_deployments(
         base_url=base_url,
         api_key=api_key,

--- a/core/llm/transports/litellm/clients.py
+++ b/core/llm/transports/litellm/clients.py
@@ -86,9 +86,9 @@ class LiteLLMAgentClient:
             return None
         if self._credential_resolver is not None:
             return self._credential_resolver(self._api_key_env) or self._api_key_default
-        from config.llm_credentials import resolve_llm_api_key
+        from config.llm_credentials import resolve_env_credential
 
-        return resolve_llm_api_key(self._api_key_env) or self._api_key_default
+        return resolve_env_credential(self._api_key_env) or self._api_key_default
 
     def _build_request_kwargs(
         self,
@@ -191,9 +191,9 @@ class LiteLLMLLMClient:
             return None
         if self._credential_resolver is not None:
             return self._credential_resolver(self._api_key_env) or self._api_key_default
-        from config.llm_credentials import resolve_llm_api_key
+        from config.llm_credentials import resolve_env_credential
 
-        return resolve_llm_api_key(self._api_key_env) or self._api_key_default
+        return resolve_env_credential(self._api_key_env) or self._api_key_default
 
     def _activate_model_fallback(self) -> bool:
         fallback = self._model_fallback

--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -69,9 +69,9 @@ class AnthropicAgentClient:
         if client is None:
             from anthropic import Anthropic
 
-            from config.llm_credentials import resolve_llm_api_key
+            from config.llm_credentials import resolve_env_credential
 
-            resolver = credential_resolver or resolve_llm_api_key
+            resolver = credential_resolver or resolve_env_credential
             api_key = resolver("ANTHROPIC_API_KEY")
             self._client = Anthropic(api_key=api_key, timeout=AGENT_CLIENT_TIMEOUT_SEC)
         else:
@@ -462,9 +462,9 @@ class OpenAIAgentClient:
     ) -> None:
         from openai import OpenAI
 
-        from config.llm_credentials import resolve_llm_api_key
+        from config.llm_credentials import resolve_env_credential
 
-        resolver = credential_resolver or resolve_llm_api_key
+        resolver = credential_resolver or resolve_env_credential
         api_key = resolver(api_key_env) or api_key_default
         self._client = OpenAI(api_key=api_key, base_url=base_url, timeout=AGENT_CLIENT_TIMEOUT_SEC)
         self._model = model

--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -917,7 +917,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
     if airflow_config is not None:
         integrations.append(_active_env_record("airflow", airflow_config.model_dump()))
 
-    telegram_bot_token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+    telegram_bot_token = resolve_env_credential("TELEGRAM_BOT_TOKEN")
     if telegram_bot_token:
         try:
             tg_config = TelegramBotConfig.model_validate(
@@ -931,7 +931,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
         else:
             integrations.append(_active_env_record("telegram", tg_config.model_dump()))
 
-    rocketchat_auth_token = os.getenv("ROCKETCHAT_AUTH_TOKEN", "").strip()
+    # PAT is keyring-backed via wizard sync_env_secret; webhook URL stays store/env only.
+    rocketchat_auth_token = resolve_env_credential("ROCKETCHAT_AUTH_TOKEN")
     rocketchat_webhook_url = os.getenv("ROCKETCHAT_WEBHOOK_URL", "").strip()
     if rocketchat_auth_token or rocketchat_webhook_url:
         try:
@@ -949,13 +950,13 @@ def load_env_integrations() -> list[dict[str, Any]]:
         else:
             integrations.append(_active_env_record("rocketchat", rocketchat_config.model_dump()))
 
-    slack_bot_token = os.getenv("SLACK_BOT_TOKEN", "").strip()
+    slack_bot_token = resolve_env_credential("SLACK_BOT_TOKEN")
     slack_webhook_url = os.getenv("SLACK_WEBHOOK_URL", "").strip()
     if slack_bot_token or slack_webhook_url:
         slack_credentials = {
             "webhook_url": slack_webhook_url,
             "bot_token": slack_bot_token,
-            "app_token": os.getenv("SLACK_APP_TOKEN", "").strip(),
+            "app_token": resolve_env_credential("SLACK_APP_TOKEN"),
         }
         slack_view, _slack_key = _classify_slack(slack_credentials, record_id="env:slack")
         if slack_view is not None:
@@ -1824,8 +1825,8 @@ def resolve_effective_integrations(
     else:
         slack_config = _slack_effective_config(
             webhook_url=os.getenv("SLACK_WEBHOOK_URL", "").strip(),
-            bot_token=os.getenv("SLACK_BOT_TOKEN", "").strip(),
-            app_token=os.getenv("SLACK_APP_TOKEN", "").strip(),
+            bot_token=resolve_env_credential("SLACK_BOT_TOKEN"),
+            app_token=resolve_env_credential("SLACK_APP_TOKEN"),
             webhook_label="SLACK_WEBHOOK_URL",
         )
         if slack_config:

--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -400,7 +400,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
         grafana_api_key = ""
     else:
         grafana_endpoint = os.getenv("GRAFANA_INSTANCE_URL", "").strip()
-        grafana_api_key = os.getenv("GRAFANA_READ_TOKEN", "").strip()
+        grafana_api_key = resolve_env_credential("GRAFANA_READ_TOKEN")
     if grafana_endpoint and grafana_api_key:
         try:
             grafana_config = GrafanaIntegrationConfig.model_validate(
@@ -434,8 +434,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
         datadog_app_key = ""
         datadog_site = ""
     else:
-        datadog_api_key = os.getenv("DD_API_KEY", "").strip()
-        datadog_app_key = os.getenv("DD_APP_KEY", "").strip()
+        datadog_api_key = resolve_env_credential("DD_API_KEY")
+        datadog_app_key = resolve_env_credential("DD_APP_KEY")
         datadog_site = os.getenv("DD_SITE", "datadoghq.com").strip() or "datadoghq.com"
     if datadog_api_key and datadog_app_key:
         try:
@@ -461,10 +461,9 @@ def load_env_integrations() -> list[dict[str, Any]]:
         integrations.append(groundcover_multi)
         groundcover_api_key = ""
     else:
-        groundcover_api_key = (
-            os.getenv("GROUNDCOVER_API_KEY", "").strip()
-            or os.getenv("GROUNDCOVER_MCP_TOKEN", "").strip()
-        )
+        groundcover_api_key = resolve_env_credential(
+            "GROUNDCOVER_API_KEY"
+        ) or resolve_env_credential("GROUNDCOVER_MCP_TOKEN")
     if groundcover_api_key:
         # The groundcover config validates the MCP URL (HTTPS-or-loopback), which
         # can raise on a bad GROUNDCOVER_MCP_URL. Guard it so one malformed value
@@ -494,7 +493,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
         integrations.append(honeycomb_multi)
         honeycomb_api_key = ""
     else:
-        honeycomb_api_key = os.getenv("HONEYCOMB_API_KEY", "").strip()
+        honeycomb_api_key = resolve_env_credential("HONEYCOMB_API_KEY")
     if honeycomb_api_key:
         try:
             honeycomb_config = HoneycombIntegrationConfig.model_validate(
@@ -519,7 +518,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
         integrations.append(coralogix_multi)
         coralogix_api_key = ""
     else:
-        coralogix_api_key = os.getenv("CORALOGIX_API_KEY", "").strip()
+        coralogix_api_key = resolve_env_credential("CORALOGIX_API_KEY")
     if coralogix_api_key:
         try:
             coralogix_config = CoralogixIntegrationConfig.model_validate(
@@ -553,9 +552,9 @@ def load_env_integrations() -> list[dict[str, Any]]:
         aws_role_arn = os.getenv("AWS_ROLE_ARN", "").strip()
         aws_external_id = os.getenv("AWS_EXTERNAL_ID", "").strip()
         aws_region = os.getenv("AWS_REGION", "us-east-1").strip() or "us-east-1"
-        aws_access_key_id = os.getenv("AWS_ACCESS_KEY_ID", "").strip()
-        aws_secret_access_key = os.getenv("AWS_SECRET_ACCESS_KEY", "").strip()
-        aws_session_token = os.getenv("AWS_SESSION_TOKEN", "").strip()
+        aws_access_key_id = resolve_env_credential("AWS_ACCESS_KEY_ID")
+        aws_secret_access_key = resolve_env_credential("AWS_SECRET_ACCESS_KEY")
+        aws_session_token = resolve_env_credential("AWS_SESSION_TOKEN")
     if aws_role_arn:
         try:
             aws_config = AWSIntegrationConfig.model_validate(
@@ -609,7 +608,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
     github_url = os.getenv("GITHUB_MCP_URL", "").strip()
     github_command = os.getenv("GITHUB_MCP_COMMAND", "").strip()
     github_args = os.getenv("GITHUB_MCP_ARGS", "").strip()
-    github_auth_token = os.getenv("GITHUB_MCP_AUTH_TOKEN", "").strip()
+    github_auth_token = resolve_env_credential("GITHUB_MCP_AUTH_TOKEN")
     github_toolsets = os.getenv("GITHUB_MCP_TOOLSETS", "").strip()
     if (github_mode == "stdio" and github_command) or (github_mode != "stdio" and github_url):
         github_config = build_github_mcp_config(
@@ -630,7 +629,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
         )
 
     sentry_org_slug = os.getenv("SENTRY_ORG_SLUG", "").strip()
-    sentry_auth_token = os.getenv("SENTRY_AUTH_TOKEN", "").strip()
+    sentry_auth_token = resolve_env_credential("SENTRY_AUTH_TOKEN")
     if sentry_org_slug and sentry_auth_token:
         sentry_config = build_sentry_config(
             {
@@ -659,7 +658,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
         )
         integrations.append(_active_env_record("gitlab", gitlab_config.model_dump()))
 
-    mongodb_connection_string = os.getenv("MONGODB_CONNECTION_STRING", "").strip()
+    mongodb_connection_string = resolve_env_credential("MONGODB_CONNECTION_STRING")
     if mongodb_connection_string:
         mongodb_config = build_mongodb_config(
             {
@@ -696,7 +695,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 else 5432,
                 "database": postgresql_database,
                 "username": os.getenv("POSTGRESQL_USERNAME", "postgres").strip() or "postgres",
-                "password": os.getenv("POSTGRESQL_PASSWORD", "").strip(),
+                "password": resolve_env_credential("POSTGRESQL_PASSWORD"),
                 "ssl_mode": os.getenv("POSTGRESQL_SSL_MODE", "prefer").strip() or "prefer",
             }
         )
@@ -716,9 +715,11 @@ def load_env_integrations() -> list[dict[str, Any]]:
         argocd_password = ""
     else:
         argocd_base_url = os.getenv("ARGOCD_BASE_URL", "").strip()
-        argocd_auth_token = os.getenv("ARGOCD_AUTH_TOKEN", os.getenv("ARGOCD_TOKEN", "")).strip()
+        argocd_auth_token = resolve_env_credential("ARGOCD_AUTH_TOKEN") or resolve_env_credential(
+            "ARGOCD_TOKEN"
+        )
         argocd_username = os.getenv("ARGOCD_USERNAME", "").strip()
-        argocd_password = os.getenv("ARGOCD_PASSWORD", "").strip()
+        argocd_password = resolve_env_credential("ARGOCD_PASSWORD")
     if argocd_base_url and (argocd_auth_token or (argocd_username and argocd_password)):
         try:
             argocd_config = ArgoCDIntegrationConfig.model_validate(
@@ -769,7 +770,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 )
             )
 
-    vercel_api_token = os.getenv("VERCEL_API_TOKEN", "").strip()
+    vercel_api_token = resolve_env_credential("VERCEL_API_TOKEN")
     if vercel_api_token:
         try:
             vercel_config = VercelConfig.model_validate(
@@ -788,7 +789,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 )
             )
 
-    opsgenie_api_key = os.getenv("OPSGENIE_API_KEY", "").strip()
+    opsgenie_api_key = resolve_env_credential("OPSGENIE_API_KEY")
     if opsgenie_api_key:
         try:
             opsgenie_config = OpsGenieIntegrationConfig.model_validate(
@@ -807,7 +808,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 )
             )
 
-    pagerduty_api_key = os.getenv("PAGERDUTY_API_KEY", "").strip()
+    pagerduty_api_key = resolve_env_credential("PAGERDUTY_API_KEY")
     if pagerduty_api_key:
         try:
             _envs: dict[str, Any] = {"api_key": pagerduty_api_key}
@@ -846,7 +847,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
 
     jira_base_url = os.getenv("JIRA_BASE_URL", "").strip()
     jira_email = os.getenv("JIRA_EMAIL", "").strip()
-    jira_api_token = os.getenv("JIRA_API_TOKEN", "").strip()
+    jira_api_token = resolve_env_credential("JIRA_API_TOKEN")
     jira_project_key = os.getenv("JIRA_PROJECT_KEY", "").strip()
     if jira_base_url and jira_email and jira_api_token:
         try:
@@ -983,8 +984,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
 
     # Shared Twilio account credentials — consumed by both the WhatsApp and
     # the SMS env-bootstrap blocks below.
-    twilio_account_sid = os.getenv("TWILIO_ACCOUNT_SID", "").strip()
-    twilio_auth_token = os.getenv("TWILIO_AUTH_TOKEN", "").strip()
+    twilio_account_sid = resolve_env_credential("TWILIO_ACCOUNT_SID")
+    twilio_auth_token = resolve_env_credential("TWILIO_AUTH_TOKEN")
 
     whatsapp_from_number = os.getenv("TWILIO_WHATSAPP_FROM", "").strip()
     if twilio_account_sid and twilio_auth_token and whatsapp_from_number:
@@ -1034,8 +1035,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 )
             )
 
-    atlas_pub = os.getenv("MONGODB_ATLAS_PUBLIC_KEY", "").strip()
-    atlas_priv = os.getenv("MONGODB_ATLAS_PRIVATE_KEY", "").strip()
+    atlas_pub = resolve_env_credential("MONGODB_ATLAS_PUBLIC_KEY")
+    atlas_priv = resolve_env_credential("MONGODB_ATLAS_PRIVATE_KEY")
     atlas_project = os.getenv("MONGODB_ATLAS_PROJECT_ID", "").strip()
     if atlas_pub and atlas_priv and atlas_project:
         try:
@@ -1220,7 +1221,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     "port": os.getenv("MARIADB_PORT", "3306").strip(),
                     "database": mariadb_database,
                     "username": os.getenv("MARIADB_USERNAME", "").strip(),
-                    "password": os.getenv("MARIADB_PASSWORD", "").strip(),
+                    "password": resolve_env_credential("MARIADB_PASSWORD"),
                     "ssl": os.getenv("MARIADB_SSL", "true").strip().lower() in ("true", "1", "yes"),
                 }
             )
@@ -1239,7 +1240,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
             dagster_config = build_dagster_config(
                 {
                     "endpoint": dagster_endpoint,
-                    "api_token": os.getenv("DAGSTER_API_TOKEN", "").strip(),
+                    "api_token": resolve_env_credential("DAGSTER_API_TOKEN"),
                 }
             )
             integrations.append(
@@ -1260,7 +1261,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     "host": rabbitmq_host,
                     "management_port": os.getenv("RABBITMQ_MANAGEMENT_PORT", "15672").strip(),
                     "username": rabbitmq_username,
-                    "password": os.getenv("RABBITMQ_PASSWORD", ""),
+                    "password": resolve_env_credential("RABBITMQ_PASSWORD"),
                     "vhost": os.getenv("RABBITMQ_VHOST", "/").strip(),
                     "ssl": os.getenv("RABBITMQ_SSL", "false").strip().lower()
                     in ("true", "1", "yes"),
@@ -1298,7 +1299,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 {
                     "query_endpoint": bs_endpoint,
                     "username": bs_username,
-                    "password": os.getenv("BETTERSTACK_PASSWORD", ""),
+                    "password": resolve_env_credential("BETTERSTACK_PASSWORD"),
                     "sources": os.getenv("BETTERSTACK_SOURCES", ""),
                 }
             )
@@ -1322,7 +1323,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 else 3306,
                 "database": mysql_database,
                 "username": os.getenv("MYSQL_USERNAME", "root").strip() or "root",
-                "password": os.getenv("MYSQL_PASSWORD", "").strip(),
+                "password": resolve_env_credential("MYSQL_PASSWORD"),
                 "ssl_mode": os.getenv("MYSQL_SSL_MODE", "preferred").strip() or "preferred",
             }
         )
@@ -1343,7 +1344,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 "port": int(_az_port) if _az_port and _az_port.isdigit() else 1433,
                 "database": azure_sql_database,
                 "username": os.getenv("AZURE_SQL_USERNAME", "").strip(),
-                "password": os.getenv("AZURE_SQL_PASSWORD", "").strip(),
+                "password": resolve_env_credential("AZURE_SQL_PASSWORD"),
                 "driver": os.getenv("AZURE_SQL_DRIVER", "ODBC Driver 18 for SQL Server").strip(),
                 "encrypt": os.getenv("AZURE_SQL_ENCRYPT", "true").strip().lower()
                 in ("true", "1", "yes"),
@@ -1364,7 +1365,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 {
                     "workspace": bitbucket_workspace,
                     "username": os.getenv("BITBUCKET_USERNAME", "").strip(),
-                    "app_password": os.getenv("BITBUCKET_APP_PASSWORD", "").strip(),
+                    "app_password": resolve_env_credential("BITBUCKET_APP_PASSWORD"),
                     "base_url": os.getenv(
                         "BITBUCKET_BASE_URL", "https://api.bitbucket.org/2.0"
                     ).strip()
@@ -1378,7 +1379,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
         os.getenv("SNOWFLAKE_ACCOUNT_IDENTIFIER", "").strip()
         or os.getenv("SNOWFLAKE_ACCOUNT", "").strip()
     )
-    snowflake_token = os.getenv("SNOWFLAKE_TOKEN", "").strip()
+    snowflake_token = resolve_env_credential("SNOWFLAKE_TOKEN")
     if snowflake_account and snowflake_token:
         integrations.append(
             _active_env_record(
@@ -1386,7 +1387,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 {
                     "account_identifier": snowflake_account,
                     "user": os.getenv("SNOWFLAKE_USER", "").strip(),
-                    "password": os.getenv("SNOWFLAKE_PASSWORD", "").strip(),
+                    "password": resolve_env_credential("SNOWFLAKE_PASSWORD"),
                     "token": snowflake_token,
                     "warehouse": os.getenv("SNOWFLAKE_WAREHOUSE", "").strip(),
                     "role": os.getenv("SNOWFLAKE_ROLE", "").strip(),
@@ -1398,7 +1399,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
         )
 
     azure_workspace_id = os.getenv("AZURE_LOG_ANALYTICS_WORKSPACE_ID", "").strip()
-    azure_access_token = os.getenv("AZURE_LOG_ANALYTICS_TOKEN", "").strip()
+    azure_access_token = resolve_env_credential("AZURE_LOG_ANALYTICS_TOKEN")
     if azure_workspace_id and azure_access_token:
         integrations.append(
             _active_env_record(
@@ -1420,9 +1421,9 @@ def load_env_integrations() -> list[dict[str, Any]]:
         )
 
     openobserve_url = os.getenv("OPENOBSERVE_URL", "").strip()
-    openobserve_token = os.getenv("OPENOBSERVE_TOKEN", "").strip()
+    openobserve_token = resolve_env_credential("OPENOBSERVE_TOKEN")
     openobserve_username = os.getenv("OPENOBSERVE_USERNAME", "").strip()
-    openobserve_password = os.getenv("OPENOBSERVE_PASSWORD", "").strip()
+    openobserve_password = resolve_env_credential("OPENOBSERVE_PASSWORD")
     if openobserve_url and (openobserve_token or (openobserve_username and openobserve_password)):
         integrations.append(
             _active_env_record(
@@ -1461,9 +1462,9 @@ def load_env_integrations() -> list[dict[str, Any]]:
             alertmanager_config = AlertmanagerIntegrationConfig.model_validate(
                 {
                     "base_url": alertmanager_url,
-                    "bearer_token": os.getenv("ALERTMANAGER_BEARER_TOKEN", "").strip(),
+                    "bearer_token": resolve_env_credential("ALERTMANAGER_BEARER_TOKEN"),
                     "username": os.getenv("ALERTMANAGER_USERNAME", "").strip(),
-                    "password": os.getenv("ALERTMANAGER_PASSWORD", "").strip(),
+                    "password": resolve_env_credential("ALERTMANAGER_PASSWORD"),
                 }
             )
             integrations.append(
@@ -1476,7 +1477,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
             _report_env_loader_failure(exc, integration="alertmanager")
 
     _kubeconfig_path = os.getenv("KUBECONFIG", "").strip()
-    _kubeconfig_content = os.getenv("KUBECONFIG_CONTENT", "").strip()
+    _kubeconfig_content = resolve_env_credential("KUBECONFIG_CONTENT")
     if _kubeconfig_path or _kubeconfig_content:
         try:
             kubernetes_config = KubernetesIntegrationConfig.model_validate(
@@ -1519,7 +1520,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
         integrations.append(splunk_multi)
     else:
         splunk_url = os.getenv("SPLUNK_URL", "").strip()
-        splunk_token = os.getenv("SPLUNK_TOKEN", "").strip()
+        splunk_token = resolve_env_credential("SPLUNK_TOKEN")
         if splunk_url and splunk_token:
             try:
                 splunk_config = SplunkIntegrationConfig.model_validate(
@@ -1543,7 +1544,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 )
 
     supabase_url = os.getenv("SUPABASE_URL", "").strip()
-    supabase_service_key = os.getenv("SUPABASE_SERVICE_KEY", "").strip()
+    supabase_service_key = resolve_env_credential("SUPABASE_SERVICE_KEY")
     if supabase_url and supabase_service_key:
         try:
             sb_config = build_supabase_config(
@@ -1601,7 +1602,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
             temporal_config = TemporalConfig.model_validate(
                 {
                     "base_url": temporal_url,
-                    "api_key": os.getenv("TEMPORAL_API_KEY", "").strip(),
+                    "api_key": resolve_env_credential("TEMPORAL_API_KEY"),
                     "namespace": temporal_namespace,
                 }
             )
@@ -1801,7 +1802,7 @@ def resolve_effective_integrations(
             },
         )
     else:
-        jwt_token = os.getenv("JWT_TOKEN", "").strip()
+        jwt_token = resolve_env_credential("JWT_TOKEN")
         if jwt_token:
             effective["tracer"] = _effective_entry(
                 "local env",
@@ -1881,7 +1882,7 @@ def resolve_effective_integrations(
                     "security_protocol": os.getenv("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT").strip(),
                     "sasl_mechanism": os.getenv("KAFKA_SASL_MECHANISM", "").strip(),
                     "sasl_username": os.getenv("KAFKA_SASL_USERNAME", "").strip(),
-                    "sasl_password": os.getenv("KAFKA_SASL_PASSWORD", "").strip(),
+                    "sasl_password": resolve_env_credential("KAFKA_SASL_PASSWORD"),
                 },
             )
 
@@ -1909,7 +1910,7 @@ def resolve_effective_integrations(
                     "port": int(os.getenv("CLICKHOUSE_PORT", "8123") or "8123"),
                     "database": os.getenv("CLICKHOUSE_DATABASE", "default").strip(),
                     "username": os.getenv("CLICKHOUSE_USER", "default").strip(),
-                    "password": os.getenv("CLICKHOUSE_PASSWORD", "").strip(),
+                    "password": resolve_env_credential("CLICKHOUSE_PASSWORD"),
                     "secure": os.getenv("CLICKHOUSE_SECURE", "false").strip().lower()
                     in ("true", "1", "yes"),
                 },

--- a/integrations/airflow/config.py
+++ b/integrations/airflow/config.py
@@ -11,6 +11,7 @@ from urllib.parse import quote
 import httpx
 from pydantic import Field, field_validator
 
+from config.llm_credentials import resolve_env_credential
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
@@ -78,7 +79,7 @@ def build_airflow_config(raw: dict[str, Any] | None) -> AirflowConfig:
 def airflow_config_from_env() -> AirflowConfig | None:
     """Load an Airflow config from env vars."""
     username = os.getenv("AIRFLOW_USERNAME", "").strip()
-    auth_token = os.getenv("AIRFLOW_AUTH_TOKEN", "").strip()
+    auth_token = resolve_env_credential("AIRFLOW_AUTH_TOKEN")
 
     if not username and not auth_token:
         return None
@@ -88,7 +89,7 @@ def airflow_config_from_env() -> AirflowConfig | None:
             "base_url": os.getenv("AIRFLOW_BASE_URL", DEFAULT_AIRFLOW_BASE_URL).strip()
             or DEFAULT_AIRFLOW_BASE_URL,
             "username": username,
-            "password": os.getenv("AIRFLOW_PASSWORD", "").strip(),
+            "password": resolve_env_credential("AIRFLOW_PASSWORD"),
             "auth_token": auth_token,
             "timeout_seconds": os.getenv(
                 "AIRFLOW_TIMEOUT_SECONDS",

--- a/integrations/gitlab/__init__.py
+++ b/integrations/gitlab/__init__.py
@@ -11,6 +11,7 @@ from urllib.parse import quote, urlsplit
 import httpx
 from pydantic import Field, field_validator
 
+from config.llm_credentials import resolve_env_credential
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
@@ -69,7 +70,7 @@ def build_gitlab_config(raw: dict[str, Any] | None) -> GitlabConfig:
 
 def gitlab_config_from_env() -> GitlabConfig | None:
     """Load a Gitlab config from env vars."""
-    auth_token = os.getenv("GITLAB_ACCESS_TOKEN", "").strip()
+    auth_token = resolve_env_credential("GITLAB_ACCESS_TOKEN")
     if not auth_token:
         return None
     return build_gitlab_config(

--- a/integrations/grafana/client.py
+++ b/integrations/grafana/client.py
@@ -25,9 +25,11 @@ def get_grafana_client() -> GrafanaClient:
     """Create a Grafana client from environment variables."""
     import os
 
+    from config.llm_credentials import resolve_env_credential
+
     return get_grafana_client_from_credentials(
         endpoint=os.getenv("GRAFANA_INSTANCE_URL", "https://tracerbio.grafana.net"),
-        api_key=os.getenv("GRAFANA_READ_TOKEN", ""),
+        api_key=resolve_env_credential("GRAFANA_READ_TOKEN"),
         account_id="env_default",
         verify_ssl=os.getenv("GRAFANA_VERIFY_SSL", "true").strip().lower() != "false",
         ca_bundle=os.getenv("GRAFANA_CA_BUNDLE", "").strip(),

--- a/integrations/jenkins/__init__.py
+++ b/integrations/jenkins/__init__.py
@@ -10,6 +10,7 @@ from typing import Any
 import httpx
 from pydantic import Field, field_validator
 
+from config.llm_credentials import resolve_env_credential
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
@@ -62,7 +63,7 @@ def build_jenkins_config(raw: dict[str, Any] | None) -> JenkinsConfig:
 def jenkins_config_from_env() -> JenkinsConfig | None:
     """Load a Jenkins config from env vars."""
     base_url = os.getenv("JENKINS_URL", "").strip()
-    api_token = os.getenv("JENKINS_API_TOKEN", "").strip()
+    api_token = resolve_env_credential("JENKINS_API_TOKEN")
     if not base_url or not api_token:
         return None
     return build_jenkins_config(

--- a/integrations/posthog/config.py
+++ b/integrations/posthog/config.py
@@ -11,6 +11,7 @@ from config.constants.posthog import (
     DEFAULT_POSTHOG_TIMEOUT_SECONDS,
     DEFAULT_POSTHOG_URL,
 )
+from config.llm_credentials import resolve_env_credential
 from config.strict_config import StrictConfigModel
 
 
@@ -57,7 +58,7 @@ def build_posthog_config(raw: dict[str, Any] | None) -> PostHogConfig:
 
 def posthog_config_from_env() -> PostHogConfig | None:
     project_id = os.getenv("POSTHOG_PROJECT_ID", "").strip()
-    personal_api_key = os.getenv("POSTHOG_PERSONAL_API_KEY", "").strip()
+    personal_api_key = resolve_env_credential("POSTHOG_PERSONAL_API_KEY")
 
     if not project_id or not personal_api_key:
         return None

--- a/integrations/sentry/__init__.py
+++ b/integrations/sentry/__init__.py
@@ -11,6 +11,7 @@ from typing import Any
 import httpx
 from pydantic import Field, field_validator
 
+from config.llm_credentials import resolve_env_credential
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
@@ -91,7 +92,7 @@ def build_sentry_config(raw: dict[str, Any] | None) -> SentryConfig:
 def sentry_config_from_env() -> SentryConfig | None:
     """Load a Sentry config from env vars."""
     organization_slug = os.getenv("SENTRY_ORG_SLUG", "").strip()
-    auth_token = os.getenv("SENTRY_AUTH_TOKEN", "").strip()
+    auth_token = resolve_env_credential("SENTRY_AUTH_TOKEN")
     if not organization_slug or not auth_token:
         return None
     return build_sentry_config(

--- a/integrations/slack/bot_api.py
+++ b/integrations/slack/bot_api.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import httpx
 
+from config.llm_credentials import resolve_env_credential
+
 _API_BASE = "https://slack.com/api"
 _REQUEST_TIMEOUT_SECONDS = 10.0
 _MAX_REQUEST_ATTEMPTS = 3
@@ -50,8 +52,6 @@ def resolve_bot_token() -> tuple[SlackBotTarget | None, str]:
     ``resolve_env_credential`` checks process env then the OS keyring (wizard
     ``sync_env_secret``), preserving the historical env-before-store order.
     """
-    from config.llm_credentials import resolve_env_credential
-
     env_token = resolve_env_credential("SLACK_BOT_TOKEN").strip()
     if env_token:
         return SlackBotTarget(bot_token=env_token), ""
@@ -94,8 +94,6 @@ def bot_token_configured(sources: dict[str, Any] | None = None) -> bool:
     INTEGRATIONS: none``) while ``SLACK_BOT_TOKEN`` / the store still have a
     usable token. ``resolve_bot_token`` already understands that shape.
     """
-    from config.llm_credentials import resolve_env_credential
-
     if resolve_env_credential("SLACK_BOT_TOKEN").strip():
         return True
     if _bot_token_from_slack_source((sources or {}).get("slack")):

--- a/integrations/slack/bot_api.py
+++ b/integrations/slack/bot_api.py
@@ -6,7 +6,6 @@ multiple tools share one client, charset headers, and error hints.
 
 from __future__ import annotations
 
-import os
 import re
 import threading
 import time
@@ -46,8 +45,14 @@ class SlackBotTarget:
 
 
 def resolve_bot_token() -> tuple[SlackBotTarget | None, str]:
-    """Resolve the Slack bot token from env first, then the integration store."""
-    env_token = os.getenv("SLACK_BOT_TOKEN", "").strip()
+    """Resolve the Slack bot token from env/keyring first, then the integration store.
+
+    ``resolve_env_credential`` checks process env then the OS keyring (wizard
+    ``sync_env_secret``), preserving the historical env-before-store order.
+    """
+    from config.llm_credentials import resolve_env_credential
+
+    env_token = resolve_env_credential("SLACK_BOT_TOKEN").strip()
     if env_token:
         return SlackBotTarget(bot_token=env_token), ""
 
@@ -89,8 +94,9 @@ def bot_token_configured(sources: dict[str, Any] | None = None) -> bool:
     INTEGRATIONS: none``) while ``SLACK_BOT_TOKEN`` / the store still have a
     usable token. ``resolve_bot_token`` already understands that shape.
     """
-    env_token = os.getenv("SLACK_BOT_TOKEN", "").strip()
-    if env_token:
+    from config.llm_credentials import resolve_env_credential
+
+    if resolve_env_credential("SLACK_BOT_TOKEN").strip():
         return True
     if _bot_token_from_slack_source((sources or {}).get("slack")):
         return True

--- a/integrations/tempo/__init__.py
+++ b/integrations/tempo/__init__.py
@@ -17,6 +17,7 @@ from typing import Any
 import httpx
 from pydantic import Field
 
+from config.llm_credentials import resolve_env_credential
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
@@ -82,9 +83,9 @@ def tempo_config_from_env() -> TempoConfig | None:
     return build_tempo_config(
         {
             "url": url,
-            "api_key": os.getenv("TEMPO_API_KEY", "").strip(),
+            "api_key": resolve_env_credential("TEMPO_API_KEY"),
             "username": os.getenv("TEMPO_USERNAME", "").strip(),
-            "password": os.getenv("TEMPO_PASSWORD", "").strip(),
+            "password": resolve_env_credential("TEMPO_PASSWORD"),
             "org_id": os.getenv("TEMPO_ORG_ID", "").strip(),
         }
     )

--- a/integrations/trello/config.py
+++ b/integrations/trello/config.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from config.llm_credentials import resolve_env_credential
+
 DEFAULT_TRELLO_BASE_URL = "https://api.trello.com/1"
 
 
@@ -36,8 +38,8 @@ def build_trello_config(raw: dict[str, Any] | None) -> TrelloConfig:
 
 def trello_config_from_env() -> TrelloConfig | None:
     """Load a Trello config from env vars."""
-    api_key = os.getenv("TRELLO_API_KEY", "").strip()
-    token = os.getenv("TRELLO_TOKEN", "").strip()
+    api_key = resolve_env_credential("TRELLO_API_KEY")
+    token = resolve_env_credential("TRELLO_TOKEN")
     if not api_key or not token:
         return None
 

--- a/platform/scheduler/credentials.py
+++ b/platform/scheduler/credentials.py
@@ -10,6 +10,7 @@ so wizard ``sync_env_secret`` writes are visible when the store is empty.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 from config.llm_credentials import resolve_env_credential
@@ -34,25 +35,23 @@ def resolve_slack_credentials(task_params: dict[str, str]) -> dict[str, str]:
     """Resolve Slack credentials from task params, integration store, env, or keyring.
 
     Priority: task.params > integration store > environment variable > system keyring.
-    Webhook URLs are not keyring-backed; ``resolve_env_credential`` still checks
-    env first and returns empty from keyring when unset.
+    Webhook URLs stay env/store only (not keyring-eligible as ``*_URL``).
     """
-    webhook_url = task_params.get("webhook_url", "")
+    webhook_url = task_params.get("webhook_url", "").strip()
     if webhook_url:
         return {"webhook_url": webhook_url}
 
-    access_token = task_params.get("access_token", "")
+    access_token = task_params.get("access_token", "").strip()
     if access_token:
         return {"access_token": access_token}
 
-    webhook = _resolve_credentials(
-        {},
-        service="slack",
-        credential_key="webhook_url",
-        env_vars=("SLACK_WEBHOOK_URL",),
-    )
-    if webhook:
-        return webhook
+    # Webhook: store then plain env — never resolve_env_credential / keyring.
+    store_webhook = _get_integration_credential("slack", "webhook_url").strip()
+    if store_webhook:
+        return {"webhook_url": store_webhook}
+    env_webhook = os.getenv("SLACK_WEBHOOK_URL", "").strip()
+    if env_webhook:
+        return {"webhook_url": env_webhook}
 
     return _resolve_credentials(
         {},

--- a/platform/scheduler/credentials.py
+++ b/platform/scheduler/credentials.py
@@ -2,23 +2,19 @@
 
 Resolves provider credentials from the integration store and environment
 rather than requiring them to be stored in task params.
+
+Secret env vars use ``resolve_env_credential`` (process env, then OS keyring)
+so wizard ``sync_env_secret`` writes are visible when the store is empty.
 """
 
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any
 
+from config.llm_credentials import resolve_env_credential
+
 logger = logging.getLogger(__name__)
-
-
-try:
-    from keyring.errors import KeyringError as _KeyringError
-except ImportError:
-
-    class _KeyringError(Exception):  # type: ignore[no-redef]
-        """Fallback when keyring is not installed."""
 
 
 def resolve_telegram_credentials(task_params: dict[str, str]) -> dict[str, str]:
@@ -26,29 +22,20 @@ def resolve_telegram_credentials(task_params: dict[str, str]) -> dict[str, str]:
 
     Priority: task.params > integration store > environment variable > system keyring.
     """
-    token = task_params.get("bot_token", "").strip()
-    if token:
-        return {"bot_token": token}
-
-    token = _get_integration_credential("telegram", "bot_token")
-    if token:
-        return {"bot_token": token}
-
-    try:
-        from config.llm_credentials import resolve_env_credential
-
-        token = resolve_env_credential("TELEGRAM_BOT_TOKEN").strip()
-    except (ImportError, _KeyringError) as exc:
-        logger.debug("Failed to resolve Telegram credentials from keyring: %s", exc)
-        token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
-
-    return {"bot_token": token} if token else {}
+    return _resolve_credentials(
+        task_params,
+        service="telegram",
+        credential_key="bot_token",
+        env_vars=("TELEGRAM_BOT_TOKEN",),
+    )
 
 
 def resolve_slack_credentials(task_params: dict[str, str]) -> dict[str, str]:
-    """Resolve Slack credentials from task params, integration store, or env.
+    """Resolve Slack credentials from task params, integration store, env, or keyring.
 
-    Priority: task.params > integration store > environment variable.
+    Priority: task.params > integration store > environment variable > system keyring.
+    Webhook URLs are not keyring-backed; ``resolve_env_credential`` still checks
+    env first and returns empty from keyring when unset.
     """
     webhook_url = task_params.get("webhook_url", "")
     if webhook_url:
@@ -76,9 +63,9 @@ def resolve_slack_credentials(task_params: dict[str, str]) -> dict[str, str]:
 
 
 def resolve_discord_credentials(task_params: dict[str, str]) -> dict[str, str]:
-    """Resolve Discord bot_token from task params, integration store, or env.
+    """Resolve Discord bot_token from task params, integration store, env, or keyring.
 
-    Priority: task.params > integration store > environment variable.
+    Priority: task.params > integration store > environment variable > system keyring.
     """
     return _resolve_credentials(
         task_params,
@@ -95,7 +82,7 @@ def _resolve_credentials(
     credential_key: str,
     env_vars: tuple[str, ...],
 ) -> dict[str, str]:
-    """Resolve a single credential from task params, integration store, or env."""
+    """Resolve a single credential from task params, store, env, or keyring."""
     value = task_params.get(credential_key, "")
     if value:
         return {credential_key: value}
@@ -105,7 +92,7 @@ def _resolve_credentials(
         return {credential_key: value}
 
     for env_var in env_vars:
-        value = os.getenv(env_var, "")
+        value = resolve_env_credential(env_var).strip()
         if value:
             return {credential_key: value}
 

--- a/surfaces/cli/llm_auth/persist.py
+++ b/surfaces/cli/llm_auth/persist.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from config.llm_credentials import save_llm_api_key
+from config.llm_credentials import save_keyring_secret
 
 
 class AuthSetupError(RuntimeError):
@@ -23,7 +23,7 @@ def persist_api_key_secret(
     env_var: str,
     value: str,
     *,
-    save_secret: SaveSecret = save_llm_api_key,
+    save_secret: SaveSecret = save_keyring_secret,
 ) -> None:
     """Persist one API-key secret through the shared auth service boundary."""
     try:

--- a/surfaces/cli/wizard/_ui.py
+++ b/surfaces/cli/wizard/_ui.py
@@ -20,7 +20,7 @@ from config.llm_auth.auth_method import (
 )
 from config.llm_auth.credentials import has_llm_api_key, save_api_key
 from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
-from config.llm_credentials import get_keyring_setup_instructions, save_llm_api_key
+from config.llm_credentials import get_keyring_setup_instructions, save_keyring_secret
 from config.version import get_opensre_version
 from integrations.store import get_integration
 from platform.terminal.theme import (
@@ -406,7 +406,7 @@ def _persist_llm_api_key(env_var: str, value: str) -> bool:
         if provider:
             save_api_key(provider, value)
         else:
-            persist_api_key_secret(env_var, value, save_secret=save_llm_api_key)
+            persist_api_key_secret(env_var, value, save_secret=save_keyring_secret)
     except (AuthSetupError, RuntimeError, ValueError) as exc:
         _console.print(f"[{ERROR}]  {GLYPH_ERROR}  {exc}[/]")
         _console.print(

--- a/surfaces/cli/wizard/configurators/observability.py
+++ b/surfaces/cli/wizard/configurators/observability.py
@@ -324,11 +324,11 @@ def _configure_tempo() -> tuple[str, str]:
             upsert_integration("tempo", {"credentials": creds})
             env_values: dict[str, str] = {"TEMPO_URL": url}
             if api_key:
-                env_values["TEMPO_API_KEY"] = api_key
+                sync_env_secret("TEMPO_API_KEY", api_key)
             if username:
                 env_values["TEMPO_USERNAME"] = username
             if password:
-                env_values["TEMPO_PASSWORD"] = password
+                sync_env_secret("TEMPO_PASSWORD", password)
             if org_id:
                 env_values["TEMPO_ORG_ID"] = org_id
             env_path = sync_env_values(env_values)

--- a/surfaces/cli/wizard/env_sync.py
+++ b/surfaces/cli/wizard/env_sync.py
@@ -12,7 +12,7 @@ from config.llm_auth.auth_method import LLM_AUTH_METHOD_ENV
 from config.llm_auth.credentials import delete as delete_provider_auth
 from config.llm_auth.credentials import save_api_key
 from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
-from config.llm_credentials import delete_llm_api_key, save_llm_api_key
+from config.llm_credentials import delete_keyring_secret, save_keyring_secret
 from surfaces.cli.wizard.config import PROJECT_ENV_PATH, ProviderOption
 
 _ENV_ASSIGNMENT = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=")
@@ -97,13 +97,13 @@ def _persist_env_secret(key: str, value: str) -> bool:
         if provider:
             delete_provider_auth(provider)
         else:
-            delete_llm_api_key(key)
+            delete_keyring_secret(key)
         return True
     try:
         if provider:
             save_api_key(provider, normalized)
         else:
-            save_llm_api_key(key, normalized)
+            save_keyring_secret(key, normalized)
     except RuntimeError:
         return False
     return True

--- a/tests/cli/test_auth_command.py
+++ b/tests/cli/test_auth_command.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import keyring
 from click.testing import CliRunner
 
-from config.llm_credentials import resolve_llm_api_key
+from config.llm_credentials import resolve_env_credential
 from surfaces.cli.__main__ import cli
 from surfaces.cli.llm_auth.service import AuthSetupResult
 from tests.shared.keyring_backend import MemoryKeyring
@@ -44,7 +44,7 @@ def test_auth_login_deepseek_stores_keyring_not_env(monkeypatch, tmp_path: Path)
 
         assert result.exit_code == 0, result.output
         assert "Authenticated: DeepSeek API key" in result.output
-        assert resolve_llm_api_key("DEEPSEEK_API_KEY") == "deepseek-secret"
+        assert resolve_env_credential("DEEPSEEK_API_KEY") == "deepseek-secret"
         env_content = env_path.read_text(encoding="utf-8")
         assert "LLM_PROVIDER=deepseek\n" in env_content
         assert "DEEPSEEK_API_KEY=" not in env_content
@@ -160,6 +160,6 @@ def test_auth_logout_deepseek_removes_keyring_secret(monkeypatch, tmp_path: Path
         result = CliRunner().invoke(cli, ["auth", "logout", "deepseek"])
 
         assert result.exit_code == 0, result.output
-        assert resolve_llm_api_key("DEEPSEEK_API_KEY") == ""
+        assert resolve_env_credential("DEEPSEEK_API_KEY") == ""
     finally:
         keyring.set_keyring(previous_backend)

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -119,7 +119,7 @@ def test_run_wizard_no_saved_provider_shows_selection(monkeypatch, tmp_path) -> 
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     exit_code = flow.run_wizard()
     assert exit_code == 0
@@ -222,7 +222,7 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -295,7 +295,7 @@ def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -371,7 +371,7 @@ def test_run_wizard_configures_coralogix(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -444,7 +444,7 @@ def test_run_wizard_configures_dagster(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -515,7 +515,7 @@ def test_run_wizard_configures_dagster_oss_skips_secret(monkeypatch, tmp_path) -
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         _dagster_configurator,
         "sync_env_values",
@@ -580,7 +580,7 @@ def test_run_wizard_configures_slack_persists_webhook(monkeypatch, tmp_path) -> 
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -656,7 +656,7 @@ def test_run_wizard_dagster_retries_on_validation_failure(monkeypatch, tmp_path)
     monkeypatch.setattr(_dagster_configurator, "validate_dagster_integration", _validate_dagster)
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -751,7 +751,7 @@ def test_run_wizard_configures_github_mcp_and_sentry(monkeypatch, tmp_path, caps
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -1674,7 +1674,7 @@ def test_run_wizard_configures_gitlab(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -1760,7 +1760,7 @@ def test_run_wizard_gitlab_retries_on_validation_failure(monkeypatch, tmp_path) 
     monkeypatch.setattr(_gitlab_configurator, "validate_gitlab_integration", _validate_gitlab)
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -1922,7 +1922,7 @@ def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2018,7 +2018,7 @@ def test_run_wizard_opensearch_retries_on_validation_failure(monkeypatch, tmp_pa
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2120,7 +2120,7 @@ def test_run_wizard_opensearch_rejects_empty_api_key(monkeypatch, tmp_path) -> N
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2217,7 +2217,7 @@ def test_run_wizard_opensearch_rejects_empty_basic_password(monkeypatch, tmp_pat
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2292,7 +2292,7 @@ def test_run_wizard_configures_telegram(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2364,7 +2364,7 @@ def test_run_wizard_telegram_retries_on_validation_failure(monkeypatch, tmp_path
     monkeypatch.setattr(_chat_notifications_configurator, "validate_telegram_bot", _validate)
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         _chat_notifications_configurator, "sync_env_values", lambda *_a, **_kw: tmp_path / ".env"
     )

--- a/tests/cli/wizard/test_tempo_env_sync.py
+++ b/tests/cli/wizard/test_tempo_env_sync.py
@@ -1,0 +1,70 @@
+"""Tempo wizard dual-writes secrets to keyring, not .env."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from surfaces.cli.wizard.configurators import observability as obs
+
+
+def test_configure_tempo_routes_secrets_to_keyring(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    prompts = iter(
+        [
+            "http://localhost:3200",
+            "tempo-bearer",
+            "tempo-user",
+            "tempo-pass",
+            "tenant-1",
+        ]
+    )
+    synced_env_values: list[dict[str, str]] = []
+    synced_env_secrets: list[tuple[str, str]] = []
+    saved: list[tuple[str, dict]] = []
+
+    monkeypatch.setattr(obs, "_integration_defaults", lambda _service: ({}, {}))
+    monkeypatch.setattr(obs, "_prompt_value", lambda *_a, **_k: next(prompts))
+    monkeypatch.setattr(
+        obs,
+        "validate_tempo_integration",
+        lambda **_kwargs: MagicMock(ok=True, detail="ok"),
+    )
+    monkeypatch.setattr(obs, "_render_integration_result", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        obs,
+        "upsert_integration",
+        lambda service, payload: saved.append((service, payload)),
+    )
+    monkeypatch.setattr(
+        obs,
+        "sync_env_values",
+        lambda values, **_k: synced_env_values.append(values) or (tmp_path / ".env"),
+    )
+    monkeypatch.setattr(
+        obs,
+        "sync_env_secret",
+        lambda key, value: synced_env_secrets.append((key, value)),
+    )
+
+    name, path = obs._configure_tempo()
+
+    assert name == "Tempo"
+    assert path == str(tmp_path / ".env")
+    assert synced_env_secrets == [
+        ("TEMPO_API_KEY", "tempo-bearer"),
+        ("TEMPO_PASSWORD", "tempo-pass"),
+    ]
+    assert synced_env_values == [
+        {
+            "TEMPO_URL": "http://localhost:3200",
+            "TEMPO_USERNAME": "tempo-user",
+            "TEMPO_ORG_ID": "tenant-1",
+        }
+    ]
+    assert "TEMPO_API_KEY" not in synced_env_values[0]
+    assert "TEMPO_PASSWORD" not in synced_env_values[0]
+    assert saved[0][0] == "tempo"
+    assert saved[0][1]["credentials"]["api_key"] == "tempo-bearer"

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -37,7 +37,7 @@ def test_llm_settings_from_env_does_not_read_secure_local_api_key(monkeypatch) -
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setattr(
-        "config.llm_credentials.resolve_llm_api_key",
+        "config.llm_credentials.resolve_env_credential",
         lambda env_var: (_ for _ in ()).throw(AssertionError(f"unexpected lookup: {env_var}")),
     )
 
@@ -51,7 +51,7 @@ def test_llm_settings_from_env_does_not_probe_provider_keys(monkeypatch) -> None
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setattr(
-        "config.llm_credentials.resolve_llm_api_key",
+        "config.llm_credentials.resolve_env_credential",
         lambda env_var: (_ for _ in ()).throw(AssertionError(f"unexpected lookup: {env_var}")),
     )
 

--- a/tests/config/test_llm_auth.py
+++ b/tests/config/test_llm_auth.py
@@ -9,7 +9,7 @@ from keyring.backend import KeyringBackend
 
 from config.llm_auth.credentials import resolve_for_request, status
 from config.llm_auth.records import resolve_provider_auth_record, save_provider_auth_record
-from config.llm_credentials import resolve_llm_api_key
+from config.llm_credentials import resolve_env_credential
 from integrations.llm_cli.base import CLIProbe
 from integrations.llm_cli.codex_oauth import CodexOAuthResult
 from surfaces.cli.llm_auth.providers import ProviderAuthProfile, resolve_auth_profile
@@ -57,7 +57,7 @@ def test_configure_deepseek_api_key_stores_keyring_and_nonsecret_env(
         )
 
         assert result.provider == "deepseek"
-        assert resolve_llm_api_key("DEEPSEEK_API_KEY") == "deepseek-secret"
+        assert resolve_env_credential("DEEPSEEK_API_KEY") == "deepseek-secret"
         env_content = env_path.read_text(encoding="utf-8")
         assert "LLM_PROVIDER=deepseek\n" in env_content
         assert "DEEPSEEK_REASONING_MODEL=deepseek-v4-flash\n" in env_content
@@ -87,7 +87,7 @@ def test_configure_api_key_does_not_store_when_validation_fails(
                 profile=resolve_auth_profile("deepseek"),
                 api_key="bad-key",
             )
-        assert resolve_llm_api_key("DEEPSEEK_API_KEY") == ""
+        assert resolve_env_credential("DEEPSEEK_API_KEY") == ""
     finally:
         keyring.set_keyring(previous_backend)
 

--- a/tests/config/test_llm_credentials.py
+++ b/tests/config/test_llm_credentials.py
@@ -60,13 +60,16 @@ def test_resolve_keyring_secret_reads_keyring_only(monkeypatch) -> None:
 def test_resolve_keyring_secret_swallows_backend_runtime_error(monkeypatch) -> None:
     """SecretService can raise bare RuntimeError when D-Bus is unset."""
     monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+    # Use a name unlikely to be present in CI secrets / ambient env.
+    env_var = "OPENSRE_TEST_MISSING_KEYRING_SECRET"
+    monkeypatch.delenv(env_var, raising=False)
 
     def _boom(_service: str, _username: str) -> str:
         raise RuntimeError("Unable to initialize SecretService: DBUS unset")
 
     monkeypatch.setattr(llm_keyring.keyring, "get_password", _boom)
-    assert llm_credentials.resolve_keyring_secret("GRAFANA_READ_TOKEN") == ""
-    assert llm_credentials.resolve_env_credential("GRAFANA_READ_TOKEN") == ""
+    assert llm_credentials.resolve_keyring_secret(env_var) == ""
+    assert llm_credentials.resolve_env_credential(env_var) == ""
 
 
 def test_unmanaged_llm_api_key_source_reports_env_keyring_and_none(monkeypatch) -> None:

--- a/tests/config/test_llm_credentials.py
+++ b/tests/config/test_llm_credentials.py
@@ -57,6 +57,18 @@ def test_resolve_keyring_secret_reads_keyring_only(monkeypatch) -> None:
         keyring.set_keyring(previous_backend)
 
 
+def test_resolve_keyring_secret_swallows_backend_runtime_error(monkeypatch) -> None:
+    """SecretService can raise bare RuntimeError when D-Bus is unset."""
+    monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+
+    def _boom(_service: str, _username: str) -> str:
+        raise RuntimeError("Unable to initialize SecretService: DBUS unset")
+
+    monkeypatch.setattr(llm_keyring.keyring, "get_password", _boom)
+    assert llm_credentials.resolve_keyring_secret("GRAFANA_READ_TOKEN") == ""
+    assert llm_credentials.resolve_env_credential("GRAFANA_READ_TOKEN") == ""
+
+
 def test_unmanaged_llm_api_key_source_reports_env_keyring_and_none(monkeypatch) -> None:
     monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
     monkeypatch.delenv("EXPERIMENTAL_API_KEY", raising=False)

--- a/tests/config/test_llm_credentials.py
+++ b/tests/config/test_llm_credentials.py
@@ -38,8 +38,21 @@ def test_resolve_env_credential_prefers_env_over_keyring(monkeypatch) -> None:
     previous_backend = keyring.get_keyring()
     keyring.set_keyring(MemoryKeyring())
     try:
-        llm_credentials.save_llm_api_key("GITLAB_ACCESS_TOKEN", "from-keyring")
+        llm_credentials.save_keyring_secret("GITLAB_ACCESS_TOKEN", "from-keyring")
         assert llm_credentials.resolve_env_credential("GITLAB_ACCESS_TOKEN") == "from-env"
+    finally:
+        keyring.set_keyring(previous_backend)
+
+
+def test_resolve_keyring_secret_reads_keyring_only(monkeypatch) -> None:
+    monkeypatch.setenv("GITLAB_ACCESS_TOKEN", "from-env")
+    monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+
+    previous_backend = keyring.get_keyring()
+    keyring.set_keyring(MemoryKeyring())
+    try:
+        llm_credentials.save_keyring_secret("GITLAB_ACCESS_TOKEN", "from-keyring")
+        assert llm_credentials.resolve_keyring_secret("GITLAB_ACCESS_TOKEN") == "from-keyring"
     finally:
         keyring.set_keyring(previous_backend)
 
@@ -52,7 +65,7 @@ def test_unmanaged_llm_api_key_source_reports_env_keyring_and_none(monkeypatch) 
     keyring.set_keyring(MemoryKeyring())
     try:
         assert llm_api_key_source("EXPERIMENTAL_API_KEY") == "none"
-        llm_credentials.save_llm_api_key("EXPERIMENTAL_API_KEY", "from-keyring")
+        llm_credentials.save_keyring_secret("EXPERIMENTAL_API_KEY", "from-keyring")
         assert llm_api_key_source("EXPERIMENTAL_API_KEY") == "keyring"
         monkeypatch.setenv("EXPERIMENTAL_API_KEY", "from-env")
         assert llm_api_key_source("EXPERIMENTAL_API_KEY") == "env"

--- a/tests/core/agent/conftest.py
+++ b/tests/core/agent/conftest.py
@@ -133,9 +133,9 @@ def _resolve_live_llm_configuration(
 
     spec = provider_spec(settings.provider)
     if spec is not None and spec.credential_kind == "api_key" and spec.api_key_env:
-        from config.llm_credentials import resolve_llm_api_key
+        from config.llm_credentials import resolve_env_credential
 
-        if not resolve_llm_api_key(spec.api_key_env):
+        if not resolve_env_credential(spec.api_key_env):
             _skip_or_fail_live_llm(
                 "Live LLM turn tests require a resolvable API key:"
                 f" provider={settings.provider!r}, env={spec.api_key_env}"

--- a/tests/core/runtime/llm/test_azure_openai_helpers.py
+++ b/tests/core/runtime/llm/test_azure_openai_helpers.py
@@ -78,7 +78,7 @@ def test_list_azure_openai_deployments_parses_response(monkeypatch) -> None:
 def test_discover_azure_openai_deployments_from_env(monkeypatch) -> None:
     monkeypatch.setenv("AZURE_OPENAI_BASE_URL", "https://example.openai.azure.com")
     monkeypatch.setattr(
-        "config.llm_credentials.resolve_llm_api_key",
+        "config.llm_credentials.resolve_env_credential",
         lambda _env: "test-key",
     )
     monkeypatch.setattr(

--- a/tests/integrations/test_catalog_secret_credential_resolve.py
+++ b/tests/integrations/test_catalog_secret_credential_resolve.py
@@ -1,0 +1,61 @@
+"""Catalog secret env loaders resolve via env then keyring (PR2)."""
+
+from __future__ import annotations
+
+import keyring
+import pytest
+
+import config.llm_credentials as llm_credentials
+from integrations.catalog import load_env_integrations
+from tests.shared.keyring_backend import MemoryKeyring
+
+
+@pytest.fixture
+def memory_keyring(monkeypatch: pytest.MonkeyPatch) -> MemoryKeyring:
+    previous = keyring.get_keyring()
+    backend = MemoryKeyring()
+    keyring.set_keyring(backend)
+    monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+    yield backend
+    keyring.set_keyring(previous)
+
+
+def _clear_secret_env(monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
+    for name in names:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_grafana_token_loads_from_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    _clear_secret_env(monkeypatch, "GRAFANA_INSTANCE_URL", "GRAFANA_READ_TOKEN")
+    monkeypatch.setenv("GRAFANA_INSTANCE_URL", "https://grafana.example.com")
+    llm_credentials.save_keyring_secret("GRAFANA_READ_TOKEN", "glsa_from_keyring")
+    records = load_env_integrations()
+    grafana = next(r for r in records if r.get("service") == "grafana")
+    assert grafana["credentials"]["api_key"] == "glsa_from_keyring"
+
+
+def test_datadog_keys_env_win_over_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    _clear_secret_env(monkeypatch, "DD_API_KEY", "DD_APP_KEY", "DD_SITE")
+    llm_credentials.save_keyring_secret("DD_API_KEY", "dd-keyring")
+    llm_credentials.save_keyring_secret("DD_APP_KEY", "dd-app-keyring")
+    monkeypatch.setenv("DD_API_KEY", "dd-env")
+    monkeypatch.setenv("DD_APP_KEY", "dd-app-env")
+    records = load_env_integrations()
+    datadog = next(r for r in records if r.get("service") == "datadog")
+    assert datadog["credentials"]["api_key"] == "dd-env"
+    assert datadog["credentials"]["app_key"] == "dd-app-env"
+
+
+def test_sentry_auth_token_loads_from_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    _clear_secret_env(monkeypatch, "SENTRY_ORG_SLUG", "SENTRY_AUTH_TOKEN")
+    monkeypatch.setenv("SENTRY_ORG_SLUG", "acme")
+    llm_credentials.save_keyring_secret("SENTRY_AUTH_TOKEN", "sentry-from-keyring")
+    records = load_env_integrations()
+    sentry = next(r for r in records if r.get("service") == "sentry")
+    assert sentry["credentials"]["auth_token"] == "sentry-from-keyring"

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -392,9 +392,13 @@ def test_env_loader_failure_reports_and_skips(
     integration must be skipped (preserving the historic caller contract)
     *and* the failure must reach Sentry via ``report_exception``."""
     # Clear ambient env so other integrations on the dev box don't enable
-    # unrelated paths and inflate the assertion.
+    # unrelated paths and inflate the assertion. Disable keyring too —
+    # secret fields resolve via resolve_env_credential (env then keyring),
+    # and a wiped env without this flag can hammer a broken session keyring
+    # under xdist or leak secrets from a prior MemoryKeyring fixture.
     for var in list(os.environ):
         monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("OPENSRE_DISABLE_KEYRING", "1")
     for var, value in env.items():
         monkeypatch.setenv(var, value)
 
@@ -438,6 +442,7 @@ def test_one_failing_env_loader_does_not_abort_remaining_integrations(
     """
     for var in list(os.environ):
         monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("OPENSRE_DISABLE_KEYRING", "1")
     monkeypatch.setenv("VERCEL_API_TOKEN", "tkn")
     monkeypatch.setenv("INCIDENT_IO_API_KEY", "tkn")
 

--- a/tests/integrations/test_from_env_credential_resolve.py
+++ b/tests/integrations/test_from_env_credential_resolve.py
@@ -1,0 +1,106 @@
+"""Package *_from_env helpers resolve secrets via env then keyring."""
+
+from __future__ import annotations
+
+import keyring
+import pytest
+
+import config.llm_credentials as llm_credentials
+from integrations.airflow.config import airflow_config_from_env
+from integrations.gitlab import gitlab_config_from_env
+from integrations.jenkins import jenkins_config_from_env
+from integrations.posthog.config import posthog_config_from_env
+from integrations.sentry import sentry_config_from_env
+from integrations.tempo import tempo_config_from_env
+from integrations.trello.config import trello_config_from_env
+from tests.shared.keyring_backend import MemoryKeyring
+
+
+@pytest.fixture
+def memory_keyring(monkeypatch: pytest.MonkeyPatch) -> MemoryKeyring:
+    previous = keyring.get_keyring()
+    backend = MemoryKeyring()
+    keyring.set_keyring(backend)
+    monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+    yield backend
+    keyring.set_keyring(previous)
+
+
+def test_tempo_api_key_from_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    monkeypatch.setenv("TEMPO_URL", "http://localhost:3200")
+    monkeypatch.delenv("TEMPO_API_KEY", raising=False)
+    monkeypatch.delenv("TEMPO_PASSWORD", raising=False)
+    llm_credentials.save_keyring_secret("TEMPO_API_KEY", "tempo-keyring")
+    config = tempo_config_from_env()
+    assert config is not None
+    assert config.api_key == "tempo-keyring"
+
+
+def test_gitlab_token_from_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    monkeypatch.delenv("GITLAB_ACCESS_TOKEN", raising=False)
+    llm_credentials.save_keyring_secret("GITLAB_ACCESS_TOKEN", "glpat-keyring")
+    config = gitlab_config_from_env()
+    assert config is not None
+    assert config.auth_token == "glpat-keyring"
+
+
+def test_jenkins_token_from_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    monkeypatch.setenv("JENKINS_URL", "https://jenkins.example.com")
+    monkeypatch.delenv("JENKINS_API_TOKEN", raising=False)
+    llm_credentials.save_keyring_secret("JENKINS_API_TOKEN", "jenkins-keyring")
+    config = jenkins_config_from_env()
+    assert config is not None
+    assert config.api_token == "jenkins-keyring"
+
+
+def test_posthog_personal_key_from_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    monkeypatch.setenv("POSTHOG_PROJECT_ID", "123")
+    monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
+    llm_credentials.save_keyring_secret("POSTHOG_PERSONAL_API_KEY", "phc-keyring")
+    config = posthog_config_from_env()
+    assert config is not None
+    assert config.personal_api_key == "phc-keyring"
+
+
+def test_airflow_password_from_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    monkeypatch.setenv("AIRFLOW_USERNAME", "admin")
+    monkeypatch.delenv("AIRFLOW_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("AIRFLOW_PASSWORD", raising=False)
+    llm_credentials.save_keyring_secret("AIRFLOW_PASSWORD", "airflow-keyring")
+    config = airflow_config_from_env()
+    assert config is not None
+    assert config.password == "airflow-keyring"
+
+
+def test_trello_secrets_from_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    monkeypatch.delenv("TRELLO_API_KEY", raising=False)
+    monkeypatch.delenv("TRELLO_TOKEN", raising=False)
+    llm_credentials.save_keyring_secret("TRELLO_API_KEY", "trello-key")
+    llm_credentials.save_keyring_secret("TRELLO_TOKEN", "trello-token")
+    config = trello_config_from_env()
+    assert config is not None
+    assert config.api_key == "trello-key"
+    assert config.token == "trello-token"
+
+
+def test_sentry_helper_token_from_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    monkeypatch.setenv("SENTRY_ORG_SLUG", "acme")
+    monkeypatch.delenv("SENTRY_AUTH_TOKEN", raising=False)
+    llm_credentials.save_keyring_secret("SENTRY_AUTH_TOKEN", "sentry-helper-keyring")
+    config = sentry_config_from_env()
+    assert config is not None
+    assert config.auth_token == "sentry-helper-keyring"

--- a/tests/integrations/test_messaging_credential_resolve.py
+++ b/tests/integrations/test_messaging_credential_resolve.py
@@ -1,0 +1,118 @@
+"""Messaging catalog/env loaders resolve secrets via env then keyring."""
+
+from __future__ import annotations
+
+import keyring
+import pytest
+
+import config.llm_credentials as llm_credentials
+from integrations.catalog import load_env_integrations
+from tests.shared.keyring_backend import MemoryKeyring
+
+
+@pytest.fixture
+def memory_keyring(monkeypatch: pytest.MonkeyPatch) -> MemoryKeyring:
+    previous = keyring.get_keyring()
+    backend = MemoryKeyring()
+    keyring.set_keyring(backend)
+    monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
+    yield backend
+    keyring.set_keyring(previous)
+
+
+def _clear_messaging_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "TELEGRAM_BOT_TOKEN",
+        "TELEGRAM_DEFAULT_CHAT_ID",
+        "ROCKETCHAT_AUTH_TOKEN",
+        "ROCKETCHAT_SERVER_URL",
+        "ROCKETCHAT_USER_ID",
+        "ROCKETCHAT_WEBHOOK_URL",
+        "ROCKETCHAT_DEFAULT_CHANNEL",
+        "SLACK_BOT_TOKEN",
+        "SLACK_APP_TOKEN",
+        "SLACK_WEBHOOK_URL",
+        "DISCORD_BOT_TOKEN",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_telegram_loads_from_keyring_when_env_empty(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    _clear_messaging_env(monkeypatch)
+    llm_credentials.save_llm_api_key("TELEGRAM_BOT_TOKEN", "111:KEYRING")
+    records = load_env_integrations()
+    telegram = next(r for r in records if r.get("service") == "telegram")
+    assert telegram["credentials"]["bot_token"] == "111:KEYRING"
+
+
+def test_telegram_env_wins_over_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    _clear_messaging_env(monkeypatch)
+    llm_credentials.save_llm_api_key("TELEGRAM_BOT_TOKEN", "111:KEYRING")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "111:ENV")
+    records = load_env_integrations()
+    telegram = next(r for r in records if r.get("service") == "telegram")
+    assert telegram["credentials"]["bot_token"] == "111:ENV"
+
+
+def test_rocketchat_pat_loads_from_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    _clear_messaging_env(monkeypatch)
+    monkeypatch.setenv("ROCKETCHAT_SERVER_URL", "https://chat.example.com")
+    monkeypatch.setenv("ROCKETCHAT_USER_ID", "u1")
+    llm_credentials.save_llm_api_key("ROCKETCHAT_AUTH_TOKEN", "pat-from-keyring")
+    records = load_env_integrations()
+    rocketchat = next(r for r in records if r.get("service") == "rocketchat")
+    assert rocketchat["credentials"]["auth_token"] == "pat-from-keyring"
+
+
+def test_rocketchat_webhook_only_still_loads_without_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    _clear_messaging_env(monkeypatch)
+    monkeypatch.setenv("ROCKETCHAT_WEBHOOK_URL", "https://chat.example.com/hooks/a/b")
+    records = load_env_integrations()
+    rocketchat = next(r for r in records if r.get("service") == "rocketchat")
+    assert rocketchat["credentials"]["webhook_url"] == "https://chat.example.com/hooks/a/b"
+    assert rocketchat["credentials"].get("auth_token", "") in ("", None)
+
+
+def test_slack_bot_token_loads_from_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    _clear_messaging_env(monkeypatch)
+    llm_credentials.save_llm_api_key("SLACK_BOT_TOKEN", "xoxb-from-keyring")
+    records = load_env_integrations()
+    slack = next(r for r in records if r.get("service") == "slack")
+    assert slack["credentials"]["bot_token"] == "xoxb-from-keyring"
+
+
+def test_slack_webhook_only_still_loads_without_bot_token(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    _clear_messaging_env(monkeypatch)
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/services/T/B/X")
+    records = load_env_integrations()
+    slack = next(r for r in records if r.get("service") == "slack")
+    assert slack["credentials"]["webhook_url"] == "https://hooks.slack.com/services/T/B/X"
+
+
+def test_slack_bot_api_resolves_token_from_keyring(
+    monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
+) -> None:
+    from integrations.slack.bot_api import resolve_bot_token
+
+    _clear_messaging_env(monkeypatch)
+    monkeypatch.setattr(
+        "integrations.catalog.resolve_effective_integrations",
+        lambda: {},
+    )
+    llm_credentials.save_llm_api_key("SLACK_BOT_TOKEN", "xoxb-bot-api-keyring")
+    target, error = resolve_bot_token()
+    assert error == ""
+    assert target is not None
+    assert target.bot_token == "xoxb-bot-api-keyring"

--- a/tests/integrations/test_messaging_credential_resolve.py
+++ b/tests/integrations/test_messaging_credential_resolve.py
@@ -41,7 +41,7 @@ def test_telegram_loads_from_keyring_when_env_empty(
     monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
 ) -> None:
     _clear_messaging_env(monkeypatch)
-    llm_credentials.save_llm_api_key("TELEGRAM_BOT_TOKEN", "111:KEYRING")
+    llm_credentials.save_keyring_secret("TELEGRAM_BOT_TOKEN", "111:KEYRING")
     records = load_env_integrations()
     telegram = next(r for r in records if r.get("service") == "telegram")
     assert telegram["credentials"]["bot_token"] == "111:KEYRING"
@@ -51,7 +51,7 @@ def test_telegram_env_wins_over_keyring(
     monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
 ) -> None:
     _clear_messaging_env(monkeypatch)
-    llm_credentials.save_llm_api_key("TELEGRAM_BOT_TOKEN", "111:KEYRING")
+    llm_credentials.save_keyring_secret("TELEGRAM_BOT_TOKEN", "111:KEYRING")
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "111:ENV")
     records = load_env_integrations()
     telegram = next(r for r in records if r.get("service") == "telegram")
@@ -64,7 +64,7 @@ def test_rocketchat_pat_loads_from_keyring(
     _clear_messaging_env(monkeypatch)
     monkeypatch.setenv("ROCKETCHAT_SERVER_URL", "https://chat.example.com")
     monkeypatch.setenv("ROCKETCHAT_USER_ID", "u1")
-    llm_credentials.save_llm_api_key("ROCKETCHAT_AUTH_TOKEN", "pat-from-keyring")
+    llm_credentials.save_keyring_secret("ROCKETCHAT_AUTH_TOKEN", "pat-from-keyring")
     records = load_env_integrations()
     rocketchat = next(r for r in records if r.get("service") == "rocketchat")
     assert rocketchat["credentials"]["auth_token"] == "pat-from-keyring"
@@ -85,7 +85,7 @@ def test_slack_bot_token_loads_from_keyring(
     monkeypatch: pytest.MonkeyPatch, memory_keyring: MemoryKeyring
 ) -> None:
     _clear_messaging_env(monkeypatch)
-    llm_credentials.save_llm_api_key("SLACK_BOT_TOKEN", "xoxb-from-keyring")
+    llm_credentials.save_keyring_secret("SLACK_BOT_TOKEN", "xoxb-from-keyring")
     records = load_env_integrations()
     slack = next(r for r in records if r.get("service") == "slack")
     assert slack["credentials"]["bot_token"] == "xoxb-from-keyring"
@@ -111,7 +111,7 @@ def test_slack_bot_api_resolves_token_from_keyring(
         "integrations.catalog.resolve_effective_integrations",
         lambda: {},
     )
-    llm_credentials.save_llm_api_key("SLACK_BOT_TOKEN", "xoxb-bot-api-keyring")
+    llm_credentials.save_keyring_secret("SLACK_BOT_TOKEN", "xoxb-bot-api-keyring")
     target, error = resolve_bot_token()
     assert error == ""
     assert target is not None

--- a/tests/integrations/test_rds.py
+++ b/tests/integrations/test_rds.py
@@ -129,7 +129,11 @@ def test_load_env_integrations_skips_rds_when_db_id_missing() -> None:
     """Gap #1 — negative: with no RDS_DB_INSTANCE_IDENTIFIER, no rds record."""
     from integrations._catalog_impl import load_env_integrations
 
-    with patch.dict(os.environ, {"AWS_REGION": "us-west-2"}, clear=True):
+    with patch.dict(
+        os.environ,
+        {"AWS_REGION": "us-west-2", "OPENSRE_DISABLE_KEYRING": "1"},
+        clear=True,
+    ):
         env_records = load_env_integrations()
 
     assert not [r for r in env_records if r.get("service") == "rds"]

--- a/tests/scheduler/test_credentials.py
+++ b/tests/scheduler/test_credentials.py
@@ -79,6 +79,11 @@ class TestSlackCredentials:
             "platform.scheduler.credentials._get_integration_credential",
             lambda *_: "",
         )
+        # Isolate from a local wizard keyring that may hold SLACK_BOT_TOKEN.
+        monkeypatch.setattr(
+            "platform.scheduler.credentials.resolve_env_credential",
+            lambda name, **_kwargs: "xoxp-from-access-env" if name == "SLACK_ACCESS_TOKEN" else "",
+        )
         creds = resolve_slack_credentials({})
         assert creds == {"access_token": "xoxp-from-access-env"}
 
@@ -89,8 +94,30 @@ class TestSlackCredentials:
             "platform.scheduler.credentials._get_integration_credential",
             lambda *_: "",
         )
+        monkeypatch.setattr(
+            "platform.scheduler.credentials.resolve_env_credential",
+            lambda name, **_kwargs: "xoxb-secondary" if name == "SLACK_BOT_TOKEN" else "",
+        )
         creds = resolve_slack_credentials({})
         assert creds == {"webhook_url": "https://hooks.slack.com/primary"}
+
+    def test_webhook_does_not_use_keyring(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("SLACK_ACCESS_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "platform.scheduler.credentials._get_integration_credential",
+            lambda *_: "",
+        )
+        # Even if keyring somehow held a webhook URL, scheduler must ignore it.
+        monkeypatch.setattr(
+            "platform.scheduler.credentials.resolve_env_credential",
+            lambda name, **_kwargs: (
+                "https://hooks.slack.com/from-keyring" if name == "SLACK_WEBHOOK_URL" else ""
+            ),
+        )
+        creds = resolve_slack_credentials({})
+        assert creds == {}
 
     def test_empty_when_nothing_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)

--- a/tests/scheduler/test_credentials.py
+++ b/tests/scheduler/test_credentials.py
@@ -32,7 +32,7 @@ class TestTelegramCredentials:
             lambda *_: "",
         )
         monkeypatch.setattr(
-            "config.llm_credentials.resolve_env_credential",
+            "platform.scheduler.credentials.resolve_env_credential",
             lambda *_args, **_kwargs: "",
         )
         creds = resolve_telegram_credentials({})
@@ -46,7 +46,7 @@ class TestTelegramCredentials:
             lambda *_: "",
         )
         monkeypatch.setattr(
-            "config.llm_credentials.resolve_env_credential",
+            "platform.scheduler.credentials.resolve_env_credential",
             lambda *_args, **_kwargs: "from_keyring",
         )
         creds = resolve_telegram_credentials({})
@@ -100,8 +100,42 @@ class TestSlackCredentials:
             "platform.scheduler.credentials._get_integration_credential",
             lambda *_: "",
         )
+        monkeypatch.setattr(
+            "platform.scheduler.credentials.resolve_env_credential",
+            lambda *_args, **_kwargs: "",
+        )
         creds = resolve_slack_credentials({})
         assert creds == {}
+
+    def test_bot_token_from_keyring(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("SLACK_ACCESS_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "platform.scheduler.credentials._get_integration_credential",
+            lambda *_: "",
+        )
+        monkeypatch.setattr(
+            "platform.scheduler.credentials.resolve_env_credential",
+            lambda name, **_kwargs: "xoxb-from-keyring" if name == "SLACK_BOT_TOKEN" else "",
+        )
+        creds = resolve_slack_credentials({})
+        assert creds == {"access_token": "xoxb-from-keyring"}
+
+    def test_env_wins_over_keyring_for_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-from-env")
+        monkeypatch.setattr(
+            "platform.scheduler.credentials._get_integration_credential",
+            lambda *_: "",
+        )
+        # resolve_env_credential prefers env; stub must still honor that contract.
+        monkeypatch.setattr(
+            "platform.scheduler.credentials.resolve_env_credential",
+            lambda name, **_kwargs: "xoxb-from-env" if name == "SLACK_BOT_TOKEN" else "",
+        )
+        creds = resolve_slack_credentials({})
+        assert creds == {"access_token": "xoxb-from-env"}
 
 
 class TestDiscordCredentials:
@@ -124,5 +158,22 @@ class TestDiscordCredentials:
             "platform.scheduler.credentials._get_integration_credential",
             lambda *_: "",
         )
+        monkeypatch.setattr(
+            "platform.scheduler.credentials.resolve_env_credential",
+            lambda *_args, **_kwargs: "",
+        )
         creds = resolve_discord_credentials({})
         assert creds == {}
+
+    def test_from_keyring(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "platform.scheduler.credentials._get_integration_credential",
+            lambda *_: "",
+        )
+        monkeypatch.setattr(
+            "platform.scheduler.credentials.resolve_env_credential",
+            lambda *_args, **_kwargs: "discord_from_keyring",
+        )
+        creds = resolve_discord_credentials({})
+        assert creds == {"bot_token": "discord_from_keyring"}

--- a/tests/watch_dog/test_alarms.py
+++ b/tests/watch_dog/test_alarms.py
@@ -238,7 +238,7 @@ def test_load_credentials_from_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
     monkeypatch.setenv("TELEGRAM_DEFAULT_CHAT_ID", "chat-1")
     monkeypatch.setattr(
-        "config.llm_credentials.resolve_llm_api_key",
+        "config.llm_credentials.resolve_env_credential",
         lambda env_var: "keyring-tok" if env_var == "TELEGRAM_BOT_TOKEN" else "",
     )
 


### PR DESCRIPTION
Fixes #4134

#### Describe the changes you have made in this PR -

Implements the first slice of the credential golden path for messaging, plus a naming cleanup for the shared keyring helpers.

**Write (unchanged):** wizard already dual-writes tokens via `sync_env_secret` (Telegram / Slack / Discord / Rocket.Chat PAT).

**Read:** secret env lookups now use `resolve_env_credential` (process env, then OS keyring) so keyring-backed wizard secrets work when the store is empty.

- Catalog env loader: `TELEGRAM_BOT_TOKEN`, `SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN`, `ROCKETCHAT_AUTH_TOKEN`
- Slack `resolve_effective` env fallback + `bot_api.resolve_bot_token` / `bot_token_configured`
- Scheduler: shared `_resolve_credentials` uses `resolve_env_credential` for all providers
- Webhook URLs stay plain env/store (not keyring)

**Naming cleanup:** keyring primitives are no longer LLM-branded:

| Old | New |
|---|---|
| `resolve_llm_api_key` (config keyring) | `resolve_keyring_secret` (keyring only) |
| `save_llm_api_key` / `delete_llm_api_key` | `save_keyring_secret` / `delete_keyring_secret` |
| (unchanged) | `resolve_env_credential` = env then keyring |

`core.llm.providers.provider_credentials.resolve_llm_api_key` stays — that one really is the LLM provider resolver. Keyring service id remains `opensre.llm` so existing entries keep working.

**Compatibility:** env still wins over keyring; store still preferred in effective merge; keyring failures / `OPENSRE_DISABLE_KEYRING` fail soft.

### Demo/Screenshot for feature changes and bug fixes -

```text
$ uv run pytest tests/scheduler/test_credentials.py \
    tests/integrations/test_messaging_credential_resolve.py \
    tests/config/test_llm_credentials.py -q
============================== passed ==============================

$ make lint && make format-check && make typecheck
All checks passed / Success: no issues found
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Writes already went to keyring; reads used `os.getenv`. Discord catalog already used `resolve_env_credential`; Telegram/Slack/Rocket.Chat did not. The fix is additive. While wiring that, the underlying helper was still named `resolve_llm_api_key` even though it stores Telegram/Slack/etc. Renamed the keyring CRUD to `*_keyring_secret`, made `resolve_keyring_secret` keyring-only, and kept `resolve_env_credential` as the public env-then-keyring API. Did not rename the LLM *provider* resolver in `provider_credentials.py`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.