### PR TITLE
fix(watchdog): treat denied sample as inaccessible, not target exit

### DIFF
--- a/tests/interactive_shell/test_watch_cmds.py
+++ b/tests/interactive_shell/test_watch_cmds.py
@@ -231,3 +231,122 @@ def test_run_watchdog_once_without_thresholds_exits(monkeypatch: pytest.MonkeyPa
     assert task.status == TaskStatus.COMPLETED
     assert task.result == "single sample (once)"
     dispatcher.dispatch.assert_not_called()
+
+
+def test_run_watchdog_first_probe_inaccessible_marks_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A live PID this user cannot introspect must fail loudly, not report
+    'target process exited' (a permission failure is not an exit)."""
+    from platform.common.task_registry import TaskRegistry
+    from tools.system.watch_dog.monitor import run_watchdog
+
+    reg = TaskRegistry()
+    task = reg.create(TaskKind.WATCHDOG, command="watchdog pid=1")
+    task.mark_running()
+    dispatcher = MagicMock()
+    dispatcher.dispatch = MagicMock(return_value=True)
+
+    monkeypatch.setattr("tools.system.watch_dog.monitor.probe", lambda *_a, **_kw: None)
+    monkeypatch.setattr("tools.system.watch_dog.monitor.pid_exists", lambda _pid: True)
+
+    run_watchdog(
+        task=task,
+        watched_pid=1,
+        interval_seconds=0.01,
+        max_cpu=None,
+        max_runtime_seconds=None,
+        max_rss_mib=None,
+        once=False,
+        dispatcher=dispatcher,
+        on_alarm=None,
+    )
+    assert task.status == TaskStatus.FAILED
+    assert "permission denied" in (task.error or "")
+    dispatcher.dispatch.assert_not_called()
+
+
+def test_run_watchdog_gone_pid_completes_as_exited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from platform.common.task_registry import TaskRegistry
+    from tools.system.watch_dog.monitor import run_watchdog
+
+    reg = TaskRegistry()
+    task = reg.create(TaskKind.WATCHDOG, command="watchdog pid=1")
+    task.mark_running()
+    dispatcher = MagicMock()
+    dispatcher.dispatch = MagicMock(return_value=True)
+
+    monkeypatch.setattr("tools.system.watch_dog.monitor.probe", lambda *_a, **_kw: None)
+    monkeypatch.setattr("tools.system.watch_dog.monitor.pid_exists", lambda _pid: False)
+
+    run_watchdog(
+        task=task,
+        watched_pid=1,
+        interval_seconds=0.01,
+        max_cpu=None,
+        max_runtime_seconds=None,
+        max_rss_mib=None,
+        once=False,
+        dispatcher=dispatcher,
+        on_alarm=None,
+    )
+    assert task.status == TaskStatus.COMPLETED
+    assert task.result == "target process exited"
+
+
+def test_run_watchdog_transient_inaccessible_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mid-watch AccessDenied tick (probe None while the PID exists) must
+    retry, then still report the real exit when the PID is truly gone."""
+    from datetime import UTC, datetime, timedelta
+
+    from platform.common.task_registry import TaskRegistry
+    from tools.system.fleet_monitoring.probe import ProcessSnapshot
+    from tools.system.watch_dog.monitor import run_watchdog
+
+    reg = TaskRegistry()
+    task = reg.create(TaskKind.WATCHDOG, command="watchdog pid=1")
+    task.mark_running()
+    dispatcher = MagicMock()
+    dispatcher.dispatch = MagicMock(return_value=True)
+
+    snap = ProcessSnapshot(
+        pid=1,
+        cpu_percent=1.0,
+        rss_mb=10.0,
+        num_fds=None,
+        num_connections=None,
+        status="running",
+        started_at=datetime.now(UTC) - timedelta(seconds=1),
+    )
+    probe_results = [snap, None, None]
+    probe_calls = {"n": 0}
+
+    def _fake_probe(*_a: object, **_kw: object) -> ProcessSnapshot | None:
+        probe_calls["n"] += 1
+        return probe_results.pop(0)
+
+    pid_exists_results = [True, False]
+    monkeypatch.setattr("tools.system.watch_dog.monitor.probe", _fake_probe)
+    monkeypatch.setattr(
+        "tools.system.watch_dog.monitor.pid_exists",
+        lambda _pid: pid_exists_results.pop(0),
+    )
+
+    run_watchdog(
+        task=task,
+        watched_pid=1,
+        interval_seconds=0.01,
+        max_cpu=None,
+        max_runtime_seconds=None,
+        max_rss_mib=None,
+        once=False,
+        dispatcher=dispatcher,
+        on_alarm=None,
+    )
+    assert probe_calls["n"] == 3
+    assert task.status == TaskStatus.COMPLETED
+    assert task.result == "target process exited"

--- a/tests/watch_dog/test_monitor.py
+++ b/tests/watch_dog/test_monitor.py
@@ -166,6 +166,7 @@ def test_process_monitor_returns_dead_sample_on_no_such_process(
 
     assert sample.pid == 123
     assert sample.alive is False
+    assert sample.accessible is False
     assert sample.cpu_percent == 0.0
 
 
@@ -214,3 +215,4 @@ def test_process_monitor_returns_dead_sample_when_process_vanishes_mid_sample(
 
     assert sample.pid == 123
     assert sample.alive is False
+    assert sample.accessible is False

--- a/tests/watch_dog/test_monitor.py
+++ b/tests/watch_dog/test_monitor.py
@@ -76,6 +76,34 @@ class _AccessDeniedProcess(_FakeProcess):
         raise psutil.AccessDenied(self.pid)
 
 
+class _TransientAccessDeniedProcess(_FakeProcess):
+    """Passes the construction-time introspection check, then denies."""
+
+    def __init__(self, pid: int, name: str) -> None:
+        super().__init__(pid, name)
+        self.memory_calls = 0
+
+    def memory_info(self) -> _MemoryInfo:
+        self.memory_calls += 1
+        if self.memory_calls > 1:
+            raise psutil.AccessDenied(self.pid)
+        return super().memory_info()
+
+
+class _GoneMidSampleProcess(_FakeProcess):
+    """Passes the construction-time introspection check, then vanishes."""
+
+    def __init__(self, pid: int, name: str) -> None:
+        super().__init__(pid, name)
+        self.memory_calls = 0
+
+    def memory_info(self) -> _MemoryInfo:
+        self.memory_calls += 1
+        if self.memory_calls > 1:
+            raise psutil.NoSuchProcess(self.pid)
+        return super().memory_info()
+
+
 def test_process_monitor_resolves_by_pid_and_warms_cpu(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -141,10 +169,42 @@ def test_process_monitor_returns_dead_sample_on_no_such_process(
     assert sample.cpu_percent == 0.0
 
 
-def test_process_monitor_returns_dead_sample_on_access_denied(
+def test_process_monitor_rejects_always_inaccessible_process(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A running process this user cannot introspect (e.g. another user's
+    daemon) is a configuration error at construction, not a false exit."""
     process = _AccessDeniedProcess(123, "python")
+    monkeypatch.setattr(
+        "tools.system.watch_dog.process_monitor.process_probe.process", lambda _pid: process
+    )
+
+    with pytest.raises(OpenSREError, match="permission denied"):
+        ProcessMonitor(WatchdogConfig(pid=123, max_cpu=90))
+
+
+def test_process_monitor_marks_transient_access_denied_inaccessible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient AccessDenied on a live process yields alive=True,
+    accessible=False so the runner retries instead of reporting an exit."""
+    process = _TransientAccessDeniedProcess(123, "python")
+    monkeypatch.setattr(
+        "tools.system.watch_dog.process_monitor.process_probe.process", lambda _pid: process
+    )
+
+    monitor = ProcessMonitor(WatchdogConfig(pid=123, max_cpu=90))
+    sample = monitor.sample()
+
+    assert sample.pid == 123
+    assert sample.alive is True
+    assert sample.accessible is False
+
+
+def test_process_monitor_returns_dead_sample_when_process_vanishes_mid_sample(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _GoneMidSampleProcess(123, "python")
     monkeypatch.setattr(
         "tools.system.watch_dog.process_monitor.process_probe.process", lambda _pid: process
     )

--- a/tests/watch_dog/test_runner.py
+++ b/tests/watch_dog/test_runner.py
@@ -41,6 +41,7 @@ def _sample(
     rss: int = 1024,
     runtime: float = 10.0,
     alive: bool = True,
+    accessible: bool = True,
 ) -> ProcessSample:
     return ProcessSample(
         pid=123,
@@ -51,6 +52,7 @@ def _sample(
         runtime_seconds=runtime,
         alive=alive,
         started_at=1_700_000_000.0,
+        accessible=accessible,
     )
 
 
@@ -91,6 +93,54 @@ def test_default_mode_keeps_polling_until_target_exits() -> None:
     assert code == SUCCESS
     assert sleeps == [2.0, 2.0]
     assert [name for name, _message in dispatcher.calls] == ["max_runtime"]
+
+
+def test_transient_inaccessible_sample_retries_instead_of_exiting() -> None:
+    """One AccessDenied tick must not end the watch as 'target exited':
+    the loop skips that tick and still alarms on the next real breach."""
+    dispatcher = _FakeDispatcher()
+    sleeps: list[float] = []
+
+    code = run_watchdog(
+        WatchdogConfig.model_validate({"pid": 123, "max_rss": "4G", "interval": 2}),
+        sampler=_FakeSampler(
+            [
+                _sample(rss=1024),
+                _sample(accessible=False),
+                _sample(rss=5 * 1024**3),
+                _sample(alive=False),
+            ]
+        ),
+        dispatcher=dispatcher,
+        _sleep=sleeps.append,
+        _clock=lambda: 100.0,
+    )
+
+    assert code == SUCCESS
+    assert sleeps == [2.0, 2.0, 2.0]
+    assert [name for name, _message in dispatcher.calls] == ["max_rss"]
+
+
+def test_inaccessible_sample_evaluates_no_thresholds() -> None:
+    """Metrics from a denied read must not feed threshold checks: this
+    sample's runtime (10s) exceeds max_runtime=1s but must not alarm."""
+    dispatcher = _FakeDispatcher()
+
+    code = run_watchdog(
+        WatchdogConfig.model_validate({"pid": 123, "max_runtime": "1s", "interval": 2}),
+        sampler=_FakeSampler(
+            [
+                _sample(accessible=False, runtime=10.0),
+                _sample(alive=False),
+            ]
+        ),
+        dispatcher=dispatcher,
+        _sleep=lambda _seconds: None,
+        _clock=lambda: 100.0,
+    )
+
+    assert code == SUCCESS
+    assert dispatcher.calls == []
 
 
 def test_target_exit_before_alarm_does_not_dispatch() -> None:

--- a/tools/system/fleet_monitoring/probe.py
+++ b/tools/system/fleet_monitoring/probe.py
@@ -27,6 +27,7 @@ import psutil
 _BYTES_PER_MIB = 1024 * 1024
 
 PROCESS_NOT_FOUND: tuple[type[BaseException], ...] = (psutil.NoSuchProcess,)
+PROCESS_INACCESSIBLE: tuple[type[BaseException], ...] = (psutil.AccessDenied,)
 PROCESS_INACCESSIBLE_OR_GONE: tuple[type[BaseException], ...] = (
     psutil.NoSuchProcess,
     psutil.AccessDenied,

--- a/tools/system/watch_dog/monitor.py
+++ b/tools/system/watch_dog/monitor.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import threading
+import time
 from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Protocol, runtime_checkable
 
 from platform.common.task_types import TaskRecord, TaskStatus
-from tools.system.fleet_monitoring.probe import probe
+from tools.system.fleet_monitoring.probe import pid_exists, probe
 
 
 @runtime_checkable
@@ -51,6 +52,7 @@ def run_watchdog(
         if on_alarm is not None:
             on_alarm(threshold, detail)
 
+    first_sample = True
     try:
         while True:
             if task.cancel_requested.is_set():
@@ -61,9 +63,22 @@ def run_watchdog(
             if snap is None:
                 if task.cancel_requested.is_set():
                     task.mark_cancelled()
-                elif task.status == TaskStatus.RUNNING:
+                    return
+                if pid_exists(watched_pid):
+                    # Alive but not introspectable (e.g. another user's
+                    # process, macOS hardened runtime). A permission
+                    # failure is not an exit: fail loudly up front, retry
+                    # when it appears mid-watch.
+                    if first_sample:
+                        task.mark_failed(f"cannot introspect pid {watched_pid} (permission denied)")
+                        return
+                    task.update_progress("no snapshot this tick (permission denied); retrying")
+                    time.sleep(sample_interval)
+                    continue
+                if task.status == TaskStatus.RUNNING:
                     task.mark_completed(result="target process exited")
                 return
+            first_sample = False
 
             runtime_s = max(0.0, (datetime.now(UTC) - snap.started_at).total_seconds())
             progress = (

--- a/tools/system/watch_dog/process_monitor.py
+++ b/tools/system/watch_dog/process_monitor.py
@@ -20,6 +20,8 @@ class ProcessSample:
     from "the process is running but this user cannot read its fields"
     (``alive=True, accessible=False``, e.g. a transient
     ``psutil.AccessDenied``). A permission failure is not an exit.
+    A dead sample carries ``accessible=False`` too (a gone process has no
+    readable fields); check ``alive`` first.
     """
 
     pid: int
@@ -134,6 +136,8 @@ class ProcessMonitor:
         )
 
     def _dead_sample(self) -> ProcessSample:
+        # A gone process has no readable fields either, so a dead sample
+        # carries accessible=False to keep the pair consistent.
         return ProcessSample(
             pid=self._pid,
             name=self._name,
@@ -143,6 +147,7 @@ class ProcessMonitor:
             runtime_seconds=0.0,
             alive=False,
             started_at=self._started_at,
+            accessible=False,
         )
 
 

--- a/tools/system/watch_dog/process_monitor.py
+++ b/tools/system/watch_dog/process_monitor.py
@@ -14,7 +14,13 @@ from tools.system.watch_dog.config import WatchdogConfig
 
 @dataclass(frozen=True)
 class ProcessSample:
-    """A point-in-time process resource sample."""
+    """A point-in-time process resource sample.
+
+    ``accessible`` distinguishes "the process is gone" (``alive=False``)
+    from "the process is running but this user cannot read its fields"
+    (``alive=True, accessible=False``, e.g. a transient
+    ``psutil.AccessDenied``). A permission failure is not an exit.
+    """
 
     pid: int
     name: str
@@ -24,6 +30,7 @@ class ProcessSample:
     runtime_seconds: float
     alive: bool
     started_at: float | None = None
+    accessible: bool = True
 
     @property
     def command(self) -> str:
@@ -48,9 +55,16 @@ class ProcessMonitor:
         self._cmdline = _safe_cmdline(self._process)
         self._started_at = _safe_create_time(self._process)
         self._warm_cpu_percent()
+        self._assert_introspectable()
 
     def sample(self) -> ProcessSample:
-        """Capture CPU, RSS, runtime, and liveness for the target process."""
+        """Capture CPU, RSS, runtime, and liveness for the target process.
+
+        A gone process yields ``alive=False``. A process that is still
+        running but denies field access (transient ``psutil.AccessDenied``)
+        yields ``alive=True, accessible=False`` so the caller can retry
+        instead of reporting a false exit.
+        """
         try:
             if not self._process.is_running():
                 return self._dead_sample()
@@ -59,8 +73,10 @@ class ProcessMonitor:
             cpu_percent = float(self._process.cpu_percent(interval=None))
             rss_bytes = int(self._process.memory_info().rss)
             started_at = float(self._process.create_time())
-        except process_probe.PROCESS_INACCESSIBLE_OR_GONE:
+        except process_probe.PROCESS_NOT_FOUND:
             return self._dead_sample()
+        except process_probe.PROCESS_INACCESSIBLE:
+            return self._inaccessible_sample()
 
         return ProcessSample(
             pid=self._pid,
@@ -78,6 +94,44 @@ class ProcessMonitor:
             self._process.cpu_percent(interval=None)
         except process_probe.PROCESS_ERROR:
             return
+
+    def _assert_introspectable(self) -> None:
+        """Fail fast when the resolved process denies field access.
+
+        A process owned by another user (a service account daemon, a
+        root-owned container) resolves by name/pid but raises
+        ``psutil.AccessDenied`` on every field read, so its thresholds
+        could never be evaluated. Surface that as a configuration error
+        up front instead of a false "target exited" on the first sample.
+        """
+        try:
+            self._process.memory_info()
+        except process_probe.PROCESS_INACCESSIBLE as exc:
+            raise OpenSREError(
+                f"Process {self._pid} ({self._name or 'unknown'}) is running but cannot "
+                "be introspected (permission denied).",
+                suggestion=(
+                    "Re-run with privileges matching the target process "
+                    "(for example via sudo) so CPU/RSS/runtime can be sampled."
+                ),
+            ) from exc
+        except process_probe.PROCESS_NOT_FOUND:
+            # Already gone: the first sample() reports the exit honestly.
+            return
+
+    def _inaccessible_sample(self) -> ProcessSample:
+        runtime = max(0.0, time.time() - self._started_at) if self._started_at else 0.0
+        return ProcessSample(
+            pid=self._pid,
+            name=self._name,
+            cmdline=self._cmdline,
+            cpu_percent=0.0,
+            rss_bytes=0,
+            runtime_seconds=runtime,
+            alive=True,
+            started_at=self._started_at,
+            accessible=False,
+        )
 
     def _dead_sample(self) -> ProcessSample:
         return ProcessSample(

--- a/tools/system/watch_dog/runner.py
+++ b/tools/system/watch_dog/runner.py
@@ -58,6 +58,18 @@ def run_watchdog(
                     click.echo(f"watchdog: target exited pid={sample.pid}")
                 return SUCCESS
 
+            if not sample.accessible:
+                # The process is still running but denied this read
+                # (transient psutil.AccessDenied). Retry next tick rather
+                # than mis-reporting an exit or alarming on zeroed metrics.
+                if config.verbose:
+                    click.echo(
+                        f"watchdog: sample inaccessible pid={sample.pid} "
+                        "(permission denied); retrying"
+                    )
+                _sleep(config.interval)
+                continue
+
             now = _clock()
             breaches = _evaluate_thresholds(config, sample, cpu_window=cpu_window, now=now)
             if config.verbose:


### PR DESCRIPTION
## TL;DR

Point `opensre watchdog` at a process it lacks permission to read (postgres, nginx, redis: anything under its own service account) and it prints `target exited` and exits 0. The process is alive. Monitoring has silently stopped, and the exit code says success.

With this PR the watchdog tells the truth: a clear permission error up front, a retry on brief permission blips, and `target exited` only when the process is really gone.

Closes #4136.

## See it

![before: false "target exited" exit 0 on a live process; after: honest permission error, and a real max-rss alarm firing on a runaway process](https://raw.githubusercontent.com/Ourbando/opensre/demo-assets/watchdog_demo_v2.gif)

Real terminal output, root-owned `syslogd` standing in for any service-account process:

**Today (main):**

```
$ opensre watchdog --name syslogd --max-rss 1G --verbose
watchdog: target exited pid=128        <- syslogd is running; exit code 0
```

**With this PR, same command:**

```
$ opensre watchdog --name syslogd --max-rss 1G --verbose
✗  OpenSREError
   Process 128 (syslogd) is running but cannot be introspected (permission denied).
   Re-run with privileges matching the target process (for example via sudo)
   so CPU/RSS/runtime can be sampled.        <- exit code 1
```

And when the watchdog can read its target, thresholds now reliably protect: the demo's third act watches a real runaway process and the `--max-rss` alarm fires.

## Why it happens

Three spots treat "I was denied a read" as "the process died":

1. `ProcessMonitor.sample()` catches `psutil.AccessDenied` in the same `except` as `NoSuchProcess` and returns a dead sample (`process_monitor.py`).
2. The runner maps any dead sample to "target exited" and returns SUCCESS (`runner.py`).
3. The REPL `watch` loop does the same through `probe()` returning `None` for both cases (`monitor.py`).

## What changed

- `ProcessSample` gains `accessible: bool`. "Gone" and "unreadable" become different facts.
- Never introspectable at startup: fail fast with an actionable `OpenSREError`, like the existing "No process found for PID" errors. A watch that can never sample can never alarm, so pretending to monitor would be worse than refusing.
- Transient denial mid-watch: skip that tick and retry, matching how `fleet_monitoring/sampler.py` already handles a failed probe (clear one tick, retry, never declare the process gone). Zeroed metrics never reach the thresholds.
- REPL loop: `pid_exists()` now separates gone (still completes as "target process exited") from unreadable (fails the task loudly on the first tick, retries later ones).

## Every case, before and after

| Case | main | this PR |
|---|---|---|
| Watch another account's process | "target exited", exit 0 | permission error + sudo hint, exit 1 |
| One denied read mid-watch (own process) | watch ends as "exited" | tick retried, watch continues |
| Process really exits | "target exited", exit 0 | same, unchanged |
| Process vanishes mid-sample | dead sample | same, unchanged |
| REPL watch, denied on first tick | task COMPLETED "target process exited" | task FAILED "cannot introspect pid (permission denied)" |
| REPL watch, denied later | task COMPLETED "target process exited" | progress note + retry; completes on the real exit |

## Tests

Every row above is pinned by a test. The one test that pinned the old behavior (`test_process_monitor_returns_dead_sample_on_access_denied`) is split into the honest cases; eight new tests cover retry, no-thresholds-on-denied-metrics, and the REPL paths. `make lint`, `make format-check`, `make typecheck` (1310 files), watchdog suites 62/62 green.

```
python -m pytest tests/watch_dog tests/interactive_shell/test_watch_cmds.py

# live check (macOS: syslogd; Linux: postgres or nginx)
opensre watchdog --name syslogd --max-rss 1G --verbose; echo $?
```

## Environment

macOS 13.7.8 (Intel), Python 3.13.7, psutil 7.2.2. Reproduced against main @ 0f07018; scripted repro in #4136.
