### PR TITLE
docs: credential resolve golden path (PR3)

### DIFF
--- a/docs/adding-tools-and-integrations.md
+++ b/docs/adding-tools-and-integrations.md
@@ -83,7 +83,28 @@ Common failure modes to consider: grouped + ungrouped log content; nested/folder
 - [ ] CLI setup flow is updated if the integration is user-configurable locally
 - [ ] `opensre onboard` parity is added, or intentionally documented as out of scope
 - [ ] New required env vars / credentials are added to `.env.example` (never `.env`)
+- [ ] Sensitive credentials follow the [Credential resolution](#credential-resolution) contract below
 - [ ] `make verify-integrations` passes
+
+### Credential resolution
+
+Secrets and non-secrets follow different write/read paths. Keep this contract when adding or changing an integration.
+
+| Surface | Write (wizard / setup) | Read (runtime) |
+| --- | --- | --- |
+| Integration store (`~/.opensre/integrations.json`) | Always on setup | First (preferred) |
+| OS keyring | Sensitive secrets via `sync_env_secret` | Via `resolve_env_credential` when env is unset |
+| `.env` / process env | Non-secrets only (`*_URL`, user ids, channels, …) | Plain `os.getenv` is OK for non-secrets |
+
+**Hard rules for new code**
+
+- Never use bare `os.getenv` for a secret env name (`*_TOKEN`, `*_KEY`, `*_PASSWORD`, `*_SECRET`, connection strings, and similar). Use `resolve_env_credential` from `config.llm_credentials` (env first, then keyring).
+- Webhook / `*_URL` values are **never** keyring-backed. Read with store → plain `os.getenv` only. Never pass them through `resolve_env_credential` or `sync_env_secret` (wizard treats `*_URL` as non-sensitive).
+- Leave `load_env_integration_services` plain-env-only (startup-safe; no keyring at boot).
+- Store still wins in `resolve_effective` / merge — env/keyring is the fallback tier only.
+- Set `OPENSRE_DISABLE_KEYRING=1` to skip keyring reads/writes (env and store still work).
+
+Canonical helpers: `resolve_env_credential` (env → keyring), `sync_env_secret` / `save_keyring_secret` (sensitive writes), `sync_env_values` (non-secrets only).
 
 ## 3. Investigation wiring
 

--- a/docs/adding-tools-and-integrations.md
+++ b/docs/adding-tools-and-integrations.md
@@ -88,23 +88,24 @@ Common failure modes to consider: grouped + ungrouped log content; nested/folder
 
 ### Credential resolution
 
-Secrets and non-secrets follow different write/read paths. Keep this contract when adding or changing an integration.
+Keyring-eligible secrets and non-keyring config follow different write/read paths.
+Keep this contract when adding or changing an integration.
 
 | Surface | Write (wizard / setup) | Read (runtime) |
 | --- | --- | --- |
 | Integration store (`~/.opensre/integrations.json`) | Always on setup | First (preferred) |
-| OS keyring | Sensitive secrets via `sync_env_secret` | Via `resolve_env_credential` when env is unset |
-| `.env` / process env | Non-secrets only (`*_URL`, user ids, channels, …) | Plain `os.getenv` is OK for non-secrets |
+| OS keyring | Keyring-eligible secrets via `sync_env_secret` | Via `resolve_env_credential` when env is unset |
+| `.env` / process env | Non-keyring config (`*_URL`, user ids, channels, …) | Plain `os.getenv` for that tier |
 
 **Hard rules for new code**
 
-- Never use bare `os.getenv` for a secret env name (`*_TOKEN`, `*_KEY`, `*_PASSWORD`, `*_SECRET`, connection strings, and similar). Use `resolve_env_credential` from `config.llm_credentials` (env first, then keyring).
-- Webhook / `*_URL` values are **never** keyring-backed. Read with store → plain `os.getenv` only. Never pass them through `resolve_env_credential` or `sync_env_secret` (wizard treats `*_URL` as non-sensitive).
+- Never use bare `os.getenv` for a keyring-eligible secret env name (`*_TOKEN`, `*_KEY`, `*_PASSWORD`, `*_SECRET`, connection strings, and similar). Use `resolve_env_credential` from `config.llm_credentials` (env first, then keyring).
+- Webhook / `*_URL` values are **never** keyring-backed (wizard routes them to store/`.env`, not `sync_env_secret`). Read with store → plain `os.getenv` only. Webhook URLs often **embed** a secret token — treat them like passwords for logging/masking, even though they are not keyring-eligible.
 - Leave `load_env_integration_services` plain-env-only (startup-safe; no keyring at boot).
 - Store still wins in `resolve_effective` / merge — env/keyring is the fallback tier only.
 - Set `OPENSRE_DISABLE_KEYRING=1` to skip keyring reads/writes (env and store still work).
 
-Canonical helpers: `resolve_env_credential` (env → keyring), `sync_env_secret` / `save_keyring_secret` (sensitive writes), `sync_env_values` (non-secrets only).
+Canonical helpers: `resolve_env_credential` (env → keyring), `sync_env_secret` / `save_keyring_secret` (keyring-eligible writes), `sync_env_values` (non-keyring `.env` keys only).
 
 ## 3. Investigation wiring
 

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -156,10 +156,12 @@ the keyring via `sync_env_secret` so a cleared `.env` still works locally.
 
 **Exceptions (never keyring):** webhook and other `*_URL` values such as
 `SLACK_WEBHOOK_URL` and `ROCKETCHAT_WEBHOOK_URL` stay store / plain env only.
+They may still embed secret tokens — do not log them unmasked.
 Set `OPENSRE_DISABLE_KEYRING=1` to skip keyring reads and writes entirely.
 
 Contributor contract: [Credential resolution](https://github.com/Tracer-Cloud/opensre/blob/main/docs/adding-tools-and-integrations.md#credential-resolution)
-in *Adding tools and integrations*.
+in *Adding tools and integrations* (internal contributor markdown in the repo;
+not a Mintlify docs-site page).
 
 | Variable | Default | Description | Module |
 |----------|---------|-------------|--------|

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -149,6 +149,18 @@ All configuration options for OpenSRE can be set via environment variables. This
 
 ## Credentials & Authentication
 
+Sensitive variables (`*_TOKEN`, `*_KEY`, `*_PASSWORD`, `*_SECRET`, and similar)
+resolve through `resolve_env_credential`: **process env first**, then the OS
+keyring when the env var is unset. Wizard setup dual-writes many of these to
+the keyring via `sync_env_secret` so a cleared `.env` still works locally.
+
+**Exceptions (never keyring):** webhook and other `*_URL` values such as
+`SLACK_WEBHOOK_URL` and `ROCKETCHAT_WEBHOOK_URL` stay store / plain env only.
+Set `OPENSRE_DISABLE_KEYRING=1` to skip keyring reads and writes entirely.
+
+Contributor contract: [Credential resolution](https://github.com/Tracer-Cloud/opensre/blob/main/docs/adding-tools-and-integrations.md#credential-resolution)
+in *Adding tools and integrations*.
+
 | Variable | Default | Description | Module |
 |----------|---------|-------------|--------|
 | `OPENSRE_DISABLE_KEYRING` | `0` | Disable OS keyring for credential storage | `llm_credentials` |

--- a/docs/messaging/rocketchat.mdx
+++ b/docs/messaging/rocketchat.mdx
@@ -85,7 +85,7 @@ opensre onboard
 Choose **Rocket.Chat** from the integration list, then pick **token**, **webhook**, or **both**. The wizard prompts for:
 
 - Token mode: **Server URL** (`ROCKETCHAT_SERVER_URL`), **personal access token** (OS keyring via `sync_env_secret`, not plain `.env`), **user ID** (`ROCKETCHAT_USER_ID`), and **default channel** (`ROCKETCHAT_DEFAULT_CHANNEL`)
-- Webhook mode: **webhook URL** — saved to the integration store (`~/.opensre/integrations.json`) and/or `ROCKETCHAT_WEBHOOK_URL` in `.env`; never written to the keyring (`*_URL` is non-secret config)
+- Webhook mode: **webhook URL** — saved to the integration store (`~/.opensre/integrations.json`) and/or `ROCKETCHAT_WEBHOOK_URL` in `.env`; never written to the keyring (`*_URL` is non-keyring config). The URL often embeds a token — treat it like a password for logging/masking.
 
 Credentials are also saved to `~/.opensre/integrations.json` via `upsert_integration("rocketchat", ...)`.
 
@@ -110,7 +110,7 @@ ROCKETCHAT_WEBHOOK_URL=https://chat.example.com/hooks/<id>/<token>
 | `ROCKETCHAT_AUTH_TOKEN` | Personal access token. Required for token mode. Resolved via env then keyring. |
 | `ROCKETCHAT_USER_ID` | User ID shown alongside the token. Required for token mode. |
 | `ROCKETCHAT_DEFAULT_CHANNEL` | Default delivery destination (`#channel` or `@user`). Required for token-mode delivery. |
-| `ROCKETCHAT_WEBHOOK_URL` | Incoming webhook URL. Store/env only — never keyring. Enables webhook mode on its own; preferred over token mode when both are set. |
+| `ROCKETCHAT_WEBHOOK_URL` | Incoming webhook URL. Store/env only — never keyring (still treat like a password when logging). Enables webhook mode on its own; preferred over token mode when both are set. |
 
 OpenSRE picks these up at startup and registers Rocket.Chat as an active integration.
 

--- a/docs/messaging/rocketchat.mdx
+++ b/docs/messaging/rocketchat.mdx
@@ -84,14 +84,14 @@ opensre onboard
 
 Choose **Rocket.Chat** from the integration list, then pick **token**, **webhook**, or **both**. The wizard prompts for:
 
-- Token mode: **Server URL** (`ROCKETCHAT_SERVER_URL`), **personal access token** (system keyring, not plain `.env`), **user ID** (`ROCKETCHAT_USER_ID`), and **default channel** (`ROCKETCHAT_DEFAULT_CHANNEL`)
-- Webhook mode: **webhook URL** — saved to the integration store only (`~/.opensre/integrations.json`), never written to `.env`, since the URL embeds its token
+- Token mode: **Server URL** (`ROCKETCHAT_SERVER_URL`), **personal access token** (OS keyring via `sync_env_secret`, not plain `.env`), **user ID** (`ROCKETCHAT_USER_ID`), and **default channel** (`ROCKETCHAT_DEFAULT_CHANNEL`)
+- Webhook mode: **webhook URL** — saved to the integration store (`~/.opensre/integrations.json`) and/or `ROCKETCHAT_WEBHOOK_URL` in `.env`; never written to the keyring (`*_URL` is non-secret config)
 
 Credentials are also saved to `~/.opensre/integrations.json` via `upsert_integration("rocketchat", ...)`.
 
 ### Option B: Environment variables
 
-Set in `.env`:
+Set in `.env` (PAT can also live in the keyring after wizard setup):
 
 ```bash
 # Token mode
@@ -107,12 +107,16 @@ ROCKETCHAT_WEBHOOK_URL=https://chat.example.com/hooks/<id>/<token>
 | Variable | Description |
 |---|---|
 | `ROCKETCHAT_SERVER_URL` | Base URL of your Rocket.Chat server. Required for token mode. |
-| `ROCKETCHAT_AUTH_TOKEN` | Personal access token. Required for token mode. |
+| `ROCKETCHAT_AUTH_TOKEN` | Personal access token. Required for token mode. Resolved via env then keyring. |
 | `ROCKETCHAT_USER_ID` | User ID shown alongside the token. Required for token mode. |
 | `ROCKETCHAT_DEFAULT_CHANNEL` | Default delivery destination (`#channel` or `@user`). Required for token-mode delivery. |
-| `ROCKETCHAT_WEBHOOK_URL` | Incoming webhook URL. Enables webhook mode on its own; preferred over token mode when both are set. |
+| `ROCKETCHAT_WEBHOOK_URL` | Incoming webhook URL. Store/env only — never keyring. Enables webhook mode on its own; preferred over token mode when both are set. |
 
 OpenSRE picks these up at startup and registers Rocket.Chat as an active integration.
+
+<Note>
+**Credential resolution.** Token mode: store → `resolve_env_credential("ROCKETCHAT_AUTH_TOKEN")` (env then keyring). Webhook mode: store → plain `ROCKETCHAT_WEBHOOK_URL` env — never keyring. Server URL, user id, and default channel stay plain env / store.
+</Note>
 
 ---
 
@@ -175,12 +179,13 @@ message to the team that DB CPU is back below 70%").
 }
 ```
 
-The tool resolves credentials internally from the integration store and
-`ROCKETCHAT_*` environment variables — the agent never sees them. In token
-mode an explicit `channel` (or the configured `default_channel`) is targeted
-via `chat.postMessage`; in webhook-only mode messages go to the webhook's
-fixed destination, and an explicit `channel` returns a configuration error
-instead of being silently ignored.
+The tool resolves credentials internally from the integration store, then the
+same env/keyring rules as setup (PAT via `resolve_env_credential`; webhook URL
+via plain env) — the agent never sees them. In token mode an explicit `channel`
+(or the configured `default_channel`) is targeted via `chat.postMessage`; in
+webhook-only mode messages go to the webhook's fixed destination, and an
+explicit `channel` returns a configuration error instead of being silently
+ignored.
 
 Delivery is an external side effect and requires approval. The result includes
 a stable `status`, `sent`, `error_type`, `channel`, and `message_length` shape

--- a/docs/messaging/slack.mdx
+++ b/docs/messaging/slack.mdx
@@ -59,7 +59,8 @@ You have two equivalent paths:
     SLACK_ALLOWED_USERS=U0123ABCD
     ```
     OpenSRE reads env as a fallback when no Slack entry exists in `~/.opensre/integrations.json`.
-    For gateway tokens, env wins over the store when both are set (same as Telegram).
+    Bot / app tokens use `resolve_env_credential` (process env, then OS keyring).
+    `SLACK_WEBHOOK_URL` is store/env only — never keyring.
   </Tab>
   <Tab title="Onboarding wizard">
     ```bash
@@ -67,8 +68,15 @@ You have two equivalent paths:
     ```
     Select **Slack** and choose webhook / Socket Mode / both. The wizard validates
     the webhook when configured, then persists credentials to the integration store.
+    Socket Mode tokens are dual-written to the OS keyring; the webhook URL is not.
   </Tab>
 </Tabs>
+
+<Note>
+**Credential resolution.** Store first when present. Then:
+`SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN` → env then keyring;
+`SLACK_WEBHOOK_URL` → plain env only (never keyring).
+</Note>
 
 ---
 

--- a/docs/messaging/telegram.mdx
+++ b/docs/messaging/telegram.mdx
@@ -140,10 +140,11 @@ OpenSRE picks these up at startup and registers Telegram as an active integratio
 <Note>
 **Credential resolution.** Every Telegram delivery surface — investigations,
 **background RCA completion notifications**, the scheduler, `/watchdog`,
-`/hermes watch`, and `/watch` — resolves the bot token
-in the same order: integration store → `TELEGRAM_BOT_TOKEN` env → system keyring;
-and the chat id as `--chat-id` → store `default_chat_id` →
-`TELEGRAM_DEFAULT_CHAT_ID` env. Either setup option above works for all of them.
+`/hermes watch`, and `/watch` — resolves the bot token the same way: integration
+store first, then `resolve_env_credential("TELEGRAM_BOT_TOKEN")` (process env,
+then OS keyring). Chat id is non-secret: `--chat-id` → store `default_chat_id` →
+`TELEGRAM_DEFAULT_CHAT_ID` env (plain `os.getenv`, never keyring). Either setup
+option above works for all of them.
 </Note>
 
 ---
@@ -272,7 +273,7 @@ is back below 70%").
 ```
 
 The tool resolves the bot token from the same credential chain as the watchdog:
-integration store, then `TELEGRAM_BOT_TOKEN`, then the system keyring.
+integration store, then `resolve_env_credential("TELEGRAM_BOT_TOKEN")` (env then keyring).
 If `chat_id` is omitted, it sends through the configured `default_chat_id`, so a
 user can ask OpenSRE to send a message through the configured Telegram bot
 without knowing or exposing the bot token.


### PR DESCRIPTION
Related to #4134

#### Describe the changes you have made in this PR -

Documents the credential golden path landed in #4135 (PR1+PR2):

- Contributor contract in `docs/adding-tools-and-integrations.md` (write/read rules; ban secret `os.getenv`; webhook/`*_URL` never keyring)
- Messaging docs (Telegram, Slack, Rocket.Chat) aligned with `resolve_env_credential` vs plain env for webhooks
- `docs/configuration/environment-variables.mdx` notes env-then-keyring for sensitive vars and the webhook exception

No runtime code changes.

### Demo/Screenshot for feature changes and bug fixes -
N/A — documentation only. Diff is the proof of change.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
PR3 of the unify-credential-resolve plan. Runtime behavior already shipped in #4135; this PR only locks the contributor/user-facing contract so new integrations do not reintroduce bare `os.getenv` for secrets or put webhook URLs on the keyring path. Prefer editing existing docs over a new Mintlify page.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

## Test plan
- [x] Docs-only change — `git status` / review rendered wording for Telegram, Slack, Rocket.Chat, env-vars, and adding-tools checklist
- [ ] Confirm Mintlify preview (if enabled) for the three `.mdx` pages