### PR TITLE
fix(session): eliminate O(n²) file reads in trace_span appends

### DIFF
--- a/core/agent_harness/session/persistence/jsonl_storage.py
+++ b/core/agent_harness/session/persistence/jsonl_storage.py
@@ -31,6 +31,10 @@ class JsonlSessionStorage:
     tree entry with ``id``, ``parent_id``, ``timestamp``, and ``type``.
     """
 
+    def __init__(self) -> None:
+        """Initialize storage with per-session last-entry-ID cache."""
+        self._last_entry_id_cache: dict[str, str | None] = {}
+
     def open_session(self, session: SessionPersistenceSource) -> None:
         with contextlib.suppress(Exception):
             path = session_path(session.session_id)
@@ -316,7 +320,14 @@ class JsonlSessionStorage:
             if not path.exists():
                 return ""
             entry_id = _new_id()
-            parent = parent_id if parent_id is not None else self._current_leaf_id(path)
+            # Use cached last entry ID if available, otherwise compute it once
+            if parent_id is not None:
+                parent = parent_id
+            elif session_id in self._last_entry_id_cache:
+                parent = self._last_entry_id_cache[session_id]
+            else:
+                parent = self._current_leaf_id(path)
+                self._last_entry_id_cache[session_id] = parent
             record = {
                 "id": entry_id,
                 "parent_id": parent,
@@ -326,6 +337,8 @@ class JsonlSessionStorage:
             }
             with path.open("a", encoding="utf-8") as fh:
                 fh.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+            # Update cache with the new entry ID for next append
+            self._last_entry_id_cache[session_id] = entry_id
             return entry_id
         return ""
 


### PR DESCRIPTION
## Problem

Issue #3938 reports that every `trace_span` append re-reads the entire session JSONL file, causing O(n²) behavior as sessions grow. The `_current_leaf_id` method reads all records to find the parent ID for each new entry.

## Solution

Cache the last entry ID per session in `JsonlSessionStorage`:

- Added `_last_entry_id_cache: dict[str, str | None]` instance variable
- First append computes parent via `_current_leaf_id`, caches result
- Subsequent appends use cached ID, update cache after write
- Explicit `parent_id` parameter still bypasses cache (preserves tree structure)

## Testing

- All existing tests pass: `tests/platform/observability/test_session_trace.py` (21 tests)
- All session tests pass: `tests/core/agent_harness/session/` (12 tests)
- No behavior changes, only performance improvement

## Performance Impact

Before: O(n²) - each append reads entire file
After: O(1) - cached lookup per append

Fixes #3938
