### PR TITLE
test: unskip empty-response shell turn test

### DIFF
--- a/tests/interactive_shell/utils/telemetry/test_execution_integration.py
+++ b/tests/interactive_shell/utils/telemetry/test_execution_integration.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import io
 
-import pytest
 from rich.console import Console
 
 from surfaces.interactive_shell.runtime.core.turn_accounting import (
@@ -29,10 +28,6 @@ def _console() -> Console:
     return Console(file=io.StringIO(), force_terminal=False, highlight=False)
 
 
-@pytest.mark.skip(
-    reason="Tool-gathering emits a progress line to the console; expectation of empty "
-    "output needs revisiting. Skipped to unblock CI."
-)
 def test_execute_shell_turn_cli_agent_empty_response_is_recorded_empty() -> None:
     recorder = _FakeRecorder()
 
@@ -59,6 +54,7 @@ def test_execute_shell_turn_cli_agent_empty_response_is_recorded_empty() -> None
         is_tty=None,
         execute_actions=fake_execute,
         answer_agent=fake_answer,
+        gather_evidence=lambda *_args, **_kwargs: None,
     )
 
     assert output.getvalue() == ""


### PR DESCRIPTION
The test was skipped because the real gather_integration_tool_evidence function printed a progress line to the console, breaking the 'assert output.getvalue() == ""' assertion.

Fix: inject a no-op gather_evidence stub via the existing seam in execute_shell_turn(), preventing any console output before answer_agent is called.

Removes the @pytest.mark.skip decorator so the test now runs in CI.

Fixes #

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
