### PR TITLE
fix(scheduler): resolve Slack bot_token store key for digest delivery (#4019)

### DIFF
--- a/platform/scheduler/credentials.py
+++ b/platform/scheduler/credentials.py
@@ -53,6 +53,16 @@ def resolve_slack_credentials(task_params: dict[str, str]) -> dict[str, str]:
     if env_webhook:
         return {"webhook_url": env_webhook}
 
+    # Bot token from the store: Socket Mode setup persists the token under the
+    # ``bot_token`` key (integrations/cli.py ``_setup_slack``), matching the
+    # canonical readers in integrations/slack/bot_api.py. Older/webhook flows may
+    # use ``access_token``. Accept either store key and normalize to the
+    # ``access_token`` field the executor reads for chat.postMessage.
+    for store_key in ("access_token", "bot_token"):
+        store_token = _get_integration_credential("slack", store_key).strip()
+        if store_token:
+            return {"access_token": store_token}
+
     return _resolve_credentials(
         {},
         service="slack",

--- a/platform/scheduler/credentials.py
+++ b/platform/scheduler/credentials.py
@@ -53,22 +53,24 @@ def resolve_slack_credentials(task_params: dict[str, str]) -> dict[str, str]:
     if env_webhook:
         return {"webhook_url": env_webhook}
 
-    # Bot token from the store: Socket Mode setup persists the token under the
+    # Bot token: store then env. Socket Mode setup persists the token under the
     # ``bot_token`` key (integrations/cli.py ``_setup_slack``), matching the
-    # canonical readers in integrations/slack/bot_api.py. Older/webhook flows may
-    # use ``access_token``. Accept either store key and normalize to the
-    # ``access_token`` field the executor reads for chat.postMessage.
+    # canonical readers in integrations/slack/bot_api.py; older/webhook flows may
+    # use ``access_token``. Accept either store key (``access_token`` preferred)
+    # and normalize to the ``access_token`` field the executor reads for
+    # chat.postMessage. Handled inline rather than via ``_resolve_credentials``
+    # so the store is queried once per key instead of re-reading ``access_token``.
     for store_key in ("access_token", "bot_token"):
         store_token = _get_integration_credential("slack", store_key).strip()
         if store_token:
             return {"access_token": store_token}
 
-    return _resolve_credentials(
-        {},
-        service="slack",
-        credential_key="access_token",
-        env_vars=("SLACK_BOT_TOKEN", "SLACK_ACCESS_TOKEN"),
-    )
+    for env_var in ("SLACK_BOT_TOKEN", "SLACK_ACCESS_TOKEN"):
+        env_token = resolve_env_credential(env_var).strip()
+        if env_token:
+            return {"access_token": env_token}
+
+    return {}
 
 
 def resolve_discord_credentials(task_params: dict[str, str]) -> dict[str, str]:

--- a/tests/scheduler/test_credentials.py
+++ b/tests/scheduler/test_credentials.py
@@ -79,6 +79,42 @@ class TestSlackCredentials:
         creds = resolve_slack_credentials({})
         assert creds == {"webhook_url": "https://hooks.slack.com/from-env"}
 
+    def test_bot_token_from_store_socket_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Socket Mode setup persists the bot token under the store ``bot_token``
+        # key (not ``access_token``); resolution must find it there without
+        # requiring SLACK_BOT_TOKEN to also be exported. Regression for #4019.
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("SLACK_ACCESS_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "platform.scheduler.credentials._get_integration_credential",
+            lambda _service, key: "xoxb-from-store" if key == "bot_token" else "",
+        )
+        monkeypatch.setattr(
+            "platform.scheduler.credentials.resolve_env_credential",
+            lambda *_args, **_kwargs: "",
+        )
+        creds = resolve_slack_credentials({})
+        assert creds == {"access_token": "xoxb-from-store"}
+
+    def test_store_access_token_key_takes_priority_over_bot_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("SLACK_ACCESS_TOKEN", raising=False)
+        store = {"access_token": "xoxp-preferred", "bot_token": "xoxb-secondary"}
+        monkeypatch.setattr(
+            "platform.scheduler.credentials._get_integration_credential",
+            lambda _service, key: store.get(key, ""),
+        )
+        monkeypatch.setattr(
+            "platform.scheduler.credentials.resolve_env_credential",
+            lambda *_args, **_kwargs: "",
+        )
+        creds = resolve_slack_credentials({})
+        assert creds == {"access_token": "xoxp-preferred"}
+
     def test_from_env_access_token_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
         monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)


### PR DESCRIPTION
Fixes #4019

#### Describe the changes you have made in this PR -

`opensre sentry digest schedule add --provider slack` refused to add a schedule for a Slack workspace configured via **Socket Mode**, exiting with the red "not configured" delivery hint even though `opensre` had just stored a valid `xoxb-` bot token.

**Root cause:** Socket Mode setup persists the token under the integration store key `bot_token` (`integrations/cli.py` `_setup_slack`), matching the canonical readers in `integrations/slack/bot_api.py`. But `resolve_slack_credentials` in `platform/scheduler/credentials.py` only queried the `access_token` store key, so the stored token was never found and `slack_delivery_ready()` returned `False` unless `SLACK_BOT_TOKEN` was **also** exported in the environment — duplicating a credential already in the store.

**Fix:** After the webhook checks, resolve the bot token from either store key (`access_token` preferred, then `bot_token`) and normalize it to the `access_token` field that the scheduler executor reads for `chat.postMessage` (`platform/scheduler/executor.py`). The existing env fallback (`SLACK_BOT_TOKEN` / `SLACK_ACCESS_TOKEN`) is unchanged, so webhook and env-based setups behave exactly as before.

Added two regression tests in `tests/scheduler/test_credentials.py`:
- `test_bot_token_from_store_socket_mode` — store holds only `bot_token`, no env set → resolves to `{"access_token": "xoxb-…"}`.
- `test_store_access_token_key_takes_priority_over_bot_token` — when both store keys are present, `access_token` wins.

### Demo/Screenshot for feature changes and bug fixes -

The regression test reproduces the bug against the pre-fix code and passes with the fix. Real captured output — `BEFORE` checks out the credential resolver from the parent commit (`git checkout HEAD~1 -- platform/scheduler/credentials.py`) so the store lookup still misses the `bot_token` key:

```
# BEFORE — pre-fix resolver: a store that holds only bot_token resolves to {},
# so slack_delivery_ready() would return False (the reported bug):
$ pytest tests/scheduler/test_credentials.py::TestSlackCredentials::test_bot_token_from_store_socket_mode
=========================== short test summary info ============================
FAILED tests/scheduler/test_credentials.py::TestSlackCredentials::test_bot_token_from_store_socket_mode
============================== 1 failed in 0.46s ===============================

# AFTER — fix in place, full credential suite:
$ pytest tests/scheduler/test_credentials.py -q
============================== 26 passed in 0.38s ==============================
```

Full local harness (per `CI.md`): `make lint`, `make format-check`, `make typecheck` all clean; `make test-scope` plus the related `tests/integrations/sentry/test_digest_delivery.py`, `tests/utils/test_slack_delivery.py`, and `tests/scheduler/` (141 tests) all pass.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is a store-key mismatch: the Slack Socket Mode setup writes the bot token under `bot_token`, while the scheduler's digest readiness check looked it up under `access_token`. I traced the credential flow end to end — from `_setup_slack` (writer) through `resolve_slack_credentials` (resolver) to `_deliver_slack` in the executor (consumer, which reads `access_token` as the `chat.postMessage` bearer token). I considered changing the executor to read `bot_token` directly, but that would fork the credential contract in two places; normalizing at the single resolver into the `access_token` field the executor already expects keeps one canonical shape and leaves webhook/env paths untouched. I kept `access_token` as the higher-priority store key so any existing setups relying on it are unaffected.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
