### PR TITLE
fix(grafana): surface API failures instead of reporting zero results (#2944)

### DIFF
--- a/integrations/grafana/base.py
+++ b/integrations/grafana/base.py
@@ -263,11 +263,13 @@ class GrafanaClientBase:
 
             logger.info("[grafana] Discovered datasource UIDs: %s", result)
             return result
-        except (requests.RequestException, ValueError) as e:
+        except (requests.RequestException, ValueError, TypeError, AttributeError) as e:
             # Best-effort bootstrap: datasource discovery runs while the client is
             # being constructed (see integrations/grafana/client.py). Raising here
             # would break client creation even when the caller passed explicit
             # datasource UIDs, so a failed discovery degrades to "none found".
+            # TypeError/AttributeError are included so a shape-changed body (e.g.
+            # a non-list payload) also degrades instead of breaking construction.
             # The query methods below no longer swallow — they surface failures so
             # the agent can tell an API error apart from an empty result (#2944).
             logger.warning("[grafana] Failed to discover datasource UIDs: %s", e)
@@ -287,7 +289,15 @@ class GrafanaClientBase:
             f"/loki/api/v1/label/{label}/values",
         )
         data = self._make_request(url)
-        values: list[str] = data.get("data", [])
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Grafana label-values response was {type(data).__name__}, expected object"
+            )
+        values = data.get("data", [])
+        if not isinstance(values, list):
+            raise ValueError(
+                f"Grafana label-values 'data' was {type(values).__name__}, expected array"
+            )
         return values
 
     def query_alert_rules(self, folder: str | None = None) -> list[dict[str, Any]]:
@@ -306,6 +316,10 @@ class GrafanaClientBase:
         )
         response.raise_for_status()
         data = response.json()
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Grafana alert-rules response was {type(data).__name__}, expected object"
+            )
 
         rules: list[dict[str, Any]] = []
         for folder_name, groups in data.items():
@@ -362,6 +376,10 @@ class GrafanaClientBase:
         )
         response.raise_for_status()
         data = response.json()
+        if not isinstance(data, list):
+            raise ValueError(
+                f"Grafana annotations response was {type(data).__name__}, expected array"
+            )
         return [_map_annotation(item) for item in data if isinstance(item, dict)]
 
     def _get_auth_headers(self) -> dict[str, str]:

--- a/integrations/grafana/base.py
+++ b/integrations/grafana/base.py
@@ -263,63 +263,69 @@ class GrafanaClientBase:
 
             logger.info("[grafana] Discovered datasource UIDs: %s", result)
             return result
-        except Exception as e:
+        except (requests.RequestException, ValueError) as e:
+            # Best-effort bootstrap: datasource discovery runs while the client is
+            # being constructed (see integrations/grafana/client.py). Raising here
+            # would break client creation even when the caller passed explicit
+            # datasource UIDs, so a failed discovery degrades to "none found".
+            # The query methods below no longer swallow — they surface failures so
+            # the agent can tell an API error apart from an empty result (#2944).
             logger.warning("[grafana] Failed to discover datasource UIDs: %s", e)
             return {}
 
     def query_loki_label_values(self, label: str = "service_name") -> list[str]:
-        """Query Loki for available values of a label."""
+        """Query Loki for available values of a label.
+
+        Raises ``requests.RequestException`` (or ``ValueError`` on a malformed
+        body) on API failure instead of returning ``[]`` so callers can tell a
+        real "no labels" apart from a connectivity/auth error (#2944).
+        """
         if not self.loki_datasource_uid:
             return []
         url = self._build_datasource_url(
             self.loki_datasource_uid,
             f"/loki/api/v1/label/{label}/values",
         )
-        try:
-            data = self._make_request(url)
-            values: list[str] = data.get("data", [])
-            return values
-        except Exception:
-            logger.debug("Failed to fetch Loki label values for %s", label, exc_info=True)
-            return []
+        data = self._make_request(url)
+        values: list[str] = data.get("data", [])
+        return values
 
     def query_alert_rules(self, folder: str | None = None) -> list[dict[str, Any]]:
-        """Query Grafana alert rules, optionally filtered by folder title."""
-        url = f"{self.instance_url}/api/ruler/grafana/api/v1/rules"
-        try:
-            response = requests.get(
-                url,
-                headers=self._get_auth_headers(),
-                timeout=10,
-                verify=self._config.ssl_verify,
-            )
-            response.raise_for_status()
-            data = response.json()
+        """Query Grafana alert rules, optionally filtered by folder title.
 
-            rules: list[dict[str, Any]] = []
-            for folder_name, groups in data.items():
-                if folder and folder.lower() not in folder_name.lower():
-                    continue
-                for group in groups:
-                    for rule in group.get("rules", []):
-                        rules.append(
-                            {
-                                "folder": folder_name,
-                                "group": group.get("name", ""),
-                                "rule_name": rule.get("grafana_alert", {}).get("title", ""),
-                                "condition": rule.get("grafana_alert", {}).get("condition", ""),
-                                "datasource_uid": _extract_datasource_uid(rule),
-                                "queries": _extract_rule_queries(rule),
-                                "state": rule.get("grafana_alert", {}).get("current_state", ""),
-                                "no_data_state": rule.get("grafana_alert", {}).get(
-                                    "no_data_state", ""
-                                ),
-                            }
-                        )
-            return rules
-        except Exception as e:
-            logger.warning("[grafana] Failed to query alert rules: %s", e)
-            return []
+        Raises ``requests.RequestException`` (or ``ValueError`` on a malformed
+        body) on API failure instead of returning ``[]`` so callers can tell a
+        real "no alert rules" apart from a connectivity/auth error (#2944).
+        """
+        url = f"{self.instance_url}/api/ruler/grafana/api/v1/rules"
+        response = requests.get(
+            url,
+            headers=self._get_auth_headers(),
+            timeout=10,
+            verify=self._config.ssl_verify,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        rules: list[dict[str, Any]] = []
+        for folder_name, groups in data.items():
+            if folder and folder.lower() not in folder_name.lower():
+                continue
+            for group in groups:
+                for rule in group.get("rules", []):
+                    rules.append(
+                        {
+                            "folder": folder_name,
+                            "group": group.get("name", ""),
+                            "rule_name": rule.get("grafana_alert", {}).get("title", ""),
+                            "condition": rule.get("grafana_alert", {}).get("condition", ""),
+                            "datasource_uid": _extract_datasource_uid(rule),
+                            "queries": _extract_rule_queries(rule),
+                            "state": rule.get("grafana_alert", {}).get("current_state", ""),
+                            "no_data_state": rule.get("grafana_alert", {}).get("no_data_state", ""),
+                        }
+                    )
+        return rules
 
     def query_annotations(
         self,
@@ -333,6 +339,10 @@ class GrafanaClientBase:
         Mirrors ``query_alert_rules``: a direct ``requests.get`` returning a list.
         ``/api/annotations`` responds with a JSON array, so ``_make_request`` (which
         returns a dict) is unsuitable here.
+
+        Raises ``requests.RequestException`` (or ``ValueError`` on a malformed
+        body) on API failure instead of returning ``[]`` so callers can tell a
+        real "no annotations" apart from a connectivity/auth error (#2944).
         """
         url = f"{self.instance_url}/api/annotations"
         params: dict[str, Any] = {
@@ -343,20 +353,16 @@ class GrafanaClientBase:
         }
         if tags:
             params["tags"] = tags  # requests repeats the param once per tag
-        try:
-            response = requests.get(
-                url,
-                headers=self._get_auth_headers(),
-                params=params,
-                timeout=10,
-                verify=self._config.ssl_verify,
-            )
-            response.raise_for_status()
-            data = response.json()
-            return [_map_annotation(item) for item in data if isinstance(item, dict)]
-        except Exception as e:
-            logger.warning("[grafana] Failed to query annotations: %s", e)
-            return []
+        response = requests.get(
+            url,
+            headers=self._get_auth_headers(),
+            params=params,
+            timeout=10,
+            verify=self._config.ssl_verify,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return [_map_annotation(item) for item in data if isinstance(item, dict)]
 
     def _get_auth_headers(self) -> dict[str, str]:
         if self.username and self.password:

--- a/integrations/grafana/tools/__init__.py
+++ b/integrations/grafana/tools/__init__.py
@@ -4,12 +4,15 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import requests
 
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
+
+logger = logging.getLogger(__name__)
 
 # Grafana client query methods raise on API failure (#2944); these are the
 # exception types a failed request or a malformed response body produces.
@@ -27,6 +30,17 @@ def _grafana_failure_message(what: str, err: Exception) -> str:
     if status:
         return f"Grafana {what} query failed: HTTP {status}"
     return f"Grafana {what} query failed: {type(err).__name__}"
+
+
+def _grafana_unavailable(source: str, what: str, err: Exception, **extra: Any) -> dict[str, Any]:
+    """Log the API failure server-side and return the tool-unavailable envelope.
+
+    The log line carries full exception detail (server-side only) — restoring the
+    warning the base client emitted before it stopped swallowing (#2944) — while
+    the returned envelope's error is limited to status/type (CWE-209).
+    """
+    logger.warning("[grafana] %s query failed: %s", what, err)
+    return tool_unavailable(source, _grafana_failure_message(what, err), **extra)
 
 
 def _query_grafana_alert_rules_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -126,9 +140,7 @@ def query_grafana_alert_rules(
     try:
         rules = client.query_alert_rules(folder=folder)
     except _GRAFANA_API_ERRORS as e:
-        return tool_unavailable(
-            "grafana_alerts", _grafana_failure_message("alert-rules", e), rules=[]
-        )
+        return _grafana_unavailable("grafana_alerts", "alert-rules", e, rules=[])
     return {
         "source": "grafana_alerts",
         "available": True,
@@ -273,9 +285,7 @@ def query_grafana_annotations(
     try:
         annotations = client.query_annotations(from_ts=from_ts, to_ts=to_ts, tags=tags, limit=limit)
     except _GRAFANA_API_ERRORS as e:
-        return tool_unavailable(
-            "grafana_annotations", _grafana_failure_message("annotations", e), annotations=[]
-        )
+        return _grafana_unavailable("grafana_annotations", "annotations", e, annotations=[])
     return {
         "source": "grafana_annotations",
         "available": True,
@@ -697,10 +707,8 @@ def query_grafana_service_names(
     try:
         service_names = client.query_loki_label_values("service_name")
     except _GRAFANA_API_ERRORS as e:
-        return tool_unavailable(
-            "grafana_loki_labels",
-            _grafana_failure_message("service-name labels", e),
-            service_names=[],
+        return _grafana_unavailable(
+            "grafana_loki_labels", "service-name labels", e, service_names=[]
         )
     return {
         "source": "grafana_loki_labels",

--- a/integrations/grafana/tools/__init__.py
+++ b/integrations/grafana/tools/__init__.py
@@ -6,8 +6,27 @@ from __future__ import annotations
 
 from typing import Any
 
+import requests
+
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
+
+# Grafana client query methods raise on API failure (#2944); these are the
+# exception types a failed request or a malformed response body produces.
+_GRAFANA_API_ERRORS = (requests.RequestException, ValueError)
+
+
+def _grafana_failure_message(what: str, err: Exception) -> str:
+    """Concise, non-leaky message distinguishing an API failure from empty results.
+
+    Includes the HTTP status when the error carries a response; otherwise the
+    exception type name. Never embeds the raw response body (CWE-209).
+    """
+    response = getattr(err, "response", None)
+    status = getattr(response, "status_code", None)
+    if status:
+        return f"Grafana {what} query failed: HTTP {status}"
+    return f"Grafana {what} query failed: {type(err).__name__}"
 
 
 def _query_grafana_alert_rules_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -104,7 +123,12 @@ def query_grafana_alert_rules(
     if not client or not client.is_configured:
         return tool_unavailable("grafana_alerts", "Grafana integration not configured", rules=[])
 
-    rules = client.query_alert_rules(folder=folder)
+    try:
+        rules = client.query_alert_rules(folder=folder)
+    except _GRAFANA_API_ERRORS as e:
+        return tool_unavailable(
+            "grafana_alerts", _grafana_failure_message("alert-rules", e), rules=[]
+        )
     return {
         "source": "grafana_alerts",
         "available": True,
@@ -246,7 +270,12 @@ def query_grafana_annotations(
     except (ValueError, TypeError, AttributeError) as e:
         return tool_unavailable("grafana_annotations", f"Invalid timestamp: {e}", annotations=[])
 
-    annotations = client.query_annotations(from_ts=from_ts, to_ts=to_ts, tags=tags, limit=limit)
+    try:
+        annotations = client.query_annotations(from_ts=from_ts, to_ts=to_ts, tags=tags, limit=limit)
+    except _GRAFANA_API_ERRORS as e:
+        return tool_unavailable(
+            "grafana_annotations", _grafana_failure_message("annotations", e), annotations=[]
+        )
     return {
         "source": "grafana_annotations",
         "available": True,
@@ -665,7 +694,14 @@ def query_grafana_service_names(
             "grafana_loki_labels", "Grafana integration not configured", service_names=[]
         )
 
-    service_names = client.query_loki_label_values("service_name")
+    try:
+        service_names = client.query_loki_label_values("service_name")
+    except _GRAFANA_API_ERRORS as e:
+        return tool_unavailable(
+            "grafana_loki_labels",
+            _grafana_failure_message("service-name labels", e),
+            service_names=[],
+        )
     return {
         "source": "grafana_loki_labels",
         "available": True,

--- a/tests/integrations/grafana/test_base.py
+++ b/tests/integrations/grafana/test_base.py
@@ -52,6 +52,15 @@ class TestQueryAlertRulesErrors:
         with patch("integrations.grafana.base.requests.get", return_value=_ok_response({})):
             assert _client().query_alert_rules() == []
 
+    def test_malformed_shape_raises_valueerror(self) -> None:
+        # A 200 body of the wrong type (list, not object) must raise ValueError —
+        # the type the tool wrapper catches — not AttributeError from .items().
+        with (
+            patch("integrations.grafana.base.requests.get", return_value=_ok_response([1, 2])),
+            pytest.raises(ValueError),
+        ):
+            _client().query_alert_rules()
+
 
 class TestQueryAnnotationsErrors:
     def test_http_error_propagates(self) -> None:
@@ -64,6 +73,15 @@ class TestQueryAnnotationsErrors:
     def test_empty_response_still_returns_empty(self) -> None:
         with patch("integrations.grafana.base.requests.get", return_value=_ok_response([])):
             assert _client().query_annotations(from_ts=0, to_ts=1) == []
+
+    def test_malformed_shape_raises_valueerror(self) -> None:
+        # A dict body (annotations API returns an array) must raise ValueError, not
+        # silently yield [] by iterating dict keys — that would be a false negative.
+        with (
+            patch("integrations.grafana.base.requests.get", return_value=_ok_response({"a": 1})),
+            pytest.raises(ValueError),
+        ):
+            _client().query_annotations(from_ts=0, to_ts=1)
 
 
 class TestQueryLokiLabelValuesErrors:
@@ -82,6 +100,19 @@ class TestQueryLokiLabelValuesErrors:
             return_value=_ok_response({"data": []}),
         ):
             assert client.query_loki_label_values("service_name") == []
+
+    def test_malformed_shape_raises_valueerror(self) -> None:
+        # A non-object body (or a non-list "data") must raise ValueError so the
+        # tool wrapper reports unavailable instead of raising AttributeError.
+        client = _client(loki_datasource_uid="loki-uid")
+        with (
+            patch(
+                "integrations.grafana.base.requests.get",
+                return_value=_ok_response(["not", "a", "dict"]),
+            ),
+            pytest.raises(ValueError),
+        ):
+            client.query_loki_label_values("service_name")
 
 
 class TestDiscoverDatasourceUidsStaysBestEffort:

--- a/tests/integrations/grafana/test_base.py
+++ b/tests/integrations/grafana/test_base.py
@@ -1,0 +1,92 @@
+"""Tests for GrafanaClientBase query methods surfacing API errors (#2944).
+
+The client must let an API failure (auth, network, malformed body) propagate
+instead of returning an empty collection, so callers can tell a real "no
+results" apart from a failure and not report a broken system as healthy.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from integrations.grafana.base import GrafanaClientBase
+from integrations.grafana.config import GrafanaAccountConfig
+
+
+def _client(**overrides: object) -> GrafanaClientBase:
+    config = GrafanaAccountConfig(
+        account_id="acct",
+        instance_url="https://grafana.example.com",
+        read_token="glsa_test",
+        **overrides,
+    )
+    return GrafanaClientBase(config)
+
+
+def _failing_response() -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status.side_effect = requests.HTTPError(response=MagicMock(status_code=401))
+    return response
+
+
+def _ok_response(payload: object) -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = payload
+    return response
+
+
+class TestQueryAlertRulesErrors:
+    def test_http_error_propagates(self) -> None:
+        with (
+            patch("integrations.grafana.base.requests.get", return_value=_failing_response()),
+            pytest.raises(requests.HTTPError),
+        ):
+            _client().query_alert_rules()
+
+    def test_empty_response_still_returns_empty(self) -> None:
+        # A genuine empty result must stay empty — only failures should raise.
+        with patch("integrations.grafana.base.requests.get", return_value=_ok_response({})):
+            assert _client().query_alert_rules() == []
+
+
+class TestQueryAnnotationsErrors:
+    def test_http_error_propagates(self) -> None:
+        with (
+            patch("integrations.grafana.base.requests.get", return_value=_failing_response()),
+            pytest.raises(requests.HTTPError),
+        ):
+            _client().query_annotations(from_ts=0, to_ts=1)
+
+    def test_empty_response_still_returns_empty(self) -> None:
+        with patch("integrations.grafana.base.requests.get", return_value=_ok_response([])):
+            assert _client().query_annotations(from_ts=0, to_ts=1) == []
+
+
+class TestQueryLokiLabelValuesErrors:
+    def test_http_error_propagates(self) -> None:
+        client = _client(loki_datasource_uid="loki-uid")
+        with (
+            patch("integrations.grafana.base.requests.get", return_value=_failing_response()),
+            pytest.raises(requests.HTTPError),
+        ):
+            client.query_loki_label_values("service_name")
+
+    def test_empty_response_still_returns_empty(self) -> None:
+        client = _client(loki_datasource_uid="loki-uid")
+        with patch(
+            "integrations.grafana.base.requests.get",
+            return_value=_ok_response({"data": []}),
+        ):
+            assert client.query_loki_label_values("service_name") == []
+
+
+class TestDiscoverDatasourceUidsStaysBestEffort:
+    def test_api_failure_degrades_to_empty(self) -> None:
+        # Discovery runs during client construction, so a failure must not raise
+        # (it would break clients that pass explicit UIDs) — it degrades to {}.
+        with patch("integrations.grafana.base.requests.get", return_value=_failing_response()):
+            assert _client().discover_datasource_uids() == {}

--- a/tests/tools/test_grafana_alert_rules_tool.py
+++ b/tests/tools/test_grafana_alert_rules_tool.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import requests
+
 from integrations.grafana.tools import query_grafana_alert_rules
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
@@ -80,3 +82,29 @@ def test_run_with_folder_filter() -> None:
         result = query_grafana_alert_rules(folder="my-folder", grafana_endpoint="http://grafana")
     assert result["folder_filter"] == "my-folder"
     mock_client.query_alert_rules.assert_called_once_with(folder="my-folder")
+
+
+def test_run_http_error_reports_unavailable_not_empty() -> None:
+    # Regression for #2944: an API failure must surface as available=False, not
+    # as an empty "0 alert rules" result the agent would read as healthy.
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    response = MagicMock(status_code=401)
+    mock_client.query_alert_rules.side_effect = requests.HTTPError(response=response)
+    with patch("integrations.grafana.tools._resolve_grafana_client", return_value=mock_client):
+        result = query_grafana_alert_rules(grafana_endpoint="http://grafana")
+    assert result["available"] is False
+    assert "401" in result["error"]
+    assert result["rules"] == []
+
+
+def test_run_connection_error_reports_unavailable() -> None:
+    # A transport error carries no response; the message falls back to the type.
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    mock_client.query_alert_rules.side_effect = requests.ConnectionError("dns failure")
+    with patch("integrations.grafana.tools._resolve_grafana_client", return_value=mock_client):
+        result = query_grafana_alert_rules(grafana_endpoint="http://grafana")
+    assert result["available"] is False
+    assert "ConnectionError" in result["error"]
+    assert result["rules"] == []

--- a/tests/tools/test_grafana_alert_rules_tool.py
+++ b/tests/tools/test_grafana_alert_rules_tool.py
@@ -108,3 +108,19 @@ def test_run_connection_error_reports_unavailable() -> None:
     assert result["available"] is False
     assert "ConnectionError" in result["error"]
     assert result["rules"] == []
+
+
+def test_run_api_failure_logs_warning(caplog) -> None:
+    # The failure must leave a server-side trace (the base client used to log
+    # before it stopped swallowing); the agent-facing envelope is not enough.
+    import logging
+
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    mock_client.query_alert_rules.side_effect = requests.ConnectionError("dns failure")
+    with (
+        patch("integrations.grafana.tools._resolve_grafana_client", return_value=mock_client),
+        caplog.at_level(logging.WARNING, logger="integrations.grafana.tools"),
+    ):
+        query_grafana_alert_rules(grafana_endpoint="http://grafana")
+    assert any("alert-rules query failed" in r.message for r in caplog.records)

--- a/tests/tools/test_grafana_annotations_tool.py
+++ b/tests/tools/test_grafana_annotations_tool.py
@@ -27,6 +27,18 @@ def test_run_http_error_reports_unavailable_not_empty() -> None:
     assert result["annotations"] == []
 
 
+def test_run_connection_error_reports_unavailable() -> None:
+    # A transport error carries no response; the message falls back to the type.
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    mock_client.query_annotations.side_effect = requests.ConnectionError("dns failure")
+    with patch("integrations.grafana.tools._resolve_grafana_client", return_value=mock_client):
+        result = query_grafana_annotations(grafana_endpoint="http://grafana")
+    assert result["available"] is False
+    assert "ConnectionError" in result["error"]
+    assert result["annotations"] == []
+
+
 class TestGrafanaAnnotationsToolContract(BaseToolContract):
     def get_tool_under_test(self):
         return query_grafana_annotations.__opensre_registered_tool__

--- a/tests/tools/test_grafana_annotations_tool.py
+++ b/tests/tools/test_grafana_annotations_tool.py
@@ -4,11 +4,27 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import requests
+
 from integrations.grafana.tools import (
     _iso_to_epoch_ms,
     query_grafana_annotations,
 )
 from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+def test_run_http_error_reports_unavailable_not_empty() -> None:
+    # Regression for #2944: an API failure must surface as available=False, not
+    # as an empty "0 annotations" result the agent would read as "nothing changed".
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    response = MagicMock(status_code=403)
+    mock_client.query_annotations.side_effect = requests.HTTPError(response=response)
+    with patch("integrations.grafana.tools._resolve_grafana_client", return_value=mock_client):
+        result = query_grafana_annotations(grafana_endpoint="http://grafana")
+    assert result["available"] is False
+    assert "403" in result["error"]
+    assert result["annotations"] == []
 
 
 class TestGrafanaAnnotationsToolContract(BaseToolContract):

--- a/tests/tools/test_grafana_service_names_tool.py
+++ b/tests/tools/test_grafana_service_names_tool.py
@@ -67,3 +67,15 @@ def test_run_http_error_reports_unavailable_not_empty() -> None:
     assert result["available"] is False
     assert "500" in result["error"]
     assert result["service_names"] == []
+
+
+def test_run_connection_error_reports_unavailable() -> None:
+    # A transport error carries no response; the message falls back to the type.
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    mock_client.query_loki_label_values.side_effect = requests.ConnectionError("dns failure")
+    with patch("integrations.grafana.tools._resolve_grafana_client", return_value=mock_client):
+        result = query_grafana_service_names(grafana_endpoint="http://grafana")
+    assert result["available"] is False
+    assert "ConnectionError" in result["error"]
+    assert result["service_names"] == []

--- a/tests/tools/test_grafana_service_names_tool.py
+++ b/tests/tools/test_grafana_service_names_tool.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import requests
+
 from integrations.grafana.tools import query_grafana_service_names
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
@@ -51,3 +53,17 @@ def test_run_happy_path() -> None:
     assert result["available"] is True
     assert result["service_names"] == ["svc-a", "svc-b"]
     mock_client.query_loki_label_values.assert_called_once_with("service_name")
+
+
+def test_run_http_error_reports_unavailable_not_empty() -> None:
+    # Regression for #2944: an API failure must surface as available=False, not
+    # as an empty "0 services" result the agent would read as healthy.
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    response = MagicMock(status_code=500)
+    mock_client.query_loki_label_values.side_effect = requests.HTTPError(response=response)
+    with patch("integrations.grafana.tools._resolve_grafana_client", return_value=mock_client):
+        result = query_grafana_service_names(grafana_endpoint="http://grafana")
+    assert result["available"] is False
+    assert "500" in result["error"]
+    assert result["service_names"] == []


### PR DESCRIPTION
Fixes #2944

#### Describe the changes you have made in this PR -

The `GrafanaClientBase` query methods `query_alert_rules`, `query_annotations`, and `query_loki_label_values` each wrapped their HTTP call in `try/except Exception` and returned an empty `{}`/`[]` on **any** failure. For an AI SRE agent this is a critical false negative: a 401, a timeout, or an outage is indistinguishable from a genuine "0 results", so the LLM reads "0 alerts" / "0 annotations", concludes the system is healthy, and the root-cause chain silently breaks.

**Fix:** the three query methods now let API failures propagate (`requests.RequestException`, or `ValueError` on a malformed body) instead of swallowing them, and their **tool** callers (`query_grafana_alert_rules`, `query_grafana_annotations`, `query_grafana_service_names`) catch the error and return the standard `tool_unavailable(...)` envelope — `available: False` with a concise `error` — so the agent can tell a real empty result apart from a connectivity/auth failure and self-correct or report it.

The error string carries the **HTTP status code or the exception type name only**, never the raw response body, to avoid information exposure (CWE-209 / `py/stack-trace-exposure`).

`discover_datasource_uids` is deliberately left **best-effort**: it runs during client construction (`integrations/grafana/client.py`), so raising there would break clients that pass explicit datasource UIDs. Its `except` is narrowed from bare `Exception` to the request/parse errors and it still degrades to `{}` with a warning — it does not feed the agent a "zero anomalies" signal, so it is out of the false-negative path this issue is about.

Not changed: the Loki/Mimir/Tempo mixins already handle `_make_request` failures correctly (they catch and return `{"success": False, "error": ...}`), so they were left untouched — `_make_request`'s exception type is unchanged so their `e.response.status_code` handling still works.

### Demo/Screenshot for feature changes and bug fixes -

New regression tests fail against the pre-fix code and pass with the fix. Real captured output (`BEFORE` checks the source out from the parent commit):

```
# BEFORE — pre-fix: a 401/timeout is swallowed, so the base method returns
# empty and the tool reports available=True with zero results (the bug):
$ git checkout HEAD~1 -- integrations/grafana/base.py integrations/grafana/tools/__init__.py
$ pytest tests/integrations/grafana/test_base.py -k propagates \
         tests/tools -k "http_error or connection_error"
FAILED tests/integrations/grafana/test_base.py::TestQueryAlertRulesErrors::test_http_error_propagates
FAILED tests/integrations/grafana/test_base.py::TestQueryAnnotationsErrors::test_http_error_propagates
FAILED tests/integrations/grafana/test_base.py::TestQueryLokiLabelValuesErrors::test_http_error_propagates
FAILED tests/tools/test_grafana_alert_rules_tool.py::test_run_http_error_reports_unavailable_not_empty
FAILED tests/tools/test_grafana_alert_rules_tool.py::test_run_connection_error_reports_unavailable
FAILED tests/tools/test_grafana_service_names_tool.py::test_run_http_error_reports_unavailable_not_empty
FAILED tests/tools/test_grafana_annotations_tool.py::test_run_http_error_reports_unavailable_not_empty

# AFTER — fix in place:
$ git checkout HEAD -- integrations/grafana/
$ pytest tests/integrations/grafana/test_base.py tests/tools -k grafana -q
146 passed, 3 skipped
```

Full local harness (per `CI.md`): `make lint`, `make format-check`, `make typecheck` all clean; `make test-scope` (146 passed, 3 skipped) green. `opensre integrations verify` runs cleanly (Grafana config path is unaffected by this runtime change).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I traced how a Grafana API failure reaches the agent. The failure originates in `GrafanaClientBase`; the tool wrappers turn client results into the investigation envelope; the agent reads that envelope. The methods were collapsing "failure" and "empty" into the same empty value at the lowest layer, which destroys information the upper layers need. I considered returning a structured error object from the client methods, but that would change their return types and ripple through every caller and test; and I considered introducing a custom exception, but `_make_request` already raises native `requests` exceptions that the Loki/Mimir/Tempo mixins depend on inspecting (`e.response.status_code`), so a new type would break them. The least-invasive correct fix is to stop swallowing in the three query methods and catch at the tool boundary — the one place that already knows how to signal unavailability via `tool_unavailable`. I kept `discover_datasource_uids` best-effort on purpose because it runs at construction time and hard-failing it would be a worse regression than a missing UID. The failure message is deliberately limited to status code / exception type to avoid leaking response bodies.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
