### PR TITLE
Revamp Mintlify docs: fix nav/CSS, replace placeholder copy, and add integration setup guides

### DIFF
--- a/docs/airflow.mdx
+++ b/docs/airflow.mdx
@@ -6,7 +6,7 @@ description: Investigate DAG failures and extract execution context from Apache 
 
 ## Overview
 
-The Airflow integration enables OpenSRE to investigate DAG failures and extract execution context directly from an Apache Airflow instance.
+When a DAG failure alert fires, OpenSRE queries your Airflow REST API for the failing DAG run, task instances, and logs — then folds that evidence into the RCA pipeline alongside metrics and logs from your observability integrations.
 
 It supports:
 
@@ -16,22 +16,6 @@ It supports:
 - Evidence collection for RCA generation
 
 This integration is designed for **incident-driven workflows**, where an alert referencing a DAG triggers an investigation.
-
----
-
-## Architecture
-
-The Airflow integration participates in the investigation pipeline as follows:
-
-1. **Alert ingestion**
-2. **Planner selects relevant tools**
-3. **Airflow API is queried**
-4. **Evidence is collected**
-5. **RCA is generated**
-
-```
-Alert → Planner → Airflow tools → Evidence → RCA
-```
 
 ---
 

--- a/docs/architecture-audit-tool.mdx
+++ b/docs/architecture-audit-tool.mdx
@@ -1,0 +1,78 @@
+---
+title: "Architecture audit tool"
+description: "Clone a GitHub repo, run architecture shell passes, and persist full audit observations from the interactive shell"
+---
+
+OpenSRE provides GitHub-backed **architecture audit** tools for reviewing repository structure — import boundaries, file placement, size limits, and shim patterns. Use them from the interactive shell (`opensre`) when you want a structured architecture review before or alongside an incident investigation.
+
+## Prerequisites
+
+- GitHub connected via [GitHub integration](/github) **or** a token in `GITHUB_TOKEN` / `GH_TOKEN`
+- For private repos, ensure the token has `repo` read scope
+
+## Typical workflow
+
+1. **Clone** the target repository into a fixed temp workspace
+2. Run architecture **shell heuristic passes** (import, placement, size, shim) via the action agent
+3. **Save** the full untruncated observation list to disk
+4. **Cleanup** the clone when finished
+
+In the REPL, describe what you want in plain language:
+
+```text
+> clone Tracer-Cloud/opensre and run an architecture audit on it
+```
+
+Or invoke tools explicitly through the action agent.
+
+## Tools
+
+| Tool | What it does | Side effects |
+| --- | --- | --- |
+| `architecture_clone_repo` | Shallow-clone `owner/repo` into `opensre/workspace` under the system temp directory | Creates files on disk |
+| `architecture_cleanup_repo` | Delete the architecture workspace (refuses paths outside the allowed directory) | Deletes clone |
+| `architecture_save_observations` | Write the full observation list to `~/.opensre/{session_id}/{repo}-architecture-audit-{uuid}.md` | Writes a file |
+
+### `architecture_clone_repo`
+
+```json
+{
+  "owner": "Tracer-Cloud",
+  "repo": "opensre",
+  "ref": "main"
+}
+```
+
+Returns `workspace_root` — the path to the clone. Always call `architecture_cleanup_repo` when finished.
+
+### `architecture_save_observations`
+
+Call **after** cleanup and **before** the final summarized report. Pass the **complete** findings from all four shell passes (import, placement, size, shim) — not the short user-facing summary.
+
+```json
+{
+  "repo_name": "opensre",
+  "observations": "## Import pass\n- ...\n## Placement pass\n- ..."
+}
+```
+
+## Verify GitHub access
+
+```bash
+opensre integrations verify github
+```
+
+Expected output includes MCP tool discovery; architecture tools additionally accept `GITHUB_TOKEN` when GitHub MCP is not configured.
+
+## Gotchas
+
+- **Always cleanup.** `architecture_clone_repo` leaves a shallow clone on disk until `architecture_cleanup_repo` runs. The tool description enforces this workflow.
+- **Workspace is fixed.** Clones go under the architecture workspace in the system temp directory — you cannot point the clone at an arbitrary path.
+- **Save the full list.** `architecture_save_observations` expects untruncated pass output. Saving only the short report template loses audit evidence.
+- **Session id required.** Saving observations needs an active interactive-shell session (`~/.opensre/sessions/`). Start `opensre` before running the audit.
+
+## Related docs
+
+- [GitHub](/github) — token scopes and MCP setup
+- [GitHub workflow tools](/github-workflow-tools) — engineering digests and PR status (separate from architecture audit)
+- [Interactive Shell Commands](/interactive-shell-commands) — slash commands and session management

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1,3 +1,29 @@
+/* OpenSRE docs site overrides. Loaded via docs.json styles. */
+
+@font-face {
+    font-family: "Britti Sans Trial";
+    src: url("/essentials/fonts/BrittiSansTrial-Regular.otf") format("opentype");
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: "Britti Sans Trial";
+    src: url("/essentials/fonts/BrittiSansTrial-Semibold.otf") format("opentype");
+    font-weight: 500;
+    font-style: normal;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: "Britti Sans Trial";
+    src: url("/essentials/fonts/BrittiSansTrial-Bold.otf") format("opentype");
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+}
+
 /* Keep this file minimal. Prefer Mintlify defaults + `sidebar.css`. */
 
 /* Radar chart helpers (used by `radar-chart.js`). */
@@ -76,61 +102,6 @@ html.dark .toc-custom-actions {
     padding-left: 0.25rem;
     font-size: 0.875rem;
     line-height: 1.75rem;
-}
-
-/* Radar chart helpers (used by `radar-chart.js`). */
-.radar-chart-container {
-    max-width: 100%;
-    margin: 2rem auto;
-    padding: 20px 30px;
-}
-
-.radar-chart-legend {
-    display: flex;
-    justify-content: center;
-    gap: 2rem;
-    margin-bottom: 1.5rem;
-    flex-wrap: wrap;
-}
-
-.radar-legend-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-}
-
-.radar-legend-color {
-    width: 16px;
-    height: 16px;
-    border-radius: 2px;
-}
-
-.radar-tooltip {
-    position: absolute;
-    background: white;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.25rem;
-    padding: 12px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    pointer-events: none;
-    opacity: 0;
-    transition: opacity 0.2s;
-    max-width: 300px;
-    z-index: 1000;
-    color: #374151;
-}
-
-.radar-tooltip.show {
-    opacity: 1;
-}
-
-html.dark .radar-tooltip {
-    background: #0a0a0a;
-    border-color: #262626;
-    color: #ffffff;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.5);
 }
 /* Fonts are loaded via docs.json configuration - Mintlify applies them automatically */
 
@@ -629,39 +600,6 @@ body {
 
 /* Add copyright text to footer - removed, using HTML approach instead */
 
-/* Style for custom TOC actions */
-.toc-custom-actions {
-    margin-top: 1rem;
-    padding-top: 0.75rem;
-    border-top: 1px solid rgba(0, 0, 0, 0.1);
-}
-
-html.dark .toc-custom-actions {
-    border-top-color: rgba(255, 255, 255, 0.1);
-}
-
-.toc-custom-action {
-    display: block;
-    font-size: 0.875rem;
-    line-height: 1.75rem;
-    color: #6b7280;
-    cursor: pointer;
-    transition: color 0.2s;
-    text-decoration: none;
-}
-
-.toc-custom-action:hover {
-    color: #171717;
-}
-
-html.dark .toc-custom-action {
-    color: #9ca3af;
-}
-
-html.dark .toc-custom-action:hover {
-    color: #ffffff;
-}
-
 /* SVG icon colors for TOC actions */
 .toc-action-icon path {
     fill: #444444;
@@ -771,14 +709,6 @@ div[class*="callout" i] *:not(code):not(pre):not(pre *) {
 details *:not(code):not(pre):not(pre *),
 summary {
     font-family: "Britti Sans Trial", sans-serif !important;
-}
-
-/* Hide navigation group titles */
-#sidebar [class*="group-title" i],
-#sidebar h3,
-#navigation-items [class*="group-title" i],
-#navigation-items h3 {
-    display: none !important;
 }
 
 /* Transparent table borders */
@@ -1550,61 +1480,6 @@ html.dark #navigation-items a[href*="sign-up"]:hover svg {
     color: #ffffff !important;
     fill: none !important;
     stroke: #ffffff !important;
-}
-
-/* Radar Chart Styles */
-.radar-chart-container {
-    max-width: 100%;
-    margin: 2rem auto;
-    padding: 20px 30px;
-}
-
-.radar-chart-legend {
-    display: flex;
-    justify-content: center;
-    gap: 2rem;
-    margin-bottom: 1.5rem;
-    flex-wrap: wrap;
-}
-
-.radar-legend-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-}
-
-.radar-legend-color {
-    width: 16px;
-    height: 16px;
-    border-radius: 2px;
-}
-
-.radar-tooltip {
-    position: absolute;
-    background: white;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.125rem;
-    padding: 12px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    pointer-events: none;
-    opacity: 0;
-    transition: opacity 0.2s;
-    max-width: 300px;
-    z-index: 1000;
-    color: #374151;
-}
-
-.radar-tooltip.show {
-    opacity: 1;
-}
-
-html.dark .radar-tooltip {
-    background: #0a0a0a;
-    border-color: #262626;
-    color: #ffffff;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.5);
 }
 
 .tooltip-title {

--- a/docs/datadog.mdx
+++ b/docs/datadog.mdx
@@ -1,58 +1,130 @@
 ---
 title: "Datadog"
+description: "Connect Datadog so OpenSRE can query logs, metrics, monitors, and events during investigations"
 ---
 
-### Step 1: Create API Key
+OpenSRE queries Datadog during alert investigations — pulling logs, metrics, monitor state, and events correlated with incidents.
 
-In Datadog, create an API Key.
+## Prerequisites
 
-To create an API key, go to your organizational settings in Datadog and click **API Keys**. Or visit [https://app.datadoghq.com/organization-settings/api-keys](https://app.datadoghq.com/organization-settings/api-keys)
+- Datadog account with API access
+- API key (organization settings)
+- Application key with read scopes (`events_read`, `logs_read_data`, `logs_read_index_data`, `monitors_read`)
 
-1. Click **\+ New Key** at the top right of the screen
-2. Name your new key **tracer**
+## Setup
 
-   <Frame>
-     ![Datadog API Key](/images/datadog_api_key.webp)
-   </Frame>
+### Option 1: Interactive CLI
 
-3. Copy your new API key and hit **Finish**
+```bash
+opensre integrations setup datadog
+```
 
-### Step 2: Create Application Key
+Or run the onboarding wizard and select **Datadog**. You will be prompted for API key, application key, and site (for example `datadoghq.com` or `datadoghq.eu`).
 
-In Datadog, create an Application Key.
+### Option 2: Environment variables
 
-To create an Application Key, go to your personal settings in Datadog and click **Application Keys**. Or visit [https://app.datadoghq.com/personal-settings/application-keys](https://app.datadoghq.com/personal-settings/application-keys)
+Add to your `.env`:
 
-1. Click **\+ New Key** at the top right of the screen
-2. Name your new key **tracer**
+```bash
+DD_API_KEY=your-api-key
+DD_APP_KEY=your-application-key
+DD_SITE=datadoghq.com          # optional — default datadoghq.com; use datadoghq.eu for EU
+```
 
-   <Frame>
-     ![Datadog App Key](/images/datadog_app_key.webp)
-   </Frame>
+| Variable | Default | Description |
+| --- | --- | --- |
+| `DD_API_KEY` | — | **Required.** Datadog API key |
+| `DD_APP_KEY` | — | **Required.** Datadog application key |
+| `DD_SITE` | `datadoghq.com` | Datadog site hostname (EU: `datadoghq.eu`) |
 
-3. Click **Edit Scope** and ensure the following minimum requirements:
-   - events_read
-   - logs_read_data
-   - logs_read_index_data
-   - monitors_read
+For multiple Datadog orgs or sites, use [multi-instance](/multi-instance-integrations) with `DD_INSTANCES`.
 
-   <Frame>
-     ![Datadog App Key Scope](/images/datadog_app_key_scope.webp)
-   </Frame>
+### Option 3: Persistent store
 
-4. Under **Actions API Access** — click **Enable**
+```json
+{
+  "version": 1,
+  "integrations": [
+    {
+      "id": "datadog-prod",
+      "service": "datadog",
+      "status": "active",
+      "credentials": {
+        "api_key": "your-api-key",
+        "app_key": "your-application-key",
+        "site": "datadoghq.com"
+      }
+    }
+  ]
+}
+```
 
-   <Frame>
-     ![Datadog App Key Configuration](/images/datadog_app_key_configuration.webp)
-   </Frame>
+### Option 4: Hosted web app (OpenSRE Cloud)
 
-### Step 3: Connect Datadog to OpenSRE
+In [app.tracer.cloud](https://app.tracer.cloud), go to **Integrations** → **Datadog**, enter a name, and paste your API and application keys.
 
-1. In OpenSRE, go to **Integrations** → **Datadog**
-2. Enter a name
-3. Paste your [<u>API Key</u>](https://app.datadoghq.com/account/login?next=%2Forganization-settings%2Fapi-keys) and [<u>Application Key</u>](https://app.datadoghq.com/account/login?next=%2Forganization-settings%2Fapplication-keys) from Datadog
-4. Click **Save**.
+<Frame>
+  ![Connect Datadog](/images/connect_datadog.png)
+</Frame>
 
-   <Frame>
-     ![Connect Datadog](/images/connect_datadog.png)
-   </Frame>
+## Creating Datadog keys
+
+### API key
+
+1. In Datadog, go to **Organization Settings** → **API Keys** ([direct link](https://app.datadoghq.com/organization-settings/api-keys))
+2. Click **+ New Key** and name it (for example `opensre`)
+3. Copy the key
+
+<Frame>
+  ![Datadog API Key](/images/datadog_api_key.webp)
+</Frame>
+
+### Application key
+
+1. Go to **User Settings** → **Application Keys** ([direct link](https://app.datadoghq.com/personal-settings/application-keys))
+2. Click **+ New Key** and name it (for example `opensre`)
+3. Under **Edit Scope**, enable at minimum: `events_read`, `logs_read_data`, `logs_read_index_data`, `monitors_read`
+4. Under **Actions API Access**, click **Enable**
+5. Copy the key
+
+<Frame>
+  ![Datadog App Key](/images/datadog_app_key.webp)
+</Frame>
+
+<Frame>
+  ![Datadog App Key Scope](/images/datadog_app_key_scope.webp)
+</Frame>
+
+<Note>
+  Some Datadog UI labels still say **tracer** from the Tracer→OpenSRE transition. Any key name works — use `opensre` for clarity.
+</Note>
+
+## Verify
+
+```bash
+opensre integrations verify datadog
+```
+
+Expected output:
+
+```
+Service: datadog
+Status: passed
+Detail: Connected to datadoghq.com and validated API access
+```
+
+Inside the REPL: `/integrations verify datadog` or `/verify datadog`.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| **403 Forbidden** | Confirm application key scopes include `logs_read_data` and `monitors_read` |
+| **Wrong site / EU account** | Set `DD_SITE=datadoghq.eu` (or your site hostname) |
+| **Verify passes but no logs in investigation** | Check index retention and that the app key can read the target log index |
+| **Multiple Datadog accounts** | Use `DD_INSTANCES` — see [Multi-instance integrations](/multi-instance-integrations) |
+
+## Security best practices
+
+- Create a dedicated application key with read-only scopes for investigations.
+- Store keys in `.env` or your secret manager — not in source control.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -13,7 +13,7 @@
   },
   "favicon": "/favicon.ico",
   "styles": {
-    "css": "/sidebar.css"
+    "css": ["/sidebar.css", "/custom.css"]
   },
   "scripts": [
     "/toc-actions.js",
@@ -45,25 +45,9 @@
               "interactive-shell-assistant",
               "deployment",
               "api",
-              "faq"
-            ]
-          },
-          {
-            "group": "Benchmark",
-            "pages": [
-              "cloudopsbench"
-            ]
-          },
-          {
-            "group": "Community",
-            "pages": [
+              "faq",
+              "cloudopsbench",
               "bi-weekly-giveaway"
-            ]
-          },
-          {
-            "group": "Configuration",
-            "pages": [
-              "configuration/environment-variables"
             ]
           }
         ]
@@ -88,6 +72,21 @@
             "group": "Enterprise",
             "pages": [
               "install-enterprise"
+            ]
+          },
+          {
+            "group": "Environment guides",
+            "pages": [
+              "environments/macos",
+              "environments/linux-local",
+              "environments/windows-local",
+              "environments/docker"
+            ]
+          },
+          {
+            "group": "Configuration",
+            "pages": [
+              "configuration/environment-variables"
             ]
           }
         ]
@@ -119,7 +118,7 @@
           },
           {
             "group": "Observability and incidents",
-            "expanded": true,
+            "expanded": false,
             "pages": [
               "alertmanager",
               "azure-monitor",
@@ -149,7 +148,7 @@
           },
           {
             "group": "Cloud, code, and collaboration",
-            "expanded": true,
+            "expanded": false,
             "pages": [
               "argocd",
               "aws",
@@ -173,7 +172,7 @@
           },
           {
             "group": "Messaging",
-            "expanded": true,
+            "expanded": false,
             "pages": [
               "messaging/index",
               "smtp",
@@ -187,6 +186,7 @@
           },
           {
             "group": "Data and workflow systems",
+            "expanded": false,
             "pages": [
               "airflow",
               "azure-sql",
@@ -203,10 +203,9 @@
               "prefect",
               "rabbitmq",
               "rds",
+              "redis",
               "snowflake",
               "supabase",
-              "redis",
-              "rds",
               "temporal"
             ]
           }

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -6,55 +6,63 @@ description: "Frequently asked questions about OpenSRE"
 <AccordionGroup>
   <Accordion title="What is OpenSRE?">
     OpenSRE is an open-source framework for building AI SRE agents that investigate production
-    incidents using your existing observability stack, cloud context, and runbooks.
+    incidents using your existing observability stack, cloud context, and runbooks. It connects to
+    60+ integrations, runs a structured RCA pipeline, and delivers findings to Slack, local files,
+    or your messaging channel of choice.
   </Accordion>
 
-<Accordion title="How do I get started quickly?">
+  <Accordion title="How do I get started quickly?">
     Install OpenSRE, run onboarding, then investigate a sample alert:
-    <br />
-    <code>opensre onboard</code>
-    <br />
-    <code>
-        opensre investigate -i
-        tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json
-    </code>
-</Accordion>
 
-<Accordion title="Which deployment path is recommended?">
-    Deploy OpenSRE as a standard Python/FastAPI app with the repo Dockerfile or your
-    host's native Python workflow. Set <code>LLM_PROVIDER</code>, add the matching
-    provider API key, and configure storage or integration env vars as needed.
-</Accordion>
+    ```bash
+    curl -fsSL https://install.opensre.com | bash
+    opensre onboard
+    opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json
+    ```
 
-<Accordion title="Can I self-host OpenSRE?">
-    Yes. You can self-host OpenSRE on your own infrastructure as a normal web
-    runtime. Before deploying, set{" "}
-    <code>LLM_PROVIDER</code> and the matching provider key (for example{" "}
-    <code>ANTHROPIC_API_KEY</code> when <code>LLM_PROVIDER=anthropic</code>).
-</Accordion>
+    See the full walkthrough in [Quickstart](/quickstart).
+  </Accordion>
 
-<Accordion title="Which model providers are supported?">
-    OpenSRE supports multiple providers, including Anthropic, OpenAI,
-    OpenRouter, and Gemini via
-    <code>LLM_PROVIDER</code> plus the matching API key. Additional providers
-    and overrides are documented in <code>.env.example</code>.
-</Accordion>
+  <Accordion title="Which deployment path is recommended?">
+    Most users start with the **local CLI** (`curl` or Homebrew install, then `opensre onboard`).
+    For org-wide hosted connectors, use [Enterprise setup](/install-enterprise) at
+    [app.tracer.cloud](https://app.tracer.cloud).
 
-<Accordion title="Does OpenSRE work with our existing tools?">
-    Usually yes. OpenSRE integrates with 60+ systems across observability,
-    cloud, incident management, data platforms, and collaboration tools. See the
-    Integrations section in docs for connector-specific setup steps.
-</Accordion>
+    Self-hosted gateway deployment is documented in [Deployment](/deployment) — Docker, env vars,
+    and health-check curl examples included.
+  </Accordion>
 
-<Accordion title="What happens when I run OpenSRE with no command?">
-    Running <code>opensre</code> starts an interactive incident-response shell
-    where you can describe issues in plain language, stream investigations live,
-    and ask grounded follow-up questions in the same session.
-</Accordion>
+  <Accordion title="Can I self-host OpenSRE?">
+    Yes. Deploy the gateway as a FastAPI app using the repo Dockerfile or your host's Python
+    workflow. Set `LLM_PROVIDER` and the matching provider key (for example `ANTHROPIC_API_KEY`
+    when `LLM_PROVIDER=anthropic`). See [Deployment](/deployment) and
+    [Environment variables](/configuration/environment-variables).
+  </Accordion>
+
+  <Accordion title="Which model providers are supported?">
+    OpenSRE supports Anthropic, OpenAI, OpenRouter, Gemini, Bedrock, Azure OpenAI, and CLI-backed
+    providers via `LLM_PROVIDER` plus the matching API key. Full provider matrix, defaults, and
+    troubleshooting: [LLM providers](/llm-providers).
+  </Accordion>
+
+  <Accordion title="Does OpenSRE work with our existing tools?">
+    Usually yes. OpenSRE integrates with observability (Datadog, Grafana, Sentry), cloud (AWS,
+    Kubernetes), incident tools (PagerDuty, OpsGenie), databases, and messaging (Slack, Telegram).
+    Browse the [Integrations overview](/integrations-overview) catalog and run
+    `opensre integrations verify` after setup.
+  </Accordion>
+
+  <Accordion title="What happens when I run OpenSRE with no command?">
+    Running `opensre` starts the interactive incident-response shell. Describe issues in plain
+    language, stream investigations live, and ask follow-up questions in the same session. Slash
+    commands (`/help`, `/investigate`, `/verify datadog`) are documented in
+    [Interactive Shell Commands](/interactive-shell-commands).
+  </Accordion>
 
   <Accordion title="How is security and telemetry handled?">
-    OpenSRE is designed for security-sensitive environments and uses structured, auditable workflows.
-    Anonymous telemetry can be disabled with <code>OPENSRE_NO_TELEMETRY=1</code>. For vulnerability
-    reports, email <code>support@opensre.com</code>.
+    OpenSRE supports reversible [masking](/masking) before external LLM calls and command-history
+    redaction via [Interactive Shell Privacy](/interactive-shell-privacy). Anonymous product
+    telemetry can be disabled with `OPENSRE_NO_TELEMETRY=1`. For vulnerability reports, email
+    `support@opensre.com`.
   </Accordion>
 </AccordionGroup>

--- a/docs/features.mdx
+++ b/docs/features.mdx
@@ -12,28 +12,66 @@ OpenSRE runs a structured RCA pipeline for each alert:
 3. **Test hypotheses** in a tool-calling loop until confidence is high enough to stop
 4. **Publish findings** as `problem.md`, `theory/hypothesis_*.md`, and `report.md` (or JSON with `--output`)
 
-Run investigations from the interactive shell (`opensre`) or one-shot via `opensre investigate -i <alert-file>`. See [Investigations overview](/investigation-overview).
+**Try it:**
+
+```bash
+opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json
+```
+
+**Gotcha:** The investigation uses whatever integrations are connected at run time. Run `opensre integrations verify` before your first production alert.
+
+See [Investigations overview](/investigation-overview).
 
 ## Integrations (60+ tools)
 
-Connect observability, cloud, databases, incident management, messaging, and workflow systems so investigations can query the same tools your engineers use. Setup via `opensre onboard`, `opensre integrations setup`, or environment variables. See [Integrations overview](/integrations-overview).
+Connect observability, cloud, databases, incident management, messaging, and workflow systems so investigations query the same tools your engineers use.
+
+**Try it:**
+
+```bash
+opensre integrations setup
+opensre integrations verify datadog
+```
+
+**Config:** Credentials live in `.env` and `~/.opensre/integrations.json`. See [Environment variables](/configuration/environment-variables).
+
+**Gotcha:** [Multi-instance integrations](/multi-instance-integrations) use env vars like `DD_INSTANCES` or `GRAFANA_INSTANCES` for prod/staging pairs.
+
+See [Integrations overview](/integrations-overview).
 
 ## Interactive shell
 
-The TTY REPL (`opensre` with no subcommand) supports:
+The TTY REPL (`opensre` with no subcommand) supports plain-language incident descriptions, slash commands, session history, fleet monitoring, and scheduled deliveries.
 
-- Plain-language incident descriptions and follow-up questions
-- Slash commands for health checks, investigations, integrations, remote agents, and more (`/help`)
-- [Session history](/sessions) with `/sessions`, `/resume`, and `/new`
-- [Local agent fleet](/fleet) monitoring for Claude Code, Cursor, Codex, and other coding agents
-- [Scheduled deliveries](/cron) and [Hermes log watch](/hermes)
+**Try it:**
+
+```bash
+opensre
+# at the prompt:
+/help
+/verify datadog
+```
+
+**Config:** Set `LLM_PROVIDER` and the matching API key before starting. Use `/effort` (OpenAI/Codex) or `OPENSRE_REASONING_EFFORT` to tune reasoning depth.
+
+**Gotcha:** The action planner never denies a turn — describe compound requests in one message and it chains slash commands automatically.
+
+See [Interactive Shell Commands](/interactive-shell-commands).
 
 ## Masking and safe sharing
 
-Reversible masking replaces sensitive infrastructure identifiers (pods, clusters, hostnames, account IDs) with stable placeholders before external LLM calls, then restores originals in user-facing output. See [Masking](/masking).
+Reversible masking replaces sensitive infrastructure identifiers (pods, clusters, hostnames, account IDs) with stable placeholders before external LLM calls, then restores originals in user-facing output.
 
-Command-history redaction and persistence controls live under [Interactive Shell Privacy](/interactive-shell-privacy).
+**Try it:** Enable masking in onboarding or set the masking env vars documented on [Masking](/masking), then run an investigation and confirm placeholders appear in LLM-facing evidence but not in your local `report.md`.
+
+**Gotcha:** Command-history redaction is separate — see [Interactive Shell Privacy](/interactive-shell-privacy).
 
 ## Remote runtime investigations
 
-Investigate deployed OpenSRE services by name — OpenSRE gathers live deployment status, recent logs, and health probes, then runs the standard RCA pipeline. See [Remote runtime investigation](/remote-runtime-investigation).
+Investigate deployed OpenSRE services by name. OpenSRE gathers live deployment status, recent logs, and health probes, then runs the standard RCA pipeline.
+
+**Try it:** From the REPL: `/remote list`, then describe the service you want to investigate.
+
+**Config:** Requires a configured remote runtime target. See [Remote runtime investigation](/remote-runtime-investigation).
+
+**Gotcha:** Remote investigations use the same integration catalog as local runs — connect observability tools first.

--- a/docs/github-workflow-tools.mdx
+++ b/docs/github-workflow-tools.mdx
@@ -17,6 +17,30 @@ execute workflow mutations.
 For ad-hoc chat mutations outside the Slack proposal flow (create issue, assign,
 merge, `gh api`, etc.), use **`github_cli`** instead — see [GitHub](github).
 
+## Setup
+
+Workflow tools use the same GitHub MCP credentials as the [GitHub integration](/github).
+
+```bash
+opensre integrations setup github
+opensre integrations verify github
+```
+
+| Requirement | Details |
+| --- | --- |
+| **Token** | `GITHUB_MCP_AUTH_TOKEN`, or browser sign-in via `opensre integrations setup` |
+| **Scopes** | `repo` minimum; add security alert scopes for `list_github_security_alerts` |
+| **Alternate env** | `GITHUB_TOKEN` / `GH_TOKEN` accepted by some workflow tools |
+
+### Example REPL turn
+
+```text
+> generate a Slack-ready morning check-in for Tracer-Cloud/opensre
+· gathering via GitHub · list work items…
+```
+
+See [GitHub workflow tools](#tools) below for the full tool table and mutation approval flow.
+
 ## Tools
 
 | Tool | Role | Side effects |

--- a/docs/grafana.mdx
+++ b/docs/grafana.mdx
@@ -1,29 +1,83 @@
 ---
 title: "Grafana"
+description: "Connect Grafana so OpenSRE can query metrics, dashboards, and alerts during investigations"
 ---
+
+OpenSRE queries Grafana (Cloud or self-hosted) for metrics, dashboard context, and alert annotations during investigations.
 
 ## Overview
 
-1. [Grafana Cloud Integration](#grafana-cloud-integration)
+1. [Grafana Cloud / self-hosted setup](#grafana-cloud--self-hosted-setup)
 2. [Local Grafana Setup (Minikube example)](#local-grafana-setup-minikube-example)
 
-## Grafana Cloud Integration
+## Grafana Cloud / self-hosted setup
 
-### Step 1: Create a token
+### Prerequisites
 
-Official documentation: [<u>How to add a token to a service account in Grafana</u>](https://grafana.com/docs/grafana/latest/administration/service-accounts/#add-a-token-to-a-service-account-in-grafana)
+- Grafana instance URL (Cloud stack URL or self-hosted origin)
+- Service account token with read access — see [Grafana service account tokens](https://grafana.com/docs/grafana/latest/administration/service-accounts/#add-a-token-to-a-service-account-in-grafana)
 
-### Step 2: Connect Grafana to OpenSRE
+### Option 1: Interactive CLI
 
-1. In OpenSRE, go to **Integrations** → **Grafana**
-2. Enter a name
-3. Enter the endpoint URL for your Grafana instance
-4. Paste the Service Account token you created in Grafana
-5. Click **Save**.
+```bash
+opensre integrations setup grafana
+```
 
-   <Frame>
-     ![Connect Grafana](/images/connect_grafana.png)
-   </Frame>
+Provide the instance URL and service account token when prompted.
+
+### Option 2: Environment variables
+
+```bash
+GRAFANA_INSTANCE_URL=https://your-stack.grafana.net
+GRAFANA_READ_TOKEN=glsa_your_service_account_token
+GRAFANA_VERIFY_SSL=true                    # optional — set false only for local/lab
+GRAFANA_CA_BUNDLE=/path/to/internal-ca.pem # optional — internal CA
+```
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `GRAFANA_INSTANCE_URL` | — | **Required.** Grafana base URL |
+| `GRAFANA_READ_TOKEN` | — | **Required.** Service account token |
+| `GRAFANA_VERIFY_SSL` | `true` | Set `false` to skip TLS verification (lab only) |
+| `GRAFANA_CA_BUNDLE` | — | PEM file for private CA (recommended for internal Grafana) |
+
+For prod/staging pairs, use `GRAFANA_INSTANCES` — see [Multi-instance integrations](/multi-instance-integrations).
+
+### Option 3: Persistent store
+
+```json
+{
+  "version": 1,
+  "integrations": [
+    {
+      "id": "grafana-prod",
+      "service": "grafana",
+      "status": "active",
+      "credentials": {
+        "endpoint": "https://your-stack.grafana.net",
+        "api_key": "glsa_your_token",
+        "verify_ssl": true
+      }
+    }
+  ]
+}
+```
+
+### Option 4: Hosted web app (OpenSRE Cloud)
+
+1. In [app.tracer.cloud](https://app.tracer.cloud), go to **Integrations** → **Grafana**
+2. Enter a name, instance URL, and service account token
+3. Click **Save**
+
+<Frame>
+  ![Connect Grafana](/images/connect_grafana.png)
+</Frame>
+
+### Verify
+
+```bash
+opensre integrations verify grafana
+```
 
 ### Self-signed or internal CA certificates
 

--- a/docs/how-investigations-work.mdx
+++ b/docs/how-investigations-work.mdx
@@ -3,6 +3,19 @@ title: "How an investigation works"
 description: "A plain-language walkthrough of what OpenSRE does between receiving an alert and posting a root-cause report"
 ---
 
+## At a glance
+
+| Step | What happens | You run |
+| --- | --- | --- |
+| Start | Alert or plain-language incident description enters the pipeline | `opensre investigate -i <alert.json>` or `opensre` then describe the incident |
+| Investigate | Tool-calling loop queries connected integrations | `/investigate` or `/verify <service>` in the REPL |
+| Output | RCA artifacts written locally (and optionally to Slack) | Open `problem.md`, `theory/hypothesis_*.md`, `report.md` |
+| Export | Single JSON for automation | `opensre investigate -i <file> --output ./rca.json` |
+
+**Config:** `LLM_PROVIDER` + matching API key; integrations via `opensre onboard` or `opensre integrations setup`. See [Environment variables](/configuration/environment-variables).
+
+**Failure modes:** No integrations connected → limited evidence; LLM misconfigured → run fails at start; tool cap / stagnation breaker → investigation stops early with partial report (see stages below).
+
 Think of OpenSRE as an on-call engineer who never sleeps. It follows the same
 instincts a good on-call engineer would: get paged, decide whether it's
 actually worth waking up for, check the obvious dashboards first, take notes

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -2,7 +2,7 @@
 title: "OpenSRE"
 ---
 
-OpenSRE is agentic alert investigation for production systems. It connects to your tools, systems and knowledge bases to investigate incidents before your team gets pages. OpenSRE delivers automated root cause analysis and recommended fixes directly to Slack, PagerDuty, or wherever your team communicates, so engineers of all skill-levels and seniority can resolve incidents fast.
+OpenSRE is agentic alert investigation for production systems. It connects to your observability stack, infrastructure, and knowledge bases to investigate incidents before your team gets paged — then delivers root-cause analysis and recommended fixes to Slack, PagerDuty, or local files.
 
 <div className="index-transition-note">
   <p className="index-transition-note-label">Tracer to OpenSRE</p>
@@ -23,47 +23,57 @@ OpenSRE is agentic alert investigation for production systems. It connects to yo
   </Card>
 </CardGroup>
 
+## First 5 minutes
+
+```bash
+# Install (macOS / Linux)
+curl -fsSL https://install.opensre.com | bash
+
+# Configure LLM + integrations
+opensre onboard
+
+# Run a sample investigation
+opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json
+```
+
+After the run completes, open the generated artifacts:
+
+- `problem.md` — incident framing
+- `theory/hypothesis_*.md` — hypotheses tested during the run
+- `report.md` — root cause, confidence, and next steps
+
+Or export JSON for automation:
+
+```bash
+opensre investigate -i <alert-file> --output ./rca.json
+```
+
+**Interactive shell** — run `opensre` with no subcommand to describe incidents in plain language and use slash commands (`/help`, `/verify datadog`, `/investigate`).
+
+<Tip>
+  Stuck? See [Quickstart troubleshooting](/quickstart#troubleshooting) (Docker running, `make` installed, LLM configured).
+</Tip>
+
 ## Start here
 
 <CardGroup cols={2}>
   <Card title="Investigations" icon="magnifying-glass" href="/investigation-overview">
     Alert ingestion, evidence collection, masking, and remote runtime workflows.
   </Card>
-  {/* Tracer tab hidden — to re-enable, restore the Tracer tab in docs/docs.json and
-      uncomment below.
-  <Card title="Monitoring" icon="chart-line" href="/introduction-monitoring">
-    Workflow monitoring, tutorials, framework support, and operational use cases.
+  <Card title="Showcase" icon="photo-film" href="/showcase">
+    Sample outputs, quickstart demos, and CloudOpsBench benchmark walkthrough.
   </Card>
-  <Card title="Platform" icon="layers-group" href="/technology/end-to-end">
-    OpenSRE architecture, product capabilities, deployment targets, and comparisons.
-  </Card>
-  */}
-  {/* Changelog disabled — daily-update workflow removed (PR #1409). To re-enable, restore the
-      Changelog tab in docs/docs.json and uncomment below.
-  <Card title="Daily updates" icon="newspaper" href="/daily-updates/overview">
-    Follow product progress and recent documentation changes.
-  </Card>
-  */}
 </CardGroup>
-
-## What it does
-
-OpenSRE enables teams to resolve incidents quickly without sacrificing fix quality or team capacity. With OpenSRE, you can:
-
-- **Stop investigating, start fixing.** When an alert fires, OpenSRE immediately pulls context from your observability tools, infrastructure, and knowledge bases. It checks recent deploys, queries logs and metrics, builds multiple root cause hypotheses, and tests them in parallel. By the time you open your laptop, you already know what broke and why.
-- **Ship the right fix, not the fast one.** When you're on-call and the pressure's on, you ship the patch that makes the alert go away. OpenSRE takes investigation off your plate so you have the time and context to fix the actual problem instead of papering over it.
-- **Give everyone the context that's usually stuck in one person's head.** Complex systems often need the engineer who built them to debug them. OpenSRE surfaces the same depth of analysis – what failed, what changed, what caused the cascade – so whoever's on-call can understand root cause without needing to page the one person who just knows.
 
 ## How it works
 
 When an alert fires, OpenSRE autonomously:
 
-1. **Ingests the alert.** Picks up alerts from your metrics, logs, traces, or incident systems and normalizes them into a single investigation.
-2. **Assembles context.** Pulls in service ownership, dependencies, recent deploys, config changes, and baselines.
-3. **Frames the problem.** Identifies impacted components, plausible failure modes, and investigation objectives.
-4. **Investigates in a loop.** Plans queries, executes them against your observability and production tooling, and synthesizes evidence into evolving hypotheses.
-5. **Decides when to stop.** Evaluates hypothesis confidence, remaining uncertainty, and whether further investigation is likely to change the outcome.
-6. **Delivers a report.** Sends likely root causes, supporting evidence, and recommended next actions to Slack, PagerDuty, or wherever your team communicates.
+1. **Ingests the alert** from metrics, logs, traces, or incident systems
+2. **Assembles context** — ownership, deploys, dependencies, baselines
+3. **Plans evidence collection** across connected integrations
+4. **Investigates in a loop** — queries tools, updates hypotheses, stops when confidence is high enough
+5. **Delivers a report** to Slack, local files, or your configured messaging channel
 
 <div className="index-diagram-frame">
   <div className="index-diagram-kicker">Investigation workflow</div>
@@ -73,3 +83,5 @@ When an alert fires, OpenSRE autonomously:
     className="index-diagram-image"
   />
 </div>
+
+See [How an investigation works](/how-investigations-work) for a plain-language walkthrough of each stage.

--- a/docs/install-enterprise.mdx
+++ b/docs/install-enterprise.mdx
@@ -3,47 +3,56 @@ title: "Enterprise setup (Tracer Cloud)"
 description: "Set up OpenSRE for your organization in app.tracer.cloud"
 ---
 
-This guide is for teams that manage OpenSRE from the hosted web app.
+This guide is for teams that manage OpenSRE from the hosted web app at [app.tracer.cloud](https://app.tracer.cloud).
 
 ## 1) Create your organization account
 
-Sign up at [tracer.cloud](https://tracer.cloud) and then continue in
-[app.tracer.cloud/sign-up](https://app.tracer.cloud/sign-up) to create or join your organization workspace.
+Sign up at [tracer.cloud](https://tracer.cloud) and continue in [app.tracer.cloud/sign-up](https://app.tracer.cloud/sign-up) to create or join your organization workspace.
 
 ## 2) Complete workspace onboarding
 
-In [app.tracer.cloud](https://app.tracer.cloud), follow onboarding to:
+In the web app, complete onboarding to:
 
-- define your workspace context
-- connect your first integrations
-- verify access and permissions
+- Define your workspace context (team name, default channels)
+- Connect your first integrations (start with observability + messaging)
+- Verify access and permissions for each connector
 
 ## 3) Configure integrations for your org
 
-Enterprise integrations are configured in the web app and shared across your organization.
+Enterprise integrations are configured in the web app and shared across your organization. Use the integration catalog for credential requirements:
 
-For Slack integration help, go to Support in the app and request assistance with Slack setup.
+- [Integrations overview](/integrations-overview) — local CLI and hosted setup paths
+- [Datadog](/datadog) — API key + application key (hosted flow in Option 3)
+- [Grafana](/grafana) — service account token + endpoint URL
+- [AWS](/aws) — cross-cloud infrastructure mapping
+- [Slack](/messaging/slack) — deliver investigation reports to channels
 
-Use the integration catalog and provider-specific docs from:
+<Frame>
+  ![Integrations](/images/integrations.png)
+</Frame>
 
-- [Local integrations overview (dev preview)](http://localhost:3000/integrations-overview)
-- [Integrations overview](/integrations-overview)
+### Verification checklist
 
-Each integration page documents required credentials, scopes, and verification guidance.
+After connecting each integration in the web app:
+
+1. Confirm the connector shows **connected** in **Integrations**
+2. Run a test investigation from the app or ask an org admin to trigger a sample alert
+3. Confirm the report arrives in your configured Slack channel (see [Slack setup](/messaging/slack))
+
+For Slack-specific help, use **Support** in the app or follow the self-serve steps in [Slack integration](/messaging/slack).
 
 ## 4) Run investigations with shared context
 
-After integrations are connected, OpenSRE investigations can use the same organization-level connectors and
-policies.
+After integrations are connected, OpenSRE investigations use the same organization-level connectors and policies. Engineers can also run local CLI investigations that reference the same integration catalog.
 
 ## Local CLI users in enterprise teams
 
-If your engineers also run local investigations, use:
+If your engineers also run local investigations:
 
 ```bash
 opensre
-# then, inside the shell:
+# inside the shell:
 onboard
 ```
 
-This configures local CLI access while keeping integrations documented in the same catalog under `Integrations`.
+This configures local LLM credentials while org-wide connectors remain in the web app. See [Install locally](/install-local) for the full local path.

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -3,22 +3,49 @@ title: "Install OpenSRE"
 description: "Choose the right OpenSRE installation path for local or enterprise environments"
 ---
 
-Use the installation path that matches your runtime and organization setup.
+Pick the path that matches where you run OpenSRE.
 
-## Install options
+## Which path?
 
-- [Local and on-prem setup](/install-local)
-- [Enterprise setup](/install-enterprise)
+| Path | Best for | Get started |
+| --- | --- | --- |
+| **Local CLI** | Laptop or self-hosted server; full `opensre` binary | [Install locally](/install-local) |
+| **Enterprise (Tracer Cloud)** | Org-wide connectors in the hosted web app | [Enterprise setup](/install-enterprise) |
 
-## Local environment guides
+## Install locally (most users)
 
-- [macOS](/environments/macos)
-- [Linux (local)](/environments/linux-local)
-- [Windows (local)](/environments/windows-local)
-- [Docker](/environments/docker)
+```bash
+# macOS / Linux
+curl -fsSL https://install.opensre.com | bash
+
+# Windows (PowerShell)
+irm https://install.opensre.com | iex
+```
+
+Then configure your LLM and integrations:
+
+```bash
+opensre onboard
+opensre integrations verify
+```
+
+See [Quickstart](/quickstart) for a full walkthrough including a sample investigation.
+
+## Environment-specific guides
+
+| Platform | Guide |
+| --- | --- |
+| macOS | [macOS](/environments/macos) |
+| Linux | [Linux (local)](/environments/linux-local) |
+| Windows | [Windows (local)](/environments/windows-local) |
+| Docker | [Docker](/environments/docker) |
+
+## Enterprise hosted setup
+
+For teams using [app.tracer.cloud](https://app.tracer.cloud), see [Enterprise setup](/install-enterprise).
 
 ## Next steps
 
-- [Quickstart](/quickstart)
 - [Investigations overview](/investigation-overview)
 - [Integrations overview](/integrations-overview)
+- [Environment variables](/configuration/environment-variables)

--- a/docs/integrations-overview.mdx
+++ b/docs/integrations-overview.mdx
@@ -49,11 +49,15 @@ Inside the interactive shell you can also run `/integrations list`, `/integratio
 
 Enterprise connectors are configured through the OpenSRE web app at [app.tracer.cloud](https://app.tracer.cloud). Once connected, they are available to all users in your organization.
 
-**Observability.** Connect [Grafana](/grafana) and [Datadog](/datadog) for logs, metrics, traces, and alerts.
+| Category | Integrations | Setup doc |
+| --- | --- | --- |
+| **Observability** | Grafana, Datadog, Sentry, Honeycomb | [Grafana](/grafana) (Option 4), [Datadog](/datadog) (Option 4) |
+| **Infrastructure** | AWS, Kubernetes | [AWS](/aws), [Kubernetes](/kubernetes) |
+| **Communication** | Slack, Discord, Telegram | [Messaging overview](/messaging/index) |
 
-**Infrastructure.** Connect [AWS](/aws) to map your environment across clouds and clusters.
+After connecting in the web app, confirm each connector shows **connected**, then run a test investigation or verify the same integration locally with `opensre integrations verify <name>` if your team also uses the CLI.
 
-**Communication.** Deliver investigation reports via [Slack, Discord, or Telegram](/messaging/index).
+See [Enterprise setup](/install-enterprise) for the full org onboarding checklist.
 
 <Frame>
   ![Integrations](/images/integrations.png)

--- a/docs/integrations/github-actions.mdx
+++ b/docs/integrations/github-actions.mdx
@@ -18,6 +18,15 @@ It is designed for situations where a failed deploy, a flaky test, or a broken s
 
 This integration uses the same GitHub MCP credentials as the existing GitHub setup when available.
 
+### Setup
+
+```bash
+opensre integrations setup github
+opensre integrations verify github
+```
+
+Ensure the GitHub MCP toolsets include `actions` (default: `repos,issues,pull_requests,actions`).
+
 ### Required
 
 - `GITHUB_MCP_AUTH_TOKEN` (or a GitHub token supplied via the GitHub MCP integration)
@@ -28,6 +37,27 @@ This integration uses the same GitHub MCP credentials as the existing GitHub set
 - `GITHUB_MCP_MODE`, `GITHUB_MCP_COMMAND`, `GITHUB_MCP_ARGS` for stdio-based MCP setups
 
 If no token is configured, GitHub Actions tools will report that the GitHub integration is unavailable.
+
+## Verify
+
+```bash
+opensre integrations verify github
+```
+
+Confirm the verify output mentions Actions tools. Then test from the REPL:
+
+```text
+> list recent failed workflow runs for Tracer-Cloud/opensre
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| **GitHub integration unavailable** | Run `opensre integrations setup github` and verify token scopes include `repo` |
+| **No workflow runs returned** | Confirm `owner`/`repo` match the repository; check token access to private repos |
+| **Step log empty** | Use `job_id` and exact `step_name` from `list_github_actions_run_jobs` |
+| **MCP connection failed** | Verify `GITHUB_MCP_URL` is reachable; see [GitHub troubleshooting](/github#troubleshooting) |
 
 ## Available tools
 

--- a/docs/interactive-shell-assistant.mdx
+++ b/docs/interactive-shell-assistant.mdx
@@ -21,6 +21,17 @@ You can name the repository inline (`… in https://github.com/org/repo`), menti
 
 The dim `· gathering via <source> · <tool> — <query hint>…` line shows which integration the assistant reached for while it works. When the same tool runs more than once, a `(2)`, `(3)`, … suffix and the query hint distinguish each call.
 
+### End-to-end example
+
+```text
+> what do the datadog logs say about payment-service errors in the last hour?
+· gathering via Datadog · query logs — payment-service errors…
+Found 847 error log lines in the last hour for service:payment-service.
+Top pattern: ConnectionTimeout to postgres-primary (412 occurrences)…
+```
+
+Prerequisites: Datadog connected (`opensre integrations verify datadog`) and `LLM_PROVIDER` configured. Run `/health` if gathering does not start.
+
 More questions that trigger live gathering:
 
 | You ask | The assistant gathers from |

--- a/docs/investigation-tool-calling.mdx
+++ b/docs/investigation-tool-calling.mdx
@@ -1,0 +1,33 @@
+---
+title: "Investigation tool calling"
+description: "Contributor guide for investigation ReAct tool schemas, LLM invoke payloads, and message shapes"
+---
+
+<Info>
+  This page is a **contributor reference** for how OpenSRE shapes tool-calling during investigations. End users do not need to configure any of this — see [How an investigation works](/how-investigations-work) and [Investigations overview](/investigation-overview) instead.
+</Info>
+
+The investigation agent does **not** call integration APIs through the LLM directly. The flow is:
+
+1. **Tools** — `get_registered_tools("investigation")`, filtered with `tool.is_available(...)`.
+2. **Schemas** — `llm.tool_schemas(tools)` from the active provider client.
+3. **Invoke** — `llm.invoke(messages, system=..., tools=tool_schemas)`; the model returns tool calls.
+4. **Execute** — Tools run locally; results append as turns for the next invoke.
+5. **Seed path** — `_build_seed_calls` may inject deterministic tool runs before the loop.
+
+## Where code lives
+
+| Concern | Location |
+| --- | --- |
+| Provider routing | `core/llm/factory.py`, `core/llm/client_builders.py` |
+| Investigation loop | `tools/investigation/stages/gather_evidence/agent.py` |
+| Tool registry | `tools/` and `integrations/<vendor>/tools/` |
+| Pipeline stages | [Investigation pipeline architecture](https://github.com/Tracer-Cloud/opensre/blob/main/docs/investigation-pipeline-architecture.md) |
+
+## Full reference
+
+The complete schema normalization rules, provider-specific adapters, and message-shape tables live in the repository source file:
+
+[docs/investigation-tool-calling.md](https://github.com/Tracer-Cloud/opensre/blob/main/docs/investigation-tool-calling.md)
+
+When changing investigation tools or LLM adapters, read that file and run the registry contract tests described in [adding tools and integrations](https://github.com/Tracer-Cloud/opensre/blob/main/docs/adding-tools-and-integrations.md).

--- a/docs/kubernetes.mdx
+++ b/docs/kubernetes.mdx
@@ -41,7 +41,7 @@ KUBECONFIG_NAMESPACE=production
 ### Option 3: Verify connectivity
 
 ```bash
-opensre verify kubernetes
+opensre integrations verify kubernetes
 ```
 
 A successful verification lists the namespaces visible to the configured credentials.

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -538,6 +538,6 @@ OpenSRE caches LLM clients on first use. To switch providers within a single pro
 - Provider literals and defaults: [`config/config.py`](https://github.com/Tracer-Cloud/opensre/blob/main/config/config.py) (`LLMProvider`, `LLMSettings`).
 - Runtime routing: [`core/llm/factory.py`](https://github.com/Tracer-Cloud/opensre/blob/main/core/llm/factory.py) (`resolve_llm_route`, `get_llm`) and client construction in [`core/llm/client_builders.py`](https://github.com/Tracer-Cloud/opensre/blob/main/core/llm/client_builders.py).
 - LiteLLM routing (when enabled): [`core/llm/transports/litellm/routing.py`](https://github.com/Tracer-Cloud/opensre/blob/main/core/llm/transports/litellm/routing.py).
-- Investigation tool-calling adapters: [`docs/investigation-tool-calling.md`](/investigation-tool-calling).
+- Investigation tool-calling adapters: [Investigation tool calling](/investigation-tool-calling).
 - API-backed provider guide: [`core/llm/AGENTS.md`](https://github.com/Tracer-Cloud/opensre/blob/main/core/llm/AGENTS.md).
 - CLI-backed provider guide: [`integrations/llm_cli/AGENTS.md`](https://github.com/Tracer-Cloud/opensre/blob/main/integrations/llm_cli/AGENTS.md).

--- a/docs/posthog.mdx
+++ b/docs/posthog.mdx
@@ -3,7 +3,7 @@ title: "PostHog"
 description: "Connect PostHog REST credentials so OpenSRE can verify access to your project"
 ---
 
-OpenSRE stores **your** PostHog project credentials for REST API access (project metadata and future REST features). Configure with `opensre integrations setup posthog` or `POSTHOG_*` environment variables.
+OpenSRE stores **your** PostHog project credentials for REST API access (project metadata and correlation during investigations). Configure with `opensre integrations setup posthog` or `POSTHOG_*` environment variables.
 
 <Info>
   Looking for agent tools during investigations (analytics, feature flags, HogQL)? Use [PostHog (MCP)](/posthog-mcp) with `opensre integrations setup posthog_mcp`.

--- a/docs/showcase.mdx
+++ b/docs/showcase.mdx
@@ -1,13 +1,72 @@
 ---
 title: "Showcase"
-description: "Real-world OpenSRE projects from the community"
+description: "Real-world OpenSRE workflows, sample outputs, and community examples"
 ---
 
-Share what you’ve built with OpenSRE.
+Concrete examples of what OpenSRE looks like in practice — from install through root-cause analysis.
 
-## Coming soon
+## Quickstart walkthrough
 
-- Community examples
-- Incident reports and demos
-- Templates you can fork
+Install, onboard, and run your first investigation in under ten minutes.
 
+<CardGroup cols={2}>
+  <Card title="Follow the quickstart" icon="rocket" href="/quickstart">
+    Step-by-step install, onboarding, and sample alert investigation.
+  </Card>
+  <Card title="Watch install + onboard" icon="play" href="/quickstart#install-opensre">
+    GIF walkthroughs for macOS, Linux, and Windows.
+  </Card>
+</CardGroup>
+
+<Frame>
+  ![Running an OpenSRE investigation on a sample alert through to a structured root-cause report](/images/quickstart-investigate.gif)
+</Frame>
+
+Typical first-run commands:
+
+```bash
+curl -fsSL https://install.opensre.com | bash
+opensre onboard
+opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json
+```
+
+## Sample investigation output
+
+A completed local run writes structured RCA artifacts you can open in any editor:
+
+| File | What it contains |
+| --- | --- |
+| `problem.md` | Incident framing, impacted components, initial hypothesis |
+| `theory/hypothesis_*.md` | Each hypothesis tested during the run, with supporting evidence |
+| `report.md` | Final root-cause summary, confidence, and recommended next steps |
+
+Export a single JSON file for automation:
+
+```bash
+opensre investigate -i <alert-file> --output ./rca.json
+```
+
+See [Investigations overview](/investigation-overview) for the full workflow, slash commands, and Slack delivery.
+
+<Frame>
+  ![Slack incident summary after an OpenSRE investigation](/images/slack_alert.png)
+</Frame>
+
+## Benchmark: CloudOpsBench
+
+Run OpenSRE against the 452-scenario CloudOpsBench Kubernetes RCA corpus and compare to published LLM-alone baselines.
+
+```bash
+uv run python -m tests.benchmarks._framework.cli run \
+  --config tests/benchmarks/cloudopsbench/config.yaml \
+  --models claude-sonnet-4-20250514
+```
+
+See [CloudOpsBench benchmark](/cloudopsbench) for configuration, integrity guards, and cost tracking.
+
+## Share your work
+
+Have a demo, runbook, or incident post-mortem powered by OpenSRE?
+
+1. Open a [GitHub Discussion](https://github.com/Tracer-Cloud/opensre/discussions) with the tag **Showcase** — include commands, integrations used, and (if possible) redacted output.
+2. Join the [bi-weekly giveaway](/bi-weekly-giveaway) for a chance to win OpenSRE swag when you share what you built.


### PR DESCRIPTION
Revamps the OpenSRE Mintlify documentation site: navigation structure, missing CSS, placeholder pages, and thin integration guides.

### Navigation (`docs/docs.json`)
- Load `custom.css` alongside `sidebar.css` so typography, index layout, and code-block styles apply in production
- Reorganize sidebar: merge Benchmark + Community into First steps; move Configuration to Installation; add Environment guides (macOS, Linux, Windows, Docker)
- Collapse large Integrations groups by default (`expanded: false`)
- Remove duplicate `rds` nav entry
- Add missing `architecture-audit-tool` page to fix broken nav link

### UI / CSS (`docs/custom.css`)
- Deduplicate radar-chart and TOC CSS blocks
- Remove rule that hid sidebar group titles
- Add `@font-face` for Britti Sans from `essentials/fonts/`

### New pages
- `docs/architecture-audit-tool.mdx` — architecture audit tools (clone, save observations, cleanup)
- `docs/investigation-tool-calling.mdx` — contributor wrapper; fixes broken link from `llm-providers.mdx`

### Content rewrites
- **Showcase** — quickstart demos, RCA artifact table, CloudOpsBench command, community CTA (replaces "Coming soon")
- **Index / Features / Install** — operator-focused commands, decision tables, troubleshooting pointers
- **Datadog & Grafana** — Honeycomb-style CLI/env/verify paths plus hosted web-app option
- **Enterprise install** — remove broken `localhost:3000` link; add verification checklist
- **How investigations work / FAQ** — operator tables and cross-links to canonical pages
- **GitHub workflow tools & GitHub Actions** — setup, verify, troubleshooting
- **Kubernetes** — fix verify command to `opensre integrations verify kubernetes`
- Minor clarity updates: PostHog, Airflow, interactive-shell-assistant

Legacy off-nav Tracer pages (`technology/`, `comparisons/`, etc.) are unchanged.