### PR TITLE
fix(watchdog): treat an unreadable live process as a failure, not an exit

### DIFF
--- a/tests/interactive_shell/test_watch_cmds.py
+++ b/tests/interactive_shell/test_watch_cmds.py
@@ -230,4 +230,67 @@ def test_run_watchdog_once_without_thresholds_exits(monkeypatch: pytest.MonkeyPa
     )
     assert task.status == TaskStatus.COMPLETED
     assert task.result == "single sample (once)"
+
+
+def test_run_watchdog_marks_completed_when_process_gone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreadable snapshot for a PID that no longer exists is a real exit."""
+    from platform.common.task_registry import TaskRegistry
+    from tools.system.watch_dog.monitor import run_watchdog
+
+    reg = TaskRegistry()
+    task = reg.create(TaskKind.WATCHDOG, command="watchdog pid=1")
+    task.mark_running()
+    dispatcher = MagicMock()
+    dispatcher.dispatch = MagicMock(return_value=True)
+
+    monkeypatch.setattr("tools.system.watch_dog.monitor.probe", lambda *_a, **_kw: None)
+    monkeypatch.setattr("tools.system.watch_dog.monitor.pid_exists", lambda _pid: False)
+
+    run_watchdog(
+        task=task,
+        watched_pid=1,
+        interval_seconds=0.01,
+        max_cpu=None,
+        max_runtime_seconds=None,
+        max_rss_mib=None,
+        once=False,
+        dispatcher=dispatcher,
+        on_alarm=None,
+    )
+    assert task.status == TaskStatus.COMPLETED
+    assert task.result == "target process exited"
+
+
+def test_run_watchdog_marks_failed_when_process_unreadable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A live PID whose snapshot is denied must fail, not report a clean exit."""
+    from platform.common.task_registry import TaskRegistry
+    from tools.system.watch_dog.monitor import run_watchdog
+
+    reg = TaskRegistry()
+    task = reg.create(TaskKind.WATCHDOG, command="watchdog pid=1")
+    task.mark_running()
+    dispatcher = MagicMock()
+    dispatcher.dispatch = MagicMock(return_value=True)
+
+    monkeypatch.setattr("tools.system.watch_dog.monitor.probe", lambda *_a, **_kw: None)
+    monkeypatch.setattr("tools.system.watch_dog.monitor.pid_exists", lambda _pid: True)
+
+    run_watchdog(
+        task=task,
+        watched_pid=1,
+        interval_seconds=0.01,
+        max_cpu=None,
+        max_runtime_seconds=None,
+        max_rss_mib=None,
+        once=False,
+        dispatcher=dispatcher,
+        on_alarm=None,
+    )
+    assert task.status == TaskStatus.FAILED
+    assert task.result != "target process exited"
+    assert "cannot be inspected" in (task.error or "")
     dispatcher.dispatch.assert_not_called()

--- a/tests/watch_dog/test_monitor.py
+++ b/tests/watch_dog/test_monitor.py
@@ -76,6 +76,20 @@ class _AccessDeniedProcess(_FakeProcess):
         raise psutil.AccessDenied(self.pid)
 
 
+class _TransientAccessDeniedProcess(_FakeProcess):
+    """Denies ``memory_info`` a fixed number of times, then succeeds."""
+
+    def __init__(self, *args: object, denials: int = 1, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+        self._denials = denials
+
+    def memory_info(self) -> _MemoryInfo:
+        if self._denials > 0:
+            self._denials -= 1
+            raise psutil.AccessDenied(self.pid)
+        return super().memory_info()
+
+
 def test_process_monitor_resolves_by_pid_and_warms_cpu(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -141,16 +155,68 @@ def test_process_monitor_returns_dead_sample_on_no_such_process(
     assert sample.cpu_percent == 0.0
 
 
-def test_process_monitor_returns_dead_sample_on_access_denied(
+def test_process_monitor_raises_when_denied_process_is_still_alive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A live-but-unreadable process must fail loudly, never look like an exit."""
+    process = _AccessDeniedProcess(123, "syslogd")
+    monkeypatch.setattr(
+        "tools.system.watch_dog.process_monitor.process_probe.process", lambda _pid: process
+    )
+    monkeypatch.setattr(
+        "tools.system.watch_dog.process_monitor.process_probe.pid_exists", lambda _pid: True
+    )
+
+    monitor = ProcessMonitor(
+        WatchdogConfig(pid=123, max_cpu=90),
+        max_access_attempts=2,
+        sleep=lambda _seconds: None,
+    )
+
+    with pytest.raises(OpenSREError, match="cannot be inspected"):
+        monitor.sample()
+
+
+def test_process_monitor_returns_dead_sample_when_denied_process_is_gone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AccessDenied that races an exit (PID no longer exists) is a real exit."""
     process = _AccessDeniedProcess(123, "python")
     monkeypatch.setattr(
         "tools.system.watch_dog.process_monitor.process_probe.process", lambda _pid: process
     )
+    monkeypatch.setattr(
+        "tools.system.watch_dog.process_monitor.process_probe.pid_exists", lambda _pid: False
+    )
 
-    monitor = ProcessMonitor(WatchdogConfig(pid=123, max_cpu=90))
+    monitor = ProcessMonitor(
+        WatchdogConfig(pid=123, max_cpu=90),
+        sleep=lambda _seconds: None,
+    )
     sample = monitor.sample()
 
     assert sample.pid == 123
     assert sample.alive is False
+
+
+def test_process_monitor_retries_transient_denial_then_samples(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient denial is retried and yields a normal live sample."""
+    process = _TransientAccessDeniedProcess(123, "python", denials=1)
+    monkeypatch.setattr(
+        "tools.system.watch_dog.process_monitor.process_probe.process", lambda _pid: process
+    )
+    monkeypatch.setattr(
+        "tools.system.watch_dog.process_monitor.process_probe.pid_exists", lambda _pid: True
+    )
+
+    monitor = ProcessMonitor(
+        WatchdogConfig(pid=123, max_cpu=90),
+        max_access_attempts=3,
+        sleep=lambda _seconds: None,
+    )
+    sample = monitor.sample()
+
+    assert sample.alive is True
+    assert sample.rss_bytes == 1024

--- a/tests/watch_dog/test_runner.py
+++ b/tests/watch_dog/test_runner.py
@@ -35,6 +35,13 @@ class _ExplodingSampler:
         raise AssertionError("watchdog sampled before credentials were validated")
 
 
+class _PermissionDeniedSampler:
+    def sample(self) -> ProcessSample:
+        raise OpenSREError(
+            "Process 123 (syslogd) is running but cannot be inspected (permission denied)."
+        )
+
+
 def _sample(
     *,
     cpu: float = 0.0,
@@ -105,6 +112,21 @@ def test_target_exit_before_alarm_does_not_dispatch() -> None:
     )
 
     assert code == SUCCESS
+    assert dispatcher.calls == []
+
+
+def test_permission_denied_does_not_report_target_exit() -> None:
+    dispatcher = _FakeDispatcher()
+
+    with pytest.raises(OpenSREError, match="cannot be inspected"):
+        run_watchdog(
+            WatchdogConfig(pid=123, max_cpu=90),
+            sampler=_PermissionDeniedSampler(),
+            dispatcher=dispatcher,
+            _sleep=lambda _seconds: None,
+            _clock=lambda: 100.0,
+        )
+
     assert dispatcher.calls == []
 
 

--- a/tools/system/fleet_monitoring/probe.py
+++ b/tools/system/fleet_monitoring/probe.py
@@ -27,6 +27,7 @@ import psutil
 _BYTES_PER_MIB = 1024 * 1024
 
 PROCESS_NOT_FOUND: tuple[type[BaseException], ...] = (psutil.NoSuchProcess,)
+PROCESS_ACCESS_DENIED: tuple[type[BaseException], ...] = (psutil.AccessDenied,)
 PROCESS_INACCESSIBLE_OR_GONE: tuple[type[BaseException], ...] = (
     psutil.NoSuchProcess,
     psutil.AccessDenied,

--- a/tools/system/watch_dog/monitor.py
+++ b/tools/system/watch_dog/monitor.py
@@ -8,7 +8,11 @@ from datetime import UTC, datetime
 from typing import Protocol, runtime_checkable
 
 from platform.common.task_types import TaskRecord, TaskStatus
-from tools.system.fleet_monitoring.probe import probe
+from tools.system.fleet_monitoring.probe import pid_exists, probe
+
+# A denied snapshot can be a momentary race; tolerate a few consecutive
+# unreadable ticks for a still-live PID before declaring it inaccessible.
+_MAX_INACCESSIBLE_TICKS = 3
 
 
 @runtime_checkable
@@ -51,6 +55,8 @@ def run_watchdog(
         if on_alarm is not None:
             on_alarm(threshold, detail)
 
+    inaccessible_ticks = 0
+
     try:
         while True:
             if task.cancel_requested.is_set():
@@ -61,9 +67,25 @@ def run_watchdog(
             if snap is None:
                 if task.cancel_requested.is_set():
                     task.mark_cancelled()
-                elif task.status == TaskStatus.RUNNING:
-                    task.mark_completed(result="target process exited")
-                return
+                    return
+                if not pid_exists(watched_pid):
+                    if task.status == TaskStatus.RUNNING:
+                        task.mark_completed(result="target process exited")
+                    return
+                # PID is still alive but unreadable (e.g. a root-owned daemon
+                # on macOS). This is never a clean exit; tolerate a few ticks
+                # for a transient denial, then fail explicitly.
+                inaccessible_ticks += 1
+                if inaccessible_ticks >= _MAX_INACCESSIBLE_TICKS:
+                    if task.status == TaskStatus.RUNNING:
+                        task.mark_failed(
+                            f"target process {watched_pid} is running but cannot be "
+                            "inspected (permission denied)"
+                        )
+                    return
+                continue
+
+            inaccessible_ticks = 0
 
             runtime_s = max(0.0, (datetime.now(UTC) - snap.started_at).total_seconds())
             progress = (

--- a/tools/system/watch_dog/process_monitor.py
+++ b/tools/system/watch_dog/process_monitor.py
@@ -4,12 +4,20 @@ from __future__ import annotations
 
 import re
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Protocol
 
 from platform.common.errors import OpenSREError
+from platform.common.exit_codes import ERROR
 from tools.system.fleet_monitoring import probe as process_probe
 from tools.system.watch_dog.config import WatchdogConfig
+
+# A permission denial can be a momentary race; retry a few times before
+# declaring the process permanently unreadable so a transient denial does
+# not abort a healthy watch.
+_DEFAULT_ACCESS_ATTEMPTS = 3
+_DEFAULT_ACCESS_RETRY_SECONDS = 0.5
 
 
 @dataclass(frozen=True)
@@ -41,26 +49,55 @@ class Sampler(Protocol):
 class ProcessMonitor:
     """Resolve and sample one process."""
 
-    def __init__(self, config: WatchdogConfig) -> None:
+    def __init__(
+        self,
+        config: WatchdogConfig,
+        *,
+        max_access_attempts: int = _DEFAULT_ACCESS_ATTEMPTS,
+        access_retry_seconds: float = _DEFAULT_ACCESS_RETRY_SECONDS,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
         self._process = _resolve_process(config)
         self._pid = self._process.pid
         self._name = _safe_process_name(self._process)
         self._cmdline = _safe_cmdline(self._process)
         self._started_at = _safe_create_time(self._process)
+        self._max_access_attempts = max(1, max_access_attempts)
+        self._access_retry_seconds = access_retry_seconds
+        self._sleep = sleep
         self._warm_cpu_percent()
 
     def sample(self) -> ProcessSample:
-        """Capture CPU, RSS, runtime, and liveness for the target process."""
-        try:
-            if not self._process.is_running():
+        """Capture CPU, RSS, runtime, and liveness for the target process.
+
+        A ``NoSuchProcess`` (or an ``AccessDenied`` whose PID is already gone)
+        is a genuine exit and yields a dead sample. An ``AccessDenied`` while
+        the PID is still alive means the process is running but unreadable
+        (e.g. a root-owned daemon on macOS); that is never a clean exit, so we
+        retry a few times to ride out a transient denial and otherwise raise.
+        """
+        attempt = 0
+        while True:
+            try:
+                return self._read_sample()
+            except process_probe.PROCESS_NOT_FOUND:
                 return self._dead_sample()
-            name = self._process.name()
-            cmdline = tuple(self._process.cmdline())
-            cpu_percent = float(self._process.cpu_percent(interval=None))
-            rss_bytes = int(self._process.memory_info().rss)
-            started_at = float(self._process.create_time())
-        except process_probe.PROCESS_INACCESSIBLE_OR_GONE:
+            except process_probe.PROCESS_ACCESS_DENIED as exc:
+                if not process_probe.pid_exists(self._pid):
+                    return self._dead_sample()
+                attempt += 1
+                if attempt >= self._max_access_attempts:
+                    raise self._inaccessible_error() from exc
+                self._sleep(self._access_retry_seconds)
+
+    def _read_sample(self) -> ProcessSample:
+        if not self._process.is_running():
             return self._dead_sample()
+        name = self._process.name()
+        cmdline = tuple(self._process.cmdline())
+        cpu_percent = float(self._process.cpu_percent(interval=None))
+        rss_bytes = int(self._process.memory_info().rss)
+        started_at = float(self._process.create_time())
 
         return ProcessSample(
             pid=self._pid,
@@ -71,6 +108,18 @@ class ProcessMonitor:
             runtime_seconds=max(0.0, time.time() - started_at),
             alive=True,
             started_at=started_at,
+        )
+
+    def _inaccessible_error(self) -> OpenSREError:
+        label = self._name or "?"
+        return OpenSREError(
+            f"Process {self._pid} ({label}) is running but cannot be inspected "
+            "(permission denied).",
+            suggestion=(
+                "Re-run with sufficient privileges (for example under sudo) to monitor "
+                "this process, or target a process your user owns."
+            ),
+            exit_code=ERROR,
         )
 
     def _warm_cpu_percent(self) -> None:


### PR DESCRIPTION
Fixes #4136

#### Describe the changes you have made in this PR -

The watchdog conflated "process I'm not allowed to inspect" (psutil `AccessDenied`, e.g. any root-owned daemon) with "process exited", reporting **"target exited" / exit 0** while the target was still running — so thresholds silently never ran. This PR makes the sampler distinguish the two: a genuine `NoSuchProcess` (or a denial where the PID is gone) still yields a dead sample and a clean exit; a denial while the PID exists is retried briefly (transient denials), then fails **loudly** with an explicit `OpenSREError` (exit 1) telling the user the process is running but unreadable. The REPL watch daemon gets the same disambiguation (`mark_failed` instead of "target process exited"). A `PROCESS_ACCESS_DENIED` constant was added to `fleet_monitoring/probe.py` so callers don't import psutil directly (keeping psutil confined per #1489).

`runner.py` (cited in the issue) needed no change: once the sampler stops fabricating `alive=False` for denials, its exit-on-dead path only sees genuine exits — a new test pins that a permission-denied sampler propagates the error and never returns SUCCESS.

### Demo/Screenshot for feature changes and bug fixes -

Before (unmodified `main`, macOS, `syslogd` PID 344 running, root-owned):

```
$ opensre watchdog --name syslogd --max-rss 1G --verbose
watchdog: target exited pid=344
$ echo $?
0
```

After (this branch, same live process):

```
$ opensre watchdog --name syslogd --max-rss 1G --verbose
✗  OpenSREError
   Process 344 (syslogd) is running but cannot be inspected (permission denied).
   Re-run with sufficient privileges (for example under sudo)...
$ echo $?
1
```

Healthy path unregressed (owned `sleep` process):

```
watchdog: status=ok pid=15218 name=sleep cpu=0.0% rss=1.2MiB runtime=0s
watchdog: status=ok pid=15218 name=sleep cpu=0.0% rss=1.2MiB runtime=2s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

*(Draft until the unchecked boxes above are true — I'm completing my line-by-line review now and will mark ready once I can honestly check them.)*

**Explain your implementation approach:**

The bug is a semantics collapse: three layers each translated "I couldn't read the process" into "the process is gone". The fix pushes the distinction to the lowest layer that can know the truth — the sampler — using `pid_exists()` as the tiebreaker after an `AccessDenied`: PID gone → real exit (dead sample, unchanged behavior); PID present → the process is alive but unreadable, which must never look like a clean exit. Transient denials get a bounded retry (3 × 0.5s) before failing, because a denial can be a momentary race. Alternatives considered: minting a dedicated exit code (rejected — `exit_codes.py` defines only SUCCESS/ERROR/USAGE_ERROR and a new code is a contract change beyond this bug) and making the runner catch-and-branch (rejected — fixing the sampler makes the runner correct transitively, smaller diff). Tests were written first and fail on `main` (5 failures pinning the bug).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
