### PR TITLE
Fix: filter investigation seed inputs and forward Grafana Basic Auth

### DIFF
--- a/integrations/grafana/tools/__init__.py
+++ b/integrations/grafana/tools/__init__.py
@@ -385,8 +385,6 @@ def _query_grafana_logs_available(sources: dict[str, dict]) -> bool:
             "limit": {"type": "integer", "default": 100},
             "grafana_endpoint": {"type": "string"},
             "grafana_api_key": {"type": "string"},
-            "grafana_username": {"type": "string"},
-            "grafana_password": {"type": "string"},
             "pipeline_name": {"type": "string"},
         },
         "required": ["service_name"],

--- a/integrations/grafana/tools/__init__.py
+++ b/integrations/grafana/tools/__init__.py
@@ -9,6 +9,16 @@ from typing import Any
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
 
+_GRAFANA_RUNTIME_PARAMS = (
+    "grafana_endpoint",
+    "grafana_api_key",
+    "grafana_username",
+    "grafana_password",
+    "grafana_verify_ssl",
+    "grafana_ca_bundle",
+    "grafana_backend",
+)
+
 
 def _query_grafana_alert_rules_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     grafana = _grafana_source(sources)
@@ -71,6 +81,7 @@ def _normalize_backend_alert_rules(raw: dict[str, Any]) -> list[dict[str, Any]]:
         },
         "required": [],
     },
+    injected_params=_GRAFANA_RUNTIME_PARAMS,
     is_available=_query_grafana_alert_rules_available,
     extract_params=_query_grafana_alert_rules_extract_params,
 )
@@ -78,6 +89,8 @@ def query_grafana_alert_rules(
     folder: str | None = None,
     grafana_endpoint: str | None = None,
     grafana_api_key: str | None = None,
+    grafana_username: str = "",
+    grafana_password: str = "",
     grafana_verify_ssl: bool = True,
     grafana_ca_bundle: str = "",
     grafana_backend: Any = None,
@@ -98,8 +111,10 @@ def query_grafana_alert_rules(
     client = _resolve_grafana_client(
         grafana_endpoint,
         grafana_api_key,
-        grafana_verify_ssl=grafana_verify_ssl,
-        grafana_ca_bundle=grafana_ca_bundle,
+        grafana_username,
+        grafana_password,
+        grafana_verify_ssl,
+        grafana_ca_bundle,
     )
     if not client or not client.is_configured:
         return tool_unavailable("grafana_alerts", "Grafana integration not configured", rules=[])
@@ -190,6 +205,7 @@ def _iso_to_epoch_ms(value: str) -> int:
         },
         "required": [],
     },
+    injected_params=_GRAFANA_RUNTIME_PARAMS,
     is_available=_query_grafana_annotations_available,
     extract_params=_query_grafana_annotations_extract_params,
 )
@@ -375,6 +391,7 @@ def _query_grafana_logs_available(sources: dict[str, dict]) -> bool:
         },
         "required": ["service_name"],
     },
+    injected_params=_GRAFANA_RUNTIME_PARAMS,
     is_available=_query_grafana_logs_available,
     extract_params=_query_grafana_logs_extract_params,
 )
@@ -542,15 +559,7 @@ def _query_grafana_metrics_available(sources: dict[str, dict]) -> bool:
     anti_examples=["Use this tool for pod logs or deployment status."],
     input_model=QueryGrafanaMetricsInput,
     output_model=QueryGrafanaMetricsOutput,
-    injected_params=(
-        "grafana_endpoint",
-        "grafana_api_key",
-        "grafana_username",
-        "grafana_password",
-        "grafana_verify_ssl",
-        "grafana_ca_bundle",
-        "grafana_backend",
-    ),
+    injected_params=_GRAFANA_RUNTIME_PARAMS,
     is_available=_query_grafana_metrics_available,
     extract_params=_query_grafana_metrics_extract_params,
 )
@@ -639,12 +648,15 @@ def _query_grafana_service_names_available(sources: dict[str, dict]) -> bool:
         },
         "required": [],
     },
+    injected_params=_GRAFANA_RUNTIME_PARAMS,
     is_available=_query_grafana_service_names_available,
     extract_params=_query_grafana_service_names_extract_params,
 )
 def query_grafana_service_names(
     grafana_endpoint: str | None = None,
     grafana_api_key: str | None = None,
+    grafana_username: str = "",
+    grafana_password: str = "",
     grafana_verify_ssl: bool = True,
     grafana_ca_bundle: str = "",
     grafana_backend: Any = None,
@@ -657,8 +669,10 @@ def query_grafana_service_names(
     client = _resolve_grafana_client(
         grafana_endpoint,
         grafana_api_key,
-        grafana_verify_ssl=grafana_verify_ssl,
-        grafana_ca_bundle=grafana_ca_bundle,
+        grafana_username,
+        grafana_password,
+        grafana_verify_ssl,
+        grafana_ca_bundle,
     )
     if not client or not client.is_configured:
         return tool_unavailable(
@@ -728,6 +742,7 @@ def _query_grafana_traces_available(sources: dict[str, dict]) -> bool:
         },
         "required": ["service_name"],
     },
+    injected_params=_GRAFANA_RUNTIME_PARAMS,
     is_available=_query_grafana_traces_available,
     extract_params=_query_grafana_traces_extract_params,
 )
@@ -737,6 +752,8 @@ def query_grafana_traces(
     limit: int = 20,
     grafana_endpoint: str | None = None,
     grafana_api_key: str | None = None,
+    grafana_username: str = "",
+    grafana_password: str = "",
     grafana_verify_ssl: bool = True,
     grafana_ca_bundle: str = "",
     grafana_backend: Any = None,
@@ -755,8 +772,10 @@ def query_grafana_traces(
     client = _resolve_grafana_client(
         grafana_endpoint,
         grafana_api_key,
-        grafana_verify_ssl=grafana_verify_ssl,
-        grafana_ca_bundle=grafana_ca_bundle,
+        grafana_username,
+        grafana_password,
+        grafana_verify_ssl,
+        grafana_ca_bundle,
     )
     if not client or not client.is_configured:
         return tool_unavailable("grafana_tempo", "Grafana integration not configured", traces=[])

--- a/tests/integrations/grafana/test_seed_calls.py
+++ b/tests/integrations/grafana/test_seed_calls.py
@@ -9,6 +9,7 @@ import pytest
 
 from integrations.config_models import GrafanaIntegrationConfig
 from integrations.grafana import tools as grafana_tools
+from integrations.grafana.tools import _GRAFANA_RUNTIME_PARAMS
 from tools.investigation.stages.gather_evidence.tools import build_seed_calls
 
 GRAFANA_TOOL_FUNCTIONS: tuple[Callable[..., dict[str, Any]], ...] = (
@@ -20,15 +21,7 @@ GRAFANA_TOOL_FUNCTIONS: tuple[Callable[..., dict[str, Any]], ...] = (
     grafana_tools.query_grafana_traces,
 )
 
-GRAFANA_RUNTIME_PARAMS = {
-    "grafana_endpoint",
-    "grafana_api_key",
-    "grafana_username",
-    "grafana_password",
-    "grafana_verify_ssl",
-    "grafana_ca_bundle",
-    "grafana_backend",
-}
+GRAFANA_RUNTIME_PARAMS = set(_GRAFANA_RUNTIME_PARAMS)
 
 
 def _tool_id(tool_function: Callable[..., dict[str, Any]]) -> str:

--- a/tests/integrations/grafana/test_seed_calls.py
+++ b/tests/integrations/grafana/test_seed_calls.py
@@ -1,0 +1,71 @@
+"""Regression tests for deterministic Grafana investigation seed calls."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from integrations.config_models import GrafanaIntegrationConfig
+from integrations.grafana import tools as grafana_tools
+from tools.investigation.stages.gather_evidence.tools import build_seed_calls
+
+GRAFANA_TOOL_FUNCTIONS: tuple[Callable[..., dict[str, Any]], ...] = (
+    grafana_tools.query_grafana_alert_rules,
+    grafana_tools.query_grafana_annotations,
+    grafana_tools.query_grafana_logs,
+    grafana_tools.query_grafana_metrics,
+    grafana_tools.query_grafana_service_names,
+    grafana_tools.query_grafana_traces,
+)
+
+GRAFANA_RUNTIME_PARAMS = {
+    "grafana_endpoint",
+    "grafana_api_key",
+    "grafana_username",
+    "grafana_password",
+    "grafana_verify_ssl",
+    "grafana_ca_bundle",
+    "grafana_backend",
+}
+
+
+def _tool_id(tool_function: Callable[..., dict[str, Any]]) -> str:
+    return tool_function.__name__
+
+
+def _local_basic_auth_state() -> dict[str, Any]:
+    return {
+        "alert_source": "grafana",
+        "resolved_integrations": {
+            "grafana_local": GrafanaIntegrationConfig(
+                endpoint="http://127.0.0.1:3001",
+                username="admin",
+                password="secret",
+            )
+        },
+    }
+
+
+@pytest.mark.parametrize("tool_function", GRAFANA_TOOL_FUNCTIONS, ids=_tool_id)
+def test_grafana_seed_call_has_valid_public_input(
+    tool_function: Callable[..., dict[str, Any]],
+) -> None:
+    """Every deterministic seed must pass the same schema validation as an LLM call."""
+    registered = tool_function.__opensre_registered_tool__  # type: ignore[attr-defined]
+
+    calls = build_seed_calls(_local_basic_auth_state(), [registered], object())
+
+    assert len(calls) == 1
+    assert registered.validate_public_input(calls[0].input) is None
+
+
+@pytest.mark.parametrize("tool_function", GRAFANA_TOOL_FUNCTIONS, ids=_tool_id)
+def test_grafana_connection_params_are_runtime_injected(
+    tool_function: Callable[..., dict[str, Any]],
+) -> None:
+    """Grafana connection details come from config and must never be model input."""
+    registered = tool_function.__opensre_registered_tool__  # type: ignore[attr-defined]
+
+    assert set(registered.injected_params) >= GRAFANA_RUNTIME_PARAMS

--- a/tests/tools/test_grafana_alert_rules_tool.py
+++ b/tests/tools/test_grafana_alert_rules_tool.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from integrations.grafana.tools import query_grafana_alert_rules
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
@@ -82,7 +84,20 @@ def test_run_with_folder_filter() -> None:
     mock_client.query_alert_rules.assert_called_once_with(folder="my-folder")
 
 
-def test_run_forwards_basic_auth_to_client() -> None:
+@pytest.mark.parametrize(
+    ("api_key", "username", "password"),
+    [
+        (None, "admin", "secret"),
+        ("glsa_test", "", ""),
+        (None, "", ""),
+    ],
+    ids=("basic-auth", "api-key", "anonymous"),
+)
+def test_run_forwards_auth_to_client(
+    api_key: str | None,
+    username: str,
+    password: str,
+) -> None:
     mock_client = MagicMock()
     mock_client.is_configured = False
     with patch(
@@ -90,8 +105,9 @@ def test_run_forwards_basic_auth_to_client() -> None:
     ) as resolve:
         query_grafana_alert_rules(
             grafana_endpoint="http://grafana",
-            grafana_username="admin",
-            grafana_password="secret",
+            grafana_api_key=api_key,
+            grafana_username=username,
+            grafana_password=password,
         )
 
-    resolve.assert_called_once_with("http://grafana", None, "admin", "secret", True, "")
+    resolve.assert_called_once_with("http://grafana", api_key, username, password, True, "")

--- a/tests/tools/test_grafana_alert_rules_tool.py
+++ b/tests/tools/test_grafana_alert_rules_tool.py
@@ -80,3 +80,18 @@ def test_run_with_folder_filter() -> None:
         result = query_grafana_alert_rules(folder="my-folder", grafana_endpoint="http://grafana")
     assert result["folder_filter"] == "my-folder"
     mock_client.query_alert_rules.assert_called_once_with(folder="my-folder")
+
+
+def test_run_forwards_basic_auth_to_client() -> None:
+    mock_client = MagicMock()
+    mock_client.is_configured = False
+    with patch(
+        "integrations.grafana.tools._resolve_grafana_client", return_value=mock_client
+    ) as resolve:
+        query_grafana_alert_rules(
+            grafana_endpoint="http://grafana",
+            grafana_username="admin",
+            grafana_password="secret",
+        )
+
+    resolve.assert_called_once_with("http://grafana", None, "admin", "secret", True, "")

--- a/tests/tools/test_grafana_logs_tool.py
+++ b/tests/tools/test_grafana_logs_tool.py
@@ -48,6 +48,15 @@ def test_extract_params_maps_fields() -> None:
     assert params["grafana_endpoint"] == "https://grafana.example.com"
 
 
+def test_basic_auth_is_runtime_only() -> None:
+    rt = query_grafana_logs.__opensre_registered_tool__
+    basic_auth_params = {"grafana_username", "grafana_password"}
+    properties = rt.input_schema.get("properties", {})
+
+    assert basic_auth_params.isdisjoint(properties)
+    assert basic_auth_params <= set(rt.injected_params)
+
+
 def test_extract_params_accepts_catalog_grafana_shape() -> None:
     rt = query_grafana_logs.__opensre_registered_tool__
     params = rt.extract_params(

--- a/tests/tools/test_grafana_service_names_tool.py
+++ b/tests/tools/test_grafana_service_names_tool.py
@@ -51,3 +51,18 @@ def test_run_happy_path() -> None:
     assert result["available"] is True
     assert result["service_names"] == ["svc-a", "svc-b"]
     mock_client.query_loki_label_values.assert_called_once_with("service_name")
+
+
+def test_run_forwards_basic_auth_to_client() -> None:
+    mock_client = MagicMock()
+    mock_client.is_configured = False
+    with patch(
+        "integrations.grafana.tools._resolve_grafana_client", return_value=mock_client
+    ) as resolve:
+        query_grafana_service_names(
+            grafana_endpoint="http://grafana",
+            grafana_username="admin",
+            grafana_password="secret",
+        )
+
+    resolve.assert_called_once_with("http://grafana", None, "admin", "secret", True, "")

--- a/tests/tools/test_grafana_service_names_tool.py
+++ b/tests/tools/test_grafana_service_names_tool.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from integrations.grafana.tools import query_grafana_service_names
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
@@ -53,7 +55,20 @@ def test_run_happy_path() -> None:
     mock_client.query_loki_label_values.assert_called_once_with("service_name")
 
 
-def test_run_forwards_basic_auth_to_client() -> None:
+@pytest.mark.parametrize(
+    ("api_key", "username", "password"),
+    [
+        (None, "admin", "secret"),
+        ("glsa_test", "", ""),
+        (None, "", ""),
+    ],
+    ids=("basic-auth", "api-key", "anonymous"),
+)
+def test_run_forwards_auth_to_client(
+    api_key: str | None,
+    username: str,
+    password: str,
+) -> None:
     mock_client = MagicMock()
     mock_client.is_configured = False
     with patch(
@@ -61,8 +76,9 @@ def test_run_forwards_basic_auth_to_client() -> None:
     ) as resolve:
         query_grafana_service_names(
             grafana_endpoint="http://grafana",
-            grafana_username="admin",
-            grafana_password="secret",
+            grafana_api_key=api_key,
+            grafana_username=username,
+            grafana_password=password,
         )
 
-    resolve.assert_called_once_with("http://grafana", None, "admin", "secret", True, "")
+    resolve.assert_called_once_with("http://grafana", api_key, username, password, True, "")

--- a/tests/tools/test_grafana_traces_tool.py
+++ b/tests/tools/test_grafana_traces_tool.py
@@ -78,6 +78,22 @@ def test_run_happy_path() -> None:
     assert len(result["pipeline_spans"]) == 1
 
 
+def test_run_forwards_basic_auth_to_client() -> None:
+    mock_client = MagicMock()
+    mock_client.is_configured = False
+    with patch(
+        "integrations.grafana.tools._resolve_grafana_client", return_value=mock_client
+    ) as resolve:
+        query_grafana_traces(
+            service_name="svc",
+            grafana_endpoint="http://grafana",
+            grafana_username="admin",
+            grafana_password="secret",
+        )
+
+    resolve.assert_called_once_with("http://grafana", None, "admin", "secret", True, "")
+
+
 def test_run_with_injected_backend() -> None:
     backend = MagicMock()
     backend.query_traces.return_value = {

--- a/tests/tools/test_grafana_traces_tool.py
+++ b/tests/tools/test_grafana_traces_tool.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from integrations.grafana.tools import query_grafana_traces
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
@@ -78,7 +80,20 @@ def test_run_happy_path() -> None:
     assert len(result["pipeline_spans"]) == 1
 
 
-def test_run_forwards_basic_auth_to_client() -> None:
+@pytest.mark.parametrize(
+    ("api_key", "username", "password"),
+    [
+        (None, "admin", "secret"),
+        ("glsa_test", "", ""),
+        (None, "", ""),
+    ],
+    ids=("basic-auth", "api-key", "anonymous"),
+)
+def test_run_forwards_auth_to_client(
+    api_key: str | None,
+    username: str,
+    password: str,
+) -> None:
     mock_client = MagicMock()
     mock_client.is_configured = False
     with patch(
@@ -87,11 +102,12 @@ def test_run_forwards_basic_auth_to_client() -> None:
         query_grafana_traces(
             service_name="svc",
             grafana_endpoint="http://grafana",
-            grafana_username="admin",
-            grafana_password="secret",
+            grafana_api_key=api_key,
+            grafana_username=username,
+            grafana_password=password,
         )
 
-    resolve.assert_called_once_with("http://grafana", None, "admin", "secret", True, "")
+    resolve.assert_called_once_with("http://grafana", api_key, username, password, True, "")
 
 
 def test_run_with_injected_backend() -> None:

--- a/tools/investigation/stages/gather_evidence/tools.py
+++ b/tools/investigation/stages/gather_evidence/tools.py
@@ -225,8 +225,16 @@ def build_seed_calls(
             injected = tool.extract_params(tool_sources)
         except Exception:
             injected = {}
+        public_properties = tool.public_input_schema.get("properties", {})
+        if not isinstance(public_properties, dict):
+            public_properties = {}
+        public_input = {
+            key: value
+            for key, value in injected.items()
+            if key in public_properties and value is not None
+        }
         tool_id = new_tool_use_id() if use_converse_ids else f"seed_{tool.name}"
-        calls.append(ToolCall(id=tool_id, name=tool.name, input=public_tool_input(injected)))
+        calls.append(ToolCall(id=tool_id, name=tool.name, input=public_tool_input(public_input)))
 
     return calls
 

--- a/tools/investigation/stages/gather_evidence/tools.py
+++ b/tools/investigation/stages/gather_evidence/tools.py
@@ -225,6 +225,9 @@ def build_seed_calls(
             injected = tool.extract_params(tool_sources)
         except Exception:
             injected = {}
+        # Seed calls are validated against the public schema before execution.
+        # Keep only declared arguments and omit None for optional fields, where
+        # absence is valid but an explicit null may violate the declared type.
         public_properties = tool.public_input_schema.get("properties", {})
         if not isinstance(public_properties, dict):
             public_properties = {}


### PR DESCRIPTION
Fixes #4148

#### Describe the changes you have made in this PR -

This PR fixes shared investigation seed-call construction and Grafana Basic Auth forwarding.

`build_seed_calls()` previously copied every value returned by `extract_params()` into public tool input. This included runtime-only parameters and optional `None` values, which could fail schema validation before execution.

Seed calls now include only non-`None` arguments declared in each tool’s public schema. This applies to every integration using deterministic investigation seed calls, while preserving complete runtime parameter injection during execution.

The Grafana-specific changes:

- Define one shared runtime-parameter declaration for all six Grafana tools.
- Forward Basic Auth credentials through the alert-rules, service-names and traces tools.
- Add regression tests covering seed validation, runtime parameter declarations and credential forwarding.

### Demo/Screenshot for feature changes and bug fixes -

Before the fix:

```text
Focused regression tests: 12 failed, 3 passed
Protected Grafana request without forwarded Basic Auth: HTTP 401
```

After the fix:

```text
Focused Grafana tests:          53 passed
Grafana integration/tool tests: 133 passed
Gather-evidence tests:          24 passed

Grafana -> Loki datasource health: OK
Unauthenticated Grafana API request: HTTP 401
OpenSRE request using Basic Auth: available=True
make verify-integrations: Grafana verification passed
```

Additional checks:

```text
make lint: passed
make format-check: passed
make typecheck: passed
```

The full test suite reported 11,686 passed and 56 skipped. Its only local failure was an unrelated terminal-colour assertion under `NO_COLOR=1` and `TERM=dumb`; the isolated test passes with colour enabled.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug had two causes. First, seed calls copied complete runtime parameters into public tool input, including undeclared configuration and optional `None` values. `build_seed_calls()` now keeps only schema-declared, non-`None` arguments. After validation, the executor still calls `extract_params()` again to obtain everything needed at runtime.

Second, some Grafana tools received Basic Auth credentials but did not forward them to the client resolver. The affected tools now pass those credentials explicitly, and all Grafana tools share one runtime-parameter declaration.

I considered changing each tool’s `extract_params()` implementation, but it must continue returning complete execution arguments. Filtering at the shared seed-call boundary fixes all similarly routed integrations without changing normal tool execution or existing API-key and anonymous-authentication paths.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

