### PR TITLE
Align CI with local Makefile: gateway quality checks and integration verify smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - "integrations/**"
       - "platform/**"
       - "tools/**"
+      - "gateway/**"
       - "tests/**"
       - "pyproject.toml"
       - "uv.lock"
@@ -33,6 +34,7 @@ on:
       - "integrations/**"
       - "platform/**"
       - "tools/**"
+      - "gateway/**"
       - "tests/**"
       - "pyproject.toml"
       - "uv.lock"
@@ -50,7 +52,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  PYTHON_SOURCE_PATHS: "config core integrations platform surfaces tools"
+  PYTHON_SOURCE_PATHS: "config core gateway integrations platform surfaces tools"
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -95,6 +97,9 @@ jobs:
 
       - name: Typecheck
         run: uv run python -m mypy $PYTHON_SOURCE_PATHS
+
+      - name: Verify integration registry (smoke)
+        run: make verify-integrations-smoke
 
       - name: Import graph
         run: uv run python .github/ci/check_imports.py --strict
@@ -252,6 +257,7 @@ jobs:
           --cov=platform
           --cov=surfaces
           --cov=tools
+          --cov=gateway
           --cov-report=
           --ignore=tests/e2e/kubernetes_local_alert_simulation
           --ignore=tests/synthetic

--- a/CI.md
+++ b/CI.md
@@ -105,7 +105,13 @@ make test-cov
 
 ## 4) Conditional checks
 
-If integration config, integration wiring, or related tools changed, also run:
+CI runs the fast registry smoke gate on every code change:
+
+```bash
+make verify-integrations-smoke
+```
+
+If integration config, integration wiring, or related tools changed, also run the live check against your local store and environment:
 
 ```bash
 make verify-integrations

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 export
 
 .PHONY: install build onboard demo benchmark benchmark-update-readme \
-	alert-template investigate-alert verify-integrations check-docker \
+	alert-template investigate-alert verify-integrations verify-integrations-smoke check-docker \
 	grafana-local-up grafana-local-down grafana-local-seed \
 	cloudwatch-demo datadog-demo crashloop-demo prefect-demo \
 	flink-demo upstream-downstream \
@@ -91,6 +91,11 @@ CLOUDOPSBENCH_LIMIT ?=
 
 verify-integrations:
 	uv run opensre integrations verify $(if $(SERVICE),$(SERVICE),) $(if $(SLACK_TEST),--send-slack-test,)
+
+verify-integrations-smoke:
+	$(PYTHON) -m pytest -q \
+	  tests/integrations/test_verification_registry.py \
+	  tests/integrations/test_registry.py
 
 check-docker:
 	@command -v docker >/dev/null 2>&1 || { echo "Docker is required for the live local Grafana stack. Install Docker Desktop or another Docker-compatible runtime, then rerun this target."; exit 1; }
@@ -513,6 +518,7 @@ help:
 	@echo "  make alert-template TEMPLATE=datadog - Print a starter alert JSON template"
 	@echo "  make investigate-alert ALERT=/path/to/alert.json - Run RCA against your own alert payload"
 	@echo "  make verify-integrations - Check local store + .env integrations before running RCA"
+	@echo "  make verify-integrations-smoke - Fast registry/catalog contract tests (CI smoke gate)"
 	@echo "  make prefect-demo    - Run Prefect ECS Fargate E2E test (alias for demo)"
 	@echo "  make prefect-local-test - Run Prefect ECS local test (CLOUD=1 for ECS)"
 	@echo "  make flink-demo      - Run Apache Flink ECS E2E test"


### PR DESCRIPTION

Today, local development runs lint, format, and typecheck against `gateway/` via `Makefile`, but GitHub Actions does not:

- `gateway/**` is missing from CI path filters, so a PR that only touches gateway code (e.g. `gateway/http/webapp.py`, `gateway/slack/dispatcher.py`) can skip CI entirely.
- `PYTHON_SOURCE_PATHS` in CI omits `gateway`, so even when CI runs, gateway production code never gets ruff or mypy coverage in the quality job.
- Gateway tests already run in the `integrations-and-misc` shard, but combined coverage on `main` did not include `gateway/` production code.

That creates a blind spot: gateway regressions can merge without the same static checks every other package gets locally and in CI.

**Integration verify smoke gate**

`CI.md` tells contributors to run `make verify-integrations` when changing integration wiring, but CI never ran an equivalent check. That meant catalog/verifier/registry drift could ship without an automated gate.

We cannot run live `make verify-integrations` in CI because it performs real network probes and requires at least one configured core integration to pass (`verification_exit_code` exits non-zero with no local store/env). CI has no credentials and should not depend on external services for every PR.

The smoke gate closes that gap by running fast contract tests (~30 tests, ~2s) that assert:

- every `SUPPORTED_VERIFY_SERVICES` entry has a registered verifier
- the verifier loader and catalog/registry stay in sync

That catches the wiring regressions the live verify command is meant to surface, without secrets or network calls.

---

### What changed

1. **Gateway CI parity**
   - Add `gateway/**` to CI path filters so gateway-only PRs trigger the workflow
   - Include `gateway` in `PYTHON_SOURCE_PATHS` so lint, format, and mypy match local `make lint` / `make format-check` / `make typecheck`
   - Add `--cov=gateway` to test shard coverage flags

2. **Integration verify smoke gate**
   - Add `make verify-integrations-smoke` — registry/catalog contract tests
   - Run it in the CI quality job after typecheck
   - Update `CI.md` §4 to distinguish CI smoke checks from live `make verify-integrations`

