### PR TITLE
feat(gateway): per-org credit metering + env-driven Clerk issuer for org silos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,6 @@ opensre-ci-fix/
 *.tfstate.*
 *.tfvars
 crash.log
+
+# Local-only Cursor agent rules — never commit/push these
+.cursor/rules/local-rules.mdc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,9 @@
 
 - Use strict typing, follow DRY principle
 - One clear purpose per file (separation of concerns)
+- Use named constants for HTTP status codes (`http.HTTPStatus`, e.g.
+  `HTTPStatus.PAYMENT_REQUIRED`) in both source and tests — never hardcoded
+  numeric literals like `402`.
 - Do not keep compatibility-only forwarding modules after refactors. Once imports and tests
   are migrated, remove the old module path in the same change and use one canonical import path.
 

--- a/config/config.py
+++ b/config/config.py
@@ -70,6 +70,28 @@ CLERK_CONFIG_PROD = ClerkConfig(
     issuer="https://clerk.tracer.cloud",
 )
 
+# Env vars injected by the org-silo infra (ECS task definition) to point JWT
+# verification at the silo's own Clerk instance instead of the defaults above.
+CLERK_ISSUER_ENV = "CLERK_ISSUER"
+CLERK_JWKS_URL_ENV = "CLERK_JWKS_URL"
+
+
+def get_clerk_config_override() -> ClerkConfig | None:
+    """Return the Clerk instance configured via CLERK_ISSUER / CLERK_JWKS_URL.
+
+    The org-silo infra injects these per deployment; when ``CLERK_ISSUER`` is
+    unset, callers fall back to the hardcoded ``CLERK_CONFIG_DEV`` /
+    ``CLERK_CONFIG_PROD`` defaults. ``CLERK_JWKS_URL`` defaults to the
+    issuer's standard ``/.well-known/jwks.json`` path when omitted. Read at
+    call time (not import time) so env loaded by ``bootstrap_opensre_env``
+    and test monkeypatching are honored.
+    """
+    issuer = os.getenv(CLERK_ISSUER_ENV, "").strip().rstrip("/")
+    if not issuer:
+        return None
+    jwks_url = os.getenv(CLERK_JWKS_URL_ENV, "").strip() or f"{issuer}/.well-known/jwks.json"
+    return ClerkConfig(jwks_url=jwks_url, issuer=issuer)
+
 
 def get_environment() -> Environment:
     """Get current environment from ENV variable.

--- a/gateway/billing/__init__.py
+++ b/gateway/billing/__init__.py
@@ -1,0 +1,1 @@
+"""Billing helpers for gateway ↔ opensre-webapp."""

--- a/gateway/billing/credits_client.py
+++ b/gateway/billing/credits_client.py
@@ -1,0 +1,140 @@
+"""Consume opensre-webapp credits before metered agent work.
+
+Contract:
+  POST {OPENSRE_WEBAPP_URL}/api/credits/consume
+  Authorization: Bearer {AGENT_USAGE_SECRET}
+  body: {"amount": <number>, "organizationId": <org>, "reason": <str>}
+  Success (2xx): {"balance", "consumed", "reason"}.
+  Shortfall: HTTP 402 with {"error": "insufficient_credits", "balance", "required"}.
+
+The client only classifies the attempt — it never decides policy. Call sites
+choose what UNCONFIGURED (metering off, e.g. dev setups) and UNAVAILABLE
+(webapp outage) mean; the gateway seams deliberately fail open on both.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from enum import Enum
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Env vars injected by the org-silo infra (ECS task definition).
+WEBAPP_URL_ENV = "OPENSRE_WEBAPP_URL"
+USAGE_SECRET_ENV = "AGENT_USAGE_SECRET"
+ORGANIZATION_ID_ENV = "OPENSRE_ORGANIZATION_ID"
+
+_TIMEOUT_SECONDS = 5.0
+
+# Metering-disabled is logged once per process, not once per turn.
+_unconfigured_logged = False
+
+
+class CreditsOutcome(Enum):
+    """Classification of one credit-consume attempt; policy belongs to callers."""
+
+    ALLOWED = "allowed"
+    DENIED = "denied"
+    UNCONFIGURED = "unconfigured"
+    UNAVAILABLE = "unavailable"
+
+
+def _env(name: str) -> str:
+    return (os.getenv(name) or "").strip()
+
+
+def organization_id_for_silo() -> str:
+    """Neon/Clerk organization id for this silo (statically injected by infra)."""
+    return _env(ORGANIZATION_ID_ENV)
+
+
+def _log_unconfigured_once(missing: str) -> None:
+    global _unconfigured_logged
+    if _unconfigured_logged:
+        return
+    _unconfigured_logged = True
+    logger.info("[credits] metering disabled: %s not set", missing)
+
+
+def consume_credits(
+    organization_id: str | None = None,
+    *,
+    amount: float = 1.0,
+    reason: str,
+    metadata: dict[str, Any] | None = None,
+) -> CreditsOutcome:
+    """POST one credit consumption to the webapp ledger and classify the result.
+
+    Args:
+        organization_id: Neon/Clerk org id; defaults to the silo's
+            ``OPENSRE_ORGANIZATION_ID`` env value.
+        amount: Credits to consume (webapp requires a positive number).
+        reason: Short machine-readable cause, e.g. ``"slack_turn"``.
+        metadata: Optional extra JSON fields merged into the request body.
+
+    Returns:
+        ``ALLOWED`` on 2xx, ``DENIED`` on HTTP 402, ``UNCONFIGURED`` when the
+        webapp URL / shared secret / org id is unset, ``UNAVAILABLE`` on
+        transport errors or any other HTTP status.
+    """
+    base_url = _env(WEBAPP_URL_ENV).rstrip("/")
+    secret = _env(USAGE_SECRET_ENV)
+    org = (organization_id or organization_id_for_silo()).strip()
+    missing = [
+        name
+        for name, value in (
+            (WEBAPP_URL_ENV, base_url),
+            (USAGE_SECRET_ENV, secret),
+            (ORGANIZATION_ID_ENV, org),
+        )
+        if not value
+    ]
+    if missing:
+        _log_unconfigured_once(", ".join(missing))
+        return CreditsOutcome.UNCONFIGURED
+
+    payload: dict[str, Any] = {"amount": amount, "organizationId": org, "reason": reason}
+    if metadata:
+        payload.update(metadata)
+
+    try:
+        response = httpx.post(
+            f"{base_url}/api/credits/consume",
+            json=payload,
+            headers={"Authorization": f"Bearer {secret}"},
+            timeout=_TIMEOUT_SECONDS,
+        )
+    except Exception as exc:
+        logger.warning(
+            "[credits] webapp unreachable for reason=%s (%s: %s)",
+            reason,
+            type(exc).__name__,
+            exc,
+        )
+        return CreditsOutcome.UNAVAILABLE
+
+    if response.status_code == 402:
+        body = _json_dict(response)
+        logger.info(
+            "[credits] denied reason=%s balance=%s required=%s",
+            reason,
+            body.get("balance"),
+            body.get("required"),
+        )
+        return CreditsOutcome.DENIED
+    if response.is_success:
+        return CreditsOutcome.ALLOWED
+    logger.warning("[credits] webapp HTTP %s for reason=%s", response.status_code, reason)
+    return CreditsOutcome.UNAVAILABLE
+
+
+def _json_dict(response: httpx.Response) -> dict[str, Any]:
+    try:
+        data = response.json()
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}

--- a/gateway/billing/credits_client.py
+++ b/gateway/billing/credits_client.py
@@ -18,6 +18,7 @@ import functools
 import logging
 import os
 from enum import Enum
+from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -130,7 +131,7 @@ def _classify_response(response: httpx.Response, *, reason: str) -> CreditsOutco
     402 → DENIED (the one refuse-the-user state); 2xx → ALLOWED; anything else
     → UNAVAILABLE, so callers fail open on server errors.
     """
-    if response.status_code == 402:
+    if response.status_code == HTTPStatus.PAYMENT_REQUIRED:
         body = _json_dict(response)
         logger.info(
             "[credits] denied reason=%s balance=%s required=%s",

--- a/gateway/billing/credits_client.py
+++ b/gateway/billing/credits_client.py
@@ -53,12 +53,13 @@ def organization_id_for_silo() -> str:
 
 
 @functools.cache
-def _log_metering_disabled_once(missing: str) -> None:
-    """Log which env vars are unset once per process (idempotent via cache).
+def _log_metering_disabled_once() -> None:
+    """Log once per process that metering is off because config is incomplete.
 
-    ``missing`` holds only env-var names, never their values.
+    The message is static — no env value or name is interpolated — so the
+    warning can never carry a secret into the logs.
     """
-    logger.info("[credits] metering disabled: %s not set", missing)
+    logger.info("[credits] metering disabled: required configuration is not fully set")
 
 
 def consume_credits(
@@ -86,15 +87,8 @@ def consume_credits(
     secret = _env(USAGE_SECRET_ENV)
     org = (organization_id or organization_id_for_silo()).strip()
 
-    missing: list[str] = []
-    if not base_url:
-        missing.append(WEBAPP_URL_ENV)
-    if not secret:
-        missing.append(USAGE_SECRET_ENV)
-    if not org:
-        missing.append(ORGANIZATION_ID_ENV)
-    if missing:
-        _log_metering_disabled_once(", ".join(missing))
+    if not (base_url and secret and org):
+        _log_metering_disabled_once()
         return CreditsOutcome.UNCONFIGURED
 
     # Metadata is spread first so the billing-critical fields always win and can

--- a/gateway/billing/credits_client.py
+++ b/gateway/billing/credits_client.py
@@ -30,6 +30,7 @@ USAGE_SECRET_ENV = "AGENT_USAGE_SECRET"
 ORGANIZATION_ID_ENV = "OPENSRE_ORGANIZATION_ID"
 
 _TIMEOUT_SECONDS = 5.0
+_CONSUME_PATH = "/api/credits/consume"
 
 
 class CreditsOutcome(Enum):
@@ -83,26 +84,30 @@ def consume_credits(
     base_url = _env(WEBAPP_URL_ENV).rstrip("/")
     secret = _env(USAGE_SECRET_ENV)
     org = (organization_id or organization_id_for_silo()).strip()
-    missing = [
-        name
-        for name, is_set in (
-            (WEBAPP_URL_ENV, bool(base_url)),
-            (USAGE_SECRET_ENV, bool(secret)),
-            (ORGANIZATION_ID_ENV, bool(org)),
-        )
-        if not is_set
-    ]
+
+    missing: list[str] = []
+    if not base_url:
+        missing.append(WEBAPP_URL_ENV)
+    if not secret:
+        missing.append(USAGE_SECRET_ENV)
+    if not org:
+        missing.append(ORGANIZATION_ID_ENV)
     if missing:
         _log_metering_disabled_once(", ".join(missing))
         return CreditsOutcome.UNCONFIGURED
 
-    payload: dict[str, Any] = {"amount": amount, "organizationId": org, "reason": reason}
-    if metadata:
-        payload.update(metadata)
+    # Metadata is spread first so the billing-critical fields always win and can
+    # never be overwritten by a supplemental key.
+    payload: dict[str, Any] = {
+        **(metadata or {}),
+        "amount": amount,
+        "organizationId": org,
+        "reason": reason,
+    }
 
     try:
         response = httpx.post(
-            f"{base_url}/api/credits/consume",
+            f"{base_url}{_CONSUME_PATH}",
             json=payload,
             headers={"Authorization": f"Bearer {secret}"},
             timeout=_TIMEOUT_SECONDS,
@@ -116,6 +121,15 @@ def consume_credits(
         )
         return CreditsOutcome.UNAVAILABLE
 
+    return _classify_response(response, reason=reason)
+
+
+def _classify_response(response: httpx.Response, *, reason: str) -> CreditsOutcome:
+    """Map a ledger HTTP response to an outcome.
+
+    402 → DENIED (the one refuse-the-user state); 2xx → ALLOWED; anything else
+    → UNAVAILABLE, so callers fail open on server errors.
+    """
     if response.status_code == 402:
         body = _json_dict(response)
         logger.info(

--- a/gateway/billing/credits_client.py
+++ b/gateway/billing/credits_client.py
@@ -14,6 +14,7 @@ choose what UNCONFIGURED (metering off, e.g. dev setups) and UNAVAILABLE
 
 from __future__ import annotations
 
+import functools
 import logging
 import os
 from enum import Enum
@@ -29,9 +30,6 @@ USAGE_SECRET_ENV = "AGENT_USAGE_SECRET"
 ORGANIZATION_ID_ENV = "OPENSRE_ORGANIZATION_ID"
 
 _TIMEOUT_SECONDS = 5.0
-
-# Metering-disabled is logged once per process, not once per turn.
-_unconfigured_logged = False
 
 
 class CreditsOutcome(Enum):
@@ -52,11 +50,12 @@ def organization_id_for_silo() -> str:
     return _env(ORGANIZATION_ID_ENV)
 
 
-def _log_unconfigured_once(missing: str) -> None:
-    global _unconfigured_logged
-    if _unconfigured_logged:
-        return
-    _unconfigured_logged = True
+@functools.cache
+def _log_metering_disabled_once(missing: str) -> None:
+    """Log which env vars are unset once per process (idempotent via cache).
+
+    ``missing`` holds only env-var names, never their values.
+    """
     logger.info("[credits] metering disabled: %s not set", missing)
 
 
@@ -86,15 +85,15 @@ def consume_credits(
     org = (organization_id or organization_id_for_silo()).strip()
     missing = [
         name
-        for name, value in (
-            (WEBAPP_URL_ENV, base_url),
-            (USAGE_SECRET_ENV, secret),
-            (ORGANIZATION_ID_ENV, org),
+        for name, is_set in (
+            (WEBAPP_URL_ENV, bool(base_url)),
+            (USAGE_SECRET_ENV, bool(secret)),
+            (ORGANIZATION_ID_ENV, bool(org)),
         )
-        if not value
+        if not is_set
     ]
     if missing:
-        _log_unconfigured_once(", ".join(missing))
+        _log_metering_disabled_once(", ".join(missing))
         return CreditsOutcome.UNCONFIGURED
 
     payload: dict[str, Any] = {"amount": amount, "organizationId": org, "reason": reason}

--- a/gateway/http/worker.py
+++ b/gateway/http/worker.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from gateway.billing.credits_client import CreditsOutcome, consume_credits
 from gateway.http.artifacts import upload_report_to_s3, write_local_report
 from gateway.http.investigation_store import InvestigationStatus, InvestigationStore
 
@@ -61,6 +62,19 @@ class InvestigationWorker:
         record = self._store.claim_next_queued()
         if record is None:
             return False
+        # Metering: only an explicit webapp denial (402) skips the run.
+        # UNCONFIGURED (dev setups without metering env) and UNAVAILABLE
+        # (webapp outage) proceed — fail-open is the intended policy so a
+        # billing outage never stalls queued investigations.
+        outcome = consume_credits(record.clerk_org_id, reason="investigation")
+        if outcome is CreditsOutcome.DENIED:
+            logger.info("[investigations] denied %s: insufficient credits", record.id)
+            self._store.finish(
+                record.id,
+                status=InvestigationStatus.FAILED,
+                error="insufficient_credits",
+            )
+            return True
         try:
             result = self._runner(record.trigger)
             local_path = write_local_report(record.id, result, base_dir=self._artifacts_dir)

--- a/gateway/slack/dispatcher.py
+++ b/gateway/slack/dispatcher.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 
 from core.agent_harness.session import SessionCore
+from gateway.billing.credits_client import CreditsOutcome, consume_credits
 from gateway.runtime.sink_protocol import GatewayAgentCallback
 from gateway.slack.approvals import (
     ApprovalBroker,
@@ -46,6 +47,10 @@ _MAX_CONVERSATION_LOCKS = 1024
 _DENIAL_REPLY = "You're not authorized to use this bot. Ask an admin to add you."
 _NEW_SESSION_REPLY = "Started a new session."
 _TURN_TIMEOUT_MESSAGE = "This is taking longer than expected. Please try again."
+# Only an explicit 402 from the credit ledger posts this; UNCONFIGURED /
+# UNAVAILABLE outcomes run the turn instead, so a misconfiguration or webapp
+# outage never masquerades to users as "out of credits".
+_CREDITS_DENIED_MESSAGE = "Out of credits — top up in the OpenSRE console."
 
 
 @dataclass
@@ -229,6 +234,19 @@ class _SlackTurnDispatcher:
             )
             session = self._apply_inbound_decision(inbound, decision)
             if session is None:
+                return
+
+            # Metering: only an explicit webapp denial (402) blocks the turn,
+            # so a config error can never masquerade to users as "out of
+            # credits". UNCONFIGURED (dev setups without metering env) and
+            # UNAVAILABLE (webapp outage) proceed — fail-open is the intended
+            # policy so a billing outage never silences the Slack coworker.
+            if consume_credits(reason="slack_turn") is CreditsOutcome.DENIED:
+                self._logger.info(
+                    "[slack-gateway] turn denied: out of credits channel=%s",
+                    inbound.channel_id,
+                )
+                self._post(inbound, _CREDITS_DENIED_MESSAGE)
                 return
 
             # Never log message bodies — audit hashes live in messaging_security.

--- a/gateway/tests/billing/__init__.py
+++ b/gateway/tests/billing/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for gateway billing helpers."""

--- a/gateway/tests/billing/test_credits_client.py
+++ b/gateway/tests/billing/test_credits_client.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from gateway.billing.credits_client import CreditsOutcome, consume_credits
+
+_URL_ENV = "OPENSRE_WEBAPP_URL"
+_SECRET_ENV = "AGENT_USAGE_SECRET"
+_ORG_ENV = "OPENSRE_ORGANIZATION_ID"
+
+
+@pytest.fixture
+def metering_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env with the webapp URL + shared secret set, so metering is live."""
+    monkeypatch.setenv(_URL_ENV, "https://app.opensre.test")
+    monkeypatch.setenv(_SECRET_ENV, "sekrit")
+
+
+def test_unconfigured_when_secret_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: URL + org present but no shared secret → metering is off.
+    monkeypatch.setenv(_URL_ENV, "https://app.opensre.test")
+    monkeypatch.delenv(_SECRET_ENV, raising=False)
+
+    def fail_if_called(*_a: object, **_k: object) -> httpx.Response:
+        raise AssertionError("no network call when metering is unconfigured")
+
+    monkeypatch.setattr("gateway.billing.credits_client.httpx.post", fail_if_called)
+
+    # Act
+    outcome = consume_credits(organization_id="org_x", reason="slack_turn")
+
+    # Assert: classified unconfigured without touching the network.
+    assert outcome is CreditsOutcome.UNCONFIGURED
+
+
+@pytest.mark.usefixtures("metering_on")
+def test_unconfigured_when_org_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: secret set but no organization id anywhere (deploy misconfig).
+    monkeypatch.delenv(_ORG_ENV, raising=False)
+
+    # Act
+    outcome = consume_credits(organization_id="", reason="slack_turn")
+
+    # Assert: unconfigured, not denied — callers must not read this as "out of credits".
+    assert outcome is CreditsOutcome.UNCONFIGURED
+
+
+@pytest.mark.usefixtures("metering_on")
+def test_402_is_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: the ledger reports a shortfall.
+    monkeypatch.setattr(
+        "gateway.billing.credits_client.httpx.post",
+        lambda *_a, **_k: httpx.Response(402, json={"balance": 0, "required": 1}),
+    )
+
+    # Act
+    outcome = consume_credits(organization_id="org_x", reason="slack_turn")
+
+    # Assert: the one genuine refuse-the-user state.
+    assert outcome is CreditsOutcome.DENIED
+
+
+@pytest.mark.usefixtures("metering_on")
+def test_2xx_is_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: the ledger consumes a credit and returns the remaining balance.
+    monkeypatch.setattr(
+        "gateway.billing.credits_client.httpx.post",
+        lambda *_a, **_k: httpx.Response(200, json={"balance": 41.5, "consumed": 1}),
+    )
+
+    # Act
+    outcome = consume_credits(organization_id="org_x", reason="slack_turn")
+
+    # Assert
+    assert outcome is CreditsOutcome.ALLOWED
+
+
+@pytest.mark.usefixtures("metering_on")
+def test_transport_error_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: the webapp is unreachable — an our-side failure, not a user's shortfall.
+    def unreachable(*_a: object, **_k: object) -> httpx.Response:
+        raise httpx.ConnectError("no route to host")
+
+    monkeypatch.setattr("gateway.billing.credits_client.httpx.post", unreachable)
+
+    # Act
+    outcome = consume_credits(organization_id="org_x", reason="slack_turn")
+
+    # Assert: UNAVAILABLE so the gateway can fail open instead of blocking the user.
+    assert outcome is CreditsOutcome.UNAVAILABLE
+
+
+@pytest.mark.usefixtures("metering_on")
+def test_5xx_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: a server error from the ledger (any non-402, non-2xx status).
+    monkeypatch.setattr(
+        "gateway.billing.credits_client.httpx.post",
+        lambda *_a, **_k: httpx.Response(500, json={}),
+    )
+
+    # Act
+    outcome = consume_credits(organization_id="org_x", reason="slack_turn")
+
+    # Assert: only 402 denies; every other error status is UNAVAILABLE (fail-open).
+    assert outcome is CreditsOutcome.UNAVAILABLE
+
+
+@pytest.mark.usefixtures("metering_on")
+def test_request_matches_webapp_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: capture the outbound request the client builds.
+    calls: list[dict[str, Any]] = []
+
+    def capture(url: str, **kwargs: Any) -> httpx.Response:
+        calls.append({"url": url, **kwargs})
+        return httpx.Response(200, json={"balance": 9, "consumed": 2.5})
+
+    monkeypatch.setattr("gateway.billing.credits_client.httpx.post", capture)
+
+    # Act
+    outcome = consume_credits(
+        "org_x", amount=2.5, reason="investigation", metadata={"investigationId": "inv-1"}
+    )
+
+    # Assert: bearer secret + the webapp's body shape ("amount", never "units").
+    assert outcome is CreditsOutcome.ALLOWED
+    (call,) = calls
+    assert call["url"] == "https://app.opensre.test/api/credits/consume"
+    assert call["headers"]["Authorization"] == "Bearer sekrit"
+    assert call["timeout"] == 5.0
+    assert call["json"] == {
+        "amount": 2.5,
+        "organizationId": "org_x",
+        "reason": "investigation",
+        "investigationId": "inv-1",
+    }

--- a/gateway/tests/billing/test_credits_client.py
+++ b/gateway/tests/billing/test_credits_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -53,7 +54,9 @@ def test_402_is_denied(monkeypatch: pytest.MonkeyPatch) -> None:
     # Arrange: the ledger reports a shortfall.
     monkeypatch.setattr(
         "gateway.billing.credits_client.httpx.post",
-        lambda *_a, **_k: httpx.Response(402, json={"balance": 0, "required": 1}),
+        lambda *_a, **_k: httpx.Response(
+            HTTPStatus.PAYMENT_REQUIRED, json={"balance": 0, "required": 1}
+        ),
     )
 
     # Act
@@ -68,7 +71,7 @@ def test_2xx_is_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
     # Arrange: the ledger consumes a credit and returns the remaining balance.
     monkeypatch.setattr(
         "gateway.billing.credits_client.httpx.post",
-        lambda *_a, **_k: httpx.Response(200, json={"balance": 41.5, "consumed": 1}),
+        lambda *_a, **_k: httpx.Response(HTTPStatus.OK, json={"balance": 41.5, "consumed": 1}),
     )
 
     # Act
@@ -98,7 +101,7 @@ def test_5xx_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
     # Arrange: a server error from the ledger (any non-402, non-2xx status).
     monkeypatch.setattr(
         "gateway.billing.credits_client.httpx.post",
-        lambda *_a, **_k: httpx.Response(500, json={}),
+        lambda *_a, **_k: httpx.Response(HTTPStatus.INTERNAL_SERVER_ERROR, json={}),
     )
 
     # Act
@@ -115,7 +118,7 @@ def test_request_matches_webapp_contract(monkeypatch: pytest.MonkeyPatch) -> Non
 
     def capture(url: str, **kwargs: Any) -> httpx.Response:
         calls.append({"url": url, **kwargs})
-        return httpx.Response(200, json={"balance": 9, "consumed": 2.5})
+        return httpx.Response(HTTPStatus.OK, json={"balance": 9, "consumed": 2.5})
 
     monkeypatch.setattr("gateway.billing.credits_client.httpx.post", capture)
 
@@ -145,7 +148,7 @@ def test_metadata_cannot_override_billing_fields(monkeypatch: pytest.MonkeyPatch
 
     def capture(_url: str, **kwargs: Any) -> httpx.Response:
         calls.append(kwargs)
-        return httpx.Response(200, json={"balance": 1})
+        return httpx.Response(HTTPStatus.OK, json={"balance": 1})
 
     monkeypatch.setattr("gateway.billing.credits_client.httpx.post", capture)
 

--- a/gateway/tests/billing/test_credits_client.py
+++ b/gateway/tests/billing/test_credits_client.py
@@ -136,3 +136,30 @@ def test_request_matches_webapp_contract(monkeypatch: pytest.MonkeyPatch) -> Non
         "reason": "investigation",
         "investigationId": "inv-1",
     }
+
+
+@pytest.mark.usefixtures("metering_on")
+def test_metadata_cannot_override_billing_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: hostile metadata tries to zero the charge and swap the org/reason.
+    calls: list[dict[str, Any]] = []
+
+    def capture(_url: str, **kwargs: Any) -> httpx.Response:
+        calls.append(kwargs)
+        return httpx.Response(200, json={"balance": 1})
+
+    monkeypatch.setattr("gateway.billing.credits_client.httpx.post", capture)
+
+    # Act
+    consume_credits(
+        organization_id="org_real",
+        amount=1.0,
+        reason="slack_turn",
+        metadata={"amount": 0, "organizationId": "org_injected", "reason": "free_ride"},
+    )
+
+    # Assert: the injected markers never reach the ledger; core fields keep their
+    # real values (a zero-credit charge to another org must be impossible).
+    (sent,) = calls
+    assert sent["json"]["amount"] == 1.0
+    assert sent["json"]["organizationId"] == "org_real"
+    assert sent["json"]["reason"] == "slack_turn"

--- a/gateway/tests/http/test_investigation_worker.py
+++ b/gateway/tests/http/test_investigation_worker.py
@@ -6,9 +6,22 @@ from typing import Any
 
 import pytest
 
+from gateway.billing.credits_client import (
+    ORGANIZATION_ID_ENV,
+    USAGE_SECRET_ENV,
+    WEBAPP_URL_ENV,
+    CreditsOutcome,
+)
 from gateway.http.artifacts import ARTIFACTS_BUCKET_ENV, upload_report_to_s3
 from gateway.http.investigation_store import InMemoryInvestigationStore, InvestigationStatus
 from gateway.http.worker import WORKER_ENABLED_ENV, InvestigationWorker, worker_enabled
+
+
+@pytest.fixture(autouse=True)
+def _metering_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Credit metering must never fire real HTTP from worker tests."""
+    for name in (WEBAPP_URL_ENV, USAGE_SECRET_ENV, ORGANIZATION_ID_ENV):
+        monkeypatch.delenv(name, raising=False)
 
 
 def _queued(store: InMemoryInvestigationStore, org: str = "org_a") -> str:
@@ -52,6 +65,55 @@ def test_run_once_marks_failed_on_runner_error(tmp_path: Path) -> None:
     assert record is not None
     assert record.status is InvestigationStatus.FAILED
     assert record.error == "RuntimeError"
+
+
+def test_run_once_credit_denial_skips_pipeline_and_marks_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = InMemoryInvestigationStore()
+    investigation_id = _queued(store)
+    runs: list[dict[str, Any]] = []
+    denials: list[tuple[str | None, str]] = []
+
+    def deny(organization_id: str | None = None, **kwargs: Any) -> CreditsOutcome:
+        denials.append((organization_id, kwargs["reason"]))
+        return CreditsOutcome.DENIED
+
+    monkeypatch.setattr("gateway.http.worker.consume_credits", deny)
+    worker = InvestigationWorker(
+        store,
+        runner=lambda trigger: runs.append(trigger) or {},
+        artifacts_dir=tmp_path,
+    )
+
+    assert worker.run_once() is True
+
+    assert runs == []
+    # The record's own org is metered, not the silo default.
+    assert denials == [("org_a", "investigation")]
+    record = store.get(investigation_id)
+    assert record is not None
+    assert record.status is InvestigationStatus.FAILED
+    assert record.error == "insufficient_credits"
+
+
+def test_run_once_proceeds_when_credits_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fail-open: a webapp outage must not stall queued investigations."""
+    store = InMemoryInvestigationStore()
+    investigation_id = _queued(store)
+    monkeypatch.setattr(
+        "gateway.http.worker.consume_credits",
+        lambda *_a, **_k: CreditsOutcome.UNAVAILABLE,
+    )
+    worker = InvestigationWorker(store, runner=lambda _t: {"report": "ok"}, artifacts_dir=tmp_path)
+
+    assert worker.run_once() is True
+
+    record = store.get(investigation_id)
+    assert record is not None
+    assert record.status is InvestigationStatus.COMPLETED
 
 
 def test_run_once_returns_false_when_queue_empty(tmp_path: Path) -> None:

--- a/gateway/tests/slack/test_dispatcher.py
+++ b/gateway/tests/slack/test_dispatcher.py
@@ -10,6 +10,12 @@ from unittest.mock import patch
 
 import pytest
 
+from gateway.billing.credits_client import (
+    ORGANIZATION_ID_ENV,
+    USAGE_SECRET_ENV,
+    WEBAPP_URL_ENV,
+    CreditsOutcome,
+)
 from gateway.slack.dispatcher import _SlackTurnDispatcher
 from gateway.slack.events import SlackInboundMessage
 from gateway.slack.settings import SlackGatewaySettings
@@ -25,6 +31,13 @@ def _isolate_slack_integration_store():
         patch(f"{_SECURITY}.upsert_instance"),
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+def _metering_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Credit metering must never fire real HTTP from dispatcher tests."""
+    for name in (WEBAPP_URL_ENV, USAGE_SECRET_ENV, ORGANIZATION_ID_ENV):
+        monkeypatch.delenv(name, raising=False)
 
 
 class _FakeMessagingClient:
@@ -176,6 +189,55 @@ def test_unauthorized_user_gets_denial_reply_and_no_turn() -> None:
     assert "not authorized" in denial
     assert "U1" not in denial
     assert "SLACK_" not in denial
+
+
+def test_out_of_credits_blocks_turn_with_short_reply(monkeypatch: pytest.MonkeyPatch) -> None:
+    messaging = _FakeMessagingClient()
+    resolver = _FakeSessionResolver()
+    turns: list[str] = []
+    reasons: list[str] = []
+
+    def deny(**kwargs: Any) -> CreditsOutcome:
+        reasons.append(kwargs["reason"])
+        return CreditsOutcome.DENIED
+
+    monkeypatch.setattr("gateway.slack.dispatcher.consume_credits", deny)
+
+    _dispatcher(
+        settings=_settings(["U1"]),
+        messaging=messaging,
+        resolver=resolver,
+        handler=lambda text, *_args: turns.append(text),
+    ).dispatch(_inbound())
+
+    assert turns == []
+    assert reasons == ["slack_turn"]
+    # Short thread reply; no balances or env details leak to the channel.
+    assert messaging.posts[0]["text"] == "Out of credits — top up in the OpenSRE console."
+    assert messaging.posts[0]["thread_ts"] == "100.1"
+
+
+@pytest.mark.parametrize(
+    "outcome", [CreditsOutcome.ALLOWED, CreditsOutcome.UNCONFIGURED, CreditsOutcome.UNAVAILABLE]
+)
+def test_non_denied_credit_outcomes_run_the_turn(
+    monkeypatch: pytest.MonkeyPatch, outcome: CreditsOutcome
+) -> None:
+    """Fail-open: metering off or a webapp outage must never block a turn."""
+    messaging = _FakeMessagingClient()
+    resolver = _FakeSessionResolver()
+    turns: list[str] = []
+    monkeypatch.setattr("gateway.slack.dispatcher.consume_credits", lambda **_kw: outcome)
+
+    def handler(text: str, _session: Any, sink: Any, _logger: logging.Logger) -> None:
+        turns.append(text)
+        sink.finalize("done")
+
+    _dispatcher(
+        settings=_settings(["U1"]), messaging=messaging, resolver=resolver, handler=handler
+    ).dispatch(_inbound())
+
+    assert len(turns) == 1
 
 
 def test_conversation_locks_are_pruned_at_cap(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/platform/auth/jwt_auth.py
+++ b/platform/auth/jwt_auth.py
@@ -24,6 +24,7 @@ from config.config import (
     JWKS_CACHE_TTL_SECONDS,
     JWT_ALGORITHM,
     Environment,
+    get_clerk_config_override,
     get_environment,
 )
 
@@ -148,17 +149,27 @@ _async_jwks_cache = AsyncJWKSCache()
 def get_valid_issuers() -> list[str]:
     """Get list of valid JWT issuers.
 
-    In production, only accept production issuer.
-    In development, accept both dev and prod issuers for flexibility.
+    The CLERK_ISSUER / CLERK_JWKS_URL override (infra-injected per org silo)
+    is accepted in every environment. Otherwise production only accepts the
+    production issuer; development accepts both hardcoded issuers for
+    flexibility.
     """
     env = get_environment()
     if env == Environment.PRODUCTION:
-        return [CLERK_CONFIG_PROD.issuer]
-    return [CLERK_CONFIG_DEV.issuer, CLERK_CONFIG_PROD.issuer]
+        issuers = [CLERK_CONFIG_PROD.issuer]
+    else:
+        issuers = [CLERK_CONFIG_DEV.issuer, CLERK_CONFIG_PROD.issuer]
+    override = get_clerk_config_override()
+    if override and override.issuer not in issuers:
+        issuers.insert(0, override.issuer)
+    return issuers
 
 
 def get_jwks_url_for_issuer(issuer: str) -> str | None:
     """Get the JWKS URL for a given issuer."""
+    override = get_clerk_config_override()
+    if override and issuer.rstrip("/") == override.issuer:
+        return override.jwks_url
     if issuer == CLERK_CONFIG_DEV.issuer:
         return CLERK_CONFIG_DEV.jwks_url
     if issuer == CLERK_CONFIG_PROD.issuer:

--- a/surfaces/__init__.py
+++ b/surfaces/__init__.py
@@ -13,7 +13,6 @@ Layering rule: surfaces may import from ``core/``, ``tools/``,
 ``surfaces/`` (it sits at the top of the dependency stack).
 
 See ``docs/ARCHITECTURE.md`` for the full layering contract and
-``opensre-notes/v0.2-ai-production-engineer/t1-design-doc.md`` for the
 restructure rationale.
 """
 

--- a/tests/benchmarks/_framework/__init__.py
+++ b/tests/benchmarks/_framework/__init__.py
@@ -3,8 +3,6 @@
 Architecture: a benchmark framework with pluggable adapters per benchmark
 suite. CloudOpsBench is the first adapter; ToolCallBench and others follow.
 
-See design: ``~/DevBox/opensre-notes/opensre-benchmark-framework.md``.
-
 Modules:
     adapters    Abstract ``BenchmarkAdapter`` ABC + typed data contracts.
     config      YAML config loader + integrity-aware validation.

--- a/tests/benchmarks/_framework/integrity.py
+++ b/tests/benchmarks/_framework/integrity.py
@@ -1,9 +1,7 @@
 """Integrity guard — Pillar 0 of the benchmark framework.
 
 Encodes the framework's honest-results discipline so that dishonest benchmark
-runs and reports are structurally impossible to produce. See
-``~/DevBox/opensre-notes/opensre-benchmark-framework.md`` § 0 for the full
-mechanism catalogue.
+runs and reports are structurally impossible to produce.
 
 This module provides two enforcement points:
 

--- a/tests/benchmarks/cloudopsbench/configs/README.md
+++ b/tests/benchmarks/cloudopsbench/configs/README.md
@@ -58,9 +58,7 @@ The benefits:
 
 Older configs from the first ~6 weeks of bench work are still flat at
 `configs/*.yml`. They map to historical experiments (some rejected, some
-baseline) per
-[`~/DevBox/tracer-cloud/opensre-notes/cloudopsbench-experiments-chain.md`](../../../../opensre-notes/cloudopsbench-experiments-chain.md).
-Migrating each into an `experiments/exp_<name>/` folder is a lazy
+baseline). Migrating each into an `experiments/exp_<name>/` folder is a lazy
 follow-up — not blocking. Mapping below for future reference:
 
 | Flat config | Likely experiment folder |

--- a/tests/benchmarks/cloudopsbench/configs/cloudopsbench_smoke.yml
+++ b/tests/benchmarks/cloudopsbench/configs/cloudopsbench_smoke.yml
@@ -41,8 +41,7 @@ seed: 42
 output_dir: .bench-results/example/
 
 # Pre-registration — Phase 0 integrity gate. Path must exist + be non-empty
-# AND be committed to git before the run. See:
-# ~/DevBox/opensre-notes/opensre-benchmark-framework.md § 0
+# AND be committed to git before the run.
 pre_registration_path: tests/benchmarks/cloudopsbench/configs/preregistrations/cloudopsbench_smoke.yml
 
 filters:

--- a/tests/benchmarks/cloudopsbench/configs/experiments/exp_db_evidence_pipeline/README.md
+++ b/tests/benchmarks/cloudopsbench/configs/experiments/exp_db_evidence_pipeline/README.md
@@ -31,11 +31,11 @@ when a new run lands.
 
 | Started | Image | Config used | S3 run dir | Status | Headline | Report |
 |---|---|---|---|---|---|---|
-| 2026-06-11T11:02Z | `6a92295` | [`smoke_db_pod_logs.yml`](smoke_db_pod_logs.yml) | `runs/cloudopsbench_db_pod_logs_smoke_openai/dev-2026-06-11T11-02-51Z_cloudopsbench/` | Completed | Admission +33pp SIG · Performance −14.8pp ns · Aggregate ns | [exp_db_evidence_pipeline.md](../../../../../../opensre-notes/exp_db_evidence_pipeline.md) |
-| 2026-06-11T12:56Z | `1ae5c83` | [`smoke_perf_only.yml`](smoke_perf_only.yml) (V1) | `runs/cloudopsbench_perf_only_smoke_openai/dev-2026-06-11T12-56-37Z_cloudopsbench/` | Completed | Performance −9.3pp ns | [exp_perf_only_smoke.md](../../../../../../opensre-notes/exp_perf_only_smoke.md) |
+| 2026-06-11T11:02Z | `6a92295` | [`smoke_db_pod_logs.yml`](smoke_db_pod_logs.yml) | `runs/cloudopsbench_db_pod_logs_smoke_openai/dev-2026-06-11T11-02-51Z_cloudopsbench/` | Completed | Admission +33pp SIG · Performance −14.8pp ns · Aggregate ns | — |
+| 2026-06-11T12:56Z | `1ae5c83` | [`smoke_perf_only.yml`](smoke_perf_only.yml) (V1) | `runs/cloudopsbench_perf_only_smoke_openai/dev-2026-06-11T12-56-37Z_cloudopsbench/` | Completed | Performance −9.3pp ns | — |
 | 2026-06-11T16:08Z | `ec2c675` | [`smoke_perf_only.yml`](smoke_perf_only.yml) (V2) | `runs/cloudopsbench_perf_only_smoke_openai/dev-2026-06-11T16-08-59Z_cloudopsbench/` | Completed | Performance −6.7pp ns | (in exp_perf_only_smoke.md) |
 | 2026-06-11T17:57Z | `65f69e0` | [`smoke_perf_only.yml`](smoke_perf_only.yml) (V3) | `runs/cloudopsbench_perf_only_smoke_openai/dev-2026-06-11T17-57-57Z_cloudopsbench/` | Completed (V3 rolled back) | Performance −13.3pp ns; worse than V1 | (in exp_perf_only_smoke.md) |
-| 2026-06-11T21:03Z | `3d20513` | [`full_n.yml`](full_n.yml) | `runs/cloudopsbench_db_evidence_pipeline_full_openai/2026-06-11T21-03-03Z_cloudopsbench/` | Aborted at 66% (cost budget) | Aggregate +7.13pp SIG · Admission +41.5pp SIG · Unseen +18.8pp SIG — **NOT promotable** (partial + SHA gap) | [exp_db_evidence_pipeline_full_partial.md](../../../../../../opensre-notes/exp_db_evidence_pipeline_full_partial.md) |
+| 2026-06-11T21:03Z | `3d20513` | [`full_n.yml`](full_n.yml) | `runs/cloudopsbench_db_evidence_pipeline_full_openai/2026-06-11T21-03-03Z_cloudopsbench/` | Aborted at 66% (cost budget) | Aggregate +7.13pp SIG · Admission +41.5pp SIG · Unseen +18.8pp SIG — **NOT promotable** (partial + SHA gap) | — |
 | 2026-06-12T~ (in flight) | `c27bee9` | [`full_n.yml`](full_n.yml) | `runs/cloudopsbench_db_evidence_pipeline_full_openai/<pending>/` | Running | (pending) | (pending) |
 
 S3 bucket: `s3://tracer-cloud-bench-results/`. To pull a run locally:
@@ -44,10 +44,6 @@ S3 bucket: `s3://tracer-cloud-bench-results/`. To pull a run locally:
 export AWS_PROFILE=tracer-cloud
 aws s3 sync s3://tracer-cloud-bench-results/<S3 run dir>/ .bench-results/<S3 run dir>/
 ```
-
-Full experiment chain (every cycle, including pre-experiment baselines and
-rejected experiments not represented here):
-[`~/DevBox/tracer-cloud/opensre-notes/cloudopsbench-experiments-chain.md`](../../../../../../opensre-notes/cloudopsbench-experiments-chain.md).
 
 ## Tracking issue
 

--- a/tests/benchmarks/cloudopsbench/configs/experiments/exp_db_evidence_pipeline/smoke_db_pod_logs.yml
+++ b/tests/benchmarks/cloudopsbench/configs/experiments/exp_db_evidence_pipeline/smoke_db_pod_logs.yml
@@ -31,8 +31,7 @@
 # follow-up ablation can attribute the lift between layers. The
 # coordinated-pair design is the load-bearing experimental unit.
 #
-# Motivation (full triage in
-# ~/DevBox/tracer-cloud/opensre-notes/cloudopsbench-experiments-chain.md §10-11):
+# Motivation:
 #   - 50.6% of Runtime opensre+llm losses (118 of 233) are DB-localization
 #     failures on the default-predictor + trimmed-prompt + vocab-fixed
 #     baseline.

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -25,6 +25,14 @@ def _stub_managed_llm_secret_persistence(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(_ui, "save_api_key", lambda *_args, **_kwargs: None)
 
 
+@pytest.fixture(autouse=True)
+def _isolate_integration_store(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Wizard reads existing config via ``integrations.store``; point it at an
+    empty temp store so tests never read the developer's real integrations
+    (e.g. a live Slack bot token) as pre-existing defaults."""
+    monkeypatch.setattr("integrations.store.STORE_PATH", tmp_path / "integrations.json")
+
+
 def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, capsys) -> None:
     # advanced -> falls back to local -> change provider? Yes -> pick anthropic -> skip integrations
     select_responses = iter(

--- a/tests/platform/auth/test_jwt_auth.py
+++ b/tests/platform/auth/test_jwt_auth.py
@@ -27,6 +27,7 @@ def _no_ambient_clerk_override(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.asyncio
 async def test_get_jwks_fetches_once_and_uses_cache_within_ttl() -> None:
     """Lock in JWKS cache behavior so refactors do not refetch per request."""
+    # Arrange
     cache = AsyncJWKSCache(_cache_ttl=3600)
     jwks_url = "https://example.com/.well-known/jwks.json"
     jwks_payload = {
@@ -50,9 +51,11 @@ async def test_get_jwks_fetches_once_and_uses_cache_within_ttl() -> None:
         mock_client.get = AsyncMock(return_value=response)
         mock_async_client_cls.return_value.__aenter__.return_value = mock_client
 
+        # Act: two lookups within the TTL should hit the network only once.
         first = await cache.get_jwks(jwks_url)
         second = await cache.get_jwks(jwks_url)
 
+    # Assert
     assert first == jwks_payload
     assert second == jwks_payload
     assert mock_client.get.await_count == 1
@@ -61,6 +64,7 @@ async def test_get_jwks_fetches_once_and_uses_cache_within_ttl() -> None:
 
 def test_get_signing_key_from_jwks_raises_on_invalid_jwk() -> None:
     """Bad JWK data should raise JWTVerificationError, not a bare Exception."""
+    # Arrange
     token = pyjwt.encode(
         {"sub": "1"},
         "secret",
@@ -69,35 +73,53 @@ def test_get_signing_key_from_jwks_raises_on_invalid_jwk() -> None:
     )
     jwks = {"keys": [{"kid": "bad-kid", "kty": "UNSUPPORTED"}]}
 
+    # Act / Assert
     with pytest.raises(JWTVerificationError, match="Failed to parse JWK"):
         get_signing_key_from_jwks(jwks, token)
 
 
-def test_default_issuers_without_override(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_production_defaults_to_prod_issuer_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange
     monkeypatch.setenv("ENV", "production")
-    assert get_valid_issuers() == [CLERK_CONFIG_PROD.issuer]
 
+    # Act
+    issuers = get_valid_issuers()
+
+    # Assert
+    assert issuers == [CLERK_CONFIG_PROD.issuer]
+
+
+def test_development_accepts_both_default_issuers(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange
     monkeypatch.setenv("ENV", "development")
-    assert get_valid_issuers() == [CLERK_CONFIG_DEV.issuer, CLERK_CONFIG_PROD.issuer]
+
+    # Act
+    issuers = get_valid_issuers()
+
+    # Assert
+    assert issuers == [CLERK_CONFIG_DEV.issuer, CLERK_CONFIG_PROD.issuer]
 
 
 def test_clerk_env_override_is_accepted_in_production(monkeypatch: pytest.MonkeyPatch) -> None:
     """The silo's infra-injected Clerk instance must reach verification (gap G1)."""
+    # Arrange: infra injects the silo's own issuer (with a trailing slash) in prod.
     monkeypatch.setenv("ENV", "production")
     monkeypatch.setenv(CLERK_ISSUER_ENV, f"{_SILO_ISSUER}/")
     monkeypatch.setenv(CLERK_JWKS_URL_ENV, f"{_SILO_ISSUER}/.well-known/jwks.json")
 
+    # Act
     issuers = get_valid_issuers()
 
-    # Trailing slash normalized; hardcoded default kept as fallback.
+    # Assert: trailing slash normalized, override wins, prod default kept as fallback.
     assert issuers[0] == _SILO_ISSUER
     assert CLERK_CONFIG_PROD.issuer in issuers
     assert get_jwks_url_for_issuer(_SILO_ISSUER) == f"{_SILO_ISSUER}/.well-known/jwks.json"
-    # Default issuers still resolve their own JWKS URLs.
     assert get_jwks_url_for_issuer(CLERK_CONFIG_PROD.issuer) == CLERK_CONFIG_PROD.jwks_url
 
 
 def test_clerk_jwks_url_defaults_from_issuer(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: only the issuer is set, no explicit JWKS URL.
     monkeypatch.setenv(CLERK_ISSUER_ENV, _SILO_ISSUER)
 
+    # Act / Assert: JWKS URL is derived from the issuer's well-known path.
     assert get_jwks_url_for_issuer(_SILO_ISSUER) == f"{_SILO_ISSUER}/.well-known/jwks.json"

--- a/tests/platform/auth/test_jwt_auth.py
+++ b/tests/platform/auth/test_jwt_auth.py
@@ -5,11 +5,23 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import jwt as pyjwt
 import pytest
 
+from config.config import CLERK_CONFIG_DEV, CLERK_CONFIG_PROD, CLERK_ISSUER_ENV, CLERK_JWKS_URL_ENV
 from platform.auth.jwt_auth import (
     AsyncJWKSCache,
     JWTVerificationError,
+    get_jwks_url_for_issuer,
     get_signing_key_from_jwks,
+    get_valid_issuers,
 )
+
+_SILO_ISSUER = "https://clerk.example-silo.com"
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_clerk_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests set CLERK_ISSUER / CLERK_JWKS_URL explicitly; ignore the dev shell."""
+    monkeypatch.delenv(CLERK_ISSUER_ENV, raising=False)
+    monkeypatch.delenv(CLERK_JWKS_URL_ENV, raising=False)
 
 
 @pytest.mark.asyncio
@@ -59,3 +71,33 @@ def test_get_signing_key_from_jwks_raises_on_invalid_jwk() -> None:
 
     with pytest.raises(JWTVerificationError, match="Failed to parse JWK"):
         get_signing_key_from_jwks(jwks, token)
+
+
+def test_default_issuers_without_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENV", "production")
+    assert get_valid_issuers() == [CLERK_CONFIG_PROD.issuer]
+
+    monkeypatch.setenv("ENV", "development")
+    assert get_valid_issuers() == [CLERK_CONFIG_DEV.issuer, CLERK_CONFIG_PROD.issuer]
+
+
+def test_clerk_env_override_is_accepted_in_production(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The silo's infra-injected Clerk instance must reach verification (gap G1)."""
+    monkeypatch.setenv("ENV", "production")
+    monkeypatch.setenv(CLERK_ISSUER_ENV, f"{_SILO_ISSUER}/")
+    monkeypatch.setenv(CLERK_JWKS_URL_ENV, f"{_SILO_ISSUER}/.well-known/jwks.json")
+
+    issuers = get_valid_issuers()
+
+    # Trailing slash normalized; hardcoded default kept as fallback.
+    assert issuers[0] == _SILO_ISSUER
+    assert CLERK_CONFIG_PROD.issuer in issuers
+    assert get_jwks_url_for_issuer(_SILO_ISSUER) == f"{_SILO_ISSUER}/.well-known/jwks.json"
+    # Default issuers still resolve their own JWKS URLs.
+    assert get_jwks_url_for_issuer(CLERK_CONFIG_PROD.issuer) == CLERK_CONFIG_PROD.jwks_url
+
+
+def test_clerk_jwks_url_defaults_from_issuer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(CLERK_ISSUER_ENV, _SILO_ISSUER)
+
+    assert get_jwks_url_for_issuer(_SILO_ISSUER) == f"{_SILO_ISSUER}/.well-known/jwks.json"


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

Adds per-organization credit metering and env-driven Clerk verification so each org's gateway silo bills against the webapp ledger and validates JWTs against its own Clerk instance.

**Credit metering** (`gateway/billing/credits_client.py`)
- `consume_credits(...)` POSTs one consumption to the webapp ledger (`{OPENSRE_WEBAPP_URL}/api/credits/consume`, bearer `AGENT_USAGE_SECRET`, body `{amount, organizationId, reason}`) and classifies the result as one of `ALLOWED` / `DENIED` / `UNCONFIGURED` / `UNAVAILABLE`.
- The client only classifies; call sites own policy. Both gateway seams **fail open**: only an explicit HTTP 402 denies a turn. A missing secret/org (`UNCONFIGURED`) or a webapp outage (`UNAVAILABLE`, incl. any non-402 error status or transport error) runs the work anyway, so a misconfiguration or outage never surfaces to users as "out of credits".
- Wired into two metered paths:
  - `gateway/slack/dispatcher.py` — checks before running a Slack turn; on `DENIED` posts "Out of credits — top up in the OpenSRE console." and stops.
  - `gateway/http/worker.py` — checks before an async investigation; on `DENIED` fails the record with `insufficient_credits`.

**Clerk issuer/JWKS override** (`config/config.py`, `platform/auth/jwt_auth.py`)
- New `CLERK_ISSUER` / `CLERK_JWKS_URL` env vars let each org silo verify tokens against its own Clerk instance. When `CLERK_ISSUER` is unset, verification falls back to the hardcoded dev/prod defaults. `CLERK_JWKS_URL` defaults to `{issuer}/.well-known/jwks.json`. The override is accepted in every environment and inserted ahead of the default issuers.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
