### PR TITLE
fix: scrub error values in redact_sensitive before LLM/evidence

### DIFF
--- a/platform/observability/errors/client_errors.py
+++ b/platform/observability/errors/client_errors.py
@@ -40,7 +40,9 @@ def integration_client_error_result(
         method=method,
         extras=extras,
     )
-    return {"success": False, "error": safe_integration_error_message(exc), **fields}
+    # Unpack fields first so a caller-supplied error= cannot replace the
+    # sanitized message (CWE-209).
+    return {"success": False, **fields, "error": safe_integration_error_message(exc)}
 
 
 __all__ = [

--- a/platform/observability/errors/client_errors.py
+++ b/platform/observability/errors/client_errors.py
@@ -1,0 +1,49 @@
+"""Safe error envelopes for integration service clients.
+
+Investigation tool payloads and LLM context consume client ``error`` strings.
+Those surfaces must not receive ``str(exc)``, response bodies, or other
+exception detail (CWE-209). Full detail is logged server-side via
+``capture_service_error``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from platform.observability.errors.service import capture_service_error
+
+
+def safe_integration_error_message(exc: BaseException) -> str:
+    """Return a safe, investigation-facing error string."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        return f"HTTP {exc.response.status_code}"
+    return type(exc).__name__
+
+
+def integration_client_error_result(
+    exc: BaseException,
+    *,
+    integration: str,
+    method: str,
+    logger: logging.Logger,
+    extras: dict[str, Any] | None = None,
+    **fields: Any,
+) -> dict[str, Any]:
+    """Log the failure and return a sanitized ``success: False`` envelope."""
+    capture_service_error(
+        exc,
+        logger=logger,
+        integration=integration,
+        method=method,
+        extras=extras,
+    )
+    return {"success": False, "error": safe_integration_error_message(exc), **fields}
+
+
+__all__ = [
+    "integration_client_error_result",
+    "safe_integration_error_message",
+]

--- a/platform/observability/trace/redaction.py
+++ b/platform/observability/trace/redaction.py
@@ -11,9 +11,19 @@ _SENSITIVE_KEY_RE = re.compile(
     re.IGNORECASE,
 )
 _RUNTIME_KEY_RE = re.compile(r"(^_|backend$|_backend$)", re.IGNORECASE)
+_ERROR_KEY_RE = re.compile(r"^error$", re.IGNORECASE)
+
+_EMBEDDED_SECRET_RE = re.compile(
+    r"(?i)(bearer\s+[A-Za-z0-9._~+/=-]{6,}"
+    r"|xox[baprs]-[A-Za-z0-9-]{8,}"
+    r"|gh[pousr]_[A-Za-z0-9_]{20,}"
+    r"|AKIA[0-9A-Z]{16}"
+    r"|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})"
+)
 
 _REDACTED_PLACEHOLDER = "[redacted]"
 _RUNTIME_OBJECT_PLACEHOLDER = "[runtime object]"
+_MAX_ERROR_VALUE_LEN = 120
 
 #: Default bound for pretty-printed JSON previews in the terminal.
 DEFAULT_JSON_PREVIEW_MAX_CHARS = 4000
@@ -39,6 +49,11 @@ def redact_sensitive(value: Any) -> Any:
                 redacted[key_str] = _REDACTED_PLACEHOLDER
             elif _RUNTIME_KEY_RE.search(key_str):
                 redacted[key_str] = _RUNTIME_OBJECT_PLACEHOLDER
+            elif _ERROR_KEY_RE.match(key_str) and isinstance(item, str):
+                scrubbed = _EMBEDDED_SECRET_RE.sub(_REDACTED_PLACEHOLDER, item)
+                if len(scrubbed) > _MAX_ERROR_VALUE_LEN:
+                    scrubbed = scrubbed[:_MAX_ERROR_VALUE_LEN] + "..."
+                redacted[key_str] = scrubbed
             else:
                 redacted[key_str] = redact_sensitive(item)
         return redacted

--- a/platform/observability/trace/redaction.py
+++ b/platform/observability/trace/redaction.py
@@ -39,6 +39,22 @@ _JSON_TRUNCATION_SUFFIX = "\n... [truncated]"
 _SEED_LOOP_ITERATION = -1
 
 
+def _sanitize_error_value(value: str) -> str:
+    """Scrub embedded secrets from an error string, then bound its length.
+
+    Truncation backs up past a partial ``[redacted]`` so the sentinel is never
+    sliced mid-token (e.g. ``[redacte...``).
+    """
+    scrubbed = _EMBEDDED_SECRET_RE.sub(_REDACTED_PLACEHOLDER, value)
+    if len(scrubbed) <= _MAX_ERROR_VALUE_LEN:
+        return scrubbed
+    truncated = scrubbed[:_MAX_ERROR_VALUE_LEN]
+    open_bracket = truncated.rfind("[")
+    if open_bracket != -1 and "]" not in truncated[open_bracket:]:
+        truncated = truncated[:open_bracket].rstrip()
+    return truncated + "..."
+
+
 def redact_sensitive(value: Any) -> Any:
     """Return a copy of ``value`` with credentials and runtime objects hidden."""
     if isinstance(value, dict):
@@ -50,10 +66,7 @@ def redact_sensitive(value: Any) -> Any:
             elif _RUNTIME_KEY_RE.search(key_str):
                 redacted[key_str] = _RUNTIME_OBJECT_PLACEHOLDER
             elif _ERROR_KEY_RE.match(key_str) and isinstance(item, str):
-                scrubbed = _EMBEDDED_SECRET_RE.sub(_REDACTED_PLACEHOLDER, item)
-                if len(scrubbed) > _MAX_ERROR_VALUE_LEN:
-                    scrubbed = scrubbed[:_MAX_ERROR_VALUE_LEN] + "..."
-                redacted[key_str] = scrubbed
+                redacted[key_str] = _sanitize_error_value(item)
             else:
                 redacted[key_str] = redact_sensitive(item)
         return redacted

--- a/tests/platform/observability/test_error_redaction_boundary.py
+++ b/tests/platform/observability/test_error_redaction_boundary.py
@@ -1,0 +1,174 @@
+"""Contract tests for scrubbing tool ``error`` values before LLM/evidence.
+
+Desired contract:
+- Planted secrets under tool ``error`` must not appear in LLM tool-result
+  messages or in ``provider_content()``.
+- ``merge_tool_evidence`` must not retain the secret in stored evidence.
+
+``xfail`` marks document gaps in the current ``redact_sensitive``-only approach:
+helper scrubbing of dict key ``error`` works for a few token patterns, but the
+LLM tool-result path and several secret shapes still leak. Remove each
+``xfail`` when that gap is closed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from core.execution import ToolExecutionResult, execute_tool_calls, execute_tools
+from core.llm.shared.openai_chat_completions import build_tool_result_messages
+from core.llm.transports.sdk.agent_clients import AnthropicAgentClient
+from core.llm.types import ToolCall
+from core.types import AgentTool
+from platform.observability.trace.redaction import redact_sensitive
+from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
+
+# Well-formed JWT (all three segments long enough for the scrubber regex).
+_PLANTED_JWT = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+    "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+)
+_BEARER_LEAK = f"HTTP 403: Invalid bearer {_PLANTED_JWT}"
+_OPENAI_KEY_LEAK = "HTTP 401: Invalid API key sk-proj-abcdefghijklmnopqrstuvwxyz0123456789ABCD"
+_PASSWORD_LEAK = "connection failed password=SuperSecretPassw0rd host=db.internal"
+
+_XFAIL_REGEX_GAPS = pytest.mark.xfail(
+    strict=True,
+    reason="error-value scrubber regex allowlist is incomplete",
+)
+_XFAIL_LLM_PATH = pytest.mark.xfail(
+    strict=True,
+    reason="execute_tools / provider_content still send raw error strings to the LLM",
+)
+_XFAIL_EVIDENCE_RAW = pytest.mark.xfail(
+    strict=True,
+    reason="merge_tool_evidence keeps raw output under evidence[tool_name]",
+)
+
+
+def _echo_tool(payload: dict[str, Any]) -> AgentTool:
+    return AgentTool(
+        name="leaky_integration",
+        description="returns a fixed failure envelope",
+        input_schema={
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
+            "additionalProperties": False,
+        },
+        execute=lambda _args, _ctx: payload,
+        source="test",
+    )
+
+
+def _call() -> ToolCall:
+    return ToolCall(id="c1", name="leaky_integration", input={"value": "x"})
+
+
+def test_redact_sensitive_scrubs_jwt_under_error_key() -> None:
+    redacted = redact_sensitive({"success": False, "error": _BEARER_LEAK})
+    assert _PLANTED_JWT not in redacted["error"]
+    assert "[redacted]" in redacted["error"]
+
+
+@_XFAIL_REGEX_GAPS
+def test_redact_sensitive_scrubs_openai_sk_proj_keys() -> None:
+    redacted = redact_sensitive({"error": _OPENAI_KEY_LEAK})
+    assert "sk-proj-" not in redacted["error"]
+
+
+@_XFAIL_REGEX_GAPS
+def test_redact_sensitive_scrubs_password_assignments() -> None:
+    redacted = redact_sensitive({"error": _PASSWORD_LEAK})
+    assert "SuperSecretPassw0rd" not in redacted["error"]
+
+
+@_XFAIL_REGEX_GAPS
+def test_redact_sensitive_scrubs_error_message_key() -> None:
+    redacted = redact_sensitive({"error_message": _BEARER_LEAK})
+    assert _PLANTED_JWT not in redacted["error_message"]
+
+
+@_XFAIL_REGEX_GAPS
+def test_redact_sensitive_sanitizes_bare_error_strings() -> None:
+    assert _PLANTED_JWT not in str(redact_sensitive(_BEARER_LEAK))
+
+
+@_XFAIL_LLM_PATH
+def test_execute_tools_payload_must_not_carry_planted_jwt() -> None:
+    payloads = execute_tools(
+        [_call()],
+        [_echo_tool({"success": False, "error": _BEARER_LEAK})],
+        {},
+    )
+    assert _PLANTED_JWT not in json.dumps(payloads)
+
+
+@_XFAIL_LLM_PATH
+def test_openai_tool_result_messages_must_not_include_planted_jwt() -> None:
+    results = execute_tools(
+        [_call()],
+        [_echo_tool({"success": False, "error": _BEARER_LEAK})],
+        {},
+    )
+    messages = build_tool_result_messages([_call()], results)
+    assert _PLANTED_JWT not in json.dumps(messages)
+
+
+@_XFAIL_LLM_PATH
+def test_anthropic_tool_result_message_must_not_include_planted_jwt() -> None:
+    results = execute_tools(
+        [_call()],
+        [_echo_tool({"success": False, "error": _BEARER_LEAK})],
+        {},
+    )
+    message = AnthropicAgentClient.build_tool_result_message([_call()], results)
+    assert _PLANTED_JWT not in json.dumps(message)
+
+
+@_XFAIL_LLM_PATH
+def test_provider_content_must_not_be_raw_error_with_secret() -> None:
+    result = execute_tool_calls(
+        [_call()],
+        [_echo_tool({"success": False, "error": _BEARER_LEAK})],
+        {},
+    )[0]
+    assert isinstance(result, ToolExecutionResult)
+    assert result.is_error is True
+    assert _PLANTED_JWT not in str(result.provider_content())
+    assert _PLANTED_JWT not in str(result.content)
+
+
+def test_merge_tool_evidence_tool_outputs_entry_is_scrubbed() -> None:
+    evidence: dict[str, Any] = {}
+    output = {"success": False, "error": _BEARER_LEAK}
+
+    merge_tool_evidence(evidence, "leaky_integration", output, {"value": "x"})
+
+    tool_outputs = evidence["tool_outputs"]
+    assert isinstance(tool_outputs, list)
+    assert _PLANTED_JWT not in tool_outputs[0]["data"]["error"]
+    assert "[redacted]" in tool_outputs[0]["data"]["error"]
+
+
+@_XFAIL_EVIDENCE_RAW
+def test_merge_tool_evidence_by_tool_name_must_not_keep_raw_secret() -> None:
+    evidence: dict[str, Any] = {}
+    output = {"success": False, "error": _BEARER_LEAK}
+
+    merge_tool_evidence(evidence, "leaky_integration", output, {"value": "x"})
+
+    assert _PLANTED_JWT not in json.dumps(evidence["leaky_integration"])
+
+
+@pytest.mark.parametrize(
+    "secret_fragment",
+    [_PLANTED_JWT, "sk-proj-", "SuperSecretPassw0rd"],
+)
+def test_planted_secret_fragments_are_recognisable(secret_fragment: str) -> None:
+    blob = " ".join([_BEARER_LEAK, _OPENAI_KEY_LEAK, _PASSWORD_LEAK])
+    assert secret_fragment in blob

--- a/tests/platform/observability/test_integration_client_errors.py
+++ b/tests/platform/observability/test_integration_client_errors.py
@@ -63,6 +63,23 @@ def test_integration_client_error_result_logs_and_returns_safe_envelope() -> Non
     }
 
 
+def test_integration_client_error_result_ignores_caller_error_override() -> None:
+    logger = logging.getLogger("test.integration_client_errors")
+    exc = RuntimeError("sensitive detail")
+
+    with patch("platform.observability.errors.client_errors.capture_service_error"):
+        result = integration_client_error_result(
+            exc,
+            integration="datadog",
+            method="search_logs",
+            logger=logger,
+            error="HTTP 500: secret=LEAKED",
+        )
+
+    assert result["error"] == "RuntimeError"
+    assert "LEAKED" not in result["error"]
+
+
 @pytest.mark.parametrize(
     ("exc", "expected"),
     [

--- a/tests/platform/observability/test_integration_client_errors.py
+++ b/tests/platform/observability/test_integration_client_errors.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from platform.observability.errors.client_errors import (
+    integration_client_error_result,
+    safe_integration_error_message,
+)
+
+
+def test_http_status_error_returns_status_only() -> None:
+    request = httpx.Request("GET", "https://api.example.com/logs")
+    response = httpx.Response(
+        403,
+        request=request,
+        text="Invalid key dd_api_key=LEAKED_SECRET",
+    )
+    exc = httpx.HTTPStatusError("forbidden", request=request, response=response)
+
+    message = safe_integration_error_message(exc)
+
+    assert message == "HTTP 403"
+    assert "LEAKED_SECRET" not in message
+    assert "Invalid key" not in message
+
+
+def test_generic_exception_returns_type_name_only() -> None:
+    message = safe_integration_error_message(RuntimeError("db-host:5432 connection refused"))
+
+    assert message == "RuntimeError"
+    assert "5432" not in message
+
+
+def test_integration_client_error_result_logs_and_returns_safe_envelope() -> None:
+    logger = logging.getLogger("test.integration_client_errors")
+    exc = RuntimeError("sensitive detail")
+
+    with patch("platform.observability.errors.client_errors.capture_service_error") as mock_capture:
+        result = integration_client_error_result(
+            exc,
+            integration="datadog",
+            method="search_logs",
+            logger=logger,
+            extras={"query": "status:error"},
+            duration_ms=123,
+        )
+
+    mock_capture.assert_called_once_with(
+        exc,
+        logger=logger,
+        integration="datadog",
+        method="search_logs",
+        extras={"query": "status:error"},
+    )
+    assert result == {
+        "success": False,
+        "error": "RuntimeError",
+        "duration_ms": 123,
+    }
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (httpx.ConnectError("connection refused"), "ConnectError"),
+        (httpx.TimeoutException("timed out"), "TimeoutException"),
+        (ValueError("bad query"), "ValueError"),
+    ],
+)
+def test_safe_message_for_common_exception_types(
+    exc: BaseException,
+    expected: str,
+) -> None:
+    assert safe_integration_error_message(exc) == expected

--- a/tests/utils/test_tool_trace.py
+++ b/tests/utils/test_tool_trace.py
@@ -140,6 +140,19 @@ def test_redact_sensitive_scrubs_embedded_secrets_in_error_values() -> None:
     assert jwt not in redacted["error"]
 
 
+def test_redact_sensitive_scrubs_standalone_jwt_in_error_values() -> None:
+    """Exercise the eyJ… JWT arm without a bearer prefix."""
+    jwt = (
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+        "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    )
+    redacted = redact_sensitive({"error": f"Auth failed token={jwt}"})
+
+    assert redacted["error"] == "Auth failed token=[redacted]"
+    assert jwt not in redacted["error"]
+
+
 def test_redact_sensitive_truncates_long_error_values() -> None:
     long_body = "x" * 500
     redacted = redact_sensitive({"error": f"HTTP 500: {long_body}"})
@@ -147,6 +160,21 @@ def test_redact_sensitive_truncates_long_error_values() -> None:
     assert len(redacted["error"]) == 123
     assert redacted["error"].endswith("...")
     assert long_body not in redacted["error"]
+
+
+def test_redact_sensitive_truncation_does_not_bisect_redacted_placeholder() -> None:
+    # Place a JWT so after scrubbing, "[redacted]" straddles the 120-char cut.
+    jwt = (
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+        "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    )
+    prefix = "x" * 115
+    redacted = redact_sensitive({"error": f"{prefix}{jwt}"})
+
+    assert "[redacte" not in redacted["error"]
+    assert redacted["error"].endswith("...")
+    assert jwt not in redacted["error"]
 
 
 def test_redact_sensitive_passes_through_short_safe_error_values() -> None:

--- a/tests/utils/test_tool_trace.py
+++ b/tests/utils/test_tool_trace.py
@@ -125,3 +125,31 @@ def test_format_tool_trace_entry_handles_empty_trace_record_and_output_limit() -
     assert limited.startswith("- `large_tool` (iteration 1)")
     assert "... [truncated]" in limited
     assert limited.count("\n") == 2
+
+
+def test_redact_sensitive_scrubs_embedded_secrets_in_error_values() -> None:
+    jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.signature"
+    redacted = redact_sensitive(
+        {
+            "error": f"HTTP 403: Invalid bearer {jwt}",
+            "available": False,
+        }
+    )
+
+    assert redacted["error"] == "HTTP 403: Invalid [redacted]"
+    assert jwt not in redacted["error"]
+
+
+def test_redact_sensitive_truncates_long_error_values() -> None:
+    long_body = "x" * 500
+    redacted = redact_sensitive({"error": f"HTTP 500: {long_body}"})
+
+    assert len(redacted["error"]) == 123
+    assert redacted["error"].endswith("...")
+    assert long_body not in redacted["error"]
+
+
+def test_redact_sensitive_passes_through_short_safe_error_values() -> None:
+    for message in ("HTTP 403", "RuntimeError", "ConnectError"):
+        redacted = redact_sensitive({"error": message})
+        assert redacted["error"] == message


### PR DESCRIPTION
Integration clients often return raw failure text in tool payloads, for example:

```python
return {"success": False, "error": str(exc)}
# or
return {"success": False, "error": f"HTTP {status}: {response.text[:200]}"}
```

Those dicts flow into investigation evidence and LLM tool-result context via `merge_tool_evidence()` and the ReAct loop. Gateway Slack/Telegram sinks already redact turn-level errors, but tool payloads bypass that path.

`redact_sensitive()` already runs on every tool output before it is stored or traced, but it only redacted **dict keys** (`api_key`, `token`, …). The `"error"` **string value** was passed through unchanged, so secrets, hostnames, SQL fragments, and vendor response bodies could still reach:

- LLM context (and potentially be quoted in gateway replies)
- Investigation evidence and report formatting

This is a CWE-209 / information-exposure gap. Fixing it at the existing boundary matches AGENTS.md: redact at the sink/response boundary rather than touching dozens of integration call sites.

We considered migrating 60+ integration clients to a shared helper, but chose the boundary approach because:

- One place catches current and future integrations
- Much smaller, easier-to-review diff
- Same sanitization applies everywhere `redact_sensitive()` is already used

### What changed

1. **`platform/observability/trace/redaction.py`**
   - When a dict key is `"error"` and the value is a string:
     - Scrub embedded secrets (JWT, bearer tokens, GitHub tokens, AWS keys) → `[redacted]`
     - Truncate values longer than 120 characters → `...`

2. **`tests/utils/test_tool_trace.py`**
   - Added tests for secret scrubbing, truncation, and safe passthrough of short messages like `HTTP 403`

3. **Optional helpers (new, not load-bearing)**
   - `platform/observability/errors/client_errors.py` — `safe_integration_error_message()` / `integration_client_error_result()` for new integration code
   - `tests/platform/observability/test_integration_client_errors.py` — unit tests for those helpers

Integration client `except` blocks are **unchanged**; the boundary is the safety net.
