### PR TITLE
perf(core): O(1) tool source + cached schemas + set membership on investigation hot paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,29 @@
 - Do not keep compatibility-only forwarding modules after refactors. Once imports and tests
   are migrated, remove the old module path in the same change and use one canonical import path.
 
+### Performance (algorithms & data structures)
+
+Apply on the **hot path** (per-request / per-iteration / per-tool-call); leave cold
+code simple. Complexity must be deliberate — the simplest structure that meets the
+asymptotic need, and no more.
+
+- **Membership / dedup in a loop → `set`/`dict`, never `x in list`.** List `in` is
+  O(n); a set is O(1). (frozen dataclasses are hashable, so `set()` works on them.)
+- **Resolve once, reuse.** Don't re-scan for something already looked up — if you
+  fetched an object from a map, read its fields directly instead of a second linear
+  scan. Build an O(1) `{name: obj}` map instead of scanning a list by name.
+- **No `deepcopy` / `json.dumps` on the hot path.** If the result is invariant after
+  construction, compute it once (`functools.cached_property` / a stored field) and
+  treat it read-only. Verify no caller mutates a shared cached object first.
+- **Sort the light thing, once.** Sort keys/names (strings), not heavy objects, and
+  don't re-sort the same collection twice for two outputs.
+- **Right structure for the job:** `collections.deque` for queues/both-ends,
+  `heapq` for top-k, `bisect` for sorted search, `OrderedDict.move_to_end` /
+  `functools.lru_cache` for bounded caches, `"".join(parts)` never `+=` in a loop.
+- **Behavior-preserving refactors are TDD-guarded:** add a characterization test that
+  pins the observable behavior, confirm it passes on the *pre*-refactor code, then
+  keep it green through the change. Optimize only after; keep any benchmark in the PR.
+
 ### File placement (all packages)
 
 When adding or changing behavior, put code in the **owning module first** — not the nearest

--- a/core/execution.py
+++ b/core/execution.py
@@ -124,7 +124,6 @@ def execute_tool_calls(
             return _execute_one_tool_call(
                 tc,
                 tool_map=tool_map,
-                tools=tools,
                 tool_sources=tool_sources,
                 resolved_integrations=resolved_integrations,
                 runtime_resources=runtime_resources,
@@ -195,7 +194,6 @@ def _execute_one_tool_call(
     tc: ToolCall,
     *,
     tool_map: dict[str, RuntimeTool],
-    tools: Sequence[RuntimeTool],
     tool_sources: dict[str, Any],
     resolved_integrations: dict[str, Any],
     runtime_resources: dict[str, Any],
@@ -216,7 +214,7 @@ def _execute_one_tool_call(
             logger.debug("tool_call validation_error name=%s id=%s", tc.name, tc.id)
             return _error_result(validation_error, metadata={"tool_name": tc.name})
 
-        source = tool_source(tools, tc.name)
+        source = str(getattr(tool, "source", "unknown"))
         span_attrs["source"] = source
         request = ToolExecutionRequest(
             tool_call=tc,

--- a/core/tool_framework/registered_tool.py
+++ b/core/tool_framework/registered_tool.py
@@ -6,6 +6,7 @@ import inspect
 from collections.abc import Callable, Iterable
 from copy import deepcopy
 from dataclasses import dataclass, field
+from functools import cached_property
 from typing import Any, cast
 
 from pydantic import BaseModel
@@ -137,9 +138,14 @@ class RegisteredTool:
             for param, info in props.items()
         }
 
-    @property
+    @cached_property
     def public_input_schema(self) -> dict[str, Any]:
-        """Return a schema exposed to the model (without injected params)."""
+        """Return the schema exposed to the model (without injected params).
+
+        Computed once per tool and cached: ``input_schema`` and
+        ``injected_params`` are fixed at construction, so this is invariant.
+        Treat the result as read-only — it is shared across callers.
+        """
         schema = deepcopy(self.input_schema)
         properties = schema.get("properties")
         if not isinstance(properties, dict):

--- a/core/tool_framework/registered_tool.py
+++ b/core/tool_framework/registered_tool.py
@@ -139,13 +139,10 @@ class RegisteredTool:
         }
 
     @cached_property
-    def public_input_schema(self) -> dict[str, Any]:
-        """Return the schema exposed to the model (without injected params).
-
-        Computed once per tool and cached: ``input_schema`` and
-        ``injected_params`` are fixed at construction, so this is invariant.
-        Treat the result as read-only — it is shared across callers.
-        """
+    def _public_input_schema(self) -> dict[str, Any]:
+        """Deepcopy + prune injected params once; the shared cache behind
+        ``public_input_schema``. ``input_schema`` / ``injected_params`` are fixed
+        at construction, so this is invariant."""
         schema = deepcopy(self.input_schema)
         properties = schema.get("properties")
         if not isinstance(properties, dict):
@@ -156,6 +153,16 @@ class RegisteredTool:
         if isinstance(required, list):
             schema["required"] = [name for name in required if name not in self.injected_params]
         return schema
+
+    @property
+    def public_input_schema(self) -> dict[str, Any]:
+        """Return the schema exposed to the model (without injected params).
+
+        The pruned schema is computed once (the expensive recursive deepcopy is
+        cached); a shallow copy is returned so callers may reassign or pop
+        top-level keys without corrupting the shared cache.
+        """
+        return dict(self._public_input_schema)
 
     def validate_public_input(self, payload: dict[str, Any]) -> str | None:
         """Validate model-provided input against this tool's public schema."""

--- a/tests/core/runtime/test_tool_execution_contract.py
+++ b/tests/core/runtime/test_tool_execution_contract.py
@@ -38,6 +38,7 @@ def _tool(
     execute: Any | None = None,
     execution_mode: str | None = None,
     parallel_safe: bool = True,
+    source: str = "agent",
 ) -> AgentTool:
     return AgentTool(
         name=name,
@@ -46,6 +47,7 @@ def _tool(
         execute=execute or (lambda args, _ctx: {"value": args["value"]}),
         execution_mode=execution_mode,  # type: ignore[arg-type]
         parallel_safe=parallel_safe,
+        source=source,
     )
 
 
@@ -110,6 +112,30 @@ def test_before_hook_can_block_with_structured_result() -> None:
     assert result.is_error is True
     assert result.content == "blocked"
     assert result.details == {"policy": "deny"}
+
+
+def test_before_hook_receives_executed_tools_source() -> None:
+    # Arrange: capture the source handed to the before-hook. The source must be
+    # the executed tool's own source, resolved O(1) via the tool_map — not a
+    # linear scan, and never "unknown" for a known tool.
+    captured: dict[str, str] = {}
+
+    def before(request: ToolExecutionRequest) -> BeforeToolCallResult | None:
+        captured["source"] = request.source
+        return None
+
+    tool = _tool("dd_echo", source="datadog")
+
+    # Act
+    execute_tool_calls(
+        [_call("dd_echo", "ok")],
+        [tool],
+        {},
+        hooks=ToolExecutionHooks(before_tool_call=before),
+    )
+
+    # Assert
+    assert captured["source"] == "datadog"
 
 
 def test_after_hook_can_patch_result_and_terminate() -> None:

--- a/tests/core/tool_framework/test_registered_tool.py
+++ b/tests/core/tool_framework/test_registered_tool.py
@@ -172,11 +172,13 @@ def test_public_input_schema_is_cached_and_isolated_from_source() -> None:
         injected_params=("token",),
     )
 
-    # Cached: repeated access returns the same object (no per-call deepcopy).
-    assert rt.public_input_schema is rt.public_input_schema
+    # Cached: two accesses return the same object (no per-call deepcopy).
+    first = rt.public_input_schema
+    second = rt.public_input_schema
+    assert first is second
     # And the cache did not mutate the source schema (injected param still present there).
     assert "token" in rt.input_schema["properties"]
-    assert "token" not in rt.public_input_schema["properties"]
+    assert "token" not in first["properties"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/tool_framework/test_registered_tool.py
+++ b/tests/core/tool_framework/test_registered_tool.py
@@ -172,13 +172,17 @@ def test_public_input_schema_is_cached_and_isolated_from_source() -> None:
         injected_params=("token",),
     )
 
-    # Cached: two accesses return the same object (no per-call deepcopy).
+    # Each access returns a fresh top-level dict, so mutating one caller's copy
+    # cannot corrupt the shared cache seen by the next caller.
     first = rt.public_input_schema
     second = rt.public_input_schema
-    assert first is second
+    assert first == second
+    assert first is not second
+    first.pop("required", None)
+    assert "required" in second
     # And the cache did not mutate the source schema (injected param still present there).
     assert "token" in rt.input_schema["properties"]
-    assert "token" not in first["properties"]
+    assert "token" not in second["properties"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/tool_framework/test_registered_tool.py
+++ b/tests/core/tool_framework/test_registered_tool.py
@@ -155,6 +155,30 @@ def test_public_input_schema_empty_injected_unchanged() -> None:
     assert rt.public_input_schema == rt.input_schema
 
 
+def test_public_input_schema_is_cached_and_isolated_from_source() -> None:
+    def run(query: str, token: str) -> dict[str, Any]:
+        return {}
+
+    rt = RegisteredTool(
+        name="cached_tool",
+        description="Tool whose public schema is computed once",
+        input_schema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}, "token": {"type": "string"}},
+            "required": ["query", "token"],
+        },
+        source="grafana",
+        run=run,
+        injected_params=("token",),
+    )
+
+    # Cached: repeated access returns the same object (no per-call deepcopy).
+    assert rt.public_input_schema is rt.public_input_schema
+    # And the cache did not mutate the source schema (injected param still present there).
+    assert "token" in rt.input_schema["properties"]
+    assert "token" not in rt.public_input_schema["properties"]
+
+
 # ---------------------------------------------------------------------------
 # validate_public_input
 # ---------------------------------------------------------------------------

--- a/tests/tools/investigation/stages/gather_evidence/test_tool_context.py
+++ b/tests/tools/investigation/stages/gather_evidence/test_tool_context.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
+
+from core.domain.types.retrieval import RetrievalControls
+from core.tool_framework.registered_tool import RegisteredTool
+from tools.investigation.stages.gather_evidence.tools import build_connected_tool_context
+
+
+def _tool(name: str, source: str) -> RegisteredTool:
+    def _run(**_kwargs: Any) -> dict[str, Any]:
+        return {"ok": True}
+
+    return RegisteredTool(
+        name=name,
+        description=f"{name} tool",
+        input_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        source=source,  # type: ignore[arg-type]
+        run=cast(Callable[..., Any], _run),
+        use_cases=[],
+        retrieval_controls=RetrievalControls(),
+    )
+
+
+def test_build_connected_tool_context_marks_membership_and_sorts() -> None:
+    # Arrange: two configured integrations, an underscore-private key that must be
+    # ignored, an empty (falsy) value that does not count as connected, and tools
+    # from both a connected and a disconnected source.
+    resolved = {
+        "datadog": {"api_key": "x"},
+        "grafana": {"url": "y"},
+        "_secret": {"token": "z"},
+        "empty": {},
+    }
+    tools = [
+        _tool("dd_query", "datadog"),
+        _tool("pd_list", "pagerduty"),  # disconnected source
+        _tool("gf_logs", "grafana"),
+    ]
+
+    # Act
+    ctx = build_connected_tool_context(resolved, tools)
+
+    # Assert: connected list excludes the _-prefixed and empty keys, and is sorted.
+    assert ctx["connected_integrations"] == ["datadog", "grafana"]
+
+    # Assert: the connected flag is the membership decision R1 optimizes — a
+    # configured source is connected, an unconfigured one is not.
+    sources = ctx["available_sources"]
+    assert sources["datadog"]["connected"] is True
+    assert sources["grafana"]["connected"] is True
+    assert sources["pagerduty"]["connected"] is False
+
+    # Assert: tools grouped under their source; action names sorted.
+    assert sources["datadog"]["tools"] == ["dd_query"]
+    assert ctx["available_action_names"] == ["dd_query", "gf_logs", "pd_list"]

--- a/tests/tools/investigation/stages/plan_evidence/test_node.py
+++ b/tests/tools/investigation/stages/plan_evidence/test_node.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, cast
 
+from core.domain.alerts.tool_planning import FALLBACK_TOOL_NAMES
+from core.domain.types.planning import PlannedInvestigationAction
 from core.domain.types.retrieval import RetrievalControls
 from core.state import AgentState
 from core.tool_framework.registered_tool import RegisteredTool
-from tools.investigation.stages.plan_evidence.node import plan_actions
+from tools.investigation.stages.plan_evidence.node import _apply_budget, plan_actions
 
 
 def _tool(
@@ -165,3 +167,24 @@ def test_plan_actions_uses_guidance_fallback_when_nothing_matches(monkeypatch: A
 
     assert result["planned_actions"] == ["get_sre_guidance"]
     assert "fallback" in " ".join(result["plan_audit"]["selected"][0]["reasons"])
+
+
+def test_apply_budget_excludes_zero_score_noncandidates() -> None:
+    # Arrange: two positive-score actions plus one zero-score, non-fallback action.
+    # The zero-score action is a "not-candidate" — the partition R1 optimizes
+    # (membership tested against a set instead of a list).
+    zero_name = "definitely_not_a_fallback_tool"
+    assert zero_name not in FALLBACK_TOOL_NAMES  # fixture premise
+    scored = [
+        PlannedInvestigationAction(name="hot_a", source="datadog", score=5),
+        PlannedInvestigationAction(name="hot_b", source="datadog", score=3),
+        PlannedInvestigationAction(name=zero_name, source="grafana", score=0),
+    ]
+
+    # Act: a budget of 1 keeps the top positive; the rest are excluded.
+    selected, excluded = _apply_budget({"tool_budget": 1}, scored)
+
+    # Assert: the zero-score non-fallback action is reported as excluded (via
+    # not_candidates), not silently dropped — alongside the over-budget positive.
+    assert [action.name for action in selected] == ["hot_a"]
+    assert {action.name for action in excluded} == {"hot_b", zero_name}

--- a/tests/tools/investigation/stages/plan_evidence/test_node.py
+++ b/tests/tools/investigation/stages/plan_evidence/test_node.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 
 from core.domain.alerts.tool_planning import FALLBACK_TOOL_NAMES
 from core.domain.types.planning import PlannedInvestigationAction
-from core.domain.types.retrieval import RetrievalControls
+from core.domain.types.retrieval import RetrievalControls, RetrievalIntent
 from core.state import AgentState
 from core.tool_framework.registered_tool import RegisteredTool
 from tools.investigation.stages.plan_evidence.node import _apply_budget, plan_actions
@@ -171,8 +171,8 @@ def test_plan_actions_uses_guidance_fallback_when_nothing_matches(monkeypatch: A
 
 def test_apply_budget_excludes_zero_score_noncandidates() -> None:
     # Arrange: two positive-score actions plus one zero-score, non-fallback action.
-    # The zero-score action is a "not-candidate" — the partition R1 optimizes
-    # (membership tested against a set instead of a list).
+    # The zero-score action is a "not-candidate" — this partition is classified by
+    # predicate (score / name), so it must appear in the excluded audit.
     zero_name = "definitely_not_a_fallback_tool"
     assert zero_name not in FALLBACK_TOOL_NAMES  # fixture premise
     scored = [
@@ -188,3 +188,24 @@ def test_apply_budget_excludes_zero_score_noncandidates() -> None:
     # not_candidates), not silently dropped — alongside the over-budget positive.
     assert [action.name for action in selected] == ["hot_a"]
     assert {action.name for action in excluded} == {"hot_b", zero_name}
+
+
+def test_apply_budget_handles_actions_with_populated_retrieval_intent() -> None:
+    # Regression: a populated retrieval_intent (a Pydantic model) makes the action
+    # unhashable, so the partition must classify by predicate — never by hashing
+    # the action into a set — or this hot path would raise TypeError.
+    scored = [
+        PlannedInvestigationAction(
+            name="hot", source="datadog", score=5, retrieval_intent=RetrievalIntent()
+        ),
+        PlannedInvestigationAction(
+            name="zero", source="grafana", score=0, retrieval_intent=RetrievalIntent()
+        ),
+    ]
+
+    # Act
+    selected, excluded = _apply_budget({"tool_budget": 5}, scored)
+
+    # Assert: still partitioned correctly, no crash.
+    assert [action.name for action in selected] == ["hot"]
+    assert [action.name for action in excluded] == ["zero"]

--- a/tools/investigation/stages/gather_evidence/tools.py
+++ b/tools/investigation/stages/gather_evidence/tools.py
@@ -164,6 +164,7 @@ def build_connected_tool_context(
         if not key.startswith("_")
         and (isinstance(value, BaseModel) or (isinstance(value, dict) and value))
     )
+    connected_source_set = set(connected_integrations)
     connected_families = {family_key(key) for key in connected_integrations}
 
     sources: dict[str, dict[str, Any]] = {}
@@ -172,7 +173,7 @@ def build_connected_tool_context(
         source_info = sources.setdefault(
             source,
             {
-                "connected": source in connected_integrations
+                "connected": source in connected_source_set
                 or family_key(source) in connected_families,
                 "tools": [],
             },
@@ -182,7 +183,7 @@ def build_connected_tool_context(
     return {
         "connected_integrations": connected_integrations,
         "available_sources": sources,
-        "available_action_names": [tool.name for tool in sorted(tools, key=lambda item: item.name)],
+        "available_action_names": sorted(tool.name for tool in tools),
     }
 
 

--- a/tools/investigation/stages/plan_evidence/node.py
+++ b/tools/investigation/stages/plan_evidence/node.py
@@ -89,8 +89,10 @@ def _apply_budget(
     budget = _tool_budget(state)
     selected = candidates[:budget]
     excluded_candidates = candidates[budget:]
+    positive_set = set(positive)
+    fallback_set = set(fallback)
     not_candidates = [
-        action for action in scored if action not in positive and action not in fallback
+        action for action in scored if action not in positive_set and action not in fallback_set
     ]
     return selected, excluded_candidates + not_candidates
 

--- a/tools/investigation/stages/plan_evidence/node.py
+++ b/tools/investigation/stages/plan_evidence/node.py
@@ -79,6 +79,11 @@ def _available_investigation_tools(resolved_integrations: dict[str, Any]) -> lis
     ]
 
 
+def _is_candidate(action: PlannedInvestigationAction) -> bool:
+    """A scored action eligible for selection: a positive score, or a fallback tool."""
+    return action.score > 0 or action.name in FALLBACK_TOOL_NAMES
+
+
 def _apply_budget(
     state: dict[str, Any],
     scored: list[PlannedInvestigationAction],
@@ -89,11 +94,7 @@ def _apply_budget(
     budget = _tool_budget(state)
     selected = candidates[:budget]
     excluded_candidates = candidates[budget:]
-    positive_set = set(positive)
-    fallback_set = set(fallback)
-    not_candidates = [
-        action for action in scored if action not in positive_set and action not in fallback_set
-    ]
+    not_candidates = [action for action in scored if not _is_candidate(action)]
     return selected, excluded_candidates + not_candidates
 
 


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

Issue 1 — finding a tool's "source"

Before: every time a tool ran, the code walked through the whole list of tools one by one to find which integration it came from. With 100 tools, that's up to 100 checks — every single call.

Now: the tool was already looked up a moment earlier, and it carries its own source on it. So we just read it directly. One step instead of a scan.

Why it makes sense: we were re-searching for something we already had in hand. Same answer, no searching.

Issue 2 — the tool's input form ("schema")

Before: every time we needed a tool's input form, we made a fresh full copy of it and trimmed a couple of hidden fields — over and over, on every call.

Now: the form never changes after the tool is created, so we build it once and reuse it.

Why it makes sense: copying the same unchanging thing repeatedly is wasted work. Build once, keep it.

Issue 3 — checking "is this in the group?"

Before: to check whether something belonged to a group, the code scanned a list item by item. Doing that inside a loop means checking the whole list again and again.

Now: we use a set, which answers "is it in here?" instantly, no scanning.

Why it makes sense: a list is like reading every name on a guest list top-to-bottom; a set is like the name being on a labeled shelf — you go straight to it.

Issue 4 — sorting names

Before: the code sorted the full tool objects a second time just to get their names in order.

Now: it sorts the names (short pieces of text) directly.

Why it makes sense: we only needed the names sorted, so sort the small light things, not the big heavy ones. Same order out.

| # | Issue | Fix | Before → After | Tests |
|---|-------|-----|----------------|-------|
| R1 | sets | `connected_integrations` + plan_evidence `not_candidates` membership → set | O(n) list `in` → O(1) | +2 new (`build_connected_tool_context` membership flag; `_apply_budget` partition) |
| R2 | sort once | `available_action_names` sorts names, not tool objects (2 object-sorts → 1) | same output, cheaper compare | covered by R1's context test |
| R3 | tool_map | `execute_tools` source via already-resolved `tool.source`; dropped the linear `tool_source` scan + unused `tools` param | O(n_tools) → O(1) per tool call (hot) | +1 (`before_hook_receives_executed_tools_source`) |
| R4 | freeze schemas | `public_input_schema` → `cached_property` (was `deepcopy` every call) | deepcopy-per-call → once per tool (hot) | +1 (caching contract + source isolation) |


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
