### PR TITLE
refactor(integrations): share relational read-only query wrapper; ado…

### DIFF
--- a/integrations/_relational.py
+++ b/integrations/_relational.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import functools
+import logging
 import os
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Concatenate, Protocol
 
 from pydantic import field_validator
 
 from config.strict_config import StrictConfigModel
+from core.tool_framework.utils.tool_availability import tool_unavailable
+from integrations._validation_helpers import report_validation_failure
 
 _TRUE_ENV_VALUES = frozenset({"true", "1", "yes"})
 
@@ -89,3 +93,74 @@ def resolve_stored_or_env_config[ConfigT](
         )
 
     return build_config({"host": host, "port": port, "database": database})
+
+
+class SupportsIsConfigured(Protocol):
+    """Minimal shape :func:`read_only_query` needs from a relational config."""
+
+    @property
+    def is_configured(self) -> bool: ...
+
+
+class ReadOnlyQueryDecorator[ConfigT: SupportsIsConfigured](Protocol):
+    """Decorator returned by :func:`read_only_query`, bound to one vendor."""
+
+    def __call__[**P](
+        self,
+        fn: Callable[Concatenate[Any, ConfigT, P], dict[str, Any]],
+        /,
+    ) -> Callable[Concatenate[ConfigT, P], dict[str, Any]]: ...
+
+
+def read_only_query[ConfigT: SupportsIsConfigured](
+    *,
+    integration: str,
+    logger: logging.Logger,
+    connect: Callable[[ConfigT], Any],
+) -> ReadOnlyQueryDecorator[ConfigT]:
+    """Build a decorator that owns the read-only diagnostic-query lifecycle.
+
+    Every relational diagnostic function repeats the same skeleton: bail out
+    when the config is incomplete, open a connection, run queries on a cursor,
+    close the connection, and convert any failure into the standard
+    ``tool_unavailable`` envelope after reporting it. This factory binds the
+    vendor-constant pieces (``integration``, ``logger``, ``connect``) once per
+    package so each decorated function contains only its own queries and
+    result shaping.
+
+    The decorated function is written as ``fn(cursor, config, ...)`` and is
+    exposed to callers as ``fn(config, ...)`` — the cursor is supplied by the
+    wrapper. ``method`` in the failure report is taken from ``fn.__name__``.
+
+    Cursor semantics stay with the vendor: the wrapper only opens
+    ``conn.cursor()`` and closes the connection, so DB-API differences (dict
+    vs. tuple rows, driver-specific error types) remain the caller's business.
+    """
+
+    def decorator[**P](
+        fn: Callable[Concatenate[Any, ConfigT, P], dict[str, Any]],
+        /,
+    ) -> Callable[Concatenate[ConfigT, P], dict[str, Any]]:
+        @functools.wraps(fn)
+        def wrapper(config: ConfigT, /, *args: P.args, **kwargs: P.kwargs) -> dict[str, Any]:
+            if not config.is_configured:
+                return tool_unavailable(integration, "Not configured.")
+            try:
+                conn = connect(config)
+                try:
+                    with conn.cursor() as cursor:
+                        return fn(cursor, config, *args, **kwargs)
+                finally:
+                    conn.close()
+            except Exception as err:
+                report_validation_failure(
+                    err,
+                    logger=logger,
+                    integration=integration,
+                    method=fn.__name__,
+                )
+                return tool_unavailable(integration, str(err))
+
+        return wrapper
+
+    return decorator

--- a/integrations/_relational.py
+++ b/integrations/_relational.py
@@ -6,7 +6,7 @@ import functools
 import logging
 import os
 from collections.abc import Callable
-from typing import Any, Concatenate, Protocol
+from typing import Any, Protocol
 
 from pydantic import field_validator
 
@@ -99,17 +99,15 @@ class SupportsIsConfigured(Protocol):
     """Minimal shape :func:`read_only_query` needs from a relational config."""
 
     @property
-    def is_configured(self) -> bool: ...
+    def is_configured(self) -> bool:
+        raise NotImplementedError
 
 
-class ReadOnlyQueryDecorator[ConfigT: SupportsIsConfigured](Protocol):
-    """Decorator returned by :func:`read_only_query`, bound to one vendor."""
-
-    def __call__[**P](
-        self,
-        fn: Callable[Concatenate[Any, ConfigT, P], dict[str, Any]],
-        /,
-    ) -> Callable[Concatenate[ConfigT, P], dict[str, Any]]: ...
+# Diagnostic query functions. Deliberately loose: the decorator rewrites the
+# signature from ``fn(cursor, config, ...)`` to ``fn(config, ...)``, and spelling
+# that precisely needs a ParamSpec, which this codebase does not otherwise use
+# and which CodeQL's Python analyzer misreads as an uninitialized local.
+type ReadOnlyQuery = Callable[..., dict[str, Any]]
 
 
 def read_only_query[ConfigT: SupportsIsConfigured](
@@ -117,7 +115,7 @@ def read_only_query[ConfigT: SupportsIsConfigured](
     integration: str,
     logger: logging.Logger,
     connect: Callable[[ConfigT], Any],
-) -> ReadOnlyQueryDecorator[ConfigT]:
+) -> Callable[[ReadOnlyQuery], ReadOnlyQuery]:
     """Build a decorator that owns the read-only diagnostic-query lifecycle.
 
     Every relational diagnostic function repeats the same skeleton: bail out
@@ -137,12 +135,9 @@ def read_only_query[ConfigT: SupportsIsConfigured](
     vs. tuple rows, driver-specific error types) remain the caller's business.
     """
 
-    def decorator[**P](
-        fn: Callable[Concatenate[Any, ConfigT, P], dict[str, Any]],
-        /,
-    ) -> Callable[Concatenate[ConfigT, P], dict[str, Any]]:
+    def decorator(fn: ReadOnlyQuery, /) -> ReadOnlyQuery:
         @functools.wraps(fn)
-        def wrapper(config: ConfigT, /, *args: P.args, **kwargs: P.kwargs) -> dict[str, Any]:
+        def wrapper(config: ConfigT, /, *args: Any, **kwargs: Any) -> dict[str, Any]:
             if not config.is_configured:
                 return tool_unavailable(integration, "Not configured.")
             try:

--- a/integrations/mysql/__init__.py
+++ b/integrations/mysql/__init__.py
@@ -14,11 +14,11 @@ from typing import Any
 
 from pydantic import Field, field_validator
 
-from core.tool_framework.utils.tool_availability import tool_unavailable
 from integrations._relational import (
     RelationalConfigBase,
     env_int,
     env_str,
+    read_only_query,
     resolve_stored_or_env_config,
 )
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
@@ -161,6 +161,10 @@ def _get_connection(config: MySQLConfig) -> Any:
     )
 
 
+# Owns the connect/query/error lifecycle for every read-only diagnostic below.
+_read_only = read_only_query(integration="mysql", logger=logger, connect=_get_connection)
+
+
 def validate_mysql_config(config: MySQLConfig) -> MySQLValidationResult:
     """Validate MySQL connectivity with a lightweight query."""
     if not config.host:
@@ -212,14 +216,12 @@ def mysql_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     }
 
 
-def get_server_status(config: MySQLConfig) -> dict[str, Any]:
+@_read_only
+def get_server_status(cursor: Any, _config: MySQLConfig) -> dict[str, Any]:
     """Retrieve server status (connections, uptime, InnoDB buffer pool metrics).
 
     Read-only: uses SHOW GLOBAL STATUS and SHOW VARIABLES.
     """
-    if not config.is_configured:
-        return tool_unavailable("mysql", "Not configured.")
-
     _STATUS_KEYS = frozenset(
         {
             "Threads_connected",
@@ -251,67 +253,55 @@ def get_server_status(config: MySQLConfig) -> dict[str, Any]:
         }
     )
 
-    try:
-        conn = _get_connection(config)
-        try:
-            with conn.cursor() as cur:
-                cur.execute("SHOW GLOBAL STATUS")
-                all_status = {row["Variable_name"]: row["Value"] for row in cur.fetchall()}
-                metrics = {k: all_status[k] for k in sorted(_STATUS_KEYS) if k in all_status}
+    cursor.execute("SHOW GLOBAL STATUS")
+    all_status = {row["Variable_name"]: row["Value"] for row in cursor.fetchall()}
+    metrics = {k: all_status[k] for k in sorted(_STATUS_KEYS) if k in all_status}
 
-                cur.execute(
-                    "SHOW VARIABLES WHERE Variable_name IN ("
-                    + ", ".join(f"'{k}'" for k in sorted(_VARIABLE_KEYS))
-                    + ")"
-                )
-                variables = {row["Variable_name"]: row["Value"] for row in cur.fetchall()}
+    cursor.execute(
+        "SHOW VARIABLES WHERE Variable_name IN ("
+        + ", ".join(f"'{k}'" for k in sorted(_VARIABLE_KEYS))
+        + ")"
+    )
+    variables = {row["Variable_name"]: row["Value"] for row in cursor.fetchall()}
 
-                # Calculate InnoDB buffer pool hit ratio
-                pool_reads = int(all_status.get("Innodb_buffer_pool_reads", 0))
-                pool_requests = int(all_status.get("Innodb_buffer_pool_read_requests", 0))
-                pool_hit_ratio = 0.0
-                if pool_requests > 0:
-                    pool_hit_ratio = round((1 - pool_reads / pool_requests) * 100, 2)
+    # Calculate InnoDB buffer pool hit ratio
+    pool_reads = int(all_status.get("Innodb_buffer_pool_reads", 0))
+    pool_requests = int(all_status.get("Innodb_buffer_pool_read_requests", 0))
+    pool_hit_ratio = 0.0
+    if pool_requests > 0:
+        pool_hit_ratio = round((1 - pool_reads / pool_requests) * 100, 2)
 
-                return {
-                    "source": "mysql",
-                    "available": True,
-                    "version": variables.get("version", "unknown"),
-                    "version_comment": variables.get("version_comment", ""),
-                    "uptime_seconds": int(all_status.get("Uptime", 0)),
-                    "connections": {
-                        "current": int(all_status.get("Threads_connected", 0)),
-                        "running": int(all_status.get("Threads_running", 0)),
-                        "max": int(variables.get("max_connections", 0)),
-                        "max_used": int(all_status.get("Max_used_connections", 0)),
-                        "aborted_clients": int(all_status.get("Aborted_clients", 0)),
-                        "aborted_connects": int(all_status.get("Aborted_connects", 0)),
-                    },
-                    "queries": {
-                        "total": int(all_status.get("Questions", 0)),
-                        "slow": int(all_status.get("Slow_queries", 0)),
-                    },
-                    "innodb": {
-                        "buffer_pool_size_bytes": int(variables.get("innodb_buffer_pool_size", 0)),
-                        "buffer_pool_hit_ratio_percent": pool_hit_ratio,
-                        "row_lock_waits": int(all_status.get("Innodb_row_lock_waits", 0)),
-                        "deadlocks": int(all_status.get("Innodb_deadlocks", 0)),
-                    },
-                    "metrics": metrics,
-                }
-        finally:
-            conn.close()
-    except Exception as err:
-        report_validation_failure(
-            err,
-            logger=logger,
-            integration="mysql",
-            method="get_server_status",
-        )
-        return tool_unavailable("mysql", str(err))
+    return {
+        "source": "mysql",
+        "available": True,
+        "version": variables.get("version", "unknown"),
+        "version_comment": variables.get("version_comment", ""),
+        "uptime_seconds": int(all_status.get("Uptime", 0)),
+        "connections": {
+            "current": int(all_status.get("Threads_connected", 0)),
+            "running": int(all_status.get("Threads_running", 0)),
+            "max": int(variables.get("max_connections", 0)),
+            "max_used": int(all_status.get("Max_used_connections", 0)),
+            "aborted_clients": int(all_status.get("Aborted_clients", 0)),
+            "aborted_connects": int(all_status.get("Aborted_connects", 0)),
+        },
+        "queries": {
+            "total": int(all_status.get("Questions", 0)),
+            "slow": int(all_status.get("Slow_queries", 0)),
+        },
+        "innodb": {
+            "buffer_pool_size_bytes": int(variables.get("innodb_buffer_pool_size", 0)),
+            "buffer_pool_hit_ratio_percent": pool_hit_ratio,
+            "row_lock_waits": int(all_status.get("Innodb_row_lock_waits", 0)),
+            "deadlocks": int(all_status.get("Innodb_deadlocks", 0)),
+        },
+        "metrics": metrics,
+    }
 
 
+@_read_only
 def get_current_processes(
+    cursor: Any,
     config: MySQLConfig,
     threshold_seconds: int = 1,
 ) -> dict[str, Any]:
@@ -320,69 +310,50 @@ def get_current_processes(
     Read-only: queries information_schema.PROCESSLIST.
     Results are capped at config.max_results.
     """
-    if not config.is_configured:
-        return tool_unavailable("mysql", "Not configured.")
-
-    try:
-        conn = _get_connection(config)
-        try:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    SELECT ID, USER, HOST, DB, COMMAND, TIME, STATE, INFO
-                    FROM information_schema.PROCESSLIST
-                    WHERE COMMAND != 'Sleep'
-                      AND ID != CONNECTION_ID()
-                      AND TIME >= %s
-                    ORDER BY TIME DESC
-                    LIMIT %s
-                    """,
-                    (threshold_seconds, config.max_results),
-                )
-                processes = []
-                for row in cur.fetchall():
-                    processes.append(
-                        {
-                            "id": row["ID"],
-                            "user": row["USER"],
-                            "host": row["HOST"] or "",
-                            "database": row["DB"] or "",
-                            "command": row["COMMAND"],
-                            "time_seconds": row["TIME"] or 0,
-                            "state": row["STATE"] or "",
-                            "query": truncate(row["INFO"] or "", _QUERY_TRUNCATE_LEN),
-                        }
-                    )
-
-                return {
-                    "source": "mysql",
-                    "available": True,
-                    "threshold_seconds": threshold_seconds,
-                    "total_processes": len(processes),
-                    "processes": processes,
-                }
-        finally:
-            conn.close()
-    except Exception as err:
-        report_validation_failure(
-            err,
-            logger=logger,
-            integration="mysql",
-            method="get_current_processes",
+    cursor.execute(
+        """
+        SELECT ID, USER, HOST, DB, COMMAND, TIME, STATE, INFO
+        FROM information_schema.PROCESSLIST
+        WHERE COMMAND != 'Sleep'
+          AND ID != CONNECTION_ID()
+          AND TIME >= %s
+        ORDER BY TIME DESC
+        LIMIT %s
+        """,
+        (threshold_seconds, config.max_results),
+    )
+    processes = []
+    for row in cursor.fetchall():
+        processes.append(
+            {
+                "id": row["ID"],
+                "user": row["USER"],
+                "host": row["HOST"] or "",
+                "database": row["DB"] or "",
+                "command": row["COMMAND"],
+                "time_seconds": row["TIME"] or 0,
+                "state": row["STATE"] or "",
+                "query": truncate(row["INFO"] or "", _QUERY_TRUNCATE_LEN),
+            }
         )
-        return tool_unavailable("mysql", str(err))
+
+    return {
+        "source": "mysql",
+        "available": True,
+        "threshold_seconds": threshold_seconds,
+        "total_processes": len(processes),
+        "processes": processes,
+    }
 
 
-def get_replication_status(config: MySQLConfig) -> dict[str, Any]:
+@_read_only
+def get_replication_status(cursor: Any, _config: MySQLConfig) -> dict[str, Any]:
     """Retrieve replication status (replica IO/SQL thread health, lag).
 
     Read-only: uses SHOW REPLICA STATUS (MySQL 8.0.22+) with fallback to
     SHOW SLAVE STATUS for older versions.
     Returns a note if the server is not configured as a replica.
     """
-    if not config.is_configured:
-        return tool_unavailable("mysql", "Not configured.")
-
     # Curated fields — includes both old (Slave_*) and new (Replica_*) column names
     _REPLICA_KEYS = (
         "Replica_IO_Running",
@@ -403,57 +374,45 @@ def get_replication_status(config: MySQLConfig) -> dict[str, Any]:
         "Exec_Master_Log_Pos",
     )
 
-    try:
-        conn = _get_connection(config)
+    rows: list[dict[str, Any]] = []
+
+    # MySQL 8.0.22+ uses SHOW REPLICA STATUS; older uses SHOW SLAVE STATUS
+    for stmt in ("SHOW REPLICA STATUS", "SHOW SLAVE STATUS"):
         try:
-            with conn.cursor() as cur:
-                rows: list[dict[str, Any]] = []
+            cursor.execute(stmt)
+            rows = list(cursor.fetchall())
+            break
+        except Exception as stmt_err:
+            import pymysql as _pymysql
 
-                # MySQL 8.0.22+ uses SHOW REPLICA STATUS; older uses SHOW SLAVE STATUS
-                for stmt in ("SHOW REPLICA STATUS", "SHOW SLAVE STATUS"):
-                    try:
-                        cur.execute(stmt)
-                        rows = list(cur.fetchall())
-                        break
-                    except Exception as stmt_err:
-                        import pymysql as _pymysql
+            if isinstance(stmt_err, _pymysql.err.ProgrammingError):
+                # SHOW REPLICA STATUS not supported on MySQL < 8.0.22; try SHOW SLAVE STATUS fallback
+                continue
+            raise
 
-                        if isinstance(stmt_err, _pymysql.err.ProgrammingError):
-                            # SHOW REPLICA STATUS not supported on MySQL < 8.0.22; try SHOW SLAVE STATUS fallback
-                            continue
-                        raise
+    if not rows:
+        return {
+            "source": "mysql",
+            "available": True,
+            "note": "This server is not configured as a replica.",
+            "replicas": [],
+        }
 
-                if not rows:
-                    return {
-                        "source": "mysql",
-                        "available": True,
-                        "note": "This server is not configured as a replica.",
-                        "replicas": [],
-                    }
+    replicas = []
+    for row in rows:
+        replicas.append({k: row[k] for k in _REPLICA_KEYS if k in row})
 
-                replicas = []
-                for row in rows:
-                    replicas.append({k: row[k] for k in _REPLICA_KEYS if k in row})
-
-                return {
-                    "source": "mysql",
-                    "available": True,
-                    "replica_count": len(replicas),
-                    "replicas": replicas,
-                }
-        finally:
-            conn.close()
-    except Exception as err:
-        report_validation_failure(
-            err,
-            logger=logger,
-            integration="mysql",
-            method="get_replication_status",
-        )
-        return tool_unavailable("mysql", str(err))
+    return {
+        "source": "mysql",
+        "available": True,
+        "replica_count": len(replicas),
+        "replicas": replicas,
+    }
 
 
+@_read_only
 def get_slow_queries(
+    cursor: Any,
     config: MySQLConfig,
     threshold_ms: float = 1000.0,
 ) -> dict[str, Any]:
@@ -463,100 +422,78 @@ def get_slow_queries(
     Results capped at config.max_results.
     Returns an informative note if performance_schema is disabled.
     """
-    if not config.is_configured:
-        return tool_unavailable("mysql", "Not configured.")
-
     # performance_schema timer uses picoseconds; convert threshold to picoseconds
     threshold_ps = int(threshold_ms * 1_000_000_000)
 
-    try:
-        conn = _get_connection(config)
-        try:
-            with conn.cursor() as cur:
-                # Check if performance_schema is enabled
-                cur.execute("SELECT @@performance_schema")
-                row = cur.fetchone()
-                if not row or not list(row.values())[0]:
-                    return {
-                        "source": "mysql",
-                        "available": True,
-                        "performance_schema_available": False,
-                        "note": (
-                            "performance_schema is disabled. "
-                            "Enable it in my.cnf to collect slow query data."
-                        ),
-                        "queries": [],
-                    }
+    # Check if performance_schema is enabled
+    cursor.execute("SELECT @@performance_schema")
+    row = cursor.fetchone()
+    if not row or not list(row.values())[0]:
+        return {
+            "source": "mysql",
+            "available": True,
+            "performance_schema_available": False,
+            "note": (
+                "performance_schema is disabled. Enable it in my.cnf to collect slow query data."
+            ),
+            "queries": [],
+        }
 
-                cur.execute(
-                    """
-                    SELECT
-                        DIGEST_TEXT,
-                        SCHEMA_NAME,
-                        COUNT_STAR,
-                        ROUND(AVG_TIMER_WAIT / 1000000000, 3) AS avg_time_ms,
-                        ROUND(SUM_TIMER_WAIT / 1000000000, 3) AS total_time_ms,
-                        ROUND(MIN_TIMER_WAIT / 1000000000, 3) AS min_time_ms,
-                        ROUND(MAX_TIMER_WAIT / 1000000000, 3) AS max_time_ms,
-                        SUM_ROWS_EXAMINED,
-                        SUM_ROWS_SENT,
-                        SUM_NO_INDEX_USED,
-                        SUM_NO_GOOD_INDEX_USED
-                    FROM performance_schema.events_statements_summary_by_digest
-                    WHERE AVG_TIMER_WAIT >= %s
-                    ORDER BY AVG_TIMER_WAIT DESC
-                    LIMIT %s
-                    """,
-                    (threshold_ps, config.max_results),
-                )
+    cursor.execute(
+        """
+        SELECT
+            DIGEST_TEXT,
+            SCHEMA_NAME,
+            COUNT_STAR,
+            ROUND(AVG_TIMER_WAIT / 1000000000, 3) AS avg_time_ms,
+            ROUND(SUM_TIMER_WAIT / 1000000000, 3) AS total_time_ms,
+            ROUND(MIN_TIMER_WAIT / 1000000000, 3) AS min_time_ms,
+            ROUND(MAX_TIMER_WAIT / 1000000000, 3) AS max_time_ms,
+            SUM_ROWS_EXAMINED,
+            SUM_ROWS_SENT,
+            SUM_NO_INDEX_USED,
+            SUM_NO_GOOD_INDEX_USED
+        FROM performance_schema.events_statements_summary_by_digest
+        WHERE AVG_TIMER_WAIT >= %s
+        ORDER BY AVG_TIMER_WAIT DESC
+        LIMIT %s
+        """,
+        (threshold_ps, config.max_results),
+    )
 
-                queries = []
-                for row in cur.fetchall():
-                    queries.append(
-                        {
-                            "digest_text": truncate(row["DIGEST_TEXT"] or "", _QUERY_TRUNCATE_LEN),
-                            "schema_name": row["SCHEMA_NAME"] or "",
-                            "count": row["COUNT_STAR"] or 0,
-                            "avg_time_ms": float(row["avg_time_ms"])
-                            if row["avg_time_ms"] is not None
-                            else 0.0,
-                            "total_time_ms": float(row["total_time_ms"])
-                            if row["total_time_ms"] is not None
-                            else 0.0,
-                            "min_time_ms": float(row["min_time_ms"])
-                            if row["min_time_ms"] is not None
-                            else 0.0,
-                            "max_time_ms": float(row["max_time_ms"])
-                            if row["max_time_ms"] is not None
-                            else 0.0,
-                            "rows_examined": row["SUM_ROWS_EXAMINED"] or 0,
-                            "rows_sent": row["SUM_ROWS_SENT"] or 0,
-                            "no_index_used": row["SUM_NO_INDEX_USED"] or 0,
-                            "no_good_index_used": row["SUM_NO_GOOD_INDEX_USED"] or 0,
-                        }
-                    )
-
-                return {
-                    "source": "mysql",
-                    "available": True,
-                    "performance_schema_available": True,
-                    "threshold_ms": threshold_ms,
-                    "total_queries": len(queries),
-                    "queries": queries,
-                }
-        finally:
-            conn.close()
-    except Exception as err:
-        report_validation_failure(
-            err,
-            logger=logger,
-            integration="mysql",
-            method="get_slow_queries",
+    queries = []
+    for row in cursor.fetchall():
+        queries.append(
+            {
+                "digest_text": truncate(row["DIGEST_TEXT"] or "", _QUERY_TRUNCATE_LEN),
+                "schema_name": row["SCHEMA_NAME"] or "",
+                "count": row["COUNT_STAR"] or 0,
+                "avg_time_ms": float(row["avg_time_ms"]) if row["avg_time_ms"] is not None else 0.0,
+                "total_time_ms": float(row["total_time_ms"])
+                if row["total_time_ms"] is not None
+                else 0.0,
+                "min_time_ms": float(row["min_time_ms"]) if row["min_time_ms"] is not None else 0.0,
+                "max_time_ms": float(row["max_time_ms"]) if row["max_time_ms"] is not None else 0.0,
+                "rows_examined": row["SUM_ROWS_EXAMINED"] or 0,
+                "rows_sent": row["SUM_ROWS_SENT"] or 0,
+                "no_index_used": row["SUM_NO_INDEX_USED"] or 0,
+                "no_good_index_used": row["SUM_NO_GOOD_INDEX_USED"] or 0,
+            }
         )
-        return tool_unavailable("mysql", str(err))
+
+    return {
+        "source": "mysql",
+        "available": True,
+        "performance_schema_available": True,
+        "threshold_ms": threshold_ms,
+        "total_queries": len(queries),
+        "queries": queries,
+    }
 
 
+@_read_only
 def get_table_stats(
+    cursor: Any,
     config: MySQLConfig,
 ) -> dict[str, Any]:
     """Retrieve table statistics (size, row counts) from information_schema.
@@ -564,77 +501,54 @@ def get_table_stats(
     Read-only: queries information_schema.TABLES for the configured database.
     Results capped at config.max_results.
     """
-    if not config.is_configured:
-        return tool_unavailable("mysql", "Not configured.")
+    cursor.execute(
+        """
+        SELECT
+            TABLE_NAME,
+            ENGINE,
+            TABLE_ROWS,
+            ROUND(DATA_LENGTH / 1024 / 1024, 3) AS data_mb,
+            ROUND(INDEX_LENGTH / 1024 / 1024, 3) AS index_mb,
+            ROUND((DATA_LENGTH + INDEX_LENGTH) / 1024 / 1024, 3) AS total_mb,
+            AUTO_INCREMENT,
+            TABLE_COLLATION,
+            CREATE_TIME,
+            UPDATE_TIME
+        FROM information_schema.TABLES
+        WHERE TABLE_SCHEMA = %s
+          AND TABLE_TYPE = 'BASE TABLE'
+        ORDER BY (DATA_LENGTH + INDEX_LENGTH) DESC
+        LIMIT %s
+        """,
+        (config.database, config.max_results),
+    )
 
-    try:
-        conn = _get_connection(config)
-        try:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    SELECT
-                        TABLE_NAME,
-                        ENGINE,
-                        TABLE_ROWS,
-                        ROUND(DATA_LENGTH / 1024 / 1024, 3) AS data_mb,
-                        ROUND(INDEX_LENGTH / 1024 / 1024, 3) AS index_mb,
-                        ROUND((DATA_LENGTH + INDEX_LENGTH) / 1024 / 1024, 3) AS total_mb,
-                        AUTO_INCREMENT,
-                        TABLE_COLLATION,
-                        CREATE_TIME,
-                        UPDATE_TIME
-                    FROM information_schema.TABLES
-                    WHERE TABLE_SCHEMA = %s
-                      AND TABLE_TYPE = 'BASE TABLE'
-                    ORDER BY (DATA_LENGTH + INDEX_LENGTH) DESC
-                    LIMIT %s
-                    """,
-                    (config.database, config.max_results),
-                )
-
-                tables = []
-                for row in cur.fetchall():
-                    tables.append(
-                        {
-                            "table_name": row["TABLE_NAME"],
-                            "engine": row["ENGINE"] or "",
-                            "row_count_estimate": row["TABLE_ROWS"] or 0,
-                            "size": {
-                                "data_mb": float(row["data_mb"])
-                                if row["data_mb"] is not None
-                                else 0.0,
-                                "index_mb": float(row["index_mb"])
-                                if row["index_mb"] is not None
-                                else 0.0,
-                                "total_mb": float(row["total_mb"])
-                                if row["total_mb"] is not None
-                                else 0.0,
-                            },
-                            "auto_increment": row["AUTO_INCREMENT"],
-                            "collation": row["TABLE_COLLATION"] or "",
-                            "created_at": str(row["CREATE_TIME"]) if row["CREATE_TIME"] else None,
-                            "updated_at": str(row["UPDATE_TIME"]) if row["UPDATE_TIME"] else None,
-                        }
-                    )
-
-                return {
-                    "source": "mysql",
-                    "available": True,
-                    "database": config.database,
-                    "total_tables": len(tables),
-                    "tables": tables,
-                }
-        finally:
-            conn.close()
-    except Exception as err:
-        report_validation_failure(
-            err,
-            logger=logger,
-            integration="mysql",
-            method="get_table_stats",
+    tables = []
+    for row in cursor.fetchall():
+        tables.append(
+            {
+                "table_name": row["TABLE_NAME"],
+                "engine": row["ENGINE"] or "",
+                "row_count_estimate": row["TABLE_ROWS"] or 0,
+                "size": {
+                    "data_mb": float(row["data_mb"]) if row["data_mb"] is not None else 0.0,
+                    "index_mb": float(row["index_mb"]) if row["index_mb"] is not None else 0.0,
+                    "total_mb": float(row["total_mb"]) if row["total_mb"] is not None else 0.0,
+                },
+                "auto_increment": row["AUTO_INCREMENT"],
+                "collation": row["TABLE_COLLATION"] or "",
+                "created_at": str(row["CREATE_TIME"]) if row["CREATE_TIME"] else None,
+                "updated_at": str(row["UPDATE_TIME"]) if row["UPDATE_TIME"] else None,
+            }
         )
-        return tool_unavailable("mysql", str(err))
+
+    return {
+        "source": "mysql",
+        "available": True,
+        "database": config.database,
+        "total_tables": len(tables),
+        "tables": tables,
+    }
 
 
 def classify(credentials: dict[str, Any], record_id: str) -> tuple[MySQLConfig | None, str | None]:

--- a/tests/integrations/test_mysql.py
+++ b/tests/integrations/test_mysql.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from integrations.mysql import (
     MySQLConfig,
     MySQLValidationResult,
     build_mysql_config,
+    get_current_processes,
+    get_replication_status,
     get_server_status,
+    get_slow_queries,
     get_table_stats,
     mysql_config_from_env,
 )
@@ -173,10 +176,24 @@ class TestMySQLValidationResult:
 
 
 class _FakeCursor:
-    """DictCursor stand-in returning queued ``fetchall`` results in order."""
+    """DictCursor stand-in returning queued results in order.
 
-    def __init__(self, results: list[list[dict[str, Any]]]) -> None:
-        self._results = list(results)
+    ``results`` feeds ``fetchall``, ``rows`` feeds ``fetchone``. Statements whose
+    text starts with any prefix in ``unsupported`` raise the same
+    ``ProgrammingError`` a real server raises for an unknown statement, which is
+    how the replication version fallback is exercised.
+    """
+
+    def __init__(
+        self,
+        results: list[list[dict[str, Any]]] | None = None,
+        *,
+        rows: list[dict[str, Any] | None] | None = None,
+        unsupported: tuple[str, ...] = (),
+    ) -> None:
+        self._results = list(results or [])
+        self._rows = list(rows or [])
+        self._unsupported = unsupported
         self.statements: list[tuple[str, Any]] = []
 
     def __enter__(self) -> _FakeCursor:
@@ -187,6 +204,13 @@ class _FakeCursor:
 
     def execute(self, statement: str, params: Any = None) -> None:
         self.statements.append((statement, params))
+        if any(statement.strip().startswith(prefix) for prefix in self._unsupported):
+            import pymysql
+
+            raise pymysql.err.ProgrammingError(1064, f"unsupported statement: {statement}")
+
+    def fetchone(self) -> dict[str, Any] | None:
+        return self._rows.pop(0) if self._rows else None
 
     def fetchall(self) -> list[dict[str, Any]]:
         return self._results.pop(0) if self._results else []
@@ -312,3 +336,245 @@ class TestGetServerStatus:
             result = get_server_status(_configured())
 
         assert result["innodb"]["buffer_pool_hit_ratio_percent"] == 0.0
+
+
+class TestGetCurrentProcesses:
+    """``get_current_processes`` shapes PROCESSLIST rows and honours the threshold."""
+
+    def test_happy_path(self) -> None:
+        cursor = _FakeCursor(
+            [
+                [
+                    {
+                        "ID": 42,
+                        "USER": "app",
+                        "HOST": "10.0.0.7:51000",
+                        "DB": "testdb",
+                        "COMMAND": "Query",
+                        "TIME": 12,
+                        "STATE": "Sending data",
+                        "INFO": "SELECT * FROM orders",
+                    }
+                ]
+            ]
+        )
+        conn = _FakeConnection(cursor)
+
+        with patch("pymysql.connect", return_value=conn):
+            result = get_current_processes(_configured(), threshold_seconds=5)
+
+        assert result["available"] is True
+        assert result["threshold_seconds"] == 5
+        assert result["total_processes"] == 1
+        proc = result["processes"][0]
+        assert proc["id"] == 42
+        assert proc["user"] == "app"
+        assert proc["database"] == "testdb"
+        assert proc["time_seconds"] == 12
+        assert proc["query"] == "SELECT * FROM orders"
+        # threshold and the result cap are bound as query params, not interpolated
+        assert cursor.statements[0][1] == (5, 50)
+
+    def test_null_columns_become_empty_strings(self) -> None:
+        cursor = _FakeCursor(
+            [
+                [
+                    {
+                        "ID": 1,
+                        "USER": "root",
+                        "HOST": None,
+                        "DB": None,
+                        "COMMAND": "Query",
+                        "TIME": None,
+                        "STATE": None,
+                        "INFO": None,
+                    }
+                ]
+            ]
+        )
+
+        with patch("pymysql.connect", return_value=_FakeConnection(cursor)):
+            result = get_current_processes(_configured())
+
+        proc = result["processes"][0]
+        assert proc["host"] == ""
+        assert proc["database"] == ""
+        assert proc["state"] == ""
+        assert proc["query"] == ""
+        assert proc["time_seconds"] == 0
+
+    def test_no_processes(self) -> None:
+        with patch("pymysql.connect", return_value=_FakeConnection(_FakeCursor([[]]))):
+            result = get_current_processes(_configured())
+
+        assert result["total_processes"] == 0
+        assert result["processes"] == []
+
+
+class TestGetSlowQueries:
+    """``get_slow_queries`` depends on performance_schema being enabled."""
+
+    def test_reports_when_performance_schema_disabled(self) -> None:
+        cursor = _FakeCursor(rows=[{"@@performance_schema": 0}])
+
+        with patch("pymysql.connect", return_value=_FakeConnection(cursor)):
+            result = get_slow_queries(_configured())
+
+        assert result["available"] is True
+        assert result["performance_schema_available"] is False
+        assert result["queries"] == []
+        assert "performance_schema is disabled" in result["note"]
+        # It must not go on to query the digest table.
+        assert len(cursor.statements) == 1
+
+    def test_happy_path(self) -> None:
+        cursor = _FakeCursor(
+            [
+                [
+                    {
+                        "DIGEST_TEXT": "SELECT * FROM orders WHERE id = ?",
+                        "SCHEMA_NAME": "testdb",
+                        "COUNT_STAR": 17,
+                        "avg_time_ms": "2.500",
+                        "total_time_ms": "42.500",
+                        "min_time_ms": "1.000",
+                        "max_time_ms": "9.000",
+                        "SUM_ROWS_EXAMINED": 340,
+                        "SUM_ROWS_SENT": 17,
+                        "SUM_NO_INDEX_USED": 1,
+                        "SUM_NO_GOOD_INDEX_USED": 0,
+                    }
+                ]
+            ],
+            rows=[{"@@performance_schema": 1}],
+        )
+        conn = _FakeConnection(cursor)
+
+        with patch("pymysql.connect", return_value=conn):
+            result = get_slow_queries(_configured(), threshold_ms=1000.0)
+
+        assert result["performance_schema_available"] is True
+        assert result["threshold_ms"] == 1000.0
+        assert result["total_queries"] == 1
+        query = result["queries"][0]
+        assert query["digest_text"] == "SELECT * FROM orders WHERE id = ?"
+        assert query["count"] == 17
+        assert query["avg_time_ms"] == 2.5
+        assert query["rows_examined"] == 340
+        assert query["no_index_used"] == 1
+        # milliseconds are converted to the picosecond timer unit
+        assert cursor.statements[1][1] == (1_000_000_000_000, 50)
+        assert conn.closed is True
+
+    def test_null_timings_default_to_zero(self) -> None:
+        cursor = _FakeCursor(
+            [
+                [
+                    {
+                        "DIGEST_TEXT": None,
+                        "SCHEMA_NAME": None,
+                        "COUNT_STAR": None,
+                        "avg_time_ms": None,
+                        "total_time_ms": None,
+                        "min_time_ms": None,
+                        "max_time_ms": None,
+                        "SUM_ROWS_EXAMINED": None,
+                        "SUM_ROWS_SENT": None,
+                        "SUM_NO_INDEX_USED": None,
+                        "SUM_NO_GOOD_INDEX_USED": None,
+                    }
+                ]
+            ],
+            rows=[{"@@performance_schema": 1}],
+        )
+
+        with patch("pymysql.connect", return_value=_FakeConnection(cursor)):
+            result = get_slow_queries(_configured())
+
+        query = result["queries"][0]
+        assert query["digest_text"] == ""
+        assert query["avg_time_ms"] == 0.0
+        assert query["max_time_ms"] == 0.0
+        assert query["rows_examined"] == 0
+
+
+class TestGetReplicationStatus:
+    """``get_replication_status`` handles both the modern and legacy statements."""
+
+    def test_not_a_replica(self) -> None:
+        cursor = _FakeCursor([[]])
+
+        with patch("pymysql.connect", return_value=_FakeConnection(cursor)):
+            result = get_replication_status(_configured())
+
+        assert result["available"] is True
+        assert result["replicas"] == []
+        assert result["note"] == "This server is not configured as a replica."
+
+    def test_uses_modern_statement_when_supported(self) -> None:
+        cursor = _FakeCursor(
+            [
+                [
+                    {
+                        "Replica_IO_Running": "Yes",
+                        "Replica_SQL_Running": "Yes",
+                        "Seconds_Behind_Source": 3,
+                        "Source_Host": "primary.internal",
+                        "Unrelated_Column": "dropped",
+                    }
+                ]
+            ]
+        )
+
+        with patch("pymysql.connect", return_value=_FakeConnection(cursor)):
+            result = get_replication_status(_configured())
+
+        assert result["replica_count"] == 1
+        replica = result["replicas"][0]
+        assert replica["Replica_IO_Running"] == "Yes"
+        assert replica["Seconds_Behind_Source"] == 3
+        # only curated keys survive
+        assert "Unrelated_Column" not in replica
+        assert cursor.statements[0][0] == "SHOW REPLICA STATUS"
+
+    def test_falls_back_to_legacy_statement(self) -> None:
+        """MySQL < 8.0.22 rejects SHOW REPLICA STATUS; SHOW SLAVE STATUS is tried next."""
+        cursor = _FakeCursor(
+            [
+                [
+                    {
+                        "Slave_IO_Running": "Yes",
+                        "Slave_SQL_Running": "No",
+                        "Seconds_Behind_Master": 120,
+                        "Last_Errno": 1236,
+                    }
+                ]
+            ],
+            unsupported=("SHOW REPLICA STATUS",),
+        )
+
+        with patch("pymysql.connect", return_value=_FakeConnection(cursor)):
+            result = get_replication_status(_configured())
+
+        assert [stmt for stmt, _ in cursor.statements] == [
+            "SHOW REPLICA STATUS",
+            "SHOW SLAVE STATUS",
+        ]
+        assert result["replica_count"] == 1
+        replica = result["replicas"][0]
+        assert replica["Slave_SQL_Running"] == "No"
+        assert replica["Seconds_Behind_Master"] == 120
+
+    def test_non_programming_errors_are_not_swallowed(self) -> None:
+        """A real failure must surface as unavailable, not be mistaken for a fallback."""
+        conn = _FakeConnection(_FakeCursor([[]]))
+        conn._cursor.execute = MagicMock(side_effect=RuntimeError("server gone"))  # type: ignore[method-assign]
+
+        with (
+            patch("pymysql.connect", return_value=conn),
+            patch("integrations._relational.report_validation_failure"),
+        ):
+            result = get_replication_status(_configured())
+
+        assert result["available"] is False
+        assert result["error"] == "server gone"

--- a/tests/integrations/test_mysql.py
+++ b/tests/integrations/test_mysql.py
@@ -1,9 +1,16 @@
 """Unit tests for the MySQL integration module."""
 
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
 from integrations.mysql import (
     MySQLConfig,
     MySQLValidationResult,
     build_mysql_config,
+    get_server_status,
+    get_table_stats,
     mysql_config_from_env,
 )
 
@@ -163,3 +170,145 @@ class TestMySQLValidationResult:
         )
         assert result.ok is False
         assert result.detail == "MySQL connection failed: connection refused"
+
+
+class _FakeCursor:
+    """DictCursor stand-in returning queued ``fetchall`` results in order."""
+
+    def __init__(self, results: list[list[dict[str, Any]]]) -> None:
+        self._results = list(results)
+        self.statements: list[tuple[str, Any]] = []
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *exc_info: Any) -> bool:
+        return False
+
+    def execute(self, statement: str, params: Any = None) -> None:
+        self.statements.append((statement, params))
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        return self._results.pop(0) if self._results else []
+
+
+class _FakeConnection:
+    def __init__(self, cursor: _FakeCursor) -> None:
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _configured() -> MySQLConfig:
+    return build_mysql_config({"host": "mysql.test.local", "database": "testdb"})
+
+
+class TestDiagnosticsUnconfigured:
+    """Diagnostics short-circuit before connecting when host/database are missing."""
+
+    def test_server_status_unavailable(self) -> None:
+        result = get_server_status(build_mysql_config({}))
+        assert result["available"] is False
+        assert result["error"] == "Not configured."
+        assert result["source"] == "mysql"
+
+    def test_table_stats_unavailable(self) -> None:
+        result = get_table_stats(build_mysql_config({"host": "mysql.test.local"}))
+        assert result["available"] is False
+        assert result["error"] == "Not configured."
+
+
+class TestGetTableStats:
+    """``get_table_stats`` shapes information_schema.TABLES rows."""
+
+    def test_happy_path(self) -> None:
+        cursor = _FakeCursor(
+            [
+                [
+                    {
+                        "TABLE_NAME": "orders",
+                        "ENGINE": "InnoDB",
+                        "TABLE_ROWS": 1200,
+                        "data_mb": "3.5",
+                        "index_mb": "1.25",
+                        "total_mb": "4.75",
+                        "AUTO_INCREMENT": 1201,
+                        "TABLE_COLLATION": "utf8mb4_general_ci",
+                        "CREATE_TIME": None,
+                        "UPDATE_TIME": None,
+                    }
+                ]
+            ]
+        )
+        conn = _FakeConnection(cursor)
+
+        with patch("pymysql.connect", return_value=conn):
+            result = get_table_stats(_configured())
+
+        assert result["available"] is True
+        assert result["database"] == "testdb"
+        assert result["total_tables"] == 1
+        table = result["tables"][0]
+        assert table["table_name"] == "orders"
+        assert table["engine"] == "InnoDB"
+        assert table["row_count_estimate"] == 1200
+        assert table["size"] == {"data_mb": 3.5, "index_mb": 1.25, "total_mb": 4.75}
+        assert table["created_at"] is None
+        assert conn.closed is True
+
+    def test_connection_failure_returns_unavailable(self) -> None:
+        with (
+            patch("pymysql.connect", side_effect=OSError("connection refused")),
+            patch("integrations._relational.report_validation_failure"),
+        ):
+            result = get_table_stats(_configured())
+
+        assert result["available"] is False
+        assert result["error"] == "connection refused"
+
+
+class TestGetServerStatus:
+    """``get_server_status`` derives connection and InnoDB metrics."""
+
+    def test_computes_buffer_pool_hit_ratio(self) -> None:
+        status_rows = [
+            {"Variable_name": "Threads_connected", "Value": "25"},
+            {"Variable_name": "Threads_running", "Value": "5"},
+            {"Variable_name": "Uptime", "Value": "432000"},
+            {"Variable_name": "Questions", "Value": "1000"},
+            {"Variable_name": "Slow_queries", "Value": "42"},
+            {"Variable_name": "Innodb_buffer_pool_reads", "Value": "10"},
+            {"Variable_name": "Innodb_buffer_pool_read_requests", "Value": "1000"},
+        ]
+        variable_rows = [
+            {"Variable_name": "version", "Value": "8.0.32"},
+            {"Variable_name": "max_connections", "Value": "151"},
+        ]
+        conn = _FakeConnection(_FakeCursor([status_rows, variable_rows]))
+
+        with patch("pymysql.connect", return_value=conn):
+            result = get_server_status(_configured())
+
+        assert result["available"] is True
+        assert result["version"] == "8.0.32"
+        assert result["uptime_seconds"] == 432000
+        assert result["connections"]["current"] == 25
+        assert result["connections"]["max"] == 151
+        assert result["queries"]["slow"] == 42
+        # 1 - (10 / 1000) = 99.0%
+        assert result["innodb"]["buffer_pool_hit_ratio_percent"] == 99.0
+        assert conn.closed is True
+
+    def test_zero_read_requests_avoids_division_by_zero(self) -> None:
+        status_rows = [{"Variable_name": "Innodb_buffer_pool_read_requests", "Value": "0"}]
+        conn = _FakeConnection(_FakeCursor([status_rows, []]))
+
+        with patch("pymysql.connect", return_value=conn):
+            result = get_server_status(_configured())
+
+        assert result["innodb"]["buffer_pool_hit_ratio_percent"] == 0.0

--- a/tests/integrations/test_relational.py
+++ b/tests/integrations/test_relational.py
@@ -1,0 +1,193 @@
+"""Unit tests for helpers shared by relational integrations."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import patch
+
+from integrations._relational import read_only_query
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _FakeConfig:
+    """Minimal stand-in for a vendor config (only ``is_configured`` is used)."""
+
+    is_configured: bool = True
+
+
+class _FakeCursor:
+    """Cursor doubling as its own context manager, like pymysql/psycopg2 cursors."""
+
+    def __init__(self) -> None:
+        self.exited = False
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *exc_info: Any) -> bool:
+        self.exited = True
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, cursor: _FakeCursor) -> None:
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _runner(connection: _FakeConnection | None = None, *, integration: str = "fakedb"):
+    """Build a decorator bound to a fake connection."""
+    conn = connection if connection is not None else _FakeConnection(_FakeCursor())
+    return read_only_query(integration=integration, logger=logger, connect=lambda _config: conn)
+
+
+class TestReadOnlyQueryGuard:
+    """The wrapper short-circuits before opening a connection."""
+
+    def test_unconfigured_returns_unavailable_envelope(self) -> None:
+        @_runner()
+        def probe(cursor: Any, config: Any) -> dict[str, Any]:
+            raise AssertionError("must not run when unconfigured")
+
+        result = probe(_FakeConfig(is_configured=False))
+
+        assert result == {
+            "source": "fakedb",
+            "available": False,
+            "error": "Not configured.",
+        }
+
+    def test_unconfigured_never_connects(self) -> None:
+        conn = _FakeConnection(_FakeCursor())
+
+        @_runner(conn)
+        def probe(cursor: Any, config: Any) -> dict[str, Any]:
+            return {"ok": True}
+
+        probe(_FakeConfig(is_configured=False))
+
+        assert conn.closed is False
+
+
+class TestReadOnlyQueryHappyPath:
+    """Configured calls receive a cursor and return the wrapped function's payload."""
+
+    def test_returns_wrapped_result(self) -> None:
+        @_runner()
+        def probe(cursor: Any, config: Any) -> dict[str, Any]:
+            return {"source": "fakedb", "available": True, "rows": 3}
+
+        assert probe(_FakeConfig())["rows"] == 3
+
+    def test_receives_cursor_and_config(self) -> None:
+        cursor = _FakeCursor()
+        conn = _FakeConnection(cursor)
+        config = _FakeConfig()
+        seen: dict[str, Any] = {}
+
+        @_runner(conn)
+        def probe(cur: Any, cfg: Any) -> dict[str, Any]:
+            seen["cursor"] = cur
+            seen["config"] = cfg
+            return {}
+
+        probe(config)
+
+        assert seen["cursor"] is cursor
+        assert seen["config"] is config
+
+    def test_forwards_extra_arguments(self) -> None:
+        @_runner()
+        def probe(cursor: Any, config: Any, threshold: int = 0) -> dict[str, Any]:
+            return {"threshold": threshold}
+
+        assert probe(_FakeConfig(), threshold=42)["threshold"] == 42
+
+    def test_closes_connection(self) -> None:
+        conn = _FakeConnection(_FakeCursor())
+
+        @_runner(conn)
+        def probe(cursor: Any, config: Any) -> dict[str, Any]:
+            return {}
+
+        probe(_FakeConfig())
+
+        assert conn.closed is True
+
+    def test_preserves_function_identity(self) -> None:
+        @_runner()
+        def probe(cursor: Any, config: Any) -> dict[str, Any]:
+            """Docstring stays put."""
+            return {}
+
+        assert probe.__name__ == "probe"
+        assert probe.__doc__ == "Docstring stays put."
+
+
+class TestReadOnlyQueryErrors:
+    """Failures become the standard unavailable envelope, not exceptions."""
+
+    def test_query_failure_returns_unavailable(self) -> None:
+        @_runner()
+        def probe(cursor: Any, config: Any) -> dict[str, Any]:
+            raise RuntimeError("table gone")
+
+        with patch("integrations._relational.report_validation_failure"):
+            result = probe(_FakeConfig())
+
+        assert result == {
+            "source": "fakedb",
+            "available": False,
+            "error": "table gone",
+        }
+
+    def test_connection_closed_when_query_fails(self) -> None:
+        conn = _FakeConnection(_FakeCursor())
+
+        @_runner(conn)
+        def probe(cursor: Any, config: Any) -> dict[str, Any]:
+            raise RuntimeError("boom")
+
+        with patch("integrations._relational.report_validation_failure"):
+            probe(_FakeConfig())
+
+        assert conn.closed is True
+
+    def test_connect_failure_returns_unavailable(self) -> None:
+        def _explode(_config: Any) -> Any:
+            raise OSError("connection refused")
+
+        decorator = read_only_query(integration="fakedb", logger=logger, connect=_explode)
+
+        @decorator
+        def probe(cursor: Any, config: Any) -> dict[str, Any]:
+            raise AssertionError("must not run when connect fails")
+
+        with patch("integrations._relational.report_validation_failure"):
+            result = probe(_FakeConfig())
+
+        assert result["available"] is False
+        assert result["error"] == "connection refused"
+
+    def test_failure_is_reported_with_wrapped_function_name(self) -> None:
+        @_runner(integration="fakedb")
+        def get_widget_stats(cursor: Any, config: Any) -> dict[str, Any]:
+            raise RuntimeError("boom")
+
+        with patch("integrations._relational.report_validation_failure") as reported:
+            get_widget_stats(_FakeConfig())
+
+        assert reported.call_count == 1
+        kwargs = reported.call_args.kwargs
+        assert kwargs["integration"] == "fakedb"
+        assert kwargs["method"] == "get_widget_stats"

--- a/tests/integrations/test_validator_sentry_capture.py
+++ b/tests/integrations/test_validator_sentry_capture.py
@@ -19,6 +19,13 @@ outer except (or are deliberate version-detection fallbacks):
 
 - ``mysql.get_replication_status`` inner ``stmt_err`` (MySQL <8.0.22 fallback)
 - ``mariadb.get_replication_status`` inner ``stmt_err`` (analogous)
+
+Some vendors no longer inline the broad-except: relational diagnostics can
+delegate the whole connect/query/error lifecycle to the shared
+``read_only_query`` wrapper in ``integrations/_relational.py``. Those cases set
+``decorated_with`` and are checked for the decorator instead; the wrapper's own
+reporting is asserted once in
+:func:`test_shared_read_only_wrapper_reports_failures`.
 """
 
 from __future__ import annotations
@@ -39,6 +46,9 @@ class MigrationCase:
     function: str  # outer function name (may include "."-separated nested suffix)
     integration: str  # expected tag.integration
     method: str  # expected tag.method
+    # When set, the function delegates its broad-except to this decorator (the
+    # shared `read_only_query` binding) instead of inlining one.
+    decorated_with: str | None = None
 
 
 CASES: tuple[MigrationCase, ...] = (
@@ -188,15 +198,44 @@ CASES: tuple[MigrationCase, ...] = (
     MigrationCase(
         "integrations/mysql.py", "validate_mysql_config", "mysql", "validate_mysql_config"
     ),
-    MigrationCase("integrations/mysql.py", "get_server_status", "mysql", "get_server_status"),
+    # MySQL diagnostics delegate the connect/query/error lifecycle to the shared
+    # `read_only_query` wrapper, so they carry the decorator instead of an
+    # inline broad-except.
     MigrationCase(
-        "integrations/mysql.py", "get_current_processes", "mysql", "get_current_processes"
+        "integrations/mysql.py",
+        "get_server_status",
+        "mysql",
+        "get_server_status",
+        decorated_with="_read_only",
     ),
     MigrationCase(
-        "integrations/mysql.py", "get_replication_status", "mysql", "get_replication_status"
+        "integrations/mysql.py",
+        "get_current_processes",
+        "mysql",
+        "get_current_processes",
+        decorated_with="_read_only",
     ),
-    MigrationCase("integrations/mysql.py", "get_slow_queries", "mysql", "get_slow_queries"),
-    MigrationCase("integrations/mysql.py", "get_table_stats", "mysql", "get_table_stats"),
+    MigrationCase(
+        "integrations/mysql.py",
+        "get_replication_status",
+        "mysql",
+        "get_replication_status",
+        decorated_with="_read_only",
+    ),
+    MigrationCase(
+        "integrations/mysql.py",
+        "get_slow_queries",
+        "mysql",
+        "get_slow_queries",
+        decorated_with="_read_only",
+    ),
+    MigrationCase(
+        "integrations/mysql.py",
+        "get_table_stats",
+        "mysql",
+        "get_table_stats",
+        decorated_with="_read_only",
+    ),
     # mariadb
     MigrationCase(
         "integrations/mariadb.py",
@@ -340,6 +379,25 @@ def _calls_to(handler: ast.ExceptHandler, func_name: str) -> list[ast.Call]:
     return matches
 
 
+def _decorator_names(fn: ast.FunctionDef) -> set[str]:
+    """Return the bare names of a function's decorators (``@foo`` and ``@foo(...)``)."""
+    names: set[str] = set()
+    for node in fn.decorator_list:
+        target = node.func if isinstance(node, ast.Call) else node
+        if isinstance(target, ast.Name):
+            names.add(target.id)
+    return names
+
+
+def _kwarg_has_name(call: ast.Call, key: str, expected: str) -> bool:
+    """True when ``key=`` is passed the non-literal expression ``expected``."""
+    for kw in call.keywords:
+        if kw.arg != key:
+            continue
+        return ast.unparse(kw.value) == expected
+    return False
+
+
 def _kwarg_str(call: ast.Call, key: str) -> str | None:
     for kw in call.keywords:
         if kw.arg == key and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
@@ -369,6 +427,17 @@ def test_broad_except_calls_report_validation_failure(case: MigrationCase) -> No
     fn = _find_function(tree, case.function)
     assert fn is not None, f"function {case.function} not found in {case.module_path}"
 
+    if case.decorated_with:
+        # The broad-except lives in the shared wrapper, which reports with
+        # integration=<vendor> and method=<wrapped fn name>. Assert the
+        # delegation is in place; the wrapper itself is covered by
+        # test_shared_read_only_wrapper_reports_failures.
+        assert case.decorated_with in _decorator_names(fn), (
+            f"{case.module_path}::{case.function} is expected to delegate error "
+            f"reporting via @{case.decorated_with}, but that decorator is missing"
+        )
+        return
+
     handlers = _broad_except_handlers(fn)
     assert handlers, f"no `except Exception` handlers in {case.module_path}::{case.function}"
 
@@ -390,6 +459,37 @@ def test_broad_except_calls_report_validation_failure(case: MigrationCase) -> No
         f"{case.module_path}::{case.function} reports the same "
         f"(integration={case.integration!r}, method={case.method!r}) "
         f"{len(matching_calls)} times; expected exactly once"
+    )
+
+
+def test_shared_read_only_wrapper_reports_failures() -> None:
+    """The shared relational wrapper must report on its broad-except.
+
+    Cases with ``decorated_with`` set delegate their error handling here, so
+    this is the single place that coverage is proven for all of them. The tags
+    are dynamic — ``integration`` is the bound vendor name and ``method`` is the
+    wrapped function's ``__name__`` — so assert on the expressions, not literals.
+    """
+    source = (_REPO_ROOT / "integrations/_relational.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    wrapper = _find_function(tree, "wrapper")
+    assert wrapper is not None, "read_only_query no longer defines its `wrapper` closure"
+
+    handlers = _broad_except_handlers(wrapper)
+    assert handlers, "read_only_query's wrapper has no `except Exception` handler"
+
+    calls = [c for h in handlers for c in _calls_to(h, "report_validation_failure")]
+    assert len(calls) == 1, (
+        f"read_only_query's wrapper should report exactly once; found {len(calls)}"
+    )
+
+    call = calls[0]
+    assert _kwarg_has_name(call, "integration", "integration"), (
+        "wrapper must tag the bound vendor name as integration="
+    )
+    assert _kwarg_has_name(call, "method", "fn.__name__"), (
+        "wrapper must tag the wrapped function's name as method="
     )
 
 


### PR DESCRIPTION
…pt in MySQL

Fixes #3532

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

PostgreSQL, MySQL and MariaDB each repeated the same connect/query/error code in every diagnostic function. The config helpers were already shared in _relational.py, but the connection and error handling were not. This adds a read_only_query wrapper there that opens the connection, hands the function a cursor, closes the connection, and turns any failure into the standard unavailable response. MySQL now uses it, so its five diagnostic functions only contain their queries. Behaviour and output are unchanged. Postgres and MariaDB are untouched. I also added tests for the wrapper and for the MySQL functions, since those paths had no direct coverage before, and updated the Sentry capture test so it knows these functions now report errors through the wrapper instead of inline.

### Demo/Screenshot for feature changes and bug fixes - 


https://github.com/user-attachments/assets/26347991-e600-41bf-bf98-08444f12a27d

- this demo runs the refactored mysql code against a real mysql server in docker. It shows all five diagnostic functions returning live data, the guard when the integration is not configured, and the error response when the connection fails. The unit tests use fake connections, so this confirms the shared wrapper also works with the real pymysql driver.


<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I extracted only the part that was actually duplicated: the connect, close, and error handling. The queries and result shaping stay in each function, so nothing vendor-specific moved into the shared file. I used a decorator that passes the cursor in, which keeps the call sites unchanged. Refactored MySQL only, so if the wrapper shape is wrong it is easy to fix before doing the other two.

<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
