### PR TITLE
perf(investigation): cut context-budget hot-path token recomputation

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -20,6 +20,7 @@ _EXPORT_MODULES = {
     "context_budget_ceiling_for_model": "core.context_budget",
     "enforce_context_budget": "core.context_budget",
     "estimate_message_tokens": "core.context_budget",
+    "system_and_tools_overhead": "core.context_budget",
     "trim_lowest_value_tool_pair": "core.context_budget",
     "truncate_content": "core.context_budget",
     "AgentEndEvent": "core.events",

--- a/core/agent/react_loop.py
+++ b/core/agent/react_loop.py
@@ -16,7 +16,11 @@ from typing import Any
 
 from core.agent.loop_host import LoopHost
 from core.agent.run_io import AgentRunInput, AgentRunResult
-from core.context_budget import context_budget_ceiling_for_model, enforce_context_budget
+from core.context_budget import (
+    context_budget_ceiling_for_model,
+    enforce_context_budget,
+    system_and_tools_overhead,
+)
 from core.events import (
     AgentEndEvent,
     AgentStartEvent,
@@ -72,6 +76,8 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
         self._runtime_tools = list(host._filter_tools(run_input.tools))
         self._tool_schemas = self._llm.tool_schemas(self._runtime_tools)
         self._ceiling = context_budget_ceiling_for_model(getattr(self._llm, "_model", None))
+        # System prompt and tool schemas are fixed for the run; serialize once.
+        self._fixed_overhead_tokens = system_and_tools_overhead(self._system, self._tool_schemas)
         self._executed: list[tuple[ToolCall, Any]] = []
         self._tool_results: list[tuple[ToolCall, ToolExecutionResult]] = []
         self._final_text = ""
@@ -137,7 +143,9 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
         transformed_messages = self._host._transform_messages(self._messages)
         llm_messages = self._host._convert_to_llm(self._llm, transformed_messages)
         enforce_context_budget(
-            llm_messages, system=self._system, tools=self._tool_schemas, ceiling=self._ceiling
+            llm_messages,
+            fixed_overhead_tokens=self._fixed_overhead_tokens,
+            ceiling=self._ceiling,
         )
         provider_request = ProviderRequest(
             messages=llm_messages,

--- a/core/context_budget.py
+++ b/core/context_budget.py
@@ -185,13 +185,22 @@ def _estimate_messages_tokens(messages: list[dict[str, Any]]) -> int:
     return sum(_message_token_estimate(message) for message in messages)
 
 
-def _system_and_tools_tokens(
+def _system_tokens(system: str | None) -> int:
+    return int(len(system) * _TOKENS_PER_CHAR) if system else 0
+
+
+def system_and_tools_overhead(
     system: str | None,
     tools: list[dict[str, Any]] | None,
 ) -> int:
-    total = 0
-    if system:
-        total += int(len(system) * _TOKENS_PER_CHAR)
+    """Fixed token overhead for the system prompt and tool schemas.
+
+    Callers on a hot path (e.g. the investigation ReAct loop) should call this
+    once and pass the result to ``enforce_context_budget`` via
+    ``fixed_overhead_tokens`` so tool schemas are not re-serialized every
+    iteration.
+    """
+    total = _system_tokens(system)
     if tools:
         for schema in tools:
             total += int(len(json.dumps(schema, default=str)) * _TOKENS_PER_CHAR)
@@ -211,7 +220,7 @@ def estimate_message_tokens(
     aggressively while system + tools (tens of thousands of tokens for
     opensre's 100+ tool registry) silently pushed us over the line.
     """
-    return _estimate_messages_tokens(messages) + _system_and_tools_tokens(system, tools)
+    return _estimate_messages_tokens(messages) + system_and_tools_overhead(system, tools)
 
 
 def trim_lowest_value_tool_pair(messages: list[dict[str, Any]]) -> bool:
@@ -341,10 +350,17 @@ def enforce_context_budget(
     *,
     system: str | None = None,
     tools: list[dict[str, Any]] | None = None,
+    fixed_overhead_tokens: int | None = None,
     ceiling: int = _TOKEN_BUDGET_CEILING,
 ) -> None:
-    """Trim low-value tool exchanges until the prompt fits under ``ceiling``."""
-    fixed_overhead_tokens = _system_and_tools_tokens(system, tools)
+    """Trim low-value tool exchanges until the prompt fits under ``ceiling``.
+
+    Pass ``fixed_overhead_tokens`` (from :func:`system_and_tools_overhead`) to
+    skip re-serializing tool schemas on every call.  When omitted the overhead
+    is computed from ``system`` and ``tools``.
+    """
+    if fixed_overhead_tokens is None:
+        fixed_overhead_tokens = system_and_tools_overhead(system, tools)
     message_tokens, total_message_tokens = _message_token_estimates(messages)
     while (total_message_tokens + fixed_overhead_tokens) > ceiling:
         if not trim_lowest_value_tool_pair(messages):

--- a/core/context_budget.py
+++ b/core/context_budget.py
@@ -162,11 +162,58 @@ def context_budget_ceiling_for_model(model: str | None) -> int:
     return max(window - _RESPONSE_HEADROOM_TOKENS, _RESPONSE_HEADROOM_TOKENS)
 
 
+def _message_token_estimate(message: dict[str, Any]) -> int:
+    total = 0
+    content = message.get("content", "")
+    if isinstance(content, str):
+        total += int(len(content) * _TOKENS_PER_CHAR)
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict):
+                total += int(len(json.dumps(block, default=str)) * _TOKENS_PER_CHAR)
+            elif isinstance(block, str):
+                total += int(len(block) * _TOKENS_PER_CHAR)
+    return total
+
+
+def _message_token_estimates(messages: list[dict[str, Any]]) -> tuple[list[int], int]:
+    tokens = [_message_token_estimate(message) for message in messages]
+    return tokens, sum(tokens)
+
+
+def _refresh_message_token_estimates(
+    messages: list[dict[str, Any]],
+    *,
+    current_estimates: list[int],
+) -> tuple[list[int], int]:
+    if len(current_estimates) != len(messages):
+        return _message_token_estimates(messages)
+    return current_estimates, sum(current_estimates)
+
+
+def _estimate_messages_tokens(messages: list[dict[str, Any]]) -> int:
+    return sum(_message_token_estimate(message) for message in messages)
+
+
+def _system_and_tools_tokens(
+    system: str | None,
+    tools: list[dict[str, Any]] | None,
+) -> int:
+    total = 0
+    if system:
+        total += int(len(system) * _TOKENS_PER_CHAR)
+    if tools:
+        for schema in tools:
+            total += int(len(json.dumps(schema, default=str)) * _TOKENS_PER_CHAR)
+    return total
+
+
 def estimate_message_tokens(
     messages: list[dict[str, Any]],
     *,
     system: str | None = None,
     tools: list[dict[str, Any]] | None = None,
+    system_tools_overhead_tokens: int | None = None,
 ) -> int:
     """Cheap upper-bound token estimate covering everything Anthropic sees.
 
@@ -175,23 +222,9 @@ def estimate_message_tokens(
     aggressively while system + tools (tens of thousands of tokens for
     opensre's 100+ tool registry) silently pushed us over the line.
     """
-    total = 0
-    for message in messages:
-        content = message.get("content", "")
-        if isinstance(content, str):
-            total += int(len(content) * _TOKENS_PER_CHAR)
-        elif isinstance(content, list):
-            for block in content:
-                if isinstance(block, dict):
-                    total += int(len(json.dumps(block, default=str)) * _TOKENS_PER_CHAR)
-                elif isinstance(block, str):
-                    total += int(len(block) * _TOKENS_PER_CHAR)
-    if system:
-        total += int(len(system) * _TOKENS_PER_CHAR)
-    if tools:
-        for schema in tools:
-            total += int(len(json.dumps(schema, default=str)) * _TOKENS_PER_CHAR)
-    return total
+    if system_tools_overhead_tokens is None:
+        system_tools_overhead_tokens = _system_and_tools_tokens(system, tools)
+    return _estimate_messages_tokens(messages) + system_tools_overhead_tokens
 
 
 def trim_lowest_value_tool_pair(messages: list[dict[str, Any]]) -> bool:
@@ -283,10 +316,11 @@ def truncate_content(content: Any, max_chars: int) -> tuple[Any, bool]:
 def _truncate_largest_message(
     messages: list[dict[str, Any]],
     *,
-    system: str | None,
-    tools: list[dict[str, Any]] | None,
+    message_tokens: list[int],
+    total_message_tokens: int,
+    fixed_overhead_tokens: int,
     ceiling: int,
-) -> bool:
+) -> tuple[bool, int]:
     """Truncate the biggest still-shrinkable message so the prompt fits.
 
     Tries messages largest-first (so an untruncatable assistant ``tool_calls``
@@ -298,20 +332,21 @@ def _truncate_largest_message(
     """
     order = sorted(
         range(len(messages)),
-        key=lambda i: estimate_message_tokens([messages[i]]),
+        key=message_tokens.__getitem__,
         reverse=True,
     )
     for idx in order:
-        overhead = estimate_message_tokens(
-            [m for i, m in enumerate(messages) if i != idx], system=system, tools=tools
-        )
+        overhead = (total_message_tokens - message_tokens[idx]) + fixed_overhead_tokens
         budget_tokens = max(ceiling - overhead - _TRUNCATION_SAFETY_TOKENS, _TRUNCATION_MIN_TOKENS)
         max_chars = int(budget_tokens / _TOKENS_PER_CHAR)
         new_content, changed = truncate_content(messages[idx].get("content"), max_chars)
         if changed:
             messages[idx]["content"] = new_content
-            return True
-    return False
+            updated_tokens = _message_token_estimate(messages[idx])
+            total_message_tokens += updated_tokens - message_tokens[idx]
+            message_tokens[idx] = updated_tokens
+            return True, total_message_tokens
+    return False, total_message_tokens
 
 
 def enforce_context_budget(
@@ -322,9 +357,18 @@ def enforce_context_budget(
     ceiling: int = _TOKEN_BUDGET_CEILING,
 ) -> None:
     """Trim low-value tool exchanges until the prompt fits under ``ceiling``."""
-    while estimate_message_tokens(messages, system=system, tools=tools) > ceiling:
+    fixed_overhead_tokens = _system_and_tools_tokens(system, tools)
+    message_tokens, total_message_tokens = _message_token_estimates(messages)
+    while (total_message_tokens + fixed_overhead_tokens) > ceiling:
         if not trim_lowest_value_tool_pair(messages):
-            if not _truncate_largest_message(messages, system=system, tools=tools, ceiling=ceiling):
+            changed, total_message_tokens = _truncate_largest_message(
+                messages,
+                message_tokens=message_tokens,
+                total_message_tokens=total_message_tokens,
+                fixed_overhead_tokens=fixed_overhead_tokens,
+                ceiling=ceiling,
+            )
+            if not changed:
                 logger.warning(
                     "[agent] context still over budget after trimming + truncation "
                     "(ceiling=%d); letting the request proceed",
@@ -335,6 +379,10 @@ def enforce_context_budget(
                 "[agent] truncated oversized message to fit context budget (ceiling=%d)", ceiling
             )
             continue
+        message_tokens, total_message_tokens = _refresh_message_token_estimates(
+            messages,
+            current_estimates=message_tokens,
+        )
         logger.warning(
             "[agent] trimmed low-value tool pair to fit context budget (ceiling=%d)", ceiling
         )

--- a/core/context_budget.py
+++ b/core/context_budget.py
@@ -181,16 +181,6 @@ def _message_token_estimates(messages: list[dict[str, Any]]) -> tuple[list[int],
     return tokens, sum(tokens)
 
 
-def _refresh_message_token_estimates(
-    messages: list[dict[str, Any]],
-    *,
-    current_estimates: list[int],
-) -> tuple[list[int], int]:
-    if len(current_estimates) != len(messages):
-        return _message_token_estimates(messages)
-    return current_estimates, sum(current_estimates)
-
-
 def _estimate_messages_tokens(messages: list[dict[str, Any]]) -> int:
     return sum(_message_token_estimate(message) for message in messages)
 
@@ -213,7 +203,6 @@ def estimate_message_tokens(
     *,
     system: str | None = None,
     tools: list[dict[str, Any]] | None = None,
-    system_tools_overhead_tokens: int | None = None,
 ) -> int:
     """Cheap upper-bound token estimate covering everything Anthropic sees.
 
@@ -222,9 +211,7 @@ def estimate_message_tokens(
     aggressively while system + tools (tens of thousands of tokens for
     opensre's 100+ tool registry) silently pushed us over the line.
     """
-    if system_tools_overhead_tokens is None:
-        system_tools_overhead_tokens = _system_and_tools_tokens(system, tools)
-    return _estimate_messages_tokens(messages) + system_tools_overhead_tokens
+    return _estimate_messages_tokens(messages) + _system_and_tools_tokens(system, tools)
 
 
 def trim_lowest_value_tool_pair(messages: list[dict[str, Any]]) -> bool:
@@ -379,10 +366,7 @@ def enforce_context_budget(
                 "[agent] truncated oversized message to fit context budget (ceiling=%d)", ceiling
             )
             continue
-        message_tokens, total_message_tokens = _refresh_message_token_estimates(
-            messages,
-            current_estimates=message_tokens,
-        )
+        message_tokens, total_message_tokens = _message_token_estimates(messages)
         logger.warning(
             "[agent] trimmed low-value tool pair to fit context budget (ceiling=%d)", ceiling
         )

--- a/core/execution.py
+++ b/core/execution.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field, replace
 from typing import Any
@@ -428,11 +428,9 @@ def public_tool_input(value: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def tool_source(tools: Sequence[RuntimeTool], tool_name: str) -> str:
-    for tool in tools:
-        if tool.name == tool_name:
-            return str(getattr(tool, "source", "unknown"))
-    return "unknown"
+def tool_source(tools: Mapping[str, RuntimeTool], tool_name: str) -> str:
+    tool = tools.get(tool_name)
+    return str(getattr(tool, "source", "unknown")) if tool else "unknown"
 
 
 def summarise(output: Any) -> str:

--- a/tests/core/test_context_budget.py
+++ b/tests/core/test_context_budget.py
@@ -9,6 +9,7 @@ from core.context_budget import (
     enforce_context_budget,
     estimate_message_tokens,
     strip_internal_message_markers,
+    system_and_tools_overhead,
 )
 
 
@@ -159,6 +160,38 @@ def test_enforce_context_budget_serializes_tool_schemas_once_per_invocation() ->
         enforce_context_budget(messages, tools=tools, ceiling=ceiling)
 
     assert schema_dump_calls <= len(tools)
+
+
+def test_enforce_context_budget_accepts_precomputed_overhead() -> None:
+    tools = [
+        {"type": "function", "name": f"tool_{index}", "parameters": {"type": "object"}}
+        for index in range(12)
+    ]
+    messages = [
+        {"role": "user", "content": "alert"},
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "t1", "name": "noop", "input": {}}],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "x" * 4000}],
+        },
+    ]
+    ceiling = 500
+    precomputed = system_and_tools_overhead(system="sys", tools=tools)
+    schema_dump_calls = 0
+    original_dumps = json.dumps
+
+    def counting_dumps(value: object, *args: object, **kwargs: object) -> str:
+        nonlocal schema_dump_calls
+        schema_dump_calls += _tool_schema_dump_count(value)
+        return original_dumps(value, *args, **kwargs)
+
+    with patch("core.context_budget.json.dumps", side_effect=counting_dumps):
+        enforce_context_budget(messages, fixed_overhead_tokens=precomputed, ceiling=ceiling)
+
+    assert schema_dump_calls == 0
 
 
 def test_enforce_context_budget_still_trims_when_over_ceiling_with_tools() -> None:

--- a/tests/core/test_context_budget.py
+++ b/tests/core/test_context_budget.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
-from core.context_budget import context_budget_ceiling_for_model, strip_internal_message_markers
+import json
+from unittest.mock import patch
+
+from core.context_budget import (
+    context_budget_ceiling_for_model,
+    enforce_context_budget,
+    estimate_message_tokens,
+    strip_internal_message_markers,
+)
 
 
 class TestGpt56ContextWindow:
@@ -67,3 +75,140 @@ def test_strip_internal_message_markers_preserves_other_underscore_keys() -> Non
     cleaned = strip_internal_message_markers(messages)
 
     assert cleaned == [{"role": "user", "content": "hi", "_custom": "keep"}]
+
+
+def test_estimate_message_tokens_includes_system_and_tools_overhead() -> None:
+    messages = [{"role": "user", "content": "abcd"}]
+    system = "sys"
+    tools = [
+        {"type": "function", "name": "alpha", "parameters": {"type": "object"}},
+        {
+            "type": "function",
+            "name": "beta",
+            "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+        },
+    ]
+
+    message_tokens = int(len("abcd") * 0.50)
+    system_tokens = int(len(system) * 0.50)
+    tool_tokens = sum(int(len(json.dumps(schema, default=str)) * 0.50) for schema in tools)
+    expected = message_tokens + system_tokens + tool_tokens
+
+    assert estimate_message_tokens(messages, system=system, tools=tools) == expected
+
+
+def test_estimate_message_tokens_distinguishes_distinct_tool_lists() -> None:
+    messages: list[dict[str, str]] = []
+    system = "system prompt"
+    tools_a = [{"type": "function", "name": "alpha"}]
+    tools_b = [{"type": "function", "name": "beta", "parameters": {"type": "object"}}]
+
+    assert estimate_message_tokens(
+        messages, system=system, tools=tools_a
+    ) != estimate_message_tokens(messages, system=system, tools=tools_b)
+    assert estimate_message_tokens(messages, system=system, tools=[]) == int(len(system) * 0.50)
+
+
+def test_estimate_message_tokens_reuses_precomputed_overhead() -> None:
+    tools = [
+        {
+            "type": "function",
+            "name": f"tool_{index}",
+            "parameters": {"type": "object", "x": "y" * 40},
+        }
+        for index in range(20)
+    ]
+    messages = [{"role": "user", "content": "hi"}]
+    system = "system prompt"
+
+    schema_dump_calls = 0
+    original_dumps = json.dumps
+
+    def counting_dumps(value: object, *args: object, **kwargs: object) -> str:
+        nonlocal schema_dump_calls
+        if isinstance(value, dict) and value.get("type") == "function":
+            schema_dump_calls += 1
+        return original_dumps(value, *args, **kwargs)
+
+    overhead = sum(int(len(json.dumps(schema, default=str)) * 0.50) for schema in tools) + int(
+        len(system) * 0.50
+    )
+
+    with patch("core.context_budget.json.dumps", side_effect=counting_dumps):
+        estimate_message_tokens(
+            messages,
+            tools=tools,
+            system=system,
+            system_tools_overhead_tokens=overhead,
+        )
+
+    assert schema_dump_calls == 0
+
+
+def test_enforce_context_budget_serializes_tool_schemas_once_per_invocation() -> None:
+    tools = [
+        {"type": "function", "name": f"tool_{index}", "parameters": {"type": "object"}}
+        for index in range(12)
+    ]
+    messages = [
+        {"role": "user", "content": "alert"},
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "t1", "name": "noop", "input": {}}],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "x" * 4000}],
+        },
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "t2", "name": "noop", "input": {}}],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "t2", "content": "y" * 4000}],
+        },
+    ]
+    ceiling = 500
+    schema_dump_calls = 0
+    original_dumps = json.dumps
+
+    def counting_dumps(value: object, *args: object, **kwargs: object) -> str:
+        nonlocal schema_dump_calls
+        if isinstance(value, dict) and value.get("type") == "function":
+            schema_dump_calls += 1
+        return original_dumps(value, *args, **kwargs)
+
+    with patch("core.context_budget.json.dumps", side_effect=counting_dumps):
+        enforce_context_budget(messages, tools=tools, ceiling=ceiling)
+
+    assert schema_dump_calls == len(tools)
+
+
+def test_enforce_context_budget_still_trims_when_over_ceiling_with_tools() -> None:
+    tools = [{"type": "function", "name": "noop", "parameters": {"type": "object"}}]
+    messages = [
+        {"role": "user", "content": "alert"},
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "t1", "name": "noop", "input": {}}],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "x" * 4000}],
+        },
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "t2", "name": "noop", "input": {}}],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "t2", "content": "y" * 4000}],
+        },
+    ]
+    ceiling = 500
+
+    enforce_context_budget(messages, tools=tools, ceiling=ceiling)
+
+    assert estimate_message_tokens(messages, tools=tools) <= ceiling
+    assert len(messages) < 5

--- a/tests/core/test_context_budget.py
+++ b/tests/core/test_context_budget.py
@@ -92,7 +92,9 @@ def test_estimate_message_tokens_includes_system_and_tools_overhead() -> None:
 
     message_tokens = int(len("abcd") * _TOKENS_PER_CHAR)
     system_tokens = int(len(system) * _TOKENS_PER_CHAR)
-    tool_tokens = sum(int(len(json.dumps(schema, default=str)) * _TOKENS_PER_CHAR) for schema in tools)
+    tool_tokens = sum(
+        int(len(json.dumps(schema, default=str)) * _TOKENS_PER_CHAR) for schema in tools
+    )
     expected = message_tokens + system_tokens + tool_tokens
 
     assert estimate_message_tokens(messages, system=system, tools=tools) == expected
@@ -110,6 +112,14 @@ def test_estimate_message_tokens_distinguishes_distinct_tool_lists() -> None:
     assert estimate_message_tokens(messages, system=system, tools=[]) == int(
         len(system) * _TOKENS_PER_CHAR
     )
+
+
+def _tool_schema_dump_count(value: object) -> int:
+    if isinstance(value, dict) and value.get("type") == "function":
+        return 1
+    if isinstance(value, list):
+        return sum(1 for item in value if isinstance(item, dict) and item.get("type") == "function")
+    return 0
 
 
 def test_enforce_context_budget_serializes_tool_schemas_once_per_invocation() -> None:
@@ -142,14 +152,13 @@ def test_enforce_context_budget_serializes_tool_schemas_once_per_invocation() ->
 
     def counting_dumps(value: object, *args: object, **kwargs: object) -> str:
         nonlocal schema_dump_calls
-        if isinstance(value, dict) and value.get("type") == "function":
-            schema_dump_calls += 1
+        schema_dump_calls += _tool_schema_dump_count(value)
         return original_dumps(value, *args, **kwargs)
 
     with patch("core.context_budget.json.dumps", side_effect=counting_dumps):
         enforce_context_budget(messages, tools=tools, ceiling=ceiling)
 
-    assert schema_dump_calls == len(tools)
+    assert schema_dump_calls <= len(tools)
 
 
 def test_enforce_context_budget_still_trims_when_over_ceiling_with_tools() -> None:

--- a/tests/core/test_context_budget.py
+++ b/tests/core/test_context_budget.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import patch
 
 from core.context_budget import (
+    _TOKENS_PER_CHAR,
     context_budget_ceiling_for_model,
     enforce_context_budget,
     estimate_message_tokens,
@@ -89,9 +90,9 @@ def test_estimate_message_tokens_includes_system_and_tools_overhead() -> None:
         },
     ]
 
-    message_tokens = int(len("abcd") * 0.50)
-    system_tokens = int(len(system) * 0.50)
-    tool_tokens = sum(int(len(json.dumps(schema, default=str)) * 0.50) for schema in tools)
+    message_tokens = int(len("abcd") * _TOKENS_PER_CHAR)
+    system_tokens = int(len(system) * _TOKENS_PER_CHAR)
+    tool_tokens = sum(int(len(json.dumps(schema, default=str)) * _TOKENS_PER_CHAR) for schema in tools)
     expected = message_tokens + system_tokens + tool_tokens
 
     assert estimate_message_tokens(messages, system=system, tools=tools) == expected
@@ -106,43 +107,9 @@ def test_estimate_message_tokens_distinguishes_distinct_tool_lists() -> None:
     assert estimate_message_tokens(
         messages, system=system, tools=tools_a
     ) != estimate_message_tokens(messages, system=system, tools=tools_b)
-    assert estimate_message_tokens(messages, system=system, tools=[]) == int(len(system) * 0.50)
-
-
-def test_estimate_message_tokens_reuses_precomputed_overhead() -> None:
-    tools = [
-        {
-            "type": "function",
-            "name": f"tool_{index}",
-            "parameters": {"type": "object", "x": "y" * 40},
-        }
-        for index in range(20)
-    ]
-    messages = [{"role": "user", "content": "hi"}]
-    system = "system prompt"
-
-    schema_dump_calls = 0
-    original_dumps = json.dumps
-
-    def counting_dumps(value: object, *args: object, **kwargs: object) -> str:
-        nonlocal schema_dump_calls
-        if isinstance(value, dict) and value.get("type") == "function":
-            schema_dump_calls += 1
-        return original_dumps(value, *args, **kwargs)
-
-    overhead = sum(int(len(json.dumps(schema, default=str)) * 0.50) for schema in tools) + int(
-        len(system) * 0.50
+    assert estimate_message_tokens(messages, system=system, tools=[]) == int(
+        len(system) * _TOKENS_PER_CHAR
     )
-
-    with patch("core.context_budget.json.dumps", side_effect=counting_dumps):
-        estimate_message_tokens(
-            messages,
-            tools=tools,
-            system=system,
-            system_tools_overhead_tokens=overhead,
-        )
-
-    assert schema_dump_calls == 0
 
 
 def test_enforce_context_budget_serializes_tool_schemas_once_per_invocation() -> None:

--- a/tools/investigation/stages/gather_evidence/agent.py
+++ b/tools/investigation/stages/gather_evidence/agent.py
@@ -14,6 +14,7 @@ from core import (
     estimate_message_tokens,
     execute_tools,
     summarise,
+    system_and_tools_overhead,
     tool_source,
 )
 from core.agent.mixins import EventEmitterMixin, ToolFilterMixin
@@ -219,6 +220,8 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
         self._current_evidence: dict[str, Any] = evidence
 
         context_ceiling = context_budget_ceiling_for_model(getattr(llm, "_model", None))
+        full_overhead = system_and_tools_overhead(system, tool_schemas)
+        system_only_overhead = system_and_tools_overhead(system, None)
         stagnant_iterations = 0
         force_conclusion = False
         self._last_assistant_text = ""
@@ -229,8 +232,9 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
             logger.debug("[agent] iteration=%d", iteration)
             self._emit("llm_start", {"iteration": iteration})
             active_tool_schemas: list[dict[str, Any]] = [] if force_conclusion else tool_schemas
+            active_overhead = system_only_overhead if force_conclusion else full_overhead
             enforce_context_budget(
-                messages, system=system, tools=active_tool_schemas, ceiling=context_ceiling
+                messages, fixed_overhead_tokens=active_overhead, ceiling=context_ceiling
             )
             try:
                 response = llm.invoke(messages, system=system, tools=active_tool_schemas)

--- a/tools/investigation/stages/gather_evidence/agent.py
+++ b/tools/investigation/stages/gather_evidence/agent.py
@@ -14,6 +14,7 @@ from core import (
     estimate_message_tokens,
     execute_tools,
     summarise,
+    tool_source,
 )
 from core.agent.mixins import EventEmitterMixin, ToolFilterMixin
 from core.llm.factory import LLMRole, get_llm
@@ -57,13 +58,6 @@ logger = logging.getLogger(__name__)
 def _mark_messages(messages: list[dict[str, Any]], key: str) -> None:
     for msg in messages:
         msg[key] = True
-
-
-def _runtime_tool_source(tool_by_name: dict[str, Any], tool_name: str) -> str:
-    tool = tool_by_name.get(tool_name)
-    if tool is None:
-        return "unknown"
-    return str(getattr(tool, "source", "unknown"))
 
 
 class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
@@ -203,7 +197,7 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
                         data=redact_sensitive(output),
                         tool_name=tc.name,
                         tool_args=redact_sensitive(tc.input),
-                        source=_runtime_tool_source(tool_by_name, tc.name),
+                        source=tool_source(tool_by_name, tc.name),
                         loop_iteration=-1,
                     )
                 )
@@ -329,7 +323,7 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
                         data=redact_sensitive(output),
                         tool_name=tc.name,
                         tool_args=redact_sensitive(tc.input),
-                        source=_runtime_tool_source(tool_by_name, tc.name),
+                        source=tool_source(tool_by_name, tc.name),
                         loop_iteration=iteration,
                     )
                 )

--- a/tools/investigation/stages/gather_evidence/agent.py
+++ b/tools/investigation/stages/gather_evidence/agent.py
@@ -14,7 +14,6 @@ from core import (
     estimate_message_tokens,
     execute_tools,
     summarise,
-    tool_source,
 )
 from core.agent.mixins import EventEmitterMixin, ToolFilterMixin
 from core.llm.factory import LLMRole, get_llm
@@ -58,6 +57,13 @@ logger = logging.getLogger(__name__)
 def _mark_messages(messages: list[dict[str, Any]], key: str) -> None:
     for msg in messages:
         msg[key] = True
+
+
+def _runtime_tool_source(tool_by_name: dict[str, Any], tool_name: str) -> str:
+    tool = tool_by_name.get(tool_name)
+    if tool is None:
+        return "unknown"
+    return str(getattr(tool, "source", "unknown"))
 
 
 class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
@@ -132,6 +138,7 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
         available_tools = list(self._filter_tools(get_available_tools(resolved)))
         tools = list(select_investigation_tools(available_tools, state_dict))
         tool_context = build_connected_tool_context(resolved, tools)
+        tool_by_name = {tool.name: tool for tool in tools}
 
         if not tools:
             logger.warning("No tools available for investigation")
@@ -196,7 +203,7 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
                         data=redact_sensitive(output),
                         tool_name=tc.name,
                         tool_args=redact_sensitive(tc.input),
-                        source=tool_source(tools, tc.name),
+                        source=_runtime_tool_source(tool_by_name, tc.name),
                         loop_iteration=-1,
                     )
                 )
@@ -322,7 +329,7 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
                         data=redact_sensitive(output),
                         tool_name=tc.name,
                         tool_args=redact_sensitive(tc.input),
-                        source=tool_source(tools, tc.name),
+                        source=_runtime_tool_source(tool_by_name, tc.name),
                         loop_iteration=iteration,
                     )
                 )


### PR DESCRIPTION
This PR optimizes the investigation context-budget hot path by removing repeated token estimation work inside the ReAct loop, while preserving existing behavior.

### What changed

- Refactored context token estimation in `core/context_budget.py`:
  - split message-token and system/tools-overhead estimation
  - precompute `system + tools` overhead once per enforcement pass
  - maintain per-message token estimates during trimming/truncation
  - update only affected message token counts after truncation
- Kept public behavior of budget enforcement/trimming intact.
- Improved evidence source lookup in `tools/investigation/stages/gather_evidence/agent.py` by using a prebuilt `tool_by_name` map instead of repeated linear scans.
- Added/updated tests in `tests/core/test_context_budget.py` to characterize behavior and validate overhead/token-estimation paths.

## Why we did this

Investigation runs a ReAct loop where `enforce_context_budget` is called repeatedly. Before this change, token estimation frequently re-walked message history and re-serialized large tool schema payloads (via `json.dumps`) across loop iterations and truncation attempts.

That created avoidable CPU overhead in a path that executes often, especially with:

- many registered tools / large schemas
- long investigation transcripts
- repeated budget checks near the context limit

This PR removes that repeated invariant work and narrows recomputation to only what changes.

## Why this was needed

- The context-budget path is on the per-iteration investigation hot path.
- Prior behavior paid repeated cost for mostly unchanged inputs.
- This impacted responsiveness and efficiency under heavier investigations.
- We needed a low-risk, behavior-preserving optimization that improves runtime cost without changing investigation output semantics.

## Behavior and risk

- No intended functional behavior change.
- Budget trimming/truncation semantics remain the same.
- Changes are internal to token accounting and lookup efficiency.
- Tests were added/updated to guard characterization and regressions.

## Validation

- `uv run pytest tests/core/test_context_budget.py tests/agent/test_investigation.py -q --tb=short`
- `make lint`
- `make format-check`
- `make typecheck`
