### PR TITLE
refactor(config): move .env/keyring writing to config/ so every setup surface shares one writer

### DIFF
--- a/config/env_file.py
+++ b/config/env_file.py
@@ -1,0 +1,227 @@
+"""Write credentials and settings to their correct storage tier.
+
+OpenSRE persists configuration in three places, and which one a value belongs in
+is decided by its **env var name**, not by the caller:
+
+* **system keyring** — anything :func:`is_sensitive_env_key` classifies as a
+  secret (``*_TOKEN``, ``*_KEY``, ``*_PASSWORD``, connection strings, …)
+* **project ``.env``** — everything else (URLs, ids, channels, model names)
+* the integration store — owned by ``integrations.store``, not this module
+
+The split is enforced rather than advised: :func:`sync_env_values` refuses a
+sensitive key and :func:`sync_env_secret` refuses a non-sensitive one, so a
+mis-classified credential fails loudly instead of landing in clear text on disk.
+Any ``.env`` rewrite also strips pre-existing secret assignments, so a file that
+predates the keyring does not keep leaking.
+
+This lives in ``config/`` — the layer floor — because every setup surface needs
+it: the onboarding wizard (``surfaces/``), ``opensre integrations setup``, and
+the interactive-shell action tools all persist the same credentials and must
+agree on where they go. ``config/local_env.py`` already owns *reading* the
+project env file; this owns writing it.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+
+from config.llm_auth.credentials import delete as delete_provider_auth
+from config.llm_auth.credentials import save_api_key
+from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
+from config.llm_credentials import delete_keyring_secret, save_keyring_secret
+from config.local_env import get_project_env_path
+
+PROJECT_ENV_PATH = get_project_env_path()
+
+_ENV_ASSIGNMENT = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=")
+_NON_SECRET_ENV_KEYS: frozenset[str] = frozenset({"DISCORD_PUBLIC_KEY"})
+# Underscore-separated terminal tokens that mark an env var as sensitive.
+# Matching the terminal component (rather than a substring or a fixed suffix
+# like ``_token``) catches both ``GITLAB_ACCESS_TOKEN`` and a bare ``TOKEN``
+# while leaving ``OPENAI_TOKEN_LIMIT`` (terminal ``limit``) alone.
+_SENSITIVE_TERMINAL_TOKENS: frozenset[str] = frozenset(
+    {
+        "token",
+        "secret",
+        "password",
+        "passwd",
+        "key",
+        "apikey",
+        "credential",
+        "credentials",
+    }
+)
+_SENSITIVE_SUBSTRINGS: tuple[str, ...] = ("connection_string",)
+
+
+@dataclass(frozen=True)
+class _PublicEnvLines:
+    """Validated `.env` content that contains no sensitive assignments."""
+
+    lines: tuple[str, ...]
+
+    @classmethod
+    def from_lines(cls, lines: list[str]) -> _PublicEnvLines:
+        public_lines = strip_secret_env_lines(lines)
+        _ensure_no_sensitive_env_lines(public_lines)
+        return cls(tuple(public_lines))
+
+    def write_to(self, target_path: Path) -> None:
+        with target_path.open("w", encoding="utf-8", newline="") as env_file:
+            env_file.writelines(self.lines)
+
+
+def env_assignment_key(line: str) -> str | None:
+    """Return the env key a ``.env`` line assigns, or ``None`` for non-assignments."""
+    match = _ENV_ASSIGNMENT.match(line)
+    return match.group(1) if match else None
+
+
+def is_sensitive_env_key(key: str) -> bool:
+    """True when an env var should be stored in the keyring, not plain .env."""
+    if key in _NON_SECRET_ENV_KEYS:
+        return False
+    lowered = key.lower()
+    terminal = lowered.rsplit("_", 1)[-1]
+    if terminal in _SENSITIVE_TERMINAL_TOKENS:
+        return True
+    return any(needle in lowered for needle in _SENSITIVE_SUBSTRINGS)
+
+
+def strip_secret_env_lines(lines: list[str]) -> list[str]:
+    """Drop sensitive assignments so ``.env`` writes never persist secrets."""
+    kept: list[str] = []
+    for line in lines:
+        key = env_assignment_key(line)
+        if key and is_sensitive_env_key(key):
+            continue
+        kept.append(line)
+    return kept
+
+
+def _ensure_no_sensitive_env_lines(lines: list[str]) -> None:
+    """Fail closed when a sensitive assignment would be written to disk."""
+    for line in lines:
+        key = env_assignment_key(line)
+        if key and is_sensitive_env_key(key):
+            raise RuntimeError(
+                f"Refusing to write sensitive env key {key!r} to .env; use the system keyring."
+            )
+
+
+def _persist_env_secret(key: str, value: str) -> bool:
+    """Store a secret in the keyring. Returns False when keyring is unavailable."""
+    normalized = value.strip()
+    provider = next(
+        (name for name, env_var in API_KEY_PROVIDER_ENVS.items() if env_var == key),
+        "",
+    )
+    if not normalized:
+        if provider:
+            delete_provider_auth(provider)
+        else:
+            delete_keyring_secret(key)
+        return True
+    try:
+        if provider:
+            save_api_key(provider, normalized)
+        else:
+            save_keyring_secret(key, normalized)
+    except RuntimeError:
+        return False
+    return True
+
+
+def set_env_value(lines: list[str], key: str, value: str) -> list[str]:
+    """Return ``lines`` with ``key`` assigned to ``value`` (appended when absent)."""
+    if is_sensitive_env_key(key):
+        raise RuntimeError(
+            f"Refusing to write sensitive env key {key!r} to .env; use sync_env_secret()."
+        )
+    updated: list[str] = []
+    replaced = False
+    for line in lines:
+        if env_assignment_key(line) != key:
+            updated.append(line)
+            continue
+        if not replaced:
+            updated.append(f"{key}={value}\n")
+            replaced = True
+
+    if not replaced:
+        if updated and not updated[-1].endswith("\n"):
+            updated[-1] = updated[-1] + "\n"
+        updated.append(f"{key}={value}\n")
+    return updated
+
+
+def read_env_lines(target_path: Path) -> list[str]:
+    """Read a ``.env`` file into lines, or return ``[]`` when it does not exist."""
+    if not target_path.exists():
+        return []
+    return target_path.read_text(encoding="utf-8").splitlines(keepends=True)
+
+
+def write_env_lines(target_path: Path, lines: list[str]) -> None:
+    """Write non-sensitive .env lines with owner-only permissions when possible."""
+    public_lines = _PublicEnvLines.from_lines(lines)
+    try:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        public_lines.write_to(target_path)
+    except PermissionError as exc:
+        raise PermissionError(
+            f"Cannot write to {target_path}: permission denied. "
+            "Ensure you have write access to this file, or run the command as the file owner."
+        ) from exc
+    if os.name != "nt":
+        with suppress(OSError):
+            target_path.chmod(0o600)
+
+
+def sync_env_secret(key: str, value: str) -> None:
+    """Persist a sensitive env value in the system keyring, not in ``.env``."""
+    if not is_sensitive_env_key(key):
+        raise ValueError(f"{key!r} is not classified as sensitive; use sync_env_values instead.")
+    _persist_env_secret(key, value)
+
+
+def sync_env_values(
+    values: dict[str, str],
+    *,
+    env_path: Path | None = None,
+) -> Path:
+    """Write multiple non-sensitive environment values into the target .env file.
+
+    Sensitive keys must be persisted with :func:`sync_env_secret` instead.
+    Existing sensitive assignments are removed from ``.env`` whenever this file
+    is rewritten so secrets do not remain in clear text.
+    """
+    sensitive_keys = [key for key in values if is_sensitive_env_key(key)]
+    if sensitive_keys:
+        joined = ", ".join(repr(key) for key in sensitive_keys)
+        raise ValueError(f"Refusing to sync sensitive env keys {joined}; use sync_env_secret().")
+
+    target_path = env_path or PROJECT_ENV_PATH
+    lines = strip_secret_env_lines(read_env_lines(target_path))
+    for key, value in values.items():
+        lines = set_env_value(lines, key, value)
+
+    write_env_lines(target_path, lines)
+    return target_path
+
+
+__all__ = [
+    "PROJECT_ENV_PATH",
+    "env_assignment_key",
+    "is_sensitive_env_key",
+    "read_env_lines",
+    "set_env_value",
+    "strip_secret_env_lines",
+    "sync_env_secret",
+    "sync_env_values",
+    "write_env_lines",
+]

--- a/config/env_file.py
+++ b/config/env_file.py
@@ -139,7 +139,7 @@ def _persist_env_secret(key: str, value: str) -> bool:
 def set_env_value(lines: list[str], key: str, value: str) -> list[str]:
     """Return ``lines`` with ``key`` assigned to ``value`` (appended when absent)."""
     if is_sensitive_env_key(key):
-        raise RuntimeError(
+        raise ValueError(
             f"Refusing to write sensitive env key {key!r} to .env; use sync_env_secret()."
         )
     updated: list[str] = []
@@ -183,10 +183,18 @@ def write_env_lines(target_path: Path, lines: list[str]) -> None:
 
 
 def sync_env_secret(key: str, value: str) -> None:
-    """Persist a sensitive env value in the system keyring, not in ``.env``."""
+    """Persist a sensitive env value in the system keyring, not in ``.env``.
+
+    Raises ``RuntimeError`` when the keyring backend cannot store the secret so
+    callers never treat a dropped credential as a successful write.
+    """
     if not is_sensitive_env_key(key):
         raise ValueError(f"{key!r} is not classified as sensitive; use sync_env_values instead.")
-    _persist_env_secret(key, value)
+    if not _persist_env_secret(key, value):
+        raise RuntimeError(
+            f"Failed to persist {key!r} to the system keyring; "
+            "secure local credential storage is unavailable."
+        )
 
 
 def sync_env_values(

--- a/surfaces/cli/wizard/configurators/alerting.py
+++ b/surfaces/cli/wizard/configurators/alerting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from config.env_file import sync_env_secret, sync_env_values
 from integrations.store import upsert_integration
 from platform.terminal.theme import ERROR, SECONDARY
 from surfaces.cli.wizard._ui import (
@@ -14,7 +15,6 @@ from surfaces.cli.wizard._ui import (
     _render_integration_result,
     _string_value,
 )
-from surfaces.cli.wizard.env_sync import sync_env_secret, sync_env_values
 from surfaces.cli.wizard.integration_health import (
     validate_alertmanager_integration,
     validate_betterstack_integration,

--- a/surfaces/cli/wizard/configurators/aws.py
+++ b/surfaces/cli/wizard/configurators/aws.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from config.env_file import sync_env_values
 from integrations.store import upsert_integration
 from platform.terminal.theme import SECONDARY
 from surfaces.cli.wizard._ui import (
@@ -13,7 +14,6 @@ from surfaces.cli.wizard._ui import (
     _render_integration_result,
     _string_value,
 )
-from surfaces.cli.wizard.env_sync import sync_env_values
 from surfaces.cli.wizard.integration_health import validate_aws_integration
 
 

--- a/surfaces/cli/wizard/configurators/chat_notifications.py
+++ b/surfaces/cli/wizard/configurators/chat_notifications.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from config.env_file import sync_env_secret, sync_env_values
 from integrations.store import upsert_integration
 from platform.terminal.theme import ERROR, GLYPH_ERROR, SECONDARY, WARNING
 from surfaces.cli.wizard._ui import (
@@ -13,7 +14,6 @@ from surfaces.cli.wizard._ui import (
     _render_integration_result,
     _string_value,
 )
-from surfaces.cli.wizard.env_sync import sync_env_secret, sync_env_values
 from surfaces.cli.wizard.integration_health import (
     validate_discord_bot,
     validate_rocketchat,

--- a/surfaces/cli/wizard/configurators/dagster.py
+++ b/surfaces/cli/wizard/configurators/dagster.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from config.env_file import sync_env_secret, sync_env_values
 from integrations.store import upsert_integration
 from platform.terminal.theme import SECONDARY
 from surfaces.cli.wizard._ui import (
@@ -11,7 +12,6 @@ from surfaces.cli.wizard._ui import (
     _render_integration_result,
     _string_value,
 )
-from surfaces.cli.wizard.env_sync import sync_env_secret, sync_env_values
 from surfaces.cli.wizard.integration_health import validate_dagster_integration
 
 

--- a/surfaces/cli/wizard/configurators/github.py
+++ b/surfaces/cli/wizard/configurators/github.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from config.env_file import sync_env_values
 from integrations.store import upsert_integration
 from platform.terminal.theme import DEVICE_CODE, SECONDARY
 from surfaces.cli.wizard._ui import (
@@ -15,7 +16,6 @@ from surfaces.cli.wizard._ui import (
     _render_integration_result,
     _string_value,
 )
-from surfaces.cli.wizard.env_sync import sync_env_values
 from surfaces.cli.wizard.integration_health import validate_github_mcp_integration
 
 DEFAULT_GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/"

--- a/surfaces/cli/wizard/configurators/gitlab.py
+++ b/surfaces/cli/wizard/configurators/gitlab.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from config.env_file import sync_env_secret, sync_env_values
 from integrations.store import upsert_integration
 from platform.terminal.theme import SECONDARY
 from surfaces.cli.wizard._ui import (
@@ -11,7 +12,6 @@ from surfaces.cli.wizard._ui import (
     _render_integration_result,
     _string_value,
 )
-from surfaces.cli.wizard.env_sync import sync_env_secret, sync_env_values
 from surfaces.cli.wizard.integration_health import validate_gitlab_integration
 
 DEFAULT_GITLAB_BASE_URL = "https://gitlab.com/api/v4"

--- a/surfaces/cli/wizard/configurators/jenkins.py
+++ b/surfaces/cli/wizard/configurators/jenkins.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from config.env_file import sync_env_secret, sync_env_values
 from integrations.store import upsert_integration
 from platform.terminal.theme import SECONDARY
 from surfaces.cli.wizard._ui import (
@@ -11,7 +12,6 @@ from surfaces.cli.wizard._ui import (
     _render_integration_result,
     _string_value,
 )
-from surfaces.cli.wizard.env_sync import sync_env_secret, sync_env_values
 from surfaces.cli.wizard.integration_health import validate_jenkins_integration
 
 

--- a/surfaces/cli/wizard/configurators/observability.py
+++ b/surfaces/cli/wizard/configurators/observability.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from config.env_file import sync_env_secret, sync_env_values
 from integrations.store import remove_integration, upsert_integration
 from platform.terminal.theme import DIM, ERROR, GLYPH_ERROR, HIGHLIGHT, SECONDARY
 from surfaces.cli.wizard._ui import (
@@ -14,7 +15,6 @@ from surfaces.cli.wizard._ui import (
     _render_integration_result,
     _string_value,
 )
-from surfaces.cli.wizard.env_sync import sync_env_secret, sync_env_values
 from surfaces.cli.wizard.integration_health import (
     validate_coralogix_integration,
     validate_datadog_integration,

--- a/surfaces/cli/wizard/configurators/openclaw.py
+++ b/surfaces/cli/wizard/configurators/openclaw.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from urllib.parse import urlparse
 
+from config.env_file import sync_env_secret, sync_env_values
 from integrations.store import upsert_integration
 from platform.terminal.theme import HIGHLIGHT, SECONDARY
 from surfaces.cli.wizard._ui import (
@@ -14,7 +15,6 @@ from surfaces.cli.wizard._ui import (
     _render_integration_result,
     _string_value,
 )
-from surfaces.cli.wizard.env_sync import sync_env_secret, sync_env_values
 from surfaces.cli.wizard.integration_health import validate_openclaw_integration
 
 DEFAULT_OPENCLAW_MCP_URL = "http://127.0.0.1:18789/"

--- a/surfaces/cli/wizard/configurators/posthog.py
+++ b/surfaces/cli/wizard/configurators/posthog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from config.constants.posthog import DEFAULT_POSTHOG_URL
+from config.env_file import sync_env_secret, sync_env_values
 from integrations.store import upsert_integration
 from platform.terminal.theme import HIGHLIGHT, SECONDARY
 from surfaces.cli.wizard._ui import (
@@ -13,7 +14,6 @@ from surfaces.cli.wizard._ui import (
     _render_integration_result,
     _string_value,
 )
-from surfaces.cli.wizard.env_sync import sync_env_secret, sync_env_values
 from surfaces.cli.wizard.integration_health import (
     validate_posthog_integration,
     validate_posthog_mcp_integration,

--- a/surfaces/cli/wizard/configurators/productivity.py
+++ b/surfaces/cli/wizard/configurators/productivity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from config.env_file import sync_env_secret, sync_env_values
 from integrations.store import upsert_integration
 from platform.terminal.theme import SECONDARY
 from surfaces.cli.wizard._ui import (
@@ -11,7 +12,6 @@ from surfaces.cli.wizard._ui import (
     _render_integration_result,
     _string_value,
 )
-from surfaces.cli.wizard.env_sync import sync_env_secret, sync_env_values
 from surfaces.cli.wizard.integration_health import (
     validate_google_docs_integration,
     validate_jira_integration,

--- a/surfaces/cli/wizard/configurators/sentry.py
+++ b/surfaces/cli/wizard/configurators/sentry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from config.env_file import sync_env_secret, sync_env_values
 from integrations.sentry import get_sentry_auth_recommendations
 from integrations.store import upsert_integration
 from platform.terminal.theme import HIGHLIGHT, SECONDARY
@@ -13,7 +14,6 @@ from surfaces.cli.wizard._ui import (
     _render_integration_result,
     _string_value,
 )
-from surfaces.cli.wizard.env_sync import sync_env_secret, sync_env_values
 from surfaces.cli.wizard.integration_health import (
     validate_sentry_integration,
     validate_sentry_mcp_integration,

--- a/surfaces/cli/wizard/configurators/vercel.py
+++ b/surfaces/cli/wizard/configurators/vercel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from config.env_file import sync_env_values
 from integrations.store import upsert_integration
 from platform.terminal.theme import SECONDARY
 from surfaces.cli.wizard._ui import (
@@ -11,7 +12,6 @@ from surfaces.cli.wizard._ui import (
     _render_integration_result,
     _string_value,
 )
-from surfaces.cli.wizard.env_sync import sync_env_values
 from surfaces.cli.wizard.integration_health import validate_vercel_integration
 
 

--- a/surfaces/cli/wizard/env_sync.py
+++ b/surfaces/cli/wizard/env_sync.py
@@ -1,204 +1,27 @@
-"""Helpers to sync wizard choices into the project .env file."""
+"""Sync wizard LLM-provider choices into the project .env file.
+
+Generic ``.env`` / keyring writing lives in :mod:`config.env_file` so every
+setup surface shares one implementation. What stays here is the part that is
+specific to the wizard's LLM provider model: which env keys a provider owns,
+stripping the previous provider's keys on a switch, and mirroring the selection
+into the wizard store.
+"""
 
 from __future__ import annotations
 
 import os
-import re
-from contextlib import suppress
-from dataclasses import dataclass
 from pathlib import Path
 
-from config.llm_auth.auth_method import LLM_AUTH_METHOD_ENV
-from config.llm_auth.credentials import delete as delete_provider_auth
-from config.llm_auth.credentials import save_api_key
-from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
-from config.llm_credentials import delete_keyring_secret, save_keyring_secret
-from surfaces.cli.wizard.config import PROJECT_ENV_PATH, ProviderOption
-
-_ENV_ASSIGNMENT = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=")
-_NON_SECRET_ENV_KEYS: frozenset[str] = frozenset({"DISCORD_PUBLIC_KEY"})
-# Underscore-separated terminal tokens that mark an env var as sensitive.
-# Matching the terminal component (rather than a substring or a fixed suffix
-# like ``_token``) catches both ``GITLAB_ACCESS_TOKEN`` and a bare ``TOKEN``
-# while leaving ``OPENAI_TOKEN_LIMIT`` (terminal ``limit``) alone.
-_SENSITIVE_TERMINAL_TOKENS: frozenset[str] = frozenset(
-    {
-        "token",
-        "secret",
-        "password",
-        "passwd",
-        "key",
-        "apikey",
-        "credential",
-        "credentials",
-    }
+from config.env_file import (
+    PROJECT_ENV_PATH,
+    env_assignment_key,
+    read_env_lines,
+    set_env_value,
+    sync_env_values,
+    write_env_lines,
 )
-_SENSITIVE_SUBSTRINGS: tuple[str, ...] = ("connection_string",)
-
-
-@dataclass(frozen=True)
-class _PublicEnvLines:
-    """Validated `.env` content that contains no sensitive assignments."""
-
-    lines: tuple[str, ...]
-
-    @classmethod
-    def from_lines(cls, lines: list[str]) -> _PublicEnvLines:
-        public_lines = _strip_sensitive_env_lines(lines)
-        _ensure_no_sensitive_env_lines(public_lines)
-        return cls(tuple(public_lines))
-
-    def write_to(self, target_path: Path) -> None:
-        with target_path.open("w", encoding="utf-8", newline="") as env_file:
-            env_file.writelines(self.lines)
-
-
-def _is_sensitive_env_key(key: str) -> bool:
-    """True when an env var should be stored in the keyring, not plain .env."""
-    if key in _NON_SECRET_ENV_KEYS:
-        return False
-    lowered = key.lower()
-    terminal = lowered.rsplit("_", 1)[-1]
-    if terminal in _SENSITIVE_TERMINAL_TOKENS:
-        return True
-    return any(needle in lowered for needle in _SENSITIVE_SUBSTRINGS)
-
-
-def _strip_sensitive_env_lines(lines: list[str]) -> list[str]:
-    """Remove secret assignments so .env only carries non-sensitive config."""
-    stripped: list[str] = []
-    for line in lines:
-        match = _ENV_ASSIGNMENT.match(line)
-        if match and _is_sensitive_env_key(match.group(1)):
-            continue
-        stripped.append(line)
-    return stripped
-
-
-def _strip_keyring_backed_secret_lines(lines: list[str]) -> list[str]:
-    """Drop sensitive assignments so `.env` writes never persist secrets."""
-    kept: list[str] = []
-    for line in lines:
-        match = _ENV_ASSIGNMENT.match(line)
-        if match and _is_sensitive_env_key(match.group(1)):
-            continue
-        kept.append(line)
-    return kept
-
-
-def _persist_env_secret(key: str, value: str) -> bool:
-    """Store a secret in the keyring. Returns False when keyring is unavailable."""
-    normalized = value.strip()
-    provider = next(
-        (name for name, env_var in API_KEY_PROVIDER_ENVS.items() if env_var == key),
-        "",
-    )
-    if not normalized:
-        if provider:
-            delete_provider_auth(provider)
-        else:
-            delete_keyring_secret(key)
-        return True
-    try:
-        if provider:
-            save_api_key(provider, normalized)
-        else:
-            save_keyring_secret(key, normalized)
-    except RuntimeError:
-        return False
-    return True
-
-
-def _set_env_value(lines: list[str], key: str, value: str) -> list[str]:
-    if _is_sensitive_env_key(key):
-        raise RuntimeError(
-            f"Refusing to write sensitive env key {key!r} to .env; use sync_env_secret()."
-        )
-    updated: list[str] = []
-    replaced = False
-    for line in lines:
-        match = _ENV_ASSIGNMENT.match(line)
-        if not match or match.group(1) != key:
-            updated.append(line)
-            continue
-        if not replaced:
-            updated.append(f"{key}={value}\n")
-            replaced = True
-
-    if not replaced:
-        if updated and not updated[-1].endswith("\n"):
-            updated[-1] = updated[-1] + "\n"
-        updated.append(f"{key}={value}\n")
-    return updated
-
-
-def _ensure_no_sensitive_env_lines(lines: list[str]) -> None:
-    """Fail closed when a sensitive assignment would be written to disk."""
-    for line in lines:
-        match = _ENV_ASSIGNMENT.match(line)
-        if match and _is_sensitive_env_key(match.group(1)):
-            raise RuntimeError(
-                f"Refusing to write sensitive env key {match.group(1)!r} to .env; use the system keyring."
-            )
-
-
-def _write_env(target_path: Path, lines: list[str]) -> None:
-    """Write non-sensitive .env lines with owner-only permissions when possible."""
-    public_lines = _PublicEnvLines.from_lines(lines)
-    try:
-        target_path.parent.mkdir(parents=True, exist_ok=True)
-        public_lines.write_to(target_path)
-    except PermissionError as exc:
-        raise PermissionError(
-            f"Cannot write to {target_path}: permission denied. "
-            "Ensure you have write access to this file, or run the command as the file owner."
-        ) from exc
-    if os.name != "nt":
-        with suppress(OSError):
-            target_path.chmod(0o600)
-
-
-def _write_env_lines(target_path: Path, lines: list[str]) -> None:
-    """Write merged env lines after rejecting sensitive assignments."""
-    _write_env(target_path, lines)
-
-
-def sync_env_secret(key: str, value: str) -> None:
-    """Persist a sensitive env value in the system keyring, not in ``.env``."""
-    if not _is_sensitive_env_key(key):
-        raise ValueError(f"{key!r} is not classified as sensitive; use sync_env_values instead.")
-    _persist_env_secret(key, value)
-
-
-def sync_env_values(
-    values: dict[str, str],
-    *,
-    env_path: Path | None = None,
-) -> Path:
-    """Write multiple non-sensitive environment values into the target .env file.
-
-    Sensitive keys must be persisted with :func:`sync_env_secret` instead.
-    Existing sensitive assignments are removed from ``.env`` whenever this file
-    is rewritten so secrets do not remain in clear text.
-    """
-    sensitive_keys = [key for key in values if _is_sensitive_env_key(key)]
-    if sensitive_keys:
-        joined = ", ".join(repr(key) for key in sensitive_keys)
-        raise ValueError(f"Refusing to sync sensitive env keys {joined}; use sync_env_secret().")
-
-    target_path = env_path or PROJECT_ENV_PATH
-    existing = (
-        target_path.read_text(encoding="utf-8").splitlines(keepends=True)
-        if target_path.exists()
-        else []
-    )
-
-    lines = _strip_keyring_backed_secret_lines(list(existing))
-    for key, value in values.items():
-        lines = _set_env_value(lines, key, value)
-
-    _write_env_lines(target_path, lines)
-    return target_path
+from config.llm_auth.auth_method import LLM_AUTH_METHOD_ENV
+from surfaces.cli.wizard.config import ProviderOption
 
 
 def sync_reasoning_model_env(
@@ -211,7 +34,10 @@ def sync_reasoning_model_env(
     values: dict[str, str] = {provider.model_env: model}
     if provider.legacy_model_env:
         values[provider.legacy_model_env] = model
-    target_path = sync_env_values(values, env_path=env_path)
+    # Resolve the default here rather than letting ``sync_env_values`` fall back
+    # to its own: ``sync_provider_env`` below already resolves against this
+    # module's ``PROJECT_ENV_PATH``, and both writers must agree on the target.
+    target_path = sync_env_values(values, env_path=env_path or PROJECT_ENV_PATH)
     os.environ.update(values)
     _sync_llm_selection_to_store(provider=provider, model=model)
     return target_path
@@ -265,8 +91,7 @@ def _provider_specific_keys(p: ProviderOption) -> set[str]:
 
 def _env_value_from_lines(lines: list[str], key: str) -> str | None:
     for line in lines:
-        match = _ENV_ASSIGNMENT.match(line)
-        if match and match.group(1) == key:
+        if env_assignment_key(line) == key:
             _, _, rhs = line.partition("=")
             return rhs.strip().strip("\"'") or None
     return None
@@ -276,8 +101,8 @@ def _remove_keys(lines: list[str], keys_to_remove: set[str]) -> list[str]:
     """Drop lines whose env key is in *keys_to_remove*."""
     result: list[str] = []
     for line in lines:
-        match = _ENV_ASSIGNMENT.match(line)
-        if match and match.group(1) in keys_to_remove:
+        key = env_assignment_key(line)
+        if key and key in keys_to_remove:
             continue
         result.append(line)
     return result
@@ -302,11 +127,7 @@ def sync_provider_env(
 
     resolved_model_provider = model_provider or provider
     target_path = env_path or PROJECT_ENV_PATH
-    existing = (
-        target_path.read_text(encoding="utf-8").splitlines(keepends=True)
-        if target_path.exists()
-        else []
-    )
+    existing = read_env_lines(target_path)
 
     # Strip every provider's API key and every provider's model keys except the
     # active provider's model slots (secrets are stored in the system keyring).
@@ -370,9 +191,9 @@ def sync_provider_env(
         values.update(extra_env)
 
     for key, value in values.items():
-        lines = _set_env_value(lines, key, value)
+        lines = set_env_value(lines, key, value)
 
-    _write_env_lines(target_path, lines)
+    write_env_lines(target_path, lines)
 
     for key in keys_to_remove:
         os.environ.pop(key, None)

--- a/surfaces/cli/wizard/flow.py
+++ b/surfaces/cli/wizard/flow.py
@@ -15,6 +15,7 @@ import questionary
 from rich.text import Text
 
 import surfaces.cli.wizard._integration_configurators as _integration_configurators_module
+from config.env_file import sync_env_values
 from config.llm_auth.auth_method import (
     API_KEY_AUTH_METHOD,
     OAUTH_AUTH_METHOD,
@@ -61,7 +62,7 @@ from surfaces.cli.wizard.configurators.github import (
     DEFAULT_GITHUB_MCP_MODE,
     DEFAULT_GITHUB_MCP_URL,
 )
-from surfaces.cli.wizard.env_sync import sync_env_values, sync_provider_env
+from surfaces.cli.wizard.env_sync import sync_provider_env
 from surfaces.cli.wizard.integration_health import IntegrationHealthResult
 from surfaces.cli.wizard.probes import ProbeResult, probe_local_target, probe_remote_target
 from surfaces.cli.wizard.store import get_store_path, save_local_config

--- a/surfaces/cli/wizard/local_llm/command.py
+++ b/surfaces/cli/wizard/local_llm/command.py
@@ -6,9 +6,10 @@ import questionary
 from rich.console import Console
 
 from config.config import DEFAULT_OLLAMA_HOST
+from config.env_file import sync_env_values
 from platform.terminal.theme import DIM, ERROR, HIGHLIGHT, WARNING
 from surfaces.cli.wizard.config import PROVIDER_BY_VALUE
-from surfaces.cli.wizard.env_sync import sync_env_values, sync_provider_env
+from surfaces.cli.wizard.env_sync import sync_provider_env
 from surfaces.cli.wizard.local_llm.hardware import detect_hardware, recommend_model
 from surfaces.cli.wizard.local_llm.ollama import (
     install,

--- a/surfaces/interactive_shell/command_registry/model/switching.py
+++ b/surfaces/interactive_shell/command_registry/model/switching.py
@@ -197,8 +197,8 @@ def switch_toolcall_model(
     provider_name: str | None = None,
 ) -> bool:
     """Set the toolcall model for the active (or named) provider."""
+    from config.env_file import sync_env_values
     from surfaces.cli.wizard.config import PROVIDER_BY_VALUE
-    from surfaces.cli.wizard.env_sync import sync_env_values
 
     raw_name = provider_name if provider_name else os.getenv("LLM_PROVIDER", "anthropic")
     resolved_name = (raw_name or "anthropic").strip().lower()

--- a/tests/cli/test_model_persistence_scenarios.py
+++ b/tests/cli/test_model_persistence_scenarios.py
@@ -27,6 +27,7 @@ def persistence_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[s
     env_path = tmp_path / "project.env"
     store_path = tmp_path / "opensre.json"
     monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+    monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", env_path)
     monkeypatch.setattr(wizard_store, "get_store_path", lambda: store_path)
     return {"env": env_path, "store": store_path}
 

--- a/tests/cli/wizard/test_configurators_chat_notifications.py
+++ b/tests/cli/wizard/test_configurators_chat_notifications.py
@@ -1,0 +1,213 @@
+"""Characterization tests for the onboarding wizard's Telegram configurator.
+
+These pin the observable behavior of
+:func:`surfaces.cli.wizard.configurators.chat_notifications._configure_telegram`
+before it is migrated onto the shared setup flow: the prompts, validate-before-
+persist ordering, the retry loop on a bad token, the credential tiers it writes
+(store + keyring + ``.env``), and the "configured but cannot deliver" advisory.
+
+This path is the reference for the credential-resolution contract in
+``docs/adding-tools-and-integrations.md`` — the keyring/``.env`` assertions here
+are what the migration must carry over, not drop.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import surfaces.cli.wizard.configurators.chat_notifications as chat_notifications
+from surfaces.cli.wizard.integration_validators.shared import IntegrationHealthResult
+
+_TOKEN = "123456789:AAExampleSecretTokenValue"
+_CHAT_ID = "-1001234567890"
+_ENV_PATH = Path("/tmp/opensre-test/.env")
+
+
+class _RecordingConsole:
+    """Minimal stand-in for the wizard console that captures printed output."""
+
+    def __init__(self) -> None:
+        self.output: list[str] = []
+
+    def print(self, *args: Any, **_kwargs: Any) -> None:
+        self.output.append(" ".join(str(arg) for arg in args))
+
+    @contextmanager
+    def status(self, *_args: Any, **_kwargs: Any) -> Iterator[None]:
+        yield
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self.output)
+
+
+@dataclass(frozen=True)
+class _Prompt:
+    """One question the configurator asked."""
+
+    label: str
+    secret: bool
+    allow_empty: bool
+
+
+@dataclass
+class _Wizard:
+    """Scripted answers/results for one run, plus everything the run did."""
+
+    console: _RecordingConsole = field(default_factory=_RecordingConsole)
+    # Scripted inputs, consumed in order.
+    answers: list[str] = field(default_factory=list)
+    results: list[IntegrationHealthResult] = field(default_factory=list)
+    # Recorded effects.
+    asked: list[_Prompt] = field(default_factory=list)
+    validated: list[str] = field(default_factory=list)
+    saved: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+    keyring: list[tuple[str, str]] = field(default_factory=list)
+    env_values: list[dict[str, str]] = field(default_factory=list)
+
+
+@pytest.fixture
+def wizard(monkeypatch: pytest.MonkeyPatch) -> _Wizard:
+    """Patch every collaborator of ``_configure_telegram`` and expose the calls."""
+    run = _Wizard()
+
+    def _fake_prompt(
+        label: str,
+        *,
+        default: str = "",
+        secret: bool = False,
+        allow_empty: bool = False,
+        back_on_cancel: bool = False,
+    ) -> str:
+        run.asked.append(_Prompt(label=label, secret=secret, allow_empty=allow_empty))
+        return run.answers.pop(0)
+
+    def _fake_validate(*, bot_token: str) -> IntegrationHealthResult:
+        run.validated.append(bot_token)
+        return run.results.pop(0)
+
+    def _fake_sync_env_values(values: dict[str, str], **_kwargs: Any) -> Path:
+        run.env_values.append(dict(values))
+        return _ENV_PATH
+
+    monkeypatch.setattr(chat_notifications, "_console", run.console)
+    monkeypatch.setattr(chat_notifications, "_integration_defaults", lambda _s: ({}, {}))
+    monkeypatch.setattr(chat_notifications, "_prompt_value", _fake_prompt)
+    monkeypatch.setattr(chat_notifications, "validate_telegram_bot", _fake_validate)
+    monkeypatch.setattr(chat_notifications, "_render_integration_result", lambda *_a: None)
+    monkeypatch.setattr(
+        chat_notifications,
+        "upsert_integration",
+        lambda service, payload: run.saved.append((service, payload)),
+    )
+    monkeypatch.setattr(
+        chat_notifications,
+        "sync_env_secret",
+        lambda key, value: run.keyring.append((key, value)),
+    )
+    monkeypatch.setattr(chat_notifications, "sync_env_values", _fake_sync_env_values)
+    return run
+
+
+def _ok(detail: str = "Connected to Telegram bot @acme_bot.") -> IntegrationHealthResult:
+    return IntegrationHealthResult(ok=True, detail=detail)
+
+
+def _bad(detail: str = "Telegram API check failed: Unauthorized") -> IntegrationHealthResult:
+    return IntegrationHealthResult(ok=False, detail=detail)
+
+
+def test_prompts_for_token_then_chat_id(wizard: _Wizard) -> None:
+    wizard.answers[:] = [_TOKEN, _CHAT_ID]
+    wizard.results[:] = [_ok()]
+
+    chat_notifications._configure_telegram()
+
+    asked = wizard.asked
+    assert len(asked) == 2
+    # The token is masked and mandatory; the chat id is asked for but skippable.
+    assert asked[0].secret is True
+    assert "token" in asked[0].label.lower()
+    assert asked[1].allow_empty is True
+    assert "chat" in asked[1].label.lower()
+
+
+def test_writes_store_keyring_and_env_on_success(wizard: _Wizard) -> None:
+    """All three credential tiers are written — the contract the refactor must keep."""
+    wizard.answers[:] = [_TOKEN, _CHAT_ID]
+    wizard.results[:] = [_ok()]
+
+    label, env_path = chat_notifications._configure_telegram()
+
+    assert wizard.saved == [
+        (
+            "telegram",
+            {"credentials": {"bot_token": _TOKEN, "default_chat_id": _CHAT_ID}},
+        )
+    ]
+    assert wizard.keyring == [("TELEGRAM_BOT_TOKEN", _TOKEN)]
+    assert wizard.env_values == [{"TELEGRAM_DEFAULT_CHAT_ID": _CHAT_ID}]
+    assert label == "Telegram"
+    assert env_path == str(_ENV_PATH)
+
+
+def test_validation_runs_before_anything_is_persisted(wizard: _Wizard) -> None:
+    wizard.answers[:] = [_TOKEN, _CHAT_ID]
+    wizard.results[:] = [_ok()]
+
+    chat_notifications._configure_telegram()
+
+    assert wizard.validated == [_TOKEN]
+
+
+def test_bad_token_re_prompts_and_saves_nothing_until_it_validates(
+    wizard: _Wizard,
+) -> None:
+    """The wizard loops on a rejected token rather than persisting junk."""
+    wizard.answers[:] = ["wrong-token", "", _TOKEN, _CHAT_ID]
+    wizard.results[:] = [_bad(), _ok()]
+
+    chat_notifications._configure_telegram()
+
+    assert wizard.validated == ["wrong-token", _TOKEN]
+    # Only the second, valid attempt reaches the store.
+    assert len(wizard.saved) == 1
+    assert wizard.saved[0][1]["credentials"]["bot_token"] == _TOKEN
+    assert wizard.keyring == [("TELEGRAM_BOT_TOKEN", _TOKEN)]
+
+
+def test_blank_chat_id_saves_none_and_warns_about_delivery(wizard: _Wizard) -> None:
+    """Token-only setup verifies, but Hermes/watchdog cannot deliver without a chat id."""
+    wizard.answers[:] = [_TOKEN, ""]
+    wizard.results[:] = [_ok()]
+
+    chat_notifications._configure_telegram()
+
+    assert wizard.saved[0][1]["credentials"]["default_chat_id"] is None
+    # No chat id means no env value to sync, but .env is still written.
+    assert wizard.env_values == [{}]
+    assert "TELEGRAM_DEFAULT_CHAT_ID" in wizard.console.text
+
+
+def test_no_delivery_warning_once_a_chat_id_is_set(wizard: _Wizard) -> None:
+    wizard.answers[:] = [_TOKEN, _CHAT_ID]
+    wizard.results[:] = [_ok()]
+
+    chat_notifications._configure_telegram()
+
+    assert "No default chat ID set" not in wizard.console.text
+
+
+def test_token_is_never_echoed_to_the_console(wizard: _Wizard) -> None:
+    wizard.answers[:] = [_TOKEN, _CHAT_ID]
+    wizard.results[:] = [_ok()]
+
+    chat_notifications._configure_telegram()
+
+    assert _TOKEN not in wizard.console.text

--- a/tests/cli/wizard/test_configurators_chat_notifications.py
+++ b/tests/cli/wizard/test_configurators_chat_notifications.py
@@ -26,7 +26,7 @@ from surfaces.cli.wizard.integration_validators.shared import IntegrationHealthR
 
 _TOKEN = "123456789:AAExampleSecretTokenValue"
 _CHAT_ID = "-1001234567890"
-_ENV_PATH = Path("/tmp/opensre-test/.env")
+_ENV_PATH = Path("sentinel.env")
 
 
 class _RecordingConsole:

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -6,12 +6,10 @@ import stat
 import keyring
 import pytest
 
+from config.env_file import is_sensitive_env_key, sync_env_secret, sync_env_values
 from config.llm_credentials import resolve_env_credential
 from surfaces.cli.wizard.config import PROVIDER_BY_VALUE
 from surfaces.cli.wizard.env_sync import (
-    _is_sensitive_env_key,
-    sync_env_secret,
-    sync_env_values,
     sync_provider_env,
     sync_reasoning_model_env,
 )
@@ -51,7 +49,7 @@ def _redirect_wizard_store(tmp_path, monkeypatch) -> None:
     ],
 )
 def test_is_sensitive_env_key_marks_secrets(key: str) -> None:
-    assert _is_sensitive_env_key(key) is True
+    assert is_sensitive_env_key(key) is True
 
 
 @pytest.mark.parametrize(
@@ -71,7 +69,7 @@ def test_is_sensitive_env_key_marks_secrets(key: str) -> None:
     ],
 )
 def test_is_sensitive_env_key_leaves_non_secrets(key: str) -> None:
-    assert _is_sensitive_env_key(key) is False
+    assert is_sensitive_env_key(key) is False
 
 
 def test_sync_provider_env_updates_provider_specific_keys(tmp_path, monkeypatch) -> None:
@@ -584,7 +582,7 @@ def test_sync_env_values_permission_error(tmp_path) -> None:
 
 
 def test_strip_keyring_backed_secret_lines_removes_all_sensitive_lines() -> None:
-    from surfaces.cli.wizard.env_sync import _strip_keyring_backed_secret_lines
+    from config.env_file import strip_secret_env_lines
 
     lines = [
         "TELEGRAM_BOT_TOKEN=fallback\n",
@@ -592,7 +590,7 @@ def test_strip_keyring_backed_secret_lines_removes_all_sensitive_lines() -> None
         "DD_SITE=old\n",
     ]
 
-    kept = _strip_keyring_backed_secret_lines(lines)
+    kept = strip_secret_env_lines(lines)
 
     assert kept == ["DD_SITE=old\n"]
 

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -542,6 +542,25 @@ def test_sync_env_values_rejects_sensitive_keys(tmp_path) -> None:
         sync_env_values({"GITLAB_ACCESS_TOKEN": "secret"}, env_path=env_path)
 
 
+def test_set_env_value_rejects_sensitive_keys_with_value_error() -> None:
+    from config.env_file import set_env_value
+
+    with pytest.raises(ValueError, match="sync_env_secret"):
+        set_env_value(["FOO=bar\n"], "GITLAB_ACCESS_TOKEN", "secret")
+
+
+def test_sync_env_secret_raises_when_keyring_unavailable(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "config.env_file.save_keyring_secret",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("Secure local credential storage is unavailable on this machine.")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to persist.*system keyring"):
+        sync_env_secret("GITLAB_ACCESS_TOKEN", "gl-secret-token")
+
+
 def test_sync_env_values_routes_secrets_to_keyring(tmp_path, monkeypatch) -> None:
     monkeypatch.delenv("GITLAB_ACCESS_TOKEN", raising=False)
     monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -2027,6 +2027,9 @@ def test_run_wizard_opensearch_retries_on_validation_failure(monkeypatch, tmp_pa
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        _observability_configurator, "sync_env_secret", lambda *_args, **_kwargs: None
+    )
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2129,6 +2132,9 @@ def test_run_wizard_opensearch_rejects_empty_api_key(monkeypatch, tmp_path) -> N
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        _observability_configurator, "sync_env_secret", lambda *_args, **_kwargs: None
+    )
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2226,6 +2232,9 @@ def test_run_wizard_opensearch_rejects_empty_basic_password(monkeypatch, tmp_pat
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        _observability_configurator, "sync_env_secret", lambda *_args, **_kwargs: None
+    )
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)

--- a/tests/integrations/telegram/test_cli_setup_characterization.py
+++ b/tests/integrations/telegram/test_cli_setup_characterization.py
@@ -1,0 +1,151 @@
+"""Characterization tests for ``opensre integrations setup telegram``.
+
+These pin the observable behavior of :func:`integrations.cli._setup_telegram`
+before it is migrated onto the shared setup flow: what it prompts for, that it
+verifies *before* it persists, and the exact credential shape it writes. They
+are written against the pre-refactor implementation and must stay green through
+the migration — anything they catch is an unintended behavior change.
+
+What is deliberately *not* pinned here: the credential tiers written. This path
+saves to the integration store only, while the onboarding wizard also writes the
+keyring and ``.env``. Unifying that is the point of the refactor, so asserting
+"no keyring write" would pin the very gap being closed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+import integrations.cli as cli
+import integrations.telegram.verifier as telegram_verifier
+
+_TOKEN = "123456789:AAExampleSecretTokenValue"
+_CHAT_ID = "-1001234567890"
+_CONNECTED = "Connected to Telegram bot @acme_bot."
+
+
+def _prompts(monkeypatch: pytest.MonkeyPatch, *answers: str) -> list[tuple[str, bool]]:
+    """Feed ``_p`` the given answers in prompt order; return the labels asked."""
+    asked: list[tuple[str, bool]] = []
+    queue = list(answers)
+
+    def _fake_p(label: str, default: str = "", secret: bool = False) -> str:
+        asked.append((label, secret))
+        return queue.pop(0)
+
+    monkeypatch.setattr(cli, "_p", _fake_p)
+    return asked
+
+
+def _verifier(
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+    detail: str = _CONNECTED,
+) -> list[tuple[str, dict[str, Any]]]:
+    """Stub the vendor verifier; return the calls it received."""
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def _fake_verify(source: str, config: dict[str, Any]) -> dict[str, str]:
+        calls.append((source, dict(config)))
+        return {"status": status, "detail": detail}
+
+    # _setup_telegram imports the verifier inside the function body, so patching
+    # the attribute on its owning module is what takes effect at call time.
+    monkeypatch.setattr(telegram_verifier, "verify_telegram", _fake_verify)
+    return calls
+
+
+def _saves(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict[str, Any]]]:
+    saved: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        cli,
+        "upsert_integration",
+        lambda service, payload: saved.append((service, payload)),
+    )
+    return saved
+
+
+def test_prompts_for_token_then_chat_id_and_saves_after_verifying(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    asked = _prompts(monkeypatch, _TOKEN, _CHAT_ID)
+    verified = _verifier(monkeypatch, "passed")
+    saved = _saves(monkeypatch)
+
+    cli._setup_telegram()
+
+    # The token is collected as a secret; the chat id is not.
+    assert [secret for _label, secret in asked] == [True, False]
+    assert "token" in asked[0][0].lower()
+    assert "chat" in asked[1][0].lower()
+
+    assert verified == [("setup", {"bot_token": _TOKEN})]
+    assert saved == [
+        (
+            "telegram",
+            {"credentials": {"bot_token": _TOKEN, "default_chat_id": _CHAT_ID}},
+        )
+    ]
+
+
+def test_blank_chat_id_is_stored_as_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A skipped chat id is persisted as ``None``, not an empty string."""
+    _prompts(monkeypatch, _TOKEN, "")
+    _verifier(monkeypatch, "passed")
+    saved = _saves(monkeypatch)
+
+    cli._setup_telegram()
+
+    assert saved[0][1]["credentials"]["default_chat_id"] is None
+
+
+def test_blank_token_exits_before_verifying_or_saving(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prompts(monkeypatch, "")
+    verified = _verifier(monkeypatch, "passed")
+    saved = _saves(monkeypatch)
+
+    with pytest.raises(SystemExit):
+        cli._setup_telegram()
+
+    assert verified == []
+    assert saved == []
+
+
+def test_failed_verification_exits_without_saving(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bad token must not overwrite a working integration."""
+    _prompts(monkeypatch, _TOKEN, _CHAT_ID)
+    _verifier(monkeypatch, "failed", "Telegram API check failed: Unauthorized")
+    saved = _saves(monkeypatch)
+
+    with pytest.raises(SystemExit):
+        cli._setup_telegram()
+
+    assert saved == []
+
+
+def test_success_reports_the_bot_and_the_verify_follow_up(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The bot label and the `integrations verify` next step are user-visible."""
+    _prompts(monkeypatch, _TOKEN, _CHAT_ID)
+    _verifier(monkeypatch, "passed")
+    _saves(monkeypatch)
+
+    cli._setup_telegram()
+
+    out = capsys.readouterr().out
+    assert "@acme_bot" in out
+    assert "opensre integrations verify telegram" in out
+    assert _TOKEN not in out
+
+
+def test_setup_handler_is_registered_for_telegram() -> None:
+    """The dispatch entry is what makes `integrations setup telegram` reachable."""
+    handler: Callable[[], None] = cli._HANDLERS["telegram"]
+    assert handler is cli._setup_telegram

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -996,6 +996,7 @@ class TestModelCommand:
         env_path = tmp_path / ".env"
         store_path = self._redirect_wizard_store(monkeypatch, tmp_path)
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", env_path)
         monkeypatch.setattr(model_cmd, "repl_tty_interactive", lambda: True)
         selections = iter(["set", "anthropic", "__provider_default__"])
         monkeypatch.setattr(model_cmd, "repl_choose_one", lambda **_: next(selections))
@@ -1059,6 +1060,7 @@ class TestModelCommand:
         import surfaces.cli.wizard.env_sync as env_sync
 
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", tmp_path / ".env")
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", tmp_path / ".env")
         store_path = self._redirect_wizard_store(monkeypatch, tmp_path)
         reset_calls: list[str] = []
         monkeypatch.setattr(
@@ -1096,6 +1098,7 @@ class TestModelCommand:
         env_path = tmp_path / ".env"
         store_path = self._redirect_wizard_store(monkeypatch, tmp_path)
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", env_path)
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("OPENSRE_LLM_AUTH_METADATA_PATH", str(tmp_path / "llm-auth.json"))
         # Keyring lookups in CI / sandboxes are flaky; force the helper into
@@ -1135,6 +1138,7 @@ class TestModelCommand:
 
         env_path = tmp_path / ".env"
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", env_path)
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         session = Session()
         session.record("slash", "/model set anthropic not-a-real-model-xyz")
@@ -1159,6 +1163,7 @@ class TestModelCommand:
 
         env_path = tmp_path / ".env"
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", env_path)
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
         console, buf = _capture()
@@ -1183,6 +1188,7 @@ class TestModelCommand:
         env_path = tmp_path / ".env"
         store_path = self._redirect_wizard_store(monkeypatch, tmp_path)
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", env_path)
         monkeypatch.setenv("LLM_PROVIDER", "openai")
 
         console, buf = _capture()
@@ -1209,6 +1215,7 @@ class TestModelCommand:
 
         env_path = tmp_path / ".env"
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", env_path)
         monkeypatch.setenv("LLM_PROVIDER", "openai")
 
         dispatch_slash("/model set gpt 5.5", Session(), _capture()[0])
@@ -1234,6 +1241,7 @@ class TestModelCommand:
 
         env_path = tmp_path / ".env"
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", env_path)
         monkeypatch.setenv("LLM_PROVIDER", "openai")
 
         console, buf = _capture()
@@ -1257,6 +1265,7 @@ class TestModelCommand:
 
         env_path = tmp_path / ".env"
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", env_path)
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
 
         console, buf = _capture()
@@ -1283,6 +1292,7 @@ class TestModelCommand:
 
         env_path = tmp_path / ".env"
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", env_path)
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         console, buf = _capture()
         dispatch_slash(
@@ -1309,6 +1319,7 @@ class TestModelCommand:
 
         env_path = tmp_path / ".env"
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", env_path)
         monkeypatch.setenv("LLM_PROVIDER", "anthropic")
         monkeypatch.setenv("ANTHROPIC_REASONING_MODEL", "not-a-real-model-xyz")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
@@ -1333,6 +1344,7 @@ class TestModelCommand:
         import surfaces.cli.wizard.env_sync as env_sync
 
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", tmp_path / ".env")
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", tmp_path / ".env")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         console, buf = _capture()
         dispatch_slash("/model set anthropic --made-up-flag x", Session(), console)
@@ -1353,6 +1365,7 @@ class TestModelCommand:
 
         env_path = tmp_path / ".env"
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", env_path)
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         console, buf = _capture()
         dispatch_slash("/model set anthropic --toolcall-model", Session(), console)
@@ -1372,6 +1385,7 @@ class TestModelCommand:
 
         env_path = tmp_path / ".env"
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", env_path)
         reset_calls: list[str] = []
         monkeypatch.setattr(
             "core.llm.factory.reset_llm_clients", lambda: reset_calls.append("reset")
@@ -1406,6 +1420,7 @@ class TestModelCommand:
         import surfaces.cli.wizard.env_sync as env_sync
 
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", tmp_path / ".env")
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", tmp_path / ".env")
         monkeypatch.setenv("LLM_PROVIDER", "codex")
         console, buf = _capture()
         dispatch_slash("/model toolcall set gpt-5.4", Session(), console)
@@ -1420,6 +1435,7 @@ class TestModelCommand:
         import surfaces.cli.wizard.env_sync as env_sync
 
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", tmp_path / ".env")
+        monkeypatch.setattr("config.env_file.PROJECT_ENV_PATH", tmp_path / ".env")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         console, buf = _capture()
         dispatch_slash("/model switch anthropic", Session(), console)


### PR DESCRIPTION
Relates to #4071, #3933

#### Describe the changes you have made in this PR -

Groundwork so that setting up an integration is written **once**, not once per surface. No user-visible behavior change.

**The problem.** Telegram (and every other integration) has three setup paths that drifted apart:

| Path | Saves to |
| --- | --- |
| `opensre onboard` → `surfaces/cli/wizard/configurators/chat_notifications.py` | store + keyring + `.env` |
| `opensre integrations setup telegram` → `integrations/cli.py` | store only |
| `configure_telegram` action tool (proposed in #4071) | store only |

All three look fine locally, because `integrations/telegram/credentials.py` resolves the store first. The divergence shows up at deploy time — `platform/deployment/ecr_deploy/prep.py:75` checks the **env var**, not the store:

```python
if not _env_set("TELEGRAM_BOT_TOKEN"):
    missing.append(DeployEnvIssue("telegram_bot", env_vars=("TELEGRAM_BOT_TOKEN",)))
```

So you can configure Telegram via the CLI, verify it, send messages — and then have `make deploy` tell you `TELEGRAM_BOT_TOKEN` is missing. Configure it via `onboard` instead and the same deploy succeeds.

**Why it drifted.** The generic `.env`/keyring writer lived in `surfaces/cli/wizard/env_sync.py`. `integrations/` (tier 2) and `tools/` (tier 2) cannot import `surfaces/` (tier 1), so the other two paths physically could not reach it and each wrote what they could.

**This PR** moves the generic half down to `config/` — the tier-4 floor everything may import — and leaves the wizard-specific half behind:

| Stays in `surfaces/cli/wizard/env_sync.py` | Moves to `config/env_file.py` |
| --- | --- |
| `sync_provider_env`, `sync_reasoning_model_env` (need `ProviderOption`) | `sync_env_values`, `sync_env_secret` |
| provider key ownership, stripping the old provider's keys on a switch | sensitive-key classification, `.env` line rewriting, `0o600` chmod, keyring persist |

`config/local_env.py` already owned *reading* the project env file (`get_project_env_path`, `_load_env_file`); writing now sits beside it. No import-linter exception was needed — `integrations → config` is an allowed edge, so the follow-up needs no layering debt entry.

Per AGENTS.md there is **no forwarding shim**: all 17 importers move to the canonical path in this change.

**Storage routing is decided by existing code, not by callers.** `is_sensitive_env_key()` classifies on the variable name, and the split is enforced rather than advised — `sync_env_values` refuses a sensitive key and `sync_env_secret` refuses a non-sensitive one. A mis-named credential fails loudly instead of landing in clear text.

### Demo/Screenshot for feature changes and bug fixes -

Routing is name-driven, so a new integration gets correct storage without the author deciding anything:

```console
$ uv run python -c "from config.env_file import is_sensitive_env_key; ..."
TELEGRAM_BOT_TOKEN           -> keyring
TELEGRAM_DEFAULT_CHAT_ID     -> .env
DISCORD_PUBLIC_KEY           -> .env      # allowlisted: public despite ending in "key"
OPENAI_TOKEN_LIMIT           -> .env      # terminal word is "limit", not "token"
```

Layering holds, which is the whole point of the move:

```console
$ uv run lint-imports
Analyzed 1331 files, 3662 dependencies.
Config is independent KEPT
Contracts: 1 kept, 0 broken.
```

Full gate:

```console
$ make lint && make format-check
All checks passed!
2612 files already formatted

$ make typecheck
Success: no issues found in 1317 source files

$ make test-scope
2180 passed, 3 skipped, 2 warnings in 87.55s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

This is a behavior-preserving refactor, so it is TDD-guarded per AGENTS.md. Both Telegram setup paths had **zero** test coverage, so the first commit characterizes them against the pre-refactor code — prompts asked, validate-before-persist ordering, the wizard's retry loop on a bad token, the exact credential shape written, the delivery advisory when no chat id is set, and the credential tiers each path touches. Those 35 tests passed before the move and stayed green through it.

I deliberately did **not** pin "the CLI path writes only the store". That is the gap being closed, and asserting it would lock the bug in.

The alternative I considered was injecting a writer callback into `integrations/` instead of moving the module — it avoids touching 17 files, but it pushes the decision of *where credentials go* back out to each caller, which is exactly the drift that caused this. Moving the writer to the floor means there is one answer and callers cannot disagree with it.

One real regression surfaced during the change, and it is worth calling out because it is the interesting part of the diff. `sync_reasoning_model_env` passed `env_path=None` and let `sync_env_values` fall back to its own module-level default. After the move that default resolved inside `config/env_file.py`, while the sibling writer `sync_provider_env` still resolved against `env_sync.PROJECT_ENV_PATH` — the name the `.env`-isolating test fixtures patch. The two writers disagreed about the target, so six tests escaped `tmp_path` and wrote to the real project `.env`. Fixed by resolving the default explicitly at the call site so both writers agree, and hardened by pinning the `config.env_file` default in both isolating fixtures (17 patch sites) so no test can reach the real file again.

**Follow-up (not in this PR):** with the writer reachable from `integrations/`, a shared `apply_setup(service, values)` can own merge → verify → persist-across-all-three-tiers, and the wizard, `integrations setup`, and the action tool from #4071 each keep only their own value collection. #4071 rebases onto that and shrinks to a thin adapter plus its execution gate.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
