### PR TITLE
feat(integrations): share one setup flow; require and resolve the Telegram chat id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,40 @@
 - Do not keep compatibility-only forwarding modules after refactors. Once imports and tests
   are migrated, remove the old module path in the same change and use one canonical import path.
 
+### Docs under `docs/`
+
+`docs/` is **user-facing**. Write for someone configuring the product, not for
+someone who has read the diff. Ask of every sentence: *does this change what the
+reader does?* If not, cut it.
+
+Leave out:
+
+- **Vendor API endpoints and internal function names.** "The token is checked
+  against `getMe`" / "saved via `upsert_integration(...)`" — the reader calls
+  neither.
+- **Where a value is stored internally**, unless they must set it themselves.
+  Keyring vs `.env` vs the integration store is our problem, not theirs.
+- **The bug a change fixed**, and the mechanism behind it. That belongs in the PR
+  description and the module docstring.
+- **Restating what a code block already shows.**
+
+Keep:
+
+- **What is required vs optional**, and what happens when something is skipped.
+- **Shortcuts that save real work** ("a public channel's `@name` works, so you can
+  skip finding the numeric id").
+- **Gotchas that are invisible until they bite** ("the bot must be an admin to
+  post").
+- Exact commands, env-var names, and values the reader types or sets.
+
+Say it in the reader's terms: "a chat the bot was never added to fails during
+setup", not "`getChat` returns `ok: false`".
+
+Deep technical detail still gets written down — in the module docstring, the PR
+description, or a page under `docs/` explicitly aimed at contributors (e.g.
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)). It just does not belong on a
+setup page.
+
 ### Performance (algorithms & data structures)
 
 Apply on the **hot path** (per-request / per-iteration / per-tool-call); leave cold

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,37 +26,16 @@
 
 ### Docs under `docs/`
 
-`docs/` is **user-facing**. Write for someone configuring the product, not for
-someone who has read the diff. Ask of every sentence: *does this change what the
-reader does?* If not, cut it.
+`docs/` is user-facing. Test every sentence: *does this change what the reader
+does?* If not, cut it.
 
-Leave out:
-
-- **Vendor API endpoints and internal function names.** "The token is checked
-  against `getMe`" / "saved via `upsert_integration(...)`" — the reader calls
-  neither.
-- **Where a value is stored internally**, unless they must set it themselves.
-  Keyring vs `.env` vs the integration store is our problem, not theirs.
-- **The bug a change fixed**, and the mechanism behind it. That belongs in the PR
-  description and the module docstring.
-- **Restating what a code block already shows.**
-
-Keep:
-
-- **What is required vs optional**, and what happens when something is skipped.
-- **Shortcuts that save real work** ("a public channel's `@name` works, so you can
-  skip finding the numeric id").
-- **Gotchas that are invisible until they bite** ("the bot must be an admin to
-  post").
-- Exact commands, env-var names, and values the reader types or sets.
-
-Say it in the reader's terms: "a chat the bot was never added to fails during
-setup", not "`getChat` returns `ok: false`".
-
-Deep technical detail still gets written down — in the module docstring, the PR
-description, or a page under `docs/` explicitly aimed at contributors (e.g.
-[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)). It just does not belong on a
-setup page.
+- Cut vendor API endpoints (`getMe`), internal function names, which credential
+  tier a value lands in, and the bug a change fixed — that belongs in the PR
+  description or a module docstring.
+- Keep required vs optional, shortcuts that save real work, gotchas that are
+  invisible until they bite, and the exact commands and env vars they type.
+- Say "a chat the bot was never added to fails during setup", not "`getChat`
+  returns `ok: false`".
 
 ### Performance (algorithms & data structures)
 

--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -35,6 +35,10 @@ from config.constants.sentry import (
     SENTRY_MAX_BREADCRUMBS,
     SENTRY_TRACES_SAMPLE_RATE,
 )
+from config.constants.telegram import (
+    TELEGRAM_BOT_TOKEN_ENV,
+    TELEGRAM_DEFAULT_CHAT_ID_ENV,
+)
 
 __all__ = [
     "AZURE_OPENAI_API_KEY_ENV",
@@ -56,6 +60,8 @@ __all__ = [
     "SENTRY_IN_APP_INCLUDE",
     "SENTRY_MAX_BREADCRUMBS",
     "SENTRY_TRACES_SAMPLE_RATE",
+    "TELEGRAM_BOT_TOKEN_ENV",
+    "TELEGRAM_DEFAULT_CHAT_ID_ENV",
     "USAGE_SECRET_ENV",
     "WEBAPP_URL_ENV",
     "ensure_opensre_tmp_dir",

--- a/config/constants/telegram.py
+++ b/config/constants/telegram.py
@@ -1,0 +1,11 @@
+"""Telegram environment variable names."""
+
+from __future__ import annotations
+
+TELEGRAM_BOT_TOKEN_ENV = "TELEGRAM_BOT_TOKEN"
+TELEGRAM_DEFAULT_CHAT_ID_ENV = "TELEGRAM_DEFAULT_CHAT_ID"
+
+__all__ = [
+    "TELEGRAM_BOT_TOKEN_ENV",
+    "TELEGRAM_DEFAULT_CHAT_ID_ENV",
+]

--- a/docs/messaging/telegram.mdx
+++ b/docs/messaging/telegram.mdx
@@ -57,7 +57,14 @@ The bot can deliver to three kinds of destinations. Pick the one that fits your 
 
 ## Step 3: Find your `chat_id`
 
-The **chat ID** identifies where the bot should post.
+The **chat ID** identifies where the bot should post. It is **required** — a bot
+token on its own passes verification but cannot deliver anything.
+
+<Tip>
+**Public channel or supergroup?** Skip this step. Setup accepts the `@name`
+directly (for example `@acme_alerts`) and resolves it to the numeric id for you.
+Private groups and DMs have no `@name`, so they still need the steps below.
+</Tip>
 
 1. Send any message in the destination chat — for a channel, post anything; for a DM, send `/start` to your bot.
 2. In a browser, open:
@@ -102,10 +109,24 @@ opensre onboard
 
 Choose **Telegram** from the integration list. The wizard prompts for:
 
-- **Bot token** — stored in the system keyring (not plain `.env`)
-- **Default chat ID** — written to `.env` as `TELEGRAM_DEFAULT_CHAT_ID`
+- **Bot token** (required) — stored in the system keyring (not plain `.env`)
+- **Default chat ID or `@channelname`** (required) — resolved to the numeric id, then
+  written to `.env` as `TELEGRAM_DEFAULT_CHAT_ID`
 
 Credentials are also saved to `~/.opensre/integrations.json` via `upsert_integration("telegram", ...)`.
+
+Both prompts are validated before anything is saved: the token against `getMe`,
+the chat against `getChat`. A chat the bot cannot reach — the usual cause being
+that the bot was never added to the channel — fails setup here rather than at the
+first alert. Every setup surface (`opensre onboard`, `opensre integrations setup
+telegram`, and the interactive shell) writes all three tiers, so a Telegram
+integration configured through any of them also satisfies the `make deploy`
+preflight, which reads environment variables.
+
+<Note>
+`getChat` proves the bot can *see* the chat, not that it may post there. A bot
+still needs the **Post Messages** admin permission on a channel (Step 2).
+</Note>
 
 Non-interactive setup:
 

--- a/docs/messaging/telegram.mdx
+++ b/docs/messaging/telegram.mdx
@@ -57,13 +57,13 @@ The bot can deliver to three kinds of destinations. Pick the one that fits your 
 
 ## Step 3: Find your `chat_id`
 
-The **chat ID** identifies where the bot should post. It is **required** — a bot
-token on its own passes verification but cannot deliver anything.
+The **chat ID** identifies where the bot should post. It is required — without it
+the bot has nowhere to send anything.
 
 <Tip>
-**Public channel or supergroup?** Skip this step. Setup accepts the `@name`
-directly (for example `@acme_alerts`) and resolves it to the numeric id for you.
-Private groups and DMs have no `@name`, so they still need the steps below.
+**Posting to a public channel?** Skip this step — setup accepts the channel's
+`@name` (for example `@acme_alerts`) directly. Private groups and DMs have no
+`@name`, so they need the steps below.
 </Tip>
 
 1. Send any message in the destination chat — for a channel, post anything; for a DM, send `/start` to your bot.
@@ -110,22 +110,17 @@ opensre onboard
 Choose **Telegram** from the integration list. The wizard prompts for:
 
 - **Bot token** (required) — stored in the system keyring (not plain `.env`)
-- **Default chat ID or `@channelname`** (required) — resolved to the numeric id, then
-  written to `.env` as `TELEGRAM_DEFAULT_CHAT_ID`
+- **Default chat ID or `@channelname`** (required) — written to `.env` as
+  `TELEGRAM_DEFAULT_CHAT_ID`
 
 Credentials are also saved to `~/.opensre/integrations.json` via `upsert_integration("telegram", ...)`.
 
-Both prompts are validated before anything is saved: the token against `getMe`,
-the chat against `getChat`. A chat the bot cannot reach — the usual cause being
-that the bot was never added to the channel — fails setup here rather than at the
-first alert. Every setup surface (`opensre onboard`, `opensre integrations setup
-telegram`, and the interactive shell) writes all three tiers, so a Telegram
-integration configured through any of them also satisfies the `make deploy`
-preflight, which reads environment variables.
+Both answers are checked before anything is saved, so a wrong token or a chat the
+bot was never added to fails here rather than silently at the first alert.
 
 <Note>
-`getChat` proves the bot can *see* the chat, not that it may post there. A bot
-still needs the **Post Messages** admin permission on a channel (Step 2).
+Setup confirms the bot can *see* the chat, not that it may post there. For a
+channel the bot still needs the **Post Messages** permission from Step 2.
 </Note>
 
 Non-interactive setup:

--- a/integrations/cli.py
+++ b/integrations/cli.py
@@ -30,6 +30,7 @@ from platform.terminal.theme import (
 
 if TYPE_CHECKING:
     from integrations.github.mcp import GitHubMcpDisplayDetailLevel
+    from integrations.setup_flow import IntegrationSetupSpec
 
 from integrations.gitlab import DEFAULT_GITLAB_BASE_URL
 from integrations.openclaw import build_openclaw_config, validate_openclaw_config
@@ -868,26 +869,35 @@ def _setup_discord() -> None:
     _register_discord_slash_command(application_id, bot_token)
 
 
-def _setup_telegram() -> None:
-    from integrations.setup_flow import apply_setup
-    from integrations.telegram.setup import (
-        BOT_TOKEN_FIELD,
-        DEFAULT_CHAT_ID_FIELD,
-        TELEGRAM_SETUP,
-    )
+def _run_spec_setup(spec: IntegrationSetupSpec) -> None:
+    """Prompt for a spec's fields, then validate, verify, and persist them.
 
-    bot_token = _p("Telegram bot token", secret=True)
-    default_chat_id = _p("Default chat ID or @channelname")
-    print("\n  Validating Telegram credentials...")
-    outcome = apply_setup(
-        TELEGRAM_SETUP,
-        {BOT_TOKEN_FIELD: bot_token, DEFAULT_CHAT_ID_FIELD: default_chat_id},
-    )
+    Each field is checked as it is answered so a blank required value fails
+    immediately, rather than after the user has worked through the rest of the
+    prompts.
+    """
+    from integrations.setup_flow import apply_setup
+
+    values: dict[str, str | None] = {}
+    for field in spec.fields:
+        value = _p(field.question, secret=field.secret)
+        if not value and field.required:
+            _die(f"{field.label} is required.")
+        values[field.name] = value
+
+    print(f"\n  Validating {spec.service} credentials...")
+    outcome = apply_setup(spec, values)
     if not outcome.ok:
         _die(outcome.detail)
     print(f"  {outcome.detail}")
     print("  Next:")
-    print("    - opensre integrations verify telegram")
+    print(f"    - opensre integrations verify {spec.service}")
+
+
+def _setup_telegram() -> None:
+    from integrations.telegram.setup import TELEGRAM_SETUP
+
+    _run_spec_setup(TELEGRAM_SETUP)
 
 
 def _setup_rocketchat() -> None:

--- a/integrations/cli.py
+++ b/integrations/cli.py
@@ -869,26 +869,23 @@ def _setup_discord() -> None:
 
 
 def _setup_telegram() -> None:
-    from integrations.telegram.verifier import verify_telegram
+    from integrations.setup_flow import apply_setup
+    from integrations.telegram.setup import (
+        BOT_TOKEN_FIELD,
+        DEFAULT_CHAT_ID_FIELD,
+        TELEGRAM_SETUP,
+    )
 
     bot_token = _p("Telegram bot token", secret=True)
-    if not bot_token:
-        _die("bot_token is required.")
-    default_chat_id = _p("Default chat ID (optional)")
-    print("\n  Validating Telegram bot token...")
-    result = verify_telegram("setup", {"bot_token": bot_token})
-    if result["status"] != "passed":
-        _die(result["detail"])
-    print(f"  {result['detail']}")
-    upsert_integration(
-        "telegram",
-        {
-            "credentials": {
-                "bot_token": bot_token,
-                "default_chat_id": default_chat_id or None,
-            }
-        },
+    default_chat_id = _p("Default chat ID or @channelname")
+    print("\n  Validating Telegram credentials...")
+    outcome = apply_setup(
+        TELEGRAM_SETUP,
+        {BOT_TOKEN_FIELD: bot_token, DEFAULT_CHAT_ID_FIELD: default_chat_id},
     )
+    if not outcome.ok:
+        _die(outcome.detail)
+    print(f"  {outcome.detail}")
     print("  Next:")
     print("    - opensre integrations verify telegram")
 

--- a/integrations/setup_flow.py
+++ b/integrations/setup_flow.py
@@ -1,0 +1,201 @@
+"""One place that turns collected credentials into a fully configured integration.
+
+Setting an integration up happens on three surfaces — the onboarding wizard
+(``opensre onboard``), ``opensre integrations setup <service>``, and the
+interactive-shell action tools. Each one only differs in how it *collects*
+values; what has to happen afterwards is identical:
+
+1. every required field is present,
+2. the credentials actually work (the integration's verifier),
+3. references the user typed are resolved to what the runtime needs (optional,
+   integration-specific — see :attr:`IntegrationSetupSpec.resolve`), and
+4. they are persisted to **every** tier that reads them — the integration
+   store, the system keyring for secrets, and the project ``.env`` for the rest.
+
+Before this module each surface reimplemented step 4, and they disagreed: the
+wizard wrote all three tiers while ``integrations setup`` wrote only the store.
+Runtime resolution hides that (it checks the store first), but anything reading
+the environment — notably the deploy preflight in
+``platform/deployment/ecr_deploy/prep.py`` — sees a half-configured integration.
+
+Callers now describe *what* the integration needs with an
+:class:`IntegrationSetupSpec` and hand collected values to :func:`apply_setup`;
+where each value lands is decided here, once.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from config.env_file import is_sensitive_env_key, sync_env_secret, sync_env_values
+from integrations.store import upsert_integration
+from integrations.verification import VerifierFn
+
+
+@dataclass(frozen=True)
+class ResolvedCredentials:
+    """Output of an integration's optional resolve step.
+
+    A non-empty *error* aborts setup; *note* is appended to the success detail
+    so the user sees what a typed reference turned into.
+    """
+
+    credentials: dict[str, str | None]
+    note: str = ""
+    error: str = ""
+
+
+ResolveFn = Callable[[dict[str, str | None]], ResolvedCredentials]
+
+
+@dataclass(frozen=True)
+class SetupField:
+    """One credential an integration needs, and where it is persisted."""
+
+    name: str
+    """Key under the integration store's ``credentials`` mapping."""
+
+    label: str
+    """Human-readable field name, used in prompts and in "X is required" errors."""
+
+    env_var: str | None = None
+    """Env var this field mirrors, or ``None`` to keep it store-only.
+
+    The tier is derived from the name — :func:`config.env_file.is_sensitive_env_key`
+    routes ``*_TOKEN``/``*_KEY``/``*_PASSWORD`` to the keyring and everything
+    else to ``.env``. Fields do not get to choose.
+    """
+
+    required: bool = True
+    """When true, a blank value fails setup instead of being stored as ``None``."""
+
+    secret: bool = False
+    """Whether collection surfaces should mask this field while it is typed."""
+
+
+@dataclass(frozen=True)
+class IntegrationSetupSpec:
+    """The full set of credentials one integration is configured with."""
+
+    service: str
+    fields: tuple[SetupField, ...]
+
+    verify: VerifierFn | None = None
+    """The integration's verifier, or ``None`` to skip verification.
+
+    Wired explicitly rather than looked up in the verifier registry: the caller
+    already knows which integration it is configuring, and an explicit reference
+    keeps the flow free of import-time registration ordering.
+    """
+
+    resolve: ResolveFn | None = None
+    """Optional post-verification rewrite of the collected credentials.
+
+    Runs after the verifier (so it can rely on the credentials being valid) and
+    before anything is persisted. Use it when what the user can reasonably type
+    is not what the runtime should store — Telegram's ``@channelname`` becoming
+    a numeric chat id, for instance.
+    """
+
+
+@dataclass(frozen=True)
+class SetupOutcome:
+    """What :func:`apply_setup` did, in a shape every surface can render."""
+
+    ok: bool
+    detail: str
+    saved: bool = False
+    env_path: Path | None = None
+
+
+def _collect_credentials(
+    spec: IntegrationSetupSpec, values: Mapping[str, str | None]
+) -> tuple[dict[str, str | None], str]:
+    """Normalize submitted values, or return the first missing required field.
+
+    The spec is authoritative: fields it declares are the credentials that get
+    stored, and anything else in *values* is ignored.
+    """
+    credentials: dict[str, str | None] = {}
+    for field in spec.fields:
+        value = (values.get(field.name) or "").strip()
+        if not value and field.required:
+            return {}, f"{field.label} is required."
+        credentials[field.name] = value or None
+    return credentials, ""
+
+
+def _verify(spec: IntegrationSetupSpec, credentials: dict[str, str | None]) -> tuple[bool, str]:
+    """Run the spec's verifier against *credentials*.
+
+    An integration with no verifier is treated as verified — the alternative
+    would be refusing to configure it at all. Verifiers take ``dict[str, str]``,
+    so unset optional fields are dropped rather than passed as ``None``.
+    """
+    if spec.verify is None:
+        return True, ""
+    probe = {name: value for name, value in credentials.items() if value}
+    outcome = spec.verify("setup", probe)
+    return outcome["status"] == "passed", outcome["detail"]
+
+
+def _persist_env(spec: IntegrationSetupSpec, credentials: dict[str, str | None]) -> Path:
+    """Mirror env-backed fields into the keyring / ``.env`` and return the ``.env`` path.
+
+    ``.env`` is rewritten even when no field targets it: the rewrite also strips
+    any stale secret assignments left by an older setup (see
+    :func:`config.env_file.sync_env_values`).
+    """
+    env_values: dict[str, str] = {}
+    for field in spec.fields:
+        if not field.env_var:
+            continue
+        value = credentials.get(field.name) or ""
+        if is_sensitive_env_key(field.env_var):
+            # A blank value clears the keyring entry, so a cleared optional
+            # secret does not keep resolving from a previous run.
+            sync_env_secret(field.env_var, value)
+        elif value:
+            env_values[field.env_var] = value
+    return sync_env_values(env_values)
+
+
+def apply_setup(
+    spec: IntegrationSetupSpec,
+    values: Mapping[str, str | None],
+) -> SetupOutcome:
+    """Validate, verify, and persist an integration's credentials to every tier.
+
+    Nothing is written unless verification passes, so a rejected credential
+    never leaves a half-configured integration behind.
+    """
+    credentials, missing = _collect_credentials(spec, values)
+    if missing:
+        return SetupOutcome(ok=False, detail=missing)
+
+    verified, detail = _verify(spec, credentials)
+    if not verified:
+        return SetupOutcome(ok=False, detail=detail)
+
+    if spec.resolve is not None:
+        resolved = spec.resolve(credentials)
+        if resolved.error:
+            return SetupOutcome(ok=False, detail=resolved.error)
+        credentials = resolved.credentials
+        detail = " ".join(part for part in (detail, resolved.note) if part)
+
+    upsert_integration(spec.service, {"credentials": credentials})
+    env_path = _persist_env(spec, credentials)
+    return SetupOutcome(ok=True, detail=detail, saved=True, env_path=env_path)
+
+
+__all__ = [
+    "IntegrationSetupSpec",
+    "ResolveFn",
+    "ResolvedCredentials",
+    "SetupField",
+    "SetupOutcome",
+    "apply_setup",
+]

--- a/integrations/setup_flow.py
+++ b/integrations/setup_flow.py
@@ -171,12 +171,15 @@ def _persist_env(spec: IntegrationSetupSpec, credentials: dict[str, str | None])
     for field in spec.fields:
         if not field.env_var:
             continue
+        # Blank values are written through rather than skipped, so clearing an
+        # optional field clears every tier. Skipping would leave the previous
+        # value in ``.env`` while the store recorded ``None``, and credential
+        # resolution falls back to the environment when the store is empty — so
+        # the value the user just cleared would keep resolving.
         value = credentials.get(field.name) or ""
         if is_sensitive_env_key(field.env_var):
-            # A blank value clears the keyring entry, so a cleared optional
-            # secret does not keep resolving from a previous run.
             sync_env_secret(field.env_var, value)
-        elif value:
+        else:
             env_values[field.env_var] = value
     return sync_env_values(env_values)
 

--- a/integrations/setup_flow.py
+++ b/integrations/setup_flow.py
@@ -58,7 +58,14 @@ class SetupField:
     """Key under the integration store's ``credentials`` mapping."""
 
     label: str
-    """Human-readable field name, used in prompts and in "X is required" errors."""
+    """Human-readable field name, used in "X is required" errors."""
+
+    prompt: str = ""
+    """Question text when collecting this field interactively; defaults to *label*.
+
+    Kept separate so the question can carry guidance ("Default chat ID or
+    @channelname") while the error stays terse ("Default chat ID is required.").
+    """
 
     env_var: str | None = None
     """Env var this field mirrors, or ``None`` to keep it store-only.
@@ -73,6 +80,11 @@ class SetupField:
 
     secret: bool = False
     """Whether collection surfaces should mask this field while it is typed."""
+
+    @property
+    def question(self) -> str:
+        """The text to prompt with."""
+        return self.prompt or self.label
 
 
 @dataclass(frozen=True)
@@ -105,9 +117,13 @@ class SetupOutcome:
     """What :func:`apply_setup` did, in a shape every surface can render."""
 
     ok: bool
+    """True only when the credentials were verified *and* persisted."""
+
     detail: str
-    saved: bool = False
+    """Renderable sentence for the user — the verifier's message, or why it failed."""
+
     env_path: Path | None = None
+    """The ``.env`` written; always set when *ok*, never set otherwise."""
 
 
 def _collect_credentials(
@@ -147,6 +163,9 @@ def _persist_env(spec: IntegrationSetupSpec, credentials: dict[str, str | None])
     ``.env`` is rewritten even when no field targets it: the rewrite also strips
     any stale secret assignments left by an older setup (see
     :func:`config.env_file.sync_env_values`).
+
+    Raises whatever the writers raise — notably ``PermissionError`` from
+    :func:`config.env_file.write_env_lines` on an unwritable ``.env``.
     """
     env_values: dict[str, str] = {}
     for field in spec.fields:
@@ -186,9 +205,19 @@ def apply_setup(
         credentials = resolved.credentials
         detail = " ".join(part for part in (detail, resolved.note) if part)
 
+    # Env/keyring before the store, so no failure can leave the store-only state
+    # this module exists to prevent. If the env write fails nothing is persisted
+    # at all; if the store write failed afterwards, credential resolution still
+    # falls back to the environment, so the integration keeps working.
+    try:
+        env_path = _persist_env(spec, credentials)
+    except (OSError, RuntimeError) as exc:
+        # A local CLI/wizard surface, so the detail may name the actual cause
+        # (usually an unwritable .env). Nothing has been persisted at this point.
+        return SetupOutcome(ok=False, detail=f"Could not save {spec.service} credentials: {exc}")
+
     upsert_integration(spec.service, {"credentials": credentials})
-    env_path = _persist_env(spec, credentials)
-    return SetupOutcome(ok=True, detail=detail, saved=True, env_path=env_path)
+    return SetupOutcome(ok=True, detail=detail, env_path=env_path)
 
 
 __all__ = [

--- a/integrations/telegram/chat_lookup.py
+++ b/integrations/telegram/chat_lookup.py
@@ -1,0 +1,75 @@
+"""Resolve a Telegram chat reference to the numeric id delivery actually uses.
+
+Telegram's ``sendMessage`` accepts either a numeric ``chat_id`` or an
+``@username`` — but the username form only works for **public** channels and
+supergroups; private groups and direct messages have no username at all. That
+asymmetry is a setup-time trap: ``@my_alerts`` is accepted here and rejected at
+the first real alert, hours later.
+
+``getChat`` removes the trap. It accepts both forms, so setup can take whichever
+the user has, and it answers the question ``getMe`` cannot: *can this bot see
+that chat at all?* Resolving to the numeric id and storing that also decouples
+delivery from the username, which a channel owner can change at any time.
+
+One limit worth being explicit about: reaching a chat is not the same as being
+allowed to post in it. A bot must be a channel administrator to send, and
+``getChat`` succeeds without that. Only an actual send proves posting rights.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+from platform.notifications.redaction import redact_token
+
+_GET_CHAT_TIMEOUT_SECONDS = 10
+
+
+def _describe(chat: dict[str, Any]) -> str:
+    """Render a chat as ``Acme Alerts (channel)`` for confirmation output."""
+    title = str(chat.get("title") or chat.get("username") or "").strip()
+    # Private chats carry no title; fall back to the account's own name.
+    if not title:
+        first = str(chat.get("first_name") or "").strip()
+        last = str(chat.get("last_name") or "").strip()
+        title = " ".join(part for part in (first, last) if part)
+    chat_type = str(chat.get("type") or "chat").strip()
+    return f"{title} ({chat_type})" if title else chat_type
+
+
+def resolve_chat_id(*, bot_token: str, chat_id: str) -> tuple[str, str, str]:
+    """Resolve *chat_id* via ``getChat``.
+
+    Returns ``(numeric_id, description, error)``. On failure the first two are
+    empty and *error* explains why, already stripped of the bot token — the
+    token is embedded in the request URL and therefore in ``requests``' error
+    messages.
+    """
+    reference = chat_id.strip()
+    if not reference:
+        return "", "", "Missing chat id."
+
+    try:
+        response = requests.get(
+            f"https://api.telegram.org/bot{bot_token}/getChat",
+            params={"chat_id": reference},
+            timeout=_GET_CHAT_TIMEOUT_SECONDS,
+        )
+        payload = response.json()
+    except Exception as exc:
+        return "", "", f"Telegram chat lookup failed: {redact_token(str(exc), bot_token)}"
+
+    if not payload.get("ok"):
+        description = str(payload.get("description", "unknown error"))
+        return "", "", f"Telegram cannot reach chat {reference}: {description}"
+
+    chat = payload.get("result", {})
+    resolved = str(chat.get("id", "")).strip()
+    if not resolved:
+        return "", "", f"Telegram returned no id for chat {reference}."
+    return resolved, _describe(chat), ""
+
+
+__all__ = ["resolve_chat_id"]

--- a/integrations/telegram/setup.py
+++ b/integrations/telegram/setup.py
@@ -50,6 +50,7 @@ TELEGRAM_SETUP = IntegrationSetupSpec(
         SetupField(
             name=DEFAULT_CHAT_ID_FIELD,
             label="Default chat ID",
+            prompt="Default chat ID or @channelname",
             env_var=TELEGRAM_DEFAULT_CHAT_ID_ENV,
         ),
     ),

--- a/integrations/telegram/setup.py
+++ b/integrations/telegram/setup.py
@@ -1,0 +1,64 @@
+"""What Telegram needs before it is considered configured.
+
+Both credentials are required. A bot token alone verifies happily against
+``getMe``, but every delivery path — the watchdog, Hermes incident sinks, the
+send-message tool — resolves a chat id through
+:func:`integrations.telegram.credentials.load_credentials_from_env` and raises
+without one. Accepting a token-only setup produces an integration that looks
+healthy in ``opensre integrations list`` and fails at the first alert.
+
+The chat id is resolved rather than trusted: users can supply the ``@username``
+of a public channel, which is far easier to obtain than a numeric id, and
+:mod:`integrations.telegram.chat_lookup` turns it into the numeric id delivery
+uses — failing setup if the bot cannot reach that chat at all.
+"""
+
+from __future__ import annotations
+
+from config.constants.telegram import TELEGRAM_BOT_TOKEN_ENV, TELEGRAM_DEFAULT_CHAT_ID_ENV
+from integrations.setup_flow import IntegrationSetupSpec, ResolvedCredentials, SetupField
+from integrations.telegram.chat_lookup import resolve_chat_id
+from integrations.telegram.verifier import verify_telegram
+
+BOT_TOKEN_FIELD = "bot_token"
+DEFAULT_CHAT_ID_FIELD = "default_chat_id"
+
+
+def _resolve_default_chat_id(credentials: dict[str, str | None]) -> ResolvedCredentials:
+    """Replace the submitted chat reference with its numeric id."""
+    numeric_id, description, error = resolve_chat_id(
+        bot_token=str(credentials.get(BOT_TOKEN_FIELD) or ""),
+        chat_id=str(credentials.get(DEFAULT_CHAT_ID_FIELD) or ""),
+    )
+    if error:
+        return ResolvedCredentials(credentials={}, error=error)
+    return ResolvedCredentials(
+        credentials={**credentials, DEFAULT_CHAT_ID_FIELD: numeric_id},
+        note=f"Delivering to {description}.",
+    )
+
+
+TELEGRAM_SETUP = IntegrationSetupSpec(
+    service="telegram",
+    fields=(
+        SetupField(
+            name=BOT_TOKEN_FIELD,
+            label="Telegram bot token",
+            env_var=TELEGRAM_BOT_TOKEN_ENV,
+            secret=True,
+        ),
+        SetupField(
+            name=DEFAULT_CHAT_ID_FIELD,
+            label="Default chat ID",
+            env_var=TELEGRAM_DEFAULT_CHAT_ID_ENV,
+        ),
+    ),
+    verify=verify_telegram,
+    resolve=_resolve_default_chat_id,
+)
+
+__all__ = [
+    "BOT_TOKEN_FIELD",
+    "DEFAULT_CHAT_ID_FIELD",
+    "TELEGRAM_SETUP",
+]

--- a/surfaces/cli/wizard/configurators/chat_notifications.py
+++ b/surfaces/cli/wizard/configurators/chat_notifications.py
@@ -233,7 +233,10 @@ def _configure_telegram() -> tuple[str, str]:
         "\n[bold]Telegram Integration[/bold]\n"
         f"[{SECONDARY}]Create a bot with @BotFather, then add it to the chat it should post "
         "in. For a public channel the @name is enough; otherwise find the numeric chat id "
-        "via getUpdates. See docs/messaging/telegram for details.[/]\n"
+        "via getUpdates. See docs/messaging/telegram for details.\n"
+        "Both answers are required — Telegram cannot deliver without a chat. Press Ctrl+C to "
+        "skip Telegram and continue onboarding; `opensre integrations setup telegram` picks it "
+        "up later.[/]\n"
     )
     while True:
         values = {

--- a/surfaces/cli/wizard/configurators/chat_notifications.py
+++ b/surfaces/cli/wizard/configurators/chat_notifications.py
@@ -3,7 +3,13 @@
 from __future__ import annotations
 
 from config.env_file import sync_env_secret, sync_env_values
+from integrations.setup_flow import apply_setup
 from integrations.store import upsert_integration
+from integrations.telegram.setup import (
+    BOT_TOKEN_FIELD,
+    DEFAULT_CHAT_ID_FIELD,
+    TELEGRAM_SETUP,
+)
 from platform.terminal.theme import ERROR, GLYPH_ERROR, SECONDARY, WARNING
 from surfaces.cli.wizard._ui import (
     Choice,
@@ -19,8 +25,8 @@ from surfaces.cli.wizard.integration_health import (
     validate_rocketchat,
     validate_rocketchat_webhook,
     validate_slack_webhook,
-    validate_telegram_bot,
 )
+from surfaces.cli.wizard.integration_validators.shared import IntegrationHealthResult
 
 
 def _configure_slack() -> tuple[str, str]:
@@ -229,8 +235,9 @@ def _configure_telegram() -> tuple[str, str]:
     _, credentials = _integration_defaults("telegram")
     _console.print(
         "\n[bold]Telegram Integration[/bold]\n"
-        f"[{SECONDARY}]Create a bot with @BotFather, add it to your chat, then find "
-        "chat_id via getUpdates. See docs/messaging/telegram for details.[/]\n"
+        f"[{SECONDARY}]Create a bot with @BotFather, then add it to the chat it should post "
+        "in. For a public channel the @name is enough; otherwise find the numeric chat id "
+        "via getUpdates. See docs/messaging/telegram for details.[/]\n"
     )
     while True:
         bot_token = _prompt_value(
@@ -239,32 +246,17 @@ def _configure_telegram() -> tuple[str, str]:
             secret=True,
         )
         default_chat_id = _prompt_value(
-            "Default chat ID (recommended for delivery)",
+            "Default chat ID or @channelname",
             default=_string_value(credentials.get("default_chat_id")),
-            allow_empty=True,
         )
-        with _console.status("Validating Telegram bot token...", spinner="dots"):
-            result = validate_telegram_bot(bot_token=bot_token)
-        _render_integration_result("Telegram", result)
-        if result.ok:
-            upsert_integration(
-                "telegram",
-                {
-                    "credentials": {
-                        "bot_token": bot_token,
-                        "default_chat_id": default_chat_id or None,
-                    }
-                },
+        with _console.status("Validating Telegram credentials...", spinner="dots"):
+            outcome = apply_setup(
+                TELEGRAM_SETUP,
+                {BOT_TOKEN_FIELD: bot_token, DEFAULT_CHAT_ID_FIELD: default_chat_id},
             )
-            sync_env_secret("TELEGRAM_BOT_TOKEN", bot_token)
-            env_values: dict[str, str] = {}
-            if default_chat_id:
-                env_values["TELEGRAM_DEFAULT_CHAT_ID"] = default_chat_id
-            env_path = sync_env_values(env_values)
-            if not default_chat_id:
-                _console.print(
-                    f"[{WARNING}]No default chat ID set — Hermes, watchdog, and scheduled "
-                    "deliveries need TELEGRAM_DEFAULT_CHAT_ID to send messages.[/]"
-                )
-            return "Telegram", str(env_path)
+        _render_integration_result(
+            "Telegram", IntegrationHealthResult(ok=outcome.ok, detail=outcome.detail)
+        )
+        if outcome.ok:
+            return "Telegram", str(outcome.env_path)
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")

--- a/surfaces/cli/wizard/configurators/chat_notifications.py
+++ b/surfaces/cli/wizard/configurators/chat_notifications.py
@@ -5,11 +5,7 @@ from __future__ import annotations
 from config.env_file import sync_env_secret, sync_env_values
 from integrations.setup_flow import apply_setup
 from integrations.store import upsert_integration
-from integrations.telegram.setup import (
-    BOT_TOKEN_FIELD,
-    DEFAULT_CHAT_ID_FIELD,
-    TELEGRAM_SETUP,
-)
+from integrations.telegram.setup import TELEGRAM_SETUP
 from platform.terminal.theme import ERROR, GLYPH_ERROR, SECONDARY, WARNING
 from surfaces.cli.wizard._ui import (
     Choice,
@@ -240,23 +236,24 @@ def _configure_telegram() -> tuple[str, str]:
         "via getUpdates. See docs/messaging/telegram for details.[/]\n"
     )
     while True:
-        bot_token = _prompt_value(
-            "Telegram bot token",
-            default=_string_value(credentials.get("bot_token")),
-            secret=True,
-        )
-        default_chat_id = _prompt_value(
-            "Default chat ID or @channelname",
-            default=_string_value(credentials.get("default_chat_id")),
-        )
-        with _console.status("Validating Telegram credentials...", spinner="dots"):
-            outcome = apply_setup(
-                TELEGRAM_SETUP,
-                {BOT_TOKEN_FIELD: bot_token, DEFAULT_CHAT_ID_FIELD: default_chat_id},
+        values = {
+            field.name: _prompt_value(
+                field.question,
+                default=_string_value(credentials.get(field.name)),
+                secret=field.secret,
+                allow_empty=not field.required,
             )
+            for field in TELEGRAM_SETUP.fields
+        }
+        with _console.status("Validating Telegram credentials...", spinner="dots"):
+            outcome = apply_setup(TELEGRAM_SETUP, values)
         _render_integration_result(
             "Telegram", IntegrationHealthResult(ok=outcome.ok, detail=outcome.detail)
         )
         if outcome.ok:
+            # apply_setup always resolves an .env path on success; narrow for mypy
+            # and fail loudly rather than returning the string "None" if it ever
+            # stops doing so.
+            assert outcome.env_path is not None, "apply_setup returned ok=True without an env_path"
             return "Telegram", str(outcome.env_path)
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")

--- a/surfaces/cli/wizard/integration_health.py
+++ b/surfaces/cli/wizard/integration_health.py
@@ -20,7 +20,6 @@ from surfaces.cli.wizard.integration_validators.http_probe_validators import (
     validate_rocketchat_webhook,
     validate_servicenow_integration,
     validate_slack_webhook,
-    validate_telegram_bot,
 )
 from surfaces.cli.wizard.integration_validators.jenkins import validate_jenkins_integration
 from surfaces.cli.wizard.integration_validators.mcp_validators import (
@@ -76,7 +75,6 @@ __all__ = [
     "validate_sentry_mcp_integration",
     "validate_servicenow_integration",
     "validate_slack_webhook",
-    "validate_telegram_bot",
     "validate_splunk_integration",
     "validate_tempo_integration",
     "validate_vercel_integration",

--- a/surfaces/cli/wizard/integration_validators/http_probe_validators.py
+++ b/surfaces/cli/wizard/integration_validators/http_probe_validators.py
@@ -6,7 +6,6 @@ import httpx
 
 from integrations.config_models import SlackWebhookConfig
 from platform.common.url_validation import validate_https_or_loopback_http_url
-from platform.notifications.redaction import redact_token
 
 from .shared import IntegrationHealthResult
 
@@ -251,39 +250,3 @@ def validate_rocketchat(
     return IntegrationHealthResult(
         ok=False, detail=f"Rocket.Chat API returned unexpected HTTP {resp.status_code}."
     )
-
-
-def validate_telegram_bot(*, bot_token: str) -> IntegrationHealthResult:
-    """Validate a Telegram bot token by calling the Bot API getMe endpoint."""
-    token = bot_token.strip()
-    if not token:
-        return IntegrationHealthResult(ok=False, detail="Missing bot_token.")
-
-    try:
-        resp = httpx.get(f"https://api.telegram.org/bot{token}/getMe", timeout=10)
-    except httpx.RequestError as err:
-        # httpx embeds the request URL — which contains the bot token — in
-        # transport error messages, so redact before surfacing the detail.
-        safe_error = redact_token(str(err), token)
-        return IntegrationHealthResult(ok=False, detail=f"Telegram API unreachable: {safe_error}")
-    except Exception as err:
-        safe_error = redact_token(str(err), token)
-        return IntegrationHealthResult(ok=False, detail=f"Telegram API check failed: {safe_error}")
-
-    try:
-        payload = resp.json()
-    except Exception as err:
-        safe_error = redact_token(str(err), token)
-        return IntegrationHealthResult(
-            ok=False,
-            detail=f"Telegram API check failed: HTTP {resp.status_code} ({safe_error}).",
-        )
-
-    if not payload.get("ok"):
-        description = payload.get("description", "unknown error")
-        return IntegrationHealthResult(ok=False, detail=f"Telegram API check failed: {description}")
-
-    user = payload.get("result", {})
-    username = str(user.get("username", "")).strip()
-    label = f"@{username}" if username else "unknown"
-    return IntegrationHealthResult(ok=True, detail=f"Connected to Telegram bot {label}.")

--- a/tests/cli/wizard/test_configurators_chat_notifications.py
+++ b/tests/cli/wizard/test_configurators_chat_notifications.py
@@ -1,18 +1,22 @@
-"""Characterization tests for the onboarding wizard's Telegram configurator.
+"""Behavior of the onboarding wizard's Telegram configurator.
 
-These pin the observable behavior of
-:func:`surfaces.cli.wizard.configurators.chat_notifications._configure_telegram`
-before it is migrated onto the shared setup flow: the prompts, validate-before-
-persist ordering, the retry loop on a bad token, the credential tiers it writes
-(store + keyring + ``.env``), and the "configured but cannot deliver" advisory.
+Written before the migration onto the shared setup flow and kept green through
+it: the prompts, validate-before-persist ordering, the retry loop on a bad
+token, the credential tiers written (store + keyring + ``.env``), and the
+``(label, env_path)`` return the wizard's summary screen renders.
 
 This path is the reference for the credential-resolution contract in
 ``docs/adding-tools-and-integrations.md`` — the keyring/``.env`` assertions here
-are what the migration must carry over, not drop.
+are what the migration had to carry over, not drop.
+
+One assertion changed deliberately: a blank chat id used to be accepted with a
+warning. It is now rejected, because every Telegram delivery path raises without
+one — the warning just deferred the failure to the first real alert.
 """
 
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -21,10 +25,12 @@ from typing import Any
 
 import pytest
 
+import integrations.setup_flow as setup_flow
 import surfaces.cli.wizard.configurators.chat_notifications as chat_notifications
-from surfaces.cli.wizard.integration_validators.shared import IntegrationHealthResult
+from integrations.setup_flow import ResolvedCredentials
 
 _TOKEN = "123456789:AAExampleSecretTokenValue"
+_CHAT_REFERENCE = "@acme_alerts"
 _CHAT_ID = "-1001234567890"
 _ENV_PATH = Path("sentinel.env")
 
@@ -63,10 +69,10 @@ class _Wizard:
     console: _RecordingConsole = field(default_factory=_RecordingConsole)
     # Scripted inputs, consumed in order.
     answers: list[str] = field(default_factory=list)
-    results: list[IntegrationHealthResult] = field(default_factory=list)
+    verify_results: list[tuple[str, str]] = field(default_factory=list)
     # Recorded effects.
     asked: list[_Prompt] = field(default_factory=list)
-    validated: list[str] = field(default_factory=list)
+    verified: list[str] = field(default_factory=list)
     saved: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
     keyring: list[tuple[str, str]] = field(default_factory=list)
     env_values: list[dict[str, str]] = field(default_factory=list)
@@ -88,60 +94,67 @@ def wizard(monkeypatch: pytest.MonkeyPatch) -> _Wizard:
         run.asked.append(_Prompt(label=label, secret=secret, allow_empty=allow_empty))
         return run.answers.pop(0)
 
-    def _fake_validate(*, bot_token: str) -> IntegrationHealthResult:
-        run.validated.append(bot_token)
-        return run.results.pop(0)
+    def _fake_verify(_source: str, config: dict[str, Any]) -> dict[str, str]:
+        run.verified.append(str(config.get("bot_token", "")))
+        status, detail = run.verify_results.pop(0)
+        return {"status": status, "detail": detail}
 
-    def _fake_sync_env_values(values: dict[str, str], **_kwargs: Any) -> Path:
-        run.env_values.append(dict(values))
-        return _ENV_PATH
+    def _fake_resolve(credentials: dict[str, str | None]) -> ResolvedCredentials:
+        return ResolvedCredentials(
+            credentials={**credentials, "default_chat_id": _CHAT_ID},
+            note="Delivering to Acme Alerts (channel).",
+        )
 
     monkeypatch.setattr(chat_notifications, "_console", run.console)
     monkeypatch.setattr(chat_notifications, "_integration_defaults", lambda _s: ({}, {}))
     monkeypatch.setattr(chat_notifications, "_prompt_value", _fake_prompt)
-    monkeypatch.setattr(chat_notifications, "validate_telegram_bot", _fake_validate)
     monkeypatch.setattr(chat_notifications, "_render_integration_result", lambda *_a: None)
     monkeypatch.setattr(
         chat_notifications,
+        "TELEGRAM_SETUP",
+        dataclasses.replace(
+            chat_notifications.TELEGRAM_SETUP, verify=_fake_verify, resolve=_fake_resolve
+        ),
+    )
+    monkeypatch.setattr(
+        setup_flow,
         "upsert_integration",
         lambda service, payload: run.saved.append((service, payload)),
     )
     monkeypatch.setattr(
-        chat_notifications,
-        "sync_env_secret",
-        lambda key, value: run.keyring.append((key, value)),
+        setup_flow, "sync_env_secret", lambda key, value: run.keyring.append((key, value))
     )
-    monkeypatch.setattr(chat_notifications, "sync_env_values", _fake_sync_env_values)
+    monkeypatch.setattr(
+        setup_flow,
+        "sync_env_values",
+        lambda values, **_kw: (run.env_values.append(dict(values)), _ENV_PATH)[1],
+    )
     return run
 
 
-def _ok(detail: str = "Connected to Telegram bot @acme_bot.") -> IntegrationHealthResult:
-    return IntegrationHealthResult(ok=True, detail=detail)
-
-
-def _bad(detail: str = "Telegram API check failed: Unauthorized") -> IntegrationHealthResult:
-    return IntegrationHealthResult(ok=False, detail=detail)
+_OK = ("passed", "Connected to Telegram bot @acme_bot.")
+_BAD = ("failed", "Telegram API check failed: Unauthorized")
 
 
 def test_prompts_for_token_then_chat_id(wizard: _Wizard) -> None:
-    wizard.answers[:] = [_TOKEN, _CHAT_ID]
-    wizard.results[:] = [_ok()]
+    wizard.answers[:] = [_TOKEN, _CHAT_REFERENCE]
+    wizard.verify_results[:] = [_OK]
 
     chat_notifications._configure_telegram()
 
     asked = wizard.asked
     assert len(asked) == 2
-    # The token is masked and mandatory; the chat id is asked for but skippable.
+    # Both fields are mandatory; only the token is masked.
     assert asked[0].secret is True
     assert "token" in asked[0].label.lower()
-    assert asked[1].allow_empty is True
+    assert asked[1].allow_empty is False
     assert "chat" in asked[1].label.lower()
 
 
 def test_writes_store_keyring_and_env_on_success(wizard: _Wizard) -> None:
-    """All three credential tiers are written — the contract the refactor must keep."""
-    wizard.answers[:] = [_TOKEN, _CHAT_ID]
-    wizard.results[:] = [_ok()]
+    """All three credential tiers are written — the contract the refactor kept."""
+    wizard.answers[:] = [_TOKEN, _CHAT_REFERENCE]
+    wizard.verify_results[:] = [_OK]
 
     label, env_path = chat_notifications._configure_telegram()
 
@@ -158,55 +171,43 @@ def test_writes_store_keyring_and_env_on_success(wizard: _Wizard) -> None:
 
 
 def test_validation_runs_before_anything_is_persisted(wizard: _Wizard) -> None:
-    wizard.answers[:] = [_TOKEN, _CHAT_ID]
-    wizard.results[:] = [_ok()]
+    wizard.answers[:] = [_TOKEN, _CHAT_REFERENCE]
+    wizard.verify_results[:] = [_OK]
 
     chat_notifications._configure_telegram()
 
-    assert wizard.validated == [_TOKEN]
+    assert wizard.verified == [_TOKEN]
 
 
 def test_bad_token_re_prompts_and_saves_nothing_until_it_validates(
     wizard: _Wizard,
 ) -> None:
     """The wizard loops on a rejected token rather than persisting junk."""
-    wizard.answers[:] = ["wrong-token", "", _TOKEN, _CHAT_ID]
-    wizard.results[:] = [_bad(), _ok()]
+    wizard.answers[:] = ["wrong-token", _CHAT_REFERENCE, _TOKEN, _CHAT_REFERENCE]
+    wizard.verify_results[:] = [_BAD, _OK]
 
     chat_notifications._configure_telegram()
 
-    assert wizard.validated == ["wrong-token", _TOKEN]
+    assert wizard.verified == ["wrong-token", _TOKEN]
     # Only the second, valid attempt reaches the store.
     assert len(wizard.saved) == 1
     assert wizard.saved[0][1]["credentials"]["bot_token"] == _TOKEN
     assert wizard.keyring == [("TELEGRAM_BOT_TOKEN", _TOKEN)]
 
 
-def test_blank_chat_id_saves_none_and_warns_about_delivery(wizard: _Wizard) -> None:
-    """Token-only setup verifies, but Hermes/watchdog cannot deliver without a chat id."""
-    wizard.answers[:] = [_TOKEN, ""]
-    wizard.results[:] = [_ok()]
+def test_typed_channel_name_is_stored_as_the_resolved_numeric_id(wizard: _Wizard) -> None:
+    wizard.answers[:] = [_TOKEN, _CHAT_REFERENCE]
+    wizard.verify_results[:] = [_OK]
 
     chat_notifications._configure_telegram()
 
-    assert wizard.saved[0][1]["credentials"]["default_chat_id"] is None
-    # No chat id means no env value to sync, but .env is still written.
-    assert wizard.env_values == [{}]
-    assert "TELEGRAM_DEFAULT_CHAT_ID" in wizard.console.text
-
-
-def test_no_delivery_warning_once_a_chat_id_is_set(wizard: _Wizard) -> None:
-    wizard.answers[:] = [_TOKEN, _CHAT_ID]
-    wizard.results[:] = [_ok()]
-
-    chat_notifications._configure_telegram()
-
-    assert "No default chat ID set" not in wizard.console.text
+    assert wizard.saved[0][1]["credentials"]["default_chat_id"] == _CHAT_ID
+    assert wizard.env_values == [{"TELEGRAM_DEFAULT_CHAT_ID": _CHAT_ID}]
 
 
 def test_token_is_never_echoed_to_the_console(wizard: _Wizard) -> None:
-    wizard.answers[:] = [_TOKEN, _CHAT_ID]
-    wizard.results[:] = [_ok()]
+    wizard.answers[:] = [_TOKEN, _CHAT_REFERENCE]
+    wizard.verify_results[:] = [_OK]
 
     chat_notifications._configure_telegram()
 

--- a/tests/cli/wizard/test_configurators_chat_notifications.py
+++ b/tests/cli/wizard/test_configurators_chat_notifications.py
@@ -27,7 +27,6 @@ import pytest
 
 import integrations.setup_flow as setup_flow
 import surfaces.cli.wizard.configurators.chat_notifications as chat_notifications
-from integrations.setup_flow import ResolvedCredentials
 
 _TOKEN = "123456789:AAExampleSecretTokenValue"
 _CHAT_REFERENCE = "@acme_alerts"
@@ -99,8 +98,8 @@ def wizard(monkeypatch: pytest.MonkeyPatch) -> _Wizard:
         status, detail = run.verify_results.pop(0)
         return {"status": status, "detail": detail}
 
-    def _fake_resolve(credentials: dict[str, str | None]) -> ResolvedCredentials:
-        return ResolvedCredentials(
+    def _fake_resolve(credentials: dict[str, str | None]) -> setup_flow.ResolvedCredentials:
+        return setup_flow.ResolvedCredentials(
             credentials={**credentials, "default_chat_id": _CHAT_ID},
             note="Delivering to Acme Alerts (channel).",
         )

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -8,7 +8,6 @@ import pytest
 
 import integrations.setup_flow as _setup_flow
 from integrations.llm_cli.codex_oauth import CodexOAuthResult
-from integrations.setup_flow import ResolvedCredentials
 from surfaces.cli.wizard import _ui, flow
 from surfaces.cli.wizard import store as wizard_store
 from surfaces.cli.wizard.configurators import chat_notifications as _chat_notifications_configurator
@@ -37,7 +36,7 @@ def _stub_telegram_setup(monkeypatch: pytest.MonkeyPatch, verify) -> None:
         dataclasses.replace(
             _chat_notifications_configurator.TELEGRAM_SETUP,
             verify=verify,
-            resolve=lambda credentials: ResolvedCredentials(credentials=credentials),
+            resolve=lambda credentials: _setup_flow.ResolvedCredentials(credentials=credentials),
         ),
     )
 

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -6,7 +6,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import integrations.setup_flow as _setup_flow
 from integrations.llm_cli.codex_oauth import CodexOAuthResult
+from integrations.setup_flow import ResolvedCredentials
 from surfaces.cli.wizard import _ui, flow
 from surfaces.cli.wizard import store as wizard_store
 from surfaces.cli.wizard.configurators import chat_notifications as _chat_notifications_configurator
@@ -17,6 +19,27 @@ from surfaces.cli.wizard.configurators import observability as _observability_co
 from surfaces.cli.wizard.env_sync import sync_provider_env
 from surfaces.cli.wizard.probes import ProbeResult
 from tests.integrations.llm_cli.testing_helpers import write_fake_runnable_cli_bin
+
+
+def _stub_telegram_setup(monkeypatch: pytest.MonkeyPatch, verify) -> None:
+    """Swap the Telegram spec's network hooks, keeping its real field definitions.
+
+    ``_configure_telegram`` runs the shared setup flow, so the seam is the spec
+    rather than a validator function: *verify* stands in for the Bot API
+    ``getMe`` probe, and the chat-id resolution is short-circuited to echo back
+    whatever the user typed.
+    """
+    import dataclasses
+
+    monkeypatch.setattr(
+        _chat_notifications_configurator,
+        "TELEGRAM_SETUP",
+        dataclasses.replace(
+            _chat_notifications_configurator.TELEGRAM_SETUP,
+            verify=verify,
+            resolve=lambda credentials: ResolvedCredentials(credentials=credentials),
+        ),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -2300,12 +2323,12 @@ def test_run_wizard_configures_telegram(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
-    monkeypatch.setattr(
-        _chat_notifications_configurator,
-        "validate_telegram_bot",
-        lambda **_kwargs: flow.IntegrationHealthResult(
-            ok=True, detail="Connected to Telegram bot @opensre_bot."
-        ),
+    _stub_telegram_setup(
+        monkeypatch,
+        lambda _source, _config: {
+            "status": "passed",
+            "detail": "Connected to Telegram bot @opensre_bot.",
+        },
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
@@ -2318,10 +2341,10 @@ def test_run_wizard_configures_telegram(monkeypatch, tmp_path) -> None:
     def _sync_env_secret(key: str, value: str) -> None:
         synced_env_secrets.append((key, value))
 
-    monkeypatch.setattr(_chat_notifications_configurator, "sync_env_values", _sync_env_values)
-    monkeypatch.setattr(_chat_notifications_configurator, "sync_env_secret", _sync_env_secret)
+    monkeypatch.setattr(_setup_flow, "sync_env_values", _sync_env_values)
+    monkeypatch.setattr(_setup_flow, "sync_env_secret", _sync_env_secret)
     monkeypatch.setattr(
-        _chat_notifications_configurator,
+        _setup_flow,
         "upsert_integration",
         lambda service, payload: saved_integrations.append((service, payload)),
     )
@@ -2366,30 +2389,26 @@ def test_run_wizard_telegram_retries_on_validation_failure(monkeypatch, tmp_path
         m.ask.return_value = next(text_responses)
         return m
 
-    def _validate(**_kwargs):
+    def _validate(_source, _config):
         nonlocal validation_call_count
         validation_call_count += 1
         if validation_call_count == 1:
-            return flow.IntegrationHealthResult(ok=False, detail="Telegram API check failed.")
-        return flow.IntegrationHealthResult(ok=True, detail="Connected to Telegram bot @bot.")
+            return {"status": "failed", "detail": "Telegram API check failed."}
+        return {"status": "passed", "detail": "Connected to Telegram bot @bot."}
 
     monkeypatch.setattr(_ui, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
-    monkeypatch.setattr(_chat_notifications_configurator, "validate_telegram_bot", _validate)
+    _stub_telegram_setup(monkeypatch, _validate)
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_setup_flow, "sync_env_values", lambda *_a, **_kw: tmp_path / ".env")
+    monkeypatch.setattr(_setup_flow, "sync_env_secret", lambda *_a, **_kw: None)
     monkeypatch.setattr(
-        _chat_notifications_configurator, "sync_env_values", lambda *_a, **_kw: tmp_path / ".env"
-    )
-    monkeypatch.setattr(
-        _chat_notifications_configurator, "sync_env_secret", lambda *_a, **_kw: None
-    )
-    monkeypatch.setattr(
-        _chat_notifications_configurator,
+        _setup_flow,
         "upsert_integration",
         lambda service, payload: saved_integrations.append((service, payload)),
     )

--- a/tests/cli/wizard/test_integration_health.py
+++ b/tests/cli/wizard/test_integration_health.py
@@ -23,7 +23,6 @@ from surfaces.cli.wizard.integration_health import (
     validate_sentry_integration,
     validate_servicenow_integration,
     validate_slack_webhook,
-    validate_telegram_bot,
     validate_vercel_integration,
 )
 
@@ -40,7 +39,6 @@ def test_legacy_integration_health_import_surface_still_exports_validators() -> 
         "validate_dagster_integration",
         "validate_datadog_integration",
         "validate_discord_bot",
-        "validate_telegram_bot",
         "validate_github_mcp_integration",
         "validate_gitlab_integration",
         "validate_google_docs_integration",
@@ -636,93 +634,6 @@ def test_validate_discord_bot_network_error(monkeypatch: pytest.MonkeyPatch) -> 
     result = validate_discord_bot(bot_token="some-token")
     assert result.ok is False
     assert "unreachable" in result.detail.lower()
-
-
-# ---------------------------------------------------------------------------
-# validate_telegram_bot
-# ---------------------------------------------------------------------------
-
-
-def test_validate_telegram_bot_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "httpx.get",
-        lambda *_a, **_kw: types.SimpleNamespace(
-            status_code=200,
-            json=lambda: {"ok": True, "result": {"username": "opensre_bot"}},
-        ),
-    )
-    result = validate_telegram_bot(bot_token="123:ABC")
-    assert result.ok is True
-    assert "opensre_bot" in result.detail
-
-
-def test_validate_telegram_bot_missing_token() -> None:
-    result = validate_telegram_bot(bot_token="   ")
-    assert result.ok is False
-    assert "missing" in result.detail.lower()
-
-
-def test_validate_telegram_bot_api_not_ok(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "httpx.get",
-        lambda *_a, **_kw: types.SimpleNamespace(
-            status_code=200,
-            json=lambda: {"ok": False, "description": "Unauthorized"},
-        ),
-    )
-    result = validate_telegram_bot(bot_token="bad-token")
-    assert result.ok is False
-    assert "unauthorized" in result.detail.lower()
-
-
-def test_validate_telegram_bot_http_error_includes_api_description(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        "httpx.get",
-        lambda *_a, **_kw: types.SimpleNamespace(
-            status_code=401,
-            json=lambda: {"ok": False, "description": "Unauthorized"},
-        ),
-    )
-    result = validate_telegram_bot(bot_token="bad-token")
-    assert result.ok is False
-    assert "unauthorized" in result.detail.lower()
-    assert "http 401" not in result.detail.lower()
-
-
-def test_validate_telegram_bot_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    import httpx as _httpx
-
-    def _raise(*_a: object, **_kw: object) -> None:
-        raise _httpx.RequestError("connection refused")
-
-    monkeypatch.setattr("httpx.get", _raise)
-    result = validate_telegram_bot(bot_token="123:ABC")
-    assert result.ok is False
-    assert "unreachable" in result.detail.lower()
-
-
-def test_validate_telegram_bot_network_error_redacts_token(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """httpx embeds the request URL — which carries the bot token — in
-    transport error messages; the validator must redact it (CWE-209)."""
-    import httpx as _httpx
-
-    token = "123456:SECRET-TOKEN-ABC"
-
-    def _raise(*_a: object, **_kw: object) -> None:
-        raise _httpx.ConnectError(
-            f"[Errno 8] nodename nor servname provided for "
-            f"https://api.telegram.org/bot{token}/getMe"
-        )
-
-    monkeypatch.setattr("httpx.get", _raise)
-    result = validate_telegram_bot(bot_token=token)
-    assert result.ok is False
-    assert token not in result.detail
-    assert "<redacted>" in result.detail
 
 
 def test_validate_betterstack_integration_succeeds(monkeypatch) -> None:

--- a/tests/integrations/telegram/test_chat_lookup.py
+++ b/tests/integrations/telegram/test_chat_lookup.py
@@ -7,7 +7,6 @@ import types
 import pytest
 
 import integrations.telegram.chat_lookup as chat_lookup
-from integrations.telegram.chat_lookup import resolve_chat_id
 
 _TOKEN = "123456:SECRET-TOKEN-ABC"
 
@@ -34,7 +33,9 @@ def test_channel_username_resolves_to_the_numeric_id(monkeypatch: pytest.MonkeyP
         },
     )
 
-    numeric_id, description, error = resolve_chat_id(bot_token=_TOKEN, chat_id="@acme_alerts")
+    numeric_id, description, error = chat_lookup.resolve_chat_id(
+        bot_token=_TOKEN, chat_id="@acme_alerts"
+    )
 
     assert error == ""
     assert numeric_id == "-1001234567890"
@@ -48,7 +49,9 @@ def test_numeric_id_is_accepted_and_confirmed(monkeypatch: pytest.MonkeyPatch) -
         {"ok": True, "result": {"id": -100999, "title": "SRE On-call", "type": "supergroup"}},
     )
 
-    numeric_id, description, error = resolve_chat_id(bot_token=_TOKEN, chat_id=" -100999 ")
+    numeric_id, description, error = chat_lookup.resolve_chat_id(
+        bot_token=_TOKEN, chat_id=" -100999 "
+    )
 
     assert error == ""
     assert numeric_id == "-100999"
@@ -65,7 +68,7 @@ def test_direct_message_falls_back_to_the_account_name(monkeypatch: pytest.Monke
         },
     )
 
-    _, description, error = resolve_chat_id(bot_token=_TOKEN, chat_id="555")
+    _, description, error = chat_lookup.resolve_chat_id(bot_token=_TOKEN, chat_id="555")
 
     assert error == ""
     assert description == "Priya B (private)"
@@ -75,7 +78,7 @@ def test_unreachable_chat_is_an_error_not_a_silent_pass(monkeypatch: pytest.Monk
     """The failure this check exists for: bot was never added to the channel."""
     _respond(monkeypatch, {"ok": False, "description": "chat not found"})
 
-    numeric_id, _, error = resolve_chat_id(bot_token=_TOKEN, chat_id="@typo_channel")
+    numeric_id, _, error = chat_lookup.resolve_chat_id(bot_token=_TOKEN, chat_id="@typo_channel")
 
     assert numeric_id == ""
     assert "@typo_channel" in error
@@ -83,7 +86,7 @@ def test_unreachable_chat_is_an_error_not_a_silent_pass(monkeypatch: pytest.Monk
 
 
 def test_blank_reference_is_rejected_without_calling_the_api() -> None:
-    numeric_id, _, error = resolve_chat_id(bot_token=_TOKEN, chat_id="   ")
+    numeric_id, _, error = chat_lookup.resolve_chat_id(bot_token=_TOKEN, chat_id="   ")
 
     assert numeric_id == ""
     assert "Missing chat id" in error
@@ -95,7 +98,7 @@ def test_transport_error_never_echoes_the_bot_token(monkeypatch: pytest.MonkeyPa
 
     monkeypatch.setattr(chat_lookup.requests, "get", _boom)
 
-    _, _, error = resolve_chat_id(bot_token=_TOKEN, chat_id="@acme_alerts")
+    _, _, error = chat_lookup.resolve_chat_id(bot_token=_TOKEN, chat_id="@acme_alerts")
 
     assert _TOKEN not in error
     assert "<redacted>" in error

--- a/tests/integrations/telegram/test_chat_lookup.py
+++ b/tests/integrations/telegram/test_chat_lookup.py
@@ -1,0 +1,101 @@
+"""Behavior of the Telegram ``getChat`` resolution used during setup."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import integrations.telegram.chat_lookup as chat_lookup
+from integrations.telegram.chat_lookup import resolve_chat_id
+
+_TOKEN = "123456:SECRET-TOKEN-ABC"
+
+
+def _respond(monkeypatch: pytest.MonkeyPatch, payload: dict[str, object]) -> dict[str, object]:
+    """Patch the API call and capture the params it was invoked with."""
+    seen: dict[str, object] = {}
+
+    def _get(_url: str, **kwargs: object) -> types.SimpleNamespace:
+        seen.update(kwargs.get("params") or {})
+        return types.SimpleNamespace(json=lambda: payload)
+
+    monkeypatch.setattr(chat_lookup.requests, "get", _get)
+    return seen
+
+
+def test_channel_username_resolves_to_the_numeric_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole point: users can supply the @name, delivery gets the id."""
+    seen = _respond(
+        monkeypatch,
+        {
+            "ok": True,
+            "result": {"id": -1001234567890, "title": "Acme Alerts", "type": "channel"},
+        },
+    )
+
+    numeric_id, description, error = resolve_chat_id(bot_token=_TOKEN, chat_id="@acme_alerts")
+
+    assert error == ""
+    assert numeric_id == "-1001234567890"
+    assert description == "Acme Alerts (channel)"
+    assert seen["chat_id"] == "@acme_alerts"
+
+
+def test_numeric_id_is_accepted_and_confirmed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _respond(
+        monkeypatch,
+        {"ok": True, "result": {"id": -100999, "title": "SRE On-call", "type": "supergroup"}},
+    )
+
+    numeric_id, description, error = resolve_chat_id(bot_token=_TOKEN, chat_id=" -100999 ")
+
+    assert error == ""
+    assert numeric_id == "-100999"
+    assert description == "SRE On-call (supergroup)"
+
+
+def test_direct_message_falls_back_to_the_account_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Private chats carry no title, so the description uses first/last name."""
+    _respond(
+        monkeypatch,
+        {
+            "ok": True,
+            "result": {"id": 555, "first_name": "Priya", "last_name": "B", "type": "private"},
+        },
+    )
+
+    _, description, error = resolve_chat_id(bot_token=_TOKEN, chat_id="555")
+
+    assert error == ""
+    assert description == "Priya B (private)"
+
+
+def test_unreachable_chat_is_an_error_not_a_silent_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The failure this check exists for: bot was never added to the channel."""
+    _respond(monkeypatch, {"ok": False, "description": "chat not found"})
+
+    numeric_id, _, error = resolve_chat_id(bot_token=_TOKEN, chat_id="@typo_channel")
+
+    assert numeric_id == ""
+    assert "@typo_channel" in error
+    assert "chat not found" in error
+
+
+def test_blank_reference_is_rejected_without_calling_the_api() -> None:
+    numeric_id, _, error = resolve_chat_id(bot_token=_TOKEN, chat_id="   ")
+
+    assert numeric_id == ""
+    assert "Missing chat id" in error
+
+
+def test_transport_error_never_echoes_the_bot_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_a: object, **_kw: object) -> None:
+        raise ConnectionError(f"url: https://api.telegram.org/bot{_TOKEN}/getChat")
+
+    monkeypatch.setattr(chat_lookup.requests, "get", _boom)
+
+    _, _, error = resolve_chat_id(bot_token=_TOKEN, chat_id="@acme_alerts")
+
+    assert _TOKEN not in error
+    assert "<redacted>" in error

--- a/tests/integrations/telegram/test_cli_setup_characterization.py
+++ b/tests/integrations/telegram/test_cli_setup_characterization.py
@@ -1,146 +1,212 @@
-"""Characterization tests for ``opensre integrations setup telegram``.
+"""Behavior of ``opensre integrations setup telegram``.
 
-These pin the observable behavior of :func:`integrations.cli._setup_telegram`
-before it is migrated onto the shared setup flow: what it prompts for, that it
-verifies *before* it persists, and the exact credential shape it writes. They
-are written against the pre-refactor implementation and must stay green through
-the migration — anything they catch is an unintended behavior change.
+Written before the migration onto the shared setup flow and kept green through
+it: what the command prompts for, that it verifies *before* it persists, and the
+credential shape it writes.
 
-What is deliberately *not* pinned here: the credential tiers written. This path
-saves to the integration store only, while the onboarding wizard also writes the
-keyring and ``.env``. Unifying that is the point of the refactor, so asserting
-"no keyring write" would pin the very gap being closed.
+Two assertions changed deliberately with the migration, and are the point of it:
+
+* the chat id is now **required** — a token-only Telegram integration verifies
+  but cannot deliver, so accepting one just moves the failure to the first alert;
+* this path now writes the keyring and ``.env`` too, not the store alone. That
+  divergence from the onboarding wizard was invisible at runtime (the store is
+  resolved first) and surfaced only in the deploy preflight, which reads env vars.
+
+The network calls are stubbed by swapping the real spec's ``verify``/``resolve``
+hooks, so the field definitions under test — including which are required —
+remain the production ones.
 """
 
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 import integrations.cli as cli
-import integrations.telegram.verifier as telegram_verifier
+import integrations.setup_flow as setup_flow
+import integrations.telegram.setup as telegram_setup
+from integrations.setup_flow import ResolvedCredentials
 
 _TOKEN = "123456789:AAExampleSecretTokenValue"
+_CHAT_REFERENCE = "@acme_alerts"
 _CHAT_ID = "-1001234567890"
 _CONNECTED = "Connected to Telegram bot @acme_bot."
+_RESOLVED_NOTE = "Delivering to Acme Alerts (channel)."
+_ENV_PATH = Path("/tmp/opensre-test/.env")
 
 
-def _prompts(monkeypatch: pytest.MonkeyPatch, *answers: str) -> list[tuple[str, bool]]:
-    """Feed ``_p`` the given answers in prompt order; return the labels asked."""
-    asked: list[tuple[str, bool]] = []
+@dataclasses.dataclass
+class _Telegram:
+    """Scripted API outcomes for one run, plus everything the run did."""
+
+    verify_status: str = "passed"
+    verify_detail: str = _CONNECTED
+    resolve_error: str = ""
+
+    asked: list[tuple[str, bool]] = dataclasses.field(default_factory=list)
+    verified: list[dict[str, Any]] = dataclasses.field(default_factory=list)
+    store: list[tuple[str, dict[str, Any]]] = dataclasses.field(default_factory=list)
+    keyring: list[tuple[str, str]] = dataclasses.field(default_factory=list)
+    env: list[dict[str, str]] = dataclasses.field(default_factory=list)
+
+
+@pytest.fixture
+def telegram(monkeypatch: pytest.MonkeyPatch) -> _Telegram:
+    run = _Telegram()
+
+    def _fake_verify(source: str, config: dict[str, Any]) -> dict[str, str]:
+        run.verified.append(dict(config))
+        return {"status": run.verify_status, "detail": run.verify_detail}
+
+    def _fake_resolve(credentials: dict[str, str | None]) -> ResolvedCredentials:
+        if run.resolve_error:
+            return ResolvedCredentials(credentials={}, error=run.resolve_error)
+        return ResolvedCredentials(
+            credentials={**credentials, "default_chat_id": _CHAT_ID}, note=_RESOLVED_NOTE
+        )
+
+    # ``_setup_telegram`` imports the spec inside the function body, so replacing
+    # the module attribute is what takes effect at call time.
+    monkeypatch.setattr(
+        telegram_setup,
+        "TELEGRAM_SETUP",
+        dataclasses.replace(
+            telegram_setup.TELEGRAM_SETUP, verify=_fake_verify, resolve=_fake_resolve
+        ),
+    )
+    monkeypatch.setattr(
+        setup_flow,
+        "upsert_integration",
+        lambda service, payload: run.store.append((service, payload)),
+    )
+    monkeypatch.setattr(
+        setup_flow, "sync_env_secret", lambda key, value: run.keyring.append((key, value))
+    )
+    monkeypatch.setattr(
+        setup_flow,
+        "sync_env_values",
+        lambda values, **_kw: (run.env.append(dict(values)), _ENV_PATH)[1],
+    )
+    return run
+
+
+def _prompts(monkeypatch: pytest.MonkeyPatch, run: _Telegram, *answers: str) -> None:
+    """Feed ``_p`` the given answers in prompt order, recording what was asked."""
     queue = list(answers)
 
     def _fake_p(label: str, default: str = "", secret: bool = False) -> str:
-        asked.append((label, secret))
+        run.asked.append((label, secret))
         return queue.pop(0)
 
     monkeypatch.setattr(cli, "_p", _fake_p)
-    return asked
-
-
-def _verifier(
-    monkeypatch: pytest.MonkeyPatch,
-    status: str,
-    detail: str = _CONNECTED,
-) -> list[tuple[str, dict[str, Any]]]:
-    """Stub the vendor verifier; return the calls it received."""
-    calls: list[tuple[str, dict[str, Any]]] = []
-
-    def _fake_verify(source: str, config: dict[str, Any]) -> dict[str, str]:
-        calls.append((source, dict(config)))
-        return {"status": status, "detail": detail}
-
-    # _setup_telegram imports the verifier inside the function body, so patching
-    # the attribute on its owning module is what takes effect at call time.
-    monkeypatch.setattr(telegram_verifier, "verify_telegram", _fake_verify)
-    return calls
-
-
-def _saves(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict[str, Any]]]:
-    saved: list[tuple[str, dict[str, Any]]] = []
-    monkeypatch.setattr(
-        cli,
-        "upsert_integration",
-        lambda service, payload: saved.append((service, payload)),
-    )
-    return saved
 
 
 def test_prompts_for_token_then_chat_id_and_saves_after_verifying(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, telegram: _Telegram
 ) -> None:
-    asked = _prompts(monkeypatch, _TOKEN, _CHAT_ID)
-    verified = _verifier(monkeypatch, "passed")
-    saved = _saves(monkeypatch)
+    _prompts(monkeypatch, telegram, _TOKEN, _CHAT_REFERENCE)
 
     cli._setup_telegram()
 
     # The token is collected as a secret; the chat id is not.
-    assert [secret for _label, secret in asked] == [True, False]
-    assert "token" in asked[0][0].lower()
-    assert "chat" in asked[1][0].lower()
+    assert [secret for _label, secret in telegram.asked] == [True, False]
+    assert "token" in telegram.asked[0][0].lower()
+    assert "chat" in telegram.asked[1][0].lower()
 
-    assert verified == [("setup", {"bot_token": _TOKEN})]
-    assert saved == [
-        (
-            "telegram",
-            {"credentials": {"bot_token": _TOKEN, "default_chat_id": _CHAT_ID}},
-        )
+    assert telegram.verified == [{"bot_token": _TOKEN, "default_chat_id": _CHAT_REFERENCE}]
+    assert telegram.store == [
+        ("telegram", {"credentials": {"bot_token": _TOKEN, "default_chat_id": _CHAT_ID}})
     ]
 
 
-def test_blank_chat_id_is_stored_as_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A skipped chat id is persisted as ``None``, not an empty string."""
-    _prompts(monkeypatch, _TOKEN, "")
-    _verifier(monkeypatch, "passed")
-    saved = _saves(monkeypatch)
+def test_credentials_reach_the_keyring_and_env_not_just_the_store(
+    monkeypatch: pytest.MonkeyPatch, telegram: _Telegram
+) -> None:
+    """The drift this path used to have: store-only writes broke deploy preflight."""
+    _prompts(monkeypatch, telegram, _TOKEN, _CHAT_REFERENCE)
 
     cli._setup_telegram()
 
-    assert saved[0][1]["credentials"]["default_chat_id"] is None
+    assert telegram.keyring == [("TELEGRAM_BOT_TOKEN", _TOKEN)]
+    assert telegram.env == [{"TELEGRAM_DEFAULT_CHAT_ID": _CHAT_ID}]
+
+
+def test_typed_channel_name_is_stored_as_the_resolved_numeric_id(
+    monkeypatch: pytest.MonkeyPatch, telegram: _Telegram
+) -> None:
+    """Users can supply @name; delivery gets the id, which cannot be renamed."""
+    _prompts(monkeypatch, telegram, _TOKEN, _CHAT_REFERENCE)
+
+    cli._setup_telegram()
+
+    assert telegram.store[0][1]["credentials"]["default_chat_id"] == _CHAT_ID
+
+
+def test_blank_chat_id_is_rejected(monkeypatch: pytest.MonkeyPatch, telegram: _Telegram) -> None:
+    """Token-only setup used to be allowed; it produces an undeliverable integration."""
+    _prompts(monkeypatch, telegram, _TOKEN, "")
+
+    with pytest.raises(SystemExit):
+        cli._setup_telegram()
+
+    assert telegram.verified == []
+    assert telegram.store == []
+
+
+def test_unreachable_chat_exits_without_saving(
+    monkeypatch: pytest.MonkeyPatch, telegram: _Telegram
+) -> None:
+    """A valid token pointed at a chat the bot cannot see is not a setup."""
+    telegram.resolve_error = "Telegram cannot reach chat @typo_channel: chat not found"
+    _prompts(monkeypatch, telegram, _TOKEN, "@typo_channel")
+
+    with pytest.raises(SystemExit):
+        cli._setup_telegram()
+
+    assert (telegram.store, telegram.keyring, telegram.env) == ([], [], [])
 
 
 def test_blank_token_exits_before_verifying_or_saving(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, telegram: _Telegram
 ) -> None:
-    _prompts(monkeypatch, "")
-    verified = _verifier(monkeypatch, "passed")
-    saved = _saves(monkeypatch)
+    _prompts(monkeypatch, telegram, "", _CHAT_REFERENCE)
 
     with pytest.raises(SystemExit):
         cli._setup_telegram()
 
-    assert verified == []
-    assert saved == []
+    assert telegram.verified == []
+    assert telegram.store == []
 
 
-def test_failed_verification_exits_without_saving(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_failed_verification_exits_without_saving(
+    monkeypatch: pytest.MonkeyPatch, telegram: _Telegram
+) -> None:
     """A bad token must not overwrite a working integration."""
-    _prompts(monkeypatch, _TOKEN, _CHAT_ID)
-    _verifier(monkeypatch, "failed", "Telegram API check failed: Unauthorized")
-    saved = _saves(monkeypatch)
+    telegram.verify_status = "failed"
+    telegram.verify_detail = "Telegram API check failed: Unauthorized"
+    _prompts(monkeypatch, telegram, _TOKEN, _CHAT_REFERENCE)
 
     with pytest.raises(SystemExit):
         cli._setup_telegram()
 
-    assert saved == []
+    assert (telegram.store, telegram.keyring, telegram.env) == ([], [], [])
 
 
-def test_success_reports_the_bot_and_the_verify_follow_up(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
+def test_success_reports_the_bot_the_chat_and_the_verify_follow_up(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], telegram: _Telegram
 ) -> None:
-    """The bot label and the `integrations verify` next step are user-visible."""
-    _prompts(monkeypatch, _TOKEN, _CHAT_ID)
-    _verifier(monkeypatch, "passed")
-    _saves(monkeypatch)
+    """The bot label, resolved chat, and `integrations verify` step are user-visible."""
+    _prompts(monkeypatch, telegram, _TOKEN, _CHAT_REFERENCE)
 
     cli._setup_telegram()
 
     out = capsys.readouterr().out
     assert "@acme_bot" in out
+    assert "Acme Alerts (channel)" in out
     assert "opensre integrations verify telegram" in out
     assert _TOKEN not in out
 

--- a/tests/integrations/telegram/test_cli_setup_characterization.py
+++ b/tests/integrations/telegram/test_cli_setup_characterization.py
@@ -170,14 +170,17 @@ def test_unreachable_chat_exits_without_saving(
     assert (telegram.store, telegram.keyring, telegram.env) == ([], [], [])
 
 
-def test_blank_token_exits_before_verifying_or_saving(
+def test_blank_token_exits_before_the_next_prompt(
     monkeypatch: pytest.MonkeyPatch, telegram: _Telegram
 ) -> None:
-    _prompts(monkeypatch, telegram, "", _CHAT_REFERENCE)
+    """Fail on the field that is blank, not after working through the rest."""
+    _prompts(monkeypatch, telegram, "")
 
     with pytest.raises(SystemExit):
         cli._setup_telegram()
 
+    # Only the token was asked for — the chat id prompt is never reached.
+    assert [label for label, _secret in telegram.asked] == ["Telegram bot token"]
     assert telegram.verified == []
     assert telegram.store == []
 

--- a/tests/integrations/telegram/test_cli_setup_characterization.py
+++ b/tests/integrations/telegram/test_cli_setup_characterization.py
@@ -29,7 +29,6 @@ import pytest
 import integrations.cli as cli
 import integrations.setup_flow as setup_flow
 import integrations.telegram.setup as telegram_setup
-from integrations.setup_flow import ResolvedCredentials
 
 _TOKEN = "123456789:AAExampleSecretTokenValue"
 _CHAT_REFERENCE = "@acme_alerts"
@@ -62,10 +61,10 @@ def telegram(monkeypatch: pytest.MonkeyPatch) -> _Telegram:
         run.verified.append(dict(config))
         return {"status": run.verify_status, "detail": run.verify_detail}
 
-    def _fake_resolve(credentials: dict[str, str | None]) -> ResolvedCredentials:
+    def _fake_resolve(credentials: dict[str, str | None]) -> setup_flow.ResolvedCredentials:
         if run.resolve_error:
-            return ResolvedCredentials(credentials={}, error=run.resolve_error)
-        return ResolvedCredentials(
+            return setup_flow.ResolvedCredentials(credentials={}, error=run.resolve_error)
+        return setup_flow.ResolvedCredentials(
             credentials={**credentials, "default_chat_id": _CHAT_ID}, note=_RESOLVED_NOTE
         )
 

--- a/tests/integrations/telegram/test_verifier.py
+++ b/tests/integrations/telegram/test_verifier.py
@@ -1,0 +1,86 @@
+"""Behavior of the Telegram ``getMe`` probe.
+
+``verify_telegram`` is the only Telegram token prober left — the wizard used to
+carry a second, httpx-based copy (``validate_telegram_bot``) that has been
+removed. These cases were ported from that copy's suite so deleting it did not
+delete its coverage, most importantly the token-redaction guarantee: the bot
+token sits inside the request URL, so it leaks into transport error messages
+unless it is scrubbed (CWE-209).
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import integrations.telegram.verifier as verifier_module
+from integrations.telegram.verifier import verify_telegram
+
+_TOKEN = "123456:SECRET-TOKEN-ABC"
+
+
+def _respond(monkeypatch: pytest.MonkeyPatch, payload: dict[str, object]) -> None:
+    monkeypatch.setattr(
+        verifier_module.requests,
+        "get",
+        lambda *_a, **_kw: types.SimpleNamespace(
+            raise_for_status=lambda: None,
+            json=lambda: payload,
+        ),
+    )
+
+
+def _raise(monkeypatch: pytest.MonkeyPatch, error: Exception) -> None:
+    def _boom(*_a: object, **_kw: object) -> None:
+        raise error
+
+    monkeypatch.setattr(verifier_module.requests, "get", _boom)
+
+
+def test_reports_the_bot_username_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    _respond(monkeypatch, {"ok": True, "result": {"username": "opensre_bot"}})
+
+    result = verify_telegram("setup", {"bot_token": _TOKEN})
+
+    assert result["status"] == "passed"
+    assert "opensre_bot" in result["detail"]
+
+
+def test_missing_token_is_reported_without_calling_the_api() -> None:
+    result = verify_telegram("setup", {"bot_token": "   "})
+
+    assert result["status"] == "missing"
+    assert "missing" in result["detail"].lower()
+
+
+def test_api_level_rejection_surfaces_the_description(monkeypatch: pytest.MonkeyPatch) -> None:
+    _respond(monkeypatch, {"ok": False, "description": "Unauthorized"})
+
+    result = verify_telegram("setup", {"bot_token": "bad-token"})
+
+    assert result["status"] == "failed"
+    assert "unauthorized" in result["detail"].lower()
+
+
+def test_network_error_is_reported_as_a_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    _raise(monkeypatch, ConnectionError("connection refused"))
+
+    result = verify_telegram("setup", {"bot_token": _TOKEN})
+
+    assert result["status"] == "failed"
+    assert "connection refused" in result["detail"]
+
+
+def test_network_error_never_echoes_the_bot_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """requests puts the full URL — token included — in its error messages."""
+    _raise(
+        monkeypatch,
+        ConnectionError(f"HTTPSConnectionPool: url: https://api.telegram.org/bot{_TOKEN}/getMe"),
+    )
+
+    result = verify_telegram("setup", {"bot_token": _TOKEN})
+
+    assert result["status"] == "failed"
+    assert _TOKEN not in result["detail"]
+    assert "<redacted>" in result["detail"]

--- a/tests/integrations/telegram/test_verifier.py
+++ b/tests/integrations/telegram/test_verifier.py
@@ -15,7 +15,6 @@ import types
 import pytest
 
 import integrations.telegram.verifier as verifier_module
-from integrations.telegram.verifier import verify_telegram
 
 _TOKEN = "123456:SECRET-TOKEN-ABC"
 
@@ -41,14 +40,14 @@ def _raise(monkeypatch: pytest.MonkeyPatch, error: Exception) -> None:
 def test_reports_the_bot_username_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
     _respond(monkeypatch, {"ok": True, "result": {"username": "opensre_bot"}})
 
-    result = verify_telegram("setup", {"bot_token": _TOKEN})
+    result = verifier_module.verify_telegram("setup", {"bot_token": _TOKEN})
 
     assert result["status"] == "passed"
     assert "opensre_bot" in result["detail"]
 
 
 def test_missing_token_is_reported_without_calling_the_api() -> None:
-    result = verify_telegram("setup", {"bot_token": "   "})
+    result = verifier_module.verify_telegram("setup", {"bot_token": "   "})
 
     assert result["status"] == "missing"
     assert "missing" in result["detail"].lower()
@@ -57,7 +56,7 @@ def test_missing_token_is_reported_without_calling_the_api() -> None:
 def test_api_level_rejection_surfaces_the_description(monkeypatch: pytest.MonkeyPatch) -> None:
     _respond(monkeypatch, {"ok": False, "description": "Unauthorized"})
 
-    result = verify_telegram("setup", {"bot_token": "bad-token"})
+    result = verifier_module.verify_telegram("setup", {"bot_token": "bad-token"})
 
     assert result["status"] == "failed"
     assert "unauthorized" in result["detail"].lower()
@@ -66,7 +65,7 @@ def test_api_level_rejection_surfaces_the_description(monkeypatch: pytest.Monkey
 def test_network_error_is_reported_as_a_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     _raise(monkeypatch, ConnectionError("connection refused"))
 
-    result = verify_telegram("setup", {"bot_token": _TOKEN})
+    result = verifier_module.verify_telegram("setup", {"bot_token": _TOKEN})
 
     assert result["status"] == "failed"
     assert "connection refused" in result["detail"]
@@ -79,7 +78,7 @@ def test_network_error_never_echoes_the_bot_token(monkeypatch: pytest.MonkeyPatc
         ConnectionError(f"HTTPSConnectionPool: url: https://api.telegram.org/bot{_TOKEN}/getMe"),
     )
 
-    result = verify_telegram("setup", {"bot_token": _TOKEN})
+    result = verifier_module.verify_telegram("setup", {"bot_token": _TOKEN})
 
     assert result["status"] == "failed"
     assert _TOKEN not in result["detail"]

--- a/tests/integrations/test_setup_flow.py
+++ b/tests/integrations/test_setup_flow.py
@@ -144,6 +144,48 @@ def test_resolve_failure_aborts_setup(recorder: _Recorder) -> None:
     assert (recorder.saved, recorder.keyring, recorder.env_values) == ([], [], [])
 
 
+def test_clearing_an_optional_field_clears_every_tier(recorder: _Recorder) -> None:
+    """Blank values are written through, not skipped.
+
+    Skipping would leave the old value in ``.env`` while the store recorded
+    ``None`` — and credential resolution falls back to the environment when the
+    store is empty, so the cleared value would keep resolving.
+    """
+    spec = IntegrationSetupSpec(
+        service="demo",
+        fields=(
+            SetupField(name="api_token", label="Token", env_var="DEMO_API_TOKEN", secret=True),
+            SetupField(name="room", label="Room", env_var="DEMO_ROOM", required=False),
+        ),
+        verify=_passing,
+    )
+
+    apply_setup(spec, {"api_token": "tok-1", "room": ""})
+
+    assert recorder.saved[0][1]["credentials"]["room"] is None
+    assert recorder.env_values == [{"DEMO_ROOM": ""}]
+
+
+def test_clearing_an_optional_secret_clears_the_keyring(recorder: _Recorder) -> None:
+    spec = IntegrationSetupSpec(
+        service="demo",
+        fields=(
+            SetupField(
+                name="api_token",
+                label="Token",
+                env_var="DEMO_API_TOKEN",
+                secret=True,
+                required=False,
+            ),
+        ),
+        verify=_passing,
+    )
+
+    apply_setup(spec, {"api_token": ""})
+
+    assert recorder.keyring == [("DEMO_API_TOKEN", "")]
+
+
 def test_env_is_written_before_the_store(recorder: _Recorder) -> None:
     """Ordering matters: a store-only write is the state this module prevents."""
     order: list[str] = []

--- a/tests/integrations/test_setup_flow.py
+++ b/tests/integrations/test_setup_flow.py
@@ -1,0 +1,152 @@
+"""Behavior of the shared integration setup flow.
+
+The contract worth protecting here is tier coverage: whatever surface collected
+the values, a successful setup must land in the integration store *and* the
+keyring *and* ``.env``. Divergence there is invisible locally — runtime resolves
+the store first — and only shows up in the deploy preflight, which reads env
+vars.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import integrations.setup_flow as setup_flow
+from integrations.setup_flow import (
+    IntegrationSetupSpec,
+    ResolvedCredentials,
+    SetupField,
+    apply_setup,
+)
+
+_ENV_PATH = Path("/tmp/opensre-test/.env")
+
+_FIELDS = (
+    SetupField(name="api_token", label="Demo API token", env_var="DEMO_API_TOKEN", secret=True),
+    SetupField(name="room", label="Demo room", env_var="DEMO_ROOM"),
+    SetupField(name="note", label="Demo note", required=False),
+)
+
+
+def _passing(_source: str, _config: dict[str, str]) -> dict[str, str]:
+    return {"status": "passed", "detail": "Demo connected."}
+
+
+_SPEC = IntegrationSetupSpec(service="demo", fields=_FIELDS, verify=_passing)
+
+
+class _Recorder:
+    """Captures every write the flow performs."""
+
+    def __init__(self) -> None:
+        self.saved: list[tuple[str, dict[str, Any]]] = []
+        self.keyring: list[tuple[str, str]] = []
+        self.env_values: list[dict[str, str]] = []
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    rec = _Recorder()
+
+    def _sync_env_values(values: dict[str, str], **_kwargs: Any) -> Path:
+        rec.env_values.append(dict(values))
+        return _ENV_PATH
+
+    monkeypatch.setattr(
+        setup_flow,
+        "upsert_integration",
+        lambda service, payload: rec.saved.append((service, payload)),
+    )
+    monkeypatch.setattr(
+        setup_flow, "sync_env_secret", lambda key, value: rec.keyring.append((key, value))
+    )
+    monkeypatch.setattr(setup_flow, "sync_env_values", _sync_env_values)
+    return rec
+
+
+def test_success_writes_store_keyring_and_env(recorder: _Recorder) -> None:
+    outcome = apply_setup(_SPEC, {"api_token": "tok-1", "room": "ops", "note": "hi"})
+
+    assert outcome.ok is True
+    assert outcome.saved is True
+    assert outcome.env_path == _ENV_PATH
+    assert recorder.saved == [
+        ("demo", {"credentials": {"api_token": "tok-1", "room": "ops", "note": "hi"}})
+    ]
+    # Routing is by env var name: the token is a secret, the room is not, and
+    # the store-only field reaches neither tier.
+    assert recorder.keyring == [("DEMO_API_TOKEN", "tok-1")]
+    assert recorder.env_values == [{"DEMO_ROOM": "ops"}]
+
+
+def test_missing_required_field_fails_before_any_write(recorder: _Recorder) -> None:
+    outcome = apply_setup(_SPEC, {"api_token": "tok-1", "room": "  "})
+
+    assert outcome.ok is False
+    assert outcome.saved is False
+    assert outcome.detail == "Demo room is required."
+    assert (recorder.saved, recorder.keyring, recorder.env_values) == ([], [], [])
+
+
+def test_optional_field_left_blank_is_stored_as_none(recorder: _Recorder) -> None:
+    apply_setup(_SPEC, {"api_token": "tok-1", "room": "ops"})
+
+    assert recorder.saved[0][1]["credentials"]["note"] is None
+
+
+def test_failed_verification_persists_nothing(recorder: _Recorder) -> None:
+    def _rejecting(_source: str, _config: dict[str, str]) -> dict[str, str]:
+        return {"status": "failed", "detail": "Demo rejected the token."}
+
+    spec = dataclasses.replace(_SPEC, verify=_rejecting)
+
+    outcome = apply_setup(spec, {"api_token": "bad", "room": "ops"})
+
+    assert outcome.ok is False
+    assert outcome.detail == "Demo rejected the token."
+    assert (recorder.saved, recorder.keyring, recorder.env_values) == ([], [], [])
+
+
+def test_resolve_step_rewrites_credentials_before_they_are_stored(recorder: _Recorder) -> None:
+    spec = dataclasses.replace(
+        _SPEC,
+        resolve=lambda creds: ResolvedCredentials(
+            credentials={**creds, "room": "-100999"}, note="Delivering to Ops (channel)."
+        ),
+    )
+
+    outcome = apply_setup(spec, {"api_token": "tok-1", "room": "@ops"})
+
+    assert outcome.ok is True
+    assert outcome.detail == "Demo connected. Delivering to Ops (channel)."
+    # The resolved value, not the typed one, reaches both the store and .env.
+    assert recorder.saved[0][1]["credentials"]["room"] == "-100999"
+    assert recorder.env_values == [{"DEMO_ROOM": "-100999"}]
+
+
+def test_resolve_failure_aborts_setup(recorder: _Recorder) -> None:
+    spec = dataclasses.replace(
+        _SPEC,
+        resolve=lambda _creds: ResolvedCredentials(credentials={}, error="Cannot reach @ops."),
+    )
+
+    outcome = apply_setup(spec, {"api_token": "tok-1", "room": "@ops"})
+
+    assert outcome.ok is False
+    assert outcome.detail == "Cannot reach @ops."
+    assert (recorder.saved, recorder.keyring, recorder.env_values) == ([], [], [])
+
+
+def test_spec_without_a_verifier_still_configures(recorder: _Recorder) -> None:
+    """An integration with nothing to verify against must not be unconfigurable."""
+    spec = dataclasses.replace(_SPEC, verify=None)
+
+    outcome = apply_setup(spec, {"api_token": "tok-1", "room": "ops"})
+
+    assert outcome.ok is True
+    assert outcome.detail == ""
+    assert recorder.saved != []

--- a/tests/integrations/test_setup_flow.py
+++ b/tests/integrations/test_setup_flow.py
@@ -17,19 +17,15 @@ from typing import Any
 import pytest
 
 import integrations.setup_flow as setup_flow
-from integrations.setup_flow import (
-    IntegrationSetupSpec,
-    ResolvedCredentials,
-    SetupField,
-    apply_setup,
-)
 
 _ENV_PATH = Path("/tmp/opensre-test/.env")
 
 _FIELDS = (
-    SetupField(name="api_token", label="Demo API token", env_var="DEMO_API_TOKEN", secret=True),
-    SetupField(name="room", label="Demo room", env_var="DEMO_ROOM"),
-    SetupField(name="note", label="Demo note", required=False),
+    setup_flow.SetupField(
+        name="api_token", label="Demo API token", env_var="DEMO_API_TOKEN", secret=True
+    ),
+    setup_flow.SetupField(name="room", label="Demo room", env_var="DEMO_ROOM"),
+    setup_flow.SetupField(name="note", label="Demo note", required=False),
 )
 
 
@@ -37,7 +33,7 @@ def _passing(_source: str, _config: dict[str, str]) -> dict[str, str]:
     return {"status": "passed", "detail": "Demo connected."}
 
 
-_SPEC = IntegrationSetupSpec(service="demo", fields=_FIELDS, verify=_passing)
+_SPEC = setup_flow.IntegrationSetupSpec(service="demo", fields=_FIELDS, verify=_passing)
 
 
 class _Recorder:
@@ -74,7 +70,7 @@ def recorder(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
 
 
 def test_success_writes_store_keyring_and_env(recorder: _Recorder) -> None:
-    outcome = apply_setup(_SPEC, {"api_token": "tok-1", "room": "ops", "note": "hi"})
+    outcome = setup_flow.apply_setup(_SPEC, {"api_token": "tok-1", "room": "ops", "note": "hi"})
 
     assert outcome.ok is True
     assert outcome.env_path == _ENV_PATH
@@ -88,7 +84,7 @@ def test_success_writes_store_keyring_and_env(recorder: _Recorder) -> None:
 
 
 def test_missing_required_field_fails_before_any_write(recorder: _Recorder) -> None:
-    outcome = apply_setup(_SPEC, {"api_token": "tok-1", "room": "  "})
+    outcome = setup_flow.apply_setup(_SPEC, {"api_token": "tok-1", "room": "  "})
 
     assert outcome.ok is False
     assert outcome.detail == "Demo room is required."
@@ -96,7 +92,7 @@ def test_missing_required_field_fails_before_any_write(recorder: _Recorder) -> N
 
 
 def test_optional_field_left_blank_is_stored_as_none(recorder: _Recorder) -> None:
-    apply_setup(_SPEC, {"api_token": "tok-1", "room": "ops"})
+    setup_flow.apply_setup(_SPEC, {"api_token": "tok-1", "room": "ops"})
 
     assert recorder.saved[0][1]["credentials"]["note"] is None
 
@@ -107,7 +103,7 @@ def test_failed_verification_persists_nothing(recorder: _Recorder) -> None:
 
     spec = dataclasses.replace(_SPEC, verify=_rejecting)
 
-    outcome = apply_setup(spec, {"api_token": "bad", "room": "ops"})
+    outcome = setup_flow.apply_setup(spec, {"api_token": "bad", "room": "ops"})
 
     assert outcome.ok is False
     assert outcome.detail == "Demo rejected the token."
@@ -117,12 +113,12 @@ def test_failed_verification_persists_nothing(recorder: _Recorder) -> None:
 def test_resolve_step_rewrites_credentials_before_they_are_stored(recorder: _Recorder) -> None:
     spec = dataclasses.replace(
         _SPEC,
-        resolve=lambda creds: ResolvedCredentials(
+        resolve=lambda creds: setup_flow.ResolvedCredentials(
             credentials={**creds, "room": "-100999"}, note="Delivering to Ops (channel)."
         ),
     )
 
-    outcome = apply_setup(spec, {"api_token": "tok-1", "room": "@ops"})
+    outcome = setup_flow.apply_setup(spec, {"api_token": "tok-1", "room": "@ops"})
 
     assert outcome.ok is True
     assert outcome.detail == "Demo connected. Delivering to Ops (channel)."
@@ -134,10 +130,12 @@ def test_resolve_step_rewrites_credentials_before_they_are_stored(recorder: _Rec
 def test_resolve_failure_aborts_setup(recorder: _Recorder) -> None:
     spec = dataclasses.replace(
         _SPEC,
-        resolve=lambda _creds: ResolvedCredentials(credentials={}, error="Cannot reach @ops."),
+        resolve=lambda _creds: setup_flow.ResolvedCredentials(
+            credentials={}, error="Cannot reach @ops."
+        ),
     )
 
-    outcome = apply_setup(spec, {"api_token": "tok-1", "room": "@ops"})
+    outcome = setup_flow.apply_setup(spec, {"api_token": "tok-1", "room": "@ops"})
 
     assert outcome.ok is False
     assert outcome.detail == "Cannot reach @ops."
@@ -151,26 +149,28 @@ def test_clearing_an_optional_field_clears_every_tier(recorder: _Recorder) -> No
     ``None`` — and credential resolution falls back to the environment when the
     store is empty, so the cleared value would keep resolving.
     """
-    spec = IntegrationSetupSpec(
+    spec = setup_flow.IntegrationSetupSpec(
         service="demo",
         fields=(
-            SetupField(name="api_token", label="Token", env_var="DEMO_API_TOKEN", secret=True),
-            SetupField(name="room", label="Room", env_var="DEMO_ROOM", required=False),
+            setup_flow.SetupField(
+                name="api_token", label="Token", env_var="DEMO_API_TOKEN", secret=True
+            ),
+            setup_flow.SetupField(name="room", label="Room", env_var="DEMO_ROOM", required=False),
         ),
         verify=_passing,
     )
 
-    apply_setup(spec, {"api_token": "tok-1", "room": ""})
+    setup_flow.apply_setup(spec, {"api_token": "tok-1", "room": ""})
 
     assert recorder.saved[0][1]["credentials"]["room"] is None
     assert recorder.env_values == [{"DEMO_ROOM": ""}]
 
 
 def test_clearing_an_optional_secret_clears_the_keyring(recorder: _Recorder) -> None:
-    spec = IntegrationSetupSpec(
+    spec = setup_flow.IntegrationSetupSpec(
         service="demo",
         fields=(
-            SetupField(
+            setup_flow.SetupField(
                 name="api_token",
                 label="Token",
                 env_var="DEMO_API_TOKEN",
@@ -181,7 +181,7 @@ def test_clearing_an_optional_secret_clears_the_keyring(recorder: _Recorder) -> 
         verify=_passing,
     )
 
-    apply_setup(spec, {"api_token": ""})
+    setup_flow.apply_setup(spec, {"api_token": ""})
 
     assert recorder.keyring == [("DEMO_API_TOKEN", "")]
 
@@ -192,7 +192,7 @@ def test_env_is_written_before_the_store(recorder: _Recorder) -> None:
     recorder.on_store = lambda: order.append("store")
     recorder.on_env = lambda: order.append("env")
 
-    apply_setup(_SPEC, {"api_token": "tok-1", "room": "ops"})
+    setup_flow.apply_setup(_SPEC, {"api_token": "tok-1", "room": "ops"})
 
     assert order == ["env", "store"]
 
@@ -207,7 +207,7 @@ def test_unwritable_env_persists_nothing_and_reports_the_failure(
 
     monkeypatch.setattr(setup_flow, "sync_env_values", _boom)
 
-    outcome = apply_setup(_SPEC, {"api_token": "tok-1", "room": "ops"})
+    outcome = setup_flow.apply_setup(_SPEC, {"api_token": "tok-1", "room": "ops"})
 
     assert outcome.ok is False
     assert "permission denied" in outcome.detail
@@ -218,7 +218,7 @@ def test_spec_without_a_verifier_still_configures(recorder: _Recorder) -> None:
     """An integration with nothing to verify against must not be unconfigurable."""
     spec = dataclasses.replace(_SPEC, verify=None)
 
-    outcome = apply_setup(spec, {"api_token": "tok-1", "room": "ops"})
+    outcome = setup_flow.apply_setup(spec, {"api_token": "tok-1", "room": "ops"})
 
     assert outcome.ok is True
     assert outcome.detail == ""

--- a/tests/integrations/test_setup_flow.py
+++ b/tests/integrations/test_setup_flow.py
@@ -10,6 +10,7 @@ vars.
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -46,6 +47,9 @@ class _Recorder:
         self.saved: list[tuple[str, dict[str, Any]]] = []
         self.keyring: list[tuple[str, str]] = []
         self.env_values: list[dict[str, str]] = []
+        # Optional hooks so a test can observe write *ordering*, not just content.
+        self.on_store: Callable[[], None] = lambda: None
+        self.on_env: Callable[[], None] = lambda: None
 
 
 @pytest.fixture
@@ -54,13 +58,14 @@ def recorder(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
 
     def _sync_env_values(values: dict[str, str], **_kwargs: Any) -> Path:
         rec.env_values.append(dict(values))
+        rec.on_env()
         return _ENV_PATH
 
-    monkeypatch.setattr(
-        setup_flow,
-        "upsert_integration",
-        lambda service, payload: rec.saved.append((service, payload)),
-    )
+    def _upsert(service: str, payload: dict[str, Any]) -> None:
+        rec.saved.append((service, payload))
+        rec.on_store()
+
+    monkeypatch.setattr(setup_flow, "upsert_integration", _upsert)
     monkeypatch.setattr(
         setup_flow, "sync_env_secret", lambda key, value: rec.keyring.append((key, value))
     )
@@ -72,7 +77,6 @@ def test_success_writes_store_keyring_and_env(recorder: _Recorder) -> None:
     outcome = apply_setup(_SPEC, {"api_token": "tok-1", "room": "ops", "note": "hi"})
 
     assert outcome.ok is True
-    assert outcome.saved is True
     assert outcome.env_path == _ENV_PATH
     assert recorder.saved == [
         ("demo", {"credentials": {"api_token": "tok-1", "room": "ops", "note": "hi"}})
@@ -87,7 +91,6 @@ def test_missing_required_field_fails_before_any_write(recorder: _Recorder) -> N
     outcome = apply_setup(_SPEC, {"api_token": "tok-1", "room": "  "})
 
     assert outcome.ok is False
-    assert outcome.saved is False
     assert outcome.detail == "Demo room is required."
     assert (recorder.saved, recorder.keyring, recorder.env_values) == ([], [], [])
 
@@ -139,6 +142,34 @@ def test_resolve_failure_aborts_setup(recorder: _Recorder) -> None:
     assert outcome.ok is False
     assert outcome.detail == "Cannot reach @ops."
     assert (recorder.saved, recorder.keyring, recorder.env_values) == ([], [], [])
+
+
+def test_env_is_written_before_the_store(recorder: _Recorder) -> None:
+    """Ordering matters: a store-only write is the state this module prevents."""
+    order: list[str] = []
+    recorder.on_store = lambda: order.append("store")
+    recorder.on_env = lambda: order.append("env")
+
+    apply_setup(_SPEC, {"api_token": "tok-1", "room": "ops"})
+
+    assert order == ["env", "store"]
+
+
+def test_unwritable_env_persists_nothing_and_reports_the_failure(
+    monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+) -> None:
+    """An unwritable .env must not leave credentials in the store alone."""
+
+    def _boom(_values: dict[str, str], **_kwargs: Any) -> Path:
+        raise PermissionError("Cannot write to /etc/.env: permission denied.")
+
+    monkeypatch.setattr(setup_flow, "sync_env_values", _boom)
+
+    outcome = apply_setup(_SPEC, {"api_token": "tok-1", "room": "ops"})
+
+    assert outcome.ok is False
+    assert "permission denied" in outcome.detail
+    assert recorder.saved == []
 
 
 def test_spec_without_a_verifier_still_configures(recorder: _Recorder) -> None:

--- a/tests/integrations/test_vendor_first_layout.py
+++ b/tests/integrations/test_vendor_first_layout.py
@@ -35,6 +35,7 @@ ALLOWED_FLAT_MODULES = frozenset(
         "registry.py",
         "scheduled_agent_bootstrap.py",
         "selectors.py",
+        "setup_flow.py",
         "store.py",
         "verify.py",
     }


### PR DESCRIPTION
Stacked on #4167 — **base is `refactor/shared-integration-setup-flow`, not `main`.** Review #4167 first; this PR's own diff is the last commit.

Relates to #4071. Follow-ups filed as #4168 (remaining 44 integrations) and #4169 (agent-driven setup).

#### Describe the changes you have made in this PR -

#4167 moved the `.env`/keyring writer down to `config/` so `integrations/` could reach it. Nothing used it yet — that PR changed no behavior. This one connects it.

**The problem.** Setting up an integration happens on three surfaces, and they persisted credentials differently:

| Surface | store | keyring | `.env` |
| --- | :-: | :-: | :-: |
| `opensre onboard` | ✅ | ✅ | ✅ |
| `opensre integrations setup telegram` | ✅ | ❌ | ❌ |
| `configure_telegram` action tool (proposed in #4071) | ✅ | ❌ | ❌ |

Runtime hides this — `integrations/telegram/credentials.py` resolves the store first — so the CLI path looks fine right up until deploy, where `platform/deployment/ecr_deploy/prep.py:75` checks the **env var**:

```python
if not _env_set("TELEGRAM_BOT_TOKEN"):
    missing.append(DeployEnvIssue("telegram_bot", env_vars=("TELEGRAM_BOT_TOKEN",)))
```

Configure Telegram with the CLI, verify it, send a message — then watch `make deploy` tell you `TELEGRAM_BOT_TOKEN` is missing. Configure the same integration with `onboard` and deploy succeeds. This is not Telegram-specific: **0 of the 45 setup handlers in `integrations/cli.py` write the keyring or `.env`.**

**The change.** `integrations/setup_flow.py` owns the whole lifecycle once — validate required fields → verify → resolve → persist to every tier — driven by a declarative spec:

```python
TELEGRAM_SETUP = IntegrationSetupSpec(
    service="telegram",
    fields=(
        SetupField(name="bot_token", label="Telegram bot token",
                   env_var="TELEGRAM_BOT_TOKEN", secret=True),
        SetupField(name="default_chat_id", label="Default chat ID",
                   env_var="TELEGRAM_DEFAULT_CHAT_ID"),
    ),
    verify=verify_telegram,
    resolve=_resolve_default_chat_id,
)
```

Callers keep only their own value collection. `_setup_telegram` and `_configure_telegram` both shrink to a prompt pair plus one `apply_setup(...)` call, and neither decides where anything is stored — `is_sensitive_env_key()` routes by variable name, and the split is enforced (`sync_env_values` refuses a secret, `sync_env_secret` refuses a non-secret).

**Two deliberate behavior changes**, both Telegram-specific:

*The chat id is now required.* A bot token alone passes `getMe`, so setup reported success — but `load_credentials_from_env()` raises without a chat id, so the watchdog, Hermes sinks, and the send-message tool all fail. The old wizard printed a warning and saved anyway; that just moved the failure to the first real alert, hours later, far from the setup that caused it.

*The chat id is resolved, not trusted.* `getChat` accepts a numeric id **or** an `@username`, so users can supply a public channel's `@name` — much easier to obtain than digging a numeric id out of `getUpdates` — and it is stored as the numeric id, which survives a channel rename. More importantly it answers the question `getMe` cannot: *can this bot see that chat?* The most common Telegram misconfiguration is forgetting to add the bot to the channel, and that now fails at setup.

One limit is documented rather than hidden: `getChat` proves reachability, not posting rights. A channel bot still needs the **Post Messages** admin permission, and only an actual send would prove it.

**Deleted:** `validate_telegram_bot`, the wizard's httpx copy of the `getMe` probe. The registered verifier in `integrations/telegram/verifier.py` is now the single prober; the deleted copy's test coverage — including its token-redaction case — moved to `tests/integrations/telegram/test_verifier.py` rather than being dropped.

### Demo/Screenshot for feature changes and bug fixes -

<img width="850" height="605" alt="image" src="https://github.com/user-attachments/assets/f160829d-e2b9-4698-9fde-26699e25b96a" />

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Both Telegram setup paths had zero test coverage before #4167, so that PR characterized them first — prompts, validate-before-persist ordering, the wizard's retry loop, the exact credential shape, and the tiers each path wrote. Those tests are what made this change safe to make, and they are updated here only where behavior changed on purpose (chat id required, CLI path now writing all three tiers). Each such edit is called out in the test module docstrings, so a reviewer can tell an intended change from a regression.

The design question was where the "which tier does this value go to" decision lives. Three options:

1. **A writer callback injected into each caller.** Avoids moving code, but hands the decision back to every caller — precisely the drift that caused the bug.
2. **Make `upsert_integration` mirror to the keyring and `.env` itself.** Tempting, because it would fix all 45 handlers in one change. It does not work: the store key is `bot_token` while the env var is `TELEGRAM_BOT_TOKEN`, so a per-integration name mapping is required regardless. That mapping *is* the spec, so there is no way to avoid writing one per integration.
3. **A declarative spec consumed by one flow** — chosen. Callers declare what the integration needs; the flow decides where it goes. It also makes agent-driven setup tractable later (#4169), since a spec is exactly the metadata an agent needs to know what to ask for.

`verify` is wired onto the spec as a direct function reference rather than looked up in the verifier registry. The caller already knows which integration it is configuring, and an explicit reference keeps the flow independent of import-time registration ordering — which also means tests can swap it with `dataclasses.replace` and still exercise the real field definitions instead of a stand-in spec.

The `resolve` hook exists because verification and normalization are genuinely different steps: `verify` answers "do these credentials work" and returns a status, while Telegram additionally needs to *rewrite* what the user typed. Folding that into the verifier would have changed the `VerifierFn` contract for all 45 integrations to serve one.

**Not in this PR:** the other 44 integrations (#4168) and the agent-driven setup tool (#4169). #4071 rebases onto this and shrinks to a thin adapter plus the execution gate it is currently missing.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
