### PR TITLE
chore: Update documentation for LiteLLM Proxy integration

### DIFF
--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -116,6 +116,8 @@ OpenAI-compatible providers continue to use Chat Completions.
 
 For providers beyond this list, LiteLLM supports [100+ backends](https://docs.litellm.ai/docs/providers). OpenSRE only wires the slugs above today — use one of them, or open an issue if you need another first-class provider.
 
+If you run a remote [LiteLLM Proxy](https://docs.litellm.ai/docs/simple_proxy), the transport setting here is unrelated — use `LLM_PROVIDER=openai` with `OPENAI_BASE_URL` instead. See [LiteLLM Proxy / Gateway](#litellm-proxy--gateway).
+
 ## Login and secret storage
 
 Use `opensre auth` for provider login without writing secrets to `.env`:
@@ -183,6 +185,27 @@ export OPENAI_TOOLCALL_MODEL=gpt-5.4-mini
 ```
 
 Uses the OpenAI SDK. Reasoning models (`o1`, `o3`, `o4`, `gpt-5*`) automatically use `max_completion_tokens` instead of `max_tokens`.
+
+#### LiteLLM Proxy / Gateway
+
+[LiteLLM Proxy](https://docs.litellm.ai/docs/simple_proxy) and other OpenAI-compatible
+gateways speak the OpenAI API, so the `openai` provider works for the integration. Point
+`OPENAI_BASE_URL` at your gateway:
+
+```bash
+export LLM_PROVIDER=openai
+export OPENAI_API_KEY=sk-your-proxy-key
+export OPENAI_BASE_URL=https://your-litellm-proxy.example.com/
+
+# Model names your proxy exposes:
+export OPENAI_REASONING_MODEL=gpt-4o
+export OPENAI_TOOLCALL_MODEL=gpt-4o-mini
+```
+
+The OpenAI SDK picks up `OPENAI_BASE_URL` from the environment automatically. 
+
+The onboarding wizard does not prompt for a base URL for the `openai` provider, so
+set `OPENAI_BASE_URL` and model env vars in `.env` by hand after running `opensre onboard`.
 
 ### Azure OpenAI
 


### PR DESCRIPTION
**Describe the changes you have made in this PR:**
OpenSRE uses the litellm Python library internally as an in-process transport (OPENSRE_LLM_TRANSPORT=litellm), but there was no documentation for users who host a remote LiteLLM Proxy/Gateway and want to point OpenSRE at it.
Since LiteLLM Proxy exposes the OpenAI Chat Completions API, the openai provider with OPENAI_BASE_URL is the natural path. The OpenAI SDK reads OPENAI_BASE_URL from the environment when base_url=None is passed to the client constructor, which is what OpenSRE's first-party OpenAI path does.

**This PR adds:**
- A new #### LiteLLM Proxy / Gateway subsection under the OpenAI provider section with env var examples
- A one-line cross-reference in the LiteLLM transport section clarifying that the transport setting controls the local library, not a remote proxy
Tested end-to-end against a self-hosted LiteLLM Proxy (inference, tool calling, opensre doctor, opensre config, opensre auth verify).


**Code Understanding and AI Usage**
- [x] Yes, I used AI assistance (continue below)
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The change is docs-only. The problem: users hosting a LiteLLM Proxy could confuse OPENSRE_LLM_TRANSPORT=litellm (local Python library transport) with connecting to a remote proxy. The docs now clarify the distinction and show the correct env vars. No code changes - the OpenAI SDK's existing OPENAI_BASE_URL support handles it.

Checklist:
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests (docs-only, no tests needed)
- [x] My code follows the project's style guidelines and conventions