### PR TITLE
refactor(mcp): share unavailable_response across MCP bridge tools

### DIFF
--- a/core/tool_framework/utils/mcp_bridge.py
+++ b/core/tool_framework/utils/mcp_bridge.py
@@ -11,11 +11,7 @@ from __future__ import annotations
 
 from core.tool_framework.utils.tool_availability import tool_unavailable
 
-__all__ = ["MCPBridgeResponse", "unavailable_response"]
-
-# MCP bridge payloads are open string-keyed maps; every bridge aliases this shape
-# under its own name (``PostHogMCPResponse``, ``OpenClawBridgeResponse``, ...).
-type MCPBridgeResponse = dict[str, object]
+__all__ = ["unavailable_response"]
 
 
 def unavailable_response(
@@ -24,7 +20,7 @@ def unavailable_response(
     *,
     tool_name: str | None = None,
     arguments: dict[str, object] | None = None,
-) -> MCPBridgeResponse:
+) -> dict[str, object]:
     """Build the standard unavailable payload for an MCP bridge tool.
 
     Extends the base ``tool_unavailable`` envelope (``source``/``available``/
@@ -33,7 +29,7 @@ def unavailable_response(
     only when ``tool_name`` is truthy; ``arguments`` is added whenever it is not
     ``None`` (an empty dict is still recorded).
     """
-    payload: MCPBridgeResponse = tool_unavailable(source, error)
+    payload: dict[str, object] = tool_unavailable(source, error)
     if tool_name:
         payload["tool"] = tool_name
     if arguments is not None:

--- a/core/tool_framework/utils/mcp_bridge.py
+++ b/core/tool_framework/utils/mcp_bridge.py
@@ -1,0 +1,41 @@
+"""Shared unavailable-response builder for MCP bridge tools.
+
+Every MCP bridge tool (``posthog_mcp``, ``sentry_mcp``, ``x_mcp``, ``openclaw``)
+returns the same degraded payload when it can't reach its backend: the base
+``tool_unavailable`` envelope, optionally annotated with the ``tool`` that was
+being dispatched and the ``arguments`` it was called with. This module holds
+that one shape so each bridge doesn't reconstruct it by hand.
+"""
+
+from __future__ import annotations
+
+from core.tool_framework.utils.tool_availability import tool_unavailable
+
+__all__ = ["MCPBridgeResponse", "unavailable_response"]
+
+# MCP bridge payloads are open string-keyed maps; every bridge aliases this shape
+# under its own name (``PostHogMCPResponse``, ``OpenClawBridgeResponse``, ...).
+type MCPBridgeResponse = dict[str, object]
+
+
+def unavailable_response(
+    source: str,
+    error: str,
+    *,
+    tool_name: str | None = None,
+    arguments: dict[str, object] | None = None,
+) -> MCPBridgeResponse:
+    """Build the standard unavailable payload for an MCP bridge tool.
+
+    Extends the base ``tool_unavailable`` envelope (``source``/``available``/
+    ``error``) with the optional ``tool`` and ``arguments`` keys that a bridge
+    attaches when a specific tool call couldn't be dispatched. ``tool`` is added
+    only when ``tool_name`` is truthy; ``arguments`` is added whenever it is not
+    ``None`` (an empty dict is still recorded).
+    """
+    payload: MCPBridgeResponse = tool_unavailable(source, error)
+    if tool_name:
+        payload["tool"] = tool_name
+    if arguments is not None:
+        payload["arguments"] = arguments
+    return payload

--- a/integrations/openclaw/tools/openclaw_mcp_tool/__init__.py
+++ b/integrations/openclaw/tools/openclaw_mcp_tool/__init__.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from core.tool_framework.telemetry import report_run_error
 from core.tool_framework.tool_decorator import tool
+from core.tool_framework.utils.mcp_bridge import unavailable_response
 from core.tool_framework.utils.mcp_params import first_list, first_string
 from core.tool_framework.utils.mcp_tool_listing import build_mcp_tool_listing
-from core.tool_framework.utils.tool_availability import tool_unavailable
 from integrations.openclaw import (
     OpenClawConfig,
     OpenClawToolCallResult,
@@ -33,12 +33,7 @@ def _openclaw_unavailable_response(
     tool_name: str | None = None,
     arguments: OpenClawParams | None = None,
 ) -> OpenClawBridgeResponse:
-    payload: OpenClawBridgeResponse = tool_unavailable("openclaw", error)
-    if tool_name:
-        payload["tool"] = tool_name
-    if arguments is not None:
-        payload["arguments"] = arguments
-    return payload
+    return unavailable_response("openclaw", error, tool_name=tool_name, arguments=arguments)
 
 
 def _resolve_config(

--- a/integrations/posthog_mcp/tools/posthog_mcp_tool/__init__.py
+++ b/integrations/posthog_mcp/tools/posthog_mcp_tool/__init__.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 
 from core.tool_framework.telemetry import report_run_error
 from core.tool_framework.tool_decorator import tool
+from core.tool_framework.utils.mcp_bridge import unavailable_response
 from core.tool_framework.utils.mcp_params import first_list, first_string
 from core.tool_framework.utils.mcp_tool_listing import build_mcp_tool_listing
-from core.tool_framework.utils.tool_availability import tool_unavailable
 from integrations.posthog_mcp import (
     PostHogMCPConfig,
     PostHogMCPToolCallResult,
@@ -37,12 +37,7 @@ def _unavailable_response(
     tool_name: str | None = None,
     arguments: PostHogMCPParams | None = None,
 ) -> PostHogMCPResponse:
-    payload: PostHogMCPResponse = tool_unavailable("posthog_mcp", error)
-    if tool_name:
-        payload["tool"] = tool_name
-    if arguments is not None:
-        payload["arguments"] = arguments
-    return payload
+    return unavailable_response("posthog_mcp", error, tool_name=tool_name, arguments=arguments)
 
 
 _KNOWN_POSTHOG_MCP_MODES = frozenset({"stdio", "sse", "streamable-http"})

--- a/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
+++ b/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 
 from core.tool_framework.telemetry import report_run_error
 from core.tool_framework.tool_decorator import tool
+from core.tool_framework.utils.mcp_bridge import unavailable_response
 from core.tool_framework.utils.mcp_params import first_list, first_string
 from core.tool_framework.utils.mcp_tool_listing import build_mcp_tool_listing
-from core.tool_framework.utils.tool_availability import tool_unavailable
 from integrations.sentry_mcp import (
     SentryMCPConfig,
     SentryMCPToolCallResult,
@@ -37,12 +37,7 @@ def _unavailable_response(
     tool_name: str | None = None,
     arguments: SentryMCPParams | None = None,
 ) -> SentryMCPResponse:
-    payload: SentryMCPResponse = tool_unavailable("sentry_mcp", error)
-    if tool_name:
-        payload["tool"] = tool_name
-    if arguments is not None:
-        payload["arguments"] = arguments
-    return payload
+    return unavailable_response("sentry_mcp", error, tool_name=tool_name, arguments=arguments)
 
 
 def _resolve_config(

--- a/integrations/x_mcp/tools/x_mcp_tool/__init__.py
+++ b/integrations/x_mcp/tools/x_mcp_tool/__init__.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 
 from core.tool_framework.telemetry import report_run_error
 from core.tool_framework.tool_decorator import tool
+from core.tool_framework.utils.mcp_bridge import unavailable_response
 from core.tool_framework.utils.mcp_params import first_list, first_string
 from core.tool_framework.utils.mcp_tool_listing import build_mcp_tool_listing
-from core.tool_framework.utils.tool_availability import tool_unavailable
 from integrations.x_mcp import (
     XMCPConfig,
     XMCPToolCallResult,
@@ -37,12 +37,7 @@ def _unavailable_response(
     tool_name: str | None = None,
     arguments: XMCPParams | None = None,
 ) -> XMCPResponse:
-    payload: XMCPResponse = tool_unavailable("x_mcp", error)
-    if tool_name:
-        payload["tool"] = tool_name
-    if arguments is not None:
-        payload["arguments"] = arguments
-    return payload
+    return unavailable_response("x_mcp", error, tool_name=tool_name, arguments=arguments)
 
 
 _KNOWN_X_MCP_MODES = frozenset({"stdio", "sse", "streamable-http"})

--- a/tests/tools/test_mcp_bridge.py
+++ b/tests/tools/test_mcp_bridge.py
@@ -1,0 +1,62 @@
+"""Tests for the shared MCP bridge unavailable-response builder."""
+
+from __future__ import annotations
+
+from core.tool_framework.utils.mcp_bridge import unavailable_response
+
+
+def test_base_envelope_without_optional_fields() -> None:
+    result = unavailable_response("posthog_mcp", "not configured")
+    assert result == {
+        "source": "posthog_mcp",
+        "available": False,
+        "error": "not configured",
+    }
+
+
+def test_source_is_passed_through() -> None:
+    assert unavailable_response("sentry_mcp", "boom")["source"] == "sentry_mcp"
+    assert unavailable_response("openclaw", "boom")["source"] == "openclaw"
+
+
+def test_tool_name_added_when_truthy() -> None:
+    result = unavailable_response("x_mcp", "failed", tool_name="post_tweet")
+    assert result["tool"] == "post_tweet"
+
+
+def test_tool_name_omitted_when_none_or_empty() -> None:
+    assert "tool" not in unavailable_response("x_mcp", "failed")
+    assert "tool" not in unavailable_response("x_mcp", "failed", tool_name=None)
+    assert "tool" not in unavailable_response("x_mcp", "failed", tool_name="")
+
+
+def test_arguments_added_when_provided() -> None:
+    args = {"conversation_id": "abc"}
+    result = unavailable_response("openclaw", "failed", arguments=args)
+    assert result["arguments"] == args
+
+
+def test_empty_arguments_dict_is_still_recorded() -> None:
+    # ``arguments={}`` is distinct from ``arguments=None``: the empty dict is kept.
+    result = unavailable_response("openclaw", "failed", arguments={})
+    assert result["arguments"] == {}
+
+
+def test_arguments_omitted_when_none() -> None:
+    assert "arguments" not in unavailable_response("openclaw", "failed", arguments=None)
+
+
+def test_all_fields_together() -> None:
+    result = unavailable_response(
+        "sentry_mcp",
+        "tool call failed",
+        tool_name="get_issue",
+        arguments={"issue_id": "42"},
+    )
+    assert result == {
+        "source": "sentry_mcp",
+        "available": False,
+        "error": "tool call failed",
+        "tool": "get_issue",
+        "arguments": {"issue_id": "42"},
+    }


### PR DESCRIPTION
Fixes #3530

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

PostHog, Sentry, X, and OpenClaw MCP tools each had their own copy of the same "not available" response builder. I moved that logic into one shared function in core/tool_framework/utils/mcp_bridge.py and made all four use it. Behavior is unchanged, and I added tests for the shared function.

### Demo/Screenshot for feature changes and bug fixes - 


https://github.com/user-attachments/assets/35c1cbd9-ff28-4b53-a554-38ef0da0ee6b


- This demo video calls the "not available" error builder for all four MCP integrations (PostHog, Sentry, X, OpenClaw) and checks that each one still returns the exact same response as before - proving the shared function works and nothing changed.


<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I put the shared builder in mcp_bridge.py and kept each tool's small _unavailable_response wrapper, which now just calls the shared function with its own source name. This way none of the call sites changed, so the risk of breaking anything is low. I also folded in x_mcp, which had the same copy even though the issue only listed three.

<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
