### PR TITLE
fix(interactive-shell): stop announcing a deferred slash command twice

### DIFF
--- a/surfaces/interactive_shell/runtime/slash_adapter.py
+++ b/surfaces/interactive_shell/runtime/slash_adapter.py
@@ -13,7 +13,7 @@ from surfaces.interactive_shell.command_registry.slash_catalog import (
     slash_invoke_tool_description,
 )
 from surfaces.interactive_shell.session import Session
-from surfaces.interactive_shell.ui import BOLD_BRAND, DIM, repl_tty_interactive
+from surfaces.interactive_shell.ui import repl_tty_interactive
 from surfaces.interactive_shell.ui.execution_confirm import execution_allowed
 from surfaces.interactive_shell.utils.telemetry.turn_outcome import (
     format_terminal_turn_outcome,
@@ -32,9 +32,6 @@ class SlashPorts(Protocol):
         raise NotImplementedError
 
     def tty_interactive(self) -> bool:
-        raise NotImplementedError
-
-    def launching_message(self, command: str) -> str:
         raise NotImplementedError
 
     def format_turn_outcome(
@@ -83,9 +80,6 @@ class ReplSlashPorts:
 
     def tty_interactive(self) -> bool:
         return repl_tty_interactive()
-
-    def launching_message(self, command: str) -> str:
-        return f"[{DIM}]Launching[/] [{BOLD_BRAND}]{command}[/]…"
 
     def format_turn_outcome(
         self,
@@ -145,9 +139,6 @@ class HeadlessSlashPorts(ReplSlashPorts):
 
     def tty_interactive(self) -> bool:
         return False
-
-    def launching_message(self, command: str) -> str:
-        return f"Launching {command}…"
 
     def format_turn_outcome(
         self,

--- a/tests/core/agent/orchestration/test_slash_tool.py
+++ b/tests/core/agent/orchestration/test_slash_tool.py
@@ -127,9 +127,20 @@ def test_interactive_picker_runs_inline_when_exclusive_stdin_active() -> None:
     assert ports.dispatched == ["/integrations"]
     assert session.terminal.pending_prompt_default is None
     assert session.terminal.pending_prompt_autosubmit is False
-    # Running inline has no prompt echo to rely on, so this path does announce
-    # the command it is about to dispatch.
-    assert "$ /integrations" in buf.getvalue()
+    # Exclusive stdin means the user typed this slash literally, so the prompt
+    # line already shows it — announcing it again would be the third rendering
+    # of one command.
+    assert buf.getvalue() == ""
+
+
+def test_agent_resolved_slash_announces_itself() -> None:
+    """Free text resolved into a slash has no prompt echo, so it must announce."""
+    ctx, buf, session, ports = _ctx(ports=FakeSlashPorts(tty=True))
+
+    slash_tool.execute_slash_tool({"command": "/health", "args": []}, ctx)
+
+    assert ports.dispatched == ["/health"]
+    assert "$ /health" in buf.getvalue()
 
 
 def test_interactive_picker_runs_inline_when_not_a_tty() -> None:

--- a/tests/core/agent/orchestration/test_slash_tool.py
+++ b/tests/core/agent/orchestration/test_slash_tool.py
@@ -34,9 +34,6 @@ class FakeSlashPorts:
     def tty_interactive(self) -> bool:
         return self.tty
 
-    def launching_message(self, command: str) -> str:
-        return f"[dim]Launching[/] [bold]{command}[/]…"
-
     def format_turn_outcome(self, command: str, *, ok: bool) -> str:
         status = "succeeded" if ok else "failed"
         return f"slash {command} ({status})"
@@ -111,8 +108,9 @@ def test_interactive_picker_command_is_deferred_to_exclusive_stdin(
     assert session.terminal.pending_prompt_default == expected
     assert session.terminal.pending_prompt_autosubmit is True
     assert session.history == []
-    assert session.terminal._turn_outcome_hint == f"queued {expected} for exclusive stdin dispatch"
-    assert "Launching" in buf.getvalue()
+    # Nothing is printed: the prefilled prompt line is the only announcement,
+    # so the command is not shown twice before it runs.
+    assert buf.getvalue() == ""
 
 
 def test_interactive_picker_runs_inline_when_exclusive_stdin_active() -> None:
@@ -129,7 +127,9 @@ def test_interactive_picker_runs_inline_when_exclusive_stdin_active() -> None:
     assert ports.dispatched == ["/integrations"]
     assert session.terminal.pending_prompt_default is None
     assert session.terminal.pending_prompt_autosubmit is False
-    assert "Launching" not in buf.getvalue()
+    # Running inline has no prompt echo to rely on, so this path does announce
+    # the command it is about to dispatch.
+    assert "$ /integrations" in buf.getvalue()
 
 
 def test_interactive_picker_runs_inline_when_not_a_tty() -> None:

--- a/tests/interactive_shell/runtime/test_slash_adapter.py
+++ b/tests/interactive_shell/runtime/test_slash_adapter.py
@@ -5,7 +5,6 @@ def test_headless_slash_messages_do_not_contain_rich_markup() -> None:
     ports = headless_slash_ports()
 
     messages = [
-        ports.launching_message("/health"),
         ports.format_turn_outcome("/health", ok=True),
         ports.format_turn_outcome("/health", ok=False),
     ]

--- a/tools/interactive_shell/actions/slash.py
+++ b/tools/interactive_shell/actions/slash.py
@@ -11,7 +11,6 @@ from core.agent_harness.session.terminal_access import (
     exclusive_stdin_active,
     session_terminal,
     set_auto_command,
-    set_turn_outcome_hint,
 )
 from core.agent_harness.tools.tool_context import (
     ActionToolContext,
@@ -122,10 +121,12 @@ def execute_slash_tool(args: dict[str, Any], ctx: ActionToolContext) -> bool:
         # live prompt: set_auto_command re-submits it as a deterministic turn
         # the loop dispatches with exclusive stdin, so no CPR replies leak in.
         # Do not record a slash history row here — dispatch_slash will record when
-        # the queued command runs. Attach a turn hint for this turn's analytics.
-        ctx.console.print(ctx.slash_ports.launching_message(escape(stripped)))
+        # the queued command runs.
+        #
+        # Nothing is printed: set_auto_command prefills the prompt and submits it,
+        # so the command is already echoed on the input line. Announcing it here
+        # as well showed the same command twice before it had even run.
         set_auto_command(ctx.session, stripped)
-        set_turn_outcome_hint(ctx.session, f"queued {stripped} for exclusive stdin dispatch")
         return True
 
     plan = plan_foreground_tool("slash", "slash")

--- a/tools/interactive_shell/actions/slash.py
+++ b/tools/interactive_shell/actions/slash.py
@@ -147,7 +147,14 @@ def execute_slash_tool(args: dict[str, Any], ctx: ActionToolContext) -> bool:
         )
         return True
 
-    ctx.console.print(f"[bold]$ {escape(stripped)}[/bold]")
+    # Announce the command unless the input line already did. Exclusive stdin is
+    # only reserved for a *literally typed* slash command (see
+    # ``turn_needs_exclusive_stdin``), so when it is active the prompt above
+    # already shows this command and a banner would repeat it. On every other
+    # path the agent resolved free text into a slash — nothing was echoed, and
+    # this banner is the only indication of what is about to run.
+    if not exclusive_stdin_active(ctx.session):
+        ctx.console.print(f"[bold]$ {escape(stripped)}[/bold]")
     _dispatch_and_translate_exit(
         stripped,
         ctx,


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

Asking the agent to run an interactive slash command printed that command **three times** before it ran:

```console
[1] ❯ setup telegram
      Launching /integrations setup telegram…                        ← removed
[1] ❯ /integrations setup telegram                                   ← prompt prefill

● assistant
Started Telegram integration setup.
queued /integrations setup telegram for exclusive stdin dispatch     ← removed

$ /integrations setup telegram

  Setting up telegram
❯ Telegram bot token
```

The deferred path in `tools/interactive_shell/actions/slash.py` hands the command back to the REPL through `set_auto_command`, which prefills the prompt **and auto-submits it** — so the input line already echoes the command. On top of that:

- an explicit `Launching …` print restated it before the prefill, and
- the turn-outcome hint restated it a third time as assistant text.

Both are removed. After:

```console
[1] ❯ setup telegram
[1] ❯ /integrations setup telegram

● assistant
Started Telegram integration setup.

  Setting up telegram
❯ Telegram bot token
```

Nothing informative is lost: the prompt echo shows the command, and the agent's own closing prose says what it did.

The third rendering — the `$ <command>` banner printed just before dispatch — goes too, but only where it is provably redundant. It cannot be removed outright: when the action agent resolves free text into a slash (`show my integrations` → `/integrations list`) nothing was echoed at the prompt, and the banner is the only indication of what ran. `exclusive_stdin_active` separates the cases — the REPL reserves stdin only when `turn_needs_exclusive_stdin` matches a **literally typed** slash command, so an active reservation implies the input line already displays it.

`launching_message` had no other caller once the print was gone, so the port method and both adapter implementations (`repl` and `headless`) are removed with it.

**One tradeoff worth flagging.** The turn-outcome hint was dual-purpose — `core/agent_harness/turns/action_driver.py` feeds it to both `display_chunks` (what the user sees) and the turn's `response_text` (analytics). Removing it means this turn's analytics record falls back to the agent's `final_text` — `"Started Telegram integration setup."` instead of `"queued … for exclusive stdin dispatch"`. That is still a record of the turn, it reads better, and the queued command records its own row when `dispatch_slash` runs it in the following turn. The alternative — splitting display from analytics in `action_driver` — would change behavior for every hint producer (e.g. `cli_parity`'s wizard outcome, which is worth showing), so it did not belong in this change.

**Not addressed here.** A literally typed slash that does *not* reserve exclusive stdin — `/integrations list`, for instance — is still shown twice, because `exclusive_stdin_active` only covers the menu/picker commands. Narrowing that further needs the turn's raw input text so the tool can compare it against the command it is about to run; `ActionToolContext` does not carry it today. Worth its own change.

### Demo/Screenshot for feature changes and bug fixes -

The deferred path now prints nothing, and the inline path still announces itself — the two are pinned separately:

```python
# tests/core/agent/orchestration/test_slash_tool.py
def test_interactive_picker_command_is_deferred_to_exclusive_stdin(...):
    assert session.terminal.pending_prompt_default == expected
    assert session.terminal.pending_prompt_autosubmit is True
    # Nothing is printed: the prefilled prompt line is the only announcement,
    # so the command is not shown twice before it runs.
    assert buf.getvalue() == ""


def test_interactive_picker_runs_inline_when_exclusive_stdin_active():
    # Exclusive stdin means the user typed this slash literally, so the prompt
    # line already shows it — announcing it again would be the third rendering
    # of one command.
    assert buf.getvalue() == ""


def test_agent_resolved_slash_announces_itself():
    """Free text resolved into a slash has no prompt echo, so it must announce."""
    assert "$ /health" in buf.getvalue()
```

The last test is the guard on the other side: it fails if the banner is ever suppressed on the path that has no prompt echo. It also replaces an `assert "Launching" not in buf.getvalue()` that became vacuously true once nothing prints "Launching" anywhere.

Gates:

```console
$ make lint && make format-check
All checks passed!
2611 files already formatted

$ make typecheck
Success: no issues found in 1317 source files

$ uv run lint-imports
Contracts: 1 kept, 0 broken.

$ uv run pytest tests/core/agent/ tests/interactive_shell/ -q -m "not live_llm"
1562 passed, 1 skipped, 31 deselected in 23.88s
```

`uv run vulture` reports nothing for the touched files.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The starting point was a screenshot of the shell, not a bug report, so the first job was working out where each of the four renderings came from — they are produced by four different mechanisms (an explicit print, a prompt prefill that auto-submits, an analytics hint rendered as assistant text, and a dispatch banner), which is why the duplication was not obvious from any single file.

That mapping is also what kept the change safe. The prompt echo is the actual input line and cannot be suppressed at all. The `$ <command>` banner looked removable but is not — it is the sole announcement whenever the agent resolves free text into a slash — so rather than delete it I looked for a condition under which it is provably redundant. `exclusive_stdin_active` is that condition, because the REPL only reserves stdin for a literally typed slash command. Two tests now pin the two sides of it, so a later change cannot silently blind the agent-resolved path.

The one judgement call is the analytics hint, covered above: it is not purely cosmetic, and I chose the narrower loss (a slightly different analytics string on one turn) over the broader change (altering how every hint producer displays).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
