### PR TITLE
Fix: Windows installer progress format crash (#4188)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -307,7 +307,10 @@ function Write-OpenSreProgressLine {
         $content = $content.Substring(0, $clearWidth)
     }
 
-    [System.Console]::Write("`r{0}`r{1}" -f (" " * $clearWidth), $content)
+    # Parenthesize the entire -f expression. Without that, PowerShell treats the
+    # comma as a Console.Write argument separator, so -f only receives one value
+    # and "{1}" raises: "Error formatting a string: Index ... argument list."
+    [System.Console]::Write(("`r{0}`r{1}" -f (" " * $clearWidth), $content))
 }
 
 function Clear-OpenSreProgressLine {

--- a/tests/cli/test_install_ps1_progress.py
+++ b/tests/cli/test_install_ps1_progress.py
@@ -113,7 +113,37 @@ def test_install_ps1_uses_bounded_short_progress_labels() -> None:
     assert "downloading archive" in source
     assert "verifying checksum" in source
     assert '" " * 100' not in source
-    assert '[System.Console]::Write("`r{0}`r{1}"' in source
+    # The -f expression must be fully parenthesized before Console.Write, otherwise
+    # PowerShell steals the second -f argument as a Write parameter (issue #4188).
+    assert '[System.Console]::Write(("`r{0}`r{1}" -f (" " * $clearWidth), $content))' in source
+
+
+def test_install_ps1_progress_format_survives_console_write_precedence() -> None:
+    """Regression for #4188: Console.Write + -f comma precedence on Windows."""
+    shell = _powershell()
+    if shell is None:
+        pytest.skip("PowerShell is not installed in this environment.")
+
+    # Mirror Write-OpenSreProgressLine's format call. The unparenthesized form
+    # throws FormatException; the parenthesized form used in install.ps1 must succeed.
+    script = textwrap.dedent(
+        r"""
+        $ErrorActionPreference = 'Stop'
+        $clearWidth = 40
+        $content = '  / #### Installing OpenSRE downloading archive 5%'
+        [System.Console]::Write(("`r{0}`r{1}" -f (" " * $clearWidth), $content))
+        Write-Output 'FORMAT_OK'
+        """
+    )
+
+    result = subprocess.run(
+        [shell, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "FORMAT_OK" in (result.stdout + result.stderr)
 
 
 def test_install_ps1_dot_sources_when_powershell_available() -> None:


### PR DESCRIPTION
Fixes #4188

#### Describe the changes you have made in this PR -
Windows `irm https://install.opensre.com | iex` fails at `[3/6] Downloading release archive` with:

`Error formatting a string: Index (zero based) must be greater than or equal to zero and less than the size of the argument list.`

Root cause: in `Write-OpenSreProgressLine`, PowerShell parses

```powershell
[System.Console]::Write("`r{0}`r{1}" -f (" " * $clearWidth), $content)
```

so the comma is treated as a `Console.Write` argument separator. `-f` only receives one value, `{1}` throws, and the download aborts. The zip URL itself is fine (manual download works).

Fix: parenthesize the entire `-f` expression before passing it to `Console.Write`, and add a regression test.

### Demo/Screenshot for feature changes and bug fixes -

**Before (published installer):**
```text
[3/6] Downloading release archive
WARNING: Attempt 1 to download '...opensre_main_windows-x64.zip' failed: Error formatting a string: Index (zero based) must be greater than or equal to zero and less than the size of the argument list...
FAILED [3/6] Downloading release archive
```

**After (local fixed `install.ps1`):** installer proceeds past `[3/6]` and completes install.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The failure is not the GitHub asset URL; it is PowerShell operator/method-call precedence around `-f` inside `[System.Console]::Write(...)`. I reproduced the broken one-liner and the parenthesized fix in isolation, then verified the full local installer path gets past step 3. Alternatives considered: avoid `-f` entirely (string interpolation) or build the line first then `Write` once; parenthesizing keeps the existing progress formatting with the smallest diff. The new test locks the parenthesized call shape and executes the format expression under PowerShell so CI would catch a regression.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
