### PR TITLE
perf(integrations): stop re-reading integrations.json on every startup

### DIFF
--- a/integrations/catalog.py
+++ b/integrations/catalog.py
@@ -169,6 +169,15 @@ def configured_integration_services() -> list[str]:
     login). Never raises; returns an empty list on any failure so callers can
     treat it as best-effort.
     """
+    try:
+        store_records = load_integrations()
+    except Exception:
+        store_records = []
+    return _configured_service_names(store_records=store_records)
+
+
+def _configured_service_names(*, store_records: list[dict[str, Any]]) -> list[str]:
+    """Merge env-visible and active store services into one deduplicated list."""
     services: list[str] = []
 
     try:
@@ -180,10 +189,6 @@ def configured_integration_services() -> list[str]:
         if service:
             services.append(service)
 
-    try:
-        store_records = load_integrations()
-    except Exception:
-        store_records = []
     for record in store_records:
         if str(record.get("status", "active")).strip().lower() != "active":
             continue
@@ -191,7 +196,7 @@ def configured_integration_services() -> list[str]:
         if service:
             services.append(service)
 
-    return list(dict.fromkeys(services))  # deduplicate, preserve order
+    return list(dict.fromkeys(services))
 
 
 # Hosted MCP integrations that strictly require a personal API token when not
@@ -227,15 +232,16 @@ def configured_integration_health() -> list[tuple[str, str]]:
     Performs no network verification (startup stays fast) and never raises; on
     any failure each service falls back to ``"ok"`` so the banner still lists it.
     """
-    services = configured_integration_services()
-    if not services:
-        return []
-
-    store_config_by_service: dict[str, dict[str, Any]] = {}
     try:
         store_records = load_integrations()
     except Exception:
         store_records = []
+
+    services = _configured_service_names(store_records=store_records)
+    if not services:
+        return []
+
+    store_config_by_service: dict[str, dict[str, Any]] = {}
     for record in store_records:
         if str(record.get("status", "active")).strip().lower() != "active":
             continue

--- a/integrations/store.py
+++ b/integrations/store.py
@@ -132,6 +132,12 @@ def clear_integrations_cache() -> None:
 
 
 def _cache_store_data(data: dict[str, Any]) -> None:
+    """Cache ``data`` under the file's current mtime.
+
+    Only safe while holding the store lock (writers stat after their own
+    write); the lock-free read path keys the cache with a pre-read mtime
+    snapshot instead — see ``_load_raw_unlocked``.
+    """
     global _cache
     _cache = (_store_mtime_ns(), data)
 
@@ -202,9 +208,16 @@ def _load_raw_unlocked() -> tuple[dict[str, Any], bool]:
     """Return store data, using the mtime cache on repeated read-only loads.
 
     Cached data is shared across callers and must be treated read-only;
-    ``load_integrations`` returns a fresh list wrapper, and all in-repo callers
-    copy records before mutating them.
+    ``load_integrations`` returns fresh per-record copies, and all in-repo
+    callers copy nested structures before mutating them.
+
+    The mtime is snapshotted **before** the disk read and reused as the cache
+    key. If a concurrent writer replaces the file mid-read, the (possibly
+    stale) data is stored under the pre-read mtime, so the next call observes
+    a different mtime, misses the cache, and re-reads fresh state — stale data
+    is never served from a cache hit.
     """
+    global _cache
     cached = _cache
     mtime_ns = _store_mtime_ns()
     if cached is not None and cached[0] == mtime_ns:
@@ -212,7 +225,7 @@ def _load_raw_unlocked() -> tuple[dict[str, Any], bool]:
 
     data, did_migrate = _read_raw_unlocked()
     if not did_migrate:
-        _cache_store_data(data)
+        _cache = (mtime_ns, data)
     else:
         clear_integrations_cache()
     return data, did_migrate
@@ -275,7 +288,7 @@ def _locked_update(mutator: Callable[[dict[str, Any]], bool]) -> tuple[dict[str,
             changed = mutator(data)
             if changed or did_migrate:
                 _save_unlocked(data)
-            elif not did_migrate:
+            else:
                 _cache_store_data(data)
             return data, changed
     except Timeout as exc:
@@ -283,8 +296,15 @@ def _locked_update(mutator: Callable[[dict[str, Any]], bool]) -> tuple[dict[str,
 
 
 def load_integrations() -> list[dict[str, Any]]:
-    """Return all active local integrations (v2 shape)."""
-    return list(_load_raw().get("integrations", []))
+    """Return all active local integrations (v2 shape).
+
+    Each record is a fresh shallow copy so callers can add or replace
+    top-level keys without poisoning the shared read cache. Nested values
+    (``instances`` lists, credential dicts) are shared and must be copied
+    before mutation — which every in-repo caller already does.
+    """
+    records = _load_raw().get("integrations", [])
+    return [dict(record) if isinstance(record, dict) else record for record in records]
 
 
 def _record_with_flat_credentials_view(record: dict[str, Any]) -> dict[str, Any]:

--- a/integrations/store.py
+++ b/integrations/store.py
@@ -54,6 +54,12 @@ STORE_PATH = INTEGRATIONS_STORE_PATH
 _VERSION = 2
 _LOCK_TIMEOUT_SECONDS = 10.0
 
+# In-process read cache keyed on ``STORE_PATH`` mtime. Writes refresh via
+# ``_save_unlocked``; mutating loads bypass the cache via ``_read_raw_unlocked``.
+# Stored as one ``(mtime_ns, data)`` tuple so concurrent readers never observe
+# a torn mtime/data pair — a single reference assignment is atomic under the GIL.
+_cache: tuple[int, dict[str, Any]] | None = None
+
 # Structural fields on an integration record — everything else at the top
 # level of a v1 record is migrated into the default instance's credentials.
 _STRUCTURAL_RECORD_FIELDS = frozenset({"id", "service", "status", "instances"})
@@ -111,6 +117,25 @@ def _lock_path() -> Path:
     return STORE_PATH.with_suffix(".lock")
 
 
+def _store_mtime_ns() -> int:
+    """Return ``STORE_PATH`` mtime in nanoseconds, or ``-1`` when missing."""
+    try:
+        return STORE_PATH.stat().st_mtime_ns
+    except OSError:
+        return -1
+
+
+def clear_integrations_cache() -> None:
+    """Drop the in-process read cache (tests and ``STORE_PATH`` monkeypatches)."""
+    global _cache
+    _cache = None
+
+
+def _cache_store_data(data: dict[str, Any]) -> None:
+    global _cache
+    _cache = (_store_mtime_ns(), data)
+
+
 def _acquire_lock() -> FileLock:
     """Create and return a FileLock for the current STORE_PATH."""
     STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -149,13 +174,15 @@ def _save_unlocked(data: dict[str, Any]) -> None:
     Callers must already hold the store lock.
     """
     _atomic_write(STORE_PATH, data)
+    _cache_store_data(data)
 
 
-def _load_raw_unlocked() -> tuple[dict[str, Any], bool]:
+def _read_raw_unlocked() -> tuple[dict[str, Any], bool]:
     """Read the store from disk and migrate in memory.
 
     Returns ``(data, did_migrate)``.  This helper does **not** write back
-    migrations and does **not** acquire any lock.
+    migrations, does **not** acquire any lock, and does **not** use the
+    read cache (callers that mutate must always see fresh disk state).
     """
     if not STORE_PATH.exists():
         return {"version": _VERSION, "integrations": []}, False
@@ -171,6 +198,26 @@ def _load_raw_unlocked() -> tuple[dict[str, Any], bool]:
     return _migrate_if_needed(data)
 
 
+def _load_raw_unlocked() -> tuple[dict[str, Any], bool]:
+    """Return store data, using the mtime cache on repeated read-only loads.
+
+    Cached data is shared across callers and must be treated read-only;
+    ``load_integrations`` returns a fresh list wrapper, and all in-repo callers
+    copy records before mutating them.
+    """
+    cached = _cache
+    mtime_ns = _store_mtime_ns()
+    if cached is not None and cached[0] == mtime_ns:
+        return cached[1], False
+
+    data, did_migrate = _read_raw_unlocked()
+    if not did_migrate:
+        _cache_store_data(data)
+    else:
+        clear_integrations_cache()
+    return data, did_migrate
+
+
 def _load_raw() -> dict[str, Any]:
     """Read the store, migrating on disk if necessary.
 
@@ -182,7 +229,7 @@ def _load_raw() -> dict[str, Any]:
         try:
             with _acquire_lock():
                 # Re-read under lock in case another process already migrated
-                data2, did_migrate2 = _load_raw_unlocked()
+                data2, did_migrate2 = _read_raw_unlocked()
                 if did_migrate2:
                     try:
                         _save_unlocked(data2)
@@ -191,6 +238,9 @@ def _load_raw() -> dict[str, Any]:
                             "Failed to persist v2 migration; continuing with in-memory v2",
                             exc_info=True,
                         )
+                        clear_integrations_cache()
+                else:
+                    _cache_store_data(data2)
                 return data2
         except Timeout:
             logger.warning(
@@ -221,10 +271,12 @@ def _locked_update(mutator: Callable[[dict[str, Any]], bool]) -> tuple[dict[str,
     """
     try:
         with _acquire_lock():
-            data, did_migrate = _load_raw_unlocked()
+            data, did_migrate = _read_raw_unlocked()
             changed = mutator(data)
             if changed or did_migrate:
                 _save_unlocked(data)
+            elif not did_migrate:
+                _cache_store_data(data)
             return data, changed
     except Timeout as exc:
         raise _lock_timeout_error() from exc

--- a/tests/integrations/test_configured_integration_services.py
+++ b/tests/integrations/test_configured_integration_services.py
@@ -114,9 +114,7 @@ class TestConfiguredIntegrationHealth:
     """
 
     def test_ok_when_classified_into_usable_config(self, monkeypatch: Any) -> None:
-        monkeypatch.setattr(
-            catalog, "configured_integration_services", lambda: ["datadog", "gitlab"]
-        )
+        monkeypatch.setattr(catalog, "load_env_integration_services", lambda: ["datadog", "gitlab"])
         monkeypatch.setattr(catalog, "load_integrations", list)
         assert catalog.configured_integration_health() == [
             ("datadog", "ok"),
@@ -124,7 +122,7 @@ class TestConfiguredIntegrationHealth:
         ]
 
     def test_hosted_mcp_without_token_is_incomplete(self, monkeypatch: Any) -> None:
-        monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["posthog_mcp"])
+        monkeypatch.setattr(catalog, "load_env_integration_services", list)
         monkeypatch.setattr(
             catalog,
             "load_integrations",
@@ -149,7 +147,7 @@ class TestConfiguredIntegrationHealth:
         assert catalog.configured_integration_health() == [("posthog_mcp", "incomplete")]
 
     def test_hosted_mcp_with_token_is_ok(self, monkeypatch: Any) -> None:
-        monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["posthog_mcp"])
+        monkeypatch.setattr(catalog, "load_env_integration_services", list)
         monkeypatch.setattr(
             catalog,
             "load_integrations",
@@ -175,7 +173,7 @@ class TestConfiguredIntegrationHealth:
 
     def test_stdio_mcp_without_token_is_ok(self, monkeypatch: Any) -> None:
         # stdio MCP authenticates via the local subprocess, so no token is needed.
-        monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["posthog_mcp"])
+        monkeypatch.setattr(catalog, "load_env_integration_services", list)
         monkeypatch.setattr(
             catalog,
             "load_integrations",
@@ -198,19 +196,20 @@ class TestConfiguredIntegrationHealth:
     def test_non_mcp_empty_token_field_is_not_flagged(self, monkeypatch: Any) -> None:
         # Only the hosted-MCP token rule applies; an unrelated service that
         # classified successfully stays "ok" even if it lacks an auth_token key.
-        monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["github"])
+        monkeypatch.setattr(catalog, "load_env_integration_services", lambda: ["github"])
         monkeypatch.setattr(catalog, "load_integrations", list)
         assert catalog.configured_integration_health() == [("github", "ok")]
 
     def test_empty_when_no_integrations(self, monkeypatch: Any) -> None:
-        monkeypatch.setattr(catalog, "configured_integration_services", list)
+        monkeypatch.setattr(catalog, "load_env_integration_services", list)
+        monkeypatch.setattr(catalog, "load_integrations", list)
         assert catalog.configured_integration_health() == []
 
     def test_defaults_ok_when_store_load_raises(self, monkeypatch: Any) -> None:
         def _boom() -> list[dict[str, Any]]:
             raise RuntimeError("store unreadable")
 
-        monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["datadog"])
+        monkeypatch.setattr(catalog, "load_env_integration_services", lambda: ["datadog"])
         monkeypatch.setattr(catalog, "load_integrations", _boom)
         # Resolution failure must not crash the banner or alarm the user: when
         # health can't be determined offline, every service falls back to "ok".
@@ -220,8 +219,34 @@ class TestConfiguredIntegrationHealth:
         def _resolve_should_not_run() -> dict[str, Any]:
             raise AssertionError("startup health must not resolve secrets")
 
-        monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["datadog"])
+        monkeypatch.setattr(catalog, "load_env_integration_services", lambda: ["datadog"])
         monkeypatch.setattr(catalog, "load_integrations", list)
         monkeypatch.setattr(catalog, "resolve_effective_integrations", _resolve_should_not_run)
 
         assert catalog.configured_integration_health() == [("datadog", "ok")]
+
+    def test_health_loads_store_at_most_once(self, monkeypatch: Any) -> None:
+        calls = 0
+
+        def counting_load() -> list[dict[str, Any]]:
+            nonlocal calls
+            calls += 1
+            return [
+                {
+                    "service": "github",
+                    "status": "active",
+                    "instances": [
+                        {
+                            "name": "default",
+                            "tags": {},
+                            "credentials": {"token": "ghp_test"},
+                        }
+                    ],
+                }
+            ]
+
+        monkeypatch.setattr(catalog, "load_env_integration_services", list)
+        monkeypatch.setattr(catalog, "load_integrations", counting_load)
+
+        assert catalog.configured_integration_health() == [("github", "ok")]
+        assert calls == 1

--- a/tests/integrations/test_store.py
+++ b/tests/integrations/test_store.py
@@ -9,7 +9,20 @@ from unittest.mock import patch
 
 import pytest
 
-from integrations.store import _save
+from integrations import store
+from integrations.store import (
+    _save,
+    clear_integrations_cache,
+    load_integrations,
+    upsert_integration,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_store_cache() -> None:
+    clear_integrations_cache()
+    yield
+    clear_integrations_cache()
 
 
 def _assert_private_permissions(store_file) -> None:
@@ -61,3 +74,39 @@ class TestSavePermissions:
 
         _assert_private_permissions(store_file)
         assert json.loads(store_file.read_text())["updated"] is True
+
+
+class TestLoadIntegrationsCache:
+    def test_repeated_loads_hit_disk_once(self, tmp_path: pytest.TempPathFactory) -> None:
+        store_file = tmp_path / "integrations.json"  # type: ignore[operator]
+        payload = {
+            "version": 2,
+            "integrations": [{"id": "gh-1", "service": "github", "status": "active", "instances": []}],
+        }
+        store_file.write_text(json.dumps(payload))
+
+        with patch("integrations.store.STORE_PATH", store_file):
+            with patch(
+                "integrations.store._read_raw_unlocked",
+                wraps=store._read_raw_unlocked,
+            ) as read_raw:
+                for _ in range(10):
+                    records = load_integrations()
+                assert len(records) == 1
+                assert records[0]["service"] == "github"
+                assert read_raw.call_count == 1
+
+    def test_save_refreshes_cache(self, tmp_path: pytest.TempPathFactory) -> None:
+        store_file = tmp_path / "integrations.json"  # type: ignore[operator]
+        store_file.write_text(json.dumps({"version": 2, "integrations": []}))
+
+        with patch("integrations.store.STORE_PATH", store_file):
+            with patch(
+                "integrations.store._read_raw_unlocked",
+                wraps=store._read_raw_unlocked,
+            ) as read_raw:
+                load_integrations()
+                upsert_integration("gitlab", {"credentials": {"token": "glpat-test"}})
+                records = load_integrations()
+                assert any(record.get("service") == "gitlab" for record in records)
+                assert read_raw.call_count == 2

--- a/tests/integrations/test_store.py
+++ b/tests/integrations/test_store.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import os
 import stat
+from collections.abc import Iterator
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -19,13 +21,13 @@ from integrations.store import (
 
 
 @pytest.fixture(autouse=True)
-def _clear_store_cache() -> None:
+def _clear_store_cache() -> Iterator[None]:
     clear_integrations_cache()
     yield
     clear_integrations_cache()
 
 
-def _assert_private_permissions(store_file) -> None:
+def _assert_private_permissions(store_file: Path) -> None:
     mode = stat.S_IMODE(store_file.stat().st_mode)
     if os.name == "nt":
         # Windows file access is governed by ACLs; chmod-style mode bits are not portable here.
@@ -35,8 +37,8 @@ def _assert_private_permissions(store_file) -> None:
 
 
 class TestSavePermissions:
-    def test_saved_file_has_0o600_permissions(self, tmp_path: pytest.TempPathFactory) -> None:
-        store_file = tmp_path / "integrations.json"  # type: ignore[operator]
+    def test_saved_file_has_0o600_permissions(self, tmp_path: Path) -> None:
+        store_file = tmp_path / "integrations.json"
         data = {"mariadb": {"host": "db.example.com", "database": "prod"}}
 
         with patch("integrations.store.STORE_PATH", store_file):
@@ -44,8 +46,8 @@ class TestSavePermissions:
 
         _assert_private_permissions(store_file)
 
-    def test_saved_file_content_is_valid_json(self, tmp_path: pytest.TempPathFactory) -> None:
-        store_file = tmp_path / "integrations.json"  # type: ignore[operator]
+    def test_saved_file_content_is_valid_json(self, tmp_path: Path) -> None:
+        store_file = tmp_path / "integrations.json"
         data = {"mariadb": {"host": "db.example.com"}}
 
         with patch("integrations.store.STORE_PATH", store_file):
@@ -54,18 +56,16 @@ class TestSavePermissions:
         content = json.loads(store_file.read_text())
         assert content == data
 
-    def test_save_creates_parent_directories(self, tmp_path: pytest.TempPathFactory) -> None:
-        nested = tmp_path / "a" / "b" / "integrations.json"  # type: ignore[operator]
+    def test_save_creates_parent_directories(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b" / "integrations.json"
 
         with patch("integrations.store.STORE_PATH", nested):
             _save({"key": "value"})
 
         assert nested.exists()
 
-    def test_save_overwrites_existing_file_with_correct_permissions(
-        self, tmp_path: pytest.TempPathFactory
-    ) -> None:
-        store_file = tmp_path / "integrations.json"  # type: ignore[operator]
+    def test_save_overwrites_existing_file_with_correct_permissions(self, tmp_path: Path) -> None:
+        store_file = tmp_path / "integrations.json"
         store_file.write_text("{}")
         store_file.chmod(0o644)
 
@@ -77,36 +77,106 @@ class TestSavePermissions:
 
 
 class TestLoadIntegrationsCache:
-    def test_repeated_loads_hit_disk_once(self, tmp_path: pytest.TempPathFactory) -> None:
-        store_file = tmp_path / "integrations.json"  # type: ignore[operator]
+    def test_repeated_loads_hit_disk_once(self, tmp_path: Path) -> None:
+        store_file = tmp_path / "integrations.json"
         payload = {
             "version": 2,
-            "integrations": [{"id": "gh-1", "service": "github", "status": "active", "instances": []}],
+            "integrations": [
+                {"id": "gh-1", "service": "github", "status": "active", "instances": []}
+            ],
+        }
+        store_file.write_text(json.dumps(payload))
+
+        with (
+            patch("integrations.store.STORE_PATH", store_file),
+            patch(
+                "integrations.store._read_raw_unlocked",
+                wraps=store._read_raw_unlocked,
+            ) as read_raw,
+        ):
+            for _ in range(10):
+                records = load_integrations()
+            assert len(records) == 1
+            assert records[0]["service"] == "github"
+            assert read_raw.call_count == 1
+
+    def test_save_refreshes_cache(self, tmp_path: Path) -> None:
+        store_file = tmp_path / "integrations.json"
+        store_file.write_text(json.dumps({"version": 2, "integrations": []}))
+
+        with (
+            patch("integrations.store.STORE_PATH", store_file),
+            patch(
+                "integrations.store._read_raw_unlocked",
+                wraps=store._read_raw_unlocked,
+            ) as read_raw,
+        ):
+            load_integrations()
+            upsert_integration("gitlab", {"credentials": {"token": "glpat-test"}})
+            records = load_integrations()
+            assert any(record.get("service") == "gitlab" for record in records)
+            assert read_raw.call_count == 2
+
+    def test_cache_records_are_isolated_from_caller_mutation(self, tmp_path: Path) -> None:
+        """Top-level record mutation by one caller must not leak into later loads."""
+        store_file = tmp_path / "integrations.json"
+        payload = {
+            "version": 2,
+            "integrations": [
+                {"id": "gh-1", "service": "github", "status": "active", "instances": []}
+            ],
         }
         store_file.write_text(json.dumps(payload))
 
         with patch("integrations.store.STORE_PATH", store_file):
-            with patch(
-                "integrations.store._read_raw_unlocked",
-                wraps=store._read_raw_unlocked,
-            ) as read_raw:
-                for _ in range(10):
-                    records = load_integrations()
-                assert len(records) == 1
-                assert records[0]["service"] == "github"
-                assert read_raw.call_count == 1
+            first = load_integrations()
+            first[0]["status"] = "mutated"
+            second = load_integrations()
+            assert second[0]["status"] == "active"
 
-    def test_save_refreshes_cache(self, tmp_path: pytest.TempPathFactory) -> None:
-        store_file = tmp_path / "integrations.json"  # type: ignore[operator]
-        store_file.write_text(json.dumps({"version": 2, "integrations": []}))
+    def test_stale_data_not_cached_when_file_changes_mid_read(self, tmp_path: Path) -> None:
+        """A concurrent overwrite during the disk read must not poison the cache.
 
-        with patch("integrations.store.STORE_PATH", store_file):
-            with patch(
-                "integrations.store._read_raw_unlocked",
-                wraps=store._read_raw_unlocked,
-            ) as read_raw:
-                load_integrations()
-                upsert_integration("gitlab", {"credentials": {"token": "glpat-test"}})
-                records = load_integrations()
-                assert any(record.get("service") == "gitlab" for record in records)
-                assert read_raw.call_count == 2
+        The cache key is the mtime snapshotted *before* the read, so data read
+        alongside a mid-read overwrite is stored under the old key and the next
+        load re-reads fresh state instead of serving the stale snapshot.
+        """
+        store_file = tmp_path / "integrations.json"
+        old_payload = {
+            "version": 2,
+            "integrations": [
+                {"id": "old-1", "service": "old", "status": "active", "instances": []}
+            ],
+        }
+        new_payload = {
+            "version": 2,
+            "integrations": [
+                {"id": "new-1", "service": "new", "status": "active", "instances": []}
+            ],
+        }
+        store_file.write_text(json.dumps(old_payload))
+
+        original_read = store._read_raw_unlocked
+        overwritten = False
+
+        def read_then_overwrite() -> tuple[dict[str, object], bool]:
+            nonlocal overwritten
+            data = original_read()
+            if not overwritten:
+                overwritten = True
+                store_file.write_text(json.dumps(new_payload))
+                # Force a different mtime even on coarse-timestamp filesystems.
+                stat_result = store_file.stat()
+                os.utime(store_file, ns=(stat_result.st_atime_ns, stat_result.st_mtime_ns + 1))
+            return data
+
+        with (
+            patch("integrations.store.STORE_PATH", store_file),
+            patch("integrations.store._read_raw_unlocked", side_effect=read_then_overwrite),
+        ):
+            first = load_integrations()
+            assert first[0]["service"] == "old"
+            # The overwrite advanced the mtime past the cached snapshot, so
+            # this load must miss the cache and see the new content.
+            second = load_integrations()
+            assert second[0]["service"] == "new"


### PR DESCRIPTION
### Problem

`load_integrations()` read and parsed `~/.opensre/integrations.json` from disk on **every call**, with no cache.

On REPL startup this happened multiple times before the first prompt:
- Session bootstrap loads integrations once
- Welcome banner loads them **twice more** (once for service names, once for health checks)

Same file, same data — parsed 3 times for no reason.

### Why fix it

Startup should stay fast, and this store is used in many places. Caching avoids repeat disk reads when the file has not changed. The banner path also had an easy win: load the store once instead of twice.

### What changed

- Cache store reads in memory; refresh when the file changes or is saved
- Writes still read fresh from disk (cache bypass)
- Banner health now loads the store once per call
- Added tests for cache behavior and single-load health
