### PR TITLE
feat(analytics): GitHub gate A/B telemetry + usage context for investigation funnel

### DIFF
--- a/gateway/runtime/turn_handler.py
+++ b/gateway/runtime/turn_handler.py
@@ -100,8 +100,8 @@ class GatewayTurnHandler:
             bound_usage_context(session_id=session_id),
             traced_session(session_id, component="gateway_turn"),
         ):
-            capture_gateway_turn_started(surface=surface)
             try:
+                capture_gateway_turn_started(surface=surface)
                 agent = self._agent_for_turn(text=text, session=session, sink=sink, logger=logger)
                 turn_result = agent.dispatch(text)
                 outbound_text = (

--- a/gateway/runtime/turn_handler.py
+++ b/gateway/runtime/turn_handler.py
@@ -4,11 +4,16 @@ Transport-agnostic — it takes ``(text, session, sink, logger)`` and drives the
 shared headless dispatch, then finalizes any outbound text on the sink. It knows
 nothing about Telegram (or any specific transport); the composition root builds
 one of these and hands it to whichever poller runs.
+
+Transports bind ``surface`` / ``user_id`` via
+:func:`platform.analytics.usage_context.bound_usage_context` before calling this
+handler so org-level analytics can attribute sessions by channel.
 """
 
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -25,6 +30,12 @@ from core.agent_harness.turns.headless_dispatch import HeadlessAgent
 from gateway.runtime.headless_subprocess_presenter import headless_subprocess_presenter_factory
 from gateway.runtime.sink_protocol import GatewaySink
 from gateway.runtime.status_messages import status_from_tool_start
+from platform.analytics.cli import (
+    capture_gateway_turn_completed,
+    capture_gateway_turn_failed,
+    capture_gateway_turn_started,
+)
+from platform.analytics.usage_context import bound_usage_context, get_surface
 from platform.observability.trace.spans import traced_session
 
 SlashPortsFactory = Callable[[], Any]
@@ -81,24 +92,45 @@ class GatewayTurnHandler:
         logger: logging.Logger,
     ) -> None:
         session.available_capabilities.update(dict.fromkeys(_UNSUPPORTED_GATEWAY_CAPABILITIES, ()))
+        session_id = getattr(session, "session_id", None)
+        surface = get_surface() or "gateway"
+        started = time.monotonic()
 
-        with traced_session(getattr(session, "session_id", None), component="gateway_turn"):
-            agent = self._agent_for_turn(text=text, session=session, sink=sink, logger=logger)
-            turn_result = agent.dispatch(text)
-            outbound_text = (
-                turn_result.assistant_response_text or turn_result.action_result.response_text
-            ).strip()
-            logger.debug(
-                "gateway_turn done intent=%s answered=%s outbound_chars=%s",
-                turn_result.final_intent,
-                turn_result.answered,
-                len(outbound_text),
-            )
-            # A streamed answer (answered=True) already resolved the placeholder status
-            # via the sink. Otherwise always finalize so the placeholder never hangs —
-            # even when the turn produced no text.
-            if not turn_result.answered:
-                sink.finalize(outbound_text or "I didn't have anything to add for that.")
+        with (
+            bound_usage_context(session_id=session_id),
+            traced_session(session_id, component="gateway_turn"),
+        ):
+            capture_gateway_turn_started(surface=surface)
+            try:
+                agent = self._agent_for_turn(text=text, session=session, sink=sink, logger=logger)
+                turn_result = agent.dispatch(text)
+                outbound_text = (
+                    turn_result.assistant_response_text or turn_result.action_result.response_text
+                ).strip()
+                logger.debug(
+                    "gateway_turn done intent=%s answered=%s outbound_chars=%s",
+                    turn_result.final_intent,
+                    turn_result.answered,
+                    len(outbound_text),
+                )
+                # A streamed answer (answered=True) already resolved the placeholder status
+                # via the sink. Otherwise always finalize so the placeholder never hangs —
+                # even when the turn produced no text.
+                if not turn_result.answered:
+                    sink.finalize(outbound_text or "I didn't have anything to add for that.")
+                capture_gateway_turn_completed(
+                    surface=surface,
+                    duration_ms=(time.monotonic() - started) * 1000.0,
+                    answered=bool(turn_result.answered),
+                    final_intent=str(turn_result.final_intent or "") or None,
+                )
+            except Exception as exc:
+                capture_gateway_turn_failed(
+                    surface=surface,
+                    duration_ms=(time.monotonic() - started) * 1000.0,
+                    error_type=type(exc).__name__,
+                )
+                raise
 
     def _agent_for_turn(
         self,

--- a/gateway/slack/dispatcher.py
+++ b/gateway/slack/dispatcher.py
@@ -37,6 +37,7 @@ from gateway.slack.thread_history import (
     session_needs_thread_seed,
 )
 from gateway.storage import SessionResolver
+from platform.analytics.usage_context import SURFACE_SLACK, bound_usage_context
 
 _ROTATE_SESSION = "__ROTATE_SESSION__"
 
@@ -354,7 +355,12 @@ class _SlackTurnDispatcher:
                     files_context := _slack_files_context(inbound.files, self._logger)
                 ):
                     agent_text = f"{agent_text}\n\n{files_context}"
-                self._handler(agent_text, session, sink, self._logger)
+                with bound_usage_context(
+                    surface=SURFACE_SLACK,
+                    session_id=session.session_id,
+                    user_id=inbound.user_id or None,
+                ):
+                    self._handler(agent_text, session, sink, self._logger)
             except Exception:
                 self._logger.exception(
                     "[slack-gateway] turn ERRORED after %.1fs channel=%s session=%s",

--- a/gateway/telegram/inbound_handler.py
+++ b/gateway/telegram/inbound_handler.py
@@ -15,6 +15,7 @@ from gateway.telegram.output_sink import GatewayOutputSink
 from gateway.telegram.poller.client import TelegramBotClient
 from gateway.telegram.session_rotation import resolve_or_rotate_session
 from gateway.telegram.settings import GatewaySettings, TelegramInboundMessage
+from platform.analytics.usage_context import SURFACE_TELEGRAM, bound_usage_context
 
 logger = logging.getLogger(__name__)
 
@@ -67,12 +68,18 @@ async def handle_polled_inbound_telegram_message(
         )
 
         event_loop = loop or asyncio.get_running_loop()
-        await event_loop.run_in_executor(
-            executor,
-            lambda: handle_callback_to_gateway_agent(
-                event.text,
-                session,
-                sink,
-                logger,
-            ),
-        )
+
+        def _run_turn() -> None:
+            with bound_usage_context(
+                surface=SURFACE_TELEGRAM,
+                session_id=session.session_id,
+                user_id=event.user_id or None,
+            ):
+                handle_callback_to_gateway_agent(
+                    event.text,
+                    session,
+                    sink,
+                    logger,
+                )
+
+        await event_loop.run_in_executor(executor, _run_turn)

--- a/gateway/tests/runtime/test_turn_handler.py
+++ b/gateway/tests/runtime/test_turn_handler.py
@@ -20,11 +20,15 @@ from tests.core.agent.orchestration.cross_surface_parity_harness import (
 
 @pytest.fixture(autouse=True)
 def _stub_gateway_turn_analytics(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("gateway.runtime.turn_handler.capture_gateway_turn_started", lambda **_: None)
+    monkeypatch.setattr(
+        "gateway.runtime.turn_handler.capture_gateway_turn_started", lambda **_: None
+    )
     monkeypatch.setattr(
         "gateway.runtime.turn_handler.capture_gateway_turn_completed", lambda **_: None
     )
-    monkeypatch.setattr("gateway.runtime.turn_handler.capture_gateway_turn_failed", lambda **_: None)
+    monkeypatch.setattr(
+        "gateway.runtime.turn_handler.capture_gateway_turn_failed", lambda **_: None
+    )
 
 
 def _patch_headless_agent(monkeypatch: Any, result: ShellTurnResult) -> MagicMock:

--- a/gateway/tests/runtime/test_turn_handler.py
+++ b/gateway/tests/runtime/test_turn_handler.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
 from rich.console import Console
 
 from core.agent_harness.session import SessionCore
@@ -15,6 +16,15 @@ from gateway.runtime.turn_handler import GatewayTurnHandler
 from tests.core.agent.orchestration.cross_surface_parity_harness import (
     RecordingGatewaySink,
 )
+
+
+@pytest.fixture(autouse=True)
+def _stub_gateway_turn_analytics(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("gateway.runtime.turn_handler.capture_gateway_turn_started", lambda **_: None)
+    monkeypatch.setattr(
+        "gateway.runtime.turn_handler.capture_gateway_turn_completed", lambda **_: None
+    )
+    monkeypatch.setattr("gateway.runtime.turn_handler.capture_gateway_turn_failed", lambda **_: None)
 
 
 def _patch_headless_agent(monkeypatch: Any, result: ShellTurnResult) -> MagicMock:
@@ -197,3 +207,30 @@ def test_turn_handler_capability_gating_is_stable_across_turns() -> None:
     assert session.available_capabilities["llm_provider"] == ()
     assert session.available_capabilities["task_cancel"] == ()
     assert session.available_capabilities["shell_commands"] == ("shell",)
+
+
+def test_turn_handler_emits_gateway_turn_analytics(monkeypatch: Any) -> None:
+    started: list[dict[str, object]] = []
+    completed: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        "gateway.runtime.turn_handler.capture_gateway_turn_started",
+        lambda **kwargs: started.append(kwargs),
+    )
+    monkeypatch.setattr(
+        "gateway.runtime.turn_handler.capture_gateway_turn_completed",
+        lambda **kwargs: completed.append(kwargs),
+    )
+    _patch_headless_agent(monkeypatch, _empty_turn_result())
+
+    from platform.analytics.usage_context import SURFACE_SLACK, bound_usage_context
+
+    session = SessionCore(storage=InMemorySessionStorage())
+    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    with bound_usage_context(surface=SURFACE_SLACK, user_id="U1"):
+        handler("hi", session, MagicMock(), logging.getLogger("test"))
+
+    assert started == [{"surface": SURFACE_SLACK}]
+    assert len(completed) == 1
+    assert completed[0]["surface"] == SURFACE_SLACK
+    assert completed[0]["answered"] is False

--- a/platform/analytics/cli.py
+++ b/platform/analytics/cli.py
@@ -869,6 +869,12 @@ def capture_github_login_prompted(*, variant: str) -> None:
     Emits both ``github_login_gate_shown`` (canonical) and ``github_login_prompted``
     (backward compatible) with identical experiment properties so existing
     PostHog boards keep working during the rename.
+
+    Do **not** combine both event names in the same funnel step or ``event IN
+    (...)`` filter — each gate presentation produces two events and that query
+    would double-count exposures. Prefer ``github_login_gate_shown`` for new
+    boards; keep ``github_login_prompted`` only for legacy charts that have not
+    migrated yet.
     """
     props = github_gate_experiment_properties(variant)
     _capture(Event.GITHUB_LOGIN_GATE_SHOWN, props)

--- a/platform/analytics/cli.py
+++ b/platform/analytics/cli.py
@@ -28,6 +28,7 @@ from platform.analytics.source import (
     TriggerMode,
     build_source_properties,
 )
+from platform.analytics.usage_context import SURFACE_CLI
 from platform.observability.errors.sentry import capture_exception
 
 if TYPE_CHECKING:
@@ -467,7 +468,55 @@ def build_cli_invoked_properties(
 
 
 def capture_cli_invoked(properties: Properties | None = None) -> None:
-    _capture(Event.CLI_INVOKED, properties)
+    # Whole-process default for local CLI; gateway binds surface per turn instead.
+    try:
+        analytics = get_analytics()
+        analytics.set_persistent_property("surface", SURFACE_CLI)
+        analytics.capture(Event.CLI_INVOKED, properties)
+    except Exception as exc:
+        capture_exception(exc)
+
+
+def capture_gateway_turn_started(*, surface: str) -> None:
+    """Mark the start of one Slack/Telegram gateway agent turn."""
+    _capture(Event.GATEWAY_TURN_STARTED, {"surface": surface})
+
+
+def capture_gateway_turn_completed(
+    *,
+    surface: str,
+    duration_ms: float,
+    answered: bool,
+    final_intent: str | None = None,
+) -> None:
+    """Mark successful completion of one gateway agent turn."""
+    props: Properties = {
+        "surface": surface,
+        "duration_ms": round(duration_ms),
+        "duration_bucket": _bucket_duration_ms(duration_ms),
+        "answered": answered,
+    }
+    if final_intent:
+        props["final_intent"] = final_intent
+    _capture(Event.GATEWAY_TURN_COMPLETED, props)
+
+
+def capture_gateway_turn_failed(
+    *,
+    surface: str,
+    duration_ms: float,
+    error_type: str,
+) -> None:
+    """Mark a failed gateway agent turn (exception during dispatch)."""
+    _capture(
+        Event.GATEWAY_TURN_FAILED,
+        {
+            "surface": surface,
+            "duration_ms": round(duration_ms),
+            "duration_bucket": _bucket_duration_ms(duration_ms),
+            "error_type": error_type,
+        },
+    )
 
 
 def capture_repl_execution_policy_decision(properties: Properties | None = None) -> None:
@@ -735,12 +784,22 @@ def identify_github_username(username: str) -> None:
 
 
 GITHUB_GATE_EXPERIMENT: Final[str] = "github_gate_v1"
+GITHUB_GATE_VERSION: Final[str] = "1"
 GITHUB_GATE_VARIANT_CONTROL: Final[str] = "control"
 GITHUB_GATE_VARIANT_FORCED: Final[str] = "forced"
 _GITHUB_GATE_VARIANTS: Final[frozenset[str]] = frozenset(
     {GITHUB_GATE_VARIANT_CONTROL, GITHUB_GATE_VARIANT_FORCED}
 )
 GITHUB_GATE_VARIANT_ENV: Final[str] = "OPENSRE_GITHUB_GATE_VARIANT"
+
+# Real user-skip sources (never used for CI/test/env bypasses).
+GITHUB_SKIP_SOURCE_MENU: Final[str] = "menu"
+GITHUB_SKIP_SOURCE_ESCAPE: Final[str] = "escape"
+GITHUB_SKIP_SOURCE_DECLINE_RETRY: Final[str] = "decline_retry"
+
+GITHUB_FAIL_DEVICE_FLOW: Final[str] = "device_flow_unavailable"
+GITHUB_FAIL_TRANSPORT: Final[str] = "transport_error"
+GITHUB_FAIL_VERIFY: Final[str] = "access_unverified"
 
 
 def assign_github_gate_variant(anonymous_id: str) -> str:
@@ -765,35 +824,84 @@ def resolve_github_gate_variant() -> str:
     return assign_github_gate_variant(get_anonymous_id())
 
 
+def github_gate_experiment_properties(variant: str, **extra: object) -> Properties:
+    """Shared experiment fields for GitHub gate exposure/outcome events."""
+    properties: Properties = {
+        "experiment_key": GITHUB_GATE_EXPERIMENT,
+        "variant": variant,
+        "gate_version": GITHUB_GATE_VERSION,
+        # Backward-compatible alias used by existing dashboards / persistent stamp.
+        "github_gate_variant": variant,
+    }
+    for key, value in extra.items():
+        if value is None:
+            continue
+        properties[key] = value  # type: ignore[assignment]
+    return properties
+
+
 def stamp_github_gate_variant(variant: str) -> None:
-    """Persist ``github_gate_variant`` on every subsequent analytics event."""
+    """Persist experiment fields on every subsequent analytics event.
+
+    Downstream events such as ``investigation_started`` inherit ``variant`` /
+    ``github_gate_variant`` via the anonymous ``distinct_id`` session, so
+    completed-vs-skipped and forced-vs-control cohorts can be joined without
+    using ``github_username``.
+    """
     if variant not in _GITHUB_GATE_VARIANTS:
         return
     try:
-        get_analytics().set_persistent_property("github_gate_variant", variant)
+        analytics = get_analytics()
+        for key, value in github_gate_experiment_properties(variant).items():
+            analytics.set_persistent_property(key, value)  # type: ignore[arg-type]
     except Exception as exc:
         capture_exception(exc)
 
 
+def capture_github_login_gate_shown(*, variant: str) -> None:
+    """Exposure event: gate was rendered to an eligible interactive install."""
+    _capture(Event.GITHUB_LOGIN_GATE_SHOWN, github_gate_experiment_properties(variant))
+
+
 def capture_github_login_prompted(*, variant: str) -> None:
-    _capture(Event.GITHUB_LOGIN_PROMPTED, {"github_gate_variant": variant})
+    """Legacy alias for :func:`capture_github_login_gate_shown`.
+
+    Emits both ``github_login_gate_shown`` (canonical) and ``github_login_prompted``
+    (backward compatible) with identical experiment properties so existing
+    PostHog boards keep working during the rename.
+    """
+    props = github_gate_experiment_properties(variant)
+    _capture(Event.GITHUB_LOGIN_GATE_SHOWN, props)
+    _capture(Event.GITHUB_LOGIN_PROMPTED, props)
 
 
-def capture_github_login_skipped(*, variant: str) -> None:
-    _capture(Event.GITHUB_LOGIN_SKIPPED, {"github_gate_variant": variant})
+def capture_github_login_skipped(*, variant: str, skip_source: str) -> None:
+    """User chose to skip (menu / Escape / decline retry). Never for CI bypasses."""
+    _capture(
+        Event.GITHUB_LOGIN_SKIPPED,
+        github_gate_experiment_properties(variant, skip_source=skip_source),
+    )
 
 
 def capture_github_login_abandoned(*, variant: str, reason: str) -> None:
     _capture(
         Event.GITHUB_LOGIN_ABANDONED,
-        {"github_gate_variant": variant, "reason": reason},
+        github_gate_experiment_properties(variant, reason=reason),
+    )
+
+
+def capture_github_login_failed(*, variant: str, reason_category: str) -> None:
+    """Non-terminal failure during a gate attempt (device flow / transport / verify)."""
+    _capture(
+        Event.GITHUB_LOGIN_FAILED,
+        github_gate_experiment_properties(variant, reason_category=reason_category),
     )
 
 
 def capture_github_login_completed(username: str, *, variant: str | None = None) -> None:
     properties: Properties = {"github_username": username}
     if variant is not None:
-        properties["github_gate_variant"] = variant
+        properties.update(github_gate_experiment_properties(variant))
     _capture(Event.GITHUB_LOGIN_COMPLETED, properties)
 
 

--- a/platform/analytics/events.py
+++ b/platform/analytics/events.py
@@ -14,9 +14,11 @@ class Event(StrEnum):
     SENTRY_INIT_SKIPPED = "sentry_init_skipped"
 
     # GitHub first-launch login (A/B: control allows skip, forced does not)
-    GITHUB_LOGIN_PROMPTED = "github_login_prompted"
+    GITHUB_LOGIN_GATE_SHOWN = "github_login_gate_shown"
+    GITHUB_LOGIN_PROMPTED = "github_login_prompted"  # legacy alias; prefer GATE_SHOWN
     GITHUB_LOGIN_SKIPPED = "github_login_skipped"
     GITHUB_LOGIN_ABANDONED = "github_login_abandoned"
+    GITHUB_LOGIN_FAILED = "github_login_failed"
     GITHUB_LOGIN_COMPLETED = "github_login_completed"
 
     # Onboarding
@@ -66,6 +68,11 @@ class Event(StrEnum):
     TERMINAL_TURN_SUMMARIZED = "terminal_turn_summarized"
     REACT_TURN_COMPLETED = "react_turn_completed"
     AI_GENERATION = "$ai_generation"
+
+    # Gateway chat turns (Slack / Telegram) — usage sessions, not inventory
+    GATEWAY_TURN_STARTED = "gateway_turn_started"
+    GATEWAY_TURN_COMPLETED = "gateway_turn_completed"
+    GATEWAY_TURN_FAILED = "gateway_turn_failed"
 
     # Update
     UPDATE_STARTED = "update_started"

--- a/platform/analytics/provider.py
+++ b/platform/analytics/provider.py
@@ -714,6 +714,7 @@ class Analytics:
         self._worker_alive = not self._disabled
         self._persistent_properties: Properties = {}
         self._identified_organization_groups: set[str] = set()
+        self._org_group_lock = threading.Lock()
 
         if not self._disabled:
             # Never block interpreter exit on PostHog; callers that need a
@@ -803,9 +804,12 @@ class Analytics:
         if not isinstance(org, str):
             return
         org_id = org.strip()
-        if not org_id or org_id in self._identified_organization_groups:
+        if not org_id:
             return
-        self._identified_organization_groups.add(org_id)
+        with self._org_group_lock:
+            if org_id in self._identified_organization_groups:
+                return
+            self._identified_organization_groups.add(org_id)
         self.group_identify(
             ORGANIZATION_GROUP_TYPE,
             org_id,

--- a/platform/analytics/provider.py
+++ b/platform/analytics/provider.py
@@ -31,6 +31,10 @@ from platform.analytics.runtime_context import (
     detect_runtime_context,
     is_ci_environment,
 )
+from platform.analytics.usage_context import (
+    ORGANIZATION_GROUP_TYPE,
+    merge_usage_enrichment,
+)
 
 _CONFIG_DIR = get_store_path().parent
 _ANONYMOUS_ID_PATH = _CONFIG_DIR / "anonymous_id"
@@ -709,6 +713,7 @@ class Analytics:
         self._shutdown = False
         self._worker_alive = not self._disabled
         self._persistent_properties: Properties = {}
+        self._identified_organization_groups: set[str] = set()
 
         if not self._disabled:
             # Never block interpreter exit on PostHog; callers that need a
@@ -723,12 +728,13 @@ class Analytics:
     def capture(self, event: Event, properties: Properties | None = None) -> None:
         if self._disabled or self._shutdown:
             return
-        envelope = _Envelope(
-            event=event.value,
-            properties=_BASE_PROPERTIES
+        merged = merge_usage_enrichment(
+            _BASE_PROPERTIES
             | self._persistent_properties
-            | _coerce_properties(event.value, properties),
+            | _coerce_properties(event.value, properties)
         )
+        self._ensure_organization_group(merged)
+        envelope = _Envelope(event=event.value, properties=merged)
         self._enqueue(envelope)
 
     def set_persistent_property(self, key: str, value: JsonScalar) -> None:
@@ -756,12 +762,55 @@ class Analytics:
         coerced = _coerce_properties("$identify", set_properties)
         if not coerced:
             return
+        properties = merge_usage_enrichment(
+            {
+                **_BASE_PROPERTIES,
+                "$process_person_profile": True,
+                "$set": coerced,
+            }
+        )
+        self._ensure_organization_group(properties)
+        self._enqueue(_Envelope(event="$identify", properties=properties))
+
+    def group_identify(
+        self,
+        group_type: str,
+        group_key: str,
+        set_properties: Properties | None = None,
+    ) -> None:
+        """Create/update a PostHog group via a ``$groupidentify`` event.
+
+        Used so CLI/gateway events that stamp ``$groups.organization`` attach to
+        the same org group the webapp uses for integration inventory.
+        """
+        if self._disabled or self._shutdown:
+            return
+        key = group_key.strip()
+        if not group_type.strip() or not key:
+            return
+        coerced = _coerce_properties("$groupidentify", set_properties)
         properties: Properties = {
             **_BASE_PROPERTIES,
-            "$process_person_profile": True,
-            "$set": coerced,
+            "$group_type": group_type,
+            "$group_key": key,
+            "$group_set": coerced,
         }
-        self._enqueue(_Envelope(event="$identify", properties=properties))
+        self._enqueue(_Envelope(event="$groupidentify", properties=properties))
+
+    def _ensure_organization_group(self, properties: Properties) -> None:
+        """Emit ``$groupidentify`` once per process for each organization id seen."""
+        org = properties.get("organization_id")
+        if not isinstance(org, str):
+            return
+        org_id = org.strip()
+        if not org_id or org_id in self._identified_organization_groups:
+            return
+        self._identified_organization_groups.add(org_id)
+        self.group_identify(
+            ORGANIZATION_GROUP_TYPE,
+            org_id,
+            {"organization_id": org_id},
+        )
 
     def _enqueue(self, envelope: _Envelope) -> None:
         pending_registered = False

--- a/platform/analytics/usage_context.py
+++ b/platform/analytics/usage_context.py
@@ -34,9 +34,7 @@ ORGANIZATION_GROUP_TYPE: Final[str] = "organization"
 _SURFACE: ContextVar[str | None] = ContextVar("analytics_surface", default=None)
 _SESSION_ID: ContextVar[str | None] = ContextVar("analytics_session_id", default=None)
 _USER_ID: ContextVar[str | None] = ContextVar("analytics_user_id", default=None)
-_ORGANIZATION_ID: ContextVar[str | None] = ContextVar(
-    "analytics_organization_id", default=None
-)
+_ORGANIZATION_ID: ContextVar[str | None] = ContextVar("analytics_organization_id", default=None)
 
 
 def get_surface() -> str | None:
@@ -140,7 +138,7 @@ def merge_usage_enrichment(properties: Properties) -> Properties:
         groups[ORGANIZATION_GROUP_TYPE] = org.strip()
         merged["$groups"] = groups
     elif "$groups" not in merged:
-        groups = enrichment.get("$groups")
-        if isinstance(groups, dict):
-            merged["$groups"] = groups
+        enrichment_groups = enrichment.get("$groups")
+        if isinstance(enrichment_groups, dict):
+            merged["$groups"] = enrichment_groups
     return merged

--- a/platform/analytics/usage_context.py
+++ b/platform/analytics/usage_context.py
@@ -1,0 +1,146 @@
+"""Org/surface/session/user context stamped onto analytics events.
+
+This is the CLI/gateway half of org-level product analytics:
+
+- ``organization_id`` + PostHog ``$groups.organization`` when the silo org is known
+- ``surface``: ``cli`` | ``slack`` | ``telegram`` (usage channel, not inventory)
+- ``session_id``: OpenSRE agent session (not PostHog web ``$session_id``)
+- ``user_id``: transport/platform user when known (best-effort)
+
+Integration setup events inherit these stamps but remain a setup funnel — they
+are not an integration inventory source of truth (that lives in the webapp).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from collections.abc import Iterator
+from contextvars import ContextVar, Token
+from typing import Final
+
+from config.constants.billing import ORGANIZATION_ID_ENV
+from platform.analytics.repl_context import get_cli_session_id
+
+type JsonScalar = str | bool | int | float
+type JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+type Properties = dict[str, JsonValue]
+
+SURFACE_CLI: Final[str] = "cli"
+SURFACE_SLACK: Final[str] = "slack"
+SURFACE_TELEGRAM: Final[str] = "telegram"
+ORGANIZATION_GROUP_TYPE: Final[str] = "organization"
+
+_SURFACE: ContextVar[str | None] = ContextVar("analytics_surface", default=None)
+_SESSION_ID: ContextVar[str | None] = ContextVar("analytics_session_id", default=None)
+_USER_ID: ContextVar[str | None] = ContextVar("analytics_user_id", default=None)
+_ORGANIZATION_ID: ContextVar[str | None] = ContextVar(
+    "analytics_organization_id", default=None
+)
+
+
+def get_surface() -> str | None:
+    """Return the bound usage surface, if any."""
+    return _SURFACE.get()
+
+
+def get_session_id() -> str | None:
+    """Return the bound OpenSRE session id, falling back to REPL session id."""
+    return _SESSION_ID.get() or get_cli_session_id()
+
+
+def get_user_id() -> str | None:
+    """Return the bound platform/user id, if any."""
+    return _USER_ID.get()
+
+
+def get_organization_id() -> str | None:
+    """Return org id from context, else ``OPENSRE_ORGANIZATION_ID`` when set."""
+    bound = _ORGANIZATION_ID.get()
+    if bound:
+        return bound
+    env_value = (os.getenv(ORGANIZATION_ID_ENV) or "").strip()
+    return env_value or None
+
+
+def bind_surface(surface: str | None) -> Token[str | None]:
+    return _SURFACE.set(surface)
+
+
+def bind_session_id(session_id: str | None) -> Token[str | None]:
+    return _SESSION_ID.set(session_id)
+
+
+def bind_user_id(user_id: str | None) -> Token[str | None]:
+    return _USER_ID.set(user_id)
+
+
+def bind_organization_id(organization_id: str | None) -> Token[str | None]:
+    return _ORGANIZATION_ID.set(organization_id)
+
+
+@contextlib.contextmanager
+def bound_usage_context(
+    *,
+    surface: str | None = None,
+    session_id: str | None = None,
+    user_id: str | None = None,
+    organization_id: str | None = None,
+) -> Iterator[None]:
+    """Bind usage analytics context for one CLI process scope or gateway turn."""
+    tokens: list[tuple[ContextVar[str | None], Token[str | None]]] = []
+    if surface is not None:
+        tokens.append((_SURFACE, bind_surface(surface)))
+    if session_id is not None:
+        tokens.append((_SESSION_ID, bind_session_id(session_id)))
+    if user_id is not None:
+        tokens.append((_USER_ID, bind_user_id(user_id)))
+    if organization_id is not None:
+        tokens.append((_ORGANIZATION_ID, bind_organization_id(organization_id)))
+    try:
+        yield
+    finally:
+        for context_var, token in reversed(tokens):
+            context_var.reset(token)
+
+
+def build_usage_enrichment() -> Properties:
+    """Properties to merge into captures when not already set by the caller."""
+    props: Properties = {}
+    organization_id = get_organization_id()
+    if organization_id:
+        props["organization_id"] = organization_id
+        props["$groups"] = {ORGANIZATION_GROUP_TYPE: organization_id}
+    surface = get_surface()
+    if surface:
+        props["surface"] = surface
+    session_id = get_session_id()
+    if session_id:
+        props["session_id"] = session_id
+    user_id = get_user_id()
+    if user_id:
+        props["user_id"] = user_id
+    return props
+
+
+def merge_usage_enrichment(properties: Properties) -> Properties:
+    """Fill missing usage keys; caller-provided values win."""
+    enrichment = build_usage_enrichment()
+    merged = dict(properties)
+    for key, value in enrichment.items():
+        if key == "$groups":
+            continue
+        if key not in merged:
+            merged[key] = value
+
+    org = merged.get("organization_id")
+    if isinstance(org, str) and org.strip():
+        existing_groups = merged.get("$groups")
+        groups = dict(existing_groups) if isinstance(existing_groups, dict) else {}
+        groups[ORGANIZATION_GROUP_TYPE] = org.strip()
+        merged["$groups"] = groups
+    elif "$groups" not in merged:
+        groups = enrichment.get("$groups")
+        if isinstance(groups, dict):
+            merged["$groups"] = groups
+    return merged

--- a/surfaces/interactive_shell/runtime/startup/first_launch_github.py
+++ b/surfaces/interactive_shell/runtime/startup/first_launch_github.py
@@ -128,8 +128,11 @@ def clear_github_login_deferral() -> None:
 
 def _propagate_username(username: str, *, variant: str) -> None:
     # ``authenticate_and_configure_github`` already calls identify_github_username
-    # when a username is present; always emit the login lifecycle event here.
-    capture_github_login_completed(username or "", variant=variant)
+    # when a username is present; only emit the one-time login lifecycle event
+    # when we have a non-empty username so PostHog completed cohorts stay clean.
+    if not username:
+        return
+    capture_github_login_completed(username, variant=variant)
 
 
 def _print_intro(console: Console, *, allow_skip: bool) -> None:

--- a/surfaces/interactive_shell/runtime/startup/first_launch_github.py
+++ b/surfaces/interactive_shell/runtime/startup/first_launch_github.py
@@ -411,9 +411,11 @@ def require_github_login_on_first_launch(console: Console | None = None) -> bool
             _defer_github_login()
             _print_skip_guidance(con)
             return True
-        emit_terminal(
-            lambda: capture_github_login_abandoned(variant=variant, reason=retry_decision)
-        )
+
+        def _abandon(reason: str = retry_decision) -> None:
+            capture_github_login_abandoned(variant=variant, reason=reason)
+
+        emit_terminal(_abandon)
         _print_forced_abort_guidance(con)
         return False
 

--- a/surfaces/interactive_shell/runtime/startup/first_launch_github.py
+++ b/surfaces/interactive_shell/runtime/startup/first_launch_github.py
@@ -16,6 +16,7 @@ Variant assignment is sticky per install anonymous id (see
 Escape hatch: ``OPENSRE_SKIP_GITHUB_LOGIN=1`` bypasses the gate so a GitHub
 outage or a disabled device flow can never permanently lock anyone out. The gate
 is also auto-bypassed in CI/test environments and when stdin is not a TTY.
+Bypasses never emit ``github_login_skipped`` — only real user choices do.
 """
 
 from __future__ import annotations
@@ -24,15 +25,24 @@ import logging
 import os
 import sys
 import time
+from collections.abc import Callable
+from typing import Literal
 
 from rich.console import Console
 from rich.markup import escape
 
 from config.repl_config import read_github_login_deferred, write_github_login_deferred
 from platform.analytics.cli import (
+    GITHUB_FAIL_DEVICE_FLOW,
+    GITHUB_FAIL_TRANSPORT,
+    GITHUB_FAIL_VERIFY,
     GITHUB_GATE_VARIANT_CONTROL,
+    GITHUB_SKIP_SOURCE_DECLINE_RETRY,
+    GITHUB_SKIP_SOURCE_ESCAPE,
+    GITHUB_SKIP_SOURCE_MENU,
     capture_github_login_abandoned,
     capture_github_login_completed,
+    capture_github_login_failed,
     capture_github_login_prompted,
     capture_github_login_skipped,
     resolve_github_gate_variant,
@@ -49,6 +59,15 @@ _SKIP_CHOICE = "skip"
 _RETRY_CHOICE = "retry"
 _DECLINE_RETRY_CHOICE = "declined_retry"
 _CANCEL_RETRY_CHOICE = "cancelled"
+
+OfferDecision = Literal["sign_in", "skip_menu", "skip_escape"]
+AttemptOutcome = Literal[
+    "success",
+    "skipped_escape",
+    "failed_device_flow",
+    "failed_transport",
+    "failed_verify",
+]
 
 
 def _skip_requested() -> bool:
@@ -108,11 +127,9 @@ def clear_github_login_deferral() -> None:
 
 
 def _propagate_username(username: str, *, variant: str) -> None:
-    if not username:
-        return
-    # ``authenticate_and_configure_github`` already calls identify_github_username;
-    # only emit the one-time login lifecycle event here.
-    capture_github_login_completed(username, variant=variant)
+    # ``authenticate_and_configure_github`` already calls identify_github_username
+    # when a username is present; always emit the login lifecycle event here.
+    capture_github_login_completed(username or "", variant=variant)
 
 
 def _print_intro(console: Console, *, allow_skip: bool) -> None:
@@ -217,14 +234,14 @@ def _sleep_until_or_cancel(seconds: float) -> None:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_attrs)  # type: ignore[attr-defined]
 
 
-def _offer_github_login(_console: Console, *, allow_skip: bool) -> bool:
-    """Return True when the user wants to start browser sign-in.
+def _offer_github_login(_console: Console, *, allow_skip: bool) -> OfferDecision:
+    """Return the user's pre-device-flow choice.
 
     When ``allow_skip`` is False (forced variant), there is no skip choice — the
     gate proceeds straight into device-flow sign-in.
     """
     if not allow_skip:
-        return True
+        return "sign_in"
 
     import questionary
 
@@ -241,10 +258,12 @@ def _offer_github_login(_console: Console, *, allow_skip: bool) -> bool:
             default=_SIGN_IN_CHOICE,
         ).ask()
     except (EOFError, KeyboardInterrupt):
-        return False
+        return "skip_escape"
     if choice is None:
-        return False
-    return bool(choice == _SIGN_IN_CHOICE)
+        return "skip_escape"
+    if choice == _SKIP_CHOICE:
+        return "skip_menu"
+    return "sign_in"
 
 
 def _ask_retry(_console: Console) -> str:
@@ -259,8 +278,8 @@ def _ask_retry(_console: Console) -> str:
     return _RETRY_CHOICE if answer else _DECLINE_RETRY_CHOICE
 
 
-def _attempt_login(console: Console, *, allow_skip: bool, variant: str) -> str:
-    """Run one login attempt. Returns ``"success"``, ``"failed"``, or ``"skipped"``."""
+def _attempt_login(console: Console, *, allow_skip: bool, variant: str) -> AttemptOutcome:
+    """Run one login attempt."""
     from integrations.github.login import authenticate_and_configure_github
     from integrations.github.mcp_oauth import GitHubDeviceFlowError
 
@@ -274,13 +293,13 @@ def _attempt_login(console: Console, *, allow_skip: bool, variant: str) -> str:
             console.print("\nSkipped GitHub sign-in.")
         else:
             console.print("\nGitHub sign-in cancelled.")
-        return "skipped"
+        return "skipped_escape"
     except GitHubDeviceFlowError as err:
         console.print(f"[yellow]GitHub sign-in is unavailable:[/yellow] {err}")
-        return "failed"
+        return "failed_device_flow"
     except Exception as err:  # network/transport issues
         console.print(f"[yellow]GitHub sign-in failed:[/yellow] {err}")
-        return "failed"
+        return "failed_transport"
 
     if result.ok:
         clear_github_login_deferral()
@@ -293,7 +312,17 @@ def _attempt_login(console: Console, *, allow_skip: bool, variant: str) -> str:
         return "success"
 
     console.print(f"[yellow]Could not verify GitHub access:[/yellow] {result.detail}")
-    return "failed"
+    return "failed_verify"
+
+
+def _failure_category(outcome: AttemptOutcome) -> str | None:
+    if outcome == "failed_device_flow":
+        return GITHUB_FAIL_DEVICE_FLOW
+    if outcome == "failed_transport":
+        return GITHUB_FAIL_TRANSPORT
+    if outcome == "failed_verify":
+        return GITHUB_FAIL_VERIFY
+    return None
 
 
 def require_github_login_on_first_launch(console: Console | None = None) -> bool:
@@ -302,16 +331,44 @@ def require_github_login_on_first_launch(console: Console | None = None) -> bool
     Returns True when the caller should proceed into the REPL (login succeeded, or
     the user skipped in the ``control`` variant), and False when startup must abort
     (forced-variant abandonment / decline).
+
+    Variant is resolved and stamped **before** the gate UI renders. At most one
+    terminal outcome event (completed / skipped / abandoned) is emitted per gate
+    run; ``github_login_failed`` may fire per failed attempt.
     """
     con = console or Console(highlight=False)
     variant = resolve_github_gate_variant()
     stamp_github_gate_variant(variant)
     allow_skip = variant == GITHUB_GATE_VARIANT_CONTROL
+    # Exposure: eligible interactive install saw the gate.
     capture_github_login_prompted(variant=variant)
     _print_intro(con, allow_skip=allow_skip)
 
-    if allow_skip and not _offer_github_login(con, allow_skip=True):
-        capture_github_login_skipped(variant=variant)
+    terminal_emitted = False
+
+    def emit_terminal(action: Callable[[], None]) -> None:
+        nonlocal terminal_emitted
+        if terminal_emitted:
+            return
+        terminal_emitted = True
+        action()
+
+    offer = _offer_github_login(con, allow_skip=allow_skip)
+    if offer == "skip_menu":
+        emit_terminal(
+            lambda: capture_github_login_skipped(
+                variant=variant, skip_source=GITHUB_SKIP_SOURCE_MENU
+            )
+        )
+        _defer_github_login()
+        _print_skip_guidance(con)
+        return True
+    if offer == "skip_escape":
+        emit_terminal(
+            lambda: capture_github_login_skipped(
+                variant=variant, skip_source=GITHUB_SKIP_SOURCE_ESCAPE
+            )
+        )
         _defer_github_login()
         _print_skip_guidance(con)
         return True
@@ -319,26 +376,46 @@ def require_github_login_on_first_launch(console: Console | None = None) -> bool
     while True:
         outcome = _attempt_login(con, allow_skip=allow_skip, variant=variant)
         if outcome == "success":
+            # completed already emitted inside _propagate_username
+            terminal_emitted = True
             return True
-        if outcome == "skipped":
+        if outcome == "skipped_escape":
             if allow_skip:
-                capture_github_login_skipped(variant=variant)
+                emit_terminal(
+                    lambda: capture_github_login_skipped(
+                        variant=variant, skip_source=GITHUB_SKIP_SOURCE_ESCAPE
+                    )
+                )
                 _defer_github_login()
                 _print_skip_guidance(con)
                 return True
-            capture_github_login_abandoned(variant=variant, reason="cancelled")
+            emit_terminal(
+                lambda: capture_github_login_abandoned(variant=variant, reason="cancelled")
+            )
             _print_forced_abort_guidance(con)
             return False
+
+        reason_category = _failure_category(outcome)
+        if reason_category is not None:
+            capture_github_login_failed(variant=variant, reason_category=reason_category)
+
         retry_decision = _ask_retry(con)
-        if retry_decision != _RETRY_CHOICE:
-            if allow_skip:
-                capture_github_login_skipped(variant=variant)
-                _defer_github_login()
-                _print_skip_guidance(con)
-                return True
-            capture_github_login_abandoned(variant=variant, reason=retry_decision)
-            _print_forced_abort_guidance(con)
-            return False
+        if retry_decision == _RETRY_CHOICE:
+            continue
+        if allow_skip:
+            emit_terminal(
+                lambda: capture_github_login_skipped(
+                    variant=variant, skip_source=GITHUB_SKIP_SOURCE_DECLINE_RETRY
+                )
+            )
+            _defer_github_login()
+            _print_skip_guidance(con)
+            return True
+        emit_terminal(
+            lambda: capture_github_login_abandoned(variant=variant, reason=retry_decision)
+        )
+        _print_forced_abort_guidance(con)
+        return False
 
 
 def require_startup_github_login(console: Console) -> bool:
@@ -347,6 +424,10 @@ def require_startup_github_login(console: Console) -> bool:
     On an unexpected gate error we deliberately do NOT fail open into the REPL:
     that would let a gate bug silently skip sign-in. Instead we only allow
     startup when an explicit, documented bypass applies.
+
+    CI / test / non-TTY / ``OPENSRE_SKIP_GITHUB_LOGIN`` paths return True without
+    emitting skip analytics — they never reach
+    :func:`require_github_login_on_first_launch`.
     """
     try:
         if not should_require_github_login():

--- a/surfaces/interactive_shell/runtime/startup/initial_input.py
+++ b/surfaces/interactive_shell/runtime/startup/initial_input.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from rich.console import Console
 
 from platform.analytics.repl_context import bound_repl_turn_context
+from platform.analytics.usage_context import SURFACE_CLI, bound_usage_context
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui.banner import render_ready_box, render_splash
 from surfaces.interactive_shell.ui.input_prompt.rendering import render_submitted_prompt
@@ -36,10 +37,13 @@ def run_initial_input(
             continue
         render_submitted_prompt(console, session, stripped)
         recorder = PromptRecorder.start(session=session, text=stripped, turn_kind=_TURN_KIND)
-        with bound_repl_turn_context(
-            session_id=session.session_id,
-            turn_kind=_TURN_KIND,
-            prompt_turn_id=recorder.turn_id if recorder is not None else None,
+        with (
+            bound_usage_context(surface=SURFACE_CLI),
+            bound_repl_turn_context(
+                session_id=session.session_id,
+                turn_kind=_TURN_KIND,
+                prompt_turn_id=recorder.turn_id if recorder is not None else None,
+            ),
         ):
             execute_shell_turn(
                 stripped,

--- a/surfaces/interactive_shell/runtime/turn_host.py
+++ b/surfaces/interactive_shell/runtime/turn_host.py
@@ -21,6 +21,7 @@ from typing import Any
 from rich.console import Console
 
 from platform.analytics.repl_context import bound_repl_turn_context
+from platform.analytics.usage_context import SURFACE_CLI, bound_usage_context
 from platform.observability.trace.spans import bind_session_trace, emit_thread_boundary
 from surfaces.interactive_shell.runtime.agent_presentation import (
     AgentEvent,
@@ -143,10 +144,13 @@ async def _run_agent_turn_loop(
         # (``action_agent -> core.agent``) before the first turn is queued.
         from surfaces.interactive_shell.runtime.shell_turn_execution import execute_shell_turn
 
-        with bound_repl_turn_context(
-            session_id=runtime.session.session_id,
-            turn_kind=_AGENT_TURN_KIND,
-            prompt_turn_id=recorder.turn_id if recorder is not None else None,
+        with (
+            bound_usage_context(surface=SURFACE_CLI),
+            bound_repl_turn_context(
+                session_id=runtime.session.session_id,
+                turn_kind=_AGENT_TURN_KIND,
+                prompt_turn_id=recorder.turn_id if recorder is not None else None,
+            ),
         ):
             await asyncio.to_thread(
                 execute_shell_turn,

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -186,9 +186,7 @@ def test_capture_github_login_lifecycle_events(monkeypatch: pytest.MonkeyPatch) 
     cli.capture_github_login_prompted(variant="control")
     cli.capture_github_login_skipped(variant="control", skip_source=cli.GITHUB_SKIP_SOURCE_MENU)
     cli.capture_github_login_abandoned(variant="forced", reason="cancelled")
-    cli.capture_github_login_failed(
-        variant="forced", reason_category=cli.GITHUB_FAIL_DEVICE_FLOW
-    )
+    cli.capture_github_login_failed(variant="forced", reason_category=cli.GITHUB_FAIL_DEVICE_FLOW)
     cli.stamp_github_gate_variant("forced")
 
     exp_control = cli.github_gate_experiment_properties("control")

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -147,7 +147,13 @@ def test_capture_github_login_completed(monkeypatch: pytest.MonkeyPatch) -> None
     assert stub.events == [
         (
             Event.GITHUB_LOGIN_COMPLETED,
-            {"github_username": "octocat", "github_gate_variant": "forced"},
+            {
+                "github_username": "octocat",
+                "experiment_key": cli.GITHUB_GATE_EXPERIMENT,
+                "variant": "forced",
+                "gate_version": cli.GITHUB_GATE_VERSION,
+                "github_gate_variant": "forced",
+            },
         ),
     ]
 
@@ -178,19 +184,41 @@ def test_capture_github_login_lifecycle_events(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(cli, "get_analytics", lambda: stub)
 
     cli.capture_github_login_prompted(variant="control")
-    cli.capture_github_login_skipped(variant="control")
+    cli.capture_github_login_skipped(variant="control", skip_source=cli.GITHUB_SKIP_SOURCE_MENU)
     cli.capture_github_login_abandoned(variant="forced", reason="cancelled")
+    cli.capture_github_login_failed(
+        variant="forced", reason_category=cli.GITHUB_FAIL_DEVICE_FLOW
+    )
     cli.stamp_github_gate_variant("forced")
 
+    exp_control = cli.github_gate_experiment_properties("control")
+    exp_forced = cli.github_gate_experiment_properties("forced")
     assert stub.events == [
-        (Event.GITHUB_LOGIN_PROMPTED, {"github_gate_variant": "control"}),
-        (Event.GITHUB_LOGIN_SKIPPED, {"github_gate_variant": "control"}),
+        (Event.GITHUB_LOGIN_GATE_SHOWN, exp_control),
+        (Event.GITHUB_LOGIN_PROMPTED, exp_control),
+        (
+            Event.GITHUB_LOGIN_SKIPPED,
+            {**exp_control, "skip_source": cli.GITHUB_SKIP_SOURCE_MENU},
+        ),
         (
             Event.GITHUB_LOGIN_ABANDONED,
-            {"github_gate_variant": "forced", "reason": "cancelled"},
+            {**exp_forced, "reason": "cancelled"},
+        ),
+        (
+            Event.GITHUB_LOGIN_FAILED,
+            {**exp_forced, "reason_category": cli.GITHUB_FAIL_DEVICE_FLOW},
         ),
     ]
-    assert stub.persistent_properties == {"github_gate_variant": "forced"}
+    assert stub.persistent_properties == exp_forced
+
+
+def test_github_gate_experiment_properties_shape() -> None:
+    props = cli.github_gate_experiment_properties("control", skip_source="menu")
+    assert props["experiment_key"] == "github_gate_v1"
+    assert props["variant"] == "control"
+    assert props["gate_version"] == "1"
+    assert props["github_gate_variant"] == "control"
+    assert props["skip_source"] == "menu"
 
 
 def test_build_cli_invoked_properties_includes_full_command_path() -> None:

--- a/tests/analytics/test_usage_context.py
+++ b/tests/analytics/test_usage_context.py
@@ -1,0 +1,149 @@
+"""Tests for org/surface/session usage analytics context."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from config.constants.billing import ORGANIZATION_ID_ENV
+from platform.analytics import provider
+from platform.analytics.events import Event
+from platform.analytics.repl_context import bound_repl_turn_context
+from platform.analytics.usage_context import (
+    ORGANIZATION_GROUP_TYPE,
+    SURFACE_CLI,
+    SURFACE_SLACK,
+    bound_usage_context,
+    build_usage_enrichment,
+    merge_usage_enrichment,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_analytics(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    provider.shutdown_analytics(flush=False)
+    provider._instance = None
+    monkeypatch.delenv("OPENSRE_NO_TELEMETRY", raising=False)
+    monkeypatch.delenv("OPENSRE_ANALYTICS_DISABLED", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv(ORGANIZATION_ID_ENV, raising=False)
+    provider._cached_anonymous_id = None
+    provider._cached_identity_persistence = "unknown"
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+    monkeypatch.setattr(provider, "_FIRST_RUN_PATH", tmp_path / "installed")
+    monkeypatch.setattr(provider.atexit, "register", lambda _func: None)
+    yield
+    provider.shutdown_analytics(flush=False)
+    provider._instance = None
+
+
+def _stub_httpx_client(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    posted_payloads: list[dict[str, object]] = []
+
+    class _StubResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+    class _StubClient:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def __enter__(self) -> _StubClient:
+            return self
+
+        def __exit__(self, _exc_type, _exc, _tb) -> None:
+            return None
+
+        def post(self, url: str, json: dict[str, object]) -> _StubResponse:
+            posted_payloads.append({"url": url, "json": json})
+            return _StubResponse()
+
+    monkeypatch.setattr(provider.httpx, "Client", _StubClient)
+    return posted_payloads
+
+
+def test_build_usage_enrichment_from_context_and_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_abc")
+    with bound_usage_context(
+        surface=SURFACE_SLACK,
+        session_id="sess-1",
+        user_id="U123",
+    ):
+        props = build_usage_enrichment()
+    assert props["organization_id"] == "org_abc"
+    assert props["$groups"] == {ORGANIZATION_GROUP_TYPE: "org_abc"}
+    assert props["surface"] == SURFACE_SLACK
+    assert props["session_id"] == "sess-1"
+    assert props["user_id"] == "U123"
+
+
+def test_session_id_falls_back_to_cli_session() -> None:
+    with bound_repl_turn_context(session_id="repl-sess"):
+        props = build_usage_enrichment()
+    assert props["session_id"] == "repl-sess"
+
+
+def test_merge_usage_enrichment_caller_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_env")
+    with bound_usage_context(surface=SURFACE_CLI, organization_id="org_ctx"):
+        merged = merge_usage_enrichment({"organization_id": "org_caller", "surface": "cli"})
+    assert merged["organization_id"] == "org_caller"
+    assert merged["$groups"] == {ORGANIZATION_GROUP_TYPE: "org_caller"}
+    assert merged["surface"] == "cli"
+
+
+def test_capture_stamps_org_groups_and_emits_groupidentify(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    posted = _stub_httpx_client(monkeypatch)
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_prod")
+
+    analytics = provider.Analytics()
+    with bound_usage_context(surface=SURFACE_CLI, session_id="s1"):
+        analytics.capture(Event.CLI_INVOKED, {"entrypoint": "opensre"})
+    analytics.shutdown(flush=True)
+
+    events = [p["json"]["event"] for p in posted]
+    assert "$groupidentify" in events
+    assert Event.CLI_INVOKED.value in events
+
+    group_payload = next(p["json"] for p in posted if p["json"]["event"] == "$groupidentify")
+    assert group_payload["properties"]["$group_type"] == ORGANIZATION_GROUP_TYPE
+    assert group_payload["properties"]["$group_key"] == "org_prod"
+    assert group_payload["properties"]["$group_set"]["organization_id"] == "org_prod"
+
+    capture_payload = next(
+        p["json"] for p in posted if p["json"]["event"] == Event.CLI_INVOKED.value
+    )
+    props = capture_payload["properties"]
+    assert props["organization_id"] == "org_prod"
+    assert props["$groups"] == {ORGANIZATION_GROUP_TYPE: "org_prod"}
+    assert props["surface"] == SURFACE_CLI
+    assert props["session_id"] == "s1"
+
+
+def test_group_identify_once_per_org(monkeypatch: pytest.MonkeyPatch) -> None:
+    posted = _stub_httpx_client(monkeypatch)
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_once")
+
+    analytics = provider.Analytics()
+    analytics.capture(Event.CLI_INVOKED)
+    analytics.capture(Event.ONBOARD_STARTED)
+    analytics.shutdown(flush=True)
+
+    group_events = [p for p in posted if p["json"]["event"] == "$groupidentify"]
+    assert len(group_events) == 1
+
+
+def test_group_identify_direct(monkeypatch: pytest.MonkeyPatch) -> None:
+    posted = _stub_httpx_client(monkeypatch)
+    analytics = provider.Analytics()
+    analytics.group_identify(ORGANIZATION_GROUP_TYPE, "org_x", {"name": "Acme"})
+    analytics.shutdown(flush=True)
+
+    assert len(posted) == 1
+    props = posted[0]["json"]["properties"]
+    assert props["$group_key"] == "org_x"
+    assert props["$group_set"] == {"name": "Acme"}

--- a/tests/interactive_shell/runtime/test_first_launch_github.py
+++ b/tests/interactive_shell/runtime/test_first_launch_github.py
@@ -10,6 +10,12 @@ from integrations.github.login import GitHubLoginResult
 from integrations.github.mcp import DEFAULT_GITHUB_MCP_TOOLSETS, DEFAULT_GITHUB_MCP_URL
 from integrations.github.mcp_oauth import GitHubDeviceCode
 from platform.analytics import source as analytics_source
+from platform.analytics.cli import (
+    GITHUB_FAIL_VERIFY,
+    GITHUB_SKIP_SOURCE_DECLINE_RETRY,
+    GITHUB_SKIP_SOURCE_ESCAPE,
+    GITHUB_SKIP_SOURCE_MENU,
+)
 from platform.terminal import theme as ui_theme
 from surfaces.interactive_shell.runtime.startup import first_launch_github as flg
 
@@ -148,7 +154,7 @@ def test_device_code_prompt_highlights_user_code(monkeypatch: pytest.MonkeyPatch
 
 def test_orchestrator_success_proceeds_and_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
-    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: True)
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: "sign_in")
     monkeypatch.setattr(
         github_login_mod,
         "authenticate_and_configure_github",
@@ -174,14 +180,14 @@ def test_orchestrator_success_proceeds_and_propagates(monkeypatch: pytest.Monkey
 
 def test_orchestrator_skip_at_menu_proceeds_in_control(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
-    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: False)
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: "skip_menu")
     deferred: list[bool] = []
-    skipped: list[str] = []
+    skipped: list[tuple[str, str]] = []
     monkeypatch.setattr(flg, "write_github_login_deferred", deferred.append)
     monkeypatch.setattr(
         flg,
         "capture_github_login_skipped",
-        lambda *, variant: skipped.append(variant),
+        lambda *, variant, skip_source: skipped.append((variant, skip_source)),
     )
     monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
     monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
@@ -190,36 +196,42 @@ def test_orchestrator_skip_at_menu_proceeds_in_control(monkeypatch: pytest.Monke
 
     assert proceed is True
     assert deferred == [True]
-    assert skipped == ["control"]
+    assert skipped == [("control", GITHUB_SKIP_SOURCE_MENU)]
 
 
 def test_orchestrator_escape_during_wait_proceeds_in_control(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
-    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: True)
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: "sign_in")
 
     def _raise_cancel(**_kwargs: object) -> GitHubLoginResult:
         raise KeyboardInterrupt
 
     monkeypatch.setattr(github_login_mod, "authenticate_and_configure_github", _raise_cancel)
     deferred: list[bool] = []
+    skipped: list[tuple[str, str]] = []
     monkeypatch.setattr(flg, "write_github_login_deferred", deferred.append)
     monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
-    monkeypatch.setattr(flg, "capture_github_login_skipped", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_skipped",
+        lambda *, variant, skip_source: skipped.append((variant, skip_source)),
+    )
     monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
 
     proceed = flg.require_github_login_on_first_launch(_console())
 
     assert proceed is True
     assert deferred == [True]
+    assert skipped == [("control", GITHUB_SKIP_SOURCE_ESCAPE)]
 
 
 def test_orchestrator_failure_then_decline_retry_skips_in_control(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
-    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: True)
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: "sign_in")
     monkeypatch.setattr(
         github_login_mod,
         "authenticate_and_configure_github",
@@ -227,15 +239,28 @@ def test_orchestrator_failure_then_decline_retry_skips_in_control(
     )
     monkeypatch.setattr(flg, "_ask_retry", lambda _console: "declined_retry")
     deferred: list[bool] = []
+    skipped: list[tuple[str, str]] = []
+    failed: list[tuple[str, str]] = []
     monkeypatch.setattr(flg, "write_github_login_deferred", deferred.append)
     monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
-    monkeypatch.setattr(flg, "capture_github_login_skipped", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_skipped",
+        lambda *, variant, skip_source: skipped.append((variant, skip_source)),
+    )
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_failed",
+        lambda *, variant, reason_category: failed.append((variant, reason_category)),
+    )
     monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
 
     proceed = flg.require_github_login_on_first_launch(_console())
 
     assert proceed is True
     assert deferred == [True]
+    assert failed == [("control", GITHUB_FAIL_VERIFY)]
+    assert skipped == [("control", GITHUB_SKIP_SOURCE_DECLINE_RETRY)]
 
 
 def test_orchestrator_forced_cancel_aborts_startup(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -274,12 +299,18 @@ def test_orchestrator_forced_decline_retry_aborts_startup(
     )
     monkeypatch.setattr(flg, "_ask_retry", lambda _console: "declined_retry")
     abandoned: list[tuple[str, str]] = []
+    failed: list[tuple[str, str]] = []
     deferred: list[bool] = []
     monkeypatch.setattr(flg, "write_github_login_deferred", deferred.append)
     monkeypatch.setattr(
         flg,
         "capture_github_login_abandoned",
         lambda *, variant, reason: abandoned.append((variant, reason)),
+    )
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_failed",
+        lambda *, variant, reason_category: failed.append((variant, reason_category)),
     )
     monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
     monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
@@ -288,6 +319,7 @@ def test_orchestrator_forced_decline_retry_aborts_startup(
 
     assert proceed is False
     assert deferred == []
+    assert failed == [("forced", GITHUB_FAIL_VERIFY)]
     assert abandoned == [("forced", "declined_retry")]
 
 
@@ -307,6 +339,7 @@ def test_orchestrator_forced_cancel_retry_aborts_startup(
         "capture_github_login_abandoned",
         lambda *, variant, reason: abandoned.append((variant, reason)),
     )
+    monkeypatch.setattr(flg, "capture_github_login_failed", lambda **_kwargs: None)
     monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
     monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
 
@@ -341,7 +374,7 @@ def test_orchestrator_forced_success_proceeds(monkeypatch: pytest.MonkeyPatch) -
 
 def test_orchestrator_retries_until_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
-    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: True)
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: "sign_in")
     calls = {"n": 0}
 
     def _login(**_kwargs: object) -> GitHubLoginResult:
@@ -353,6 +386,7 @@ def test_orchestrator_retries_until_success(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(github_login_mod, "authenticate_and_configure_github", _login)
     monkeypatch.setattr(flg, "_ask_retry", lambda _console: "retry")
     monkeypatch.setattr(flg, "capture_github_login_completed", lambda _username, **_kwargs: None)
+    monkeypatch.setattr(flg, "capture_github_login_failed", lambda **_kwargs: None)
     monkeypatch.setattr(flg, "clear_github_login_deferral", lambda: None)
     monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
     monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
@@ -361,6 +395,97 @@ def test_orchestrator_retries_until_success(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert proceed is True
     assert calls["n"] == 2
+
+
+def test_gate_shown_before_ui_and_stamps_variant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Variant is resolved/stamped and exposure fires before the menu/device UI."""
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "forced")
+    order: list[str] = []
+
+    def _stamp(variant: str) -> None:
+        order.append(f"stamp:{variant}")
+
+    def _prompted(*, variant: str) -> None:
+        order.append(f"shown:{variant}")
+
+    def _offer(_console: object, **_kwargs: object) -> str:
+        order.append("offer")
+        return "sign_in"
+
+    monkeypatch.setattr(flg, "stamp_github_gate_variant", _stamp)
+    monkeypatch.setattr(flg, "capture_github_login_prompted", _prompted)
+    monkeypatch.setattr(flg, "_offer_github_login", _offer)
+    monkeypatch.setattr(
+        github_login_mod,
+        "authenticate_and_configure_github",
+        lambda **_kwargs: GitHubLoginResult(ok=True, username="octocat", detail="OK"),
+    )
+    monkeypatch.setattr(flg, "capture_github_login_completed", lambda *_a, **_k: None)
+    monkeypatch.setattr(flg, "clear_github_login_deferral", lambda: None)
+
+    assert flg.require_github_login_on_first_launch(_console()) is True
+    assert order[:3] == ["stamp:forced", "shown:forced", "offer"]
+
+
+def test_no_duplicate_terminal_outcome_on_menu_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: "skip_menu")
+    outcomes: list[str] = []
+    monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
+    monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
+    monkeypatch.setattr(flg, "write_github_login_deferred", lambda _v: None)
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_skipped",
+        lambda **_kwargs: outcomes.append("skipped"),
+    )
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_completed",
+        lambda *_a, **_k: outcomes.append("completed"),
+    )
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_abandoned",
+        lambda **_kwargs: outcomes.append("abandoned"),
+    )
+
+    assert flg.require_github_login_on_first_launch(_console()) is True
+    assert outcomes == ["skipped"]
+
+
+def test_startup_bypass_does_not_emit_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CI/test/env bypasses must not be counted as user skips."""
+    monkeypatch.setenv("OPENSRE_SKIP_GITHUB_LOGIN", "1")
+    skipped: list[object] = []
+    shown: list[object] = []
+    monkeypatch.setattr(flg, "capture_github_login_skipped", lambda **_k: skipped.append(True))
+    monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_k: shown.append(True))
+    monkeypatch.setattr(flg, "is_test_run", lambda: False)
+    monkeypatch.setattr(flg, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(flg, "_github_already_configured", lambda: False)
+    monkeypatch.setattr(flg, "read_github_login_deferred", lambda: False)
+
+    assert flg.require_startup_github_login(_console()) is True
+    assert shown == []
+    assert skipped == []
+
+
+def test_orchestrator_offer_escape_skip_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: "skip_escape")
+    skipped: list[tuple[str, str]] = []
+    monkeypatch.setattr(flg, "write_github_login_deferred", lambda _v: None)
+    monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
+    monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_skipped",
+        lambda *, variant, skip_source: skipped.append((variant, skip_source)),
+    )
+
+    assert flg.require_github_login_on_first_launch(_console()) is True
+    assert skipped == [("control", GITHUB_SKIP_SOURCE_ESCAPE)]
 
 
 def test_clear_github_login_deferral_noop_when_not_deferred(

--- a/tests/interactive_shell/runtime/test_first_launch_github.py
+++ b/tests/interactive_shell/runtime/test_first_launch_github.py
@@ -178,6 +178,33 @@ def test_orchestrator_success_proceeds_and_propagates(monkeypatch: pytest.Monkey
     assert cleared == [True]
 
 
+def test_orchestrator_success_without_username_skips_completed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auth can succeed without a resolvable username; do not pollute completed."""
+    monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
+    monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: "sign_in")
+    monkeypatch.setattr(
+        github_login_mod,
+        "authenticate_and_configure_github",
+        lambda **_kwargs: GitHubLoginResult(ok=True, username="", detail="OK"),
+    )
+    completed: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(
+        flg,
+        "capture_github_login_completed",
+        lambda username, *, variant=None: completed.append((username, variant)),
+    )
+    monkeypatch.setattr(flg, "clear_github_login_deferral", lambda: None)
+    monkeypatch.setattr(flg, "capture_github_login_prompted", lambda **_kwargs: None)
+    monkeypatch.setattr(flg, "stamp_github_gate_variant", lambda _variant: None)
+
+    proceed = flg.require_github_login_on_first_launch(_console())
+
+    assert proceed is True
+    assert completed == []
+
+
 def test_orchestrator_skip_at_menu_proceeds_in_control(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENSRE_GITHUB_GATE_VARIANT", "control")
     monkeypatch.setattr(flg, "_offer_github_login", lambda _console, **_kwargs: "skip_menu")


### PR DESCRIPTION
## Summary
- Enrich the GitHub first-launch gate A/B with `github_login_gate_shown`, experiment fields (`experiment_key` / `variant` / `gate_version`), `skip_source`, and `github_login_failed`, while keeping `github_login_completed` and excluding CI/test/env bypasses from user-skip counts.
- Stamp persistent experiment properties onto later analytics events so investigations join on anonymous `distinct_id` (not `github_username`).
- Add CLI/gateway usage-context enrichment (surface / session / org group) and gateway turn lifecycle events so PostHog can attribute onboarding → investigation by channel.

## Test plan
- [x] `uv run python -m pytest tests/interactive_shell/runtime/test_first_launch_github.py tests/analytics/test_cli.py -q`
- [x] `uv run python -m pytest tests/analytics/test_usage_context.py gateway/tests/runtime/test_turn_handler.py -q`
- [x] Confirm PostHog dashboard still shows existing A/B tiles plus onboarding completed-vs-skipped → investigation tables
- [x] Spot-check: control menu skip emits `github_login_skipped` with `skip_source=menu`; forced cancel emits `github_login_abandoned`; `OPENSRE_SKIP_GITHUB_LOGIN=1` emits neither

## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
We already had offline sticky forced/control assignment. This change only fills analysis gaps: canonical exposure event, experiment properties on all gate outcomes, real-user skip sources, non-terminal failures, and persistent stamps so investigation events inherit variant without using GitHub username. Usage-context + gateway turn events are included so the same PostHog project can attribute CLI vs Slack/Telegram sessions in the onboarding funnel.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.