### PR TITLE
feat(sentry): add Rocket.Chat as digest / uptime-watch delivery provider

### DIFF
--- a/docs/sentry.mdx
+++ b/docs/sentry.mdx
@@ -103,9 +103,9 @@ Detail: Sentry validated for org your-org; 30 issue(s) in the last 7 days
 
 ## Morning digest (scheduled)
 
-Deliver a daily unresolved-issues summary to Slack or Telegram. This uses the
-headless **sentry-summary** skill path (one search + LLM answer), not the
-investigation pipeline or generic `opensre cron` kinds.
+Deliver a daily unresolved-issues summary to Slack, Telegram, or Rocket.Chat.
+This uses the headless **sentry-summary** skill path (one search + LLM
+answer), not the investigation pipeline or generic `opensre cron` kinds.
 
 | Command | What it does |
 | --- | --- |
@@ -136,6 +136,18 @@ opensre sentry digest schedule add \
   --chat-id C0123ABCD
 ```
 
+Example — same schedule to a Rocket.Chat channel (requires token credentials —
+see [Rocket.Chat](/messaging/rocketchat), an incoming webhook alone cannot
+target an explicit `--chat-id`):
+
+```bash
+opensre sentry digest schedule add \
+  --cron "0 8 * * 1-5" \
+  --tz Europe/London \
+  --provider rocketchat \
+  --chat-id "#alerts"
+```
+
 Optional `--project my-service` scopes the digest to one Sentry project.
 
 The gateway daemon picks up scheduled digests automatically when it is running.
@@ -150,9 +162,9 @@ investigation) to enumerate the full issue set over a custom window.
 ## Uptime watch (downtime notifications)
 
 Poll Sentry **uptime monitors** (Alerts / Uptime — not the Issues digest) and
-ping Slack or Telegram only when a monitor transitions to **down** or
-**recovered**. Quiet polls deliver nothing. This is separate from the morning
-Issues digest (`sentry-summary` / Feature #10).
+ping Slack, Telegram, or Rocket.Chat only when a monitor transitions to
+**down** or **recovered**. Quiet polls deliver nothing. This is separate from
+the morning Issues digest (`sentry-summary` / Feature #10).
 
 | Command | What it does |
 | --- | --- |

--- a/integrations/sentry/digest_delivery.py
+++ b/integrations/sentry/digest_delivery.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from platform.scheduler.credentials import resolve_slack_credentials, resolve_telegram_credentials
+from platform.scheduler.credentials import (
+    resolve_rocketchat_credentials,
+    resolve_slack_credentials,
+    resolve_telegram_credentials,
+)
 from platform.scheduler.types import Provider
 
 
@@ -17,6 +21,18 @@ def slack_delivery_ready() -> bool:
     return bool(creds.get("webhook_url") or creds.get("access_token"))
 
 
+def rocketchat_delivery_ready() -> bool:
+    """Return True when Rocket.Chat token credentials are available.
+
+    Digest tasks always target an explicit ``--chat-id`` destination, which an
+    incoming webhook's fixed destination cannot honor — same rule as the
+    ``rocketchat`` cron provider — so readiness requires the full token trio,
+    not just a configured webhook.
+    """
+    creds = resolve_rocketchat_credentials({})
+    return bool(creds.get("server_url") and creds.get("auth_token") and creds.get("user_id"))
+
+
 def delivery_provider_ready(provider: Provider | str) -> bool:
     """Return True when ``provider`` can deliver scheduled digest messages."""
     name = provider.value if isinstance(provider, Provider) else str(provider).strip().lower()
@@ -24,12 +40,14 @@ def delivery_provider_ready(provider: Provider | str) -> bool:
         return telegram_delivery_ready()
     if name == Provider.SLACK.value:
         return slack_delivery_ready()
+    if name == Provider.ROCKETCHAT.value:
+        return rocketchat_delivery_ready()
     return False
 
 
 def any_digest_delivery_ready() -> bool:
     """Return True when at least one supported digest delivery provider is configured."""
-    return telegram_delivery_ready() or slack_delivery_ready()
+    return telegram_delivery_ready() or slack_delivery_ready() or rocketchat_delivery_ready()
 
 
 def digest_delivery_setup_hint(provider: Provider | str | None = None) -> str:
@@ -46,9 +64,17 @@ def digest_delivery_setup_hint(provider: Provider | str | None = None) -> str:
                 "Slack is not configured for delivery. Run "
                 "`opensre integrations setup slack` or set SLACK_WEBHOOK_URL / SLACK_BOT_TOKEN."
             )
+        if name == Provider.ROCKETCHAT.value:
+            return (
+                "Rocket.Chat is not configured for delivery with token credentials. Run "
+                "`opensre integrations setup rocketchat` or set ROCKETCHAT_SERVER_URL, "
+                "ROCKETCHAT_AUTH_TOKEN, and ROCKETCHAT_USER_ID (a webhook alone cannot "
+                "target an explicit --chat-id)."
+            )
     return (
-        "No digest delivery channel is configured. Connect Telegram or Slack first "
-        "(`opensre integrations setup telegram` or `opensre integrations setup slack`)."
+        "No digest delivery channel is configured. Connect Telegram, Slack, or Rocket.Chat "
+        "first (`opensre integrations setup telegram`, `opensre integrations setup slack`, "
+        "or `opensre integrations setup rocketchat`)."
     )
 
 
@@ -56,6 +82,7 @@ __all__ = [
     "any_digest_delivery_ready",
     "delivery_provider_ready",
     "digest_delivery_setup_hint",
+    "rocketchat_delivery_ready",
     "slack_delivery_ready",
     "telegram_delivery_ready",
 ]

--- a/surfaces/cli/commands/sentry_digest.py
+++ b/surfaces/cli/commands/sentry_digest.py
@@ -91,7 +91,7 @@ def sentry_uptime_check(project_slug: str) -> None:
 
 @sentry_uptime_command.group(name="watch")
 def sentry_uptime_watch_command() -> None:
-    """Schedule polling that pings Slack/Telegram on uptime transitions."""
+    """Schedule polling that pings Slack/Telegram/Rocket.Chat on uptime transitions."""
 
 
 @sentry_uptime_watch_command.command(name="add")
@@ -113,7 +113,7 @@ def sentry_uptime_watch_command() -> None:
 )
 @click.option(
     "--provider",
-    type=click.Choice(["telegram", "slack"], case_sensitive=False),
+    type=click.Choice(["telegram", "slack", "rocketchat"], case_sensitive=False),
     required=True,
     help="Messaging provider for delivery.",
 )
@@ -321,7 +321,7 @@ def sentry_digest_schedule_command() -> None:
 )
 @click.option(
     "--provider",
-    type=click.Choice(["telegram", "slack"], case_sensitive=False),
+    type=click.Choice(["telegram", "slack", "rocketchat"], case_sensitive=False),
     required=True,
     help="Messaging provider for delivery.",
 )

--- a/tests/integrations/sentry/test_digest_delivery.py
+++ b/tests/integrations/sentry/test_digest_delivery.py
@@ -8,6 +8,7 @@ from integrations.sentry.digest_delivery import (
     any_digest_delivery_ready,
     delivery_provider_ready,
     digest_delivery_setup_hint,
+    rocketchat_delivery_ready,
     slack_delivery_ready,
     telegram_delivery_ready,
 )
@@ -40,6 +41,37 @@ class TestDigestDeliveryReadiness:
         assert slack_delivery_ready() is True
         assert delivery_provider_ready("slack") is True
 
+    def test_rocketchat_ready_with_full_token_trio(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "integrations.sentry.digest_delivery.resolve_rocketchat_credentials",
+            lambda _params: {
+                "server_url": "https://chat.example.com",
+                "auth_token": "tok",
+                "user_id": "u1",
+            },
+        )
+        assert rocketchat_delivery_ready() is True
+        assert delivery_provider_ready(Provider.ROCKETCHAT) is True
+        assert any_digest_delivery_ready() is True
+
+    def test_rocketchat_not_ready_with_webhook_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A webhook alone cannot target an explicit --chat-id destination."""
+        monkeypatch.setattr(
+            "integrations.sentry.digest_delivery.resolve_telegram_credentials",
+            lambda _params: {},
+        )
+        monkeypatch.setattr(
+            "integrations.sentry.digest_delivery.resolve_slack_credentials",
+            lambda _params: {},
+        )
+        monkeypatch.setattr(
+            "integrations.sentry.digest_delivery.resolve_rocketchat_credentials",
+            lambda _params: {"webhook_url": "https://chat.example.com/hooks/a/b"},
+        )
+        assert rocketchat_delivery_ready() is False
+        assert delivery_provider_ready(Provider.ROCKETCHAT) is False
+        assert any_digest_delivery_ready() is False
+
     def test_none_ready(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
             "integrations.sentry.digest_delivery.resolve_telegram_credentials",
@@ -49,9 +81,14 @@ class TestDigestDeliveryReadiness:
             "integrations.sentry.digest_delivery.resolve_slack_credentials",
             lambda _params: {},
         )
+        monkeypatch.setattr(
+            "integrations.sentry.digest_delivery.resolve_rocketchat_credentials",
+            lambda _params: {},
+        )
         assert any_digest_delivery_ready() is False
-        assert "Telegram or Slack" in digest_delivery_setup_hint()
+        assert "Telegram, Slack, or Rocket.Chat" in digest_delivery_setup_hint()
 
     def test_provider_specific_hint(self) -> None:
         assert "Telegram" in digest_delivery_setup_hint(Provider.TELEGRAM)
         assert "Slack" in digest_delivery_setup_hint(Provider.SLACK)
+        assert "Rocket.Chat" in digest_delivery_setup_hint(Provider.ROCKETCHAT)

--- a/tests/integrations/sentry/test_digest_delivery.py
+++ b/tests/integrations/sentry/test_digest_delivery.py
@@ -42,6 +42,17 @@ class TestDigestDeliveryReadiness:
         assert delivery_provider_ready("slack") is True
 
     def test_rocketchat_ready_with_full_token_trio(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Isolate telegram/slack too: any_digest_delivery_ready() must read
+        # True because of Rocket.Chat specifically, not because a real
+        # TELEGRAM_BOT_TOKEN/SLACK_WEBHOOK_URL happens to be set locally.
+        monkeypatch.setattr(
+            "integrations.sentry.digest_delivery.resolve_telegram_credentials",
+            lambda _params: {},
+        )
+        monkeypatch.setattr(
+            "integrations.sentry.digest_delivery.resolve_slack_credentials",
+            lambda _params: {},
+        )
         monkeypatch.setattr(
             "integrations.sentry.digest_delivery.resolve_rocketchat_credentials",
             lambda _params: {


### PR DESCRIPTION
Fixes #4210

#### Describe the changes you have made in this PR -

Adds **`rocketchat`** to the Sentry digest and uptime-watch `--provider` choices, completing delivery-surface parity with the cron provider shipped in #4130.

- `integrations/sentry/digest_delivery.py` — new `rocketchat_delivery_ready()` checking the full token trio (`server_url`/`auth_token`/`user_id`); wired into `delivery_provider_ready`, `any_digest_delivery_ready`, and `digest_delivery_setup_hint`.
- `surfaces/cli/commands/sentry_digest.py` — `rocketchat` added to both `--provider` `Choice` lists (`sentry digest schedule add` and `sentry uptime watch add`); the uptime-watch group docstring updated to mention it.
- **Deliberate scope rule**: readiness requires the token trio, not a webhook alone — both digest and uptime-watch tasks target an explicit `--chat-id`, which an incoming webhook's fixed destination cannot honor. Same rule the cron provider (#4130) and `rocketchat_send_message` tool (#4129) already follow.
- Docs: `docs/sentry.mdx` gets a Rocket.Chat example for both commands.
- **No new delivery code** — scheduled/triggered runs go through the existing `platform.scheduler.executor` `Provider.ROCKETCHAT` dispatch from #4130.

**Testing** — `make lint`, `make format-check`, `make typecheck`, and `make check-layers-strict` pass; `tests/integrations/sentry/`, `tests/cli/test_sentry_digest.py`, and `tests/scheduler/` pass (138 tests). New coverage: rocketchat-ready with the token trio, not-ready with webhook-only, the general and provider-specific setup hints. Verified end-to-end against a real Rocket.Chat workspace by calling `platform.scheduler.executor.deliver_scheduled_message` with `Provider.ROCKETCHAT` directly — the same path `sentry uptime watch add`'s activation notice and scheduled digest runs use — and confirmed real delivery (screenshot below). A full `sentry digest schedule add` demo isn't possible in this environment since I don't have a Sentry integration configured locally, but that command's only new logic here is the `--provider` choice and the readiness gate, both covered by the unit tests.

### Demo/Screenshot for feature changes and bug fixes 

<img width="1638" height="130" alt="CleanShot 2026-07-22 at 16 12 45@2x" src="https://github.com/user-attachments/assets/00768561-b149-407e-8d1a-94d328a02cfd" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I noticed while auditing the messaging providers that Sentry's digest/uptime-watch commands had their own independent `--provider` choice list (not shared with `opensre cron`), and it didn't even include Discord — so Rocket.Chat was one of several gaps, not a special case. Since the scheduler's Provider enum and executor dispatch already know how to deliver to Rocket.Chat (#4130), this PR is purely a delivery-surface change: teach Sentry's readiness gate about the new provider and expose it as a CLI choice. No new transport code.

The one decision specific to this PR: readiness deliberately requires the token trio, not just "is rocketchat configured at all." Digest and uptime-watch tasks always carry an explicit `--chat-id`, and a webhook's destination is fixed at creation time — so a webhook-only setup would either silently ignore `--chat-id` or fail confusingly at delivery time. Rejecting it at the readiness gate, with a hint explaining why, is more honest and consistent with the routing rule already established for the cron provider and the send-message tool.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions