### PR TITLE
feat(rocketchat): add Rocket.Chat alarms for the watchdog (/watch, opensre watchdog)

### DIFF
--- a/.importlinter.strict
+++ b/.importlinter.strict
@@ -79,6 +79,8 @@ ignore_imports =
     tools.pi_coding_tool.validation -> integrations.pi
     tools.system.python_execution_tool.credentials -> integrations.github.client
     tools.system.python_execution_tool.credentials -> integrations.github.helpers
+    tools.system.watch_dog.runner -> integrations.rocketchat.alarms
+    tools.system.watch_dog.runner -> integrations.rocketchat.credentials
     tools.system.watch_dog.runner -> integrations.telegram.alarms
     tools.system.watch_dog.runner -> integrations.telegram.credentials
     tools.work_status_report_tool -> integrations.github.client

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -70,7 +70,7 @@ PR reviewers expect a **visible demo** (terminal log or screenshot) in the PR un
 3. `/watch <pid> --max-cpu 80` — expect `task … started.` (use a real PID, e.g. the shell’s Python process).
 4. `/watches` — table columns include id, pid, kind, status, thresholds, last sample.
 5. `/unwatch <task_id>` or `/cancel <task_id>` — then `/watches` again; status should show **cancelled**.
-6. Optional: lower `--max-cpu` so a threshold trips; after Telegram sends, the REPL prints one line: `[task …] alarm fired: … (telegram delivered)`.
+6. Optional: lower `--max-cpu` so a threshold trips; after delivery, the REPL prints one line: `[task …] alarm fired: … (telegram delivered)`. Add `--provider rocketchat --chat-id "#channel"` to `/watch` to alarm via Rocket.Chat instead (`… (rocketchat delivered)`).
 
 Automated equivalent (runs in `make test-cov`):  
 `uv run pytest tests/interactive_shell/test_watchdog_repl_e2e_demo.py -v --tb=short`

--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -105,7 +105,7 @@ When you type `/` and browse completions with the arrow keys, the full descripti
 
 | Command | What it does |
 | --- | --- |
-| `/watch` | Watch a process and send Telegram threshold alarms **elevated** |
+| `/watch` | Watch a process and send threshold alarms via Telegram or Rocket.Chat **elevated** |
 | `/watches` | List active watchdog tasks with latest samples |
 | `/unwatch <id>` | Stop a watchdog task by id **elevated** |
 | `/watchdog` | CLI-parity wrapper for the watchdog monitor |

--- a/docs/messaging/rocketchat.mdx
+++ b/docs/messaging/rocketchat.mdx
@@ -212,6 +212,24 @@ See [Background investigations](/background-investigations) for the full command
 
 ---
 
+## Watchdog alarms
+
+The process watchdog (`/watch`, `opensre watchdog`) can send threshold alarms to Rocket.Chat instead of Telegram:
+
+```text
+/watch <pid> --max-cpu 80 --provider rocketchat --chat-id "#alerts"
+```
+
+CLI:
+
+```bash
+opensre watchdog --pid <pid> --max-cpu 80 --provider rocketchat --chat-id "#alerts"
+```
+
+`--chat-id` overrides the configured `default_channel` (token mode) or is optional in webhook-only mode (the webhook's destination is fixed). Alarms require token credentials with a resolvable channel, or a configured incoming webhook — the same rule as scheduled deliveries. Cooldown suppresses repeat alarms for the same threshold (`--cooldown`, default 5 minutes).
+
+---
+
 ## Scheduled deliveries (cron)
 
 With token credentials configured (Steps 1–4), Rocket.Chat can receive recurring reports:

--- a/integrations/rocketchat/alarms.py
+++ b/integrations/rocketchat/alarms.py
@@ -1,0 +1,99 @@
+"""Rocket.Chat alarm dispatcher with per-key cooldown.
+
+Shared by features that need throttled Rocket.Chat alerts (watchdog
+thresholds, Hermes incident sinks) — mirrors
+:class:`integrations.telegram.alarms.AlarmDispatcher`.
+
+Credential resolution lives in :mod:`integrations.rocketchat.credentials`;
+raw transport in :mod:`integrations.rocketchat.delivery`. This module owns
+only the throttling + dispatch policy.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from integrations.rocketchat.credentials import RocketChatCredentials
+from integrations.rocketchat.delivery import post_rocketchat_message, post_rocketchat_webhook
+from platform.common.truncation import truncate
+from platform.notifications.cooldown import CooldownGate
+from platform.notifications.limits import MAX_MESSAGE_SIZE
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_COOLDOWN_SECONDS = 300.0
+_ROCKETCHAT_MESSAGE_LIMIT = MAX_MESSAGE_SIZE
+
+
+class RocketChatAlarmDispatcher:
+    """Dispatch Rocket.Chat alarms with per-key cooldown.
+
+    Token credentials with a channel are preferred; the incoming webhook
+    (fixed destination) is used only when token credentials are absent — the
+    routing rule already established for ``rocketchat_send_message``, the
+    cron provider, and the background-notify channel.
+    """
+
+    def __init__(
+        self,
+        creds: RocketChatCredentials,
+        *,
+        cooldown_seconds: float = _DEFAULT_COOLDOWN_SECONDS,
+    ) -> None:
+        self._creds = creds
+        self._gate = CooldownGate(cooldown_seconds)
+
+    def dispatch(self, threshold_name: str, message: str) -> bool:
+        """Send to Rocket.Chat unless this threshold is in cooldown."""
+        now = self._now()
+
+        remaining = self._gate.try_reserve(threshold_name, now)
+        if remaining is not None:
+            logger.debug(
+                "alarm suppressed by cooldown: name=%s remaining=%.1fs",
+                threshold_name,
+                remaining,
+            )
+            return False
+
+        text = truncate(message, _ROCKETCHAT_MESSAGE_LIMIT, suffix="…")
+
+        # The cooldown slot was reserved before this network call. If the
+        # delivery returns ok=False OR raises, the slot stays armed for the
+        # cooldown window and the next caller for the same key is silently
+        # suppressed — emit the same warning in both paths so operators see
+        # the original failure instead of only the suppression debug line.
+        try:
+            if self._creds.has_token:
+                ok, error, _message_id = post_rocketchat_message(
+                    self._creds.server_url,
+                    self._creds.channel,
+                    text,
+                    self._creds.auth_token,
+                    self._creds.user_id,
+                )
+            else:
+                ok, error = post_rocketchat_webhook(self._creds.webhook_url, text)
+        except Exception as exc:
+            logger.warning(
+                "alarm delivery raised and cooldown remains armed: name=%s error=%s",
+                threshold_name,
+                exc,
+                exc_info=True,
+            )
+            return False
+
+        if ok:
+            return True
+
+        logger.warning(
+            "alarm delivery failed and cooldown remains armed: name=%s error=%s",
+            threshold_name,
+            error,
+        )
+        return False
+
+    @staticmethod
+    def _now() -> float:
+        return time.monotonic()

--- a/integrations/rocketchat/credentials.py
+++ b/integrations/rocketchat/credentials.py
@@ -1,0 +1,135 @@
+"""Rocket.Chat credential resolution for alarm dispatch (watchdog, Hermes).
+
+``server_url``/``auth_token``/``user_id``/``webhook_url`` reuse the
+scheduler's resolver (:func:`platform.scheduler.credentials.resolve_rocketchat_credentials`)
+so task-params > integration-store > environment precedence stays identical
+across the cron provider, Sentry digest, and alarm dispatchers. This module
+adds channel resolution (explicit override -> store ``default_channel`` ->
+``ROCKETCHAT_DEFAULT_CHANNEL`` env) and raises a setup-friendly error when
+nothing usable is configured.
+
+Routing rule (matches ``rocketchat_send_message``, the cron provider, and the
+background-notify channel): token credentials with a channel are preferred;
+the incoming webhook (fixed destination) is the fallback only when token
+credentials are absent.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+
+from platform.common.errors import OpenSREError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RocketChatCredentials:
+    """Resolved Rocket.Chat delivery target — token mode, webhook mode, or both.
+
+    ``auth_token`` and ``webhook_url`` are excluded from the generated
+    ``__repr__`` (the webhook URL embeds its own token) so neither leaks into
+    pytest assertion output, tracebacks, or structured log capture.
+    """
+
+    server_url: str = ""
+    auth_token: str = field(default="", repr=False)
+    user_id: str = ""
+    webhook_url: str = field(default="", repr=False)
+    channel: str = ""
+
+    @property
+    def has_token(self) -> bool:
+        return bool(self.server_url and self.auth_token and self.user_id)
+
+
+def _store_default_channel() -> str:
+    try:
+        from integrations.catalog import resolve_effective_integrations
+
+        entry = resolve_effective_integrations().get("rocketchat", {})
+        config = entry.get("config", {}) if isinstance(entry, dict) else {}
+        if not isinstance(config, dict):
+            return ""
+        return str(config.get("default_channel") or "").strip()
+    except (ImportError, KeyError, TypeError, ValueError, OSError, RuntimeError) as exc:
+        logger.debug(
+            "Failed to resolve Rocket.Chat default_channel from the store: %s",
+            exc,
+            exc_info=True,
+        )
+        return ""
+
+
+def _resolve_channel(channel_override: str | None) -> str:
+    stripped_override = channel_override.strip() if channel_override else ""
+    if stripped_override:
+        return stripped_override
+    store_channel = _store_default_channel()
+    if store_channel:
+        return store_channel
+    return os.getenv("ROCKETCHAT_DEFAULT_CHANNEL", "").strip()
+
+
+def load_credentials_from_env(
+    *,
+    channel_override: str | None = None,
+) -> RocketChatCredentials:
+    """Resolve Rocket.Chat credentials for alarm dispatch.
+
+    Raises :class:`OpenSREError` with a setup-friendly suggestion when
+    neither a usable token+channel combination nor a webhook is configured.
+    """
+    from platform.scheduler.credentials import resolve_rocketchat_credentials
+
+    creds = resolve_rocketchat_credentials({})
+    server_url = creds.get("server_url", "")
+    auth_token = creds.get("auth_token", "")
+    user_id = creds.get("user_id", "")
+    webhook_url = creds.get("webhook_url", "")
+    has_pat = bool(server_url and auth_token and user_id)
+    channel = _resolve_channel(channel_override)
+
+    if has_pat:
+        if channel:
+            return RocketChatCredentials(
+                server_url=server_url,
+                auth_token=auth_token,
+                user_id=user_id,
+                webhook_url=webhook_url,
+                channel=channel,
+            )
+        raise OpenSREError(
+            "Rocket.Chat has no channel to deliver to.",
+            suggestion=(
+                "Pass --chat-id, set a default channel during "
+                "`opensre integrations setup rocketchat`, or export "
+                "ROCKETCHAT_DEFAULT_CHANNEL=<channel>."
+            ),
+        )
+
+    if webhook_url:
+        # An explicit channel needs token credentials — the webhook's
+        # destination is fixed at creation time and cannot honor one.
+        stripped_override = channel_override.strip() if channel_override else ""
+        if stripped_override:
+            raise OpenSREError(
+                "An explicit channel needs Rocket.Chat token credentials.",
+                suggestion=(
+                    "Configure server_url/auth_token/user_id with "
+                    "`opensre integrations setup rocketchat`, or drop --chat-id "
+                    "to use the incoming webhook's fixed destination."
+                ),
+            )
+        return RocketChatCredentials(webhook_url=webhook_url)
+
+    raise OpenSREError(
+        "Rocket.Chat is not configured.",
+        suggestion=(
+            "Configure Rocket.Chat with `opensre integrations setup rocketchat` "
+            "(or `opensre onboard`), or export ROCKETCHAT_SERVER_URL, "
+            "ROCKETCHAT_AUTH_TOKEN, ROCKETCHAT_USER_ID (or ROCKETCHAT_WEBHOOK_URL)."
+        ),
+    )

--- a/integrations/rocketchat/credentials.py
+++ b/integrations/rocketchat/credentials.py
@@ -54,7 +54,15 @@ def _store_default_channel() -> str:
         if not isinstance(config, dict):
             return ""
         return str(config.get("default_channel") or "").strip()
-    except (ImportError, KeyError, TypeError, ValueError, OSError, RuntimeError) as exc:
+    except (
+        ImportError,
+        AttributeError,
+        KeyError,
+        TypeError,
+        ValueError,
+        OSError,
+        RuntimeError,
+    ) as exc:
         logger.debug(
             "Failed to resolve Rocket.Chat default_channel from the store: %s",
             exc,

--- a/integrations/telegram/alarms.py
+++ b/integrations/telegram/alarms.py
@@ -14,7 +14,6 @@ throttling + dispatch policy.
 from __future__ import annotations
 
 import logging
-import threading
 import time
 
 from integrations.telegram.credentials import TelegramCredentials
@@ -23,6 +22,7 @@ from integrations.telegram.delivery import (
     truncate_for_telegram_html,
 )
 from platform.common.truncation import truncate
+from platform.notifications.cooldown import CooldownGate
 from platform.notifications.limits import MAX_MESSAGE_SIZE
 
 logger = logging.getLogger(__name__)
@@ -42,30 +42,21 @@ class AlarmDispatcher:
         parse_mode: str = "",
     ) -> None:
         self._creds = creds
-        self._cooldown_seconds = cooldown_seconds
         self._parse_mode = parse_mode
-        self._last_dispatched: dict[str, float] = {}
-        self._lock = threading.Lock()
+        self._gate = CooldownGate(cooldown_seconds)
 
     def dispatch(self, threshold_name: str, message: str) -> bool:
         """Send to Telegram unless this threshold is in cooldown."""
         now = self._now()
 
-        # Reserve the cooldown slot under the lock BEFORE the network call so
-        # a concurrent dispatch on the same threshold sees the reservation and
-        # is suppressed. Without this, two threads could both pass the check
-        # (state of last_dispatched at "check" time != "use" time, classic
-        # TOCTOU) and both send.
-        with self._lock:
-            last = self._last_dispatched.get(threshold_name)
-            if last is not None and (now - last) < self._cooldown_seconds:
-                logger.debug(
-                    "alarm suppressed by cooldown: name=%s remaining=%.1fs",
-                    threshold_name,
-                    self._cooldown_seconds - (now - last),
-                )
-                return False
-            self._last_dispatched[threshold_name] = now
+        remaining = self._gate.try_reserve(threshold_name, now)
+        if remaining is not None:
+            logger.debug(
+                "alarm suppressed by cooldown: name=%s remaining=%.1fs",
+                threshold_name,
+                remaining,
+            )
+            return False
 
         if self._parse_mode.upper() == "HTML":
             text = truncate_for_telegram_html(message, _TELEGRAM_MESSAGE_LIMIT, suffix="…")

--- a/platform/notifications/cooldown.py
+++ b/platform/notifications/cooldown.py
@@ -1,0 +1,43 @@
+"""Shared per-key cooldown/throttle gate for alarm dispatchers.
+
+Telegram and Rocket.Chat alarm dispatchers (watchdog thresholds, Hermes
+incident sinks) both need to suppress repeat deliveries for the same key
+within a cooldown window. This module owns the throttling primitive so each
+dispatcher only implements its own transport.
+"""
+
+from __future__ import annotations
+
+import threading
+
+
+class CooldownGate:
+    """Thread-safe per-key cooldown gate.
+
+    ``try_reserve`` reserves the cooldown slot for a key *before* the caller's
+    network call, so a concurrent dispatch on the same key sees the
+    reservation and is suppressed. Without this, two threads could both pass
+    the check (state of "last dispatched" at check time != use time, classic
+    TOCTOU) and both send.
+    """
+
+    def __init__(self, cooldown_seconds: float) -> None:
+        self._cooldown_seconds = cooldown_seconds
+        self._last_dispatched: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def try_reserve(self, key: str, now: float) -> float | None:
+        """Reserve *key* at time *now* unless it is still in cooldown.
+
+        Returns ``None`` (and reserves the slot) when the key is not in
+        cooldown. Returns the remaining cooldown time in seconds, without
+        reserving, when the key is still suppressed.
+        """
+        with self._lock:
+            last = self._last_dispatched.get(key)
+            if last is not None:
+                remaining = self._cooldown_seconds - (now - last)
+                if remaining > 0:
+                    return remaining
+            self._last_dispatched[key] = now
+            return None

--- a/surfaces/cli/commands/watchdog.py
+++ b/surfaces/cli/commands/watchdog.py
@@ -45,7 +45,20 @@ from tools.system.watch_dog.runner import run_watchdog
     help="Minimum gap between repeated alarms per threshold.",
 )
 @click.option("--once", is_flag=True, help="Exit after the first threshold alarm.")
-@click.option("--chat-id", type=str, default=None, help="Override TELEGRAM_DEFAULT_CHAT_ID.")
+@click.option(
+    "--provider",
+    type=click.Choice(["telegram", "rocketchat"], case_sensitive=False),
+    default="telegram",
+    show_default=True,
+    help="Messaging provider for alarm delivery.",
+)
+@click.option(
+    "--chat-id",
+    type=str,
+    default=None,
+    help="Override the provider's default chat/channel (TELEGRAM_DEFAULT_CHAT_ID or "
+    "ROCKETCHAT_DEFAULT_CHANNEL).",
+)
 @click.option("--verbose", is_flag=True, help="Print one line per sampled process state.")
 def watchdog_command(
     pid: int | None,
@@ -58,10 +71,11 @@ def watchdog_command(
     interval: float,
     cooldown: str,
     once: bool,
+    provider: str,
     chat_id: str | None,
     verbose: bool,
 ) -> None:
-    """Monitor a process and send Telegram alarms when thresholds trip."""
+    """Monitor a process and send alarms via Telegram or Rocket.Chat when thresholds trip."""
     try:
         config = WatchdogConfig.model_validate(
             {
@@ -75,6 +89,7 @@ def watchdog_command(
                 "interval": interval,
                 "cooldown": cooldown,
                 "once": once,
+                "provider": provider,
                 "chat_id": chat_id,
                 "verbose": verbose,
             }

--- a/surfaces/interactive_shell/command_registry/watch_cmds.py
+++ b/surfaces/interactive_shell/command_registry/watch_cmds.py
@@ -10,6 +10,10 @@ from dataclasses import dataclass
 from rich.console import Console
 from rich.markup import escape
 
+from integrations.rocketchat.alarms import RocketChatAlarmDispatcher
+from integrations.rocketchat.credentials import (
+    load_credentials_from_env as load_rocketchat_credentials_from_env,
+)
 from integrations.telegram.alarms import AlarmDispatcher
 from integrations.telegram.credentials import load_credentials_from_env
 from platform.common.errors import OpenSREError
@@ -43,6 +47,8 @@ class WatchdogStartSpec:
     cooldown_seconds: float = 300.0
     interval_seconds: float = 2.0
     once: bool = False
+    provider: str = "telegram"
+    chat_id: str = ""
 
 
 def _parse_duration_seconds(raw: str) -> float | None:
@@ -93,7 +99,7 @@ def parse_watch_argv(argv: list[str]) -> WatchdogStartSpec | str:
     if not argv:
         return (
             f"[{ERROR}]usage:[/] /watch <pid> [--max-cpu N] [--max-runtime D] [--max-rss S] "
-            f"[--cooldown D] [--interval N] [--once]"
+            f"[--cooldown D] [--interval N] [--once] [--provider telegram|rocketchat] [--chat-id ID]"
         )
     if argv[0].startswith("-"):
         return f"[{ERROR}]usage:[/] /watch <pid> ...  — the process id must come first"
@@ -111,6 +117,8 @@ def parse_watch_argv(argv: list[str]) -> WatchdogStartSpec | str:
     cooldown_seconds = 300.0
     interval_seconds = 2.0
     once = False
+    provider = "telegram"
+    chat_id = ""
 
     i = 1
     while i < len(argv):
@@ -125,7 +133,17 @@ def parse_watch_argv(argv: list[str]) -> WatchdogStartSpec | str:
             return f"[{ERROR}]missing value for[/] {escape(token)}"
         value = argv[i + 1]
         i += 2
-        if token == "--max-cpu":
+        if token == "--provider":
+            normalized_provider = value.strip().lower()
+            if normalized_provider not in ("telegram", "rocketchat"):
+                return (
+                    f"[{ERROR}]invalid --provider:[/] {escape(value)} "
+                    f"[{ERROR}](must be telegram or rocketchat)[/]"
+                )
+            provider = normalized_provider
+        elif token == "--chat-id":
+            chat_id = value
+        elif token == "--max-cpu":
             try:
                 pct = float(value)
             except ValueError:
@@ -165,6 +183,8 @@ def parse_watch_argv(argv: list[str]) -> WatchdogStartSpec | str:
         cooldown_seconds=cooldown_seconds,
         interval_seconds=interval_seconds,
         once=once,
+        provider=provider,
+        chat_id=chat_id,
     )
 
 
@@ -180,6 +200,8 @@ def _watch_command_summary(spec: WatchdogStartSpec) -> str:
     parts.append(f"interval={spec.interval_seconds:g}s")
     if spec.once:
         parts.append("once")
+    if spec.provider != "telegram":
+        parts.append(f"provider={spec.provider}")
     return " ".join(parts)
 
 
@@ -202,7 +224,14 @@ def _cmd_watch(session: Session, console: Console, args: list[str]) -> bool:
         return True
 
     try:
-        creds = load_credentials_from_env()
+        if parsed.provider == "rocketchat":
+            rc_creds = load_rocketchat_credentials_from_env(channel_override=parsed.chat_id or None)
+            dispatcher: AlarmDispatcher | RocketChatAlarmDispatcher = RocketChatAlarmDispatcher(
+                rc_creds, cooldown_seconds=parsed.cooldown_seconds
+            )
+        else:
+            creds = load_credentials_from_env(chat_id_override=parsed.chat_id or None)
+            dispatcher = AlarmDispatcher(creds, cooldown_seconds=parsed.cooldown_seconds)
     except OpenSREError as exc:
         console.print(f"[{ERROR}]{escape(str(exc))}[/]")
         return True
@@ -211,13 +240,13 @@ def _cmd_watch(session: Session, console: Console, args: list[str]) -> bool:
     task = session.task_registry.create(TaskKind.WATCHDOG, command=summary)
     task.mark_running()
     task.attach_pid(parsed.pid)
-    dispatcher = AlarmDispatcher(creds, cooldown_seconds=parsed.cooldown_seconds)
+    provider_label = parsed.provider
 
     def _on_alarm(threshold: str, detail: str) -> None:
         with _CONSOLE_PRINT_LOCK:
             console.print(
                 f"[task {escape(task.task_id)}] alarm fired: {escape(threshold)} "
-                f"{escape(detail)} (telegram delivered)"
+                f"{escape(detail)} ({provider_label} delivered)"
             )
 
     start_watchdog_daemon_thread(
@@ -320,7 +349,7 @@ def _validate_watch_args(args: list[str]) -> str | None:
     if not args:
         return (
             f"[{ERROR}]usage:[/] /watch <pid> [--max-cpu N] [--max-runtime D] [--max-rss S] "
-            f"[--cooldown D] [--interval N] [--once]"
+            f"[--cooldown D] [--interval N] [--once] [--provider telegram|rocketchat] [--chat-id ID]"
         )
     return None
 
@@ -332,9 +361,14 @@ COMMANDS: list[SlashCommand] = [
         _cmd_watch,
         usage=(
             "/watch <pid> [--max-cpu N] [--max-runtime D] [--max-rss S] "
-            "[--cooldown D] [--interval N] [--once]",
+            "[--cooldown D] [--interval N] [--once] "
+            "[--provider telegram|rocketchat] [--chat-id ID]",
         ),
-        notes=("Alarms are sent to Telegram when Telegram delivery is configured.",),
+        notes=(
+            "Alarms are sent via the configured --provider (telegram by "
+            "default, or rocketchat) when that provider's delivery is "
+            "configured.",
+        ),
         validate_args=_validate_watch_args,
     ),
     SlashCommand(

--- a/tests/integrations/test_rocketchat_alarms.py
+++ b/tests/integrations/test_rocketchat_alarms.py
@@ -1,0 +1,180 @@
+"""Tests for integrations.rocketchat.alarms.RocketChatAlarmDispatcher."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from integrations.rocketchat.alarms import RocketChatAlarmDispatcher
+from integrations.rocketchat.credentials import RocketChatCredentials
+
+_TOKEN_CREDS = RocketChatCredentials(
+    server_url="https://chat.example.com",
+    auth_token="tok",
+    user_id="u1",
+    channel="#incidents",
+)
+_WEBHOOK_CREDS = RocketChatCredentials(webhook_url="https://chat.example.com/hooks/abc/def")
+
+
+def _patch_clock(monkeypatch: pytest.MonkeyPatch, ticks: list[float]) -> None:
+    iterator = iter(ticks)
+
+    def _now() -> float:
+        return next(iterator)
+
+    monkeypatch.setattr(RocketChatAlarmDispatcher, "_now", staticmethod(_now))
+
+
+def _stub_post_message(
+    monkeypatch: pytest.MonkeyPatch, *, ok: bool = True, error: str = ""
+) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def _fake_post(
+        server_url: str, channel: str, text: str, auth_token: str, user_id: str
+    ) -> tuple[bool, str, str]:
+        calls.append(
+            {
+                "server_url": server_url,
+                "channel": channel,
+                "text": text,
+                "auth_token": auth_token,
+                "user_id": user_id,
+            }
+        )
+        return ok, error, "m-1" if ok else ""
+
+    monkeypatch.setattr("integrations.rocketchat.alarms.post_rocketchat_message", _fake_post)
+    return calls
+
+
+def _stub_post_webhook(
+    monkeypatch: pytest.MonkeyPatch, *, ok: bool = True, error: str = ""
+) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def _fake_webhook(webhook_url: str, text: str) -> tuple[bool, str]:
+        calls.append({"webhook_url": webhook_url, "text": text})
+        return ok, error
+
+    monkeypatch.setattr("integrations.rocketchat.alarms.post_rocketchat_webhook", _fake_webhook)
+    return calls
+
+
+def test_first_dispatch_calls_token_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_post_message(monkeypatch)
+    _patch_clock(monkeypatch, [100.0])
+
+    dispatcher = RocketChatAlarmDispatcher(_TOKEN_CREDS)
+
+    assert dispatcher.dispatch("max_cpu", "CPU pegged at 95%") is True
+    assert len(calls) == 1
+    assert calls[0] == {
+        "server_url": "https://chat.example.com",
+        "channel": "#incidents",
+        "text": "CPU pegged at 95%",
+        "auth_token": "tok",
+        "user_id": "u1",
+    }
+
+
+def test_webhook_only_creds_use_webhook_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_post_webhook(monkeypatch)
+    _patch_clock(monkeypatch, [100.0])
+
+    dispatcher = RocketChatAlarmDispatcher(_WEBHOOK_CREDS)
+
+    assert dispatcher.dispatch("max_cpu", "CPU pegged at 95%") is True
+    assert calls[0]["webhook_url"] == "https://chat.example.com/hooks/abc/def"
+
+
+def test_second_dispatch_within_cooldown_is_suppressed(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_post_message(monkeypatch)
+    _patch_clock(monkeypatch, [100.0, 200.0])
+
+    dispatcher = RocketChatAlarmDispatcher(_TOKEN_CREDS, cooldown_seconds=300.0)
+
+    assert dispatcher.dispatch("max_cpu", "first") is True
+    assert dispatcher.dispatch("max_cpu", "second") is False
+    assert len(calls) == 1
+    assert calls[0]["text"] == "first"
+
+
+def test_second_dispatch_after_cooldown_calls_transport_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _stub_post_message(monkeypatch)
+    _patch_clock(monkeypatch, [100.0, 450.0])
+
+    dispatcher = RocketChatAlarmDispatcher(_TOKEN_CREDS, cooldown_seconds=300.0)
+
+    assert dispatcher.dispatch("max_cpu", "first") is True
+    assert dispatcher.dispatch("max_cpu", "second") is True
+    assert len(calls) == 2
+
+
+def test_cooldown_is_per_threshold_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_post_message(monkeypatch)
+    _patch_clock(monkeypatch, [100.0, 110.0])
+
+    dispatcher = RocketChatAlarmDispatcher(_TOKEN_CREDS, cooldown_seconds=300.0)
+
+    assert dispatcher.dispatch("max_cpu", "cpu") is True
+    assert dispatcher.dispatch("max_runtime", "runtime") is True
+    assert len(calls) == 2
+
+
+def test_dispatch_returns_false_on_transport_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A failed delivery still arms cooldown; otherwise a bad token, bad
+    # channel, or network outage retries on every watchdog sample.
+    calls = _stub_post_message(monkeypatch, ok=False, error="channel not found")
+    _patch_clock(monkeypatch, [100.0, 105.0])
+
+    dispatcher = RocketChatAlarmDispatcher(_TOKEN_CREDS, cooldown_seconds=300.0)
+
+    assert dispatcher.dispatch("max_cpu", "first") is False
+    assert dispatcher.dispatch("max_cpu", "second") is False
+    assert len(calls) == 1
+
+
+def test_failed_dispatch_retries_after_cooldown(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_post_message(monkeypatch, ok=False, error="channel not found")
+    _patch_clock(monkeypatch, [100.0, 105.0, 450.0])
+
+    dispatcher = RocketChatAlarmDispatcher(_TOKEN_CREDS, cooldown_seconds=300.0)
+
+    assert dispatcher.dispatch("max_cpu", "first") is False
+    assert dispatcher.dispatch("max_cpu", "suppressed") is False
+    assert dispatcher.dispatch("max_cpu", "retry") is False
+    assert [call["text"] for call in calls] == ["first", "retry"]
+
+
+def test_dispatch_truncates_messages_over_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_post_message(monkeypatch)
+    _patch_clock(monkeypatch, [100.0])
+
+    dispatcher = RocketChatAlarmDispatcher(_TOKEN_CREDS)
+    oversized = "X" * 5000
+
+    assert dispatcher.dispatch("max_cpu", oversized) is True
+    assert len(calls[0]["text"]) <= 4096
+    assert calls[0]["text"].endswith("…")
+
+
+def test_dispatch_transport_exception_returns_false_and_keeps_cooldown_armed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(*_a: Any, **_kw: Any) -> None:
+        raise RuntimeError("network exploded")
+
+    monkeypatch.setattr("integrations.rocketchat.alarms.post_rocketchat_message", _raise)
+    _patch_clock(monkeypatch, [100.0, 105.0])
+
+    dispatcher = RocketChatAlarmDispatcher(_TOKEN_CREDS, cooldown_seconds=300.0)
+
+    assert dispatcher.dispatch("max_cpu", "first") is False
+    # Cooldown stayed armed after the raise — the second call within the
+    # window is suppressed rather than retrying immediately.
+    assert dispatcher.dispatch("max_cpu", "second") is False

--- a/tests/integrations/test_rocketchat_credentials.py
+++ b/tests/integrations/test_rocketchat_credentials.py
@@ -1,0 +1,176 @@
+"""Tests for integrations.rocketchat.credentials."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from integrations.rocketchat.credentials import (
+    RocketChatCredentials,
+    load_credentials_from_env,
+)
+from platform.common.errors import OpenSREError
+
+_ROCKETCHAT_ENV_VARS = (
+    "ROCKETCHAT_SERVER_URL",
+    "ROCKETCHAT_AUTH_TOKEN",
+    "ROCKETCHAT_USER_ID",
+    "ROCKETCHAT_WEBHOOK_URL",
+    "ROCKETCHAT_DEFAULT_CHANNEL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make credential resolution hermetic — no local machine leakage.
+
+    Patches the real underlying store lookup (``resolve_effective_integrations``)
+    rather than ``_store_default_channel`` itself, so tests exercise the real
+    channel-resolution code path (including its store-failure resilience)
+    instead of a stub that would hide it.
+    """
+    for env_var in _ROCKETCHAT_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setattr(
+        "platform.scheduler.credentials._get_integration_credential",
+        lambda *_: "",
+    )
+    monkeypatch.setattr(
+        "integrations.catalog.resolve_effective_integrations",
+        lambda: {},
+    )
+
+
+def test_credentials_repr_does_not_leak_auth_token_or_webhook_url() -> None:
+    creds = RocketChatCredentials(
+        server_url="https://chat.example.com",
+        auth_token="super-secret-token",
+        user_id="u1",
+        webhook_url="https://chat.example.com/hooks/abc/super-secret-hook-token",
+        channel="#incidents",
+    )
+    rendered = repr(creds)
+    assert "super-secret-token" not in rendered
+    assert "super-secret-hook-token" not in rendered
+    assert "#incidents" in rendered
+
+
+def test_token_mode_with_channel_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ROCKETCHAT_SERVER_URL", "https://chat.example.com")
+    monkeypatch.setenv("ROCKETCHAT_AUTH_TOKEN", "tok")
+    monkeypatch.setenv("ROCKETCHAT_USER_ID", "u1")
+
+    creds = load_credentials_from_env(channel_override="#ops")
+
+    assert creds.has_token is True
+    assert creds.channel == "#ops"
+
+
+def test_token_mode_falls_back_to_default_channel(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ROCKETCHAT_SERVER_URL", "https://chat.example.com")
+    monkeypatch.setenv("ROCKETCHAT_AUTH_TOKEN", "tok")
+    monkeypatch.setenv("ROCKETCHAT_USER_ID", "u1")
+    monkeypatch.setenv("ROCKETCHAT_DEFAULT_CHANNEL", "#incidents")
+
+    creds = load_credentials_from_env()
+
+    assert creds.channel == "#incidents"
+
+
+def test_token_mode_without_any_channel_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ROCKETCHAT_SERVER_URL", "https://chat.example.com")
+    monkeypatch.setenv("ROCKETCHAT_AUTH_TOKEN", "tok")
+    monkeypatch.setenv("ROCKETCHAT_USER_ID", "u1")
+
+    with pytest.raises(OpenSREError) as exc_info:
+        load_credentials_from_env()
+    assert "channel" in str(exc_info.value).lower()
+
+
+def test_webhook_only_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ROCKETCHAT_WEBHOOK_URL", "https://chat.example.com/hooks/abc/def")
+
+    creds = load_credentials_from_env()
+
+    assert creds.has_token is False
+    assert creds.webhook_url == "https://chat.example.com/hooks/abc/def"
+
+
+def test_webhook_only_rejects_explicit_channel(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ROCKETCHAT_WEBHOOK_URL", "https://chat.example.com/hooks/abc/def")
+
+    with pytest.raises(OpenSREError) as exc_info:
+        load_credentials_from_env(channel_override="#ops")
+    assert "token credentials" in str(exc_info.value).lower()
+
+
+def test_token_mode_preferred_over_webhook_when_both_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ROCKETCHAT_SERVER_URL", "https://chat.example.com")
+    monkeypatch.setenv("ROCKETCHAT_AUTH_TOKEN", "tok")
+    monkeypatch.setenv("ROCKETCHAT_USER_ID", "u1")
+    monkeypatch.setenv("ROCKETCHAT_WEBHOOK_URL", "https://chat.example.com/hooks/abc/def")
+    monkeypatch.setenv("ROCKETCHAT_DEFAULT_CHANNEL", "#incidents")
+
+    creds = load_credentials_from_env()
+
+    assert creds.has_token is True
+    assert creds.channel == "#incidents"
+
+
+def test_token_without_channel_never_falls_back_to_webhook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mixed config: full token + webhook + no channel must error, not
+    silently fall back to the webhook's fixed destination."""
+    monkeypatch.setenv("ROCKETCHAT_SERVER_URL", "https://chat.example.com")
+    monkeypatch.setenv("ROCKETCHAT_AUTH_TOKEN", "tok")
+    monkeypatch.setenv("ROCKETCHAT_USER_ID", "u1")
+    monkeypatch.setenv("ROCKETCHAT_WEBHOOK_URL", "https://chat.example.com/hooks/abc/def")
+
+    with pytest.raises(OpenSREError) as exc_info:
+        load_credentials_from_env()
+    assert "channel" in str(exc_info.value).lower()
+
+
+def test_nothing_configured_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(OpenSREError) as exc_info:
+        load_credentials_from_env()
+    assert "not configured" in str(exc_info.value).lower()
+
+
+def test_channel_override_beats_default_channel(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ROCKETCHAT_SERVER_URL", "https://chat.example.com")
+    monkeypatch.setenv("ROCKETCHAT_AUTH_TOKEN", "tok")
+    monkeypatch.setenv("ROCKETCHAT_USER_ID", "u1")
+    monkeypatch.setenv("ROCKETCHAT_DEFAULT_CHANNEL", "#default")
+
+    creds = load_credentials_from_env(channel_override="#explicit")
+
+    assert creds.channel == "#explicit"
+
+
+def test_blank_channel_override_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ROCKETCHAT_SERVER_URL", "https://chat.example.com")
+    monkeypatch.setenv("ROCKETCHAT_AUTH_TOKEN", "tok")
+    monkeypatch.setenv("ROCKETCHAT_USER_ID", "u1")
+    monkeypatch.setenv("ROCKETCHAT_DEFAULT_CHANNEL", "#default")
+
+    creds = load_credentials_from_env(channel_override="   ")
+
+    assert creds.channel == "#default"
+
+
+def test_real_store_default_channel_resilient_to_store_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom() -> Any:
+        raise RuntimeError("store is locked")
+
+    monkeypatch.setattr("integrations.catalog.resolve_effective_integrations", _boom)
+
+    from integrations.rocketchat.credentials import _store_default_channel
+
+    assert _store_default_channel() == ""

--- a/tests/integrations/test_rocketchat_credentials.py
+++ b/tests/integrations/test_rocketchat_credentials.py
@@ -174,3 +174,15 @@ def test_real_store_default_channel_resilient_to_store_failure(
     from integrations.rocketchat.credentials import _store_default_channel
 
     assert _store_default_channel() == ""
+
+
+def test_real_store_default_channel_resilient_to_none_return(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """resolve_effective_integrations() returning None (not a dict) must not
+    raise AttributeError from the unguarded .get('rocketchat', {}) call."""
+    monkeypatch.setattr("integrations.catalog.resolve_effective_integrations", lambda: None)
+
+    from integrations.rocketchat.credentials import _store_default_channel
+
+    assert _store_default_channel() == ""

--- a/tests/interactive_shell/test_watch_cmds.py
+++ b/tests/interactive_shell/test_watch_cmds.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 from rich.console import Console
 
+from integrations.rocketchat.credentials import RocketChatCredentials
 from integrations.telegram.credentials import TelegramCredentials
 from platform.common.task_types import TaskKind, TaskStatus
 from surfaces.interactive_shell.command_registry import SLASH_COMMANDS, dispatch_slash
@@ -52,6 +53,26 @@ def test_parse_watch_argv_parses_flags() -> None:
     assert raw.once is True
 
 
+def test_parse_watch_argv_parses_provider_and_chat_id() -> None:
+    raw = parse_watch_argv(["999", "--provider", "rocketchat", "--chat-id", "#ops"])
+    assert isinstance(raw, WatchdogStartSpec)
+    assert raw.provider == "rocketchat"
+    assert raw.chat_id == "#ops"
+
+
+def test_parse_watch_argv_defaults_provider_to_telegram() -> None:
+    raw = parse_watch_argv(["999"])
+    assert isinstance(raw, WatchdogStartSpec)
+    assert raw.provider == "telegram"
+    assert raw.chat_id == ""
+
+
+def test_parse_watch_argv_rejects_unknown_provider() -> None:
+    out = parse_watch_argv(["999", "--provider", "discord"])
+    assert isinstance(out, str)
+    assert "invalid --provider" in out
+
+
 def test_dispatch_watch_creates_watchdog_task(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -87,6 +108,89 @@ def test_dispatch_watch_creates_watchdog_task(
     assert watchdogs[0].status == TaskStatus.RUNNING
     assert "max_cpu=80" in (watchdogs[0].command or "")
     assert "started" in buf.getvalue()
+
+
+def test_dispatch_watch_creates_rocketchat_watchdog_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_rc_load(**kwargs: object) -> RocketChatCredentials:
+        captured.update(kwargs)
+        return RocketChatCredentials(
+            server_url="https://chat.example.com",
+            auth_token="tok",
+            user_id="u1",
+            channel="#ops",
+        )
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.watch_cmds."
+        "load_rocketchat_credentials_from_env",
+        _fake_rc_load,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.watch_cmds.pid_exists",
+        lambda _pid: True,
+    )
+
+    def _fake_start(**_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.watch_cmds.start_watchdog_daemon_thread",
+        _fake_start,
+    )
+
+    session = Session()
+    session.terminal.trust_mode = True
+    console, buf = _capture()
+    dispatch_slash(
+        f"/watch {__import__('os').getpid()} --max-cpu 80 --provider rocketchat --chat-id #ops",
+        session,
+        console,
+        is_tty=True,
+    )
+
+    watchdogs = [t for t in session.task_registry.list_recent(20) if t.kind == TaskKind.WATCHDOG]
+    assert len(watchdogs) == 1
+    assert watchdogs[0].status == TaskStatus.RUNNING
+    assert "provider=rocketchat" in (watchdogs[0].command or "")
+    assert "started" in buf.getvalue()
+    assert captured == {"channel_override": "#ops"}
+
+
+def test_dispatch_watch_reports_rocketchat_configuration_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from platform.common.errors import OpenSREError
+
+    def _raise_missing(**_kw: object) -> RocketChatCredentials:
+        raise OpenSREError("Rocket.Chat is not configured.")
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.watch_cmds."
+        "load_rocketchat_credentials_from_env",
+        _raise_missing,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.watch_cmds.pid_exists",
+        lambda _pid: True,
+    )
+
+    session = Session()
+    session.terminal.trust_mode = True
+    console, buf = _capture()
+    dispatch_slash(
+        f"/watch {__import__('os').getpid()} --provider rocketchat",
+        session,
+        console,
+        is_tty=True,
+    )
+
+    watchdogs = [t for t in session.task_registry.list_recent(20) if t.kind == TaskKind.WATCHDOG]
+    assert len(watchdogs) == 0
+    assert "Rocket.Chat is not configured" in buf.getvalue()
 
 
 def test_unwatch_marks_watchdog_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/platform/notifications/test_cooldown.py
+++ b/tests/platform/notifications/test_cooldown.py
@@ -1,0 +1,40 @@
+"""Tests for platform.notifications.cooldown.CooldownGate."""
+
+from __future__ import annotations
+
+from platform.notifications.cooldown import CooldownGate
+
+
+def test_first_reservation_succeeds() -> None:
+    gate = CooldownGate(cooldown_seconds=300.0)
+    assert gate.try_reserve("key", now=100.0) is None
+
+
+def test_second_reservation_within_cooldown_is_suppressed() -> None:
+    gate = CooldownGate(cooldown_seconds=300.0)
+    assert gate.try_reserve("key", now=100.0) is None
+    remaining = gate.try_reserve("key", now=200.0)
+    assert remaining is not None
+    assert remaining == 200.0
+
+
+def test_second_reservation_after_cooldown_succeeds() -> None:
+    gate = CooldownGate(cooldown_seconds=300.0)
+    assert gate.try_reserve("key", now=100.0) is None
+    assert gate.try_reserve("key", now=450.0) is None
+
+
+def test_cooldown_is_per_key() -> None:
+    gate = CooldownGate(cooldown_seconds=300.0)
+    assert gate.try_reserve("a", now=100.0) is None
+    assert gate.try_reserve("b", now=110.0) is None
+
+
+def test_reservation_happens_before_result_is_used() -> None:
+    """A suppressed call must not reset the reservation for the key."""
+    gate = CooldownGate(cooldown_seconds=300.0)
+    assert gate.try_reserve("key", now=100.0) is None
+    gate.try_reserve("key", now=150.0)  # suppressed, must not re-arm
+    remaining = gate.try_reserve("key", now=200.0)
+    assert remaining is not None
+    assert remaining == 200.0

--- a/tests/watch_dog/test_build_dispatcher.py
+++ b/tests/watch_dog/test_build_dispatcher.py
@@ -1,0 +1,68 @@
+"""Tests for tools.system.watch_dog.runner._build_dispatcher provider routing."""
+
+from __future__ import annotations
+
+import pytest
+
+from integrations.rocketchat.alarms import RocketChatAlarmDispatcher
+from integrations.rocketchat.credentials import RocketChatCredentials
+from integrations.telegram.alarms import AlarmDispatcher
+from integrations.telegram.credentials import TelegramCredentials
+from tools.system.watch_dog.config import WatchdogConfig
+from tools.system.watch_dog.runner import _build_dispatcher
+
+
+def test_defaults_to_telegram(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "tools.system.watch_dog.runner.load_credentials_from_env",
+        lambda **_kw: TelegramCredentials(bot_token="tok", chat_id="chat-1"),
+    )
+    config = WatchdogConfig(pid=1, max_cpu=80.0, chat_id="chat-1")
+
+    dispatcher = _build_dispatcher(config)
+
+    assert isinstance(dispatcher, AlarmDispatcher)
+
+
+def test_rocketchat_provider_builds_rocketchat_dispatcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tools.system.watch_dog.runner.load_rocketchat_credentials_from_env",
+        lambda **_kw: RocketChatCredentials(
+            server_url="https://chat.example.com",
+            auth_token="tok",
+            user_id="u1",
+            channel="#incidents",
+        ),
+    )
+    config = WatchdogConfig(pid=1, max_cpu=80.0, provider="rocketchat", chat_id="#incidents")
+
+    dispatcher = _build_dispatcher(config)
+
+    assert isinstance(dispatcher, RocketChatAlarmDispatcher)
+
+
+def test_rocketchat_provider_passes_chat_id_as_channel_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_load(**kwargs: object) -> RocketChatCredentials:
+        captured.update(kwargs)
+        return RocketChatCredentials(
+            server_url="https://chat.example.com",
+            auth_token="tok",
+            user_id="u1",
+            channel="#ops",
+        )
+
+    monkeypatch.setattr(
+        "tools.system.watch_dog.runner.load_rocketchat_credentials_from_env",
+        _fake_load,
+    )
+    config = WatchdogConfig(pid=1, max_cpu=80.0, provider="rocketchat", chat_id="#ops")
+
+    _build_dispatcher(config)
+
+    assert captured == {"channel_override": "#ops"}

--- a/tests/watch_dog/test_cli.py
+++ b/tests/watch_dog/test_cli.py
@@ -25,6 +25,7 @@ def test_watchdog_help_lists_expected_flags() -> None:
         "--interval",
         "--cooldown",
         "--once",
+        "--provider",
         "--chat-id",
         "--verbose",
     ):
@@ -74,8 +75,52 @@ def test_watchdog_cli_maps_flags_to_config(monkeypatch: pytest.MonkeyPatch) -> N
     assert config.interval == 5
     assert config.cooldown == 300
     assert config.once is True
+    assert config.provider == "telegram"
     assert config.chat_id == "chat-1"
     assert config.verbose is True
+
+
+def test_watchdog_cli_defaults_provider_to_telegram(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, WatchdogConfig] = {}
+
+    def _fake_run(config: WatchdogConfig) -> int:
+        captured["config"] = config
+        return 0
+
+    monkeypatch.setattr("surfaces.cli.commands.watchdog.run_watchdog", _fake_run)
+
+    result = CliRunner().invoke(watchdog_command, ["--pid", "123", "--max-cpu", "90"])
+
+    assert result.exit_code == 0
+    assert captured["config"].provider == "telegram"
+
+
+def test_watchdog_cli_accepts_rocketchat_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, WatchdogConfig] = {}
+
+    def _fake_run(config: WatchdogConfig) -> int:
+        captured["config"] = config
+        return 0
+
+    monkeypatch.setattr("surfaces.cli.commands.watchdog.run_watchdog", _fake_run)
+
+    result = CliRunner().invoke(
+        watchdog_command,
+        ["--pid", "123", "--max-cpu", "90", "--provider", "rocketchat", "--chat-id", "#ops"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["config"].provider == "rocketchat"
+    assert captured["config"].chat_id == "#ops"
+
+
+def test_watchdog_cli_rejects_unknown_provider() -> None:
+    result = CliRunner().invoke(
+        watchdog_command,
+        ["--pid", "123", "--max-cpu", "90", "--provider", "discord"],
+    )
+
+    assert result.exit_code != 0
 
 
 def test_watchdog_cli_rejects_invalid_selector() -> None:

--- a/tests/watch_dog/test_runner.py
+++ b/tests/watch_dog/test_runner.py
@@ -253,3 +253,35 @@ def test_alarm_message_uses_markdown_formatting_for_rocketchat() -> None:
     assert "`zsh`" in message
     assert "<b>" not in message
     assert "<code>" not in message
+
+
+def test_alarm_message_markdown_neutralizes_backticks_in_command() -> None:
+    """A command containing a literal backtick (shell command substitution,
+    e.g. `` echo `date` ``) must not terminate the Markdown code span early —
+    caught by review on the same PR that introduced Rocket.Chat formatting."""
+    dispatcher = _FakeDispatcher()
+
+    sample = ProcessSample(
+        pid=123,
+        name="zsh",
+        cmdline=("zsh", "-c", "echo `date`"),
+        cpu_percent=95.0,
+        rss_bytes=1024,
+        runtime_seconds=30.0,
+        alive=True,
+        started_at=1_700_000_000.0,
+    )
+    code = run_watchdog(
+        WatchdogConfig(pid=123, max_cpu=90, once=True, provider="rocketchat"),
+        sampler=_FakeSampler([sample]),
+        dispatcher=dispatcher,
+        _sleep=lambda _seconds: None,
+        _clock=lambda: 100.0,
+    )
+
+    assert code == ERROR
+    message = dispatcher.calls[0][1]
+    # The literal backtick must not survive into the code span — it would
+    # close the span early and spill the rest of the field as plain text.
+    assert "echo `date`" not in message
+    assert "echo ˋdate" in message

--- a/tests/watch_dog/test_runner.py
+++ b/tests/watch_dog/test_runner.py
@@ -220,3 +220,36 @@ def test_alarm_message_uses_html_formatting() -> None:
     assert "<b>🚨 OpenSRE Watchdog Alarm</b>" in message
     assert "&lt;unsafe&gt;" in message
     assert "<script>" not in message
+
+
+def test_alarm_message_uses_markdown_formatting_for_rocketchat() -> None:
+    """Rocket.Chat renders Markdown, not HTML — sending the Telegram-flavored
+    <b>/<code> tags would show up as literal text (caught during manual demo
+    testing). The rocketchat provider must get **bold**/`code` instead."""
+    dispatcher = _FakeDispatcher()
+
+    sample = ProcessSample(
+        pid=123,
+        name="zsh",
+        cmdline=("zsh", "-c", "sleep 1"),
+        cpu_percent=95.0,
+        rss_bytes=1024,
+        runtime_seconds=30.0,
+        alive=True,
+        started_at=1_700_000_000.0,
+    )
+    code = run_watchdog(
+        WatchdogConfig(pid=123, max_cpu=90, once=True, provider="rocketchat"),
+        sampler=_FakeSampler([sample]),
+        dispatcher=dispatcher,
+        _sleep=lambda _seconds: None,
+        _clock=lambda: 100.0,
+    )
+
+    assert code == ERROR
+    message = dispatcher.calls[0][1]
+    assert "**🚨 OpenSRE Watchdog Alarm**" in message
+    assert "**host**" in message
+    assert "`zsh`" in message
+    assert "<b>" not in message
+    assert "<code>" not in message

--- a/tools/system/watch_dog/config.py
+++ b/tools/system/watch_dog/config.py
@@ -11,6 +11,7 @@ from pydantic import Field, field_validator, model_validator
 from config.strict_config import StrictConfigModel
 
 ThresholdName = Literal["max_cpu", "max_runtime", "max_rss"]
+AlarmProvider = Literal["telegram", "rocketchat"]
 
 _DURATION_RE = re.compile(r"^(?P<value>\d+(?:\.\d+)?)(?P<unit>[smh]?)$")
 _BYTE_RE = re.compile(r"^(?P<value>\d+(?:\.\d+)?)(?P<unit>[kmgt]?b?)$", re.IGNORECASE)
@@ -83,6 +84,7 @@ class WatchdogConfig(StrictConfigModel):
     interval: float = Field(default=5.0, gt=0)
     cooldown: float = Field(default=300.0, gt=0)
     once: bool = False
+    provider: AlarmProvider = "telegram"
     chat_id: str | None = None
     verbose: bool = False
 

--- a/tools/system/watch_dog/runner.py
+++ b/tools/system/watch_dog/runner.py
@@ -214,18 +214,31 @@ def _format_alarm_message_html(sample: ProcessSample, breach: ThresholdBreach) -
     )
 
 
+def _md_code(value: str) -> str:
+    """Wrap *value* in a backtick code span, neutralizing inner backticks.
+
+    A literal backtick in the value (e.g. a shell command using command
+    substitution like `` echo `date` ``) would otherwise terminate the code
+    span early and render the rest of the field as unformatted text. Swap it
+    for the visually similar U+02CB MODIFIER LETTER GRAVE ACCENT, matching
+    how the HTML formatter's html.escape() neutralizes markup characters in
+    the same fields.
+    """
+    return f"`{value.replace('`', 'ˋ')}`"
+
+
 def _format_alarm_message_markdown(sample: ProcessSample, breach: ThresholdBreach) -> str:
     started, command = _alarm_started_and_command(sample)
 
     return "\n".join(
         [
             "**🚨 OpenSRE Watchdog Alarm**",
-            f"**host**       `{socket.gethostname()}`",
-            f"**pid**        `{sample.pid}`  (`{sample.name or '-'}`)",
-            f"**cmd**        `{command}`",
-            f"**threshold**  `{_format_threshold_breach(breach)}`",
-            f"**runtime**    `{_format_duration(sample.runtime_seconds)}`",
-            f"**started**    `{started}`",
+            f"**host**       {_md_code(socket.gethostname())}",
+            f"**pid**        {_md_code(str(sample.pid))}  ({_md_code(sample.name or '-')})",
+            f"**cmd**        {_md_code(command)}",
+            f"**threshold**  {_md_code(_format_threshold_breach(breach))}",
+            f"**runtime**    {_md_code(_format_duration(sample.runtime_seconds))}",
+            f"**started**    {_md_code(started)}",
         ]
     )
 

--- a/tools/system/watch_dog/runner.py
+++ b/tools/system/watch_dog/runner.py
@@ -13,6 +13,10 @@ from typing import Protocol
 
 import click
 
+from integrations.rocketchat.alarms import RocketChatAlarmDispatcher
+from integrations.rocketchat.credentials import (
+    load_credentials_from_env as load_rocketchat_credentials_from_env,
+)
 from integrations.telegram.alarms import AlarmDispatcher
 from integrations.telegram.credentials import load_credentials_from_env
 from platform.common.exit_codes import ERROR, SUCCESS
@@ -89,7 +93,10 @@ def run_watchdog(
         return SUCCESS
 
 
-def _build_dispatcher(config: WatchdogConfig) -> AlarmDispatcher:
+def _build_dispatcher(config: WatchdogConfig) -> Dispatcher:
+    if config.provider == "rocketchat":
+        rc_creds = load_rocketchat_credentials_from_env(channel_override=config.chat_id)
+        return RocketChatAlarmDispatcher(rc_creds, cooldown_seconds=config.cooldown)
     creds = load_credentials_from_env(chat_id_override=config.chat_id)
     return AlarmDispatcher(creds, cooldown_seconds=config.cooldown, parse_mode="HTML")
 

--- a/tools/system/watch_dog/runner.py
+++ b/tools/system/watch_dog/runner.py
@@ -20,7 +20,7 @@ from integrations.rocketchat.credentials import (
 from integrations.telegram.alarms import AlarmDispatcher
 from integrations.telegram.credentials import load_credentials_from_env
 from platform.common.exit_codes import ERROR, SUCCESS
-from tools.system.watch_dog.config import WatchdogConfig
+from tools.system.watch_dog.config import AlarmProvider, WatchdogConfig
 from tools.system.watch_dog.process_monitor import ProcessMonitor, ProcessSample, Sampler
 
 
@@ -82,7 +82,7 @@ def run_watchdog(
             for breach in breaches:
                 active_dispatcher.dispatch(
                     breach.name,
-                    _format_alarm_message(sample, breach),
+                    _format_alarm_message(sample, breach, provider=config.provider),
                 )
 
             if breaches and config.once:
@@ -170,7 +170,7 @@ def _format_sample_log(
     )
 
 
-def _format_alarm_message(sample: ProcessSample, breach: ThresholdBreach) -> str:
+def _alarm_started_and_command(sample: ProcessSample) -> tuple[str, str]:
     started = "-"
     if sample.started_at is not None:
         started = datetime.fromtimestamp(sample.started_at, tz=UTC).isoformat()
@@ -179,6 +179,26 @@ def _format_alarm_message(sample: ProcessSample, breach: ThresholdBreach) -> str
     command = sample.command or "-"
     if len(command) > 180:
         command = f"{command[:177]}..."
+    return started, command
+
+
+def _format_alarm_message(
+    sample: ProcessSample, breach: ThresholdBreach, *, provider: AlarmProvider
+) -> str:
+    """Format the alarm body for the delivering provider.
+
+    Telegram renders HTML (``parse_mode="HTML"``); Rocket.Chat renders
+    Markdown and displays literal ``<b>``/``<code>`` tags as text, so each
+    provider gets its own markup around the same fields rather than sending
+    one format to both.
+    """
+    if provider == "rocketchat":
+        return _format_alarm_message_markdown(sample, breach)
+    return _format_alarm_message_html(sample, breach)
+
+
+def _format_alarm_message_html(sample: ProcessSample, breach: ThresholdBreach) -> str:
+    started, command = _alarm_started_and_command(sample)
 
     return "\n".join(
         [
@@ -190,6 +210,22 @@ def _format_alarm_message(sample: ProcessSample, breach: ThresholdBreach) -> str
             f"<b>threshold</b>  <code>{html.escape(_format_threshold_breach(breach))}</code>",
             f"<b>runtime</b>    <code>{html.escape(_format_duration(sample.runtime_seconds))}</code>",
             f"<b>started</b>    <code>{html.escape(started)}</code>",
+        ]
+    )
+
+
+def _format_alarm_message_markdown(sample: ProcessSample, breach: ThresholdBreach) -> str:
+    started, command = _alarm_started_and_command(sample)
+
+    return "\n".join(
+        [
+            "**🚨 OpenSRE Watchdog Alarm**",
+            f"**host**       `{socket.gethostname()}`",
+            f"**pid**        `{sample.pid}`  (`{sample.name or '-'}`)",
+            f"**cmd**        `{command}`",
+            f"**threshold**  `{_format_threshold_breach(breach)}`",
+            f"**runtime**    `{_format_duration(sample.runtime_seconds)}`",
+            f"**started**    `{started}`",
         ]
     )
 


### PR DESCRIPTION
Fixes #4214

#### Describe the changes you have made in this PR -

Adds **Rocket.Chat** as an alarm delivery provider for the process watchdog (`/watch`, `/watches`, `/unwatch`, `opensre watchdog`), which previously only delivered via Telegram.

**New shared primitives:**
- `platform/notifications/cooldown.py` — extracted the thread-safe, TOCTOU-safe per-key throttle mechanism that used to live inside `integrations.telegram.alarms.AlarmDispatcher`, so it's shared instead of duplicated per provider.
- `integrations/telegram/alarms.py` — refactored to delegate to the shared `CooldownGate`. Behavior-preserving: all 25 pre-existing tests pass unchanged.
- `integrations/rocketchat/credentials.py` (new) — `RocketChatCredentials` + `load_credentials_from_env`, mirroring `integrations.telegram.credentials`. Reuses the scheduler's `resolve_rocketchat_credentials` (same task-params > store > env precedence as the cron provider and Sentry digest) and adds channel resolution.
- `integrations/rocketchat/alarms.py` (new) — `RocketChatAlarmDispatcher`, mirroring `AlarmDispatcher`'s `dispatch(name, message) -> bool` interface so it satisfies the `Dispatcher` Protocol `tools/system/watch_dog/runner.py` already defines. Routing rule matches `rocketchat_send_message`, the cron provider, and the background-notify channel: token credentials with a channel are required and never silently fall back to the webhook.

**Wiring:**
- `tools/system/watch_dog/config.py` — `provider` field on `WatchdogConfig` (`telegram` default, `rocketchat`).
- `tools/system/watch_dog/runner.py` — `_build_dispatcher` branches on provider.
- `surfaces/cli/commands/watchdog.py` — `--provider` option on `opensre watchdog`.
- `surfaces/interactive_shell/command_registry/watch_cmds.py` — `--provider`/`--chat-id` on `/watch`; the on-alarm message now names the actual delivering provider instead of a hardcoded `(telegram delivered)`.
- `.importlinter.strict` — registered the new `tools.system.watch_dog.runner -> integrations.rocketchat.*` edges in the same T-4 debt bucket as the existing telegram ones.
- Docs: `/watch` command table, a new "Watchdog alarms" section on the Rocket.Chat messaging page, and the REPL demo checklist in `docs/DEVELOPMENT.md`.

**Bug caught during manual testing:** the alarm message was hardcoded Telegram HTML (`<b>`/`<code>` tags) — a real Rocket.Chat delivery rendered literal `<b>OpenSRE Watchdog Alarm</b>` text instead of bold, since Rocket.Chat renders Markdown, not HTML. `_format_alarm_message` now takes the delivering provider and renders `**bold**`/`` `code` `` Markdown for rocketchat while keeping the Telegram HTML output byte-identical (same pre-existing escaping test, unaffected).

Commits are deliberately granular (14 total): each primitive/wiring layer lands with its own tests, the behavior-preserving Telegram cooldown refactor is isolated, and the formatting bug fix is its own commit found via the end-to-end demo below.

**Testing** — `make lint`, `make format-check`, `make typecheck`, `make check-layers-strict` all pass. 105 tests across `tests/watch_dog/`, `tests/interactive_shell/test_watch_cmds.py`, `tests/platform/notifications/`, `tests/integrations/test_rocketchat_credentials.py`, and `tests/integrations/test_rocketchat_alarms.py` pass, zero regressions. Verified end-to-end against a real Rocket.Chat workspace: `opensre watchdog --pid $$ --max-runtime 1s --provider rocketchat --chat-id "#opensre-test" --once` fired a real alarm and delivered it correctly formatted (screenshot below, before/after the Markdown fix).

### Demo/Screenshot for feature changes and bug fixes -

<img width="1610" height="122" alt="image" src="https://github.com/user-attachments/assets/16c356d8-acb1-4d85-80d4-0cdd3ebc8266" />


<img width="2218" height="362" alt="CleanShot 2026-07-22 at 17 47 13@2x" src="https://github.com/user-attachments/assets/3e0bf8e9-78f0-4b5a-a0de-30cdb103c20f" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I work at Rocket.Chat and found that both the watchdog and Hermes incident escalation hardcode Telegram — `AlarmDispatcher` is constructed directly from `TelegramCredentials` in three call sites. Rather than writing a second, duplicated cooldown implementation for Rocket.Chat, I extracted the cooldown mechanism first (behavior-preserving refactor, verified against the existing test suite before writing anything new) so both dispatchers share one throttle primitive — straightforward DRY, and it means the Hermes follow-up (#4215) only needs to reuse `RocketChatAlarmDispatcher`, not reimplement it.

The formatting bug is the most instructive part: I only found it by actually running `opensre watchdog --provider rocketchat` end-to-end and looking at what landed in the real channel, rather than trusting unit tests alone — the message-formatting code had never been exercised against a non-Telegram provider before. Fixing it meant recognizing that `_format_alarm_message` conflated "the alarm's content" with "Telegram's HTML markup"; splitting those let Rocket.Chat get correctly rendered Markdown without touching Telegram's output at all.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
