### PR TITLE
feat(analytics): stamp org, surface, and session on usage lifecycle events

### DIFF
--- a/gateway/http/worker.py
+++ b/gateway/http/worker.py
@@ -75,7 +75,25 @@ class InvestigationWorker:
             )
             return True
         try:
-            result = self._runner(record.trigger)
+            from platform.analytics.cli import track_investigation
+            from platform.analytics.source import EntrypointSource, TriggerMode
+            from platform.analytics.usage_context import bound_usage_context
+
+            org_id = (record.clerk_org_id or "").strip() or None
+            with (
+                bound_usage_context(
+                    organization_id=org_id,
+                    session_id=record.id,
+                ),
+                track_investigation(
+                    entrypoint=EntrypointSource.REMOTE_HTTP,
+                    trigger_mode=TriggerMode.SERVICE_RUNTIME,
+                    investigation_id=record.id,
+                    investigation_target=str((record.trigger or {}).get("alert_name") or "")
+                    or None,
+                ),
+            ):
+                result = self._runner(record.trigger)
             local_path = write_local_report(record.id, result, base_dir=self._artifacts_dir)
             s3_key = upload_report_to_s3(
                 local_path, org_id=record.clerk_org_id, investigation_id=record.id

--- a/gateway/http/worker.py
+++ b/gateway/http/worker.py
@@ -77,13 +77,18 @@ class InvestigationWorker:
         try:
             from platform.analytics.cli import track_investigation
             from platform.analytics.source import EntrypointSource, TriggerMode
-            from platform.analytics.usage_context import bound_usage_context
+            from platform.analytics.usage_context import (
+                bound_usage_context,
+                ensure_process_session_id,
+            )
 
             org_id = (record.clerk_org_id or "").strip() or None
             with (
                 bound_usage_context(
                     organization_id=org_id,
-                    session_id=record.id,
+                    # Process session groups HTTP investigations for this worker;
+                    # keep investigation_id as the per-run identifier.
+                    session_id=ensure_process_session_id(),
                 ),
                 track_investigation(
                     entrypoint=EntrypointSource.REMOTE_HTTP,

--- a/gateway/runtime/turn_handler.py
+++ b/gateway/runtime/turn_handler.py
@@ -35,7 +35,11 @@ from platform.analytics.cli import (
     capture_gateway_turn_failed,
     capture_gateway_turn_started,
 )
-from platform.analytics.usage_context import bound_usage_context, get_surface
+from platform.analytics.usage_context import (
+    CANONICAL_SURFACES,
+    bound_usage_context,
+    get_surface,
+)
 from platform.observability.trace.spans import traced_session
 
 SlashPortsFactory = Callable[[], Any]
@@ -94,12 +98,10 @@ class GatewayTurnHandler:
         session.available_capabilities.update(dict.fromkeys(_UNSUPPORTED_GATEWAY_CAPABILITIES, ()))
         session_id = getattr(session, "session_id", None)
         surface = get_surface()
-        if surface not in {"cli", "slack", "telegram"}:
+        if surface not in CANONICAL_SURFACES:
             # Require transport binding (Slack/Telegram dispatchers). Do not invent
             # a non-canonical surface that breaks channel breakdowns.
-            logger.warning(
-                "gateway_turn missing surface binding; analytics events will omit surface"
-            )
+            logger.warning("gateway_turn missing surface binding; started/completed omit surface")
             surface = None
         started = time.monotonic()
 
@@ -134,12 +136,13 @@ class GatewayTurnHandler:
                         final_intent=str(turn_result.final_intent or "") or None,
                     )
             except Exception as exc:
-                if surface:
-                    capture_gateway_turn_failed(
-                        surface=surface,
-                        duration_ms=(time.monotonic() - started) * 1000.0,
-                        error_type=type(exc).__name__,
-                    )
+                # Always emit failure analytics (surface optional) so miswired
+                # transports remain visible in PostHog.
+                capture_gateway_turn_failed(
+                    surface=surface,
+                    duration_ms=(time.monotonic() - started) * 1000.0,
+                    error_type=type(exc).__name__,
+                )
                 raise
 
     def _agent_for_turn(

--- a/gateway/runtime/turn_handler.py
+++ b/gateway/runtime/turn_handler.py
@@ -93,7 +93,14 @@ class GatewayTurnHandler:
     ) -> None:
         session.available_capabilities.update(dict.fromkeys(_UNSUPPORTED_GATEWAY_CAPABILITIES, ()))
         session_id = getattr(session, "session_id", None)
-        surface = get_surface() or "gateway"
+        surface = get_surface()
+        if surface not in {"cli", "slack", "telegram"}:
+            # Require transport binding (Slack/Telegram dispatchers). Do not invent
+            # a non-canonical surface that breaks channel breakdowns.
+            logger.warning(
+                "gateway_turn missing surface binding; analytics events will omit surface"
+            )
+            surface = None
         started = time.monotonic()
 
         with (
@@ -101,7 +108,8 @@ class GatewayTurnHandler:
             traced_session(session_id, component="gateway_turn"),
         ):
             try:
-                capture_gateway_turn_started(surface=surface)
+                if surface:
+                    capture_gateway_turn_started(surface=surface)
                 agent = self._agent_for_turn(text=text, session=session, sink=sink, logger=logger)
                 turn_result = agent.dispatch(text)
                 outbound_text = (
@@ -118,18 +126,20 @@ class GatewayTurnHandler:
                 # even when the turn produced no text.
                 if not turn_result.answered:
                     sink.finalize(outbound_text or "I didn't have anything to add for that.")
-                capture_gateway_turn_completed(
-                    surface=surface,
-                    duration_ms=(time.monotonic() - started) * 1000.0,
-                    answered=bool(turn_result.answered),
-                    final_intent=str(turn_result.final_intent or "") or None,
-                )
+                if surface:
+                    capture_gateway_turn_completed(
+                        surface=surface,
+                        duration_ms=(time.monotonic() - started) * 1000.0,
+                        answered=bool(turn_result.answered),
+                        final_intent=str(turn_result.final_intent or "") or None,
+                    )
             except Exception as exc:
-                capture_gateway_turn_failed(
-                    surface=surface,
-                    duration_ms=(time.monotonic() - started) * 1000.0,
-                    error_type=type(exc).__name__,
-                )
+                if surface:
+                    capture_gateway_turn_failed(
+                        surface=surface,
+                        duration_ms=(time.monotonic() - started) * 1000.0,
+                        error_type=type(exc).__name__,
+                    )
                 raise
 
     def _agent_for_turn(

--- a/gateway/tests/http/test_investigation_worker.py
+++ b/gateway/tests/http/test_investigation_worker.py
@@ -18,6 +18,8 @@ def _metering_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
     """Credit metering must never fire real HTTP from worker tests."""
     for name in (WEBAPP_URL_ENV, USAGE_SECRET_ENV, ORGANIZATION_ID_ENV):
         monkeypatch.delenv(name, raising=False)
+    # Lifecycle analytics enrichment is covered separately; keep worker tests offline.
+    monkeypatch.setenv("OPENSRE_ANALYTICS_DISABLED", "1")
 
 
 def _queued(store: InMemoryInvestigationStore, org: str = "org_a") -> str:

--- a/integrations/hermes/investigation.py
+++ b/integrations/hermes/investigation.py
@@ -78,12 +78,15 @@ def run_incident_investigation(
         SURFACE_CLI,
         bound_usage_context,
         ensure_process_session_id,
+        get_surface,
     )
 
     alert = build_alert_from_incident(incident)
+    # Preserve an outer Slack/Telegram surface if already bound; default to CLI
+    # for standalone Hermes watch processes.
     with (
         bound_usage_context(
-            surface=SURFACE_CLI,
+            surface=None if get_surface() else SURFACE_CLI,
             session_id=ensure_process_session_id(),
         ),
         track_investigation(

--- a/integrations/hermes/investigation.py
+++ b/integrations/hermes/investigation.py
@@ -72,8 +72,27 @@ def run_incident_investigation(
     :class:`TelegramSink` maps it to an operator-visible "attempted (failed)"
     marker.
     """
+    from platform.analytics.cli import track_investigation
+    from platform.analytics.source import EntrypointSource, TriggerMode
+    from platform.analytics.usage_context import (
+        SURFACE_CLI,
+        bound_usage_context,
+        ensure_process_session_id,
+    )
+
     alert = build_alert_from_incident(incident)
-    state = run_investigation(alert)
+    with (
+        bound_usage_context(
+            surface=SURFACE_CLI,
+            session_id=ensure_process_session_id(),
+        ),
+        track_investigation(
+            entrypoint=EntrypointSource.CLI_COMMAND,
+            trigger_mode=TriggerMode.SERVICE_RUNTIME,
+            investigation_target=incident.title[:120] or None,
+        ),
+    ):
+        state = run_investigation(alert)
     return _extract_summary(state)
 
 

--- a/platform/analytics/cli.py
+++ b/platform/analytics/cli.py
@@ -470,8 +470,11 @@ def build_cli_invoked_properties(
 def capture_cli_invoked(properties: Properties | None = None) -> None:
     # Whole-process default for local CLI; gateway binds surface per turn instead.
     try:
+        from platform.analytics.usage_context import ensure_process_session_id
+
         analytics = get_analytics()
         analytics.set_persistent_property("surface", SURFACE_CLI)
+        ensure_process_session_id()
         analytics.capture(Event.CLI_INVOKED, properties)
     except Exception as exc:
         capture_exception(exc)
@@ -672,56 +675,62 @@ def track_investigation(
     session: SessionCore | None = None,
 ) -> Generator[InvestigationTracker]:
     """Capture investigation lifecycle once, with nested-call dedupe."""
+    from platform.analytics.usage_context import bound_usage_context
+
     depth = _INVESTIGATION_TRACKING_DEPTH.get()
     token = _INVESTIGATION_TRACKING_DEPTH.set(depth + 1)
     loop_metrics_token = begin_investigation_loop_metrics_scope() if depth == 0 else None
-    tracker: InvestigationTracker
-    if depth > 0:
-        tracker = InvestigationTracker(shared_properties={}, enabled=False)
-    else:
-        resolved_id = investigation_id or str(uuid4())
-        shared_properties = build_source_properties(
-            entrypoint=entrypoint,
-            trigger_mode=trigger_mode,
-            investigation_id=resolved_id,
-        )
-        if investigation_target:
-            shared_properties["investigation_target"] = investigation_target
-        if session is not None:
-            session.last_investigation_id = resolved_id
-        _capture(
-            Event.INVESTIGATION_STARTED,
-            _investigation_started_properties(
-                input_path=input_path,
-                input_json=input_json,
-                interactive=interactive,
-                evaluate_requested=evaluate_requested,
-                shared_properties=shared_properties,
-            ),
-        )
-        tracker = InvestigationTracker(shared_properties=shared_properties, enabled=True)
+    session_id = str(getattr(session, "session_id", "") or "") or None
+    # Bind session for the full lifecycle so background threads still stamp
+    # session_id (ContextVars do not cross threads unless rebound here).
+    with bound_usage_context(session_id=session_id):
+        tracker: InvestigationTracker
+        if depth > 0:
+            tracker = InvestigationTracker(shared_properties={}, enabled=False)
+        else:
+            resolved_id = investigation_id or str(uuid4())
+            shared_properties = build_source_properties(
+                entrypoint=entrypoint,
+                trigger_mode=trigger_mode,
+                investigation_id=resolved_id,
+            )
+            if investigation_target:
+                shared_properties["investigation_target"] = investigation_target
+            if session is not None:
+                session.last_investigation_id = resolved_id
+            _capture(
+                Event.INVESTIGATION_STARTED,
+                _investigation_started_properties(
+                    input_path=input_path,
+                    input_json=input_json,
+                    interactive=interactive,
+                    evaluate_requested=evaluate_requested,
+                    shared_properties=shared_properties,
+                ),
+            )
+            tracker = InvestigationTracker(shared_properties=shared_properties, enabled=True)
 
-    try:
-        yielded = tracker
-        yield yielded
-    except Exception as exc:
-        failure_message = str(exc).strip()[:500]
-        failure_detail = "".join(traceback.format_exception_only(exc)).strip()[:500]
-        capture_investigation_failed(
-            tracker=yielded,
-            failure_type=type(exc).__name__,
-            failure_message=failure_message or type(exc).__name__,
-            failure_detail=failure_detail or None,
-            investigation_target=investigation_target,
-        )
-        raise
-    else:
-        if not yielded.failed and not yielded.completed:
-            capture_investigation_completed(tracker=yielded)
-    finally:
-        _INVESTIGATION_TRACKING_DEPTH.reset(token)
-        if depth == 0 and loop_metrics_token is not None:
-            reset_investigation_loop_metrics(loop_metrics_token)
+        try:
+            yielded = tracker
+            yield yielded
+        except Exception as exc:
+            failure_message = str(exc).strip()[:500]
+            failure_detail = "".join(traceback.format_exception_only(exc)).strip()[:500]
+            capture_investigation_failed(
+                tracker=yielded,
+                failure_type=type(exc).__name__,
+                failure_message=failure_message or type(exc).__name__,
+                failure_detail=failure_detail or None,
+                investigation_target=investigation_target,
+            )
+            raise
+        else:
+            if not yielded.failed and not yielded.completed:
+                capture_investigation_completed(tracker=yielded)
+        finally:
+            _INVESTIGATION_TRACKING_DEPTH.reset(token)
+            if depth == 0 and loop_metrics_token is not None:
+                reset_investigation_loop_metrics(loop_metrics_token)
 
 
 def capture_integration_setup_started(service: str) -> None:

--- a/platform/analytics/cli.py
+++ b/platform/analytics/cli.py
@@ -519,6 +519,7 @@ def capture_gateway_turn_failed(
         "duration_ms": round(duration_ms),
         "duration_bucket": _bucket_duration_ms(duration_ms),
         "error_type": error_type,
+        "surface_missing": not bool(surface),
     }
     if surface:
         props["surface"] = surface
@@ -684,8 +685,8 @@ def track_investigation(
     token = _INVESTIGATION_TRACKING_DEPTH.set(depth + 1)
     loop_metrics_token = begin_investigation_loop_metrics_scope() if depth == 0 else None
     session_id = str(getattr(session, "session_id", "") or "") or None
-    # Bind session for the full lifecycle so background threads still stamp
-    # session_id (ContextVars do not cross threads unless rebound here).
+    # Bind session for the full lifecycle so nested pipeline work (and callers
+    # that did not bind usage context) still stamp session_id explicitly.
     with bound_usage_context(session_id=session_id):
         tracker: InvestigationTracker
         if depth > 0:

--- a/platform/analytics/cli.py
+++ b/platform/analytics/cli.py
@@ -506,20 +506,23 @@ def capture_gateway_turn_completed(
 
 def capture_gateway_turn_failed(
     *,
-    surface: str,
+    surface: str | None,
     duration_ms: float,
     error_type: str,
 ) -> None:
-    """Mark a failed gateway agent turn (exception during dispatch)."""
-    _capture(
-        Event.GATEWAY_TURN_FAILED,
-        {
-            "surface": surface,
-            "duration_ms": round(duration_ms),
-            "duration_bucket": _bucket_duration_ms(duration_ms),
-            "error_type": error_type,
-        },
-    )
+    """Mark a failed gateway agent turn (exception during dispatch).
+
+    ``surface`` may be omitted when transport context was unbound so failures
+    still land in PostHog for regression detection.
+    """
+    props: Properties = {
+        "duration_ms": round(duration_ms),
+        "duration_bucket": _bucket_duration_ms(duration_ms),
+        "error_type": error_type,
+    }
+    if surface:
+        props["surface"] = surface
+    _capture(Event.GATEWAY_TURN_FAILED, props)
 
 
 def capture_repl_execution_policy_decision(properties: Properties | None = None) -> None:

--- a/platform/analytics/usage_context.py
+++ b/platform/analytics/usage_context.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import threading
 from collections.abc import Iterator
 from contextvars import ContextVar, Token
 from typing import Final
@@ -30,6 +31,9 @@ type Properties = dict[str, JsonValue]
 SURFACE_CLI: Final[str] = "cli"
 SURFACE_SLACK: Final[str] = "slack"
 SURFACE_TELEGRAM: Final[str] = "telegram"
+CANONICAL_SURFACES: Final[frozenset[str]] = frozenset(
+    {SURFACE_CLI, SURFACE_SLACK, SURFACE_TELEGRAM}
+)
 ORGANIZATION_GROUP_TYPE: Final[str] = "organization"
 
 _SURFACE: ContextVar[str | None] = ContextVar("analytics_surface", default=None)
@@ -40,13 +44,16 @@ _ORGANIZATION_ID: ContextVar[str | None] = ContextVar("analytics_organization_id
 # Process-scoped fallback for one-shot CLI workloads (e.g. ``opensre investigate``)
 # that never enter a REPL session. Bound ContextVar / REPL session_id always win.
 _PROCESS_SESSION_ID: str | None = None
+_PROCESS_SESSION_ID_LOCK = threading.Lock()
 
 
 def ensure_process_session_id() -> str:
     """Return a stable session id for this process, minting one on first use."""
     global _PROCESS_SESSION_ID
     if _PROCESS_SESSION_ID is None:
-        _PROCESS_SESSION_ID = str(uuid4())
+        with _PROCESS_SESSION_ID_LOCK:
+            if _PROCESS_SESSION_ID is None:
+                _PROCESS_SESSION_ID = str(uuid4())
     return _PROCESS_SESSION_ID
 
 

--- a/platform/analytics/usage_context.py
+++ b/platform/analytics/usage_context.py
@@ -18,6 +18,7 @@ import os
 from collections.abc import Iterator
 from contextvars import ContextVar, Token
 from typing import Final
+from uuid import uuid4
 
 from config.constants.billing import ORGANIZATION_ID_ENV
 from platform.analytics.repl_context import get_cli_session_id
@@ -36,6 +37,18 @@ _SESSION_ID: ContextVar[str | None] = ContextVar("analytics_session_id", default
 _USER_ID: ContextVar[str | None] = ContextVar("analytics_user_id", default=None)
 _ORGANIZATION_ID: ContextVar[str | None] = ContextVar("analytics_organization_id", default=None)
 
+# Process-scoped fallback for one-shot CLI workloads (e.g. ``opensre investigate``)
+# that never enter a REPL session. Bound ContextVar / REPL session_id always win.
+_PROCESS_SESSION_ID: str | None = None
+
+
+def ensure_process_session_id() -> str:
+    """Return a stable session id for this process, minting one on first use."""
+    global _PROCESS_SESSION_ID
+    if _PROCESS_SESSION_ID is None:
+        _PROCESS_SESSION_ID = str(uuid4())
+    return _PROCESS_SESSION_ID
+
 
 def get_surface() -> str | None:
     """Return the bound usage surface, if any."""
@@ -43,8 +56,8 @@ def get_surface() -> str | None:
 
 
 def get_session_id() -> str | None:
-    """Return the bound OpenSRE session id, falling back to REPL session id."""
-    return _SESSION_ID.get() or get_cli_session_id()
+    """Return OpenSRE session id: bound → REPL → process fallback."""
+    return _SESSION_ID.get() or get_cli_session_id() or _PROCESS_SESSION_ID
 
 
 def get_user_id() -> str | None:

--- a/surfaces/interactive_shell/runtime/background/runner.py
+++ b/surfaces/interactive_shell/runtime/background/runner.py
@@ -117,57 +117,63 @@ def _start_background_investigation(
     session.terminal.background_investigations[task.task_id] = record
 
     def _worker() -> None:
-        try:
-            with track_investigation(
-                entrypoint=EntrypointSource.CLI_REPL_FILE,
-                trigger_mode=TriggerMode.FILE,
-                input_path=input_path,
-                interactive=True,
-                investigation_id=investigation_id,
-                investigation_target=investigation_target or None,
-                session=session,
-            ) as tracker:
-                final_state = run_fn(cancel_requested=task.cancel_requested, **kwargs)
-                tracker.record_loop_metrics_from_state(final_state)
-            root = str(final_state.get("root_cause") or "")
-            record.status = "completed"
-            record.root_cause = root
-            record.top_analysis = _top_analysis(final_state)
-            record.next_steps = _next_steps(final_state)
-            record.stats = _stats(final_state)
-            record.final_state = dict(final_state)
-            record.notification_results = deliver_background_notifications(
-                record=record,
-                channels=session.terminal.background_notification_preferences.channels,
-            )
-            task.mark_completed(result=root)
-            session.terminal.enqueue_background_notice(
-                f"[{HIGHLIGHT}]background investigation complete[/] "
-                f"[{DIM}]— task {escape(task.task_id)} ready; "
-                f"use[/] [{HIGHLIGHT}]/background show {escape(task.task_id)}[/]",
-            )
-        except KeyboardInterrupt:
-            record.status = "cancelled"
-            task.mark_cancelled()
-            session.terminal.enqueue_background_notice(
-                f"[{WARNING}]background investigation cancelled[/] "
-                f"[{DIM}]for task {escape(task.task_id)}.[/]",
-            )
-        except OpenSREError as exc:
-            record.status = "failed"
-            task.mark_failed(str(exc))
-            session.terminal.enqueue_background_notice(
-                f"[{ERROR}]background investigation failed[/] "
-                f"[{DIM}]for task {escape(task.task_id)}:[/] {escape(str(exc))}",
-            )
-        except Exception as exc:  # noqa: BLE001
-            record.status = "failed"
-            task.mark_failed(str(exc))
-            report_exception(exc, context="surfaces.interactive_shell.background_investigation")
-            session.terminal.enqueue_background_notice(
-                f"[{ERROR}]background investigation failed[/] "
-                f"[{DIM}]for task {escape(task.task_id)}:[/] {escape(str(exc))}",
-            )
+        from platform.analytics.usage_context import SURFACE_CLI, bound_usage_context
+
+        with bound_usage_context(
+            surface=SURFACE_CLI,
+            session_id=session.session_id,
+        ):
+            try:
+                with track_investigation(
+                    entrypoint=EntrypointSource.CLI_REPL_FILE,
+                    trigger_mode=TriggerMode.FILE,
+                    input_path=input_path,
+                    interactive=True,
+                    investigation_id=investigation_id,
+                    investigation_target=investigation_target or None,
+                    session=session,
+                ) as tracker:
+                    final_state = run_fn(cancel_requested=task.cancel_requested, **kwargs)
+                    tracker.record_loop_metrics_from_state(final_state)
+                root = str(final_state.get("root_cause") or "")
+                record.status = "completed"
+                record.root_cause = root
+                record.top_analysis = _top_analysis(final_state)
+                record.next_steps = _next_steps(final_state)
+                record.stats = _stats(final_state)
+                record.final_state = dict(final_state)
+                record.notification_results = deliver_background_notifications(
+                    record=record,
+                    channels=session.terminal.background_notification_preferences.channels,
+                )
+                task.mark_completed(result=root)
+                session.terminal.enqueue_background_notice(
+                    f"[{HIGHLIGHT}]background investigation complete[/] "
+                    f"[{DIM}]— task {escape(task.task_id)} ready; "
+                    f"use[/] [{HIGHLIGHT}]/background show {escape(task.task_id)}[/]",
+                )
+            except KeyboardInterrupt:
+                record.status = "cancelled"
+                task.mark_cancelled()
+                session.terminal.enqueue_background_notice(
+                    f"[{WARNING}]background investigation cancelled[/] "
+                    f"[{DIM}]for task {escape(task.task_id)}.[/]",
+                )
+            except OpenSREError as exc:
+                record.status = "failed"
+                task.mark_failed(str(exc))
+                session.terminal.enqueue_background_notice(
+                    f"[{ERROR}]background investigation failed[/] "
+                    f"[{DIM}]for task {escape(task.task_id)}:[/] {escape(str(exc))}",
+                )
+            except Exception as exc:  # noqa: BLE001
+                record.status = "failed"
+                task.mark_failed(str(exc))
+                report_exception(exc, context="surfaces.interactive_shell.background_investigation")
+                session.terminal.enqueue_background_notice(
+                    f"[{ERROR}]background investigation failed[/] "
+                    f"[{DIM}]for task {escape(task.task_id)}:[/] {escape(str(exc))}",
+                )
 
     thread = threading.Thread(
         target=_worker,

--- a/surfaces/interactive_shell/runtime/investigation_adapter.py
+++ b/surfaces/interactive_shell/runtime/investigation_adapter.py
@@ -240,6 +240,10 @@ class ReplInvestigationLaunchPorts:
         exception_context: str,
         target: str,
     ) -> ForegroundInvestigationResult:
+        from surfaces.interactive_shell.utils.telemetry.investigation_analytics import (
+            publish_investigation_outcome_analytics,
+        )
+
         outcome = run_foreground_investigation(
             session=cast(Session, session),
             console=console,
@@ -248,6 +252,7 @@ class ReplInvestigationLaunchPorts:
             exception_context=exception_context,
             target=target,
         )
+        publish_investigation_outcome_analytics(outcome)
         return ForegroundInvestigationResult(status=outcome.status)
 
 

--- a/surfaces/interactive_shell/runtime/startup/initial_input.py
+++ b/surfaces/interactive_shell/runtime/startup/initial_input.py
@@ -38,7 +38,10 @@ def run_initial_input(
         render_submitted_prompt(console, session, stripped)
         recorder = PromptRecorder.start(session=session, text=stripped, turn_kind=_TURN_KIND)
         with (
-            bound_usage_context(surface=SURFACE_CLI),
+            bound_usage_context(
+                surface=SURFACE_CLI,
+                session_id=session.session_id,
+            ),
             bound_repl_turn_context(
                 session_id=session.session_id,
                 turn_kind=_TURN_KIND,

--- a/surfaces/interactive_shell/runtime/turn_host.py
+++ b/surfaces/interactive_shell/runtime/turn_host.py
@@ -145,7 +145,10 @@ async def _run_agent_turn_loop(
         from surfaces.interactive_shell.runtime.shell_turn_execution import execute_shell_turn
 
         with (
-            bound_usage_context(surface=SURFACE_CLI),
+            bound_usage_context(
+                surface=SURFACE_CLI,
+                session_id=runtime.session.session_id,
+            ),
             bound_repl_turn_context(
                 session_id=runtime.session.session_id,
                 turn_kind=_AGENT_TURN_KIND,

--- a/tests/analytics/test_usage_context.py
+++ b/tests/analytics/test_usage_context.py
@@ -34,13 +34,14 @@ def _reset_analytics(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
     monkeypatch.setattr(provider, "_FIRST_RUN_PATH", tmp_path / "installed")
     monkeypatch.setattr(provider.atexit, "register", lambda _func: None)
-    import platform.analytics.usage_context as usage_context
+    import sys
 
-    usage_context._PROCESS_SESSION_ID = None
+    usage_ctx = sys.modules["platform.analytics.usage_context"]
+    usage_ctx._PROCESS_SESSION_ID = None
     yield
     provider.shutdown_analytics(flush=False)
     provider._instance = None
-    usage_context._PROCESS_SESSION_ID = None
+    usage_ctx._PROCESS_SESSION_ID = None
 
 
 def _stub_httpx_client(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:

--- a/tests/analytics/test_usage_context.py
+++ b/tests/analytics/test_usage_context.py
@@ -34,9 +34,13 @@ def _reset_analytics(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
     monkeypatch.setattr(provider, "_FIRST_RUN_PATH", tmp_path / "installed")
     monkeypatch.setattr(provider.atexit, "register", lambda _func: None)
+    import platform.analytics.usage_context as usage_context
+
+    usage_context._PROCESS_SESSION_ID = None
     yield
     provider.shutdown_analytics(flush=False)
     provider._instance = None
+    usage_context._PROCESS_SESSION_ID = None
 
 
 def _stub_httpx_client(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
@@ -147,3 +151,69 @@ def test_group_identify_direct(monkeypatch: pytest.MonkeyPatch) -> None:
     props = posted[0]["json"]["properties"]
     assert props["$group_key"] == "org_x"
     assert props["$group_set"] == {"name": "Acme"}
+
+
+def test_process_session_id_stamps_cli_investigate_without_repl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    posted = _stub_httpx_client(monkeypatch)
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_cli")
+
+    from platform.analytics import cli as analytics_cli
+    from platform.analytics.usage_context import ensure_process_session_id
+
+    analytics = provider.Analytics()
+    monkeypatch.setattr(provider, "_instance", analytics)
+    monkeypatch.setattr(analytics_cli, "get_analytics", lambda: analytics)
+
+    analytics_cli.capture_cli_invoked({"entrypoint": "opensre"})
+    process_session = ensure_process_session_id()
+    with analytics_cli.track_investigation(
+        entrypoint=analytics_cli.EntrypointSource.CLI_COMMAND,
+        trigger_mode=analytics_cli.TriggerMode.FILE,
+        input_path="alert.json",
+    ):
+        pass
+    analytics.shutdown(flush=True)
+
+    started = next(
+        p["json"] for p in posted if p["json"]["event"] == Event.INVESTIGATION_STARTED.value
+    )
+    props = started["properties"]
+    assert props["organization_id"] == "org_cli"
+    assert props["$groups"] == {ORGANIZATION_GROUP_TYPE: "org_cli"}
+    assert props["surface"] == SURFACE_CLI
+    assert props["session_id"] == process_session
+
+
+def test_track_investigation_binds_session_from_session_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    posted = _stub_httpx_client(monkeypatch)
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_repl")
+
+    from platform.analytics import cli as analytics_cli
+
+    analytics = provider.Analytics()
+    monkeypatch.setattr(provider, "_instance", analytics)
+    monkeypatch.setattr(analytics_cli, "get_analytics", lambda: analytics)
+    analytics.set_persistent_property("surface", SURFACE_CLI)
+
+    class _Session:
+        session_id = "repl-session-123"
+        last_investigation_id = ""
+
+    with analytics_cli.track_investigation(
+        entrypoint=analytics_cli.EntrypointSource.CLI_REPL_FILE,
+        trigger_mode=analytics_cli.TriggerMode.FILE,
+        session=_Session(),  # type: ignore[arg-type]
+    ):
+        pass
+    analytics.shutdown(flush=True)
+
+    started = next(
+        p["json"] for p in posted if p["json"]["event"] == Event.INVESTIGATION_STARTED.value
+    )
+    assert started["properties"]["session_id"] == "repl-session-123"
+    assert started["properties"]["surface"] == SURFACE_CLI
+    assert started["properties"]["organization_id"] == "org_repl"

--- a/tools/interactive_shell/actions/investigation.py
+++ b/tools/interactive_shell/actions/investigation.py
@@ -42,11 +42,23 @@ def run_text_investigation(
     action_already_listed: bool = False,
 ) -> None:
     def _run(task: TaskRecord) -> dict[str, object]:
-        return ports.run_text_investigation(
-            alert_text=alert_text,
-            context_overrides=session.accumulated_context or None,
-            cancel_requested=task.cancel_requested,
-        )
+        from platform.analytics.cli import track_investigation
+        from platform.analytics.source import EntrypointSource, TriggerMode
+
+        with track_investigation(
+            entrypoint=EntrypointSource.CLI_PASTE,
+            trigger_mode=TriggerMode.PASTE,
+            interactive=True,
+            session=session,  # type: ignore[arg-type]
+            investigation_target=alert_text[:120] or None,
+        ) as tracker:
+            final_state = ports.run_text_investigation(
+                alert_text=alert_text,
+                context_overrides=session.accumulated_context or None,
+                cancel_requested=task.cancel_requested,
+            )
+            tracker.record_loop_metrics_from_state(final_state)
+            return final_state
 
     def _start_background() -> None:
         ports.start_background_text(

--- a/tools/interactive_shell/actions/investigation.py
+++ b/tools/interactive_shell/actions/investigation.py
@@ -45,13 +45,15 @@ def run_text_investigation(
         from platform.analytics.cli import track_investigation
         from platform.analytics.source import EntrypointSource, TriggerMode
 
-        with track_investigation(
-            entrypoint=EntrypointSource.CLI_PASTE,
-            trigger_mode=TriggerMode.PASTE,
-            interactive=True,
-            session=session,  # type: ignore[arg-type]
-            investigation_target=alert_text[:120] or None,
-        ) as tracker:
+        with (
+            track_investigation(
+                entrypoint=EntrypointSource.CLI_PASTE,
+                trigger_mode=TriggerMode.PASTE,
+                interactive=True,
+                session=session,  # type: ignore[arg-type]
+                investigation_target=alert_text[:120] or None,
+            ) as tracker
+        ):
             final_state = ports.run_text_investigation(
                 alert_text=alert_text,
                 context_overrides=session.accumulated_context or None,


### PR DESCRIPTION
## Summary
- Ensure investigation/run/session lifecycle events stamp `organization_id`, `surface` (`cli`|`slack`|`telegram`), stable OpenSRE `session_id`, `user_id` when known, and PostHog `$groups.organization`.
- Close binder gaps: process session for CLI one-shots, REPL/background thread rebinding, free-text FG investigation tracking, HTTP worker + Hermes lifecycle wrapping.
- Stop inventing a non-canonical `gateway` surface when transport context is missing.

## Test plan
- [x] `uv run pytest tests/analytics/test_usage_context.py tests/analytics/test_cli.py gateway/tests/http/test_investigation_worker.py gateway/tests/runtime/test_turn_handler.py::test_turn_handler_emits_gateway_turn_analytics -q`
- [ ] After deploy: run CLI investigate with `OPENSRE_ORGANIZATION_ID` set and confirm Live events include org/surface/session_id
- [ ] After deploy: Slack/Telegram turn shows `surface` + `session_id` + org group on `gateway_turn_*`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Central enrichment already existed from #4201, but several workload entrypoints never bound session/org context (background threads drop ContextVars; CLI one-shots had no session; HTTP/Hermes skipped `track_investigation`). This PR binds session in `track_investigation`, mints a process session for CLI, rebinds in background workers, wraps missing lifecycle paths, and keeps surfaces limited to cli/slack/telegram.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.