### PR TITLE
Add Google Vertex AI as an LLM provider using LiteLLM

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -159,6 +159,12 @@ BEDROCK_REASONING_MODEL = "us.anthropic.claude-sonnet-4-6"
 BEDROCK_CLASSIFICATION_MODEL = "us.anthropic.claude-sonnet-4-6"
 BEDROCK_TOOLCALL_MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
+# Google Vertex AI model constants (Gemini models served via Vertex; ADC auth)
+VERTEX_AI_REASONING_MODEL = "gemini-2.5-pro"
+VERTEX_AI_CLASSIFICATION_MODEL = "gemini-2.5-flash"
+VERTEX_AI_TOOLCALL_MODEL = "gemini-2.5-flash-lite"
+DEFAULT_VERTEX_AI_LOCATION = "us-central1"
+
 # Ollama local model constants
 DEFAULT_OLLAMA_MODEL = "llama3.2"
 DEFAULT_OLLAMA_HOST = "http://localhost:11434"
@@ -175,6 +181,7 @@ LLMProvider = Literal[
     "minimax",
     "groq",
     "azure-openai",
+    "vertex-ai",
     "codex",
     "cursor",
     "claude-code",
@@ -195,6 +202,7 @@ PROVIDER_ANTHROPIC: LLMProvider = "anthropic"
 PROVIDER_OPENAI: LLMProvider = "openai"
 PROVIDER_BEDROCK: LLMProvider = "bedrock"
 PROVIDER_OLLAMA: LLMProvider = "ollama"
+PROVIDER_VERTEX_AI: LLMProvider = "vertex-ai"
 
 
 def get_configured_llm_provider() -> str:
@@ -367,6 +375,24 @@ def _llm_settings_env_payload(provider: str) -> dict[str, object]:
             "BEDROCK_TOOLCALL_MODEL", BEDROCK_TOOLCALL_MODEL
         ).strip()
         or BEDROCK_TOOLCALL_MODEL,
+        "vertex_ai_project": os.getenv("VERTEX_AI_PROJECT", "").strip(),
+        "vertex_ai_location": os.getenv("VERTEX_AI_LOCATION", DEFAULT_VERTEX_AI_LOCATION).strip()
+        or DEFAULT_VERTEX_AI_LOCATION,
+        "vertex_ai_reasoning_model": os.getenv(
+            "VERTEX_AI_REASONING_MODEL",
+            os.getenv("VERTEX_AI_MODEL", VERTEX_AI_REASONING_MODEL),
+        ).strip()
+        or VERTEX_AI_REASONING_MODEL,
+        "vertex_ai_classification_model": os.getenv(
+            "VERTEX_AI_CLASSIFICATION_MODEL",
+            os.getenv("VERTEX_AI_MODEL", VERTEX_AI_CLASSIFICATION_MODEL),
+        ).strip()
+        or VERTEX_AI_CLASSIFICATION_MODEL,
+        "vertex_ai_toolcall_model": os.getenv(
+            "VERTEX_AI_TOOLCALL_MODEL",
+            os.getenv("VERTEX_AI_MODEL", VERTEX_AI_TOOLCALL_MODEL),
+        ).strip()
+        or VERTEX_AI_TOOLCALL_MODEL,
         "ollama_model": os.getenv("OLLAMA_MODEL", DEFAULT_OLLAMA_MODEL).strip()
         or DEFAULT_OLLAMA_MODEL,
         "ollama_host": os.getenv("OLLAMA_HOST", DEFAULT_OLLAMA_HOST).strip() or DEFAULT_OLLAMA_HOST,
@@ -421,6 +447,11 @@ class LLMSettings(StrictConfigModel):
     bedrock_reasoning_model: str = BEDROCK_REASONING_MODEL
     bedrock_classification_model: str = BEDROCK_CLASSIFICATION_MODEL
     bedrock_toolcall_model: str = BEDROCK_TOOLCALL_MODEL
+    vertex_ai_project: str = ""
+    vertex_ai_location: str = DEFAULT_VERTEX_AI_LOCATION
+    vertex_ai_reasoning_model: str = VERTEX_AI_REASONING_MODEL
+    vertex_ai_classification_model: str = VERTEX_AI_CLASSIFICATION_MODEL
+    vertex_ai_toolcall_model: str = VERTEX_AI_TOOLCALL_MODEL
     max_tokens: int = Field(default=DEFAULT_MAX_TOKENS, gt=0)
 
     @field_validator("ollama_host", mode="before")
@@ -647,6 +678,13 @@ BEDROCK_LLM_CONFIG = LLMModelConfig(
     reasoning_model=BEDROCK_REASONING_MODEL,
     classification_model=BEDROCK_CLASSIFICATION_MODEL,
     toolcall_model=BEDROCK_TOOLCALL_MODEL,
+    max_tokens=DEFAULT_MAX_TOKENS,
+)
+
+VERTEX_AI_LLM_CONFIG = LLMModelConfig(
+    reasoning_model=VERTEX_AI_REASONING_MODEL,
+    classification_model=VERTEX_AI_CLASSIFICATION_MODEL,
+    toolcall_model=VERTEX_AI_TOOLCALL_MODEL,
     max_tokens=DEFAULT_MAX_TOKENS,
 )
 

--- a/config/llm_auth/credentials.py
+++ b/config/llm_auth/credentials.py
@@ -121,7 +121,16 @@ def _probe_vertex_ai_ambient(spec: ProviderSpec) -> _AmbientProbeResult:
             detail=f"Could not resolve Google Application Default Credentials: {exc}",
         )
 
-    project = project_hint or discovered_project or "auto-discovered"
+    project = project_hint or discovered_project
+    if not project:
+        return _AmbientProbeResult(
+            ok=False,
+            detail=(
+                "Google Application Default Credentials resolved, but no GCP project "
+                "could be determined (ADC did not discover one and VERTEX_AI_PROJECT is "
+                "not set). Set VERTEX_AI_PROJECT — Vertex AI requests require a project."
+            ),
+        )
     return _AmbientProbeResult(
         ok=True,
         detail=(

--- a/config/llm_auth/credentials.py
+++ b/config/llm_auth/credentials.py
@@ -200,6 +200,23 @@ def status(provider: str) -> CredentialStatus:
         )
 
     if spec.credential_kind == "ambient":
+        if spec.project_env:
+            project = _env_value(spec.project_env)
+            location = _env_value(spec.location_env) if spec.location_env else ""
+            location_detail = f", location {location}" if location else ""
+            return CredentialStatus(
+                provider=spec.value,
+                configured=bool(project),
+                source="ambient" if project else "none",
+                verified=bool(project),
+                stale=False,
+                detail=(
+                    f"{spec.project_env} is configured ({project}{location_detail}); "
+                    f"{spec.label} uses Google Application Default Credentials."
+                    if project
+                    else f"{spec.project_env} is not set."
+                ),
+            )
         region = os.getenv("AWS_REGION", "").strip() or os.getenv("AWS_DEFAULT_REGION", "").strip()
         return CredentialStatus(
             provider=spec.value,

--- a/config/llm_auth/credentials.py
+++ b/config/llm_auth/credentials.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
@@ -48,6 +49,14 @@ class CredentialStatus:
 
 
 @dataclass(frozen=True)
+class _AmbientProbeResult:
+    """Outcome of an actual (not env-presence-only) ambient credential check."""
+
+    ok: bool
+    detail: str
+
+
+@dataclass(frozen=True)
 class CredentialResolution:
     """Request-time credential resolution for one provider."""
 
@@ -84,6 +93,58 @@ def _normalize_source(raw: str | None, *, fallback: CredentialSource) -> Credent
 
 def _env_value(env_var: str) -> str:
     return os.getenv(env_var, "").strip()
+
+
+def _probe_vertex_ai_ambient(spec: ProviderSpec) -> _AmbientProbeResult:
+    """Attempt real Google ADC resolution; env vars alone do not prove ADC works."""
+    import google.auth
+    from google.auth.exceptions import DefaultCredentialsError
+
+    project_hint = _env_value(spec.project_env) if spec.project_env else ""
+    location = _env_value(spec.location_env) if spec.location_env else ""
+    location_detail = f", location {location}" if location else ""
+
+    try:
+        _credentials, discovered_project = google.auth.default()
+    except DefaultCredentialsError as exc:
+        return _AmbientProbeResult(
+            ok=False,
+            detail=(
+                f"Google Application Default Credentials are not configured ({exc}). "
+                "Run `gcloud auth application-default login` or set "
+                "GOOGLE_APPLICATION_CREDENTIALS."
+            ),
+        )
+    except Exception as exc:
+        return _AmbientProbeResult(
+            ok=False,
+            detail=f"Could not resolve Google Application Default Credentials: {exc}",
+        )
+
+    project = project_hint or discovered_project or "auto-discovered"
+    return _AmbientProbeResult(
+        ok=True,
+        detail=(
+            f"Google Application Default Credentials resolved (project {project}"
+            f"{location_detail}); {spec.label} uses ADC."
+        ),
+    )
+
+
+def _probe_bedrock_ambient(spec: ProviderSpec) -> _AmbientProbeResult:
+    region = os.getenv("AWS_REGION", "").strip() or os.getenv("AWS_DEFAULT_REGION", "").strip()
+    if not region:
+        return _AmbientProbeResult(detail="AWS_REGION or AWS_DEFAULT_REGION is not set.", ok=False)
+    return _AmbientProbeResult(
+        ok=True,
+        detail=f"AWS region is configured ({region}); {spec.label} uses the AWS credential chain.",
+    )
+
+
+_AMBIENT_PROBES: dict[str, Callable[[ProviderSpec], _AmbientProbeResult]] = {
+    "vertex-ai": _probe_vertex_ai_ambient,
+    "bedrock": _probe_bedrock_ambient,
+}
 
 
 def _source_status(provider: str, source: CredentialSource, detail: str) -> CredentialStatus:
@@ -200,35 +261,34 @@ def status(provider: str) -> CredentialStatus:
         )
 
     if spec.credential_kind == "ambient":
-        if spec.project_env:
-            project = _env_value(spec.project_env)
-            location = _env_value(spec.location_env) if spec.location_env else ""
-            location_detail = f", location {location}" if location else ""
+        ambient_probe = _AMBIENT_PROBES.get(spec.value)
+        if ambient_probe is None:
             return CredentialStatus(
-                provider=spec.value,
-                configured=bool(project),
-                source="ambient" if project else "none",
-                verified=bool(project),
-                stale=False,
-                detail=(
-                    f"{spec.project_env} is configured ({project}{location_detail}); "
-                    f"{spec.label} uses Google Application Default Credentials."
-                    if project
-                    else f"{spec.project_env} is not set."
-                ),
+                spec.value,
+                False,
+                "unknown",
+                False,
+                False,
+                "No ambient credential probe registered.",
             )
-        region = os.getenv("AWS_REGION", "").strip() or os.getenv("AWS_DEFAULT_REGION", "").strip()
+        try:
+            result = ambient_probe(spec)
+        except Exception as exc:
+            return CredentialStatus(
+                spec.value,
+                False,
+                "unknown",
+                False,
+                False,
+                f"{spec.label} ambient credential check failed unexpectedly: {exc}",
+            )
         return CredentialStatus(
             provider=spec.value,
-            configured=bool(region),
-            source="ambient" if region else "none",
-            verified=bool(region),
+            configured=result.ok,
+            source="ambient" if result.ok else "none",
+            verified=result.ok,
             stale=False,
-            detail=(
-                f"AWS region is configured ({region}); Bedrock uses the AWS credential chain."
-                if region
-                else "AWS_REGION or AWS_DEFAULT_REGION is not set."
-            ),
+            detail=result.detail,
         )
 
     if spec.credential_kind == "local":

--- a/config/llm_auth/provider_catalog.py
+++ b/config/llm_auth/provider_catalog.py
@@ -23,6 +23,8 @@ class ProviderSpec:
     cli_model_env: str | None = None
     endpoint_env: str = ""
     api_version_env: str = ""
+    project_env: str = ""
+    location_env: str = ""
     allow_custom_models: bool = False
 
     @property
@@ -138,6 +140,17 @@ PROVIDER_SPECS: tuple[ProviderSpec, ...] = (
         model_env="BEDROCK_REASONING_MODEL",
         toolcall_model_env="BEDROCK_TOOLCALL_MODEL",
         classification_model_env="BEDROCK_CLASSIFICATION_MODEL",
+        allow_custom_models=True,
+    ),
+    ProviderSpec(
+        value="vertex-ai",
+        label="Google Vertex AI (ADC auth)",
+        credential_kind="ambient",
+        model_env="VERTEX_AI_REASONING_MODEL",
+        toolcall_model_env="VERTEX_AI_TOOLCALL_MODEL",
+        classification_model_env="VERTEX_AI_CLASSIFICATION_MODEL",
+        project_env="VERTEX_AI_PROJECT",
+        location_env="VERTEX_AI_LOCATION",
         allow_custom_models=True,
     ),
     ProviderSpec(

--- a/core/llm/AGENTS.md
+++ b/core/llm/AGENTS.md
@@ -16,6 +16,7 @@ agent loop. Subprocess-backed LLM CLIs live under `integrations/llm_cli/`.
 | `core/llm/internal/client_cache_key.py` | Singleton cache invalidation key `(transport, runtime_provider)`. |
 | `core/llm/providers/openai_compat_providers.py` | OpenAI-compatible provider catalog and model/base-URL resolution. |
 | `core/llm/providers/azure_openai.py` | Azure OpenAI helpers: endpoint normalization, deployment selection, LiteLLM kwargs. |
+| `core/llm/providers/vertex_ai.py` | Vertex AI helpers: project/location resolution, LiteLLM kwargs (ambient ADC auth, no API key). |
 | `core/llm/transports/litellm/routing.py` | Per-provider LiteLLM client construction (model prefix, `api_base`, `api_version`). |
 | `core/llm/transports/litellm/clients.py` | `LiteLLMAgentClient` / `LiteLLMLLMClient` wrappers around `litellm.completion`. |
 | `core/llm/transports/sdk/agent_clients.py` | Native SDK tool-calling clients (Anthropic, OpenAI, Bedrock, CLI-backed). |
@@ -86,6 +87,19 @@ Azure uses **deployment names** (not public OpenAI model IDs) and a resource **b
 
 Do not add a separate Azure client class — extend `transports/litellm/routing.py` and helpers in
 `providers/azure_openai.py`.
+
+### Google Vertex AI (`vertex-ai`)
+
+Vertex AI authenticates via Google Application Default Credentials (ADC) — no API key:
+
+- `VERTEX_AI_PROJECT`, `VERTEX_AI_LOCATION` (defaults to `us-central1`)
+- `VERTEX_AI_*_MODEL` env vars hold Gemini model IDs served via Vertex (e.g. `gemini-2.5-pro`)
+- LiteLLM model string: `vertex_ai/<model>` via `resolve_vertex_ai_request_kwargs()`
+
+Do not add a separate Vertex client class — extend `transports/litellm/routing.py` and helpers in
+`providers/vertex_ai.py`. Like Bedrock, `credential_kind="ambient"`: OpenSRE never stores a
+Vertex secret and does not enforce a required-field precondition — a missing project surfaces
+as a LiteLLM/google-auth error at request time.
 
 For investigation tool calling details, see
 [`docs/investigation-tool-calling.md`](../../docs/investigation-tool-calling.md).

--- a/core/llm/providers/vertex_ai.py
+++ b/core/llm/providers/vertex_ai.py
@@ -1,0 +1,71 @@
+"""Google Vertex AI provider helpers for LiteLLM routing.
+
+Vertex AI authenticates via Google Application Default Credentials (ADC) —
+``gcloud auth application-default login``, ``GOOGLE_APPLICATION_CREDENTIALS``
+pointing to a service-account key, or the GCE/GKE metadata server. OpenSRE
+never stores a Vertex secret; it only carries the non-secret project and
+location that LiteLLM needs to build the Vertex request URL.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from core.llm.types import ModelType
+
+VERTEX_AI_PROVIDER = "vertex-ai"
+
+VERTEX_AI_PROJECT_ENV = "VERTEX_AI_PROJECT"
+VERTEX_AI_LOCATION_ENV = "VERTEX_AI_LOCATION"
+
+
+def is_vertex_ai_provider(provider: str) -> bool:
+    """Return whether *provider* is the Vertex AI LLM slug."""
+    return provider.strip().lower() == VERTEX_AI_PROVIDER
+
+
+def resolve_vertex_ai_location(value: str = "") -> str:
+    """Return the configured Vertex AI region, falling back to the OpenSRE default."""
+    from config.config import DEFAULT_VERTEX_AI_LOCATION
+
+    location = (value or os.getenv(VERTEX_AI_LOCATION_ENV, "")).strip()
+    return location or DEFAULT_VERTEX_AI_LOCATION
+
+
+def select_vertex_ai_model(settings: Any, model_type: ModelType) -> str:
+    """Return the configured Vertex AI model for *model_type*."""
+    attr = f"vertex_ai_{model_type}_model"
+    return str(getattr(settings, attr))
+
+
+def resolve_vertex_ai_request_kwargs(settings: Any, *, model_type: ModelType) -> dict[str, str]:
+    """Resolve LiteLLM request fields for Vertex AI from runtime settings.
+
+    ``vertex_project`` is omitted (not raised on) when unset, matching Bedrock's
+    ambient-credential precedent: OpenSRE does not enforce a required-field
+    precondition here — a missing project surfaces as a LiteLLM/google-auth
+    error at request time instead.
+    """
+    model = select_vertex_ai_model(settings, model_type)
+    kwargs: dict[str, str] = {
+        "litellm_model": f"vertex_ai/{model}",
+        "vertex_location": resolve_vertex_ai_location(
+            str(getattr(settings, "vertex_ai_location", ""))
+        ),
+    }
+    project = str(getattr(settings, "vertex_ai_project", "")).strip()
+    if project:
+        kwargs["vertex_project"] = project
+    return kwargs
+
+
+__all__ = [
+    "VERTEX_AI_LOCATION_ENV",
+    "VERTEX_AI_PROJECT_ENV",
+    "VERTEX_AI_PROVIDER",
+    "is_vertex_ai_provider",
+    "resolve_vertex_ai_location",
+    "resolve_vertex_ai_request_kwargs",
+    "select_vertex_ai_model",
+]

--- a/core/llm/transport_mode.py
+++ b/core/llm/transport_mode.py
@@ -20,8 +20,13 @@ def use_litellm_transport() -> bool:
 def use_litellm_for_provider(provider: str) -> bool:
     """Return ``True`` when *provider* must route through LiteLLM."""
     from core.llm.providers.azure_openai import is_azure_openai_provider
+    from core.llm.providers.vertex_ai import is_vertex_ai_provider
 
-    return use_litellm_transport() or is_azure_openai_provider(provider)
+    return (
+        use_litellm_transport()
+        or is_azure_openai_provider(provider)
+        or is_vertex_ai_provider(provider)
+    )
 
 
 def current_llm_transport() -> str:

--- a/core/llm/transports/litellm/clients.py
+++ b/core/llm/transports/litellm/clients.py
@@ -56,6 +56,8 @@ class LiteLLMAgentClient:
         api_key_env: str | None = None,
         api_key_default: str = "",
         temperature: float | None = None,
+        vertex_project: str | None = None,
+        vertex_location: str | None = None,
         credential_resolver: Callable[[str], str] | None = None,
         completion_func: Callable[..., Any] | None = None,
     ) -> None:
@@ -66,6 +68,8 @@ class LiteLLMAgentClient:
         self._api_key_env = api_key_env
         self._api_key_default = api_key_default
         self._temperature = temperature
+        self._vertex_project = vertex_project
+        self._vertex_location = vertex_location
         self._credential_resolver = credential_resolver
         self._completion_func = completion_func
 
@@ -112,6 +116,10 @@ class LiteLLMAgentClient:
             kwargs["api_version"] = self._api_version
         if self._temperature is not None:
             kwargs["temperature"] = self._temperature
+        if self._vertex_project is not None:
+            kwargs["vertex_project"] = self._vertex_project
+        if self._vertex_location is not None:
+            kwargs["vertex_location"] = self._vertex_location
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"
@@ -156,6 +164,8 @@ class LiteLLMLLMClient:
         api_version: str | None = None,
         api_key_env: str | None = None,
         api_key_default: str = "",
+        vertex_project: str | None = None,
+        vertex_location: str | None = None,
         credential_resolver: Callable[[str], str] | None = None,
         completion_func: Callable[..., Any] | None = None,
         usage_callback: Callable[[str, int | None, int | None], object] | None = None,
@@ -169,6 +179,8 @@ class LiteLLMLLMClient:
         self._api_version = api_version
         self._api_key_env = api_key_env
         self._api_key_default = api_key_default
+        self._vertex_project = vertex_project
+        self._vertex_location = vertex_location
         self._credential_resolver = credential_resolver
         self._completion_func = completion_func
         self._usage_callback = usage_callback
@@ -231,6 +243,10 @@ class LiteLLMLLMClient:
             kwargs["api_version"] = self._api_version
         if self._temperature is not None:
             kwargs["temperature"] = self._temperature
+        if self._vertex_project is not None:
+            kwargs["vertex_project"] = self._vertex_project
+        if self._vertex_location is not None:
+            kwargs["vertex_location"] = self._vertex_location
         return kwargs
 
     def _rebuild_after_model_fallback(self, prompt_or_messages: Any) -> dict[str, Any] | None:

--- a/core/llm/transports/litellm/routing.py
+++ b/core/llm/transports/litellm/routing.py
@@ -19,6 +19,10 @@ from core.llm.providers.openai_compat_providers import (
     is_openai_compat_provider,
     resolve_openai_compat_provider,
 )
+from core.llm.providers.vertex_ai import (
+    is_vertex_ai_provider,
+    resolve_vertex_ai_request_kwargs,
+)
 from core.llm.transports.litellm.clients import LiteLLMAgentClient, LiteLLMLLMClient
 from core.llm.types import ModelType
 
@@ -65,6 +69,18 @@ def build_litellm_agent_client(settings: Any, provider: str) -> LiteLLMAgentClie
             api_key_env=resolved.api_key_env,
             api_key_default=resolved.api_key_default,
             temperature=resolved.temperature,
+        )
+
+    if is_vertex_ai_provider(provider):
+        from config.config import VERTEX_AI_LLM_CONFIG
+
+        vertex = resolve_vertex_ai_request_kwargs(settings, model_type="reasoning")
+        return LiteLLMAgentClient(
+            litellm_model=vertex["litellm_model"],
+            max_tokens=VERTEX_AI_LLM_CONFIG.max_tokens,
+            vertex_project=vertex.get("vertex_project"),
+            vertex_location=vertex.get("vertex_location"),
+            api_key_env=None,
         )
 
     raise RuntimeError(
@@ -137,6 +153,22 @@ def build_litellm_llm_client(
             api_key_env=compat.api_key_env,
             api_key_default=compat.api_key_default,
             temperature=compat.temperature,
+            usage_callback=usage_callback,
+        )
+
+    if is_vertex_ai_provider(provider):
+        from config.config import VERTEX_AI_LLM_CONFIG
+
+        vertex = resolve_vertex_ai_request_kwargs(settings, model_type=model_type)
+        raw_fallback = _fallback("vertex_ai")
+        vertex_fallback_model = f"vertex_ai/{raw_fallback}" if raw_fallback else None
+        return LiteLLMLLMClient(
+            litellm_model=vertex["litellm_model"],
+            model_fallback=vertex_fallback_model,
+            max_tokens=VERTEX_AI_LLM_CONFIG.max_tokens,
+            vertex_project=vertex.get("vertex_project"),
+            vertex_location=vertex.get("vertex_location"),
+            api_key_env=None,
             usage_callback=usage_callback,
         )
 

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -349,6 +349,11 @@ Always routed through LiteLLM (like Azure OpenAI) as `vertex_ai/<model>`. Curate
 model choices are Gemini models served via Vertex; any other Vertex-supported
 model ID also works by typing it directly (`allow_custom_models`).
 
+The default (`gemini-2.5-pro`/`-flash`/`-flash-lite`) is the GA Gemini generation.
+Gemini 3.x (`gemini-3.1-pro-preview`, `gemini-3-flash-preview`,
+`gemini-3.1-flash-lite-preview`) is selectable in the wizard but is Preview-only
+in Vertex Model Garden as of mid-2026 — expect availability and pricing to change.
+
 ### Ollama (local)
 
 ```bash

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -21,6 +21,7 @@ OpenSRE is provider-agnostic: bring your own model. Selection is controlled by t
 | NVIDIA NIM   | `nvidia`       | `NVIDIA_API_KEY`                | `meta/llama-3.1-405b-instruct`                | `meta/llama-3.1-8b-instruct`                    |
 | MiniMax      | `minimax`      | `MINIMAX_API_KEY`               | `MiniMax-M3`                                  | `MiniMax-M2.7-highspeed`                        |
 | Amazon Bedrock| `bedrock`     | AWS IAM (`AWS_REGION`)          | `us.anthropic.claude-sonnet-4-6`              | `us.anthropic.claude-haiku-4-5-20251001-v1:0`   |
+| Google Vertex AI | `vertex-ai` | Google ADC (`VERTEX_AI_PROJECT`) | `gemini-2.5-pro`                            | `gemini-2.5-flash-lite`                         |
 | Ollama (local)| `ollama`     | None (local daemon)             | `llama3.2`                                    | `llama3.2`                                      |
 | GitHub Copilot CLI| `copilot`| `copilot login` or `gh auth login` (CLI) | Copilot CLI default                           | Copilot CLI default                             |
 | xAI Groq API key | `groq`      | `GROQ_API_KEY`                  | `llama-3.3-70b-versatile`                     | `llama-3.1-8b-instant`                          |
@@ -109,6 +110,7 @@ When `OPENSRE_LLM_TRANSPORT=litellm` (or when using `LLM_PROVIDER=azure-openai`)
 | `groq` | OpenAI-compatible SDK | `openai/<model>` + Groq base URL | Opt-in |
 | `ollama` | OpenAI-compatible SDK | `openai/<model>` + `${OLLAMA_HOST}/v1` | Opt-in |
 | `azure-openai` | — | `azure/<deployment>` | **Always** via LiteLLM |
+| `vertex-ai` | — | `vertex_ai/<model>` | **Always** via LiteLLM; uses Google ADC |
 
 The native OpenAI SDK transport uses the Responses API for GPT-5.6 agent tool calls, including
 replaying reasoning and function-call items between tool steps. Older OpenAI models and
@@ -324,6 +326,28 @@ No API key — auth uses the AWS credential chain (environment variables, shared
 - **Application inference profile** ARNs (`…:application-inference-profile/…`) do not encode the vendor in the ID; those are always sent through **Converse**, which works for any backing model in the profile.
 
 Defaults in `config/config.py` are US cross-region inference profile IDs for Anthropic Claude; override with IDs or ARNs that are **inference-access enabled** in your account and region.
+
+### Google Vertex AI
+
+```bash
+export LLM_PROVIDER=vertex-ai
+export VERTEX_AI_PROJECT=my-gcp-project
+# Optional (defaults to us-central1):
+export VERTEX_AI_LOCATION=us-central1
+# Optional overrides:
+export VERTEX_AI_REASONING_MODEL=gemini-2.5-pro
+export VERTEX_AI_TOOLCALL_MODEL=gemini-2.5-flash-lite
+```
+
+No API key — auth uses Google Application Default Credentials (ADC): run
+`gcloud auth application-default login`, or set `GOOGLE_APPLICATION_CREDENTIALS`
+to a service-account key file, or rely on the ambient GCE/GKE metadata server.
+Your principal needs the Vertex AI User IAM role (or equivalent) in the
+configured project.
+
+Always routed through LiteLLM (like Azure OpenAI) as `vertex_ai/<model>`. Curated
+model choices are Gemini models served via Vertex; any other Vertex-supported
+model ID also works by typing it directly (`allow_custom_models`).
 
 ### Ollama (local)
 

--- a/surfaces/cli/wizard/config.py
+++ b/surfaces/cli/wizard/config.py
@@ -255,6 +255,15 @@ VERTEX_AI_MODELS = (
     ModelOption(value=VERTEX_AI_REASONING_MODEL, label="Gemini 2.5 Pro (Vertex) — default"),
     ModelOption(value="gemini-2.5-flash", label="Gemini 2.5 Flash (Vertex)"),
     ModelOption(value="gemini-2.5-flash-lite", label="Gemini 2.5 Flash-Lite (Vertex)"),
+    # Gemini 3.x is Preview-only in Vertex Model Garden as of the July 2026 release
+    # notes (docs.cloud.google.com/vertex-ai/generative-ai/docs/release-notes) — not
+    # curated as the default. Same IDs as the direct Gemini provider's GEMINI_MODELS,
+    # since Vertex serves Gemini under the same publisher-model IDs.
+    ModelOption(value="gemini-3.1-pro-preview", label="Gemini 3.1 Pro (Vertex, preview)"),
+    ModelOption(value="gemini-3-flash-preview", label="Gemini 3 Flash (Vertex, preview)"),
+    ModelOption(
+        value="gemini-3.1-flash-lite-preview", label="Gemini 3.1 Flash-Lite (Vertex, preview)"
+    ),
 )
 
 OLLAMA_MODELS = (

--- a/surfaces/cli/wizard/config.py
+++ b/surfaces/cli/wizard/config.py
@@ -19,6 +19,7 @@ from config.config import (
     NVIDIA_REASONING_MODEL,
     OPENAI_REASONING_MODEL,
     OPENROUTER_REASONING_MODEL,
+    VERTEX_AI_REASONING_MODEL,
 )
 from config.llm_auth.provider_catalog import require_provider_spec
 from config.local_env import PROJECT_ROOT as PROJECT_ROOT
@@ -248,6 +249,12 @@ BEDROCK_MODELS = (
         value="mistral.mistral-large-3-675b-instruct",
         label="Mistral Large 3 675B Instruct (on-demand)",
     ),
+)
+
+VERTEX_AI_MODELS = (
+    ModelOption(value=VERTEX_AI_REASONING_MODEL, label="Gemini 2.5 Pro (Vertex) — default"),
+    ModelOption(value="gemini-2.5-flash", label="Gemini 2.5 Flash (Vertex)"),
+    ModelOption(value="gemini-2.5-flash-lite", label="Gemini 2.5 Flash-Lite (Vertex)"),
 )
 
 OLLAMA_MODELS = (
@@ -675,6 +682,27 @@ SUPPORTED_PROVIDERS = (
         credential_secret=False,
         # credential_kind="none" causes flow.py to skip the credential prompt
         # entirely.  Region is picked up from AWS_DEFAULT_REGION / ~/.aws/config.
+        credential_kind="none",
+        allow_custom_models=True,
+    ),
+    ProviderOption(
+        value="vertex-ai",
+        label="Google Vertex AI (ADC auth)",
+        group="Hosted providers",
+        # Intentionally empty: Vertex AI authenticates via Google Application
+        # Default Credentials (gcloud ADC, a service-account key, or GCE/GKE
+        # metadata) — no API key to prompt for, same as Bedrock's IAM auth.
+        api_key_env="",
+        model_env="VERTEX_AI_REASONING_MODEL",
+        default_model=VERTEX_AI_REASONING_MODEL,
+        models=VERTEX_AI_MODELS,
+        toolcall_model_env="VERTEX_AI_TOOLCALL_MODEL",
+        classification_model_env="VERTEX_AI_CLASSIFICATION_MODEL",
+        credential_label="GCP project + region (uses Application Default Credentials)",
+        credential_secret=False,
+        # credential_kind="none" causes flow.py to skip the credential prompt
+        # entirely. Project/region are picked up from VERTEX_AI_PROJECT /
+        # VERTEX_AI_LOCATION, set outside the wizard (same as Bedrock's region).
         credential_kind="none",
         allow_custom_models=True,
     ),

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -107,6 +107,38 @@ def test_llm_settings_from_env_deepseek(monkeypatch) -> None:
     assert settings.deepseek_api_key == ""
 
 
+def test_llm_settings_accepts_vertex_ai_without_project() -> None:
+    settings = LLMSettings.model_validate({"provider": "vertex-ai"})
+
+    assert settings.provider == "vertex-ai"
+    assert settings.vertex_ai_project == ""
+    assert settings.vertex_ai_location == "us-central1"
+
+
+def test_llm_settings_from_env_vertex_ai(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "vertex-ai")
+    monkeypatch.setenv("VERTEX_AI_PROJECT", "my-gcp-project")
+    monkeypatch.delenv("VERTEX_AI_LOCATION", raising=False)
+
+    settings = LLMSettings.from_env()
+
+    assert settings.provider == "vertex-ai"
+    assert settings.vertex_ai_project == "my-gcp-project"
+    assert settings.vertex_ai_location == "us-central1"
+    assert settings.vertex_ai_reasoning_model == "gemini-2.5-pro"
+    assert settings.vertex_ai_toolcall_model == "gemini-2.5-flash-lite"
+
+
+def test_llm_settings_from_env_vertex_ai_custom_location(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "vertex-ai")
+    monkeypatch.setenv("VERTEX_AI_PROJECT", "my-gcp-project")
+    monkeypatch.setenv("VERTEX_AI_LOCATION", "europe-west1")
+
+    settings = LLMSettings.from_env()
+
+    assert settings.vertex_ai_location == "europe-west1"
+
+
 def test_llm_settings_minimax_provider_accepted() -> None:
     settings = LLMSettings.model_validate(
         {

--- a/tests/config/test_llm_credentials.py
+++ b/tests/config/test_llm_credentials.py
@@ -75,6 +75,25 @@ def test_status_vertex_ai_configured_via_metadata_without_project_env(monkeypatc
     assert "discovered-project" in result.detail
 
 
+def test_status_vertex_ai_not_configured_when_adc_resolves_without_project(
+    monkeypatch,
+) -> None:
+    """ADC succeeding is not enough — a request still needs a resolvable project.
+
+    Regression test: this used to fall back to a display-only "auto-discovered"
+    placeholder and report configured=True, even though request routing has no
+    project to send and the subsequent LiteLLM call would fail.
+    """
+    monkeypatch.delenv("VERTEX_AI_PROJECT", raising=False)
+    monkeypatch.setattr(google.auth, "default", lambda: (object(), None))
+
+    result = status("vertex-ai")
+
+    assert result.configured is False
+    assert result.source == "none"
+    assert "VERTEX_AI_PROJECT" in result.detail
+
+
 def test_status_bedrock_ignores_vertex_project_env(monkeypatch) -> None:
     """The ambient status branch must not cross-check unrelated providers' env vars."""
     monkeypatch.setenv("VERTEX_AI_PROJECT", "my-gcp-project")

--- a/tests/config/test_llm_credentials.py
+++ b/tests/config/test_llm_credentials.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import subprocess
 
+import google.auth
 import keyring
+from google.auth.exceptions import DefaultCredentialsError
 
 import config.llm_credentials as llm_credentials
 import config.llm_keyring as llm_keyring
@@ -31,26 +33,46 @@ def _darwin_platform() -> str:
     return "Darwin"
 
 
-def test_status_vertex_ai_configured_when_project_env_set(monkeypatch) -> None:
+def test_status_vertex_ai_configured_when_adc_resolves(monkeypatch) -> None:
     monkeypatch.setenv("VERTEX_AI_PROJECT", "my-gcp-project")
     monkeypatch.setenv("VERTEX_AI_LOCATION", "europe-west1")
-    monkeypatch.delenv("AWS_REGION", raising=False)
-    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.setattr(google.auth, "default", lambda: (object(), "my-gcp-project"))
 
     result = status("vertex-ai")
 
     assert result.configured is True
     assert result.source == "ambient"
-    assert "VERTEX_AI_PROJECT" in result.detail
+    assert "my-gcp-project" in result.detail
 
 
-def test_status_vertex_ai_not_configured_without_project(monkeypatch) -> None:
-    monkeypatch.delenv("VERTEX_AI_PROJECT", raising=False)
+def test_status_vertex_ai_not_configured_when_adc_missing_despite_project_env(
+    monkeypatch,
+) -> None:
+    """VERTEX_AI_PROJECT being set is not proof that ADC actually resolves."""
+    monkeypatch.setenv("VERTEX_AI_PROJECT", "my-gcp-project")
+
+    def _raise_no_adc() -> tuple[object, str | None]:
+        raise DefaultCredentialsError("no ADC found")
+
+    monkeypatch.setattr(google.auth, "default", _raise_no_adc)
 
     result = status("vertex-ai")
 
     assert result.configured is False
     assert result.source == "none"
+
+
+def test_status_vertex_ai_configured_via_metadata_without_project_env(monkeypatch) -> None:
+    """ADC discovered through GCE/GKE metadata counts even with no project env set."""
+    monkeypatch.delenv("VERTEX_AI_PROJECT", raising=False)
+    monkeypatch.delenv("VERTEX_AI_LOCATION", raising=False)
+    monkeypatch.setattr(google.auth, "default", lambda: (object(), "discovered-project"))
+
+    result = status("vertex-ai")
+
+    assert result.configured is True
+    assert result.source == "ambient"
+    assert "discovered-project" in result.detail
 
 
 def test_status_bedrock_ignores_vertex_project_env(monkeypatch) -> None:

--- a/tests/config/test_llm_credentials.py
+++ b/tests/config/test_llm_credentials.py
@@ -31,6 +31,40 @@ def _darwin_platform() -> str:
     return "Darwin"
 
 
+def test_status_vertex_ai_configured_when_project_env_set(monkeypatch) -> None:
+    monkeypatch.setenv("VERTEX_AI_PROJECT", "my-gcp-project")
+    monkeypatch.setenv("VERTEX_AI_LOCATION", "europe-west1")
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+
+    result = status("vertex-ai")
+
+    assert result.configured is True
+    assert result.source == "ambient"
+    assert "VERTEX_AI_PROJECT" in result.detail
+
+
+def test_status_vertex_ai_not_configured_without_project(monkeypatch) -> None:
+    monkeypatch.delenv("VERTEX_AI_PROJECT", raising=False)
+
+    result = status("vertex-ai")
+
+    assert result.configured is False
+    assert result.source == "none"
+
+
+def test_status_bedrock_ignores_vertex_project_env(monkeypatch) -> None:
+    """The ambient status branch must not cross-check unrelated providers' env vars."""
+    monkeypatch.setenv("VERTEX_AI_PROJECT", "my-gcp-project")
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+
+    result = status("bedrock")
+
+    assert result.configured is False
+    assert "AWS_REGION" in result.detail
+
+
 def test_resolve_env_credential_prefers_env_over_keyring(monkeypatch) -> None:
     monkeypatch.setenv("GITLAB_ACCESS_TOKEN", "from-env")
     monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)

--- a/tests/core/runtime/llm/test_vertex_ai_routing.py
+++ b/tests/core/runtime/llm/test_vertex_ai_routing.py
@@ -1,0 +1,69 @@
+"""Google Vertex AI LiteLLM routing tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from core.llm.transport_mode import use_litellm_for_provider
+from core.llm.transports.litellm.clients import LiteLLMAgentClient, LiteLLMLLMClient
+from core.llm.transports.litellm.routing import build_litellm_agent_client, build_litellm_llm_client
+
+
+def _vertex_settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        provider="vertex-ai",
+        vertex_ai_project="my-gcp-project",
+        vertex_ai_location="us-central1",
+        vertex_ai_reasoning_model="gemini-2.5-pro",
+        vertex_ai_classification_model="gemini-2.5-flash",
+        vertex_ai_toolcall_model="gemini-2.5-flash-lite",
+    )
+
+
+def test_use_litellm_for_provider_is_always_true_for_vertex_ai() -> None:
+    assert use_litellm_for_provider("vertex-ai") is True
+
+
+def test_build_litellm_agent_client_for_vertex_ai() -> None:
+    client = build_litellm_agent_client(_vertex_settings(), "vertex-ai")
+
+    assert isinstance(client, LiteLLMAgentClient)
+    assert client._litellm_model == "vertex_ai/gemini-2.5-pro"
+    assert client._vertex_project == "my-gcp-project"
+    assert client._vertex_location == "us-central1"
+    assert client._api_key_env is None
+
+
+def test_build_litellm_llm_client_for_vertex_ai() -> None:
+    client = build_litellm_llm_client(
+        _vertex_settings(),
+        "vertex-ai",
+        "reasoning",
+    )
+
+    assert isinstance(client, LiteLLMLLMClient)
+    assert client._litellm_model == "vertex_ai/gemini-2.5-pro"
+    assert client._vertex_project == "my-gcp-project"
+    assert client._vertex_location == "us-central1"
+    assert client._model_fallback == "vertex_ai/gemini-2.5-flash-lite"
+    assert client._api_key_env is None
+
+
+def test_vertex_ai_defaults_location_when_unset() -> None:
+    settings = _vertex_settings()
+    settings.vertex_ai_location = ""
+
+    client = build_litellm_agent_client(settings, "vertex-ai")
+
+    assert client._vertex_location == "us-central1"
+
+
+def test_vertex_ai_omits_project_when_unset_instead_of_raising() -> None:
+    """Bedrock parity: a missing project is not an OpenSRE-side precondition —
+    it surfaces as a LiteLLM/google-auth error at request time instead."""
+    settings = _vertex_settings()
+    settings.vertex_ai_project = ""
+
+    client = build_litellm_agent_client(settings, "vertex-ai")
+
+    assert client._vertex_project is None


### PR DESCRIPTION
Adds `vertex-ai` as a first-class LLM_PROVIDER option, following the Bedrock precedent: ambient-only auth (Google ADC — gcloud login, a service-account key, or GCE/GKE metadata), no API key stored by OpenSRE, and no wizard prompt for project/region since project/location live outside the credential flow. Routing always goes through LiteLLM (vertex_ai/<model>), the same carve-out used for Azure OpenAI, so no new native SDK client or dependency was needed — google-auth was already present.

I don't have a lot of working experience programming, so feel free to ask for anything or do changes.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve? It adds support for Vertex AI using LiteLLM, using a similar approach as when Azure whas added: https://github.com/Tracer-Cloud/opensre/pull/3651/.
- What alternative approaches did you consider? I did not.
- Why did you choose this specific implementation? I like a generic approach in anything in general, and LiteLLM seems to be a good choice for providing access to AI models.

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
