### PR TITLE
fix(deps): bump setuptools to 83.0.0 for the MANIFEST.in NFC/NFD exclusion bypass

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3709,11 +3709,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `setuptools` from 82.0.1 to 83.0.0, closing the MANIFEST.in exclusion bypass advisory (Unicode NFC/NFD normalization collision on macOS APFS/HFS+).

Lock-only change: 3 insertions, 3 deletions in `uv.lock` — the package's version and hashes. No other dependency moved.

Exposure here is nil, and worth stating plainly

The advisory is that `MANIFEST.in` exclude / global-exclude / prune directives silently fail to match when the on-disk name is NFD and the rule is NFC, so an intentionally-excluded file gets packed into the sdist.

This project has no `MANIFEST.in`. There are no exclusion rules, so there is nothing to bypass. The bump is alert hygiene, not a fix for a live risk.

Nor is setuptools broadly present at runtime. It enters only through `pyinstaller` / `pyinstaller-hooks-contrib`, which live in the `release` and `release-binary` optional extras and are not installed for dev or runtime. It is additionally the PEP 517 build backend via `[build-system] requires = ["setuptools>=68.0"]`, which resolves independently of the lock.