### PR TITLE
docs(integrations): add AGENTS.md for the shared setup-flow conventions

### DIFF
--- a/integrations/AGENTS.md
+++ b/integrations/AGENTS.md
@@ -1,0 +1,60 @@
+# Integrations
+
+`integrations/<vendor>/` owns everything about one vendor: config normalization,
+verifier, clients, helpers, catalog/store wiring, and the vendor's tools
+(`integrations/<vendor>/tools/`). Read
+[docs/adding-tools-and-integrations.md](../docs/adding-tools-and-integrations.md)
+for the full definition of done before adding one.
+
+## Setup flow — how a vendor becomes "configured"
+
+Setup runs on three surfaces — `opensre onboard` (wizard),
+`opensre integrations setup <vendor>` (CLI), and the interactive-shell action
+tools. They differ only in how they **collect** values; what happens afterwards
+is identical and lives in one place: [`setup_flow.py`](setup_flow.py).
+
+- **Declare an `IntegrationSetupSpec`** in `integrations/<vendor>/setup.py`
+  (fields + verifier), then hand collected values to `apply_setup()`. It
+  verifies, optionally resolves, and persists to **every tier** — the
+  integration store, the keyring (secrets), and the project `.env`.
+- **Never hand-roll `upsert_integration` + env writes in a surface handler.**
+  That store-only vs. three-tier split is exactly the bug this module exists to
+  prevent: runtime resolves the store first and hides it, but the deploy
+  preflight reads `.env` and sees a half-configured integration.
+- **`SetupField`** carries `name`/`label`/`prompt`/`env_var`/`default`/
+  `required`/`secret`/`constant`. The tier is derived from `env_var`
+  automatically (`*_TOKEN`/`*_KEY`/`*_PASSWORD` → keyring, else `.env`); a field
+  never chooses its own tier.
+
+## Cross-field rules go in the verifier, not a setup hook
+
+A rule that spans several fields — either/or, XOR, all-or-nothing — belongs in
+`integrations/<vendor>/verifier.py`, **not** a setup-only check. There is
+deliberately **no `validate` hook** on the spec.
+
+Why: `opensre integrations verify <vendor>` (health checks) calls only the
+verifier. A setup-only check would let setup and health checks disagree on what
+"configured" means. Enforcing the rule in the verifier gives one definition,
+exercised by both.
+
+- Precedent: `verify_rocketchat` rejects an incomplete "webhook **or** the
+  server-url/token/user-id trio".
+- A UI picker is **not** a validation guarantee — an agent or a hand-edited
+  store bypasses it, so the verifier must still reject bad combinations.
+
+## Mode pickers (`SetupMode`)
+
+When a vendor has mutually-distinct config paths (an auth method; webhook vs.
+Socket Mode), declare `SetupMode`s + `mode_prompt` on the spec instead of
+prompting every field flat. The picker scopes which fields are collected; fields
+outside the chosen mode are **cleared, not prompted**, so choosing one mode turns
+the others off. The verifier still enforces the real combination (see above).
+
+## Pointers
+
+| File | What |
+| --- | --- |
+| [`setup_flow.py`](setup_flow.py) | The contract: `apply_setup`, `SetupField`, `SetupMode`, and the `resolve`/`finalize` hooks |
+| `<vendor>/setup.py` | The per-vendor spec (e.g. `rocketchat`, `telegram`) |
+| `<vendor>/verifier.py` | Verification **and** cross-field rules |
+| [docs/adding-tools-and-integrations.md](../docs/adding-tools-and-integrations.md) | Full checklist / definition of done |


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

Adds `integrations/AGENTS.md` — package-local guidance an agent reads before structural changes in `integrations/` (per the root AGENTS.md convention). It captures the direction the setup-spec migration (batches 1–8) established, which `docs/adding-tools-and-integrations.md` did not yet mention:

- New vendors declare an `IntegrationSetupSpec` and persist via `apply_setup` — never hand-roll `upsert_integration` + env writes in a surface handler (that store-only vs. three-tier split is the bug `setup_flow` exists to prevent).
- **Cross-field rules (either/or, XOR, all-or-nothing) live in the verifier, not a setup-only hook**, so `integrations verify` and setup agree on "configured". There is deliberately no `validate` hook.
- Mutually-distinct config paths use `SetupMode` pickers that clear non-selected fields.

Docs-only; pointers to `setup_flow.py` and the full checklist. Follows up the setup-spec work in #4222.

### Demo/Screenshot for feature changes and bug fixes -

N/A — documentation only.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Distilled the conventions already documented in `setup_flow.py` docstrings and the verifier-based cross-field rule established in #4219 into a short, discoverable package-local AGENTS.md, with pointers rather than duplicated detail.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] My code follows the project's style guidelines and conventions