### PR TITLE
refactor(integrations): load store once in health banner path

### DIFF
--- a/integrations/catalog.py
+++ b/integrations/catalog.py
@@ -169,6 +169,15 @@ def configured_integration_services() -> list[str]:
     login). Never raises; returns an empty list on any failure so callers can
     treat it as best-effort.
     """
+    try:
+        store_records = load_integrations()
+    except Exception:
+        store_records = []
+    return _configured_service_names(store_records=store_records)
+
+
+def _configured_service_names(*, store_records: list[dict[str, Any]]) -> list[str]:
+    """Merge env-visible and active store services into one deduplicated list."""
     services: list[str] = []
 
     try:
@@ -180,10 +189,6 @@ def configured_integration_services() -> list[str]:
         if service:
             services.append(service)
 
-    try:
-        store_records = load_integrations()
-    except Exception:
-        store_records = []
     for record in store_records:
         if str(record.get("status", "active")).strip().lower() != "active":
             continue
@@ -191,7 +196,7 @@ def configured_integration_services() -> list[str]:
         if service:
             services.append(service)
 
-    return list(dict.fromkeys(services))  # deduplicate, preserve order
+    return list(dict.fromkeys(services))
 
 
 # Hosted MCP integrations that strictly require a personal API token when not
@@ -227,15 +232,16 @@ def configured_integration_health() -> list[tuple[str, str]]:
     Performs no network verification (startup stays fast) and never raises; on
     any failure each service falls back to ``"ok"`` so the banner still lists it.
     """
-    services = configured_integration_services()
-    if not services:
-        return []
-
-    store_config_by_service: dict[str, dict[str, Any]] = {}
     try:
         store_records = load_integrations()
     except Exception:
         store_records = []
+
+    services = _configured_service_names(store_records=store_records)
+    if not services:
+        return []
+
+    store_config_by_service: dict[str, dict[str, Any]] = {}
     for record in store_records:
         if str(record.get("status", "active")).strip().lower() != "active":
             continue

--- a/tests/integrations/test_configured_integration_services.py
+++ b/tests/integrations/test_configured_integration_services.py
@@ -114,9 +114,7 @@ class TestConfiguredIntegrationHealth:
     """
 
     def test_ok_when_classified_into_usable_config(self, monkeypatch: Any) -> None:
-        monkeypatch.setattr(
-            catalog, "configured_integration_services", lambda: ["datadog", "gitlab"]
-        )
+        monkeypatch.setattr(catalog, "load_env_integration_services", lambda: ["datadog", "gitlab"])
         monkeypatch.setattr(catalog, "load_integrations", list)
         assert catalog.configured_integration_health() == [
             ("datadog", "ok"),
@@ -124,7 +122,7 @@ class TestConfiguredIntegrationHealth:
         ]
 
     def test_hosted_mcp_without_token_is_incomplete(self, monkeypatch: Any) -> None:
-        monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["posthog_mcp"])
+        monkeypatch.setattr(catalog, "load_env_integration_services", list)
         monkeypatch.setattr(
             catalog,
             "load_integrations",
@@ -149,7 +147,7 @@ class TestConfiguredIntegrationHealth:
         assert catalog.configured_integration_health() == [("posthog_mcp", "incomplete")]
 
     def test_hosted_mcp_with_token_is_ok(self, monkeypatch: Any) -> None:
-        monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["posthog_mcp"])
+        monkeypatch.setattr(catalog, "load_env_integration_services", list)
         monkeypatch.setattr(
             catalog,
             "load_integrations",
@@ -175,7 +173,7 @@ class TestConfiguredIntegrationHealth:
 
     def test_stdio_mcp_without_token_is_ok(self, monkeypatch: Any) -> None:
         # stdio MCP authenticates via the local subprocess, so no token is needed.
-        monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["posthog_mcp"])
+        monkeypatch.setattr(catalog, "load_env_integration_services", list)
         monkeypatch.setattr(
             catalog,
             "load_integrations",
@@ -198,19 +196,20 @@ class TestConfiguredIntegrationHealth:
     def test_non_mcp_empty_token_field_is_not_flagged(self, monkeypatch: Any) -> None:
         # Only the hosted-MCP token rule applies; an unrelated service that
         # classified successfully stays "ok" even if it lacks an auth_token key.
-        monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["github"])
+        monkeypatch.setattr(catalog, "load_env_integration_services", lambda: ["github"])
         monkeypatch.setattr(catalog, "load_integrations", list)
         assert catalog.configured_integration_health() == [("github", "ok")]
 
     def test_empty_when_no_integrations(self, monkeypatch: Any) -> None:
-        monkeypatch.setattr(catalog, "configured_integration_services", list)
+        monkeypatch.setattr(catalog, "load_env_integration_services", list)
+        monkeypatch.setattr(catalog, "load_integrations", list)
         assert catalog.configured_integration_health() == []
 
     def test_defaults_ok_when_store_load_raises(self, monkeypatch: Any) -> None:
         def _boom() -> list[dict[str, Any]]:
             raise RuntimeError("store unreadable")
 
-        monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["datadog"])
+        monkeypatch.setattr(catalog, "load_env_integration_services", lambda: ["datadog"])
         monkeypatch.setattr(catalog, "load_integrations", _boom)
         # Resolution failure must not crash the banner or alarm the user: when
         # health can't be determined offline, every service falls back to "ok".
@@ -220,8 +219,34 @@ class TestConfiguredIntegrationHealth:
         def _resolve_should_not_run() -> dict[str, Any]:
             raise AssertionError("startup health must not resolve secrets")
 
-        monkeypatch.setattr(catalog, "configured_integration_services", lambda: ["datadog"])
+        monkeypatch.setattr(catalog, "load_env_integration_services", lambda: ["datadog"])
         monkeypatch.setattr(catalog, "load_integrations", list)
         monkeypatch.setattr(catalog, "resolve_effective_integrations", _resolve_should_not_run)
 
         assert catalog.configured_integration_health() == [("datadog", "ok")]
+
+    def test_health_loads_store_at_most_once(self, monkeypatch: Any) -> None:
+        calls = 0
+
+        def counting_load() -> list[dict[str, Any]]:
+            nonlocal calls
+            calls += 1
+            return [
+                {
+                    "service": "github",
+                    "status": "active",
+                    "instances": [
+                        {
+                            "name": "default",
+                            "tags": {},
+                            "credentials": {"token": "ghp_test"},
+                        }
+                    ],
+                }
+            ]
+
+        monkeypatch.setattr(catalog, "load_env_integration_services", list)
+        monkeypatch.setattr(catalog, "load_integrations", counting_load)
+
+        assert catalog.configured_integration_health() == [("github", "ok")]
+        assert calls == 1


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

`configured_integration_health()` used to discover configured services via `configured_integration_services()` (which loads `integrations.json`) and then call `load_integrations()` again for credentials. That is two store reads for one banner health pass.

This PR extracts `_configured_service_names(store_records=...)` so health loads the store once and reuses that list for both service names and offline health. Public `configured_integration_services()` behavior is unchanged.

Intentionally **does not** add an in-process store cache (see discussion on #4198) — a tiny local JSON re-read is fine; caching adds stale-value risk without a measured win.

### Demo/Screenshot for feature changes and bug fixes - 
```text
$ uv run pytest tests/integrations/test_configured_integration_services.py -q
.................                                                        [100%]
17 passed
```

New regression: `test_health_loads_store_at_most_once` asserts `load_integrations` is called exactly once from `configured_integration_health()`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
`configured_integration_health` needs both the service list and store credentials. Calling `configured_integration_services()` forced a second load. Passing already-loaded records into a shared helper keeps one disk read per health call without a process-wide cache.

Alternatives considered: (1) mtime-keyed cache in `integrations/store.py` (#4198) — rejected for complexity and stale-value risk on a small file; (2) leave the double load — fine for perf, but the shared helper is a clearer API for this call path.

Key pieces:
- `_configured_service_names` — merge env + active store services from an already-loaded record list
- `configured_integration_services` — load once, then call the helper
- `configured_integration_health` — load once, reuse for names + credential lookup

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
