### PR TITLE
fix(session): make trace_span appends O(1) and keep spans out of the message parent-chain

### DIFF
--- a/core/agent_harness/session/persistence/jsonl_repo.py
+++ b/core/agent_harness/session/persistence/jsonl_repo.py
@@ -257,7 +257,10 @@ def _resolve_entry_id(entries: list[dict[str, Any]], entry_ref: str | None) -> s
         ]
         return matches[0] if len(matches) == 1 else entry_ref
     for rec in reversed(entries):
-        if rec.get("type") == "leaf":
+        rec_type = rec.get("type")
+        if rec_type == "trace_span":
+            continue
+        if rec_type == "leaf":
             parent = str(rec.get("parent_id") or "")
             return parent or None
         return str(rec.get("id") or "") or None

--- a/core/agent_harness/session/persistence/jsonl_storage.py
+++ b/core/agent_harness/session/persistence/jsonl_storage.py
@@ -206,7 +206,12 @@ class JsonlSessionStorage:
         attributes: dict[str, Any] | None = None,
         parent_id: str | None = None,
     ) -> str:
-        """Append a product ``trace_span`` for ATM / debug (thread, route, stage, …)."""
+        """Append a product ``trace_span`` for ATM / debug (thread, route, stage, …).
+
+        Spans are diagnostic sidecar records: without an explicit ``parent_id``
+        they stay detached (no leaf lookup), keeping the append O(1) and out of
+        the conversation parent-chain.
+        """
         payload: dict[str, Any] = {
             "span_kind": span_kind,
             "name": name,
@@ -221,6 +226,7 @@ class JsonlSessionStorage:
             "trace_span",
             payload,
             parent_id=parent_id,
+            resolve_parent=False,
         )
 
     def append_investigation_result(
@@ -310,13 +316,16 @@ class JsonlSessionStorage:
         payload: dict[str, Any],
         *,
         parent_id: str | None = None,
+        resolve_parent: bool = True,
     ) -> str:
         with contextlib.suppress(Exception):
             path = session_path(session_id)
             if not path.exists():
                 return ""
             entry_id = _new_id()
-            parent = parent_id if parent_id is not None else self._current_leaf_id(path)
+            parent = parent_id
+            if parent is None and resolve_parent:
+                parent = self._current_leaf_id(path)
             record = {
                 "id": entry_id,
                 "parent_id": parent,
@@ -343,9 +352,12 @@ class JsonlSessionStorage:
     def _current_leaf_id(self, path: Path) -> str | None:
         records = self._read_records(path)
         for rec in reversed(records):
-            if rec.get("type") == "leaf":
+            rec_type = rec.get("type")
+            if rec_type == "trace_span":
+                continue
+            if rec_type == "leaf":
                 return str(rec.get("parent_id") or "") or None
-            if rec.get("type") != "session":
+            if rec_type != "session":
                 return str(rec.get("id") or "") or None
         return None
 

--- a/tests/interactive_shell/sessions/test_store.py
+++ b/tests/interactive_shell/sessions/test_store.py
@@ -360,6 +360,54 @@ def test_flush_leaf_parents_to_last_real_entry_not_trace_span(tmp_path: Path) ->
     assert leaf["parent_id"] == stub["id"]
 
 
+def test_append_trace_span_noop_when_file_missing(tmp_path: Path) -> None:
+    with _patch_dir(tmp_path):
+        entry_id = SessionStore.append_trace_span("nonexistent-id", span_kind="llm", name="invoke")
+
+    assert entry_id == ""
+    assert not list(tmp_path.glob("*.jsonl"))
+
+
+def test_load_session_walks_through_chained_trace_span_in_legacy_files(tmp_path: Path) -> None:
+    sid = uuid.uuid4().hex
+    started_at = "2026-01-01T00:00:00+00:00"
+    records = [
+        {"type": "session", "version": 2, "id": sid, "created_at": started_at, "cwd": ""},
+        {
+            "id": "m1",
+            "parent_id": None,
+            "timestamp": started_at,
+            "type": "message",
+            "role": "user",
+            "content": "q",
+        },
+        {
+            "id": "s1",
+            "parent_id": "m1",
+            "timestamp": started_at,
+            "type": "trace_span",
+            "span_kind": "llm",
+            "name": "invoke",
+            "status": "ok",
+        },
+        {
+            "id": "m2",
+            "parent_id": "s1",
+            "timestamp": started_at,
+            "type": "message",
+            "role": "assistant",
+            "content": "a",
+        },
+    ]
+    (tmp_path / f"{sid}.jsonl").write_text("\n".join(json.dumps(rec) for rec in records) + "\n")
+
+    with _patch_dir(tmp_path):
+        loaded = SessionStore.load_session(sid)
+
+    assert loaded is not None
+    assert loaded["cli_agent_messages"] == [("user", "q"), ("assistant", "a")]
+
+
 def test_load_session_ignores_trailing_trace_span(tmp_path: Path) -> None:
     session = _make_session()
     with _patch_dir(tmp_path):

--- a/tests/interactive_shell/sessions/test_store.py
+++ b/tests/interactive_shell/sessions/test_store.py
@@ -294,6 +294,87 @@ def test_append_tool_call_reopens_finalized_session(tmp_home: Path) -> None:
     assert any(r["type"] == "tool_call" for r in records)
 
 
+# ── append_trace_span ─────────────────────────────────────────────────────────
+
+
+def test_append_trace_span_stays_out_of_parent_chain(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "hello")
+
+        SessionStore.append_trace_span(
+            session.session_id, span_kind="llm", name="invoke", duration_ms=5
+        )
+        SessionStore.append_message(session.session_id, role="user", content="next")
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    span = next(r for r in records if r["type"] == "trace_span")
+    stub = next(r for r in records if r["type"] == "custom_message")
+    message = next(r for r in records if r["type"] == "message")
+    assert span["parent_id"] is None
+    assert message["parent_id"] == stub["id"]
+
+
+def test_append_trace_span_appends_without_reading_file(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "hello")
+
+        with patch.object(JsonlSessionStorage, "_read_records") as read_records:
+            SessionStore.append_trace_span(session.session_id, span_kind="tool", name="grep")
+
+    read_records.assert_not_called()
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    assert any(r["type"] == "trace_span" for r in records)
+
+
+def test_append_trace_span_keeps_explicit_parent(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+
+        parent = SessionStore.append_trace_span(session.session_id, span_kind="turn", name="turn")
+        SessionStore.append_trace_span(
+            session.session_id, span_kind="llm", name="invoke", parent_id=parent
+        )
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    spans = [r for r in records if r["type"] == "trace_span"]
+    assert spans[1]["parent_id"] == spans[0]["id"]
+
+
+def test_flush_leaf_parents_to_last_real_entry_not_trace_span(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "hello")
+        SessionStore.append_trace_span(session.session_id, span_kind="llm", name="invoke")
+
+        SessionStore.flush(session)
+
+    records = _read_lines(tmp_path / f"{session.session_id}.jsonl")
+    leaf = next(r for r in records if r["type"] == "leaf")
+    stub = _turn_stubs(records)[0]
+    assert leaf["parent_id"] == stub["id"]
+
+
+def test_load_session_ignores_trailing_trace_span(tmp_path: Path) -> None:
+    session = _make_session()
+    with _patch_dir(tmp_path):
+        SessionStore.open_session(session)
+        SessionStore.append_turn(session, "chat", "hello")
+        SessionStore.append_message(session.session_id, role="user", content="q")
+        SessionStore.append_message(session.session_id, role="assistant", content="a")
+        SessionStore.append_trace_span(session.session_id, span_kind="llm", name="invoke")
+
+        loaded = SessionStore.load_session(session.session_id)
+
+    assert loaded is not None
+    assert loaded["cli_agent_messages"] == [("user", "q"), ("assistant", "a")]
+
+
 # ── flush ─────────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Fixes #3938

#### Describe the changes you have made in this PR -

Every `trace_span` append (one per LLM call and per tool call, on by default in the REPL) re-read and re-parsed the entire session JSONL to resolve a parent id — O(n) per span, O(n^2) over a session — and the resolved span then became the parent of the next real message or tool_call, threading the conversation tree through diagnostic records.

Trace spans are sidecar telemetry, not conversation nodes, so this PR detaches them from the session tree:

- `core/agent_harness/session/persistence/jsonl_storage.py`
  - `append_trace_span` now writes a detached record: `_append_entry` gained a `resolve_parent` flag, and spans skip the current-leaf lookup entirely. A span append is now a single file-append with no read, independent of session size. An explicit `parent_id` (span-to-span linking) is still honored.
  - `_current_leaf_id` skips `trace_span` records, so the next real message/tool_call — and the flush-time `leaf` — parents to the last real entry even when spans were written in between.
- `core/agent_harness/session/persistence/jsonl_repo.py`
  - `_resolve_entry_id` skips trailing `trace_span` records when resolving the branch tip. Without this, resuming an unflushed session whose last record is a detached span would rebuild an empty branch.
- `tests/interactive_shell/sessions/test_store.py` — five new tests pinning: span `parent_id` stays null and the next message parents past it; a span append performs zero file reads; explicit span parents are preserved; the flush `leaf` parents to the last real entry; `load_session` ignores a trailing span.

No change to the in-memory backend: `append_trace_span` exists only on the JSONL storage and is reached only through the REPL's JSONL trace sink.

### Demo/Screenshot for feature changes and bug fixes - 

Micro-benchmark — append one `trace_span` to a session file of N records, before vs after:

| records | before (ms/append) | after (ms/append) | speedup |
|--------:|-------------------:|------------------:|--------:|
| 1,000   | 2.284              | 0.057             | 40x     |
| 4,000   | 9.197              | 0.061             | 151x    |
| 16,000  | 38.678             | 0.060             | 648x    |
| 64,000  | 166.699            | 0.067             | 2,495x  |



---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
