### PR TITLE
fix(investigation): deliver pipeline errors when a deferred stage import fails in astream_investigation

### DIFF
--- a/tests/tools/investigation/test_streaming_loop_metrics.py
+++ b/tests/tools/investigation/test_streaming_loop_metrics.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from config.constants.investigation import MAX_INVESTIGATION_LOOPS
 from platform.analytics.investigation_loop import (
     begin_investigation_loop_metrics_scope,
     bound_loop_metrics,
@@ -57,6 +58,33 @@ async def test_astream_failure_propagates_wrapped_stream_error(
     assert wrapped.loop_count == 5
     assert wrapped.iteration_cap == 20
     assert isinstance(wrapped.cause, RuntimeError)
+
+
+@pytest.mark.anyio
+async def test_astream_delivers_stream_error_when_deferred_import_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing deferred stage import must still reach the consumer as a wrapped error."""
+    monkeypatch.delattr("core.state.updates.apply_state_updates")
+
+    with pytest.raises(InvestigationPipelineStreamError) as exc_info:
+        async for _event in astream_investigation("alert text"):
+            pass
+
+    wrapped = exc_info.value
+    assert isinstance(wrapped.cause, ImportError)
+    assert wrapped.loop_count == 0
+    assert wrapped.iteration_cap == MAX_INVESTIGATION_LOOPS
+
+
+def test_loop_metrics_for_error_falls_back_when_metrics_import_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools.investigation.capability import _loop_metrics_for_error
+
+    monkeypatch.delattr("platform.analytics.investigation_loop.loop_metrics_from_state")
+
+    assert _loop_metrics_for_error(None) == (0, MAX_INVESTIGATION_LOOPS)
 
 
 def test_main_thread_bridge_binds_metrics_from_wrapped_stream_failure() -> None:

--- a/tools/investigation/capability.py
+++ b/tools/investigation/capability.py
@@ -8,9 +8,10 @@ import contextvars
 import logging
 import queue
 import threading
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Callable, Mapping
 from typing import TYPE_CHECKING, Any, cast
 
+from config.constants.investigation import MAX_INVESTIGATION_LOOPS
 from core.domain.stream import StreamEvent
 from core.state import AgentState
 from platform.observability.errors.boundary import report_and_reraise
@@ -54,6 +55,16 @@ def _capture_exception_once(
 
     capture_exception(exc, context=context, tags=tags)
     _mark_exception_captured(exc)
+
+
+def _loop_metrics_for_error(state: Mapping[str, Any] | None) -> tuple[int, int]:
+    """Return ``(loop_count, iteration_cap)`` for error delivery; never raises."""
+    try:
+        from platform.analytics.investigation_loop import loop_metrics_from_state
+
+        return loop_metrics_from_state(state)
+    except Exception:
+        return 0, MAX_INVESTIGATION_LOOPS
 
 
 def _traced_node(node_name: str, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
@@ -287,17 +298,15 @@ async def astream_investigation(
             )
 
     def _run_pipeline() -> None:
+        state = initial
         try:
             from core.state.updates import apply_state_updates
-            from platform.analytics.investigation_loop import loop_metrics_from_state
             from tools.investigation.reporting.node import generate_report
             from tools.investigation.stages.diagnose import diagnose
             from tools.investigation.stages.gather_evidence import ConnectedInvestigationAgent
             from tools.investigation.stages.intake import extract_alert
             from tools.investigation.stages.plan_evidence import plan_actions
             from tools.investigation.stages.resolve_integrations import resolve_integrations
-
-            state = initial
 
             # --- resolve_integrations ---
             _put(_make_node_event("on_chain_start", "resolve_integrations", {}))
@@ -449,7 +458,7 @@ async def astream_investigation(
             )
 
         except Exception as exc:
-            loop_count, iteration_cap = loop_metrics_from_state(state)
+            loop_count, iteration_cap = _loop_metrics_for_error(state)
             _capture_exception_once(exc, context="pipeline.astream_investigation")
             with contextlib.suppress(RuntimeError):
                 loop.call_soon_threadsafe(


### PR DESCRIPTION
Fixes #3941 

#### Describe the changes you have made in this PR -

`astream_investigation`'s background `_run_pipeline` read loop metrics as the first line of its `except Exception` handler — `loop_count, iteration_cap = loop_metrics_from_state(state)` — but both `state` and the `loop_metrics_from_state` import were bound only inside the `try`, after the block of deferred stage imports. If any of those imports raised, the handler itself raised `UnboundLocalError`, pre-empting both the Sentry capture and the queued `InvestigationPipelineStreamError`; only the `finally` `None` sentinel reached the consumer, which treated it as a clean end. The streaming investigation finished silently with empty results and the real exception was lost — exactly the failure the deferred-import pattern exists to isolate.

Changes in `tools/investigation/capability.py`:

- `state = initial` moved above the `try` — a pure binding that cannot raise, so the handler always has it.
- The `loop_metrics_from_state` import is removed from the `try` body; it was imported there but used only in the `except` handler, which was the fragility.
- New module-level `_loop_metrics_for_error` helper: imports and reads the metrics inside its own `try` and falls back to `(0, MAX_INVESTIGATION_LOOPS)` if anything raises. The handler can no longer fail before `_capture_exception_once` and the error delivery run, regardless of where in the pipeline the failure occurred.

Tests in `tests/tools/investigation/test_streaming_loop_metrics.py` (written first, TDD):

- `test_astream_delivers_stream_error_when_deferred_import_fails` — breaks the first deferred import (the widest unbound window: neither `state` nor the metrics import bound) and asserts the consumer receives a wrapped `InvestigationPipelineStreamError` with the `ImportError` cause and fallback metrics. Red on the pre-fix code with the exact defect signature: `DID NOT RAISE` for the consumer while the thread died on `UnboundLocalError: cannot access local variable 'loop_metrics_from_state'`.
- `test_loop_metrics_for_error_falls_back_when_metrics_import_fails` — pins that the handler's metrics read never raises even when `platform.analytics.investigation_loop` itself is broken.

The pre-existing test `test_astream_failure_propagates_wrapped_stream_error` (mid-pipeline failure with real state metrics) stays green, pinning that the fallback path did not change the normal error flow.

Reviewer note: while verifying, an unrelated pre-existing test-isolation defect surfaced — `run_investigation` binds loop metrics into a ContextVar without scope cleanup, so `tests/analytics/test_investigation_loop.py::test_reset_investigation_loop_metrics_restores_prior_binding` fails if run after `tests/tools/investigation/test_runners_agent_class.py`. Default suite order never triggers it and it is untouched by this PR; it deserves its own issue.


### Demo/Screenshot for feature changes and bug fixes - 

Before (pre-fix, new test run): the consumer completes with no events and no error while the thread swallows the real failure —

    E   Failed: DID NOT RAISE <class 'tools.investigation.streaming.InvestigationPipelineStreamError'>
      ImportError: cannot import name 'apply_state_updates' from 'core.state.updates'
      UnboundLocalError: cannot access local variable 'loop_metrics_from_state' where it is not associated with a value

After: the same scenario delivers the wrapped error with fallback metrics —

    tests/tools/investigation/test_streaming_loop_metrics.py ....    [100%]
    4 passed

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
