### PR TITLE
fix(interactive-shell): show usage hint instead of CLI error for bare group slash commands (#4157)

### DIFF
--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -25,8 +25,14 @@ from surfaces.interactive_shell.runtime.subprocess_runner import (
     build_opensre_cli_argv,
     start_background_cli_task,
 )
-from surfaces.interactive_shell.ui import DIM, ERROR, print_command_output
-from surfaces.interactive_shell.ui.components.choice_menu import prepare_repl_output_line
+from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT, print_command_output
+from surfaces.interactive_shell.ui.components.choice_menu import (
+    CRUMB_SEP,
+    prepare_repl_output_line,
+    repl_choose_one,
+    repl_section_break,
+    repl_tty_interactive,
+)
 from surfaces.interactive_shell.utils.telemetry.turn_outcome import format_wizard_cli_outcome
 
 _UPDATE_SUBPROCESS_TIMEOUT_SECONDS = 300
@@ -333,12 +339,116 @@ def _cmd_tests(session: Session, console: Console, args: list[str]) -> bool:
     return run_cli_command(console, ["tests", *args], capture_output=True)
 
 
-def _cmd_guardrails(session: Session, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+# ---------------------------------------------------------------------------
+# Usage hint tuples (shared between bare-invocation guards and COMMANDS catalog)
+# ---------------------------------------------------------------------------
+_GUARDRAILS_USAGE = (
+    "/guardrails audit",
+    "/guardrails init",
+    "/guardrails rules",
+    "/guardrails test",
+)
+_CRON_USAGE = (
+    "/cron list",
+    "/cron add",
+    "/cron remove <id>",
+    "/cron run <id>",
+    "/cron logs <id>",
+)
+_SENTRY_USAGE = (
+    "/sentry digest run",
+    "/sentry digest schedule list",
+    "/sentry digest schedule add",
+    "/sentry digest schedule run <id>",
+    "/sentry digest schedule remove <id>",
+    "/sentry uptime check",
+    "/sentry uptime watch list",
+    "/sentry uptime watch add",
+    "/sentry uptime watch run <id>",
+    "/sentry uptime watch remove <id>",
+)
+_MISSES_USAGE = (
+    "/misses list",
+    "/misses stats",
+    "/misses export --out <dir>",
+    "/misses convert <miss_id>",
+)
+_DEBUG_USAGE = ("/debug sentry",)
+_WATCHDOG_USAGE = ("/watchdog --pid <pid> [--max-rss <size>] [--max-cpu <percent>]",)
+
+
+def _print_bare_group_usage(
+    session: Session,
+    console: Console,
+    name: str,
+    usage: tuple[str, ...],
+    *,
+    needs: str = "a subcommand",
+) -> bool:
+    """Show a usage hint instead of shelling out to a bare Click group.
+
+    ``guardrails``/``cron``/``sentry``/``misses``/``debug`` are Click groups
+    with no default subcommand, and ``watchdog`` always requires ``--pid``, so
+    delegating a bare invocation to the CLI hits a Click usage/validation error
+    (non-zero exit) and surfaces as a confusing "CLI command exited with
+    non-zero code N" message.  Print the same usage hints ``/help`` shows
+    instead, and mark the turn as failed so slash analytics are accurate.
+    """
+    console.print(f"[{ERROR}]{name} needs {needs}.[/] Try one of:")
+    for line in usage:
+        console.print(f"  [bold]{line}[/bold]")
+    session.mark_latest(ok=False, kind="slash")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# /guardrails
+# ---------------------------------------------------------------------------
+
+
+def _interactive_guardrails_menu(console: Console) -> bool:
+    root = "/guardrails"
+    while True:
+        sub = repl_choose_one(
+            title="guardrails",
+            breadcrumb=root,
+            choices=[
+                ("audit", "audit — recent guardrail audit log entries"),
+                ("init", "init — create a starter guardrails config"),
+                ("rules", "rules — list configured guardrail rules"),
+                ("test", "test — check a text string against the rules"),
+                ("done", "done"),
+            ],
+        )
+        if sub is None or sub == "done":
+            return True
+        if sub == "test":
+            console.print()
+            text = console.input(f"[{HIGHLIGHT}]text to test> [/]").strip()
+            if not text:
+                repl_section_break(console)
+                continue
+            run_cli_command(console, ["guardrails", "test", text], capture_output=True)
+        else:
+            run_cli_command(console, ["guardrails", sub], capture_output=True)
+        repl_section_break(console)
+
+
+def _cmd_guardrails(session: Session, console: Console, args: list[str]) -> bool:
     # ``opensre guardrails`` and its subcommands are all non-interactive printers
     # (init/test/audit/rules just ``click.echo``). Capture so the output — and
     # Click's usage block when no subcommand is given — reaches the REPL buffer
     # instead of bypassing ``console.print`` via the child's inherited stdout FD.
+    if not args:
+        if repl_tty_interactive():
+            return _interactive_guardrails_menu(console)
+        return _print_bare_group_usage(session, console, "/guardrails", _GUARDRAILS_USAGE)
     return run_cli_command(console, ["guardrails", *args], capture_output=True)
+
+
+# ---------------------------------------------------------------------------
+# /update  /uninstall  /config  /messaging  /hermes
+# ---------------------------------------------------------------------------
 
 
 def _cmd_update(session: Session, console: Console, args: list[str]) -> bool:  # noqa: ARG001
@@ -370,25 +480,169 @@ def _cmd_hermes(session: Session, console: Console, args: list[str]) -> bool:  #
     return run_cli_command(console, ["hermes", *args])
 
 
-def _cmd_cron(session: Session, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+# ---------------------------------------------------------------------------
+# /cron
+# ---------------------------------------------------------------------------
+
+
+def _cron_task_choices() -> list[tuple[str, str]]:
+    from platform.scheduler.store import list_tasks
+
+    return [
+        (task.display_id(), f"{task.display_id()}  {task.kind.value} · {task.cron}")
+        for task in list_tasks()
+    ]
+
+
+def _interactive_cron_menu(console: Console) -> bool:
+    root = "/cron"
+    while True:
+        sub = repl_choose_one(
+            title="cron",
+            breadcrumb=root,
+            choices=[
+                ("list", "list — all scheduled delivery tasks"),
+                ("add", "add — schedule a new task (needs several options)"),
+                ("remove", "remove — delete a scheduled task"),
+                ("run", "run — run a scheduled task now"),
+                ("logs", "logs — execution history for a task"),
+                ("done", "done"),
+            ],
+        )
+        if sub is None or sub == "done":
+            return True
+        if sub == "list":
+            run_cli_command(console, ["cron", "list"])
+        elif sub == "add":
+            # ``cron add`` has several required options (--kind, --cron,
+            # --provider, --chat-id) with no sane picker defaults — show its
+            # own --help instead of guessing at values.
+            run_cli_command(console, ["cron", "add", "--help"], capture_output=True)
+        elif sub in ("remove", "run", "logs"):
+            choices = _cron_task_choices()
+            if not choices:
+                console.print(f"[{DIM}]no scheduled tasks to {sub}.[/]")
+            else:
+                task_id = repl_choose_one(
+                    title=f"cron {sub}",
+                    breadcrumb=f"{root}{CRUMB_SEP}{sub}",
+                    choices=choices,
+                )
+                if task_id:
+                    run_cli_command(console, ["cron", sub, task_id])
+        repl_section_break(console)
+
+
+def _cmd_cron(session: Session, console: Console, args: list[str]) -> bool:
+    if not args:
+        if repl_tty_interactive():
+            return _interactive_cron_menu(console)
+        return _print_bare_group_usage(session, console, "/cron", _CRON_USAGE)
     return run_cli_command(console, ["cron", *args])
 
 
-def _cmd_sentry(session: Session, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+# ---------------------------------------------------------------------------
+# /sentry
+# ---------------------------------------------------------------------------
+
+
+def _cmd_sentry(session: Session, console: Console, args: list[str]) -> bool:
+    if not args:
+        return _print_bare_group_usage(session, console, "/sentry", _SENTRY_USAGE)
     return run_cli_command(console, ["sentry", *args], capture_output=True)
 
 
-def _cmd_watchdog(session: Session, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+# ---------------------------------------------------------------------------
+# /watchdog
+# ---------------------------------------------------------------------------
+
+
+def _cmd_watchdog(session: Session, console: Console, args: list[str]) -> bool:
+    if not args:
+        return _print_bare_group_usage(
+            session, console, "/watchdog", _WATCHDOG_USAGE, needs="--pid"
+        )
     return run_cli_command(console, ["watchdog", *args])
 
 
-def _cmd_debug(session: Session, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+# ---------------------------------------------------------------------------
+# /debug
+# ---------------------------------------------------------------------------
+
+
+def _cmd_debug(session: Session, console: Console, args: list[str]) -> bool:
+    # ``debug`` currently has exactly one subcommand, so there is nothing to
+    # pick between — run it directly on a TTY rather than showing a one-item menu.
+    if not args:
+        if repl_tty_interactive():
+            return run_cli_command(console, ["debug", "sentry"])
+        return _print_bare_group_usage(session, console, "/debug", _DEBUG_USAGE)
     return run_cli_command(console, ["debug", *args])
 
 
-def _cmd_misses(session: Session, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+# ---------------------------------------------------------------------------
+# /misses
+# ---------------------------------------------------------------------------
+
+
+def _miss_id_choices() -> list[tuple[str, str]]:
+    from core.domain.feedback import load_misses
+
+    return [
+        (
+            row["miss_id"],
+            f"{row['miss_id']}  {row.get('alert_name') or '<unknown>'} "
+            f"· {row.get('taxonomy') or 'unknown'}",
+        )
+        for row in load_misses()
+        if row.get("miss_id")
+    ]
+
+
+def _interactive_misses_menu(console: Console) -> bool:
+    root = "/misses"
+    while True:
+        sub = repl_choose_one(
+            title="misses",
+            breadcrumb=root,
+            choices=[
+                ("list", "list — recent misses"),
+                ("stats", "stats — taxonomy breakdown and recurrence"),
+                ("export", "export — top misses to benchmark scenarios (needs --out)"),
+                ("convert", "convert — a single miss to a benchmark scenario"),
+                ("done", "done"),
+            ],
+        )
+        if sub is None or sub == "done":
+            return True
+        if sub in ("list", "stats"):
+            run_cli_command(console, ["misses", sub], capture_output=True)
+        elif sub == "export":
+            # ``--out <dir>`` is required with no sane picker default — show
+            # its own --help instead of guessing at a directory.
+            run_cli_command(console, ["misses", "export", "--help"], capture_output=True)
+        elif sub == "convert":
+            choices = _miss_id_choices()
+            if not choices:
+                console.print(f"[{DIM}]no misses recorded to convert.[/]")
+            else:
+                miss_id = repl_choose_one(
+                    title="miss to convert",
+                    breadcrumb=f"{root}{CRUMB_SEP}convert",
+                    choices=choices,
+                )
+                if miss_id:
+                    run_cli_command(console, ["misses", "convert", miss_id], capture_output=True)
+        repl_section_break(console)
+
+
+def _cmd_misses(session: Session, console: Console, args: list[str]) -> bool:
     # Non-interactive printers only (list/stats/export/convert) — capture so the
     # output reaches the REPL buffer instead of the child's inherited stdout.
+    if not args:
+        if repl_tty_interactive():
+            return _interactive_misses_menu(console)
+        return _print_bare_group_usage(session, console, "/misses", _MISSES_USAGE)
     return run_cli_command(console, ["misses", *args], capture_output=True)
 
 
@@ -434,12 +688,7 @@ COMMANDS: list[SlashCommand] = [
         "/guardrails",
         "Manage sensitive information guardrail rules.",
         _cmd_guardrails,
-        usage=(
-            "/guardrails audit",
-            "/guardrails init",
-            "/guardrails rules",
-            "/guardrails test",
-        ),
+        usage=_GUARDRAILS_USAGE,
     ),
     SlashCommand(
         "/update",
@@ -478,46 +727,31 @@ COMMANDS: list[SlashCommand] = [
         "/cron",
         "Manage cron-driven scheduled deliveries.",
         _cmd_cron,
-        usage=("/cron list", "/cron add", "/cron remove <id>", "/cron run <id>", "/cron logs <id>"),
+        usage=_CRON_USAGE,
     ),
     SlashCommand(
         "/sentry",
         "Schedule and run automated Sentry morning digests or uptime watches.",
         _cmd_sentry,
-        usage=(
-            "/sentry digest run",
-            "/sentry digest schedule list",
-            "/sentry digest schedule add",
-            "/sentry digest schedule run <id>",
-            "/sentry digest schedule remove <id>",
-            "/sentry uptime check",
-            "/sentry uptime watch list",
-            "/sentry uptime watch add",
-            "/sentry uptime watch run <id>",
-            "/sentry uptime watch remove <id>",
-        ),
+        usage=_SENTRY_USAGE,
     ),
     SlashCommand(
         "/watchdog",
         "Monitor one process and send threshold alarms.",
         _cmd_watchdog,
-        usage=("/watchdog --pid <pid> [--max-rss <size>] [--max-cpu <percent>]",),
+        usage=_WATCHDOG_USAGE,
         examples=("/watchdog --pid 123 --max-rss 1G",),
     ),
     SlashCommand(
         "/debug",
         "run targeted runtime diagnostics",
         _cmd_debug,
+        usage=_DEBUG_USAGE,
     ),
     SlashCommand(
         "/misses",
         "Triage investigation misses and export them as benchmark scenarios.",
         _cmd_misses,
-        usage=(
-            "/misses list",
-            "/misses stats",
-            "/misses export --out <dir>",
-            "/misses convert <miss_id>",
-        ),
+        usage=_MISSES_USAGE,
     ),
 ]

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -2859,16 +2859,20 @@ class TestCliDelegatedCommands:
 
     @pytest.mark.parametrize(
         "slash_input",
-        ["/guardrails", "/guardrails rules", "/guardrails --help"],
+        ["/guardrails rules", "/guardrails --help"],
     )
     def test_slash_guardrails_opts_into_output_capture(
         self, monkeypatch: object, slash_input: str
     ) -> None:
-        """Bare ``/guardrails`` (no subcommand), known subcommands, and flag-style
-        invocations must all call ``run_cli_command`` with
-        ``capture_output=True``. Without this, Click's usage block (printed for
-        the no-subcommand case) and subcommand output bypass ``console.print``
-        and never reach the REPL buffer — see issue #2388.
+        """Known subcommands and flag-style invocations of ``/guardrails`` must
+        call ``run_cli_command`` with ``capture_output=True`` so their output
+        reaches the REPL buffer instead of bypassing ``console.print`` — see
+        issue #2388.
+
+        Bare ``/guardrails`` (no subcommand) is handled by the bare-invocation
+        guard in ``_cmd_guardrails`` (issue #4157) and does NOT reach
+        ``run_cli_command``.  See :class:`TestBareInvocationGuards` for
+        coverage of that path.
         """
         from surfaces.interactive_shell.command_registry import cli_parity as m
 
@@ -3033,3 +3037,299 @@ class TestCliDelegatedCommands:
         assert session.history[-1]["ok"] is False
         assert delegated == []
         assert started == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #4157 — bare CLI slash commands must not produce non-zero exit errors
+# ---------------------------------------------------------------------------
+
+
+class TestBareInvocationGuards:
+    """Bare invocations of Click-backed group commands must never reach the CLI.
+
+    /guardrails, /cron, /sentry, /watchdog, /misses, and /debug are Click
+    groups (or require mandatory flags) that exit non-zero when invoked
+    without arguments.  The REPL must intercept the bare call and show a
+    usage hint (headless) or an interactive picker (TTY) instead of
+    delegating to the subprocess.
+    """
+
+    @staticmethod
+    def _no_run(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Patch subprocess.run so any delegation raises — proves we never call it."""
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        def _boom(*_args: object, **_kwargs: object) -> object:
+            raise AssertionError("subprocess.run must not be called for bare invocation")
+
+        monkeypatch.setattr(m.subprocess, "run", _boom)
+
+    @staticmethod
+    def _stub_run(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+        """Replace run_cli_command with a no-op that records args."""
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        delegated: list[list[str]] = []
+        monkeypatch.setattr(
+            m,
+            "run_cli_command",
+            lambda _console, args, **_kwargs: (delegated.append(args), True)[1],
+        )
+        return delegated
+
+    # /guardrails ---------------------------------------------------------
+
+    def test_bare_guardrails_shows_usage_in_headless(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        self._no_run(monkeypatch)
+        monkeypatch.setattr(m, "repl_tty_interactive", lambda: False)
+
+        session = Session()
+        console, buf = _capture()
+        result = dispatch_slash("/guardrails", session, console)
+
+        assert result is True
+        output = buf.getvalue()
+        assert "/guardrails audit" in output
+        assert "non-zero" not in output
+        assert session.history[-1]["ok"] is False
+
+    def test_guardrails_with_subcommand_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        delegated = self._stub_run(monkeypatch)
+
+        session = Session()
+        console, _ = _capture()
+        dispatch_slash("/guardrails audit", session, console)
+
+        assert delegated == [["guardrails", "audit"]]
+
+    def test_bare_guardrails_tty_uses_interactive_picker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        self._no_run(monkeypatch)
+        monkeypatch.setattr(m, "repl_tty_interactive", lambda: True)
+        picker_called: list[bool] = []
+        monkeypatch.setattr(
+            m,
+            "_interactive_guardrails_menu",
+            lambda _console: picker_called.append(True) or True,
+        )
+
+        result = dispatch_slash("/guardrails", Session(), Console())
+
+        assert result is True
+        assert picker_called == [True]
+
+    # /cron ---------------------------------------------------------------
+
+    def test_bare_cron_shows_usage_in_headless(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        self._no_run(monkeypatch)
+        monkeypatch.setattr(m, "repl_tty_interactive", lambda: False)
+
+        session = Session()
+        console, buf = _capture()
+        result = dispatch_slash("/cron", session, console)
+
+        assert result is True
+        output = buf.getvalue()
+        assert "/cron list" in output
+        assert "non-zero" not in output
+        assert session.history[-1]["ok"] is False
+
+    def test_cron_with_subcommand_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        delegated = self._stub_run(monkeypatch)
+
+        session = Session()
+        console, _ = _capture()
+        dispatch_slash("/cron list", session, console)
+
+        assert delegated == [["cron", "list"]]
+
+    def test_bare_cron_tty_uses_interactive_picker(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        self._no_run(monkeypatch)
+        monkeypatch.setattr(m, "repl_tty_interactive", lambda: True)
+        picker_called: list[bool] = []
+        monkeypatch.setattr(
+            m,
+            "_interactive_cron_menu",
+            lambda _console: picker_called.append(True) or True,
+        )
+
+        result = dispatch_slash("/cron", Session(), Console())
+
+        assert result is True
+        assert picker_called == [True]
+
+    # /sentry -------------------------------------------------------------
+
+    def test_bare_sentry_shows_usage_in_headless(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        self._no_run(monkeypatch)
+        monkeypatch.setattr(m, "repl_tty_interactive", lambda: False)
+
+        session = Session()
+        console, buf = _capture()
+        result = dispatch_slash("/sentry", session, console)
+
+        assert result is True
+        output = buf.getvalue()
+        assert "/sentry digest run" in output
+        assert "non-zero" not in output
+        assert session.history[-1]["ok"] is False
+
+    def test_sentry_with_subcommand_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        delegated = self._stub_run(monkeypatch)
+
+        session = Session()
+        console, _ = _capture()
+        dispatch_slash("/sentry digest run", session, console)
+
+        assert delegated == [["sentry", "digest", "run"]]
+
+    # /watchdog -----------------------------------------------------------
+
+    def test_bare_watchdog_shows_usage_in_headless(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        self._no_run(monkeypatch)
+        monkeypatch.setattr(m, "repl_tty_interactive", lambda: False)
+
+        session = Session()
+        console, buf = _capture()
+        result = dispatch_slash("/watchdog", session, console)
+
+        assert result is True
+        output = buf.getvalue()
+        assert "--pid" in output
+        assert "non-zero" not in output
+        assert session.history[-1]["ok"] is False
+
+    def test_watchdog_with_flags_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        delegated = self._stub_run(monkeypatch)
+
+        session = Session()
+        console, _ = _capture()
+        dispatch_slash("/watchdog --pid 123 --max-rss 1G", session, console)
+
+        assert delegated == [["watchdog", "--pid", "123", "--max-rss", "1G"]]
+
+    # /debug --------------------------------------------------------------
+
+    def test_bare_debug_shows_usage_in_headless(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        self._no_run(monkeypatch)
+        monkeypatch.setattr(m, "repl_tty_interactive", lambda: False)
+
+        session = Session()
+        console, buf = _capture()
+        result = dispatch_slash("/debug", session, console)
+
+        assert result is True
+        output = buf.getvalue()
+        assert "/debug sentry" in output
+        assert "non-zero" not in output
+        assert session.history[-1]["ok"] is False
+
+    def test_bare_debug_tty_runs_only_subcommand_directly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Bare /debug on TTY runs 'debug sentry' directly (single-subcommand shortcut)."""
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        monkeypatch.setattr(m, "repl_tty_interactive", lambda: True)
+        delegated = self._stub_run(monkeypatch)
+
+        result = dispatch_slash("/debug", Session(), Console())
+
+        assert result is True
+        assert delegated == [["debug", "sentry"]]
+
+    def test_debug_with_subcommand_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        delegated = self._stub_run(monkeypatch)
+
+        session = Session()
+        console, _ = _capture()
+        dispatch_slash("/debug sentry", session, console)
+
+        assert delegated == [["debug", "sentry"]]
+
+    # /misses -------------------------------------------------------------
+
+    def test_bare_misses_shows_usage_in_headless(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        self._no_run(monkeypatch)
+        monkeypatch.setattr(m, "repl_tty_interactive", lambda: False)
+
+        session = Session()
+        console, buf = _capture()
+        result = dispatch_slash("/misses", session, console)
+
+        assert result is True
+        output = buf.getvalue()
+        assert "/misses list" in output
+        assert "non-zero" not in output
+        assert session.history[-1]["ok"] is False
+
+    def test_misses_with_subcommand_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        delegated = self._stub_run(monkeypatch)
+
+        session = Session()
+        console, _ = _capture()
+        dispatch_slash("/misses list", session, console)
+
+        assert delegated == [["misses", "list"]]
+
+    def test_bare_misses_tty_uses_interactive_picker(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        self._no_run(monkeypatch)
+        monkeypatch.setattr(m, "repl_tty_interactive", lambda: True)
+        picker_called: list[bool] = []
+        monkeypatch.setattr(
+            m,
+            "_interactive_misses_menu",
+            lambda _console: picker_called.append(True) or True,
+        )
+
+        result = dispatch_slash("/misses", Session(), Console())
+
+        assert result is True
+        assert picker_called == [True]
+
+    # Parametric regression -----------------------------------------------
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "/guardrails",
+            "/cron",
+            "/sentry",
+            "/watchdog",
+            "/misses",
+            "/debug",
+        ],
+    )
+    def test_bare_group_command_never_exits_shell(
+        self, monkeypatch: pytest.MonkeyPatch, command: str
+    ) -> None:
+        """Bare group commands must never return False and exit the shell (#4157)."""
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        monkeypatch.setattr(m, "repl_tty_interactive", lambda: False)
+        self._no_run(monkeypatch)
+
+        session = Session()
+        console, _ = _capture()
+        result = dispatch_slash(command, session, console)
+
+        assert result is True, f"{command!r} bare invocation returned False (would exit shell)"


### PR DESCRIPTION
## Summary

Fixes #4157 — `/guardrails`, `/cron`, `/sentry`, `/watchdog`, `/misses`, and `/debug` are Click groups (or require mandatory flags) that exit non-zero when invoked without arguments. Selecting them bare from `/help` or typing them without a subcommand produced a confusing `CLI command exited with non-zero code N` message instead of helpful guidance.

## Changes

- **`_print_bare_group_usage()`** helper: intercepts bare invocations, prints the same usage hints `/help` shows, and marks the turn as `ok=False` (matching the existing `/tests` guard).
- **Usage tuples** (`_GUARDRAILS_USAGE`, `_CRON_USAGE`, `_SENTRY_USAGE`, `_MISSES_USAGE`, `_DEBUG_USAGE`, `_WATCHDOG_USAGE`) shared between the guards and the `COMMANDS` catalog — no duplication.
- **Bare invocation guards** for all six commands:
  - Non-TTY/headless: prints usage hint, no subprocess spawned.
  - Interactive TTY: launches an arrow-key picker (`_interactive_guardrails_menu`, `_interactive_cron_menu`, `_interactive_misses_menu`) or runs the single subcommand directly (`/debug sentry`).
- **`TestBareInvocationGuards`** (22 new tests): headless usage-hint output, no `subprocess.run` call on bare invocation, with-args delegation still works, and TTY picker path is invoked for each command.
- **Updated** `test_slash_guardrails_opts_into_output_capture`: bare `/guardrails` is no longer expected to reach `run_cli_command`; the two remaining parameterized cases (with a subcommand or a flag) still verify `capture_output=True`.

## Pre-PR Checklist

- [x] Lint passes (`ruff check`)
- [x] Format passes (`ruff format --check`)
- [x] Typecheck passes (`mypy`)
- [x] All 22 new tests pass; 174 passing tests with no regressions introduced
- [x] Pre-existing failures in `TestInvestigateFileCommand` and `TestSaveCommand` are unrelated to this change (confirmed by running on main before applying the fix)