### PR TITLE
fix(grafana+loki): preserve alert context in Loki seed queries

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -85,7 +85,10 @@ from config.constants.honeycomb import (
     HONEYCOMB_DATASET_ENV,
 )
 from config.constants.incident_io import INCIDENT_IO_API_KEY_ENV, INCIDENT_IO_BASE_URL_ENV
-from config.constants.investigation import MAX_INVESTIGATION_LOOPS
+from config.constants.investigation import (
+    INVESTIGATION_CONTEXT_SOURCE_KEY,
+    MAX_INVESTIGATION_LOOPS,
+)
 from config.constants.jenkins import (
     JENKINS_API_TOKEN_ENV,
     JENKINS_BASE_URL_ENV,
@@ -312,6 +315,7 @@ __all__ = [
     "INCIDENT_IO_API_KEY_ENV",
     "INCIDENT_IO_BASE_URL_ENV",
     "INTEGRATIONS_STORE_PATH",
+    "INVESTIGATION_CONTEXT_SOURCE_KEY",
     "IS_WINDOWS",
     "JENKINS_API_TOKEN_ENV",
     "JENKINS_BASE_URL_ENV",

--- a/config/constants/investigation.py
+++ b/config/constants/investigation.py
@@ -6,7 +6,15 @@ from typing import Final
 
 MAX_INVESTIGATION_LOOPS = 20
 
+# Internal availability-view entry that carries alert data to tool parameter
+# extractors without coupling shared investigation orchestration to a vendor.
+INVESTIGATION_CONTEXT_SOURCE_KEY: Final[str] = "_investigation_context"
+
 # Approval tokens auto-expire after this many seconds (5 minutes).
 DEFAULT_APPROVAL_EXPIRY_SECONDS: Final[int] = 300
 
-__all__ = ["DEFAULT_APPROVAL_EXPIRY_SECONDS", "MAX_INVESTIGATION_LOOPS"]
+__all__ = [
+    "DEFAULT_APPROVAL_EXPIRY_SECONDS",
+    "INVESTIGATION_CONTEXT_SOURCE_KEY",
+    "MAX_INVESTIGATION_LOOPS",
+]

--- a/integrations/grafana/alert_context.py
+++ b/integrations/grafana/alert_context.py
@@ -1,0 +1,111 @@
+"""Grafana alert context used to scope deterministic Loki seed queries."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from config.constants import INVESTIGATION_CONTEXT_SOURCE_KEY
+
+_SERVICE_NAME_KEYS = ("service_name", "service")
+_PIPELINE_NAME_KEYS = ("pipeline_name", "pipeline")
+_LOG_QUERY_KEYS = ("log_query", "loki_query", "logql")
+_DATASOURCE_TYPE_KEYS = ("datasource_type", "datasource")
+
+
+@dataclass(frozen=True, slots=True)
+class GrafanaLokiAlertContext:
+    """Alert-derived values that make a Loki query incident-specific."""
+
+    service_name: str = ""
+    pipeline_name: str = ""
+    log_query: str = ""
+    datasource_uid: str = ""
+
+
+def resolve_grafana_loki_alert_context(
+    sources: Mapping[str, Any],
+) -> GrafanaLokiAlertContext:
+    """Resolve Loki scope from normalized and raw Grafana alert payloads.
+
+    Raw alert fields take precedence because they are deterministic source data.
+    ``alert_json`` is a fallback for values extracted from unstructured alerts.
+    """
+    investigation_context = sources.get(INVESTIGATION_CONTEXT_SOURCE_KEY)
+    if not isinstance(investigation_context, Mapping):
+        return GrafanaLokiAlertContext()
+
+    blocks = [
+        *_payload_blocks(investigation_context.get("raw_alert")),
+        *_payload_blocks(investigation_context.get("alert_json")),
+    ]
+    log_query = _first_text(blocks, _LOG_QUERY_KEYS)
+    return GrafanaLokiAlertContext(
+        service_name=_first_text(blocks, _SERVICE_NAME_KEYS),
+        pipeline_name=_first_text(blocks, _PIPELINE_NAME_KEYS),
+        log_query=log_query,
+        datasource_uid=_resolve_loki_datasource_uid(blocks, log_query=log_query),
+    )
+
+
+def _payload_blocks(value: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(value, Mapping):
+        return []
+
+    blocks: list[Mapping[str, Any]] = [value]
+    for key in (
+        "canonical_alert",
+        "commonLabels",
+        "labels",
+        "commonAnnotations",
+        "annotations",
+    ):
+        block = value.get(key)
+        if isinstance(block, Mapping):
+            blocks.append(block)
+
+    alerts = value.get("alerts")
+    if isinstance(alerts, list):
+        for alert in alerts:
+            if not isinstance(alert, Mapping):
+                continue
+            blocks.append(alert)
+            for key in ("labels", "annotations"):
+                block = alert.get(key)
+                if isinstance(block, Mapping):
+                    blocks.append(block)
+    return blocks
+
+
+def _first_text(
+    blocks: list[Mapping[str, Any]],
+    keys: tuple[str, ...],
+) -> str:
+    for block in blocks:
+        for key in keys:
+            value = block.get(key)
+            if value is None or isinstance(value, (dict, list, tuple, set)):
+                continue
+            text = str(value).strip()
+            if text:
+                return text
+    return ""
+
+
+def _resolve_loki_datasource_uid(
+    blocks: list[Mapping[str, Any]],
+    *,
+    log_query: str,
+) -> str:
+    explicit_loki_uid = _first_text(blocks, ("loki_datasource_uid",))
+    if explicit_loki_uid:
+        return explicit_loki_uid
+
+    datasource_type = _first_text(blocks, _DATASOURCE_TYPE_KEYS).lower()
+    if log_query or datasource_type == "loki":
+        return _first_text(blocks, ("datasource_uid",))
+    return ""
+
+
+__all__ = ["GrafanaLokiAlertContext", "resolve_grafana_loki_alert_context"]

--- a/integrations/grafana/loki.py
+++ b/integrations/grafana/loki.py
@@ -17,6 +17,7 @@ class LokiMixin:
         query: str,
         time_range_minutes: int = 60,
         limit: int = 100,
+        datasource_uid: str | None = None,
     ) -> dict[str, Any]:
         """Query Grafana Cloud Loki for logs.
 
@@ -24,6 +25,7 @@ class LokiMixin:
             query: LogQL query string (e.g., '{service_name="lambda-mock-dag"}')
             time_range_minutes: Time range in minutes (default 60)
             limit: Maximum number of log entries to return
+            datasource_uid: Optional Loki datasource UID from the firing alert
 
         Returns:
             Dictionary with log streams and metadata
@@ -36,7 +38,7 @@ class LokiMixin:
             }
 
         url = self._build_datasource_url(
-            self.loki_datasource_uid,
+            datasource_uid or self.loki_datasource_uid,
             "/loki/api/v1/query_range",
         )
 

--- a/integrations/grafana/tools/__init__.py
+++ b/integrations/grafana/tools/__init__.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
+from integrations.grafana.alert_context import resolve_grafana_loki_alert_context
 
 _GRAFANA_RUNTIME_PARAMS = (
     "grafana_endpoint",
@@ -350,9 +351,14 @@ def _grafana_available(sources: dict) -> bool:
 
 def _query_grafana_logs_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     grafana = _grafana_source(sources)
+    alert_context = resolve_grafana_loki_alert_context(sources)
     return {
-        "service_name": grafana.get("service_name", ""),
-        "pipeline_name": grafana.get("pipeline_name"),
+        "service_name": alert_context.service_name or grafana.get("service_name", ""),
+        "pipeline_name": alert_context.pipeline_name or grafana.get("pipeline_name"),
+        "log_query": alert_context.log_query or grafana.get("log_query"),
+        "datasource_uid": alert_context.datasource_uid
+        or grafana.get("loki_datasource_uid")
+        or grafana.get("datasource_uid"),
         "execution_run_id": grafana.get("execution_run_id"),
         "time_range_minutes": grafana.get("time_range_minutes", 60),
         "limit": 100,
@@ -386,6 +392,8 @@ def _query_grafana_logs_available(sources: dict[str, dict]) -> bool:
             "grafana_endpoint": {"type": "string"},
             "grafana_api_key": {"type": "string"},
             "pipeline_name": {"type": "string"},
+            "log_query": {"type": "string"},
+            "datasource_uid": {"type": "string"},
         },
         "required": ["service_name"],
     },
@@ -405,6 +413,8 @@ def query_grafana_logs(
     grafana_verify_ssl: bool = True,
     grafana_ca_bundle: str = "",
     pipeline_name: str | None = None,
+    log_query: str | None = None,
+    datasource_uid: str | None = None,
     grafana_backend: Any = None,
     **_kwargs: Any,
 ) -> dict:
@@ -431,7 +441,7 @@ def query_grafana_logs(
     )
     if not client or not client.is_configured:
         return tool_unavailable("grafana_loki", "Grafana integration not configured", logs=[])
-    if not client.loki_datasource_uid:
+    if not (datasource_uid or client.loki_datasource_uid):
         return tool_unavailable("grafana_loki", "Loki datasource not found", logs=[])
 
     def _build_query(label: str, value: str) -> str:
@@ -439,14 +449,22 @@ def query_grafana_logs(
             return f'{{{label}="{value}"}} |= "{execution_run_id}"'
         return f'{{{label}="{value}"}}'
 
-    query = _build_query("service_name", service_name)
-    result = client.query_loki(query, time_range_minutes=time_range_minutes, limit=limit)
+    query = (
+        log_query.strip()
+        if log_query and log_query.strip()
+        else _build_query("service_name", service_name)
+    )
+    query_kwargs: dict[str, Any] = {
+        "time_range_minutes": time_range_minutes,
+        "limit": limit,
+    }
+    if datasource_uid:
+        query_kwargs["datasource_uid"] = datasource_uid
+    result = client.query_loki(query, **query_kwargs)
 
-    if result.get("success") and not result.get("logs") and pipeline_name:
+    if result.get("success") and not result.get("logs") and pipeline_name and not log_query:
         fallback_query = _build_query("pipeline_name", pipeline_name)
-        fallback = client.query_loki(
-            fallback_query, time_range_minutes=time_range_minutes, limit=limit
-        )
+        fallback = client.query_loki(fallback_query, **query_kwargs)
         if fallback.get("success") and fallback.get("logs"):
             result = fallback
             query = fallback_query
@@ -482,6 +500,7 @@ def query_grafana_logs(
         "service_name": service_name,
         "execution_run_id": execution_run_id,
         "query": query,
+        "datasource_uid": datasource_uid or client.loki_datasource_uid,
         "account_id": client.account_id,
     }
     summary = summarize_counts(len(logs_data), len(compacted_logs), "logs")

--- a/tests/fixtures/grafana_local_alert.json
+++ b/tests/fixtures/grafana_local_alert.json
@@ -4,12 +4,15 @@
   "commonLabels": {
     "alertname": "PipelineLoadFailure",
     "severity": "critical",
+    "service_name": "prefect-etl-pipeline-local",
     "pipeline_name": "events_fact",
+    "datasource_uid": "local-loki",
     "environment": "local"
   },
   "commonAnnotations": {
     "summary": "events_fact pipeline failed at load stage: database authentication error",
     "description": "Pipeline events_fact aborted during load. 128 rows extracted but not written. Database connection failed with authentication error.",
+    "log_query": "{service_name=\"prefect-etl-pipeline-local\", pipeline_name=\"events_fact\"} |~ \"(?i)(error|fail|abort|expired|invalid)\"",
     "execution_run_id": "local-events-fact-run-001",
     "correlation_id": "local-events-fact-corr-001"
   },

--- a/tests/integrations/grafana/test_alert_context.py
+++ b/tests/integrations/grafana/test_alert_context.py
@@ -1,0 +1,93 @@
+"""Tests for Grafana alert-derived Loki query scope."""
+
+from __future__ import annotations
+
+from config.constants import INVESTIGATION_CONTEXT_SOURCE_KEY
+from integrations.grafana.alert_context import resolve_grafana_loki_alert_context
+
+
+def test_resolves_common_grafana_webhook_fields() -> None:
+    context = resolve_grafana_loki_alert_context(
+        {
+            INVESTIGATION_CONTEXT_SOURCE_KEY: {
+                "raw_alert": {
+                    "commonLabels": {
+                        "service_name": "checkout",
+                        "pipeline_name": "orders",
+                        "datasource_uid": "loki-prod",
+                    },
+                    "commonAnnotations": {
+                        "log_query": '{service_name="checkout"} |= "failed"',
+                    },
+                }
+            }
+        }
+    )
+
+    assert context.service_name == "checkout"
+    assert context.pipeline_name == "orders"
+    assert context.log_query == '{service_name="checkout"} |= "failed"'
+    assert context.datasource_uid == "loki-prod"
+
+
+def test_raw_alert_precedes_normalized_alert_json() -> None:
+    context = resolve_grafana_loki_alert_context(
+        {
+            INVESTIGATION_CONTEXT_SOURCE_KEY: {
+                "raw_alert": {"labels": {"service_name": "source-service"}},
+                "alert_json": {
+                    "service_name": "model-service",
+                    "log_query": '{service_name="model-service"}',
+                },
+            }
+        }
+    )
+
+    assert context.service_name == "source-service"
+    assert context.log_query == '{service_name="model-service"}'
+
+
+def test_resolves_fields_from_individual_alert_when_common_fields_are_absent() -> None:
+    context = resolve_grafana_loki_alert_context(
+        {
+            INVESTIGATION_CONTEXT_SOURCE_KEY: {
+                "raw_alert": {
+                    "alerts": [
+                        {
+                            "labels": {
+                                "service": "payments",
+                                "pipeline": "settlement",
+                                "loki_datasource_uid": "loki-eu",
+                            },
+                            "annotations": {
+                                "logql": '{service="payments"} | json',
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    assert context.service_name == "payments"
+    assert context.pipeline_name == "settlement"
+    assert context.log_query == '{service="payments"} | json'
+    assert context.datasource_uid == "loki-eu"
+
+
+def test_does_not_treat_metric_datasource_uid_as_loki() -> None:
+    context = resolve_grafana_loki_alert_context(
+        {
+            INVESTIGATION_CONTEXT_SOURCE_KEY: {
+                "raw_alert": {
+                    "commonLabels": {
+                        "service_name": "checkout",
+                        "datasource_uid": "grafanacloud-prom",
+                    }
+                }
+            }
+        }
+    )
+
+    assert context.service_name == "checkout"
+    assert context.datasource_uid == ""

--- a/tests/integrations/grafana/test_loki.py
+++ b/tests/integrations/grafana/test_loki.py
@@ -142,6 +142,15 @@ class TestQueryLokiSuccess:
         assert host.last_params["start"] == str(expected_start)
         assert host.last_params["end"] == str(expected_end)
 
+    def test_explicit_datasource_uid_overrides_discovered_uid(self) -> None:
+        host = _FakeLokiHost(loki_datasource_uid="discovered-loki")
+        host.make_request_mock.return_value = _two_stream_response()
+
+        host.query_loki(_QUERY, datasource_uid="alert-loki")
+
+        assert host.last_url is not None
+        assert "/api/datasources/proxy/uid/alert-loki/loki/api/v1/query_range" in host.last_url
+
 
 # ---------------------------------------------------------------------------
 # Not configured short-circuit

--- a/tests/integrations/grafana/test_seed_calls.py
+++ b/tests/integrations/grafana/test_seed_calls.py
@@ -62,3 +62,33 @@ def test_grafana_connection_params_are_runtime_injected(
     registered = tool_function.__opensre_registered_tool__  # type: ignore[attr-defined]
 
     assert set(registered.injected_params) >= GRAFANA_RUNTIME_PARAMS
+
+
+def test_loki_seed_call_uses_scope_from_grafana_alert() -> None:
+    registered = grafana_tools.query_grafana_logs.__opensre_registered_tool__
+    state = {
+        **_local_basic_auth_state(),
+        "raw_alert": {
+            "commonLabels": {
+                "service_name": "checkout",
+                "pipeline_name": "orders",
+                "datasource_uid": "loki-prod",
+            },
+            "commonAnnotations": {
+                "log_query": '{service_name="checkout"} | json | level="error"',
+            },
+        },
+    }
+
+    calls = build_seed_calls(state, [registered], object())
+
+    assert len(calls) == 1
+    assert calls[0].input == {
+        "service_name": "checkout",
+        "pipeline_name": "orders",
+        "log_query": '{service_name="checkout"} | json | level="error"',
+        "datasource_uid": "loki-prod",
+        "time_range_minutes": 60,
+        "limit": 100,
+    }
+    assert registered.validate_public_input(calls[0].input) is None

--- a/tests/tools/test_grafana_logs_tool.py
+++ b/tests/tools/test_grafana_logs_tool.py
@@ -154,6 +154,38 @@ def test_run_happy_path() -> None:
     assert len(result["error_logs"]) == 1
 
 
+def test_run_uses_alert_logql_and_datasource_uid() -> None:
+    mock_client = MagicMock()
+    mock_client.is_configured = True
+    mock_client.loki_datasource_uid = "discovered-loki"
+    mock_client.account_id = "acc-1"
+    mock_client.query_loki.return_value = {
+        "success": True,
+        "logs": [{"message": "error crash"}],
+        "total_logs": 1,
+    }
+    log_query = '{service_name="checkout"} | json | level="error"'
+
+    with patch(
+        "integrations.grafana.tools.get_grafana_client_from_credentials", return_value=mock_client
+    ):
+        result = query_grafana_logs(
+            service_name="checkout",
+            log_query=log_query,
+            datasource_uid="loki-prod",
+            grafana_endpoint="https://grafana.example.com",
+        )
+
+    assert result["available"] is True
+    assert result["query"] == log_query
+    mock_client.query_loki.assert_called_once_with(
+        log_query,
+        time_range_minutes=60,
+        limit=100,
+        datasource_uid="loki-prod",
+    )
+
+
 def test_run_fallback_to_pipeline_name() -> None:
     mock_client = MagicMock()
     mock_client.is_configured = True

--- a/tools/investigation/stages/gather_evidence/tools.py
+++ b/tools/investigation/stages/gather_evidence/tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from config.constants import INVESTIGATION_CONTEXT_SOURCE_KEY
 from core import public_tool_input
 from core.domain.alerts.alert_source import (
     SECONDARY_TOOL_SOURCES,
@@ -199,6 +200,14 @@ def build_seed_calls(
 
     resolved = state.get("resolved_integrations") or {}
     tool_sources = availability_view(resolved)
+    investigation_context = {
+        key: state[key] for key in ("alert_json", "raw_alert") if state.get(key) is not None
+    }
+    if investigation_context:
+        tool_sources = {
+            **tool_sources,
+            INVESTIGATION_CONTEXT_SOURCE_KEY: investigation_context,
+        }
 
     # Enrich kubernetes tool_sources with alert-extracted context so seed calls
     # use the correct namespace/pod rather than the default from the integration config.


### PR DESCRIPTION
Fixes #4235

#### Describe the changes you have made in this PR 

Grafana alerts may include `service_name`, `pipeline_name`, LogQL, and a Loki datasource UID, but the deterministic Loki seed call previously only received integration configuration.

This PR:

- passes raw and normalized alert context to seed parameter extractors
- resolves Loki-specific context inside the Grafana integration
- preserves alert-provided LogQL instead of rebuilding a broader query
- allows a confirmed alert datasource UID to override the discovered default
- retains the existing service and pipeline fallbacks when LogQL is absent
- avoids treating ordinary metric datasource UIDs as Loki
- updates the local Grafana fixture for end-to-end verification

The shared investigation layer only transports generic alert context. Grafana-specific parsing remains owned by `integrations/grafana`.

_This should narrow initial log retrieval, reduce unnecessary scanning, and improve the quality of early investigation evidence without changing fallback behaviour._

### Demo/Screenshot for feature changes and bug fixes -

Verified against the repository's local Grafana and Loki stack:

```json
{
  "service_name": "prefect-etl-pipeline-local",
  "pipeline_name": "events_fact",
  "query": "{service_name=\"prefect-etl-pipeline-local\", pipeline_name=\"events_fact\"} |~ \"(?i)(error|fail|abort|expired|invalid)\"",
  "datasource_uid": "local-loki",
  "available": true,
  "total_logs": 4,
  "error": null
}
```

Validation completed:

- `make lint`
- `make format-check`
- `make typecheck`
- `make verify-integrations-smoke`
- `make verify-integrations`
- `env -u NO_COLOR TERM=xterm-256color make test-cov`
  - 12,188 passed
  - 61 skipped
  - 84% coverage

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

- [ x] I have reviewed every single line of the AI-generated code
- [ x] I can explain the purpose and logic of each function/component I added
- [ x] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The root cause was that seed parameter extractors only received resolved
integration data, so the Grafana tool could not access fields from the firing
alert.

The implementation adds a generic internal investigation-context entry during
seed construction. A Grafana-owned resolver reads supported webhook shapes,
applies raw-alert precedence, and returns Loki-specific query context. The Loki
tool then uses supplied LogQL and datasource UID while preserving its existing
fallback behavior.

Keeping the parser inside `integrations/grafana` avoids adding vendor-specific
branches to shared investigation orchestration.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

