### PR TITLE
docs(contributing): correct inverted pytest.mark.synthetic guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,14 +109,19 @@ verification) follow [docs/adding-tools-and-integrations.md](docs/adding-tools-a
 - New features should have corresponding tests
 - Aim for >80% code coverage (run `make test-cov` to check)
 
-#### Tests under `tests/synthetic/` need an explicit `pytest.mark.synthetic` marker
+#### Choosing the `pytest.mark.synthetic` marker under `tests/synthetic/`
 
-The synthetic test tree has its own Make target (`make test-synthetic`) and is excluded from `make test-cov`. The two targets use marker filters:
+The marker means **this test needs a live LLM** (`pytest.ini`: "LLM-based synthetic RCA
+scenario tests (non-deterministic)"). It does not mean "this file lives under
+`tests/synthetic/`". Which way you mark decides which job runs your file:
 
-- `make test-cov` runs `pytest --ignore=tests/synthetic -m "not synthetic"`, so the whole `tests/synthetic/` tree is excluded.
-- `make test-synthetic` runs `pytest -m synthetic`, so a file without `pytest.mark.synthetic` is collected but skipped.
+- **Needs a live LLM, or is otherwise non-deterministic** → add the module-level marker.
+  Runs under `make test-synthetic`.
+- **Deterministic (no LLM call)** → leave it unmarked. Runs in the
+  [Synthetic Deterministic Tests](.github/workflows/synthetic-deterministic.yml) job on
+  every PR touching `tests/synthetic/**`.
 
-If you add a new test file under `tests/synthetic/`, declare the marker at module level so the file runs under `make test-synthetic`:
+To mark a file:
 
 ```python
 import pytest
@@ -124,9 +129,21 @@ import pytest
 pytestmark = pytest.mark.synthetic
 ```
 
-Without this marker the new file silently runs in **zero** standard CI configurations. The pattern is already in `tests/synthetic/rds_postgres/test_suite.py`; new files in the same tree should follow it.
+The pattern is already in `tests/synthetic/rds_postgres/test_suite.py`.
 
-See [#1671](https://github.com/Tracer-Cloud/opensre/issues/1671) for the meta-issue tracking this discoverability gap.
+Where each target lands:
+
+- `make test-cov` runs `pytest --ignore=tests/synthetic -m "not synthetic"` — the tree is
+  excluded either way, so `tests/synthetic/` never contributes to coverage.
+- `make test-synthetic` runs `pytest -m synthetic`, so an **unmarked** file is collected
+  but skipped.
+- `synthetic-deterministic.yml` runs
+  `pytest tests/synthetic -m "not synthetic and not live_llm and not e2e and not axis2"`,
+  so **unmarked deterministic files are exactly what it runs**.
+
+Do not blanket-apply the marker to the whole tree — for example via a `tests/synthetic/conftest.py`
+that auto-marks every collected item. That would exclude every deterministic test from the
+only job that runs it.
 
 ### 4. Run Local Checks (Required Before PR)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,9 @@ import pytest
 pytestmark = pytest.mark.synthetic
 ```
 
-The pattern is already in `tests/synthetic/rds_postgres/test_suite.py`.
+The pattern is already in `tests/synthetic/hermes/test_suite.py`. Per-test
+`@pytest.mark.synthetic` decorators work too — see
+`tests/synthetic/rds_postgres/test_suite.py` — when only some tests in the file need an LLM.
 
 Where each target lands:
 


### PR DESCRIPTION
[IMPROVEMENT] CONTRIBUTING.md pytest.mark.synthetic guidance is inverted since the deterministic CI guardrail landed

Current state

`CONTRIBUTING.md` (the "Tests under `tests/synthetic/` need an explicit `pytest.mark.synthetic` marker" section) tells contributors:

> Without this marker the new file silently runs in **zero** standard CI configurations.

That is no longer true, and following it now *removes* a deterministic test from CI.

**How it went stale:**

- `c90a8414` (2026-05-08, #1675) added the section, closing #1671. It was correct at the time: `make test-cov` ignores the tree and `make test-synthetic` filters on `-m synthetic`.
- `7c5ee16b` (2026-06-26, #3101, *"ci: add deterministic synthetic test guardrail"*) added [`.github/workflows/synthetic-deterministic.yml`](https://github.com/Tracer-Cloud/opensre/blob/main/.github/workflows/synthetic-deterministic.yml), which runs:

  ```
  pytest tests/synthetic -m "not synthetic and not live_llm and not e2e and not axis2"
  ```

  This inverted the meaning: **unmarked files are exactly what that job selects.**
- `CONTRIBUTING.md` was never updated.

The marker's real meaning is "needs a live LLM / non-deterministic" — per `pytest.ini` ("LLM-based synthetic RCA scenario tests (non-deterministic)") and the workflow's own header comment ("run every offline (no-LLM) synthetic test ... Tests that need a live LLM are excluded via the marker filter below").

**Verified on `main` @ `d0e554f1`:**

```
$ uv run pytest tests/synthetic \
    -m "not synthetic and not live_llm and not e2e and not axis2" --collect-only -q
...
============== 180/295 tests collected (115 deselected) in 6.67s ==============
```

31 of the 45 test files under `tests/synthetic/` carry no module-level `synthetic` marker; 29 of those carry no other exclusion marker either, and are what the deterministic job runs.

**Live landmine:** the now-closed #1671 proposed, as its "more robust" option, a `tests/synthetic/conftest.py` that auto-applies `pytest.mark.synthetic` to every collected item. That file does not exist today. Shipping it now would push the 180 collected tests to **0** and silently disable the entire deterministic synthetic guardrail, with a green CI check still reported. The closed issue reads as an open invitation to do exactly that.

Desired state

Rewrite the section so the marker is presented as a **decision**, not a requirement:

- **Needs a live LLM / non-deterministic** → add `pytestmark = pytest.mark.synthetic`; runs under `make test-synthetic`.
- **Deterministic (no LLM call)** → leave unmarked; runs in the Synthetic Deterministic Tests job on every PR touching `tests/synthetic/**`.

Keep the existing `make test-cov` / `make test-synthetic` notes (both still accurate), add the `synthetic-deterministic.yml` row that is currently missing, and add an explicit warning against blanket auto-marking the tree.

Docs-only, one file. PR to follow.

## AI usage disclosure

Investigated and drafted with AI assistance (Claude Code). The commit history, workflow filter, and the 180/295 collection count were verified against `main` by running the commands above.

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is a stale doc that actively misleads. The marker's meaning was defined by `pytest.ini` and relied on by two `make` targets; when #3101 added a third consumer (the deterministic CI job) with an inverted filter, the doc silently became wrong. A contributor adding a deterministic test and following the current text would mark it and drop it out of the only job that runs it.

I considered three approaches:

1. **Add the missing workflow bullet only.** Rejected — the "runs in zero CI configurations" sentence would still be there contradicting it.
2. **Enforce it mechanically** (a CI assertion that the deterministic job collects a non-zero count, or `--strict-markers`). Better long-term, but it is a CI change rather than a docs fix and belongs in its own issue with maintainer input on where the assertion lives.
3. **Reframe the section as a decision** — chosen. It fixes the incorrect claim and makes the marker's real meaning explicit at the top, so the rule is derivable rather than memorized, and it documents all three consumers in one place.

I verified each claim rather than trusting the doc: `git log -S` for the commit that introduced the sentence, `git log` on the workflow for the commit that invalidated it, the workflow's marker filter and header comment, and the `--collect-only` count above.

There are no functions or classes in this change — it is documentation. The edge case I tested is the one the doc gets wrong: what happens to an unmarked deterministic file under each of the three consumers.

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue <!-- no separate issue; PR-first per CONTRIBUTING.md path 1 -->
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests <!-- N/A: docs-only -->
- [x] My code follows the project's style guidelines and conventions