### PR TITLE
fix(grafana): key the client cache on credentials, not just endpoint

### DIFF
--- a/integrations/grafana/client.py
+++ b/integrations/grafana/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 
 from integrations.grafana.base import GrafanaClientBase
@@ -13,6 +14,28 @@ from integrations.grafana.tempo import TempoMixin
 logger = logging.getLogger(__name__)
 
 _grafana_client_cache: dict[str, GrafanaClient] = {}
+
+
+def _credential_fingerprint(
+    *,
+    api_key: str,
+    username: str,
+    password: str,
+    verify_ssl: bool,
+    ca_bundle: str,
+) -> str:
+    """Hash everything that changes how requests authenticate or verify TLS.
+
+    Used as part of the client cache key so rotating a token, switching auth
+    mode, or changing TLS trust invalidates the cached client instead of
+    silently reusing one built from the previous credentials (#4192). Hashed
+    rather than stored raw so the cache key never carries a live secret in
+    memory/logs.
+    """
+    fingerprint_input = "\x1f".join(
+        (api_key, username, password, str(verify_ssl), ca_bundle)
+    ).encode("utf-8")
+    return hashlib.sha256(fingerprint_input).hexdigest()
 
 
 class GrafanaClient(LokiMixin, TempoMixin, MimirMixin, GrafanaClientBase):
@@ -46,9 +69,26 @@ def get_grafana_client_from_credentials(
     ca_bundle: str = "",
 ) -> GrafanaClient:
     """Create a Grafana client from integration credentials."""
-    cache_key = f"creds_{account_id}_{endpoint}"
+    fingerprint = _credential_fingerprint(
+        api_key=api_key,
+        username=username,
+        password=password,
+        verify_ssl=verify_ssl,
+        ca_bundle=ca_bundle,
+    )
+    cache_key_prefix = f"creds_{account_id}_{endpoint}_"
+    cache_key = f"{cache_key_prefix}{fingerprint}"
     if cache_key in _grafana_client_cache:
         return _grafana_client_cache[cache_key]
+
+    # Drop any client cached under the old credentials for this account_id +
+    # endpoint — it is superseded and would otherwise linger indefinitely.
+    for stale_key in [
+        key
+        for key in _grafana_client_cache
+        if key.startswith(cache_key_prefix) and key != cache_key
+    ]:
+        del _grafana_client_cache[stale_key]
 
     config = GrafanaAccountConfig(
         account_id=account_id,
@@ -91,3 +131,8 @@ def get_grafana_client_from_credentials(
 
     _grafana_client_cache[cache_key] = client
     return client
+
+
+def clear_grafana_client_cache() -> None:
+    """Drop every cached client; test-only, real processes never need this."""
+    _grafana_client_cache.clear()

--- a/tests/integrations/grafana/test_client.py
+++ b/tests/integrations/grafana/test_client.py
@@ -2,7 +2,20 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from integrations.grafana.client import get_grafana_client
+import pytest
+
+from integrations.grafana.client import (
+    clear_grafana_client_cache,
+    get_grafana_client,
+    get_grafana_client_from_credentials,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_grafana_client_cache():
+    clear_grafana_client_cache()
+    yield
+    clear_grafana_client_cache()
 
 
 def test_get_grafana_client_reads_verify_ssl_and_ca_bundle_from_env(monkeypatch) -> None:
@@ -41,3 +54,93 @@ def test_get_grafana_client_defaults_verify_ssl_true_when_unset(monkeypatch) -> 
         verify_ssl=True,
         ca_bundle="",
     )
+
+
+def _patched_discovery():
+    return patch(
+        "integrations.grafana.client.GrafanaClient.discover_datasource_uids",
+        return_value={},
+    )
+
+
+def test_get_grafana_client_from_credentials_rebuilds_on_token_rotation() -> None:
+    """#4192: rotating a token must not keep returning the client built from
+    the previous one — the cache key ignored api_key entirely."""
+    with _patched_discovery():
+        first = get_grafana_client_from_credentials(
+            endpoint="https://grafana.example.com",
+            api_key="token-one",
+            account_id="user_integration",
+        )
+        second = get_grafana_client_from_credentials(
+            endpoint="https://grafana.example.com",
+            api_key="token-two",
+            account_id="user_integration",
+        )
+
+    assert first is not second
+    assert second.read_token == "token-two"
+
+
+def test_get_grafana_client_from_credentials_rebuilds_on_tls_change() -> None:
+    """Basic auth and TLS settings must also invalidate the cached client."""
+    with _patched_discovery():
+        first = get_grafana_client_from_credentials(
+            endpoint="https://grafana.example.com",
+            api_key="token",
+            account_id="user_integration",
+            verify_ssl=True,
+        )
+        second = get_grafana_client_from_credentials(
+            endpoint="https://grafana.example.com",
+            api_key="token",
+            account_id="user_integration",
+            verify_ssl=False,
+            ca_bundle="/etc/ssl/internal-ca.pem",
+        )
+
+    assert first is not second
+    assert second.ssl_verify != first.ssl_verify
+
+
+def test_get_grafana_client_from_credentials_reuses_client_for_same_config() -> None:
+    """Identical normalized configuration should still hit the cache."""
+    with _patched_discovery():
+        first = get_grafana_client_from_credentials(
+            endpoint="https://grafana.example.com",
+            api_key="token-one",
+            account_id="user_integration",
+        )
+        second = get_grafana_client_from_credentials(
+            endpoint="https://grafana.example.com",
+            api_key="token-one",
+            account_id="user_integration",
+        )
+
+    assert first is second
+
+
+def test_get_grafana_client_from_credentials_evicts_stale_cache_entry() -> None:
+    """Rotating a token should not leave the old client cached forever."""
+    with _patched_discovery():
+        get_grafana_client_from_credentials(
+            endpoint="https://grafana.example.com",
+            api_key="token-one",
+            account_id="user_integration",
+        )
+        get_grafana_client_from_credentials(
+            endpoint="https://grafana.example.com",
+            api_key="token-two",
+            account_id="user_integration",
+        )
+
+    from integrations.grafana.client import _grafana_client_cache
+
+    matching = [
+        client
+        for client in _grafana_client_cache.values()
+        if client.instance_url == "https://grafana.example.com"
+        and client.account_id == "user_integration"
+    ]
+    assert len(matching) == 1
+    assert matching[0].read_token == "token-two"


### PR DESCRIPTION
## Summary

`get_grafana_client_from_credentials` cached clients under `f"creds_{account_id}_{endpoint}"` alone. Rotating a service-account token, switching Basic Auth credentials, or changing `verify_ssl`/`ca_bundle` therefore kept silently returning the client built from the *previous* configuration until process restart.

- Fold a SHA-256 fingerprint of `api_key`/`username`/`password`/`verify_ssl`/`ca_bundle` into the cache key, so any credential or TLS change builds a fresh client. The fingerprint is hashed rather than stored raw so the cache key never carries a live secret.
- Evict the superseded cache entry for that `account_id`+`endpoint` instead of leaking it in memory forever.
- Add a `clear_grafana_client_cache()` test helper.

This is filed exactly as **#4192** describes it. It's also a plausible root cause of **#2836** ("empty token → 401 on every investigation, every time, on Windows"): all runtime call sites share the default `account_id="user_integration"`, so if any early call (e.g. a health-check/verify path) resolves with an empty/wrong token first, the poisoned client gets cached and every subsequent call — even with a correct token — reuses it for the rest of the process, matching the reported symptom of *persistent*, *every-time* 401s despite a valid, correctly-scoped token.

Fixes #4192. Likely fixes #2836.

## Test plan
- [x] Added regression tests: token rotation, Basic Auth/TLS change, and same-config reuse all produce the expected cache behavior; a separate test asserts the stale entry is evicted, not merely shadowed.
- [x] `pytest tests/integrations/grafana/ tests/tools/test_grafana_*` — 182 passed, no regressions.