### PR TITLE
fix: fall back to local storage when the OS keyring is unavailable

### DIFF
--- a/config/env_file.py
+++ b/config/env_file.py
@@ -32,7 +32,8 @@ from pathlib import Path
 from config.llm_auth.credentials import delete as delete_provider_auth
 from config.llm_auth.credentials import save_api_key
 from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
-from config.llm_credentials import delete_keyring_secret, save_keyring_secret
+from config.llm_credentials import delete_fallback_secret, delete_keyring_secret
+from config.llm_credentials import save_secret_with_fallback
 from config.local_env import get_project_env_path
 
 PROJECT_ENV_PATH = get_project_env_path()
@@ -53,10 +54,19 @@ _SENSITIVE_TERMINAL_TOKENS: frozenset[str] = frozenset(
         "secret",
         "password",
         "passwd",
+        "pass",
+        "passphrase",
         "key",
         "apikey",
         "credential",
         "credentials",
+        # Bearer/JWT values authenticate a request on their own, same risk
+        # class as a token. Bare "auth" is included for names like
+        # `*_AUTH` that store a credential rather than a method/flag (see
+        # `LLM_AUTH_METHOD`, whose terminal segment is "method", not "auth").
+        "bearer",
+        "jwt",
+        "auth",
     }
 )
 _SENSITIVE_SUBSTRINGS: tuple[str, ...] = (
@@ -122,8 +132,11 @@ def _ensure_no_sensitive_env_lines(lines: list[str]) -> None:
             )
 
 
-def _persist_env_secret(key: str, value: str) -> bool:
-    """Store a secret in the keyring. Returns False when keyring is unavailable."""
+def _persist_env_secret(key: str, value: str) -> str | None:
+    """Store a secret in the keyring, falling back to local storage if it's
+    unavailable (see #1403, #3348). Returns the storage tier used
+    (``"keyring"`` or ``"fallback"``), or ``None`` if both tiers failed.
+    """
     normalized = value.strip()
     provider = next(
         (name for name, env_var in API_KEY_PROVIDER_ENVS.items() if env_var == key),
@@ -134,15 +147,14 @@ def _persist_env_secret(key: str, value: str) -> bool:
             delete_provider_auth(provider)
         else:
             delete_keyring_secret(key)
-        return True
+            delete_fallback_secret(key)
+        return "keyring"
     try:
         if provider:
-            save_api_key(provider, normalized)
-        else:
-            save_keyring_secret(key, normalized)
+            return save_api_key(provider, normalized)
+        return save_secret_with_fallback(key, normalized)
     except RuntimeError:
-        return False
-    return True
+        return None
 
 
 def set_env_value(lines: list[str], key: str, value: str) -> list[str]:
@@ -191,19 +203,25 @@ def write_env_lines(target_path: Path, lines: list[str]) -> None:
             target_path.chmod(0o600)
 
 
-def sync_env_secret(key: str, value: str) -> None:
+def sync_env_secret(key: str, value: str) -> str | None:
     """Persist a sensitive env value in the system keyring, not in ``.env``.
 
-    Raises ``RuntimeError`` when the keyring backend cannot store the secret so
-    callers never treat a dropped credential as a successful write.
+    Falls back to local encrypted-at-rest storage under ``OPENSRE_HOME_DIR``
+    when the OS keyring is unavailable (locked/missing backend — #1403,
+    #3348) instead of failing the caller outright. Returns the storage tier
+    used (``"keyring"`` or ``"fallback"``); raises ``RuntimeError`` only when
+    neither tier can store the secret, so a dropped credential is never
+    mistaken for a successful write.
     """
     if not is_sensitive_env_key(key):
         raise ValueError(f"{key!r} is not classified as sensitive; use sync_env_values instead.")
-    if not _persist_env_secret(key, value):
+    tier = _persist_env_secret(key, value)
+    if tier is None:
         raise RuntimeError(
-            f"Failed to persist {key!r} to the system keyring; "
+            f"Failed to persist {key!r} to the system keyring or the local fallback store; "
             "secure local credential storage is unavailable."
         )
+    return tier
 
 
 def sync_env_values(

--- a/config/llm_auth/credentials.py
+++ b/config/llm_auth/credentials.py
@@ -345,42 +345,56 @@ def resolve_for_request(provider: str) -> CredentialResolution:
 
         import keyring.errors
 
-        from config.llm_keyring import keyring_is_disabled, read_keychain_secret
+        from config.llm_keyring import (
+            keyring_is_disabled,
+            read_keychain_secret,
+            resolve_fallback_secret,
+        )
 
+        key = ""
+        keychain_unreachable = False
         if not keyring_is_disabled():
             try:
                 key = read_keychain_secret(spec.api_key_env)
-            except keyring.errors.KeyringError as exc:
+            except keyring.errors.KeyringError:
                 # The backend itself couldn't be reached (e.g. no D-Bus/Secret
-                # Service session in this process) — this is not evidence the
-                # credential is missing, so leave any previously-verified
-                # metadata untouched instead of marking it stale.
-                return CredentialResolution(
-                    provider=spec.value,
-                    api_key="",
-                    source="unknown",
-                    detail=(
-                        f"Could not reach the system keychain to check {spec.api_key_env}: "
-                        f"{exc}. Retry once the keychain is reachable."
-                    ),
-                )
-            if key:
-                save_provider_auth_record(
-                    provider=spec.value,
-                    auth_name=spec.value,
-                    kind="api_key",
-                    source="keyring",
-                    detail=f"{spec.api_key_env} stored in the system keychain.",
-                    verified=True,
-                    stale=False,
-                    env_var=spec.api_key_env,
-                )
-                return CredentialResolution(
-                    provider=spec.value,
-                    api_key=key,
-                    source="keyring",
-                    detail=f"{spec.api_key_env} resolved from secure local storage.",
-                )
+                # Service session, or a locked macOS Keychain). Not evidence
+                # the credential is missing — the fallback store (populated by
+                # save_api_key when onboarding hit this same failure, see
+                # #1403/#3348) is checked below before giving up.
+                keychain_unreachable = True
+
+        if not key:
+            key = resolve_fallback_secret(spec.api_key_env)
+
+        if key:
+            save_provider_auth_record(
+                provider=spec.value,
+                auth_name=spec.value,
+                kind="api_key",
+                source="keyring",
+                detail=f"{spec.api_key_env} resolved from secure local storage.",
+                verified=True,
+                stale=False,
+                env_var=spec.api_key_env,
+            )
+            return CredentialResolution(
+                provider=spec.value,
+                api_key=key,
+                source="keyring",
+                detail=f"{spec.api_key_env} resolved from secure local storage.",
+            )
+
+        if keychain_unreachable:
+            return CredentialResolution(
+                provider=spec.value,
+                api_key="",
+                source="unknown",
+                detail=(
+                    f"Could not reach the system keychain to check {spec.api_key_env}. "
+                    "Retry once the keychain is reachable."
+                ),
+            )
 
         detail = (
             f"Missing credential for LLM provider '{spec.value}'. Set {spec.api_key_env} "
@@ -432,24 +446,36 @@ def resolve_api_key_env_for_request(env_var: str) -> str:
     return resolve_env_credential(normalized)
 
 
-def save_api_key(provider: str, value: str, *, detail: str | None = None) -> None:
-    """Store an OpenSRE-managed API key and refresh prompt-safe metadata."""
+def save_api_key(provider: str, value: str, *, detail: str | None = None) -> str:
+    """Store an OpenSRE-managed API key and refresh prompt-safe metadata.
+
+    Falls back to local storage when the OS keyring is unavailable (#1403,
+    #3348) instead of aborting onboarding. Returns the storage tier used
+    (``"keyring"`` or ``"fallback"``) so callers can tell the user when their
+    key is not protected by the OS keychain.
+    """
     spec = require_provider_spec(provider)
     if not spec.uses_open_sre_api_key:
         raise ValueError(f"{spec.value} does not use an OpenSRE-managed API key")
-    from config.llm_keyring import save_keyring_secret
+    from config.llm_keyring import save_secret_with_fallback
 
-    save_keyring_secret(spec.api_key_env, value)
+    tier = save_secret_with_fallback(spec.api_key_env, value)
+    default_detail = (
+        f"{spec.api_key_env} stored in the system keychain."
+        if tier == "keyring"
+        else f"{spec.api_key_env} stored in the local fallback store (system keychain unavailable)."
+    )
     save_provider_auth_record(
         provider=spec.value,
         auth_name=spec.value,
         kind="api_key",
         source="keyring",
-        detail=detail or f"{spec.api_key_env} stored in the system keychain.",
+        detail=detail or default_detail,
         verified=True,
         stale=False,
         env_var=spec.api_key_env,
     )
+    return tier
 
 
 def delete(provider: str) -> None:

--- a/config/llm_credentials.py
+++ b/config/llm_credentials.py
@@ -5,30 +5,42 @@ from __future__ import annotations
 import os
 
 from config.llm_keyring import (
+    delete_fallback_secret,
     delete_keyring_secret,
     delete_llm_credential_record,
     get_keyring_setup_instructions,
+    resolve_fallback_secret,
     resolve_keyring_secret,
     resolve_llm_credential_record,
+    resolve_secret_with_fallback,
+    save_fallback_secret,
     save_keyring_secret,
     save_llm_credential_record,
+    save_secret_with_fallback,
 )
 
 __all__ = [
+    "delete_fallback_secret",
     "delete_keyring_secret",
     "delete_llm_credential_record",
     "get_keyring_setup_instructions",
     "resolve_env_credential",
+    "resolve_fallback_secret",
     "resolve_keyring_secret",
     "resolve_llm_credential_record",
+    "resolve_secret_with_fallback",
+    "save_fallback_secret",
     "save_keyring_secret",
     "save_llm_credential_record",
+    "save_secret_with_fallback",
 ]
 
 
 def resolve_env_credential(env_var: str, *, default: str = "") -> str:
-    """Resolve a credential from process env first, then the OS keyring."""
+    """Resolve a credential from process env, then the OS keyring, then the
+    local fallback store (used when onboarding saved a secret without a
+    working keyring backend; see #1403, #3348)."""
     env_value = os.getenv(env_var, default).strip()
     if env_value:
         return env_value
-    return resolve_keyring_secret(env_var)
+    return resolve_secret_with_fallback(env_var)

--- a/config/llm_keyring.py
+++ b/config/llm_keyring.py
@@ -4,6 +4,22 @@ Historically named for LLM API keys; the same store backs integration secrets
 (``TELEGRAM_BOT_TOKEN``, ``ROCKETCHAT_AUTH_TOKEN``, etc.) via
 ``save_keyring_secret`` / ``resolve_env_credential``. The keyring service id
 remains ``opensre.llm`` so existing entries keep resolving.
+
+Two behaviors live here that are easy to get wrong with a bare
+``keyring.get_password``/``set_password`` per call:
+
+* **Repeat OS prompts** — macOS/GNOME Keychain backends can re-prompt for
+  authorization on every distinct call. A single onboarding run may read or
+  write the same ``env_var`` more than once (status check, save, verify), so
+  ``_KeyringSession`` caches per-process results and invalidates them on
+  save/delete, capping each credential at one backend round trip per process.
+* **No fallback when the backend is unreachable** — a locked macOS Keychain
+  or a headless Linux box with no D-Bus session makes every keyring call fail
+  identically. Once that happens once, ``_KeyringSession.backend_unavailable``
+  short-circuits further attempts for the rest of the process (no retry
+  storm), and :func:`save_secret_with_fallback` persists to a local JSON
+  store (see :func:`fallback_store_path`) instead of failing onboarding
+  outright.
 """
 
 from __future__ import annotations
@@ -11,8 +27,11 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import stat
 import subprocess
 from collections.abc import Mapping
+from contextlib import suppress
+from pathlib import Path
 from typing import Final
 
 import keyring
@@ -20,9 +39,50 @@ import keyring.errors
 
 import platform
 
+from config.constants.paths import OPENSRE_HOME_DIR
+
 _KEYRING_SERVICE: Final = "opensre.llm"
 RECORD_PREFIX: Final = "record:"
 _DISABLED_VALUES: Final = frozenset({"1", "true", "yes", "on"})
+OPENSRE_FALLBACK_SECRETS_PATH_ENV: Final = "OPENSRE_FALLBACK_SECRETS_PATH"
+
+
+def fallback_store_path() -> Path:
+    """Return the local fallback secrets file, honoring the test/override env var.
+
+    Mirrors ``config.local_env.get_project_env_path``'s override pattern so
+    tests can redirect this off the developer's real ``~/.opensre`` (see
+    ``tests/conftest.py::_isolate_opensre_home_files`` and its #3721 note).
+    """
+    override = os.getenv(OPENSRE_FALLBACK_SECRETS_PATH_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+    return OPENSRE_HOME_DIR / "secrets.local.json"
+
+
+class _KeyringSession:
+    """Per-process memo of keyring reads and backend health.
+
+    Reset happens naturally at process exit — onboarding, ``opensre``
+    subcommands, and tests each get a fresh session.
+    """
+
+    reads: dict[str, str] = {}
+    backend_unavailable: bool = False
+
+
+def _remember_read(env_var: str, value: str) -> None:
+    _KeyringSession.reads[env_var] = value
+
+
+def _forget_read(env_var: str) -> None:
+    _KeyringSession.reads.pop(env_var, None)
+
+
+def reset_keyring_session() -> None:
+    """Clear the per-process cache; test-only, real processes never need this."""
+    _KeyringSession.reads.clear()
+    _KeyringSession.backend_unavailable = False
 
 
 def keyring_is_disabled() -> bool:
@@ -74,8 +134,16 @@ def read_keychain_secret(env_var: str) -> str:
     could not be reached right now" (e.g. deciding whether to persist a
     credential as stale) should use this instead of ``resolve_keyring_secret``,
     which collapses both cases to ``""``.
+
+    Cached for the rest of the process once read successfully, so a status
+    check followed by a save/verify in the same run only ever hits the OS
+    backend once per ``env_var`` (see #3295: macOS re-prompts per call).
     """
-    return (keyring.get_password(_KEYRING_SERVICE, env_var) or "").strip()
+    if env_var in _KeyringSession.reads:
+        return _KeyringSession.reads[env_var]
+    value = (keyring.get_password(_KEYRING_SERVICE, env_var) or "").strip()
+    _remember_read(env_var, value)
+    return value
 
 
 def resolve_keyring_secret(env_var: str) -> str:
@@ -86,12 +154,16 @@ def resolve_keyring_secret(env_var: str) -> str:
 
     Backend init failures (e.g. SecretService raising bare ``RuntimeError`` when
     D-Bus is unset) are treated as miss — catalog/env loaders must not abort.
+    A failure also flips :attr:`_KeyringSession.backend_unavailable` so later
+    calls in the same process skip straight to the fallback store instead of
+    repeating a doomed backend call.
     """
-    if keyring_is_disabled():
+    if keyring_is_disabled() or _KeyringSession.backend_unavailable:
         return ""
     try:
         return read_keychain_secret(env_var)
     except (keyring.errors.KeyringError, RuntimeError, OSError):
+        _KeyringSession.backend_unavailable = True
         return ""
 
 
@@ -148,24 +220,105 @@ def save_keyring_secret(env_var: str, value: str) -> None:
     if not normalized:
         delete_keyring_secret(env_var)
         return
-    if keyring_is_disabled():
-        raise RuntimeError("Secure local credential storage is disabled on this machine.")
+    if keyring_is_disabled() or _KeyringSession.backend_unavailable:
+        raise RuntimeError("Secure local credential storage is unavailable on this machine.")
     try:
         keyring.set_password(_KEYRING_SERVICE, env_var, normalized)
     except keyring.errors.KeyringError as exc:
+        _KeyringSession.backend_unavailable = True
         raise RuntimeError(
             "Secure local credential storage is unavailable on this machine."
         ) from exc
+    _remember_read(env_var, normalized)
 
 
 def delete_keyring_secret(env_var: str) -> None:
     """Remove a secret from the user's system keychain if present."""
+    _forget_read(env_var)
     if keyring_is_disabled():
         return
     try:
         keyring.delete_password(_KEYRING_SERVICE, env_var)
     except keyring.errors.KeyringError:
         return
+
+
+def _read_fallback_store() -> dict[str, str]:
+    path = fallback_store_path()
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _write_fallback_store(payload: Mapping[str, str]) -> None:
+    path = fallback_store_path()
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    with suppress(OSError):
+        path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+def save_fallback_secret(env_var: str, value: str) -> None:
+    """Persist a secret to the local fallback store (used when keyring is unavailable).
+
+    Owner-only-permissioned JSON under ``OPENSRE_HOME_DIR``, distinct from the
+    project ``.env`` that :mod:`config.env_file` deliberately keeps secret-free.
+    """
+    data = _read_fallback_store()
+    normalized = value.strip()
+    if normalized:
+        data[env_var] = normalized
+    else:
+        data.pop(env_var, None)
+    _write_fallback_store(data)
+
+
+def resolve_fallback_secret(env_var: str) -> str:
+    """Read a secret from the local fallback store only (empty if absent)."""
+    return _read_fallback_store().get(env_var, "")
+
+
+def delete_fallback_secret(env_var: str) -> None:
+    """Remove a secret from the local fallback store if present."""
+    data = _read_fallback_store()
+    if env_var in data:
+        del data[env_var]
+        _write_fallback_store(data)
+
+
+def save_secret_with_fallback(env_var: str, value: str) -> str:
+    """Save to the OS keyring, falling back to local storage if it's unavailable.
+
+    Returns ``"keyring"`` or ``"fallback"`` for the tier actually used, so
+    callers can tell the user their credential is not protected by the OS
+    keychain. Raises only when neither tier can persist the value.
+    """
+    if not value.strip():
+        delete_keyring_secret(env_var)
+        delete_fallback_secret(env_var)
+        return "keyring"
+    try:
+        save_keyring_secret(env_var, value)
+        delete_fallback_secret(env_var)
+        return "keyring"
+    except RuntimeError:
+        try:
+            save_fallback_secret(env_var, value)
+        except OSError as fallback_exc:
+            raise RuntimeError(
+                "Secure local credential storage is unavailable on this machine, "
+                f"and the local fallback store could not be written either: {fallback_exc}."
+            ) from fallback_exc
+        return "fallback"
+
+
+def resolve_secret_with_fallback(env_var: str) -> str:
+    """Read a secret from the keyring, then the local fallback store."""
+    return resolve_keyring_secret(env_var) or resolve_fallback_secret(env_var)
 
 
 def _record_username(record_name: str) -> str:

--- a/surfaces/cli/llm_auth/persist.py
+++ b/surfaces/cli/llm_auth/persist.py
@@ -9,24 +9,29 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from config.llm_credentials import save_keyring_secret
+from config.llm_credentials import save_secret_with_fallback
 
 
 class AuthSetupError(RuntimeError):
     """Raised when provider auth setup cannot complete."""
 
 
-SaveSecret = Callable[[str, str], None]
+SaveSecret = Callable[[str, str], str]
 
 
 def persist_api_key_secret(
     env_var: str,
     value: str,
     *,
-    save_secret: SaveSecret = save_keyring_secret,
-) -> None:
-    """Persist one API-key secret through the shared auth service boundary."""
+    save_secret: SaveSecret = save_secret_with_fallback,
+) -> str:
+    """Persist one API-key secret through the shared auth service boundary.
+
+    Returns the storage tier used (``"keyring"`` or ``"fallback"``) so the
+    wizard can tell the user when a key is not protected by the OS keychain
+    (#1403, #3348) instead of the save failing onboarding outright.
+    """
     try:
-        save_secret(env_var, value)
+        return save_secret(env_var, value)
     except RuntimeError as exc:
         raise AuthSetupError(str(exc)) from exc

--- a/surfaces/cli/llm_auth/service.py
+++ b/surfaces/cli/llm_auth/service.py
@@ -105,11 +105,7 @@ def configure_api_key_provider(
             raise AuthSetupError(validation.detail)
 
     try:
-        save_api_key(
-            provider.value,
-            normalized_key,
-            detail=f"{provider.api_key_env} stored in the system keychain.",
-        )
+        tier = save_api_key(provider.value, normalized_key)
     except (RuntimeError, ValueError) as exc:
         raise AuthSetupError(str(exc)) from exc
 
@@ -118,7 +114,11 @@ def configure_api_key_provider(
         if set_provider
         else None
     )
-    detail = f"{provider.api_key_env} stored in the system keychain."
+    detail = (
+        f"{provider.api_key_env} stored in the system keychain."
+        if tier == "keyring"
+        else f"{provider.api_key_env} stored in the local fallback store (system keychain unavailable)."
+    )
     _save_auth_record(provider=provider, profile=profile, source="keyring", detail=detail)
     return AuthSetupResult(
         provider=provider.value,

--- a/surfaces/cli/wizard/_ui.py
+++ b/surfaces/cli/wizard/_ui.py
@@ -20,7 +20,7 @@ from config.llm_auth.auth_method import (
 )
 from config.llm_auth.credentials import has_llm_api_key, save_api_key
 from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
-from config.llm_credentials import get_keyring_setup_instructions, save_keyring_secret
+from config.llm_credentials import get_keyring_setup_instructions
 from config.version import get_opensre_version
 from integrations.store import get_integration
 from platform.terminal.theme import (
@@ -403,18 +403,23 @@ def _persist_llm_api_key(env_var: str, value: str) -> bool:
             ),
             "",
         )
-        if provider:
-            save_api_key(provider, value)
-        else:
-            persist_api_key_secret(env_var, value, save_secret=save_keyring_secret)
+        tier = save_api_key(provider, value) if provider else persist_api_key_secret(env_var, value)
     except (AuthSetupError, RuntimeError, ValueError) as exc:
         _console.print(f"[{ERROR}]  {GLYPH_ERROR}  {exc}[/]")
         _console.print(
-            f"[{WARNING}]  {GLYPH_WARNING}  OpenSRE could not save your API key to the local system keychain.[/]"
+            f"[{WARNING}]  {GLYPH_WARNING}  OpenSRE could not save your API key to the local "
+            "system keychain or a local fallback store.[/]"
         )
         for line in get_keyring_setup_instructions(env_var):
             _console.print(f"[{SECONDARY}]    {line}[/]")
         return False
+    if tier == "fallback":
+        _console.print(
+            f"[{WARNING}]  {GLYPH_WARNING}  System keychain unavailable — {env_var} was saved to "
+            "a local fallback store instead (less protected than the OS keychain).[/]"
+        )
+        for line in get_keyring_setup_instructions(env_var):
+            _console.print(f"[{SECONDARY}]    {line}[/]")
     return True
 
 

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -48,6 +48,12 @@ def _redirect_wizard_store(tmp_path, monkeypatch) -> None:
         "DATABASE_CONNECTION_STRING",
         # Inline kubeconfig YAML embeds credentials; path-only KUBECONFIG does not.
         "KUBECONFIG_CONTENT",
+        # #4212: real-world shapes the terminal-token set previously missed.
+        "GH_APP_PRIVATE_KEY_PASSPHRASE",
+        "DB_PASS",
+        "SLACK_BEARER",
+        "AUTH0_CLIENT_JWT",
+        "SERVICE_AUTH",
     ],
 )
 def test_is_sensitive_env_key_marks_secrets(key: str) -> None:
@@ -73,6 +79,11 @@ def test_is_sensitive_env_key_marks_secrets(key: str) -> None:
         # Path to a kubeconfig file is not the credential itself.
         "KUBECONFIG",
         "HELM_KUBECONFIG",
+        # Terminal token is "method", not "auth" — a flag, not a credential.
+        "LLM_AUTH_METHOD",
+        # "passthrough"/"password_less" collapse to a terminal token that is
+        # not exactly "pass"/"password".
+        "PROXY_PASSTHROUGH",
     ],
 )
 def test_is_sensitive_env_key_leaves_non_secrets(key: str) -> None:
@@ -556,16 +567,38 @@ def test_set_env_value_rejects_sensitive_keys_with_value_error() -> None:
         set_env_value(["FOO=bar\n"], "GITLAB_ACCESS_TOKEN", "secret")
 
 
-def test_sync_env_secret_raises_when_keyring_unavailable(monkeypatch) -> None:
+def test_sync_env_secret_raises_when_keyring_and_fallback_both_unavailable(monkeypatch) -> None:
     monkeypatch.setattr(
-        "config.env_file.save_keyring_secret",
+        "config.env_file.save_secret_with_fallback",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            RuntimeError("Secure local credential storage is unavailable on this machine.")
+            RuntimeError(
+                "Secure local credential storage is unavailable on this machine, "
+                "and the local fallback store could not be written either."
+            )
         ),
     )
 
-    with pytest.raises(RuntimeError, match="Failed to persist.*system keyring"):
+    with pytest.raises(RuntimeError, match="Failed to persist.*keyring or the local fallback"):
         sync_env_secret("GITLAB_ACCESS_TOKEN", "gl-secret-token")
+
+
+def test_sync_env_secret_falls_back_to_local_store_when_keyring_unavailable(monkeypatch) -> None:
+    """#1403, #3348: a locked/missing keyring backend must not abort onboarding
+    — the secret should land in the local fallback store and still resolve.
+
+    ``OPENSRE_DISABLE_KEYRING`` stands in for "backend unavailable" here: it
+    drives ``save_keyring_secret``/``resolve_keyring_secret`` through the same
+    RuntimeError/empty-read paths a locked Keychain or missing D-Bus session
+    would, without depending on the real OS backend in CI. The fallback file
+    itself is already redirected off the developer's real ``~/.opensre`` by
+    the root conftest's ``_isolate_opensre_home_files`` autouse fixture.
+    """
+    monkeypatch.setenv("OPENSRE_DISABLE_KEYRING", "1")
+
+    tier = sync_env_secret("GITLAB_ACCESS_TOKEN", "gl-secret-token")
+
+    assert tier == "fallback"
+    assert resolve_env_credential("GITLAB_ACCESS_TOKEN") == "gl-secret-token"
 
 
 def test_sync_env_values_routes_secrets_to_keyring(tmp_path, monkeypatch) -> None:

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -159,7 +159,6 @@ def test_run_wizard_no_saved_provider_shows_selection(monkeypatch, tmp_path) -> 
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     exit_code = flow.run_wizard()
     assert exit_code == 0
@@ -188,7 +187,10 @@ def test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable(
         _ui,
         "save_api_key",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            RuntimeError("Secure local credential storage is unavailable on this machine.")
+            RuntimeError(
+                "Secure local credential storage is unavailable on this machine, "
+                "and the local fallback store could not be written either."
+            )
         ),
     )
     monkeypatch.setattr(
@@ -205,7 +207,8 @@ def test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable(
 
     assert exit_code == 1
     output = capsys.readouterr().out
-    assert "OpenSRE could not save your API key to the local system keychain." in output
+    assert "OpenSRE could not save your API key to the local system keychain or a local" in output
+    assert "fallback store." in output
     assert "Install it first: sudo apt update && sudo apt install -y gnome-keyring" in output
     assert "dbus-user-session" in output
     assert "Start a D-Bus shell: dbus-run-session -- sh" in output
@@ -256,7 +259,6 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -338,7 +340,6 @@ def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -423,7 +424,6 @@ def test_run_wizard_configures_coralogix(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -499,7 +499,6 @@ def test_run_wizard_configures_dagster(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -568,7 +567,6 @@ def test_run_wizard_configures_dagster_oss_skips_secret(monkeypatch, tmp_path) -
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         _setup_flow,
         "sync_env_values",
@@ -639,7 +637,6 @@ def test_run_wizard_configures_slack_persists_webhook(monkeypatch, tmp_path) -> 
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -723,7 +720,6 @@ def test_run_wizard_dagster_retries_on_validation_failure(monkeypatch, tmp_path)
     _stub_dagster_setup(monkeypatch, _validate_dagster)
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -818,7 +814,6 @@ def test_run_wizard_configures_github_mcp_and_sentry(monkeypatch, tmp_path, caps
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -1745,7 +1740,6 @@ def test_run_wizard_configures_gitlab(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -1835,7 +1829,6 @@ def test_run_wizard_gitlab_retries_on_validation_failure(monkeypatch, tmp_path) 
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2002,7 +1995,6 @@ def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2106,7 +2098,6 @@ def test_run_wizard_opensearch_retries_on_validation_failure(monkeypatch, tmp_pa
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(_setup_flow, "sync_env_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
@@ -2197,7 +2188,6 @@ def test_run_wizard_opensearch_allows_url_only_when_auth_blank(monkeypatch, tmp_
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(_setup_flow, "sync_env_secret", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(_setup_flow, "sync_env_values", lambda *_a, **_kw: tmp_path / ".env")
     monkeypatch.setattr(
@@ -2296,7 +2286,6 @@ def test_run_wizard_opensearch_rejects_empty_basic_password(monkeypatch, tmp_pat
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(_setup_flow, "sync_env_secret", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(_setup_flow, "sync_env_values", lambda *_a, **_kw: tmp_path / ".env")
     monkeypatch.setattr(
@@ -2367,7 +2356,6 @@ def test_run_wizard_configures_telegram(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2439,7 +2427,6 @@ def test_run_wizard_telegram_retries_on_validation_failure(monkeypatch, tmp_path
     _stub_telegram_setup(monkeypatch, _validate)
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(_setup_flow, "sync_env_values", lambda *_a, **_kw: tmp_path / ".env")
     monkeypatch.setattr(_setup_flow, "sync_env_secret", lambda *_a, **_kw: None)
     monkeypatch.setattr(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,11 +72,24 @@ def _restore_os_environ():
 
 
 @pytest.fixture(autouse=True)
-def _disable_system_keyring(request, monkeypatch) -> None:
-    """Keep tests isolated from any real developer keychain entries."""
+def _disable_system_keyring(request, monkeypatch) -> Iterator[None]:
+    """Keep tests isolated from any real developer keychain entries.
+
+    Also resets the per-process keyring session cache (added for #3295/#1403):
+    a test that intentionally provokes a backend failure sets
+    ``_KeyringSession.backend_unavailable`` sticky for the rest of the
+    process, which would otherwise make unrelated later tests in the same
+    worker silently skip a working ``MemoryKeyring()`` backend.
+    """
+    from config.llm_keyring import reset_keyring_session
+
+    reset_keyring_session()
     if request.node.get_closest_marker("live_llm") is not None:
+        yield
         return
     monkeypatch.setenv("OPENSRE_DISABLE_KEYRING", "1")
+    yield
+    reset_keyring_session()
 
 
 @pytest.fixture(autouse=True)
@@ -103,6 +116,7 @@ def _isolate_opensre_home_files(request, monkeypatch, tmp_path) -> None:
         return
     monkeypatch.setenv("OPENSRE_WIZARD_STORE_PATH", str(tmp_path / "opensre.json"))
     monkeypatch.setenv("OPENSRE_LLM_AUTH_METADATA_PATH", str(tmp_path / "llm-auth.json"))
+    monkeypatch.setenv("OPENSRE_FALLBACK_SECRETS_PATH", str(tmp_path / "secrets.local.json"))
 
 
 def pytest_configure(config):


### PR DESCRIPTION
## Summary

`save_keyring_secret`/`sync_env_secret` had no fallback: any OS keychain failure raised a `RuntimeError` that onboarding treated as fatal, with no path to a working state. One root cause, four symptoms:

- **#3348** — `opensre onboard` fails outright on macOS when the login Keychain is locked (e.g. after waking from sleep).
- **#1403** — `opensre onboard` fails outright on headless Linux/EC2, where `keyring` has no working backend at all (`keyring.backends.fail.Keyring`).
- **#3591** — "better LLM key failure UX during onboarding" *is* this fix, once a fallback exists.
- **#3295** — macOS shows 3 separate Keychain authorization prompts per run, because each read/write of the same credential (status check, save, verify) hit the OS backend independently with no per-process memoization.

### What changed

`config/llm_keyring.py`:
- `save_secret_with_fallback` / `resolve_secret_with_fallback`: try the OS keyring first, and only fall back to a local JSON store (owner-only permissions, under `OPENSRE_HOME_DIR`, distinct from the project `.env` that `config/env_file.py` deliberately keeps secret-free) when the keyring backend is unavailable. Raises only when *both* tiers fail.
- `fallback_store_path()` honors an `OPENSRE_FALLBACK_SECRETS_PATH` override, mirroring the existing `get_project_env_path()` pattern, so tests (and anyone else) can redirect it off `~/.opensre`.
- A per-process `_KeyringSession` memoizes successful reads and flips a sticky `backend_unavailable` flag on the first hard failure, so a run that touches the same credential more than once (status check → save → verify) hits the OS backend at most once instead of re-prompting macOS Keychain authorization on every call.

Wired through `config/env_file.py` (`sync_env_secret`, used by every integration's setup flow, not just LLM keys), `config/llm_auth/credentials.py` (`save_api_key`, `resolve_for_request`), and the wizard's `_persist_llm_api_key`, which now prints a clear (non-fatal) warning when the fallback tier was used instead of aborting onboarding.

Also hardens `is_sensitive_env_key` (**#4212**) with `passphrase`/`pass`/`bearer`/`jwt`/`auth` terminal tokens, so those credential shapes route to secure storage instead of landing in plaintext `.env`. Checked against `config/constants/**` for false positives (e.g. `LLM_AUTH_METHOD`'s terminal segment is `method`, not `auth`).

Fixes #3295, #3348, #1403, #3591, #4212.

## Test plan
- [x] New tests: fallback save/resolve round-trip when the keyring is disabled/unavailable, "both tiers fail" still raises, and the expanded `is_sensitive_env_key` classifications (including non-regressions like `LLM_AUTH_METHOD`, `PROXY_PASSTHROUGH`).
- [x] Updated `tests/cli/wizard/test_flow.py`: removed now-redundant `save_keyring_secret` stubs (every test already runs with `OPENSRE_DISABLE_KEYRING=1` and an isolated fallback path via the root conftest) and updated the "both tiers unavailable" regression test's expected message.
- [x] Added a `reset_keyring_session()` test hook and wired it into the existing `_disable_system_keyring` autouse fixture in `tests/conftest.py` — the new sticky `backend_unavailable` flag is process-global, so a test that intentionally provokes a backend failure would otherwise leak that state into unrelated later tests in the same worker.
- [x] `pytest tests/config/ tests/cli/wizard/ tests/cli/test_auth_command.py tests/integrations/test_*credential_resolve.py tests/interactive_shell/test_model_credential_entry.py` — 377 passed (5 pre-existing, unrelated failures confirmed present on `main` too: Windows-only perf-threshold/encoding/`os.fpathconf` issues, nothing touching credential storage).