### PR TITLE
fix(agent): compact conversation overflow into a running summary instead of dropping turns

### DIFF
--- a/core/agent_harness/prompts/conversation_memory.py
+++ b/core/agent_harness/prompts/conversation_memory.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import re
 
-MAX_CONVERSATION_TURNS = 12
-MAX_CONVERSATION_MESSAGES = MAX_CONVERSATION_TURNS * 2
+from core.state import MAX_CONVERSATION_TURNS
+from core.state.transcript_window import SESSION_SUMMARY_PREFIX
 
 NO_HISTORY_PLACEHOLDER = "(no prior messages in this CLI thread)"
 _ACTION_FACT_MARKERS = (
@@ -87,6 +87,10 @@ def _latest_want_me_to_offer(
         except (TypeError, ValueError):
             continue
         if role != "assistant" or not isinstance(content, str):
+            continue
+        # A compacted session summary can quote an old offer; only live
+        # assistant messages carry an actionable "Want me to:".
+        if content.startswith(SESSION_SUMMARY_PREFIX):
             continue
         match = _WANT_ME_TO_RE.search(content)
         if not match:

--- a/core/agent_harness/prompts/conversation_memory.py
+++ b/core/agent_harness/prompts/conversation_memory.py
@@ -148,6 +148,12 @@ def format_prior_action_facts(
             continue
         if role != "assistant" or not isinstance(content, str):
             continue
+        # A compacted session summary quotes old tool output wholesale; letting
+        # it in as one giant "fact" can spend the whole budget and starve
+        # newer live results. The summary reaches the model via the history
+        # block instead.
+        if content.startswith(SESSION_SUMMARY_PREFIX):
+            continue
         text = content.strip()
         if not text:
             continue

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -29,8 +29,8 @@ from core.agent_harness.ports import (
     ToolProvider,
 )
 from core.agent_harness.prompts import build_action_system_prompt, build_action_user_message
-from core.agent_harness.prompts.conversation_memory import MAX_CONVERSATION_MESSAGES
 from core.agent_harness.session.integration_resolution import resolve_and_cache_integrations
+from core.agent_harness.turns.conversation_recording import record_conversation_turn
 from core.agent_harness.turns.turn_plan import TurnPlan
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
@@ -303,10 +303,7 @@ def _turn_resolved_integrations(
 
 
 def _persist_tool_calling_error(session: SessionStore, user_text: str, error_text: str) -> None:
-    session.cli_agent_messages.append(("user", user_text))
-    session.cli_agent_messages.append(("assistant", error_text))
-    if len(session.cli_agent_messages) > MAX_CONVERSATION_MESSAGES:
-        session.cli_agent_messages[:] = session.cli_agent_messages[-MAX_CONVERSATION_MESSAGES:]
+    record_conversation_turn(session, user_text, error_text)
 
 
 def _render_tool_calling_error(output: OutputSink, message: str) -> None:

--- a/core/agent_harness/turns/conversation_recording.py
+++ b/core/agent_harness/turns/conversation_recording.py
@@ -1,0 +1,25 @@
+"""Record a conversation turn on a session, keeping it within the window."""
+
+from __future__ import annotations
+
+from core.agent_harness.ports import SessionStore
+from core.state import MAX_CONVERSATION_MESSAGES
+from core.state.transcript_window import compact_messages_to_window
+
+
+def record_conversation_turn(session: SessionStore, user_text: str, assistant_text: str) -> None:
+    """Append one user/assistant exchange and compact to the message window.
+
+    The single write path for ``session.cli_agent_messages`` in the turn
+    engine; sessions backed by ``MutableAgentState`` apply the same window
+    through ``record_turn``.
+    """
+    session.cli_agent_messages.append(("user", user_text))
+    session.cli_agent_messages.append(("assistant", assistant_text))
+    if len(session.cli_agent_messages) > MAX_CONVERSATION_MESSAGES:
+        session.cli_agent_messages[:] = compact_messages_to_window(
+            session.cli_agent_messages, max_messages=MAX_CONVERSATION_MESSAGES
+        )
+
+
+__all__ = ["record_conversation_turn"]

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -36,11 +36,9 @@ from core.agent_harness.ports import (
     TurnAccounting,
 )
 from core.agent_harness.prompts import build_cli_agent_prompt_from_provider
-from core.agent_harness.prompts.conversation_memory import (
-    MAX_CONVERSATION_MESSAGES,
-    expand_affirmative_follow_up,
-)
+from core.agent_harness.prompts.conversation_memory import expand_affirmative_follow_up
 from core.agent_harness.session.terminal_access import agent_turn_executed_slashes
+from core.agent_harness.turns.conversation_recording import record_conversation_turn
 from core.agent_harness.turns.transcript_compaction import auto_compact_if_needed
 from core.agent_harness.turns.turn_plan import TurnPlan, build_turn_plan
 from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
@@ -127,10 +125,7 @@ def _stream_response(
 
 
 def _record_answer_turn(session: SessionStore, message: str, assistant_text: str) -> None:
-    session.cli_agent_messages.append(("user", message))
-    session.cli_agent_messages.append(("assistant", assistant_text))
-    if len(session.cli_agent_messages) > MAX_CONVERSATION_MESSAGES:
-        session.cli_agent_messages[:] = session.cli_agent_messages[-MAX_CONVERSATION_MESSAGES:]
+    record_conversation_turn(session, message, assistant_text)
 
 
 def _record_action_only_turn(session: SessionStore, message: str, assistant_text: str) -> None:

--- a/core/agent_harness/turns/transcript_compaction.py
+++ b/core/agent_harness/turns/transcript_compaction.py
@@ -6,9 +6,14 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
+from core.state.transcript_window import (
+    SESSION_SUMMARY_PREFIX,
+    SUMMARY_MAX_CHARS,
+    format_messages_for_summary,
+)
+
 DEFAULT_AUTO_COMPACTION_CHARS = 48_000
 _KEEP_RECENT_MESSAGES = 8
-_SUMMARY_MAX_CHARS = 6_000
 
 
 @dataclass(frozen=True)
@@ -60,7 +65,7 @@ def compact_session_branch(
     kept = messages[-_KEEP_RECENT_MESSAGES:]
     compacted = messages[:-_KEEP_RECENT_MESSAGES]
     final_summary = summary or deterministic_summary(compacted)
-    session.agent.messages = [("assistant", f"Session summary:\n{final_summary}"), *kept]
+    session.agent.messages = [("assistant", f"{SESSION_SUMMARY_PREFIX}{final_summary}"), *kept]
     after_chars = _message_chars(list(session.agent.messages))
     session.storage.append_compaction(
         session.session_id,
@@ -92,8 +97,8 @@ def auto_compact_if_needed(
 def deterministic_summary(messages: list[tuple[str, str]]) -> str:
     if not messages:
         return ""
-    first = _render_message_excerpt(messages[:4])
-    recent = _render_message_excerpt(messages[-4:]) if len(messages) > 4 else ""
+    first = format_messages_for_summary(messages[:4])
+    recent = format_messages_for_summary(messages[-4:]) if len(messages) > 4 else ""
     parts = [
         f"Compacted {len(messages)} earlier conversation messages.",
         "Earlier context:",
@@ -101,17 +106,7 @@ def deterministic_summary(messages: list[tuple[str, str]]) -> str:
     ]
     if recent:
         parts.extend(["Most recent compacted context:", recent])
-    return "\n".join(part for part in parts if part).strip()[:_SUMMARY_MAX_CHARS]
-
-
-def _render_message_excerpt(messages: list[tuple[str, str]]) -> str:
-    lines: list[str] = []
-    for role, text in messages:
-        compact = " ".join(str(text).split())
-        if len(compact) > 700:
-            compact = compact[:697] + "..."
-        lines.append(f"- {role}: {compact}")
-    return "\n".join(lines)
+    return "\n".join(part for part in parts if part).strip()[:SUMMARY_MAX_CHARS]
 
 
 def _estimate_tokens(chars: int) -> int:

--- a/core/agent_harness/turns/transcript_compaction.py
+++ b/core/agent_harness/turns/transcript_compaction.py
@@ -10,6 +10,9 @@ from core.state.transcript_window import (
     SESSION_SUMMARY_PREFIX,
     SUMMARY_MAX_CHARS,
     format_messages_for_summary,
+    is_summary_message,
+    merge_summary_texts,
+    summary_text,
 )
 
 DEFAULT_AUTO_COMPACTION_CHARS = 48_000
@@ -55,6 +58,8 @@ def compact_session_branch(
     The LLM-summary path is intentionally optional at this layer. When callers
     do not provide a summary, compaction uses a deterministic fallback so the
     shell can always recover space without depending on another provider call.
+    A leading session-summary message (from message-window compaction) is
+    carried through whole and merged head-first, never excerpted per line.
     """
 
     messages = list(session.agent.messages)
@@ -64,7 +69,11 @@ def compact_session_branch(
     before_chars = _message_chars(messages)
     kept = messages[-_KEEP_RECENT_MESSAGES:]
     compacted = messages[:-_KEEP_RECENT_MESSAGES]
-    final_summary = summary or deterministic_summary(compacted)
+    prior = ""
+    if compacted and is_summary_message(compacted[0]):
+        prior = summary_text(compacted[0])
+        compacted = compacted[1:]
+    final_summary = merge_summary_texts(prior, summary or deterministic_summary(compacted))
     session.agent.messages = [("assistant", f"{SESSION_SUMMARY_PREFIX}{final_summary}"), *kept]
     after_chars = _message_chars(list(session.agent.messages))
     session.storage.append_compaction(

--- a/core/agent_harness/turns/turn_snapshot.py
+++ b/core/agent_harness/turns/turn_snapshot.py
@@ -10,7 +10,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-from core.agent_harness.prompts.conversation_memory import MAX_CONVERSATION_MESSAGES
+from core.state import MAX_CONVERSATION_MESSAGES
+from core.state.transcript_window import compact_messages_to_window
 
 if TYPE_CHECKING:
     from config.llm_reasoning_effort import ReasoningEffortChoice
@@ -112,7 +113,8 @@ class TurnSnapshot:
 
     conversation_messages: tuple[tuple[str, str], ...]
     """Snapshot of recent CLI conversation: ``(role, content)`` pairs, oldest
-    first, capped to ``MAX_CONVERSATION_MESSAGES`` entries at assembly time."""
+    first, compacted to the ``MAX_CONVERSATION_MESSAGES`` window at assembly
+    time (overflow becomes a leading session-summary message)."""
 
     configured_integrations: tuple[str, ...]
     """Integration names known to be configured at turn start."""
@@ -167,11 +169,13 @@ class TurnSnapshot:
         source also exposes ``select_turn_runtime_input`` directly or through
         ``source.agent``, runtime request fields are snapshotted too.
         """
-        messages = session.cli_agent_messages
-        snapshot: tuple[tuple[str, str], ...] = tuple(
+        valid_messages = [
             (str(role), str(content))
-            for role, content in messages[-MAX_CONVERSATION_MESSAGES:]
+            for role, content in session.cli_agent_messages
             if isinstance(role, str) and isinstance(content, str)
+        ]
+        snapshot: tuple[tuple[str, str], ...] = tuple(
+            compact_messages_to_window(valid_messages, max_messages=MAX_CONVERSATION_MESSAGES)
         )
         runtime_input = _select_runtime_request_input(text, session)
         last_observation = _read_last_observation(session, runtime_input)

--- a/core/state/agent_state.py
+++ b/core/state/agent_state.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Literal
 
+from core.state.transcript_window import compact_messages_to_window
+
 MAX_CONVERSATION_TURNS = 12
 MAX_CONVERSATION_MESSAGES = MAX_CONVERSATION_TURNS * 2
 
@@ -48,7 +50,7 @@ class MutableAgentState:
     def record_turn(self, user_message: str, assistant_message: str) -> None:
         self._messages.append(("user", user_message))
         self._messages.append(("assistant", assistant_message))
-        self._trim_messages()
+        self._compact_messages()
 
     def reset_observation(self) -> None:
         self._last_observation = None
@@ -59,11 +61,13 @@ class MutableAgentState:
 
     def _replace_messages(self, messages: Sequence[tuple[str, str]]) -> None:
         self._messages = list(messages)
-        self._trim_messages()
+        self._compact_messages()
 
-    def _trim_messages(self) -> None:
+    def _compact_messages(self) -> None:
         if len(self._messages) > MAX_CONVERSATION_MESSAGES:
-            self._messages[:] = self._messages[-MAX_CONVERSATION_MESSAGES:]
+            self._messages[:] = compact_messages_to_window(
+                self._messages, max_messages=MAX_CONVERSATION_MESSAGES
+            )
 
 
 __all__ = [

--- a/core/state/transcript_window.py
+++ b/core/state/transcript_window.py
@@ -58,16 +58,23 @@ def compact_messages_to_window(
     overflow = entries[: len(entries) - keep_count]
 
     prior = ""
-    if overflow and _is_summary_message(overflow[0]):
-        prior = overflow[0][1][len(SESSION_SUMMARY_PREFIX) :]
+    if overflow and is_summary_message(overflow[0]):
+        prior = summary_text(overflow[0])
         overflow = overflow[1:]
 
-    overflow_lines = format_messages_for_summary(overflow)
-    merged = "\n".join(part for part in (prior, overflow_lines) if part)[:summary_max_chars]
+    merged = merge_summary_texts(
+        prior, format_messages_for_summary(overflow), max_chars=summary_max_chars
+    )
     return [("assistant", f"{SESSION_SUMMARY_PREFIX}{merged}"), *kept]
 
 
-def _is_summary_message(entry: tuple[str, str]) -> bool:
+def merge_summary_texts(prior: str, addition: str, *, max_chars: int = SUMMARY_MAX_CHARS) -> str:
+    """Merge summary bodies keeping the head; the tail truncates first."""
+    return "\n".join(part for part in (prior, addition) if part)[:max_chars]
+
+
+def is_summary_message(entry: tuple[str, str]) -> bool:
+    """True when ``entry`` is a session-summary assistant message."""
     role, content = entry
     return (
         role == "assistant"
@@ -76,9 +83,17 @@ def _is_summary_message(entry: tuple[str, str]) -> bool:
     )
 
 
+def summary_text(entry: tuple[str, str]) -> str:
+    """Return the summary body of a session-summary message."""
+    return entry[1][len(SESSION_SUMMARY_PREFIX) :]
+
+
 __all__ = [
     "SUMMARY_MAX_CHARS",
     "SESSION_SUMMARY_PREFIX",
     "compact_messages_to_window",
     "format_messages_for_summary",
+    "is_summary_message",
+    "merge_summary_texts",
+    "summary_text",
 ]

--- a/core/state/transcript_window.py
+++ b/core/state/transcript_window.py
@@ -1,0 +1,83 @@
+"""Transcript window compaction: overflow becomes a running summary message.
+
+When a conversation transcript exceeds its message window, the oldest
+messages are compacted into a single leading ``Session summary:`` assistant
+message, so facts stated early in a session stay visible. This enforces the
+message-count window; the char-threshold session compaction in the turns
+layer is a separate mechanism that shares the same summary-message format.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+SESSION_SUMMARY_PREFIX = "Session summary:\n"
+SUMMARY_MAX_CHARS = 6_000
+_SUMMARY_LINE_MAX_CHARS = 700
+
+
+def format_messages_for_summary(
+    messages: Sequence[tuple[str, str]],
+    *,
+    max_line_chars: int = _SUMMARY_LINE_MAX_CHARS,
+) -> str:
+    """Render messages as compact ``- role: text`` lines, one per message."""
+    lines: list[str] = []
+    for role, text in messages:
+        compact = " ".join(str(text).split())
+        if len(compact) > max_line_chars:
+            compact = compact[: max_line_chars - 3] + "..."
+        lines.append(f"- {role}: {compact}")
+    return "\n".join(lines)
+
+
+def compact_messages_to_window(
+    messages: Sequence[tuple[str, str]],
+    *,
+    max_messages: int,
+    summary_max_chars: int = SUMMARY_MAX_CHARS,
+) -> list[tuple[str, str]]:
+    """Return ``messages`` within the window, compacting overflow into a summary.
+
+    Within the window the list is returned unchanged. On overflow, the most
+    recent messages are kept verbatim (an even count, so user/assistant turn
+    pairing survives) and everything older is summarized into one leading
+    ``Session summary:`` assistant message. An existing leading summary is
+    merged, never stacked; the merged text keeps its head and truncates its
+    tail, so the earliest facts are the last to go.
+    """
+    entries = list(messages)
+    if len(entries) <= max_messages:
+        return entries
+
+    keep_count = max(max_messages - 2, 2)
+    if keep_count % 2:
+        keep_count -= 1
+    kept = entries[-keep_count:]
+    overflow = entries[: len(entries) - keep_count]
+
+    prior = ""
+    if overflow and _is_summary_message(overflow[0]):
+        prior = overflow[0][1][len(SESSION_SUMMARY_PREFIX) :]
+        overflow = overflow[1:]
+
+    overflow_lines = format_messages_for_summary(overflow)
+    merged = "\n".join(part for part in (prior, overflow_lines) if part)[:summary_max_chars]
+    return [("assistant", f"{SESSION_SUMMARY_PREFIX}{merged}"), *kept]
+
+
+def _is_summary_message(entry: tuple[str, str]) -> bool:
+    role, content = entry
+    return (
+        role == "assistant"
+        and isinstance(content, str)
+        and content.startswith(SESSION_SUMMARY_PREFIX)
+    )
+
+
+__all__ = [
+    "SUMMARY_MAX_CHARS",
+    "SESSION_SUMMARY_PREFIX",
+    "compact_messages_to_window",
+    "format_messages_for_summary",
+]

--- a/core/state/transcript_window.py
+++ b/core/state/transcript_window.py
@@ -46,14 +46,15 @@ def compact_messages_to_window(
     merged, never stacked; the merged text keeps its head and truncates its
     tail, so the earliest facts are the last to go.
     """
+    if max_messages < 1:
+        raise ValueError("max_messages must be >= 1")
     entries = list(messages)
     if len(entries) <= max_messages:
         return entries
 
-    keep_count = max(max_messages - 2, 2)
-    if keep_count % 2:
-        keep_count -= 1
-    kept = entries[-keep_count:]
+    keep_count = max_messages - 1
+    keep_count -= keep_count % 2
+    kept = entries[-keep_count:] if keep_count else []
     overflow = entries[: len(entries) - keep_count]
 
     prior = ""

--- a/tests/core/agent/orchestration/test_conversation_window.py
+++ b/tests/core/agent/orchestration/test_conversation_window.py
@@ -1,0 +1,76 @@
+"""A fact stated early in a long conversation must stay visible to the model.
+
+Drives the real turn-recording paths (orchestrator and action driver) through a
+session whose ``cli_agent_messages`` aliases ``agent.messages``, mirroring the
+production session wiring, and checks the history block the assistant prompt
+renders from.
+"""
+
+from __future__ import annotations
+
+from core.agent_harness.prompts.conversation_memory import format_recent_conversation
+from core.agent_harness.turns.action_driver import _persist_tool_calling_error
+from core.agent_harness.turns.orchestrator import _record_answer_turn
+from core.state import MAX_CONVERSATION_MESSAGES, MutableAgentState
+from core.state.transcript_window import SESSION_SUMMARY_PREFIX
+
+_FACT = "prod-eu-42"
+
+
+class _Session:
+    def __init__(self) -> None:
+        self.agent = MutableAgentState()
+
+    @property
+    def cli_agent_messages(self) -> list[tuple[str, str]]:
+        return self.agent.messages
+
+
+def _run_short_turns(session: _Session, count: int, start: int = 2) -> None:
+    for i in range(start, start + count):
+        _record_answer_turn(
+            session,
+            f"Turn {i}: what's the status of service-{i}?",
+            f"service-{i} looks healthy.",
+        )
+
+
+def test_turn_one_fact_survives_fourteen_turns() -> None:
+    session = _Session()
+    _record_answer_turn(
+        session,
+        f"my cluster is named {_FACT}",
+        f"Got it — your cluster is {_FACT}.",
+    )
+
+    _run_short_turns(session, count=13)
+
+    history_block = format_recent_conversation(session.cli_agent_messages)
+    assert _FACT in history_block
+    assert len(session.cli_agent_messages) <= MAX_CONVERSATION_MESSAGES
+
+
+def test_window_holds_single_summary_over_long_sessions() -> None:
+    session = _Session()
+    _record_answer_turn(session, f"remember {_FACT}", "noted")
+
+    _run_short_turns(session, count=40)
+
+    messages = session.cli_agent_messages
+    summaries = [m for m in messages if m[1].startswith(SESSION_SUMMARY_PREFIX)]
+    assert len(summaries) == 1
+    assert messages[0] == summaries[0]
+    assert _FACT in messages[0][1]
+    assert len(messages) <= MAX_CONVERSATION_MESSAGES
+
+
+def test_tool_error_recording_compacts_instead_of_dropping() -> None:
+    session = _Session()
+    _record_answer_turn(session, f"remember {_FACT}", "noted")
+
+    for i in range(2, 16):
+        _persist_tool_calling_error(session, f"turn {i} request", f"turn {i} error")
+
+    history_block = format_recent_conversation(session.cli_agent_messages)
+    assert _FACT in history_block
+    assert len(session.cli_agent_messages) <= MAX_CONVERSATION_MESSAGES

--- a/tests/core/agent/prompts/test_conversation_history.py
+++ b/tests/core/agent/prompts/test_conversation_history.py
@@ -90,3 +90,22 @@ def test_prior_action_facts_extracts_tool_outputs_and_values() -> None:
     assert "slack_send_message input" in rendered
     assert "London" in rendered
     assert "paste the original message" not in rendered
+
+
+def test_prior_action_facts_skips_session_summary() -> None:
+    """A tool-heavy summary must not consume the facts budget and starve
+    live tool results."""
+    summary_body = "\n".join(
+        f"- assistant: tool: old_tool_{i} result: stale-summary-output-{i} " + "x" * 300
+        for i in range(20)
+    )
+    messages = [
+        ("assistant", f"Session summary:\n{summary_body}"),
+        ("user", "check the queue"),
+        ("assistant", "queue_depth result: important-live-fact"),
+    ]
+
+    rendered = format_prior_action_facts(messages)
+
+    assert "important-live-fact" in rendered
+    assert "stale-summary-output" not in rendered

--- a/tests/core/agent/prompts/test_conversation_history.py
+++ b/tests/core/agent/prompts/test_conversation_history.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 from core.agent_harness.prompts.conversation_memory import (
-    MAX_CONVERSATION_MESSAGES,
-    MAX_CONVERSATION_TURNS,
     NO_HISTORY_PLACEHOLDER,
     format_prior_action_facts,
     format_recent_conversation,
 )
+from core.state import MAX_CONVERSATION_MESSAGES, MAX_CONVERSATION_TURNS
 
 
 def test_placeholder_when_no_history() -> None:

--- a/tests/core/agent/test_turn_snapshot_runtime_request.py
+++ b/tests/core/agent/test_turn_snapshot_runtime_request.py
@@ -7,10 +7,11 @@ import pytest
 
 from core.agent import Agent
 from core.agent_harness.prompts import PromptEnvelope
-from core.agent_harness.prompts.conversation_memory import MAX_CONVERSATION_MESSAGES
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
 from core.llm.types import AgentLLMResponse
 from core.messages import UserRuntimeMessage
+from core.state import MAX_CONVERSATION_MESSAGES
+from core.state.transcript_window import SESSION_SUMMARY_PREFIX
 from core.types import AgentTool
 
 
@@ -197,8 +198,10 @@ def test_turn_snapshot_from_session_snapshots_shell_and_runtime_request_fields()
 
     assert session.agent.seen_text == "next turn"
     assert ctx.text == "next turn"
-    assert len(ctx.conversation_messages) == MAX_CONVERSATION_MESSAGES
-    assert ctx.conversation_messages[0] == ("user", "2")
+    assert len(ctx.conversation_messages) <= MAX_CONVERSATION_MESSAGES
+    assert ctx.conversation_messages[0][1].startswith(SESSION_SUMMARY_PREFIX)
+    assert "0" in ctx.conversation_messages[0][1]
+    assert ctx.conversation_messages[-1] == ("user", str(MAX_CONVERSATION_MESSAGES + 1))
     assert ctx.configured_integrations == ("github",)
     assert ctx.last_state == {"root_cause": "db saturation"}
     assert ctx.last_synthetic_observation_path == "/tmp/observation.json"

--- a/tests/core/agent_harness/prompts/test_conversation_memory_follow_up.py
+++ b/tests/core/agent_harness/prompts/test_conversation_memory_follow_up.py
@@ -59,6 +59,25 @@ def test_leaves_affirmative_unchanged_without_want_me_to() -> None:
     assert expand_affirmative_follow_up("yes", history) == "yes"
 
 
+def test_ignores_offers_inside_session_summary() -> None:
+    history = [
+        (
+            "assistant",
+            "Session summary:\n"
+            "- user: check the pipeline\n"
+            "- assistant: I found a failing job. Want me to: rerun stale-marker-pipeline?\n"
+            "- user: no thanks",
+        ),
+        ("user", "what is toil?"),
+        ("assistant", "Toil is repetitive manual work."),
+    ]
+
+    expanded = expand_affirmative_follow_up("yes", history)
+
+    assert expanded == "yes"
+    assert "stale-marker-pipeline" not in expanded
+
+
 def test_expands_bare_sure_without_slack_prefix() -> None:
     history = [
         ("assistant", "**Want me to:** dig into the top Sentry issue?"),

--- a/tests/core/agent_harness/turns/test_transcript_compaction.py
+++ b/tests/core/agent_harness/turns/test_transcript_compaction.py
@@ -1,0 +1,67 @@
+"""Char-threshold compaction must preserve an existing window summary."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from core.agent_harness.turns.transcript_compaction import compact_session_branch
+from core.state.transcript_window import SESSION_SUMMARY_PREFIX
+
+
+class _FakeStorage:
+    def __init__(self) -> None:
+        self.compactions: list[dict[str, Any]] = []
+
+    def append_compaction(self, session_id: str, **kwargs: Any) -> str:
+        self.compactions.append({"session_id": session_id, **kwargs})
+        return "entry-id"
+
+
+class _FakeSession:
+    def __init__(self, messages: list[tuple[str, str]]) -> None:
+        self.agent = SimpleNamespace(messages=list(messages))
+        self.storage = _FakeStorage()
+        self.session_id = "session-under-test"
+
+
+def _long_turns(n: int) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    for i in range(n):
+        out.append(("user", f"question {i} " + "y" * 200))
+        out.append(("assistant", f"answer {i} " + "z" * 200))
+    return out
+
+
+def test_char_compaction_preserves_existing_window_summary() -> None:
+    """A fact sitting past the 700-char excerpt cut inside a prior window
+    summary must survive char-threshold compaction."""
+    deep_fact = "deep-fact-prod-eu-42"
+    prior_summary = "x" * 750 + " " + deep_fact
+    messages = [
+        ("assistant", f"{SESSION_SUMMARY_PREFIX}{prior_summary}"),
+        *_long_turns(10),
+    ]
+    session = _FakeSession(messages)
+
+    result = compact_session_branch(session)
+
+    assert result is not None
+    head_role, head_content = session.agent.messages[0]
+    assert head_role == "assistant"
+    assert head_content.startswith(SESSION_SUMMARY_PREFIX)
+    assert deep_fact in head_content
+    summaries = [m for m in session.agent.messages if m[1].startswith(SESSION_SUMMARY_PREFIX)]
+    assert len(summaries) == 1
+
+
+def test_char_compaction_without_prior_summary_unchanged() -> None:
+    session = _FakeSession(_long_turns(10))
+
+    result = compact_session_branch(session)
+
+    assert result is not None
+    head = session.agent.messages[0][1]
+    assert head.startswith(SESSION_SUMMARY_PREFIX)
+    assert "Compacted" in head
+    assert len(session.agent.messages) == 9

--- a/tests/core/state/test_agent_state.py
+++ b/tests/core/state/test_agent_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from core.state import MAX_CONVERSATION_MESSAGES, MutableAgentState
+from core.state.transcript_window import SESSION_SUMMARY_PREFIX
 
 
 def test_record_turn_appends_transcript() -> None:
@@ -9,19 +10,27 @@ def test_record_turn_appends_transcript() -> None:
     assert state.messages == [("user", "hello"), ("assistant", "hi there")]
 
 
-def test_message_cap_trims_oldest() -> None:
+def test_message_cap_compacts_oldest_into_summary() -> None:
     state = MutableAgentState()
     for index in range(MAX_CONVERSATION_MESSAGES + 3):
         state.record_turn(f"user {index}", f"assistant {index}")
 
-    assert len(state.messages) == MAX_CONVERSATION_MESSAGES
-    assert state.messages[0] == ("user", "user 15")
+    assert len(state.messages) <= MAX_CONVERSATION_MESSAGES
+    role, content = state.messages[0]
+    assert role == "assistant"
+    assert content.startswith(SESSION_SUMMARY_PREFIX)
+    assert "user 0" in content
+    assert state.messages[-1] == (
+        "assistant",
+        f"assistant {MAX_CONVERSATION_MESSAGES + 2}",
+    )
 
 
-def test_messages_setter_replaces_and_trims() -> None:
+def test_messages_setter_replaces_and_compacts() -> None:
     state = MutableAgentState()
     state.messages = [("user", str(i)) for i in range(MAX_CONVERSATION_MESSAGES + 5)]
-    assert len(state.messages) == MAX_CONVERSATION_MESSAGES
+    assert len(state.messages) <= MAX_CONVERSATION_MESSAGES
+    assert state.messages[0][1].startswith(SESSION_SUMMARY_PREFIX)
 
 
 def test_last_observation_roundtrip_and_reset() -> None:

--- a/tests/core/state/test_transcript_window.py
+++ b/tests/core/state/test_transcript_window.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from core.state.transcript_window import (
     SESSION_SUMMARY_PREFIX,
     compact_messages_to_window,
@@ -83,6 +85,25 @@ def test_summary_truncates_tail_not_head() -> None:
     summary = messages[0][1]
     assert len(summary) <= len(SESSION_SUMMARY_PREFIX) + 2_000
     assert "first-fact-alpha" in summary
+
+
+def test_tiny_caps_never_exceed_the_window() -> None:
+    messages = _turns(5)
+
+    three = compact_messages_to_window(messages, max_messages=3)
+    assert len(three) <= 3
+    assert three[0][1].startswith(SESSION_SUMMARY_PREFIX)
+    assert three[1:] == messages[-2:]
+
+    one = compact_messages_to_window(messages, max_messages=1)
+    assert len(one) == 1
+    assert one[0][1].startswith(SESSION_SUMMARY_PREFIX)
+    assert "question 1" in one[0][1]
+
+
+def test_rejects_nonpositive_window() -> None:
+    with pytest.raises(ValueError, match="max_messages"):
+        compact_messages_to_window(_turns(2), max_messages=0)
 
 
 def test_format_messages_for_summary_truncates_long_lines() -> None:

--- a/tests/core/state/test_transcript_window.py
+++ b/tests/core/state/test_transcript_window.py
@@ -1,0 +1,93 @@
+"""Tests for transcript window compaction: overflow becomes a running summary."""
+
+from __future__ import annotations
+
+from core.state.transcript_window import (
+    SESSION_SUMMARY_PREFIX,
+    compact_messages_to_window,
+    format_messages_for_summary,
+)
+
+_MAX = 24
+
+
+def _turns(n: int, start: int = 1) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    for i in range(start, start + n):
+        out.append(("user", f"question {i}"))
+        out.append(("assistant", f"answer {i}"))
+    return out
+
+
+def test_compact_is_noop_within_window() -> None:
+    messages = _turns(12)
+
+    assert compact_messages_to_window(messages, max_messages=_MAX) == messages
+
+
+def test_overflow_compacts_into_leading_summary() -> None:
+    messages = _turns(14)
+
+    compacted = compact_messages_to_window(messages, max_messages=_MAX)
+
+    assert len(compacted) <= _MAX
+    role, content = compacted[0]
+    assert role == "assistant"
+    assert content.startswith(SESSION_SUMMARY_PREFIX)
+    assert "question 1" in content
+    assert compacted[-1] == ("assistant", "answer 14")
+    assert compacted[1:] == messages[-(len(compacted) - 1) :]
+
+
+def test_compact_keeps_whole_turns_after_summary() -> None:
+    compacted = compact_messages_to_window(_turns(14), max_messages=_MAX)
+
+    kept = compacted[1:]
+    assert len(kept) % 2 == 0
+    assert kept[0][0] == "user"
+
+
+def test_recompaction_merges_into_single_summary() -> None:
+    messages = _turns(14)
+    compacted = compact_messages_to_window(messages, max_messages=_MAX)
+    compacted.extend(_turns(3, start=15))
+
+    recompacted = compact_messages_to_window(compacted, max_messages=_MAX)
+
+    summaries = [m for m in recompacted if m[1].startswith(SESSION_SUMMARY_PREFIX)]
+    assert len(summaries) == 1
+    assert recompacted[0] == summaries[0]
+
+
+def test_early_fact_survives_repeated_compactions() -> None:
+    messages: list[tuple[str, str]] = [
+        ("user", "my cluster is named prod-eu-42"),
+        ("assistant", "Noted: prod-eu-42."),
+    ]
+    for i in range(2, 40):
+        messages.append(("user", f"turn {i} question"))
+        messages.append(("assistant", f"turn {i} answer"))
+        messages = compact_messages_to_window(messages, max_messages=_MAX)
+
+    assert len(messages) <= _MAX
+    assert "prod-eu-42" in messages[0][1]
+
+
+def test_summary_truncates_tail_not_head() -> None:
+    messages: list[tuple[str, str]] = [("user", "first-fact-alpha"), ("assistant", "ok")]
+    for i in range(2, 30):
+        messages.append(("user", f"padding {i} " + "x" * 600))
+        messages.append(("assistant", "y" * 600))
+        messages = compact_messages_to_window(messages, max_messages=_MAX, summary_max_chars=2_000)
+
+    summary = messages[0][1]
+    assert len(summary) <= len(SESSION_SUMMARY_PREFIX) + 2_000
+    assert "first-fact-alpha" in summary
+
+
+def test_format_messages_for_summary_truncates_long_lines() -> None:
+    text = format_messages_for_summary([("user", "z" * 1_000)])
+
+    assert text.startswith("- user: ")
+    assert len(text) <= len("- user: ") + 700
+    assert text.endswith("...")


### PR DESCRIPTION
Fixes #4085 

#### Describe the changes you have made in this PR -

In a long interactive-shell conversation the agent forgot earlier turns: history is hard-capped at 24 messages (12 turns) at the end of every turn, while the compaction safety net only fires past 48,000 chars — a threshold a 24-message list of ordinary turns cannot reach. The cap always won, so anything older than ~12 turns was deleted with no summary. Since the provider receives only the current turn plus a rendered history block built from this capped list, a fact stated in turn 1 was simply gone by turn 14 (reproduced exactly as described in the issue; credit to @Davidson3556 for the diagnosis and the running-summary direction in #4091).

The fix makes the message-count window compact instead of delete, with one policy point:

- `core/state/transcript_window.py` (new leaf, stdlib-only) — `compact_messages_to_window`: within the window the list is unchanged; on overflow the most recent turns are kept verbatim (even count, user/assistant pairing preserved) and everything older is summarized into a single leading `Session summary:` assistant message. An existing summary is merged, never stacked; merged text truncates tail-first so the earliest facts are the last to go. `SESSION_SUMMARY_PREFIX`, `SUMMARY_MAX_CHARS`, and the line formatter are shared with the char-threshold compactor, so both mechanisms produce one summary format and cannot stack.
- Write paths (two writers, one policy): `MutableAgentState.record_turn`/setter compact via the leaf, and the new `core/agent_harness/turns/conversation_recording.py::record_conversation_turn` does the same for port-based sessions — `orchestrator._record_answer_turn` and `action_driver._persist_tool_calling_error` are one-line delegations to it. (`SessionStore` does not expose `.agent`, so a shared helper rather than routing through the state object.)
- Read side: `TurnSnapshot.from_session` compacts the snapshot through the same function instead of a raw `[-24:]` slice — belt-and-suspenders; a write path that ever bypassed compaction would produce a summarized snapshot instead of a silent drop.
- `_latest_want_me_to_offer` skips summary messages, so a bare "yes" can never expand into a stale `Want me to:` offer quoted inside compacted history (pinned by a test that plants a marker offer in a summary and asserts it does not leak).
- Constants dedup (secondary issue finding): `MAX_CONVERSATION_TURNS`/`MAX_CONVERSATION_MESSAGES` now live only in `core/state/agent_state.py`; the duplicate in `conversation_memory.py` is removed and all importers use the canonical path.

Unchanged by design: the char-threshold auto-compaction stays as the safety valve for few-but-huge messages; `format_recent_conversation` needs no changes (the summary is an ordinary assistant message inside the window); the evidence-gather 3-turn slice is pre-existing and out of scope; the deterministic extractive summary is kept — swapping in an LLM-generated summary is the agreed follow-up.

Tests (all written red-first against the defect they pin): 14 new/updated across `tests/core/state/test_transcript_window.py` (window spec: no-op within window, overflow compaction, turn pairing, single-summary merge, early-fact survival over 40 turns, tail-not-head truncation, line truncation), `tests/core/state/test_agent_state.py`, `tests/core/agent/orchestration/test_conversation_window.py` (end-to-end issue repro through the real recording paths, long-session single-summary invariant, tool-error path), `tests/core/agent/test_turn_snapshot_runtime_request.py`, and `tests/core/agent_harness/prompts/test_conversation_memory_follow_up.py` (stale-offer guard).


### Demo/Screenshot for feature changes and bug fixes - 

Repro driving the real production functions (no mocks of code under test), before vs after:

    === before ===
    turn-1 fact ('prod-eu-42') in the model's history block? False
    first retained line: ('user', "Turn 3: what's the status of service-3?")
    would compaction fire here? False (975 chars vs 48000 threshold)

    === after ===
    turn-1 fact ('prod-eu-42') in the model's history block? True
    first retained line: ('assistant', "Session summary:\n- user: my cluster is named prod-eu-42\n- assistant: ...")


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
