### PR TITLE
fix(grafana): prevent datasource discovery stampede on parallel tool calls (#4245)

### DIFF
--- a/integrations/grafana/client.py
+++ b/integrations/grafana/client.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import threading
+from collections import defaultdict
 
 from integrations.grafana.base import GrafanaClientBase
 from integrations.grafana.config import GrafanaAccountConfig
@@ -13,6 +15,12 @@ from integrations.grafana.tempo import TempoMixin
 logger = logging.getLogger(__name__)
 
 _grafana_client_cache: dict[str, GrafanaClient] = {}
+
+# One lock per cache key so only concurrent callers for the *same*
+# (account_id, endpoint) pair serialise — callers for different pairs
+# proceed in parallel.  The outer dict itself is only ever mutated while
+# the corresponding per-key lock is held, so no second lock is needed.
+_grafana_client_locks: defaultdict[str, threading.Lock] = defaultdict(threading.Lock)
 
 
 class GrafanaClient(LokiMixin, TempoMixin, MimirMixin, GrafanaClientBase):
@@ -45,24 +53,34 @@ def get_grafana_client_from_credentials(
     verify_ssl: bool = True,
     ca_bundle: str = "",
 ) -> GrafanaClient:
-    """Create a Grafana client from integration credentials."""
+    """Create a Grafana client from integration credentials.
+
+    Datasource discovery (``discover_datasource_uids``) is an HTTP call that
+    can take up to 10 seconds.  When an investigation batches several Grafana
+    tools in one turn they all call this function concurrently with the same
+    ``(account_id, endpoint)`` pair.  Without synchronisation every caller
+    races past the cache check before any of them writes the result, so each
+    one pays the full discovery cost independently — multiplying timeout hits
+    when the endpoint is unreachable.
+
+    The fix uses a per-cache-key ``threading.Lock``: the first caller acquires
+    it, performs discovery, and writes the cache.  All concurrent callers for
+    the same key block on the lock and then read the already-populated entry on
+    the fast path, making discovery happen at most once per
+    ``(account_id, endpoint)`` pair per process lifetime.
+    """
     cache_key = f"creds_{account_id}_{endpoint}"
+
+    # Fast path — already cached, no lock needed.
     if cache_key in _grafana_client_cache:
         return _grafana_client_cache[cache_key]
 
-    config = GrafanaAccountConfig(
-        account_id=account_id,
-        instance_url=endpoint.rstrip("/"),
-        read_token=api_key,
-        username=username,
-        password=password,
-        verify_ssl=verify_ssl,
-        ca_bundle=ca_bundle,
-    )
-    client = GrafanaClient(config=config)
+    with _grafana_client_locks[cache_key]:
+        # Re-check inside the lock: a concurrent caller may have built and
+        # cached the client while we were waiting.
+        if cache_key in _grafana_client_cache:
+            return _grafana_client_cache[cache_key]
 
-    discovered = client.discover_datasource_uids()
-    if discovered:
         config = GrafanaAccountConfig(
             account_id=account_id,
             instance_url=endpoint.rstrip("/"),
@@ -71,23 +89,36 @@ def get_grafana_client_from_credentials(
             password=password,
             verify_ssl=verify_ssl,
             ca_bundle=ca_bundle,
-            loki_datasource_uid=discovered.get("loki_uid", ""),
-            tempo_datasource_uid=discovered.get("tempo_uid", ""),
-            mimir_datasource_uid=discovered.get("mimir_uid", ""),
         )
         client = GrafanaClient(config=config)
-        logger.info(
-            "[grafana] Client ready for account_id=%s with datasource discovery status: loki=%s tempo=%s mimir=%s",
-            account_id,
-            config.loki_datasource_uid,
-            config.tempo_datasource_uid,
-            config.mimir_datasource_uid,
-        )
-    else:
-        logger.warning(
-            "[grafana] Could not discover datasource UIDs for account_id=%s — queries will fail",
-            account_id,
-        )
 
-    _grafana_client_cache[cache_key] = client
-    return client
+        discovered = client.discover_datasource_uids()
+        if discovered:
+            config = GrafanaAccountConfig(
+                account_id=account_id,
+                instance_url=endpoint.rstrip("/"),
+                read_token=api_key,
+                username=username,
+                password=password,
+                verify_ssl=verify_ssl,
+                ca_bundle=ca_bundle,
+                loki_datasource_uid=discovered.get("loki_uid", ""),
+                tempo_datasource_uid=discovered.get("tempo_uid", ""),
+                mimir_datasource_uid=discovered.get("mimir_uid", ""),
+            )
+            client = GrafanaClient(config=config)
+            logger.info(
+                "[grafana] Client ready for account_id=%s with datasource discovery status: loki=%s tempo=%s mimir=%s",
+                account_id,
+                config.loki_datasource_uid,
+                config.tempo_datasource_uid,
+                config.mimir_datasource_uid,
+            )
+        else:
+            logger.warning(
+                "[grafana] Could not discover datasource UIDs for account_id=%s — queries will fail",
+                account_id,
+            )
+
+        _grafana_client_cache[cache_key] = client
+        return client

--- a/tests/integrations/grafana/test_client.py
+++ b/tests/integrations/grafana/test_client.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from unittest.mock import patch
+import threading
+from unittest.mock import MagicMock, patch
 
-from integrations.grafana.client import get_grafana_client
+import pytest
+
+from integrations.grafana.client import get_grafana_client, get_grafana_client_from_credentials
 
 
 def test_get_grafana_client_reads_verify_ssl_and_ca_bundle_from_env(monkeypatch) -> None:
@@ -41,3 +44,196 @@ def test_get_grafana_client_defaults_verify_ssl_true_when_unset(monkeypatch) -> 
         verify_ssl=True,
         ca_bundle="",
     )
+
+
+# ---------------------------------------------------------------------------
+# Stampede / single-flight tests (issue #4245)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_grafana_cache():
+    """Isolate each test from module-level cache state."""
+    import integrations.grafana.client as m
+
+    original_cache = dict(m._grafana_client_cache)
+    original_locks = dict(m._grafana_client_locks)
+    m._grafana_client_cache.clear()
+    m._grafana_client_locks.clear()
+    yield
+    m._grafana_client_cache.clear()
+    m._grafana_client_cache.update(original_cache)
+    m._grafana_client_locks.clear()
+    m._grafana_client_locks.update(original_locks)
+
+
+def _make_fake_grafana_client(discover_return: dict) -> MagicMock:
+    """Return a GrafanaClient stand-in whose discover_datasource_uids is controlled."""
+    client = MagicMock()
+    client.discover_datasource_uids.return_value = discover_return
+    return client
+
+
+class TestClientCaching:
+    def test_second_call_returns_cached_client(self) -> None:
+        """A second call with the same credentials must not call discover again."""
+        with patch("integrations.grafana.client.GrafanaClient") as MockClient:
+            instance = _make_fake_grafana_client({})
+            MockClient.return_value = instance
+
+            first = get_grafana_client_from_credentials(
+                endpoint="https://g.example.com",
+                api_key="tok",
+                account_id="acct1",
+            )
+            second = get_grafana_client_from_credentials(
+                endpoint="https://g.example.com",
+                api_key="tok",
+                account_id="acct1",
+            )
+
+        assert first is second
+        # discover_datasource_uids must have been called exactly once
+        assert instance.discover_datasource_uids.call_count == 1
+
+    def test_different_endpoints_get_separate_clients(self) -> None:
+        """Different (account_id, endpoint) pairs are cached independently."""
+        call_count: list[int] = [0]
+
+        def _fake_discover() -> dict:
+            call_count[0] += 1
+            return {}
+
+        with patch("integrations.grafana.client.GrafanaClient") as MockClient:
+            MockClient.side_effect = lambda _config: _make_fake_grafana_client(
+                {"called": call_count[0]}
+            )
+            # Patch discover on every instance by wrapping side_effect
+            instances: list[MagicMock] = []
+
+            def _mk(config):  # type: ignore[override]
+                m = MagicMock()
+                m.discover_datasource_uids.return_value = {}
+                instances.append(m)
+                return m
+
+            MockClient.side_effect = _mk
+
+            c1 = get_grafana_client_from_credentials(
+                endpoint="https://g1.example.com",
+                api_key="tok",
+                account_id="acct1",
+            )
+            c2 = get_grafana_client_from_credentials(
+                endpoint="https://g2.example.com",
+                api_key="tok",
+                account_id="acct1",
+            )
+
+        assert c1 is not c2
+        # Two separate discoveries happened (one per endpoint)
+        assert len(instances) >= 2
+
+
+class TestConcurrentCacheStampede:
+    """Regression tests for the race condition described in issue #4245.
+
+    When N threads call get_grafana_client_from_credentials concurrently with
+    the same (account_id, endpoint), discover_datasource_uids must be called
+    exactly once — not once per thread.
+    """
+
+    def test_concurrent_callers_share_single_discovery(self) -> None:
+        """N threads calling get_grafana_client_from_credentials concurrently
+        for the same key must trigger discover_datasource_uids exactly once.
+
+        Strategy: the first thread to enter _discover sleeps long enough that
+        the remaining threads all arrive and queue on the per-key lock.  After
+        the sleep, the lock is released, the cache is written, and the waiting
+        threads all read the cached entry without calling _discover again.
+        """
+        import time
+
+        discovery_call_count = 0
+        count_lock = threading.Lock()
+        results: list[object] = []
+        errors: list[Exception] = []
+
+        def _make_client(config):  # type: ignore[override]
+            nonlocal discovery_call_count
+            m = MagicMock()
+
+            def _discover():
+                nonlocal discovery_call_count
+                # Sleep so sibling threads can pile up on the module-level lock.
+                time.sleep(0.15)
+                with count_lock:
+                    discovery_call_count += 1
+                return {}
+
+            m.discover_datasource_uids.side_effect = _discover
+            return m
+
+        def _caller():
+            try:
+                client = get_grafana_client_from_credentials(
+                    endpoint="https://g.example.com",
+                    api_key="tok",
+                    account_id="stampede_acct",
+                )
+                results.append(client)
+            except Exception as exc:
+                errors.append(exc)
+
+        with patch("integrations.grafana.client.GrafanaClient", side_effect=_make_client):
+            threads = [threading.Thread(target=_caller) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+
+        assert not errors, f"Threads raised exceptions: {errors}"
+        assert len(results) == 8, "Not all threads returned a result"
+        # Every thread must have received the same cached object
+        assert len({id(r) for r in results}) == 1, (
+            "Threads got different client instances — cache was not shared"
+        )
+        # Discovery must have run exactly once despite 8 concurrent callers
+        assert discovery_call_count == 1, (
+            f"discover_datasource_uids ran {discovery_call_count} times instead of 1 "
+            "(cache stampede not prevented)"
+        )
+
+    def test_failed_discovery_is_still_cached(self) -> None:
+        """Even when discovery fails, the client (without UIDs) is cached so
+        subsequent callers don't retry the doomed network call."""
+        discovery_call_count = 0
+
+        def _make_client(config):  # type: ignore[override]
+            nonlocal discovery_call_count
+            m = MagicMock()
+
+            def _discover():
+                nonlocal discovery_call_count
+                discovery_call_count += 1
+                return {}  # empty == failure path in get_grafana_client_from_credentials
+
+            m.discover_datasource_uids.side_effect = _discover
+            return m
+
+        with patch("integrations.grafana.client.GrafanaClient", side_effect=_make_client):
+            c1 = get_grafana_client_from_credentials(
+                endpoint="https://g.example.com",
+                api_key="tok",
+                account_id="failed_acct",
+            )
+            c2 = get_grafana_client_from_credentials(
+                endpoint="https://g.example.com",
+                api_key="tok",
+                account_id="failed_acct",
+            )
+
+        assert c1 is c2
+        assert discovery_call_count == 1, (
+            "Failed discovery was retried on the second call — client not cached"
+        )


### PR DESCRIPTION
## Summary

Fixes #4245.

`get_grafana_client_from_credentials` caches the built client per `(account_id, endpoint)` but used a plain read-then-write dict with no synchronisation around `discover_datasource_uids()` — a network call that takes up to 10 seconds. When an investigation batches multiple Grafana tools in one turn (Mimir, Loki, Tempo, alert rules, annotations, service names), all callers race past the cache check before any of them finishes, so every one pays the full discovery cost independently. Against an unreachable instance this multiplies the 10 s connect timeout by the number of parallel tools and floods the terminal with repeated failure pairs.

## Root cause

```
cache_key = f"creds_{account_id}_{endpoint}"
if cache_key in _grafana_client_cache:   # ← all threads see miss
    return _grafana_client_cache[cache_key]

client = GrafanaClient(config=config)
discovered = client.discover_datasource_uids()  # ← every thread calls this
...
_grafana_client_cache[cache_key] = client       # ← last writer wins
```

## Fix

Add a `defaultdict(threading.Lock)` keyed by `cache_key`. The first caller acquires the key lock, builds the client, runs discovery, and writes the cache. Concurrent callers for the **same key** block on the lock and read the populated entry when it becomes available — without calling `discover_datasource_uids` again. Callers for **different keys** get independent locks and run in parallel.

A fast-path read before the lock acquisition keeps steady-state overhead at zero — no locking at all once the entry is cached.

```python
# Fast path — already cached, no lock needed.
if cache_key in _grafana_client_cache:
    return _grafana_client_cache[cache_key]

with _grafana_client_locks[cache_key]:
    # Re-check inside the lock: a concurrent caller may have built and
    # cached the client while we were waiting.
    if cache_key in _grafana_client_cache:
        return _grafana_client_cache[cache_key]

    # ... build client, run discovery, write cache ...
```

## Changes

- **`integrations/grafana/client.py`**: add `_grafana_client_locks` (`defaultdict(threading.Lock)`), wrap the construction block in a per-key lock with double-checked read, update docstring to explain the concurrency contract.
- **`tests/integrations/grafana/test_client.py`**: add `TestClientCaching` (second call returns same object; discover runs once; different endpoints independent) and `TestConcurrentCacheStampede` (8 threads share a single discovery; failed-discovery client is also cached).

## Testing

```
pytest tests/integrations/grafana/test_client.py -v
# 6 passed
```

Lint and format: `ruff check` and `ruff format --check` both pass.

## Pre-PR Checklist

- [x] `ruff check` — no issues
- [x] `ruff format --check` — clean
- [x] 6 tests pass, 0 regressions