### PR TITLE
Fix Slack digest delivery for Socket Mode bot_token store key

### DIFF
--- a/platform/scheduler/credentials.py
+++ b/platform/scheduler/credentials.py
@@ -53,12 +53,21 @@ def resolve_slack_credentials(task_params: dict[str, str]) -> dict[str, str]:
     if env_webhook:
         return {"webhook_url": env_webhook}
 
-    return _resolve_credentials(
+    resolved = _resolve_credentials(
         {},
         service="slack",
         credential_key="access_token",
         env_vars=("SLACK_BOT_TOKEN", "SLACK_ACCESS_TOKEN"),
     )
+    if resolved:
+        return resolved
+
+    # Socket Mode setup persists the xoxb token under bot_token, not access_token.
+    store_bot_token = _get_integration_credential("slack", "bot_token").strip()
+    if store_bot_token:
+        return {"access_token": store_bot_token}
+
+    return {}
 
 
 def resolve_discord_credentials(task_params: dict[str, str]) -> dict[str, str]:

--- a/tests/integrations/sentry/test_digest_delivery.py
+++ b/tests/integrations/sentry/test_digest_delivery.py
@@ -40,6 +40,18 @@ class TestDigestDeliveryReadiness:
         assert slack_delivery_ready() is True
         assert delivery_provider_ready("slack") is True
 
+    def test_slack_ready_with_socket_mode_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "integrations.sentry.digest_delivery.resolve_telegram_credentials",
+            lambda _params: {},
+        )
+        monkeypatch.setattr(
+            "integrations.sentry.digest_delivery.resolve_slack_credentials",
+            lambda _params: {"access_token": "xoxb-socket-mode"},
+        )
+        assert slack_delivery_ready() is True
+        assert delivery_provider_ready(Provider.SLACK) is True
+
     def test_none_ready(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
             "integrations.sentry.digest_delivery.resolve_telegram_credentials",

--- a/tests/scheduler/test_credentials.py
+++ b/tests/scheduler/test_credentials.py
@@ -172,6 +172,23 @@ class TestSlackCredentials:
         creds = resolve_slack_credentials({})
         assert creds == {"access_token": "xoxb-from-env"}
 
+    def test_bot_token_from_integration_store(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("SLACK_ACCESS_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "platform.scheduler.credentials._get_integration_credential",
+            lambda service, key: (
+                "xoxb-from-store" if service == "slack" and key == "bot_token" else ""
+            ),
+        )
+        monkeypatch.setattr(
+            "platform.scheduler.credentials.resolve_env_credential",
+            lambda *_args, **_kwargs: "",
+        )
+        creds = resolve_slack_credentials({})
+        assert creds == {"access_token": "xoxb-from-store"}
+
 
 class TestDiscordCredentials:
     def test_from_params(self) -> None:


### PR DESCRIPTION
Fixes #4019

## Summary
- Fall back to the integration store bot_token key in resolve_slack_credentials when access_token is not present
- Map the stored xoxb token to access_token so Sentry digest scheduling and delivery readiness work for Socket Mode setups without requiring SLACK_BOT_TOKEN in env

## Test plan
- [x] uv run pytest tests/scheduler/test_credentials.py::TestSlackCredentials -q
- [x] uv run pytest tests/integrations/sentry/test_digest_delivery.py -q
- [x] make lint && make format-check && make typecheck

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Socket Mode Slack setup stores credentials under bot_token, but the scheduler credential resolver only checked access_token in the integration store. The fix adds a final store lookup for bot_token and returns it as access_token, matching how env/keyring SLACK_BOT_TOKEN was already normalized. Regression tests cover both the resolver and slack_delivery_ready().

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
