### PR TITLE
fix(correlation): score periodicity by threshold crossings, not elevation

### DIFF
--- a/core/domain/correlation/scoring.py
+++ b/core/domain/correlation/scoring.py
@@ -144,7 +144,11 @@ def score_periodic_spikes(
     values: tuple[float, ...],
     spike_threshold: float,
 ) -> PeriodicityScore:
-    repeated_spikes = sum(1 for value in values if value >= spike_threshold)
+    repeated_spikes = sum(
+        1
+        for previous, current in zip(values, values[1:], strict=False)
+        if previous < spike_threshold <= current
+    )
 
     if repeated_spikes <= 1:
         score = 0.0

--- a/tests/core/domain/correlation/test_scoring.py
+++ b/tests/core/domain/correlation/test_scoring.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from core.domain.correlation.scoring import (
     rank_upstream_candidates,
+    score_periodic_spikes,
     score_time_window_correlation,
     score_topology_adjacency,
 )
@@ -31,6 +32,50 @@ def test_score_topology_adjacency_requires_target_relationship() -> None:
     )
 
     assert score.adjacency_score == 1.0
+
+
+def test_score_periodic_spikes_counts_distinct_threshold_crossings() -> None:
+    score = score_periodic_spikes(
+        signal_name="upstream_cpu",
+        values=(20.0, 82.0, 30.0, 85.0, 28.0, 88.0),
+        spike_threshold=80.0,
+    )
+
+    assert score.repeated_spikes == 3
+    assert score.score == 1.0
+
+
+def test_score_periodic_spikes_treats_single_sustained_spike_as_one_event() -> None:
+    score = score_periodic_spikes(
+        signal_name="upstream_cpu",
+        values=(20.0, 90.0, 90.0, 90.0, 20.0),
+        spike_threshold=80.0,
+    )
+
+    assert score.repeated_spikes == 1
+    assert score.score == 0.0
+
+
+def test_score_periodic_spikes_does_not_count_window_start_elevation() -> None:
+    score = score_periodic_spikes(
+        signal_name="upstream_cpu",
+        values=(90.0, 20.0, 90.0),
+        spike_threshold=80.0,
+    )
+
+    assert score.repeated_spikes == 1
+    assert score.score == 0.0
+
+
+def test_score_periodic_spikes_detects_recurrence_that_starts_elevated() -> None:
+    score = score_periodic_spikes(
+        signal_name="upstream_cpu",
+        values=(90.0, 20.0, 90.0, 20.0, 90.0),
+        spike_threshold=80.0,
+    )
+
+    assert score.repeated_spikes == 2
+    assert score.score == 1.0
 
 
 def test_rank_upstream_candidates_orders_by_confidence_then_name() -> None:


### PR DESCRIPTION
Fixes #4249 
<!-- Add the issue number above, or delete this line if no issue is filed. -->

#### Describe the changes you have made in this PR -

**The problem**

`score_periodic_spikes` (in `core/domain/correlation/scoring.py`) is supposed to detect whether an upstream signal spikes *repeatedly* — a recurring pattern like a cron job, retry storm, or connection-pool thrash. Instead, it counts every sample at or above `spike_threshold` rather than the number of times the signal actually **crosses** the threshold. So a single *sustained* spike — one crossing that stays high for several samples — is mis-read as a repeated/periodic pattern.

**Example**

```python
from core.domain.correlation.scoring import score_periodic_spikes

# One spike: crosses 80 once, stays high for three samples, then falls back.
score_periodic_spikes(
    signal_name="upstream_cpu",
    values=(20.0, 90.0, 90.0, 90.0, 20.0),
    spike_threshold=80.0,
)
# actual  : PeriodicityScore(repeated_spikes=3, score=1.0, ...)   # counted 3 elevated samples
# expected: PeriodicityScore(repeated_spikes=1, score=0.0, ...)   # one crossing = one spike
```

**The problematic code**

```python
repeated_spikes = sum(1 for value in values if value >= spike_threshold)
```

This counts elevated *samples*. But the field is named `repeated_spikes`, the docstring says "repeated threshold **crossings**", and the existing test is named `test_periodic_spikes_score_repeated_threshold_crossings` — all three describe crossings. They only agree when every spike is exactly one sample wide, which is precisely the shape the existing fixtures use, so the divergence was never caught.

**The fix**

Count below→above threshold crossings, so only genuinely recurring spikes score `1.0`:

```python
repeated_spikes = sum(
        1
        for previous, current in zip(values, values[1:], strict=False)
        if previous < spike_threshold <= current
    )
```

Sustained highs that are causally relevant are not lost: a *new* sustained rise still registers on the **time-window** axis (weight `0.45`), which is the axis designed to reward change that co-moves with the symptom; a *pre-existing* flat-high is correctly de-emphasized. Both existing tests stay green (their fixtures use one-sample spikes, where crossings == samples), and a new regression test pins the sustained-spike case.

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The periodicity axis is meant to reward *recurring* spikes, so the count must reflect distinct spike events, not how long a spike lasts. The original `sum(...)` counts elevated samples, which conflates one sustained high with a repeating pattern. I considered adding a separate "sustained elevation" axis, but that changes the model and the weight budget; the sustained case is already handled by the time-window axis, so the correct, minimal fix is to count below→above crossings within the existing axis. The loop walks the series once (O(n)), incrementing only on a fresh crossing (previous sample below, current at/above the threshold), which keeps the `repeated_spikes` field honest to its name and preserves the existing behavior for one-sample spikes.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
