### PR TITLE
fix(correlation): count periodic spikes by threshold crossings

### DIFF
--- a/core/domain/correlation/scoring.py
+++ b/core/domain/correlation/scoring.py
@@ -144,7 +144,13 @@ def score_periodic_spikes(
     values: tuple[float, ...],
     spike_threshold: float,
 ) -> PeriodicityScore:
-    repeated_spikes = sum(1 for value in values if value >= spike_threshold)
+    repeated_spikes = 0
+    was_above_threshold = False
+    for value in values:
+        is_above_threshold = value >= spike_threshold
+        if is_above_threshold and not was_above_threshold:
+            repeated_spikes += 1
+        was_above_threshold = is_above_threshold
 
     if repeated_spikes <= 1:
         score = 0.0

--- a/tests/synthetic/rds_postgres/correlation/test_periodicity.py
+++ b/tests/synthetic/rds_postgres/correlation/test_periodicity.py
@@ -21,3 +21,14 @@ def test_periodic_spikes_score_low_when_not_repeated() -> None:
 
     assert result.repeated_spikes == 1
     assert result.score == 0.0
+
+
+def test_periodic_spikes_counts_sustained_plateau_as_one_spike() -> None:
+    result = score_periodic_spikes(
+        signal_name="RDS CPU",
+        values=(20.0, 90.0, 90.0, 90.0, 20.0),
+        spike_threshold=80.0,
+    )
+
+    assert result.repeated_spikes == 1
+    assert result.score == 0.0


### PR DESCRIPTION
## Summary

This PR fixes the spike periodicity scoring logic by counting upward threshold crossings instead of every sample above the threshold. A sustained elevated signal is now correctly treated as a single spike event rather than multiple repeated spikes.

### Changes
- Count upward threshold crossings instead of per-sample threshold hits.
- Fix false positives for sustained spike events.
- Add a regression test covering sustained plateau behavior.

### Impact
- Correctly identifies a sustained spike as a single event.
- Prevents incorrect periodicity scoring for continuous elevated signals.
- Improves scoring accuracy without affecting existing behavior for repeated spikes.

### Testing
- Added a regression test for sustained plateau behavior.
- Full test suite could not be executed locally due to missing development dependencies (`uv`, `pytest`, and `pydantic`).