### PR TITLE
Add EKS evicted pods synthetic scenario

### DIFF
--- a/tests/synthetic/eks/014-evicted-pods/alert.json
+++ b/tests/synthetic/eks/014-evicted-pods/alert.json
@@ -1,0 +1,28 @@
+{
+  "title": "[synthetic-k8s] Payments API availability degraded",
+  "state": "alerting",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "KubernetesPodAvailability",
+    "severity": "critical",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api",
+    "kube_node": "ip-10-0-1-73.us-east-1.compute.internal"
+  },
+  "commonAnnotations": {
+    "summary": "Payments API has reduced availability because one replica is no longer serving traffic.",
+    "description": "One replica became unavailable. Remaining replicas continue serving requests, but application capacity has decreased.",
+    "error": "Replica count dropped unexpectedly.",
+    "suspected_symptom": "Application degradation that initially resembles a pod crash.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "kube_node": "ip-10-0-1-73.us-east-1.compute.internal",
+    "k8s_failure_mode": "pod_evicted",
+    "context_sources": "eks"
+  }
+}

--- a/tests/synthetic/eks/014-evicted-pods/answer.yml
+++ b/tests/synthetic/eks/014-evicted-pods/answer.yml
@@ -1,0 +1,52 @@
+root_cause_category: resource_exhaustion
+
+required_keywords:
+  - Evicted
+  - ephemeral-storage
+  - DiskPressure
+
+forbidden_categories:
+  - healthy
+  - unknown
+  - configuration_error
+  - code_defect
+  - data_quality
+
+optimal_trajectory:
+  - get_eks_node_health
+  - list_eks_pods
+  - get_eks_events
+
+max_investigation_loops: 3
+
+ruling_out_keywords:
+  - CrashLoopBackOff
+  - OOMKilled
+
+required_queries:
+  - get_eks_node_health
+  - list_eks_pods
+
+model_response: |
+  ROOT_CAUSE: One replica of the payments-api Deployment was evicted because the Kubernetes node ran out of ephemeral storage. The affected node entered DiskPressure, causing kubelet to evict the pod to protect node stability. This is a node-level resource exhaustion issue rather than an application failure.
+
+  ROOT_CAUSE_CATEGORY: resource_exhaustion
+
+  VALIDATED_CLAIMS:
+  - The affected pod is in Failed phase with reason 'Evicted'. [evidence: eks_pods]
+  - Kubernetes events report that the node was low on ephemeral-storage and the pod was evicted. [evidence: eks_events]
+  - The affected node is Ready but reports DiskPressure=True. [evidence: eks_node_health]
+
+  NON_VALIDATED_CLAIMS:
+  - There is no evidence that the application crashed.
+  - There is no evidence of CrashLoopBackOff.
+  - There is no evidence of OOMKilled.
+  - The application code is not responsible for this failure.
+
+  CAUSAL_CHAIN:
+  - Ephemeral storage usage increased on the node.
+  - The node entered DiskPressure.
+  - Kubelet evicted the affected pod.
+  - One deployment replica became unavailable.
+  - Application capacity was reduced.
+  - The monitoring alert fired.

--- a/tests/synthetic/eks/014-evicted-pods/eks_events.json
+++ b/tests/synthetic/eks/014-evicted-pods/eks_events.json
@@ -1,0 +1,24 @@
+{
+  "warning_events": [
+    {
+      "namespace": "payments",
+      "reason": "Evicted",
+      "message": "The node was low on resource: ephemeral-storage. Container payments-api was using 2.3Gi, which exceeds the available ephemeral storage.",
+      "type": "Warning",
+      "count": 1,
+      "involved_object": "Pod/payments-api-7f9dd8b6c4-k2m4p",
+      "first_time": "2026-04-18T10:42:00Z",
+      "last_time": "2026-04-18T10:42:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "NodeHasDiskPressure",
+      "message": "Node ip-10-0-1-73.us-east-1.compute.internal status is now: NodeHasDiskPressure.",
+      "type": "Warning",
+      "count": 1,
+      "involved_object": "Node/ip-10-0-1-73.us-east-1.compute.internal",
+      "first_time": "2026-04-18T10:41:00Z",
+      "last_time": "2026-04-18T10:41:00Z"
+    }
+  ]
+}

--- a/tests/synthetic/eks/014-evicted-pods/eks_node_health.json
+++ b/tests/synthetic/eks/014-evicted-pods/eks_node_health.json
@@ -1,0 +1,30 @@
+{
+  "nodes": [
+    {
+      "name": "ip-10-0-1-74.us-east-1.compute.internal",
+      "internal_ip": "10.0.1.74",
+      "ready": "True",
+      "memory_pressure": "False",
+      "disk_pressure": "False",
+      "pid_pressure": "False",
+      "capacity_cpu": "4",
+      "capacity_memory": "16Gi",
+      "allocatable_cpu": "3500m",
+      "allocatable_memory": "14Gi",
+      "instance_type": "m5.xlarge"
+    },
+    {
+      "name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "internal_ip": "10.0.1.73",
+      "ready": "True",
+      "memory_pressure": "False",
+      "disk_pressure": "True",
+      "pid_pressure": "False",
+      "capacity_cpu": "4",
+      "capacity_memory": "16Gi",
+      "allocatable_cpu": "3500m",
+      "allocatable_memory": "14Gi",
+      "instance_type": "m5.xlarge"
+    }
+  ]
+}

--- a/tests/synthetic/eks/014-evicted-pods/eks_pods.json
+++ b/tests/synthetic/eks/014-evicted-pods/eks_pods.json
@@ -1,0 +1,94 @@
+{
+  "pods": [
+    {
+      "name": "payments-api-7f9dd8b6c4-x7gr9",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-74.us-east-1.compute.internal",
+      "start_time": "2026-04-18T10:20:11Z",
+      "containers": [
+        {
+          "name": "payments-api",
+          "ready": true,
+          "restart_count": 0,
+          "state": {
+            "running": true,
+            "started_at": "2026-04-18T10:20:18Z"
+          }
+        }
+      ],
+      "conditions": [
+        {
+          "type": "Initialized",
+          "status": "True",
+          "reason": "",
+          "message": ""
+        },
+        {
+          "type": "Ready",
+          "status": "True",
+          "reason": "",
+          "message": ""
+        },
+        {
+          "type": "ContainersReady",
+          "status": "True",
+          "reason": "",
+          "message": ""
+        },
+        {
+          "type": "PodScheduled",
+          "status": "True",
+          "reason": "",
+          "message": ""
+        }
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-k2m4p",
+      "namespace": "payments",
+      "phase": "Failed",
+      "node_name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "start_time": "2026-04-18T10:20:14Z",
+      "containers": [
+        {
+          "name": "payments-api",
+          "ready": false,
+          "restart_count": 0,
+          "state": {
+            "terminated": {
+              "reason": "Evicted",
+              "finished_at": "2026-04-18T10:42:00Z"
+            }
+          }
+        }
+      ],
+      "conditions": [
+        {
+          "type": "Initialized",
+          "status": "True",
+          "reason": "",
+          "message": ""
+        },
+        {
+          "type": "Ready",
+          "status": "False",
+          "reason": "Evicted",
+          "message": "The node was low on resource: ephemeral-storage."
+        },
+        {
+          "type": "ContainersReady",
+          "status": "False",
+          "reason": "Evicted",
+          "message": "Pod was evicted due to ephemeral-storage pressure."
+        },
+        {
+          "type": "PodScheduled",
+          "status": "True",
+          "reason": "",
+          "message": ""
+        }
+      ]
+    }
+  ]
+}

--- a/tests/synthetic/eks/014-evicted-pods/scenario.yml
+++ b/tests/synthetic/eks/014-evicted-pods/scenario.yml
@@ -1,0 +1,16 @@
+base: 000-healthy
+scenario_id: 014-evicted-pods
+failure_mode: evicted_pods
+severity: critical
+scenario_difficulty: 3
+adversarial_signals:
+  - looks_like_crashloop
+  - node_state_normal
+  - application_level_symptom_only
+# Listed explicitly because node health and events carry the eviction
+# evidence. The pod appears to have failed, but the root cause is
+# node-level ephemeral storage pressure.
+available_evidence:
+  - eks_pods
+  - eks_events
+  - eks_node_health


### PR DESCRIPTION
## Summary

Adds a new EKS synthetic scenario for evicted pods caused by node DiskPressure and ephemeral storage exhaustion.

## Changes

- Added new synthetic scenario: `014-evicted-pods`
- Added `scenario.yml`
- Added `alert.json`
- Added `eks_events.json`
- Added `eks_node_health.json`
- Added `eks_pods.json`
- Added `answer.yml`

## Validation

```bash
pytest tests/synthetic
```

**Result:**

```
240 passed, 57 skipped
```