### PR TITLE
fix(deps): bump httplib2 to 0.32.0 for the gzip decompression-bomb advisory

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1174,14 +1174,14 @@ wheels = [
 
 [[package]]
 name = "httplib2"
-version = "0.31.2"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/f5/ccf58de92d61e3ad921119668f54ed36ca1d0cf5dcc5c1657dfb164fd78b/httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025", size = 254283, upload-time = "2026-06-26T10:13:56.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a0/550eec327e5f5c7b732531c489f5307efec41f047b0d703bd4ca1e5ad2db/httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816", size = 93148, upload-time = "2026-06-26T10:13:54.985Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps the locked `httplib2` from 0.31.2 to 0.32.0, closing the unbounded
gzip/deflate decompression advisory (Dependabot alert #31). Lockfile-only —
`0.32.0` already satisfies the existing `httplib2<1.0.0,>=0.19.0` constraint
from `google-api-python-client`, so `pyproject.toml` is unchanged.

`httplib2` is a transitive dependency: `google-api-python-client` (direct dep)
→ `httplib2`. The only consumer in this repo is
`integrations/google_docs/client.py`, which calls Google's own HTTPS endpoints
rather than untrusted or attacker-controlled servers, so real exposure was low.
Patching anyway: the amplification is unbounded, and a compromised or
MITM'd endpoint is exactly the scenario the advisory describes.

The upstream fix is structural rather than a version-only change — the
unbounded `gzip.GzipFile(...).read()` and `zlib.decompress()` calls named in
the advisory are replaced by a `LimitDecoder` (ratio 100, 10 MB safe limit,
10 GB hard limit), and `_decompressContent` now requires an explicit limits
argument.