### PR TITLE
refactor(session): use SESSION_SUMMARY_PREFIX when restoring a session

### DIFF
--- a/core/agent_harness/session/persistence/jsonl_repo.py
+++ b/core/agent_harness/session/persistence/jsonl_repo.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import core.agent_harness.session.persistence.paths as storage_paths
 from core.agent_harness.session.persistence.ports import CHAT_KINDS
+from core.state.transcript_window import SESSION_SUMMARY_PREFIX
 
 _ROOT_CAUSE_PREVIEW_CHARS = 80
 _DEFAULT_RCA_HISTORY_LIMIT = 50
@@ -291,7 +292,7 @@ def _messages_for_branch(branch: list[dict[str, Any]]) -> list[tuple[str, str]]:
         if rec.get("type") == "compaction":
             summary = str(rec.get("summary") or "").strip()
             if summary:
-                messages.append(("assistant", f"Session summary:\n{summary}"))
+                messages.append(("assistant", f"{SESSION_SUMMARY_PREFIX}{summary}"))
             continue
         if rec.get("type") != "message":
             continue

--- a/tests/core/agent_harness/session/test_synthetic_observation_binding.py
+++ b/tests/core/agent_harness/session/test_synthetic_observation_binding.py
@@ -63,3 +63,15 @@ def test_suggest_synthetic_failure_follow_up_missing_observation_clears_path(
         )
 
     assert session.last_synthetic_observation_path is None
+
+
+def test_messages_for_branch_uses_session_summary_prefix() -> None:
+    from core.agent_harness.session.persistence.jsonl_repo import _messages_for_branch
+    from core.state.transcript_window import SESSION_SUMMARY_PREFIX
+
+    branch = [
+        {"type": "compaction", "summary": "All checks passed."},
+    ]
+    messages = _messages_for_branch(branch)
+    assert len(messages) == 1
+    assert messages[0] == ("assistant", f"{SESSION_SUMMARY_PREFIX}All checks passed.")


### PR DESCRIPTION
Fixes #4346

- Replaced hardcoded `"Session summary:\n"` string in `core/agent_harness/session/persistence/jsonl_repo.py` with `SESSION_SUMMARY_PREFIX` imported from `core.state.transcript_window`.
- Added a unit test in `test_synthetic_observation_binding.py` verifying that session compaction restoration uses the expected prefix.