### PR TITLE
fix(grafana): clear error messages for Loki 429/5xx

### DIFF
--- a/integrations/grafana/loki.py
+++ b/integrations/grafana/loki.py
@@ -3,10 +3,23 @@
 from __future__ import annotations
 
 import time
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from integrations.grafana.base import GrafanaClientBase
+
+
+def _describe_status(status: int) -> str:
+    """Human-readable reason for a failed Loki response status."""
+    if status == HTTPStatus.TOO_MANY_REQUESTS:
+        return (
+            f"Loki rate-limited the query ({status}). "
+            "Retry later, shorten the time range, or lower the limit."
+        )
+    if status >= HTTPStatus.INTERNAL_SERVER_ERROR:
+        return f"Loki is unavailable ({status}). Server-side failure, retry later."
+    return f"Loki query failed: {status}"
 
 
 class LokiMixin:
@@ -81,7 +94,7 @@ class LokiMixin:
             response_text = ""
             if hasattr(e, "response") and e.response is not None:
                 response_text = e.response.text[:300]
-                error_msg = f"Loki query failed: {e.response.status_code}"
+                error_msg = _describe_status(e.response.status_code)
 
             return {
                 "success": False,

--- a/tests/integrations/grafana/test_loki.py
+++ b/tests/integrations/grafana/test_loki.py
@@ -8,6 +8,7 @@ without a wrapped HTTP response, and the empty-result envelope.
 
 from __future__ import annotations
 
+from http import HTTPStatus
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -191,19 +192,40 @@ class TestQueryLokiExceptions:
             "logs": [],
         }
 
-    def test_exception_with_response_includes_status_and_truncated_text(self) -> None:
+    @pytest.mark.parametrize(
+        ("status", "expected_error"),
+        [
+            (
+                HTTPStatus.TOO_MANY_REQUESTS,
+                "Loki rate-limited the query (429). "
+                "Retry later, shorten the time range, or lower the limit.",
+            ),
+            (
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                "Loki is unavailable (500). Server-side failure, retry later.",
+            ),
+            (
+                HTTPStatus.BAD_GATEWAY,
+                "Loki is unavailable (502). Server-side failure, retry later.",
+            ),
+            (HTTPStatus.NOT_FOUND, "Loki query failed: 404"),
+        ],
+    )
+    def test_exception_with_response_includes_status_and_truncated_text(
+        self, status: HTTPStatus, expected_error: str
+    ) -> None:
         host = _FakeLokiHost()
 
         long_text = "x" * 500
-        response = MagicMock(status_code=502, text=long_text)
-        err = RuntimeError("bad gateway")
+        response = MagicMock(status_code=status, text=long_text)
+        err = RuntimeError("upstream failure")
         err.response = response  # type: ignore[attr-defined]
         host.make_request_mock.side_effect = err
 
         result = host.query_loki(_QUERY)
 
         assert result["success"] is False
-        assert result["error"] == "Loki query failed: 502"
+        assert result["error"] == expected_error
         assert result["response"] == long_text[:300]
         assert len(result["response"]) == 300
         assert result["logs"] == []


### PR DESCRIPTION
Fixes #4369
#### Describe the changes you have made in this PR -
Loki 429/5xx errors returned only a bare status code like "Loki query failed: 429". Added _describe_status() in integrations/grafana/loki.py mapping 429 to a rate limit message and 5xx to a server unavailable message. No raise added, matches existing behavior.

## Code Understanding and AI Usage
Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions