### PR TITLE
Flush pending CLI analytics on exit

### DIFF
--- a/surfaces/cli/__main__.py
+++ b/surfaces/cli/__main__.py
@@ -30,6 +30,7 @@ from surfaces.cli.invocation import (  # noqa: E402
     resolve_command_parts,
 )
 from surfaces.cli.telemetry import (  # noqa: E402
+    analytics_needs_flush,
     build_cli_invoked_properties,
     capture_cli_invoked,
     capture_exception,
@@ -45,6 +46,11 @@ from surfaces.cli.telemetry import (  # noqa: E402
 
 if TYPE_CHECKING:
     from platform.analytics.provider import Properties
+
+# One-shot CLI exit: a queued or in-flight event (e.g. ``investigation_completed``)
+# dies with the process because the sender runs on a daemon thread, so wait briefly
+# for the POST to land before returning.
+_ANALYTICS_FLUSH_TIMEOUT_SECONDS = 2.0
 
 _CAPTURE_CLI_ANALYTICS = "capture_cli_analytics"
 _CLI_ANALYTICS_CAPTURED = "cli_analytics_captured"
@@ -285,8 +291,12 @@ def main(argv: list[str] | None = None) -> int:
                 _sentry_sdk.flush(timeout=2)
         raise
     finally:
-        # Non-blocking: daemon worker may still drain in-flight events briefly.
-        shutdown_analytics(flush=False)
+        # Drain pending events so one-shot runs do not lose them, and stay
+        # non-blocking when the worker is idle.
+        if analytics_needs_flush():
+            shutdown_analytics(flush=True, timeout=_ANALYTICS_FLUSH_TIMEOUT_SECONDS)
+        else:
+            shutdown_analytics(flush=False)
     return 0
 
 

--- a/surfaces/cli/telemetry.py
+++ b/surfaces/cli/telemetry.py
@@ -29,6 +29,12 @@ def capture_cli_invoked(properties: Properties | None = None) -> None:
     _capture(properties)
 
 
+def analytics_needs_flush() -> bool:
+    from platform.analytics.provider import analytics_needs_flush as _needs_flush
+
+    return _needs_flush()
+
+
 def shutdown_analytics(*, flush: bool = False, timeout: float | None = None) -> None:
     from platform.analytics.provider import shutdown_analytics as _shutdown
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -598,3 +598,43 @@ def test_valid_theme_flag_passes_normalized_value(monkeypatch) -> None:
     assert exit_code == 0
     assert len(load_calls) >= 1
     assert all(call.get("cli_theme") == "blue" for call in load_calls)
+
+
+def test_main_flushes_analytics_when_events_are_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A one-shot CLI exit must drain queued events (e.g. investigation_completed)."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr("surfaces.cli.__main__.capture_first_run_if_needed", lambda: None)
+    monkeypatch.setattr("surfaces.cli.__main__.capture_cli_invoked", lambda *_args: None)
+    monkeypatch.setattr("surfaces.cli.__main__.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("surfaces.cli.__main__.analytics_needs_flush", lambda: True)
+    monkeypatch.setattr(
+        "surfaces.cli.__main__.shutdown_analytics",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    exit_code = main(["integrations", "show", "nonexistent"])
+
+    assert exit_code != 0
+    assert calls and calls[0]["flush"] is True
+    assert calls[0]["timeout"] > 0
+
+
+def test_main_does_not_block_when_no_events_are_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr("surfaces.cli.__main__.capture_first_run_if_needed", lambda: None)
+    monkeypatch.setattr("surfaces.cli.__main__.capture_cli_invoked", lambda *_args: None)
+    monkeypatch.setattr("surfaces.cli.__main__.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("surfaces.cli.__main__.analytics_needs_flush", lambda: False)
+    monkeypatch.setattr(
+        "surfaces.cli.__main__.shutdown_analytics",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    exit_code = main(["integrations", "show", "nonexistent"])
+
+    assert exit_code != 0
+    assert calls == [{"flush": False}]


### PR DESCRIPTION
## Problem
One-shot CLI runs lose their last analytics events. `surfaces/cli/__main__.py` exits with `shutdown_analytics(flush=False)`, so a queued or in-flight event dies with the process — most visibly `investigation_completed`, which never reached PostHog on a CLI investigation probe (org-analytics QA finding).

## Fix
Mirror the `/quit` behaviour in the interactive shell (`command_registry/system.py`): drain only when there is something pending.

- `surfaces/cli/telemetry.py`: add a lazy `analytics_needs_flush()` shim.
- `surfaces/cli/__main__.py`: in the `finally` block, `shutdown_analytics(flush=True, timeout=2.0)` when `analytics_needs_flush()`, else stay non-blocking with `flush=False`.

Exit stays instant when the worker is idle; worst case adds a bounded 2s wait (same budget as the install entrypoint).

## Tests
`tests/cli/test_main.py`: two cases — pending events flush with a positive timeout; no pending events stay non-blocking. `tests/cli/test_main.py` + `tests/analytics` pass (156), ruff check/format clean.
