### PR TITLE
test(cloudtrail): add direct unit test for _shape_event normalizer

### DIFF
--- a/tests/fixtures/cloudtrail/single_lookup_event.json
+++ b/tests/fixtures/cloudtrail/single_lookup_event.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Single raw CloudTrail event as it reaches _shape_event: ReadOnly is the string 'false' (not a bool), Resources contains one valid dict entry plus one degraded null entry to exercise resources_truncated, and CloudTrailEvent embeds an errorCode. Uses the AWS documentation account 123456789012.",
+  "EventId": "3a7c9e1b-5f2d-4a8e-b1c6-9d4e7a2f8c15",
+  "EventName": "DeleteBucketPolicy",
+  "ReadOnly": "false",
+  "AccessKeyId": "AKIAIOSFODNN7EXAMPLE",
+  "EventTime": "2026-07-10T14:22:03+00:00",
+  "EventSource": "s3.amazonaws.com",
+  "Username": "release-bot",
+  "Resources": [
+    {"ResourceType": "AWS::S3::Bucket", "ResourceName": "prod-artifacts-bucket"},
+    null
+  ],
+  "CloudTrailEvent": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"AIDA2EXAMPLE9XLZQW\",\"arn\":\"arn:aws:iam::123456789012:user/release-bot\",\"accountId\":\"123456789012\",\"accessKeyId\":\"AKIAIOSFODNN7EXAMPLE\",\"userName\":\"release-bot\"},\"eventTime\":\"2026-07-10T14:22:03Z\",\"eventSource\":\"s3.amazonaws.com\",\"eventName\":\"DeleteBucketPolicy\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"203.0.113.55\",\"userAgent\":\"aws-cli/2.17.0\",\"errorCode\":\"AccessDenied\",\"errorMessage\":\"Access Denied\",\"requestParameters\":{\"bucketName\":\"prod-artifacts-bucket\"},\"responseElements\":null,\"requestID\":\"9f3b1c7d-4a2e-4f6b-8c1d-2e9f7a5b3c40\",\"eventID\":\"3a7c9e1b-5f2d-4a8e-b1c6-9d4e7a2f8c15\",\"readOnly\":false,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"123456789012\"}"
+}

--- a/tests/tools/test_cloudtrail_shape_event.py
+++ b/tests/tools/test_cloudtrail_shape_event.py
@@ -1,0 +1,36 @@
+"""Unit test for CloudTrail's ``_shape_event`` normalizer against a saved payload.
+
+Loads a realistic raw CloudTrail event fixture and calls ``_shape_event``
+directly — no AWS SDK call, no mocked HTTP client, no tool invocation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from integrations.cloudtrail.tools.cloudtrail_events_tool import _shape_event
+
+_FIXTURE = (
+    Path(__file__).resolve().parent.parent / "fixtures" / "cloudtrail" / "single_lookup_event.json"
+)
+
+
+def test_shape_event_normalizes_raw_fixture() -> None:
+    raw = json.loads(_FIXTURE.read_text())
+
+    shaped = _shape_event(raw)
+
+    assert shaped["event_id"] == "3a7c9e1b-5f2d-4a8e-b1c6-9d4e7a2f8c15"
+    assert shaped["event_name"] == "DeleteBucketPolicy"
+    assert shaped["event_source"] == "s3.amazonaws.com"
+    assert shaped["username"] == "release-bot"
+    # ReadOnly arrives as the string "false" and must be coerced to a real bool.
+    assert shaped["read_only"] is False
+    # High-signal fields are pulled out of the CloudTrailEvent JSON string.
+    assert shaped["aws_region"] == "eu-west-1"
+    assert shaped["source_ip_address"] == "203.0.113.55"
+    assert shaped["error_code"] == "AccessDenied"
+    # Only the valid dict entry survives; the null entry marks the list truncated.
+    assert shaped["resources"] == [{"type": "AWS::S3::Bucket", "name": "prod-artifacts-bucket"}]
+    assert shaped["resources_truncated"] is True


### PR DESCRIPTION
Fixes #4367

#### Describe the changes you have made in this PR -

Adds a direct unit test for CloudTrail's `_shape_event` normalizer
(`integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py`),
which previously only had indirect coverage through the full tool with
`execute_aws_sdk_call` mocked.

- `tests/fixtures/cloudtrail/single_lookup_event.json` — a realistic raw
  CloudTrail event (ReadOnly as the string `"false"`, a `null` entry in
  `Resources` to exercise truncation, and an `errorCode` embedded in the
  `CloudTrailEvent` JSON string).
- `tests/tools/test_cloudtrail_shape_event.py` — loads the fixture and calls
  `_shape_event` directly. No live API, no HTTP mocking, no network.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/tools/test_cloudtrail_shape_event.py -q --tb=line
collected 1 item
tests/tools/test_cloudtrail_shape_event.py .                             [100%]
1 passed in 1.11s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
`_shape_event` is a pure dict-in/dict-out function with no I/O, making it the
cleanest isolated target among CloudTrail/CloudWatch/Loki candidates —
CloudWatch's tool calls boto3 inline with no separable parser, and Loki's
`query_loki` mixes HTTP fetch with stream-flattening. The fixture mirrors the
shape CloudTrail events have after `aws_sdk_client._sanitize_response`
(datetimes as ISO strings), and is deliberately constructed to exercise three
behaviors in `_shape_event`: `ReadOnly` string-to-bool coercion, extraction of
`awsRegion`/`sourceIPAddress`/`errorCode` from the embedded `CloudTrailEvent`
JSON string, and `resources_truncated` detection when a non-dict entry
appears in `Resources`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions