### PR TITLE
test(utils): add wait_until polling helper

### DIFF
--- a/tests/utils/polling.py
+++ b/tests/utils/polling.py
@@ -1,0 +1,30 @@
+"""Generic polling helper for tests that need to wait on an async condition."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+
+def wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout: float,
+    interval: float = 0.05,
+) -> None:
+    """Poll ``predicate`` until it returns true or ``timeout`` elapses.
+
+    Args:
+        predicate: Zero-arg callable returning True once the awaited
+            condition is satisfied.
+        timeout: Maximum seconds to poll before raising.
+        interval: Seconds to sleep between polls.
+
+    Raises:
+        TimeoutError: If ``predicate`` never returns true within ``timeout``.
+    """
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        if time.monotonic() >= deadline:
+            raise TimeoutError(f"wait_until: predicate not satisfied within {timeout}s")
+        time.sleep(interval)

--- a/tests/utils/test_polling.py
+++ b/tests/utils/test_polling.py
@@ -1,0 +1,24 @@
+"""Unit tests for the wait_until polling helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.utils.polling import wait_until
+
+
+def test_wait_until_returns_once_predicate_becomes_true() -> None:
+    calls = {"count": 0}
+
+    def predicate() -> bool:
+        calls["count"] += 1
+        return calls["count"] >= 3
+
+    wait_until(predicate, timeout=1, interval=0.01)
+
+    assert calls["count"] == 3
+
+
+def test_wait_until_raises_timeout_error_when_predicate_never_true() -> None:
+    with pytest.raises(TimeoutError):
+        wait_until(lambda: False, timeout=0.05, interval=0.01)


### PR DESCRIPTION
Fixes #4359

#### Describe the changes you have made in this PR -

Adds a shared `wait_until(predicate, *, timeout, interval=0.05)` polling
helper to `tests/utils/polling.py`. Fleet/smoke tests currently hand-roll
`while ... time.sleep(...)` polling loops inline in multiple files (e.g.
`tests/fleet_monitoring/test_bus.py`'s `_drain_subscriber`, which has a
comment explicitly calling out avoiding the flaky bare-`sleep` pattern), and
`tests/cli/test_smoke.py`. This PR adds only the helper — **no call sites are
migrated** in this change, per the task scope (C-38); that's left to the
follow-up tasks it unblocks (C-39…C-42).

**Path decision:** `tests/utils/` is this repo's established home for
cross-package, stateless test helpers (`cloudwatch_helpers.py`,
`hermes_logs_helper.py`, `command_runner.py`, etc.) — fleet and smoke tests
live in separate packages (`tests/fleet_monitoring/`, `tests/cli/`), so a
fleet-local helper would be too narrow. `tests/shared/` was considered but is
scoped to e2e/live-integration helpers (e.g. `slack_polling.py`), not generic
sync utilities. New file: `tests/utils/polling.py`, matching that package's
existing style (pure function, full type hints, Google-style docstring).

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/utils/test_polling.py -q --tb=line
collected 2 items
tests/utils/test_polling.py ..                                           [100%]
2 passed in 1.40s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
`wait_until` polls `predicate()` in a `while` loop against a `time.monotonic()`
deadline, sleeping `interval` seconds between checks, and raises
`TimeoutError` if the deadline passes before the predicate returns true. This
mirrors the deadline/`time.monotonic()` pattern already used ad hoc across
the fleet tests, just generalized into one reusable, generically-typed
function (`Callable[[], bool]`) instead of a boolean-returning,
Slack-specific variant like `poll_for_message`. Two unit tests cover the two
observable behaviors: it returns once the predicate flips true (and doesn't
over/under-poll — asserted via a call counter), and it raises `TimeoutError`
when the predicate never becomes true within the timeout.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions