### PR TITLE
fix(config): validate alert listener port range and handle null/TypeE…

### DIFF
--- a/config/repl_config.py
+++ b/config/repl_config.py
@@ -198,8 +198,8 @@ class ReplConfig:
         else:
             raw_port = file_conf.get("alert_listener_port", 0)
             try:
-                if raw_port is None:
-                    raise TypeError("Port cannot be None")
+                if isinstance(raw_port, (bool, float)) or raw_port is None:
+                    raise TypeError(f"Invalid port type: {type(raw_port).__name__}")
                 alert_listener_port = int(raw_port)
                 if not (0 <= alert_listener_port <= 65535):
                     raise ValueError(f"Port out of range: {alert_listener_port}")

--- a/config/repl_config.py
+++ b/config/repl_config.py
@@ -187,19 +187,26 @@ class ReplConfig:
         if (env_val := os.getenv("OPENSRE_ALERT_LISTENER_PORT")) is not None:
             try:
                 alert_listener_port = int(env_val.strip())
-            except ValueError:
+                if not (0 <= alert_listener_port <= 65535):
+                    raise ValueError(f"Port out of range: {alert_listener_port}")
+            except (ValueError, TypeError):
                 log.warning(
                     "OPENSRE_ALERT_LISTENER_PORT=%r is not a valid port number; defaulting to 0 (random).",
                     env_val,
                 )
                 alert_listener_port = 0
         else:
+            raw_port = file_conf.get("alert_listener_port", 0)
             try:
-                alert_listener_port = int(file_conf.get("alert_listener_port", 0))
-            except ValueError:
+                if raw_port is None:
+                    raise TypeError("Port cannot be None")
+                alert_listener_port = int(raw_port)
+                if not (0 <= alert_listener_port <= 65535):
+                    raise ValueError(f"Port out of range: {alert_listener_port}")
+            except (ValueError, TypeError):
                 log.warning(
                     "config.yml interactive.alert_listener_port=%r is not a valid port number; defaulting to 0 (random).",
-                    file_conf.get("alert_listener_port"),
+                    raw_port,
                 )
                 alert_listener_port = 0
 

--- a/tests/config/test_repl_config.py
+++ b/tests/config/test_repl_config.py
@@ -374,3 +374,75 @@ class TestGithubLoginDeferral:
         assert read_github_login_deferred() is True
         write_github_login_deferred(False)
         assert read_github_login_deferred() is False
+
+
+class TestAlertListenerPortParsing:
+    @pytest.mark.parametrize(
+        ("raw_yaml_value", "expected_port", "should_warn"),
+        [
+            ("null", 0, True),
+            ("not_a_number", 0, True),
+            ("-1", 0, True),
+            ("65536", 0, True),
+            ("0", 0, False),
+            ("8080", 8080, False),
+        ],
+    )
+    def test_file_backed_alert_listener_port(
+        self,
+        raw_yaml_value: str,
+        expected_port: int,
+        should_warn: bool,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        config_file = tmp_path / "config.yml"
+        config_file.write_text(
+            f"interactive:\n  alert_listener_port: {raw_yaml_value}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("OPENSRE_ALERT_LISTENER_PORT", raising=False)
+
+        import config.constants as const_module
+
+        monkeypatch.setattr(const_module, "OPENSRE_HOME_DIR", tmp_path)
+
+        with caplog.at_level("WARNING"):
+            cfg = ReplConfig.load()
+
+        assert cfg.alert_listener_port == expected_port
+        if should_warn:
+            assert "interactive.alert_listener_port=" in caplog.text
+        else:
+            assert "interactive.alert_listener_port=" not in caplog.text
+
+    @pytest.mark.parametrize(
+        ("env_value", "expected_port", "should_warn"),
+        [
+            ("invalid", 0, True),
+            ("-1", 0, True),
+            ("65536", 0, True),
+            ("0", 0, False),
+            ("8080", 8080, False),
+        ],
+    )
+    def test_env_backed_alert_listener_port(
+        self,
+        env_value: str,
+        expected_port: int,
+        should_warn: bool,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setenv("OPENSRE_ALERT_LISTENER_PORT", env_value)
+
+        with caplog.at_level("WARNING"):
+            cfg = ReplConfig.load()
+
+        assert cfg.alert_listener_port == expected_port
+        if should_warn:
+            assert "OPENSRE_ALERT_LISTENER_PORT=" in caplog.text
+        else:
+            assert "OPENSRE_ALERT_LISTENER_PORT=" not in caplog.text
+

--- a/tests/config/test_repl_config.py
+++ b/tests/config/test_repl_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -396,7 +397,7 @@ class TestAlertListenerPortParsing:
         raw_yaml_value: str,
         expected_port: int,
         should_warn: bool,
-        tmp_path,
+        tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
@@ -448,4 +449,3 @@ class TestAlertListenerPortParsing:
             assert "OPENSRE_ALERT_LISTENER_PORT=" in caplog.text
         else:
             assert "OPENSRE_ALERT_LISTENER_PORT=" not in caplog.text
-

--- a/tests/config/test_repl_config.py
+++ b/tests/config/test_repl_config.py
@@ -381,6 +381,9 @@ class TestAlertListenerPortParsing:
         ("raw_yaml_value", "expected_port", "should_warn"),
         [
             ("null", 0, True),
+            ("true", 0, True),
+            ("false", 0, True),
+            ("3.14", 0, True),
             ("not_a_number", 0, True),
             ("-1", 0, True),
             ("65536", 0, True),


### PR DESCRIPTION

Fixes #4377

#### Describe the changes you have made in this PR -
- Hardened `ReplConfig.load()` in `config/repl_config.py` to catch `TypeError` alongside `ValueError` during file-backed alert listener port resolution (fixing CLI startup crash when YAML contains `alert_listener_port: null`, lists, or maps).
- Added TCP port range validation (`0 <= port <= 65535`) to both file-backed (`~/.opensre/config.yml`) and environment-backed (`OPENSRE_ALERT_LISTENER_PORT`) port parsers.
- Out-of-range or malformed port configurations now log a warning and fall back to port `0` (random available port) without crashing CLI startup.
- Added parameterized unit tests in `tests/config/test_repl_config.py` (`TestAlertListenerPortParsing`) covering null, non-numeric strings, negative numbers (`-1`), numbers > 65535 (`65536`), `0`, and valid ports (`8080`).

### Demo/Screenshot for feature changes and bug fixes - 
```text
$ pytest tests/config/test_repl_config.py -k "TestAlertListenerPortParsing"
============================= test session starts =============================
tests/config/test_repl_config.py::TestAlertListenerPortParsing::test_file_backed_alert_listener_port[null-0-True] PASSED
tests/config/test_repl_config.py::TestAlertListenerPortParsing::test_file_backed_alert_listener_port[not_a_number-0-True] PASSED
tests/config/test_repl_config.py::TestAlertListenerPortParsing::test_file_backed_alert_listener_port[-1-0-True] PASSED
tests/config/test_repl_config.py::TestAlertListenerPortParsing::test_file_backed_alert_listener_port[65536-0-True] PASSED
tests/config/test_repl_config.py::TestAlertListenerPortParsing::test_file_backed_alert_listener_port[0-0-False] PASSED
tests/config/test_repl_config.py::TestAlertListenerPortParsing::test_file_backed_alert_listener_port[8080-8080-False] PASSED
tests/config/test_repl_config.py::TestAlertListenerPortParsing::test_env_backed_alert_listener_port[invalid-0-True] PASSED
tests/config/test_repl_config.py::TestAlertListenerPortParsing::test_env_backed_alert_listener_port[-1-0-True] PASSED
tests/config/test_repl_config.py::TestAlertListenerPortParsing::test_env_backed_alert_listener_port[65536-0-True] PASSED
tests/config/test_repl_config.py::TestAlertListenerPortParsing::test_env_backed_alert_listener_port[0-0-False] PASSED
tests/config/test_repl_config.py::TestAlertListenerPortParsing::test_env_backed_alert_listener_port[8080-8080-False] PASSED
============================= 11 passed in 1.45s =============================
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- **Problem solved:** Previously, `ReplConfig.load()` only caught `ValueError` when attempting `int(file_conf.get("alert_listener_port", 0))`. If `alert_listener_port: null` was present in `config.yml`, `file_conf.get(...)` returned `None`, which caused `int(None)` to raise an unhandled `TypeError` crashing CLI startup. Furthermore, out-of-range ports (e.g., `-1` or `65536`) were converted without validation, causing late socket binding failures.
- **Alternative approaches considered:** Explicit checking `raw_port is None` prior to `int()`. We chose catching `(ValueError, TypeError)` combined with explicit range checking (`0 <= port <= 65535`) for both file and environment sources to gracefully handle nulls, non-numeric strings, lists/dicts, and invalid numeric port values uniformly.
- **Implementation details:** In `ReplConfig.load()` inside `config/repl_config.py`, both `OPENSRE_ALERT_LISTENER_PORT` and `file_conf.get("alert_listener_port")` now validate `0 <= port <= 65535`. Any `TypeError` or `ValueError` logs a warning and falls back safely to `0`. Parameterized unit tests in `TestAlertListenerPortParsing` verify behavior for file and env sources across all edge cases.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions