### PR TITLE
refactor(jwt_auth): remove restating comments, add proper deprecation for verify_jwt

### DIFF
--- a/platform/auth/jwt_auth.py
+++ b/platform/auth/jwt_auth.py
@@ -12,6 +12,7 @@ import base64
 import binascii
 import json
 import time
+import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -98,7 +99,6 @@ class AsyncJWKSCache:
     _cache_ttl: int = JWKS_CACHE_TTL_SECONDS
 
     def _get_lock(self, jwks_url: str) -> asyncio.Lock:
-        """Get or create a lock for the given URL."""
         if jwks_url not in self._locks:
             self._locks[jwks_url] = asyncio.Lock()
         return self._locks[jwks_url]
@@ -116,7 +116,6 @@ class AsyncJWKSCache:
             if now - cached.fetched_at < self._cache_ttl:
                 return cached.keys
 
-        # Need to fetch - use lock to prevent thundering herd
         lock = self._get_lock(jwks_url)
         async with lock:
             # Double-check cache after acquiring lock
@@ -125,13 +124,11 @@ class AsyncJWKSCache:
                 if now - cached.fetched_at < self._cache_ttl:
                     return cached.keys
 
-            # Fetch JWKS asynchronously
             async with httpx.AsyncClient(timeout=10.0) as client:
                 response = await client.get(jwks_url)
                 response.raise_for_status()
                 jwks_data = response.json()
 
-            # Cache the result
             self._cache[jwks_url] = CachedJWKS(keys=jwks_data, fetched_at=now)
             from typing import cast
 
@@ -236,33 +233,27 @@ async def verify_jwt_async(token: str) -> JWTClaims:
         JWTInvalidIssuerError: If the issuer is not valid.
         JWTMissingClaimError: If required claims are missing.
     """
-    # Decode without verification to get the issuer
     unverified_payload = decode_jwt_payload_unverified(token)
     issuer = unverified_payload.get("iss")
 
     if not issuer:
         raise JWTMissingClaimError("JWT missing required 'iss' claim")
 
-    # Validate issuer
     valid_issuers = get_valid_issuers()
     if issuer not in valid_issuers:
         raise JWTInvalidIssuerError(f"Invalid issuer '{issuer}'. Expected one of: {valid_issuers}")
 
-    # Get JWKS URL for this issuer
     jwks_url = get_jwks_url_for_issuer(issuer)
     if not jwks_url:
         raise JWTInvalidIssuerError(f"No JWKS URL configured for issuer: {issuer}")
 
-    # Fetch JWKS asynchronously
     try:
         jwks_data = await _async_jwks_cache.get_jwks(jwks_url)
     except httpx.HTTPError as e:
         raise JWTVerificationError(f"Failed to fetch JWKS: {e}") from e
 
-    # Get signing key
     signing_key = get_signing_key_from_jwks(jwks_data, token)
 
-    # Verify the token
     try:
         payload = jwt.decode(
             token,
@@ -283,7 +274,6 @@ async def verify_jwt_async(token: str) -> JWTClaims:
     except jwt.InvalidTokenError as e:
         raise JWTVerificationError(f"Invalid JWT: {e}") from e
 
-    # Validate required claims
     if not payload.get("sub"):
         raise JWTMissingClaimError("JWT missing required 'sub' claim")
 
@@ -296,9 +286,15 @@ async def verify_jwt_async(token: str) -> JWTClaims:
 def verify_jwt(token: str) -> JWTClaims:
     """Synchronous wrapper for verify_jwt_async.
 
-    DEPRECATED: Use verify_jwt_async directly in async contexts.
-    This exists for backwards compatibility but will block the event loop.
+    .. deprecated::
+       Use :func:`verify_jwt_async` directly in async contexts.
+       This exists for backwards compatibility but will block the event loop.
     """
+    warnings.warn(
+        "verify_jwt is deprecated, use verify_jwt_async instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     try:
         loop = asyncio.get_event_loop()
         if loop.is_running():


### PR DESCRIPTION
## Summary

Remove 11 restating banner comments from `platform/auth/jwt_auth.py` and replace the bare `DEPRECATED:` comment on `verify_jwt` with Python's standard `warnings.warn(..., DeprecationWarning)` + a Sphinx `.. deprecated::` directive in the docstring.

## Related Issue

Fixes #4337

## What changed

- Removed restating comments (e.g., `# Decode without verification to get the issuer` above `decode_jwt_payload_unverified(token)`)
- Added `warnings.warn(..., DeprecationWarning, stacklevel=2)` to `verify_jwt` so callers see a runtime deprecation signal
- Added Sphinx `.. deprecated::` directive to `verify_jwt` docstring

## Why this approach

The issue asks to clean the file and deprecate `verify_jwt` "the usual way." Python's standard library deprecation pattern (`warnings.warn`) requires no new dependencies and is the convention used across the ecosystem.

## Testing done

- `pytest tests/platform/auth/test_jwt_auth.py` � all 6 tests pass
- `ruff check` � clean
- `ruff format --check` � already formatted
- `mypy` � no issues

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (if user-facing)
- [ ] Lint/format passes
- [x] Linked issue referenced
- [ ] Commits signed off if org requires DCO
- [x] No unrelated changes bundled in

## AI Usage

This contribution was developed with assistance from an AI coding agent (OpenCode). The agent identified the changes needed, implemented them, and ran verification checks. Every change was reviewed by a human before submission.
