### PR TITLE
refactor(llm): use HTTPStatus for rate-limit checks

### DIFF
--- a/core/llm/shared/openai_chat_completions.py
+++ b/core/llm/shared/openai_chat_completions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import time
 from collections.abc import Callable, Iterator
+from http import HTTPStatus
 from typing import Any
 
 from core.llm.shared.llm_retry import (
@@ -260,7 +261,7 @@ def invoke_with_litellm_agent_retries(
                 ) from err
             if (
                 is_exception_named(err, "RateLimitError")
-                or getattr(err, "status_code", None) == 429
+                or getattr(err, "status_code", None) == HTTPStatus.TOO_MANY_REQUESTS
             ):
                 maybe_raise_credit_exhausted(provider_name, err)
                 last_err = err
@@ -323,7 +324,7 @@ def invoke_with_litellm_llm_retries(
                 ) from err
             if (
                 is_exception_named(err, "RateLimitError")
-                or getattr(err, "status_code", None) == 429
+                or getattr(err, "status_code", None) == HTTPStatus.TOO_MANY_REQUESTS
             ):
                 last_err = err
                 if attempt == _RETRY_MAX_ATTEMPTS - 1:
@@ -397,7 +398,7 @@ def stream_with_litellm_retries(
                 ) from err
             if (
                 is_exception_named(err, "RateLimitError")
-                or getattr(err, "status_code", None) == 429
+                or getattr(err, "status_code", None) == HTTPStatus.TOO_MANY_REQUESTS
             ):
                 if attempt == _RETRY_MAX_ATTEMPTS - 1:
                     raise RuntimeError(


### PR DESCRIPTION
Fixes #4283

#### Describe the changes you have made in this PR -

Imported the standard-library `HTTPStatus` enum and replaced the three raw `429` rate-limit comparisons in the shared OpenAI Chat Completions retry helpers with `HTTPStatus.TOO_MANY_REQUESTS`. This preserves the existing retry behavior and user-facing messages while following the repository's named-status convention.

### Demo/Screenshot for feature changes and bug fixes -

Terminal validation:

```text
make lint: All checks passed!
make format-check: 2814 files already formatted
make typecheck: Success: no issues found in 1465 source files
make test-scope: 1397 passed, 30 skipped
tests/core/runtime/llm/test_litellm_compat.py: 9 passed
make verify-integrations-smoke: 31 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The affected retry helpers recognize a rate-limit error either by exception class name or by its `status_code`. I replaced only the raw numeric comparisons with the corresponding standard-library enum member. I considered a module-level integer constant, but `HTTPStatus.TOO_MANY_REQUESTS` directly follows the project's documented convention and remains equal to integer status values because `HTTPStatus` is an integer enum. No functions, messages, or control flow changed.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests (N/A: this is a behavior-preserving refactor covered by existing focused and scoped tests)
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
