### PR TITLE
improvement:implemented frozenset to speed up allowed-user checks

### DIFF
--- a/integrations/messaging_security.py
+++ b/integrations/messaging_security.py
@@ -21,7 +21,7 @@ import string
 import time
 from enum import StrEnum
 
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 from config.strict_config import StrictConfigModel
 
@@ -109,6 +109,22 @@ class MessagingIdentityPolicy(StrictConfigModel):
         default=False,
         description="Whether inbound messaging is enabled for this platform",
     )
+
+    # Cached set view of allowed_user_ids for O(1) membership checks. Lazily
+    # built on first access and rebuilt whenever this module changes
+    # allowed_user_ids (see function complete_pairing). allowed_user_ids remains the
+    # sole source of truth and storage format; this is a derived cache only.
+    _allowed_user_id_set: frozenset[str] | None = PrivateAttr(default=None)
+
+    def allowed_user_id_set(self) -> frozenset[str]:
+        """Return a cached ``frozenset`` of allowed_user_ids for fast membership checks."""
+        if self._allowed_user_id_set is None:
+            self._allowed_user_id_set = frozenset(self.allowed_user_ids)
+        return self._allowed_user_id_set
+
+    def _invalidate_allowed_user_id_cache(self) -> None:
+        """Drop the cached set so it is rebuilt from allowed_user_ids on next access."""
+        self._allowed_user_id_set = None
 
 
 # ---------------------------------------------------------------------------
@@ -233,7 +249,7 @@ def authorize_inbound_message(
     # Already-authorized users skip the pairing path entirely.
     # This prevents an allowed user from accidentally consuming a pending
     # pairing code meant for someone else.
-    if user_id in policy.allowed_user_ids:
+    if user_id in policy.allowed_user_id_set():
         return AuthorizationResult(allowed=True, reason="User is authorized")
 
     # Check if this is a pairing attempt (only when a pairing is actually pending)
@@ -318,8 +334,9 @@ def complete_pairing(
         return False, f"Invalid pairing code. {remaining} attempts remaining."
 
     # Pairing successful
-    if user_id not in policy.allowed_user_ids:
+    if user_id not in policy.allowed_user_id_set():
         policy.allowed_user_ids.append(user_id)
+        policy._invalidate_allowed_user_id_cache()
     policy.pairing_secret_hash = None
     policy.pairing_created_at = None
     policy.pairing_attempts = 0


### PR DESCRIPTION
Fixes #4364

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
Replaced list-based `in` membership checks on `allowed_user_ids` with a cached `frozenset` for O(1) lookups.

- Added a method `MessagingIdentityPolicy.allowed_user_id_set()`, a lazily-built, cached `frozenset[str]` view over `allowed_user_ids`.
- Added a method `MessagingIdentityPolicy._invalidate_allowed_user_id_cache()` to drop the cache so it rebuilds on next access.
- Function `authorize_inbound_message` now checks membership via `policy.allowed_user_id_set()` instead of `user_id in policy.allowed_user_ids`.
- Function `complete_pairing` checks membership via the cached set and calls `_invalidate_allowed_user_id_cache()` right after appending a newly-paired user, so the cache stays consistent with the saved list.

### Demo/Screenshot for feature changes and bug fixes - 
```
(opensre) deepak@deepakdhakad:~/opensre$ uv run mypy integrations && uv run pytest tests/integrations/test_messaging_security.py 
mypy.ini: note: unused section(s): [mypy-apscheduler], [mypy-pyfiglet], [mypy-tree_sitter], [mypy-tree_sitter.*]
Success: no issues found in 605 source files
======================================= test session starts ========================================
.
.
(19 durations < 0.005s hidden.  Use -vv to show these durations.)
======================================== 33 passed in 0.74s ========================================
```
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [✓] No, I wrote all the code myself

**Explain your implementation approach:**
`allowed_user_ids` stays a `list[str]` (unchanged storage format). Added a lazily-built, cached `frozenset` (`allowed_user_id_set()`, via pydantic `PrivateAttr`) alongside it for O(1) membership checks, and an explicit invalidation call (`_invalidate_allowed_user_id_cache()`) right after `complete_pairing` appends a user, so the cache rebuilds from the current list on next access. `authorize_inbound_message` and `complete_pairing` now check membership against the cached set instead of scanning the list.

<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [✓] I have added proper PR title and linked to the issue
- [✓] I have performed a self-review of my code
- [✓] **I can explain the purpose of every function, class, and logic block I added**
- [✓] I understand why my changes work and have tested them thoroughly
- [✓] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
