### PR TITLE
test(fleet_monitoring): use wait_until in test_probe.py

### DIFF
--- a/tests/fleet_monitoring/test_probe.py
+++ b/tests/fleet_monitoring/test_probe.py
@@ -6,7 +6,6 @@ import os
 import pathlib
 import subprocess
 import sys
-import time
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -15,6 +14,7 @@ from unittest.mock import patch
 import psutil
 import pytest
 
+from tests.utils.polling import wait_until
 from tools.system.fleet_monitoring.probe import (
     ProcessSnapshot,
     probe,
@@ -46,7 +46,7 @@ _SOURCE_ROOTS = (
 @pytest.fixture
 def busy_process() -> Iterator[int]:
     """Spawn a subprocess burning CPU in a tight loop; yields its PID.
-    The warmup sleep ensures the process has accumulated enough CPU time for
+    The warmup wait ensures the process has accumulated enough CPU time for
     psutil.cpu_percent(interval>0) to measure a non-zero delta.
     """
     proc = subprocess.Popen(
@@ -55,7 +55,12 @@ def busy_process() -> Iterator[int]:
         stderr=subprocess.DEVNULL,
     )
 
-    time.sleep(0.1)
+    process = psutil.Process(proc.pid)
+    wait_until(
+        lambda: sum(process.cpu_times()[:2]) > 0.0,
+        timeout=2.0,
+        interval=0.01,
+    )
 
     yield proc.pid
 


### PR DESCRIPTION
Fixes #4360

**Depends on #4381 (C-38's `wait_until` helper).** This PR is opened against the `test/wait-until-polling-helper` branch rather than `main` since `tests/utils/polling.py` doesn't exist on `main` yet. Once #4381 merges, this should be retargeted to `main` (or rebased) before merging.

#### Describe the changes you have made in this PR -

`tests/fleet_monitoring/test_probe.py` had exactly one bare sleep: a fixed `time.sleep(0.1)` warmup in the `busy_process` fixture, meant to let the spawned subprocess accumulate enough CPU time for `psutil.cpu_percent(interval>0)` to measure a non-zero delta later. Replaced it with `wait_until(lambda: sum(process.cpu_times()[:2]) > 0.0, timeout=2.0, interval=0.01)`, which polls the actual condition the sleep was standing in for (measurable accumulated CPU time) instead of waiting a fixed, potentially-too-short-or-too-long duration. Also dropped the now-unused `import time` (it had no other use in the file). Only this one file was touched, per the task's scope.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/fleet_monitoring/test_probe.py -q --tb=line
collected 7 items
tests/fleet_monitoring/test_probe.py .......                             [100%]
7 passed in 6.57s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The fixture's docstring already stated the real intent of the sleep: waiting for the subprocess to accumulate measurable CPU time. `psutil.Process.cpu_times()` returns a named tuple whose first two fields are user and system CPU seconds, so `sum(process.cpu_times()[:2]) > 0.0` is a direct, faithful predicate for that condition — polling it with `wait_until` converts a flaky fixed-duration guess into a condition-based wait that finishes as soon as the real prerequisite is met (and still bounds worst-case wait via `timeout=2.0`). `test_probe_returns_nonzero_cpu_for_busy_process`, the only consumer of this fixture, still passes, confirming the busy subprocess still has non-zero CPU by the time it's probed.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
