### PR TITLE
test(fleet_monitoring): use wait_until in test_tail.py

### DIFF
--- a/tests/fleet_monitoring/test_tail.py
+++ b/tests/fleet_monitoring/test_tail.py
@@ -15,6 +15,7 @@ review hammered on:
 
 from __future__ import annotations
 
+import contextlib
 import os
 import queue
 import threading
@@ -24,6 +25,7 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.utils.polling import wait_until
 from tools.system.fleet_monitoring import tail as tail_mod
 from tools.system.fleet_monitoring.tail import (
     DEFAULT_MAX_BYTES,
@@ -446,7 +448,8 @@ class TestAttachSession:
         log.write_bytes(b"already-here")
         with self._make_session(log) as sess:
             # Give the reader a couple of poll cycles to (not) push.
-            time.sleep(0.1)
+            with contextlib.suppress(TimeoutError):
+                wait_until(lambda: not sess._queue.empty(), timeout=0.1, interval=0.01)  # noqa: SLF001
             items: list[object] = []
             while True:
                 try:
@@ -517,9 +520,7 @@ class TestAttachSession:
         monkeypatch.setattr(tail_mod, "pid_exists", _fake_pid_exists)
         with self._make_session(log) as sess:
             # Wait up to 2s for the reader thread to exit naturally.
-            deadline = time.monotonic() + 2.0
-            while time.monotonic() < deadline and sess._thread.is_alive():  # noqa: SLF001
-                time.sleep(0.01)
+            wait_until(lambda: not sess._thread.is_alive(), timeout=2.0, interval=0.01)  # noqa: SLF001
             assert not sess._thread.is_alive()  # noqa: SLF001
             # ``producer_exited`` is the signal the slash-command trailer
             # uses to print "· process exited" — must flip True only on


### PR DESCRIPTION
Fixes #4361

**Depends on #4381 (C-38's `wait_until` helper).** This PR is opened against the `test/wait-until-polling-helper` branch rather than `main` since `tests/utils/polling.py` doesn't exist on `main` yet. Once #4381 merges, this should be retargeted to `main` (or rebased) before merging.

#### Describe the changes you have made in this PR -

`tests/fleet_monitoring/test_tail.py` had two bare sleeps, replaced with `wait_until`:

1. `test_reader_exits_when_pid_dies` had a hand-rolled `deadline = time.monotonic() + 2.0; while ... and sess._thread.is_alive(): time.sleep(0.01)` loop — a direct `wait_until(lambda: not sess._thread.is_alive(), timeout=2.0, interval=0.01)` fit.
2. `test_does_not_replay_pre_attach_content` used a fixed `time.sleep(0.1)` to "give the reader a couple of poll cycles to (not) push" before asserting the queue stayed empty. Since this test is checking that nothing arrives, it's the inverse of a normal wait: replaced with `wait_until(lambda: not sess._queue.empty(), timeout=0.1, interval=0.01)` wrapped in `contextlib.suppress(TimeoutError)` — a `TimeoutError` here is the expected (nothing showed up) outcome, and if an item *did* unexpectedly appear early, the test now fails faster instead of always waiting the full 0.1s.

Only this one file was touched, per the task's scope.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/fleet_monitoring/test_tail.py -q --tb=line
collected 54 items
tests/fleet_monitoring/test_tail.py .................................... [ 66%]
..................                                                       [100%]
54 passed in 1.23s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The two sleeps needed different treatment. The pid-death test's loop was already structurally identical to `wait_until`'s contract (poll a boolean condition against a deadline), so it's a mechanical swap. The pre-attach-content test is different: it isn't waiting for something to happen, it's waiting to confirm nothing happens, so I inverted the framing — poll for the queue becoming non-empty (the failure condition) and treat `wait_until` timing out as success. `contextlib.suppress(TimeoutError)` makes that inversion explicit rather than catching the exception with a bare `try/except: pass`. `time` stays imported since `_drain_until` (an existing local helper, out of scope for this task) still uses `time.monotonic()`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
