### PR TITLE
test(fleet_monitoring): use wait_until in test_lifecycle.py

### DIFF
--- a/tests/fleet_monitoring/test_lifecycle.py
+++ b/tests/fleet_monitoring/test_lifecycle.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-import time
+import tempfile
 
 import pytest
 
+from tests.utils.polling import wait_until
 from tools.system.fleet_monitoring.lifecycle import TerminateResult, terminate
 
 # Windows ``os.kill`` / ``signal.SIGTERM`` delivery to a Python ``Popen`` child
@@ -21,42 +22,68 @@ _skip_win32_posix_signals = pytest.mark.skipif(
 )
 
 
+def _make_ready_path() -> str:
+    """Reserve a path that does not yet exist, for a child to touch once ready."""
+    fd, ready_path = tempfile.mkstemp()
+    os.close(fd)
+    os.unlink(ready_path)
+    return ready_path
+
+
+def _wait_for_ready(ready_path: str) -> None:
+    """Poll until the child signals it has registered its handler, then clean up."""
+    try:
+        wait_until(lambda: os.path.exists(ready_path), timeout=2.0, interval=0.01)
+    finally:
+        if os.path.exists(ready_path):
+            os.unlink(ready_path)
+
+
 def _spawn_sleep() -> subprocess.Popen[bytes]:
     """Spawn a Python child that exits cleanly on SIGTERM.
 
-    The child installs a SIGTERM handler that calls ``sys.exit(0)``
-    so it exits promptly and predictably.
+    The child installs a SIGTERM handler that calls ``sys.exit(0)`` so it
+    exits promptly and predictably, then touches ``ready_path`` so the parent
+    can wait_until the handler is actually registered instead of sleeping a
+    fixed guess before sending the signal.
     """
+    ready_path = _make_ready_path()
     proc = subprocess.Popen(
         [
             sys.executable,
             "-c",
             (
-                "import signal, sys, time; "
+                "import pathlib, signal, sys; "
                 "signal.signal(signal.SIGTERM, lambda *_: sys.exit(0)); "
-                "time.sleep(60)"
+                f"pathlib.Path({ready_path!r}).touch(); "
+                "import time; time.sleep(60)"
             ),
         ],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    # Give the child a moment to register its signal handler.
-    time.sleep(0.2)
+    _wait_for_ready(ready_path)
     return proc
 
 
 def _spawn_unkillable() -> subprocess.Popen[bytes]:
     """Spawn a child that traps SIGTERM and refuses to die."""
+    ready_path = _make_ready_path()
     proc = subprocess.Popen(
         [
             sys.executable,
             "-c",
-            ("import signal, time; signal.signal(signal.SIGTERM, lambda *_: None); time.sleep(60)"),
+            (
+                "import pathlib, signal; "
+                "signal.signal(signal.SIGTERM, lambda *_: None); "
+                f"pathlib.Path({ready_path!r}).touch(); "
+                "import time; time.sleep(60)"
+            ),
         ],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    time.sleep(0.2)
+    _wait_for_ready(ready_path)
     return proc
 
 

--- a/tests/fleet_monitoring/test_lifecycle.py
+++ b/tests/fleet_monitoring/test_lifecycle.py
@@ -62,7 +62,12 @@ def _spawn_sleep() -> subprocess.Popen[bytes]:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    _wait_for_ready(ready_path)
+    try:
+        _wait_for_ready(ready_path)
+    except TimeoutError:
+        proc.kill()
+        proc.wait()
+        raise
     return proc
 
 
@@ -83,7 +88,12 @@ def _spawn_unkillable() -> subprocess.Popen[bytes]:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    _wait_for_ready(ready_path)
+    try:
+        _wait_for_ready(ready_path)
+    except TimeoutError:
+        proc.kill()
+        proc.wait()
+        raise
     return proc
 
 


### PR DESCRIPTION
Fixes #4362

**Depends on #4381 (C-38's `wait_until` helper).** This PR is opened against the `test/wait-until-polling-helper` branch rather than `main` since `tests/utils/polling.py` doesn't exist on `main` yet. Once #4381 merges, this should be retargeted to `main` (or rebased) before merging.

#### Describe the changes you have made in this PR -

`tests/fleet_monitoring/test_lifecycle.py` had two bare sleeps: `_spawn_sleep()` and `_spawn_unkillable()` each did a fixed `time.sleep(0.2)` after spawning a child process, to "give the child a moment to register its signal handler" before the tests send it SIGTERM.

This sleep guards a real race, not just a slow test: if the parent sends SIGTERM before the child's handler is installed, the default disposition kills the child outright. For `_spawn_unkillable()` specifically, that would make `test_force_kill_after_grace_period` pass for the wrong reason (child dies on first SIGTERM instead of exercising the SIGKILL escalation path).

Rather than convert this into a `wait_until` on a proxy condition, I made the wait meaningful: both child scripts now `pathlib.Path(ready_path).touch()` immediately after registering their signal handler, and the parent calls `wait_until(lambda: os.path.exists(ready_path), timeout=2.0, interval=0.01)` before returning the process — polling the actual readiness condition instead of guessing a fixed delay is long enough (and never longer than it needs to be on a fast machine). Only this one file was touched, per the task's scope.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/fleet_monitoring/test_lifecycle.py -q --tb=line
collected 5 items
tests/fleet_monitoring/test_lifecycle.py .....                           [100%]
5 passed in 21.17s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`_make_ready_path()` reserves a filesystem path via `tempfile.mkstemp()` and immediately deletes it, so its later existence is an unambiguous signal (rather than reusing an already-existing temp file, which would be true from the start). Both child one-liners now `pathlib.Path(<path>).touch()` right after `signal.signal(...)`, so the touch happens exactly when the handler is live. `_wait_for_ready()` wraps the `wait_until` call in a `try/finally` that removes the marker file regardless of outcome, so a timeout doesn't leak a stray temp file. I kept the childrens' inline "import signal, sys" style but added `import pathlib` (and moved the `import time` for the child's own 60s sleep to a second statement, since it's only needed after the touch) — the child scripts themselves are otherwise unchanged (same handler behavior, same eventual `time.sleep(60)` placeholder workload).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
