### PR TITLE
test(fleet_monitoring): use wait_until in test_lifecycle.py

### DIFF
--- a/tests/fleet_monitoring/test_lifecycle.py
+++ b/tests/fleet_monitoring/test_lifecycle.py
@@ -30,13 +30,18 @@ def _make_ready_path() -> str:
     return ready_path
 
 
+def _cleanup_ready_path(ready_path: str) -> None:
+    """Remove the readiness marker if the child created it."""
+    if os.path.exists(ready_path):
+        os.unlink(ready_path)
+
+
 def _wait_for_ready(ready_path: str) -> None:
     """Poll until the child signals it has registered its handler, then clean up."""
     try:
         wait_until(lambda: os.path.exists(ready_path), timeout=2.0, interval=0.01)
     finally:
-        if os.path.exists(ready_path):
-            os.unlink(ready_path)
+        _cleanup_ready_path(ready_path)
 
 
 def _spawn_sleep() -> subprocess.Popen[bytes]:
@@ -67,6 +72,10 @@ def _spawn_sleep() -> subprocess.Popen[bytes]:
     except TimeoutError:
         proc.kill()
         proc.wait()
+        # The child is now guaranteed dead (proc.wait() returned), so this
+        # check can't race with a late touch() the way _wait_for_ready's own
+        # cleanup could if the child wrote the marker just before the raise.
+        _cleanup_ready_path(ready_path)
         raise
     return proc
 
@@ -93,6 +102,10 @@ def _spawn_unkillable() -> subprocess.Popen[bytes]:
     except TimeoutError:
         proc.kill()
         proc.wait()
+        # The child is now guaranteed dead (proc.wait() returned), so this
+        # check can't race with a late touch() the way _wait_for_ready's own
+        # cleanup could if the child wrote the marker just before the raise.
+        _cleanup_ready_path(ready_path)
         raise
     return proc
 

--- a/tests/fleet_monitoring/test_lifecycle.py
+++ b/tests/fleet_monitoring/test_lifecycle.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-import time
+import tempfile
 
 import pytest
 
+from tests.utils.polling import wait_until
 from tools.system.fleet_monitoring.lifecycle import TerminateResult, terminate
 
 # Windows ``os.kill`` / ``signal.SIGTERM`` delivery to a Python ``Popen`` child
@@ -21,42 +22,68 @@ _skip_win32_posix_signals = pytest.mark.skipif(
 )
 
 
+def _make_ready_path() -> str:
+    """Reserve a path that does not yet exist, for a child to touch once ready."""
+    fd, ready_path = tempfile.mkstemp()
+    os.close(fd)
+    os.unlink(ready_path)
+    return ready_path
+
+
+def _wait_for_ready(ready_path: str) -> None:
+    """Poll until the child signals it has registered its handler, then clean up."""
+    try:
+        wait_until(lambda: os.path.exists(ready_path), timeout=2.0, interval=0.01)
+    finally:
+        if os.path.exists(ready_path):
+            os.unlink(ready_path)
+
+
 def _spawn_sleep() -> subprocess.Popen[bytes]:
     """Spawn a Python child that exits cleanly on SIGTERM.
 
-    The child installs a SIGTERM handler that calls ``sys.exit(0)``
-    so it exits promptly and predictably.
+    The child installs a SIGTERM handler that calls ``sys.exit(0)`` so it
+    exits promptly and predictably, then touches ``ready_path`` so the parent
+    can wait_until the handler is actually registered instead of sleeping a
+    fixed guess before sending the signal.
     """
+    ready_path = _make_ready_path()
     proc = subprocess.Popen(
         [
             sys.executable,
             "-c",
             (
-                "import signal, sys, time; "
+                "import pathlib, signal, sys; "
                 "signal.signal(signal.SIGTERM, lambda *_: sys.exit(0)); "
-                "time.sleep(60)"
+                f"pathlib.Path({ready_path!r}).touch(); "
+                "import time; time.sleep(60)"
             ),
         ],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    # Give the child a moment to register its signal handler.
-    time.sleep(0.2)
+    _wait_for_ready(ready_path)
     return proc
 
 
 def _spawn_unkillable() -> subprocess.Popen[bytes]:
     """Spawn a child that traps SIGTERM and refuses to die."""
+    ready_path = _make_ready_path()
     proc = subprocess.Popen(
         [
             sys.executable,
             "-c",
-            ("import signal, time; signal.signal(signal.SIGTERM, lambda *_: None); time.sleep(60)"),
+            (
+                "import pathlib, signal; "
+                "signal.signal(signal.SIGTERM, lambda *_: None); "
+                f"pathlib.Path({ready_path!r}).touch(); "
+                "import time; time.sleep(60)"
+            ),
         ],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    time.sleep(0.2)
+    _wait_for_ready(ready_path)
     return proc
 
 

--- a/tests/fleet_monitoring/test_lifecycle.py
+++ b/tests/fleet_monitoring/test_lifecycle.py
@@ -62,7 +62,12 @@ def _spawn_sleep() -> subprocess.Popen[bytes]:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    _wait_for_ready(ready_path)
+    try:
+        _wait_for_ready(ready_path)
+    except TimeoutError:
+        proc.kill()
+        proc.wait()
+        raise
     return proc
 
 
@@ -83,7 +88,12 @@ def _spawn_unkillable() -> subprocess.Popen[bytes]:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    _wait_for_ready(ready_path)
+    try:
+        _wait_for_ready(ready_path)
+    except TimeoutError:
+        proc.kill()
+        proc.wait()
+        raise
     return proc
 
 


### PR DESCRIPTION
Fixes #4362

Depends on #4381 (C-38's `wait_until` helper). Opened against `test/wait-until-polling-helper` since `tests/utils/polling.py` isn't on `main` yet; retarget/rebase once #4381 merges.

#### Describe the changes you have made in this PR -

Replaces the two fixed `time.sleep(0.2)` warmups in `_spawn_sleep`/`_spawn_unkillable` with a real readiness marker file the child touches after installing its SIGTERM handler, polled via `wait_until`. Includes two follow-up fixes from Greptile review: killing/reaping the child if the readiness wait times out (was leaking a running process), and a second cleanup pass after `proc.wait()` to close a narrow race where the marker file could be left behind. Only this one file was touched.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/fleet_monitoring/test_lifecycle.py -q --tb=line
5 passed in 21.22s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`_make_ready_path()` reserves then deletes a temp path so its later existence is an unambiguous signal. Both children `touch()` it right after registering their handler; the parent `wait_until`s on its existence instead of guessing a fixed delay. `_cleanup_ready_path()` centralizes the existence-check-then-unlink so it can run both in `_wait_for_ready`'s `finally` and again after `proc.kill()`/`proc.wait()` in the timeout path, closing the window where a late `touch()` could otherwise escape cleanup.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
