### PR TITLE
improvement(evidence-driver): replace bare -24 slice with MAX_CONVERSATION_MESSAGES (SM-90)

### DIFF
--- a/core/agent_harness/turns/evidence_driver.py
+++ b/core/agent_harness/turns/evidence_driver.py
@@ -31,6 +31,7 @@ from core.agent_harness.prompts.gather import build_gather_system_prompt
 from core.agent_harness.session.integration_resolution import resolve_and_cache_integrations
 from core.domain.alerts.alert_source import secondary_tool_sources
 from core.events import runtime_event_callback_from_observer
+from core.state import MAX_CONVERSATION_MESSAGES
 from platform.analytics.react_turn import run_react_agent_with_telemetry
 from platform.harness_ports import enrich_resolved_with_repo_scopes
 from platform.observability.trace.prompts import persist_turn_system_prompt
@@ -159,7 +160,7 @@ def _resolve_gather_integrations(
 
 
 def _build_gather_user_message(session: SessionStore, message: str) -> str:
-    messages = session.cli_agent_messages[-24:]
+    messages = session.cli_agent_messages[-MAX_CONVERSATION_MESSAGES:]
     history = format_recent_conversation(messages, max_turns=3)
     if history == NO_HISTORY_PLACEHOLDER:
         return message

--- a/tests/core/agent_harness/test_evidence_driver_context.py
+++ b/tests/core/agent_harness/test_evidence_driver_context.py
@@ -1,0 +1,71 @@
+"""Tests for gather context window truncation in evidence_driver (issue #4345)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from core.agent_harness.turns.evidence_driver import _build_gather_user_message
+from core.state import MAX_CONVERSATION_MESSAGES
+
+
+def _make_session(messages: list[dict[str, Any]]) -> MagicMock:
+    s = MagicMock()
+    s.cli_agent_messages = messages
+    return s
+
+
+def _fake_message(i: int) -> dict[str, Any]:
+    return {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg-{i}"}
+
+
+def test_uses_all_messages_when_below_limit() -> None:
+    """When history is short, all messages must be passed to format_recent_conversation."""
+    messages = [_fake_message(i) for i in range(5)]
+    session = _make_session(messages)
+
+    captured: list[list[Any]] = []
+
+    import core.agent_harness.turns.evidence_driver as mod
+
+    real_fmt = mod.format_recent_conversation
+
+    def _spy(msgs: list[Any], **kwargs: Any) -> str:
+        captured.append(list(msgs))
+        return real_fmt(msgs, **kwargs)
+
+    import unittest.mock
+
+    with unittest.mock.patch.object(mod, "format_recent_conversation", _spy):
+        _build_gather_user_message(session, "question")
+
+    assert captured, "format_recent_conversation was not called"
+    assert len(captured[0]) == 5, "All 5 messages must be forwarded when below limit"
+
+
+def test_truncates_to_max_conversation_messages() -> None:
+    """Only the last MAX_CONVERSATION_MESSAGES messages must reach format_recent_conversation."""
+    n = MAX_CONVERSATION_MESSAGES + 10
+    messages = [_fake_message(i) for i in range(n)]
+    session = _make_session(messages)
+
+    captured: list[list[Any]] = []
+
+    import core.agent_harness.turns.evidence_driver as mod
+
+    real_fmt = mod.format_recent_conversation
+
+    def _spy(msgs: list[Any], **kwargs: Any) -> str:
+        captured.append(list(msgs))
+        return real_fmt(msgs, **kwargs)
+
+    import unittest.mock
+
+    with unittest.mock.patch.object(mod, "format_recent_conversation", _spy):
+        _build_gather_user_message(session, "question")
+
+    assert captured, "format_recent_conversation was not called"
+    assert len(captured[0]) == MAX_CONVERSATION_MESSAGES, (
+        f"Expected {MAX_CONVERSATION_MESSAGES} messages, got {len(captured[0])} (issue #4345)"
+    )
+    assert captured[0][-1]["content"] == f"msg-{n - 1}"


### PR DESCRIPTION
Fixes #4345

## What

`_build_gather_user_message` in `core/agent_harness/turns/evidence_driver.py` used a hard-coded `[-24:]` slice. The constant `MAX_CONVERSATION_MESSAGES` already exists in `core.state` (= `MAX_CONVERSATION_TURNS * 2` = 24) — the gather window should use the same source of truth.

## Change

- Import `MAX_CONVERSATION_MESSAGES` from `core.state`
- Replace `session.cli_agent_messages[-24:]` → `session.cli_agent_messages[-MAX_CONVERSATION_MESSAGES:]`
- Add two tests covering: (a) short history passes all messages through, (b) long history is capped at `MAX_CONVERSATION_MESSAGES`

## Demo / Screenshot

```
$ uv run pytest tests/core/agent_harness/test_evidence_driver_context.py -v
collected 2 items

tests/core/agent_harness/test_evidence_driver_context.py::test_uses_all_messages_when_below_limit PASSED [ 50%]
tests/core/agent_harness/test_evidence_driver_context.py::test_truncates_to_max_conversation_messages PASSED [100%]

============================== 2 passed in 0.64s ===============================
```

## Code Understanding and AI Usage

- [x] Yes, I used AI assistance
- [x] I have reviewed every single line
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases
- [x] I have modified the AI output to follow this project's coding standards

**Implementation approach:** Single-line change in `_build_gather_user_message` plus import. No behaviour change — `MAX_CONVERSATION_MESSAGES` evaluates to the same value (24) as the removed literal, so the slice boundary is identical. The benefit is that future changes to `MAX_CONVERSATION_TURNS` automatically update the gather window without hunting for magic numbers.

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases
- [x] My code follows the project's style guidelines