### PR TITLE
test: re-enable empty-response telemetry coverage

### DIFF
--- a/tests/interactive_shell/utils/telemetry/test_execution_integration.py
+++ b/tests/interactive_shell/utils/telemetry/test_execution_integration.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import io
 
-import pytest
 from rich.console import Console
 
 from surfaces.interactive_shell.runtime.core.turn_accounting import (
@@ -29,10 +28,6 @@ def _console() -> Console:
     return Console(file=io.StringIO(), force_terminal=False, highlight=False)
 
 
-@pytest.mark.skip(
-    reason="Tool-gathering emits a progress line to the console; expectation of empty "
-    "output needs revisiting. Skipped to unblock CI."
-)
 def test_execute_shell_turn_cli_agent_empty_response_is_recorded_empty() -> None:
     recorder = _FakeRecorder()
 
@@ -58,6 +53,7 @@ def test_execute_shell_turn_cli_agent_empty_response_is_recorded_empty() -> None
         confirm_fn=None,
         is_tty=None,
         execute_actions=fake_execute,
+        gather_evidence=lambda *_args, **_kwargs: None,
         answer_agent=fake_answer,
     )
 


### PR DESCRIPTION
Fixes #4268

#### Describe the changes you have made in this PR -

Re-enables the empty-response telemetry integration test and injects a no-op `gather_evidence` seam.

The test is intended to verify that an empty assistant response is recorded as empty. Allowing the default gather adapter to run made the test depend on integration discovery and console progress output, which is unrelated to the telemetry behavior under test. Passing a no-op gather function keeps the test deterministic, preserves the original empty-console assertion, and removes the stale skip marker.

The now-unused `pytest` import is also removed.

### Demo/Screenshot for feature changes and bug fixes -

```text
uv run pytest tests/interactive_shell/utils/telemetry/test_execution_integration.py -q --tb=line
1 passed in 2.74s

uv run ruff check tests/interactive_shell/utils/telemetry/test_execution_integration.py
All checks passed!
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every changed line
- [x] I can explain the purpose and logic of the change
- [x] I tested the affected behavior and relevant edge condition
- [x] I verified the change follows the project's existing injection-seam pattern

**Explain your implementation approach:**

The skipped test was exercising two concerns at once: telemetry recording and the default integration-gathering adapter. The latter can emit progress output and perform slow integration discovery, while the assertions only concern the recorded empty response and final intent. Injecting `gather_evidence=lambda *_args, **_kwargs: None` uses the existing test seam to isolate the unit of behavior being tested. This is preferable to weakening the console assertion or mocking internal implementation details.

---

## Checklist before requesting a review
- [x] I have added a proper PR title and linked to the issue
- [x] I have performed a self-review of the change
- [x] I can explain the purpose of every changed line
- [x] I understand why the change works and tested it
- [x] I considered the relevant edge case: no gathered evidence and an empty assistant response
- [x] The change is test-only and does not modify core behavior
- [x] The change follows the project's style guidelines

---

Maintainer edits are allowed.