### PR TITLE
perf: reuse normalized log sample sets

### DIFF
--- a/platform/common/log_compaction.py
+++ b/platform/common/log_compaction.py
@@ -253,6 +253,7 @@ def build_error_taxonomy(
         }
 
     buckets: dict[str, dict[str, Any]] = {}
+    normalized_samples: dict[str, set[str]] = {}
 
     for log in logs:
         message = log.get("message", "")
@@ -269,6 +270,7 @@ def build_error_taxonomy(
                 "last_seen": timestamp,
                 "sample_messages": [],
             }
+            normalized_samples[error_type] = set()
 
         bucket = buckets[error_type]
         bucket["count"] += 1
@@ -281,9 +283,10 @@ def build_error_taxonomy(
         # Collect unique sample messages (up to max_samples)
         if len(bucket["sample_messages"]) < max_samples:
             normalized = _normalize_message(message)
-            existing_normalized = {_normalize_message(m) for m in bucket["sample_messages"]}
-            if normalized not in existing_normalized:
+            bucket_normalized_samples = normalized_samples[error_type]
+            if normalized not in bucket_normalized_samples:
                 bucket["sample_messages"].append(message)
+                bucket_normalized_samples.add(normalized)
 
         # Collect affected components
         for comp in _extract_components(message):


### PR DESCRIPTION
Fixes #4273

#### Describe the changes you have made in this PR -

Reuses one normalized sample-message set per error bucket in `build_error_taxonomy`.

Previously, every candidate log line rebuilt a set by normalizing all sample messages already selected for that bucket. The new private `normalized_samples` mapping records each accepted normalized message once and reuses that set for subsequent membership checks.

Returned taxonomy data, ordering, deduplication behavior, and sample limits remain unchanged.

### Demo/Screenshot for feature changes and bug fixes -

```text
uv run pytest tests/tools/test_log_compaction.py -q --tb=line
36 passed in 1.42s

uv run ruff check config core gateway integrations platform surfaces tools tests
All checks passed!

uv run --extra dev mypy config core gateway integrations platform surfaces tools
Success: no issues found in 1474 source files
```

Targeted formatting also passes for `platform/common/log_compaction.py`.
The repository-wide format check is currently blocked by an unrelated pre-existing formatting difference in `tools/interactive_shell/actions/sample_alert.py`; this PR does not modify that file.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I reviewed every changed line
- [x] I can explain the purpose and logic of the change
- [x] I tested the affected behavior and deduplication edge cases
- [x] I verified the change follows the project's existing style and typing rules

**Explain your implementation approach:**

The previous implementation recomputed normalized forms of all selected samples for every incoming line. I kept a separate per-bucket set rather than adding internal data to the returned bucket dictionaries, so the public result shape stays identical. Each accepted sample adds its normalized form once, and later candidates perform a direct set-membership check.

---

## Checklist before requesting a review
- [x] Proper PR title and linked issue
- [x] Self-reviewed the change
- [x] Tested existing log-compaction behavior
- [x] Considered duplicate normalized messages and sample caps
- [x] Full lint and type-check pass
- [x] Changed only the requested implementation file
