### PR TITLE
docs(s3): add AWS S3 user docs page (C-35, #4356)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -156,6 +156,7 @@
               "argocd",
               "aws",
               "aws_lambda",
+              "s3",
               "kubernetes",
               "cloudtrail_events",
               "bitbucket",

--- a/docs/s3.mdx
+++ b/docs/s3.mdx
@@ -9,18 +9,23 @@ All S3 access is read-only and routed through the shared AWS client, so the inte
 
 ## Prerequisites
 
-- AWS credentials configured per the [AWS integration](/aws) (role ARN recommended)
+- AWS credentials with S3 read access, configured per the [AWS integration](/aws)
 - An S3 bucket you want OpenSRE to read from
 - IAM permissions for the two S3 actions listed below
 
 ## Setup
 
-S3 has no credentials of its own — it reuses the AWS integration. Configure credentials and region there first:
+S3 has no credentials of its own — it uses the same AWS credentials as the rest of the [AWS integration](/aws). The S3 tools build their client from the ambient AWS credential chain: environment keys, a shared credentials profile, or an attached instance/task role — plus the region.
 
 ```bash
-AWS_ROLE_ARN=arn:aws:iam::123456789012:role/OpenSREReadOnly
+AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 AWS_REGION=us-east-1
 ```
+
+<Info>
+`AWS_ROLE_ARN` is assumed only by `opensre integrations verify aws` — the S3 tools do **not** assume it. The credentials above must have S3 read access themselves.
+</Info>
 
 The bucket, key, and prefix OpenSRE reads are **not** environment variables — they come from the alert's resolved sources. Each S3 tool turns on for the planner only when the sources carry the fields it needs:
 
@@ -28,7 +33,7 @@ The bucket, key, and prefix OpenSRE reads are **not** environment variables — 
 | --- | --- | --- |
 | `s3` | `bucket`, `key`, `prefix` | `list_s3_objects` (needs `bucket`), `inspect_s3_object` / `get_s3_object` (need `bucket` + `key`), `check_s3_marker` (needs `bucket` + `prefix`) |
 | `s3_audit` | `bucket`, `key` | `get_s3_object` — fetch an audit payload referenced by an alert |
-| `s3_processed` | `bucket`, `prefix` | `check_s3_marker` — check a pipeline's output location |
+| `s3_processed` | `bucket` (`prefix` optional) | `check_s3_marker` — check a pipeline's output location |
 
 ## IAM permissions
 
@@ -81,7 +86,7 @@ Expected output:
 ```
 Service: aws
 Status: passed
-Detail: STS caller identity resolved for arn:aws:iam::123456789012:role/OpenSREReadOnly
+Detail: Connected to AWS STS via static-creds in us-east-1; caller identity account=123456789012 arn=arn:aws:iam::123456789012:user/opensre.
 ```
 
 This confirms the credentials S3 rides on. It does not test bucket-level access — that is exercised the first time a tool runs against a bucket.
@@ -91,6 +96,6 @@ This confirms the credentials S3 rides on. It does not test bucket-level access 
 | Symptom | Fix |
 | --- | --- |
 | **S3 tools never run** | The alert's sources have no `s3` entry, or it lacks the required field — object-level tools need both `bucket` **and** `key`, not just `bucket`. |
-| **AccessDenied on `GetObject` / `ListBucket`** | Add the IAM policy above to the role or user used by the AWS integration. |
+| **AccessDenied on `GetObject` / `ListBucket`** | Attach the IAM policy above to the credentials the S3 tools actually use — the ambient credential chain (env keys or instance/task role), not only a role that the verifier assumes. |
 | **`check_s3_marker` reports no marker when the run finished** | It only counts files whose key contains `_SUCCESS` or `marker` (case-insensitive). A completion file named anything else won't be detected. |
 | **A binary object returns metadata but no readable text** | The object isn't UTF-8 (e.g. Parquet or gzip); you still get size, type, and ETag, but there is no text sample to read. |

--- a/docs/s3.mdx
+++ b/docs/s3.mdx
@@ -1,0 +1,96 @@
+---
+title: "AWS S3"
+description: "Inspect S3 objects, metadata, and pipeline markers during investigations"
+---
+
+OpenSRE uses AWS S3 to read object metadata and content when an alert points at data in a bucket — inspecting the files a pipeline produced, sampling an object to spot a schema change, pulling an audit payload, or confirming a run finished by checking for a completion marker.
+
+All S3 access is read-only and routed through the shared AWS client, so the integration cannot mutate or delete your objects.
+
+## Prerequisites
+
+- AWS credentials configured per the [AWS integration](/aws) (role ARN recommended)
+- An S3 bucket you want OpenSRE to read from
+- IAM permissions for the two S3 actions listed below
+
+## Setup
+
+S3 has no credentials of its own — it reuses the AWS integration. Configure credentials and region there first:
+
+```bash
+AWS_ROLE_ARN=arn:aws:iam::123456789012:role/OpenSREReadOnly
+AWS_REGION=us-east-1
+```
+
+The bucket, key, and prefix OpenSRE reads are **not** environment variables — they come from the alert's resolved sources. Each S3 tool turns on for the planner only when the sources carry the fields it needs:
+
+| Source key | Fields | Turns on |
+| --- | --- | --- |
+| `s3` | `bucket`, `key`, `prefix` | `list_s3_objects` (needs `bucket`), `inspect_s3_object` / `get_s3_object` (need `bucket` + `key`), `check_s3_marker` (needs `bucket` + `prefix`) |
+| `s3_audit` | `bucket`, `key` | `get_s3_object` — fetch an audit payload referenced by an alert |
+| `s3_processed` | `bucket`, `prefix` | `check_s3_marker` — check a pipeline's output location |
+
+## IAM permissions
+
+The integration only needs two read-only S3 actions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+Attach this to the same IAM role or user configured for the [AWS integration](/aws). If you already use the AWS managed `ReadOnlyAccess` policy, both actions are covered.
+
+## Tools
+
+| Tool | IAM action | What it returns |
+| --- | --- | --- |
+| `list_s3_objects` | `s3:ListBucket` | Object keys under an optional prefix, each with size, last-modified, ETag, and storage class (up to 100 keys). |
+| `inspect_s3_object` | `s3:GetObject` | Object metadata — size, content type, ETag, version ID, user metadata — plus a decoded text sample of the first few KB. |
+| `get_s3_object` | `s3:GetObject` | The full object body (up to 1 MB) as text, for audit payloads, config, or manifest files. |
+| `check_s3_marker` | `s3:ListBucket` | Whether a completion marker is present under a prefix, plus the file list — a signal that a pipeline run finished. |
+
+### Use cases
+
+- Listing what a pipeline wrote to a bucket, or confirming an expected file is present
+- Sampling an object to detect a schema or format change in upstream input data
+- Reading an audit payload or manifest to trace an external vendor interaction
+- Confirming a batch job completed by checking for its `_SUCCESS` marker
+
+## Verify
+
+S3 shares the AWS integration's verification. Verify credentials and region with:
+
+```bash
+opensre integrations verify aws
+```
+
+Expected output:
+
+```
+Service: aws
+Status: passed
+Detail: STS caller identity resolved for arn:aws:iam::123456789012:role/OpenSREReadOnly
+```
+
+This confirms the credentials S3 rides on. It does not test bucket-level access — that is exercised the first time a tool runs against a bucket.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| **S3 tools never run** | The alert's sources have no `s3` entry, or it lacks the required field — object-level tools need both `bucket` **and** `key`, not just `bucket`. |
+| **AccessDenied on `GetObject` / `ListBucket`** | Add the IAM policy above to the role or user used by the AWS integration. |
+| **`check_s3_marker` reports no marker when the run finished** | It only counts files whose key contains `_SUCCESS` or `marker` (case-insensitive). A completion file named anything else won't be detected. |
+| **A binary object returns metadata but no readable text** | The object isn't UTF-8 (e.g. Parquet or gzip); you still get size, type, and ETag, but there is no text sample to read. |


### PR DESCRIPTION
Fixes #4356

#### Describe the changes you have made in this PR -

Adds a user-facing docs page for the AWS S3 integration, which had tools but no docs-site page.

- **New:** `docs/s3.mdx` — modeled on `docs/rds.mdx`: intro, prerequisites, setup (S3 reuses the shared AWS credentials), IAM permissions (`s3:ListBucket`, `s3:GetObject`), the four read-only tools (`list_s3_objects`, `inspect_s3_object`, `get_s3_object`, `check_s3_marker`), verification via `opensre integrations verify aws`, and troubleshooting.
- **Changed:** `docs/docs.json` — registers `s3` in the "Cloud, code, and collaboration" group so the page appears in the site nav.

Docs-only change; no runtime code touched.

### Demo/Screenshot for feature changes and bug fixes -

<!-- Run `make docs-dev` and paste a screenshot of the S3 page showing in the sidebar. -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The task (C-35) was to document the existing AWS S3 integration, which shipped tools but no docs page. I read the four tool definitions in `integrations/s3/tools/` and the client in `integrations/aws/s3_client.py` so the page describes the real registered tools and their inputs/outputs, rather than guessing. I followed the shape of `docs/rds.mdx` — another AWS-backed integration — for consistency in section order and tables. Key decisions: I documented the source-dict fields (`s3` / `s3_audit` / `s3_processed`) that gate when each tool becomes available; listed only the two IAM actions the calls require (`s3:ListBucket`, `s3:GetObject`), matching the least-privilege policy in `docs/aws.mdx`; pointed verification at the shared `opensre integrations verify aws` since S3 has no separate verifier; and called out real gotchas (verify checks credentials but not bucket-level access, and `check_s3_marker` only matches keys containing `_SUCCESS`/`marker`). Finally I registered the page in `docs/docs.json` so it appears in the site nav.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions