### PR TITLE
refactor(kafka): drop comments that only restate the next line (SM-78)

### DIFF
--- a/integrations/kafka/__init__.py
+++ b/integrations/kafka/__init__.py
@@ -259,21 +259,17 @@ def get_consumer_group_lag(
         consumer = _get_consumer(config)
 
         try:
-            # Get committed offsets for the group
             group_offsets = admin.list_consumer_group_offsets(
                 [ConsumerGroupTopicPartitions(group_id)]
             )
-            # Wait for the future to resolve
             group_result = None
             for group_future in group_offsets.values():
                 group_result = group_future.result()
 
-            # Build partition lag info
             lag_info = []
             for tp in group_result.topic_partitions if group_result else []:
                 if tp.error:
                     continue
-                # Get high watermark for this partition
                 lo, hi = consumer.get_watermark_offsets(
                     TopicPartition(tp.topic, tp.partition),
                     timeout=config.timeout_seconds,


### PR DESCRIPTION
Fixes #4334

#### Describe the changes you have made in this PR -

Removes four banner comments in `integrations/kafka/__init__.py` (in `get_consumer_group_lag`) that only restated the line beneath them:

- `# Get committed offsets for the group`
- `# Wait for the future to resolve`
- `# Build partition lag info`
- `# Get high watermark for this partition`

No comments explaining a non-obvious rule/limit/quirk were removed, and the `# type: ignore[attr-defined]` directive is kept. Comment-only change — no code touched, no behavior change.

### Demo/Screenshot for feature changes and bug fixes -

Comment-only refactor; verified locally with the full CI harness:

make lint          -> All checks passed!
make format-check  -> already formatted
make typecheck     -> Success: no issues found in 1474 source files
make test-scope    -> 59 passed (tests/integrations/test_kafka.py + kafka tool tests)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

SM-78 asks to delete comments in `integrations/kafka/__init__.py` that only echo the next line. I scanned the whole file for comments and TODOs and found exactly four such banners in `get_consumer_group_lag`, each just restating the call right below it (e.g. `# Get committed offsets` above `admin.list_consumer_group_offsets(...)`). I deleted only those four, kept the `# type: ignore` directive, and left all code untouched so behavior is identical. I confirmed the diff is comment-only and ran lint, format-check, typecheck, and the scoped Kafka tests — all green.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions