### PR TITLE
Improvement:stop  scanning full history once max_entries is reached

### DIFF
--- a/core/agent_harness/prompts/conversation_memory.py
+++ b/core/agent_harness/prompts/conversation_memory.py
@@ -141,7 +141,10 @@ def format_prior_action_facts(
     command stdout, and value-shaped lines such as weather readings.
     """
     facts: list[str] = []
-    for entry in messages:
+    limit = max_entries if max_entries > 0 else None
+    # Walk newest-first so we can stop as soon as `limit` facts are found,
+    # instead of scanning the full history and trimming afterward.
+    for entry in reversed(messages):
         try:
             role, content = entry
         except (TypeError, ValueError):
@@ -163,13 +166,16 @@ def format_prior_action_facts(
         ) and not _VALUE_LINE_RE.search(text):
             continue
         facts.append(text)
+        if limit is not None and len(facts) >= limit:
+            break
 
     if not facts:
         return ""
 
     rendered: list[str] = []
     remaining = max(max_chars, 0)
-    for idx, fact in enumerate(facts[-max_entries:], start=1):
+    # `facts` was collected newest-first; reverse back to maintain chronological order
+    for idx, fact in enumerate(reversed(facts), start=1):
         if remaining <= 0:
             break
         chunk = f"- Prior assistant/tool output {idx}:\n{fact.strip()}"


### PR DESCRIPTION
Fixes #4272

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
`format_prior_action_facts` in `core/agent_harness/prompts/conversation_memory.py` now walks the conversation newest-first and stops as soon as `max_entries` qualifying facts are collected, instead of scanning every message before trimming to the last max_entries. The `SESSION_SUMMARY_PREFIX` skip is unchanged, and rendered output (ordering, numbering, truncation) is identical to before — verified against the existing `tests/core/agent/prompts/test_conversation_history.py` suite, which passes unmodified.
### Demo/Screenshot for feature changes and bug fixes - 
```
(opensre) deepak@deepakdhakad:~/opensre$ uv run mypy core/agent_harness/ && uv run pytest tests/core/agent/prompts/test_conversation_history.py 
mypy.ini: note: unused section(s): [mypy-kubernetes], [mypy-kubernetes.*], [mypy-questionary], [mypy-questionary.*], [mypy-confluent_kafka], [mypy-confluent_kafka.*], [mypy-apscheduler], [mypy-pyodbc], [mypy-pyfiglet], [mypy-tree_sitter], [mypy-tree_sitter.*], [mypy-integrations.opensre.hf_remote]
Success: no issues found in 58 source files
======================================= test session starts ========================================
.
.
(19 durations < 0.005s hidden.  Use -vv to show these durations.)
======================================== 9 passed in 0.75s =========================================
```
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [✓] No, I wrote all the code myself

**Explain your implementation approach:**
Walked messages in reverse order(newest-first) instead of front-to-back, breaking out of the loop as soon as `max_entries` qualifying facts are collected that avoids scanning the full history when only the last few facts matter. Since this collects facts newest-to-oldest, I render with `reversed(facts)` to restore the original oldest-first numbering, so output stays identical. `SESSION_SUMMARY_PREFIX` skip is untouched, and all existing tests pass unchanged.
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [✓] I have added proper PR title and linked to the issue
- [✓] I have performed a self-review of my code
- [✓] **I can explain the purpose of every function, class, and logic block I added**
- [✓] I understand why my changes work and have tested them thoroughly
- [✓] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
