### PR TITLE
Clarify groundcover helpers module and function docstrings

### DIFF
--- a/integrations/groundcover/helpers.py
+++ b/integrations/groundcover/helpers.py
@@ -1,9 +1,14 @@
 """Shared helpers for groundcover investigation tools.
 
-All groundcover tools share one client factory, one normalized output envelope,
-and one signal-query runner so logs/traces/events/issues/apm stay consistent.
-The OpenSRE output envelope is provider-agnostic and never exposes raw MCP
-protocol frames to the investigator.
+Exports, by pipeline stage:
+
+- ``groundcover_creds``, ``make_client``, ``client_for_source``: build a
+  ``GroundcoverClient`` from a resolved source entry's credentials.
+- ``base_extract_params``: inject that client into a tool's params without
+  exposing credentials to the model.
+- ``run_signal_query``, ``build_envelope``, ``needs_query``, ``unavailable``,
+  ``compact_rows``, ``time_range``: run a gcQL query and shape the result into
+  the provider-agnostic OpenSRE envelope, never exposing raw MCP protocol frames.
 
 This module lives under ``tools/utils`` (skipped by the tool registry) so it
 is shared infrastructure, not a registered tool.
@@ -64,7 +69,7 @@ GCQL_GUIDANCE = (
 
 
 def groundcover_creds(gc: dict[str, Any]) -> dict[str, Any]:
-    """Extract the credential subset a GroundcoverClient needs from a source entry."""
+    """Extract api_key/mcp_url/tenant_uuid/backend_id/timezone from a source entry."""
     return {
         "api_key": gc.get("api_key", ""),
         "mcp_url": gc.get("mcp_url", ""),
@@ -96,7 +101,7 @@ def make_client(creds: dict[str, Any]) -> GroundcoverClient | None:
 
 
 def unavailable(source: str, error: str, **extra: Any) -> dict[str, Any]:
-    """Standard unavailable envelope (no MCP call was made or it failed)."""
+    """tool_unavailable envelope with data=[], summary={}, truncated=False defaults."""
     return tool_unavailable(source, error, data=[], summary={}, truncated=False, **extra)
 
 
@@ -155,7 +160,8 @@ def build_envelope(
     *,
     tr: dict[str, str],
 ) -> dict[str, Any]:
-    """Turn a GroundcoverToolResult into the normalized OpenSRE envelope."""
+    """Turn a GroundcoverToolResult into an envelope dict with source/available/query/
+    time_range/data/summary/truncated/error (+ notes when present)."""
     if not result.success:
         return tool_unavailable(
             source,


### PR DESCRIPTION
Fixes #4341

#### Describe the changes you have made in this PR -
Rewrote the module docstring and 3 function docstrings in integrations/groundcover/helpers.py that didn't state a clear contract. Module docstring now lists every export grouped by pipeline stage (build client, inject into params, run query and shape envelope). groundcover_creds, unavailable, and build_envelope now state exact input/output shape instead of vague phrases like "credential subset" or "standard envelope". No renames, no logic or behavior change.

### Demo/Screenshot for feature changes and bug fixes -
`ruff check` and `ruff format --check` both pass on the file, no diff beyond docstrings.


## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)


**Explain your implementation approach:**
Read every function body first to check which docstrings were actually vague versus already fine. Most already stated their return shape; only groundcover_creds, unavailable, and build_envelope didn't say what callers get back, so only those plus the module docstring changed. Verified each new docstring against the real code: groundcover_creds's key list matches the dict it returns, unavailable's defaults match the tool_unavailable call, and build_envelope's key list matches both its success path and its tool_unavailable failure path (checked core/tool_framework/utils/tool_availability.py to confirm both paths return the same key set). No alternative approach considered, it's a docstring-only fix scoped to one file.


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions