### PR TITLE
fix(docs): reformat AGENTS.md code block for ruff 0.16 markdown formatting

### DIFF
--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -125,14 +125,14 @@ the single instantiation site — when `Agent.__init__`'s signature changes,
 from core.agent_harness.agent_builder import AgentConfig, build_agent
 
 config = AgentConfig(
-    llm=llm_client,                    # or None to fall back to get_llm(LLMRole.AGENT)
+    llm=llm_client,  # or None to fall back to get_llm(LLMRole.AGENT)
     system=system_prompt,
     tools=tuple(agent_tools),
     resolved_integrations=resolved,
     max_iterations=6,
-    tool_resources={},                  # optional
-    tool_hooks=None,                    # optional
-    on_runtime_event=observer_callback, # optional
+    tool_resources={},  # optional
+    tool_hooks=None,  # optional
+    on_runtime_event=observer_callback,  # optional
 )
 agent = build_agent(config)
 ```


### PR DESCRIPTION
<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

`quality (ubuntu-latest)` was failing on `main` at the `Format check` step. `uv.lock` picked up `ruff` 0.16.0 (from an earlier dependency bump), and that version formats fenced Python code blocks inside Markdown files — a behavior 0.15.x didn't have. This flagged inline-comment spacing (`# comment` alignment) in the example `AgentConfig(...)` snippet in `core/agent_harness/AGENTS.md`.

Ran `make format` (equivalently `ruff format`) locally with `ruff==0.16.0` to bring the snippet in line with the new formatter output — purely whitespace, no semantic change to the example.

### Demo/Screenshot for feature changes and bug fixes -

Before fix, locally with ruff 0.16.0:
```
$ uv run python -m ruff format --check config core gateway integrations platform surfaces tools tests/
unformatted: File would be reformatted
   --> core/agent_harness/AGENTS.md:1:1
1 file would be reformatted, 2914 files already formatted
```

After fix:
```
$ uv run python -m ruff format --check config core gateway integrations platform surfaces tools tests/
2915 files already formatted
```

Failing CI run this fixes: https://github.com/Tracer-Cloud/opensre/actions/runs/30355846653

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`main`'s CI `quality` job was red because the pinned `ruff` version moved to 0.16.0, which now reformats Markdown-embedded Python fences by default. This is a pure formatting diff — ran `ruff format` and committed its output for the one affected file, per the `CI.md` "docs/process-only" shortcut (single `.md` file, no runtime code touched).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.