### PR TITLE
chore(comments): describe behavior instead of citing tracker numbers

### DIFF
--- a/integrations/eks/eks_k8s_client.py
+++ b/integrations/eks/eks_k8s_client.py
@@ -112,7 +112,8 @@ def build_k8s_clients(
     else:
         # No role_arn and no explicit creds: fall back to ambient AWS
         # credentials (env AK/SK, shared config profile, or instance profile
-        # / IRSA). Preserves the #724 fallback behaviour.
+        # / IRSA), so investigations still work when no AWS integration is
+        # explicitly configured.
         logger.info("[eks] No role_arn or explicit credentials; using ambient AWS credentials")
         sess = botocore.session.get_session()
         ambient = sess.get_credentials()

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -487,7 +487,8 @@ def family_key(service_key: str) -> str:
 
 # Wire the concrete resolver into the platform-level seam so callers in
 # ``tools/`` can normalize service keys without importing from
-# ``integrations/`` directly (T-4 layering audit, issue #3352, item 27).
+# ``integrations/`` directly, keeping ``platform/`` free of a reverse
+# dependency on ``integrations/``.
 # Kept at import time so any consumer that has already imported the
 # ``integrations`` package (every CLI entry point does so during startup)
 # sees the real mapping instead of the identity fallback.


### PR DESCRIPTION
## Summary

Fixes [#4348](https://github.com/Tracer-Cloud/opensre/issues/4348) (Task ID: SM-93)

A couple of comments in these files were pointing at old ticket numbers (`#NNNN` style, plus one `T-4` tracker code) instead of just explaining what the code actually does. I rewrote both so they describe the rule/behavior directly, no tracker references needed to understand them. The ticket link belongs here in the PR, not buried in the code.

## Changes

- `integrations/registry.py`: the comment used to just say "(T-4 layering audit, issue #3352, item 27)". I replaced that with the actual reason the resolver gets wired at import time, it keeps `platform/` from having a reverse dependency on `integrations/`.
- `integrations/eks/eks_k8s_client.py`: the comment said "Preserves the #724 fallback behaviour," which doesn't mean anything without opening that ticket. I rewrote it to explain why the ambient-credentials fallback exists, so investigations keep working even when no AWS integration has been explicitly set up.

## Focused Verification
- Lint: all checks passed
- Format check: all files already formatted
- Typecheck: no issues found in 1474 source files
- Scoped tests (`tests/integrations/`, `tests/tools/test_eks_*`, `tests/benchmarks/cloudopsbench/`): 3310 passed, 7 skipped, 2 failed
- Both failures (`test_changed_paths_handles_quoted_filenames`, `test_codex_auth_payload_and_write_auth_shape`) are pre-existing, Windows-only environment issues (non-ASCII filename encoding and POSIX file-permission bits Windows doesn't enforce). Confirmed by stashing this change and rerunning both tests against a clean `main`; they fail identically with zero code changes present. Not caused by this PR, and CI runs on Linux where these are not an issue
  
## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
