### PR TITLE
refactor(wizard): drop issue numbers from flow + env_sync comments (SM-95)

### DIFF
--- a/surfaces/cli/wizard/env_sync.py
+++ b/surfaces/cli/wizard/env_sync.py
@@ -157,7 +157,7 @@ def sync_provider_env(
             active_non_secret.add(provider.api_version_env)
     # A ``host`` credential (e.g. the Ollama host) is non-secret runtime config
     # that the wizard persists to ``.env`` — keep it as an active key so this
-    # sync does not strip it back out in the same wizard run (see #3291).
+    # sync does not strip it back out in the same wizard run.
     if provider.credential_kind == "host" and provider.api_key_env:
         active_non_secret.add(provider.api_key_env)
     keys_to_remove -= active_non_secret

--- a/surfaces/cli/wizard/flow.py
+++ b/surfaces/cli/wizard/flow.py
@@ -675,7 +675,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
     provider_extra_env: dict[str, str] = {}
     credential_state: CredentialState = OK
     # Records a ``continue_unsaved`` secret export so it can be re-applied after
-    # ``sync_provider_env`` pops it, before the in-process shell handoff (#3591).
+    # ``sync_provider_env`` pops it, before the in-process shell handoff.
     session_env_sink: dict[str, str] = {}
     while True:
         credential_state = OK
@@ -813,7 +813,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                 # A ``host`` credential (e.g. the Ollama host) is not a secret api key: never
                 # migrate a stale legacy ``api_key`` value into it — that would leak a
                 # secret-shaped value into .env and point the runtime at a bogus host. Fall
-                # through to the host prompt instead (#3291).
+                # through to the host prompt instead.
                 if not has_api_key and legacy_api_key and provider.credential_kind != "host":
                     migration_outcome = _persist_llm_credential_with_recovery(
                         provider, legacy_api_key, session_env_sink=session_env_sink
@@ -895,7 +895,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         # sync_provider_env pops every secret provider's api-key env; re-apply the
         # session-only value the user chose to continue with so the in-process shell
         # handoff can read it. A secret is never written to .env — the keyring stays the
-        # only persistent store (#3591). A ``host`` value normally goes straight to .env
+        # only persistent store. A ``host`` value normally goes straight to .env
         # and never reaches this sink; it only lands here when its .env write failed and
         # the user picked "continue without saving", where re-applying it to os.environ
         # is exactly what is wanted.


### PR DESCRIPTION

No `#NNNN` or tracker codes remain in either file.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

SM-95 asks to remove issue/ticket numbers from comments in `flow.py` and `env_sync.py` and rewrite each as a standalone behavior sentence. I grepped both files for `#NNNN` and `T-`/`SM-`-style tracker codes and found four references (`#3591` twice, `#3291` twice). Each comment already described the behavior and only trailed a tracker link, so I dropped the `(#NNNN)` / `(see #NNNN)` suffix, leaving a complete sentence in every case — I did not reword the surrounding explanations or touch any code. I confirmed the diff is comment-only, that no tracker codes remain, and ran lint, format-check, typecheck, the wizard test suite, and the registry smoke gate — all pass.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
