### PR TITLE
chore(gateway): remove unused Telegram gateway startup helper

### DIFF
--- a/gateway/telegram/settings.py
+++ b/gateway/telegram/settings.py
@@ -146,26 +146,3 @@ def load_gateway_settings() -> GatewaySettings:
         )
     except ValidationError as exc:
         raise GatewayConfigurationError("Invalid Telegram gateway configuration") from exc
-
-
-def try_load_gateway_settings_for_startup(
-    *,
-    logger: logging.Logger,
-    respect_auto_start: bool = True,
-) -> GatewaySettings | None:
-    """Load gateway settings for optional background startup; return None when skipped."""
-    try:
-        settings = load_gateway_settings()
-    except GatewayConfigurationError as exc:
-        logger.debug("[telegram-gateway] startup skipped: %s", exc)
-        return None
-
-    if respect_auto_start and not settings.auto_start_enabled:
-        logger.debug("[telegram-gateway] auto-start disabled in config")
-        return None
-
-    if not settings.bot_token:
-        logger.warning("[telegram-gateway] no bot token configured")
-        return None
-
-    return settings

--- a/gateway/tests/telegram/test_get_gateway_settings.py
+++ b/gateway/tests/telegram/test_get_gateway_settings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Iterator
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -17,7 +17,6 @@ from gateway.telegram.settings import (
     load_telegram_credentials,
     store_allowed_users,
     store_bot_token,
-    try_load_gateway_settings_for_startup,
 )
 from integrations.messaging_security import MessagingIdentityPolicy
 
@@ -209,47 +208,3 @@ def test_load_gateway_settings_missing_token_raises() -> None:
         pytest.raises(GatewayConfigurationError, match="bot token is missing"),
     ):
         load_gateway_settings()
-
-
-# ---------------------------------------------------------------------------
-# try_load_gateway_settings_for_startup
-# ---------------------------------------------------------------------------
-
-
-@patch("gateway.telegram.settings.load_gateway_settings")
-def test_try_load_skips_when_auto_start_disabled(mock_load: MagicMock) -> None:
-    mock_load.return_value = GatewaySettings(bot_token="tok", auto_start_enabled=False)
-    logger = logging.getLogger("gateway.test")
-    assert try_load_gateway_settings_for_startup(logger=logger) is None
-
-
-@patch("gateway.telegram.settings.load_gateway_settings")
-def test_try_load_ignores_auto_start_when_disabled(mock_load: MagicMock) -> None:
-    mock_load.return_value = GatewaySettings(bot_token="tok", auto_start_enabled=False)
-    logger = logging.getLogger("gateway.test")
-    settings = try_load_gateway_settings_for_startup(
-        logger=logger,
-        respect_auto_start=False,
-    )
-    assert settings is not None
-    assert settings.bot_token == "tok"
-
-
-@patch("gateway.telegram.settings.load_gateway_settings")
-def test_try_load_skips_on_configuration_error(mock_load: MagicMock) -> None:
-    mock_load.side_effect = GatewayConfigurationError("missing integration")
-    logger = logging.getLogger("gateway.test")
-    assert try_load_gateway_settings_for_startup(logger=logger) is None
-
-
-@patch("gateway.telegram.settings.load_gateway_settings")
-def test_try_load_skips_when_bot_token_empty(mock_load: MagicMock) -> None:
-    mock_load.return_value = GatewaySettings(bot_token="")
-    logger = logging.getLogger("gateway.test")
-    assert (
-        try_load_gateway_settings_for_startup(
-            logger=logger,
-            respect_auto_start=False,
-        )
-        is None
-    )


### PR DESCRIPTION
## Summary

Fixes [#4429](https://github.com/Tracer-Cloud/opensre/issues/4429)

`try_load_gateway_settings_for_startup` in `gateway/telegram/settings.py` had no call sites left anywhere in the codebase, only its own definition and the test file written for it. I traced it back through git history to figure out which of the two options in the issue applied (remove it, or wire it back in).

Turns out its only caller used to live in `surfaces/interactive_shell/main.py`, auto-starting a background Telegram poller when the interactive shell launched. That caller was deleted in an earlier refactor (commit `1fdb2b61`, "Feature/gateway code"), and this helper function got left behind by accident. Since then, the Telegram gateway has moved to its own separate daemon process (`opensre gateway start`, wired through `gateway/runtime/manager.py` and `gateway/telegram/wiring.py`), which already loads settings and starts polling on its own. Wiring the old helper back into the shell would mean two separate processes polling the same Telegram bot at once, which Telegram's API does not allow, so removing it was the right call, not rewiring it.

## Changes

- `gateway/telegram/settings.py`: removed the unused `try_load_gateway_settings_for_startup` function.
- `gateway/tests/telegram/test_get_gateway_settings.py`: removed the 4 tests written only for that function, dropped it from the import list, and removed the now unused `MagicMock` import that only those tests needed.

## Testing

Ran lint, format check, and typecheck, all clean, no issues.

For tests, I ran the full `gateway/tests/` suite since the acceptance criteria specifically call out that the Telegram gateway needs to keep working after this change: 388 passed, 4 failed, 2 errors.

All 4 failures and 2 errors are unrelated to this change. They come from `os.WNOHANG`, a POSIX-only constant that does not exist on Windows, used by daemon process-management tests (`test_gateway_daemon.py`) and one Slack test that depends on the same daemon path. I confirmed this by stashing my changes and running those same tests against a clean `main`, same failures, same errors, with zero code changes present. These only fail locally on Windows; CI runs on Linux where this is not an issue.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions