### PR TITLE
refactor(honeycomb): vendor-first config module (T-18 exemplar)

### DIFF
--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -190,7 +190,6 @@ from integrations.config_models import (
     GrafanaIntegrationConfig,
     GroundcoverIntegrationConfig,
     HelmIntegrationConfig,
-    HoneycombIntegrationConfig,
     IncidentIoIntegrationConfig,
     JiraIntegrationConfig,
     KubernetesIntegrationConfig,
@@ -221,6 +220,7 @@ from integrations.grafana import classify as _classify_grafana
 from integrations.groundcover import classify as _classify_groundcover
 from integrations.helm import classify as _classify_helm
 from integrations.honeycomb import classify as _classify_honeycomb
+from integrations.honeycomb.config import HoneycombIntegrationConfig
 from integrations.incident_io import classify as _classify_incident_io
 from integrations.jenkins import classify as _classify_jenkins
 from integrations.jenkins import jenkins_config_from_env

--- a/integrations/config_models.py
+++ b/integrations/config_models.py
@@ -23,8 +23,6 @@ _LOCAL_GRAFANA_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0"}
 DEFAULT_GROUNDCOVER_MCP_URL = "https://mcp.groundcover.com/api/mcp"
 DEFAULT_GROUNDCOVER_TIMEZONE = "UTC"
 DEFAULT_DATADOG_SITE = "datadoghq.com"
-DEFAULT_HONEYCOMB_BASE_URL = "https://api.honeycomb.io"
-DEFAULT_HONEYCOMB_DATASET = "__all__"
 DEFAULT_CORALOGIX_BASE_URL = "https://api.coralogix.com"
 DEFAULT_OPSGENIE_BASE_URLS: dict[str, str] = {
     "us": "https://api.opsgenie.com",
@@ -196,22 +194,6 @@ class GroundcoverIntegrationConfig(StrictConfigModel):
         if self.backend_id:
             headers["X-Backend-Id"] = self.backend_id
         return headers
-
-
-class HoneycombIntegrationConfig(StrictConfigModel):
-    """Normalized Honeycomb credentials used by resolution and verification flows."""
-
-    api_key: str
-    dataset: str = DEFAULT_HONEYCOMB_DATASET
-    base_url: str = DEFAULT_HONEYCOMB_BASE_URL
-    integration_id: str = ""
-
-    _normalize_dataset = field_validator("dataset", mode="before")(
-        normalize_with_default(DEFAULT_HONEYCOMB_DATASET)
-    )
-    _normalize_base_url = field_validator("base_url", mode="before")(
-        normalize_url(DEFAULT_HONEYCOMB_BASE_URL)
-    )
 
 
 class CoralogixIntegrationConfig(StrictConfigModel):

--- a/integrations/honeycomb/__init__.py
+++ b/integrations/honeycomb/__init__.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from integrations._validation_helpers import report_classify_failure
-from integrations.config_models import HoneycombIntegrationConfig
+from integrations.honeycomb.config import HoneycombIntegrationConfig
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/honeycomb/client.py
+++ b/integrations/honeycomb/client.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import httpx
 
-from integrations.config_models import HoneycombIntegrationConfig
+from integrations.honeycomb.config import HoneycombIntegrationConfig
 from integrations.probes import ProbeResult
 from platform.observability.errors.service import capture_service_error
 

--- a/integrations/honeycomb/config.py
+++ b/integrations/honeycomb/config.py
@@ -1,0 +1,27 @@
+"""Honeycomb integration configuration."""
+
+from __future__ import annotations
+
+from pydantic import field_validator
+
+from config.strict_config import StrictConfigModel
+from integrations._validators import normalize_url, normalize_with_default
+
+DEFAULT_HONEYCOMB_BASE_URL = "https://api.honeycomb.io"
+DEFAULT_HONEYCOMB_DATASET = "__all__"
+
+
+class HoneycombIntegrationConfig(StrictConfigModel):
+    """Normalized Honeycomb credentials used by resolution and verification flows."""
+
+    api_key: str
+    dataset: str = DEFAULT_HONEYCOMB_DATASET
+    base_url: str = DEFAULT_HONEYCOMB_BASE_URL
+    integration_id: str = ""
+
+    _normalize_dataset = field_validator("dataset", mode="before")(
+        normalize_with_default(DEFAULT_HONEYCOMB_DATASET)
+    )
+    _normalize_base_url = field_validator("base_url", mode="before")(
+        normalize_url(DEFAULT_HONEYCOMB_BASE_URL)
+    )

--- a/integrations/honeycomb/setup.py
+++ b/integrations/honeycomb/setup.py
@@ -12,7 +12,7 @@ from config.constants.honeycomb import (
     HONEYCOMB_BASE_URL_ENV,
     HONEYCOMB_DATASET_ENV,
 )
-from integrations.config_models import DEFAULT_HONEYCOMB_BASE_URL, DEFAULT_HONEYCOMB_DATASET
+from integrations.honeycomb.config import DEFAULT_HONEYCOMB_BASE_URL, DEFAULT_HONEYCOMB_DATASET
 from integrations.honeycomb.verifier import verify_honeycomb
 from integrations.setup_flow import IntegrationSetupSpec, SetupField
 

--- a/integrations/honeycomb/tools/__init__.py
+++ b/integrations/honeycomb/tools/__init__.py
@@ -8,8 +8,8 @@ from typing import Any
 
 from core.tool_framework.base import BaseTool
 from core.tool_framework.utils.tool_availability import tool_unavailable
-from integrations.config_models import HoneycombIntegrationConfig
 from integrations.honeycomb.client import HoneycombClient
+from integrations.honeycomb.config import HoneycombIntegrationConfig
 
 
 def _honeycomb_available(sources: dict) -> bool:

--- a/integrations/honeycomb/verifier.py
+++ b/integrations/honeycomb/verifier.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from integrations.config_models import HoneycombIntegrationConfig
 from integrations.honeycomb.client import HoneycombClient
+from integrations.honeycomb.config import HoneycombIntegrationConfig
 from integrations.verification import register_probe_verifier
 
 verify_honeycomb = register_probe_verifier(

--- a/tests/integrations/honeycomb/test_client.py
+++ b/tests/integrations/honeycomb/test_client.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from integrations.config_models import HoneycombIntegrationConfig
 from integrations.honeycomb.client import HoneycombClient
+from integrations.honeycomb.config import HoneycombIntegrationConfig
 
 
 @pytest.fixture

--- a/tests/integrations/test_config_validation.py
+++ b/tests/integrations/test_config_validation.py
@@ -8,7 +8,6 @@ from integrations.config_models import (
     BetterStackIntegrationConfig,
     CoralogixIntegrationConfig,
     GrafanaIntegrationConfig,
-    HoneycombIntegrationConfig,
     SlackWebhookConfig,
     SnowflakeIntegrationConfig,
     TracerIntegrationConfig,
@@ -19,6 +18,7 @@ from integrations.github.mcp import (
     build_github_mcp_config,
 )
 from integrations.grafana.config import GrafanaAccountConfig
+from integrations.honeycomb.config import HoneycombIntegrationConfig
 from integrations.sentry import build_sentry_config
 from integrations.snowflake import classify as classify_snowflake
 


### PR DESCRIPTION
Refs #3551

#### Describe the changes you have made in this PR -

First exemplar for the T-18 vendor-first completion. Moves `HoneycombIntegrationConfig` (and its two `DEFAULT_HONEYCOMB_*` constants) out of the shared `integrations/config_models.py` and into a vendor-local `integrations/honeycomb/config.py`, so the Honeycomb package now owns its full `{config, client, verifier, tools}` set with nothing left in the central flat module.

All 8 import sites are rewritten to the canonical `integrations.honeycomb.config` path — no forwarding shim (per AGENTS.md: no compat-only modules after a refactor). The central `_catalog_impl.py` imports it directly, matching the `airflow.config` precedent already in that file.

This sets the pattern and review bar for the remaining ~41 config models, which will land in risk-ordered domain batches (observability → databases → cloud/infra → alerting → messaging bots last, since the AC singles out the Telegram path).

Files:
- new `integrations/honeycomb/config.py`
- `integrations/config_models.py` (model + constants removed)
- `integrations/honeycomb/{__init__,client,verifier,setup}.py`, `tools/__init__.py`
- `integrations/_catalog_impl.py`
- `tests/integrations/honeycomb/test_client.py`, `tests/integrations/test_config_validation.py`

### Demo/Screenshot for feature changes and bug fixes -

Acceptance criteria — all three surfaces verified to boot through the catalog/registry path this change touches:

CLI:
    $ opensre integrations verify honeycomb
    SERVICE   │ SOURCE │ STATUS    │ DETAIL
    honeycomb │ -      │ ⚠ missing │ Not configured in local store or environment variables.
    (exit 0 — resolves through the migrated config module)

Interactive shell:
    install_harness_ports() → catalog + registry wired OK

Telegram gateway:
    gateway.http.webapp imports clean; honeycomb classify path returns "honeycomb"

Checks:
    make lint          → All checks passed
    make format-check  → 2828 files already formatted
    make typecheck     → Success: no issues found in 1476 source files
    make test-scope    → 3141 passed, 6 skipped

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: `config_models.py` is the last big "legacy flat module" — 42 vendor config models in one 1,260-line file — blocking the vendor-first (T-1) layout where each `integrations/<vendor>/` is self-contained.

I picked Honeycomb as the exemplar because it's a leaf observability vendor with an existing client/verifier/tools/setup and its own e2e-adjacent unit tests, so the blast radius is small and well-guarded. The move is a pure symbol relocation: the model and its defaults go to `honeycomb/config.py`, and every importer switches to that path.

Alternative considered: a temporary re-export shim in `config_models.py`. Rejected — AGENTS.md forbids compat-only forwarding modules after a refactor, and the import count is small enough to migrate atomically. I also considered keeping the `DEFAULT_HONEYCOMB_*` constants central, but co-locating them with the model is what makes the package self-contained.

One subtlety: `test_catalog_silent_fallback_elimination.py` patches `integrations.honeycomb.HoneycombIntegrationConfig`. That name stays bound in the package namespace via `__init__.py`, so the patch target is unaffected — confirmed by the passing suite.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
