### PR TITLE
docs(helm): write clearer helpers docstrings

### DIFF
--- a/integrations/helm/helpers.py
+++ b/integrations/helm/helpers.py
@@ -1,4 +1,9 @@
-"""Shared helpers for Helm investigation tools."""
+"""Build a ``HelmClient`` from raw tool params, or a standard unavailable
+response when Helm can't run for this call.
+
+Helm tools call ``helm_client_for_run`` first; if it returns ``None`` they
+return ``helm_base_unavailable(...)`` instead of invoking the client.
+"""
 
 from __future__ import annotations
 
@@ -21,6 +26,28 @@ def helm_client_for_run(
     default_namespace: str = "",
     integration_id: str = "",
 ) -> HelmClient | None:
+    """Validate raw Helm tool params and build a ``HelmClient`` from them.
+
+    Args:
+        helm_path: Path or name of the ``helm`` executable; defaults to
+            ``"helm"`` on the ``PATH`` when empty.
+        kube_context: ``kubectl``/``helm`` context name to target; empty
+            means the client's default context.
+        kubeconfig: Path to a kubeconfig file; empty means the default
+            kubeconfig resolution (``$KUBECONFIG`` / ``~/.kube/config``).
+        default_namespace: Namespace to scope Helm operations to when a
+            call doesn't specify one; empty means no default namespace.
+        integration_id: Store-registered integration id, used to resolve
+            per-integration credentials/config; empty for the ad hoc/no-store
+            case.
+
+    Returns:
+        A ``HelmClient`` configured from the validated params, or ``None``
+        if the params fail ``HelmIntegrationConfig`` validation or building
+        the config raises unexpectedly (logged at debug level). Callers must
+        check for ``None`` and fall back to ``helm_base_unavailable(...)``
+        instead of calling into the client.
+    """
     try:
         cfg = HelmIntegrationConfig.model_validate(
             {
@@ -40,4 +67,15 @@ def helm_client_for_run(
 
 
 def helm_base_unavailable(error: str) -> dict[str, Any]:
+    """Build the standard Helm "unavailable" tool response.
+
+    Args:
+        error: Human-readable reason the Helm tool can't run right now
+            (e.g. why ``helm_client_for_run`` returned ``None``).
+
+    Returns:
+        ``{"source": "helm", "available": False, "error": error}``, the
+        envelope Helm tools return directly as their result instead of
+        calling into a ``HelmClient``.
+    """
     return tool_unavailable("helm", error)


### PR DESCRIPTION
Fixes #4339

#### Describe the changes you have made in this PR -

`helm_client_for_run` and `helm_base_unavailable` in `integrations/helm/helpers.py` had no docstrings at all, so callers had to read the implementation to learn what each param means, when the client comes back `None`, and what the unavailable envelope looks like. Added docstrings that state the contract: `helm_client_for_run`'s params/defaults and the `None` return on validation/unexpected failure, `helm_base_unavailable`'s single `error` param and the exact envelope shape it returns, and a short module docstring tying the two together (call `helm_client_for_run` first; fall back to `helm_base_unavailable(...)` on `None`). No renames.

### Demo/Screenshot for feature changes and bug fixes -

```
$ make lint
.venv/bin/python -m ruff check config core gateway integrations platform surfaces tools tests/
All checks passed!
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Read the actual implementation to write accurate docstrings rather than generic ones: `helm_client_for_run` builds a `HelmIntegrationConfig` via `model_validate`, returning `None` on `ValidationError` or any other exception (logged at debug), and only returns a real `HelmClient` on success, so the docstring calls out that callers must handle `None`. `helm_base_unavailable` just wraps `tool_unavailable("helm", error)`, whose exact return shape (`{"source", "available", "error"}`) I confirmed by reading `core/tool_framework/utils/tool_availability.py` before documenting it, so the docstring reflects the real envelope rather than a guess.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
