### PR TITLE
refactor(integrations): replace raw HTTP status integers with HTTPStatus in http_probe_validators

### DIFF
--- a/surfaces/cli/wizard/integration_validators/http_probe_validators.py
+++ b/surfaces/cli/wizard/integration_validators/http_probe_validators.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from http import HTTPStatus
+
 import httpx
 
 from integrations.config_models import SlackWebhookConfig
@@ -25,11 +27,16 @@ def validate_slack_webhook(*, webhook_url: str) -> IntegrationHealthResult:
     except httpx.RequestError as err:
         return IntegrationHealthResult(ok=False, detail=f"Slack webhook validation failed: {err}")
 
-    if response.status_code == 404:
+    if response.status_code == HTTPStatus.NOT_FOUND:
         return IntegrationHealthResult(
             ok=False, detail="Slack webhook returned 404; the URL looks invalid."
         )
-    if response.status_code in {200, 400, 403, 405}:
+    if response.status_code in {
+        HTTPStatus.OK,
+        HTTPStatus.BAD_REQUEST,
+        HTTPStatus.FORBIDDEN,
+        HTTPStatus.METHOD_NOT_ALLOWED,
+    }:
         return IntegrationHealthResult(
             ok=True,
             detail=f"Slack webhook endpoint reachable (HTTP {response.status_code}) using a non-posting probe.",
@@ -51,13 +58,13 @@ def validate_notion_integration(*, api_key: str, database_id: str) -> Integratio
             },
             timeout=10,
         )
-        if resp.status_code == 200:
+        if resp.status_code == HTTPStatus.OK:
             return IntegrationHealthResult(
                 ok=True, detail="Notion database reachable and token valid."
             )
-        if resp.status_code == 401:
+        if resp.status_code == HTTPStatus.UNAUTHORIZED:
             return IntegrationHealthResult(ok=False, detail="Notion API key is invalid or expired.")
-        if resp.status_code == 404:
+        if resp.status_code == HTTPStatus.NOT_FOUND:
             return IntegrationHealthResult(
                 ok=False,
                 detail="Notion database not found. Check the database ID and sharing settings.",
@@ -80,7 +87,7 @@ def validate_jira_integration(
             headers={"Accept": "application/json"},
             timeout=10,
         )
-        if resp.status_code == 200:
+        if resp.status_code == HTTPStatus.OK:
             data = resp.json()
             display = data.get("displayName") or data.get("emailAddress") or email
 
@@ -90,11 +97,11 @@ def validate_jira_integration(
                 headers={"Accept": "application/json"},
                 timeout=10,
             )
-            if project_resp.status_code == 404:
+            if project_resp.status_code == HTTPStatus.NOT_FOUND:
                 return IntegrationHealthResult(
                     ok=False, detail=f"Project '{project_key}' not found. Check the project key."
                 )
-            if project_resp.status_code != 200:
+            if project_resp.status_code != HTTPStatus.OK:
                 return IntegrationHealthResult(
                     ok=False,
                     detail=f"Could not verify project '{project_key}': HTTP {project_resp.status_code}.",
@@ -103,11 +110,11 @@ def validate_jira_integration(
             return IntegrationHealthResult(
                 ok=True, detail=f"Jira connected as {display}, project '{project_key}' verified."
             )
-        if resp.status_code == 401:
+        if resp.status_code == HTTPStatus.UNAUTHORIZED:
             return IntegrationHealthResult(
                 ok=False, detail="Jira credentials invalid. Check email and API token."
             )
-        if resp.status_code == 404:
+        if resp.status_code == HTTPStatus.NOT_FOUND:
             return IntegrationHealthResult(
                 ok=False, detail="Jira base URL not found. Check the URL."
             )
@@ -143,10 +150,10 @@ def validate_discord_bot(*, bot_token: str) -> IntegrationHealthResult:
     except httpx.RequestError as err:
         return IntegrationHealthResult(ok=False, detail=f"Discord API unreachable: {err}")
 
-    if resp.status_code == 200:
+    if resp.status_code == HTTPStatus.OK:
         username = resp.json().get("username", "unknown")
         return IntegrationHealthResult(ok=True, detail=f"Discord bot authenticated as @{username}.")
-    if resp.status_code == 401:
+    if resp.status_code == HTTPStatus.UNAUTHORIZED:
         return IntegrationHealthResult(ok=False, detail="Discord bot token is invalid or revoked.")
     return IntegrationHealthResult(
         ok=False, detail=f"Discord API returned unexpected HTTP {resp.status_code}."
@@ -166,11 +173,16 @@ def validate_rocketchat_webhook(*, webhook_url: str) -> IntegrationHealthResult:
             ok=False, detail=f"Rocket.Chat webhook validation failed: {err}"
         )
 
-    if resp.status_code == 404:
+    if resp.status_code == HTTPStatus.NOT_FOUND:
         return IntegrationHealthResult(
             ok=False, detail="Rocket.Chat webhook returned 404; the URL looks invalid."
         )
-    if resp.status_code in {200, 400, 403, 405}:
+    if resp.status_code in {
+        HTTPStatus.OK,
+        HTTPStatus.BAD_REQUEST,
+        HTTPStatus.FORBIDDEN,
+        HTTPStatus.METHOD_NOT_ALLOWED,
+    }:
         return IntegrationHealthResult(
             ok=True,
             detail=f"Rocket.Chat webhook endpoint reachable (HTTP {resp.status_code}) "
@@ -201,13 +213,13 @@ def validate_rocketchat(
     except httpx.RequestError as err:
         return IntegrationHealthResult(ok=False, detail=f"Rocket.Chat API unreachable: {err}")
 
-    if resp.status_code == 200:
+    if resp.status_code == HTTPStatus.OK:
         try:
             username = resp.json().get("username", "unknown")
         except Exception:
             username = "unknown"
         return IntegrationHealthResult(ok=True, detail=f"Rocket.Chat authenticated as @{username}.")
-    if resp.status_code == 401:
+    if resp.status_code == HTTPStatus.UNAUTHORIZED:
         return IntegrationHealthResult(
             ok=False, detail="Rocket.Chat auth token or user ID is invalid or expired."
         )


### PR DESCRIPTION
Fixes #4264 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
- Added HTTPStatus import from http.
- Replaced raw status code numbers with HTTPStatus enums in surfaces/cli/wizard/integration_validators/http_probe_validators.py.
- No logic or behavior changes.

### Demo/Screenshot for feature changes and bug fixes - 
```bash
$ make lint format-check typecheck
.venv/bin/python -m ruff check config core gateway integrations platform surfaces tools tests/
All checks passed!
.venv/bin/python -m ruff format --check config core gateway integrations platform surfaces tools tests/
2916 files already formatted
.venv/bin/python -m mypy config core gateway integrations platform surfaces tools
mypy.ini: note: unused section(s): [mypy-apscheduler], [mypy-tree_sitter], [mypy-tree_sitter.*]
Success: no issues found in 1476 source files

$ uv run pytest tests/cli/wizard/ -q --tb=line
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/samet/Masaüstü/opensre/opensre
configfile: pytest.ini
plugins: asyncio-1.3.0, anyio-4.13.0, xdist-3.8.0, cov-7.1.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 237 items
...
=========================== short test summary info ============================
FAILED tests/cli/wizard/test_env_sync.py::test_sync_env_values_routes_secrets_to_keyring - tests.cli.wizard.conftest.LiveNetworkCallBlocked: A wizard test attempted a...
FAILED tests/cli/wizard/test_env_sync.py::test_sync_env_secret_with_blank_value_deletes_the_stored_secret - tests.cli.wizard.conftest.LiveNetworkCallBlocked: A wizard test attempted a...
======================== 2 failed, 235 passed in 13.95s ========================

```
> **Note on test failures:** 
> The 2 failures in tests/cli/wizard/test_env_sync.py (LiveNetworkCallBlocked) were verified to reproduce on the untouched main branch as well, confirming they are unrelated to this refactor.
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [X] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Replaced magic numbers with standard HTTPStatus enums to clean up the code and improve readability as requested in the issue.

---

## Checklist before requesting a review
- [X] I have added proper PR title and linked to the issue
- [X] I have performed a self-review of my code
- [X] **I can explain the purpose of every function, class, and logic block I added**
- [X] I understand why my changes work and have tested them thoroughly
- [X] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [X] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
