### PR TITLE
SM-94: Replace tracker references in comments

### DIFF
--- a/integrations/datadog/tools/__init__.py
+++ b/integrations/datadog/tools/__init__.py
@@ -516,9 +516,8 @@ class QueryDatadogMetricsOutput(BaseModel):
 
 
 def _metrics_is_available(_sources: dict[str, dict]) -> bool:
-    # Hidden from the planner until the Metrics API v2 implementation lands (see #669).
-    # Flip back to `bool(sources.get("datadog", {}).get("connection_verified"))` once
-    # the stub body below is replaced with a real request.
+    # Hidden from the planner until the Metrics API v2 implementation is complete.
+    # Re-enable availability once the stub below is replaced with a real Metrics API request.
     return False
 
 

--- a/surfaces/cli/constants.py
+++ b/surfaces/cli/constants.py
@@ -45,8 +45,8 @@ def __getattr__(name: str) -> tuple[str, ...]:
     # `click.Choice` validators stay in sync with what cmd_setup / cmd_verify
     # can actually dispatch. Eagerly importing `integrations.registry` here
     # creates a circular import (registry -> verifiers -> integrations.github.mcp ->
-    # cli.*). Deferring to first access lets `cli` finish
-    # bootstrapping. See #1973 (verify) and #2537 (setup).
+    # cli.*). Deferring the import until first access allows the CLI to finish
+    # bootstrapping before the integration registry is loaded.
     if name == "SETUP_SERVICES":
         from integrations.registry import SUPPORTED_SETUP_SERVICES
 


### PR DESCRIPTION
## Summary

Replaced tracker references in comments with behavior-focused explanations.

### Changes

- Removed tracker reference from `integrations/datadog/tools/__init__.py`
- Removed tracker references from `surfaces/cli/constants.py`
- Updated comments to explain implementation behavior instead of referencing GitHub issue numbers.

Closes #4349