### PR TITLE
docs(agent_harness): state the cache-stats contract in models.py docstrings (SM-87)

### DIFF
--- a/core/agent_harness/grounding/models.py
+++ b/core/agent_harness/grounding/models.py
@@ -1,4 +1,9 @@
-"""Small value models for interactive-shell grounding diagnostics."""
+"""Cache-stats value types for the interactive-shell grounding reference sources.
+
+Each grounding reference source (AGENTS.md, docs, CLI help) reports its cache
+health as a :class:`CacheStats` so the shell can log uniform hit/miss
+diagnostics regardless of which caching strategy that source uses.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +11,18 @@ from pydantic import BaseModel, ConfigDict
 
 
 class CacheStats(BaseModel):
-    """Grounding-cache diagnostics shared by shell reference sources."""
+    """One reference source's cache health: hit/miss counts, plus size or freshness.
+
+    Always set ``name`` plus ``hits``/``misses`` (both default to 0 for a
+    fresh cache). Populate exactly one of these two optional groups to match
+    the caching strategy in use, leave the other group at its ``None`` default:
+
+    * ``currsize``/``maxsize``: a bounded (LRU-style) cache, reporting how
+      many entries are stored against the cap.
+    * ``cached``/``signature``/``created_at_monotonic``: a single cached
+      value, reporting whether it is currently populated and when it was
+      last (re)built.
+    """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -20,7 +36,12 @@ class CacheStats(BaseModel):
     created_at_monotonic: float | None = None
 
     def render(self) -> str:
-        """Compact single-line summary for terminal diagnostics."""
+        """Return one line like ``hits=N misses=N ...`` for log output.
+
+        Appends ``entries=currsize/maxsize`` when the bounded-cache fields
+        are set, ``cached=yes|no`` when the single-value-cache fields are
+        set, or neither suffix when only hits/misses are populated.
+        """
         if self.cached is not None:
             return f"hits={self.hits} misses={self.misses} cached={'yes' if self.cached else 'no'}"
         if self.currsize is not None:


### PR DESCRIPTION
## Summary

Fixes [#4342](https://github.com/Tracer-Cloud/opensre/issues/4342) (Task ID: SM-87)

`core/agent_harness/grounding/models.py` had vague docstrings that didn't tell a caller what to actually pass in or what they'd get back. I rewrote the module docstring, the `CacheStats` class docstring, and the `render()` docstring so each one states the real contract instead of a generic one-liner. Nothing got renamed, same as the issue asked.

## Changes

Before doing anything, I checked all three real callers of `CacheStats` (`agents_md_reference.py`, `docs_reference.py`, `cli_reference.py`) to make sure the docstrings describe what actually happens, not a guess.

- Module docstring: now says this file holds cache-stats value types for the grounding reference sources, not just "small value models."
- `CacheStats` class docstring: explains that `name`/`hits`/`misses` are always set, and that callers fill in exactly one of two field groups depending on their caching strategy, either `currsize`/`maxsize` for a bounded cache, or `cached`/`signature`/`created_at_monotonic` for a single cached value. That distinction existed in the code already but was never written down anywhere.
- `render()` docstring: says what the output actually looks like and which field group controls which format.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the scoped test suite (`tests/core/`) since this touches `core/`: 1404 passed, 30 skipped, 1 failed.

The one failure, `test_old_context_package_is_removed`, is unrelated to this change. It's checking that an old `core.context` package no longer exists, and it fails the same way with this change stashed out on a clean `main`, so it's a pre-existing local environment issue, not something this PR causes.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions