### PR TITLE
docs(llm): rewrite comments without issue references

### DIFF
--- a/core/llm/transports/sdk/llm_clients.py
+++ b/core/llm/transports/sdk/llm_clients.py
@@ -114,8 +114,9 @@ def _format_anthropic_retry_error(err: Exception) -> str:
 # OpenAI:    "The provided model identifier is invalid."
 # OpenRouter: "Invalid model name passed in model=<name>. Call `/v1/models`…"
 # Detection is an any-match because there is no stable error code across
-# providers. Add phrases here when a new provider uses different wording —
-# the failure mode is "fall through to a generic HTTP 400 message" (#1806).
+# providers. Add phrases here when a new provider uses different wording;
+# without a matching phrase, an invalid-model 400 falls through to a
+# generic error message instead of the specific invalid-model one.
 _OPENAI_INVALID_MODEL_IDENTIFIER_PHRASES = (
     "model identifier",  # OpenAI / LiteLLM
     "invalid model id",  # OpenAI
@@ -480,8 +481,7 @@ class BedrockLLMClient:
                     # missing IAM, missing per-region/per-model Bedrock access
                     # opt-in, or an AWS Marketplace billing problem (e.g.
                     # ``INVALID_PAYMENT_INSTRUMENT``). Surface the upstream
-                    # AWS-provided reason so the user knows which one to fix
-                    # — see issue #1808.
+                    # AWS-provided reason so the user knows which one to fix.
                     err_msg = err.response.get("Error", {}).get("Message", "") or ""
                     err_msg_str = str(err_msg)
                     if (


### PR DESCRIPTION
Fixes #4347

#### Describe the changes you have made in this PR -

`core/llm/transports/sdk/llm_clients.py` had two comments citing issue numbers (`#1806`, `#1808`) instead of describing the rule on their own. Rewrote both as self-contained behavior statements and dropped the numbers: the invalid-model-phrase comment now states what happens when no phrase matches (falls through to a generic error instead of the specific invalid-model one), and the Bedrock AccessDeniedException comment now ends on the actual rule (surface the upstream AWS reason) without the "see issue" tail. No other comments in the file cite tracker codes.

### Demo/Screenshot for feature changes and bug fixes -

```
$ make lint
All checks passed!
$ uv run pytest tests/core/runtime/llm/test_llm_client.py -q --tb=short
92 passed in 5.59s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Grepped the file for `#[0-9]+` and tracker-code patterns first to confirm exactly two hits, matching the task's stated count. Both comments already described real behavior; the fix was purely subtractive, i.e. removing the trailing issue reference and rephrasing the sentence so it still reads as a complete rule without it, rather than rewriting the surrounding explanation. Re-ran the grep after editing to confirm zero tracker codes remain, then verified with lint, typecheck, and the test file that directly exercises both edited code paths (invalid-model detection and the Bedrock AccessDeniedException branch), since this is a comment-only change with no logic touched.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
