### PR TITLE
refactor(jenkins): use HTTPStatus constants

### DIFF
--- a/integrations/jenkins/client.py
+++ b/integrations/jenkins/client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
+from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -299,7 +300,7 @@ class JenkinsClient:
 
         try:
             resp = self._get_client().get(f"/{_job_api_path(safe_name)}/{number}/wfapi/describe")
-            if resp.status_code == 404:
+            if resp.status_code == HTTPStatus.NOT_FOUND:
                 # Not a Pipeline job, or the Stage View plugin is absent.
                 return {
                     "success": True,
@@ -414,8 +415,9 @@ def make_jenkins_client(
 
     Returns None unless URL, username, and token are all present. Jenkins Basic
     auth sends ``username:api_token``; an empty username yields a ``:token`` pair
-    that Jenkins rejects with 401, so the factory refuses to build such a client
-    — every caller gets a clean "not configured" path instead of a 401.
+    that Jenkins rejects with HTTPStatus.UNAUTHORIZED, so the factory refuses
+    to build such a client—every caller gets a clean "not configured" path
+    instead of an HTTPStatus.UNAUTHORIZED response.
     """
     url = (base_url or "").strip()
     user = (username or "").strip()


### PR DESCRIPTION
Fixes #4296

### Describe the changes you have made in this PR -

This PR replaces the bare HTTP status code literal used in the Jenkins client with the corresponding `http.HTTPStatus` enum member, improving readability and maintaining consistency with the project's coding standards.

**Changes made:**
- Added `from http import HTTPStatus`
- Replaced the `404` status code comparison with `HTTPStatus.NOT_FOUND`
- Updated the related documentation to reference `HTTPStatus.UNAUTHORIZED` for consistency

### Demo/Screenshot for feature changes and bug fixes -

**Validation**

```text
python -m ruff check integrations/jenkins/client.py
All checks passed!

python -m ruff format --check integrations/jenkins/client.py
1 file already formatted
```

No behavior changes were introduced. This is a readability and maintainability refactor only.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

### Checklist

- [x] I have read the contributing guidelines.
- [x] This PR addresses only **SM-38**.
- [x] Only one file was modified.
- [x] No behavior or user-facing messages were changed.
- [x] Ruff checks and formatting passed.