### PR TITLE
Signal log truncation and retry with larger tail on step miss

### DIFF
--- a/integrations/github/tools/actions.py
+++ b/integrations/github/tools/actions.py
@@ -707,8 +707,12 @@ def get_github_actions_step_log(
         and wants_step
         and extracted["match_strategy"] == "full-log"
     ):
+        # original_length is characters (same units as len(log_text)); tail_lines
+        # is a line count. Estimate total lines from the tail's own chars-per-line.
+        chars_per_line = max(len(log_text) // max(log_text.count("\n"), 1), 1)
+        estimated_lines = max(original_length // chars_per_line, 1)
         retry_tail_lines = min(
-            max(original_length, _STEP_LOG_RETRY_TAIL_LINES), _STEP_LOG_MAX_RETRY_TAIL_LINES
+            max(estimated_lines, _STEP_LOG_RETRY_TAIL_LINES), _STEP_LOG_MAX_RETRY_TAIL_LINES
         )
         if retry_tail_lines > tail_lines:
             retry_text, retry_original_length, retry_error = _fetch_job_log(

--- a/integrations/github/tools/actions.py
+++ b/integrations/github/tools/actions.py
@@ -701,6 +701,8 @@ def get_github_actions_step_log(
     # length, once before accepting that fallback.
     wants_step = bool(step_name or failed_step or step_number is not None)
     truncated = original_length is not None and original_length > len(log_text)
+    retry_attempted = False
+    retry_error: str | None = None
     if (
         original_length is not None
         and truncated
@@ -715,6 +717,7 @@ def get_github_actions_step_log(
             max(estimated_lines, _STEP_LOG_RETRY_TAIL_LINES), _STEP_LOG_MAX_RETRY_TAIL_LINES
         )
         if retry_tail_lines > tail_lines:
+            retry_attempted = True
             retry_text, retry_original_length, retry_error = _fetch_job_log(
                 config, owner, repo, job_id, retry_tail_lines
             )
@@ -737,8 +740,10 @@ def get_github_actions_step_log(
             "job_conclusion": job.get("conclusion", ""),
             "job_steps": normalized_steps,
             "truncated": truncated,
-            "returned_length": len(log_text),
-            "original_length": original_length,
+            "returned_chars": len(log_text),
+            "original_chars": original_length,
+            "retry_attempted": retry_attempted,
+            "retry_error": retry_error,
         }
     )
     return extracted

--- a/integrations/github/tools/actions.py
+++ b/integrations/github/tools/actions.py
@@ -55,17 +55,20 @@ def _extract_workflow_jobs(result: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _extract_log_text(result: dict[str, Any]) -> tuple[str, int | None]:
-    """Extract log text and its original (pre-tail) length from an MCP tool result.
+    """Extract log text and its original (pre-tail) line count from an MCP tool result.
 
-    ``original_length`` is the full log's length before ``tail_lines`` truncated
-    it, in the same units as the returned text's length; ``None`` when the MCP
-    response doesn't report it.
+    ``original_lines`` is the job's total log line count before ``tail_lines``
+    truncated it (github-mcp-server's ``get_job_logs`` reports this as
+    ``original_length``, despite the name it's a line count, not a character
+    count: it's the ring buffer's total line tally, from the same downstream
+    fetch that also produces the tailed ``logs_content``). ``None`` when the
+    MCP response doesn't report it.
     """
     json_result = _extract_json_text(result)
     if isinstance(json_result, dict) and "logs_content" in json_result:
         text = str(json_result["logs_content"] or "").strip()
-        original_length = json_result.get("original_length")
-        return text, original_length if isinstance(original_length, int) else None
+        original_lines = json_result.get("original_length")
+        return text, original_lines if isinstance(original_lines, int) else None
     return str(result.get("text") or "").strip(), None
 
 
@@ -560,7 +563,7 @@ _STEP_LOG_MAX_RETRY_TAIL_LINES = 20000
 def _fetch_job_log(
     config: Any, owner: str, repo: str, job_id: int, tail_lines: int
 ) -> tuple[str, int | None, str | None]:
-    """Fetch job log text via get_job_logs. Returns (text, original_length, error)."""
+    """Fetch job log text via get_job_logs. Returns (text, original_lines, error)."""
     log_result = call_github_mcp_tool(
         config,
         "get_job_logs",
@@ -574,8 +577,8 @@ def _fetch_job_log(
     )
     if log_result.get("is_error"):
         return "", None, str(log_result.get("text") or "unknown error")
-    text, original_length = _extract_log_text(log_result)
-    return text, original_length, None
+    text, original_lines = _extract_log_text(log_result)
+    return text, original_lines, None
 
 
 @tool(
@@ -665,7 +668,7 @@ def get_github_actions_step_log(
         ) | {"error": "Unexpected job metadata format"}
 
     # Fetch job logs
-    log_text, original_length, log_error = _fetch_job_log(config, owner, repo, job_id, tail_lines)
+    log_text, original_lines, log_error = _fetch_job_log(config, owner, repo, job_id, tail_lines)
     if log_error is not None:
         return code_host_unavailable_payload(
             source="github",
@@ -698,37 +701,35 @@ def get_github_actions_step_log(
     # A requested step that missed because the tail cut off its ##[group] block
     # looks identical to "no such step" (both fall back to match_strategy
     # "full-log"). Re-fetch a bigger tail, sized from the log's own reported
-    # length, once before accepting that fallback.
+    # total line count, once before accepting that fallback.
     wants_step = bool(step_name or failed_step or step_number is not None)
-    truncated = original_length is not None and original_length > len(log_text)
+    returned_lines = len(log_text.splitlines())
+    truncated = original_lines is not None and original_lines > returned_lines
     retry_attempted = False
     retry_error: str | None = None
     if (
-        original_length is not None
+        original_lines is not None
         and truncated
         and wants_step
         and extracted["match_strategy"] == "full-log"
     ):
-        # original_length is characters (same units as len(log_text)); tail_lines
-        # is a line count. Estimate total lines from the tail's own chars-per-line.
-        chars_per_line = max(len(log_text) // max(log_text.count("\n"), 1), 1)
-        estimated_lines = max(original_length // chars_per_line, 1)
         retry_tail_lines = min(
-            max(estimated_lines, _STEP_LOG_RETRY_TAIL_LINES), _STEP_LOG_MAX_RETRY_TAIL_LINES
+            max(original_lines, _STEP_LOG_RETRY_TAIL_LINES), _STEP_LOG_MAX_RETRY_TAIL_LINES
         )
         if retry_tail_lines > tail_lines:
             retry_attempted = True
-            retry_text, retry_original_length, retry_error = _fetch_job_log(
+            retry_text, retry_original_lines, retry_error = _fetch_job_log(
                 config, owner, repo, job_id, retry_tail_lines
             )
             if retry_error is None:
-                log_text, original_length = retry_text, retry_original_length
+                log_text, original_lines = retry_text, retry_original_lines
                 extracted = extract_step_log(
                     log_text,
                     step_name=step_name or failed_step,
                     step_number=step_number,
                 )
-                truncated = original_length is not None and original_length > len(log_text)
+                returned_lines = len(log_text.splitlines())
+                truncated = original_lines is not None and original_lines > returned_lines
 
     extracted.update(
         {
@@ -740,8 +741,8 @@ def get_github_actions_step_log(
             "job_conclusion": job.get("conclusion", ""),
             "job_steps": normalized_steps,
             "truncated": truncated,
-            "returned_chars": len(log_text),
-            "original_chars": original_length,
+            "returned_lines": returned_lines,
+            "original_lines": original_lines,
             "retry_attempted": retry_attempted,
             "retry_error": retry_error,
         }

--- a/integrations/github/tools/actions.py
+++ b/integrations/github/tools/actions.py
@@ -159,8 +159,6 @@ def _normalize_run(run: dict[str, Any]) -> dict[str, Any]:
 
 UNGROUPED_SECTION_NAME = "ungrouped"
 
-_STEP_LOG_MAX_RETRY_TAIL_LINES = 20000
-
 
 def _append_log_section(sections: list[dict[str, str]], name: str, lines: list[str]) -> None:
     """Append a non-empty log section preserving original ordering."""
@@ -718,7 +716,8 @@ def get_github_actions_step_log(
         and wants_step
         and extracted["match_strategy"] == "full-log"
     ):
-        retry_tail_lines = min(original_lines, _STEP_LOG_MAX_RETRY_TAIL_LINES)
+        # get_job_logs already clamps to the server's content window.
+        retry_tail_lines = original_lines
         if retry_tail_lines > tail_lines:
             retry_attempted = True
             retry_text, retry_original_lines, retry_error = _fetch_job_log(

--- a/integrations/github/tools/actions.py
+++ b/integrations/github/tools/actions.py
@@ -54,12 +54,19 @@ def _extract_workflow_jobs(result: dict[str, Any]) -> list[dict[str, Any]]:
     return []
 
 
-def _extract_log_text(result: dict[str, Any]) -> str:
-    """Extract log text from MCP tool result."""
+def _extract_log_text(result: dict[str, Any]) -> tuple[str, int | None]:
+    """Extract log text and its original (pre-tail) length from an MCP tool result.
+
+    ``original_length`` is the full log's length before ``tail_lines`` truncated
+    it, in the same units as the returned text's length; ``None`` when the MCP
+    response doesn't report it.
+    """
     json_result = _extract_json_text(result)
     if isinstance(json_result, dict) and "logs_content" in json_result:
-        return str(json_result["logs_content"] or "").strip()
-    return str(result.get("text") or "").strip()
+        text = str(json_result["logs_content"] or "").strip()
+        original_length = json_result.get("original_length")
+        return text, original_length if isinstance(original_length, int) else None
+    return str(result.get("text") or "").strip(), None
 
 
 def _normalize_step(step: dict[str, Any]) -> dict[str, Any]:
@@ -178,7 +185,9 @@ def _extract_log_sections(log_text: str) -> list[dict[str, str]]:
         _append_log_section(sections, current_name or UNGROUPED_SECTION_NAME, current_lines)
 
     if not saw_group:
-        return [{"name": "full-log", "text": log_text.strip()}]
+        # No ##[group] markers at all: nothing to select by name/number.
+        # extract_step_log's own full-log fallback handles this case.
+        return []
     return [section for section in sections if section.get("text")]
 
 
@@ -544,6 +553,31 @@ def list_github_actions_run_jobs(
     return payload
 
 
+_STEP_LOG_RETRY_TAIL_LINES = 5000
+_STEP_LOG_MAX_RETRY_TAIL_LINES = 20000
+
+
+def _fetch_job_log(
+    config: Any, owner: str, repo: str, job_id: int, tail_lines: int
+) -> tuple[str, int | None, str | None]:
+    """Fetch job log text via get_job_logs. Returns (text, original_length, error)."""
+    log_result = call_github_mcp_tool(
+        config,
+        "get_job_logs",
+        {
+            "owner": owner,
+            "repo": repo,
+            "job_id": job_id,
+            "return_content": True,
+            "tail_lines": tail_lines,
+        },
+    )
+    if log_result.get("is_error"):
+        return "", None, str(log_result.get("text") or "unknown error")
+    text, original_length = _extract_log_text(log_result)
+    return text, original_length, None
+
+
 @tool(
     name="get_github_actions_step_log",
     source="github",
@@ -631,27 +665,14 @@ def get_github_actions_step_log(
         ) | {"error": "Unexpected job metadata format"}
 
     # Fetch job logs
-    log_result = call_github_mcp_tool(
-        config,
-        "get_job_logs",
-        {
-            "owner": owner,
-            "repo": repo,
-            "job_id": job_id,
-            "return_content": True,
-            "tail_lines": tail_lines,
-        },
-    )
-
-    if log_result.get("is_error"):
+    log_text, original_length, log_error = _fetch_job_log(config, owner, repo, job_id, tail_lines)
+    if log_error is not None:
         return code_host_unavailable_payload(
             source="github",
             integration_name="GitHub Actions",
             empty_key="log_text",
             empty_value="",
-        ) | {"error": log_result.get("text")}
-
-    log_text = _extract_log_text(log_result)
+        ) | {"error": log_error}
 
     # Detect first failed step if not specified
     failed_step = ""
@@ -669,10 +690,39 @@ def get_github_actions_step_log(
 
     # Extract and filter step log
     extracted = extract_step_log(
-        str(log_text),
+        log_text,
         step_name=step_name or failed_step,
         step_number=step_number,
     )
+
+    # A requested step that missed because the tail cut off its ##[group] block
+    # looks identical to "no such step" (both fall back to match_strategy
+    # "full-log"). Re-fetch a bigger tail, sized from the log's own reported
+    # length, once before accepting that fallback.
+    wants_step = bool(step_name or failed_step or step_number is not None)
+    truncated = original_length is not None and original_length > len(log_text)
+    if (
+        original_length is not None
+        and truncated
+        and wants_step
+        and extracted["match_strategy"] == "full-log"
+    ):
+        retry_tail_lines = min(
+            max(original_length, _STEP_LOG_RETRY_TAIL_LINES), _STEP_LOG_MAX_RETRY_TAIL_LINES
+        )
+        if retry_tail_lines > tail_lines:
+            retry_text, retry_original_length, retry_error = _fetch_job_log(
+                config, owner, repo, job_id, retry_tail_lines
+            )
+            if retry_error is None:
+                log_text, original_length = retry_text, retry_original_length
+                extracted = extract_step_log(
+                    log_text,
+                    step_name=step_name or failed_step,
+                    step_number=step_number,
+                )
+                truncated = original_length is not None and original_length > len(log_text)
+
     extracted.update(
         {
             "source": "github",
@@ -682,6 +732,9 @@ def get_github_actions_step_log(
             "job_name": job.get("name", ""),
             "job_conclusion": job.get("conclusion", ""),
             "job_steps": normalized_steps,
+            "truncated": truncated,
+            "returned_length": len(log_text),
+            "original_length": original_length,
         }
     )
     return extracted

--- a/integrations/github/tools/actions.py
+++ b/integrations/github/tools/actions.py
@@ -63,13 +63,17 @@ def _extract_log_text(result: dict[str, Any]) -> tuple[str, int | None]:
     count: it's the ring buffer's total line tally, from the same downstream
     fetch that also produces the tailed ``logs_content``). ``None`` when the
     MCP response doesn't report it.
+
+    Text is returned unstripped: ``original_length`` counts blank lines, so
+    stripping here would report a complete log as truncated. ``extract_step_log``
+    strips every branch it returns, so rendered output is unaffected.
     """
     json_result = _extract_json_text(result)
     if isinstance(json_result, dict) and "logs_content" in json_result:
-        text = str(json_result["logs_content"] or "").strip()
+        text = str(json_result["logs_content"] or "")
         original_lines = json_result.get("original_length")
         return text, original_lines if isinstance(original_lines, int) else None
-    return str(result.get("text") or "").strip(), None
+    return str(result.get("text") or ""), None
 
 
 def _normalize_step(step: dict[str, Any]) -> dict[str, Any]:
@@ -154,6 +158,8 @@ def _normalize_run(run: dict[str, Any]) -> dict[str, Any]:
 
 
 UNGROUPED_SECTION_NAME = "ungrouped"
+
+_STEP_LOG_MAX_RETRY_TAIL_LINES = 20000
 
 
 def _append_log_section(sections: list[dict[str, str]], name: str, lines: list[str]) -> None:
@@ -556,8 +562,27 @@ def list_github_actions_run_jobs(
     return payload
 
 
-_STEP_LOG_RETRY_TAIL_LINES = 5000
-_STEP_LOG_MAX_RETRY_TAIL_LINES = 20000
+def _step_log_unavailable_payload(error: Any = None) -> dict[str, Any]:
+    """Unavailable/error payload for ``get_github_actions_step_log``.
+
+    Carries the same truncation and retry keys as the success payload so callers
+    never have to key-check before reading them.
+    """
+    payload = code_host_unavailable_payload(
+        source="github",
+        integration_name="GitHub Actions",
+        empty_key="log_text",
+        empty_value="",
+    ) | {
+        "truncated": False,
+        "returned_lines": 0,
+        "original_lines": None,
+        "retry_attempted": False,
+        "retry_error": None,
+    }
+    if error is not None:
+        payload["error"] = error
+    return payload
 
 
 def _fetch_job_log(
@@ -631,12 +656,7 @@ def get_github_actions_step_log(
         github_url, github_mode, github_token, github_command, github_args
     )
     if config is None:
-        return code_host_unavailable_payload(
-            source="github",
-            integration_name="GitHub Actions",
-            empty_key="log_text",
-            empty_value="",
-        )
+        return _step_log_unavailable_payload()
 
     # Fetch job metadata
     job_result = call_github_mcp_tool(
@@ -651,31 +671,16 @@ def get_github_actions_step_log(
     )
 
     if job_result.get("is_error"):
-        return code_host_unavailable_payload(
-            source="github",
-            integration_name="GitHub Actions",
-            empty_key="log_text",
-            empty_value="",
-        ) | {"error": job_result.get("text")}
+        return _step_log_unavailable_payload(job_result.get("text"))
 
     job = _extract_json_text(job_result)
     if not isinstance(job, dict):
-        return code_host_unavailable_payload(
-            source="github",
-            integration_name="GitHub Actions",
-            empty_key="log_text",
-            empty_value="",
-        ) | {"error": "Unexpected job metadata format"}
+        return _step_log_unavailable_payload("Unexpected job metadata format")
 
     # Fetch job logs
     log_text, original_lines, log_error = _fetch_job_log(config, owner, repo, job_id, tail_lines)
     if log_error is not None:
-        return code_host_unavailable_payload(
-            source="github",
-            integration_name="GitHub Actions",
-            empty_key="log_text",
-            empty_value="",
-        ) | {"error": log_error}
+        return _step_log_unavailable_payload(log_error)
 
     # Detect first failed step if not specified
     failed_step = ""
@@ -713,23 +718,31 @@ def get_github_actions_step_log(
         and wants_step
         and extracted["match_strategy"] == "full-log"
     ):
-        retry_tail_lines = min(
-            max(original_lines, _STEP_LOG_RETRY_TAIL_LINES), _STEP_LOG_MAX_RETRY_TAIL_LINES
-        )
+        retry_tail_lines = min(original_lines, _STEP_LOG_MAX_RETRY_TAIL_LINES)
         if retry_tail_lines > tail_lines:
             retry_attempted = True
             retry_text, retry_original_lines, retry_error = _fetch_job_log(
                 config, owner, repo, job_id, retry_tail_lines
             )
             if retry_error is None:
-                log_text, original_lines = retry_text, retry_original_lines
-                extracted = extract_step_log(
-                    log_text,
+                retry_extracted = extract_step_log(
+                    retry_text,
                     step_name=step_name or failed_step,
                     step_number=step_number,
                 )
-                returned_lines = len(log_text.splitlines())
-                truncated = original_lines is not None and original_lines > returned_lines
+                # Adopt the bigger body only if it found the step. Otherwise it
+                # is the same full-log fallback orders of magnitude larger,
+                # headed straight into the agent's context; keep the first
+                # response. "full-log" plus retry_attempted and no retry_error
+                # already says a wider window was fetched and still missed.
+                if retry_extracted["match_strategy"] != "full-log":
+                    extracted = retry_extracted
+                    log_text = retry_text
+                    # A retry without original_length must not erase a known count.
+                    if retry_original_lines is not None:
+                        original_lines = retry_original_lines
+                    returned_lines = len(log_text.splitlines())
+                    truncated = original_lines is not None and original_lines > returned_lines
 
     extracted.update(
         {

--- a/tests/tools/test_github_actions_tool.py
+++ b/tests/tools/test_github_actions_tool.py
@@ -524,3 +524,140 @@ def test_get_step_log_reports_retry_error_when_retry_fetch_fails() -> None:
     assert result["retry_attempted"] is True
     assert result["retry_error"] == "rate limited"
     assert result["truncated"] is True
+
+
+def _job_logs_result(arguments: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "tool": "get_job_logs",
+        "arguments": arguments,
+        "is_error": False,
+        "text": json.dumps(payload),
+        "structured_content": None,
+        "content": [],
+    }
+
+
+def test_get_step_log_keeps_small_body_when_retry_also_misses_the_step() -> None:
+    """A retry that still can't find the step must not swap the small first
+    response for the multi-thousand-line retry body: that goes straight into the
+    agent's context for no gain."""
+    small_log = "##[group]Checkout\nCloning repository\n##[endgroup]"
+    huge_log = "\n".join(f"unrelated log line {i}" for i in range(3000))
+
+    def mcp_response(config: object, tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        if tool != "get_job_logs":
+            return _mcp_response(config, tool, arguments)
+        content = small_log if arguments.get("tail_lines") == 500 else huge_log
+        return _job_logs_result(
+            arguments, {"job_id": 9001, "logs_content": content, "original_length": 5000}
+        )
+
+    log_tool = cast(Any, get_github_actions_step_log)
+    with (
+        patch("integrations.github.tools.actions.resolve_github_mcp_config", return_value=object()),
+        patch("integrations.github.tools.actions.call_github_mcp_tool", side_effect=mcp_response),
+    ):
+        result = log_tool(
+            owner="org",
+            repo="repo",
+            run_id=101,
+            job_id=9001,
+            step_name="Deploy",
+            github_token="tok",
+        )
+
+    assert result["retry_attempted"] is True
+    assert result["retry_error"] is None
+    assert result["match_strategy"] == "full-log"
+    assert result["log_text"] == small_log
+    assert result["returned_lines"] == len(small_log.splitlines())
+
+
+def test_get_step_log_does_not_report_complete_log_with_blank_lines_as_truncated() -> None:
+    """original_length counts blank lines too, so the returned text must be
+    measured unstripped or a complete log looks truncated and burns a retry."""
+    logs_content = "\nsetup\nrun tests\nteardown\n\n"
+
+    def mcp_response(config: object, tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        if tool != "get_job_logs":
+            return _mcp_response(config, tool, arguments)
+        return _job_logs_result(
+            arguments,
+            {
+                "job_id": 9001,
+                "logs_content": logs_content,
+                "original_length": len(logs_content.splitlines()),
+            },
+        )
+
+    log_tool = cast(Any, get_github_actions_step_log)
+    with (
+        patch("integrations.github.tools.actions.resolve_github_mcp_config", return_value=object()),
+        patch("integrations.github.tools.actions.call_github_mcp_tool", side_effect=mcp_response),
+    ):
+        result = log_tool(owner="org", repo="repo", run_id=101, job_id=9001, github_token="tok")
+
+    assert result["returned_lines"] == 5
+    assert result["truncated"] is False
+    assert result["retry_attempted"] is False
+
+
+def test_get_step_log_retry_without_original_length_keeps_known_line_count() -> None:
+    """A retry response that omits original_length must not turn a known total
+    into None and silently flip truncated back to False."""
+
+    def mcp_response(config: object, tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        if tool != "get_job_logs":
+            return _mcp_response(config, tool, arguments)
+        if arguments.get("tail_lines") == 500:
+            return _job_logs_result(
+                arguments,
+                {
+                    "job_id": 9001,
+                    "logs_content": "##[group]Checkout\nCloning repository\n##[endgroup]",
+                    "original_length": 5000,
+                },
+            )
+        return _job_logs_result(
+            arguments,
+            {
+                "job_id": 9001,
+                "logs_content": (
+                    "##[group]Checkout\nCloning repository\n##[endgroup]\n"
+                    "##[group]Deploy\nkubectl apply -f manifests/\n##[endgroup]"
+                ),
+            },
+        )
+
+    log_tool = cast(Any, get_github_actions_step_log)
+    with (
+        patch("integrations.github.tools.actions.resolve_github_mcp_config", return_value=object()),
+        patch("integrations.github.tools.actions.call_github_mcp_tool", side_effect=mcp_response),
+    ):
+        result = log_tool(
+            owner="org",
+            repo="repo",
+            run_id=101,
+            job_id=9001,
+            step_name="Deploy",
+            github_token="tok",
+        )
+
+    assert result["match_strategy"] == "step_name"
+    assert result["original_lines"] == 5000
+    assert result["truncated"] is True
+
+
+def test_get_step_log_unavailable_payload_carries_truncation_keys() -> None:
+    """The error paths must expose the same keys as the success path so callers
+    never have to key-check before reading them."""
+    log_tool = cast(Any, get_github_actions_step_log)
+    with patch("integrations.github.tools.actions.resolve_github_mcp_config", return_value=None):
+        result = log_tool(owner="org", repo="repo", run_id=101, job_id=9001)
+
+    assert result["available"] is False
+    assert result["truncated"] is False
+    assert result["returned_lines"] == 0
+    assert result["original_lines"] is None
+    assert result["retry_attempted"] is False
+    assert result["retry_error"] is None

--- a/tests/tools/test_github_actions_tool.py
+++ b/tests/tools/test_github_actions_tool.py
@@ -388,7 +388,7 @@ def test_extract_step_log_ungrouped_only_step_number_reports_full_log() -> None:
     assert "plain log line 2" in result["log_text"]
 
 
-def test_get_step_log_reports_truncated_when_original_length_exceeds_returned() -> None:
+def test_get_step_log_reports_truncated_when_original_lines_exceeds_returned() -> None:
     log_tool = cast(Any, get_github_actions_step_log)
     with (
         patch("integrations.github.tools.actions.resolve_github_mcp_config", return_value=object()),
@@ -396,10 +396,38 @@ def test_get_step_log_reports_truncated_when_original_length_exceeds_returned() 
     ):
         result = log_tool(owner="org", repo="repo", run_id=101, job_id=9001, github_token="tok")
     assert result["truncated"] is True
-    assert result["original_chars"] == 2000
-    assert result["returned_chars"] < result["original_chars"]
+    assert result["original_lines"] == 2000
+    assert result["returned_lines"] < result["original_lines"]
     assert result["retry_attempted"] is False
     assert result["retry_error"] is None
+
+
+def test_get_step_log_no_retry_when_original_length_field_missing() -> None:
+    """A get_job_logs response without original_length must degrade safely:
+    no truncation signal, no retry attempt."""
+
+    def mcp_response(config: object, tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        if tool != "get_job_logs":
+            return _mcp_response(config, tool, arguments)
+        return {
+            "tool": tool,
+            "arguments": arguments,
+            "is_error": False,
+            "text": json.dumps({"job_id": 9001, "logs_content": "no group markers here"}),
+            "structured_content": None,
+            "content": [],
+        }
+
+    log_tool = cast(Any, get_github_actions_step_log)
+    with (
+        patch("integrations.github.tools.actions.resolve_github_mcp_config", return_value=object()),
+        patch("integrations.github.tools.actions.call_github_mcp_tool", side_effect=mcp_response),
+    ):
+        result = log_tool(owner="org", repo="repo", run_id=101, job_id=9001, github_token="tok")
+
+    assert result["original_lines"] is None
+    assert result["truncated"] is False
+    assert result["retry_attempted"] is False
 
 
 def test_get_step_log_retries_with_larger_tail_when_step_missing() -> None:

--- a/tests/tools/test_github_actions_tool.py
+++ b/tests/tools/test_github_actions_tool.py
@@ -396,8 +396,10 @@ def test_get_step_log_reports_truncated_when_original_length_exceeds_returned() 
     ):
         result = log_tool(owner="org", repo="repo", run_id=101, job_id=9001, github_token="tok")
     assert result["truncated"] is True
-    assert result["original_length"] == 2000
-    assert result["returned_length"] < result["original_length"]
+    assert result["original_chars"] == 2000
+    assert result["returned_chars"] < result["original_chars"]
+    assert result["retry_attempted"] is False
+    assert result["retry_error"] is None
 
 
 def test_get_step_log_retries_with_larger_tail_when_step_missing() -> None:
@@ -441,3 +443,56 @@ def test_get_step_log_retries_with_larger_tail_when_step_missing() -> None:
 
     assert result["match_strategy"] == "step_name"
     assert "kubectl apply" in result["log_text"]
+    assert result["retry_attempted"] is True
+    assert result["retry_error"] is None
+
+
+def test_get_step_log_reports_retry_error_when_retry_fetch_fails() -> None:
+    """If the larger-tail retry itself fails, surface that instead of silently
+    keeping the truncated first response with no explanation."""
+
+    def mcp_response(config: object, tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        if tool != "get_job_logs":
+            return _mcp_response(config, tool, arguments)
+        if arguments.get("tail_lines") == 500:
+            return {
+                "tool": tool,
+                "arguments": arguments,
+                "is_error": False,
+                "text": json.dumps(
+                    {
+                        "job_id": 9001,
+                        "logs_content": "##[group]Checkout\nCloning repository\n##[endgroup]",
+                        "original_length": 5000,
+                    }
+                ),
+                "structured_content": None,
+                "content": [],
+            }
+        return {
+            "tool": tool,
+            "arguments": arguments,
+            "is_error": True,
+            "text": "rate limited",
+            "structured_content": None,
+            "content": [],
+        }
+
+    log_tool = cast(Any, get_github_actions_step_log)
+    with (
+        patch("integrations.github.tools.actions.resolve_github_mcp_config", return_value=object()),
+        patch("integrations.github.tools.actions.call_github_mcp_tool", side_effect=mcp_response),
+    ):
+        result = log_tool(
+            owner="org",
+            repo="repo",
+            run_id=101,
+            job_id=9001,
+            step_name="Deploy",
+            github_token="tok",
+        )
+
+    assert result["match_strategy"] == "full-log"
+    assert result["retry_attempted"] is True
+    assert result["retry_error"] == "rate limited"
+    assert result["truncated"] is True

--- a/tests/tools/test_github_actions_tool.py
+++ b/tests/tools/test_github_actions_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -369,3 +370,74 @@ final runner summary
     assert "annotation between groups" in result["log_text"]
     assert "line 2" in result["log_text"]
     assert "final runner summary" in result["log_text"]
+
+
+def test_extract_step_log_ungrouped_only_step_number_reports_full_log() -> None:
+    """A log with zero ##[group] markers has no real steps to pick by number.
+
+    Regression for the bug where the single ungrouped-log fallback section was
+    itself miscounted as step #1.
+    """
+    result = extract_step_log(
+        "plain log line 1\nplain log line 2\n",
+        step_number=1,
+    )
+    assert result["match_strategy"] == "full-log"
+    assert result["step_name"] == "full-log"
+    assert "plain log line 1" in result["log_text"]
+    assert "plain log line 2" in result["log_text"]
+
+
+def test_get_step_log_reports_truncated_when_original_length_exceeds_returned() -> None:
+    log_tool = cast(Any, get_github_actions_step_log)
+    with (
+        patch("integrations.github.tools.actions.resolve_github_mcp_config", return_value=object()),
+        patch("integrations.github.tools.actions.call_github_mcp_tool", side_effect=_mcp_response),
+    ):
+        result = log_tool(owner="org", repo="repo", run_id=101, job_id=9001, github_token="tok")
+    assert result["truncated"] is True
+    assert result["original_length"] == 2000
+    assert result["returned_length"] < result["original_length"]
+
+
+def test_get_step_log_retries_with_larger_tail_when_step_missing() -> None:
+    """First fetch (tail_lines=500) truncates the log before the Deploy group;
+    the tool should re-fetch a bigger tail instead of settling for full-log."""
+
+    def mcp_response(config: object, tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        if tool != "get_job_logs":
+            return _mcp_response(config, tool, arguments)
+        if arguments.get("tail_lines") == 500:
+            logs_content = "##[group]Checkout\nCloning repository\n##[endgroup]"
+        else:
+            logs_content = (
+                "##[group]Checkout\nCloning repository\n##[endgroup]\n"
+                "##[group]Deploy\nkubectl apply -f manifests/\n##[endgroup]"
+            )
+        return {
+            "tool": tool,
+            "arguments": arguments,
+            "is_error": False,
+            "text": json.dumps(
+                {"job_id": 9001, "logs_content": logs_content, "original_length": 5000}
+            ),
+            "structured_content": None,
+            "content": [],
+        }
+
+    log_tool = cast(Any, get_github_actions_step_log)
+    with (
+        patch("integrations.github.tools.actions.resolve_github_mcp_config", return_value=object()),
+        patch("integrations.github.tools.actions.call_github_mcp_tool", side_effect=mcp_response),
+    ):
+        result = log_tool(
+            owner="org",
+            repo="repo",
+            run_id=101,
+            job_id=9001,
+            step_name="Deploy",
+            github_token="tok",
+        )
+
+    assert result["match_strategy"] == "step_name"
+    assert "kubectl apply" in result["log_text"]


### PR DESCRIPTION
Fixes #4425

#### Describe the changes you have made in this PR -

`integrations/github/tools/actions.py` only, per the issue's scope:

1. **Truncation signal**: returns `truncated`, `returned_lines`, `original_lines`, `retry_attempted`, `retry_error`. Error payloads carry the same keys.

2. **Retry on step miss**: when a requested step falls back to `full-log` on a truncated log, re-fetch once with `tail_lines` set to the log's total line count. The bigger body is adopted only if it matched the step, so a failed retry can't push a huge log into context.

3. **Fixed the ungrouped-only log bug**: a log with zero `##[group]` markers faked a "full-log" section counted as step 1, so `step_number=1` wrongly reported `match_strategy="step_number"`. `_extract_log_sections` now returns `[]`.

### Demo/Screenshot for feature changes and bug fixes -

`make lint`, `make format-check`, `make typecheck`, `make verify-integrations-smoke` pass. Full suite 13,568 passed. `test_github_actions_tool.py`: 44 passed.

Verified against six real failed jobs via the live GitHub MCP. `original_lines` exact in all six (559, 559, 8781, 68, 508, 53), `truncated` correctly `false` on the two that fit in the tail. On the 8781-line job, keeping the first response returns 57,683 chars instead of 696,693.

### Known limitation

Step matching doesn't work on real logs today, and this PR doesn't change that: every log line starts with an RFC3339 timestamp, so `line.startswith("##[group]")` never matches (0 sections found on the 8781-line job despite 18 markers present). The retry therefore fires and misses. Truncation signalling and the ungrouped fix are unaffected. Filing that parsing bug separately with a follow-up PR.

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Traced `extract_step_log` and `_extract_log_sections` to confirm the zero-groups gap the issue describes, which PR 2755 didn't cover.

`original_length` is a line count, not chars: `github-mcp-server` returns it as `totalLines` from `downloadLogContent`, and a live call reported 8781 for a log of exactly 8781 lines.

Retry is sized from `original_lines` with no client-side ceiling, since `get_job_logs` alrontent window (`min(tailLines, contentWindowSize)`, 5000 by default).

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions