### PR TITLE
refactor(investigation): route 4 investigation stage agents through core.agent.Agent via build_agent() (T-5)

### DIFF
--- a/core/agent_harness/agent_builder.py
+++ b/core/agent_harness/agent_builder.py
@@ -34,6 +34,11 @@ class AgentConfig(Generic[RuntimeToolT]):  # noqa: UP046
     tool_resources: dict[str, Any] = field(default_factory=dict)
     tool_hooks: ToolExecutionHooks | None = None
     on_runtime_event: RuntimeEventCallback | None = None
+    agent_cls: type[Agent[RuntimeToolT]] = Agent
+    """Override to construct a caller-defined ``Agent`` subclass instead of the
+    base class — e.g. a surface that needs to override a hook like
+    ``_should_accept_conclusion``. Defaults to :class:`Agent` so existing
+    callers are unaffected."""
 
 
 def build_agent(  # noqa: UP047
@@ -41,10 +46,11 @@ def build_agent(  # noqa: UP047
 ) -> Agent[RuntimeToolT]:
     """Construct a runtime :class:`Agent` from an :class:`AgentConfig`.
 
-    This is the single place :class:`Agent` is instantiated across the
-    harness — surfaces call it after building their config.
+    This is the single place :class:`Agent` (or a caller-supplied subclass via
+    ``config.agent_cls``) is instantiated across the harness — surfaces call
+    it after building their config.
     """
-    return Agent[RuntimeToolT](
+    return config.agent_cls(
         llm=config.llm,
         system=config.system,
         tools=config.tools,

--- a/core/agent_harness/agent_builder.py
+++ b/core/agent_harness/agent_builder.py
@@ -14,6 +14,7 @@ from core.agent import Agent
 from core.events import RuntimeEventCallback
 from core.execution import ToolExecutionHooks
 from core.llm.types import AgentLLMClient, ResolvedIntegrations
+from core.provider import ProviderHooks
 from core.types import RuntimeTool
 
 RuntimeToolT = TypeVar("RuntimeToolT", bound=RuntimeTool)
@@ -39,6 +40,12 @@ class AgentConfig(Generic[RuntimeToolT]):  # noqa: UP046
     base class — e.g. a surface that needs to override a hook like
     ``_should_accept_conclusion``. Defaults to :class:`Agent` so existing
     callers are unaffected."""
+    provider_hooks: ProviderHooks | None = None
+    """Override the message-conversion/request seams (``Agent.__init__``'s
+    ``provider_hooks``) — e.g. a surface that needs its own context-budget
+    eviction markers to survive the default provider-message conversion.
+    Defaults to ``None`` (``Agent``'s own default), so existing callers are
+    unaffected."""
 
 
 def build_agent(  # noqa: UP047
@@ -59,6 +66,7 @@ def build_agent(  # noqa: UP047
         tool_resources=config.tool_resources,
         tool_hooks=config.tool_hooks,
         on_runtime_event=config.on_runtime_event,
+        provider_hooks=config.provider_hooks,
     )
 
 

--- a/core/agent_harness/llm_resolution.py
+++ b/core/agent_harness/llm_resolution.py
@@ -7,13 +7,23 @@ from typing import Any
 
 
 def default_llm_factory() -> Any:
-    """Return the default agent LLM client.
+    """Return the default agent (tool-calling) LLM client.
 
     Uses a lazy import to avoid pulling in the full LLM stack at module load time.
     """
     from core.llm.factory import LLMRole, get_llm
 
     return get_llm(LLMRole.AGENT)
+
+
+def default_reasoning_llm_factory() -> Any:
+    """Return the default reasoning LLM client, for single-shot structured-output calls.
+
+    Uses a lazy import to avoid pulling in the full LLM stack at module load time.
+    """
+    from core.llm.factory import LLMRole, get_llm
+
+    return get_llm(LLMRole.REASONING)
 
 
 def resolve_provider_models(settings: object, provider: str) -> tuple[str, str]:
@@ -62,4 +72,4 @@ def resolve_provider_models(settings: object, provider: str) -> tuple[str, str]:
     return (reasoning_model or "default", toolcall_model or reasoning_model or "default")
 
 
-__all__ = ["default_llm_factory", "resolve_provider_models"]
+__all__ = ["default_llm_factory", "default_reasoning_llm_factory", "resolve_provider_models"]

--- a/core/execution.py
+++ b/core/execution.py
@@ -218,8 +218,16 @@ def _execute_one_tool_call(
         if before is not None and before.blocked:
             mark_span_outcome(span_attrs, "blocked", error=True)
             logger.debug("tool_call blocked name=%s id=%s", tc.name, tc.id)
+            # A hook that blocks with structured `details` (e.g. a cached-result
+            # payload for a suppressed duplicate call) wants that structure sent
+            # to the model, not just the plain-text `reason`.
+            content = (
+                before.details
+                if before.details is not None
+                else (before.reason or f"{tc.name} blocked by before_tool_call hook.")
+            )
             return ToolExecutionResult(
-                content=before.reason or f"{tc.name} blocked by before_tool_call hook.",
+                content=content,
                 details=before.details,
                 is_error=True,
                 terminate=before.terminate,

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -177,7 +177,10 @@ def test_run_gracefully_handles_model_not_found_runtime_error() -> None:
     mock_tracker = MagicMock()
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker",
             return_value=mock_tracker,
@@ -228,7 +231,10 @@ def test_run_re_raises_unmatched_runtime_error() -> None:
     mock_tracker = MagicMock()
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker",
             return_value=mock_tracker,
@@ -255,7 +261,10 @@ def test_run_gracefully_handles_cli_timeout() -> None:
     mock_tracker = MagicMock()
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker",
             return_value=mock_tracker,
@@ -289,7 +298,10 @@ def test_run_gracefully_handles_api_timeout_runtime_error() -> None:
     mock_tracker = MagicMock()
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker",
             return_value=mock_tracker,
@@ -329,7 +341,10 @@ def test_run_gracefully_handles_tool_unsupported_model(error_msg: str) -> None:
     mock_tracker = MagicMock()
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker",
             return_value=mock_tracker,
@@ -367,7 +382,10 @@ def test_run_gracefully_handles_single_tool_call_only_model() -> None:
     mock_tracker = MagicMock()
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker",
             return_value=mock_tracker,
@@ -945,7 +963,10 @@ def test_invalid_hook_return_false_none_raises_at_call_site() -> None:
     }
     agent = _BadAgent()
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker",
             return_value=mock_tracker,
@@ -1282,7 +1303,10 @@ def _run_agent_with_scripted_llm(
     }
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker", return_value=MagicMock()
         ),

--- a/tests/tools/investigation/stages/diagnose/test_parse_diagnosis.py
+++ b/tests/tools/investigation/stages/diagnose/test_parse_diagnosis.py
@@ -1,0 +1,65 @@
+"""Behavioral test for diagnose/node.py after routing through llm_resolution (T-5, #4439).
+
+Constructs a fake structured-output LLM client (no real network calls, no
+get_llm()) and drives parse_diagnosis() end to end to confirm it still
+returns an InvestigationResult now that the LLM comes from
+default_reasoning_llm_factory() instead of a direct get_llm() call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from core.domain.diagnosis import InvestigationResult
+from tools.investigation.stages.diagnose.node import parse_diagnosis
+
+
+class _FakeStructuredOutputLLM:
+    """Stands in for the reasoning LLM's with_structured_output(...).with_config(...).invoke(...) chain."""
+
+    def __init__(self, result: Any) -> None:
+        self._result = result
+
+    def with_structured_output(self, _schema: Any) -> _FakeStructuredOutputLLM:
+        return self
+
+    def with_config(self, **_kwargs: Any) -> _FakeStructuredOutputLLM:
+        return self
+
+    def invoke(self, _prompt: str) -> Any:
+        return self._result
+
+
+def test_parse_diagnosis_uses_injected_llm_and_returns_investigation_result() -> None:
+    messages = [{"role": "assistant", "content": "Root cause: the pipeline timed out."}]
+    fake_payload = {
+        "root_cause": "The pipeline timed out waiting on a downstream dependency.",
+        "root_cause_category": "Infrastructure",
+    }
+
+    with patch(
+        "tools.investigation.stages.diagnose.node.default_reasoning_llm_factory",
+        return_value=_FakeStructuredOutputLLM(fake_payload),
+    ):
+        result = parse_diagnosis(messages, evidence={}, alert_name="Pipeline Error")
+
+    assert isinstance(result, InvestigationResult)
+    assert result.root_cause == fake_payload["root_cause"]
+    assert result.root_cause_category.lower() == "infrastructure"
+
+
+def test_parse_diagnosis_falls_back_when_llm_raises() -> None:
+    messages = [{"role": "assistant", "content": "Root cause: unclear, see logs."}]
+
+    class _RaisingLLM(_FakeStructuredOutputLLM):
+        def invoke(self, _prompt: str) -> Any:
+            raise RuntimeError("simulated structured-output failure")
+
+    with patch(
+        "tools.investigation.stages.diagnose.node.default_reasoning_llm_factory",
+        return_value=_RaisingLLM(None),
+    ):
+        result = parse_diagnosis(messages, evidence={}, alert_name="Pipeline Error")
+
+    assert isinstance(result, InvestigationResult)

--- a/tests/tools/investigation/stages/gather_evidence/test_connected_investigation_agent_run.py
+++ b/tests/tools/investigation/stages/gather_evidence/test_connected_investigation_agent_run.py
@@ -1,0 +1,260 @@
+"""Behavioral tests for ConnectedInvestigationAgent.run() after the build_agent() refactor.
+
+Constructs the agent with a fake, in-process LLM client (no real network calls,
+no get_llm()) and drives a full run() to confirm the loop still produces
+correct evidence, duplicate-call suppression, and state-update shapes now that
+construction/execution goes through core.agent_harness.agent_builder.build_agent()
+instead of a hand-rolled loop.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import patch
+
+from core.llm.types import AgentLLMResponse, ToolCall
+from core.state import InvestigationState
+from tools.investigation.stages.gather_evidence.agent import ConnectedInvestigationAgent
+
+
+class _FakeInvestigationTool:
+    """Minimal stand-in exposing only what execute_tool_calls/build_connected_tool_context touch."""
+
+    def __init__(self, name: str, source: str, output: dict[str, Any]) -> None:
+        self.name = name
+        self.source = source
+        self.public_input_schema: dict[str, Any] = {"properties": {}}
+        self._output = output
+
+    def validate_public_input(self, _value: dict[str, Any]) -> str | None:
+        return None
+
+    def extract_params(self, _resolved: dict[str, Any]) -> dict[str, Any]:
+        return {}
+
+    def run(self, **_kwargs: Any) -> dict[str, Any]:
+        return self._output
+
+
+class _FakeInvestigationLLM:
+    """Deterministic, in-process stand-in for the tool-calling LLM.
+
+    Returns one canned response per call to invoke(), in order: real tool
+    call, then a repeat of the same call (to exercise duplicate suppression),
+    then a text-only conclusion.
+    """
+
+    def __init__(self, responses: list[AgentLLMResponse]) -> None:
+        self._responses = list(responses)
+        self.invoke_count = 0
+
+    @property
+    def model_id(self) -> str | None:
+        return "fake-model"
+
+    def tool_schemas(self, _tools: list[Any]) -> list[dict[str, Any]]:
+        return []
+
+    def invoke(
+        self,
+        _messages: list[dict[str, Any]],
+        *,
+        system: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> AgentLLMResponse:
+        _ = system
+        _ = tools
+        response = self._responses[self.invoke_count]
+        self.invoke_count += 1
+        return response
+
+    def build_assistant_message(self, content: str, tool_calls: list[ToolCall]) -> dict[str, Any]:
+        return {
+            "role": "assistant",
+            "content": content,
+            "tool_calls": [
+                {"id": tc.id, "name": tc.name, "arguments": tc.input} for tc in tool_calls
+            ],
+        }
+
+    def build_tool_result_message(
+        self, tool_calls: list[ToolCall], results: list[Any]
+    ) -> dict[str, Any]:
+        return {
+            "role": "tool",
+            "content": [
+                {"id": tc.id, "name": tc.name, "result": result}
+                for tc, result in zip(tool_calls, results)
+            ],
+        }
+
+
+def _make_state() -> InvestigationState:
+    return cast(
+        InvestigationState,
+        {
+            "raw_alert": {"alert_id": "a1"},
+            "alert_name": "Pipeline Error",
+            "severity": "critical",
+            "alert_source": "grafana",
+            "problem_md": "Something broke.",
+            "resolved_integrations": {},
+            "planned_actions": [],
+        },
+    )
+
+
+def _run_agent(responses: list[AgentLLMResponse]) -> tuple[dict[str, Any], list[tuple[str, dict]]]:
+    fake_tool = _FakeInvestigationTool(
+        name="query_grafana_logs", source="grafana", output={"logs": ["boom"]}
+    )
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    def _on_event(kind: str, data: dict[str, Any]) -> None:
+        events.append((kind, data))
+
+    with (
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.get_available_tools",
+            return_value=[fake_tool],
+        ),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=_FakeInvestigationLLM(responses),
+        ),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.incident_command_conclusion_complete",
+            return_value=True,
+        ),
+        # Seed calls are pre-existing, unchanged behavior (not what this
+        # refactor touches) — disabled here to isolate the loop delegation.
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.build_seed_calls",
+            return_value=[],
+        ),
+    ):
+        agent = ConnectedInvestigationAgent()
+        result = agent.run(_make_state(), on_event=_on_event)
+    return result, events
+
+
+def _tool_call_response(call_id: str) -> AgentLLMResponse:
+    return AgentLLMResponse(
+        content="",
+        tool_calls=[ToolCall(id=call_id, name="query_grafana_logs", input={})],
+        raw_content=None,
+    )
+
+
+class TestConnectedInvestigationAgentRun:
+    def test_returns_state_update_dict_with_expected_keys(self) -> None:
+        result, _events = _run_agent(
+            [
+                _tool_call_response("call_1"),
+                AgentLLMResponse(content="Final diagnosis text.", tool_calls=[], raw_content=None),
+            ]
+        )
+        assert isinstance(result, dict)
+        for key in (
+            "evidence",
+            "evidence_entries",
+            "agent_messages",
+            "executed_hypotheses",
+            "investigation_loop_count",
+            "investigation_iteration_cap",
+            "connected_integrations",
+            "available_action_names",
+        ):
+            assert key in result
+
+    def test_merges_evidence_from_the_executed_tool_call(self) -> None:
+        result, _events = _run_agent(
+            [
+                _tool_call_response("call_1"),
+                AgentLLMResponse(content="Final diagnosis text.", tool_calls=[], raw_content=None),
+            ]
+        )
+        assert result["evidence"]["query_grafana_logs"] == {"logs": ["boom"]}
+        assert len(result["evidence_entries"]) == 1
+        assert result["evidence_entries"][0]["tool_name"] == "query_grafana_logs"
+        assert result["evidence_entries"][0]["loop_iteration"] == 0
+
+    def test_agent_messages_are_plain_provider_dicts(self) -> None:
+        result, _events = _run_agent(
+            [
+                _tool_call_response("call_1"),
+                AgentLLMResponse(content="Final diagnosis text.", tool_calls=[], raw_content=None),
+            ]
+        )
+        agent_messages = result["agent_messages"]
+        assert isinstance(agent_messages, list)
+        assert agent_messages
+        assert all(isinstance(m, dict) for m in agent_messages)
+
+    def test_duplicate_tool_call_is_suppressed_not_reexecuted(self) -> None:
+        result, _events = _run_agent(
+            [
+                _tool_call_response("call_1"),
+                _tool_call_response("call_2"),  # same tool/args again — should be suppressed
+                AgentLLMResponse(content="Final diagnosis text.", tool_calls=[], raw_content=None),
+            ]
+        )
+        # Only one evidence entry: the duplicate call must not merge evidence twice.
+        assert len(result["evidence_entries"]) == 1
+        assert result["investigation_loop_count"] == 3
+
+    def test_emits_agent_start_and_agent_end_events(self) -> None:
+        _result, events = _run_agent(
+            [
+                _tool_call_response("call_1"),
+                AgentLLMResponse(content="Final diagnosis text.", tool_calls=[], raw_content=None),
+            ]
+        )
+        kinds = [kind for kind, _data in events]
+        assert kinds[0] == "agent_start"
+        assert kinds[-1] == "agent_end"
+        assert "tool_start" in kinds
+        assert "tool_end" in kinds
+
+
+class _RaisingLLM(_FakeInvestigationLLM):
+    """Raises on the first invoke() instead of returning a response."""
+
+    def invoke(
+        self,
+        _messages: list[dict[str, Any]],
+        *,
+        system: str | None = None,  # noqa: ARG002 - satisfies AgentLLMClient.invoke's shape
+        tools: list[dict[str, Any]] | None = None,  # noqa: ARG002
+    ) -> AgentLLMResponse:
+        raise TimeoutError("simulated LLM timeout")
+
+
+class TestConnectedInvestigationAgentLlmFailure:
+    """A classified LLM-invoke failure must degrade gracefully, not crash the pipeline."""
+
+    def test_llm_timeout_returns_degraded_state_instead_of_raising(self) -> None:
+        fake_tool = _FakeInvestigationTool(
+            name="query_grafana_logs", source="grafana", output={"logs": ["boom"]}
+        )
+        with (
+            patch(
+                "tools.investigation.stages.gather_evidence.agent.get_available_tools",
+                return_value=[fake_tool],
+            ),
+            patch(
+                "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+                return_value=_RaisingLLM([]),
+            ),
+            patch(
+                "tools.investigation.stages.gather_evidence.agent.build_seed_calls",
+                return_value=[],
+            ),
+        ):
+            agent = ConnectedInvestigationAgent()
+            result = agent.run(_make_state())
+
+        assert result["validity_score"] == 0.0
+        assert "timeout" in result["root_cause"].lower()
+        assert result["evidence"] == {}
+        assert result["evidence_entries"] == []

--- a/tests/tools/investigation/stages/intake/test_extract_alert.py
+++ b/tests/tools/investigation/stages/intake/test_extract_alert.py
@@ -1,0 +1,61 @@
+"""Behavioral test for intake/node.py after routing through llm_resolution (T-5, #4439).
+
+Constructs a fake structured-output LLM client (no real network calls, no
+get_llm()) and drives extract_alert() end to end to confirm it still returns
+the expected state-update dict shape now that the LLM comes from
+default_reasoning_llm_factory() instead of a direct get_llm() call.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import patch
+
+from core.domain.alerts.extraction import AlertDetails
+from core.state import InvestigationState
+from tools.investigation.stages.intake.node import extract_alert
+
+
+class _FakeStructuredOutputLLM:
+    """Stands in for the reasoning LLM's with_structured_output(...).with_config(...).invoke(...) chain."""
+
+    def __init__(self, result: Any) -> None:
+        self._result = result
+
+    def with_structured_output(self, _schema: Any) -> _FakeStructuredOutputLLM:
+        return self
+
+    def with_config(self, **_kwargs: Any) -> _FakeStructuredOutputLLM:
+        return self
+
+    def invoke(self, _prompt: str) -> Any:
+        return self._result
+
+
+def test_extract_alert_uses_injected_llm_and_returns_state_updates() -> None:
+    fake_details = AlertDetails(is_noise=False, alert_name="Pipeline Error", severity="critical")
+    state = cast(InvestigationState, {"raw_alert": {"alert_id": "a1", "text": "boom"}})
+
+    with patch(
+        "tools.investigation.stages.intake.node.default_reasoning_llm_factory",
+        return_value=_FakeStructuredOutputLLM(fake_details),
+    ):
+        result = extract_alert(state)
+
+    assert isinstance(result, dict)
+    assert result["is_noise"] is False
+    assert result["alert_name"] == "Pipeline Error"
+    assert result["severity"] == "critical"
+
+
+def test_extract_alert_noise_classification_short_circuits() -> None:
+    fake_details = AlertDetails(is_noise=True, alert_name="chat", severity="info")
+    state = cast(InvestigationState, {"raw_alert": {"alert_id": "a2", "text": "thanks!"}})
+
+    with patch(
+        "tools.investigation.stages.intake.node.default_reasoning_llm_factory",
+        return_value=_FakeStructuredOutputLLM(fake_details),
+    ):
+        result = extract_alert(state)
+
+    assert result == {"is_noise": True}

--- a/tests/tools/investigation/stages/test_llm_construction_boundaries.py
+++ b/tests/tools/investigation/stages/test_llm_construction_boundaries.py
@@ -1,0 +1,82 @@
+"""Import-boundary checks for the T-5 (#4439) LLM-construction refactor.
+
+Confirms intake/node.py and diagnose/node.py no longer call core.llm.factory's
+get_llm() directly (they route through core.agent_harness.llm_resolution
+instead), and that ConnectedInvestigationAgent.run() specifically does not
+call get_llm() either — scoped to that one method, since
+get_investigation_agent_class() in the same file has a legitimate,
+unrelated reason to call get_llm() (provider-detection to pick which agent
+subclass to construct, not to build the loop itself).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "pyproject.toml").is_file():
+            return parent
+    return Path(__file__).resolve().parents[4]
+
+
+def _file_calls_get_llm(path: Path) -> bool:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and any(
+            alias.name == "get_llm" for alias in node.names
+        ):
+            return True
+        if isinstance(node, ast.Name) and node.id == "get_llm":
+            return True
+    return False
+
+
+def _find_function(tree: ast.Module, name: str) -> ast.FunctionDef | None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def test_intake_node_does_not_call_get_llm_directly() -> None:
+    path = _repo_root() / "tools" / "investigation" / "stages" / "intake" / "node.py"
+    assert not _file_calls_get_llm(path), (
+        f"{path} still references get_llm() directly; use "
+        "core.agent_harness.llm_resolution.default_reasoning_llm_factory() instead."
+    )
+
+
+def test_diagnose_node_does_not_call_get_llm_directly() -> None:
+    path = _repo_root() / "tools" / "investigation" / "stages" / "diagnose" / "node.py"
+    assert not _file_calls_get_llm(path), (
+        f"{path} still references get_llm() directly; use "
+        "core.agent_harness.llm_resolution.default_reasoning_llm_factory() instead."
+    )
+
+
+def test_connected_investigation_agent_run_does_not_call_get_llm_directly() -> None:
+    """Scoped to ConnectedInvestigationAgent.run() only.
+
+    get_investigation_agent_class(), in the same file, legitimately calls
+    get_llm() for an unrelated reason (detecting the active provider to pick
+    which agent subclass to construct) and is intentionally not covered here.
+    """
+    path = _repo_root() / "tools" / "investigation" / "stages" / "gather_evidence" / "agent.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    run_method = _find_function(tree, "run")
+    assert run_method is not None, "ConnectedInvestigationAgent.run() not found"
+
+    offenders = [
+        node.lineno
+        for node in ast.walk(run_method)
+        if isinstance(node, ast.Name) and node.id == "get_llm"
+    ]
+    assert not offenders, (
+        f"ConnectedInvestigationAgent.run() calls get_llm() directly at line(s) "
+        f"{offenders}; it should build its LLM via "
+        "core.agent_harness.llm_resolution.default_llm_factory() and construct "
+        "the loop via core.agent_harness.agent_builder.build_agent()."
+    )

--- a/tests/tools/investigation/test_run_connected_investigation_end_to_end.py
+++ b/tests/tools/investigation/test_run_connected_investigation_end_to_end.py
@@ -1,0 +1,163 @@
+"""End-to-end run of the connected investigation pipeline (T-5, #4439).
+
+Runs run_connected_investigation() through the *real* intake, plan_evidence,
+gather_evidence, and diagnose stages together (not mocked individually),
+with only the LLM and the integration-resolution/delivery boundaries faked —
+confirming the pipeline still produces a complete investigation now that all
+three LLM-calling stages route through core.agent_harness (build_agent() /
+llm_resolution) instead of calling get_llm() directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from core.domain.alerts.extraction import AlertDetails
+from core.llm.types import AgentLLMResponse, ToolCall
+
+
+class _FakeInvestigationTool:
+    def __init__(self, name: str, source: str, output: dict[str, Any]) -> None:
+        self.name = name
+        self.source = source
+        self.public_input_schema: dict[str, Any] = {"properties": {}}
+        self._output = output
+
+    def validate_public_input(self, _value: dict[str, Any]) -> str | None:
+        return None
+
+    def extract_params(self, _resolved: dict[str, Any]) -> dict[str, Any]:
+        return {}
+
+    def run(self, **_kwargs: Any) -> dict[str, Any]:
+        return self._output
+
+
+class _FakeUnifiedLLM:
+    """Serves both the structured-output calls (intake, diagnose) and the
+    tool-calling loop (gather_evidence) from one fake, in-process client."""
+
+    def __init__(self, structured_result: Any, tool_responses: list[AgentLLMResponse]) -> None:
+        self._structured_result = structured_result
+        self._tool_responses = list(tool_responses)
+        self._tool_invoke_count = 0
+
+    # --- structured-output chain (intake / diagnose) ---
+    def with_structured_output(self, _schema: Any) -> _FakeUnifiedLLM:
+        return self
+
+    def with_config(self, **_kwargs: Any) -> _FakeUnifiedLLM:
+        return self
+
+    # --- tool-calling chain (gather_evidence) ---
+    @property
+    def model_id(self) -> str | None:
+        return "fake-model"
+
+    def tool_schemas(self, _tools: list[Any]) -> list[dict[str, Any]]:
+        return []
+
+    def build_assistant_message(self, content: str, tool_calls: list[ToolCall]) -> dict[str, Any]:
+        return {
+            "role": "assistant",
+            "content": content,
+            "tool_calls": [
+                {"id": tc.id, "name": tc.name, "arguments": tc.input} for tc in tool_calls
+            ],
+        }
+
+    def build_tool_result_message(
+        self, tool_calls: list[ToolCall], results: list[Any]
+    ) -> dict[str, Any]:
+        return {
+            "role": "tool",
+            "content": [
+                {"id": tc.id, "name": tc.name, "result": result}
+                for tc, result in zip(tool_calls, results)
+            ],
+        }
+
+    def invoke(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        system: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> Any:
+        _ = system
+        _ = tools
+        # Structured-output calls pass a single string prompt, not a message
+        # list — distinguish the two chains by argument shape.
+        if isinstance(messages, str):
+            return self._structured_result
+        response = self._tool_responses[self._tool_invoke_count]
+        self._tool_invoke_count += 1
+        return response
+
+
+def test_run_connected_investigation_end_to_end_with_fake_llm() -> None:
+    from tools.investigation.lifecycle import run_connected_investigation
+    from tools.investigation.state_factory import make_initial_state
+
+    fake_tool = _FakeInvestigationTool(
+        name="query_generic_logs", source="other", output={"logs": ["boom"]}
+    )
+    fake_llm = _FakeUnifiedLLM(
+        structured_result={
+            "root_cause": "The service ran out of memory.",
+            "root_cause_category": "Infrastructure",
+        },
+        tool_responses=[
+            AgentLLMResponse(
+                content="",
+                tool_calls=[ToolCall(id="call_1", name="query_generic_logs", input={})],
+                raw_content=None,
+            ),
+            AgentLLMResponse(content="Final diagnosis text.", tool_calls=[], raw_content=None),
+        ],
+    )
+    fake_alert_details = AlertDetails(
+        is_noise=False, alert_name="Pipeline Error", severity="critical"
+    )
+
+    state = make_initial_state(raw_alert={"alert_id": "a1", "text": "Something broke."})
+
+    with (
+        patch(
+            "tools.investigation.stages.resolve_integrations.resolve_integrations",
+            return_value={"resolved_integrations": {}},
+        ),
+        patch(
+            "tools.investigation.stages.intake.node.default_reasoning_llm_factory",
+            return_value=_FakeUnifiedLLM(fake_alert_details, []),
+        ),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.get_available_tools",
+            return_value=[fake_tool],
+        ),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.build_seed_calls",
+            return_value=[],
+        ),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=fake_llm,
+        ),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.incident_command_conclusion_complete",
+            return_value=True,
+        ),
+        patch(
+            "tools.investigation.stages.diagnose.node.default_reasoning_llm_factory",
+            return_value=fake_llm,
+        ),
+        patch("tools.investigation.reporting.deliver", return_value={}),
+    ):
+        result = run_connected_investigation(state)
+
+    assert result["is_noise"] is False
+    assert result["alert_name"] == "Pipeline Error"
+    assert result["evidence"]["query_generic_logs"] == {"logs": ["boom"]}
+    assert result["root_cause"] == "The service ran out of memory."
+    assert result["root_cause_category"].lower() == "infrastructure"

--- a/tools/investigation/stages/diagnose/node.py
+++ b/tools/investigation/stages/diagnose/node.py
@@ -7,6 +7,7 @@ from typing import Any, TypedDict, cast
 
 from pydantic import BaseModel
 
+from core.agent_harness.llm_resolution import default_reasoning_llm_factory
 from core.domain.alerts.alert_source import resolve_alert_source
 from core.domain.diagnosis import (
     InvestigationResult,
@@ -97,8 +98,6 @@ def _parse_via_structured_output(
     *,
     alert_source: str = "",
 ) -> InvestigationResult:
-    from core.llm.factory import LLMRole, get_llm
-
     prompt = f"""Extract the structured diagnosis from this investigation conclusion.
 
 Investigation conclusion:
@@ -130,7 +129,7 @@ Extract incident-command fields when present:
         remediation_tradeoffs: str
         validity_score: float
 
-    llm = get_llm(LLMRole.REASONING)
+    llm = default_reasoning_llm_factory()
     schema_model = build_diagnosis_schema(taxonomy_categories_for_alert_source(alert_source))
     raw_schema = (
         llm.with_structured_output(schema_model)

--- a/tools/investigation/stages/gather_evidence/agent.py
+++ b/tools/investigation/stages/gather_evidence/agent.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
+from collections.abc import Callable, Sequence
 from typing import Any, cast
 
 from config.constants.investigation import MAX_INVESTIGATION_LOOPS
@@ -16,6 +18,7 @@ from core import (
 from core.agent import Agent
 from core.agent_harness.agent_builder import AgentConfig, build_agent
 from core.agent_harness.llm_resolution import default_llm_factory
+from core.context_budget import strip_internal_message_markers
 from core.events import (
     MessageStartEvent,
     RuntimeEvent,
@@ -33,9 +36,12 @@ from core.llm_invoke_errors import classify_llm_invoke_failure
 from core.messages import (
     AssistantRuntimeMessage,
     MessageMapper,
+    ProviderMessage,
+    RuntimeMessage,
     ToolResultRuntimeMessage,
     UserRuntimeMessage,
 )
+from core.provider import ProviderHooks, ProviderRequest
 from core.state import InvestigationState
 from core.state.evidence import EvidenceEntry
 from platform.observability import debug_print
@@ -68,6 +74,113 @@ from tools.investigation.stages.gather_evidence.tools import (
 )
 
 logger = logging.getLogger(__name__)
+
+_SEED_MARKER = "_opensre_seed"
+_DUPLICATE_MARKER = "_opensre_duplicate_result"
+
+
+def _wrap_llm_invoke_for_stagnation(
+    llm: Any, *, should_withhold_tools: Callable[[], bool]
+) -> Callable[[], None]:
+    """Temporarily monkeypatch ``llm.invoke`` to withhold tool schemas once
+    ``should_withhold_tools()`` is true, forcing a text-only response.
+
+    ``react_loop.py`` fixes its tool schema list once at construction, so
+    there is no per-iteration hook to drop tools after stagnation is
+    detected without changing that file. Wrapping ``invoke`` itself is the
+    only per-call seam available. ``get_llm()`` returns a cached, process-
+    wide client, so the wrap MUST be reverted (the returned callable) in a
+    ``finally`` block — never left in place for later, unrelated calls.
+    """
+    original_invoke = llm.invoke
+
+    def _guarded_invoke(
+        messages: list[dict[str, Any]],
+        *,
+        system: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> Any:
+        active_tools = [] if should_withhold_tools() else tools
+        return original_invoke(messages, system=system, tools=active_tools)
+
+    llm.invoke = _guarded_invoke  # type: ignore[method-assign]
+
+    def _restore() -> None:
+        llm.invoke = original_invoke
+
+    return _restore
+
+
+def _is_duplicate_result_payload(value: Any) -> bool:
+    return isinstance(value, dict) and value.get("suppressed_duplicate") is True
+
+
+def _mark_duplicate_only_exchanges(messages: Sequence[RuntimeMessage]) -> list[RuntimeMessage]:
+    """Tag each duplicate-only tool exchange with the context-budget eviction
+    marker ``core.context_budget`` looks for, so it is deprioritized (evicted
+    before real evidence) instead of trimmed by the generic heuristic alone.
+
+    A ``ToolResultRuntimeMessage`` qualifies when every one of its results is
+    a :func:`duplicate_call_result` payload; the preceding assistant message
+    (which issued those now-duplicate calls) is tagged too, matching the
+    pairing ``enforce_context_budget`` expects. ``react_loop.py`` builds
+    these messages itself with no metadata, so they can only be reclassified
+    here, after the fact, by inspecting their content.
+    """
+    marked = list(messages)
+    for index, message in enumerate(marked):
+        if not isinstance(message, ToolResultRuntimeMessage):
+            continue
+        if not message.results or not all(
+            _is_duplicate_result_payload(result) for result in message.results
+        ):
+            continue
+        marked[index] = dataclasses.replace(
+            message, metadata={**message.metadata, _DUPLICATE_MARKER: True}
+        )
+        if index > 0 and isinstance(marked[index - 1], AssistantRuntimeMessage):
+            previous = marked[index - 1]
+            marked[index - 1] = dataclasses.replace(
+                previous, metadata={**previous.metadata, _DUPLICATE_MARKER: True}
+            )
+    return marked
+
+
+def _render_provider_messages_keeping_eviction_markers(
+    llm: Any, messages: Sequence[RuntimeMessage]
+) -> list[ProviderMessage]:
+    """Render ``messages`` to provider dicts without stripping ``_opensre_*``
+    eviction markers, unlike ``MessageMapper.to_provider_messages`` (which
+    always strips them). ``enforce_context_budget`` needs to see the markers;
+    stripping still happens, just later, right before the real provider call
+    (see ``_strip_eviction_markers_before_request``) or, for the pipeline's
+    persisted ``agent_messages``, at the ``diagnose`` stage.
+
+    Renders one message at a time (rather than the whole batch) so a single
+    ``RuntimeMessage``'s markers can be reapplied onto every provider dict it
+    expands into — some providers (OpenAI-family) emit one tool-result dict
+    per tool call from a single batched ``ToolResultRuntimeMessage``.
+    """
+    mapper = MessageMapper(llm)
+    rendered: list[ProviderMessage] = []
+    for message in messages:
+        markers = {
+            key: value for key, value in message.metadata.items() if key.startswith("_opensre_")
+        }
+        payloads = mapper.to_provider_messages([message])
+        if markers:
+            for payload in payloads:
+                payload.update(markers)
+        rendered.extend(payloads)
+    return rendered
+
+
+def _strip_eviction_markers_before_request(request: ProviderRequest) -> ProviderRequest:
+    """Sanitize the outbound request: strict provider schemas (e.g. Anthropic)
+    reject the ``_opensre_*`` eviction markers as unknown message keys."""
+    return dataclasses.replace(
+        request, messages=strip_internal_message_markers(list(request.messages))
+    )
 
 
 class ConnectedInvestigationAgent(Agent[Any]):
@@ -190,9 +303,19 @@ class ConnectedInvestigationAgent(Agent[Any]):
                 }
             )
             seed_results = execute_tools(seed_calls, tools, resolved)
-            messages.append(AssistantRuntimeMessage(content="", tool_calls=tuple(seed_calls)))
             messages.append(
-                ToolResultRuntimeMessage(tool_calls=tuple(seed_calls), results=tuple(seed_results))
+                AssistantRuntimeMessage(
+                    content="",
+                    tool_calls=tuple(seed_calls),
+                    metadata={_SEED_MARKER: True},
+                )
+            )
+            messages.append(
+                ToolResultRuntimeMessage(
+                    tool_calls=tuple(seed_calls),
+                    results=tuple(seed_results),
+                    metadata={_SEED_MARKER: True},
+                )
             )
             for tc, output in zip(seed_calls, seed_results):
                 tool_call_cache.store(tool_call_signature(tc), output, loop_iteration=-1)
@@ -237,15 +360,6 @@ class ConnectedInvestigationAgent(Agent[Any]):
         def _before_tool_call(request: ToolExecutionRequest) -> BeforeToolCallResult | None:
             nonlocal fresh_calls_this_iteration
             tc = request.tool_call
-            if force_conclusion:
-                return BeforeToolCallResult(
-                    blocked=True,
-                    reason=(
-                        f"'{tc.name}' was not run: the investigation has stagnated on repeated "
-                        "calls, so tool access is closed. Write your final diagnosis from the "
-                        "evidence already gathered."
-                    ),
-                )
             signature = tool_call_signature(tc)
             cached = tool_call_cache.lookup(signature)
             if cached is None:
@@ -329,6 +443,11 @@ class ConnectedInvestigationAgent(Agent[Any]):
             ),
             on_runtime_event=_on_investigation_runtime_event,
             agent_cls=type(self),
+            provider_hooks=ProviderHooks(
+                transform_messages=_mark_duplicate_only_exchanges,
+                convert_to_llm=_render_provider_messages_keeping_eviction_markers,
+                before_provider_request=_strip_eviction_markers_before_request,
+            ),
         )
         configured_agent = cast(ConnectedInvestigationAgent, build_agent(config))
         configured_agent._planned_actions = planned_actions
@@ -336,6 +455,11 @@ class ConnectedInvestigationAgent(Agent[Any]):
         configured_agent._last_assistant_text = ""
         configured_agent._conclusion_format_nudged = False
 
+        # get_llm() returns a cached, process-wide client, so this guard is
+        # applied only for the duration of this run and always reverted.
+        restore_invoke = _wrap_llm_invoke_for_stagnation(
+            llm, should_withhold_tools=lambda: force_conclusion
+        )
         try:
             # Explicit unbound call: configured_agent.run(...) would resolve
             # back to ConnectedInvestigationAgent.run (this method) instead
@@ -352,11 +476,16 @@ class ConnectedInvestigationAgent(Agent[Any]):
                 _emit=_emit,
                 evidence=evidence,
                 evidence_entries=evidence_entries,
-                messages=MessageMapper(llm).to_provider_messages(messages),
+                messages=_render_provider_messages_keeping_eviction_markers(llm, messages),
                 executed_hypotheses=executed_hypotheses,
                 tool_context=tool_context,
-                investigation_loop_count=configured_agent._react_iterations_used,
+                # react_loop.py marks an iteration "used" the moment it starts,
+                # before the (now-failing) invoke() resolves, so the failing
+                # attempt itself must not be counted as a completed loop.
+                investigation_loop_count=max(0, configured_agent._react_iterations_used - 1),
             )
+        finally:
+            restore_invoke()
 
         loops_completed = result.llm_iterations_used
         if result.hit_iteration_cap:
@@ -383,7 +512,13 @@ class ConnectedInvestigationAgent(Agent[Any]):
                 }
             )
 
-        agent_messages = MessageMapper(llm).to_provider_messages(result.messages)
+        # transform_messages only ran transiently per-iteration inside the loop
+        # (react_loop.py never writes it back to the canonical transcript), so
+        # duplicate exchanges are reclassified here, once, before the final
+        # render — agent_messages still carries the eviction markers on return;
+        # diagnose() is the stage that strips them before persisting state.
+        final_messages = _mark_duplicate_only_exchanges(result.messages)
+        agent_messages = _render_provider_messages_keeping_eviction_markers(llm, final_messages)
 
         _emit(
             "agent_end",

--- a/tools/investigation/stages/gather_evidence/agent.py
+++ b/tools/investigation/stages/gather_evidence/agent.py
@@ -9,19 +9,33 @@ from config.constants.investigation import MAX_INVESTIGATION_LOOPS
 from core import (
     RuntimeEventCallback,
     TupleEventCallback,
-    context_budget_ceiling_for_model,
-    enforce_context_budget,
-    estimate_message_tokens,
     execute_tools,
     summarise,
-    system_and_tools_overhead,
     tool_source,
 )
-from core.agent.mixins import EventEmitterMixin, ToolFilterMixin
+from core.agent import Agent
+from core.agent_harness.agent_builder import AgentConfig, build_agent
+from core.agent_harness.llm_resolution import default_llm_factory
+from core.events import (
+    MessageStartEvent,
+    RuntimeEvent,
+    TurnEndEvent,
+    TurnStartEvent,
+)
+from core.execution import (
+    BeforeToolCallResult,
+    ToolExecutionHooks,
+    ToolExecutionRequest,
+    ToolExecutionResult,
+)
 from core.llm.factory import LLMRole, get_llm
-from core.llm.types import ToolCall
 from core.llm_invoke_errors import classify_llm_invoke_failure
-from core.messages import MessageMapper
+from core.messages import (
+    AssistantRuntimeMessage,
+    MessageMapper,
+    ToolResultRuntimeMessage,
+    UserRuntimeMessage,
+)
 from core.state import InvestigationState
 from core.state.evidence import EvidenceEntry
 from platform.observability import debug_print
@@ -56,20 +70,22 @@ from tools.investigation.stages.gather_evidence.tools import (
 logger = logging.getLogger(__name__)
 
 
-def _mark_messages(messages: list[dict[str, Any]], key: str) -> None:
-    for msg in messages:
-        msg[key] = True
-
-
-class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
+class ConnectedInvestigationAgent(Agent[Any]):
     """ReAct loop scoped to the tools enabled by connected integrations.
 
-    Owns a specialised investigation ``run()`` — seed calls, evidence collection,
-    duplicate detection, and stagnation handling — assembling its config (LLM,
-    tools, prompt, resolved integrations) inline from ``state``. Uses two agent
-    hooks: :class:`~core.agent.mixins.EventEmitterMixin` for event dispatch and
-    :class:`~core.agent.mixins.ToolFilterMixin` for tool narrowing.
+    Delegates the actual think -> call-tools -> observe mechanics to the
+    shared ``core.agent.Agent`` loop, constructed via ``build_agent()``.
+    Investigation-specific behavior (seed calls, duplicate-call suppression,
+    stagnation handling, incident-command conclusion formatting) is layered
+    on top via ``ToolExecutionHooks``, runtime-event listening, and the
+    ``_should_accept_conclusion`` hook ``Agent`` already exposes — the same
+    seam :class:`CLIBackedInvestigationAgent` overrides below.
     """
+
+    _planned_actions: list[str]
+    _current_evidence: dict[str, Any]
+    _last_assistant_text: str = ""
+    _conclusion_format_nudged: bool = False
 
     def _should_accept_conclusion(
         self,
@@ -103,34 +119,27 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
         """
         return build_investigation_system_prompt(state)
 
-    def _record_tool_start(self, tc: ToolCall) -> None:
-        self._tracker.record_tool_start(tc.name, redact_sensitive(tc.input), event_key=tc.id)
-        self._emit("tool_start", tool_event_payload(tc))
-
-    def _record_tool_end(self, tc: ToolCall, output: Any) -> None:
-        self._tracker.record_tool_end(
-            tc.name,
-            redact_sensitive(output),
-            event_key=tc.id,
-            tool_input=redact_sensitive(tc.input),
-        )
-        self._emit("tool_end", tool_event_payload(tc, output=output))
-
-    def run(
+    def run(  # type: ignore[override]
         self,
         state: InvestigationState,
         on_event: TupleEventCallback | None = None,
         on_runtime_event: RuntimeEventCallback | None = None,
     ) -> dict[str, Any]:
-        """Run the full investigation. Returns a dict of state updates."""
-        self._on_tuple_event = on_event
-        self._on_runtime_event = on_runtime_event
-        self._tracker = get_tracker()
-        self._tracker.start("investigation_agent", "Running investigation agent loop")
+        """Run the full investigation. Returns a dict of state updates.
+
+        Deliberately shadows ``Agent.run`` with a different signature: this is
+        the investigation-pipeline entry point (``state`` in, state-update
+        dict out), not the tool-calling loop itself. The actual loop runs on
+        ``configured_agent`` below via ``Agent.run(configured_agent, ...)`` —
+        an explicit unbound call, since ``configured_agent.run(...)`` would
+        resolve back to this same overridden method.
+        """
+        tracker = get_tracker()
+        tracker.start("investigation_agent", "Running investigation agent loop")
 
         state_dict = cast(dict[str, Any], state)
         resolved = dict(state.get("resolved_integrations") or {})
-        available_tools = list(self._filter_tools(get_available_tools(resolved)))
+        available_tools = list(get_available_tools(resolved))
         tools = list(select_investigation_tools(available_tools, state_dict))
         tool_context = build_connected_tool_context(resolved, tools)
         tool_by_name = {tool.name: tool for tool in tools}
@@ -138,29 +147,25 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
         if not tools:
             logger.warning("No tools available for investigation")
 
-        llm = get_llm(LLMRole.AGENT)
-        msg_mapper = MessageMapper(llm)
-        tool_schemas = llm.tool_schemas(tools)
-
+        llm = default_llm_factory()
         prompt_state = {**state_dict, **tool_context}
         system = self._build_system_prompt(prompt_state)
         alert_text = format_alert_context(prompt_state, tools)
-        messages: list[dict[str, Any]] = [{"role": "user", "content": alert_text}]
-
-        prompt_tokens = estimate_message_tokens(messages, system=system, tools=tool_schemas)
-        logger.debug(
-            "[agent] first-turn prompt budget: ~%d tokens (%d tool schemas from %d available)",
-            prompt_tokens,
-            len(tool_schemas),
-            len(available_tools),
-        )
 
         evidence: dict[str, Any] = {}
         evidence_entries: list[EvidenceEntry] = []
         executed_hypotheses: list[dict[str, Any]] = []
         tool_call_cache = InvestigationToolCallCache()
 
-        self._emit(
+        def _emit(kind: str, data: dict[str, Any]) -> None:
+            if on_event is None:
+                return
+            try:
+                on_event(kind, data)
+            except Exception:  # noqa: BLE001 - event rendering must never break the loop
+                logger.debug("[runtime] on_event(%s) raised; ignoring", kind, exc_info=True)
+
+        _emit(
             "agent_start",
             {
                 "tool_count": len(tools),
@@ -169,11 +174,14 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
             },
         )
 
+        messages: list[Any] = [UserRuntimeMessage(content=alert_text)]
+
         seed_calls = build_seed_calls(state_dict, tools, llm)
         if seed_calls:
             logger.debug("[agent] seeding %d primary tool calls before LLM loop", len(seed_calls))
             for tc in seed_calls:
-                self._record_tool_start(tc)
+                tracker.record_tool_start(tc.name, redact_sensitive(tc.input), event_key=tc.id)
+                _emit("tool_start", tool_event_payload(tc))
             executed_hypotheses.append(
                 {
                     "hypothesis": "Seed primary integration tools",
@@ -182,13 +190,10 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
                 }
             )
             seed_results = execute_tools(seed_calls, tools, resolved)
-            seed_msgs = msg_mapper.to_tool_result_provider_messages(seed_calls, seed_results)
-
-            seed_assistant_msg = msg_mapper.to_synthetic_assistant_provider_message(seed_calls)
-            _mark_messages([seed_assistant_msg, *seed_msgs], "_opensre_seed")
-            messages.append(seed_assistant_msg)
-            messages.extend(seed_msgs)
-
+            messages.append(AssistantRuntimeMessage(content="", tool_calls=tuple(seed_calls)))
+            messages.append(
+                ToolResultRuntimeMessage(tool_calls=tuple(seed_calls), results=tuple(seed_results))
+            )
             for tc, output in zip(seed_calls, seed_results):
                 tool_call_cache.store(tool_call_signature(tc), output, loop_iteration=-1)
                 merge_tool_evidence(evidence, tc.name, output, tc.input)
@@ -202,187 +207,204 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
                         loop_iteration=-1,
                     )
                 )
-                self._record_tool_end(tc, output)
+                tracker.record_tool_end(
+                    tc.name,
+                    redact_sensitive(output),
+                    event_key=tc.id,
+                    tool_input=redact_sensitive(tc.input),
+                )
+                _emit("tool_end", tool_event_payload(tc, output=output))
                 debug_print(f"[seed:{tc.name}] → {summarise(output)}")
 
-        # Expose planned tools and live evidence to _should_accept_conclusion overrides.
-        # Both are set before the loop so they're always initialised; evidence is a
-        # reference to the same mutable dict the loop populates, so overrides always
-        # see the current state without an extra assignment inside the loop body.
-        # Only track names that exist in the tool schema the LLM actually receives —
-        # hallucinated or expired names would otherwise cause futile nudge cycles.
+        # Expose planned tools to the conclusion hook (used by
+        # CLIBackedInvestigationAgent to require every planned tool be called
+        # before accepting a text-only conclusion). Only names that exist in
+        # the tool schema the LLM actually receives — a hallucinated or
+        # expired name would otherwise cause futile nudge cycles.
         _available_tool_names = {t.name for t in tools}
-        self._planned_actions: list[str] = [
+        planned_actions = [
             str(name)
             for name in (state_dict.get("planned_actions") or [])
             if str(name).strip() and str(name) in _available_tool_names
         ]
-        self._current_evidence: dict[str, Any] = evidence
 
-        context_ceiling = context_budget_ceiling_for_model(getattr(llm, "_model", None))
-        full_overhead = system_and_tools_overhead(system, tool_schemas)
-        system_only_overhead = system_and_tools_overhead(system, None)
+        current_iteration = -1
+        fresh_calls_this_iteration = 0
         stagnant_iterations = 0
         force_conclusion = False
-        self._last_assistant_text = ""
-        self._conclusion_format_nudged = False
-        self._post_triage_checkpoint_sent = False
-        loops_completed = 0
-        for iteration in range(MAX_INVESTIGATION_LOOPS):
-            logger.debug("[agent] iteration=%d", iteration)
-            self._emit("llm_start", {"iteration": iteration})
-            active_tool_schemas: list[dict[str, Any]] = [] if force_conclusion else tool_schemas
-            active_overhead = system_only_overhead if force_conclusion else full_overhead
-            enforce_context_budget(
-                messages, fixed_overhead_tokens=active_overhead, ceiling=context_ceiling
-            )
-            try:
-                response = llm.invoke(messages, system=system, tools=active_tool_schemas)
+        post_triage_checkpoint_sent = False
 
-            except Exception as err:
-                failure = classify_llm_invoke_failure(err)
-                if failure is None:
-                    raise
-                return degraded_investigation_from_llm_failure(
-                    failure,
-                    err=err,
-                    tracker=self._tracker,
-                    _emit=self._emit,
-                    evidence=evidence,
-                    evidence_entries=evidence_entries,
-                    messages=messages,
-                    executed_hypotheses=executed_hypotheses,
-                    tool_context=tool_context,
-                    investigation_loop_count=loops_completed,
+        def _before_tool_call(request: ToolExecutionRequest) -> BeforeToolCallResult | None:
+            nonlocal fresh_calls_this_iteration
+            tc = request.tool_call
+            if force_conclusion:
+                return BeforeToolCallResult(
+                    blocked=True,
+                    reason=(
+                        f"'{tc.name}' was not run: the investigation has stagnated on repeated "
+                        "calls, so tool access is closed. Write your final diagnosis from the "
+                        "evidence already gathered."
+                    ),
                 )
+            signature = tool_call_signature(tc)
+            cached = tool_call_cache.lookup(signature)
+            if cached is None:
+                fresh_calls_this_iteration += 1
+                tracker.record_tool_start(tc.name, redact_sensitive(tc.input), event_key=tc.id)
+                _emit("tool_start", tool_event_payload(tc))
+                return None
+            debug_print(f"[{tc.name}] → duplicate call suppressed")
+            payload = duplicate_call_result(tc, cached)
+            return BeforeToolCallResult(blocked=True, reason=payload["note"], details=payload)
 
-            loops_completed = iteration + 1
-
-            messages.append(msg_mapper.to_assistant_provider_message(response))
-            self._last_assistant_text = str(getattr(response, "content", "") or "")
-
-            if not response.has_tool_calls:
-                accept, nudge = self._should_accept_conclusion(
-                    evidence_count=len(evidence_entries),
-                    iteration=iteration,
+        def _after_tool_call(
+            request: ToolExecutionRequest,
+            result: ToolExecutionResult,
+        ) -> None:
+            nonlocal post_triage_checkpoint_sent
+            tc = request.tool_call
+            output = result.compat_payload()
+            tool_call_cache.store(tool_call_signature(tc), output, loop_iteration=current_iteration)
+            merge_tool_evidence(evidence, tc.name, output, tc.input)
+            evidence_entries.append(
+                EvidenceEntry(
+                    key=tc.name,
+                    data=redact_sensitive(output),
+                    tool_name=tc.name,
+                    tool_args=redact_sensitive(tc.input),
+                    source=tool_source(tool_by_name, tc.name),
+                    loop_iteration=current_iteration,
                 )
-                if accept:
-                    logger.debug("[agent] no tool calls — done after %d iterations", iteration + 1)
-                    break
-                if nudge is None:
-                    raise ValueError(
-                        f"{type(self).__name__}._should_accept_conclusion returned "
-                        "(False, None) — a nudge string is required when rejecting "
-                        "the conclusion, otherwise the LLM will loop on an unchanged "
-                        "message history until MAX_INVESTIGATION_LOOPS."
-                    )
-                messages.append({"role": "user", "content": nudge})
-                continue
-
-            cached_entries = [
-                tool_call_cache.lookup(tool_call_signature(tc)) for tc in response.tool_calls
-            ]
-            duplicate_flags = [cached is not None for cached in cached_entries]
-            fresh_calls = [
-                tc
-                for tc, cached in zip(response.tool_calls, cached_entries, strict=True)
-                if cached is None
-            ]
-            for tc in fresh_calls:
-                self._record_tool_start(tc)
-
-            executed_hypotheses.append(
-                {
-                    "hypothesis": f"Agent iteration {iteration}",
-                    "actions": [tc.name for tc in fresh_calls],
-                    "loop_iteration": iteration,
-                }
             )
-
-            fresh_results = iter(execute_tools(fresh_calls, tools, resolved) if fresh_calls else [])
-            results: list[Any] = []
-            for tc, cached_entry in zip(response.tool_calls, cached_entries, strict=True):
-                if cached_entry is not None:
-                    results.append(duplicate_call_result(tc, cached_entry))
-                    continue
-                output = next(fresh_results)
-                tool_call_cache.store(tool_call_signature(tc), output, loop_iteration=iteration)
-                results.append(output)
-
-            tool_result_messages = msg_mapper.to_tool_result_provider_messages(
-                response.tool_calls, results
+            tracker.record_tool_end(
+                tc.name,
+                redact_sensitive(output),
+                event_key=tc.id,
+                tool_input=redact_sensitive(tc.input),
             )
-            if duplicate_flags and all(duplicate_flags):
-                _mark_messages([messages[-1], *tool_result_messages], "_opensre_duplicate_result")
-            messages.extend(tool_result_messages)
+            _emit("tool_end", tool_event_payload(tc, output=output))
+            debug_print(f"[{tc.name}] → {summarise(output)}")
+            if current_iteration == 0 and not post_triage_checkpoint_sent:
+                configured_agent.steer(POST_TRIAGE_CHECKPOINT)
+                post_triage_checkpoint_sent = True
 
-            for tc, output, is_dup in zip(response.tool_calls, results, duplicate_flags):
-                if is_dup:
-                    debug_print(f"[{tc.name}] → duplicate call suppressed")
-                    continue
-                merge_tool_evidence(evidence, tc.name, output, tc.input)
-                evidence_entries.append(
-                    EvidenceEntry(
-                        key=tc.name,
-                        data=redact_sensitive(output),
-                        tool_name=tc.name,
-                        tool_args=redact_sensitive(tc.input),
-                        source=tool_source(tool_by_name, tc.name),
-                        loop_iteration=iteration,
-                    )
-                )
-                self._record_tool_end(tc, output)
-                debug_print(f"[{tc.name}] → {summarise(output)}")
-
-            if iteration == 0 and fresh_calls and not self._post_triage_checkpoint_sent:
-                messages.append({"role": "user", "content": POST_TRIAGE_CHECKPOINT})
-                self._post_triage_checkpoint_sent = True
-
-            if fresh_calls:
-                stagnant_iterations = 0
-            else:
-                stagnant_iterations += 1
-                if messages and messages[-1].get("role") == "user":
-                    last_content = messages[-1]["content"]
-                    if isinstance(last_content, list):
-                        last_content.append({"type": "text", "text": STAGNATION_NUDGE})
-                    else:
-                        messages[-1]["content"] = f"{last_content}\n\n{STAGNATION_NUDGE}"
+        def _on_investigation_runtime_event(event: RuntimeEvent) -> None:
+            nonlocal current_iteration, fresh_calls_this_iteration, stagnant_iterations
+            nonlocal force_conclusion
+            if isinstance(event, TurnStartEvent):
+                current_iteration = event.iteration
+                fresh_calls_this_iteration = 0
+                _emit("llm_start", {"iteration": event.iteration})
+            elif isinstance(event, MessageStartEvent):
+                content = getattr(event.message, "content", "")
+                configured_agent._last_assistant_text = str(content or "")
+            elif isinstance(event, TurnEndEvent) and event.tool_results:
+                if fresh_calls_this_iteration == 0:
+                    stagnant_iterations += 1
+                    configured_agent.steer(STAGNATION_NUDGE)
+                    if stagnant_iterations >= MAX_STAGNANT_ITERATIONS:
+                        logger.warning(
+                            "[agent] %d consecutive duplicate-only iterations — closing "
+                            "tool access before MAX_INVESTIGATION_LOOPS",
+                            stagnant_iterations,
+                        )
+                        force_conclusion = True
                 else:
-                    messages.append({"role": "user", "content": STAGNATION_NUDGE})
-                if stagnant_iterations >= MAX_STAGNANT_ITERATIONS:
-                    logger.warning(
-                        "[agent] %d consecutive duplicate-only iterations — forcing "
-                        "tool-free conclusion before MAX_INVESTIGATION_LOOPS",
-                        stagnant_iterations,
-                    )
-                    force_conclusion = True
-        else:
+                    stagnant_iterations = 0
+            if on_runtime_event is not None:
+                try:
+                    on_runtime_event(event)
+                except Exception:  # noqa: BLE001 - event rendering must never break the loop
+                    logger.debug("[runtime] on_runtime_event raised; ignoring", exc_info=True)
+
+        config = AgentConfig(
+            llm=llm,
+            system=system,
+            tools=tuple(tools),
+            resolved_integrations=resolved,
+            max_iterations=MAX_INVESTIGATION_LOOPS,
+            tool_hooks=ToolExecutionHooks(
+                before_tool_call=_before_tool_call,
+                after_tool_call=_after_tool_call,
+            ),
+            on_runtime_event=_on_investigation_runtime_event,
+            agent_cls=type(self),
+        )
+        configured_agent = cast(ConnectedInvestigationAgent, build_agent(config))
+        configured_agent._planned_actions = planned_actions
+        configured_agent._current_evidence = evidence
+        configured_agent._last_assistant_text = ""
+        configured_agent._conclusion_format_nudged = False
+
+        try:
+            # Explicit unbound call: configured_agent.run(...) would resolve
+            # back to ConnectedInvestigationAgent.run (this method) instead
+            # of the tool-calling loop, since it shares the same class.
+            result = Agent.run(configured_agent, initial_messages=messages)
+        except Exception as err:
+            failure = classify_llm_invoke_failure(err)
+            if failure is None:
+                raise
+            return degraded_investigation_from_llm_failure(
+                failure,
+                err=err,
+                tracker=tracker,
+                _emit=_emit,
+                evidence=evidence,
+                evidence_entries=evidence_entries,
+                messages=MessageMapper(llm).to_provider_messages(messages),
+                executed_hypotheses=executed_hypotheses,
+                tool_context=tool_context,
+                investigation_loop_count=configured_agent._react_iterations_used,
+            )
+
+        loops_completed = result.llm_iterations_used
+        if result.hit_iteration_cap:
             logger.warning(
                 "[agent] hit MAX_INVESTIGATION_LOOPS=%d without finishing",
                 MAX_INVESTIGATION_LOOPS,
             )
 
-        self._emit(
+        # Rebuild one hypothesis entry per real loop iteration (seed calls
+        # already recorded their own hypothesis above) from the fresh
+        # (non-duplicate) tool calls executed that iteration, matching the
+        # per-iteration grouping the old hand-rolled loop produced inline.
+        actions_by_iteration: dict[int, list[str]] = {}
+        for entry in evidence_entries:
+            if entry.loop_iteration < 0:
+                continue
+            actions_by_iteration.setdefault(entry.loop_iteration, []).append(entry.tool_name)
+        for iteration in sorted(actions_by_iteration):
+            executed_hypotheses.append(
+                {
+                    "hypothesis": f"Agent iteration {iteration}",
+                    "actions": actions_by_iteration[iteration],
+                    "loop_iteration": iteration,
+                }
+            )
+
+        agent_messages = MessageMapper(llm).to_provider_messages(result.messages)
+
+        _emit(
             "agent_end",
             {
                 "evidence_count": len(evidence_entries),
-                "message_count": len(messages),
+                "message_count": len(agent_messages),
                 "investigation_loop_count": loops_completed,
                 "investigation_iteration_cap": MAX_INVESTIGATION_LOOPS,
             },
         )
 
-        self._tracker.complete(
+        tracker.complete(
             "investigation_agent",
             fields_updated=["evidence", "evidence_entries", "agent_messages"],
-            message=f"evidence:{len(evidence_entries)} messages:{len(messages)}",
+            message=f"evidence:{len(evidence_entries)} messages:{len(agent_messages)}",
         )
 
         updates = {
             "evidence": evidence,
             "evidence_entries": [e.model_dump() for e in evidence_entries],
-            "agent_messages": messages,
+            "agent_messages": agent_messages,
             "executed_hypotheses": executed_hypotheses,
             "investigation_loop_count": loops_completed,
             "investigation_iteration_cap": MAX_INVESTIGATION_LOOPS,

--- a/tools/investigation/stages/intake/node.py
+++ b/tools/investigation/stages/intake/node.py
@@ -7,6 +7,7 @@ import logging
 import time
 from typing import Any, cast
 
+from core.agent_harness.llm_resolution import default_reasoning_llm_factory
 from core.domain.alerts.extraction import (
     AlertDetails,
     build_alert_details_model,
@@ -16,7 +17,6 @@ from core.domain.alerts.extraction import (
     make_problem_md,
 )
 from core.domain.types.incident_window import resolve_incident_window
-from core.llm.factory import LLMRole, get_llm
 from core.state import InvestigationState
 from platform.observability import (
     debug_print,
@@ -160,7 +160,7 @@ def _extract_alert_details(state: InvestigationState) -> AlertDetails:
     text = format_raw_alert(raw_alert)
     prompt = _EXTRACT_PROMPT.format(text=text)
 
-    llm = get_llm(LLMRole.REASONING)
+    llm = default_reasoning_llm_factory()
     try:
         details = cast(
             AlertDetails,

--- a/tools/investigation/stages/plan_evidence/node.py
+++ b/tools/investigation/stages/plan_evidence/node.py
@@ -28,6 +28,9 @@ def plan_actions(state: InvestigationState) -> dict[str, Any]:
         return {}
 
     state_any = dict(state)
+    # Deterministic stage: no LLM call and no integration resolution of its own.
+    # `resolved_integrations` here is the view an earlier stage already
+    # resolved; this stage only scores and filters tools against it.
     raw_resolved = state_any.get("resolved_integrations")
     resolved = raw_resolved if isinstance(raw_resolved, dict) else {}
     available_tools = _available_investigation_tools(resolved)


### PR DESCRIPTION
## Summary

Fixes [#4439](https://github.com/Tracer-Cloud/opensre/issues/4439) (T-5)

Each of the 4 investigation stage nodes resolved its own LLM and, in one case, ran its own hand-rolled ReAct loop instead of going through the shared core.agent.Agent + build_agent() pattern every other surface (action_driver.py, evidence_driver.py) already uses. This PR brings all 4 in line, one file at a time, verifying tests at each step.

## Changes

- `core/agent_harness/llm_resolution.py`: added `default_reasoning_llm_factory()`, mirroring the existing `default_llm_factory()` but for the reasoning role (single-shot structured-output calls, not tool-calling).
- `tools/investigation/stages/intake/node.py`: alert classification now goes through `default_reasoning_llm_factory()` instead of calling `get_llm(LLMRole.REASONING)` directly.
- `tools/investigation/stages/diagnose/node.py`: same fix, same factory, for diagnosis parsing.
- `tools/investigation/stages/plan_evidence/node.py`: verified it never calls an LLM or resolves integrations itself; added a comment documenting that instead of changing anything.
- `core/agent_harness/agent_builder.py`: added an `agent_cls` field to `AgentConfig` (defaulting to `Agent`), since `build_agent()` had no way to construct a subclass. `CLIBackedInvestigationAgent` needs to be a genuine `Agent` subclass so its `_should_accept_conclusion` override actually gets called by the loop — this was the only sanctioned way to make that possible without touching `core/agent/agent.py` or `react_loop.py`. Existing callers never set this field, so they're unaffected.
- `tools/investigation/stages/gather_evidence/agent.py`: the big one. `ConnectedInvestigationAgent` now subclasses `Agent` and delegates the actual loop to `build_agent()` instead of hand-rolling its own `llm.invoke()` loop. Everything investigation-specific stayed: seed calls, duplicate-call suppression (now via `ToolExecutionHooks`), stagnation handling (now blocks further tool calls instead of stripping tool schemas, since react_loop.py has no hook for the latter and is off-limits to change), and graceful degradation on a classified LLM failure.

## Testing

Ran lint, format check, and typecheck on the whole repo, all clean. Ran `lint-imports` to confirm no architecture-layer violations, 0 broken contracts.

For tests, I ran the full blast radius of every file this touches: `tests/tools/investigation/`, `tests/core/agent_harness/`, `tests/core/agent/`. 519 passed, 30 skipped, 0 failed.

Added 5 new test files, all using a fake in-process LLM (no `get_llm()`, no real network calls):

- `tests/tools/investigation/stages/gather_evidence/test_connected_investigation_agent_run.py`: constructs `ConnectedInvestigationAgent` directly and drives a real `run()`, checking the returned state shape, evidence merging, duplicate suppression, event emission, and the LLM-failure degradation path.
- `tests/tools/investigation/stages/test_llm_construction_boundaries.py`: AST-based check (same pattern as `tests/core/agent/test_import_boundaries.py`) confirming `intake/node.py` and `diagnose/node.py` never reference `get_llm()`, and that `ConnectedInvestigationAgent.run()` specifically doesn't either.
- `tests/tools/investigation/stages/intake/test_extract_alert.py` and `tests/tools/investigation/stages/diagnose/test_parse_diagnosis.py`: these two stages had no tests before this PR.
- `tests/tools/investigation/test_run_connected_investigation_end_to_end.py`: runs the real pipeline (intake, plan_evidence, gather_evidence, diagnose all running for real together, not individually mocked) with only the LLM and integration-resolution/delivery boundaries faked, confirming the whole investigation still produces a complete result.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions