### PR TITLE
Refactor: use HTTPStatus for CLI update rate limit

### DIFF
--- a/surfaces/cli/lifecycle/update.py
+++ b/surfaces/cli/lifecycle/update.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 import sys
+from http import HTTPStatus
 
 from config.version import get_opensre_version
 
@@ -44,7 +45,7 @@ def _fetch_latest_version() -> str:
     except httpx.TimeoutException as exc:
         raise RuntimeError("request timed out") from exc
     except httpx.HTTPStatusError as exc:
-        if exc.response.status_code == 429:
+        if exc.response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
             raise RuntimeError("GitHub API rate limit exceeded, try again later") from exc
         raise RuntimeError(f"GitHub API returned HTTP {exc.response.status_code}") from exc
     except httpx.ConnectError as exc:


### PR DESCRIPTION
Fixes #4307 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
Replaced the raw HTTP status code `429` in the CLI update flow with the named standard-library enum `HTTPStatus.TOO_MANY_REQUESTS`.
This is a behavior-preserving maintainability change. The GitHub API rate-limit error message and update flow are unchanged.


### Demo/Screenshot for feature changes and bug fixes - 
<img width="2027" height="348" alt="Screenshot 2026-07-29 003549" src="https://github.com/user-attachments/assets/af880c09-4b24-487c-a937-56d4285ef630" />



## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
