### PR TITLE
chore(azure_sql): remove comments that only restate the next line (SM-75)

### DIFF
--- a/integrations/azure_sql/__init__.py
+++ b/integrations/azure_sql/__init__.py
@@ -205,7 +205,6 @@ def validate_azure_sql_config(config: AzureSQLConfig) -> AzureSQLValidationResul
             version_info = cursor.fetchone()[0]
             cursor.close()
 
-            # Extract meaningful version snippet
             version = version_info.split("\n")[0] if version_info else "unknown"
 
             return AzureSQLValidationResult(
@@ -263,12 +262,10 @@ def get_server_status(config: AzureSQLConfig) -> dict[str, Any]:
         try:
             cursor = conn.cursor()
 
-            # Get version
             cursor.execute("SELECT @@VERSION")
             version_info = cursor.fetchone()[0]
             version = version_info.split("\n")[0] if version_info else "unknown"
 
-            # Get service tier and SLO
             cursor.execute("""
                 SELECT
                     edition,
@@ -281,7 +278,6 @@ def get_server_status(config: AzureSQLConfig) -> dict[str, Any]:
             service_objective = slo_row[1] if slo_row else "unknown"
             elastic_pool = slo_row[2] if slo_row else None
 
-            # Get recent resource utilization (last 5 minutes)
             cursor.execute("""
                 SELECT TOP 1
                     avg_cpu_percent,
@@ -296,7 +292,6 @@ def get_server_status(config: AzureSQLConfig) -> dict[str, Any]:
             """)
             resource_row = cursor.fetchone()
 
-            # Get connection count
             cursor.execute("""
                 SELECT
                     COUNT(*) as total_connections,
@@ -307,7 +302,6 @@ def get_server_status(config: AzureSQLConfig) -> dict[str, Any]:
             """)
             conn_row = cursor.fetchone()
 
-            # Get database size
             cursor.execute("""
                 SELECT
                     SUM(size * 8.0 / 1024) as size_mb
@@ -492,7 +486,6 @@ def get_resource_stats(
 
             cursor.close()
 
-            # Compute summary
             throttling_risk = "none"
             if samples:
                 max_cpu: float = max(float(s["avg_cpu_percent"]) for s in samples)


### PR DESCRIPTION
## Summary

Fixes [#4331](https://github.com/Tracer-Cloud/opensre/issues/4331) (Task ID: SM-75)

`integrations/azure_sql/__init__.py` had a handful of banner comments that added nothing beyond what the very next line already says, things like `# Get version` right above a `cursor.execute("SELECT @@VERSION")` call. I found and removed seven of these.

## Changes

Removed these seven comments, each sitting directly above the one line it was just describing:

- `# Extract meaningful version snippet` (in `validate_azure_sql_config`)
- `# Get version`, `# Get service tier and SLO`, `# Get recent resource utilization (last 5 minutes)`, `# Get connection count`, `# Get database size` (all in `get_server_status`)
- `# Compute summary` (in `get_resource_stats`)

Kept two kinds of comments on purpose:

- The section header separating the diagnostic-query functions (`# Read-only diagnostic queries (Azure SQL DMVs)`), since it labels a whole block of functions, not a single line.
- Every docstring that actually explains something non-obvious: read-only guarantees, result caps, that some DMVs are Azure-specific and don't exist on-prem, and that callers must close the connection themselves. Those all pass the "says a rule/limit/quirk" bar, so I left them alone.

No behavior change, comments only.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the full existing test suite for this module: `tests/integrations/test_azure_sql.py` plus all five `tests/tools/test_azure_sql_*_tool.py` files. 84 passed, 0 failed, which is expected since this is a comment-only change.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions