### PR TITLE
chore(messaging_security): remove comments that only restate the next line (SM-76)

### DIFF
--- a/integrations/messaging_security.py
+++ b/integrations/messaging_security.py
@@ -6,8 +6,6 @@ This module implements the identity model for inbound messaging platforms
 1. MessagingIdentityPolicy — per-platform allowlist and pairing config.
 2. DM pairing helpers — one-time code generation, hashing, and verification.
 3. Inbound message authorization — check whether a sender is allowed.
-
-Prerequisite for issue #1482 (conversational loop).
 """
 
 from __future__ import annotations
@@ -236,7 +234,6 @@ def authorize_inbound_message(
             reason="Inbound messaging is not enabled for this platform",
         )
 
-    # Check allowed chat IDs first (if configured).
     # This runs before the /pair check so that pairing cannot bypass chat restrictions.
     # When allowed_chat_ids is set, a None chat_id means the message is from
     # an unidentifiable context (e.g. a DM with no chat_id) — treat as blocked.
@@ -252,7 +249,6 @@ def authorize_inbound_message(
     if user_id in policy.allowed_user_id_set():
         return AuthorizationResult(allowed=True, reason="User is authorized")
 
-    # Check if this is a pairing attempt (only when a pairing is actually pending)
     if message_text and message_text.strip().lower().startswith("/pair "):
         if policy.pairing_secret_hash:
             return AuthorizationResult(
@@ -265,7 +261,6 @@ def authorize_inbound_message(
             reason="No pairing is pending",
         )
 
-    # Check allowed user IDs
     if not policy.allowed_user_ids:
         if policy.require_dm_pairing:
             return AuthorizationResult(
@@ -303,7 +298,6 @@ def complete_pairing(
     if not policy.pairing_secret_hash:
         return False, "No pairing is pending. Ask the operator to run `opensre messaging pair`."
 
-    # Check TTL expiry
     if _is_pairing_expired(policy):
         policy.pairing_secret_hash = None
         policy.pairing_created_at = None
@@ -313,7 +307,6 @@ def complete_pairing(
             "Pairing code has expired. Ask the operator to run `opensre messaging pair` again.",
         )
 
-    # Check brute-force limit
     if policy.pairing_attempts >= _MAX_PAIRING_ATTEMPTS:
         policy.pairing_secret_hash = None
         policy.pairing_created_at = None
@@ -333,7 +326,6 @@ def complete_pairing(
             return False, "Too many failed attempts. Pairing code invalidated."
         return False, f"Invalid pairing code. {remaining} attempts remaining."
 
-    # Pairing successful
     if user_id not in policy.allowed_user_id_set():
         policy.allowed_user_ids.append(user_id)
         policy._invalidate_allowed_user_id_cache()


### PR DESCRIPTION
## Summary

Fixes [#4332](https://github.com/Tracer-Cloud/opensre/issues/4332) (Task ID: SM-76)

`integrations/messaging_security.py` had a run of step-list `# Check...` banners that added nothing beyond what the very next line already shows, plus a stale issue-number reference in the module docstring. Cleaned both up.

## Changes

Removed six banner comments, each sitting directly above the line it was just restating:

- `# Check allowed chat IDs first (if configured).`
- `# Check if this is a pairing attempt (only when a pairing is actually pending)`
- `# Check allowed user IDs`
- `# Check TTL expiry`
- `# Check brute-force limit`
- `# Pairing successful`

Also removed `Prerequisite for issue #1482 (conversational loop).` from the module docstring, since the file's own comment rules explicitly say not to put issue numbers in comments.

Kept every comment that explains an actual security rule instead of just narrating the code:

- Why the chat-ID check has to run before the `/pair` check (so pairing can't be used to bypass chat restrictions).
- Why a missing chat ID is treated as blocked rather than allowed.
- Why already-authorized users skip the pairing path entirely (prevents accidentally hijacking a pairing code meant for someone else).
- The cache-invalidation contract on `allowed_user_id_set` (when it gets rebuilt, and that `allowed_user_ids` stays the source of truth).
- Why the HMAC fallback key is derived from the hostname the way it is (unique per machine, deterministic across restarts).

No behavior change, comments only.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the existing test suite for this module, `tests/integrations/test_messaging_security.py`: 33 passed, 0 failed, expected since this is a comment-only change.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions