### PR TITLE
chore(rabbitmq): spell out timeout constant unit (SM-63)

### DIFF
--- a/integrations/rabbitmq/__init__.py
+++ b/integrations/rabbitmq/__init__.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_RABBITMQ_MANAGEMENT_PORT = 15672
 DEFAULT_RABBITMQ_VHOST = "/"
-DEFAULT_RABBITMQ_TIMEOUT_S = 10
+DEFAULT_RABBITMQ_TIMEOUT_SECONDS = 10
 DEFAULT_RABBITMQ_MAX_RESULTS = 50
 
 
@@ -49,7 +49,7 @@ class RabbitMQConfig(StrictConfigModel):
     vhost: str = DEFAULT_RABBITMQ_VHOST
     ssl: bool = False
     verify_ssl: bool = True
-    timeout_seconds: int = Field(default=DEFAULT_RABBITMQ_TIMEOUT_S, gt=0)
+    timeout_seconds: int = Field(default=DEFAULT_RABBITMQ_TIMEOUT_SECONDS, gt=0)
     max_results: int = Field(default=DEFAULT_RABBITMQ_MAX_RESULTS, gt=0, le=200)
     integration_id: str = ""
 


### PR DESCRIPTION
## Summary

Fixes [#4320](https://github.com/Tracer-Cloud/opensre/issues/4320) (Task ID: SM-63)

`DEFAULT_RABBITMQ_TIMEOUT_S` used a short unit suffix instead of spelling out the unit, unlike the rest of the duration constants in this module.

## Changes

Renamed `DEFAULT_RABBITMQ_TIMEOUT_S` to `DEFAULT_RABBITMQ_TIMEOUT_SECONDS` in `integrations/rabbitmq/__init__.py` and updated its only use site (the `timeout_seconds` field default on `RabbitMQConfig`). No other file references this constant, and the function argument `timeout_seconds` itself was left untouched since it already spells out the unit. No behavior change.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the existing RabbitMQ test suite (`tests/integrations/test_rabbitmq.py` and the five `tests/tools/test_rabbitmq_*_tool.py` files): 81 passed, 0 failed.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions