### PR TITLE
chore(cli): spell out session event poll constant unit (SM-60)

### DIFF
--- a/surfaces/cli/investigation/investigate.py
+++ b/surfaces/cli/investigation/investigate.py
@@ -16,7 +16,7 @@ from tools.investigation.session_runner import InvestigationPumpCancelled, check
 
 _logger = logging.getLogger(__name__)
 
-_SESSION_EVENT_POLL_S = 0.25
+_SESSION_EVENT_POLL_SECONDS = 0.25
 
 if TYPE_CHECKING:
     from platform.analytics.cli import InvestigationTracker
@@ -122,7 +122,7 @@ def stream_investigation_cli(
     try:
         while True:
             try:
-                item = event_queue.get(timeout=_SESSION_EVENT_POLL_S)
+                item = event_queue.get(timeout=_SESSION_EVENT_POLL_SECONDS)
             except queue.Empty:
                 continue
             if isinstance(item, BaseException):


### PR DESCRIPTION
## Summary

Fixes [#4317](https://github.com/Tracer-Cloud/opensre/issues/4317) (Task ID: SM-60)

`_SESSION_EVENT_POLL_S` used a short unit suffix instead of spelling out the unit.

## Changes

Renamed `_SESSION_EVENT_POLL_S` to `_SESSION_EVENT_POLL_SECONDS` in `surfaces/cli/investigation/investigate.py` and updated its only use site (the `event_queue.get(timeout=...)` call). No behavior change.

Note: `tools/investigation/session_runner.py` has its own separate module-private constant with the same name. It is not imported from or shared with `investigate.py`, so it is untouched here and out of scope for this task.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the existing test suite for this module (`tests/cli/test_investigate.py` and `tests/cli/test_investigate_positional_alert_file.py`): 16 passed, 0 failed.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions