### PR TITLE
chore(hermes): spell out thread join timeout constant unit (SM-70)

### DIFF
--- a/integrations/hermes/agent.py
+++ b/integrations/hermes/agent.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 IncidentSink = Callable[[HermesIncident], None]
 
 DEFAULT_LOG_PATH: Final[Path] = Path.home() / ".hermes" / "logs" / "errors.log"
-_THREAD_JOIN_TIMEOUT_S: Final[float] = 2.0
+_THREAD_JOIN_TIMEOUT_SECONDS: Final[float] = 2.0
 
 
 class HermesAgent:
@@ -102,7 +102,7 @@ class HermesAgent:
         )
         self._thread.start()
 
-    def stop(self, *, timeout: float = _THREAD_JOIN_TIMEOUT_S) -> None:
+    def stop(self, *, timeout: float = _THREAD_JOIN_TIMEOUT_SECONDS) -> None:
         """Signal the polling thread and wait until it has exited.
 
         The poller is joined for up to ``timeout`` seconds first so slow


### PR DESCRIPTION
## Summary

Fixes [#4327](https://github.com/Tracer-Cloud/opensre/issues/4327) (Task ID: SM-70)

`_THREAD_JOIN_TIMEOUT_S` used a short unit suffix instead of spelling out the unit.

## Changes

Renamed `_THREAD_JOIN_TIMEOUT_S` to `_THREAD_JOIN_TIMEOUT_SECONDS` in `integrations/hermes/agent.py` and updated its only use site (the `stop()` method's `timeout` default). No behavior change.

Note: `tools/system/fleet_monitoring/tail.py` has its own separate module-private constant with the same name. It is not imported from or shared with `agent.py`, so it is untouched here and out of scope for this task.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the existing test suite for this module (`tests/hermes/test_agent.py`): 9 passed, 0 failed.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions