### PR TITLE
chore(fleet_monitoring): spell out duration constant units in tail.py (SM-68)

### DIFF
--- a/tools/system/fleet_monitoring/tail.py
+++ b/tools/system/fleet_monitoring/tail.py
@@ -36,11 +36,11 @@ from tools.system.fleet_monitoring.probe import pid_exists
 
 DEFAULT_MAX_BYTES: Final[int] = 4 * 1024 * 1024
 DEFAULT_QUEUE_MAX: Final[int] = 128
-DEFAULT_POLL_INTERVAL_S: Final[float] = 0.1
+DEFAULT_POLL_INTERVAL_SECONDS: Final[float] = 0.1
 DEFAULT_READ_BUFFER: Final[int] = 4096
 
-_LSOF_TIMEOUT_S: Final[float] = 5.0
-_THREAD_JOIN_TIMEOUT_S: Final[float] = 1.0
+_LSOF_TIMEOUT_SECONDS: Final[float] = 5.0
+_THREAD_JOIN_TIMEOUT_SECONDS: Final[float] = 1.0
 _SENTINEL: Final[object] = object()
 
 
@@ -155,7 +155,7 @@ def _resolve_macos_target(pid: int) -> _ResolvedTarget:
             text=True,
             encoding="utf-8",
             errors="replace",
-            timeout=_LSOF_TIMEOUT_S,
+            timeout=_LSOF_TIMEOUT_SECONDS,
             check=False,
         )
     except FileNotFoundError as exc:
@@ -264,7 +264,7 @@ class AttachSession:
         *,
         buffer_bytes: int = DEFAULT_MAX_BYTES,
         queue_max: int = DEFAULT_QUEUE_MAX,
-        poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+        poll_interval_s: float = DEFAULT_POLL_INTERVAL_SECONDS,
         read_buffer: int = DEFAULT_READ_BUFFER,
     ) -> None:
         self.target = target
@@ -397,7 +397,7 @@ class AttachSession:
             return
         self._closed = True
         self._stop_event.set()
-        self._thread.join(timeout=_THREAD_JOIN_TIMEOUT_S)
+        self._thread.join(timeout=_THREAD_JOIN_TIMEOUT_SECONDS)
         # Closing the fd while the reader is still inside ``read()`` is
         # undefined behavior with buffered IO. With ``buffering=0`` it's
         # tolerated (the read returns EBADF and the thread exits via
@@ -420,7 +420,7 @@ def attach(
     *,
     buffer_bytes: int = DEFAULT_MAX_BYTES,
     queue_max: int = DEFAULT_QUEUE_MAX,
-    poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+    poll_interval_s: float = DEFAULT_POLL_INTERVAL_SECONDS,
     read_buffer: int = DEFAULT_READ_BUFFER,
 ) -> AttachSession:
     """Validate the target eagerly and return a ready-to-iterate session.
@@ -443,7 +443,7 @@ def attach(
 
 __all__ = [
     "DEFAULT_MAX_BYTES",
-    "DEFAULT_POLL_INTERVAL_S",
+    "DEFAULT_POLL_INTERVAL_SECONDS",
     "DEFAULT_QUEUE_MAX",
     "DEFAULT_READ_BUFFER",
     "AttachSession",


### PR DESCRIPTION
## Summary

Fixes [#4325](https://github.com/Tracer-Cloud/opensre/issues/4325) (Task ID: SM-68)

Three named duration constants in this file used short unit suffixes instead of spelling out the unit.

## Changes

Renamed in `tools/system/fleet_monitoring/tail.py`:

- `DEFAULT_POLL_INTERVAL_S` to `DEFAULT_POLL_INTERVAL_SECONDS`
- `_LSOF_TIMEOUT_S` to `_LSOF_TIMEOUT_SECONDS`
- `_THREAD_JOIN_TIMEOUT_S` to `_THREAD_JOIN_TIMEOUT_SECONDS`

Updated every use site in the file, including the `__all__` export for `DEFAULT_POLL_INTERVAL_SECONDS`. Left the `poll_interval_s` function parameter names untouched, as instructed. No behavior change.

Note: `integrations/hermes/tailer.py` and `integrations/hermes/agent.py` have their own separate constants with the same short names. They are not imported from or shared with `tail.py`, so they are untouched here and out of scope for this task.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the existing test suite (`tests/fleet_monitoring/test_tail.py` and `tests/interactive_shell/test_agents_commands.py`, which exercises this module through the trace slash command): 108 passed, 3 failed. The 3 failures are pre-existing and unrelated to this change, they fail identically on unmodified `main` (verified via `git stash`). They are Windows-only environment issues: two exercise `_resolve_linux_target`'s Linux-specific path parsing on a Windows temp path, and one hits a Windows file-locking restriction on renaming an open file. None of them touch the renamed constants.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions