### PR TITLE
chore(investigation): spell out session event poll constant unit (SM-67)

### DIFF
--- a/tools/investigation/session_runner.py
+++ b/tools/investigation/session_runner.py
@@ -18,7 +18,7 @@ from tools.investigation.alert_templates import build_alert_template
 
 _logger = logging.getLogger(__name__)
 
-_SESSION_EVENT_POLL_S = 0.25
+_SESSION_EVENT_POLL_SECONDS = 0.25
 
 StreamRendererFn = Callable[[Iterator[StreamEvent]], dict[str, Any]]
 
@@ -160,7 +160,7 @@ def run_session_alert_payload(
                     _cancel_pump()
                     raise KeyboardInterrupt
                 try:
-                    item = event_queue.get(timeout=_SESSION_EVENT_POLL_S)
+                    item = event_queue.get(timeout=_SESSION_EVENT_POLL_SECONDS)
                 except queue.Empty:
                     continue
                 if isinstance(item, BaseException):


### PR DESCRIPTION
## Summary

Fixes [#4324](https://github.com/Tracer-Cloud/opensre/issues/4324) (Task ID: SM-67)

`_SESSION_EVENT_POLL_S` used a short unit suffix instead of spelling out the unit.

## Changes

Renamed `_SESSION_EVENT_POLL_S` to `_SESSION_EVENT_POLL_SECONDS` in `tools/investigation/session_runner.py` and updated its only use site (the `event_queue.get(timeout=...)` call). No behavior change.

Note: `surfaces/cli/investigation/investigate.py` has its own separate module-private constant with the same name. It is not imported from or shared with `session_runner.py`, so it is untouched here and out of scope for this task.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the existing test suite for this module (`tests/tools/investigation/test_session_runner.py`): 5 passed, 0 failed.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions