### PR TITLE
chore(observability): spell out empty duration constant unit (SM-66)

### DIFF
--- a/platform/observability/otlp_parser.py
+++ b/platform/observability/otlp_parser.py
@@ -17,7 +17,7 @@ _OTLP_SCALAR_KINDS = ("stringValue", "intValue", "boolValue", "doubleValue")
 _NANOSECONDS_PER_MILLISECOND = 1_000_000
 #: Decimal places kept on parsed OTLP durations (ms).
 _OTLP_DURATION_MS_DECIMAL_PLACES = 4
-_EMPTY_DURATION_MS = 0.0
+_EMPTY_DURATION_MILLISECONDS = 0.0
 _UNKNOWN_SPAN_NAME = "unknown"
 
 
@@ -46,9 +46,9 @@ def _duration_ms(start_unix_nano: Any, end_unix_nano: Any) -> float:
         start = int(start_unix_nano)
         end = int(end_unix_nano)
     except (TypeError, ValueError):
-        return _EMPTY_DURATION_MS
+        return _EMPTY_DURATION_MILLISECONDS
     if end <= start:
-        return _EMPTY_DURATION_MS
+        return _EMPTY_DURATION_MILLISECONDS
     return round(
         (end - start) / _NANOSECONDS_PER_MILLISECOND,
         _OTLP_DURATION_MS_DECIMAL_PLACES,


### PR DESCRIPTION
## Summary

Fixes [#4323](https://github.com/Tracer-Cloud/opensre/issues/4323) (Task ID: SM-66)

`_EMPTY_DURATION_MS` used a short unit suffix instead of spelling out the unit.

## Changes

Renamed `_EMPTY_DURATION_MS` to `_EMPTY_DURATION_MILLISECONDS` in `platform/observability/otlp_parser.py` and updated both use sites in `_duration_ms()`. No behavior change.

Left `_OTLP_DURATION_MS_DECIMAL_PLACES` untouched since it isn't named in this task and isn't itself a duration value, it's a decimal-places count.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the test suites exercising this module (`tests/platform/observability/test_otlp_trace.py`, `tests/integrations/grafana/test_tempo.py`, `tests/integrations/tempo/test_client.py`): 21 passed, 0 failed.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions