### PR TITLE
chore(mongodb): spell out timeout constant unit (SM-65)

### DIFF
--- a/integrations/mongodb/__init__.py
+++ b/integrations/mongodb/__init__.py
@@ -28,7 +28,7 @@ from integrations._validation_helpers import report_classify_failure, report_val
 logger = logging.getLogger(__name__)
 
 DEFAULT_MONGODB_AUTH_SOURCE = "admin"
-DEFAULT_MONGODB_TIMEOUT_MS = 5000
+DEFAULT_MONGODB_TIMEOUT_MILLISECONDS = 5000
 DEFAULT_MONGODB_MAX_RESULTS = 50
 
 
@@ -100,8 +100,8 @@ def _get_client(config: MongoDBConfig) -> Any:
         config.connection_string,
         authSource=config.auth_source,
         tls=config.tls,
-        serverSelectionTimeoutMS=DEFAULT_MONGODB_TIMEOUT_MS,
-        connectTimeoutMS=DEFAULT_MONGODB_TIMEOUT_MS,
+        serverSelectionTimeoutMS=DEFAULT_MONGODB_TIMEOUT_MILLISECONDS,
+        connectTimeoutMS=DEFAULT_MONGODB_TIMEOUT_MILLISECONDS,
         socketTimeoutMS=int(config.timeout_seconds * 1000),
         appName="opensre",
     )


### PR DESCRIPTION
## Summary

Fixes [#4322](https://github.com/Tracer-Cloud/opensre/issues/4322) (Task ID: SM-65)

`DEFAULT_MONGODB_TIMEOUT_MS` used a short unit suffix instead of spelling out the unit.

## Changes

Renamed `DEFAULT_MONGODB_TIMEOUT_MS` to `DEFAULT_MONGODB_TIMEOUT_MILLISECONDS` in `integrations/mongodb/__init__.py` and updated both use sites (`serverSelectionTimeoutMS` and `connectTimeoutMS` on the Mongo client). No behavior change.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the existing MongoDB test suite (`tests/integrations/test_mongodb_integration.py` and the five non-Atlas `tests/tools/test_mongodb_*_tool.py` files): 59 passed, 0 failed.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions