### PR TITLE
chore(wizard): use HTTPStatus enum in probes.py (SM-56)

### DIFF
--- a/surfaces/cli/wizard/probes.py
+++ b/surfaces/cli/wizard/probes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import asdict, dataclass
+from http import HTTPStatus
 from pathlib import Path
 from urllib.error import URLError
 from urllib.parse import urlparse
@@ -61,10 +62,10 @@ def probe_remote_target(timeout_seconds: float = 3.0) -> ProbeResult:
     request = Request(url, method="GET")
     try:
         with _open_probe_request(request, timeout_seconds) as response:
-            status = getattr(response, "status", 200)
+            status = getattr(response, "status", HTTPStatus.OK)
             return ProbeResult(
                 target="remote",
-                reachable=200 <= status < 500,
+                reachable=HTTPStatus.OK <= status < HTTPStatus.INTERNAL_SERVER_ERROR,
                 detail=f"Tracer remote target reachable at {url} (HTTP {status})",
             )
     except URLError as err:


### PR DESCRIPTION
## Summary

Fixes [#4314](https://github.com/Tracer-Cloud/opensre/issues/4314) (Task ID: SM-56)

`surfaces/cli/wizard/probes.py` compared raw HTTP status numbers instead of using `http.HTTPStatus`, against the project convention of naming status codes.

## Changes

In `probe_remote_target()`:

- Added `from http import HTTPStatus`
- `getattr(response, "status", 200)` now defaults to `HTTPStatus.OK`
- `200 <= status < 500` is now `HTTPStatus.OK <= status < HTTPStatus.INTERNAL_SERVER_ERROR`

`HTTPStatus` is an `IntEnum`, so it compares against plain ints identically to the literals it replaces, and in this Python version formats in f-strings the same way a plain int does (verified `f"HTTP {HTTPStatus.OK}"` renders `HTTP 200`, not `HTTP HTTPStatus.OK`). No behavior change and no user-facing message changes.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the nearest test suite that exercises this module (`tests/cli/wizard/test_flow.py`, which imports `ProbeResult` from this file): 85 passed, 0 failed. That suite monkeypatches `probe_remote_target` itself rather than exercising its internal status logic, so I also ran a standalone smoke check across the boundary status codes (200, 404, 499, 500, 503) confirming `reachable` and the rendered detail message are identical to the pre-change behavior at every boundary.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions