### PR TITLE
chore(wizard): use HTTPStatus enum in grafana_seed.py (SM-48)

### DIFF
--- a/surfaces/cli/wizard/grafana_seed.py
+++ b/surfaces/cli/wizard/grafana_seed.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import time
 from contextlib import suppress
+from http import HTTPStatus
 from typing import Any
 
 import requests
@@ -24,7 +25,7 @@ def wait_for_loki(timeout_seconds: int = 30) -> None:
     while time.time() < deadline:
         try:
             response = requests.get(f"{LOCAL_LOKI_URL}/ready", timeout=2)
-            if response.status_code == 200:
+            if response.status_code == HTTPStatus.OK:
                 return
             last_error = f"HTTP {response.status_code}"
         except requests.RequestException as exc:


### PR DESCRIPTION
## Summary

Fixes [#4306](https://github.com/Tracer-Cloud/opensre/issues/4306) (Task ID: SM-48)

`surfaces/cli/wizard/grafana_seed.py` compared a raw HTTP status number instead of using `http.HTTPStatus`, against the project convention of naming status codes.

## Changes

In `wait_for_loki()`:

- Added `from http import HTTPStatus`
- `response.status_code == 200` is now `response.status_code == HTTPStatus.OK`

`HTTPStatus` is an `IntEnum`, so it compares equal to a plain int identically to the literal it replaces. No behavior change and no user-facing message changes.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

No dedicated unit test file exists for this module (`tests/integrations/grafana/test_seed_calls.py` and `tests/cli/wizard/test_configurators_observability.py` only reference it by name in an unrelated context, they don't exercise `wait_for_loki`). Ran a standalone smoke check across status codes (200, 201, 404, 503) confirming only exactly 200 succeeds and every other code raises the same `SystemExit` with the same message as before the change.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions