### PR TITLE
refactor(deployment): name the gateway deployment modules after what they do

### DIFF
--- a/.env.deploy.example
+++ b/.env.deploy.example
@@ -21,7 +21,7 @@ AWS_SECRET_ACCESS_KEY=your_secret_access_key
 # AWS_ROLE_ARN=arn:aws:iam::123456789012:role/YourDeployRole
 # AWS_EXTERNAL_ID=optional_external_id
 
-# ─── Gateway deploy (make bake-gateway / make deploy-gateway) ───────────────
+# ─── Gateway deploy (make build-gateway-image / make deploy-gateway) ────────
 # Optional: git ref (commit SHA, tag, or branch) to bake into the gateway AMI.
 # Defaults to the local git HEAD commit SHA at bake time.
 # The ref must exist on GitHub — push your branch/commit before baking.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -67,7 +67,7 @@ deploys launch from that AMI in ~2–3 minutes.
 
 ```bash
 # Step 1 — bake a gateway AMI (run once per code change, takes ~5-10 minutes):
-make bake-gateway
+make build-gateway-image
 
 # Step 2 — launch EC2 instance from the saved AMI (fast):
 make deploy-gateway
@@ -109,8 +109,8 @@ Restrict the allowed source CIDR with `OPENSRE_WEB_API_INGRESS_CIDR` (default `0
 Installs OpenSRE inline on a fresh EC2 instance via SSM — slower but requires no bake step:
 
 ```bash
-make deploy-gateway-direct
-make destroy-gateway-direct
+make install-gateway-on-new-server
+make destroy-gateway-on-new-server
 ```
 
 ---
@@ -123,7 +123,7 @@ make destroy-gateway-direct
 | Runtime | Docker inside EC2 | systemd on EC2 host |
 | Shell access | Inside slim container | Full EC2 host |
 | ECR repository | Required | Not needed |
-| Update path | `make build-image && make deploy` | `make bake-gateway && make deploy-gateway` |
+| Update path | `make build-image && make deploy` | `make build-gateway-image && make deploy-gateway` |
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ export
 	trigger-alert trigger-alert-verify regen-trigger-config \
 	prefect-local-test run dev docs-dev \
 	build-image deploy destroy test-deploy \
-	bake-gateway deploy-gateway destroy-gateway \
-	deploy-gateway-direct destroy-gateway-direct \
+	build-gateway-image deploy-gateway destroy-gateway \
+	install-gateway-on-new-server destroy-gateway-on-new-server \
 	deploy-lambda deploy-prefect deploy-flink destroy-lambda destroy-prefect destroy-flink \
 	test test-full test-cov test-scope test-cli-smoke test-turn-live test-grafana \
 	rabbitmq-local-up rabbitmq-local-down test-rabbitmq-real \
@@ -302,8 +302,8 @@ test-deploy:
 
 # Gateway deploy (Telegram and/or Slack Socket Mode; no Docker/ECR)
 # Step 1 — bake once per code change (launches temp EC2, installs opensre, snapshots AMI):
-bake-gateway:
-	$(PYTHON) -m platform.deployment.gateway.lifecycle bake-ami
+build-gateway-image:
+	$(PYTHON) -m platform.deployment.gateway.lifecycle build-server-image
 
 # Step 2 — launch gateway instance from pre-baked AMI (fast):
 deploy-gateway:
@@ -313,11 +313,11 @@ destroy-gateway:
 	$(PYTHON) -m platform.deployment.gateway.lifecycle destroy
 
 # Gateway direct deploy (no pre-baked AMI — installs inline via SSM)
-deploy-gateway-direct:
-	$(PYTHON) -m platform.deployment.gateway.lifecycle deploy-direct
+install-gateway-on-new-server:
+	$(PYTHON) -m platform.deployment.gateway.lifecycle install-on-new-server
 
-destroy-gateway-direct:
-	$(PYTHON) -m platform.deployment.gateway.lifecycle destroy-direct
+destroy-gateway-on-new-server:
+	$(PYTHON) -m platform.deployment.gateway.lifecycle destroy-installed-server
 
 # Deploy Lambda test case
 deploy-lambda:
@@ -499,8 +499,10 @@ help:
 	@echo "  make test-deploy       - Run EC2 deployment e2e tests"
 	@echo ""
 	@echo "  GATEWAY DEPLOY (systemd, no Docker — gateway only)"
-	@echo "  make bake-gateway    - Bake a gateway AMI (run once per code change; saves AMI id locally)"
-	@echo "  make deploy-gateway  - Launch gateway EC2 instance from pre-baked AMI (fast)"
+	@echo "  make build-gateway-image - Build a server image with the gateway installed (saves the image id locally)"
+	@echo "  make deploy-gateway  - Start a gateway server from the image built above (fast)"
+	@echo "  make install-gateway-on-new-server  - Start a plain server and install the gateway on it (no image)"
+	@echo "  make destroy-gateway-on-new-server  - Tear down the server created by the command above"
 	@echo "  make destroy-gateway - Terminate gateway instance and clean up (set OPENSRE_GATEWAY_DESTROY_PURGE_AMI=1 to also deregister AMI)"
 	@echo ""
 	@echo "  E2E TEST INFRA (AWS SDK)"

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ opensre uninstall   # remove opensre and all local data
 Two primary AWS EC2 paths and a general hosted option:
 
 - **EC2 (Docker/ECR):** `make build-image` then `make deploy` — runs `opensre-web` and `opensre-gateway` containers on one instance.
-- **Gateway (AMI + systemd):** `make bake-gateway` then `make deploy-gateway` — Telegram gateway only, no Docker, baked into a custom AMI.
+- **Gateway (AMI + systemd):** `make build-gateway-image` then `make deploy-gateway` — Telegram gateway only, no Docker; the gateway is installed into a server image that new servers start from.
 - **Hosted (Railway / ECS / Vercel):** deploy with the repo `Dockerfile`; set `LLM_PROVIDER` and the matching API key (see [`.env.example`](.env.example)), plus `DATABASE_URI` and `REDIS_URI` if persistence is needed.
 
 **[Full deployment steps and prerequisites → DEPLOYMENT.md](DEPLOYMENT.md)**

--- a/core/llm/providers/azure_openai.py
+++ b/core/llm/providers/azure_openai.py
@@ -106,7 +106,7 @@ def azure_deployment_not_found_remediation_steps() -> list[str]:
     return [
         (
             "Set AZURE_OPENAI_*_MODEL to your deployment name from the Azure portal, "
-            "not a model ID from /openai/models."
+            + "not a model ID from /openai/models."
         ),
         f"List deployments: {azure_deployments_list_curl_command()}",
         "Create or rename the deployment in Azure AI Foundry if needed.",

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -99,7 +99,7 @@ Quick reference:
 | Path | Commands |
 | ---- | -------- |
 | EC2 (Docker/ECR — web + gateway) | `make build-image` → `make deploy` / `make destroy` |
-| Gateway (AMI + systemd — gateway only) | `make bake-gateway` → `make deploy-gateway` / `make destroy-gateway` |
+| Gateway (AMI + systemd — gateway only) | `make build-gateway-image` → `make deploy-gateway` / `make destroy-gateway` |
 | Hosted (Railway / ECS / Vercel) | Deploy with repo `Dockerfile`; set `LLM_PROVIDER` + API key |
 
 ### Hosted runtime (Railway / ECS / Vercel)

--- a/docs/principal-scoped-storage.mdx
+++ b/docs/principal-scoped-storage.mdx
@@ -77,42 +77,6 @@ With no scope bound — a terminal run — every path resolves to the flat
 Alice and Bob in the same Slack thread get different session files and different
 binding rows. They share the org's integrations store.
 
-## Many teammates on one silo
-
-One gateway process serves one organization. Teammates share credentials and the
-credit bill; they do not share conversation transcripts.
-
-| Piece | Stateful? | Shared across teammates? |
-| --- | --- | --- |
-| Agent / `HeadlessAgent` | No — new instance every turn | N/A |
-| Session JSONL | Yes — under `users/<slack_user_id>/sessions/` | No (per actor) |
-| `gateway/bindings.json` | Yes — one org file | File shared; rows keyed by actor |
-| `integrations.json` | Yes | Yes (org) |
-
-Concurrency: Socket Mode / Telegram each use a small thread pool. Turns in the
-**same** Slack thread are serialized by a conversation lock; Alice and Bob still
-keep separate session bindings. Different threads can run in parallel.
-
-```mermaid
-flowchart TB
-  subgraph shared ["Org-shared"]
-    I[integrations.json]
-    B[bindings.json]
-  end
-  subgraph private ["Per Slack user"]
-    A[users/U_ALICE/sessions]
-    C[users/U_BOB/sessions]
-  end
-  Turn[Stateless agent turn] --> I
-  Turn --> B
-  Turn --> A
-  Turn --> C
-```
-
-Regression coverage: `gateway/tests/test_multi_actor_concurrency.py` (store) and
-`gateway/tests/slack/test_dispatcher_multi_actor.py` (dispatcher + real
-session resolver).
-
 ## Other surfaces
 
 `principal` and `actor` are optional on the binding store and resolver. Callers

--- a/docs/principal-scoped-storage.mdx
+++ b/docs/principal-scoped-storage.mdx
@@ -77,6 +77,42 @@ With no scope bound — a terminal run — every path resolves to the flat
 Alice and Bob in the same Slack thread get different session files and different
 binding rows. They share the org's integrations store.
 
+## Many teammates on one silo
+
+One gateway process serves one organization. Teammates share credentials and the
+credit bill; they do not share conversation transcripts.
+
+| Piece | Stateful? | Shared across teammates? |
+| --- | --- | --- |
+| Agent / `HeadlessAgent` | No — new instance every turn | N/A |
+| Session JSONL | Yes — under `users/<slack_user_id>/sessions/` | No (per actor) |
+| `gateway/bindings.json` | Yes — one org file | File shared; rows keyed by actor |
+| `integrations.json` | Yes | Yes (org) |
+
+Concurrency: Socket Mode / Telegram each use a small thread pool. Turns in the
+**same** Slack thread are serialized by a conversation lock; Alice and Bob still
+keep separate session bindings. Different threads can run in parallel.
+
+```mermaid
+flowchart TB
+  subgraph shared ["Org-shared"]
+    I[integrations.json]
+    B[bindings.json]
+  end
+  subgraph private ["Per Slack user"]
+    A[users/U_ALICE/sessions]
+    C[users/U_BOB/sessions]
+  end
+  Turn[Stateless agent turn] --> I
+  Turn --> B
+  Turn --> A
+  Turn --> C
+```
+
+Regression coverage: `gateway/tests/test_multi_actor_concurrency.py` (store) and
+`gateway/tests/slack/test_dispatcher_multi_actor.py` (dispatcher + real
+session resolver).
+
 ## Other surfaces
 
 `principal` and `actor` are optional on the binding store and resolver. Callers

--- a/gateway/tests/slack/test_dispatcher_multi_actor.py
+++ b/gateway/tests/slack/test_dispatcher_multi_actor.py
@@ -262,7 +262,7 @@ def test_same_thread_alice_bob_interleaved_turns_stay_isolated(
 
     order = [ALICE, BOB, ALICE, BOB, ALICE, BOB]
     barrier = threading.Barrier(len(order))
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def worker(user_id: str, idx: int) -> None:
         try:
@@ -273,7 +273,7 @@ def test_same_thread_alice_bob_interleaved_turns_stay_isolated(
                 thread_ts=thread_ts,
                 text=f"turn-{idx}",
             )
-        except BaseException as exc:  # noqa: BLE001
+        except Exception as exc:
             errors.append(exc)
 
     threads = [
@@ -313,7 +313,7 @@ def test_many_actors_parallel_turns_all_bindings_survive(
     """Fan-out across N actors / N threads — every binding row remains."""
     n = 8
     barrier = threading.Barrier(n)
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
     sessions: dict[str, str] = {}
     lock = threading.Lock()
 
@@ -343,7 +343,7 @@ def test_many_actors_parallel_turns_all_bindings_survive(
                 thread_ts=f"{1000 + idx}.1",
                 text=f"hi-{idx}",
             )
-        except BaseException as exc:  # noqa: BLE001
+        except Exception as exc:
             errors.append(exc)
 
     threads = [threading.Thread(target=worker, args=(i,), name=f"u{i}") for i in range(n)]

--- a/gateway/tests/slack/test_dispatcher_multi_actor.py
+++ b/gateway/tests/slack/test_dispatcher_multi_actor.py
@@ -1,0 +1,366 @@
+"""Dispatcher-level concurrency: many teammates, distinct sessions, no binding loss.
+
+Complements ``gateway/tests/test_multi_actor_concurrency.py`` (store layer) by
+driving ``_SlackTurnDispatcher._run_turn`` the way the Socket Mode pool does —
+several threads, real ``SessionResolver`` + ``FileBindingStore``, mocked LLM
+handler.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from config.constants import paths
+from config.constants.billing import ORGANIZATION_ID_ENV, USAGE_SECRET_ENV, WEBAPP_URL_ENV
+from config.principal import Principal
+from core.agent_harness.session import InMemorySessionStorage, SessionCore, SessionManager
+from gateway.billing.credits_client import CreditsOutcome
+from gateway.slack.dispatcher import _SlackTurnDispatcher
+from gateway.slack.events import SlackInboundMessage
+from gateway.slack.principal import slack_scope
+from gateway.slack.security import SlackInboundDecision
+from gateway.slack.settings import SlackGatewaySettings
+from gateway.storage import FileBindingStore, SessionResolver
+
+_ORG = "org_dispatcher_concurrency"
+_TEAM = "T_CONC"
+_CHANNEL = "C_SHARED"
+ALICE = "U_ALICE"
+BOB = "U_BOB"
+
+
+class _FakeMessagingClient:
+    def __init__(self) -> None:
+        self.posts: list[dict[str, Any]] = []
+        self.updates: list[dict[str, Any]] = []
+        self.reactions: list[dict[str, str]] = []
+
+    def post_message(
+        self,
+        *,
+        channel: str,
+        text: str,
+        thread_ts: str | None = None,
+        blocks: Any = None,
+    ) -> str | None:
+        self.posts.append(
+            {"channel": channel, "text": text, "thread_ts": thread_ts, "blocks": blocks}
+        )
+        return f"ts-{len(self.posts)}"
+
+    def update_message(self, *, channel: str, ts: str, text: str, blocks: Any = None) -> bool:
+        self.updates.append({"channel": channel, "ts": ts, "text": text, "blocks": blocks})
+        return True
+
+    def add_reaction(self, *, channel: str, timestamp: str, emoji: str) -> bool:
+        self.reactions.append(
+            {"op": "add", "channel": channel, "timestamp": timestamp, "emoji": emoji}
+        )
+        return True
+
+    def remove_reaction(self, *, channel: str, timestamp: str, emoji: str) -> bool:
+        self.reactions.append(
+            {"op": "remove", "channel": channel, "timestamp": timestamp, "emoji": emoji}
+        )
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+    monkeypatch.delenv(paths.CONTEXT_ROOT_ENV, raising=False)
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, _ORG)
+    for name in (WEBAPP_URL_ENV, USAGE_SECRET_ENV):
+        monkeypatch.delenv(name, raising=False)
+    return tmp_path
+
+
+@pytest.fixture
+def resolver(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SessionResolver:
+    monkeypatch.setattr(SessionCore, "warm_resolved_integrations", lambda _self, **_k: None)
+    monkeypatch.setattr(SessionCore, "hydrate_configured_integrations", lambda _self: None)
+    store = FileBindingStore(tmp_path / "bindings.json")
+    repo = SimpleNamespace(load_session=lambda _session_id: None)
+    manager = SessionManager(storage=InMemorySessionStorage(), repo=repo)
+    return SessionResolver(store, manager=manager, platform="slack")
+
+
+def _settings() -> SlackGatewaySettings:
+    return SlackGatewaySettings(
+        bot_token="xoxb-test",
+        app_token="xapp-test",
+        allowed_user_ids=[],
+        allow_open_workspace=True,
+        status_update_interval_seconds=0.01,
+        turn_timeout_seconds=60.0,
+    )
+
+
+def _inbound(*, user_id: str, thread_ts: str, text: str = "hello") -> SlackInboundMessage:
+    return SlackInboundMessage(
+        team_id=_TEAM,
+        user_id=user_id,
+        channel_id=_CHANNEL,
+        ts=thread_ts,
+        thread_ts=thread_ts,
+        text=text,
+    )
+
+
+def _join(threads: list[threading.Thread], timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    for thread in threads:
+        thread.join(timeout=max(0.0, deadline - time.monotonic()))
+    alive = [t.name for t in threads if t.is_alive()]
+    assert not alive, f"threads still running: {alive}"
+
+
+def _run_turn(
+    dispatcher: _SlackTurnDispatcher,
+    *,
+    user_id: str,
+    thread_ts: str,
+    text: str = "hello",
+) -> None:
+    inbound = _inbound(user_id=user_id, thread_ts=thread_ts, text=text)
+    scope = slack_scope(Principal.org(_ORG), user_id)
+    dispatcher._run_turn(inbound, scope)
+
+
+@pytest.fixture
+def allow_all_security():
+    decision = SlackInboundDecision(allowed=True)
+    with (
+        patch(
+            "gateway.slack.dispatcher.enforce_inbound_slack_message_security",
+            return_value=decision,
+        ),
+        patch("gateway.slack.dispatcher.persist_policy_if_needed"),
+        patch("gateway.slack.dispatcher.session_needs_thread_seed", return_value=False),
+        patch(
+            "gateway.slack.dispatcher.consume_credits",
+            return_value=CreditsOutcome.UNCONFIGURED,
+        ),
+        patch("gateway.slack.dispatcher.mark_turn_working"),
+        patch("gateway.slack.dispatcher.mark_turn_done"),
+        patch("gateway.slack.dispatcher.mark_turn_failed"),
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("allow_all_security")
+def test_concurrent_alice_bob_different_threads_keep_distinct_sessions(
+    resolver: SessionResolver,
+) -> None:
+    """Parallel pool turns (different Slack threads) must not share sessions."""
+    turns: list[tuple[str, str]] = []
+    lock = threading.Lock()
+    barrier = threading.Barrier(2)
+
+    def handler(text: str, session: Any, sink: Any, _logger: logging.Logger) -> None:
+        barrier.wait(timeout=5)
+        with lock:
+            # user id is embedded in the agent text prefix.
+            turns.append((text, session.session_id))
+        sink.finalize("ok")
+
+    dispatcher = _SlackTurnDispatcher(
+        settings=_settings(),
+        messaging=_FakeMessagingClient(),
+        session_resolver=resolver,
+        handler=handler,
+        logger=logging.getLogger("test.conc"),
+    )
+
+    threads = [
+        threading.Thread(
+            target=_run_turn,
+            kwargs={"dispatcher": dispatcher, "user_id": ALICE, "thread_ts": "100.1"},
+            name="alice",
+        ),
+        threading.Thread(
+            target=_run_turn,
+            kwargs={"dispatcher": dispatcher, "user_id": BOB, "thread_ts": "200.1"},
+            name="bob",
+        ),
+    ]
+    for t in threads:
+        t.start()
+    _join(threads)
+
+    assert len(turns) == 2
+    by_user = {}
+    for text, session_id in turns:
+        if f"user=<@{ALICE}>" in text:
+            by_user[ALICE] = session_id
+        elif f"user=<@{BOB}>" in text:
+            by_user[BOB] = session_id
+    assert set(by_user) == {ALICE, BOB}
+    assert by_user[ALICE] != by_user[BOB]
+
+    alice_bound = resolver._bindings.get_session_id(
+        platform="slack",
+        chat_id=f"{_TEAM}:{_CHANNEL}:100.1",
+        principal=Principal.org(_ORG),
+        actor=ALICE,
+    )
+    bob_bound = resolver._bindings.get_session_id(
+        platform="slack",
+        chat_id=f"{_TEAM}:{_CHANNEL}:200.1",
+        principal=Principal.org(_ORG),
+        actor=BOB,
+    )
+    assert alice_bound == by_user[ALICE]
+    assert bob_bound == by_user[BOB]
+    # Cross-actor lookups on the other conversation must miss.
+    assert (
+        resolver._bindings.get_session_id(
+            platform="slack",
+            chat_id=f"{_TEAM}:{_CHANNEL}:100.1",
+            principal=Principal.org(_ORG),
+            actor=BOB,
+        )
+        is None
+    )
+
+
+@pytest.mark.usefixtures("allow_all_security")
+def test_same_thread_alice_bob_interleaved_turns_stay_isolated(
+    resolver: SessionResolver,
+) -> None:
+    """Same Slack thread: conversation lock serializes, sessions stay per actor."""
+    thread_ts = "300.1"
+    conversation_key = f"{_TEAM}:{_CHANNEL}:{thread_ts}"
+    seen: list[tuple[str, str]] = []
+    lock = threading.Lock()
+
+    def handler(text: str, session: Any, sink: Any, _logger: logging.Logger) -> None:
+        with lock:
+            if f"user=<@{ALICE}>" in text:
+                seen.append((ALICE, session.session_id))
+            elif f"user=<@{BOB}>" in text:
+                seen.append((BOB, session.session_id))
+        # Brief pause so the other thread contends on the conversation lock.
+        time.sleep(0.02)
+        sink.finalize("ok")
+
+    dispatcher = _SlackTurnDispatcher(
+        settings=_settings(),
+        messaging=_FakeMessagingClient(),
+        session_resolver=resolver,
+        handler=handler,
+        logger=logging.getLogger("test.same-thread"),
+    )
+
+    order = [ALICE, BOB, ALICE, BOB, ALICE, BOB]
+    barrier = threading.Barrier(len(order))
+    errors: list[BaseException] = []
+
+    def worker(user_id: str, idx: int) -> None:
+        try:
+            barrier.wait(timeout=5)
+            _run_turn(
+                dispatcher,
+                user_id=user_id,
+                thread_ts=thread_ts,
+                text=f"turn-{idx}",
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=worker, args=(user_id, i), name=f"{user_id}-{i}")
+        for i, user_id in enumerate(order)
+    ]
+    for t in threads:
+        t.start()
+    _join(threads)
+
+    assert not errors, errors
+    assert len(seen) == 6
+    alice_ids = {sid for user, sid in seen if user == ALICE}
+    bob_ids = {sid for user, sid in seen if user == BOB}
+    assert len(alice_ids) == 1
+    assert len(bob_ids) == 1
+    assert alice_ids.isdisjoint(bob_ids)
+
+    assert resolver._bindings.get_session_id(
+        platform="slack",
+        chat_id=conversation_key,
+        principal=Principal.org(_ORG),
+        actor=ALICE,
+    ) == next(iter(alice_ids))
+    assert resolver._bindings.get_session_id(
+        platform="slack",
+        chat_id=conversation_key,
+        principal=Principal.org(_ORG),
+        actor=BOB,
+    ) == next(iter(bob_ids))
+
+
+@pytest.mark.usefixtures("allow_all_security")
+def test_many_actors_parallel_turns_all_bindings_survive(
+    resolver: SessionResolver,
+) -> None:
+    """Fan-out across N actors / N threads — every binding row remains."""
+    n = 8
+    barrier = threading.Barrier(n)
+    errors: list[BaseException] = []
+    sessions: dict[str, str] = {}
+    lock = threading.Lock()
+
+    def handler(text: str, session: Any, sink: Any, _logger: logging.Logger) -> None:
+        barrier.wait(timeout=5)
+        for i in range(n):
+            uid = f"U_{i:03d}"
+            if f"user=<@{uid}>" in text:
+                with lock:
+                    sessions[uid] = session.session_id
+                break
+        sink.finalize("ok")
+
+    dispatcher = _SlackTurnDispatcher(
+        settings=_settings(),
+        messaging=_FakeMessagingClient(),
+        session_resolver=resolver,
+        handler=handler,
+        logger=logging.getLogger("test.fanout"),
+    )
+
+    def worker(idx: int) -> None:
+        try:
+            _run_turn(
+                dispatcher,
+                user_id=f"U_{idx:03d}",
+                thread_ts=f"{1000 + idx}.1",
+                text=f"hi-{idx}",
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,), name=f"u{i}") for i in range(n)]
+    for t in threads:
+        t.start()
+    _join(threads)
+
+    assert not errors, errors
+    assert set(sessions) == {f"U_{i:03d}" for i in range(n)}
+    assert len(set(sessions.values())) == n
+
+    for i in range(n):
+        uid = f"U_{i:03d}"
+        bound = resolver._bindings.get_session_id(
+            platform="slack",
+            chat_id=f"{_TEAM}:{_CHANNEL}:{1000 + i}.1",
+            principal=Principal.org(_ORG),
+            actor=uid,
+        )
+        assert bound == sessions[uid]

--- a/gateway/tests/test_multi_actor_concurrency.py
+++ b/gateway/tests/test_multi_actor_concurrency.py
@@ -92,7 +92,7 @@ def test_concurrent_alice_bob_bind_same_thread_keeps_both_rows(bindings_path: Pa
     """Two actors binding the same Slack thread at once must both survive."""
     store = FileBindingStore(bindings_path)
     barrier = threading.Barrier(2)
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def worker(actor: str, session_id: str) -> None:
         try:
@@ -104,7 +104,7 @@ def test_concurrent_alice_bob_bind_same_thread_keeps_both_rows(bindings_path: Pa
                 principal=ACME,
                 actor=actor,
             )
-        except BaseException as exc:  # noqa: BLE001 — collect for assert
+        except Exception as exc:
             errors.append(exc)
 
     threads = [
@@ -140,7 +140,7 @@ def test_concurrent_many_actors_all_bindings_survive(bindings_path: Path) -> Non
     store = FileBindingStore(bindings_path)
     n = 12
     barrier = threading.Barrier(n)
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def worker(idx: int) -> None:
         actor = f"U_{idx:03d}"
@@ -159,7 +159,7 @@ def test_concurrent_many_actors_all_bindings_survive(bindings_path: Path) -> Non
                 platform=_PLATFORM, chat_id=_THREAD, principal=ACME, actor=actor
             )
             assert got == f"sess-{idx}"
-        except BaseException as exc:  # noqa: BLE001
+        except Exception as exc:
             errors.append(exc)
 
     threads = [threading.Thread(target=worker, args=(i,), name=f"u{i}") for i in range(n)]
@@ -189,7 +189,7 @@ def test_concurrent_rotate_same_actor_leaves_valid_document(bindings_path: Path)
     )
     n = 8
     barrier = threading.Barrier(n)
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
     winners: list[str] = []
 
     def worker() -> None:
@@ -197,7 +197,7 @@ def test_concurrent_rotate_same_actor_leaves_valid_document(bindings_path: Path)
             barrier.wait(timeout=5)
             new_id = store.rotate(platform=_PLATFORM, chat_id=_THREAD, principal=ACME, actor=ALICE)
             winners.append(new_id)
-        except BaseException as exc:  # noqa: BLE001
+        except Exception as exc:
             errors.append(exc)
 
     threads = [threading.Thread(target=worker, name=f"rot{i}") for i in range(n)]
@@ -267,7 +267,7 @@ def test_concurrent_alice_bob_session_appends_do_not_mix() -> None:
     """Scoped writers append into different trees; neither sees the other's lines."""
     storage = JsonlSessionStorage()
     barrier = threading.Barrier(2)
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
     paths_seen: dict[str, str] = {}
 
     def worker(actor: str, session_id: str, marker: str) -> None:
@@ -290,7 +290,7 @@ def test_concurrent_alice_bob_session_appends_do_not_mix() -> None:
                 texts = [r.get("content") for r in rows if r.get("type") == "message"]
                 assert all(isinstance(t, str) and t.startswith(marker) for t in texts)
                 assert len(texts) == 20
-        except BaseException as exc:  # noqa: BLE001
+        except Exception as exc:
             errors.append(exc)
 
     threads = [
@@ -332,7 +332,7 @@ def test_same_session_concurrent_appends_remain_line_parseable() -> None:
         path = session_path(session_id)
 
     barrier = threading.Barrier(2)
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def worker(tag: str) -> None:
         try:
@@ -345,7 +345,7 @@ def test_same_session_concurrent_appends_remain_line_parseable() -> None:
                         content=f"{tag}-{i}",
                         metadata={"kind": "chat"},
                     )
-        except BaseException as exc:  # noqa: BLE001
+        except Exception as exc:
             errors.append(exc)
 
     threads = [

--- a/gateway/tests/test_multi_actor_concurrency.py
+++ b/gateway/tests/test_multi_actor_concurrency.py
@@ -1,0 +1,364 @@
+"""Concurrency: many teammates on one org must not corrupt shared indexes or mix sessions.
+
+The safety claim for silo Slack is:
+
+* **Shared** — one ``bindings.json`` (and one ``integrations.json``) per org.
+* **Private** — each actor's session JSONL under ``users/<U>/sessions/``.
+* **Compute** — fresh agent per turn; several turns may run on threads at once.
+
+These tests hammer the shared binding document and per-actor session writers
+the way a busy gateway does (several ``ThreadPoolExecutor`` workers), and check
+for lost rows, unreadable JSON, and cross-actor session bleed.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from config.constants import paths
+from config.constants.billing import ORGANIZATION_ID_ENV
+from config.principal import Actor, Principal, StorageScope
+from config.scope_context import bound_storage_scope
+from core.agent_harness.session.persistence.jsonl_storage import JsonlSessionStorage
+from core.agent_harness.session.persistence.paths import session_path, sessions_dir
+from gateway.storage.session.file_bindings import FileBindingStore
+
+ACME = Principal.org("org_acme")
+ALICE = "U_ALICE"
+BOB = "U_BOB"
+_PLATFORM = "slack"
+_THREAD = "C_SHARED:1.0"
+
+
+class _SessionStub:
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        self.started_at = time.time()
+
+
+@pytest.fixture
+def host(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "host"
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", root)
+    monkeypatch.delenv(paths.CONTEXT_ROOT_ENV, raising=False)
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, ACME.id)
+    return root
+
+
+@pytest.fixture
+def bindings_path(host: Path) -> Path:
+    path = host / "orgs" / ACME.id / "gateway" / "bindings.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _scope(actor_id: str) -> StorageScope:
+    return StorageScope(principal=ACME, actor=Actor(id=actor_id))
+
+
+def _join(threads: list[threading.Thread], timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    for thread in threads:
+        thread.join(timeout=max(0.0, deadline - time.monotonic()))
+    alive = [t.name for t in threads if t.is_alive()]
+    assert not alive, f"threads still running: {alive}"
+
+
+def _read_bindings(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _parseable_jsonl(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        rec = json.loads(line)
+        assert isinstance(rec, dict), f"non-object JSONL line in {path}: {line!r}"
+        rows.append(rec)
+    return rows
+
+
+# ── Shared bindings.json ────────────────────────────────────────────────────
+
+
+def test_concurrent_alice_bob_bind_same_thread_keeps_both_rows(bindings_path: Path) -> None:
+    """Two actors binding the same Slack thread at once must both survive."""
+    store = FileBindingStore(bindings_path)
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+
+    def worker(actor: str, session_id: str) -> None:
+        try:
+            barrier.wait(timeout=5)
+            store.bind(
+                platform=_PLATFORM,
+                chat_id=_THREAD,
+                session_id=session_id,
+                principal=ACME,
+                actor=actor,
+            )
+        except BaseException as exc:  # noqa: BLE001 — collect for assert
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=worker, args=(ALICE, "sess-alice"), name="alice"),
+        threading.Thread(target=worker, args=(BOB, "sess-bob"), name="bob"),
+    ]
+    for t in threads:
+        t.start()
+    _join(threads)
+
+    assert not errors, errors
+    assert (
+        store.get_session_id(platform=_PLATFORM, chat_id=_THREAD, principal=ACME, actor=ALICE)
+        == "sess-alice"
+    )
+    assert (
+        store.get_session_id(platform=_PLATFORM, chat_id=_THREAD, principal=ACME, actor=BOB)
+        == "sess-bob"
+    )
+    data = _read_bindings(bindings_path)
+    assert isinstance(data.get("bindings"), list)
+    keys = {
+        (r.get("principal_id"), r.get("actor_id"), r.get("session_id"))
+        for r in data["bindings"]
+        if isinstance(r, dict)
+    }
+    assert (ACME.id, ALICE, "sess-alice") in keys
+    assert (ACME.id, BOB, "sess-bob") in keys
+
+
+def test_concurrent_many_actors_all_bindings_survive(bindings_path: Path) -> None:
+    """Fan-out like a busy channel: N actors, one shared index, no lost rows."""
+    store = FileBindingStore(bindings_path)
+    n = 12
+    barrier = threading.Barrier(n)
+    errors: list[BaseException] = []
+
+    def worker(idx: int) -> None:
+        actor = f"U_{idx:03d}"
+        try:
+            barrier.wait(timeout=5)
+            store.bind(
+                platform=_PLATFORM,
+                chat_id=_THREAD,
+                session_id=f"sess-{idx}",
+                principal=ACME,
+                actor=actor,
+            )
+            # Interleave reads the way status / has_any_actor_binding does.
+            assert store.has_any_actor_binding(platform=_PLATFORM, chat_id=_THREAD, principal=ACME)
+            got = store.get_session_id(
+                platform=_PLATFORM, chat_id=_THREAD, principal=ACME, actor=actor
+            )
+            assert got == f"sess-{idx}"
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,), name=f"u{i}") for i in range(n)]
+    for t in threads:
+        t.start()
+    _join(threads)
+
+    assert not errors, errors
+    data = _read_bindings(bindings_path)
+    actors = {
+        r.get("actor_id")
+        for r in data["bindings"]
+        if isinstance(r, dict) and r.get("chat_id") == _THREAD
+    }
+    assert actors == {f"U_{i:03d}" for i in range(n)}
+
+
+def test_concurrent_rotate_same_actor_leaves_valid_document(bindings_path: Path) -> None:
+    """Contended writes for one key must not produce unreadable JSON."""
+    store = FileBindingStore(bindings_path)
+    store.bind(
+        platform=_PLATFORM,
+        chat_id=_THREAD,
+        session_id="seed",
+        principal=ACME,
+        actor=ALICE,
+    )
+    n = 8
+    barrier = threading.Barrier(n)
+    errors: list[BaseException] = []
+    winners: list[str] = []
+
+    def worker() -> None:
+        try:
+            barrier.wait(timeout=5)
+            new_id = store.rotate(platform=_PLATFORM, chat_id=_THREAD, principal=ACME, actor=ALICE)
+            winners.append(new_id)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, name=f"rot{i}") for i in range(n)]
+    for t in threads:
+        t.start()
+    _join(threads)
+
+    assert not errors, errors
+    data = _read_bindings(bindings_path)  # must parse
+    alice_rows = [
+        r
+        for r in data["bindings"]
+        if isinstance(r, dict) and r.get("actor_id") == ALICE and r.get("chat_id") == _THREAD
+    ]
+    assert len(alice_rows) == 1
+    final = store.get_session_id(platform=_PLATFORM, chat_id=_THREAD, principal=ACME, actor=ALICE)
+    assert final in winners
+    assert final == alice_rows[0]["session_id"]
+
+
+def _mp_bind_worker(bindings: str, actor: str, session_id: str) -> None:
+    store = FileBindingStore(Path(bindings))
+    store.bind(
+        platform=_PLATFORM,
+        chat_id=_THREAD,
+        session_id=session_id,
+        principal=ACME,
+        actor=actor,
+    )
+
+
+def test_multiprocess_alice_bob_bind_no_corrupt_json(bindings_path: Path) -> None:
+    """Two OS processes (closer to two writers) must leave a valid document."""
+    ctx = multiprocessing.get_context("spawn")
+    procs = [
+        ctx.Process(target=_mp_bind_worker, args=(str(bindings_path), ALICE, "sess-alice-mp")),
+        ctx.Process(target=_mp_bind_worker, args=(str(bindings_path), BOB, "sess-bob-mp")),
+    ]
+    for p in procs:
+        p.start()
+    deadline = time.monotonic() + 30
+    for p in procs:
+        p.join(timeout=max(0.0, deadline - time.monotonic()))
+    alive = [p.pid for p in procs if p.is_alive()]
+    for p in procs:
+        if p.is_alive():
+            p.terminate()
+            p.join(5)
+    assert not alive, f"processes hung: {alive}"
+    assert all(p.exitcode == 0 for p in procs), [p.exitcode for p in procs]
+
+    data = _read_bindings(bindings_path)
+    by_actor = {
+        r["actor_id"]: r["session_id"]
+        for r in data["bindings"]
+        if isinstance(r, dict) and r.get("chat_id") == _THREAD
+    }
+    assert by_actor[ALICE] == "sess-alice-mp"
+    assert by_actor[BOB] == "sess-bob-mp"
+
+
+# ── Per-actor session JSONL ─────────────────────────────────────────────────
+
+
+@pytest.mark.usefixtures("host")
+def test_concurrent_alice_bob_session_appends_do_not_mix() -> None:
+    """Scoped writers append into different trees; neither sees the other's lines."""
+    storage = JsonlSessionStorage()
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+    paths_seen: dict[str, str] = {}
+
+    def worker(actor: str, session_id: str, marker: str) -> None:
+        try:
+            with bound_storage_scope(_scope(actor)):
+                barrier.wait(timeout=5)
+                stub = _SessionStub(session_id)
+                storage.open_session(stub)
+                for i in range(20):
+                    storage.append_message(
+                        session_id,
+                        role="user",
+                        content=f"{marker}-{i}",
+                        metadata={"kind": "chat", "actor": actor},
+                    )
+                path = session_path(session_id)
+                paths_seen[actor] = str(path)
+                assert actor in str(path)
+                rows = _parseable_jsonl(path)
+                texts = [r.get("content") for r in rows if r.get("type") == "message"]
+                assert all(isinstance(t, str) and t.startswith(marker) for t in texts)
+                assert len(texts) == 20
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=worker, args=(ALICE, "alice-sess", "alice"), name="alice"),
+        threading.Thread(target=worker, args=(BOB, "bob-sess", "bob"), name="bob"),
+    ]
+    for t in threads:
+        t.start()
+    _join(threads)
+
+    assert not errors, errors
+    assert paths_seen[ALICE] != paths_seen[BOB]
+    alice_text = Path(paths_seen[ALICE]).read_text(encoding="utf-8")
+    bob_text = Path(paths_seen[BOB]).read_text(encoding="utf-8")
+    assert "alice-" in alice_text and "bob-" not in alice_text
+    assert "bob-" in bob_text and "alice-" not in bob_text
+    # Org integrations root stays shared; session homes stay private.
+    with bound_storage_scope(_scope(ALICE)):
+        alice_sessions = sessions_dir()
+    with bound_storage_scope(_scope(BOB)):
+        bob_sessions = sessions_dir()
+    assert alice_sessions != bob_sessions
+    assert ALICE in str(alice_sessions)
+    assert BOB in str(bob_sessions)
+
+
+@pytest.mark.usefixtures("host")
+def test_same_session_concurrent_appends_remain_line_parseable() -> None:
+    """If two threads append the same file (lock skipped), lines must stay JSON.
+
+    Production serializes per conversation, so this should not happen for one
+    actor. The test pins whether the append-only writer is still safe under
+    accidental double-entry — a regression tripwire for data corruption.
+    """
+    storage = JsonlSessionStorage()
+    session_id = "shared-sess"
+    with bound_storage_scope(_scope(ALICE)):
+        storage.open_session(_SessionStub(session_id))
+        path = session_path(session_id)
+
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+
+    def worker(tag: str) -> None:
+        try:
+            with bound_storage_scope(_scope(ALICE)):
+                barrier.wait(timeout=5)
+                for i in range(40):
+                    storage.append_message(
+                        session_id,
+                        role="assistant",
+                        content=f"{tag}-{i}",
+                        metadata={"kind": "chat"},
+                    )
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=worker, args=("a",), name="a"),
+        threading.Thread(target=worker, args=("b",), name="b"),
+    ]
+    for t in threads:
+        t.start()
+    _join(threads)
+
+    assert not errors, errors
+    rows = _parseable_jsonl(path)
+    messages = [r for r in rows if r.get("type") == "message"]
+    assert len(messages) == 80
+    contents = {r.get("content") for r in messages}
+    assert {f"a-{i}" for i in range(40)} | {f"b-{i}" for i in range(40)} <= contents

--- a/integrations/kubernetes/tools/__init__.py
+++ b/integrations/kubernetes/tools/__init__.py
@@ -471,7 +471,7 @@ class KubernetesDescribePodTool(BaseTool):
     ]
     anti_examples = [
         "Fetching a non-pod resource such as a deployment, service, or node (use "
-        "kubernetes_get_resource)",
+        + "kubernetes_get_resource)",
         "Listing many pods at once (use kubernetes_list_pods)",
     ]
     surfaces = ("investigation", "chat")
@@ -1105,9 +1105,9 @@ class KubernetesGetResourceTool(BaseTool):
     ]
     anti_examples = [
         "Inspecting a pod's containers, conditions, or env var keys (use "
-        "kubernetes_describe_pod — same detail, redacts env values)",
+        + "kubernetes_describe_pod — same detail, redacts env values)",
         "Listing multiple resources or filtering by label/field selector (use the "
-        "matching kubernetes_list_* tool instead)",
+        + "matching kubernetes_list_* tool instead)",
     ]
     surfaces = ("investigation", "chat")
     requires = ["resource_type", "name"]

--- a/platform/deployment/ecr_deploy/instance.py
+++ b/platform/deployment/ecr_deploy/instance.py
@@ -296,8 +296,8 @@ def wait_for_web_process(
                     f"{docker} ps --filter name={container_name} --filter status=running -q",
                     (
                         "curl -sf http://localhost:8000/health 2>/dev/null "
-                        "|| curl -sf http://localhost:8000/ok 2>/dev/null "
-                        "|| true"
+                        + "|| curl -sf http://localhost:8000/ok 2>/dev/null "
+                        + "|| true"
                     ),
                 ],
                 region=region,

--- a/platform/deployment/gateway/README.md
+++ b/platform/deployment/gateway/README.md
@@ -12,11 +12,12 @@ inside the gateway session.
 
 | Path | Purpose |
 | ---- | ------- |
-| `systemd/opensre-gateway.service` | systemd unit file baked into the AMI. Reads env from `/etc/opensre/gateway.env`. |
+| `systemd/opensre-gateway.service` | systemd unit file included in the server image. Reads env from `/etc/opensre/gateway.env`. |
 | `stack.py` | `GatewayStack` dataclass + helpers to persist AMI id and deployment outputs under `~/.opensre/deployments/`. |
-| `bake.py` | `bake_ami()` — launches a temp builder EC2 instance, runs inline install commands via SSM, snapshots an AMI, and terminates the builder. |
+| `build_server_image.py` | `build_server_image()` — launches a temp builder EC2 instance, runs inline install commands via SSM, snapshots an AMI, and terminates the builder. |
+| `install_on_new_server.py` | `install_on_new_server()` / `destroy_installed_server()` — starts a plain EC2 instance and installs the gateway on it from the published installer, with no image built first. |
 | `provision.py` | `provision_gateway_via_ssm()` and `wait_for_gateway_ready()` — writes `/etc/opensre/gateway.env` and restarts the service via SSM. |
-| `lifecycle.py` | CLI entrypoint: `bake-ami`, `deploy`, `destroy` subcommands. |
+| `lifecycle.py` | CLI entrypoint: `build-server-image`, `deploy`, `destroy`, `install-on-new-server`, `destroy-installed-server` subcommands. |
 
 ## Commands
 
@@ -24,16 +25,20 @@ Run from the **repo root** (`make install` first).
 
 | Command | What it does |
 | ------- | ------------ |
-| `make bake-gateway` | Launch temp EC2, install OpenSRE @ current git HEAD, snapshot AMI, save AMI id locally |
+| `make build-gateway-image` | Launch temp EC2, install OpenSRE @ current git HEAD, snapshot AMI, save AMI id locally |
 | `make deploy-gateway` | Destroy any prior stack, launch EC2 from saved AMI, write env, start service |
 | `make destroy-gateway` | Terminate instance, delete IAM profile/role; AMI kept by default |
+| `make install-gateway-on-new-server` | Start a plain EC2 instance and install the gateway on it, no image needed |
+| `make destroy-gateway-on-new-server` | Tear down the server created by the command above |
 
 Equivalent Python entrypoints:
 
 ```bash
-uv run python -m platform.deployment.gateway.lifecycle bake-ami
+uv run python -m platform.deployment.gateway.lifecycle build-server-image
 uv run python -m platform.deployment.gateway.lifecycle deploy
 uv run python -m platform.deployment.gateway.lifecycle destroy
+uv run python -m platform.deployment.gateway.lifecycle install-on-new-server
+uv run python -m platform.deployment.gateway.lifecycle destroy-installed-server
 ```
 
 ### Prerequisites
@@ -57,8 +62,8 @@ Copy [`.env.deploy.example`](../../../.env.deploy.example) and set
 is deployed and operated separately, not from this repo.
 
 | `LLM_PROVIDER` + API key | Yes | Gateway service |
-| `OPENSRE_GATEWAY_GIT_REF` | No | Git ref to bake (default: local HEAD SHA) |
-| `OPENSRE_GATEWAY_AMI_ID` | No | Skip bake, use existing AMI id |
+| `OPENSRE_GATEWAY_GIT_REF` | No | Git ref to install into the image (default: local HEAD SHA) |
+| `OPENSRE_GATEWAY_AMI_ID` | No | Skip the image build, use an existing image id |
 | `OPENSRE_GATEWAY_DESTROY_PURGE_AMI` | No | Set to `1` to also deregister AMI on destroy |
 | `OPENSRE_STACK_SUFFIX` | No | Per-developer resource name suffix |
 
@@ -76,7 +81,7 @@ Outputs written to `~/.opensre/deployments/opensre-gateway.json`.
 
 ```bash
 # Bake once per code change (takes ~5-10 minutes):
-make bake-gateway
+make build-gateway-image
 
 # Fast redeploy using the saved AMI id (takes ~2-3 minutes):
 make deploy-gateway
@@ -86,7 +91,7 @@ make deploy-gateway
 
 ### Rollback
 
-To roll back to a previously baked AMI:
+To roll back to a previously built image:
 
 ```bash
 OPENSRE_GATEWAY_AMI_ID=ami-<previous-id> make deploy-gateway
@@ -121,4 +126,4 @@ continuity matters.
 | `curl`, `sudo`, `systemctl` | Not available | Available |
 | Dependency install | Baked into Docker image | Baked into AMI |
 | ECR repository | Required | Not needed |
-| Update path | `make build-image && make deploy` | `make bake-gateway && make deploy-gateway` |
+| Update path | `make build-image && make deploy` | `make build-gateway-image && make deploy-gateway` |

--- a/platform/deployment/gateway/build_server_image.py
+++ b/platform/deployment/gateway/build_server_image.py
@@ -1,4 +1,12 @@
-"""Bake a custom AMI with OpenSRE gateway pre-installed."""
+"""Build a reusable server image with the gateway already installed.
+
+Runs once per code change: it starts a temporary server, installs the gateway on
+it, saves the result as an image, and throws the temporary server away. Servers
+started from that image are ready immediately.
+
+The alternative is :mod:`platform.deployment.gateway.install_on_new_server`,
+which installs onto each new server instead of reusing an image.
+"""
 
 from __future__ import annotations
 
@@ -38,12 +46,15 @@ logger = logging.getLogger(__name__)
 _SERVICE_FILE = Path(__file__).parent / "systemd" / "opensre-gateway.service"
 _OPENSRE_REPO = "Tracer-Cloud/opensre"
 
+# These suffixes name live AWS IAM resources for the temporary builder server.
+# Renaming them would orphan anything already deployed, so they keep the older
+# "bake" wording even though the module no longer uses it.
 _BUILDER_ROLE_SUFFIX = "-bake-role"
 _BUILDER_PROFILE_SUFFIX = "-bake-profile"
 
 
 def _resolve_git_ref() -> str:
-    """Return the git ref to bake into the AMI.
+    """Return the git ref to install into the image.
 
     Resolution order:
       1. ``OPENSRE_GATEWAY_GIT_REF`` environment variable.
@@ -98,7 +109,7 @@ def _build_install_commands(git_ref: str) -> list[str]:
         # create system user and persistent data dirs
         (
             "id opensre &>/dev/null || useradd --system --create-home "
-            "--home-dir /var/lib/opensre-gateway --shell /sbin/nologin opensre"
+            + "--home-dir /var/lib/opensre-gateway --shell /sbin/nologin opensre"
         ),
         "mkdir -p /var/lib/opensre-gateway/.opensre/gateway",
         "chown -R opensre:opensre /var/lib/opensre-gateway",
@@ -108,7 +119,7 @@ def _build_install_commands(git_ref: str) -> list[str]:
         f"/opt/opensre/.venv/bin/pip install --quiet {install_url}",
         # smoke-check: verify the CLI is importable
         "/opt/opensre/.venv/bin/opensre --help > /dev/null",
-        # env file directory (populated at deploy time, not bake time)
+        # env file directory (populated at deploy time, not while building the image)
         "mkdir -p /etc/opensre && chmod 750 /etc/opensre && chown root:opensre /etc/opensre",
         # install systemd unit (base64-inlined from local repo)
         (
@@ -120,7 +131,7 @@ def _build_install_commands(git_ref: str) -> list[str]:
     ]
 
 
-def bake_ami(
+def build_server_image(
     *,
     region: str = DEFAULT_REGION,
     ami_id_path: object = None,
@@ -223,7 +234,7 @@ def bake_ami(
 
     print()
     print("=" * 60)
-    print("AMI bake complete")
+    print("Server image build complete")
     print(f"  AMI id : {image_id}")
     print(f"  Git ref: {git_ref}")
     print("  Run `make deploy-gateway` to launch an instance from this AMI.")

--- a/platform/deployment/gateway/install_on_new_server.py
+++ b/platform/deployment/gateway/install_on_new_server.py
@@ -1,3 +1,12 @@
+"""Start a new server and install the gateway on it, with no image built first.
+
+The other path in this package builds a server image once
+(:mod:`platform.deployment.gateway.build_server_image`) so later servers start
+ready. This one skips that: it launches a plain server and installs the gateway
+there and then, by downloading the published installer. Slower per server, but
+nothing to rebuild when the code changes.
+"""
+
 from __future__ import annotations
 
 import base64
@@ -37,6 +46,9 @@ from platform.deployment.gateway.provision import (
 
 # ── Constants ──────────────────────────────────────────────────────────────────
 
+# Names live AWS resources (IAM profile, role, security group) for servers this
+# module created. Renaming it would orphan anything already deployed, so it stays
+# as-is even though the module no longer says "direct".
 _DIRECT_STACK_NAME = "opensre-gateway-direct"
 _STACK_SUFFIX_ENV = "OPENSRE_STACK_SUFFIX"
 _OUTPUTS_DIR = OPENSRE_HOME_DIR / "deployments"
@@ -67,7 +79,7 @@ _SERVICE_NAME = "opensre-gateway"
 _INSTALL_MAX_POLL_ATTEMPTS = 30
 
 # Systemd unit content for the curl-install binary path.
-# ExecStart points to /usr/local/bin/opensre (not the venv path used by bake).
+# ExecStart points to /usr/local/bin/opensre (not the venv path the image build uses).
 _SERVICE_UNIT = """\
 [Unit]
 Description=OpenSRE Gateway Daemon
@@ -127,7 +139,7 @@ def _load_outputs() -> dict[str, Any]:
     if not path.exists():
         raise FileNotFoundError(
             f"No direct-deploy outputs found for stack '{_direct_stack_name()}'. "
-            "Run `make deploy-gateway-direct` first."
+            "Run `make install-gateway-on-new-server` first."
         )
     result = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(result, dict):
@@ -178,7 +190,7 @@ def _build_curl_install_commands() -> list[str]:
         # --no-log-init avoids filling large sparse wtmp/lastlog files on Ubuntu.
         (
             "useradd --system --no-log-init --create-home "
-            "--home-dir /var/lib/opensre-gateway --shell /usr/sbin/nologin opensre || true"
+            + "--home-dir /var/lib/opensre-gateway --shell /usr/sbin/nologin opensre || true"
         ),
         "mkdir -p /var/lib/opensre-gateway/.opensre/gateway",
         "chown -R opensre:opensre /var/lib/opensre-gateway",
@@ -221,7 +233,7 @@ def _format_ssm_failure(result: dict[str, str]) -> str:
 # ── Deploy ─────────────────────────────────────────────────────────────────────
 
 
-def deploy_direct(
+def install_on_new_server(
     *,
     env_vars: dict[str, str] | None = None,
     region: str = DEFAULT_REGION,
@@ -244,7 +256,7 @@ def deploy_direct(
     start_time = time.time()
 
     print("=" * 60)
-    print(f"Deploying {stack_name} (curl installer, no pre-baked AMI)")
+    print(f"Deploying {stack_name} (installer download, no prebuilt image)")
     print("=" * 60)
     print()
 
@@ -338,7 +350,7 @@ def deploy_direct(
 # ── Destroy ────────────────────────────────────────────────────────────────────
 
 
-def destroy_direct(*, region: str = DEFAULT_REGION) -> dict[str, list[str]]:
+def destroy_installed_server(*, region: str = DEFAULT_REGION) -> dict[str, list[str]]:
     """Terminate the direct-deploy EC2 instance and clean up IAM resources."""
     stack_name = _direct_stack_name()
     start_time = time.time()
@@ -437,14 +449,14 @@ def _cleanup_existing(*, region: str = DEFAULT_REGION) -> bool:
         print(f"Terminating stack instance {instance_id}...")
         terminate_instance(instance_id, region)
 
-    # Always run destroy_direct so IAM profile/role are cleaned up even when
-    # the outputs file is missing.  destroy_direct() falls back to derived
+    # Always run destroy_installed_server so IAM profile/role are cleaned up even when
+    # the outputs file is missing.  destroy_installed_server() falls back to derived
     # names ({stack_name}-profile / {stack_name}-role) when no outputs file
     # exists, so orphaned IAM resources are never left behind.
-    destroy_direct(region=region)
+    destroy_installed_server(region=region)
 
     print()
     return True
 
 
-__all__ = ["deploy_direct", "destroy_direct"]
+__all__ = ["install_on_new_server", "destroy_installed_server"]

--- a/platform/deployment/gateway/lifecycle.py
+++ b/platform/deployment/gateway/lifecycle.py
@@ -29,8 +29,11 @@ from platform.deployment.aws.ec2 import (
 )
 from platform.deployment.aws.ssm import wait_for_ssm_registration
 from platform.deployment.ecr_deploy.prep import run_lifecycle_main, validate_deploy_env
-from platform.deployment.gateway.bake import bake_ami
-from platform.deployment.gateway.direct_deploy import deploy_direct, destroy_direct
+from platform.deployment.gateway.build_server_image import build_server_image
+from platform.deployment.gateway.install_on_new_server import (
+    destroy_installed_server,
+    install_on_new_server,
+)
 from platform.deployment.gateway.provision import (
     provision_gateway_via_ssm,
     wait_for_gateway_ready,
@@ -97,7 +100,7 @@ def _resolve_ami_id() -> str:
 
     Resolution order:
       1. ``OPENSRE_GATEWAY_AMI_ID`` environment variable.
-      2. AMI id saved on disk by the last ``make bake-gateway`` run.
+      2. AMI id saved on disk by the last ``make build-gateway-image`` run.
 
     Raises:
         RuntimeError: When neither source is available.
@@ -108,10 +111,10 @@ def _resolve_ami_id() -> str:
     if ami_id_exists():
         return load_ami_id()
     raise RuntimeError(
-        "No pre-built gateway AMI found. Run `make bake-gateway` first to build one, "
+        "No pre-built gateway AMI found. Run `make build-gateway-image` first to build one, "
         f"or set {GATEWAY_AMI_ID_ENV} to an existing AMI id.\n\n"
         "  Quick start:\n"
-        "    make bake-gateway   # bake once, saves AMI id locally\n"
+        "    make build-gateway-image   # build once, saves the image id locally\n"
         "    make deploy-gateway # launch from saved AMI (fast)\n\n"
         "  Or in one step:\n"
         f"    {GATEWAY_AMI_ID_ENV}=<ami-id> make deploy-gateway"
@@ -247,7 +250,7 @@ def destroy() -> dict[str, list[str]]:
     """Terminate the EC2 instance and clean up EC2/IAM resources.
 
     The custom AMI is kept by default so that a subsequent deploy does not need
-    a full re-bake. Set ``OPENSRE_GATEWAY_DESTROY_PURGE_AMI=1`` to also
+    a full image rebuild. Set ``OPENSRE_GATEWAY_DESTROY_PURGE_AMI=1`` to also
     deregister the AMI and delete its backing snapshot (e.g. for a full
     account cleanup).
     """
@@ -345,25 +348,31 @@ def destroy() -> dict[str, list[str]]:
 def main() -> None:
     parser = argparse.ArgumentParser(description="OpenSRE gateway deployment lifecycle")
     subparsers = parser.add_subparsers(dest="command", required=True)
-    subparsers.add_parser("bake-ami", help="Bake a gateway AMI (run once per code change)")
-    subparsers.add_parser("deploy", help="Launch EC2 instance using a pre-built gateway AMI")
-    subparsers.add_parser("destroy", help="Tear down the gateway AMI stack")
     subparsers.add_parser(
-        "deploy-direct",
-        help="Launch a fresh EC2 instance and install the gateway inline via SSM (no pre-baked AMI)",
+        "build-server-image",
+        help="Build a server image with the gateway installed (run once per code change)",
     )
-    subparsers.add_parser("destroy-direct", help="Tear down the direct-deploy gateway stack")
+    subparsers.add_parser("deploy", help="Start a gateway server from the prebuilt image")
+    subparsers.add_parser("destroy", help="Tear down the server started from the image")
+    subparsers.add_parser(
+        "install-on-new-server",
+        help="Start a new server and install the gateway on it, without building an image first",
+    )
+    subparsers.add_parser(
+        "destroy-installed-server",
+        help="Tear down the server created by install-on-new-server",
+    )
     args = parser.parse_args()
 
-    if args.command == "bake-ami":
-        bake_ami(region=REGION)
+    if args.command == "build-server-image":
+        build_server_image(region=REGION)
     elif args.command == "deploy":
         deploy()
-    elif args.command == "deploy-direct":
+    elif args.command == "install-on-new-server":
         validate_deploy_env()
-        deploy_direct(env_vars=_collect_deploy_env_vars(), region=REGION)
-    elif args.command == "destroy-direct":
-        destroy_direct(region=REGION)
+        install_on_new_server(env_vars=_collect_deploy_env_vars(), region=REGION)
+    elif args.command == "destroy-installed-server":
+        destroy_installed_server(region=REGION)
     else:
         destroy()
 

--- a/platform/deployment/gateway/stack.py
+++ b/platform/deployment/gateway/stack.py
@@ -106,7 +106,7 @@ def _ami_id_path(*, path: Path | None = None) -> Path:
 
 
 def save_ami_id(ami_id: str, *, path: Path | None = None) -> Path:
-    """Persist the AMI id produced by ``make bake-gateway``."""
+    """Persist the AMI id produced by ``make build-gateway-image``."""
     ami_path = _ami_id_path(path=path)
     ami_path.parent.mkdir(parents=True, exist_ok=True)
     ami_path.write_text(ami_id.strip() + "\n", encoding="utf-8")
@@ -114,12 +114,12 @@ def save_ami_id(ami_id: str, *, path: Path | None = None) -> Path:
 
 
 def load_ami_id(*, path: Path | None = None) -> str:
-    """Load the AMI id saved by the last ``make bake-gateway`` run."""
+    """Load the AMI id saved by the last ``make build-gateway-image`` run."""
     ami_path = _ami_id_path(path=path)
     if not ami_path.exists():
         raise FileNotFoundError(
             f"No saved gateway AMI id found at {ami_path}. "
-            "Run `make bake-gateway` first, or set OPENSRE_GATEWAY_AMI_ID."
+            "Run `make build-gateway-image` first, or set OPENSRE_GATEWAY_AMI_ID."
         )
     return ami_path.read_text(encoding="utf-8").strip()
 

--- a/surfaces/cli/wizard/validation.py
+++ b/surfaces/cli/wizard/validation.py
@@ -80,7 +80,13 @@ def _check_ollama(host: str, model: str) -> ValidationResult:
 
     normalized_model = normalize_model_tag(model)
     base_name = model.split(":")[0]
-    matched = normalized_model in available or any(m.split(":")[0] == base_name for m in available)
+    # An explicit tag must match exactly: asking for llama3.1:8b and silently
+    # accepting llama3.1:latest would validate a different model than the one
+    # that then gets used. Only an untagged request falls back to the base name.
+    asked_for_a_tag = ":" in model
+    matched = normalized_model in available or (
+        not asked_for_a_tag and any(m.split(":")[0] == base_name for m in available)
+    )
     if not matched:
         listed = ", ".join(available) or "none pulled yet"
         return ValidationResult(

--- a/tests/cli/test_local_llm.py
+++ b/tests/cli/test_local_llm.py
@@ -256,9 +256,11 @@ def test_validate_ollama_returns_success_on_valid_inference(monkeypatch) -> None
     ],
 )
 def test_validate_ollama_exact_tag_matching(monkeypatch, model, available, should_pass) -> None:
+    # Stub both calls unconditionally. Stubbing the POST only in the passing case
+    # let the failing case reach a real Ollama on localhost, so the test passed or
+    # failed depending on whether the developer happened to be running one.
     monkeypatch.setattr(httpx, "get", lambda *_a, **_kw: _tags_response(available))
-    if should_pass:
-        monkeypatch.setattr(httpx, "post", lambda *_a, **_kw: _chat_response("OpenSRE ready"))
+    monkeypatch.setattr(httpx, "post", lambda *_a, **_kw: _chat_response("OpenSRE ready"))
 
     result = validate_provider_credentials(
         provider=PROVIDER_BY_VALUE["ollama"],

--- a/tests/fleet_monitoring/meters/test_claude_code.py
+++ b/tests/fleet_monitoring/meters/test_claude_code.py
@@ -149,11 +149,11 @@ def test_sample_chunk_surfaces_latest_assistant_model(meter: ClaudeCodeMeter) ->
         [
             (
                 '{"type":"assistant","message":{"model":"claude-sonnet-4-5",'
-                '"usage":{"input_tokens":10,"output_tokens":5}}}'
+                + '"usage":{"input_tokens":10,"output_tokens":5}}}'
             ),
             (
                 '{"type":"assistant","message":{"model":"claude-opus-4-1",'
-                '"usage":{"input_tokens":20,"output_tokens":8}}}'
+                + '"usage":{"input_tokens":20,"output_tokens":8}}}'
             ),
         ]
     )

--- a/tests/fleet_monitoring/meters/test_codex.py
+++ b/tests/fleet_monitoring/meters/test_codex.py
@@ -210,12 +210,12 @@ def test_sample_chunk_surfaces_latest_turn_snapshot_model(meter: CodexMeter) -> 
             '{"type":"turn_context","payload":{"turn_id":"t_1","model":"gpt-5"}}',
             (
                 '{"type":"event_msg","payload":{"type":"token_count","info":'
-                '{"last_token_usage":{"input_tokens":10,"output_tokens":5}}}}'
+                + '{"last_token_usage":{"input_tokens":10,"output_tokens":5}}}}'
             ),
             '{"type":"turn_context","payload":{"turn_id":"t_2","model":"gpt-5-codex"}}',
             (
                 '{"type":"event_msg","payload":{"type":"token_count","info":'
-                '{"last_token_usage":{"input_tokens":20,"output_tokens":10}}}}'
+                + '{"last_token_usage":{"input_tokens":20,"output_tokens":10}}}}'
             ),
         ]
     )

--- a/tests/integrations/vercel/test_client.py
+++ b/tests/integrations/vercel/test_client.py
@@ -302,11 +302,11 @@ def test_get_runtime_logs_stream_json_response(monkeypatch: pytest.MonkeyPatch) 
     lines = [
         (
             '{"rowId":"log_1","timestampInMs":1704067200000,"message":"Error loading resource",'
-            '"level":"error","source":"request","requestPath":"/foo","responseStatusCode":404}'
+            + '"level":"error","source":"request","requestPath":"/foo","responseStatusCode":404}'
         ),
         (
             '{"rowId":"log_2","timestampInMs":1704067201000,"message":"ok","level":"info",'
-            '"source":"request","requestPath":"/bar","responseStatusCode":200}'
+            + '"source":"request","requestPath":"/bar","responseStatusCode":200}'
         ),
     ]
     monkeypatch.setattr(

--- a/tests/interactive_shell/runtime/test_background_notifications.py
+++ b/tests/interactive_shell/runtime/test_background_notifications.py
@@ -704,9 +704,9 @@ def test_notifications_module_does_not_eagerly_import_rocketchat() -> None:
             "-c",
             (
                 "import surfaces.interactive_shell.runtime.background.notifications as n; "
-                "import sys; "
-                "assert 'integrations.rocketchat.delivery' not in sys.modules; "
-                "print('OK: rocketchat not eagerly imported')"
+                + "import sys; "
+                + "assert 'integrations.rocketchat.delivery' not in sys.modules; "
+                + "print('OK: rocketchat not eagerly imported')"
             ),
         ],
         capture_output=True,
@@ -732,10 +732,10 @@ def test_notifications_module_does_not_eagerly_import_telegram() -> None:
             "-c",
             (
                 "import surfaces.interactive_shell.runtime.background.notifications as n; "
-                "import sys; "
-                "assert 'integrations.telegram.delivery' not in sys.modules; "
-                "assert 'integrations.telegram.credentials' not in sys.modules; "
-                "print('OK: telegram not eagerly imported')"
+                + "import sys; "
+                + "assert 'integrations.telegram.delivery' not in sys.modules; "
+                + "assert 'integrations.telegram.credentials' not in sys.modules; "
+                + "print('OK: telegram not eagerly imported')"
             ),
         ],
         capture_output=True,

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -64,8 +64,8 @@ def test_agent_presentation_import_does_not_load_shell_turn_execution() -> None:
             "-c",
             (
                 "import sys; "
-                "import surfaces.interactive_shell.runtime.agent_presentation; "
-                "print('surfaces.interactive_shell.runtime.shell_turn_execution' in sys.modules)"
+                + "import surfaces.interactive_shell.runtime.agent_presentation; "
+                + "print('surfaces.interactive_shell.runtime.shell_turn_execution' in sys.modules)"
             ),
         ],
         check=True,

--- a/tests/platform/deployment/deploy_gateway/test_build_server_image.py
+++ b/tests/platform/deployment/deploy_gateway/test_build_server_image.py
@@ -1,4 +1,4 @@
-"""Tests for the gateway AMI bake path."""
+"""Tests for building a server image with the gateway installed."""
 
 from __future__ import annotations
 
@@ -6,16 +6,16 @@ import pytest
 
 import platform.deployment.gateway.stack as stack_module
 from platform.deployment.aws.config import GATEWAY_AMI_GIT_REF_ENV
-from platform.deployment.gateway import bake as bake_module
+from platform.deployment.gateway import build_server_image as image_module
 
 _FAKE_INSTANCE_ID = "i-builder1234567890"
 _FAKE_AMI_ID = "ami-0abc1234567890def"
 
 
-def _stub_bake_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Stub every external side effect in bake_ami() except AMI id persistence."""
+def _stub_image_build_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub every external side effect in build_server_image() except AMI id persistence."""
     monkeypatch.setattr(
-        bake_module,
+        image_module,
         "create_instance_profile",
         lambda *_a, **_kw: {
             "ProfileName": "p",
@@ -23,31 +23,31 @@ def _stub_bake_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
             "RoleName": "r",
         },
     )
-    monkeypatch.setattr(bake_module, "get_latest_al2023_ami", lambda *_a, **_kw: "ami-base")
+    monkeypatch.setattr(image_module, "get_latest_al2023_ami", lambda *_a, **_kw: "ami-base")
     monkeypatch.setattr(
-        bake_module, "launch_instance", lambda *_a, **_kw: {"InstanceId": _FAKE_INSTANCE_ID}
+        image_module, "launch_instance", lambda *_a, **_kw: {"InstanceId": _FAKE_INSTANCE_ID}
     )
-    monkeypatch.setattr(bake_module, "wait_for_running", lambda *_a, **_kw: None)
-    monkeypatch.setattr(bake_module, "wait_for_ssm_registration", lambda *_a, **_kw: None)
+    monkeypatch.setattr(image_module, "wait_for_running", lambda *_a, **_kw: None)
+    monkeypatch.setattr(image_module, "wait_for_ssm_registration", lambda *_a, **_kw: None)
     monkeypatch.setattr(
-        bake_module,
+        image_module,
         "run_ssm_shell_command",
         lambda *_a, **_kw: {"status": "Success", "stderr": ""},
     )
-    monkeypatch.setattr(bake_module, "create_image_from_instance", lambda *_a, **_kw: _FAKE_AMI_ID)
-    monkeypatch.setattr(bake_module, "terminate_instance", lambda *_a, **_kw: None)
-    monkeypatch.setattr(bake_module, "delete_instance_profile", lambda *_a, **_kw: None)
+    monkeypatch.setattr(image_module, "create_image_from_instance", lambda *_a, **_kw: _FAKE_AMI_ID)
+    monkeypatch.setattr(image_module, "terminate_instance", lambda *_a, **_kw: None)
+    monkeypatch.setattr(image_module, "delete_instance_profile", lambda *_a, **_kw: None)
 
 
-def test_bake_ami_uses_env_var_git_ref(
+def test_build_server_image_uses_env_var_git_ref(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: pytest.TempPathFactory,
 ) -> None:
-    """bake_ami() uses OPENSRE_GATEWAY_GIT_REF when set."""
+    """build_server_image() uses OPENSRE_GATEWAY_GIT_REF when set."""
     ami_id_file = tmp_path / "gateway-id.txt"
     monkeypatch.setattr(stack_module, "_AMI_ID_FILE", ami_id_file)
     monkeypatch.setenv(GATEWAY_AMI_GIT_REF_ENV, "v0.3.0")
-    _stub_bake_dependencies(monkeypatch)
+    _stub_image_build_dependencies(monkeypatch)
 
     captured_commands: list[list[str]] = []
 
@@ -55,34 +55,34 @@ def test_bake_ami_uses_env_var_git_ref(
         captured_commands.append(commands)
         return {"status": "Success", "stderr": ""}
 
-    monkeypatch.setattr(bake_module, "run_ssm_shell_command", capture_ssm)
+    monkeypatch.setattr(image_module, "run_ssm_shell_command", capture_ssm)
 
-    result = bake_module.bake_ami(ami_id_path=ami_id_file)
+    result = image_module.build_server_image(ami_id_path=ami_id_file)
 
     assert result == _FAKE_AMI_ID
     joined = "\n".join(" ".join(c) if isinstance(c, list) else c for c in captured_commands[0])
     assert "v0.3.0" in joined
 
 
-def test_bake_ami_saves_ami_id_to_file(
+def test_build_server_image_saves_ami_id_to_file(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: pytest.TempPathFactory,
 ) -> None:
-    """bake_ami() persists the new AMI id so deploy can reuse it."""
+    """build_server_image() persists the new AMI id so deploy can reuse it."""
     ami_id_file = tmp_path / "gateway-id.txt"
     monkeypatch.setattr(stack_module, "_AMI_ID_FILE", ami_id_file)
     monkeypatch.delenv(GATEWAY_AMI_GIT_REF_ENV, raising=False)
-    _stub_bake_dependencies(monkeypatch)
+    _stub_image_build_dependencies(monkeypatch)
     # make _resolve_git_ref return a deterministic value without running git
-    monkeypatch.setattr(bake_module, "_resolve_git_ref", lambda: "deadbeef1234")
+    monkeypatch.setattr(image_module, "_resolve_git_ref", lambda: "deadbeef1234")
 
-    bake_module.bake_ami(ami_id_path=ami_id_file)
+    image_module.build_server_image(ami_id_path=ami_id_file)
 
     assert ami_id_file.exists()
     assert ami_id_file.read_text().strip() == _FAKE_AMI_ID
 
 
-def test_bake_ami_terminates_builder_on_failure(
+def test_build_server_image_terminates_builder_on_failure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: pytest.TempPathFactory,
 ) -> None:
@@ -94,7 +94,7 @@ def test_bake_ami_terminates_builder_on_failure(
     terminated: list[str] = []
 
     monkeypatch.setattr(
-        bake_module,
+        image_module,
         "create_instance_profile",
         lambda *_a, **_kw: {
             "ProfileName": "p",
@@ -102,23 +102,23 @@ def test_bake_ami_terminates_builder_on_failure(
             "RoleName": "r",
         },
     )
-    monkeypatch.setattr(bake_module, "get_latest_al2023_ami", lambda *_a, **_kw: "ami-base")
+    monkeypatch.setattr(image_module, "get_latest_al2023_ami", lambda *_a, **_kw: "ami-base")
     monkeypatch.setattr(
-        bake_module, "launch_instance", lambda *_a, **_kw: {"InstanceId": _FAKE_INSTANCE_ID}
+        image_module, "launch_instance", lambda *_a, **_kw: {"InstanceId": _FAKE_INSTANCE_ID}
     )
-    monkeypatch.setattr(bake_module, "wait_for_running", lambda *_a, **_kw: None)
-    monkeypatch.setattr(bake_module, "wait_for_ssm_registration", lambda *_a, **_kw: None)
+    monkeypatch.setattr(image_module, "wait_for_running", lambda *_a, **_kw: None)
+    monkeypatch.setattr(image_module, "wait_for_ssm_registration", lambda *_a, **_kw: None)
     monkeypatch.setattr(
-        bake_module,
+        image_module,
         "run_ssm_shell_command",
         lambda *_a, **_kw: {"status": "Failed", "stderr": "something went wrong"},
     )
     monkeypatch.setattr(
-        bake_module, "terminate_instance", lambda iid, *_a, **_kw: terminated.append(iid)
+        image_module, "terminate_instance", lambda iid, *_a, **_kw: terminated.append(iid)
     )
-    monkeypatch.setattr(bake_module, "delete_instance_profile", lambda *_a, **_kw: None)
+    monkeypatch.setattr(image_module, "delete_instance_profile", lambda *_a, **_kw: None)
 
     with pytest.raises(RuntimeError, match="Install commands failed"):
-        bake_module.bake_ami(ami_id_path=ami_id_file)
+        image_module.build_server_image(ami_id_path=ami_id_file)
 
     assert _FAKE_INSTANCE_ID in terminated

--- a/tests/platform/deployment/deploy_gateway/test_install_on_new_server.py
+++ b/tests/platform/deployment/deploy_gateway/test_install_on_new_server.py
@@ -1,4 +1,4 @@
-"""Tests for platform.deployment.gateway.direct_deploy."""
+"""Tests for installing the gateway onto a newly started server."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-import platform.deployment.gateway.direct_deploy as direct_module
+import platform.deployment.gateway.install_on_new_server as install_module
 from platform.deployment.aws.config import EC2_UBUNTU_ROOT_DEVICE_NAME
 
 _INSTANCE_ID = "i-direct123"
@@ -21,48 +21,48 @@ _FAKE_PROFILE = {
 
 
 def _stub_deploy(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[str]]:
-    """Stub every external call in deploy_direct() and return captured SSM calls."""
+    """Stub every external call in install_on_new_server() and return captured SSM calls."""
     calls: dict[str, list[str]] = {"ssm_commands": [], "launch_kwargs": []}
 
-    monkeypatch.setattr(direct_module, "create_instance_profile", lambda *_a, **_kw: _FAKE_PROFILE)
-    monkeypatch.setattr(direct_module, "get_latest_ubuntu2204_ami", lambda _region: _BASE_AMI)
+    monkeypatch.setattr(install_module, "create_instance_profile", lambda *_a, **_kw: _FAKE_PROFILE)
+    monkeypatch.setattr(install_module, "get_latest_ubuntu2204_ami", lambda _region: _BASE_AMI)
     monkeypatch.setattr(
-        direct_module, "create_stack_security_group", lambda *_a, **_kw: "sg-direct123"
+        install_module, "create_stack_security_group", lambda *_a, **_kw: "sg-direct123"
     )
 
     def fake_launch_instance(*_args: object, **kwargs: object) -> dict[str, str]:
         calls["launch_kwargs"].append(kwargs)
         return {"InstanceId": _INSTANCE_ID}
 
-    monkeypatch.setattr(direct_module, "launch_instance", fake_launch_instance)
+    monkeypatch.setattr(install_module, "launch_instance", fake_launch_instance)
     monkeypatch.setattr(
-        direct_module,
+        install_module,
         "wait_for_running",
         lambda *_a, **_kw: {"PublicIpAddress": _PUBLIC_IP},
     )
-    monkeypatch.setattr(direct_module, "wait_for_ssm_registration", lambda *_a, **_kw: None)
+    monkeypatch.setattr(install_module, "wait_for_ssm_registration", lambda *_a, **_kw: None)
 
     def fake_run_ssm(instance_id: str, *, commands: list[str], **_kw: object) -> dict[str, str]:
         calls["ssm_commands"].extend(commands)
         return {"status": "Success", "stdout": "", "stderr": ""}
 
-    monkeypatch.setattr(direct_module, "run_ssm_shell_command", fake_run_ssm)
-    monkeypatch.setattr(direct_module, "provision_gateway_via_ssm", lambda *_a, **_kw: None)
-    monkeypatch.setattr(direct_module, "wait_for_gateway_ready", lambda *_a, **_kw: None)
-    monkeypatch.setattr(direct_module, "_cleanup_existing", lambda **_kw: False)
+    monkeypatch.setattr(install_module, "run_ssm_shell_command", fake_run_ssm)
+    monkeypatch.setattr(install_module, "provision_gateway_via_ssm", lambda *_a, **_kw: None)
+    monkeypatch.setattr(install_module, "wait_for_gateway_ready", lambda *_a, **_kw: None)
+    monkeypatch.setattr(install_module, "_cleanup_existing", lambda **_kw: False)
 
     return calls
 
 
-def test_deploy_direct_returns_all_required_keys(
+def test_install_on_new_server_returns_all_required_keys(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """deploy_direct() must return all expected output keys."""
-    monkeypatch.setattr(direct_module, "_OUTPUTS_DIR", tmp_path)
+    """install_on_new_server() must return all expected output keys."""
+    monkeypatch.setattr(install_module, "_OUTPUTS_DIR", tmp_path)
     _stub_deploy(monkeypatch)
 
-    outputs = direct_module.deploy_direct(env_vars={}, region="us-east-1")
+    outputs = install_module.install_on_new_server(env_vars={}, region="us-east-1")
 
     assert outputs["InstanceId"] == _INSTANCE_ID
     assert outputs["PublicIpAddress"] == _PUBLIC_IP
@@ -74,94 +74,94 @@ def test_deploy_direct_returns_all_required_keys(
     assert "GitRef" not in outputs
 
 
-def test_deploy_direct_persists_outputs(
+def test_install_on_new_server_persists_outputs(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """deploy_direct() must write outputs to the expected path."""
-    monkeypatch.setattr(direct_module, "_OUTPUTS_DIR", tmp_path)
+    """install_on_new_server() must write outputs to the expected path."""
+    monkeypatch.setattr(install_module, "_OUTPUTS_DIR", tmp_path)
     _stub_deploy(monkeypatch)
 
-    direct_module.deploy_direct(env_vars={}, region="us-east-1")
+    install_module.install_on_new_server(env_vars={}, region="us-east-1")
 
-    stack_name = direct_module._direct_stack_name()
+    stack_name = install_module._direct_stack_name()
     output_file = tmp_path / f"{stack_name}.json"
     assert output_file.exists()
     data = json.loads(output_file.read_text())
     assert data["InstanceId"] == _INSTANCE_ID
 
 
-def test_deploy_direct_uses_ubuntu_root_device_for_volume_resize(
+def test_install_on_new_server_uses_ubuntu_root_device_for_volume_resize(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """Ubuntu AMIs use /dev/sda1; direct deploy must pass that root device name."""
-    monkeypatch.setattr(direct_module, "_OUTPUTS_DIR", tmp_path)
+    monkeypatch.setattr(install_module, "_OUTPUTS_DIR", tmp_path)
     calls = _stub_deploy(monkeypatch)
 
-    direct_module.deploy_direct(env_vars={}, region="us-east-1")
+    install_module.install_on_new_server(env_vars={}, region="us-east-1")
 
     assert calls["launch_kwargs"]
     assert calls["launch_kwargs"][0]["root_device_name"] == EC2_UBUNTU_ROOT_DEVICE_NAME
 
 
-def test_deploy_direct_uses_curl_installer(
+def test_install_on_new_server_uses_curl_installer(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """Install commands must use the curl installer URL, not pip or git."""
-    monkeypatch.setattr(direct_module, "_OUTPUTS_DIR", tmp_path)
+    monkeypatch.setattr(install_module, "_OUTPUTS_DIR", tmp_path)
     calls = _stub_deploy(monkeypatch)
 
-    direct_module.deploy_direct(env_vars={}, region="us-east-1")
+    install_module.install_on_new_server(env_vars={}, region="us-east-1")
 
     joined = "\n".join(calls["ssm_commands"])
-    assert direct_module._INSTALL_URL in joined
+    assert install_module._INSTALL_URL in joined
     assert "curl" in joined
     assert "pip install" not in joined
     assert "git+" not in joined
 
 
-def test_deploy_direct_binary_path_in_service_unit(
+def test_install_on_new_server_binary_path_in_service_unit(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """The embedded systemd unit must use /usr/local/bin/opensre, not the venv path."""
-    monkeypatch.setattr(direct_module, "_OUTPUTS_DIR", tmp_path)
+    monkeypatch.setattr(install_module, "_OUTPUTS_DIR", tmp_path)
     _stub_deploy(monkeypatch)
 
-    direct_module.deploy_direct(env_vars={}, region="us-east-1")
+    install_module.install_on_new_server(env_vars={}, region="us-east-1")
 
-    assert "/usr/local/bin/opensre" in direct_module._SERVICE_UNIT
-    assert "/opt/opensre/.venv" not in direct_module._SERVICE_UNIT
+    assert "/usr/local/bin/opensre" in install_module._SERVICE_UNIT
+    assert "/opt/opensre/.venv" not in install_module._SERVICE_UNIT
 
 
-def test_deploy_direct_raises_on_install_failure(
+def test_install_on_new_server_raises_on_install_failure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """deploy_direct() must raise RuntimeError when the install SSM command fails."""
-    monkeypatch.setattr(direct_module, "_OUTPUTS_DIR", tmp_path)
+    """install_on_new_server() must raise RuntimeError when the install SSM command fails."""
+    monkeypatch.setattr(install_module, "_OUTPUTS_DIR", tmp_path)
     _stub_deploy(monkeypatch)
 
     monkeypatch.setattr(
-        direct_module,
+        install_module,
         "run_ssm_shell_command",
         lambda *_a, **_kw: {"status": "Failed", "stdout": "", "stderr": "curl error"},
     )
 
     with pytest.raises(RuntimeError, match="Install commands failed"):
-        direct_module.deploy_direct(env_vars={}, region="us-east-1")
+        install_module.install_on_new_server(env_vars={}, region="us-east-1")
 
 
-def test_destroy_direct_terminates_instance_and_cleans_iam(
+def test_destroy_installed_server_terminates_instance_and_cleans_iam(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """destroy_direct() must terminate the instance and delete the IAM profile."""
-    monkeypatch.setattr(direct_module, "_OUTPUTS_DIR", tmp_path)
+    """destroy_installed_server() must terminate the instance and delete the IAM profile."""
+    monkeypatch.setattr(install_module, "_OUTPUTS_DIR", tmp_path)
 
-    stack_name = direct_module._direct_stack_name()
+    stack_name = install_module._direct_stack_name()
     outputs_file = tmp_path / f"{stack_name}.json"
     outputs_file.write_text(
         json.dumps(
@@ -177,17 +177,17 @@ def test_destroy_direct_terminates_instance_and_cleans_iam(
     deleted_profiles: list[str] = []
 
     monkeypatch.setattr(
-        direct_module,
+        install_module,
         "terminate_instance",
         lambda instance_id, _region: terminated.append(instance_id),
     )
     monkeypatch.setattr(
-        direct_module,
+        install_module,
         "delete_instance_profile",
         lambda profile, _role, _region: deleted_profiles.append(profile),
     )
 
-    results = direct_module.destroy_direct(region="us-east-1")
+    results = install_module.destroy_installed_server(region="us-east-1")
 
     assert _INSTANCE_ID in terminated
     assert deleted_profiles == ["opensre-gateway-direct-profile"]
@@ -195,16 +195,16 @@ def test_destroy_direct_terminates_instance_and_cleans_iam(
     assert not outputs_file.exists()
 
 
-def test_destroy_direct_handles_missing_outputs(
+def test_destroy_installed_server_handles_missing_outputs(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """destroy_direct() must not crash when no outputs file exists."""
-    monkeypatch.setattr(direct_module, "_OUTPUTS_DIR", tmp_path)
-    monkeypatch.setattr(direct_module, "terminate_instance", lambda *_a, **_kw: None)
-    monkeypatch.setattr(direct_module, "delete_instance_profile", lambda *_a, **_kw: None)
+    """destroy_installed_server() must not crash when no outputs file exists."""
+    monkeypatch.setattr(install_module, "_OUTPUTS_DIR", tmp_path)
+    monkeypatch.setattr(install_module, "terminate_instance", lambda *_a, **_kw: None)
+    monkeypatch.setattr(install_module, "delete_instance_profile", lambda *_a, **_kw: None)
 
-    results = direct_module.destroy_direct(region="us-east-1")
+    results = install_module.destroy_installed_server(region="us-east-1")
 
     assert isinstance(results["deleted"], list)
     assert isinstance(results["failed"], list)
@@ -217,57 +217,57 @@ def test_cleanup_existing_cleans_iam_when_no_outputs_file(
     """_cleanup_existing() must delete the IAM profile/role even when no outputs file exists.
 
     Regression: tagged instances were terminated but the outputs file was absent,
-    so destroy_direct() was skipped and IAM resources were silently orphaned.
+    so destroy_installed_server() was skipped and IAM resources were silently orphaned.
     """
-    monkeypatch.setattr(direct_module, "_OUTPUTS_DIR", tmp_path)
+    monkeypatch.setattr(install_module, "_OUTPUTS_DIR", tmp_path)
     # No outputs file — simulates a lost or never-written outputs file.
 
     terminated: list[str] = []
     deleted_profiles: list[str] = []
 
     monkeypatch.setattr(
-        direct_module,
+        install_module,
         "find_stack_instance_ids",
         lambda _stack, *, region: ["i-orphan01"],  # noqa: ARG005
     )
     monkeypatch.setattr(
-        direct_module,
+        install_module,
         "terminate_instance",
         lambda instance_id, _region: terminated.append(instance_id),
     )
     monkeypatch.setattr(
-        direct_module,
+        install_module,
         "delete_instance_profile",
         lambda profile, _role, _region: deleted_profiles.append(profile),
     )
 
-    ran = direct_module._cleanup_existing(region="us-east-1")
+    ran = install_module._cleanup_existing(region="us-east-1")
 
     assert ran is True
     assert "i-orphan01" in terminated
     # IAM must be cleaned up using derived names, not skipped.
-    stack_name = direct_module._direct_stack_name()
+    stack_name = install_module._direct_stack_name()
     assert deleted_profiles == [f"{stack_name}-profile"]
 
 
 def test_stack_name_includes_suffix(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENSRE_STACK_SUFFIX", "joe")
-    assert direct_module._direct_stack_name() == "opensre-gateway-direct-joe"
+    assert install_module._direct_stack_name() == "opensre-gateway-direct-joe"
 
 
 def test_stack_name_default_when_no_suffix(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENSRE_STACK_SUFFIX", raising=False)
-    assert direct_module._direct_stack_name() == "opensre-gateway-direct"
+    assert install_module._direct_stack_name() == "opensre-gateway-direct"
 
 
 def test_curl_install_commands_structure() -> None:
     """_build_curl_install_commands() must contain all required setup steps."""
-    commands = direct_module._build_curl_install_commands()
+    commands = install_module._build_curl_install_commands()
     joined = "\n".join(commands)
 
     assert "set -eu" in joined
     assert "useradd" in joined  # creates opensre user
-    assert direct_module._INSTALL_URL in joined  # curl installer URL
+    assert install_module._INSTALL_URL in joined  # curl installer URL
     assert "/usr/local/bin" in joined  # install dir
     assert "export HOME=/root" in joined  # SSM has no HOME set
     assert "OPENSRE_AUTO_LAUNCH=0" in joined  # no interactive wizard

--- a/tests/platform/deployment/deploy_gateway/test_lifecycle.py
+++ b/tests/platform/deployment/deploy_gateway/test_lifecycle.py
@@ -79,7 +79,7 @@ def test_deploy_fails_fast_when_no_ami_id(
     monkeypatch.setattr(stack_module, "_AMI_ID_FILE", tmp_path / "nonexistent.txt")
     monkeypatch.setattr(lifecycle_module, "validate_deploy_env", lambda: None)
 
-    with pytest.raises(RuntimeError, match="bake-gateway"):
+    with pytest.raises(RuntimeError, match="build-gateway-image"):
         lifecycle_module.deploy()
 
 


### PR DESCRIPTION
`platform/deployment/gateway/` had two modules whose names only made sense
relative to each other, and one of them had no docstring at all — so nothing in
the file explained itself:

| Was | Now |
|-----|-----|
| `bake.py` | `build_server_image.py` |
| `direct_deploy.py` | `install_on_new_server.py` |
| `bake_ami()` | `build_server_image()` |
| `deploy_direct()` / `destroy_direct()` | `install_on_new_server()` / `destroy_installed_server()` |
| `make bake-gateway` | `make build-gateway-image` |
| `make deploy-gateway-direct` / `destroy-gateway-direct` | `make install-gateway-on-new-server` / `destroy-gateway-on-new-server` |
| CLI `bake-ami` / `deploy-direct` / `destroy-direct` | `build-server-image` / `install-on-new-server` / `destroy-installed-server` |

"Bake" is standard infrastructure jargon for building a machine image, and
"direct" described what the module *isn't* — it deploys without building an
image first. Neither told a reader what the file does.

Both modules now open with a plain-English docstring that also points at the
other one, so whichever you open first explains the choice between them.