### PR TITLE
chore(supabase): use HTTPStatus enum for status comparisons (SM-52)

### DIFF
--- a/integrations/supabase/__init__.py
+++ b/integrations/supabase/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
+from http import HTTPStatus
 from typing import Any
 from urllib.parse import urlparse
 
@@ -167,7 +168,7 @@ def validate_supabase_config(config: SupabaseConfig) -> SupabaseValidationResult
 
     try:
         status, _ = _make_request(config, "/rest/v1/")
-        if status == 200:
+        if status == HTTPStatus.OK:
             return SupabaseValidationResult(
                 ok=True,
                 detail=f"Connected to Supabase project at {config.url}.",
@@ -213,7 +214,7 @@ def get_service_health(config: SupabaseConfig) -> dict[str, Any]:
     try:
         status, _ = _make_request(config, "/rest/v1/")
         services["postgrest"] = {
-            "healthy": status == 200,
+            "healthy": status == HTTPStatus.OK,
             "status_code": status,
         }
     except Exception as err:
@@ -228,7 +229,7 @@ def get_service_health(config: SupabaseConfig) -> dict[str, Any]:
         elif isinstance(body, str):
             detail = body
         services["auth"] = {
-            "healthy": status == 200,
+            "healthy": status == HTTPStatus.OK,
             "status_code": status,
             "detail": detail,
         }
@@ -239,7 +240,7 @@ def get_service_health(config: SupabaseConfig) -> dict[str, Any]:
     try:
         status, _ = _make_request(config, "/storage/v1/health")
         services["storage"] = {
-            "healthy": status == 200,
+            "healthy": status == HTTPStatus.OK,
             "status_code": status,
         }
     except Exception as err:
@@ -271,7 +272,7 @@ def get_storage_buckets(config: SupabaseConfig) -> dict[str, Any]:
     try:
         status, body = _make_request(config, "/storage/v1/bucket")
 
-        if status != 200:
+        if status != HTTPStatus.OK:
             return tool_unavailable("supabase", f"Storage API returned HTTP {status}.")
 
         raw_buckets: list[dict[str, Any]] = body if isinstance(body, list) else []


### PR DESCRIPTION
## Summary

Fixes [#4310](https://github.com/Tracer-Cloud/opensre/issues/4310) (Task ID: SM-52)

`integrations/supabase/__init__.py` compared raw HTTP status numbers instead of using `http.HTTPStatus`, against the project convention of naming status codes.

## Changes

Added `from http import HTTPStatus` and replaced every bare `200` comparison with `HTTPStatus.OK`:

- `validate_supabase_config()`: `status == 200` to `status == HTTPStatus.OK`
- `get_service_health()`: the `healthy` check for all three services (PostgREST, Auth, Storage)
- `get_storage_buckets()`: `status != 200` to `status != HTTPStatus.OK`

`HTTPStatus` is an `IntEnum`, so it compares equal to a plain int identically to the literals it replaces. No behavior change and no user-facing message changes.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the existing test suite for this module (`tests/integrations/test_supabase.py`): 38 passed, 0 failed.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions