### PR TITLE
chore(rocketchat): use HTTPStatus enum for status comparisons (SM-31)

### DIFF
--- a/integrations/rocketchat/delivery.py
+++ b/integrations/rocketchat/delivery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from http import HTTPStatus
 from typing import Any
 
 from platform.common.truncation import truncate
@@ -48,7 +49,7 @@ def post_rocketchat_message(
         safe_error = redact_token(response.error, auth_token)
         logger.warning("[rocketchat] post message exception: %s", safe_error)
         return False, safe_error, ""
-    if response.status_code != 200 or response.data.get("success") is not True:
+    if response.status_code != HTTPStatus.OK or response.data.get("success") is not True:
         error_message = extract_http_error(response.data, response.status_code, response.text)
         safe_error = redact_token(error_message, auth_token)
         logger.warning("[rocketchat] post message failed: %s", safe_error)
@@ -76,7 +77,7 @@ def post_rocketchat_webhook(
         safe_error = redact_token(response.error, webhook_url)
         logger.warning("[rocketchat] webhook post exception: %s", safe_error)
         return False, safe_error
-    if response.status_code != 200 or response.data.get("success") is not True:
+    if response.status_code != HTTPStatus.OK or response.data.get("success") is not True:
         error_message = extract_http_error(response.data, response.status_code, response.text)
         safe_error = redact_token(error_message, webhook_url)
         logger.warning("[rocketchat] webhook post failed: %s", safe_error)


### PR DESCRIPTION
## Summary

Fixes [#4289](https://github.com/Tracer-Cloud/opensre/issues/4289) (Task ID: SM-31)

`integrations/rocketchat/delivery.py` compared raw HTTP status numbers instead of using `http.HTTPStatus`, against the project convention of naming status codes.

## Changes

Added `from http import HTTPStatus` and replaced both bare `200` comparisons with `HTTPStatus.OK`:

- `post_rocketchat_message()`: `response.status_code != 200` to `response.status_code != HTTPStatus.OK`
- `post_rocketchat_webhook()`: same check

`HTTPStatus` is an `IntEnum`, so it compares equal to a plain int identically to the literal it replaces. No behavior change and no user-facing message changes.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the existing test suite for this module (`tests/utils/test_rocketchat_delivery.py`): 24 passed, 0 failed.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions