### PR TITLE
chore(fix_sentry_issue): use HTTPStatus enum for status comparisons (SM-54)

### DIFF
--- a/tools/cross_vendor/fix_sentry_issue/context.py
+++ b/tools/cross_vendor/fix_sentry_issue/context.py
@@ -8,6 +8,7 @@ to the coding agent, which adds its own safety rules + prompt-injection guard.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from http import HTTPStatus
 
 import httpx
 
@@ -99,11 +100,11 @@ def _fetch_issue(config: SentryConfig, issue_id: str) -> dict:
         issue = get_sentry_issue(config=config, issue_id=issue_id)
     except httpx.HTTPStatusError as exc:
         status = exc.response.status_code
-        if status == 404:
+        if status == HTTPStatus.NOT_FOUND:
             raise FixIssueError(
                 ERR_ISSUE_NOT_FOUND, f"Sentry issue {issue_id} not found (404). Check the URL."
             ) from exc
-        if status in (401, 403):
+        if status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
             raise FixIssueError(
                 ERR_SENTRY_UNAVAILABLE,
                 f"Sentry rejected the request ({status}); check SENTRY_AUTH_TOKEN access.",


### PR DESCRIPTION
## Summary

Fixes [#4312](https://github.com/Tracer-Cloud/opensre/issues/4312) (Task ID: SM-54)

`tools/cross_vendor/fix_sentry_issue/context.py` compared raw HTTP status numbers instead of using `http.HTTPStatus`, against the project convention of naming status codes.

## Changes

Added `from http import HTTPStatus` and replaced the bare status literals in `_fetch_issue()`:

- `status == 404` to `status == HTTPStatus.NOT_FOUND`
- `status in (401, 403)` to `status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN)`

`HTTPStatus` is an `IntEnum`, so it compares equal to a plain int identically to the literals it replaces. Left the `(404)` and `({status})` text inside the user-facing error message strings untouched, since those are literal message text, not code comparisons, and the task says not to change user-facing messages. No behavior change.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the existing test suite for this tool (`tests/tools/test_fix_sentry_issue.py` and `tests/tools/test_fix_sentry_issue_ship.py`): 36 passed, 0 failed.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions