### PR TITLE
chore(scheduler): use HTTPStatus enum for Slack status range check (SM-55)

### DIFF
--- a/platform/scheduler/executor.py
+++ b/platform/scheduler/executor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from http import HTTPStatus
 
 from platform.scheduler.claim_store import complete_run, try_claim
 from platform.scheduler.credentials import (
@@ -169,7 +170,7 @@ def _deliver_slack(task: ScheduledTask, message: str) -> tuple[bool, str, str]:
         )
         if not response.ok:
             return False, f"Slack API error: {response.error}", ""
-        if not 200 <= response.status_code < 300:
+        if not HTTPStatus.OK <= response.status_code < HTTPStatus.MULTIPLE_CHOICES:
             error_text = response.text[:200] if response.text else f"HTTP {response.status_code}"
             return False, f"Slack HTTP error: {error_text}", ""
         if response.data.get("ok") is not True:


### PR DESCRIPTION
## Summary

Fixes [#4313](https://github.com/Tracer-Cloud/opensre/issues/4313) (Task ID: SM-55)

`platform/scheduler/executor.py` compared raw HTTP status numbers instead of using `http.HTTPStatus`, against the project convention of naming status codes.

## Changes

Added `from http import HTTPStatus` and replaced the bare range check in `_deliver_slack()`:

- `not 200 <= response.status_code < 300` to `not HTTPStatus.OK <= response.status_code < HTTPStatus.MULTIPLE_CHOICES`

`HTTPStatus` is an `IntEnum`, so it compares identically to the plain ints it replaces. No behavior change and no user-facing message changes.

Left the two `[:200]` occurrences alone (`response.text[:200]` and `error[:200]`), they are string truncation lengths, not HTTP status codes.

## Testing

Ran lint, format check, and typecheck on the file, all clean.

Ran the existing test suite for this module (`tests/scheduler/test_executor.py`): 11 passed, 0 failed.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions