### PR TITLE
refactor(hermes): spell out Hermes correlator window constants

### DIFF
--- a/integrations/hermes/correlator.py
+++ b/integrations/hermes/correlator.py
@@ -29,8 +29,8 @@ from typing import Final
 
 from integrations.hermes.incident import HermesIncident, IncidentSeverity
 
-DEFAULT_DEDUP_WINDOW_S: Final[float] = 300.0  # 5 minutes
-DEFAULT_ESCALATION_WINDOW_S: Final[float] = 600.0  # 10 minutes
+DEFAULT_DEDUP_WINDOW_SECONDS: Final[float] = 300.0  # 5 minutes
+DEFAULT_ESCALATION_WINDOW_SECONDS: Final[float] = 600.0  # 10 minutes
 DEFAULT_ESCALATION_THRESHOLD: Final[int] = 3
 _SEVERITY_ORDER: Final[tuple[IncidentSeverity, ...]] = (
     IncidentSeverity.LOW,
@@ -114,8 +114,8 @@ class IncidentCorrelator:
     def __init__(
         self,
         *,
-        dedup_window_s: float = DEFAULT_DEDUP_WINDOW_S,
-        escalation_window_s: float = DEFAULT_ESCALATION_WINDOW_S,
+        dedup_window_s: float = DEFAULT_DEDUP_WINDOW_SECONDS,
+        escalation_window_s: float = DEFAULT_ESCALATION_WINDOW_SECONDS,
         escalation_threshold: int = DEFAULT_ESCALATION_THRESHOLD,
         routing_matrix: dict[str, RouteDestination] | None = None,
     ) -> None:

--- a/tests/hermes/test_correlator.py
+++ b/tests/hermes/test_correlator.py
@@ -8,7 +8,7 @@ import pytest
 
 from integrations.hermes.correlating_sink import CorrelatingSink
 from integrations.hermes.correlator import (
-    DEFAULT_DEDUP_WINDOW_S,
+    DEFAULT_DEDUP_WINDOW_SECONDS,
     IncidentCorrelator,
     RouteDestination,
     correlate_all,
@@ -243,7 +243,7 @@ class TestCorrelatingSink:
 
     def test_dedup_window_default_constant_is_documented(self) -> None:
         # Catches anyone tightening the default below the AlarmDispatcher cooldown.
-        assert DEFAULT_DEDUP_WINDOW_S == 300.0
+        assert DEFAULT_DEDUP_WINDOW_SECONDS == 300.0
 
     def test_escalation_metric_tracks_correctly(self) -> None:
         delivered: list[HermesIncident] = []


### PR DESCRIPTION
Fixes #4329

Rename `DEFAULT_DEDUP_WINDOW_S` → `DEFAULT_DEDUP_WINDOW_SECONDS` and `DEFAULT_ESCALATION_WINDOW_S` → `DEFAULT_ESCALATION_WINDOW_SECONDS`. Function args unchanged.

```
$ make lint          # passed
$ make format-check  # passed
$ make typecheck     # passed
$ make test-scope    # 180 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [ ] No
- [x] Yes

**If yes:**
- [x] Reviewed every changed line
- [x] Can explain the change
- [x] Tested and confirmed no behavior change
- [x] Output already conformed to project conventions

**Approach:**

Word-boundary sed over the two listed files; verified the 5 occurrences and that function args were untouched.

## Checklist
- [x] PR title + linked issue
- [x] Self-reviewed
- [x] Can explain every change
- [x] Tested
- [x] Follows project conventions