### PR TITLE
refactor(hermes): spell out Hermes sink bridge timeout constant

### DIFF
--- a/integrations/hermes/sinks.py
+++ b/integrations/hermes/sinks.py
@@ -86,7 +86,7 @@ _DEFAULT_BRIDGE_WORKERS: Final[int] = 2
 # than a typical investigation pipeline but well under the
 # AlarmDispatcher cooldown (300s default) so a retry on the next
 # matching incident gets a fresh shot.
-_DEFAULT_BRIDGE_TIMEOUT_S: Final[float] = 45.0
+_DEFAULT_BRIDGE_TIMEOUT_SECONDS: Final[float] = 45.0
 
 _SEVERITY_EMOJI: Final[dict[IncidentSeverity, str]] = {
     IncidentSeverity.LOW: "🟢",
@@ -118,7 +118,7 @@ class TelegramSinkConfig:
     max_inlined_records: int = _MAX_INLINED_RECORDS
     max_record_chars: int = _MAX_RECORD_CHARS
     max_summary_chars: int = _MAX_SUMMARY_CHARS
-    bridge_timeout_s: float = _DEFAULT_BRIDGE_TIMEOUT_S
+    bridge_timeout_s: float = _DEFAULT_BRIDGE_TIMEOUT_SECONDS
     bridge_workers: int = _DEFAULT_BRIDGE_WORKERS
     # Run bridge synchronously on the calling thread instead of offloading
     # to the executor. Used by unit tests that want deterministic


### PR DESCRIPTION
Fixes #4326

Rename `_DEFAULT_BRIDGE_TIMEOUT_S` → `_DEFAULT_BRIDGE_TIMEOUT_SECONDS`. Function arg unchanged.

```
$ make lint  # passed
$ pytest tests/hermes/test_sinks.py  # 39 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [ ] No
- [x] Yes

**If yes:**
- [x] Reviewed every changed line
- [x] Can explain the change
- [x] Tested and confirmed no behavior change
- [x] Output already conformed to project conventions

**Approach:**

Word-boundary sed; verified the 2 occurrences and that the function arg was untouched.

## Checklist
- [x] PR title + linked issue
- [x] Self-reviewed
- [x] Can explain every change
- [x] Tested
- [x] Follows project conventions