### PR TITLE
Improve: spell out MariaDB timeout constant unit

### DIFF
--- a/integrations/mariadb/__init__.py
+++ b/integrations/mariadb/__init__.py
@@ -31,7 +31,7 @@ from platform.common.truncation import truncate
 logger = logging.getLogger(__name__)
 
 DEFAULT_MARIADB_PORT = 3306
-DEFAULT_MARIADB_TIMEOUT_S = 5
+DEFAULT_MARIADB_TIMEOUT_SECONDS = 5
 DEFAULT_MARIADB_MAX_RESULTS = 50
 _QUERY_TRUNCATE_LEN = 200
 
@@ -45,7 +45,7 @@ class MariaDBConfig(RelationalConfigBase):
     username: str = ""
     password: str = ""
     ssl: bool = True
-    timeout_seconds: int = Field(default=DEFAULT_MARIADB_TIMEOUT_S, gt=0)
+    timeout_seconds: int = Field(default=DEFAULT_MARIADB_TIMEOUT_SECONDS, gt=0)
     max_results: int = Field(default=DEFAULT_MARIADB_MAX_RESULTS, gt=0, le=200)
     integration_id: str = ""
 


### PR DESCRIPTION
Fixes #4318

#### Describe the changes you have made in this PR -

Renamed `DEFAULT_MARIADB_TIMEOUT_S` to `DEFAULT_MARIADB_TIMEOUT_SECONDS` in the MariaDB integration and updated its reference. No behavior changes.

### Demo/Screenshot for feature changes and bug fixes -

```text
$ make lint
All checks passed!

$ make test-scope
47 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

This change spells out the timeout constant’s unit by replacing the abbreviated `_S` suffix with `_SECONDS`. I updated the declaration and its only MariaDB configuration reference. The timeout value remains unchanged, so runtime behavior is identical.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions