### PR TITLE
refactor(rocketchat): use HTTPStatus in the verifier (SM-30)

### DIFF
--- a/integrations/rocketchat/verifier.py
+++ b/integrations/rocketchat/verifier.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -20,14 +21,19 @@ def _verify_webhook(source: str, webhook_url: str) -> dict[str, str]:
     except Exception as exc:
         return result("rocketchat", source, "failed", f"Rocket.Chat webhook unreachable: {exc}")
 
-    if response.status_code == 404:
+    if response.status_code == HTTPStatus.NOT_FOUND:
         return result(
             "rocketchat",
             source,
             "failed",
             "Rocket.Chat webhook returned 404; the URL looks invalid.",
         )
-    if response.status_code in {200, 400, 403, 405}:
+    if response.status_code in {
+        HTTPStatus.OK,
+        HTTPStatus.BAD_REQUEST,
+        HTTPStatus.FORBIDDEN,
+        HTTPStatus.METHOD_NOT_ALLOWED,
+    }:
         return result(
             "rocketchat",
             source,
@@ -66,14 +72,14 @@ def verify_rocketchat(source: str, config: dict[str, Any]) -> dict[str, str]:
     except Exception as exc:
         return result("rocketchat", source, "failed", f"Rocket.Chat API check failed: {exc}")
 
-    if response.status_code == 401:
+    if response.status_code == HTTPStatus.UNAUTHORIZED:
         return result(
             "rocketchat",
             source,
             "failed",
             "Rocket.Chat auth failed: auth_token or user_id is invalid or expired.",
         )
-    if response.status_code != 200:
+    if response.status_code != HTTPStatus.OK:
         return result(
             "rocketchat",
             source,


### PR DESCRIPTION
Replace the bare HTTP status literals in the webhook and REST probes with the matching `http.HTTPStatus` members, per the project rule against numeric status literals.

- `404` -> `HTTPStatus.NOT_FOUND`
- `{200, 400, 403, 405}` -> `{OK, BAD_REQUEST, FORBIDDEN, METHOD_NOT_ALLOWED}`
- `401` -> `HTTPStatus.UNAUTHORIZED`
- `!= 200` -> `!= HTTPStatus.OK`

`HTTPStatus` is an `IntEnum`, so the comparisons and the set membership test behave identically. User-facing result messages are unchanged.

Fixes #4288

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

SM-30. `integrations/rocketchat/verifier.py` was the only file touched.

All four comparison sites in that file now use the named enum. `HTTPStatus` derives from `IntEnum`, so it inherits `int.__hash__`; that matters for the set-membership branch, where `response.status_code` is the plain `int` httpx returns and `200 in {HTTPStatus.OK, ...}` still matches.

Deliberately **not** changed, per the issue's "do not change behavior or user-facing messages":

- the literal `404` inside the result string `"Rocket.Chat webhook returned 404; the URL looks invalid."`
- the `404` mentioned in `_verify_webhook`'s docstring

### Demo/Screenshot for feature changes and bug fixes -

<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

```
$ uv run ruff check integrations/rocketchat/verifier.py
All checks passed!

$ uv run ruff format --check integrations/rocketchat/verifier.py
1 file already formatted

$ uv run mypy integrations/rocketchat/verifier.py
Success: no issues found in 1 source file

$ uv run pytest tests/integrations/test_rocketchat.py tests/integrations/rocketchat/ -q
tests/integrations/test_rocketchat.py ...........................        [ 84%]
tests/integrations/rocketchat/test_setup.py .....                        [100%]
============================== 32 passed in 1.19s ==============================
```
<img width="1464" height="1756" alt="image" src="https://github.com/user-attachments/assets/fbe0e453-848b-498a-8b00-e06af52926ee" />Full harness also run green on this change:

```
$ make lint                        -> All checks passed!
$ make format-check                -> 2850 files already formatted
$ make typecheck                   -> Success: no issues found in 1484 source files
$ make verify-integrations-smoke   -> 31 passed in 2.10s
$ make test-cov                    -> 12638 passed, 60 skipped in 126.66s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

<!--
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

The problem here is readability, not correctness. A reader hitting `if response.status_code in {200, 400, 403, 405}` has to work out why those four particular codes count as "reachable" for a Rocket.Chat webhook. With the names spelled out, the intent, the endpoint answered at all, even to reject us, reads straight off the line.

The one thing worth actually checking rather than assuming is the set-membership test. Swapping `==` comparisons is obviously safe, but `in {…}` resolves through hashing, not `__eq__`. `HTTPStatus` derives from `IntEnum` and therefore inherits `int.__hash__`, so `hash(HTTPStatus.OK) == hash(200)` and the lookup still finds the integer `status_code` that httpx returns. Had `HTTPStatus` been a plain `Enum`, this refactor would have silently turned that branch into a permanent miss and every reachable webhook would have started reporting "unexpected HTTP". That is the edge case I verified.

Two functions are involved. `_verify_webhook` is a non-posting reachability probe: a GET against a valid incoming-webhook URL never delivers a message, so a `404` is the signal that the URL or its embedded token is wrong, while `200/400/403/405` all prove something is listening. `verify_rocketchat` is the REST path against `/api/v1/me`, where `401` means the `auth_token`/`user_id` pair is bad and anything other than `200` is a generic failure.

I considered extracting the four "reachable" codes into a module-level named constant, which would read nicely, but it introduces a symbol the issue did not ask for and pushes past the one-file scope. I also left the `404` in the user-facing string and the docstring alone, the issue explicitly forbids changing user-facing messages, and prose reads better with the number anyway.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests — n/a, behavior-preserving refactor covered by the existing 32 tests
- [x] My code follows the project's style guidelines and conventions
