### PR TITLE
refactor(google-docs): use HTTPStatus in the API error handler (SM-29)

### DIFF
--- a/integrations/google_docs/client.py
+++ b/integrations/google_docs/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+from http import HTTPStatus
 from pathlib import Path
 from typing import Any, cast
 
@@ -28,15 +29,15 @@ def _handle_google_api_error(exc: Exception, operation: str) -> dict[str, Any]:
     # Try to extract HTTP error details
     if hasattr(exc, "resp"):
         status_code = getattr(exc.resp, "status", None)
-        if status_code == 403:
+        if status_code == HTTPStatus.FORBIDDEN:
             error_msg = (
                 f"Insufficient permissions to {operation}. Check service account has access."
             )
-        elif status_code == 404:
+        elif status_code == HTTPStatus.NOT_FOUND:
             error_msg = f"Resource not found while {operation}. Verify folder/document ID."
-        elif status_code == 429:
+        elif status_code == HTTPStatus.TOO_MANY_REQUESTS:
             error_msg = f"Rate limit exceeded while {operation}. Please retry later."
-        elif status_code == 400:
+        elif status_code == HTTPStatus.BAD_REQUEST:
             error_msg = f"Invalid request while {operation}. Check parameters."
         elif status_code:
             error_msg = f"HTTP {status_code} error while {operation}: {exc}"


### PR DESCRIPTION
Replace the bare HTTP status literals in `_handle_google_api_error` with the matching `http.HTTPStatus` members, per the project rule against numeric status literals.

- `403` -> `HTTPStatus.FORBIDDEN`
- `404` -> `HTTPStatus.NOT_FOUND`
- `429` -> `HTTPStatus.TOO_MANY_REQUESTS`
- `400` -> `HTTPStatus.BAD_REQUEST`

`HTTPStatus` is an `IntEnum`, so comparing it against the integer status the Google client puts on `exc.resp.status` behaves identically. The generic `elif status_code:` fallback and every error message are unchanged.

Fixes #4287

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

SM-29. `integrations/google_docs/client.py` was the only file touched.

Every status comparison in that file lives in one place, `_handle_google_api_error`, which maps a `googleapiclient` exception onto an operator-readable message. `status_code` there comes from `getattr(exc.resp, "status", None)`, so it is an `int` or `None`; `HTTPStatus` being an `IntEnum` means both the match and the `None` fall-through behave exactly as before.

Left alone: the trailing `elif status_code:` catch-all, which is a truthiness check on "some code we have no specific message for" rather than a comparison against a particular status, so there is nothing to name.

### Demo/Screenshot for feature changes and bug fixes -

<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

```
$ uv run ruff check integrations/google_docs/client.py
All checks passed!

$ uv run ruff format --check integrations/google_docs/client.py
1 file already formatted

$ uv run mypy integrations/google_docs/client.py
Success: no issues found in 1 source file

$ uv run pytest tests/integrations/google_docs/ tests/tools/test_google_docs_create_report_tool.py -q
============================== 47 passed in 0.63s ==============================
```

`tests/integrations/google_docs/test_integration.py` already exercises this function directly `test_handle_google_api_error_with_403`, `_with_404`, `_with_429`, so the existing suite pins the exact branches this PR touches.

<img width="1624" height="1756" alt="image" src="https://github.com/user-attachments/assets/3926ae68-8496-49cb-82a7-60b83fd0e5f8" />

Full harness also run green on this change:

```
$ make lint                        -> All checks passed!
$ make format-check                -> 2850 files already formatted
$ make typecheck                   -> Success: no issues found in 1484 source files
$ make verify-integrations-smoke   -> 31 passed in 2.10s
$ make test-cov                    -> 12638 passed, 60 skipped in 126.66s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

<!--
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

`_handle_google_api_error` is the single place where a raw Google API exception becomes something an operator can act on "insufficient permissions to create document, check the service account has access" instead of a stack-trace string. Every other method in `GoogleDocsClient` funnels its `except` branch through it. Since that mapping *is* the function, the status codes are exactly the part a reader needs to follow, and naming them removes the step where you translate `429` in your head.

The detail I checked rather than assumed: this is not an httpx-style `response.status_code`. It comes from `getattr(exc.resp, "status", None)` on a `googleapiclient` `HttpError`, and it can legitimately be `None` when the exception has no `resp` shaped the way we expect. `None == HTTPStatus.FORBIDDEN` evaluates `False` exactly as `None == 403` did, so the `None` case still falls past all four branches, past the `elif status_code:` guard, and out with the generic `str(exc)` message. Unchanged.

I left that final `elif status_code:` as-is on purpose, swapping it would have meant inventing a comparison that isn't there.

The alternative I considered was collapsing the `if/elif` chain into a dict keyed by `HTTPStatus` with the message templates as values. It reads more cleanly and would scale better if more codes get added. I rejected it because it changes control flow rather than just naming constants: it makes the diff harder to check against the existing tests, and the issue scopes this to replacing literals. If maintainers would prefer the dict form, it is a small follow-up.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests — n/a, behavior-preserving refactor already covered by direct unit tests on this function
- [x] My code follows the project's style guidelines and conventions