### PR TITLE
refactor(tool-framework): drop comments that restate the next line (S…

### DIFF
--- a/core/tool_framework/utils/data_validation.py
+++ b/core/tool_framework/utils/data_validation.py
@@ -44,26 +44,20 @@ class MetricsValidator:
         if "data" in normalized and isinstance(normalized["data"], list):
             validated_data, _ = _validate_data_list(normalized["data"], self._validate_flat_metrics)
             normalized["data"] = validated_data
-            # Also check aggregated values if present
             if "max_cpu" in normalized or "max_ram" in normalized:
                 normalized = self._validate_flat_metrics(normalized)
 
-        # Check nested memory metrics
         if "memory" in normalized:
             normalized["memory"] = self._validate_memory_metric(normalized["memory"])
 
-        # Check CPU metrics
         if "cpu" in normalized:
             normalized["cpu"] = self._validate_cpu_metric(normalized["cpu"])
 
-        # Check disk metrics
         if "disk" in normalized:
             normalized["disk"] = self._validate_disk_metric(normalized["disk"])
 
-        # Check for flat structure metrics (cpu, ram, disk at top level)
         normalized = self._validate_flat_metrics(normalized)
 
-        # Check for percentage fields at top level
         for key in ["percent", "percentage", "usage_percent"]:
             if key in normalized:
                 value = normalized[key]
@@ -93,7 +87,6 @@ class MetricsValidator:
 
         normalized = memory_data.copy()
 
-        # Check for impossible percentage values
         if "percent" in memory_data:
             raw_percent = memory_data["percent"]
 
@@ -285,7 +278,6 @@ class MetricsValidator:
                 # Don't set to None - keep raw value but mark as invalid
                 # LLM can use interpretation to understand it
 
-        # Check "max_ram" if present
         if "max_ram" in normalized:
             raw_max_ram = normalized["max_ram"]
             if isinstance(raw_max_ram, int | float) and raw_max_ram > 100:


### PR DESCRIPTION
Delete the eight `# Check ...` banners in `data_validation.py` that only repeat the condition immediately below them (nested memory / CPU / disk metrics, flat metrics, top-level percentage fields, aggregated values, impossible percentages, `max_ram`).

Comments carrying a rule the code does not state are kept, including both notes explaining that `"ram"` is treated as a memory field, the byte-threshold markers in `_infer_memory_unit`, and the rationale for allowing CPU above 100% but flagging above 1000%.

Comments only; the diff is eight deletions and no code change.

Fixes #4266

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

SM-73. `core/tool_framework/utils/data_validation.py` was the only file touched.

Deleted (line numbers pre-edit):

| Line | Comment | The line it restated |
| --- | --- | --- |
| 47 | `# Also check aggregated values if present` | `if "max_cpu" in normalized or "max_ram" in normalized:` |
| 51 | `# Check nested memory metrics` | `if "memory" in normalized:` |
| 55 | `# Check CPU metrics` | `if "cpu" in normalized:` |
| 59 | `# Check disk metrics` | `if "disk" in normalized:` |
| 63 | `# Check for flat structure metrics (cpu, ram, disk at top level)` | `normalized = self._validate_flat_metrics(normalized)` |
| 66 | `# Check for percentage fields at top level` | `for key in ["percent", "percentage", "usage_percent"]:` |
| 96 | `# Check for impossible percentage values` | `if "percent" in memory_data:` ... `> 100` |
| 288 | `# Check "max_ram" if present` | `if "max_ram" in normalized:` |

Line 63's parenthetical is not lost, `_validate_flat_metrics`'s own docstring already reads "Validate metrics in flat structure (cpu, ram, disk at top level)."

Kept, because each states a rule the code does not:

- both notes explaining that `"ram"` is routed through memory validation, the issue calls this one out explicitly
- the byte-threshold markers in `_infer_memory_unit` (`# >= 1GB`, `# >= 1MB`, and the note on values above 100 but under 1MB)
- the multi-core rationale for allowing CPU past 100% but flagging past 1000%
- `# Mark as invalid, LLM should use interpretation` and `# Don't set to None - keep raw value but mark as invalid`, which explain a deliberate asymmetry in how invalid values are blanked

### Demo/Screenshot for feature changes and bug fixes -

<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

Proof the change is comment-only, filtering the diff for any changed line that is *not* a deleted comment returns nothing:

```
$ git diff --stat
 core/tool_framework/utils/data_validation.py | 8 --------
 1 file changed, 8 deletions(-)

$ git diff | grep -E '^[+-]' | grep -vE '^[+-]{3}' | grep -vE '^-\s*#'
(empty)

$ uv run ruff check core/tool_framework/utils/data_validation.py
All checks passed!

$ uv run mypy core/tool_framework/utils/data_validation.py
Success: no issues found in 1 source file

$ uv run pytest tests/core/tool_framework/utils/test_data_validation.py tests/tools/test_tracer_host_metrics_tool.py -q
============================== 22 passed in 0.87s ==============================
```

Because this file sits under `core/`, I ran the full suite rather than only the scoped tests:

```
$ make lint          -> All checks passed!
$ make format-check  -> 2850 files already formatted
$ make typecheck     -> Success: no issues found in 1484 source files
$ make test-cov      -> 12638 passed, 60 skipped in 126.66s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

<!--
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

Since "I only touched comments" is the kind of claim that is easy to get wrong, I verified it mechanically instead of by eye: filtering the diff for any changed line that isn't a deleted comment returns nothing. And because the file lives under `core/`, `.github/ci/test_scope_rules.py` escalates it to the full suite, so I ran `make test-cov` rather than the scoped target.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests — n/a, comment-only diff
- [x] My code follows the project's style guidelines and conventions
