### PR TITLE
refactor(interactive-shell): spell out the progress throttle unit (SM…

### DIFF
--- a/surfaces/interactive_shell/ui/streaming/__init__.py
+++ b/surfaces/interactive_shell/ui/streaming/__init__.py
@@ -42,7 +42,7 @@ from surfaces.interactive_shell.ui.streaming.console import StreamingConsole
 # Throttle for the optional ``update_streaming_progress`` hook on the
 # console — caps cross-thread queueing on long bursts of chunks. Same
 # value (and intent) as ``runtime.core.state.PROMPT_REFRESH_INTERVAL_S``.
-_PROGRESS_INTERVAL_S = 0.1
+_PROGRESS_INTERVAL_SECONDS = 0.1
 
 # Markdown rendering constants — extracted so streaming.py and any
 # external caller (e.g. agent_actions.py for the planned-actions
@@ -170,7 +170,7 @@ def stream_to_console(
         nonlocal progress_hook
         if progress_hook is None:
             return last_progress_at
-        if not force and now - last_progress_at < _PROGRESS_INTERVAL_S:
+        if not force and now - last_progress_at < _PROGRESS_INTERVAL_SECONDS:
             return last_progress_at
         try:
             progress_hook(total_bytes)


### PR DESCRIPTION
Rename `_PROGRESS_INTERVAL_S` to `_PROGRESS_INTERVAL_SECONDS` and update its one reference. The constant is module-private and the repo-wide grep shows only the definition and that single use, so the rename is contained to this file. No behavior change.

`PROMPT_REFRESH_INTERVAL_S` is left alone — it is public with three importers.

Fixes #4265

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

SM-57. `surfaces/interactive_shell/ui/streaming/__init__.py` was the only file touched.

The diff is two lines: the definition, and the throttle check inside `_maybe_update_progress`. `grep -rn "_PROGRESS_INTERVAL_S\b" --include="*.py" .` now returns nothing no re-exports and no test references, which is what makes this safe as a single-file rename.

`PROMPT_REFRESH_INTERVAL_S` is **not** renamed. It is public and imported by `prompt_manager.py`, `confirmation.py`, and listed in `state.py`'s `__all__`; the issue flags that as maintainer-scope.

One thing I noticed while in the file but deliberately kept out of this PR: the comment above the constant says it holds the same *value* as `runtime.core.state.PROMPT_REFRESH_INTERVAL_S`, but that one is `0.25` (`state.py:21`) against this one's `0.1`. That is a factual fix unrelated to the rename, so I left it out rather than pad a two-line diff, noted on the issue instead. Happy to fix it in a follow-up if you want it.

### Demo/Screenshot for feature changes and bug fixes -

<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

```
$ grep -rn "_PROGRESS_INTERVAL_S\b" --include="*.py" .
(no matches, the old name is gone repo-wide)

$ uv run ruff check surfaces/interactive_shell/ui/streaming/__init__.py
All checks passed!

$ uv run ruff format --check surfaces/interactive_shell/ui/streaming/__init__.py
1 file already formatted

$ uv run mypy surfaces/interactive_shell/ui/streaming/__init__.py
Success: no issues found in 1 source file

$ uv run pytest tests/interactive_shell/ui/test_streaming.py tests/interactive_shell/ui/test_rendering.py -q
============================== 54 passed in 0.68s ==============================
```

Full harness also run green on this change:

```
$ make lint          -> All checks passed!
$ make format-check  -> 2850 files already formatted
$ make typecheck     -> Success: no issues found in 1484 source files
$ make test-cov      -> 12638 passed, 60 skipped in 126.66s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

<!--
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

`_PROGRESS_INTERVAL_SECONDS` throttles the optional `update_streaming_progress` hook so that a fast burst of LLM chunks doesn't flood the cross-thread queue feeding the bottom-toolbar token counter. The only consumer is `_maybe_update_progress`, a closure inside `stream_to_console`, which compares `now - last_progress_at` against it a seconds-domain float derived from `time.monotonic()`. `_S` is ambiguous at a glance, and misreading a unit inside a `time.monotonic()` delta is how you end up with a 1000x-wrong throttle, so spelling it out is the whole point.

Before renaming I checked the blast radius rather than trusting the leading underscore to mean "local". That distinction is real in this tree: `_FRAME_INTERVAL_S`, the constant in the sibling SM-59 issue, is private by the same convention yet referenced from three test files. For this one the grep returned exactly two hits, both in the target file, which is what makes it a contained rename and not a cascade.

I did not touch `PROMPT_REFRESH_INTERVAL_S`. Renaming it would ripple into `prompt_manager.py`, `confirmation.py`, and `state.py`'s `__all__`, and the issue explicitly puts that out of scope.
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests — n/a, rename with no behavior change
- [x] My code follows the project's style guidelines and conventions
