### PR TITLE
refactor(telegram): use HTTPStatus for delivery success

### DIFF
--- a/integrations/telegram/delivery.py
+++ b/integrations/telegram/delivery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import re
+from http import HTTPStatus
 from typing import Any
 
 from platform.common.truncation import truncate
@@ -149,7 +150,7 @@ def post_telegram_message(
         error = redact_token(response.error, bot_token)
         logger.warning("[telegram] post message exception: %s", error)
         return False, error, ""
-    if response.status_code != 200:
+    if response.status_code != HTTPStatus.OK:
         logger.warning("[telegram] post message failed: %s", response.status_code)
         if response.data:
             error_message = str(


### PR DESCRIPTION
Fixes #4303

#### Describe the changes you have made in this PR -

Replaced Telegram delivery's bare `200` success check with `HTTPStatus.OK` and imported `HTTPStatus` from the standard library. The accepted response and error behavior are unchanged.

### Demo/Screenshot for feature changes and bug fixes -

```text
uv run python -m pytest -q tests/utils/test_telegram_delivery.py
25 passed

uv run ruff check integrations/telegram/delivery.py
All checks passed!

uv run ruff format --check integrations/telegram/delivery.py
1 file already formatted

uv run mypy integrations/telegram
Success: no issues found in 19 source files
```

The broader `tests/integrations` scope produced 3140 passed and 7 skipped, with one unrelated Windows-only failure in `test_codex_auth_payload_and_write_auth_shape`: Windows reported mode `0666` where the POSIX-specific assertion expects `0600`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`post_json` exposes the HTTP response status as an integer, and Telegram delivery accepts only HTTP 200 before reading `result.message_id`. `HTTPStatus.OK` is an `IntEnum` with the same value, so using it keeps the comparison and all existing error paths identical while making the meaning explicit and following the repository rule against raw HTTP status literals.

I considered adding a new test, but this issue requires a one-file, behavior-preserving refactor. The existing Telegram delivery suite already covers the success response, API errors, transport exceptions, token redaction, and non-JSON error bodies, so changing tests would add scope without testing new behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests (not applicable; this is a behavior-preserving refactor)
- [x] My code follows the project's style guidelines and conventions

---

Allow edits from maintainers is enabled.