### PR TITLE
refactor(sentry): use HTTPStatus for bad requests

### DIFF
--- a/integrations/sentry/__init__.py
+++ b/integrations/sentry/__init__.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass
+from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -177,7 +178,7 @@ def describe_sentry_api_error(
         detail = str(err)
 
     hints: list[str] = []
-    if err.response.status_code == 400:
+    if err.response.status_code == HTTPStatus.BAD_REQUEST:
         if _OR_SPLIT.search(query.split("\n", maxsplit=1)[0]):
             hints.append(
                 "Sentry issue search does not support OR; use one keyword or phrase at a time."
@@ -307,7 +308,7 @@ def list_sentry_issues(
             )
             return payload if isinstance(payload, list) else []
         except httpx.HTTPStatusError as err:
-            if err.response.status_code == 400:
+            if err.response.status_code == HTTPStatus.BAD_REQUEST:
                 last_error = err
                 continue
             raise


### PR DESCRIPTION
Fixes #4290

#### Describe the changes you have made in this PR -

Replaced the two raw `400` status comparisons in the shared Sentry integration helpers with `HTTPStatus.BAD_REQUEST`. This follows the repository convention for HTTP status codes without changing retry behavior, diagnostic hints, or user-facing messages.

### Demo/Screenshot for feature changes and bug fixes -

```text
uv run python .github/ci/run_test_scope.py --base main
55 passed, 1 skipped

uv run python -m pytest -q \
  tests/integrations/test_verification_registry.py \
  tests/integrations/test_registry.py
31 passed

uv run python -m ruff check config core gateway integrations platform surfaces tools tests/
All checks passed!

uv run python -m ruff format --check config core gateway integrations platform surfaces tools tests/
2937 files already formatted

uv run python -m mypy config core gateway integrations platform surfaces tools
Success: no issues found in 1484 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`httpx` exposes response status codes as integers. `HTTPStatus.BAD_REQUEST` is an `IntEnum` with the same value as `400`, so these comparisons remain equivalent.

The first comparison adds useful guidance when Sentry rejects a query. The second retries alternative query segments after the same response. I kept both control-flow paths and all messages unchanged. A separate constant was unnecessary because the standard-library enum is already the project convention.

The existing scoped tests cover the HTTP 400 diagnostic and retry paths, so no test changes were needed for this behavior-preserving, one-file refactor.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests (not applicable; this is a behavior-preserving integration refactor)
- [x] My code follows the project's style guidelines and conventions

---

Allow edits from maintainers is enabled.
