### PR TITLE
refactor(codex): use HTTPStatus in OAuth flow

### DIFF
--- a/integrations/llm_cli/codex_oauth.py
+++ b/integrations/llm_cli/codex_oauth.py
@@ -234,7 +234,7 @@ class _CallbackHandler(BaseHTTPRequestHandler):
                 error_description=str(exc),
             )
             self._write_page(
-                400,
+                HTTPStatus.BAD_REQUEST,
                 "OpenSRE OAuth login failed while saving credentials. Return to the terminal.",
             )
             self.server.callback_event.set()

--- a/integrations/llm_cli/codex_oauth.py
+++ b/integrations/llm_cli/codex_oauth.py
@@ -14,6 +14,7 @@ from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlencode, urlparse
@@ -123,10 +124,12 @@ class _CallbackHandler(BaseHTTPRequestHandler):
             if self.server.callback_result is None:
                 self._handle_success_token_callback(parsed.query)
                 return
-            self._write_page(200, "OpenSRE OAuth login completed. You can close this tab.")
+            self._write_page(
+                HTTPStatus.OK, "OpenSRE OAuth login completed. You can close this tab."
+            )
             return
         if parsed.path != CODEX_OAUTH_CALLBACK_PATH:
-            self.send_response(404)
+            self.send_response(HTTPStatus.NOT_FOUND)
             self.end_headers()
             return
 
@@ -138,7 +141,7 @@ class _CallbackHandler(BaseHTTPRequestHandler):
                 error_description="OAuth callback state did not match the login request.",
             )
             self._write_page(
-                400,
+                HTTPStatus.BAD_REQUEST,
                 "OpenSRE OAuth login failed. Return to the terminal and retry.",
             )
             self.server.callback_event.set()
@@ -151,7 +154,7 @@ class _CallbackHandler(BaseHTTPRequestHandler):
                 error_description=query.get("error_description", [""])[0],
             )
             self._write_page(
-                400,
+                HTTPStatus.BAD_REQUEST,
                 "OpenSRE OAuth login was not completed. Return to the terminal.",
             )
             self.server.callback_event.set()
@@ -164,7 +167,7 @@ class _CallbackHandler(BaseHTTPRequestHandler):
                 error_description="OAuth callback did not include an authorization code.",
             )
             self._write_page(
-                400,
+                HTTPStatus.BAD_REQUEST,
                 "OpenSRE OAuth login failed. Return to the terminal and retry.",
             )
             self.server.callback_event.set()
@@ -183,7 +186,7 @@ class _CallbackHandler(BaseHTTPRequestHandler):
                 error_description=str(exc),
             )
             self._write_page(
-                400,
+                HTTPStatus.BAD_REQUEST,
                 "OpenSRE OAuth login failed while saving credentials. Return to the terminal.",
             )
             self.server.callback_event.set()
@@ -205,7 +208,7 @@ class _CallbackHandler(BaseHTTPRequestHandler):
                 error_description="OAuth success callback did not include an id_token.",
             )
             self._write_page(
-                400,
+                HTTPStatus.BAD_REQUEST,
                 "OpenSRE OAuth login failed. Return to the terminal and retry.",
             )
             self.server.callback_event.set()
@@ -238,11 +241,11 @@ class _CallbackHandler(BaseHTTPRequestHandler):
             return
 
         self.server.callback_result = _CallbackResult(login=result)
-        self._write_page(200, "OpenSRE OAuth login completed. You can close this tab.")
+        self._write_page(HTTPStatus.OK, "OpenSRE OAuth login completed. You can close this tab.")
         self.server.callback_event.set()
 
     def _redirect(self, location: str) -> None:
-        self.send_response(302)
+        self.send_response(HTTPStatus.FOUND)
         self.send_header("Location", location)
         self.send_header("Content-Length", "0")
         self.end_headers()
@@ -330,7 +333,7 @@ def exchange_codex_oauth_code(
         )
     except httpx.HTTPError as exc:
         raise CodexOAuthError(f"OpenAI OAuth token exchange failed: {exc}") from exc
-    if response.status_code != 200:
+    if response.status_code != HTTPStatus.OK:
         raise CodexOAuthError(
             f"OpenAI OAuth token exchange failed with HTTP {response.status_code}."
         )


### PR DESCRIPTION
Fixes #4304

#### Describe the changes you have made in this PR -

Replaced applicable bare HTTP status code literals in `integrations/llm_cli/codex_oauth.py` with the corresponding standard-library `HTTPStatus` enum members:

- `200` -> `HTTPStatus.OK`
- `302` -> `HTTPStatus.FOUND`
- `400` -> `HTTPStatus.BAD_REQUEST`
- `404` -> `HTTPStatus.NOT_FOUND`

The token-exchange success comparison also uses `HTTPStatus.OK`. This is a one-file, behavior-preserving maintainability refactor; OAuth control flow, status values, error messages, redirect behavior, and credential handling are unchanged.

### Demo/Screenshot for feature changes and bug fixes -

No UI or user-visible behavior changed, so terminal validation is the relevant proof for this refactor.

Focused validation:

```text
uv run python -m compileall integrations/llm_cli/codex_oauth.py
passed

uv run pytest -q tests/integrations/llm_cli/test_codex_oauth.py
11 passed in 3.41s
```

Additional validation:

```text
make lint
All checks passed!

make format-check
2978 files already formatted

make typecheck
Success: no issues found in 1510 source files
```

`make test-cov` was executed. Result: `12700 passed, 58 skipped, 13 warnings`; it exited with status 2 because two unrelated wizard keyring tests attempted SecretService/DBus detection and were blocked by the suite's live-network guard:

```text
FAILED tests/cli/wizard/test_env_sync.py::test_sync_env_values_routes_secrets_to_keyring
FAILED tests/cli/wizard/test_env_sync.py::test_sync_env_secret_with_blank_value_deletes_the_stored_secret
```

No tests or other files were changed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

* [ ] No, I wrote all the code myself
* [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

* [x] I have reviewed every single line of the AI-generated code
* [x] I can explain the purpose and logic of each function/component I added
* [x] I have tested edge cases and understand how the code handles them
* [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

This issue requests a readability-only refactor, so the implementation avoids changing control flow or introducing helpers. `HTTPStatus` is an `IntEnum`, so its members remain compatible with `BaseHTTPRequestHandler.send_response()`, the existing `_write_page()` integer annotation, and comparisons against `httpx.Response.status_code`. The exact runtime status values and OAuth behavior are therefore preserved.

## Checklist before requesting a review

* [x] I have added a proper PR title and linked the issue
* [x] I have performed a self-review of my code
* [x] I can explain the purpose of every function, class, and logic block I changed
* [x] I understand why my changes work and have tested edge cases
* [x] The existing focused tests cover the affected behavior
* [x] My code follows the project's style guidelines and conventions
* [x] Exactly one file was modified
* [x] No user-facing messages or runtime behavior were changed
