### PR TITLE
Use HTTPStatus.OK in Dagster client (SM-42)

### DIFF
--- a/integrations/dagster/client.py
+++ b/integrations/dagster/client.py
@@ -7,6 +7,7 @@ on transport, HTTP, or GraphQL-level errors, so callers don't branch on exceptio
 from __future__ import annotations
 
 import logging
+from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -82,7 +83,7 @@ class DagsterClient:
         except httpx.RequestError as exc:
             return {"error": f"Request to Dagster failed: {exc}"}
 
-        if response.status_code != 200:
+        if response.status_code != HTTPStatus.OK:
             body_preview = response.text[:200] if response.text else ""
             return {"error": f"HTTP {response.status_code}: {body_preview}"}
 


### PR DESCRIPTION
Fixes #4300

#### Describe the changes you have made in this PR -
- Import `HTTPStatus` in `integrations/dagster/client.py`
- Replace bare `!= 200` with `!= HTTPStatus.OK` in `_post`
- Behavior and error messages unchanged

### Demo/Screenshot for feature changes and bug fixes -
```
uv run ruff check integrations/dagster/client.py  # All checks passed
uv run mypy integrations/dagster/client.py        # Success
uv run pytest tests/integrations/test_dagster.py  # 67 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The project rule requires named `http.HTTPStatus` members instead of bare numeric status literals. This file had a single comparison (`response.status_code != 200`). I replaced it with `HTTPStatus.OK` (value 200) so the check is identical at runtime. The error string still interpolates `response.status_code` because that is the live response value, not a status literal.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.