### PR TITLE
refactor(state): spell out _FRAME_INTERVAL_SECONDS (SM-59)

### DIFF
--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -151,7 +151,7 @@ class SpinnerState:
     # callback runs: prompt_toolkit evaluates the message several times per
     # render pass (layout measurement + paint), so a per-call counter can land
     # on the same frame every visible render and freeze the animation.
-    _FRAME_INTERVAL_S = 0.1
+    _FRAME_INTERVAL_SECONDS = 0.1
     _THINKING_VERBS = (
         "thinking",
         "pondering",
@@ -224,7 +224,7 @@ class SpinnerState:
             return ""
         elapsed = time.monotonic() - self.started_at
         token_count = self.bytes_in // _CHARS_PER_TOKEN
-        frame_idx = int(elapsed / self._FRAME_INTERVAL_S)
+        frame_idx = int(elapsed / self._FRAME_INTERVAL_SECONDS)
         glyph = self._SPINNER_FRAMES[frame_idx % len(self._SPINNER_FRAMES)]
         if token_count > 0:
             tokens_str = format_token_count_short(token_count)

--- a/tests/interactive_shell/runtime/test_spinner_state.py
+++ b/tests/interactive_shell/runtime/test_spinner_state.py
@@ -34,14 +34,14 @@ def test_spinner_frame_is_a_function_of_elapsed_time_not_call_count() -> None:
     assert all(_glyph(spinner) == first for _ in range(10))
 
     # A frame interval later the glyph must have advanced.
-    spinner.started_at -= SpinnerState._FRAME_INTERVAL_S * 1.01
+    spinner.started_at -= SpinnerState._FRAME_INTERVAL_SECONDS * 1.01
     assert _glyph(spinner) != first
 
     # Over a full cycle of elapsed time, every frame is visited in order.
     spinner.start()
     seen = []
     for step in range(len(_GLYPHS)):
-        spinner.started_at = time.monotonic() - step * SpinnerState._FRAME_INTERVAL_S * 1.001
+        spinner.started_at = time.monotonic() - step * SpinnerState._FRAME_INTERVAL_SECONDS * 1.001
         seen.append(_glyph(spinner))
     assert seen == list(_GLYPHS)
 

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -805,7 +805,7 @@ class TestSpinnerState:
 
         seen = set()
         for step in range(len(spinner._SPINNER_FRAMES)):
-            spinner.started_at = time.monotonic() - step * spinner._FRAME_INTERVAL_S * 1.001
+            spinner.started_at = time.monotonic() - step * spinner._FRAME_INTERVAL_SECONDS * 1.001
             seen.add(_extract_glyph(spinner.inline_spinner_ansi(), spinner._SPINNER_FRAMES))
         assert seen == set(spinner._SPINNER_FRAMES)
 


### PR DESCRIPTION
Fixes #4316

Rename `_FRAME_INTERVAL_S` → `_FRAME_INTERVAL_SECONDS` in `surfaces/interactive_shell/runtime/core/state.py` (1 declaration + 1 use). Public `PROMPT_REFRESH_INTERVAL_S` left untouched per the issue. Two test files updated to match the rename.

```
$ make lint           # passed
$ make format-check   # passed
$ make typecheck      # passed
$ make test-scope     # 1350 passed, 1 skipped
```

---

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [ ] No
- [x] Yes

**If yes:**
- [x] Reviewed every changed line
- [x] Can explain the change
- [x] Tested and confirmed no behavior change
- [x] Output already conformed to project conventions

**Approach:**

Mechanical constant rename. No behavior change — `_FRAME_INTERVAL_SECONDS = 0.1` is the same value as the old `_FRAME_INTERVAL_S`, and the test files were updated only to follow the rename into the references they make to the attribute. Scope kept to the listed file plus the two test files that read the constant; `PROMPT_REFRESH_INTERVAL_S` (public, used by 3+ importers) left untouched per the issue.

## Checklist
- [x] PR title + linked issue
- [x] Self-reviewed
- [x] Can explain every change
- [x] Tested
- [x] Follows project conventions