### PR TITLE
refactor(sentry): use HTTPStatus for forbidden response

### DIFF
--- a/integrations/sentry/uptime.py
+++ b/integrations/sentry/uptime.py
@@ -11,6 +11,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
 from pathlib import Path
 from typing import Any, Literal
 
@@ -199,7 +200,7 @@ def list_sentry_uptime_monitors(*, config: SentryConfig) -> list[UptimeMonitor]:
             err,
             project_slug=config.project_slug,
         )
-        if err.response.status_code == 403:
+        if err.response.status_code == HTTPStatus.FORBIDDEN:
             detail = f"{detail} {_ALERTS_READ_HINT}"
         raise RuntimeError(detail) from err
 


### PR DESCRIPTION
Fixes #4291

#### Describe the changes you have made in this PR -

Replaced the raw `403` comparison in the Sentry uptime client with `HTTPStatus.FORBIDDEN`, keeping behavior unchanged while following the repository's named-status convention.

### Demo/Screenshot for feature changes and bug fixes -

```text
tests/integrations/sentry/test_uptime.py: 15 passed
make test-scope: 55 passed, 1 skipped
make verify-integrations-smoke: 31 passed
make lint: All checks passed
make format-check: 2978 files already formatted
make typecheck: Success: no issues found in 1510 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The uptime error handler needs to recognize a forbidden Sentry response so it can append the existing permissions hint. I imported Python's standard `HTTPStatus` enum and used `HTTPStatus.FORBIDDEN` in that comparison. Keeping the existing numeric literal was considered, but it conflicts with the project's explicit named-status rule; introducing a separate constant would duplicate the standard library enum.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
