### PR TITLE
refactor(openclaw): split MCP bridge tool types, results, and params …

### DIFF
--- a/integrations/openclaw/tools/openclaw_mcp_tool/__init__.py
+++ b/integrations/openclaw/tools/openclaw_mcp_tool/__init__.py
@@ -1,15 +1,24 @@
-"""OpenClaw MCP-backed bridge tools."""
+"""OpenClaw MCP-backed bridge tools.
+
+Package layout (separation of concerns):
+
+- ``models.py``   — payload type aliases shared by the whole package.
+- ``results.py``  — pure shaping of MCP results/failures into agent payloads.
+- ``params.py``   — availability + ``extract_params`` reads over the agent-state
+  ``openclaw`` source.
+- ``__init__.py`` — this file: config resolution, MCP dispatch, and the
+  ``@tool`` entrypoints. They stay here because the tool registry discovers a
+  package's tools on its own module (``TOOL_MODULES`` would be needed to look
+  into sub-modules) and tests patch the bridge callables on this module.
+"""
 
 from __future__ import annotations
 
 from core.tool_framework.telemetry import report_run_error
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.mcp_bridge import unavailable_response
-from core.tool_framework.utils.mcp_params import first_list, first_string
 from core.tool_framework.utils.mcp_tool_listing import build_mcp_tool_listing
 from integrations.openclaw import (
     OpenClawConfig,
-    OpenClawToolCallResult,
     build_openclaw_config,
     describe_openclaw_error,
     openclaw_config_from_env,
@@ -21,19 +30,21 @@ from integrations.openclaw import (
 from integrations.openclaw import (
     list_openclaw_tools as list_openclaw_mcp_tools,
 )
-
-OpenClawParams = dict[str, object]
-OpenClawBridgeResponse = dict[str, object]
-OpenClawConversationRow = dict[str, object]
-
-
-def _openclaw_unavailable_response(
-    error: str,
-    *,
-    tool_name: str | None = None,
-    arguments: OpenClawParams | None = None,
-) -> OpenClawBridgeResponse:
-    return unavailable_response("openclaw", error, tool_name=tool_name, arguments=arguments)
+from integrations.openclaw.tools.openclaw_mcp_tool.models import (
+    OpenClawBridgeResponse,
+    OpenClawParams,
+)
+from integrations.openclaw.tools.openclaw_mcp_tool.params import (
+    conversation_detail_params,
+    conversation_search_params,
+    extract_params,
+    is_available,
+)
+from integrations.openclaw.tools.openclaw_mcp_tool.results import (
+    conversation_rows_from_result,
+    normalize_tool_result,
+    unavailable_result,
+)
 
 
 def _resolve_config(
@@ -63,81 +74,6 @@ def _resolve_config(
     return env_config
 
 
-def _openclaw_available(sources: dict[str, dict]) -> bool:
-    return bool(sources.get("openclaw", {}).get("connection_verified"))
-
-
-def _openclaw_extract_params(sources: dict[str, dict]) -> OpenClawParams:
-    openclaw = sources.get("openclaw", {})
-    if not openclaw:
-        return {}
-    return {
-        "openclaw_url": first_string(openclaw, "openclaw_url", "url"),
-        "openclaw_mode": first_string(openclaw, "openclaw_mode", "mode"),
-        "openclaw_token": first_string(openclaw, "openclaw_token", "auth_token"),
-        "openclaw_command": first_string(openclaw, "openclaw_command", "command"),
-        "openclaw_args": first_list(openclaw, "openclaw_args", "args"),
-    }
-
-
-def _openclaw_conversation_id(sources: dict[str, dict]) -> str:
-    openclaw = sources.get("openclaw", {})
-    return str(
-        openclaw.get("openclaw_conversation_id") or openclaw.get("conversation_id") or ""
-    ).strip()
-
-
-def _openclaw_conversation_params(sources: dict[str, dict]) -> OpenClawParams:
-    params = _openclaw_extract_params(sources)
-    openclaw = sources.get("openclaw", {})
-    params["search"] = (
-        openclaw.get("openclaw_search_query")
-        or openclaw.get("search_query")
-        or openclaw.get("search")
-        or ""
-    )
-    params["limit"] = 10
-    return params
-
-
-def _openclaw_conversation_detail_params(sources: dict[str, dict]) -> OpenClawParams:
-    params = _openclaw_extract_params(sources)
-    conversation_id = _openclaw_conversation_id(sources)
-    if conversation_id:
-        params["conversation_id"] = conversation_id
-    return params
-
-
-def _normalize_tool_result(result: OpenClawToolCallResult) -> OpenClawBridgeResponse:
-    if result.get("is_error"):
-        return _openclaw_unavailable_response(
-            str(result.get("text") or "OpenClaw MCP tool call failed."),
-            tool_name=str(result.get("tool", "")).strip() or None,
-            arguments=result.get("arguments", {}),
-        )
-    return {
-        "source": "openclaw",
-        "available": True,
-        "tool": result.get("tool"),
-        "arguments": result.get("arguments", {}),
-        "text": result.get("text", ""),
-        "structured_content": result.get("structured_content"),
-        "content": result.get("content", []),
-    }
-
-
-def _conversation_rows_from_result(result: OpenClawToolCallResult) -> list[OpenClawConversationRow]:
-    structured = result.get("structured_content")
-    if isinstance(structured, list):
-        return [item for item in structured if isinstance(item, dict)]
-    if isinstance(structured, dict):
-        conversations = structured.get("conversations")
-        if isinstance(conversations, list):
-            return [item for item in conversations if isinstance(item, dict)]
-        return [structured]
-    return []
-
-
 def _normalize_named_bridge_call(
     config: OpenClawConfig,
     *,
@@ -163,13 +99,13 @@ def _normalize_named_bridge_call(
             method=f"invoke_openclaw_mcp_tool('{tool_name}')",
             extras={"mcp_tool": tool_name, "transport": config.mode},
         )
-        return _openclaw_unavailable_response(
+        return unavailable_result(
             describe_openclaw_error(err, config),
             tool_name=tool_name,
             arguments=arguments,
         )
 
-    payload = _normalize_tool_result(result)
+    payload = normalize_tool_result(result)
     if payload.get("available") is False:
         payload.setdefault("tool", tool_name)
         payload.setdefault("arguments", arguments)
@@ -217,8 +153,8 @@ def _normalize_named_bridge_call(
         },
         "required": [],
     },
-    is_available=_openclaw_available,
-    extract_params=_openclaw_extract_params,
+    is_available=is_available,
+    extract_params=extract_params,
 )
 def list_openclaw_bridge_tools(
     name_filter: str | None = None,
@@ -243,13 +179,13 @@ def list_openclaw_bridge_tools(
         openclaw_args,
     )
     if config is None:
-        payload = _openclaw_unavailable_response("OpenClaw MCP integration is not configured.")
+        payload = unavailable_result("OpenClaw MCP integration is not configured.")
         payload["tools"] = []
         return payload
 
     runtime_error = openclaw_runtime_unavailable_reason(config)
     if runtime_error is not None:
-        payload = _openclaw_unavailable_response(runtime_error)
+        payload = unavailable_result(runtime_error)
         payload["tools"] = []
         return payload
 
@@ -264,7 +200,7 @@ def list_openclaw_bridge_tools(
             method="list_openclaw_mcp_tools",
             extras={"transport": config.mode},
         )
-        payload = _openclaw_unavailable_response(describe_openclaw_error(err, config))
+        payload = unavailable_result(describe_openclaw_error(err, config))
         payload["tools"] = []
         return payload
 
@@ -305,8 +241,8 @@ def list_openclaw_bridge_tools(
         },
         "required": [],
     },
-    is_available=_openclaw_available,
-    extract_params=_openclaw_conversation_params,
+    is_available=is_available,
+    extract_params=conversation_search_params,
 )
 def search_openclaw_conversations(
     search: str = "",
@@ -327,13 +263,13 @@ def search_openclaw_conversations(
         openclaw_args,
     )
     if config is None:
-        payload = _openclaw_unavailable_response("OpenClaw MCP integration is not configured.")
+        payload = unavailable_result("OpenClaw MCP integration is not configured.")
         payload["conversations"] = []
         return payload
 
     runtime_error = openclaw_runtime_unavailable_reason(config)
     if runtime_error is not None:
-        payload = _openclaw_unavailable_response(runtime_error)
+        payload = unavailable_result(runtime_error)
         payload["conversations"] = []
         return payload
 
@@ -356,13 +292,13 @@ def search_openclaw_conversations(
             method="invoke_openclaw_mcp_tool('conversations_list')",
             extras={"transport": config.mode},
         )
-        payload = _openclaw_unavailable_response(describe_openclaw_error(err, config))
+        payload = unavailable_result(describe_openclaw_error(err, config))
         payload["conversations"] = []
         return payload
 
-    payload = _normalize_tool_result(result)
+    payload = normalize_tool_result(result)
     payload["search"] = search.strip()
-    payload["conversations"] = _conversation_rows_from_result(result)
+    payload["conversations"] = conversation_rows_from_result(result)
     return payload
 
 
@@ -388,8 +324,8 @@ def search_openclaw_conversations(
         },
         "required": ["conversation_id"],
     },
-    is_available=_openclaw_available,
-    extract_params=_openclaw_conversation_detail_params,
+    is_available=is_available,
+    extract_params=conversation_detail_params,
 )
 def get_openclaw_conversation(
     conversation_id: str | None = None,
@@ -403,7 +339,7 @@ def get_openclaw_conversation(
     """Fetch a specific OpenClaw conversation."""
     normalized_conversation_id = (conversation_id or "").strip()
     if not normalized_conversation_id:
-        return _openclaw_unavailable_response("conversation_id is required.")
+        return unavailable_result("conversation_id is required.")
 
     config = _resolve_config(
         openclaw_url,
@@ -413,11 +349,11 @@ def get_openclaw_conversation(
         openclaw_args,
     )
     if config is None:
-        return _openclaw_unavailable_response("OpenClaw MCP integration is not configured.")
+        return unavailable_result("OpenClaw MCP integration is not configured.")
 
     runtime_error = openclaw_runtime_unavailable_reason(config)
     if runtime_error is not None:
-        return _openclaw_unavailable_response(runtime_error)
+        return unavailable_result(runtime_error)
 
     return _normalize_named_bridge_call(
         config,
@@ -450,8 +386,8 @@ def get_openclaw_conversation(
         },
         "required": ["conversation_id", "content"],
     },
-    is_available=_openclaw_available,
-    extract_params=_openclaw_conversation_detail_params,
+    is_available=is_available,
+    extract_params=conversation_detail_params,
 )
 def send_openclaw_message(
     conversation_id: str | None = None,
@@ -467,9 +403,9 @@ def send_openclaw_message(
     normalized_conversation_id = (conversation_id or "").strip()
     normalized_content = (content or "").strip()
     if not normalized_conversation_id:
-        return _openclaw_unavailable_response("conversation_id is required.")
+        return unavailable_result("conversation_id is required.")
     if not normalized_content:
-        return _openclaw_unavailable_response("content is required.")
+        return unavailable_result("content is required.")
 
     config = _resolve_config(
         openclaw_url,
@@ -479,11 +415,11 @@ def send_openclaw_message(
         openclaw_args,
     )
     if config is None:
-        return _openclaw_unavailable_response("OpenClaw MCP integration is not configured.")
+        return unavailable_result("OpenClaw MCP integration is not configured.")
 
     runtime_error = openclaw_runtime_unavailable_reason(config)
     if runtime_error is not None:
-        return _openclaw_unavailable_response(runtime_error)
+        return unavailable_result(runtime_error)
 
     return _normalize_named_bridge_call(
         config,
@@ -516,8 +452,8 @@ def send_openclaw_message(
         },
         "required": ["tool_name"],
     },
-    is_available=_openclaw_available,
-    extract_params=_openclaw_extract_params,
+    is_available=is_available,
+    extract_params=extract_params,
 )
 def call_openclaw_bridge_tool(
     tool_name: str | None = None,
@@ -532,7 +468,7 @@ def call_openclaw_bridge_tool(
     """Call a specific OpenClaw MCP bridge tool."""
     normalized_tool_name = (tool_name or "").strip()
     if not normalized_tool_name:
-        return _openclaw_unavailable_response(
+        return unavailable_result(
             "tool_name is required to call an OpenClaw MCP tool.",
             arguments=arguments or {},
         )
@@ -545,7 +481,7 @@ def call_openclaw_bridge_tool(
         openclaw_args,
     )
     if config is None:
-        return _openclaw_unavailable_response(
+        return unavailable_result(
             "OpenClaw MCP integration is not configured.",
             tool_name=normalized_tool_name or None,
             arguments=arguments or {},
@@ -553,7 +489,7 @@ def call_openclaw_bridge_tool(
 
     runtime_error = openclaw_runtime_unavailable_reason(config)
     if runtime_error is not None:
-        return _openclaw_unavailable_response(
+        return unavailable_result(
             runtime_error,
             tool_name=normalized_tool_name,
             arguments=arguments or {},
@@ -570,10 +506,10 @@ def call_openclaw_bridge_tool(
             method="invoke_openclaw_mcp_tool",
             extras={"mcp_tool": normalized_tool_name, "transport": config.mode},
         )
-        return _openclaw_unavailable_response(
+        return unavailable_result(
             describe_openclaw_error(err, config),
             tool_name=normalized_tool_name,
             arguments=arguments or {},
         )
 
-    return _normalize_tool_result(result)
+    return normalize_tool_result(result)

--- a/integrations/openclaw/tools/openclaw_mcp_tool/models.py
+++ b/integrations/openclaw/tools/openclaw_mcp_tool/models.py
@@ -1,0 +1,20 @@
+"""Typed payload shapes exchanged with the OpenClaw MCP bridge.
+
+Aliases only — no logic, so every other module in this package (and the tool
+entrypoints in ``__init__``) can import them without a cycle.
+"""
+
+from __future__ import annotations
+
+__all__ = ["OpenClawBridgeResponse", "OpenClawConversationRow", "OpenClawParams"]
+
+# Arguments handed to an MCP tool call, or connection overrides passed into a
+# bridge tool (``openclaw_url``, ``openclaw_mode``, ...).
+OpenClawParams = dict[str, object]
+
+# Payload a bridge tool returns to the agent: always carries ``source`` and
+# ``available``; the remaining keys depend on the tool.
+OpenClawBridgeResponse = dict[str, object]
+
+# One conversation record as returned by ``conversations_list``.
+OpenClawConversationRow = dict[str, object]

--- a/integrations/openclaw/tools/openclaw_mcp_tool/params.py
+++ b/integrations/openclaw/tools/openclaw_mcp_tool/params.py
@@ -1,0 +1,73 @@
+"""Read OpenClaw connection settings off the verified agent-state source.
+
+These back the ``is_available`` / ``extract_params`` hooks of the bridge tools:
+pure dict reads over the ``openclaw`` source, with no bridge traffic.
+"""
+
+from __future__ import annotations
+
+from core.tool_framework.utils.mcp_params import first_list, first_string
+from integrations.openclaw.tools.openclaw_mcp_tool.models import OpenClawParams
+
+__all__ = [
+    "conversation_detail_params",
+    "conversation_search_params",
+    "extract_params",
+    "is_available",
+]
+
+SEARCH_RESULT_LIMIT = 10
+
+
+def is_available(sources: dict[str, dict]) -> bool:
+    """True only once the OpenClaw integration has a verified connection."""
+    return bool(sources.get("openclaw", {}).get("connection_verified"))
+
+
+def extract_params(sources: dict[str, dict]) -> OpenClawParams:
+    """Connection overrides for a bridge call, read from the OpenClaw source.
+
+    Reads both the prefixed catalog keys (``openclaw_url``) and the short
+    runtime aliases produced by ``OpenClawConfig.model_dump()`` (``url``).
+    """
+    openclaw = sources.get("openclaw", {})
+    if not openclaw:
+        return {}
+    return {
+        "openclaw_url": first_string(openclaw, "openclaw_url", "url"),
+        "openclaw_mode": first_string(openclaw, "openclaw_mode", "mode"),
+        "openclaw_token": first_string(openclaw, "openclaw_token", "auth_token"),
+        "openclaw_command": first_string(openclaw, "openclaw_command", "command"),
+        "openclaw_args": first_list(openclaw, "openclaw_args", "args"),
+    }
+
+
+def conversation_id(sources: dict[str, dict]) -> str:
+    """Conversation id carried on the OpenClaw source, or an empty string."""
+    openclaw = sources.get("openclaw", {})
+    return str(
+        openclaw.get("openclaw_conversation_id") or openclaw.get("conversation_id") or ""
+    ).strip()
+
+
+def conversation_search_params(sources: dict[str, dict]) -> OpenClawParams:
+    """Connection overrides plus the conversation search query and row limit."""
+    params = extract_params(sources)
+    openclaw = sources.get("openclaw", {})
+    params["search"] = (
+        openclaw.get("openclaw_search_query")
+        or openclaw.get("search_query")
+        or openclaw.get("search")
+        or ""
+    )
+    params["limit"] = SEARCH_RESULT_LIMIT
+    return params
+
+
+def conversation_detail_params(sources: dict[str, dict]) -> OpenClawParams:
+    """Connection overrides plus the conversation id, when the source carries one."""
+    params = extract_params(sources)
+    resolved_conversation_id = conversation_id(sources)
+    if resolved_conversation_id:
+        params["conversation_id"] = resolved_conversation_id
+    return params

--- a/integrations/openclaw/tools/openclaw_mcp_tool/results.py
+++ b/integrations/openclaw/tools/openclaw_mcp_tool/results.py
@@ -1,0 +1,67 @@
+"""Stable result shapes for the OpenClaw bridge tools.
+
+Pure shaping of an MCP call result (or a failure reason) into the payload the
+agent sees. Nothing here talks to the bridge — dispatch lives in ``__init__``.
+"""
+
+from __future__ import annotations
+
+from core.tool_framework.utils.mcp_bridge import unavailable_response
+from integrations.openclaw import OpenClawToolCallResult
+from integrations.openclaw.tools.openclaw_mcp_tool.models import (
+    OpenClawBridgeResponse,
+    OpenClawConversationRow,
+    OpenClawParams,
+)
+
+__all__ = ["conversation_rows_from_result", "normalize_tool_result", "unavailable_result"]
+
+SOURCE = "openclaw"
+
+
+def unavailable_result(
+    error: str,
+    *,
+    tool_name: str | None = None,
+    arguments: OpenClawParams | None = None,
+) -> OpenClawBridgeResponse:
+    """Degraded payload for any OpenClaw bridge call that could not complete."""
+    return unavailable_response(SOURCE, error, tool_name=tool_name, arguments=arguments)
+
+
+def normalize_tool_result(result: OpenClawToolCallResult) -> OpenClawBridgeResponse:
+    """Shape a raw MCP tool-call result into a bridge response."""
+    if result.get("is_error"):
+        return unavailable_result(
+            str(result.get("text") or "OpenClaw MCP tool call failed."),
+            tool_name=str(result.get("tool", "")).strip() or None,
+            arguments=result.get("arguments", {}),
+        )
+    return {
+        "source": SOURCE,
+        "available": True,
+        "tool": result.get("tool"),
+        "arguments": result.get("arguments", {}),
+        "text": result.get("text", ""),
+        "structured_content": result.get("structured_content"),
+        "content": result.get("content", []),
+    }
+
+
+def conversation_rows_from_result(
+    result: OpenClawToolCallResult,
+) -> list[OpenClawConversationRow]:
+    """Pull conversation rows out of a ``conversations_list`` result.
+
+    The MCP side may return a bare list, a ``{"conversations": [...]}`` wrapper,
+    or a single conversation dict; anything else yields no rows.
+    """
+    structured = result.get("structured_content")
+    if isinstance(structured, list):
+        return [item for item in structured if isinstance(item, dict)]
+    if isinstance(structured, dict):
+        conversations = structured.get("conversations")
+        if isinstance(conversations, list):
+            return [item for item in conversations if isinstance(item, dict)]
+        return [structured]
+    return []


### PR DESCRIPTION
…into sibling modules

Fixes #4276

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Splits the 579-line `integrations/openclaw/tools/openclaw_mcp_tool/__init__.py` into sibling modules, following the layout the Slack/Telegram/RocketChat tool packages already use: `models.py` holds the payload type aliases, `results.py` holds the result-shaping helpers, and `params.py` holds the agent-state source reads that back each tool's `is_available`/`extract_params` hooks. `__init__.py` keeps only config resolution, MCP dispatch, and the five `@tool` entrypoints. This is a pure move — the tool bodies are unchanged apart from the renamed helpers, so there is no behavior change and all existing imports and tests keep working.

---

## Demo

<img width="1478" height="610" alt="image" src="https://github.com/user-attachments/assets/a8602f0e-4ad1-47dc-b43f-cfc7f6cad973" />

<img width="1478" height="610" alt="image" src="https://github.com/user-attachments/assets/dc706518-71d2-4fe5-9c3d-aa3dbf208702" />

All the tests work fine

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I moved out only the code that has no coupling to the bridge callables, which keeps the change behavior-preserving. `models.py` is a pure leaf (three type aliases) so every other module in the package can import it without a cycle; `results.py` and `params.py` are likewise pure — they shape payloads and read dicts, and never talk to the MCP bridge. Config resolution, MCP dispatch, and the `@tool` entrypoints deliberately stay in `__init__.py` for two reasons: registry discovery only scans a package's own module unless it declares `TOOL_MODULES` (`tools/registry_discovery.py`), and the existing tests patch `openclaw_mcp_tool.invoke_openclaw_mcp_tool`, `.list_openclaw_mcp_tools`, `.openclaw_config_from_env`, `.build_openclaw_config`, and `.openclaw_runtime_unavailable_reason` at that module path across three test files — moving the tool bodies into a sibling would silently turn those patches into no-ops. Pushing the tool functions into a `tool.py` is a sensible follow-up, but it needs a `TOOL_MODULES` manifest plus repointed patch targets, so I kept it out of this behavior-preserving first split. Verified with `make lint`, `make format-check`, `make typecheck` (clean on `integrations/openclaw`), `make test-scope`, and the wider openclaw unit/integration/telemetry/registry-index/e2e runs — 172 passed, 9 network-gated skips, no new `make vulture` findings.

<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
