### PR TITLE
refactor(protocols): docstring-only Protocol bodies (CodeQL py/ineffectual-statement)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,12 +236,15 @@ Steps:
 - Information exposure through an exception (CWE-209 / CodeQL `py/stack-trace-exposure`): never send an exception's detail — `str(exc)`, `repr(exc)`, `traceback.format_exc()`, `exc.args`, provider/model/field internals — to an **external surface**. External surfaces are HTTP responses (`JSONResponse`/`HTTPException.detail` in `gateway/http/`) and chat gateway messages delivered to Slack/Telegram users (`OutputSink.render_error` on the gateway sinks). Log full detail server-side (`logger` + `capture_exception`) and return a generic message or `type(exc).__name__` only. The local CLI/terminal sink is **not** external — it may show detail. Redact at the sink/response boundary, not per call site, so the shared turn engine keeps detail for local dev.
 - Cyclic imports (CodeQL `py/cyclic-import`): CodeQL counts **function-local** and `TYPE_CHECKING` imports as part of a cycle, so making an import lazy does **not** clear the alert. Break the cycle structurally — move the shared symbol (type, exception, helper) into a **leaf** module both sides import, and never add a back-edge from a lower-level module up to a higher-level one. Precedent: `surfaces/cli/wizard/validation_result.py` and `surfaces/cli/llm_auth/persist.py` exist only to hold shared symbols so `validation` ↔ `azure_openai` and `_ui` → `service` stay acyclic.
 - CodeQL does not model `NoReturn`: it treats `pytest.skip`, `pytest.fail`, `sys.exit`, `typer.Exit` and custom raise-helpers as if they return, so any code after them looks reachable. Two alerts come from this — `py/uninitialized-local-variable` when a name is bound in `try` and the `except` only calls such a function, and unreachable-code when a `with` body ends in a bare `raise`. Do **not** silence with a comment: bind the name on every path CodeQL can see. Prefer a sentinel over exception control flow for ordinary "not found" — `next(iterable, None)` plus an explicit `if x is None:` guard, not `try: next(...) except StopIteration:`. `mypy` narrows correctly after the guard because it *does* honour `NoReturn`. For the bare-`raise` case, extract a `_raise()` helper.
-- Protocol stub bodies (CodeQL `py/ineffectual-statement`): a bare `...` (or
-  `pass`) on a `Protocol` method is a valid PEP-544 idiom but trips CodeQL as a
-  statement with no effect. Do **not** write `def foo(self) -> T: ...`. Use a
-  one-line docstring as the only body (see Code Style above). Do not keep both a
-  docstring and a trailing `...`. Prefer documenting the contract on the port
-  over silencing the alert with a comment.
+- Protocol stub bodies (CodeQL `py/ineffectual-statement`): a bare `...` on a
+  `Protocol` method is a valid PEP-544 idiom but trips CodeQL as a statement
+  with no effect. Do **not** write `def foo(self) -> T: ...`. Use a one-line
+  docstring as the only body (see Code Style above), and do not keep both a
+  docstring and a trailing `...`/`pass`. Prefer documenting the contract on the
+  port over silencing the alert with a comment. Note the scope: CodeQL catches
+  only `...`, so a clean scan does **not** mean the codebase follows the rule —
+  `pass` and `raise NotImplementedError` are invisible to it, and 108 of the
+  latter remain.
 - `py/ineffectual-statement` does **not** understand `await`: a bare
   `await some_task` reads to CodeQL as a discarded expression. It is not — the
   await is the side effect. Cancelling a task and then awaiting it is the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,14 +24,19 @@
 - Do not keep compatibility-only forwarding modules after refactors. Once imports and tests
   are migrated, remove the old module path in the same change and use one canonical import path.
 - Protocol methods use a **docstring-only body** — never `...`, `pass`, or
-  `raise NotImplementedError` as the stub. Precedent:
-  `platform/filestorage/ports.py`, `core/agent_harness/ports.py`.
+  `raise NotImplementedError` as the stub, and never a docstring *plus* a
+  trailing `...`/`pass`. Precedent: `platform/filestorage/ports.py`,
+  `core/agent_harness/ports.py`, `core/agent/loop_host.py`.
 
   ```python
   class ObjectStore(Protocol):
       def put_object(self, key: str, data: bytes) -> None:
           """Store ``data`` under ``key``."""
   ```
+
+  Neither ruff nor mypy enforces this — mypy exempts Protocol bodies from
+  "missing return", so a `pass` under a `-> list[str]` signature passes
+  `make typecheck`. It is a review rule, and only the `...` form trips CodeQL.
 
 ### Docs under `docs/`
 
@@ -226,5 +231,11 @@ Steps:
   one-line docstring as the only body (see Code Style above). Do not keep both a
   docstring and a trailing `...`. Prefer documenting the contract on the port
   over silencing the alert with a comment.
+- `py/ineffectual-statement` does **not** understand `await`: a bare
+  `await some_task` reads to CodeQL as a discarded expression. It is not — the
+  await is the side effect. Cancelling a task and then awaiting it is the
+  standard way to reap it (`gateway/discord/worker.py`, where the awaited task
+  still has to run `client.close()`). Dismiss that alert as a false positive;
+  do not delete the await and do not launder it through a throwaway assignment.
 - CI typecheck does **not** cover `tests/`: `make typecheck` runs mypy over `PYTHON_SOURCE_PATHS` (`config core gateway integrations platform surfaces tools`) only. Type errors in test files never fail CI, so do not assume a clean `make typecheck` means the tests you just wrote are type-clean — run mypy on the test path directly when it matters.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,15 @@
   solely inside `config/config.py` (nothing it imports needs it) may live there.
 - Do not keep compatibility-only forwarding modules after refactors. Once imports and tests
   are migrated, remove the old module path in the same change and use one canonical import path.
+- Protocol methods use a **docstring-only body** — never `...`, `pass`, or
+  `raise NotImplementedError` as the stub. Precedent:
+  `platform/filestorage/ports.py`, `core/agent_harness/ports.py`.
+
+  ```python
+  class ObjectStore(Protocol):
+      def put_object(self, key: str, data: bytes) -> None:
+          """Store ``data`` under ``key``."""
+  ```
 
 ### Docs under `docs/`
 
@@ -211,5 +220,11 @@ Steps:
 - Information exposure through an exception (CWE-209 / CodeQL `py/stack-trace-exposure`): never send an exception's detail — `str(exc)`, `repr(exc)`, `traceback.format_exc()`, `exc.args`, provider/model/field internals — to an **external surface**. External surfaces are HTTP responses (`JSONResponse`/`HTTPException.detail` in `gateway/http/`) and chat gateway messages delivered to Slack/Telegram users (`OutputSink.render_error` on the gateway sinks). Log full detail server-side (`logger` + `capture_exception`) and return a generic message or `type(exc).__name__` only. The local CLI/terminal sink is **not** external — it may show detail. Redact at the sink/response boundary, not per call site, so the shared turn engine keeps detail for local dev.
 - Cyclic imports (CodeQL `py/cyclic-import`): CodeQL counts **function-local** and `TYPE_CHECKING` imports as part of a cycle, so making an import lazy does **not** clear the alert. Break the cycle structurally — move the shared symbol (type, exception, helper) into a **leaf** module both sides import, and never add a back-edge from a lower-level module up to a higher-level one. Precedent: `surfaces/cli/wizard/validation_result.py` and `surfaces/cli/llm_auth/persist.py` exist only to hold shared symbols so `validation` ↔ `azure_openai` and `_ui` → `service` stay acyclic.
 - CodeQL does not model `NoReturn`: it treats `pytest.skip`, `pytest.fail`, `sys.exit`, `typer.Exit` and custom raise-helpers as if they return, so any code after them looks reachable. Two alerts come from this — `py/uninitialized-local-variable` when a name is bound in `try` and the `except` only calls such a function, and unreachable-code when a `with` body ends in a bare `raise`. Do **not** silence with a comment: bind the name on every path CodeQL can see. Prefer a sentinel over exception control flow for ordinary "not found" — `next(iterable, None)` plus an explicit `if x is None:` guard, not `try: next(...) except StopIteration:`. `mypy` narrows correctly after the guard because it *does* honour `NoReturn`. For the bare-`raise` case, extract a `_raise()` helper.
+- Protocol stub bodies (CodeQL `py/ineffectual-statement`): a bare `...` (or
+  `pass`) on a `Protocol` method is a valid PEP-544 idiom but trips CodeQL as a
+  statement with no effect. Do **not** write `def foo(self) -> T: ...`. Use a
+  one-line docstring as the only body (see Code Style above). Do not keep both a
+  docstring and a trailing `...`. Prefer documenting the contract on the port
+  over silencing the alert with a comment.
 - CI typecheck does **not** cover `tests/`: `make typecheck` runs mypy over `PYTHON_SOURCE_PATHS` (`config core gateway integrations platform surfaces tools`) only. Type errors in test files never fail CI, so do not assume a clean `make typecheck` means the tests you just wrote are type-clean — run mypy on the test path directly when it matters.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,12 @@
   solely inside `config/config.py` (nothing it imports needs it) may live there.
 - Do not keep compatibility-only forwarding modules after refactors. Once imports and tests
   are migrated, remove the old module path in the same change and use one canonical import path.
-- Protocol methods use a **docstring-only body** — never `...`, `pass`, or
-  `raise NotImplementedError` as the stub, and never a docstring *plus* a
-  trailing `...`/`pass`. Precedent: `platform/filestorage/ports.py`,
-  `core/agent_harness/ports.py`, `core/agent/loop_host.py`.
+- Protocol methods you **add or change** use a **docstring-only body** — no
+  `...`, no `pass`, no `raise NotImplementedError`, and never a docstring *plus*
+  a trailing `...`/`pass`. Precedent (all fully compliant):
+  `platform/filestorage/ports.py`, `platform/deployment_contracts/ports.py`,
+  `core/agent/loop_host.py`, `gateway/runtime/sink_protocol.py`,
+  `core/llm/types.py`.
 
   ```python
   class ObjectStore(Protocol):
@@ -34,9 +36,18 @@
           """Store ``data`` under ``key``."""
   ```
 
-  Neither ruff nor mypy enforces this — mypy exempts Protocol bodies from
-  "missing return", so a `pass` under a `-> list[str]` signature passes
-  `make typecheck`. It is a review rule, and only the `...` form trips CodeQL.
+  **The codebase is not yet compliant, and no tool will tell you.** An AST scan
+  of product code counts 89 docstring-only Protocol methods against **108
+  `raise NotImplementedError` stubs in 23 files** (`core/agent_harness/ports.py`,
+  `platform/harness_ports.py`, `gateway/storage/session/binding_store.py` and
+  others). Those are pre-existing and out of scope for a drive-by — do not
+  mass-convert them, and do not cite a file as precedent without checking it.
+
+  Enforcement is review-only:
+  - CodeQL `py/ineffectual-statement` catches **only** the bare `...` form.
+  - `pass` and `raise NotImplementedError` trip nothing.
+  - mypy exempts Protocol bodies from "missing return", so `pass` under a
+    `-> list[str]` signature passes `make typecheck`.
 
 ### Docs under `docs/`
 

--- a/core/agent/loop_host.py
+++ b/core/agent/loop_host.py
@@ -33,33 +33,33 @@ class LoopHost[RuntimeToolT: RuntimeTool](Protocol):
     _tool_hooks: ToolExecutionHooks
 
     def _filter_tools(self, tools: list[RuntimeToolT]) -> list[RuntimeToolT]:
-        pass
+        """Narrow the tool list the loop may call this iteration."""
 
     def _emit_runtime(self, event: RuntimeEvent) -> None:
-        pass
+        """Publish one runtime event to whoever is watching the turn."""
 
     def _drain_steering_messages(self, messages: list[RuntimeMessage]) -> None:
-        pass
+        """Append any queued steering messages, in place."""
 
     def _pop_follow_up_message(self) -> str | None:
-        pass
+        """The next queued follow-up prompt, or None when there is none."""
 
     def _should_accept_conclusion(
         self, *, evidence_count: int, iteration: int
     ) -> tuple[bool, str | None]:
-        pass
+        """Whether the loop may conclude now, and why not when it may not."""
 
     def _transform_messages(self, messages: list[RuntimeMessage]) -> list[RuntimeMessage]:
-        pass
+        """Adjust runtime messages before they are converted for the provider."""
 
     def _convert_to_llm(self, llm: Any, messages: list[RuntimeMessage]) -> list[ProviderMessage]:
-        pass
+        """Render runtime messages in the provider's wire shape."""
 
     def _before_request(self, request: ProviderRequest) -> ProviderRequest:
-        pass
+        """Last chance to alter the request before it is sent."""
 
     def _after_response(self, request: ProviderRequest, response: Any) -> Any:
-        pass
+        """Inspect or replace the provider response before the loop reads it."""
 
 
 __all__ = ["LoopHost"]

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -11,7 +11,7 @@ Nothing here imports ``interactive_shell``.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Sequence
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
 

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -15,9 +15,6 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
 
-if TYPE_CHECKING:
-    pass
-
 # A tool-loop event callback: ``(kind, data)`` where kind is e.g. "tool_start".
 ToolEventObserver = Callable[[str, dict[str, Any]], None]
 

--- a/gateway/runtime/concurrency.py
+++ b/gateway/runtime/concurrency.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import threading
-from collections.abc import Callable
 
 from core.agent_harness.session import SessionCore
 from gateway.runtime.sink_protocol import GatewayAgentCallback, GatewaySink
@@ -83,8 +82,6 @@ def gated_callback(
     """Return the callback form expected by Telegram and Slack wiring."""
     return ConcurrencyLimitedTurnHandler(handler=handler, gate=gate)
 
-
-TurnCallbackFactory = Callable[[GatewayAgentCallback, TurnConcurrencyGate], GatewayAgentCallback]
 
 __all__ = [
     "ConcurrencyLimitedTurnHandler",

--- a/integrations/llm_cli/base.py
+++ b/integrations/llm_cli/base.py
@@ -42,7 +42,6 @@ class LLMCLIAdapter(Protocol):
 
     def detect(self) -> CLIProbe:
         """Resolve binary, version, and auth. Never raises; returns a structured probe."""
-        pass
 
     def build(
         self,
@@ -53,12 +52,9 @@ class LLMCLIAdapter(Protocol):
         reasoning_effort: str | None = None,
     ) -> CLIInvocation:
         """Build argv for a non-interactive run (no approval prompts, no TTY)."""
-        pass
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
         """Extract the model answer from a successful run."""
-        pass
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         """Human-readable failure when returncode != 0 or output is unusable."""
-        pass

--- a/platform/deployment_contracts/ports.py
+++ b/platform/deployment_contracts/ports.py
@@ -9,6 +9,8 @@ from platform.deployment_contracts.models import AgentRun, AgentRunSource, Agent
 
 
 class AgentRunRepository(Protocol):
+    """Durable store for agent runs, one queue per organization."""
+
     def enqueue_agent_run(
         self,
         *,
@@ -16,9 +18,11 @@ class AgentRunRepository(Protocol):
         source: AgentRunSource,
         prompt: str,
         source_event_id: str | None = None,
-    ) -> AgentRun: ...
+    ) -> AgentRun:
+        """Queue a new run for ``organization_id`` and return it."""
 
-    def fetch_agent_run_by_id(self, run_id: str) -> AgentRun | None: ...
+    def fetch_agent_run_by_id(self, run_id: str) -> AgentRun | None:
+        """The run with ``run_id``, or None when no such run exists."""
 
     def claim_oldest_available_agent_run(
         self,
@@ -26,7 +30,8 @@ class AgentRunRepository(Protocol):
         organization_id: str,
         worker_id: str,
         lease_duration: timedelta,
-    ) -> AgentRun | None: ...
+    ) -> AgentRun | None:
+        """Lease the oldest queued run to ``worker_id``, or None when the queue is empty."""
 
     def extend_owned_agent_run_lease(
         self,
@@ -34,7 +39,8 @@ class AgentRunRepository(Protocol):
         run_id: str,
         worker_id: str,
         lease_duration: timedelta,
-    ) -> bool: ...
+    ) -> bool:
+        """Renew the lease. False when ``worker_id`` no longer owns the run."""
 
     def finalize_owned_agent_run(
         self,
@@ -44,4 +50,5 @@ class AgentRunRepository(Protocol):
         status: AgentRunStatus,
         result: dict[str, Any] | None = None,
         error_code: str | None = None,
-    ) -> bool: ...
+    ) -> bool:
+        """Record the terminal ``status``. False when ``worker_id`` lost ownership."""


### PR DESCRIPTION
Two CodeQL alerts, plus the same defect wherever else it appeared.

**`py/ineffectual-statement` (#2049)** — five `Protocol` methods in `platform/deployment_contracts/ports.py` had a bare `...` body. Python needs at least one statement in a function body, and a Protocol method has no implementation, so it needs a placeholder. `...` is the idiom inherited from `.pyi` stub files; at runtime it evaluates the `Ellipsis` singleton and discards it, which is exactly what the rule detects — a discarded expression value is usually a typo (`x.show` for `x.show()`).

A docstring is the same kind of placeholder — a string-literal statement — but CodeQL explicitly exempts it ("will not flag a statement consisting solely of a string") and it documents the contract. Both bodies return `None`; there is no behavioural difference.

Sweeping for the same shape found two more files the scanner had not reported:

- `integrations/llm_cli/base.py` — three methods had a docstring **and** a
  trailing `pass`. Dropped the `pass`.
- `core/agent/loop_host.py` — nine `LoopHost` methods had a bare `pass` and no
  docstring. Replaced with one-line docstrings naming each seam.
- `core/agent_harness/ports.py` — removed a dead `if TYPE_CHECKING: pass` block.

`pass` never trips CodeQL, so these were invisible to CI. Worth knowing: mypy
exempts Protocol bodies from "missing return", so `pass` under a
`-> list[RuntimeToolT]` signature passes `make typecheck` too. Neither tool
enforces this, which is why it is now written down.

**`py/unused-global-variable` (#1975)** — `TurnCallbackFactory` in
`gateway/runtime/concurrency.py` was defined, referenced nowhere, and not in
`__all__`. Removed, along with the now-unused `Callable` import.