### PR TITLE
docs: fix moved source references

### DIFF
--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -96,7 +96,7 @@ to it instead of re-implementing bootstrap + persistence:
   `gateway/storage/session/resolver.py::SessionResolver` owns per-chat
   chat-id ↔ session-id binding + metadata; it delegates `create` / `resolve` /
   `rotate` to `SessionManager`. Turn dispatch uses `HeadlessAgent` via
-  `gateway/turn_handler.py`'s `GatewayTurnHandler` with
+  `gateway/runtime/turn_handler.py`'s `GatewayTurnHandler` with
   :class:`~core.agent_harness.tools.tool_provider.DefaultToolProvider`
   built from the **live per-chat session** each turn (same tool resolution as
   shell). There is no separate gateway-owned ``Agent`` instance.

--- a/surfaces/interactive_shell/AGENTS.md
+++ b/surfaces/interactive_shell/AGENTS.md
@@ -172,9 +172,10 @@ owning area rather than adding more logic to the caller.
   (`rich.markup.escape`): alerts, command output, file paths, integration names,
   model/provider labels, errors, docs snippets, and model text that is not
   already intentionally rendered as Markdown.
-- Use semantic tokens from `ui/theme.py`. Do not introduce raw hex colors, Rich
-  named colors, or raw ANSI escapes outside `ui/theme.py` unless a narrow
-  prompt-toolkit compatibility path requires it.
+- Use semantic tokens from `platform/terminal/theme.py`. Do not introduce raw
+  hex colors, Rich named colors, or raw ANSI escapes outside
+  `platform/terminal/theme.py` unless a narrow prompt-toolkit compatibility
+  path requires it.
 - Any raw terminal-mode code must check TTY support and restore terminal state
   in `finally`.
 - Be careful mixing `prompt_toolkit.patch_stdout`, Rich live rendering, and


### PR DESCRIPTION
Fixes #4586

#### Describe the changes you have made in this PR -

- Update `GatewayTurnHandler` to its current `gateway/runtime/turn_handler.py` location.
- Update the interactive-shell theme reference to the canonical `platform/terminal/theme.py` module.

UnRot v0.5.4 identified both stale paths during an open-source agent-config scan. I verified both replacements against the current repository tree.

### Demo/Screenshot for feature changes and bug fixes -

```text
$ unrot check . --rules broken-refs
The two stale references are no longer reported.
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

This is a documentation-only correction. I resolved each stale path to the current file that owns the documented class or theme tokens. No runtime code changed.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests (not a core feature)
- [x] My code follows the project's style guidelines and conventions

