### PR TITLE
refactor: promote Environment to StrEnum

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -8,7 +8,7 @@ import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 from difflib import get_close_matches
-from enum import Enum
+from enum import StrEnum
 from typing import Literal
 
 from pydantic import Field, ValidationError, field_validator, model_validator
@@ -50,7 +50,7 @@ class LLMModelConfig(StrictConfigModel):
     max_tokens: int
 
 
-class Environment(Enum):
+class Environment(StrEnum):
     """Application environment."""
 
     DEVELOPMENT = "development"

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -6,8 +6,10 @@ import pytest
 from pydantic import ValidationError
 
 from config.config import (
+    Environment,
     LLMSettings,
     describe_llm_resolution,
+    get_environment,
     has_credentials_for_active_llm_provider,
     llm_provider_error_context,
     resolve_llm_settings,
@@ -418,3 +420,29 @@ def test_llm_provider_error_context_never_raises(monkeypatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "not-a-real-provider")
 
     assert llm_provider_error_context() == ""
+
+
+def test_environment_is_str_enum_with_stable_values() -> None:
+    assert set(Environment) == {Environment.DEVELOPMENT, Environment.PRODUCTION}
+    assert Environment.DEVELOPMENT.value == "development"
+    assert Environment.PRODUCTION.value == "production"
+    # StrEnum round-trips from its string value and compares equal to it,
+    # which is what the `.value` call sites and `== Environment.X` checks rely on.
+    assert Environment("production") is Environment.PRODUCTION
+    assert Environment.PRODUCTION == "production"
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        ("production", Environment.PRODUCTION),
+        ("prod", Environment.PRODUCTION),
+        ("development", Environment.DEVELOPMENT),
+        ("", Environment.DEVELOPMENT),
+        ("anything-else", Environment.DEVELOPMENT),
+    ],
+)
+def test_get_environment_maps_env_var(monkeypatch, env_value: str, expected: Environment) -> None:
+    monkeypatch.setenv("ENV", env_value)
+
+    assert get_environment() == expected


### PR DESCRIPTION
Fixes #4526

#### Describe the changes you have made in this PR -

Promotes `Environment` in `config/config.py` from a plain `Enum` (with string
values) to `StrEnum`, matching the repo convention for closed string
vocabularies (see `platform/filestorage/enums.py`).

- Members and values are unchanged: `DEVELOPMENT = "development"`, `PRODUCTION = "production"`.
- No behavior change: the five `get_environment().value` call sites still get
  the same plain strings, and every comparison already uses `== Environment.X`
  (no `str(env)` / f-string on a member exists, so `StrEnum`'s different `str()`
  output is never observed).
- `from enum import Enum` -> `from enum import StrEnum` (Enum had no other use in the file).
- Adds unit tests in `tests/config/test_config.py` pinning the members/values,
  the string round-trip, and the `ENV` -> `Environment` mapping.

### Demo/Screenshot for feature changes and bug fixes -

```
$ make lint && make format-check && make typecheck
All checks passed!
3019 files already formatted
Success: no issues found in 1529 source files

$ pytest tests/config/test_config.py tests/platform/auth/test_jwt_auth.py -q
55 passed, 1 warning in 3.28s
```

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
