### PR TITLE
Refactor: replace ExecutionVerdict Literal with StrEnum

### DIFF
--- a/tests/interactive_shell/shell/test_policy.py
+++ b/tests/interactive_shell/shell/test_policy.py
@@ -6,40 +6,41 @@ operators, substitution) and only rejects genuinely empty input.
 
 from __future__ import annotations
 
+from tools.interactive_shell.shared import ExecutionVerdict
 from tools.interactive_shell.shell.policy import evaluate_shell_command
 
 
 def test_read_only_shell_is_allow() -> None:
     r = evaluate_shell_command("pwd")
-    assert r.verdict == "allow"
+    assert r.verdict is ExecutionVerdict.ALLOW
     assert r.tool_type == "shell"
 
 
 def test_restricted_shell_is_allow() -> None:
     """Alpha mode removed the restricted deny floor; ``sudo`` now runs."""
     r = evaluate_shell_command("sudo ls /")
-    assert r.verdict == "allow"
+    assert r.verdict is ExecutionVerdict.ALLOW
     assert r.shell_classification == "unrestricted"
 
 
 def test_operator_shell_is_allow() -> None:
     """Shell operators run through a shell instead of being blocked."""
     r = evaluate_shell_command("ls | grep x")
-    assert r.verdict == "allow"
+    assert r.verdict is ExecutionVerdict.ALLOW
 
 
 def test_mutating_shell_is_allow() -> None:
     r = evaluate_shell_command("rm -rf /tmp/x")
-    assert r.verdict == "allow"
+    assert r.verdict is ExecutionVerdict.ALLOW
     assert r.shell_classification == "unrestricted"
 
 
 def test_passthrough_shell_is_allow() -> None:
     r = evaluate_shell_command("!echo hi")
-    assert r.verdict == "allow"
+    assert r.verdict is ExecutionVerdict.ALLOW
 
 
 def test_empty_shell_input_is_deny() -> None:
     """Only genuinely empty input is rejected (input validation, not a guardrail)."""
     r = evaluate_shell_command("!")
-    assert r.verdict == "deny"
+    assert r.verdict is ExecutionVerdict.DENY

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -1550,6 +1550,7 @@ class TestExecutionAllowedRespectsDispatchCancelled:
         from surfaces.interactive_shell.ui.execution_confirm import execution_allowed
         from tools.interactive_shell.shared import (
             ExecutionPolicyResult,
+            ExecutionVerdict,
         )
 
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
@@ -1560,7 +1561,7 @@ class TestExecutionAllowedRespectsDispatchCancelled:
             raise controller_runtime.DispatchCancelled("cancelled while awaiting confirmation")
 
         policy = ExecutionPolicyResult(
-            verdict="ask",
+            verdict=ExecutionVerdict.ASK,
             tool_type="opensre_cli",
             reason="this opensre subcommand may change local config or infrastructure",
         )
@@ -1592,6 +1593,7 @@ class TestExecutionAllowedRespectsDispatchCancelled:
         from surfaces.interactive_shell.ui.execution_confirm import execution_allowed
         from tools.interactive_shell.shared import (
             ExecutionPolicyResult,
+            ExecutionVerdict,
         )
 
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
@@ -1599,7 +1601,7 @@ class TestExecutionAllowedRespectsDispatchCancelled:
         console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
 
         policy = ExecutionPolicyResult(
-            verdict="ask",
+            verdict=ExecutionVerdict.ASK,
             tool_type="opensre_cli",
             reason="this opensre subcommand may change local config or infrastructure",
         )

--- a/tests/interactive_shell/tools/shared/test_execution_policy.py
+++ b/tests/interactive_shell/tools/shared/test_execution_policy.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from tools.interactive_shell.shared import (
     ConfirmationOutcome,
     ExecutionPolicyResult,
+    ExecutionVerdict,
     ToolExecutionMode,
     ToolExecutionPlan,
     allow_tool,
@@ -29,10 +30,29 @@ from tools.interactive_shell.shared import (
 def _ask_result() -> ExecutionPolicyResult:
     """An explicit ``ask`` verdict (the default policy no longer emits these)."""
     return ExecutionPolicyResult(
-        verdict="ask",
+        verdict=ExecutionVerdict.ASK,
         tool_type="slash",
         reason="this command may change configuration or run heavy work",
     )
+
+
+def test_execution_verdict_members_round_trip_from_strings() -> None:
+    assert ExecutionVerdict.ALLOW.value == "allow"
+    assert ExecutionVerdict.ASK.value == "ask"
+    assert ExecutionVerdict.DENY.value == "deny"
+    assert ExecutionVerdict("allow") is ExecutionVerdict.ALLOW
+    assert ExecutionVerdict("ask") is ExecutionVerdict.ASK
+    assert ExecutionVerdict("deny") is ExecutionVerdict.DENY
+
+
+def test_execution_policy_result_normalizes_string_verdict() -> None:
+    result = ExecutionPolicyResult(
+        verdict="allow",
+        tool_type="slash",
+        reason=None,
+    )
+
+    assert result.verdict is ExecutionVerdict.ALLOW
 
 
 # --- Default-allow policy decisions -----------------------------------------
@@ -40,7 +60,7 @@ def _ask_result() -> ExecutionPolicyResult:
 
 def test_allow_tool_is_allow() -> None:
     r = allow_tool("slash")
-    assert r.verdict == "allow"
+    assert r.verdict is ExecutionVerdict.ALLOW
     assert r.tool_type == "slash"
     assert r.reason is None
 
@@ -48,7 +68,7 @@ def test_allow_tool_is_allow() -> None:
 def test_allow_tool_carries_arbitrary_tool_type() -> None:
     for tool_type in ("investigation", "sample_alert", "synthetic_test", "code_agent"):
         r = allow_tool(tool_type)
-        assert r.verdict == "allow"
+        assert r.verdict is ExecutionVerdict.ALLOW
         assert r.tool_type == tool_type
 
 
@@ -61,7 +81,7 @@ def test_plan_foreground_tool_defaults_classification_to_tool_type() -> None:
     assert plan.tool_type == "slash"
     assert plan.classification == "slash"
     assert plan.execution_mode is ToolExecutionMode.FOREGROUND
-    assert plan.policy.verdict == "allow"
+    assert plan.policy.verdict is ExecutionVerdict.ALLOW
 
 
 def test_plan_foreground_tool_accepts_explicit_classification() -> None:
@@ -69,7 +89,7 @@ def test_plan_foreground_tool_accepts_explicit_classification() -> None:
     assert plan.tool_type == "investigation"
     assert plan.classification == "investigation_launch"
     assert plan.execution_mode is ToolExecutionMode.FOREGROUND
-    assert plan.policy.verdict == "allow"
+    assert plan.policy.verdict is ExecutionVerdict.ALLOW
 
 
 # --- resolve_confirmation: pure decision (no side effects) ------------------
@@ -83,7 +103,7 @@ def test_resolve_allow_verdict_proceeds() -> None:
 
 def test_resolve_deny_verdict_blocks() -> None:
     result = ExecutionPolicyResult(
-        verdict="deny",
+        verdict=ExecutionVerdict.DENY,
         tool_type="shell",
         reason="empty command.",
         hint="Enter a command to run.",

--- a/tests/interactive_shell/ui/test_execution_confirm.py
+++ b/tests/interactive_shell/ui/test_execution_confirm.py
@@ -15,6 +15,7 @@ from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui.execution_confirm import execution_allowed
 from tools.interactive_shell.shared import (
     ExecutionPolicyResult,
+    ExecutionVerdict,
     allow_tool,
 )
 
@@ -22,7 +23,7 @@ from tools.interactive_shell.shared import (
 def _ask_result() -> ExecutionPolicyResult:
     """An explicit ``ask`` verdict (the default policy no longer emits these)."""
     return ExecutionPolicyResult(
-        verdict="ask",
+        verdict=ExecutionVerdict.ASK,
         tool_type="slash",
         reason="this command may change configuration or run heavy work",
     )
@@ -73,7 +74,7 @@ def test_deny_verdict_blocks() -> None:
     # The default policy never emits a deny; construct one explicitly to cover
     # the execution_allowed deny path.
     r = ExecutionPolicyResult(
-        verdict="deny",
+        verdict=ExecutionVerdict.DENY,
         tool_type="shell",
         reason="empty command.",
         hint="Enter a command to run.",

--- a/tools/interactive_shell/cli.py
+++ b/tools/interactive_shell/cli.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from platform.common.task_types import TaskKind
 from tools.interactive_shell.shared import (
     ExecutionPolicyResult,
+    ExecutionVerdict,
     ToolExecutionMode,
     ToolExecutionPlan,
 )
@@ -199,7 +200,7 @@ def to_tool_execution_plan(plan: OpensreExecutionPlan) -> ToolExecutionPlan:
         mode = ToolExecutionMode.FOREGROUND_STREAMING
     if not plan.requires_confirmation:
         policy = ExecutionPolicyResult(
-            verdict="allow",
+            verdict=ExecutionVerdict.ALLOW,
             tool_type="cli_command",
             reason=None,
             hint=None,
@@ -207,7 +208,7 @@ def to_tool_execution_plan(plan: OpensreExecutionPlan) -> ToolExecutionPlan:
         )
     else:
         policy = ExecutionPolicyResult(
-            verdict="ask",
+            verdict=ExecutionVerdict.ASK,
             tool_type="cli_command",
             reason=plan.confirmation_reason,
             hint="Use a read-only subcommand (health, version, list, status, show)",

--- a/tools/interactive_shell/shared/execution_policy.py
+++ b/tools/interactive_shell/shared/execution_policy.py
@@ -37,9 +37,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Literal
 
-ExecutionVerdict = Literal["allow", "ask", "deny"]
+
+class ExecutionVerdict(StrEnum):
+    """Policy decision for whether a tool may execute."""
+
+    ALLOW = "allow"
+    ASK = "ask"
+    DENY = "deny"
 
 
 class ToolExecutionMode(StrEnum):
@@ -57,6 +62,10 @@ class ExecutionPolicyResult:
     reason: str | None
     hint: str | None = None
     shell_classification: str | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize string verdicts supplied by existing callers."""
+        object.__setattr__(self, "verdict", ExecutionVerdict(self.verdict))
 
 
 @dataclass(frozen=True)
@@ -106,7 +115,7 @@ def resolve_confirmation(
     (``interactive_shell.ui.execution_confirm``) renders the decision and emits
     analytics.
     """
-    if result.verdict == "deny":
+    if result.verdict is ExecutionVerdict.DENY:
         return ConfirmationPlan(
             outcome=ConfirmationOutcome.DENY,
             result=result,
@@ -114,7 +123,7 @@ def resolve_confirmation(
             analytics_reason=result.reason,
         )
 
-    if result.verdict == "allow":
+    if result.verdict is ExecutionVerdict.ALLOW:
         return ConfirmationPlan(
             outcome=ConfirmationOutcome.ALLOW,
             result=result,
@@ -153,7 +162,11 @@ def allow_tool(tool_type: str) -> ExecutionPolicyResult:
     so every caller resolves to ``allow``. ``tool_type`` is carried through for
     analytics and confirmation UX.
     """
-    return ExecutionPolicyResult(verdict="allow", tool_type=tool_type, reason=None)
+    return ExecutionPolicyResult(
+        verdict=ExecutionVerdict.ALLOW,
+        tool_type=tool_type,
+        reason=None,
+    )
 
 
 def plan_foreground_tool(

--- a/tools/interactive_shell/shell/policy.py
+++ b/tools/interactive_shell/shell/policy.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import config.constants.platform as _platform
 from tools.interactive_shell.shared import (
     ExecutionPolicyResult,
+    ExecutionVerdict,
     ToolExecutionMode,
     ToolExecutionPlan,
 )
@@ -32,7 +33,7 @@ def evaluate_shell_from_parsed(parsed: ParsedShellCommand) -> ExecutionPolicyRes
     """
     if parsed.parse_error is not None:
         return ExecutionPolicyResult(
-            verdict="deny",
+            verdict=ExecutionVerdict.DENY,
             tool_type="shell",
             reason=parsed.parse_error,
             hint="Enter a command to run.",
@@ -40,7 +41,7 @@ def evaluate_shell_from_parsed(parsed: ParsedShellCommand) -> ExecutionPolicyRes
         )
 
     return ExecutionPolicyResult(
-        verdict="allow",
+        verdict=ExecutionVerdict.ALLOW,
         tool_type="shell",
         reason=None,
         shell_classification="unrestricted",

--- a/tools/interactive_shell/shell/runner.py
+++ b/tools/interactive_shell/shell/runner.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import config.constants.platform as _platform
+from tools.interactive_shell.shared import ExecutionVerdict
 from tools.interactive_shell.shell import execution as shell_execution
 from tools.interactive_shell.shell.display import format_shell_command_for_display
 from tools.interactive_shell.shell.parsing import (
@@ -75,7 +76,7 @@ def run_shell_command(
             command=command,
             ok=False,
             response_text=plan.policy.reason or "shell command blocked",
-            cancelled=plan.policy.verdict != "deny",
+            cancelled=plan.policy.verdict is not ExecutionVerdict.DENY,
         )
 
     if not quiet:


### PR DESCRIPTION
Fixes #4537

#### Describe the changes you have made in this PR -

Replaced the `ExecutionVerdict` `Literal` alias with a `StrEnum` containing `ALLOW`, `ASK`, and `DENY`.

Updated policy, shell, CLI, and test call sites to use enum members. Added normalization in the frozen policy-result dataclass so existing plain-string verdict inputs remain compatible. No behavior changes: alpha policy still defaults to allow.

### Demo/Screenshot for feature changes and bug fixes -

```text
$ make lint
All checks passed!

$ .venv/bin/python -m pytest \
  tests/interactive_shell/shell/test_policy.py \
  tests/interactive_shell/tools/shared/test_execution_policy.py \
  tests/interactive_shell/ui/test_execution_confirm.py -q

24 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I used `StrEnum` so verdict values remain string-compatible for equality checks and serialization while providing a defined set of policy outcomes. The enum keeps the existing values—`allow`, `ask`, and `deny`—unchanged.

`ExecutionPolicyResult` normalizes its verdict in `__post_init__`, which ensures callers that still provide a plain string receive an enum member. This is required because annotating a frozen dataclass field does not perform runtime conversion. Tests cover enum values, string round-tripping, and string-input normalization.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions