### PR TITLE
refactor: add watchdog threshold enum

### DIFF
--- a/tests/watch_dog/test_config.py
+++ b/tests/watch_dog/test_config.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from tools.system.watch_dog.config import (
     WatchdogConfig,
+    WatchdogThreshold,
     parse_byte_size,
     parse_duration_seconds,
 )
@@ -24,6 +25,15 @@ def test_parse_byte_size_accepts_binary_suffixes() -> None:
     assert parse_byte_size("512M") == 512 * 1024**2
     assert parse_byte_size("1K") == 1024
     assert parse_byte_size(4096) == 4096
+
+
+def test_watchdog_threshold_members_are_stable() -> None:
+    assert [threshold.value for threshold in WatchdogThreshold] == [
+        "max_cpu",
+        "max_runtime",
+        "max_rss",
+    ]
+    assert WatchdogThreshold("max_cpu") is WatchdogThreshold.MAX_CPU
 
 
 def test_watchdog_config_requires_pid_or_name_xor() -> None:
@@ -63,7 +73,7 @@ def test_thresholds_are_returned_in_stable_order() -> None:
     )
 
     assert [threshold.name for threshold in config.thresholds()] == [
-        "max_cpu",
-        "max_runtime",
-        "max_rss",
+        WatchdogThreshold.MAX_CPU,
+        WatchdogThreshold.MAX_RUNTIME,
+        WatchdogThreshold.MAX_RSS,
     ]

--- a/tools/system/watch_dog/config.py
+++ b/tools/system/watch_dog/config.py
@@ -4,14 +4,23 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Literal
 
 from pydantic import Field, field_validator, model_validator
 
 from config.strict_config import StrictConfigModel
 
-ThresholdName = Literal["max_cpu", "max_runtime", "max_rss"]
 AlarmProvider = Literal["telegram", "rocketchat"]
+
+
+class WatchdogThreshold(StrEnum):
+    """Closed set of watchdog thresholds."""
+
+    MAX_CPU = "max_cpu"
+    MAX_RUNTIME = "max_runtime"
+    MAX_RSS = "max_rss"
+
 
 _DURATION_RE = re.compile(r"^(?P<value>\d+(?:\.\d+)?)(?P<unit>[smh]?)$")
 _BYTE_RE = re.compile(r"^(?P<value>\d+(?:\.\d+)?)(?P<unit>[kmgt]?b?)$", re.IGNORECASE)
@@ -21,7 +30,7 @@ _BYTE_RE = re.compile(r"^(?P<value>\d+(?:\.\d+)?)(?P<unit>[kmgt]?b?)$", re.IGNOR
 class Threshold:
     """A configured watchdog threshold."""
 
-    name: ThresholdName
+    name: WatchdogThreshold
     limit: float
 
 
@@ -122,9 +131,9 @@ class WatchdogConfig(StrictConfigModel):
         """Return thresholds in stable evaluation order."""
         thresholds: list[Threshold] = []
         if self.max_cpu is not None:
-            thresholds.append(Threshold("max_cpu", self.max_cpu))
+            thresholds.append(Threshold(WatchdogThreshold.MAX_CPU, self.max_cpu))
         if self.max_runtime is not None:
-            thresholds.append(Threshold("max_runtime", self.max_runtime))
+            thresholds.append(Threshold(WatchdogThreshold.MAX_RUNTIME, self.max_runtime))
         if self.max_rss is not None:
-            thresholds.append(Threshold("max_rss", float(self.max_rss)))
+            thresholds.append(Threshold(WatchdogThreshold.MAX_RSS, float(self.max_rss)))
         return tuple(thresholds)

--- a/tools/system/watch_dog/runner.py
+++ b/tools/system/watch_dog/runner.py
@@ -20,7 +20,7 @@ from integrations.rocketchat.credentials import (
 from integrations.telegram.alarms import AlarmDispatcher
 from integrations.telegram.credentials import load_credentials_from_env
 from platform.common.exit_codes import ERROR, SUCCESS
-from tools.system.watch_dog.config import AlarmProvider, WatchdogConfig
+from tools.system.watch_dog.config import AlarmProvider, WatchdogConfig, WatchdogThreshold
 from tools.system.watch_dog.process_monitor import ProcessMonitor, ProcessSample, Sampler
 
 
@@ -35,7 +35,7 @@ class Dispatcher(Protocol):
 class ThresholdBreach:
     """A threshold violation observed for a sample."""
 
-    name: str
+    name: WatchdogThreshold
     limit: float
     observed: float
     window_seconds: float | None = None
@@ -81,7 +81,7 @@ def run_watchdog(
 
             for breach in breaches:
                 active_dispatcher.dispatch(
-                    breach.name,
+                    breach.name.value,
                     _format_alarm_message(sample, breach, provider=config.provider),
                 )
 
@@ -115,7 +115,7 @@ def _evaluate_thresholds(
         if observed_cpu >= config.max_cpu:
             breaches.append(
                 ThresholdBreach(
-                    name="max_cpu",
+                    name=WatchdogThreshold.MAX_CPU,
                     limit=config.max_cpu,
                     observed=observed_cpu,
                     window_seconds=config.cpu_window,
@@ -125,7 +125,7 @@ def _evaluate_thresholds(
     if config.max_runtime is not None and sample.runtime_seconds >= config.max_runtime:
         breaches.append(
             ThresholdBreach(
-                name="max_runtime",
+                name=WatchdogThreshold.MAX_RUNTIME,
                 limit=config.max_runtime,
                 observed=sample.runtime_seconds,
             )
@@ -134,7 +134,7 @@ def _evaluate_thresholds(
     if config.max_rss is not None and sample.rss_bytes >= config.max_rss:
         breaches.append(
             ThresholdBreach(
-                name="max_rss",
+                name=WatchdogThreshold.MAX_RSS,
                 limit=float(config.max_rss),
                 observed=float(sample.rss_bytes),
             )
@@ -244,16 +244,16 @@ def _format_alarm_message_markdown(sample: ProcessSample, breach: ThresholdBreac
 
 
 def _format_threshold_breach(breach: ThresholdBreach) -> str:
-    if breach.name == "max_cpu":
+    if breach.name == WatchdogThreshold.MAX_CPU:
         window = f"  window={_format_duration(breach.window_seconds or 0)}"
         return f"max_cpu  limit={breach.limit:.1f}%  observed={breach.observed:.1f}%{window}"
-    if breach.name == "max_runtime":
+    if breach.name == WatchdogThreshold.MAX_RUNTIME:
         return (
             "max_runtime  "
             f"limit={_format_duration(breach.limit)}  "
             f"observed={_format_duration(breach.observed)}"
         )
-    if breach.name == "max_rss":
+    if breach.name == WatchdogThreshold.MAX_RSS:
         return (
             "max_rss  "
             f"limit={_format_bytes(breach.limit)}  "


### PR DESCRIPTION
Fixes #4525

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Added a `WatchdogThreshold` `StrEnum` for the fixed watchdog threshold names.
- Updated watchdog threshold config and breach handling to use the enum internally.
- Kept dispatcher calls string-based by passing enum `.value`, so alarm cooldown keys and message output stay unchanged.
- Added a small enum coverage test for stable values and string round-trip behavior.

### Demo/Screenshot for feature changes and bug fixes - 

Focused local checks:

```text
python -m ruff check tools/system/watch_dog/config.py tools/system/watch_dog/runner.py tests/watch_dog/test_config.py
All checks passed!

python -m ruff format --check tools/system/watch_dog/config.py tools/system/watch_dog/runner.py tests/watch_dog/test_config.py
3 files already formatted

python -m pytest --confcutdir=tests/watch_dog tests/watch_dog/test_config.py tests/watch_dog/test_runner.py
17 passed in 1.59s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The watchdog threshold names are a closed vocabulary: `max_cpu`, `max_runtime`, and `max_rss`. This change replaces the previous `Literal` alias with a `StrEnum` so the set is represented in one place and still behaves like strings at external boundaries.

I kept `AlarmProvider` unchanged because provider values are outside this issue's scope. I also kept alarm dispatch receiving plain string names via `.value`, which preserves cooldown keys and formatted message output. The added test pins the enum values and verifies construction from the existing string value.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.