### PR TITLE
refactor(probes): promote verification ProbeStatus to StrEnum

### DIFF
--- a/integrations/probes.py
+++ b/integrations/probes.py
@@ -4,29 +4,41 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Any
+
+
+class ProbeStatus(StrEnum):
+    """Closed set of integration verification probe outcomes."""
+
+    PASSED = "passed"
+    FAILED = "failed"
+    MISSING = "missing"
 
 
 @dataclass(frozen=True)
 class ProbeResult:
     """Result returned by verification-facing client probe methods."""
 
-    status: str
+    status: ProbeStatus
     detail: str
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "status", ProbeStatus(self.status))
+
     @property
     def ok(self) -> bool:
-        return self.status == "passed"
+        return self.status is ProbeStatus.PASSED
 
     @classmethod
     def passed(cls, detail: str, **metadata: Any) -> ProbeResult:
-        return cls(status="passed", detail=detail, metadata=metadata)
+        return cls(status=ProbeStatus.PASSED, detail=detail, metadata=metadata)
 
     @classmethod
     def failed(cls, detail: str, **metadata: Any) -> ProbeResult:
-        return cls(status="failed", detail=detail, metadata=metadata)
+        return cls(status=ProbeStatus.FAILED, detail=detail, metadata=metadata)
 
     @classmethod
     def missing(cls, detail: str, **metadata: Any) -> ProbeResult:
-        return cls(status="missing", detail=detail, metadata=metadata)
+        return cls(status=ProbeStatus.MISSING, detail=detail, metadata=metadata)

--- a/integrations/verify.py
+++ b/integrations/verify.py
@@ -24,6 +24,7 @@ from integrations.registry import (
     INTEGRATION_SPECS_BY_SERVICE,
     SUPPORTED_VERIFY_SERVICES,
 )
+from integrations.probes import ProbeStatus
 from integrations.slack.verifier import RUNTIME_SEND_TEST_KEY as _SLACK_RUNTIME_SEND_TEST_KEY
 from integrations.store import get_integration
 from integrations.verification import VerifierFn, get_verifier, result
@@ -46,10 +47,10 @@ register_all_verifiers()
 # than spawning one thread per integration (SUPPORTED_VERIFY_SERVICES is 50+).
 _MAX_PARALLEL_VERIFIERS = 16
 
-_STATUS_STYLE: dict[str, tuple[str, str]] = {
-    "passed": (GLYPH_SUCCESS, f"bold {HIGHLIGHT}"),
-    "failed": (GLYPH_ERROR, f"bold {ERROR}"),
-    "missing": (GLYPH_WARNING, f"bold {WARNING}"),
+_STATUS_STYLE: dict[ProbeStatus, tuple[str, str]] = {
+    ProbeStatus.PASSED: (GLYPH_SUCCESS, f"bold {HIGHLIGHT}"),
+    ProbeStatus.FAILED: (GLYPH_ERROR, f"bold {ERROR}"),
+    ProbeStatus.MISSING: (GLYPH_WARNING, f"bold {WARNING}"),
 }
 
 
@@ -180,7 +181,11 @@ def format_verification_results(results: list[dict[str, str]]) -> str:
 
     for row in results:
         status = row.get("status", "?")
-        glyph, style = _STATUS_STYLE.get(status, (GLYPH_BULLET, TEXT))
+        try:
+            probe_status = ProbeStatus(status)
+            glyph, style = _STATUS_STYLE.get(probe_status, (GLYPH_BULLET, TEXT))
+        except ValueError:
+            glyph, style = (GLYPH_BULLET, TEXT)
         table.add_row(
             escape(row.get("service", "?")),
             escape(row.get("source", "-")),

--- a/tests/integrations/test_probe_status_enums.py
+++ b/tests/integrations/test_probe_status_enums.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from integrations.probes import ProbeResult, ProbeStatus
+
+
+def test_probe_status_members_round_trip_from_string() -> None:
+    assert set(ProbeStatus) == {
+        ProbeStatus.PASSED,
+        ProbeStatus.FAILED,
+        ProbeStatus.MISSING,
+    }
+    assert ProbeStatus("passed") is ProbeStatus.PASSED
+    assert ProbeStatus.PASSED == "passed"
+
+
+def test_probe_result_ok_uses_enum_members() -> None:
+    assert ProbeResult.passed("ok").ok is True
+    assert ProbeResult.failed("bad").ok is False
+    assert ProbeResult.missing("absent").ok is False
+
+
+def test_probe_result_coerces_string_status() -> None:
+    result = ProbeResult(status="failed", detail="config error")
+    assert result.status is ProbeStatus.FAILED
+    assert result.status == "failed"


### PR DESCRIPTION
Fixes #4516

#### Describe the changes you have made in this PR -

Promote integration verification probe outcomes from duplicated string literals to a closed `ProbeStatus` `StrEnum`, wire `ProbeResult` factories/`ok` through the enum, and key `integrations/verify.py` status styling on enum members. String values stay identical (`passed` / `failed` / `missing`) so verifier dicts and existing comparisons keep working.

### Demo/Screenshot for feature changes and bug fixes -

N/A (refactor-only; behavior unchanged).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Probe outcomes were hard-coded in `ProbeResult` factories and again in `_STATUS_STYLE`, so typos only fail at runtime. I added `ProbeStatus(StrEnum)` beside `ProbeResult`, typed the dataclass field, coerced plain strings in `__post_init__` (frozen dataclass requirement from the issue), and switched factories/`ok` to enum members. `verify.py` now styles rows by resolving the string status to `ProbeStatus` while still rendering the original string for output. Added `tests/integrations/test_probe_status_enums.py` following the existing fleet/filestorage enum test pattern.

---

## Problem

Integration verifiers return one of three probe statuses as bare strings. Those literals are repeated in `ProbeResult` factories and `integrations/verify.py` styling, so a typo (e.g. `"passsed"`) only surfaces at runtime and UI code can drift from factories.

## Triage / Root cause

`integrations/probes.py` typed `ProbeResult.status` as `str` and factories passed raw strings; `integrations/verify.py` duplicated the same three strings in `_STATUS_STYLE`.

## Fix

- Add `ProbeStatus` `StrEnum` with unchanged values.
- Type/coerce `ProbeResult.status`; factories return enum members; `ok` checks `ProbeStatus.PASSED`.
- Key `_STATUS_STYLE` on `ProbeStatus` and resolve row status through the enum in `format_verification_results`.

## Verification

`uv run pytest tests/integrations/test_probe_status_enums.py tests/integrations/test_integration_probes.py tests/integrations/test_verify.py` — 42 passed.

## Notes / Risks

- Verifier return dicts still carry string statuses from existing call sites; `StrEnum` members compare equal to those strings when bridged through `probe_access()` results.
- Out of scope: `tables.py` `_CONNECTED_STATUSES` (called out in #4516).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions