### PR TITLE
refactor(o11y): spell out _MS duration constants in otlp_parser (SM-66)

### DIFF
--- a/platform/observability/otlp_parser.py
+++ b/platform/observability/otlp_parser.py
@@ -15,7 +15,7 @@ _OTLP_SCALAR_KINDS = ("stringValue", "intValue", "boolValue", "doubleValue")
 
 #: Nanoseconds → milliseconds for OTLP span duration.
 _NANOSECONDS_PER_MILLISECOND = 1_000_000
-#: Decimal places kept on parsed OTLP durations (ms).
+#: Decimal places kept on parsed OTLP durations (milliseconds).
 _OTLP_DURATION_MILLISECONDS_DECIMAL_PLACES = 4
 _EMPTY_DURATION_MILLISECONDS = 0.0
 _UNKNOWN_SPAN_NAME = "unknown"

--- a/platform/observability/otlp_parser.py
+++ b/platform/observability/otlp_parser.py
@@ -16,8 +16,8 @@ _OTLP_SCALAR_KINDS = ("stringValue", "intValue", "boolValue", "doubleValue")
 #: Nanoseconds → milliseconds for OTLP span duration.
 _NANOSECONDS_PER_MILLISECOND = 1_000_000
 #: Decimal places kept on parsed OTLP durations (ms).
-_OTLP_DURATION_MS_DECIMAL_PLACES = 4
-_EMPTY_DURATION_MS = 0.0
+_OTLP_DURATION_MILLISECONDS_DECIMAL_PLACES = 4
+_EMPTY_DURATION_MILLISECONDS = 0.0
 _UNKNOWN_SPAN_NAME = "unknown"
 
 
@@ -46,12 +46,12 @@ def _duration_ms(start_unix_nano: Any, end_unix_nano: Any) -> float:
         start = int(start_unix_nano)
         end = int(end_unix_nano)
     except (TypeError, ValueError):
-        return _EMPTY_DURATION_MS
+        return _EMPTY_DURATION_MILLISECONDS
     if end <= start:
-        return _EMPTY_DURATION_MS
+        return _EMPTY_DURATION_MILLISECONDS
     return round(
         (end - start) / _NANOSECONDS_PER_MILLISECOND,
-        _OTLP_DURATION_MS_DECIMAL_PLACES,
+        _OTLP_DURATION_MILLISECONDS_DECIMAL_PLACES,
     )
 
 


### PR DESCRIPTION
Fixes #4323 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Rename `_MS` abbreviated constants to spell out their unit in full.
- `_EMPTY_DURATION_MS` → `_EMPTY_DURATION_MILLISECONDS`
- `_OTLP_DURATION_MS_DECIMAL_PLACES` → `_OTLP_DURATION_MILLISECONDS_DECIMAL_PLACES`
- `make lint` passed.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
