### PR TITLE
Report bytes transferred alongside file counts in SyncReport

### DIFF
--- a/platform/filestorage/engine.py
+++ b/platform/filestorage/engine.py
@@ -40,10 +40,16 @@ class SyncReport:
     #: resolves these by pulling first; a push-only run cannot.
     kept_remote: list[str] = field(default_factory=list)
     skipped: int = 0
+    uploaded_bytes: int = 0
+    downloaded_bytes: int = 0
 
     @property
     def changed(self) -> int:
         return len(self.uploaded) + len(self.downloaded)
+
+    @property
+    def total_bytes(self) -> int:
+        return self.uploaded_bytes + self.downloaded_bytes
 
 
 def content_tag(data: bytes) -> str:
@@ -144,6 +150,7 @@ def push(
                 continue
         store.put_object(key, data)
         result.uploaded.append(key)
+        result.uploaded_bytes += len(data)
     return result
 
 
@@ -166,7 +173,9 @@ def pull(
         if not _should_download(obj, target):
             result.skipped += 1
             continue
-        _write_atomically(target, store.get_object(obj.key))
+        data = store.get_object(obj.key)
+        result.downloaded_bytes += len(data)
+        _write_atomically(target, data)
         result.downloaded.append(obj.key)
     return result
 

--- a/platform/filestorage/messages.py
+++ b/platform/filestorage/messages.py
@@ -19,6 +19,18 @@ from config.constants.filestorage import (
 from platform.filestorage.engine import SyncReport
 from platform.filestorage.operations import SyncStatus
 
+
+def _human_size(n: int) -> str:
+    """Format byte count as a human-readable string (e.g. ``"1.2 KB"``)."""
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024**2:
+        return f"{n / 1024:.1f} KB"
+    if n < 1024**3:
+        return f"{n / 1024**2:.1f} MB"
+    return f"{n / 1024**3:.1f} GB"
+
+
 DISABLED_HELP = f"""Remote sync is off.
 
 To turn it on, point opensre at a store you own:
@@ -58,9 +70,11 @@ def format_report_lines(report: SyncReport) -> tuple[str, ...]:
     uploaded = list(report.uploaded)
     kept_remote = list(report.kept_remote)
     skipped = report.skipped
+    down_size = f" ({_human_size(report.downloaded_bytes)})" if report.downloaded_bytes else ""
+    up_size = f" ({_human_size(report.uploaded_bytes)})" if report.uploaded_bytes else ""
     lines: list[str] = [
-        f"Sync complete — {len(downloaded)} downloaded, "
-        f"{len(uploaded)} uploaded, {skipped} already current."
+        f"Sync complete — {len(downloaded)} downloaded{down_size}, "
+        f"{len(uploaded)} uploaded{up_size}, {skipped} already current."
     ]
     if kept_remote:
         lines.append(f"{len(kept_remote)} kept the store's newer copy:")

--- a/platform/filestorage/messages.py
+++ b/platform/filestorage/messages.py
@@ -72,9 +72,10 @@ def format_report_lines(report: SyncReport) -> tuple[str, ...]:
     skipped = report.skipped
     down_size = f" ({_human_size(report.downloaded_bytes)})" if report.downloaded_bytes else ""
     up_size = f" ({_human_size(report.uploaded_bytes)})" if report.uploaded_bytes else ""
+    total_size = f" ({_human_size(report.total_bytes)} total)" if report.total_bytes else ""
     lines: list[str] = [
         f"Sync complete — {len(downloaded)} downloaded{down_size}, "
-        f"{len(uploaded)} uploaded{up_size}, {skipped} already current."
+        f"{len(uploaded)} uploaded{up_size}, {skipped} already current{total_size}."
     ]
     if kept_remote:
         lines.append(f"{len(kept_remote)} kept the store's newer copy:")

--- a/platform/filestorage/messages.py
+++ b/platform/filestorage/messages.py
@@ -21,14 +21,14 @@ from platform.filestorage.operations import SyncStatus
 
 
 def _human_size(n: int) -> str:
-    """Format byte count as a human-readable string (e.g. ``"1.2 KB"``)."""
+    """Format byte count as a human-readable string (e.g. ``"1.2 KiB"``)."""
     if n < 1024:
         return f"{n} B"
     if n < 1024**2:
-        return f"{n / 1024:.1f} KB"
+        return f"{n / 1024:.1f} KiB"
     if n < 1024**3:
-        return f"{n / 1024**2:.1f} MB"
-    return f"{n / 1024**3:.1f} GB"
+        return f"{n / 1024**2:.1f} MiB"
+    return f"{n / 1024**3:.1f} GiB"
 
 
 DISABLED_HELP = f"""Remote sync is off.

--- a/platform/filestorage/operations.py
+++ b/platform/filestorage/operations.py
@@ -58,6 +58,8 @@ def _owned_report(report: SyncReport) -> SyncReport:
         downloaded=list(report.downloaded),
         kept_remote=list(report.kept_remote),
         skipped=report.skipped,
+        uploaded_bytes=report.uploaded_bytes,
+        downloaded_bytes=report.downloaded_bytes,
     )
 
 

--- a/tests/filestorage/test_service_and_registry.py
+++ b/tests/filestorage/test_service_and_registry.py
@@ -97,9 +97,9 @@ def test_format_report_lines_shows_nonzero_byte_sizes() -> None:
         skipped=2,
     )
     lines = format_report_lines(report)
-    assert "4.4 KB" in lines[0]
-    assert "1.2 KB" in lines[0]
-    assert "5.6 KB total" in lines[0]
+    assert "4.4 KiB" in lines[0]
+    assert "1.2 KiB" in lines[0]
+    assert "5.6 KiB total" in lines[0]
 
 
 def test_format_report_lines_omits_size_when_no_bytes_moved() -> None:
@@ -115,8 +115,8 @@ def test_format_report_lines_shows_only_download_size_when_upload_is_zero() -> N
         uploaded=[], downloaded=["b"], uploaded_bytes=0, downloaded_bytes=2048, skipped=1
     )
     lines = format_report_lines(report)
-    assert "2.0 KB" in lines[0]
-    assert "2.0 KB total" in lines[0]
+    assert "2.0 KiB" in lines[0]
+    assert "2.0 KiB total" in lines[0]
 
 
 def test_format_report_lines_shows_small_byte_count_in_bytes() -> None:
@@ -133,8 +133,8 @@ def test_format_report_lines_handles_megabyte_boundary() -> None:
         uploaded=[], downloaded=[], uploaded_bytes=0, downloaded_bytes=2_500_000, skipped=3
     )
     lines = format_report_lines(report)
-    assert "2.4 MB" in lines[0]
-    assert "2.4 MB total" in lines[0]
+    assert "2.4 MiB" in lines[0]
+    assert "2.4 MiB total" in lines[0]
 
 
 def test_factory_delegates_to_registry() -> None:

--- a/tests/filestorage/test_service_and_registry.py
+++ b/tests/filestorage/test_service_and_registry.py
@@ -88,6 +88,55 @@ def test_formatters_return_immutable_tuples() -> None:
     assert "2 uploaded" in format_report_lines(report)[0]
 
 
+def test_format_report_lines_shows_nonzero_byte_sizes() -> None:
+    report = SyncReport(
+        uploaded=["a"],
+        downloaded=["b"],
+        uploaded_bytes=4500,
+        downloaded_bytes=1200,
+        skipped=2,
+    )
+    lines = format_report_lines(report)
+    assert "4.4 KB" in lines[0]
+    assert "1.2 KB" in lines[0]
+    assert "5.6 KB total" in lines[0]
+
+
+def test_format_report_lines_omits_size_when_no_bytes_moved() -> None:
+    report = SyncReport(
+        uploaded=["a"], downloaded=[], uploaded_bytes=0, downloaded_bytes=0, skipped=1
+    )
+    lines = format_report_lines(report)
+    assert lines[0] == "Sync complete — 0 downloaded, 1 uploaded, 1 already current."
+
+
+def test_format_report_lines_shows_only_download_size_when_upload_is_zero() -> None:
+    report = SyncReport(
+        uploaded=[], downloaded=["b"], uploaded_bytes=0, downloaded_bytes=2048, skipped=1
+    )
+    lines = format_report_lines(report)
+    assert "2.0 KB" in lines[0]
+    assert "2.0 KB total" in lines[0]
+
+
+def test_format_report_lines_shows_small_byte_count_in_bytes() -> None:
+    report = SyncReport(
+        uploaded=["a"], downloaded=[], uploaded_bytes=500, downloaded_bytes=0, skipped=0
+    )
+    lines = format_report_lines(report)
+    assert "500 B" in lines[0]
+    assert "500 B total" in lines[0]
+
+
+def test_format_report_lines_handles_megabyte_boundary() -> None:
+    report = SyncReport(
+        uploaded=[], downloaded=[], uploaded_bytes=0, downloaded_bytes=2_500_000, skipped=3
+    )
+    lines = format_report_lines(report)
+    assert "2.4 MB" in lines[0]
+    assert "2.4 MB total" in lines[0]
+
+
 def test_factory_delegates_to_registry() -> None:
     store = _MemStore()
     register_object_store("factory-test", lambda _cfg: store)


### PR DESCRIPTION
Fixes #4551

**Problem:** `SyncReport` only counted files (e.g. "2 uploaded") with no indication of how much data was transferred. Users had no visibility into the volume of bytes moved during a remote sync.

**Changes:**

- **`platform/filestorage/engine.py`** — Added `uploaded_bytes` and `downloaded_bytes` fields to the `SyncReport` dataclass, plus a `total_bytes` computed property. `push()` now accumulates `result.uploaded_bytes += len(data)` per uploaded file. `pull()` captures the return of `store.get_object()` to track `downloaded_bytes` before the atomic write.

- **`platform/filestorage/messages.py`** — Added `_human_size()` to format byte counts with IEC labels (`B`/`KiB`/`MiB`/`GiB`) for the existing 1024-based scaling. Updated `format_report_lines()` to show per-direction and total transfer sizes inline:  
  `Sync complete — 2 downloaded (1.2 KiB), 3 uploaded (4.4 KiB), 1 already current (5.6 KiB total).`  
  When no bytes were transferred, size suffixes are omitted so existing zero-byte output remains unchanged.

- **`platform/filestorage/operations.py`** — Updated `_owned_report()` to preserve the new byte fields for concurrency-safe snapshots.

- **`tests/filestorage/test_service_and_registry.py`** — Added coverage for nonzero transfer sizes, zero-byte behavior, one-direction transfers, byte-sized transfers, and MiB formatting.

**Design decisions:**

- Byte fields default to `0`, so existing `SyncReport` construction remains backward-compatible.
- CLI, `/remote-sync`, and gateway surfaces all share `format_report_lines()`; no duplicated surface logic was added.
- Binary scaling uses the repository-consistent IEC unit labels.

**Verification:**

- `ruff check`: clean
- `ruff format`: clean
- `mypy`: clean
- focused filestorage tests: pass
- Greptile: 5/5 with no actionable defects

The previous repository-wide `tools-runtime` failure was unrelated to this PR: the workflow selected Anthropic with an empty `ANTHROPIC_API_KEY`, causing three LLM credential tests to fail while 4,736 tests passed.