### PR TITLE
docs: add AWS EC2 page in the docs and nav

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -162,6 +162,7 @@
               "cloudtrail_events",
               "bitbucket",
               "elb",
+              "ec2",
               "github",
               "github-workflow-tools",
               "architecture-audit-tool",

--- a/docs/ec2.mdx
+++ b/docs/ec2.mdx
@@ -1,0 +1,88 @@
+---
+title: "AWS EC2"
+description: "Discover EC2 instances by tag, tier, or VPC to map application tiers and investigate non-Kubernetes alerts"
+---
+
+OpenSRE uses AWS EC2 to discover virtual machine instances, filter them by tag (such as `tier`), instance IDs, or VPC, and group instances into application tiers (such as web or worker). This helps answer questions like "which application tier(s) plausibly drive load on this RDS?" when investigating non-Kubernetes alerts or bridging load balancers (ELB) and databases (RDS).
+
+All EC2 API calls are read-only and routed through the shared `aws_sdk_client` allowlist, so the integration cannot mutate your EC2 resources.
+
+## Prerequisites
+
+- AWS credentials configured per the [AWS integration](/aws) (role ARN recommended)
+- An EC2 environment with tagged instances, explicit instance IDs, or a VPC you want OpenSRE to inspect
+- IAM permissions for `ec2:DescribeInstances`
+
+## Setup
+
+### Environment variables
+
+```bash
+AWS_REGION=us-east-1
+```
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `AWS_REGION` | `us-east-1` | AWS region the EC2 instances live in. |
+
+The tool accepts parameter hints from the resolved `ec2` source:
+
+- `tier`: Filter instances by the `tier` tag (e.g. `web` or `worker`). When multiple tiers are in scope, `tier` is left empty so instances across all tiers are enumerated and returned grouped by tier in `by_tier`.
+- `instance_ids`: List of explicit EC2 instance IDs.
+- `vpc_id`: VPC ID filter to limit discovery to a specific network.
+- `region`: AWS region override (defaults to `AWS_REGION` or `us-east-1`).
+
+## IAM permissions
+
+The integration only needs read-only EC2 describe permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+Attach this policy to the same IAM role or user already configured for the [AWS integration](/aws). If you are already using the AWS managed `ReadOnlyAccess` policy, `ec2:DescribeInstances` is already included.
+
+## Verify
+
+```bash
+opensre integrations verify aws
+```
+
+EC2 shares the AWS integration's credential check — there is no separate `ec2` verify target. A successful AWS verify confirms your AWS credentials are valid; the EC2 tool becomes available whenever `tier`, `instance_ids`, `vpc_id`, or `_backend` is present in the resolved `ec2` source.
+
+Expected output:
+
+```
+Service: aws
+Status: passed
+Detail: Authenticated via assume-role in us-east-1 as arn:aws:iam::123456789012:role/OpenSREReadOnly (account 123456789012)
+```
+
+## Tools
+
+| Tool | AWS API call | What it returns |
+| --- | --- | --- |
+| `ec2_instances_by_tag` | `ec2:DescribeInstances` | Active EC2 instances filtered by `tier` tag, instance IDs, or `vpc_id`. Returns per-instance metadata (ID, tier, ASG, private IP, VPC, subnet, AZ, state, instance type, security groups), a `by_tier` mapping of tier name to instance IDs, `tiers_detected`, and a precomputed summary (counts by tier, total active instances, primary tier, VPCs in scope, AZs in scope). |
+
+The tool becomes available to the planner whenever `tier`, `instance_ids`, `vpc_id`, or `_backend` is present in the resolved `ec2` sources.
+
+### Use cases
+
+- Discovering EC2 application tiers when investigating a non-Kubernetes alert
+- Mapping a tier name (`web`, `worker`, etc.) to its active instance IDs
+- Bridging EC2 → RDS when answering "which application tier drives database load"
+
+## Gotcha
+
+Terminated or stopped EC2 instances (`terminated`, `stopped`, `stopping`, `shutting-down`) are automatically excluded from the tool's results so they do not distort load-attribution or topology analysis. If an expected instance does not appear in the returned list, verify that the instance is in the `running` state and properly tagged with `tier` or `Tier`. Additionally, at least one filter (`tier`, `instance_ids`, or `vpc_id`) must be provided in the tool call or resolved sources, or the tool will return an unavailable status.

--- a/docs/ec2.mdx
+++ b/docs/ec2.mdx
@@ -27,7 +27,7 @@ AWS_REGION=us-east-1
 
 The tool accepts parameter hints from the resolved `ec2` source:
 
-- `tier`: Filter instances by the `tier` tag (e.g. `web` or `worker`). When multiple tiers are in scope, `tier` is left empty so instances across all tiers are enumerated and returned grouped by tier in `by_tier`.
+- `tiers`: List of tier names in the resolved `ec2` source (e.g. `["web"]` or `["web", "worker"]`). The parameter extractor maps a single item to the singular `tier` tool argument, or leaves `tier` empty when multiple tiers are in scope so instances across all tiers are enumerated and returned grouped in `by_tier`.
 - `instance_ids`: List of explicit EC2 instance IDs.
 - `vpc_id`: VPC ID filter to limit discovery to a specific network.
 - `region`: AWS region override (defaults to `AWS_REGION` or `us-east-1`).
@@ -59,7 +59,7 @@ Attach this policy to the same IAM role or user already configured for the [AWS 
 opensre integrations verify aws
 ```
 
-EC2 shares the AWS integration's credential check — there is no separate `ec2` verify target. A successful AWS verify confirms your AWS credentials are valid; the EC2 tool becomes available whenever `tier`, `instance_ids`, `vpc_id`, or `_backend` is present in the resolved `ec2` source.
+EC2 shares the AWS integration's credential check — there is no separate `ec2` verify target. A successful AWS verify confirms your AWS credentials are valid; the EC2 tool becomes available whenever `tiers`, `instance_ids`, `vpc_id`, or `_backend` is present in the resolved `ec2` source.
 
 Expected output:
 
@@ -75,7 +75,7 @@ Detail: Authenticated via assume-role in us-east-1 as arn:aws:iam::123456789012:
 | --- | --- | --- |
 | `ec2_instances_by_tag` | `ec2:DescribeInstances` | Active EC2 instances filtered by `tier` tag, instance IDs, or `vpc_id`. Returns per-instance metadata (ID, tier, ASG, private IP, VPC, subnet, AZ, state, instance type, security groups), a `by_tier` mapping of tier name to instance IDs, `tiers_detected`, and a precomputed summary (counts by tier, total active instances, primary tier, VPCs in scope, AZs in scope). |
 
-The tool becomes available to the planner whenever `tier`, `instance_ids`, `vpc_id`, or `_backend` is present in the resolved `ec2` sources.
+The tool becomes available to the planner whenever `tiers`, `instance_ids`, `vpc_id`, or `_backend` is present in the resolved `ec2` sources.
 
 ### Use cases
 


### PR DESCRIPTION
Fixes #4271 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR - 
- Added `docs/ec2.mdx` which contains documentation of the AWS EC2 integration. It covers prerequisites, environment variables (`AWS_REGION`), source resolution options (`tier`, `instance_ids`, `vpc_id`), IAM permissions (`ec2:DescribeInstances`), verification flow (`opensre integrations verify aws`), diagnostic tool (`ec2_instances_by_tag`), use cases, and gotchas (automatic exclusion of inactive instances).
- Updated `docs/docs.json` by adding `ec2` to the *Cloud, code, and collaboration* navigation group under the *Integrations* tab so that page render in the sodebar.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

- **Problem Solved:** The AWS EC2 package had diagnostic tools in `integrations/ec2`, but it didn't had a dedicated documentation page on the docs site and navigation sidebar.
- **Implementation:** As the #4271 issue mentioned to follow the shape of `docs/rds.mdx` / `docs/kafka.mdx` documentation, so I tried to maintain this in the `docs/ec2.mdx`. Used AI to understand the  `integrations/ec2` completely in more detailed manner.
- **Key Details Covered:**
   - `ec2_instances_by_tag` tool parameters, inputs and outputs (`by_tier` grouping and `build_ec2_summary`).
   -  Shared AWS verification.
   - Gotcha: Inactive EC2 instance states (`terminated`, `stopped`, `stopping`, `shutting-down`) are filtered out to prevent skewing topology load-attribution during investigations.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
