### PR TITLE
Remove duplicate /history slash command registration

### DIFF
--- a/surfaces/interactive_shell/command_registry/tasks_cmds.py
+++ b/surfaces/interactive_shell/command_registry/tasks_cmds.py
@@ -1,4 +1,4 @@
-"""Slash commands: /history, /tasks, /cancel."""
+"""Slash commands: /tasks, /cancel, /stop."""
 
 from __future__ import annotations
 
@@ -10,7 +10,6 @@ from rich.markup import escape
 from surfaces.interactive_shell.command_registry.types import (
     SlashCommand,
 )
-from surfaces.interactive_shell.prompt_history import load_command_history_entries
 from surfaces.interactive_shell.runtime import Session, TaskKind, TaskRecord, TaskStatus
 from surfaces.interactive_shell.ui import (
     BOLD_BRAND,
@@ -115,22 +114,6 @@ def _task_detail_label(task: TaskRecord) -> str:
     return first_line or "—"
 
 
-def _cmd_history(_session: Session, console: Console, _args: list[str]) -> bool:
-    entries = load_command_history_entries()
-    if not entries:
-        console.print(f"[{DIM}]no history yet.[/]")
-        return True
-
-    table = repl_table(title="Command history\n", title_style=BOLD_BRAND)
-    table.add_column("#", style=DIM, justify="right")
-    table.add_column("text", overflow="fold")
-
-    for i, entry in enumerate(entries, start=1):
-        table.add_row(str(i), escape(entry))
-    print_repl_table(console, table)
-    return True
-
-
 def _cmd_tasks(session: Session, console: Console, _args: list[str]) -> bool:
     tasks = session.task_registry.list_recent(n=50)
     if not tasks:
@@ -218,7 +201,6 @@ def _cmd_cancel(session: Session, console: Console, args: list[str]) -> bool:
 
 
 COMMANDS: list[SlashCommand] = [
-    SlashCommand("/history", "Show persisted command history.", _cmd_history),
     SlashCommand(
         "/tasks",
         "List recent and in-flight shell tasks.",

--- a/tests/interactive_shell/command_registry/test_no_duplicate_slash_names.py
+++ b/tests/interactive_shell/command_registry/test_no_duplicate_slash_names.py
@@ -16,13 +16,6 @@ from surfaces.interactive_shell.command_registry import (
     SLASH_COMMANDS,
 )
 
-# One duplicate predates this guard: "/history" is registered by both
-# tasks_cmds and privacy_cmds, and privacy_cmds merges later, so the
-# tasks_cmds command is unreachable. Pinned rather than fixed here so the guard
-# can land without changing unrelated commands; removing the dead registration
-# should shrink this set to empty.
-KNOWN_DUPLICATES = frozenset({"/history"})
-
 
 def test_no_two_commands_claim_the_same_name() -> None:
     # Arrange
@@ -32,9 +25,9 @@ def test_no_two_commands_claim_the_same_name() -> None:
     duplicates = {name for name, count in counts.items() if count > 1}
 
     # Assert
-    assert sorted(duplicates - KNOWN_DUPLICATES) == [], (
+    assert sorted(duplicates) == [], (
         "these slash names are registered more than once and would overwrite "
-        f"each other: {sorted(duplicates - KNOWN_DUPLICATES)}"
+        f"each other: {sorted(duplicates)}"
     )
 
 
@@ -45,4 +38,4 @@ def test_every_registered_command_survives_the_lookup_table() -> None:
 
     # Assert
     assert lost == []
-    assert len(SLASH_COMMANDS) == len(_MERGED_SEQUENCE) - len(KNOWN_DUPLICATES)
+    assert len(SLASH_COMMANDS) == len(_MERGED_SEQUENCE)


### PR DESCRIPTION
Fixes #4548

## Summary
- Remove the unreachable `/history` registration from `tasks_cmds.py` (privacy_cmds owns the real handler with clear/off/on/retention)
- Drop the `KNOWN_DUPLICATES` pin from the duplicate-name guard now that the dead registration is gone

## Test plan
- [x] uv run pytest tests/interactive_shell/command_registry/test_no_duplicate_slash_names.py -q
- [x] uv run pytest tests/interactive_shell/history/ tests/interactive_shell/test_commands.py -k history -q
- [x] make lint && make format-check

## Code Understanding and AI Usage
- [x] Yes, I used AI assistance
- [x] I reviewed every line and understand the change
- [x] Tests pass locally
