### PR TITLE
fix: keep marker-rejecting models usable by degrading prompt caching to uncached

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,5 +258,17 @@ Steps:
   when appending to an existing file: **use the import style the file already
   established** (an existing `import core.context_budget as budget` means new
   code calls `budget.name`, not `from core.context_budget import name`).
+- Shared client state under concurrent turns: LLM clients are cached per role
+  (`get_llm`) and the gateway runs turns in parallel, so **one client instance
+  serves several in-flight requests**. An instance flag mutated inside an error
+  handler is then read by requests that were already built under the old value.
+  Branch on **what the current request carried**, not on the flag's present
+  value — capture the fact locally where the request is built
+  (`marked = strip_cache_markers(kwargs) != kwargs`) and consult that in the
+  `except`. Precedent: the prompt-cache fallback, where a first 400 cleared
+  `_cache_markers_enabled` and a second already-marked request skipped its
+  uncached retry and failed the turn. Test it by having the fake dependency
+  mutate the shared state *before* raising, which reproduces the race
+  deterministically without threads.
 - CI typecheck does **not** cover `tests/`: `make typecheck` runs mypy over `PYTHON_SOURCE_PATHS` (`config core gateway integrations platform surfaces tools`) only. Type errors in test files never fail CI, so do not assume a clean `make typecheck` means the tests you just wrote are type-clean — run mypy on the test path directly when it matters.
 

--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -42,6 +42,9 @@ from core.llm.transports.sdk.anthropic_cache import (
     cached_system as _anthropic_cached_system,
 )
 from core.llm.transports.sdk.anthropic_cache import (
+    is_cache_unsupported_error as _is_cache_unsupported_error,
+)
+from core.llm.transports.sdk.anthropic_cache import (
     messages_with_cache as _anthropic_messages_with_cache,
 )
 from core.llm.transports.sdk.anthropic_cache import (
@@ -69,6 +72,11 @@ class AnthropicAgentClient:
 
     provider_name = "Anthropic"
     auth_error_hint = "Check ANTHROPIC_API_KEY."
+    # Best-effort prompt caching: a class default so every instance starts
+    # marking; flipped to an instance False for the client's lifetime the
+    # first time the provider rejects the cache markers with a 400 (e.g.
+    # Bedrock-hosted Claude models that predate prompt caching).
+    _cache_markers_enabled = True
 
     def __init__(
         self,
@@ -152,15 +160,17 @@ class AnthropicAgentClient:
             RateLimitError,
         )
 
+        cache = self._cache_markers_enabled
+        clean_messages = strip_internal_message_markers(messages)
         kwargs: dict[str, Any] = {
             "model": self._model,
             "max_tokens": self._max_tokens,
-            "messages": _anthropic_messages_with_cache(strip_internal_message_markers(messages)),
+            "messages": _anthropic_messages_with_cache(clean_messages) if cache else clean_messages,
         }
         if system:
-            kwargs["system"] = _anthropic_cached_system(system)
+            kwargs["system"] = _anthropic_cached_system(system) if cache else system
         if tools:
-            kwargs["tools"] = _anthropic_tools_with_cache(tools)
+            kwargs["tools"] = _anthropic_tools_with_cache(tools) if cache else tools
 
         backoff = _RETRY_INITIAL_BACKOFF_SEC
         last_err: Exception | None = None
@@ -179,6 +189,18 @@ class AnthropicAgentClient:
                 # distinguish credit exhaustion (fatal) from real schema
                 # errors before wrapping into a generic RuntimeError.
                 maybe_raise_credit_exhausted(self.provider_name, err)
+                if self._cache_markers_enabled and _is_cache_unsupported_error(err):
+                    # Caching is best-effort: rebuild the request without
+                    # markers (the flag now disables them) and never mark
+                    # again on this client. The flag guards the recursion.
+                    self._cache_markers_enabled = False
+                    logger.warning(
+                        "%s model '%s' rejected prompt-cache markers; retrying without "
+                        "prompt caching (requests will pay full input price).",
+                        self.provider_name,
+                        self._model,
+                    )
+                    return self.invoke(messages, system=system, tools=tools)
                 raise RuntimeError(self._bad_request_error_message(err)) from err
             except RateLimitError as err:
                 # OpenAI's insufficient_quota lands here too, dressed as 429

--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -189,10 +189,11 @@ class AnthropicAgentClient:
                 # distinguish credit exhaustion (fatal) from real schema
                 # errors before wrapping into a generic RuntimeError.
                 maybe_raise_credit_exhausted(self.provider_name, err)
-                if self._cache_markers_enabled and _is_cache_unsupported_error(err):
-                    # Caching is best-effort: rebuild the request without
-                    # markers (the flag now disables them) and never mark
-                    # again on this client. The flag guards the recursion.
+                if cache and _is_cache_unsupported_error(err):
+                    # Keyed on what *this* request carried, not the shared
+                    # flag: a concurrent turn may already have cleared it, and
+                    # this request still went out marked. Rebuilding with the
+                    # flag off guards the recursion.
                     self._cache_markers_enabled = False
                     logger.warning(
                         "%s model '%s' rejected prompt-cache markers; retrying without "

--- a/core/llm/transports/sdk/anthropic_cache.py
+++ b/core/llm/transports/sdk/anthropic_cache.py
@@ -8,6 +8,13 @@ resent input into cache reads (~0.1x input price) instead of full-price tokens.
 Marking a prefix shorter than the model's minimum cacheable length is safe: the
 request succeeds and simply is not cached, so callers do not need to measure
 prompt size before marking.
+
+Not every deployment supports the markers themselves: Bedrock rejects
+``cache_control`` with a 400 for Claude models that predate prompt caching.
+Clients therefore treat caching as best-effort — on a 400 that blames the
+markers (:func:`is_cache_unsupported_error`), they retry once without markers
+(:func:`strip_cache_markers`) and stop marking for the client's lifetime, so an
+unsupported model works uncached instead of failing every call.
 """
 
 from __future__ import annotations
@@ -73,9 +80,86 @@ def messages_with_cache(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [*messages[:-1], {**last, "content": marked_content}]
 
 
+#: Substrings a provider 400 uses when the request failed *because of* the
+#: cache markers: Anthropic names the offending ``cache_control`` field,
+#: Bedrock's Converse-era wording says "cachePoint" / "prompt caching".
+_CACHE_UNSUPPORTED_SIGNALS: Final[tuple[str, ...]] = (
+    "cache_control",
+    "cachepoint",
+    "prompt caching",
+    "prompt cache",
+    # Bedrock's ValidationException often rejects the request without naming the
+    # offending field, so the generic wording has to count as a signal too. These
+    # are matched only on a 400, where the request is already failing.
+    "does not support the requested feature",
+    "invalid request body",
+)
+
+
+def is_cache_unsupported_error(err: Exception) -> bool:
+    """True when a bad-request error blames the cache markers themselves.
+
+    Only meaningful for 400-class errors — callers must check the error type
+    first so unrelated failures (auth, rate limits) are never eaten.
+    """
+    message = str(err).lower()
+    return any(signal in message for signal in _CACHE_UNSUPPORTED_SIGNALS)
+
+
+def strip_cache_markers(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Copy of request ``kwargs`` with every marker this module adds removed.
+
+    Strips exactly the spots :func:`cached_system`, :func:`tools_with_cache`,
+    and :func:`messages_with_cache` write to — system blocks, top-level tool
+    schemas, and message content blocks. It deliberately does not recurse into
+    tool ``input_schema`` bodies, where ``cache_control`` could be a
+    legitimate user-defined property name.
+    """
+    out = dict(kwargs)
+    system = out.get("system")
+    if isinstance(system, list):
+        blocks = [_block_without_marker(block) for block in system]
+        # Exactly invert cached_system: a lone text block goes back to the plain
+        # string a non-caching client would have sent, since a model that rejects
+        # the markers may not accept block-form system either.
+        if (
+            len(blocks) == 1
+            and isinstance(blocks[0], dict)
+            and set(blocks[0]) == {"type", "text"}
+            and blocks[0].get("type") == "text"
+        ):
+            out["system"] = blocks[0]["text"]
+        else:
+            out["system"] = blocks
+    tools = out.get("tools")
+    if isinstance(tools, list):
+        out["tools"] = [_block_without_marker(tool) for tool in tools]
+    messages = out.get("messages")
+    if isinstance(messages, list):
+        out["messages"] = [_message_without_marker(message) for message in messages]
+    return out
+
+
+def _block_without_marker(block: Any) -> Any:
+    if isinstance(block, dict) and "cache_control" in block:
+        return {key: value for key, value in block.items() if key != "cache_control"}
+    return block
+
+
+def _message_without_marker(message: Any) -> Any:
+    if not isinstance(message, dict):
+        return message
+    content = message.get("content")
+    if not isinstance(content, list):
+        return message
+    return {**message, "content": [_block_without_marker(block) for block in content]}
+
+
 __all__ = [
     "ANTHROPIC_CACHE_CONTROL",
     "cached_system",
+    "is_cache_unsupported_error",
     "messages_with_cache",
+    "strip_cache_markers",
     "tools_with_cache",
 ]

--- a/core/llm/transports/sdk/llm_clients.py
+++ b/core/llm/transports/sdk/llm_clients.py
@@ -275,6 +275,9 @@ class LLMClient:
 
     def _create_with_retry(self, kwargs: dict[str, Any]) -> Any:
         """Call the messages API with the shared backoff and error mapping."""
+        # What this request carries, decided before any concurrent turn can
+        # clear the shared flag.
+        marked = strip_cache_markers(kwargs) != kwargs
         from platform.guardrails.engine import GuardrailBlockedError
 
         backoff_seconds = _RETRY_INITIAL_BACKOFF_SEC
@@ -298,10 +301,10 @@ class LLMClient:
                 # only dependable probe is to retry without them. Markers are
                 # disabled only if that retry actually succeeds, leaving genuine
                 # bad requests (bad max_tokens, oversized prompt) untouched.
-                if self._cache_markers_enabled and is_cache_unsupported_error(err):
-                    # Caching is best-effort: retry the same request uncached
-                    # and never mark again on this client. The flag guards the
-                    # recursion, so this path runs at most once.
+                if marked and is_cache_unsupported_error(err):
+                    # Keyed on what this request carried: a concurrent turn may
+                    # already have cleared the shared flag. The stripped retry
+                    # carries no markers, so this path runs at most once.
                     self._cache_markers_enabled = False
                     logger.warning(
                         "Model '%s' rejected prompt-cache markers; retrying without "
@@ -332,6 +335,9 @@ class LLMClient:
         from platform.guardrails.engine import GuardrailBlockedError
 
         kwargs = self._build_request_kwargs(prompt_or_messages)
+        # What this request carries, decided before any concurrent turn can
+        # clear the shared flag.
+        marked = strip_cache_markers(kwargs) != kwargs
 
         backoff_seconds = _RETRY_INITIAL_BACKOFF_SEC
         max_attempts = _RETRY_MAX_ATTEMPTS
@@ -353,9 +359,10 @@ class LLMClient:
                     "Check your configured model name and try again."
                 ) from err
             except AnthropicBadRequestError as err:
-                if not emitted and self._cache_markers_enabled and is_cache_unsupported_error(err):
-                    # Best-effort caching: rebuild the request without markers
-                    # (the flag now disables them) and stream that instead.
+                if not emitted and marked and is_cache_unsupported_error(err):
+                    # Keyed on what this request carried, not the shared flag.
+                    # Only before the first chunk: retrying after output has
+                    # reached the caller would duplicate visible text.
                     self._cache_markers_enabled = False
                     logger.warning(
                         "Model '%s' rejected prompt-cache markers; retrying without "
@@ -435,6 +442,9 @@ class BedrockLLMClient:
         if self._temperature is not None:
             kwargs["temperature"] = self._temperature
 
+        # What this request carries, decided before any concurrent turn can
+        # clear the shared flag.
+        marked = strip_cache_markers(kwargs) != kwargs
         backoff_seconds = _RETRY_INITIAL_BACKOFF_SEC
         max_attempts = _RETRY_MAX_ATTEMPTS
         last_err: Exception | None = None
@@ -447,10 +457,10 @@ class BedrockLLMClient:
                 # so wording alone cannot tell a marker rejection from any other
                 # bad request. Retry once stripped and keep markers off only if
                 # that actually fixed it.
-                if self._cache_markers_enabled and is_cache_unsupported_error(err):
-                    # Caching is best-effort: retry the same request uncached
-                    # and never mark again on this client. The flag guards the
-                    # recursion, so this path runs at most once.
+                if marked and is_cache_unsupported_error(err):
+                    # Keyed on what this request carried: a concurrent turn may
+                    # already have cleared the shared flag. The stripped retry
+                    # carries no markers, so this path runs at most once.
                     self._cache_markers_enabled = False
                     logger.warning(
                         "Bedrock model '%s' rejected prompt-cache markers; retrying "

--- a/core/llm/transports/sdk/llm_clients.py
+++ b/core/llm/transports/sdk/llm_clients.py
@@ -44,7 +44,11 @@ from core.llm.shared.structured_output import (
     json_schema_for_structured_output,
 )
 from core.llm.shared.usage import llm_response_with_usage
-from core.llm.transports.sdk.anthropic_cache import cached_system
+from core.llm.transports.sdk.anthropic_cache import (
+    cached_system,
+    is_cache_unsupported_error,
+    strip_cache_markers,
+)
 from core.llm.types import LLMResponse
 
 logger = logging.getLogger(__name__)
@@ -177,6 +181,11 @@ def _resolve_openai_reasoning_effort(*, model: str, api_key_env: str) -> str | N
 
 
 class LLMClient:
+    # Best-effort prompt caching: a class default so every instance starts
+    # marking; flipped to an instance False for the client's lifetime the
+    # first time the provider rejects the cache markers with a 400.
+    _cache_markers_enabled = True
+
     def __init__(
         self, *, model: str, max_tokens: int = 1024, temperature: float | None = None
     ) -> None:
@@ -245,7 +254,7 @@ class LLMClient:
             "messages": messages,
         }
         if system:
-            kwargs["system"] = cached_system(system)
+            kwargs["system"] = cached_system(system) if self._cache_markers_enabled else system
         if self._temperature is not None:
             kwargs["temperature"] = self._temperature
         return kwargs
@@ -284,6 +293,22 @@ class LLMClient:
                     "Check your configured model name and try again."
                 ) from err
             except AnthropicBadRequestError as err:
+                # Any bad request may be the markers' fault: Bedrock's
+                # ValidationException does not reliably name the field, so the
+                # only dependable probe is to retry without them. Markers are
+                # disabled only if that retry actually succeeds, leaving genuine
+                # bad requests (bad max_tokens, oversized prompt) untouched.
+                if self._cache_markers_enabled and is_cache_unsupported_error(err):
+                    # Caching is best-effort: retry the same request uncached
+                    # and never mark again on this client. The flag guards the
+                    # recursion, so this path runs at most once.
+                    self._cache_markers_enabled = False
+                    logger.warning(
+                        "Model '%s' rejected prompt-cache markers; retrying without "
+                        "prompt caching (requests will pay full input price).",
+                        self._model,
+                    )
+                    return self._create_with_retry(strip_cache_markers(kwargs))
                 raise RuntimeError(_format_anthropic_bad_request(err)) from err
             except GuardrailBlockedError:
                 raise
@@ -328,6 +353,17 @@ class LLMClient:
                     "Check your configured model name and try again."
                 ) from err
             except AnthropicBadRequestError as err:
+                if not emitted and self._cache_markers_enabled and is_cache_unsupported_error(err):
+                    # Best-effort caching: rebuild the request without markers
+                    # (the flag now disables them) and stream that instead.
+                    self._cache_markers_enabled = False
+                    logger.warning(
+                        "Model '%s' rejected prompt-cache markers; retrying without "
+                        "prompt caching (requests will pay full input price).",
+                        self._model,
+                    )
+                    yield from self.invoke_stream(prompt_or_messages)
+                    return
                 raise RuntimeError(_format_anthropic_bad_request(err)) from err
             except GuardrailBlockedError:
                 raise
@@ -349,6 +385,11 @@ class BedrockLLMClient:
     - Anthropic Claude models → AnthropicBedrock SDK (existing behaviour)
     - Non-Anthropic models (Mistral, GPT OSS, Llama, etc.) → boto3 ``converse`` API
     """
+
+    # Best-effort prompt caching: Bedrock rejects cache markers with a 400 for
+    # Claude models that predate prompt caching, so the first such rejection
+    # flips this to an instance False for the client's lifetime.
+    _cache_markers_enabled = True
 
     def __init__(
         self, *, model: str, max_tokens: int = 1024, temperature: float | None = None
@@ -390,7 +431,7 @@ class BedrockLLMClient:
             "messages": messages,
         }
         if system:
-            kwargs["system"] = cached_system(system)
+            kwargs["system"] = cached_system(system) if self._cache_markers_enabled else system
         if self._temperature is not None:
             kwargs["temperature"] = self._temperature
 
@@ -402,6 +443,21 @@ class BedrockLLMClient:
                 response = self._anthropic_client.messages.create(**kwargs)
                 break
             except AnthropicBadRequestError as err:
+                # Bedrock's ValidationException often does not name the field,
+                # so wording alone cannot tell a marker rejection from any other
+                # bad request. Retry once stripped and keep markers off only if
+                # that actually fixed it.
+                if self._cache_markers_enabled and is_cache_unsupported_error(err):
+                    # Caching is best-effort: retry the same request uncached
+                    # and never mark again on this client. The flag guards the
+                    # recursion, so this path runs at most once.
+                    self._cache_markers_enabled = False
+                    logger.warning(
+                        "Bedrock model '%s' rejected prompt-cache markers; retrying "
+                        "without prompt caching (requests will pay full input price).",
+                        self._model,
+                    )
+                    return self._invoke_anthropic(prompt_or_messages)
                 err_msg = str(err)
                 err_msg_lower = err_msg.lower()
                 if "on-demand throughput" in err_msg or "inference profile" in err_msg_lower:

--- a/tests/core/runtime/llm/test_cache_marker_degradation.py
+++ b/tests/core/runtime/llm/test_cache_marker_degradation.py
@@ -156,3 +156,33 @@ def test_bedrock_client_falls_back_the_same_way(monkeypatch: Any) -> None:
     assert response.content == "fine"
     retried = sdk.messages.create.call_args_list[-1].kwargs
     assert "cache_control" not in json.dumps(retried["system"])
+
+
+def test_concurrent_rejection_still_retries_uncached(monkeypatch: Any) -> None:
+    """A second in-flight marked request must not be stranded by the first.
+
+    Clients are shared across concurrent turns. If one call's rejection flips
+    the shared flag before another call handles its own rejection, the second
+    request — already sent *with* markers — would see the flag off, skip its
+    retry, and fail. The retry decision must depend on what this request
+    carried, not on the shared flag's current value.
+    """
+    # Arrange: the SDK flips the flag before raising, as a racing call would.
+    client, sdk = _anthropic_client(monkeypatch)
+    calls: list[dict[str, Any]] = []
+
+    def _create(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        if "cache_control" in json.dumps(kwargs.get("system", "")):
+            client._cache_markers_enabled = False  # another turn got there first
+            raise _bad_request(GENERIC_BEDROCK_REJECTION)
+        return _ok_response()
+
+    sdk.messages.create.side_effect = _create
+
+    # Act
+    response = client.invoke(_messages())
+
+    # Assert: it still recovered rather than surfacing the 400.
+    assert response.content == "fine"
+    assert "cache_control" not in json.dumps(calls[-1].get("system", ""))

--- a/tests/core/runtime/llm/test_cache_marker_degradation.py
+++ b/tests/core/runtime/llm/test_cache_marker_degradation.py
@@ -1,0 +1,158 @@
+"""Prompt-cache markers must never make a model unusable.
+
+Caching is an optimisation. A model that rejects the markers — older Bedrock
+model IDs are the realistic case — must still answer, uncached. Detection by
+error wording alone is not enough: Bedrock's ``ValidationException`` text varies
+and does not always name the field, so a request that only fails *because of* the
+markers can look like an ordinary bad request.
+
+The rule these tests pin: a 400 whose wording implicates the markers — including
+Bedrock's generic ``ValidationException`` phrasings, which name no field — must
+degrade to an uncached retry rather than failing the call. Bad requests that are
+not about caching still raise, and leave caching enabled.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.llm.transports.sdk.llm_clients import BedrockLLMClient, LLMClient
+
+SYSTEM_PROMPT = "You are a classifier. " * 200
+
+
+def _bad_request(message: str) -> Exception:
+    """An SDK-shaped 400 the client's except-clause will match."""
+    from anthropic import BadRequestError
+
+    response = SimpleNamespace(status_code=400, headers={}, request=SimpleNamespace())
+    return BadRequestError(message, response=response, body=None)
+
+
+def _ok_response() -> SimpleNamespace:
+    return SimpleNamespace(
+        content=[SimpleNamespace(type="text", text="fine")],
+        stop_reason="end_turn",
+        usage=SimpleNamespace(input_tokens=5, output_tokens=1),
+    )
+
+
+def _anthropic_client(monkeypatch: Any) -> tuple[LLMClient, MagicMock]:
+    client = LLMClient.__new__(LLMClient)
+    client._model = "claude-sonnet-4-6"
+    client._max_tokens = 128
+    client._temperature = None
+    client._api_key = "test-key"
+    sdk = MagicMock()
+    client._client = sdk
+    monkeypatch.setattr(client, "_ensure_client", lambda: None)
+    return client, sdk
+
+
+def _bedrock_client(monkeypatch: Any) -> tuple[BedrockLLMClient, MagicMock]:
+    client = BedrockLLMClient.__new__(BedrockLLMClient)
+    client._model = "us.anthropic.claude-3-5-sonnet-20240620-v1:0"
+    client._max_tokens = 128
+    client._temperature = None
+    sdk = MagicMock()
+    client._anthropic_client = sdk
+    return client, sdk
+
+
+def _messages() -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": "classify"},
+    ]
+
+
+# Bedrock does not always name the offending field.
+GENERIC_BEDROCK_REJECTION = "ValidationException: This model does not support the requested feature"
+
+
+def test_generic_rejection_still_falls_back_to_uncached(monkeypatch: Any) -> None:
+    """The wording names no field, so only a retry can tell markers were at fault."""
+    # Arrange: markers rejected, stripped request accepted.
+    client, sdk = _anthropic_client(monkeypatch)
+    sdk.messages.create.side_effect = [_bad_request(GENERIC_BEDROCK_REJECTION), _ok_response()]
+
+    # Act
+    response = client.invoke(_messages())
+
+    # Assert: answered anyway, and the retry carried no cache markers.
+    assert response.content == "fine"
+    retried = sdk.messages.create.call_args_list[-1].kwargs
+    assert "cache_control" not in json.dumps(retried["system"])
+
+
+def test_markers_stay_off_after_a_rejection(monkeypatch: Any) -> None:
+    """One probe per client, not one per call."""
+    # Arrange
+    client, sdk = _anthropic_client(monkeypatch)
+    sdk.messages.create.side_effect = [
+        _bad_request(GENERIC_BEDROCK_REJECTION),
+        _ok_response(),
+        _ok_response(),
+    ]
+
+    # Act
+    client.invoke(_messages())
+    sdk.messages.create.reset_mock()
+    client.invoke(_messages())
+
+    # Assert: the second call never re-sends markers.
+    sent = sdk.messages.create.call_args.kwargs
+    assert "cache_control" not in json.dumps(sent["system"])
+    assert sdk.messages.create.call_count == 1
+
+
+def test_unrelated_bad_request_is_not_masked(monkeypatch: Any) -> None:
+    """A genuine 400 must surface, not be reported as a caching problem."""
+    # Arrange: both attempts fail — the request itself is bad.
+    client, sdk = _anthropic_client(monkeypatch)
+    sdk.messages.create.side_effect = [
+        _bad_request("max_tokens: must be <= 8192"),
+        _bad_request("max_tokens: must be <= 8192"),
+    ]
+
+    # Act / Assert
+    with pytest.raises(RuntimeError, match="max_tokens"):
+        client.invoke(_messages())
+
+
+def test_unrelated_bad_request_leaves_caching_on(monkeypatch: Any) -> None:
+    """A bad request that is not about markers must not disable caching."""
+    # Arrange
+    client, sdk = _anthropic_client(monkeypatch)
+    sdk.messages.create.side_effect = [
+        _bad_request("max_tokens: must be <= 8192"),
+        _bad_request("max_tokens: must be <= 8192"),
+    ]
+
+    # Act
+    with pytest.raises(RuntimeError):
+        client.invoke(_messages())
+
+    # Assert
+    assert client._cache_markers_enabled is True
+
+
+def test_bedrock_client_falls_back_the_same_way(monkeypatch: Any) -> None:
+    """Bedrock is the realistic home of marker-rejecting model IDs."""
+    # Arrange
+    client, sdk = _bedrock_client(monkeypatch)
+    sdk.messages.create.side_effect = [_bad_request(GENERIC_BEDROCK_REJECTION), _ok_response()]
+    monkeypatch.setattr(client, "_ensure_client", lambda: None, raising=False)
+
+    # Act
+    response = client._invoke_anthropic(_messages())
+
+    # Assert
+    assert response.content == "fine"
+    retried = sdk.messages.create.call_args_list[-1].kwargs
+    assert "cache_control" not in json.dumps(retried["system"])

--- a/tests/core/runtime/llm/test_cache_marker_fallback.py
+++ b/tests/core/runtime/llm/test_cache_marker_fallback.py
@@ -1,0 +1,288 @@
+"""Prompt-cache markers must degrade, never break a request.
+
+Bedrock rejects ``cache_control`` with a 400 for Claude models that predate
+prompt caching, and every Anthropic-shaped client sends the marker
+unconditionally. Without a fallback, one env var pinning an old model
+(``BEDROCK_REASONING_MODEL=anthropic.claude-3-...``) turns every LLM call into
+a hard failure. The contract pinned here: a 400 that blames the markers is
+retried once without them, the client stops marking for its lifetime, and any
+other 400 keeps its existing error mapping.
+"""
+
+from __future__ import annotations
+
+import types
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import core.llm.transports.sdk.llm_clients as sdk_llm
+from core.llm.transports.sdk.agent_clients import AnthropicAgentClient
+from core.llm.transports.sdk.anthropic_cache import (
+    is_cache_unsupported_error,
+    strip_cache_markers,
+)
+
+_CACHE_REJECTION_MESSAGE = (
+    "messages.0: Extra inputs are not permitted: cache_control is not supported for this model"
+)
+
+
+def _bad_request(message: str) -> Exception:
+    """Real AnthropicBadRequestError without httpx response plumbing."""
+    err = sdk_llm.AnthropicBadRequestError.__new__(sdk_llm.AnthropicBadRequestError)
+    Exception.__init__(err, message)
+    err.status_code = 400  # type: ignore[attr-defined]
+    err.message = message  # type: ignore[attr-defined]
+    err.body = {}  # type: ignore[attr-defined]
+    err.request = None  # type: ignore[assignment]
+    err.response = None  # type: ignore[assignment]
+    return err
+
+
+class _FlakyMessages:
+    """messages.create that raises on the first call, then succeeds."""
+
+    def __init__(self, first_error: Exception) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._first_error = first_error
+
+    def create(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        if len(self.calls) == 1:
+            raise self._first_error
+        return SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="ok")],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=2),
+        )
+
+
+class _InactiveGuardrailEngine:
+    is_active = False
+
+    def __call__(self) -> _InactiveGuardrailEngine:
+        return self
+
+
+def _has_cache_marker(kwargs: dict[str, Any]) -> bool:
+    blocks: list[Any] = []
+    system = kwargs.get("system")
+    if isinstance(system, list):
+        blocks.extend(system)
+    blocks.extend(kwargs.get("tools") or [])
+    for message in kwargs.get("messages") or []:
+        content = message.get("content") if isinstance(message, dict) else None
+        if isinstance(content, list):
+            blocks.extend(content)
+    return any(isinstance(block, dict) and "cache_control" in block for block in blocks)
+
+
+class TestCacheHelpers:
+    def test_is_cache_unsupported_error_matches_marker_rejections(self) -> None:
+        assert is_cache_unsupported_error(_bad_request(_CACHE_REJECTION_MESSAGE))
+        assert is_cache_unsupported_error(
+            _bad_request("This model does not support prompt caching.")
+        )
+
+    def test_is_cache_unsupported_error_ignores_other_bad_requests(self) -> None:
+        assert not is_cache_unsupported_error(_bad_request("on-demand throughput isn't supported"))
+        assert not is_cache_unsupported_error(_bad_request("max_tokens is too large"))
+
+    def test_strip_removes_markers_from_system_tools_and_messages(self) -> None:
+        # Arrange
+        kwargs = {
+            "model": "m",
+            "system": [{"type": "text", "text": "s", "cache_control": {"type": "ephemeral"}}],
+            "tools": [{"name": "t", "cache_control": {"type": "ephemeral"}}],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "u", "cache_control": {"type": "ephemeral"}}
+                    ],
+                }
+            ],
+        }
+
+        # Act
+        stripped = strip_cache_markers(kwargs)
+
+        # Assert
+        assert not _has_cache_marker(stripped)
+        # Lone text block collapses back to the plain string a non-caching
+        # client would have sent (models that reject markers may also reject
+        # block-form system).
+        assert stripped["system"] == "s"
+        assert stripped["tools"] == [{"name": "t"}]
+        assert _has_cache_marker(kwargs), "input kwargs must not be mutated"
+
+    def test_strip_keeps_user_schema_property_named_cache_control(self) -> None:
+        """Only the marker positions are stripped, never tool schema bodies."""
+        # Arrange
+        schema = {"properties": {"cache_control": {"type": "string"}}}
+        kwargs = {
+            "tools": [{"name": "t", "input_schema": schema, "cache_control": {"type": "ephemeral"}}]
+        }
+
+        # Act
+        stripped = strip_cache_markers(kwargs)
+
+        # Assert
+        (tool,) = stripped["tools"]
+        assert "cache_control" not in tool
+        assert tool["input_schema"] == schema
+
+
+class TestBedrockMessagesClientFallback:
+    def _client(self, messages: _FlakyMessages) -> sdk_llm.BedrockLLMClient:
+        client = sdk_llm.BedrockLLMClient.__new__(sdk_llm.BedrockLLMClient)
+        client._model = "anthropic.claude-3-haiku-20240307-v1:0"
+        client._max_tokens = 256
+        client._temperature = None
+        client._anthropic_client = types.SimpleNamespace(messages=messages)  # type: ignore[assignment]
+        return client
+
+    @pytest.fixture(autouse=True)
+    def _inactive_guardrails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "platform.guardrails.engine.get_guardrail_engine", _InactiveGuardrailEngine()
+        )
+
+    def test_cache_rejection_retries_without_markers(self) -> None:
+        # Arrange
+        messages = _FlakyMessages(_bad_request(_CACHE_REJECTION_MESSAGE))
+        client = self._client(messages)
+
+        # Act
+        response = client._invoke_anthropic(
+            [{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}]
+        )
+
+        # Assert
+        assert response.content == "ok"
+        assert len(messages.calls) == 2
+        assert _has_cache_marker(messages.calls[0])
+        assert not _has_cache_marker(messages.calls[1])
+        assert messages.calls[1]["system"] == "sys"
+
+    def test_fallback_is_sticky_for_the_client_lifetime(self) -> None:
+        # Arrange — first invoke must carry a system prefix so markers are
+        # present; without them there is nothing to strip and the 400 raises.
+        messages = _FlakyMessages(_bad_request(_CACHE_REJECTION_MESSAGE))
+        client = self._client(messages)
+        client._invoke_anthropic(
+            [{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}]
+        )
+
+        # Act
+        client._invoke_anthropic(
+            [{"role": "system", "content": "sys"}, {"role": "user", "content": "again"}]
+        )
+
+        # Assert: exactly one failed marked attempt ever, no markers afterwards.
+        assert len(messages.calls) == 3
+        assert _has_cache_marker(messages.calls[0])
+        assert not _has_cache_marker(messages.calls[1])
+        assert not _has_cache_marker(messages.calls[2])
+        assert messages.calls[2]["system"] == "sys"
+
+    def test_unrelated_bad_request_keeps_existing_error_mapping(self) -> None:
+        # Arrange
+        messages = _FlakyMessages(_bad_request("on-demand throughput isn't supported"))
+        client = self._client(messages)
+
+        # Act / Assert
+        with pytest.raises(RuntimeError, match="inference profile"):
+            client._invoke_anthropic([{"role": "user", "content": "hi"}])
+        assert len(messages.calls) == 1, "unrelated 400s must not be retried"
+
+
+class TestAnthropicMessagesClientFallback:
+    @pytest.fixture(autouse=True)
+    def _inactive_guardrails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "platform.guardrails.engine.get_guardrail_engine", _InactiveGuardrailEngine()
+        )
+
+    def _client(self, messages: _FlakyMessages) -> sdk_llm.LLMClient:
+        client = sdk_llm.LLMClient.__new__(sdk_llm.LLMClient)
+        client._model = "claude-sonnet-4-6"
+        client._max_tokens = 256
+        client._temperature = None
+        client._api_key = "test-key"
+        client._client = types.SimpleNamespace(messages=messages)  # type: ignore[assignment]
+        return client
+
+    def test_cache_rejection_retries_stripped_and_disables_markers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Arrange
+        messages = _FlakyMessages(_bad_request(_CACHE_REJECTION_MESSAGE))
+        client = self._client(messages)
+        monkeypatch.setattr(client, "_ensure_client", lambda: None)  # keep the injected fake client
+
+        # Act
+        response = client.invoke(
+            [{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}]
+        )
+
+        # Assert
+        assert response.content == "ok"
+        assert len(messages.calls) == 2
+        assert _has_cache_marker(messages.calls[0])
+        assert not _has_cache_marker(messages.calls[1])
+        assert not client._cache_markers_enabled
+        # And the next request is built without markers from the start.
+        kwargs = client._build_request_kwargs(
+            [{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}]
+        )
+        assert kwargs["system"] == "sys"
+
+    def test_unrelated_bad_request_still_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Arrange
+        messages = _FlakyMessages(_bad_request("max_tokens is too large"))
+        client = self._client(messages)
+        monkeypatch.setattr(client, "_ensure_client", lambda: None)
+
+        # Act / Assert
+        with pytest.raises(RuntimeError):
+            client.invoke("hi")
+        assert len(messages.calls) == 1
+
+
+class TestAgentClientFallback:
+    def _client(self, messages: _FlakyMessages) -> AnthropicAgentClient:
+        return AnthropicAgentClient(
+            model="claude-sonnet-4-6",
+            client=types.SimpleNamespace(messages=messages),
+        )
+
+    def test_cache_rejection_retries_without_markers_across_all_positions(self) -> None:
+        # Arrange
+        messages = _FlakyMessages(_bad_request(_CACHE_REJECTION_MESSAGE))
+        client = self._client(messages)
+        tools = [{"name": "t", "description": "d", "input_schema": {"type": "object"}}]
+
+        # Act
+        response = client.invoke([{"role": "user", "content": "hi"}], system="sys", tools=tools)
+
+        # Assert
+        assert response.content == "ok"
+        assert len(messages.calls) == 2
+        assert _has_cache_marker(messages.calls[0])
+        assert not _has_cache_marker(messages.calls[1])
+        assert messages.calls[1]["system"] == "sys"
+        assert messages.calls[1]["tools"] == tools
+        assert not client._cache_markers_enabled
+
+    def test_unrelated_bad_request_still_raises(self) -> None:
+        # Arrange
+        messages = _FlakyMessages(_bad_request("tools.0: input_schema is invalid"))
+        client = self._client(messages)
+
+        # Act / Assert
+        with pytest.raises(RuntimeError, match="request rejected"):
+            client.invoke([{"role": "user", "content": "hi"}], system="sys")
+        assert len(messages.calls) == 1


### PR DESCRIPTION
Prompt caching landed in `main` as an unconditional request shape: every Anthropic-shaped call marks its system prefix with `cache_control`. Models that do not support the markers reject the request with HTTP 400 — older Bedrock
Claude model IDs are the realistic case — which made caching a hard dependency rather than an optimisation. A user on such a model would see every call fail.

Caching is now best-effort:

- `anthropic_cache.py` gains `is_cache_unsupported_error()` and `strip_cache_markers()`. The stripper removes markers from exactly the three  spots this module writes them — system blocks, top-level tool schemas, and  message content blocks — and deliberately does not recurse into tool  `input_schema` bodies, where `cache_control` could be a legitimate
  user-defined property name.
- `strip_cache_markers` exactly inverts `cached_system`: a lone text block  collapses back to the plain string a non-caching client would have sent. This
  matters because a model old enough to reject `cache_control` may not accept
  block-form `system` either, so the retry has to look like the request we would
  have made if caching had never existed.
- Every Anthropic-shaped path degrades on a marker rejection: `LLMClient.invoke`,
  `LLMClient.invoke_stream`, `BedrockLLMClient._invoke_anthropic`, and
  `BedrockAgentClient` via `AnthropicAgentClient`. Each retries once without
  markers, logs a warning naming the model, and disables marking for that
  client's lifetime so the probe costs one request, not one per call.
- Marking is gated on an instance flag with a `True` class default, so a fresh
  client starts optimistic and only the rejecting one stays uncached.