### PR TITLE
Remove duplicate /history slash command from tasks_cmds

### DIFF
--- a/surfaces/interactive_shell/command_registry/tasks_cmds.py
+++ b/surfaces/interactive_shell/command_registry/tasks_cmds.py
@@ -1,4 +1,4 @@
-"""Slash commands: /history, /tasks, /cancel."""
+"""Slash commands: /tasks, /cancel, /stop."""
 
 from __future__ import annotations
 
@@ -10,7 +10,6 @@ from rich.markup import escape
 from surfaces.interactive_shell.command_registry.types import (
     SlashCommand,
 )
-from surfaces.interactive_shell.prompt_history import load_command_history_entries
 from surfaces.interactive_shell.runtime import Session, TaskKind, TaskRecord, TaskStatus
 from surfaces.interactive_shell.ui import (
     BOLD_BRAND,
@@ -115,22 +114,6 @@ def _task_detail_label(task: TaskRecord) -> str:
     return first_line or "—"
 
 
-def _cmd_history(_session: Session, console: Console, _args: list[str]) -> bool:
-    entries = load_command_history_entries()
-    if not entries:
-        console.print(f"[{DIM}]no history yet.[/]")
-        return True
-
-    table = repl_table(title="Command history\n", title_style=BOLD_BRAND)
-    table.add_column("#", style=DIM, justify="right")
-    table.add_column("text", overflow="fold")
-
-    for i, entry in enumerate(entries, start=1):
-        table.add_row(str(i), escape(entry))
-    print_repl_table(console, table)
-    return True
-
-
 def _cmd_tasks(session: Session, console: Console, _args: list[str]) -> bool:
     tasks = session.task_registry.list_recent(n=50)
     if not tasks:
@@ -218,7 +201,6 @@ def _cmd_cancel(session: Session, console: Console, args: list[str]) -> bool:
 
 
 COMMANDS: list[SlashCommand] = [
-    SlashCommand("/history", "Show persisted command history.", _cmd_history),
     SlashCommand(
         "/tasks",
         "List recent and in-flight shell tasks.",

--- a/tests/interactive_shell/command_registry/test_no_duplicate_slash_names.py
+++ b/tests/interactive_shell/command_registry/test_no_duplicate_slash_names.py
@@ -16,33 +16,19 @@ from surfaces.interactive_shell.command_registry import (
     SLASH_COMMANDS,
 )
 
-# One duplicate predates this guard: "/history" is registered by both
-# tasks_cmds and privacy_cmds, and privacy_cmds merges later, so the
-# tasks_cmds command is unreachable. Pinned rather than fixed here so the guard
-# can land without changing unrelated commands; removing the dead registration
-# should shrink this set to empty.
-KNOWN_DUPLICATES = frozenset({"/history"})
-
 
 def test_no_two_commands_claim_the_same_name() -> None:
-    # Arrange
+    """No slash name is registered more than once."""
     counts = Counter(command.name for command in _MERGED_SEQUENCE)
-
-    # Act
     duplicates = {name for name, count in counts.items() if count > 1}
-
-    # Assert
-    assert sorted(duplicates - KNOWN_DUPLICATES) == [], (
+    assert sorted(duplicates) == [], (
         "these slash names are registered more than once and would overwrite "
-        f"each other: {sorted(duplicates - KNOWN_DUPLICATES)}"
+        f"each other: {sorted(duplicates)}"
     )
 
 
 def test_every_registered_command_survives_the_lookup_table() -> None:
     """No command is lost between the merged sequence and the dispatch dict."""
-    # Arrange / Act
     lost = sorted({command.name for command in _MERGED_SEQUENCE} - set(SLASH_COMMANDS))
-
-    # Assert
     assert lost == []
-    assert len(SLASH_COMMANDS) == len(_MERGED_SEQUENCE) - len(KNOWN_DUPLICATES)
+    assert len(SLASH_COMMANDS) == len(_MERGED_SEQUENCE)


### PR DESCRIPTION
## Summary

Removes dead `_cmd_history` handler and its `SlashCommand` registration from `tasks_cmds.py` — the `privacy_cmds.py` version (with `clear`, `off`, `on`, `retention` subcommands + interactive TTY menu) was already the only reachable one. The duplicate was silently overwritten by the dict comprehension in `_MERGED_SEQUENCE`.

## Changes

- `tasks_cmds.py`: Removed `_cmd_history` function, its `SlashCommand` entry, unused `load_command_history_entries` import, updated docstring
- `test_no_duplicate_slash_names.py`: Removed `KNOWN_DUPLICATES` (was `{"/history"}`), simplified assertions since no duplicates remain

## Testing

- 169 command tests, 47 history tests, 9 slash catalog tests all pass
- Typecheck clean
- `test_no_two_commands_claim_the_same_name` now enforces zero known duplicates