### PR TITLE
Fix: Replace magic HTTP status codes with HTTPStatus enum in RabbitMQ integration

### DIFF
--- a/integrations/rabbitmq/__init__.py
+++ b/integrations/rabbitmq/__init__.py
@@ -21,6 +21,7 @@ import logging
 import os
 import urllib.parse
 from dataclasses import dataclass
+from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -152,9 +153,9 @@ def _http_get(client: httpx.Client, path: str) -> tuple[Any | None, str | None]:
     except httpx.RequestError as err:
         return None, f"RabbitMQ request failed: {err}"
 
-    if response.status_code == 401:
+    if response.status_code == HTTPStatus.UNAUTHORIZED:
         return None, "RabbitMQ authentication failed (check username/password)."
-    if response.status_code == 404:
+    if response.status_code == HTTPStatus.NOT_FOUND:
         if path == "/api/overview":
             return None, (
                 "RabbitMQ Management API not found — enable the "
@@ -162,7 +163,7 @@ def _http_get(client: httpx.Client, path: str) -> tuple[Any | None, str | None]:
                 "`rabbitmq-plugins enable rabbitmq_management`."
             )
         return None, f"RabbitMQ endpoint not found: {path}"
-    if response.status_code >= 400:
+    if response.status_code >= HTTPStatus.BAD_REQUEST:
         return None, (
             f"RabbitMQ management API returned HTTP {response.status_code}: {response.text[:200]}"
         )
@@ -374,14 +375,14 @@ def get_broker_overview(config: RabbitMQConfig) -> dict[str, Any]:
             except httpx.RequestError as exc:
                 alarm_payload = {"ok": False, "detail": str(exc)}
             else:
-                if alarm_resp.status_code == 200:
+                if alarm_resp.status_code == HTTPStatus.OK:
                     alarm_payload = {"ok": True, "detail": "ok"}
-                elif alarm_resp.status_code in (401, 403):
+                elif alarm_resp.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
                     alarm_payload = {
                         "ok": None,
                         "detail": "alarm status unknown (insufficient permissions)",
                     }
-                elif alarm_resp.status_code == 404:
+                elif alarm_resp.status_code == HTTPStatus.NOT_FOUND:
                     alarm_payload = {
                         "ok": None,
                         "detail": "alarm endpoint not available on this broker version",


### PR DESCRIPTION
Fixes #4285

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Replace raw HTTP status code integers with `http.HTTPStatus` enum constants in `integrations/rabbitmq/__init__.py`.

This is a pure readability improvement with zero behavioral change — `HTTPStatus` is a stdlib `IntEnum`, so `HTTPStatus.UNAUTHORIZED == 401` is `True` at runtime.

**Changes (1 file, 7 insertions, 6 deletions):**

| Location | Before | After |
|----------|--------|-------|
| `_http_get()` L156 | `== 401` | `== HTTPStatus.UNAUTHORIZED` |
| `_http_get()` L158 | `== 404` | `== HTTPStatus.NOT_FOUND` |
| `_http_get()` L166 | `>= 400` | `>= HTTPStatus.BAD_REQUEST` |
| `get_broker_overview()` L378 | `== 200` | `== HTTPStatus.OK` |
| `get_broker_overview()` L380 | `in (401, 403)` | `in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN)` |
| `get_broker_overview()` L385 | `== 404` | `== HTTPStatus.NOT_FOUND` |

Added `from http import HTTPStatus` to imports (stdlib — no new dependencies).

### Demo/Screenshot for feature changes and bug fixes -

**Lint (ruff):**
```
$ uv run ruff check integrations/rabbitmq/__init__.py
All checks passed!
```

**Format check:**
```
$ uv run ruff format --check integrations/rabbitmq/__init__.py
1 file already formatted
```

**Type check (mypy):**
```
$ uv run mypy integrations/rabbitmq/__init__.py
Success: no issues found in 1 source file
```

**Unit tests (all 81 RabbitMQ tests pass):**
```
$ uv run pytest tests/integrations/test_rabbitmq.py tests/tools/test_rabbitmq_broker_overview_tool.py tests/tools/test_rabbitmq_queue_backlog_tool.py tests/tools/test_rabbitmq_node_health_tool.py tests/tools/test_rabbitmq_consumer_health_tool.py tests/tools/test_rabbitmq_connection_stats_tool.py -v
...
============================= 81 passed in 8.73s ==============================
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**What problem does this solve?**
The RabbitMQ integration used magic integer literals (`200`, `401`, `403`, `404`, `400`) for HTTP status code comparisons. These require the reader to mentally map each number to its meaning, which slows down code review and incident debugging.

**What alternative did I consider?**
Defining project-level constants like `HTTP_OK = 200`, but rejected that because Python's stdlib already provides `http.HTTPStatus` — an `IntEnum` that is the idiomatic solution for this exact problem.

**Why this implementation?**
`HTTPStatus` members are `IntEnum` values, so `HTTPStatus.OK == 200` is `True`. This makes the change a zero-risk drop-in replacement: every comparison behaves identically at runtime, the import is from the stdlib (no new dependency), and ruff's import sorter handles placement automatically. The approach is consistent with the sibling issues (#4279, #4280) that request the same pattern elsewhere.

**What do the touched functions do?**
- `_http_get()` — shared HTTP GET helper for the RabbitMQ Management API. It catches `httpx.RequestError`, then checks for 401 (bad credentials), 404 (management plugin not enabled / endpoint missing), and generic ≥ 400 errors before returning parsed JSON.
- Alarm health-check block inside `get_broker_overview()` — hits `/api/healthchecks/alarms` and classifies the response: 200 → healthy, 401/403 → insufficient permissions (unknown), 404 → endpoint not available on this broker version, anything else (typically 503) → alarms active, parse the structured reason.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
