### PR TITLE
refactor(llm): use StrEnum for model roles

### DIFF
--- a/core/llm/client_builders.py
+++ b/core/llm/client_builders.py
@@ -62,7 +62,9 @@ def _native_sdk_agent_client(route: LLMRoute) -> AgentLLMClient:
     settings, provider = route.settings, route.provider
 
     if is_openai_compat_provider(provider):
-        resolved = resolve_openai_compat_provider(settings, provider, "reasoning")
+        from core.llm.types import ModelType
+
+        resolved = resolve_openai_compat_provider(settings, provider, ModelType.REASONING)
         max_tokens = 1024 if provider == PROVIDER_OLLAMA else resolved.config.max_tokens
         return sdk.OpenAIAgentClient(
             model=resolved.model,
@@ -133,11 +135,12 @@ def _native_sdk_llm_client(route: LLMRoute, model_type: ModelType) -> Any:
     )
     from core.llm.providers.provider_registry import FIRST_PARTY_PROVIDERS
     from core.llm.transports.sdk import llm_clients as sdk
+    from core.llm.types import ModelType
 
     settings, provider = route.settings, route.provider
 
     def _fallback_model(provider_prefix: str) -> str | None:
-        if model_type == "toolcall":
+        if model_type is ModelType.TOOLCALL:
             return None
         return str(getattr(settings, f"{provider_prefix}_toolcall_model", None) or "") or None
 

--- a/core/llm/factory.py
+++ b/core/llm/factory.py
@@ -26,7 +26,7 @@ in :mod:`core.llm.internal.client_cache`.
 from __future__ import annotations
 
 import re
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Literal, overload
 
 from core.llm import client_builders
@@ -36,7 +36,7 @@ from core.llm.transport_mode import use_litellm_for_provider
 from core.llm.types import AgentLLMClient, LLMRoute, ModelType
 
 
-class LLMRole(Enum):
+class LLMRole(StrEnum):
     """The model tier a caller needs, independent of provider/transport."""
 
     AGENT = "agent"  # tool-calling ReAct (action, gather, investigation)
@@ -47,9 +47,9 @@ class LLMRole(Enum):
 
 # The non-agent roles map onto the model-tier attribute suffix used by settings.
 _MODEL_TYPE_BY_ROLE: dict[LLMRole, ModelType] = {
-    LLMRole.REASONING: "reasoning",
-    LLMRole.CLASSIFICATION: "classification",
-    LLMRole.TOOLCALL: "toolcall",
+    LLMRole.REASONING: ModelType.REASONING,
+    LLMRole.CLASSIFICATION: ModelType.CLASSIFICATION,
+    LLMRole.TOOLCALL: ModelType.TOOLCALL,
 }
 
 

--- a/core/llm/transports/litellm/routing.py
+++ b/core/llm/transports/litellm/routing.py
@@ -48,7 +48,7 @@ def build_litellm_agent_client(settings: Any, provider: str) -> LiteLLMAgentClie
     if is_azure_openai_provider(provider):
         from config.config import AZURE_OPENAI_LLM_CONFIG
 
-        azure = resolve_azure_openai_request_kwargs(settings, model_type="reasoning")
+        azure = resolve_azure_openai_request_kwargs(settings, model_type=ModelType.REASONING)
         return LiteLLMAgentClient(
             litellm_model=azure["litellm_model"],
             max_tokens=AZURE_OPENAI_LLM_CONFIG.max_tokens,
@@ -60,7 +60,7 @@ def build_litellm_agent_client(settings: Any, provider: str) -> LiteLLMAgentClie
     if is_openai_compat_provider(provider):
         from config.config import PROVIDER_OLLAMA
 
-        resolved = resolve_openai_compat_provider(settings, provider, "reasoning")
+        resolved = resolve_openai_compat_provider(settings, provider, ModelType.REASONING)
         max_tokens = 1024 if provider == PROVIDER_OLLAMA else resolved.config.max_tokens
         return LiteLLMAgentClient(
             litellm_model=_litellm_model_for_compat(resolved.model),
@@ -74,7 +74,7 @@ def build_litellm_agent_client(settings: Any, provider: str) -> LiteLLMAgentClie
     if is_vertex_ai_provider(provider):
         from config.config import VERTEX_AI_LLM_CONFIG
 
-        vertex = resolve_vertex_ai_request_kwargs(settings, model_type="reasoning")
+        vertex = resolve_vertex_ai_request_kwargs(settings, model_type=ModelType.REASONING)
         return LiteLLMAgentClient(
             litellm_model=vertex["litellm_model"],
             max_tokens=VERTEX_AI_LLM_CONFIG.max_tokens,
@@ -101,7 +101,7 @@ def build_litellm_llm_client(
     from core.llm.providers.provider_registry import FIRST_PARTY_PROVIDERS
 
     def _fallback(provider_prefix: str) -> str | None:
-        if model_type == "toolcall":
+        if model_type is ModelType.TOOLCALL:
             return None
         attr = f"{provider_prefix}_toolcall_model"
         return str(getattr(settings, attr, None) or "")
@@ -143,7 +143,7 @@ def build_litellm_llm_client(
         raw_fallback = _fallback(provider)
         fallback_model: str | None = None
         if raw_fallback:
-            fallback_compat = resolve_openai_compat_provider(settings, provider, "toolcall")
+            fallback_compat = resolve_openai_compat_provider(settings, provider, ModelType.TOOLCALL)
             fallback_model = _litellm_model_for_compat(fallback_compat.model)
         return LiteLLMLLMClient(
             litellm_model=_litellm_model_for_compat(compat.model),

--- a/core/llm/types.py
+++ b/core/llm/types.py
@@ -4,13 +4,20 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from typing import Any, Literal, Protocol, TypeAlias, runtime_checkable
+from enum import StrEnum
+from typing import Any, Protocol, TypeAlias, runtime_checkable
 
 from core.types import RuntimeTool
 
 ResolvedIntegrations: TypeAlias = dict[str, Any]  # noqa: UP040
 
-ModelType: TypeAlias = Literal["reasoning", "classification", "toolcall"]  # noqa: UP040
+
+class ModelType(StrEnum):
+    """Configured model tiers for non-agent LLM clients."""
+
+    REASONING = "reasoning"
+    CLASSIFICATION = "classification"
+    TOOLCALL = "toolcall"
 
 
 @dataclass(frozen=True)

--- a/tests/core/runtime/llm/test_factory.py
+++ b/tests/core/runtime/llm/test_factory.py
@@ -6,7 +6,15 @@ from types import SimpleNamespace
 
 import pytest
 
-from core.llm.factory import LLMRole, LLMRoute, get_llm, reset_llm_clients, resolve_llm_route
+from core.llm.factory import (
+    _MODEL_TYPE_BY_ROLE,
+    LLMRole,
+    LLMRoute,
+    get_llm,
+    reset_llm_clients,
+    resolve_llm_route,
+)
+from core.llm.types import ModelType
 
 
 @pytest.fixture(autouse=True)
@@ -61,6 +69,15 @@ def test_get_llm_routes_agent_and_non_agent_roles(monkeypatch: pytest.MonkeyPatc
     assert get_llm(LLMRole.REASONING) == "LLM:reasoning"
     assert get_llm(LLMRole.CLASSIFICATION) == "LLM:classification"
     assert get_llm(LLMRole.TOOLCALL) == "LLM:toolcall"
+
+
+def test_llm_roles_and_model_types_are_string_enums() -> None:
+    """The role-to-tier map keeps typed, round-trippable public values."""
+    assert LLMRole("reasoning") is LLMRole.REASONING
+    assert ModelType("reasoning") is ModelType.REASONING
+    assert _MODEL_TYPE_BY_ROLE[LLMRole.REASONING] is ModelType.REASONING
+    assert _MODEL_TYPE_BY_ROLE[LLMRole.CLASSIFICATION] is ModelType.CLASSIFICATION
+    assert _MODEL_TYPE_BY_ROLE[LLMRole.TOOLCALL] is ModelType.TOOLCALL
 
 
 def test_get_llm_caches_per_role_and_invalidates_on_config_change(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
Fixes #4523

#### Describe the changes you have made in this PR -

Replaced the `Literal` model-tier alias and `Enum` role with `StrEnum` classes.
The existing string values are preserved, while role-to-tier routing now uses typed
enum members. Updated the LiteLLM and native SDK call sites that consume the model
tier, and added a factory test covering enum construction and mapping.

### Demo/Screenshot for feature changes and bug fixes -

```
1498 passed, 29 skipped in 77.40s
Success: no issues found in 4 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`StrEnum` retains `str` behavior, so runtime configuration names and interpolation
remain compatible while callers receive a real, discoverable type. I used enum
members at the internal boundaries instead of raw strings so strict typing catches
invalid tiers. The test verifies enum value round-tripping and every non-agent
role-to-tier mapping. The scoped core suite also exercises the existing routing
and client-cache behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
