### PR TITLE
fix(bench): report.json records whether the run completed

### DIFF
--- a/tests/benchmarks/_framework/runner.py
+++ b/tests/benchmarks/_framework/runner.py
@@ -306,7 +306,12 @@ class BenchmarkRunner:
 
         # Persist a JSON sidecar to output_dir/report.json regardless of validation
         (output_dir / "report.json").write_text(
-            json.dumps(_report_to_dict(report, self.cost), ensure_ascii=False, indent=2) + "\n",
+            json.dumps(
+                _report_to_dict(report, self.cost, aborted=aborted, abort_reason=abort_reason),
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
             encoding="utf-8",
         )
 
@@ -824,10 +829,26 @@ def _cell_to_dict(case: BenchmarkCase, run: RunResult, score: CaseScore) -> dict
     }
 
 
-def _report_to_dict(report: BenchmarkReport, cost: CostTracker) -> dict[str, Any]:
-    """Serializable shape for report.json."""
+def _report_to_dict(
+    report: BenchmarkReport,
+    cost: CostTracker,
+    *,
+    aborted: bool = False,
+    abort_reason: str | None = None,
+) -> dict[str, Any]:
+    """Serializable shape for report.json.
+
+    ``aborted`` / ``abort_reason`` mirror the same fields on ``RunOutcome``.
+    The CLI already refuses to let a halted run exit 0, but that exit code
+    is not part of the run directory the bench container uploads to S3, so
+    the artifact carries the fact too. The pre-registration's
+    ``stopping_rules.partial`` clause depends on telling a partial run from
+    a complete one after the fact.
+    """
     return {
         "run_id": report.run_id,
+        "aborted": aborted,
+        "abort_reason": abort_reason,
         "config_hash": report.config_hash,
         "started_at": report.started_at,
         "ended_at": report.ended_at,

--- a/tests/benchmarks/_framework/tests/test_reporting.py
+++ b/tests/benchmarks/_framework/tests/test_reporting.py
@@ -24,6 +24,8 @@ def _write_report_json(run_dir: Path) -> dict:
     cases_dir.mkdir(parents=True, exist_ok=True)
     report = {
         "run_id": "dev-2026-01-01T00-00-00Z_cloudopsbench",
+        "aborted": False,
+        "abort_reason": None,
         "config_hash": "abc123",
         "started_at": "2026-01-01T00:00:00+00:00",
         "ended_at": "2026-01-01T00:05:00+00:00",

--- a/tests/benchmarks/_framework/tests/test_runner_budget.py
+++ b/tests/benchmarks/_framework/tests/test_runner_budget.py
@@ -16,6 +16,7 @@ See Greptile P1 review on the bench-image PR for the original report.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -83,6 +84,27 @@ def _runner(tmp_path: Path) -> BenchmarkRunner:
         }
     )
     return BenchmarkRunner(config=config, adapter=_TinyAdapter())
+
+
+def _two_llm_runner(tmp_path: Path) -> tuple[BenchmarkRunner, Path]:
+    """Runner over two model arms, so a halt can land between them."""
+    out_dir = tmp_path / "out"
+    config = BenchmarkConfig.model_validate(
+        {
+            "benchmark": "tiny",
+            "modes": ["opensre+llm"],
+            "llms": ["claude-4-sonnet", "gpt-5"],
+            "model_versions": {
+                "claude-4-sonnet": "claude-sonnet-4-5-20250929",
+                "gpt-5": "gpt-5-2025-08-07",
+            },
+            "seed": 42,
+            "cost_budget_usd": 10.0,
+            "output_dir": str(out_dir),
+            "report_formats": ["json"],
+        }
+    )
+    return BenchmarkRunner(config=config, adapter=_TinyAdapter()), out_dir
 
 
 def _call_run_one_cell(runner: BenchmarkRunner, tmp_path: Path) -> None:
@@ -174,3 +196,61 @@ def test_run_one_cell_catches_other_exceptions_as_cell_failure(tmp_path: Path) -
     with patch("tools.investigation.capability.run_investigation", _raises_runtime):
         # Should NOT raise — cell-level failure recorded in the _CellResult
         _call_run_one_cell(runner, tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# report.json must disclose that a run halted                                 #
+# --------------------------------------------------------------------------- #
+
+_INVESTIGATION_OK = {"root_cause": "ok", "report": "ok", "evidence_entries": []}
+
+
+def _read_report_json(out_dir: Path, run_id: str) -> dict[str, Any]:
+    return json.loads((out_dir / run_id / "report.json").read_text(encoding="utf-8"))
+
+
+def test_report_json_records_a_halted_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A run halted part-way through the grid must say so in report.json.
+
+    The exit-code path already refuses to let a halt pass as success
+    (``cli.py``: "a halted run that exits 0 is silently lost"), but the exit
+    code is not part of the run directory the bench container uploads to S3.
+    The pre-registration's ``stopping_rules.partial`` clause turns on this
+    distinction: "Numbers from a partial run are NEVER promoted to a
+    baseline; only complete runs are baselines", so the artifact has to
+    carry it.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    runner, out_dir = _two_llm_runner(tmp_path)
+    with patch(
+        "tools.investigation.capability.run_investigation",
+        return_value=_INVESTIGATION_OK,
+    ):
+        outcome = runner.run_without_integrity()
+
+    assert outcome.aborted, "second model arm should not have been reachable"
+    report = _read_report_json(out_dir, outcome.report.run_id)
+    assert report["aborted"] is True
+    assert "OPENAI_API_KEY" in (report["abort_reason"] or "")
+
+
+def test_report_json_records_a_complete_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The flip side: a run that finished the grid records that plainly, so
+    the field distinguishes the two rather than only ever appearing on
+    failure."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    runner, out_dir = _two_llm_runner(tmp_path)
+    with patch(
+        "tools.investigation.capability.run_investigation",
+        return_value=_INVESTIGATION_OK,
+    ):
+        outcome = runner.run_without_integrity()
+
+    assert not outcome.aborted, outcome.abort_reason
+    report = _read_report_json(out_dir, outcome.report.run_id)
+    assert report["aborted"] is False
+    assert report["abort_reason"] is None


### PR DESCRIPTION
Fixes #4567

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

**The bug:** a halted run's `report.json` is byte-identical to a complete run's. No signal in the uploaded artifact tells you which one you have.

The exit code can't fix this alone:

- `RunOutcome` already carries `aborted` and `abort_reason`, and the CLI rejects zero exit on a halt
- the entrypoint runs with `set -e` off so failed benches still upload (`tests/benchmarks/cloudopsbench/infra/entrypoint.sh:76-78`)
- the upload is just artifacts: `report.json`, `provenance.json`, cases (`tests/benchmarks/cloudopsbench/README.md:109`), and no exit code travels with them

So today, whoever reads the numbers has no way to know.

- `runner.py`: `_report_to_dict` gains both as keyword-only parameters with defaults, passed from locals already in scope.
- `test_runner_budget.py`: two tests, one per field. They run the real `run()` via `run_without_integrity()` (which skips the pre-flight gate that `run()` adds). Both funnel into `_run_inner`, and the `report.json` write sits before the `dev_mode` branch, so it's the production write under test.
- `test_reporting.py`: the fixture docstring says it mirrors `_report_to_dict`, so it gains the same keys.

Backward compatible: existing callers don't change, `report.json` readers pull named keys only (never the whole dict), so the new fields don't appear in rendered output, and no schema validates against these keys.

### Demo/Screenshot for feature changes and bug fixes -

<img width="1360" height="730" alt="opensre_demo_4567" src="https://github.com/user-attachments/assets/b6cff091-782f-4e04-91d2-87c579038c85" />

Two runs of the same two-arm grid through the production `run()`, using the repo's own tiny-adapter harness. `complete/` had every provider key present and ran all 36 cells. `halted/` had the second provider's key absent and stopped at 18. `report_validation` passed for both, and their `report.json` key sets are identical.

Put the same question to both runs. **Before this PR:**

```console
$ jq '.aborted' complete/report.json halted/report.json
null
null
```

**After this PR**, same command, same two runs:

```console
$ jq '.aborted' complete/report.json halted/report.json
false
true

$ jq -r '.abort_reason' halted/report.json
LLM dispatch failed: 'gpt-5' requires env var OPENAI_API_KEY to be set. Run with `set -a && source .env && set +a` or export the key first.
```

The keys are record-only. The rendered `report.md` does not surface them.

Why the exit code cannot carry this on its own:

```mermaid
flowchart LR
    B["bench run<br>(knows it halted)"] -->|"exit code"| C["container status<br>(set +e; not a file)"]
    B -->|"run directory"| S["S3: report.json<br>provenance.json, cases/"]
    C -.->|"not uploaded"| S
    S --> R["whoever reads<br>the numbers"]
```

The tests, against unpatched and patched code:

```
vs unpatched : 2 failed, KeyError: 'aborted'   (4 existing pass)
with the fix : 6 passed
tests/benchmarks -n auto : 496 passed, 18 skipped   (baseline 494)
```

Reproduce on this branch: `pytest tests/benchmarks/_framework/tests/test_runner_budget.py -k report_json -q` drives the same sequence (2 passed, 4 deselected in 1.92s).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Why.** The pre-registration's `stopping_rules.partial` bars promoting partial-run numbers to a baseline. Enforcing that needs the artifact to say what kind of run it describes, and today only the process exit code knows.

**Alternatives.**

- Fields on `BenchmarkReport`: no. That is the integrity contract `report_validation` checks; the serialiser is where run-level facts (`cost`, `opensre_sha`) already live.
- Fixing the upstream cause, where an abort drops the in-flight batch: not in this PR. It changes the numbers a halted run reports, and that call is yours. Recording the status changes none.
- Inferring completion from cell counts at read time: needs an expected count the artifact does not carry, and guesses where the runner has the fact.

**How.** Two keyword-only parameters with defaults go on `_report_to_dict`, two keys go out. The write site (`tests/benchmarks/_framework/runner.py:308`) passes them from the abort handlers, and the names follow `RunOutcome`'s exactly, so there is one vocabulary for the concept. `host` at `tests/benchmarks/_framework/runner.py:844` is the precedent for a record-only field.

The tests force the abort by omitting a provider key, then verify both fields reach `report.json`:

- complete run: `aborted: false`, reason `null`
- halted run: `aborted: true`, reason is the exception message

**On the reason string.** `abort_reason` is not provider text. It comes from four exceptions defined in this repo: `CostBudgetExceeded`, `UnknownLLM`, `ModelVersionMismatch`, `MissingAPIKey`. Each has a message authored here, and `MissingAPIKey` embeds the env var name, never its value. Both handlers already print this string today, so the report isn't leaking anything new.

If you want it out of the uploaded set, drop it and I'll keep just the boolean. That's the field the pre-registration rule actually needs.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
