### PR TITLE
refactor: make MemoryType a StrEnum for persisted memory frontmatter

### DIFF
--- a/core/agent_harness/session/memory_extraction.py
+++ b/core/agent_harness/session/memory_extraction.py
@@ -21,6 +21,7 @@ from typing import Any, Protocol
 
 from core.domain.memory import (
     MEMORY_TYPES,
+    MemoryType,
     auto_extract_enabled,
     ensure_memory_store,
     find_memory_safety_issues,
@@ -315,9 +316,10 @@ def _save_extracted(items: list[dict[str, Any]], messages: list[tuple[str, str]]
         slug = slugify(name)
         if not is_valid_slug(slug):
             continue
+        # ``memory_type`` was already validated against MEMORY_TYPES above.
         if save_memory(
             slug=slug,
-            memory_type=memory_type,  # type: ignore[arg-type]
+            memory_type=MemoryType(memory_type),
             description=description,
             body=content,
         ):

--- a/core/domain/memory/frontmatter.py
+++ b/core/domain/memory/frontmatter.py
@@ -39,10 +39,9 @@ def parse_memory_file(text: str) -> MemoryRecord | None:
         return None
 
     body = "\n".join(lines[close_idx + 1 :]).strip("\n")
-    typed: MemoryType = memory_type  # type: ignore[assignment]
     return MemoryRecord(
         slug=slug,
-        memory_type=typed,
+        memory_type=MemoryType(memory_type),
         description=fields["description"],
         created_at=fields["created"],
         updated_at=fields["updated"],

--- a/core/domain/memory/models.py
+++ b/core/domain/memory/models.py
@@ -3,11 +3,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, get_args
+from enum import StrEnum
 
-MemoryType = Literal["user", "infrastructure", "preference", "investigation_learning"]
 
-MEMORY_TYPES: tuple[str, ...] = get_args(MemoryType)
+class MemoryType(StrEnum):
+    """Closed vocabulary for a persisted memory's frontmatter ``type``."""
+
+    USER = "user"
+    INFRASTRUCTURE = "infrastructure"
+    PREFERENCE = "preference"
+    INVESTIGATION_LEARNING = "investigation_learning"
+
+
+MEMORY_TYPES: tuple[str, ...] = tuple(t.value for t in MemoryType)
 
 MAX_DESCRIPTION_CHARS = 200
 MAX_BODY_CHARS = 10_000
@@ -26,6 +34,11 @@ class MemoryRecord:
     created_at: str
     updated_at: str
     body: str
+
+    def __post_init__(self) -> None:
+        # Coerce plain strings (from disk / tool args) into real enum members so
+        # ``memory_type`` is always a ``MemoryType`` regardless of entry point.
+        object.__setattr__(self, "memory_type", MemoryType(self.memory_type))
 
 
 __all__ = [

--- a/tests/core/domain/memory/test_models.py
+++ b/tests/core/domain/memory/test_models.py
@@ -1,0 +1,58 @@
+"""Pin the ``MemoryType`` closed vocabulary and its on-disk string identity."""
+
+from __future__ import annotations
+
+from core.domain.memory.frontmatter import serialize_memory
+from core.domain.memory.models import MEMORY_TYPES, MemoryRecord, MemoryType
+
+
+def test_members_pin_expected_values() -> None:
+    assert MemoryType.USER == "user"
+    assert MemoryType.INFRASTRUCTURE == "infrastructure"
+    assert MemoryType.PREFERENCE == "preference"
+    assert MemoryType.INVESTIGATION_LEARNING == "investigation_learning"
+
+
+def test_round_trip_from_string() -> None:
+    assert MemoryType("user") is MemoryType.USER
+    assert MemoryType("infrastructure") is MemoryType.INFRASTRUCTURE
+    assert MemoryType("preference") is MemoryType.PREFERENCE
+    assert MemoryType("investigation_learning") is MemoryType.INVESTIGATION_LEARNING
+
+
+def test_memory_types_are_plain_string_values() -> None:
+    assert MEMORY_TYPES == (
+        "user",
+        "infrastructure",
+        "preference",
+        "investigation_learning",
+    )
+    assert all(type(value) is str for value in MEMORY_TYPES)
+
+
+def test_record_coerces_plain_string_to_member() -> None:
+    record = MemoryRecord(
+        slug="db-primary",
+        memory_type="infrastructure",
+        description="primary db host",
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+        body="host: db-1",
+    )
+    assert record.memory_type is MemoryType.INFRASTRUCTURE
+
+
+def test_serialized_frontmatter_keeps_bare_value() -> None:
+    record = MemoryRecord(
+        slug="db-primary",
+        memory_type=MemoryType.USER,
+        description="prefers concise reports",
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+        body="likes brevity",
+    )
+    serialized = serialize_memory(record)
+    # StrEnum stringifies to the bare value; a plain Enum would write
+    # "type: MemoryType.USER" and break every existing on-disk memory.
+    assert "type: user\n" in serialized
+    assert "MemoryType" not in serialized

--- a/tools/system/agent_memory/results.py
+++ b/tools/system/agent_memory/results.py
@@ -19,7 +19,7 @@ def saved_result(record: MemoryRecord, *, created: bool) -> dict[str, Any]:
     return {
         "status": "created" if created else "updated",
         "name": record.slug,
-        "type": record.memory_type,
+        "type": record.memory_type.value,
         "description": record.description,
         "path": str(memory_path(record.slug)),
     }
@@ -43,7 +43,7 @@ def recall_result(records: list[MemoryRecord], *, total_stored: int) -> dict[str
         memories.append(
             {
                 "name": record.slug,
-                "type": record.memory_type,
+                "type": record.memory_type.value,
                 "description": record.description,
                 "updated": record.updated_at,
                 "content": body,
@@ -60,7 +60,7 @@ def index_result(records: list[MemoryRecord]) -> dict[str, Any]:
         "memories": [
             {
                 "name": record.slug,
-                "type": record.memory_type,
+                "type": record.memory_type.value,
                 "description": record.description,
                 "updated": record.updated_at,
             }

--- a/tools/system/agent_memory/tool.py
+++ b/tools/system/agent_memory/tool.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from core.domain.memory import (
     MEMORY_TYPES,
+    MemoryType,
     delete_memory,
     list_memories,
     load_memory,
@@ -92,7 +93,10 @@ def memory_remember(name: str, type: str, description: str, content: str) -> dic
         return error
     slug = normalize_name(name)
     assert slug is not None  # validate_remember_args already checked
-    result = save_memory(slug=slug, memory_type=type, description=description, body=content)  # type: ignore[arg-type]
+    # ``type`` was already validated against MEMORY_TYPES by validate_remember_args.
+    result = save_memory(
+        slug=slug, memory_type=MemoryType(type), description=description, body=content
+    )
     if result is None:
         return {"error": "write_failed", "detail": "could not write the memory file to disk"}
     record, created = result


### PR DESCRIPTION
Fixes #4518

#### Describe the changes you have made in this PR -

Converts `MemoryType` in `core/domain/memory/models.py` from a `Literal` + `get_args` into an `enum.StrEnum`. A `Literal` is only a type hint — nothing stops a stray string from being persisted and later failing validation in the `agent_memory` tool. A `StrEnum` makes adding a memory type a deliberate enum change while still comparing and serializing as a plain string.

**On-disk frontmatter strings are unchanged.** `enum.StrEnum.__str__` returns the bare value (`user`, not `MemoryType.USER`), so `serialize_memory` keeps writing `type: user` and existing memories still load. This is pinned by a test.

Changes:
- `MemoryType(StrEnum)` with the four current values unchanged (`user`, `infrastructure`, `preference`, `investigation_learning`).
- `MEMORY_TYPES` derived from the enum: `tuple(t.value for t in MemoryType)` — a tuple of plain string values, so the `x not in MEMORY_TYPES` membership checks (frontmatter parse, memory extraction, tool validation) and the `list(MEMORY_TYPES)` JSON tool schema stay byte-identical.
- `MemoryRecord.__post_init__` coerces `memory_type` into a real member via `object.__setattr__` (the dataclass is `frozen=True`), so every entry point stores an actual `MemoryType`.
- Coerce at the already-validated `save_memory` boundaries (`memory_extraction.py`, `agent_memory/tool.py`) and emit `.value` on `agent_memory` result payloads — dropping the previous `# type: ignore[arg-type]`/`[assignment]` casts.
- New unit tests in `tests/core/domain/memory/test_models.py`.

There is no YAML or Pydantic in this path (frontmatter is a hand-rolled `key: value` block, `MemoryRecord` is a plain frozen dataclass), so the `RepresenterError` / `model_dump` gotchas from the issue don't apply.

### Demo/Screenshot for feature changes and bug fixes -

Focused verification (repo-wide `make lint`/`format-check`/`typecheck` also pass clean):

```
$ uv run mypy core/domain/memory tools/system/agent_memory core/agent_harness/session/memory_extraction.py
Success: no issues found in ... source files

$ uv run pytest tests/core/domain/memory/ tests/tools/test_agent_memory.py \
    tests/core/agent_harness/session/test_memory_extraction.py tests/interactive_shell/test_memory_cmds.py -q
115 passed
```

The new enum test pins the issue's acceptance criterion:

```python
def test_round_trip_from_string() -> None:
    assert MemoryType("user") is MemoryType.USER
    ...

def test_serialized_frontmatter_keeps_bare_value() -> None:
    serialized = serialize_memory(record)   # record.memory_type == MemoryType.USER
    assert "type: user\n" in serialized     # not "type: MemoryType.USER"
    assert "MemoryType" not in serialized
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: memory `type` was a `Literal`, which the type checker enforces but the runtime does not — an unexpected string could be written to disk and only blow up later when the `agent_memory` tool re-validated it. Making it a `StrEnum` turns the set of valid types into a real, closed vocabulary while keeping every string-based consumer working (a `StrEnum` member *is* a `str`).

The one real risk is the on-disk format. A plain `Enum` stringifies as `MemoryType.USER`, which would silently corrupt the frontmatter and break loading of every existing memory. `StrEnum` stringifies to the bare value, so the serialized file is unchanged — I added an explicit test asserting the serialized frontmatter contains `type: user` and never the substring `MemoryType`.

Because `MemoryRecord` is a frozen dataclass, annotating the field does not coerce anything, so I added a `__post_init__` that coerces via `object.__setattr__` — this guarantees `record.memory_type` is always a real member regardless of whether the caller passed a member or a validated string. I kept `MEMORY_TYPES` as a tuple of the plain `.value` strings so membership checks and the JSON tool schema sent to the model are byte-identical to before. I also coerced at the two validated `save_memory` boundaries and switched the tool result dicts to `.value`, which let me remove the pre-existing `# type: ignore` casts.

Alternative considered: widening `save_memory`'s signature to `MemoryType | str`. I preferred coercing at the boundary instead, so the internal contract stays a single, precise type.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
