### PR TITLE
docs(remote-sync): remove internal module path wording

### DIFF
--- a/docs/configuration/remote-sync.mdx
+++ b/docs/configuration/remote-sync.mdx
@@ -51,7 +51,7 @@ conversations — a different prefix is a different history, not a backup of the
 same one.
 </Note>
 
-All surfaces share one entry point, `platform/filestorage/operations.py`, with the wording in `messages.py`:
+All surfaces share one remote-sync engine entry point:
 
 | Surface | How you invoke it |
 |---|---|


### PR DESCRIPTION
Fixes #4553

#### Describe the changes you have made in this PR -
Replaced the remote-sync docs sentence that named internal module paths with a neutral engine description. The table, Warning, and command examples remain unchanged.

### Demo/Screenshot for feature changes and bug fixes -
Not applicable for this docs-only change. Verification was limited to the upstream preflight, a grep confirming the internal path strings are gone, and review of the one-line diff.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The page already had the correct command surface and safety guidance. The only stale part was the sentence that exposed internal module paths, so I replaced that sentence with a user-facing description of the shared remote-sync engine. That keeps the docs accurate without changing behavior or surrounding content.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the projects style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
