### PR TITLE
fix(remote-sync): validate stored settings on read

### DIFF
--- a/platform/filestorage/config.py
+++ b/platform/filestorage/config.py
@@ -26,6 +26,7 @@ from config.constants.filestorage import (
 from platform.filestorage.errors import RemoteSyncConfigError
 
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
+_REMOTE_SYNC_STRING_KEYS = frozenset({"bucket", "provider", "prefix", "region", "profile"})
 
 
 @dataclass(frozen=True)
@@ -63,6 +64,26 @@ def _stored_section() -> dict[str, Any]:
         raise RemoteSyncConfigError(str(exc)) from exc
 
 
+def _validated_stored_section() -> dict[str, Any]:
+    """Stored settings with scalar fields validated before downstream use."""
+    section = _stored_section()
+    for key in ("enabled", *sorted(_REMOTE_SYNC_STRING_KEYS)):
+        if key not in section:
+            continue
+        value = section[key]
+        if key == "enabled":
+            if isinstance(value, (bool, str)):
+                continue
+            raise RemoteSyncConfigError(
+                f"invalid remote_sync.enabled: expected a bool or string, got {type(value).__name__}"
+            )
+        if not isinstance(value, str):
+            raise RemoteSyncConfigError(
+                f"invalid remote_sync.{key}: expected a string, got {type(value).__name__}"
+            )
+    return section
+
+
 def _truthy(value: object) -> bool:
     if isinstance(value, bool):
         return value
@@ -91,7 +112,7 @@ def remote_sync_enabled() -> bool:
     env = os.getenv(REMOTE_SYNC_ENV)
     if env is not None and env.strip() != "":
         return env.strip().lower() in _TRUTHY
-    return _truthy(_stored_section().get("enabled"))
+    return _truthy(_validated_stored_section().get("enabled"))
 
 
 def _lazy_stored() -> Callable[[], dict[str, Any]]:
@@ -104,7 +125,7 @@ def _lazy_stored() -> Callable[[], dict[str, Any]]:
 
     def read() -> dict[str, Any]:
         if "section" not in cache:
-            cache["section"] = _stored_section()
+            cache["section"] = _validated_stored_section()
         return cache["section"]
 
     return read

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -910,6 +910,23 @@ def test_env_only_config_ignores_a_corrupt_settings_file(
     assert config.prefix == "env-prefix"
 
 
+def test_stored_remote_sync_values_are_validated_on_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bad stored remote_sync value should fail early with its key name."""
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import update_section
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+    update_section("remote_sync", {"enabled": True, "bucket": ["my-bucket"]})
+    monkeypatch.delenv(REMOTE_SYNC_ENV, raising=False)
+
+    # Act / Assert
+    with pytest.raises(RemoteSyncConfigError, match=r"remote_sync\.bucket"):
+        load_remote_sync_config()
+
+
 def test_list_prefix_is_delimited_so_a_sibling_bucket_path_cannot_match() -> None:
     """Prefix "opensre" must not also sweep in "opensre-backup/"."""
     # Arrange


### PR DESCRIPTION
Fixes #4559

#### Describe the changes you have made in this PR -
Validate stored `remote_sync` values before they are consumed so malformed YAML fails early with the offending key name. The change preserves env precedence and only touches the remote-sync config path plus a focused regression test.

### Demo/Screenshot for feature changes and bug fixes -
Verified with a direct Python check in this checkout:
- env-only config still loads when `config.yml` is malformed
- a stored `remote_sync.bucket` list now raises `RemoteSyncConfigError: invalid remote_sync.bucket: expected a string, got list`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I validated the stored `remote_sync` section at the config boundary instead of letting malformed YAML flow into later S3/provider code. The validator checks the scalar fields that this feature reads, raises `RemoteSyncConfigError` with the specific offending key, and keeps the environment-variable precedence rule intact. I chose the narrow config-layer fix because it keeps the surfaces and the engine unchanged while making the failure mode deterministic and easier to understand.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
