### PR TITLE
fix(filestorage): retry transient AWS object-store failures

### DIFF
--- a/platform/filestorage/providers/aws.py
+++ b/platform/filestorage/providers/aws.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Any
 
 import boto3
@@ -18,6 +19,17 @@ if TYPE_CHECKING:
 
 _SERVER_SIDE_ENCRYPTION = "AES256"
 PROVIDER_NAME = BuiltInProvider.AWS
+_RETRYABLE_CLIENT_ERROR_CODES = {
+    "ConnectionClosedError",
+    "InternalError",
+    "RequestTimeout",
+    "SlowDown",
+    "Throttling",
+    "ThrottlingException",
+    "ServiceUnavailable",
+}
+_MAX_ATTEMPTS = 3
+_BASE_SLEEP_SECONDS = 0.1
 
 
 class S3ObjectStore:
@@ -35,8 +47,9 @@ class S3ObjectStore:
         full_prefix = (
             self._config.key_for(prefix) if prefix else f"{self._config.prefix.rstrip('/')}/"
         )
-        out: list[RemoteObject] = []
-        try:
+
+        def _collect() -> list[RemoteObject]:
+            out: list[RemoteObject] = []
             for page in self._pages(full_prefix):
                 for item in page.get("Contents", []):
                     key = str(item["Key"])
@@ -50,29 +63,32 @@ class S3ObjectStore:
                             etag=str(item.get("ETag", "")).strip('"'),
                         )
                     )
+            return out
+
+        try:
+            return self._retry(_collect)
         except (BotoCoreError, ClientError) as exc:
-            raise RemoteSyncUnavailableError(
-                f"cannot list {self.describe()} — {_reason(exc)}"
-            ) from exc
-        return out
+            raise RemoteSyncUnavailableError(f"cannot list {self.describe()} — {_reason(exc)}") from exc
 
     def get_object(self, key: str) -> bytes:
         try:
-            response = self._client.get_object(
-                Bucket=self._config.bucket, Key=self._config.key_for(key)
+            return self._retry(
+                lambda: self._client.get_object(
+                    Bucket=self._config.bucket, Key=self._config.key_for(key)
+                )["Body"].read()
             )
-            body: bytes = response["Body"].read()
-            return body
         except (BotoCoreError, ClientError) as exc:
             raise RemoteSyncUnavailableError(f"cannot read {key} — {_reason(exc)}") from exc
 
     def put_object(self, key: str, data: bytes) -> None:
         try:
-            self._client.put_object(
-                Bucket=self._config.bucket,
-                Key=self._config.key_for(key),
-                Body=data,
-                ServerSideEncryption=_SERVER_SIDE_ENCRYPTION,
+            self._retry(
+                lambda: self._client.put_object(
+                    Bucket=self._config.bucket,
+                    Key=self._config.key_for(key),
+                    Body=data,
+                    ServerSideEncryption=_SERVER_SIDE_ENCRYPTION,
+                )
             )
         except (BotoCoreError, ClientError) as exc:
             raise RemoteSyncUnavailableError(f"cannot write {key} — {_reason(exc)}") from exc
@@ -85,10 +101,39 @@ class S3ObjectStore:
         prefix = f"{self._config.prefix.rstrip('/')}/"
         return full_key[len(prefix) :] if full_key.startswith(prefix) else full_key
 
+    def _retry(self, fn: Any) -> Any:
+        last_exc: Exception | None = None
+        for attempt in range(1, _MAX_ATTEMPTS + 1):
+            try:
+                return fn()
+            except (BotoCoreError, ClientError) as exc:
+                last_exc = exc
+                if not _is_retryable(exc) or attempt == _MAX_ATTEMPTS:
+                    break
+                time.sleep(_backoff_seconds(attempt))
+        assert last_exc is not None
+        raise last_exc
+
 
 def _reason(exc: Exception) -> str:
     """The AWS-side cause, for a local operator to act on."""
     return f"{type(exc).__name__}: {exc}"
+
+
+def _backoff_seconds(attempt: int) -> float:
+    return _BASE_SLEEP_SECONDS * (2 ** (attempt - 1))
+
+
+def _is_retryable(exc: Exception) -> bool:
+    if isinstance(exc, ClientError):
+        code = str(exc.response.get("Error", {}).get("Code", ""))
+        return code in _RETRYABLE_CLIENT_ERROR_CODES and code not in {
+            "NoSuchBucket",
+            "AccessDenied",
+            "InvalidBucketName",
+            "NoSuchKey",
+        }
+    return True
 
 
 def _build_client(config: RemoteSyncConfig) -> Any:

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -382,6 +382,63 @@ def test_aws_failures_name_their_cause() -> None:
     assert "NoSuchBucket" in str(caught.value)
 
 
+def test_aws_transient_failures_retry_before_succeeding(monkeypatch: pytest.MonkeyPatch) -> None:
+    from botocore.exceptions import EndpointConnectionError
+
+    from platform.filestorage.config import RemoteSyncConfig
+    from platform.filestorage.providers.aws import S3ObjectStore
+
+    calls = {"get_object": 0, "sleep": []}
+
+    class _Body:
+        def read(self) -> bytes:
+            return b"payload"
+
+    class _Client:
+        def get_object(self, **_kwargs: object) -> dict[str, object]:
+            calls["get_object"] += 1
+            if calls["get_object"] < 3:
+                raise EndpointConnectionError(endpoint_url="https://s3.example.test")
+            return {"Body": _Body()}
+
+    monkeypatch.setattr("platform.filestorage.providers.aws.time.sleep", lambda seconds: calls["sleep"].append(seconds))
+
+    store = S3ObjectStore(RemoteSyncConfig(bucket="bucket"), client=_Client())
+    assert store.get_object("sessions/a.jsonl") == b"payload"
+    assert calls["get_object"] == 3
+    assert calls["sleep"] == [0.1, 0.2]
+
+
+def test_aws_permanent_failures_do_not_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    from botocore.exceptions import ClientError
+
+    from platform.filestorage.config import RemoteSyncConfig
+    from platform.filestorage.errors import RemoteSyncUnavailableError
+    from platform.filestorage.providers.aws import S3ObjectStore
+
+    slept: list[float] = []
+
+    class _Client:
+        def put_object(self, **_kwargs: object) -> None:
+            raise ClientError(
+                {
+                    "Error": {
+                        "Code": "NoSuchBucket",
+                        "Message": "The specified bucket does not exist",
+                    }
+                },
+                "PutObject",
+            )
+
+    monkeypatch.setattr("platform.filestorage.providers.aws.time.sleep", lambda seconds: slept.append(seconds))
+
+    store = S3ObjectStore(RemoteSyncConfig(bucket="missing"), client=_Client())
+    with pytest.raises(RemoteSyncUnavailableError) as caught:
+        store.put_object("sessions/a.jsonl", b"payload")
+    assert "NoSuchBucket" in str(caught.value)
+    assert slept == []
+
+
 # ── Edge cases ───────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Fixes #4555

#### Describe the changes you have made in this PR -
- Added a small retry loop with exponential backoff in `platform/filestorage/providers/aws.py` so transient S3 transport failures can recover before the sync aborts.
- Kept permanent AWS errors such as `NoSuchBucket`, `AccessDenied`, `InvalidBucketName`, and `NoSuchKey` failing immediately.
- Added regression tests that prove transient retries succeed and permanent bucket errors do not retry.

### Demo/Screenshot for feature changes and bug fixes -
- Verification: `uv run pytest tests/filestorage/test_remote_sync.py -k 'aws'`
- Result: `3 passed, 43 deselected`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The AWS provider is the narrowest place to handle transport retries because it already owns the S3 client. I kept the retry policy local to that provider so the rest of the filestorage engine and surfaces stay unchanged, and I covered both the transient and permanent error paths with focused fake-client tests.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
