### PR TITLE
refactor(config): promote ReasoningEffort to StrEnum

### DIFF
--- a/config/llm_reasoning_effort.py
+++ b/config/llm_reasoning_effort.py
@@ -6,17 +6,22 @@ import os
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Literal, cast
+from enum import StrEnum
 
-ReasoningEffortChoice = Literal["low", "medium", "high", "xhigh", "max"]
 
-REASONING_EFFORT_OPTIONS: tuple[ReasoningEffortChoice, ...] = (
-    "low",
-    "medium",
-    "high",
-    "xhigh",
-    "max",
-)
+class ReasoningEffort(StrEnum):
+    """Closed user-facing reasoning-effort vocabulary for REPL and env overrides."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    XHIGH = "xhigh"
+    MAX = "max"  # user-facing alias; runtime maps to xhigh
+
+
+ReasoningEffortChoice = ReasoningEffort
+
+REASONING_EFFORT_OPTIONS: tuple[ReasoningEffort, ...] = tuple(ReasoningEffort)
 
 _RUNTIME_ENV_KEY = "OPENSRE_REASONING_EFFORT"
 _RUNTIME_VALUES = frozenset({"low", "medium", "high", "xhigh"})
@@ -26,31 +31,32 @@ _reasoning_effort_session: ContextVar[str | None] = ContextVar(
 )
 
 
-def parse_reasoning_effort(value: str | None) -> ReasoningEffortChoice | None:
+def parse_reasoning_effort(value: str | None) -> ReasoningEffort | None:
     """Return the normalized user-facing effort choice, if valid."""
     if value is None:
         return None
     normalized = value.strip().lower()
-    if normalized in REASONING_EFFORT_OPTIONS:
-        return cast(ReasoningEffortChoice, normalized)
-    return None
+    try:
+        return ReasoningEffort(normalized)
+    except ValueError:
+        return None
 
 
-def runtime_reasoning_effort(choice: ReasoningEffortChoice | None) -> str | None:
+def runtime_reasoning_effort(choice: ReasoningEffort | None) -> str | None:
     """Map a user-facing choice to the runtime value sent to model providers."""
     if choice is None:
         return None
-    return "xhigh" if choice == "max" else choice
+    return ReasoningEffort.XHIGH.value if choice is ReasoningEffort.MAX else choice.value
 
 
-def display_reasoning_effort(choice: ReasoningEffortChoice | None) -> str:
+def display_reasoning_effort(choice: ReasoningEffort | None) -> str:
     """Human-readable label for tables and slash-command output."""
     if choice is None:
         return "(default)"
     runtime = runtime_reasoning_effort(choice)
-    if runtime and runtime != choice:
+    if runtime and runtime != choice.value:
         return f"{choice} (runtime: {runtime})"
-    return choice
+    return choice.value
 
 
 def get_active_reasoning_effort() -> str | None:
@@ -104,7 +110,7 @@ def describe_reasoning_effort_default(provider: str | None, model: str | None) -
 
 
 @contextmanager
-def apply_reasoning_effort(choice: ReasoningEffortChoice | None) -> Iterator[None]:
+def apply_reasoning_effort(choice: ReasoningEffort | None) -> Iterator[None]:
     """Temporarily expose a session effort override to downstream model clients.
 
     ``choice is None`` means defer to shell/env defaults: do not clear
@@ -126,6 +132,7 @@ def apply_reasoning_effort(choice: ReasoningEffortChoice | None) -> Iterator[Non
 
 __all__ = [
     "REASONING_EFFORT_OPTIONS",
+    "ReasoningEffort",
     "ReasoningEffortChoice",
     "apply_reasoning_effort",
     "describe_reasoning_effort_default",

--- a/config/llm_reasoning_effort.py
+++ b/config/llm_reasoning_effort.py
@@ -42,21 +42,30 @@ def parse_reasoning_effort(value: str | None) -> ReasoningEffort | None:
         return None
 
 
-def runtime_reasoning_effort(choice: ReasoningEffort | None) -> str | None:
+def _coerce_reasoning_effort(choice: ReasoningEffort | str | None) -> ReasoningEffort | None:
+    """Normalize session/env plain strings into enum members at API boundaries."""
+    if choice is None or isinstance(choice, ReasoningEffort):
+        return choice
+    return parse_reasoning_effort(choice)
+
+
+def runtime_reasoning_effort(choice: ReasoningEffort | str | None) -> str | None:
     """Map a user-facing choice to the runtime value sent to model providers."""
-    if choice is None:
+    coerced = _coerce_reasoning_effort(choice)
+    if coerced is None:
         return None
-    return ReasoningEffort.XHIGH.value if choice is ReasoningEffort.MAX else choice.value
+    return ReasoningEffort.XHIGH.value if coerced is ReasoningEffort.MAX else coerced.value
 
 
-def display_reasoning_effort(choice: ReasoningEffort | None) -> str:
+def display_reasoning_effort(choice: ReasoningEffort | str | None) -> str:
     """Human-readable label for tables and slash-command output."""
-    if choice is None:
+    coerced = _coerce_reasoning_effort(choice)
+    if coerced is None:
         return "(default)"
-    runtime = runtime_reasoning_effort(choice)
-    if runtime and runtime != choice.value:
-        return f"{choice} (runtime: {runtime})"
-    return choice.value
+    runtime = runtime_reasoning_effort(coerced)
+    if runtime and runtime != coerced.value:
+        return f"{coerced} (runtime: {runtime})"
+    return coerced.value
 
 
 def get_active_reasoning_effort() -> str | None:
@@ -110,7 +119,7 @@ def describe_reasoning_effort_default(provider: str | None, model: str | None) -
 
 
 @contextmanager
-def apply_reasoning_effort(choice: ReasoningEffort | None) -> Iterator[None]:
+def apply_reasoning_effort(choice: ReasoningEffort | str | None) -> Iterator[None]:
     """Temporarily expose a session effort override to downstream model clients.
 
     ``choice is None`` means defer to shell/env defaults: do not clear
@@ -119,10 +128,11 @@ def apply_reasoning_effort(choice: ReasoningEffort | None) -> Iterator[None]:
     Non-None choices use a :class:`contextvars.ContextVar` so concurrent REPL or
     CLI invocations on different threads/tasks do not race on ``os.environ``.
     """
-    if choice is None:
+    coerced = _coerce_reasoning_effort(choice)
+    if coerced is None:
         yield
         return
-    runtime = runtime_reasoning_effort(choice)
+    runtime = runtime_reasoning_effort(coerced)
     token = _reasoning_effort_session.set(runtime)
     try:
         yield

--- a/surfaces/interactive_shell/command_registry/settings_cmds.py
+++ b/surfaces/interactive_shell/command_registry/settings_cmds.py
@@ -10,6 +10,7 @@ from rich.markup import escape
 import surfaces.interactive_shell.command_registry.repl_data as repl_data
 from config.llm_reasoning_effort import (
     REASONING_EFFORT_OPTIONS,
+    ReasoningEffort,
     describe_reasoning_effort_default,
     display_reasoning_effort,
     parse_reasoning_effort,
@@ -40,12 +41,16 @@ _VERBOSE_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("off", "disable verbose logging"),
 )
 
-_EFFORT_FIRST_ARGS: tuple[tuple[str, str], ...] = (
-    ("low", "favor speed and lower reasoning cost"),
-    ("medium", "balanced reasoning effort"),
-    ("high", "favor more thorough reasoning"),
-    ("xhigh", "favor deepest supported reasoning"),
-    ("max", "alias for xhigh"),
+_EFFORT_HELP: dict[ReasoningEffort, str] = {
+    ReasoningEffort.LOW: "favor speed and lower reasoning cost",
+    ReasoningEffort.MEDIUM: "balanced reasoning effort",
+    ReasoningEffort.HIGH: "favor more thorough reasoning",
+    ReasoningEffort.XHIGH: "favor deepest supported reasoning",
+    ReasoningEffort.MAX: "alias for xhigh",
+}
+
+_EFFORT_FIRST_ARGS: tuple[tuple[str, str], ...] = tuple(
+    (effort.value, _EFFORT_HELP[effort]) for effort in REASONING_EFFORT_OPTIONS
 )
 
 
@@ -81,7 +86,7 @@ def _cmd_effort(session: Session, console: Console, args: list[str]) -> bool:
     reasoning_model = ""
     if settings is not None:
         reasoning_model, _toolcall_model = resolve_provider_models(settings, provider)
-    supported_values = ", ".join(REASONING_EFFORT_OPTIONS)
+    supported_values = ", ".join(option.value for option in REASONING_EFFORT_OPTIONS)
 
     if not args:
         console.print(
@@ -115,7 +120,7 @@ def _cmd_effort(session: Session, console: Console, args: list[str]) -> bool:
             f"[{DIM}]current provider {provider} ignores this setting; "
             "switch to openai or codex to use it.[/]"
         )
-    elif effort in {"xhigh", "max"}:
+    elif effort in {ReasoningEffort.XHIGH, ReasoningEffort.MAX}:
         console.print(
             f"[{DIM}]xhigh/max work best with newer GPT-5 or Codex models; "
             "older reasoning models may reject them.[/]"

--- a/tests/core/runtime/llm/test_messages_client_system_cache.py
+++ b/tests/core/runtime/llm/test_messages_client_system_cache.py
@@ -30,6 +30,9 @@ def _messages_client() -> LLMClient:
     client._temperature = None
     client._api_key = "test-key"
     client._client = MagicMock()
+    # _build_request_kwargs refreshes credentials; these tests only assert kwargs
+    # shape, so skip env/keychain resolution (see test_cache_marker_degradation).
+    client._ensure_client = lambda: None  # type: ignore[method-assign]
     return client
 
 

--- a/tests/core/runtime/llm/test_reasoning_effort.py
+++ b/tests/core/runtime/llm/test_reasoning_effort.py
@@ -8,12 +8,15 @@ import threading
 import pytest
 
 from config.llm_reasoning_effort import (
+    ReasoningEffort,
     ReasoningEffortChoice,
     apply_reasoning_effort,
     describe_reasoning_effort_default,
     display_reasoning_effort,
     get_active_reasoning_effort,
     infer_reasoning_effort_default,
+    parse_reasoning_effort,
+    runtime_reasoning_effort,
 )
 
 _ENV_KEY = "OPENSRE_REASONING_EFFORT"
@@ -22,6 +25,29 @@ _ENV_KEY = "OPENSRE_REASONING_EFFORT"
 @pytest.fixture(autouse=True)
 def _clear_reasoning_effort_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(_ENV_KEY, raising=False)
+
+
+def test_parse_reasoning_effort_accepts_enum_values() -> None:
+    assert parse_reasoning_effort("low") is ReasoningEffort.LOW
+    assert parse_reasoning_effort(" MAX ") is ReasoningEffort.MAX
+    assert parse_reasoning_effort("invalid") is None
+
+
+def test_runtime_reasoning_effort_maps_max_to_xhigh() -> None:
+    assert runtime_reasoning_effort(ReasoningEffort.MAX) == "xhigh"
+    assert runtime_reasoning_effort(ReasoningEffort.HIGH) == "high"
+
+
+def test_reasoning_effort_members_round_trip_from_string() -> None:
+    assert set(ReasoningEffort) == {
+        ReasoningEffort.LOW,
+        ReasoningEffort.MEDIUM,
+        ReasoningEffort.HIGH,
+        ReasoningEffort.XHIGH,
+        ReasoningEffort.MAX,
+    }
+    assert ReasoningEffort("max") is ReasoningEffort.MAX
+    assert ReasoningEffort.MAX == "max"
 
 
 def test_apply_none_preserves_shell_env_effort(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -37,7 +63,7 @@ def test_apply_none_preserves_shell_env_effort(monkeypatch: pytest.MonkeyPatch) 
 def test_apply_non_none_overrides_env_until_exit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(_ENV_KEY, "low")
 
-    with apply_reasoning_effort("high"):
+    with apply_reasoning_effort(ReasoningEffort.HIGH):
         assert get_active_reasoning_effort() == "high"
 
     assert get_active_reasoning_effort() == "low"
@@ -54,8 +80,8 @@ def test_concurrent_threads_do_not_cross_session_overrides() -> None:
             observed[tid] = get_active_reasoning_effort()
 
     threads = (
-        threading.Thread(target=worker, args=(1, "high")),
-        threading.Thread(target=worker, args=(2, "low")),
+        threading.Thread(target=worker, args=(1, ReasoningEffort.HIGH)),
+        threading.Thread(target=worker, args=(2, ReasoningEffort.LOW)),
     )
     for t in threads:
         t.start()
@@ -64,6 +90,10 @@ def test_concurrent_threads_do_not_cross_session_overrides() -> None:
 
     assert observed[1] == "high"
     assert observed[2] == "low"
+
+
+def test_display_reasoning_effort_formats_max_alias() -> None:
+    assert display_reasoning_effort(ReasoningEffort.MAX) == "max (runtime: xhigh)"
 
 
 def test_display_reasoning_effort_formats_default_in_parentheses() -> None:

--- a/tests/core/runtime/llm/test_reasoning_effort.py
+++ b/tests/core/runtime/llm/test_reasoning_effort.py
@@ -96,6 +96,10 @@ def test_display_reasoning_effort_formats_max_alias() -> None:
     assert display_reasoning_effort(ReasoningEffort.MAX) == "max (runtime: xhigh)"
 
 
+def test_display_reasoning_effort_accepts_plain_string() -> None:
+    assert display_reasoning_effort("max") == "max (runtime: xhigh)"
+
+
 def test_display_reasoning_effort_formats_default_in_parentheses() -> None:
     assert display_reasoning_effort(None) == "(default)"
 


### PR DESCRIPTION
Fixes #4517

#### Describe the changes you have made in this PR -

Promote the closed reasoning-effort vocabulary to a shared `ReasoningEffort` `StrEnum` in `config/llm_reasoning_effort.py`, derive `REASONING_EFFORT_OPTIONS` from the enum, and build `/effort` slash completions from the enum plus a help-text map instead of duplicating the value list in `settings_cmds.py`. The max→xhigh runtime mapping is unchanged.

## Problem

`ReasoningEffortChoice` was a duplicated `Literal` in config while `_EFFORT_FIRST_ARGS` in `settings_cmds.py` repeated the same five strings for slash completions.

## Fix

- Add `ReasoningEffort(StrEnum)` with identical string values.
- Derive options and slash completions from the enum.
- Extend `tests/core/runtime/llm/test_reasoning_effort.py` for parse, round-trip, and max→xhigh behavior.

## Verification

- `uv run python -m pytest tests/core/runtime/llm/test_reasoning_effort.py -q` → 10 passed

## Notes / Risks

- `OPENSRE_REASONING_EFFORT` still accepts plain strings; session override behavior unchanged.

### Demo/Screenshot for feature changes and bug fixes -

N/A — internal refactor with unit-test coverage only.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue asked for one enum to replace the duplicated Literal + slash tuple. I followed the existing `ProbeStatus` / filestorage enum precedent: leaf-module `StrEnum`, `tuple(Enum)` for options, and slash help text kept in a side map keyed by enum members so completions stay derived rather than duplicated. `parse_reasoning_effort` uses `ReasoningEffort(value)` with `ValueError` → `None`, and `runtime_reasoning_effort` keeps the max→xhigh alias via `ReasoningEffort.MAX`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions