### PR TITLE
fix(filestorage): upload remote-sync files concurrently

### DIFF
--- a/platform/filestorage/engine.py
+++ b/platform/filestorage/engine.py
@@ -18,6 +18,7 @@ import hashlib
 import logging
 import os
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -135,22 +136,30 @@ def push(
                 raise UnsyncablePathError(f"refusing to upload {path}")
             planned.append((root, path))
 
-    for root, path in planned:
+    def _upload(root: SyncRoot, path: Path) -> tuple[str, str, int]:
         key = _relative_key(root, path)
         data = path.read_bytes()
         existing = by_key.get(key)
         if existing is not None:
             if comparable_etag(existing) == content_tag(data):
-                result.skipped += 1
-                continue
+                return ("skipped", key, 0)
             if existing.last_modified > _modified_at(path):
                 # The store holds the more recent write, so uploading would
                 # destroy it. Same rule pull applies in the other direction.
-                result.kept_remote.append(key)
-                continue
+                return ("kept_remote", key, 0)
         store.put_object(key, data)
-        result.uploaded.append(key)
-        result.uploaded_bytes += len(data)
+        return ("uploaded", key, len(data))
+
+    max_workers = min(4, len(planned)) or 1
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        for status, key, size in executor.map(lambda item: _upload(*item), planned):
+            if status == "skipped":
+                result.skipped += 1
+            elif status == "kept_remote":
+                result.kept_remote.append(key)
+            else:
+                result.uploaded.append(key)
+                result.uploaded_bytes += size
     return result
 
 

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -8,6 +8,7 @@ file are excluded by an allowlist of roots and again by name.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+import threading
 from pathlib import Path
 
 import pytest
@@ -349,6 +350,53 @@ def test_second_push_reuploads_nothing(home: Path, roots: tuple[SyncRoot, ...]) 
     # Assert
     assert report.uploaded == []
     assert report.skipped == 2
+
+
+def test_push_uses_bounded_concurrency(home: Path, roots: tuple[SyncRoot, ...]) -> None:
+    """A sync should overlap uploads without skipping the validation pass."""
+
+    class _BlockingStore(FakeObjectStore):
+        def __init__(self) -> None:
+            super().__init__()
+            self.active = 0
+            self.max_active = 0
+            self.lock = threading.Lock()
+            self.entered = threading.Event()
+            self.release = threading.Event()
+
+        def put_object(self, key: str, data: bytes) -> None:
+            with self.lock:
+                self.active += 1
+                self.max_active = max(self.max_active, self.active)
+                self.entered.set()
+            try:
+                self.release.wait(timeout=2)
+                super().put_object(key, data)
+            finally:
+                with self.lock:
+                    self.active -= 1
+
+    store = _BlockingStore()
+    waiter = threading.Thread(target=push, args=(store,), kwargs={"roots": roots})
+    waiter.start()
+    assert store.entered.wait(timeout=2)
+
+    for _ in range(200):
+        with store.lock:
+            if store.max_active >= 2:
+                break
+        threading.Event().wait(0.01)
+    else:
+        store.release.set()
+        waiter.join(timeout=2)
+        assert not waiter.is_alive()
+        raise AssertionError(f"expected concurrent uploads, saw max_active={store.max_active}")
+
+    store.release.set()
+    waiter.join(timeout=2)
+
+    assert not waiter.is_alive()
+    assert store.max_active >= 2
 
 
 def test_aws_failures_name_their_cause() -> None:


### PR DESCRIPTION
Problem
`push()` uploads files one at a time, so large remote-sync runs look hung even after the upfront validation pass finishes.

Triage / Root cause
`platform/filestorage/engine.py::push()` iterated serially over the planned uploads. That kept the validate-then-transfer ordering intact, but it also forced every file transfer to wait on the previous one.

Fix
- Keep the existing upfront validation pass unchanged so deny-list and path checks still happen before any upload starts.
- Fan out only the upload step with a bounded `ThreadPoolExecutor`.
- Collect each worker result back into `SyncReport` on the main thread.
- Add a regression test that blocks one upload and proves another upload enters concurrently.

Verification
- `uv run pytest tests/filestorage/test_remote_sync.py -q` -> `45 passed`
- `gh auth status` -> active account is `santhiprakash`
- `/home/ubuntu/fleet-ops/scripts/check-existing-pr.sh tracer-cloud/opensre "remote-sync concurrent uploads" --branch issue/4557-transfer-files-concurrently --issue 4557` -> no obvious duplicate PR found
- `python3 /home/ubuntu/Projects/open-source/scripts/preflight_ship.py --repo tracer-cloud/opensre --local /home/ubuntu/Projects/open-source/tracer-cloud/opensre --branch main --file platform/filestorage/engine.py --must-contain 'store.put_object(key, data)' --must-not-contain 'bounded concurrency' --search 'Transfer files concurrently'` -> preflight clear

Notes / Risks
- Concurrency is capped at 4 workers to avoid unbounded fan-out.
- The transfer order inside `SyncReport.uploaded` is not guaranteed to match filesystem order anymore; the report still records the correct set of transferred files.
- `ruff` is not installed in this checkout, so I could not run the repo's formatter/linter locally.

Model Used
- OpenAI Codex gpt-5.4-mini

Checklist
- [x] Linked issue
- [x] Focused change
- [x] Regression test added
- [x] Verification run recorded
