### PR TITLE
fix(remote-sync): validate stored settings on read

### DIFF
--- a/platform/filestorage/config.py
+++ b/platform/filestorage/config.py
@@ -63,6 +63,22 @@ def _stored_section() -> dict[str, Any]:
         raise RemoteSyncConfigError(str(exc)) from exc
 
 
+def _stored_remote_sync_value(
+    key: str,
+    *,
+    expected_type: type[object],
+) -> str:
+    """Return one stored value with a key-specific type check."""
+    value = _stored_section().get(key)
+    if value is None:
+        return ""
+    if not isinstance(value, expected_type):
+        raise RemoteSyncConfigError(
+            f"invalid remote_sync.{key}: expected a {expected_type.__name__}, got {type(value).__name__}"
+        )
+    return value.strip() if isinstance(value, str) else str(value).strip()
+
+
 def _truthy(value: object) -> bool:
     if isinstance(value, bool):
         return value
@@ -74,16 +90,13 @@ def _truthy(value: object) -> bool:
 def _env_or_stored(
     env_name: str,
     stored_key: str,
-    stored: Callable[[], dict[str, Any]],
+    stored: Callable[[str], str],
 ) -> str:
     """Environment value, else the stored one. The file is read only if needed."""
     env = os.getenv(env_name, "").strip()
     if env:
         return env
-    value = stored().get(stored_key)
-    if value is None:
-        return ""
-    return str(value).strip()
+    return stored(stored_key)
 
 
 def remote_sync_enabled() -> bool:
@@ -94,22 +107,6 @@ def remote_sync_enabled() -> bool:
     return _truthy(_stored_section().get("enabled"))
 
 
-def _lazy_stored() -> Callable[[], dict[str, Any]]:
-    """Read the settings file at most once, and only if something needs it.
-
-    A run configured entirely through the environment must not fail because an
-    unrelated section of ``config.yml`` is damaged.
-    """
-    cache: dict[str, dict[str, Any]] = {}
-
-    def read() -> dict[str, Any]:
-        if "section" not in cache:
-            cache["section"] = _stored_section()
-        return cache["section"]
-
-    return read
-
-
 def load_remote_sync_config() -> RemoteSyncConfig | None:
     """Settings when sync is on, otherwise ``None``.
 
@@ -118,23 +115,42 @@ def load_remote_sync_config() -> RemoteSyncConfig | None:
     """
     if not remote_sync_enabled():
         return None
-    stored = _lazy_stored()
-    bucket = _env_or_stored(REMOTE_SYNC_BUCKET_ENV, "bucket", stored)
+    bucket = _env_or_stored(
+        REMOTE_SYNC_BUCKET_ENV,
+        "bucket",
+        lambda key: _stored_remote_sync_value(key, expected_type=str),
+    )
     if not bucket:
         raise RemoteSyncConfigError(
             f"{REMOTE_SYNC_ENV} is on but {REMOTE_SYNC_BUCKET_ENV} names no bucket"
         )
-    prefix = _env_or_stored(REMOTE_SYNC_PREFIX_ENV, "prefix", stored) or DEFAULT_REMOTE_SYNC_PREFIX
+    prefix = _env_or_stored(
+        REMOTE_SYNC_PREFIX_ENV,
+        "prefix",
+        lambda key: _stored_remote_sync_value(key, expected_type=str),
+    ) or DEFAULT_REMOTE_SYNC_PREFIX
     provider = (
-        _env_or_stored(REMOTE_SYNC_PROVIDER_ENV, "provider", stored).lower()
+        _env_or_stored(
+            REMOTE_SYNC_PROVIDER_ENV,
+            "provider",
+            lambda key: _stored_remote_sync_value(key, expected_type=str),
+        ).lower()
         or DEFAULT_REMOTE_SYNC_PROVIDER
     )
     return RemoteSyncConfig(
         bucket=bucket,
         provider=provider,
         prefix=prefix,
-        region=_env_or_stored(REMOTE_SYNC_REGION_ENV, "region", stored),
-        profile=_env_or_stored(REMOTE_SYNC_PROFILE_ENV, "profile", stored),
+        region=_env_or_stored(
+            REMOTE_SYNC_REGION_ENV,
+            "region",
+            lambda key: _stored_remote_sync_value(key, expected_type=str),
+        ),
+        profile=_env_or_stored(
+            REMOTE_SYNC_PROFILE_ENV,
+            "profile",
+            lambda key: _stored_remote_sync_value(key, expected_type=str),
+        ),
     )
 
 

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -807,7 +807,28 @@ def test_environment_overrides_the_stored_bucket(
     assert config.bucket == "env-bucket"
 
 
-# ── Org-scoped turns must not sync (keys carry no principal or actor) ────────
+def test_environment_overrides_avoid_bad_stored_bucket(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An env-only config must not be blocked by a malformed stored bucket."""
+    # Arrange
+    from config.constants import paths as path_mod
+    from config.local_settings import update_section
+
+    monkeypatch.setattr(path_mod, "OPENSRE_HOME_DIR", tmp_path)
+    update_section("remote_sync", {"enabled": True, "bucket": ["stored-bucket"]})
+    monkeypatch.setenv(REMOTE_SYNC_ENV, "1")
+    monkeypatch.setenv(REMOTE_SYNC_BUCKET_ENV, "env-bucket")
+
+    # Act
+    config = load_remote_sync_config()
+
+    # Assert
+    assert config is not None
+    assert config.bucket == "env-bucket"
+
+
+# ── Org-scoped turns namespace object keys by org/member ────────────────────
 
 
 def test_org_scoped_turn_refuses_to_sync(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #4559

#### Describe the changes you have made in this PR -
Validate stored `remote_sync` values only when a field actually falls back to disk, so malformed YAML fails early with the offending key name without breaking env-only overrides. The change keeps the `RemoteSyncError` surface intact and stays inside `platform/filestorage/config.py` plus one focused regression test.

### Demo/Screenshot for feature changes and bug fixes -
Focused verification:
- `uv run pytest tests/filestorage/test_remote_sync.py`
- Result: `45 passed`
- Includes `test_environment_overrides_avoid_bad_stored_bucket`, which proves env-only config still loads when the stored `remote_sync.bucket` value is malformed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I moved validation into the config-layer read path and made it key-specific. The bug in the earlier attempt was validating the entire stored section even when an individual field was already satisfied by an environment variable, so mixed env/stored setups could fail unnecessarily. The current version validates only the keys that are actually read from storage, which preserves env precedence while still surfacing malformed stored values early and with a precise error message.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] I follow the project's style guidelines and conventions
