### PR TITLE
refactor(state): promote AgentMode to StrEnum

### DIFF
--- a/core/state/types.py
+++ b/core/state/types.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from enum import StrEnum
+from typing import Any
 
 from pydantic import Field
 from typing_extensions import TypedDict
@@ -10,7 +11,11 @@ from typing_extensions import TypedDict
 from config.strict_config import StrictConfigModel
 from core.state.agent_state import AgentMessageRole
 
-AgentMode = Literal["chat", "investigation", "agent_incident"]
+
+class AgentMode(StrEnum):
+    CHAT = "chat"
+    INVESTIGATION = "investigation"
+    AGENT_INCIDENT = "agent_incident"
 
 
 class ChatMessage(TypedDict, total=False):

--- a/tests/core/state/test_agent_state.py
+++ b/tests/core/state/test_agent_state.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from core.state import MAX_CONVERSATION_MESSAGES, MutableAgentState
+from core.state import MAX_CONVERSATION_MESSAGES, AgentMode, AgentStateModel, MutableAgentState
 from core.state.transcript_window import SESSION_SUMMARY_PREFIX
 
 
@@ -32,6 +32,14 @@ def test_messages_setter_replaces_and_compacts() -> None:
     assert len(state.messages) <= MAX_CONVERSATION_MESSAGES
     assert state.messages[0][1].startswith(SESSION_SUMMARY_PREFIX)
 
+
+def test_agent_mode_accepts_existing_strings_and_serializes_to_strings() -> None:
+    state = AgentStateModel.model_validate({"mode": AgentMode.INVESTIGATION})
+
+    assert state.mode is AgentMode.INVESTIGATION
+    assert AgentMode("chat") is AgentMode.CHAT
+    assert AgentMode("agent_incident") is AgentMode.AGENT_INCIDENT
+    assert state.model_dump(mode="json")["mode"] == "investigation"
 
 def test_last_observation_roundtrip_and_reset() -> None:
     state = MutableAgentState()


### PR DESCRIPTION
Fixes #4519

#### Describe the changes you have made in this PR -

Promoted `AgentMode` from a `Literal` alias to a `StrEnum` in `core/state/types.py`, keeping the same three string values for `chat`, `investigation`, and `agent_incident`.

Added a focused regression test in `tests/core/state/test_agent_state.py` that pins:
- construction from existing strings
- enum identity for the current members
- JSON serialization still emitting the original string values

### Demo/Screenshot for feature changes and bug fixes -

```text
uv run ruff check core/state/types.py tests/core/state/test_agent_state.py
All checks passed!

uv run pytest tests/core/state/test_agent_state.py -q
6 passed in 0.95s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`AgentMode` is a closed, string-valued vocabulary used by the shared agent state model and its TypedDict slices. Converting it to `StrEnum` makes the contract explicit without changing any persisted values or runtime behavior.

I kept the change narrow by only updating the shared type definition and adding one regression test that exercises the accepted strings and JSON serialization. That gives us a single source of truth for the mode vocabulary while preserving the existing state shape.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
