### PR TITLE
refactor: readable entry points — startup extracted from gateway boot, plain names, TurnResult, Python API docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,20 @@
   solely inside `config/config.py` (nothing it imports needs it) may live there.
 - Do not keep compatibility-only forwarding modules after refactors. Once imports and tests
   are migrated, remove the old module path in the same change and use one canonical import path.
+- Test fakes: never inline a lambda that builds an ad-hoc `type(...)` object (or
+  nests another lambda) into `monkeypatch.setattr` / `patch`. Extract a named
+  `def` and pass it — `type(...)` inside the helper body is fine:
+
+  ```python
+  def _build_harness() -> Any:
+      return type("H", (), {"resolve_env_variables": lambda _self: None})()
+
+  monkeypatch.setattr(startup, "_build_harness", _build_harness)
+  ```
+
+  Trivial lambdas (`lambda **_kw: None`, `lambda: sentinel`) stay inline.
+  Precedent: `gateway/tests/runtime/test_startup.py` (`_StubHarness`),
+  `tests/cli/test_integrations_setup_github.py` (`_prompt_answering`).
 - Protocol methods you **add or change** use a **docstring-only body** — no
   `...`, no `pass`, no `raise NotImplementedError`, and never a docstring *plus*
   a trailing `...`/`pass`. Precedent (all fully compliant):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,6 +266,17 @@ Steps:
   result (`_finished = await task` in `gateway/discord/worker.py`
   `_reap_cancelled_task`) over a bare expression statement; do not "fix" by
   skipping the await.
+- Implicit string concatenation in a list (CodeQL
+  `py/implicit-string-concatenation-in-list`): two adjacent string literals
+  inside a list/tuple display are indistinguishable from a **missing comma**,
+  so a long message split over two lines trips it. Do not silence it with an
+  explicit `+` — extract the text to a module constant and reference that. The
+  same implicit concatenation is fine in a parenthesised assignment, where no
+  comma could have been intended. Precedent:
+  `tools/system/python_execution_tool/__init__.py`
+  (`_RUNTIME_FACTS_ANTI_EXAMPLE`). Bites hardest in `use_cases` /
+  `anti_examples` / `examples` tool metadata, where entries are prose and
+  routinely exceed the 100-char line limit.
 - Mixed import styles (CodeQL `py/import-and-import-from`): importing one
   module with both `import X as alias` and `from X import name` — even when
   the `from` import is function-local — raises an alert. It usually happens

--- a/README.md
+++ b/README.md
@@ -158,6 +158,19 @@ opensre investigate --service api-backend
 opensre hermes watch
 ```
 
+**From Python** — drive the agent in-process from your own code (source checkout required):
+
+```python
+from core.agent_harness import AgentHarness
+
+harness = AgentHarness.start()
+result = harness.dispatch_message("why is checkout-api slow?")
+if result.answered:
+    print(result.primary_response_text)
+```
+
+See **[Python API](https://www.opensre.com/docs/python-api)** for sessions, conversations, and custom output sinks.
+
 Other useful commands:
 
 ```bash

--- a/core/agent_harness/__init__.py
+++ b/core/agent_harness/__init__.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from core.agent_harness.turns.headless_adapters import BufferOutputSink
     from core.agent_harness.turns.headless_dispatch import HeadlessAgent
     from core.agent_harness.turns.orchestrator import run_turn, stream_answer
-    from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
+    from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
     from core.agent_harness.turns.turn_snapshot import (
         AgentRuntimeRequest,
         TurnSnapshot,
@@ -42,7 +42,7 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "AgentHarness": ("core.agent_harness.harness", "AgentHarness"),
     "HarnessConfig": ("core.agent_harness.harness", "HarnessConfig"),
     "HarnessStartupResult": ("core.agent_harness.harness", "HarnessStartupResult"),
-    "ShellTurnResult": ("core.agent_harness.turns.turn_results", "ShellTurnResult"),
+    "TurnResult": ("core.agent_harness.turns.turn_results", "TurnResult"),
     "ToolCallingTurnResult": ("core.agent_harness.turns.turn_results", "ToolCallingTurnResult"),
     "AgentRuntimeRequest": ("core.agent_harness.turns.turn_snapshot", "AgentRuntimeRequest"),
     "TurnSnapshot": ("core.agent_harness.turns.turn_snapshot", "TurnSnapshot"),
@@ -90,9 +90,9 @@ __all__ = [
     "HarnessConfig",
     "HarnessStartupResult",
     "HeadlessAgent",
-    "ShellTurnResult",
     "ToolCallingDeps",
     "ToolCallingTurnResult",
+    "TurnResult",
     "TurnSnapshot",
     "TurnSnapshotSource",
     "build_default_headless_agent",

--- a/core/agent_harness/accounting/turn_accounting.py
+++ b/core/agent_harness/accounting/turn_accounting.py
@@ -6,7 +6,7 @@ import contextlib
 import logging
 from typing import Any
 
-from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 
 log = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class DefaultTurnAccounting:
     def record_action_result(self, action_result: ToolCallingTurnResult) -> None:
         _ = action_result
 
-    def finalize(self, result: ShellTurnResult) -> ShellTurnResult:
+    def finalize(self, result: TurnResult) -> TurnResult:
         response = (result.assistant_response_text or "").strip()
         if response:
             _append_turn_detail(

--- a/core/agent_harness/harness.py
+++ b/core/agent_harness/harness.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from core.agent_harness.ports import PromptContextProvider
     from core.agent_harness.session.session_core import SessionCore
     from core.agent_harness.turns.headless_dispatch import HeadlessAgent
-    from core.agent_harness.turns.turn_results import ShellTurnResult
+    from core.agent_harness.turns.turn_results import TurnResult
 
 
 @dataclass(frozen=True)
@@ -175,7 +175,7 @@ class AgentHarness:
         message: str,
         *,
         agent: HeadlessAgent | None = None,
-    ) -> ShellTurnResult:
+    ) -> TurnResult:
         """Run one headless turn for ``message``.
 
         Prefer :meth:`attach_agent` once, then call this per message::

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, Protocol, runtime_checkable
 
-from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 
 # A tool-loop event callback: ``(kind, data)`` where kind is e.g. "tool_start".
 ToolEventObserver = Callable[[str, dict[str, Any]], None]
@@ -203,7 +203,7 @@ class TurnAccounting(Protocol):
     def record_action_result(self, action_result: ToolCallingTurnResult) -> None:
         raise NotImplementedError
 
-    def finalize(self, result: ShellTurnResult) -> ShellTurnResult:
+    def finalize(self, result: TurnResult) -> TurnResult:
         raise NotImplementedError
 
 

--- a/core/agent_harness/turns/headless_adapters.py
+++ b/core/agent_harness/turns/headless_adapters.py
@@ -15,8 +15,8 @@ from core.agent_harness.ports import (
     ToolEventObserver,
 )
 from core.agent_harness.turns.turn_results import (
-    ShellTurnResult,
     ToolCallingTurnResult,
+    TurnResult,
 )
 
 
@@ -142,7 +142,7 @@ class NoopTurnAccounting:
     def record_action_result(self, action_result: ToolCallingTurnResult) -> None:
         _ = action_result
 
-    def finalize(self, result: ShellTurnResult) -> ShellTurnResult:
+    def finalize(self, result: TurnResult) -> TurnResult:
         return result
 
 

--- a/core/agent_harness/turns/headless_dispatch.py
+++ b/core/agent_harness/turns/headless_dispatch.py
@@ -59,7 +59,7 @@ from core.agent_harness.turns.headless_adapters import (
 )
 from core.agent_harness.turns.orchestrator import run_turn, stream_answer
 from core.agent_harness.turns.turn_plan import TurnPlan
-from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from core.execution import ToolExecutionHooks
 
 
@@ -156,8 +156,8 @@ class HeadlessAgent:
             return DefaultTurnAccounting(self._store, message)
         return NoopTurnAccounting()
 
-    def dispatch(self, message: str) -> ShellTurnResult:
-        """Run one full turn for ``message`` and return the :class:`ShellTurnResult`."""
+    def dispatch(self, message: str) -> TurnResult:
+        """Run one full turn for ``message`` and return the :class:`TurnResult`."""
         accounting = self._accounting_for(message)
 
         def execute_actions(

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -42,7 +42,7 @@ from core.agent_harness.session.terminal_access import agent_turn_executed_slash
 from core.agent_harness.turns.conversation_recording import record_conversation_turn
 from core.agent_harness.turns.transcript_compaction import auto_compact_if_needed
 from core.agent_harness.turns.turn_plan import TurnPlan, build_turn_plan
-from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
 from core.llm_invoke_errors import is_cli_timeout_error
 from platform.observability.trace.spans import component_span, emit_route
@@ -327,7 +327,7 @@ def run_turn(
     accounting: TurnAccounting,
     confirm_fn: ConfirmFn | None = None,
     is_tty: bool | None = None,
-) -> ShellTurnResult:
+) -> TurnResult:
     """Run one full turn through three paths, in order:
 
     1. ``summarize_observation`` — a successful action left discovery output, so
@@ -412,7 +412,7 @@ def run_turn(
                     handoff_contents=handoff_contents,
                     turn_plan=turn_plan,
                 )
-            result = ShellTurnResult(
+            result = TurnResult(
                 final_intent="cli_agent_summarized",
                 action_result=action_result,
                 assistant_response_text=_response_text(run),
@@ -420,7 +420,7 @@ def run_turn(
             )
         elif route.intent == "handled_without_llm":
             _record_action_only_turn(session, text, action_result.response_text)
-            result = ShellTurnResult(
+            result = TurnResult(
                 final_intent="cli_agent_handled",
                 action_result=action_result,
                 assistant_response_text=action_result.response_text,
@@ -436,7 +436,7 @@ def run_turn(
                     handoff_contents=handoff_contents,
                     turn_plan=turn_plan,
                 )
-            result = ShellTurnResult(
+            result = TurnResult(
                 final_intent="cli_agent_fallback",
                 action_result=action_result,
                 assistant_response_text=_response_text(run),

--- a/core/agent_harness/turns/turn_results.py
+++ b/core/agent_harness/turns/turn_results.py
@@ -33,7 +33,7 @@ class ToolCallingTurnResult:
 
 
 @dataclass(frozen=True)
-class ShellTurnResult:
+class TurnResult:
     """Outcome of a full turn: the action phase plus the conversational answer."""
 
     final_intent: str
@@ -56,7 +56,7 @@ class ShellTurnResult:
 
 
 __all__ = [
-    "ShellTurnResult",
     "ToolCallingAccountingStatus",
     "ToolCallingTurnResult",
+    "TurnResult",
 ]

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -5,7 +5,8 @@ description: "Use the OpenSRE backend API: health, alert intake, investigations"
 ---
 
 The OpenSRE backend serves one HTTP API (FastAPI, `gateway/http/webapp.py`). All
-routes live on a single port (default `8000`). In production, always call the
+routes live on a single port (default `8000`). To drive the agent in-process
+from your own code instead, see the [Python API](/python-api). In production, always call the
 API over HTTPS — deploy behind a TLS-terminating load balancer (the backend is
 Terraform-managed, separately from this repo).
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -45,6 +45,7 @@
               "interactive-shell-assistant",
               "deployment",
               "api",
+              "python-api",
               "faq",
               "cloudopsbench",
               "bi-weekly-giveaway"

--- a/docs/python-api.mdx
+++ b/docs/python-api.mdx
@@ -1,0 +1,91 @@
+---
+title: "Python API"
+slug: "python-api"
+description: "Drive the OpenSRE agent in-process from your own Python code"
+---
+
+Use this when your Python code runs on the same machine as OpenSRE and you want
+agent answers without shelling out to the CLI. To call OpenSRE over the network
+instead, use the [HTTP API](/api).
+
+## Prerequisites
+
+The standalone CLI installer does not expose an importable package, so embed
+from a source checkout:
+
+```bash
+git clone https://github.com/Tracer-Cloud/opensre.git
+cd opensre && make install
+```
+
+Configure a provider once (`opensre onboard`) — the harness reuses the same
+config and credentials as the CLI. Run your script inside the checkout's
+environment with `uv run python your_script.py`.
+
+## One turn
+
+```python
+from core.agent_harness import AgentHarness
+
+harness = AgentHarness.start()
+result = harness.dispatch_message("why is checkout-api slow?")
+if result.answered:
+    print(result.primary_response_text)
+```
+
+`AgentHarness.start()` resolves the environment, opens a session, and attaches
+an agent with the standard ports — the same tools and prompts the interactive
+shell uses.
+
+Always check `result.answered` before trusting the text: when a turn fails (for
+example the LLM provider is unreachable), the error message itself lands in
+`result.primary_response_text`.
+
+## A conversation
+
+Each `dispatch_message` call is one turn in the same session, so follow-ups see
+earlier context:
+
+```python
+harness.dispatch_message("list unresolved Sentry issues from the last 24 hours")
+result = harness.dispatch_message("which of those affect checkout?")
+```
+
+To resume a previous session instead of starting a new one, pass its ID:
+
+```python
+from core.agent_harness import AgentHarness, HarnessConfig
+
+harness = AgentHarness.start(HarnessConfig(session_id="abc123"))
+```
+
+## Custom output and ports
+
+`start()` buffers all output. To capture tool progress yourself — stream to a
+websocket, collect for a report — build the agent explicitly and pass your own
+sink:
+
+```python
+from core.agent_harness import (
+    AgentHarness,
+    BufferOutputSink,
+    HarnessConfig,
+    build_default_headless_agent,
+)
+
+harness = AgentHarness(HarnessConfig())
+startup = harness.startup()
+sink = BufferOutputSink()
+agent = build_default_headless_agent(session=startup.session, output=sink)
+harness.attach_agent(agent)
+
+harness.dispatch_message("summarize open incidents")
+print(sink.lines)      # rendered output lines
+print(sink.streamed)   # streamed answer chunks
+```
+
+Any object implementing the `OutputSink` protocol
+(`core.agent_harness.ports.OutputSink`: `print`, `render_response_header`,
+`render_error`, `stream`) works in place of `BufferOutputSink`.
+`build_default_headless_agent` also accepts a custom logger, prompt surface,
+and tool observers — see its docstring for the full port list.

--- a/gateway/config/logging_config.py
+++ b/gateway/config/logging_config.py
@@ -42,7 +42,7 @@ def _quiet_noisy_loggers() -> None:
         logging.getLogger(name).setLevel(logging.WARNING)
 
 
-def configure_gateway_logging() -> logging.Logger:
+def configure_logging() -> logging.Logger:
     """Configure root logging for the dedicated Telegram gateway process."""
     gateway_logger = logging.getLogger("gateway")
 

--- a/gateway/runtime/manager.py
+++ b/gateway/runtime/manager.py
@@ -23,9 +23,7 @@ from typing import Any
 
 from rich.console import Console
 
-from core.agent_harness.harness import AgentHarness, HarnessConfig
-from core.llm.internal.preload import preload_llm_clients
-from gateway.config.configure_gateway_logging import configure_gateway_logging
+from gateway.config.logging_config import configure_logging
 from gateway.discord.background import DiscordGatewayBackground
 from gateway.discord.wiring import start_discord_worker
 from gateway.runtime.concurrency import (
@@ -42,7 +40,7 @@ from gateway.runtime.daemon import (
     write_component_status,
 )
 from gateway.runtime.errors import GatewayConfigurationError
-from gateway.runtime.readiness import set_gateway_ready
+from gateway.runtime.readiness import set_ready
 from gateway.runtime.remote_run_worker import (
     RemoteRunWorker,
     build_remote_run_worker,
@@ -93,29 +91,12 @@ class GatewayManager:
 
     def start_gateway(self, *, wait: bool = True) -> GatewayManager:
         """Assemble the turn handler, start all components, and own the lifecycle."""
-        from gateway.runtime.bootstrap import install_runtime
+        from gateway.runtime import startup
 
-        logger = self.logger = configure_gateway_logging()
-        set_gateway_ready(False)
-        bootstrap = self._hydrate_credentials(logger)
-
-        harness = AgentHarness(HarnessConfig(open_storage=False))
-        harness.resolve_env_variables()
-        # Mirror shell boot: register harness adapters here (gateway cannot import
-        # surfaces.boundary without a surfaces↔gateway peer import).
-        install_runtime(harness_adapters=True, scheduler_runners=False)
-        # Env-gated (OPENSRE_NO_TELEMETRY / DO_NOT_TRACK / missing DSN) — free when off.
-        from platform.observability.errors.sentry import init_sentry
-
-        init_sentry(entrypoint="gateway")
-        # PATH gaps + sandbox usability probes — before the first mid-turn failure.
-        from platform.sandbox.capabilities import boot_capability_warnings
-
-        for warning in boot_capability_warnings():
-            logger.warning("[gateway] capability: %s", warning)
-        # Load the LLM client graph as one snapshot at boot (avoids a stale
-        # mixed-version process after a code change).
-        preload_llm_clients()
+        logger = self.logger = configure_logging()
+        set_ready(False)
+        bootstrap = self._load_credentials(logger)
+        startup.run(logger)
 
         # Compose the transport-agnostic turn handler. Action tools are resolved
         # per turn from each chat's live session inside the handler (not here).
@@ -141,7 +122,7 @@ class GatewayManager:
         # Deploy health waits (EC2 Docker + AMI) match this line for Telegram
         # and/or Slack — do not rely on transport-specific log strings alone.
         logger.info("[gateway] ready")
-        set_gateway_ready(True)
+        set_ready(True)
 
         signal.signal(signal.SIGINT, self._handle_signal)
         signal.signal(signal.SIGTERM, self._handle_signal)
@@ -152,7 +133,7 @@ class GatewayManager:
 
     def stop(self, *, timeout: float = 8.0) -> bool:
         """Shut down all components and return whether the chat worker stopped."""
-        set_gateway_ready(False)
+        set_ready(False)
         stopped = True
         if self.remote_run_worker is not None:
             stopped = self.remote_run_worker.stop(timeout=timeout)
@@ -173,7 +154,7 @@ class GatewayManager:
         self._stopped.set()
         return stopped
 
-    def _hydrate_credentials(self, logger: logging.Logger) -> GatewayBootstrap | None:
+    def _load_credentials(self, logger: logging.Logger) -> GatewayBootstrap | None:
         """Hydrate before any transport, scheduler, or worker can start."""
         try:
             hydrator = self._credential_hydrator_factory()

--- a/gateway/runtime/readiness.py
+++ b/gateway/runtime/readiness.py
@@ -8,7 +8,7 @@ _lock = threading.Lock()
 _ready = False
 
 
-def set_gateway_ready(ready: bool) -> None:
+def set_ready(ready: bool) -> None:
     """Publish whether mandatory Gateway startup dependencies are healthy."""
     global _ready
     with _lock:
@@ -21,4 +21,4 @@ def is_gateway_ready() -> bool:
         return _ready
 
 
-__all__ = ["is_gateway_ready", "set_gateway_ready"]
+__all__ = ["is_gateway_ready", "set_ready"]

--- a/gateway/runtime/startup.py
+++ b/gateway/runtime/startup.py
@@ -1,0 +1,64 @@
+"""Everything the gateway process does once, before any component starts.
+
+Distinct from :mod:`gateway.runtime.bootstrap`, which registers harness
+adapters and scheduler runners — one step of the sequence below.
+
+``start_gateway`` is a lifecycle method: assemble the turn handler, start the
+components, own the signals. The process-level setup underneath it — resolving
+env vars, registering harness adapters, error reporting, capability probes,
+warming the LLM client graph — is not gateway logic and does not belong there.
+
+Order is load-bearing:
+
+1. **env variables** first, because adapter and integration hydration can depend
+   on credentials supplied through the environment;
+2. **harness adapters** next, so the tool and integration registries are
+   populated;
+3. **LLM clients** last, so the preloaded snapshot reflects the registered set.
+
+Sentry and the capability probes sit between them: both are diagnostics, and the
+capability warnings are deliberately emitted at boot so a withheld capability
+reads as a startup warning rather than a confusing mid-turn answer.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core.agent_harness.harness import AgentHarness, HarnessConfig
+from core.llm.internal.preload import preload_llm_clients
+from gateway.runtime.bootstrap import install_runtime
+from platform.observability.errors.sentry import init_sentry
+from platform.sandbox.capabilities import boot_capability_warnings
+
+
+def _build_harness() -> AgentHarness:
+    """The gateway's harness: storage stays closed; each turn resolves its own session."""
+    return AgentHarness(HarnessConfig(open_storage=False))
+
+
+def run(logger: logging.Logger) -> AgentHarness:
+    """Run the shared process setup and return the harness the gateway will use.
+
+    Safe to call once per process, before any component starts.
+    """
+    harness = _build_harness()
+    harness.resolve_env_variables()
+
+    # Registered here rather than via the shell boundary: gateway must not import
+    # surfaces (peer packages).
+    install_runtime(harness_adapters=True, scheduler_runners=False)
+
+    # Env-gated (OPENSRE_NO_TELEMETRY / DO_NOT_TRACK / missing DSN) — free when off.
+    init_sentry(entrypoint="gateway")
+
+    for warning in boot_capability_warnings():
+        logger.warning("[gateway] capability: %s", warning)
+
+    # One snapshot at boot, so a code change mid-process cannot leave a
+    # mixed-version client graph.
+    preload_llm_clients()
+    return harness
+
+
+__all__ = ["run"]

--- a/gateway/tests/main/test_agent_life_cycle.py
+++ b/gateway/tests/main/test_agent_life_cycle.py
@@ -25,7 +25,7 @@ from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
 from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStorage
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
-from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from gateway.runtime.manager import GatewayManager, start_gateway
 from gateway.telegram.inbound_handler import (
     handle_polled_inbound_telegram_message,
@@ -57,7 +57,7 @@ def test_gateway_start_returns_running_gateway_handle(monkeypatch) -> None:
         "config.local_env.bootstrap_opensre_env_once",
         lambda **_kwargs: None,
     )
-    monkeypatch.setattr("gateway.runtime.manager.configure_gateway_logging", lambda: logger)
+    monkeypatch.setattr("gateway.runtime.manager.configure_logging", lambda: logger)
     _patch_non_telegram_components(monkeypatch)
     monkeypatch.setattr("gateway.telegram.wiring.load_gateway_settings", lambda: settings)
     monkeypatch.setattr(
@@ -93,7 +93,7 @@ def test_gateway_start_returns_running_gateway_handle(monkeypatch) -> None:
 
     sink = MagicMock()
     session = MagicMock()
-    agent_cls.return_value.dispatch.return_value = ShellTurnResult(
+    agent_cls.return_value.dispatch.return_value = TurnResult(
         final_intent="cli_agent_handled",
         action_result=ToolCallingTurnResult(
             planned_count=1,
@@ -174,7 +174,7 @@ def test_polled_telegram_message_reaches_start_gateway_agent_callback(monkeypatc
         "config.local_env.bootstrap_opensre_env_once",
         lambda **_kwargs: None,
     )
-    monkeypatch.setattr("gateway.runtime.manager.configure_gateway_logging", lambda: logger)
+    monkeypatch.setattr("gateway.runtime.manager.configure_logging", lambda: logger)
     _patch_non_telegram_components(monkeypatch)
     monkeypatch.setattr("gateway.telegram.wiring.load_gateway_settings", lambda: settings)
     monkeypatch.setattr("gateway.runtime.manager.signal.signal", lambda *_args: None)
@@ -233,7 +233,7 @@ def test_gateway_start_continues_without_telegram_configuration(monkeypatch) -> 
         "config.local_env.bootstrap_opensre_env_once",
         lambda **_kwargs: None,
     )
-    monkeypatch.setattr("gateway.runtime.manager.configure_gateway_logging", lambda: logger)
+    monkeypatch.setattr("gateway.runtime.manager.configure_logging", lambda: logger)
     monkeypatch.setattr("gateway.runtime.manager.signal.signal", lambda *_args: None)
     monkeypatch.setattr("gateway.runtime.manager.clear_component_status", lambda: None)
     _patch_non_telegram_components(monkeypatch)

--- a/gateway/tests/runtime/test_credential_hydration.py
+++ b/gateway/tests/runtime/test_credential_hydration.py
@@ -123,6 +123,6 @@ def test_manager_fails_closed_with_generic_error() -> None:
     )
 
     with pytest.raises(GatewayConfigurationError, match="hydration failed"):
-        manager._hydrate_credentials(logging.getLogger("test"))
+        manager._load_credentials(logging.getLogger("test"))
 
     assert manager.components["credentials"] == "failed"

--- a/gateway/tests/runtime/test_session_agents.py
+++ b/gateway/tests/runtime/test_session_agents.py
@@ -11,7 +11,7 @@ from rich.console import Console
 
 from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStorage
-from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from gateway.runtime.live_sink import LiveOutputSink
 from gateway.runtime.session_agents import SessionAgentPool
 from gateway.runtime.turn_handler import GatewayTurnHandler
@@ -30,8 +30,8 @@ def _stub_gateway_turn_analytics(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def _empty_result() -> ShellTurnResult:
-    return ShellTurnResult(
+def _empty_result() -> TurnResult:
+    return TurnResult(
         final_intent="cli_agent_handled",
         action_result=ToolCallingTurnResult(
             planned_count=0,

--- a/gateway/tests/runtime/test_slash_routing.py
+++ b/gateway/tests/runtime/test_slash_routing.py
@@ -168,7 +168,9 @@ def test_gateway_manager_registers_harness_adapters(monkeypatch: pytest.MonkeyPa
     def _install_runtime(*, harness_adapters: bool = True, scheduler_runners: bool = True) -> None:
         calls.append((harness_adapters, scheduler_runners))
 
-    monkeypatch.setattr("gateway.runtime.bootstrap.install_runtime", _install_runtime)
+    # Registration happens in gateway.runtime.startup, which imports the helper at
+    # module scope — patch the name it resolved, not the source module.
+    monkeypatch.setattr("gateway.runtime.startup.install_runtime", _install_runtime)
     monkeypatch.setattr(
         "gateway.runtime.manager.start_telegram_worker",
         lambda **_kwargs: (MagicMock(), MagicMock()),

--- a/gateway/tests/runtime/test_startup.py
+++ b/gateway/tests/runtime/test_startup.py
@@ -1,0 +1,94 @@
+"""Gateway process boot: one named step, in a fixed order.
+
+``start_gateway`` opened with thirteen statements of process setup — harness
+construction, env resolution, adapter registration, Sentry, capability warnings,
+LLM preload — before any gateway-specific work. None of it is gateway logic, and
+the ordering constraints between the steps were documented only as inline
+comments inside a lifecycle method.
+
+The order is load-bearing and is what these tests pin:
+
+* env variables resolve **before** adapters register, because adapter/integration
+  hydration can depend on env-provided credentials;
+* the LLM client graph preloads **after** adapters, so the snapshot sees the
+  registered set;
+* capability warnings are emitted at startup, before the first mid-turn failure can
+  present as a confusing answer.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+
+def test_startup_runs_the_steps_in_the_required_order(monkeypatch: Any) -> None:
+    # Arrange
+    from gateway.runtime import startup
+
+    order: list[str] = []
+    monkeypatch.setattr(startup, "install_runtime", lambda **_kw: order.append("adapters"))
+    monkeypatch.setattr(startup, "init_sentry", lambda **_kw: order.append("sentry"))
+    monkeypatch.setattr(startup, "preload_llm_clients", lambda: order.append("preload"))
+    monkeypatch.setattr(startup, "boot_capability_warnings", lambda: ["curl missing"])
+
+    class _Harness:
+        def resolve_env_variables(self) -> None:
+            order.append("env")
+
+    monkeypatch.setattr(startup, "_build_harness", lambda: _Harness())
+
+    # Act
+    startup.run(logging.getLogger("test.startup"))
+
+    # Assert
+    assert order.index("env") < order.index("adapters"), order
+    assert order.index("adapters") < order.index("preload"), order
+
+
+def test_startup_logs_every_capability_warning(monkeypatch: Any) -> None:
+    """A missing capability must surface at startup, not mid-turn."""
+    # Arrange
+    from gateway.runtime import startup
+
+    monkeypatch.setattr(startup, "install_runtime", lambda **_kw: None)
+    monkeypatch.setattr(startup, "init_sentry", lambda **_kw: None)
+    monkeypatch.setattr(startup, "preload_llm_clients", lambda: None)
+    monkeypatch.setattr(
+        startup, "boot_capability_warnings", lambda: ["curl is not on PATH", "network blocked"]
+    )
+    monkeypatch.setattr(
+        startup,
+        "_build_harness",
+        lambda: type("H", (), {"resolve_env_variables": lambda _self: None})(),
+    )
+
+    logged: list[str] = []
+
+    class _Logger(logging.Logger):
+        def __init__(self) -> None:
+            super().__init__("test.startup")
+
+        def warning(self, msg: str, *args: Any, **_kw: Any) -> None:
+            logged.append(msg % args if args else msg)
+
+    # Act
+    startup.run(_Logger())
+
+    # Assert
+    assert any("curl is not on PATH" in line for line in logged), logged
+    assert any("network blocked" in line for line in logged), logged
+
+
+def test_startup_returns_the_harness_for_the_caller(monkeypatch: Any) -> None:
+    """The gateway keeps the harness it booted; boot does not hide it."""
+    from gateway.runtime import startup
+
+    sentinel = type("H", (), {"resolve_env_variables": lambda _self: None})()
+    monkeypatch.setattr(startup, "install_runtime", lambda **_kw: None)
+    monkeypatch.setattr(startup, "init_sentry", lambda **_kw: None)
+    monkeypatch.setattr(startup, "preload_llm_clients", lambda: None)
+    monkeypatch.setattr(startup, "boot_capability_warnings", lambda: [])
+    monkeypatch.setattr(startup, "_build_harness", lambda: sentinel)
+
+    assert startup.run(logging.getLogger("test.startup")) is sentinel

--- a/gateway/tests/runtime/test_startup.py
+++ b/gateway/tests/runtime/test_startup.py
@@ -22,6 +22,17 @@ import logging
 from typing import Any
 
 
+class _StubHarness:
+    """Stands in for :class:`AgentHarness`; records that env resolution ran."""
+
+    def __init__(self, order: list[str] | None = None) -> None:
+        self._order = order
+
+    def resolve_env_variables(self) -> None:
+        if self._order is not None:
+            self._order.append("env")
+
+
 def test_startup_runs_the_steps_in_the_required_order(monkeypatch: Any) -> None:
     # Arrange
     from gateway.runtime import startup
@@ -32,11 +43,7 @@ def test_startup_runs_the_steps_in_the_required_order(monkeypatch: Any) -> None:
     monkeypatch.setattr(startup, "preload_llm_clients", lambda: order.append("preload"))
     monkeypatch.setattr(startup, "boot_capability_warnings", lambda: ["curl missing"])
 
-    class _Harness:
-        def resolve_env_variables(self) -> None:
-            order.append("env")
-
-    monkeypatch.setattr(startup, "_build_harness", lambda: _Harness())
+    monkeypatch.setattr(startup, "_build_harness", lambda: _StubHarness(order))
 
     # Act
     startup.run(logging.getLogger("test.startup"))
@@ -57,11 +64,7 @@ def test_startup_logs_every_capability_warning(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         startup, "boot_capability_warnings", lambda: ["curl is not on PATH", "network blocked"]
     )
-    monkeypatch.setattr(
-        startup,
-        "_build_harness",
-        lambda: type("H", (), {"resolve_env_variables": lambda _self: None})(),
-    )
+    monkeypatch.setattr(startup, "_build_harness", _StubHarness)
 
     logged: list[str] = []
 
@@ -84,7 +87,7 @@ def test_startup_returns_the_harness_for_the_caller(monkeypatch: Any) -> None:
     """The gateway keeps the harness it booted; boot does not hide it."""
     from gateway.runtime import startup
 
-    sentinel = type("H", (), {"resolve_env_variables": lambda _self: None})()
+    sentinel = _StubHarness()
     monkeypatch.setattr(startup, "install_runtime", lambda **_kw: None)
     monkeypatch.setattr(startup, "init_sentry", lambda **_kw: None)
     monkeypatch.setattr(startup, "preload_llm_clients", lambda: None)

--- a/gateway/tests/runtime/test_turn_handler.py
+++ b/gateway/tests/runtime/test_turn_handler.py
@@ -12,7 +12,7 @@ from rich.console import Console
 
 from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStorage
-from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from gateway.runtime.turn_handler import GatewayTurnHandler
 from tests.core.agent.orchestration.cross_surface_parity_harness import (
     RecordingGatewaySink,
@@ -32,7 +32,7 @@ def _stub_gateway_turn_analytics(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def _patch_headless_agent(monkeypatch: Any, result: ShellTurnResult) -> MagicMock:
+def _patch_headless_agent(monkeypatch: Any, result: TurnResult) -> MagicMock:
     """Patch the gateway agent factory so construction is inert and dispatch returns ``result``.
 
     Returns the factory mock. The built agent is ``factory.return_value``; when the
@@ -88,7 +88,7 @@ def test_turn_handler_resolves_action_tools_from_live_session(monkeypatch: Any) 
 
     agent_cls = _patch_headless_agent(
         monkeypatch,
-        ShellTurnResult(
+        TurnResult(
             final_intent="cli_agent_handled",
             action_result=ToolCallingTurnResult(
                 planned_count=1,
@@ -113,8 +113,8 @@ def test_turn_handler_resolves_action_tools_from_live_session(monkeypatch: Any) 
     assert recorded == [chat_integrations]
 
 
-def _empty_turn_result(*, llm_run: Any = None) -> ShellTurnResult:
-    return ShellTurnResult(
+def _empty_turn_result(*, llm_run: Any = None) -> TurnResult:
+    return TurnResult(
         final_intent="cli_agent_handled",
         action_result=ToolCallingTurnResult(
             planned_count=0,

--- a/gateway/tests/test_logging_config.py
+++ b/gateway/tests/test_logging_config.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 
-from gateway.config.configure_gateway_logging import (
+from gateway.config.logging_config import (
     _GatewayLogFormatter,
     _GatewayProcessLogFilter,
     _quiet_noisy_loggers,

--- a/integrations/sentry/morning_digest_runner.py
+++ b/integrations/sentry/morning_digest_runner.py
@@ -12,7 +12,7 @@ from core.agent_harness.session.integration_resolution import (
 )
 from core.agent_harness.turns.default_headless_agent import build_default_headless_agent
 from core.agent_harness.turns.headless_adapters import BufferOutputSink
-from core.agent_harness.turns.turn_results import ShellTurnResult
+from core.agent_harness.turns.turn_results import TurnResult
 from integrations.sentry.project_scope import (
     apply_sentry_project_scope,
     payload_project_slug,
@@ -59,7 +59,7 @@ def _require_sentry_configured() -> None:
         )
 
 
-def _dispatch_headless_turn(message: str, payload: AgentPayload) -> ShellTurnResult:
+def _dispatch_headless_turn(message: str, payload: AgentPayload) -> TurnResult:
     _require_sentry_configured()
 
     harness = AgentHarness(

--- a/surfaces/interactive_shell/runtime/core/turn_accounting.py
+++ b/surfaces/interactive_shell/runtime/core/turn_accounting.py
@@ -13,9 +13,9 @@ from dataclasses import dataclass
 # The neutral "facts only" turn-result models live in the decoupled agent
 # package; this module owns only the shell's accounting side effects over them.
 from core.agent_harness.turns.turn_results import (
-    ShellTurnResult,
     ToolCallingAccountingStatus,
     ToolCallingTurnResult,
+    TurnResult,
 )
 from platform.analytics.cli import capture_terminal_turn_summarized
 from surfaces.interactive_shell.session import Session
@@ -41,7 +41,7 @@ class ShellTurnAccounting:
         self._record_action_analytics(action_result)
         self._record_terminal_turn(action_result)
 
-    def finalize(self, result: ShellTurnResult) -> ShellTurnResult:
+    def finalize(self, result: TurnResult) -> TurnResult:
         """Flush the recorder, persist the turn, and stamp the session intent."""
         self._flush_prompt_recorder(result)
         if result.llm_run is not None:
@@ -102,7 +102,7 @@ class ShellTurnAccounting:
             session_fallback_rate_percent=snapshot.fallback_rate_percent,
         )
 
-    def _flush_prompt_recorder(self, result: ShellTurnResult) -> None:
+    def _flush_prompt_recorder(self, result: TurnResult) -> None:
         # Pending turn LLM/error state is consumed unconditionally so a turn
         # that stages it can never leak it into a later turn's flush.
         pending_run = self.session.terminal.pop_pending_turn_llm()
@@ -120,7 +120,7 @@ class ShellTurnAccounting:
 
 __all__ = [
     "ShellTurnAccounting",
-    "ShellTurnResult",
+    "TurnResult",
     "ToolCallingAccountingStatus",
     "ToolCallingTurnResult",
 ]

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -17,7 +17,7 @@ from rich.console import Console
 from core.agent_harness.ports import OutputSink
 from core.agent_harness.turns.orchestrator import run_turn
 from core.agent_harness.turns.turn_plan import TurnPlan
-from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from core.execution import ToolExecutionHooks
 from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
 from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink
@@ -50,7 +50,7 @@ def execute_shell_turn(
     answer_agent: AnswerShellQuestion | None = None,
     output: OutputSink | None = None,
     tool_hooks: ToolExecutionHooks | None = None,
-) -> ShellTurnResult:
+) -> TurnResult:
     """Execute one submitted interactive-shell turn.
 
     The action driver, gather pass, and conversational assistant default to the

--- a/tests/cli/test_integrations_setup_github.py
+++ b/tests/cli/test_integrations_setup_github.py
@@ -14,12 +14,23 @@ from integrations.github.mcp import GitHubMCPValidationResult
 from surfaces.cli.__main__ import cli
 
 
+def _prompt_answering(answer: object) -> object:
+    """A questionary prompt double: calling it yields an object whose ``ask()`` returns ``answer``."""
+
+    def _prompt(*_args: object, **_kwargs: object) -> object:
+        return type("X", (), {"ask": lambda *_aa, **_kk: answer})()
+
+    return _prompt
+
+
 def _mock_confirm(monkeypatch: pytest.MonkeyPatch, *, advanced: bool) -> None:
     """Mock the advanced-settings confirm prompt at the top of ``_setup_github``."""
-    monkeypatch.setattr(
-        "integrations.cli.questionary.confirm",
-        lambda *_a, **_k: type("X", (), {"ask": lambda *_aa, **_kk: advanced})(),
-    )
+    monkeypatch.setattr("integrations.cli.questionary.confirm", _prompt_answering(advanced))
+
+
+def _mock_select_auto(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock the transport-mode select prompt to answer "auto"."""
+    monkeypatch.setattr("integrations.cli.questionary.select", _prompt_answering("auto"))
 
 
 def _patch_apply_setup(monkeypatch: pytest.MonkeyPatch, fake: object) -> None:
@@ -42,10 +53,7 @@ def test_setup_github_prints_connected_and_saves_on_validation_success(
     _mock_confirm(monkeypatch, advanced=True)
     monkeypatch.setattr("integrations.cli._setup_github_auth_token", lambda _mode: "ghp_x")
     monkeypatch.setattr("integrations.cli._prompt_github_repo_report_level", lambda: "full")
-    monkeypatch.setattr(
-        "integrations.cli.questionary.select",
-        lambda *_a, **_k: type("X", (), {"ask": lambda *_aa, **_kk: "auto"})(),
-    )
+    _mock_select_auto(monkeypatch)
 
     monkeypatch.setattr(
         "integrations.github.mcp.validate_github_mcp_config",
@@ -158,10 +166,7 @@ def test_setup_github_exits_without_save_on_validation_failure(
     monkeypatch.setattr("integrations.cli._p", fake_p)
     _mock_confirm(monkeypatch, advanced=True)
     monkeypatch.setattr("integrations.cli._setup_github_auth_token", lambda _mode: "")
-    monkeypatch.setattr(
-        "integrations.cli.questionary.select",
-        lambda *_a, **_k: type("X", (), {"ask": lambda *_aa, **_kk: "auto"})(),
-    )
+    _mock_select_auto(monkeypatch)
     monkeypatch.setattr(
         "integrations.github.mcp.validate_github_mcp_config",
         lambda _c, **_kwargs: GitHubMCPValidationResult(
@@ -200,10 +205,7 @@ def test_cmd_setup_github_skips_saved_line_on_validation_failure(
     monkeypatch.setattr("integrations.cli._p", fake_p)
     _mock_confirm(monkeypatch, advanced=True)
     monkeypatch.setattr("integrations.cli._setup_github_auth_token", lambda _mode: "x")
-    monkeypatch.setattr(
-        "integrations.cli.questionary.select",
-        lambda *_a, **_k: type("X", (), {"ask": lambda *_aa, **_kk: "auto"})(),
-    )
+    _mock_select_auto(monkeypatch)
     monkeypatch.setattr(
         "integrations.github.mcp.validate_github_mcp_config",
         lambda _c, **_kwargs: GitHubMCPValidationResult(
@@ -241,10 +243,7 @@ def test_cmd_setup_github_prints_saved_after_success(
     _mock_confirm(monkeypatch, advanced=True)
     monkeypatch.setattr("integrations.cli._setup_github_auth_token", lambda _mode: "tok")
     monkeypatch.setattr("integrations.cli._prompt_github_repo_report_level", lambda: "standard")
-    monkeypatch.setattr(
-        "integrations.cli.questionary.select",
-        lambda *_a, **_k: type("X", (), {"ask": lambda *_aa, **_kk: "auto"})(),
-    )
+    _mock_select_auto(monkeypatch)
     monkeypatch.setattr(
         "integrations.github.mcp.validate_github_mcp_config",
         lambda _c, **_kwargs: GitHubMCPValidationResult(

--- a/tests/cli/test_uninstall.py
+++ b/tests/cli/test_uninstall.py
@@ -70,11 +70,10 @@ def test_run_uninstall_cancelled_by_user(
 
     import questionary as _q
 
-    monkeypatch.setattr(
-        _q,
-        "confirm",
-        lambda *_args, **_kwargs: type("Q", (), {"ask": lambda _self: False})(),
-    )
+    def _confirm_no(*_args: object, **_kwargs: object) -> object:
+        return type("Q", (), {"ask": lambda _self: False})()
+
+    monkeypatch.setattr(_q, "confirm", _confirm_no)
 
     rc = run_uninstall(yes=False)
 

--- a/tests/core/agent/orchestration/cross_surface_parity_harness.py
+++ b/tests/core/agent/orchestration/cross_surface_parity_harness.py
@@ -24,7 +24,7 @@ from core.agent_harness.turns.headless_dispatch import (
     HeadlessAgent,
     NoopTurnAccounting,
 )
-from core.agent_harness.turns.turn_results import ShellTurnResult
+from core.agent_harness.turns.turn_results import TurnResult
 from core.llm.types import AgentLLMResponse, ToolCall
 from core.tool_framework.registered_tool import RegisteredTool
 from gateway.runtime.turn_handler import GatewayTurnHandler
@@ -58,7 +58,7 @@ class TurnSnapshot:
     probe_ran: bool
 
     @classmethod
-    def from_result(cls, result: ShellTurnResult, *, probe_ran: bool) -> TurnSnapshot:
+    def from_result(cls, result: TurnResult, *, probe_ran: bool) -> TurnSnapshot:
         return cls(
             final_intent=result.final_intent,
             action_handled=result.action_result.handled,
@@ -300,7 +300,7 @@ def _dispatch_turn(
     session: Session,
     *,
     gather_enabled: bool = True,
-) -> ShellTurnResult:
+) -> TurnResult:
     output = BufferOutputSink()
     agent = HeadlessAgent(
         tools=DefaultToolProvider(
@@ -340,7 +340,7 @@ def snapshot_headless(message: str, *, integrations: dict[str, Any] | None = Non
 
 def _install_gateway_dispatch_spy(
     monkeypatch: Any,
-    captured: list[ShellTurnResult],
+    captured: list[TurnResult],
 ) -> None:
     """Spy on the gateway pool's agent factory (not ``HeadlessAgent`` directly).
 
@@ -355,7 +355,7 @@ def _install_gateway_dispatch_spy(
         agent = real_build(**kwargs)
         original_dispatch = type(agent).dispatch
 
-        def dispatch(message: str) -> ShellTurnResult:
+        def dispatch(message: str) -> TurnResult:
             result = original_dispatch(agent, message)
             captured.append(result)
             return result
@@ -377,7 +377,7 @@ def snapshot_gateway_handler(
 ) -> TurnSnapshot:
     session = fresh_session(integrations=integrations)
     sink = RecordingGatewaySink()
-    captured: list[ShellTurnResult] = []
+    captured: list[TurnResult] = []
     _install_gateway_dispatch_spy(monkeypatch, captured)
     before = probe_run_count()
     handler = GatewayTurnHandler(
@@ -445,7 +445,7 @@ def run_gateway_turn_with_sink(
     """Run one gateway turn and return both routing snapshot and transport sink."""
     session = fresh_session(integrations=integrations)
     sink = RecordingGatewaySink()
-    captured: list[ShellTurnResult] = []
+    captured: list[TurnResult] = []
     _install_gateway_dispatch_spy(monkeypatch, captured)
     before = probe_run_count()
     handler = GatewayTurnHandler(

--- a/tests/core/agent/orchestration/test_cross_surface_components.py
+++ b/tests/core/agent/orchestration/test_cross_surface_components.py
@@ -12,14 +12,14 @@ from rich.console import Console
 from core.agent_harness.session import InMemorySessionStorage
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.orchestrator import run_turn
-from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from gateway.runtime.turn_handler import GatewayTurnHandler
 from surfaces.interactive_shell.session import Session
 
 
 def test_gateway_turn_handler_delegates_to_agent_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
     agent = MagicMock()
-    agent.dispatch.return_value = ShellTurnResult(
+    agent.dispatch.return_value = TurnResult(
         final_intent="cli_agent_handled",
         action_result=ToolCallingTurnResult(
             planned_count=1,
@@ -70,7 +70,7 @@ def test_gateway_turn_handler_does_not_finalize_answered_turn(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     agent = MagicMock()
-    agent.dispatch.return_value = ShellTurnResult(
+    agent.dispatch.return_value = TurnResult(
         final_intent="cli_agent_fallback",
         action_result=ToolCallingTurnResult(0, 0, 0, False, False),
         assistant_response_text="streamed answer",
@@ -107,7 +107,7 @@ def test_run_turn_routes_unhandled_action_to_answer_callback() -> None:
         def record_action_result(self, _result: ToolCallingTurnResult) -> None:
             return None
 
-        def finalize(self, result: ShellTurnResult) -> ShellTurnResult:
+        def finalize(self, result: TurnResult) -> TurnResult:
             return result
 
     session = Session(storage=InMemorySessionStorage())
@@ -152,7 +152,7 @@ def test_run_turn_builds_turn_plan_for_action_path(
         def record_action_result(self, _result: ToolCallingTurnResult) -> None:
             return None
 
-        def finalize(self, result: ShellTurnResult) -> ShellTurnResult:
+        def finalize(self, result: TurnResult) -> TurnResult:
             return result
 
     session = Session(storage=InMemorySessionStorage())
@@ -194,7 +194,7 @@ def test_run_turn_passes_turn_plan_to_gather(
         def record_action_result(self, _result: ToolCallingTurnResult) -> None:
             return None
 
-        def finalize(self, result: ShellTurnResult) -> ShellTurnResult:
+        def finalize(self, result: TurnResult) -> TurnResult:
             return result
 
     session = Session(storage=InMemorySessionStorage())
@@ -235,7 +235,7 @@ def test_run_turn_passes_turn_plan_to_answer(
         def record_action_result(self, _result: ToolCallingTurnResult) -> None:
             return None
 
-        def finalize(self, result: ShellTurnResult) -> ShellTurnResult:
+        def finalize(self, result: TurnResult) -> TurnResult:
             return result
 
     session = Session(storage=InMemorySessionStorage())

--- a/tests/core/agent_harness/test_default_headless_agent.py
+++ b/tests/core/agent_harness/test_default_headless_agent.py
@@ -9,7 +9,7 @@ from rich.console import Console
 
 from core.agent_harness.turns.default_headless_agent import build_default_headless_agent
 from core.agent_harness.turns.headless_adapters import BufferOutputSink
-from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 
 
 def test_build_default_headless_agent_sets_gateway_surface() -> None:
@@ -60,7 +60,7 @@ def test_factory_and_sink_are_package_level_exports() -> None:
 
 
 def test_primary_response_text_prefers_assistant() -> None:
-    result = ShellTurnResult(
+    result = TurnResult(
         final_intent="ok",
         action_result=ToolCallingTurnResult(
             planned_count=0,
@@ -74,7 +74,7 @@ def test_primary_response_text_prefers_assistant() -> None:
         llm_run=object(),
     )
     assert result.primary_response_text == "from assistant"
-    empty_assistant = ShellTurnResult(
+    empty_assistant = TurnResult(
         final_intent="ok",
         action_result=ToolCallingTurnResult(
             planned_count=0,

--- a/tests/core/agent_harness/test_dispatch_message.py
+++ b/tests/core/agent_harness/test_dispatch_message.py
@@ -10,7 +10,7 @@ from core.agent_harness.turns.headless_dispatch import (
     NullToolProvider,
     StaticReasoningClientProvider,
 )
-from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 
 
 class _Echo:
@@ -42,9 +42,9 @@ def test_dispatch_message_reuses_attached_agent(monkeypatch: Any) -> None:
     calls: list[str] = []
 
     class _Agent:
-        def dispatch(self, message: str) -> ShellTurnResult:
+        def dispatch(self, message: str) -> TurnResult:
             calls.append(message)
-            return ShellTurnResult(
+            return TurnResult(
                 final_intent="cli_agent_handled",
                 action_result=_empty_action(),
                 assistant_response_text=f"ok:{message}",

--- a/tests/integrations/sentry/test_morning_digest_runner.py
+++ b/tests/integrations/sentry/test_morning_digest_runner.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from integrations.sentry.morning_digest_runner import (
     build_morning_digest_prompt,
     run_sentry_morning_digest,
@@ -50,7 +50,7 @@ class TestRunSentryMorningDigest:
         )
         monkeypatch.setattr(
             "integrations.sentry.morning_digest_runner._dispatch_headless_turn",
-            lambda _message, _payload: ShellTurnResult(
+            lambda _message, _payload: TurnResult(
                 final_intent="chat",
                 action_result=ToolCallingTurnResult(
                     planned_count=0,
@@ -74,7 +74,7 @@ class TestRunSentryMorningDigest:
         )
         monkeypatch.setattr(
             "integrations.sentry.morning_digest_runner._dispatch_headless_turn",
-            lambda _message, _payload: ShellTurnResult(
+            lambda _message, _payload: TurnResult(
                 final_intent="chat",
                 action_result=ToolCallingTurnResult(
                     planned_count=1,

--- a/tests/interactive_shell/runtime/test_turn_accounting.py
+++ b/tests/interactive_shell/runtime/test_turn_accounting.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.agent_harness.accounting.token_accounting import LlmRunInfo
-from core.agent_harness.turns.turn_results import ShellTurnResult, ToolCallingTurnResult
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from surfaces.interactive_shell.runtime.core.turn_accounting import ShellTurnAccounting
 from surfaces.interactive_shell.session import Session
 
@@ -26,8 +26,8 @@ class _FakeRecorder:
         self.flushed += 1
 
 
-def _result(*, llm_run: Any | None = None, text: str = "done") -> ShellTurnResult:
-    return ShellTurnResult(
+def _result(*, llm_run: Any | None = None, text: str = "done") -> TurnResult:
+    return TurnResult(
         final_intent="slash",
         action_result=ToolCallingTurnResult(
             planned_count=0,

--- a/tools/system/python_execution_tool/__init__.py
+++ b/tools/system/python_execution_tool/__init__.py
@@ -18,6 +18,12 @@ _RUNTIME_FACT_KEYS = ", ".join((*STATIC_FACT_KEYS, *LIVE_FACT_KEYS))
 _NEVER_RUN = ", ".join(f"`{command}`" for command in BLOCKED_INTROSPECTION_COMMANDS)
 
 
+_RUNTIME_FACTS_ANTI_EXAMPLE = (
+    "Calling this tool only to read inputs['opensre_runtime'] — runtime facts "
+    "(version, PID, host, cloud, disk, memory, tools) are already in the environment block"
+)
+
+
 class PythonExecutionTool(BaseTool):
     """Run generated Python code with structured inputs and approved credentials."""
 
@@ -51,8 +57,7 @@ class PythonExecutionTool(BaseTool):
         "List scratchpad files with pathlib; read disk/memory with psutil (no ls/df/free)",
     ]
     anti_examples = [
-        "Calling this tool only to read inputs['opensre_runtime'] — runtime facts "
-        "(version, PID, host, cloud, disk, memory, tools) are already in the environment block",
+        _RUNTIME_FACTS_ANTI_EXAMPLE,
         "Changing local files or shelling out to other processes",
         f"Calling {', '.join(BLOCKED_INTROSPECTION_COMMANDS)} (all blocked by the sandbox)",
         "Probing cloud instance metadata over the network (use the injected cloud facts)",

--- a/tools/system/python_execution_tool/__init__.py
+++ b/tools/system/python_execution_tool/__init__.py
@@ -31,8 +31,11 @@ class PythonExecutionTool(BaseTool):
         "Execute generated Python code in a restricted subprocess, capture stdout, stderr, "
         "exceptions, and timeout state, and return the result to the agent. Network access is "
         "blocked by default; opt in only for approved API-backed analysis. Subprocess spawning "
-        "is always blocked — for runtime facts read `inputs['opensre_runtime']` (injected "
-        f"automatically with: {_RUNTIME_FACT_KEYS}). For filesystem introspection use pure "
+        "is always blocked. Runtime facts "
+        f"({_RUNTIME_FACT_KEYS}) are already stated in the conversation's environment block — "
+        "answer them from there directly and never call this tool just to re-read them; code "
+        "already running for another reason can reuse them via `inputs['opensre_runtime']` "
+        "(injected automatically). For filesystem introspection use pure "
         "Python: `pathlib.Path(...).iterdir()` to list directories, "
         "`Path('/etc/hostname').read_text()` for the pod name, `psutil.disk_usage('/')` and "
         "`psutil.virtual_memory()` for disk/memory. "
@@ -44,10 +47,12 @@ class PythonExecutionTool(BaseTool):
         "Compute metrics or summaries from structured evidence already in context",
         "Run a small API-backed calculation with approved credentials",
         "Parse logs or JSON payloads when a direct tool result needs post-processing",
-        "Read runtime facts (version, time, uptime, PID, cloud, kubeconfig, tools) via inputs['opensre_runtime']",
+        "Reuse inputs['opensre_runtime'] inside code that is already computing something else",
         "List scratchpad files with pathlib; read disk/memory with psutil (no ls/df/free)",
     ]
     anti_examples = [
+        "Calling this tool only to read inputs['opensre_runtime'] — runtime facts "
+        "(version, PID, host, cloud, disk, memory, tools) are already in the environment block",
         "Changing local files or shelling out to other processes",
         f"Calling {', '.join(BLOCKED_INTROSPECTION_COMMANDS)} (all blocked by the sandbox)",
         "Probing cloud instance metadata over the network (use the injected cloud facts)",


### PR DESCRIPTION
Follow-on to the entry-point work. The theme is names and narrative: someone reading this code for the first time should be able to follow how a process starts and how a request becomes an answer, without decoding jargon or chasing aliases.

**Gateway boot is one named step.** `start_gateway` opened with thirteen statements of process setup — harness construction, env resolution, adapter registration, Sentry, capability probes, LLM preload — before any gateway work.
None of it is gateway logic, and the ordering constraints between the steps survived only as inline comments inside a lifecycle method. They now live in `gateway/runtime/startup.py`, whose docstring states why the order is load-bearing: env before adapters (hydration can need env credentials), adapters before preload (the snapshot must see the registered set). `start_gateway` reads as a lifecycle again:

```python

logger = self.logger = configure_logging()
set_ready(False)
bootstrap = self._load_credentials(logger)
startup.run(logger)

```