### PR TITLE
refactor: unify ForegroundInvestigationStatus as a StrEnum

### DIFF
--- a/surfaces/interactive_shell/ui/foreground_investigation.py
+++ b/surfaces/interactive_shell/ui/foreground_investigation.py
@@ -16,6 +16,7 @@ from platform.common.task_types import TaskKind, TaskRecord
 from platform.observability.trace.spans import mark_span_outcome, traced_session
 from platform.terminal.theme import DIM, ERROR, WARNING
 from surfaces.interactive_shell.ui.investigation_outcome import (
+    ForegroundInvestigationStatus,
     InvestigationOutcome,
     classify_investigation_failure,
     failure_detail_from_exception,
@@ -119,7 +120,7 @@ def _run_foreground_investigation_body(
         task.mark_cancelled()
         console.print(f"[{WARNING}]investigation cancelled.[/]")
         return InvestigationOutcome(
-            status="cancelled",
+            status=ForegroundInvestigationStatus.CANCELLED,
             target=normalized_target,
             investigation_id=str(getattr(session, "last_investigation_id", "") or ""),
             failure_category="user_cancelled",
@@ -135,7 +136,7 @@ def _run_foreground_investigation_body(
             console.print(f"[{WARNING}]suggestion:[/] {escape(exc.suggestion)}")
         category, integration, integration_detail = classify_investigation_failure(exc)
         return InvestigationOutcome(
-            status="failed",
+            status=ForegroundInvestigationStatus.FAILED,
             target=normalized_target,
             investigation_id=str(getattr(session, "last_investigation_id", "") or ""),
             error_message=user_facing_error_message(exc),
@@ -153,7 +154,7 @@ def _run_foreground_investigation_body(
         _render_credit_exhausted_recovery_hint(console, message)
         category, integration, integration_detail = classify_investigation_failure(exc)
         return InvestigationOutcome(
-            status="failed",
+            status=ForegroundInvestigationStatus.FAILED,
             target=normalized_target,
             investigation_id=str(getattr(session, "last_investigation_id", "") or ""),
             error_message=user_facing_error_message(exc),
@@ -185,7 +186,7 @@ def _run_foreground_investigation_body(
         restore_stdin_terminal()
         prompt_investigation_feedback(final_state)
     return InvestigationOutcome(
-        status="completed",
+        status=ForegroundInvestigationStatus.COMPLETED,
         target=normalized_target,
         investigation_id=str(getattr(session, "last_investigation_id", "") or ""),
         final_state=final_state,

--- a/surfaces/interactive_shell/ui/investigation_outcome.py
+++ b/surfaces/interactive_shell/ui/investigation_outcome.py
@@ -9,8 +9,8 @@ from pathlib import Path
 from typing import Any, Literal
 
 from platform.common.errors import OpenSREError
+from tools.interactive_shell.shared.investigation_launch import ForegroundInvestigationStatus
 
-InvestigationStatus = Literal["completed", "failed", "cancelled"]
 FailureCategory = Literal[
     "config",
     "integration",
@@ -46,7 +46,7 @@ _INTEGRATION_KEYWORDS: tuple[tuple[str, str], ...] = (
 class InvestigationOutcome:
     """Facts from one foreground investigation run."""
 
-    status: InvestigationStatus
+    status: ForegroundInvestigationStatus
     target: str = ""
     investigation_id: str = ""
     final_state: dict[str, Any] | None = None
@@ -150,8 +150,8 @@ def user_facing_error_message(exc: BaseException, *, max_lines: int = 3) -> str:
 
 __all__ = [
     "FailureCategory",
+    "ForegroundInvestigationStatus",
     "InvestigationOutcome",
-    "InvestigationStatus",
     "classify_investigation_failure",
     "failure_detail_from_exception",
     "normalize_investigation_target",

--- a/tools/interactive_shell/shared/investigation_launch.py
+++ b/tools/interactive_shell/shared/investigation_launch.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Literal, Protocol, runtime_checkable
+from enum import StrEnum
+from typing import Any, Protocol, runtime_checkable
 
 from rich.console import Console
 from rich.markup import escape
@@ -22,7 +23,22 @@ from tools.interactive_shell.shared.execution_policy import (
     plan_foreground_tool,
 )
 
-ForegroundInvestigationStatus = Literal["completed", "failed", "cancelled"]
+
+class ForegroundInvestigationStatus(StrEnum):
+    """Terminal outcome of one foreground REPL/UI investigation run.
+
+    Distinct from ``gateway.http.investigation_store.InvestigationStatus``,
+    which tracks a different state machine (the async gateway job lifecycle,
+    including in-flight ``QUEUED``/``RUNNING`` states this one never has).
+    Do not merge the two. Canonical definition lives here (``tools/``, tier 2)
+    rather than in ``surfaces/interactive_shell/ui/investigation_outcome.py``
+    (tier 1) because tier 2 may not import tier 1 (see docs/ARCHITECTURE.md);
+    ``investigation_outcome.py`` re-exports this instead of duplicating it.
+    """
+
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
 
 
 class InvestigationSession(Protocol):

--- a/tools/interactive_shell/shared/investigation_launch.py
+++ b/tools/interactive_shell/shared/investigation_launch.py
@@ -197,6 +197,7 @@ def launch_investigation(
 
 __all__ = [
     "ForegroundInvestigationResult",
+    "ForegroundInvestigationStatus",
     "InvestigationLaunchPorts",
     "InvestigationSession",
     "launch_investigation",


### PR DESCRIPTION
Fixes #4529

**Design-sensitive per the issue's own note - please coordinate/confirm before merging.**

#### Describe the changes you have made in this PR -

Unifies the duplicated foreground-investigation status vocabulary into one `ForegroundInvestigationStatus(StrEnum)` with the same three values (`completed`/`failed`/`cancelled`), replacing two separate `Literal["completed", "failed", "cancelled"]` aliases that were passed directly between each other (`investigation_adapter.py` does `ForegroundInvestigationResult(status=outcome.status)`).

The canonical definition lives in `tools/interactive_shell/shared/investigation_launch.py` (tier 2), not `investigation_outcome.py` (tier 1/`surfaces`), because `docs/ARCHITECTURE.md`'s CI-enforced layer rule forbids tier 2 importing tier 1. `investigation_outcome.py` imports and re-exports it instead. Also updated the four `InvestigationOutcome(status=...)` construction sites in `foreground_investigation.py` to use enum members (mypy doesn't coerce plain string literals to a StrEnum-typed field, even though they'd compare equal at runtime).

`gateway/http/investigation_store.py`'s `InvestigationStatus` (async job lifecycle: `queued`/`running`/`completed`/`failed`) is completely untouched - confirmed via `make check-imports` and by grepping for any import path connecting the two; they only ever shared a class name, not code. `FailureCategory` left as `Literal` per the issue's optional scope. No string values renamed.

### Demo/Screenshot for feature changes and bug fixes -

```
$ make lint && make typecheck && make check-imports
All checks passed! / Success: no issues found in 1477 source files / All 3 import checks passed.

$ uv run pytest tests/interactive_shell/ tests/tools/ gateway/tests/ -q
4147 + 24 passed, 2 skipped
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

First traced every usage of both `Literal` aliases to confirm they really were the same concept passed between modules (`investigation_adapter.py:256`), and separately confirmed zero import path connects to `gateway/http/investigation_store.py`'s `InvestigationStatus`. My first attempt defined the shared enum in `investigation_outcome.py` (surfaces/) and had `investigation_launch.py` (tools/) import it - `make check-imports` caught that this violates the tier-2-must-not-import-tier-1 rule, so I flipped it: the enum now lives in `tools/`, and `surfaces/` (which is allowed to import `tools/`) re-exports it. Construction call sites using plain string literals only needed updating in one production file (`foreground_investigation.py`); per this repo's AGENTS.md, `make typecheck` doesn't cover `tests/`, so the ~15 test files constructing with `status="completed"` etc. don't need touching and keep passing at runtime since `StrEnum` subclasses `str`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
