### PR TITLE
Separate the tenant organization id from the billing organization id, and extract CLI process startup

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -298,6 +298,11 @@ from config.constants.temporal import (
     TEMPORAL_BASE_URL_ENV,
     TEMPORAL_NAMESPACE_ENV,
 )
+from config.constants.tenancy import (
+    CREDENTIALS_API_URL_ENV,
+    CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV,
+    TENANT_ORGANIZATION_ID_ENV,
+)
 from config.constants.tracer import TRACER_BASE_URL_ENV, TRACER_JWT_TOKEN_ENV
 from config.constants.twilio import (
     TWILIO_ACCOUNT_SID_ENV,
@@ -461,6 +466,9 @@ __all__ = [
     "OPENSRE_MEMORY_GATEWAY_ENABLED_ENV",
     "OPENSRE_TMP_DIR",
     "ORGANIZATION_ID_ENV",
+    "TENANT_ORGANIZATION_ID_ENV",
+    "CREDENTIALS_API_URL_ENV",
+    "CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV",
     "ORGS_DIR_NAME",
     "PAGERDUTY_API_KEY_ENV",
     "PAGERDUTY_BASE_URL_ENV",

--- a/config/constants/billing.py
+++ b/config/constants/billing.py
@@ -7,6 +7,12 @@ from typing import Final
 # Injected by the org-silo infra (ECS task definition). Metering/vault stay off
 # unless the webapp URL, an auth token, and the org id are all set.
 WEBAPP_URL_ENV: Final[str] = "OPENSRE_WEBAPP_URL"
+
+#: The organization this deployment serves, for usage attribution and for the
+#: fail-closed mount-ownership check in ``config.constants.paths``. Not the
+#: control plane's ``ORGANIZATION_ID``
+#: (``config.constants.tenancy.TENANT_ORGANIZATION_ID_ENV``) — that one selects
+#: which tenant's credentials to hydrate, and the two must not be merged.
 ORGANIZATION_ID_ENV: Final[str] = "OPENSRE_ORGANIZATION_ID"
 
 # Silo → webapp auth. The silo mints a short-lived M2M token (`mt_…`) from its

--- a/config/constants/tenancy.py
+++ b/config/constants/tenancy.py
@@ -1,0 +1,33 @@
+"""Env names the multi-tenant control plane injects into a gateway silo.
+
+A silo is one gateway task serving one tenant. The control plane's ECS task
+definition supplies these three so the gateway can say who it is and fetch that
+tenant's credentials at startup.
+
+Distinct from :data:`config.constants.billing.ORGANIZATION_ID_ENV`
+(``OPENSRE_ORGANIZATION_ID``), which the product reads to attribute usage and to
+enforce that a mounted context volume belongs to the organization being served.
+Both name an organization, but different systems set them and neither may stand
+in for the other: reading the billing name here fails hydration in a deployed
+silo, and falling back to this one there would weaken a fail-closed ownership
+check.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+#: The tenant this silo serves, assigned by the control plane.
+TENANT_ORGANIZATION_ID_ENV: Final[str] = "ORGANIZATION_ID"
+
+#: Where the gateway exchanges its identity for the tenant's credentials.
+CREDENTIALS_API_URL_ENV: Final[str] = "OPENSRE_CREDENTIALS_API_URL"
+
+#: Secrets Manager ARN holding this tenant's bootstrap bundle.
+CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV: Final[str] = "OPENSRE_CREDENTIALS_BOOTSTRAP_SECRET_ARN"
+
+__all__ = [
+    "CREDENTIALS_API_URL_ENV",
+    "CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV",
+    "TENANT_ORGANIZATION_ID_ENV",
+]

--- a/gateway/runtime/credential_hydration.py
+++ b/gateway/runtime/credential_hydration.py
@@ -7,9 +7,9 @@ import os
 from dataclasses import dataclass, replace
 from typing import Any, Protocol
 
+from config.constants.billing import ORGANIZATION_ID_ENV
 from integrations.credentials_api import CredentialsApiClient, hydrate_integration_store
 
-_ORGANIZATION_ID = "ORGANIZATION_ID"
 _API_URL = "OPENSRE_CREDENTIALS_API_URL"
 _SECRET_ARN = "OPENSRE_CREDENTIALS_BOOTSTRAP_SECRET_ARN"
 
@@ -42,7 +42,7 @@ class CredentialHydrationConfig:
     def from_environment(cls) -> CredentialHydrationConfig | None:
         """Return ``None`` when disabled, and reject partial configuration."""
         required_values = {
-            _ORGANIZATION_ID: os.getenv(_ORGANIZATION_ID, "").strip(),
+            ORGANIZATION_ID_ENV: os.getenv(ORGANIZATION_ID_ENV, "").strip(),
             _SECRET_ARN: os.getenv(_SECRET_ARN, "").strip(),
         }
         credentials_api_url = os.getenv(_API_URL, "").strip()
@@ -54,7 +54,7 @@ class CredentialHydrationConfig:
         if credentials_api_url and not credentials_api_url.lower().startswith("https://"):
             raise ValueError("Credentials API URL must use HTTPS")
         return cls(
-            organization_id=required_values[_ORGANIZATION_ID],
+            organization_id=required_values[ORGANIZATION_ID_ENV],
             credentials_api_url=credentials_api_url or None,
             bootstrap_secret_arn=required_values[_SECRET_ARN],
         )

--- a/gateway/runtime/credential_hydration.py
+++ b/gateway/runtime/credential_hydration.py
@@ -7,11 +7,12 @@ import os
 from dataclasses import dataclass, replace
 from typing import Any, Protocol
 
-from config.constants.billing import ORGANIZATION_ID_ENV
+from config.constants.tenancy import (
+    CREDENTIALS_API_URL_ENV,
+    CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV,
+    TENANT_ORGANIZATION_ID_ENV,
+)
 from integrations.credentials_api import CredentialsApiClient, hydrate_integration_store
-
-_API_URL = "OPENSRE_CREDENTIALS_API_URL"
-_SECRET_ARN = "OPENSRE_CREDENTIALS_BOOTSTRAP_SECRET_ARN"
 
 
 class SecretsManagerClient(Protocol):
@@ -42,10 +43,12 @@ class CredentialHydrationConfig:
     def from_environment(cls) -> CredentialHydrationConfig | None:
         """Return ``None`` when disabled, and reject partial configuration."""
         required_values = {
-            ORGANIZATION_ID_ENV: os.getenv(ORGANIZATION_ID_ENV, "").strip(),
-            _SECRET_ARN: os.getenv(_SECRET_ARN, "").strip(),
+            TENANT_ORGANIZATION_ID_ENV: os.getenv(TENANT_ORGANIZATION_ID_ENV, "").strip(),
+            CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV: os.getenv(
+                CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV, ""
+            ).strip(),
         }
-        credentials_api_url = os.getenv(_API_URL, "").strip()
+        credentials_api_url = os.getenv(CREDENTIALS_API_URL_ENV, "").strip()
         if not any(required_values.values()) and not credentials_api_url:
             return None
         missing = [name for name, value in required_values.items() if not value]
@@ -54,9 +57,9 @@ class CredentialHydrationConfig:
         if credentials_api_url and not credentials_api_url.lower().startswith("https://"):
             raise ValueError("Credentials API URL must use HTTPS")
         return cls(
-            organization_id=required_values[ORGANIZATION_ID_ENV],
+            organization_id=required_values[TENANT_ORGANIZATION_ID_ENV],
             credentials_api_url=credentials_api_url or None,
-            bootstrap_secret_arn=required_values[_SECRET_ARN],
+            bootstrap_secret_arn=required_values[CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV],
         )
 
 

--- a/gateway/runtime/manager.py
+++ b/gateway/runtime/manager.py
@@ -23,7 +23,7 @@ from typing import Any
 
 from rich.console import Console
 
-from config.constants.billing import ORGANIZATION_ID_ENV
+from config.constants.tenancy import TENANT_ORGANIZATION_ID_ENV
 from gateway.config.logging_config import configure_logging
 from gateway.discord.background import DiscordGatewayBackground
 from gateway.discord.wiring import start_discord_worker
@@ -259,7 +259,7 @@ class GatewayManager:
         bootstrap: GatewayBootstrap | None,
     ) -> None:
         """Start the Neon run worker when a bootstrap bundle supplies its DSN."""
-        organization_id = os.getenv(ORGANIZATION_ID_ENV, "").strip()
+        organization_id = os.getenv(TENANT_ORGANIZATION_ID_ENV, "").strip()
         database_url = bootstrap.database_url if bootstrap is not None else None
         if not organization_id or not database_url:
             self.components["api_runs"] = "not configured"

--- a/gateway/runtime/manager.py
+++ b/gateway/runtime/manager.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from rich.console import Console
 
+from config.constants.billing import ORGANIZATION_ID_ENV
 from gateway.config.logging_config import configure_logging
 from gateway.discord.background import DiscordGatewayBackground
 from gateway.discord.wiring import start_discord_worker
@@ -258,7 +259,7 @@ class GatewayManager:
         bootstrap: GatewayBootstrap | None,
     ) -> None:
         """Start the Neon run worker when a bootstrap bundle supplies its DSN."""
-        organization_id = os.getenv("ORGANIZATION_ID", "").strip()
+        organization_id = os.getenv(ORGANIZATION_ID_ENV, "").strip()
         database_url = bootstrap.database_url if bootstrap is not None else None
         if not organization_id or not database_url:
             self.components["api_runs"] = "not configured"

--- a/gateway/tests/conftest.py
+++ b/gateway/tests/conftest.py
@@ -3,12 +3,32 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 
 from config.platform_bootstrap import ensure_project_platform_package
 
 ensure_project_platform_package()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_gateway_runtime_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep every gateway test off the developer's real ``~/.opensre/gateway``.
+
+    ``GatewayManager.stop()`` clears the component status file, and
+    ``start_gateway`` rewrites the pidfile. Both resolve through module globals
+    captured at import time, so the root ``OPENSRE_HOME_DIR`` override does not
+    reach them: a unit test that merely constructs a manager and stops it
+    deleted the status file of the daemon actually running on the machine,
+    leaving ``opensre gateway status`` blank until the next restart.
+    """
+    from gateway.runtime import daemon
+
+    runtime_dir = tmp_path / "gateway"
+    monkeypatch.setattr(daemon, "GATEWAY_PID_FILE", runtime_dir / "gateway.pid")
+    monkeypatch.setattr(daemon, "GATEWAY_LOG_FILE", runtime_dir / "gateway.log")
+    monkeypatch.setattr(daemon, "GATEWAY_COMPONENTS_FILE", runtime_dir / "components.json")
 
 
 @pytest.fixture(autouse=True)

--- a/gateway/tests/runtime/test_credential_hydration.py
+++ b/gateway/tests/runtime/test_credential_hydration.py
@@ -10,7 +10,11 @@ from typing import Any
 
 import pytest
 
-from config.constants.billing import ORGANIZATION_ID_ENV
+from config.constants.tenancy import (
+    CREDENTIALS_API_URL_ENV,
+    CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV,
+    TENANT_ORGANIZATION_ID_ENV,
+)
 from gateway.runtime.credential_hydration import (
     CredentialHydrationConfig,
     GatewayCredentialHydrator,
@@ -106,9 +110,9 @@ def test_hydrates_exact_secret_and_atomically_writes_private_v2_store(
 def test_partial_environment_configuration_is_rejected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org-a")
-    monkeypatch.delenv("OPENSRE_CREDENTIALS_API_URL", raising=False)
-    monkeypatch.delenv("OPENSRE_CREDENTIALS_BOOTSTRAP_SECRET_ARN", raising=False)
+    monkeypatch.setenv(TENANT_ORGANIZATION_ID_ENV, "org-a")
+    monkeypatch.delenv(CREDENTIALS_API_URL_ENV, raising=False)
+    monkeypatch.delenv(CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV, raising=False)
 
     with pytest.raises(ValueError, match="incomplete"):
         CredentialHydrationConfig.from_environment()

--- a/gateway/tests/runtime/test_credential_hydration.py
+++ b/gateway/tests/runtime/test_credential_hydration.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import pytest
 
+from config.constants.billing import ORGANIZATION_ID_ENV
 from gateway.runtime.credential_hydration import (
     CredentialHydrationConfig,
     GatewayCredentialHydrator,
@@ -105,7 +106,7 @@ def test_hydrates_exact_secret_and_atomically_writes_private_v2_store(
 def test_partial_environment_configuration_is_rejected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("ORGANIZATION_ID", "org-a")
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org-a")
     monkeypatch.delenv("OPENSRE_CREDENTIALS_API_URL", raising=False)
     monkeypatch.delenv("OPENSRE_CREDENTIALS_BOOTSTRAP_SECRET_ARN", raising=False)
 

--- a/gateway/tests/runtime/test_manager.py
+++ b/gateway/tests/runtime/test_manager.py
@@ -28,3 +28,26 @@ def test_wait_blocks_until_stop_not_telegram_thread_exit() -> None:
 
     manager.stop()
     assert manager.wait(timeout=0.01) is True
+
+
+def test_manager_stop_never_touches_the_real_gateway_directory() -> None:
+    """Stopping a manager must not clear the running daemon's status file.
+
+    ``stop()`` calls ``clear_component_status()``, which resolves a module
+    global captured at import time. Without the isolation fixture in
+    ``gateway/tests/conftest.py`` this test deleted
+    ``~/.opensre/gateway/components.json`` on the developer's machine.
+    """
+    # Arrange
+    from pathlib import Path
+
+    from gateway.runtime import daemon
+
+    real_gateway_dir = Path.home() / ".opensre" / "gateway"
+
+    # Act
+    GatewayManager().stop()
+
+    # Assert
+    assert real_gateway_dir not in daemon.GATEWAY_COMPONENTS_FILE.parents
+    assert real_gateway_dir not in daemon.GATEWAY_PID_FILE.parents

--- a/gateway/tests/runtime/test_organization_id_env.py
+++ b/gateway/tests/runtime/test_organization_id_env.py
@@ -1,0 +1,52 @@
+"""Gateway reads the organization id the infra actually injects.
+
+``config.constants.billing`` defines ``ORGANIZATION_ID_ENV`` as
+``OPENSRE_ORGANIZATION_ID`` and documents it as "injected by the org-silo infra
+(ECS task definition)". Two gateway call sites read a bare ``ORGANIZATION_ID``
+instead, so on a real deployment they find nothing and degrade silently —
+credential hydration stays off and the Neon run worker reports
+``api_runs: not configured`` with no error.
+
+Its sibling variables in the same bootstrap family
+(``OPENSRE_CREDENTIALS_API_URL``, ``OPENSRE_CREDENTIALS_BOOTSTRAP_SECRET_ARN``)
+are both prefixed, which is what marks the bare name as the odd one out rather
+than a deliberate control-plane convention.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from config.constants.billing import ORGANIZATION_ID_ENV
+
+
+def test_credential_hydration_reads_the_injected_variable(monkeypatch: Any) -> None:
+    # Arrange
+    from gateway.runtime.credential_hydration import CredentialHydrationConfig
+
+    monkeypatch.delenv("ORGANIZATION_ID", raising=False)
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_from_infra")
+    monkeypatch.setenv("OPENSRE_CREDENTIALS_BOOTSTRAP_SECRET_ARN", "arn:aws:secret")
+    monkeypatch.setenv("OPENSRE_CREDENTIALS_API_URL", "https://credentials.example")
+
+    # Act
+    config = CredentialHydrationConfig.from_environment()
+
+    # Assert
+    assert config is not None, "hydration disabled despite the infra-injected org id"
+    assert config.organization_id == "org_from_infra"
+
+
+def test_remote_runs_read_the_injected_variable(monkeypatch: Any) -> None:
+    """The Neon run worker must not report 'not configured' on a real deployment."""
+    # Arrange
+    import gateway.runtime.manager as manager_module
+
+    monkeypatch.delenv("ORGANIZATION_ID", raising=False)
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_from_infra")
+    source = __import__("inspect").getsource(manager_module.GatewayManager._start_remote_runs)
+
+    # Assert: read through the shared constant, not a bare literal.
+    assert '"ORGANIZATION_ID"' not in source, (
+        "reads a bare ORGANIZATION_ID the org-silo infra never sets"
+    )

--- a/gateway/tests/runtime/test_organization_id_env.py
+++ b/gateway/tests/runtime/test_organization_id_env.py
@@ -80,6 +80,20 @@ def test_tenant_id_does_not_satisfy_the_mount_ownership_check(
     assert declared_owner == ""
 
 
+def test_whitespace_is_not_a_tenant_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A blank-but-present tenant id must not build a config.
+
+    Without trimming it reads as set, and hydration would then request another
+    tenant's credentials under an empty organization id.
+    """
+    # Arrange
+    monkeypatch.setenv(TENANT_ORGANIZATION_ID_ENV, "   ")
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="incomplete"):
+        CredentialHydrationConfig.from_environment()
+
+
 def test_hydration_stays_disabled_outside_a_silo(monkeypatch: pytest.MonkeyPatch) -> None:
     """A local run with no silo env at all is not a misconfiguration."""
     # Arrange

--- a/gateway/tests/runtime/test_organization_id_env.py
+++ b/gateway/tests/runtime/test_organization_id_env.py
@@ -1,52 +1,89 @@
-"""Gateway reads the organization id the infra actually injects.
+"""The tenant id and the billing org id are separate env vars.
 
-``config.constants.billing`` defines ``ORGANIZATION_ID_ENV`` as
-``OPENSRE_ORGANIZATION_ID`` and documents it as "injected by the org-silo infra
-(ECS task definition)". Two gateway call sites read a bare ``ORGANIZATION_ID``
-instead, so on a real deployment they find nothing and degrade silently —
-credential hydration stays off and the Neon run worker reports
-``api_runs: not configured`` with no error.
-
-Its sibling variables in the same bootstrap family
-(``OPENSRE_CREDENTIALS_API_URL``, ``OPENSRE_CREDENTIALS_BOOTSTRAP_SECRET_ARN``)
-are both prefixed, which is what marks the bare name as the odd one out rather
-than a deliberate control-plane convention.
+The control plane's ECS task definition supplies ``ORGANIZATION_ID``; the product
+reads ``OPENSRE_ORGANIZATION_ID`` to attribute usage and to enforce that a
+mounted context volume belongs to the organization being served. Reading the
+billing name during hydration crashed startup in a deployed silo and left the
+remote-run worker unstarted, so these tests pin that the gateway reads the
+injected name and that neither var stands in for the other.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import os
+
+import pytest
 
 from config.constants.billing import ORGANIZATION_ID_ENV
+from config.constants.tenancy import (
+    CREDENTIALS_API_URL_ENV,
+    CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV,
+    TENANT_ORGANIZATION_ID_ENV,
+)
+from gateway.runtime.credential_hydration import CredentialHydrationConfig
+
+_BOOTSTRAP_ARN = "arn:aws:secretsmanager:eu-west-2:1:secret:bootstrap"
 
 
-def test_credential_hydration_reads_the_injected_variable(monkeypatch: Any) -> None:
-    # Arrange
-    from gateway.runtime.credential_hydration import CredentialHydrationConfig
+@pytest.fixture(autouse=True)
+def _silo_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start from an unset environment holding only the secret ARN."""
+    for name in (TENANT_ORGANIZATION_ID_ENV, ORGANIZATION_ID_ENV, CREDENTIALS_API_URL_ENV):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv(CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV, _BOOTSTRAP_ARN)
 
-    monkeypatch.delenv("ORGANIZATION_ID", raising=False)
-    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_from_infra")
-    monkeypatch.setenv("OPENSRE_CREDENTIALS_BOOTSTRAP_SECRET_ARN", "arn:aws:secret")
-    monkeypatch.setenv("OPENSRE_CREDENTIALS_API_URL", "https://credentials.example")
+
+def test_env_names_are_distinct() -> None:
+    """The two constants must never collapse onto one spelling."""
+    assert TENANT_ORGANIZATION_ID_ENV == "ORGANIZATION_ID"
+    assert ORGANIZATION_ID_ENV == "OPENSRE_ORGANIZATION_ID"
+
+
+def test_hydration_reads_the_injected_tenant_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A silo configured the way ECS configures it hydrates successfully."""
+    # Arrange: exactly what the control plane injects, and nothing else.
+    monkeypatch.setenv(TENANT_ORGANIZATION_ID_ENV, "org-from-control-plane")
 
     # Act
     config = CredentialHydrationConfig.from_environment()
 
     # Assert
-    assert config is not None, "hydration disabled despite the infra-injected org id"
-    assert config.organization_id == "org_from_infra"
+    assert config is not None
+    assert config.organization_id == "org-from-control-plane"
 
 
-def test_remote_runs_read_the_injected_variable(monkeypatch: Any) -> None:
-    """The Neon run worker must not report 'not configured' on a real deployment."""
+def test_billing_org_id_does_not_satisfy_hydration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Setting only the billing name is incomplete configuration, not a tenant id."""
+    # Arrange: a value distinctive enough to spot if it ever leaks into hydration.
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org-billing-must-not-leak")
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="incomplete"):
+        CredentialHydrationConfig.from_environment()
+
+
+def test_tenant_id_does_not_satisfy_the_mount_ownership_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fail-closed volume check must not see the control plane's value.
+
+    ``config.constants.paths`` refuses a turn when the declared silo owner is
+    absent; accepting the tenant id there would weaken that check.
+    """
     # Arrange
-    import gateway.runtime.manager as manager_module
+    monkeypatch.setenv(TENANT_ORGANIZATION_ID_ENV, "org-from-control-plane")
 
-    monkeypatch.delenv("ORGANIZATION_ID", raising=False)
-    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_from_infra")
-    source = __import__("inspect").getsource(manager_module.GatewayManager._start_remote_runs)
+    # Act
+    declared_owner = os.getenv(ORGANIZATION_ID_ENV, "")
 
-    # Assert: read through the shared constant, not a bare literal.
-    assert '"ORGANIZATION_ID"' not in source, (
-        "reads a bare ORGANIZATION_ID the org-silo infra never sets"
-    )
+    # Assert
+    assert declared_owner == ""
+
+
+def test_hydration_stays_disabled_outside_a_silo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A local run with no silo env at all is not a misconfiguration."""
+    # Arrange
+    monkeypatch.delenv(CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV, raising=False)
+
+    # Act / Assert
+    assert CredentialHydrationConfig.from_environment() is None

--- a/gateway/tests/runtime/test_remote_runs_tenant_env.py
+++ b/gateway/tests/runtime/test_remote_runs_tenant_env.py
@@ -1,0 +1,124 @@
+"""``_start_remote_runs`` identifies the tenant from the injected env var.
+
+This path fails silently: a blank organization id does not raise, it marks
+``api_runs`` "not configured" and returns, so a silo whose runs never execute
+looks healthy. Reading the wrong env name here is therefore invisible without a
+test that pins which name is read.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from config.constants.billing import ORGANIZATION_ID_ENV
+from config.constants.tenancy import TENANT_ORGANIZATION_ID_ENV
+from gateway.runtime.credential_hydration import GatewayBootstrap
+from gateway.runtime.manager import GatewayManager
+
+_DSN = "postgresql://user:pw@neon.example/db"
+
+
+class _RecordingWorker:
+    """Captures the organization id the manager passed to the factory."""
+
+    def __init__(self, organization_id: str) -> None:
+        self.organization_id = organization_id
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+
+def _recording_factory(built: list[_RecordingWorker]) -> Any:
+    def factory(org: str, _dsn: str, _handler: Any, _gate: Any, _log: Any) -> _RecordingWorker:
+        worker = _RecordingWorker(org)
+        built.append(worker)
+        return worker
+
+    return factory
+
+
+@pytest.fixture(autouse=True)
+def _clear_org_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neither organization env var is set unless a test sets it."""
+    for name in (TENANT_ORGANIZATION_ID_ENV, ORGANIZATION_ID_ENV):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _start(manager: GatewayManager) -> None:
+    manager._start_remote_runs(
+        logging.getLogger("test"),
+        object(),
+        GatewayBootstrap(database_url=_DSN),
+    )
+
+
+def test_worker_starts_with_the_injected_tenant_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The tenant id ECS injects reaches the worker, and the worker starts."""
+    # Arrange
+    monkeypatch.setenv(TENANT_ORGANIZATION_ID_ENV, "org-from-control-plane")
+    built: list[_RecordingWorker] = []
+    manager = GatewayManager(remote_run_worker_factory=_recording_factory(built))
+
+    # Act
+    _start(manager)
+
+    # Assert
+    assert [w.organization_id for w in built] == ["org-from-control-plane"]
+    assert built[0].started is True
+    assert manager.components["api_runs"] == "polling"
+
+
+def test_billing_org_id_does_not_start_the_worker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The billing var must not stand in for the tenant id.
+
+    This is the regression: the manager read ``OPENSRE_ORGANIZATION_ID``, which a
+    silo does not set, so the worker never started and nothing said so.
+    """
+    # Arrange: only the billing name is set, with a value that must not leak.
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org-billing-must-not-leak")
+    built: list[_RecordingWorker] = []
+    manager = GatewayManager(remote_run_worker_factory=_recording_factory(built))
+
+    # Act
+    _start(manager)
+
+    # Assert
+    assert built == []
+    assert manager.remote_run_worker is None
+    assert manager.components["api_runs"] == "not configured"
+
+
+def test_blank_tenant_id_leaves_the_worker_unstarted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Whitespace is not an identity."""
+    # Arrange
+    monkeypatch.setenv(TENANT_ORGANIZATION_ID_ENV, "   ")
+    built: list[_RecordingWorker] = []
+    manager = GatewayManager(remote_run_worker_factory=_recording_factory(built))
+
+    # Act
+    _start(manager)
+
+    # Assert
+    assert built == []
+    assert manager.components["api_runs"] == "not configured"
+
+
+def test_tenant_id_without_a_database_url_is_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote runs need both the tenant identity and the bootstrap DSN."""
+    # Arrange
+    monkeypatch.setenv(TENANT_ORGANIZATION_ID_ENV, "org-from-control-plane")
+    built: list[_RecordingWorker] = []
+    manager = GatewayManager(remote_run_worker_factory=_recording_factory(built))
+
+    # Act
+    manager._start_remote_runs(logging.getLogger("test"), object(), GatewayBootstrap())
+
+    # Assert
+    assert built == []
+    assert manager.components["api_runs"] == "not configured"

--- a/surfaces/cli/__main__.py
+++ b/surfaces/cli/__main__.py
@@ -10,7 +10,6 @@ Enable shell tab-completion (add to your shell profile for persistence):
 from __future__ import annotations
 
 import os
-import signal
 import sys
 from contextlib import suppress
 from typing import TYPE_CHECKING
@@ -23,6 +22,7 @@ import click  # noqa: E402
 
 from config.constants.product import RELEASE_STAGE_BANNER  # noqa: E402
 from config.version import get_opensre_version  # noqa: E402
+from surfaces.cli import startup  # noqa: E402
 from surfaces.cli.group import LazyRichGroup, ThemeParamType  # noqa: E402
 from surfaces.cli.invocation import (  # noqa: E402
     ensure_utf8_stdio,
@@ -36,7 +36,6 @@ from surfaces.cli.telemetry import (  # noqa: E402
     capture_cli_invoked,
     capture_exception,
     capture_first_run_if_needed,
-    init_sentry,
     load_structured_error_type,
     render_landing,
     render_structured_error,
@@ -190,34 +189,6 @@ def cli(
     ReplConfig.load(cli_theme=theme)
 
 
-def _install_sigint_handler() -> None:
-    """Handle Ctrl+C between prompts (when prompt_toolkit is not active).
-
-    prompt_toolkit intercepts Ctrl+C internally while a prompt is running, so
-    the key binding in prompt_support.py handles that case.  This SIGINT handler
-    covers everything else: long-running operations, streaming output, etc.
-    """
-
-    def _handler(_signum: int, _frame: object) -> None:
-        from platform.terminal.prompt_support import handle_ctrl_c_press
-
-        handle_ctrl_c_press()
-
-    signal.signal(signal.SIGINT, _handler)
-
-
-def _is_update_invocation(argv: list[str]) -> bool:
-    command_parts = resolve_command_parts(cli, argv)
-    return bool(command_parts) and command_parts[0] == "update"
-
-
-def _sentry_entrypoint_for_invocation(argv: list[str]) -> str:
-    command_parts = resolve_command_parts(cli, argv)
-    if command_parts and command_parts[0] == "debug":
-        return "debug"
-    return "cli"
-
-
 def _should_capture_cli_exception(exc: click.ClickException) -> bool:
     """Return whether a Click error represents an unexpected internal failure."""
     return should_report_exception(exc)
@@ -231,31 +202,7 @@ def main(argv: list[str] | None = None) -> int:
         print_fast_version(cli_argv)
         return 0
 
-    from config.local_env import bootstrap_opensre_env_once
-
-    bootstrap_opensre_env_once(override=False)
-    try:
-        init_sentry(entrypoint=_sentry_entrypoint_for_invocation(cli_argv))
-    except ModuleNotFoundError as exc:
-        if exc.name != "sentry_sdk" or not _is_update_invocation(cli_argv):
-            raise
-    # Wire CLI-flavored implementations into the observability ports
-    # (ProgressTracker, debug_print) so any core code under core/domain,
-    # tools/investigation, utils that calls into the abstractions routes
-    # through the Rich-aware adapters during this process.
-    from surfaces.interactive_shell.ui.output.boundary import (
-        install_product_adapters,
-    )
-
-    install_product_adapters()
-    from platform.terminal.prompt_support import (
-        install_questionary_ctrl_c_double_exit,
-        install_questionary_escape_cancel,
-    )
-
-    install_questionary_escape_cancel()
-    install_questionary_ctrl_c_double_exit()
-    _install_sigint_handler()
+    startup.run(cli, cli_argv)
     StructuredError = load_structured_error_type()
 
     try:

--- a/surfaces/cli/signals.py
+++ b/surfaces/cli/signals.py
@@ -1,0 +1,25 @@
+"""Signal handling for the CLI process."""
+
+from __future__ import annotations
+
+import signal
+
+
+def install_sigint_handler() -> None:
+    """Handle Ctrl+C between prompts (when prompt_toolkit is not active).
+
+    prompt_toolkit intercepts Ctrl+C internally while a prompt is running, so the
+    key binding in ``prompt_support`` covers that case. This handler covers
+    everything else: long-running operations, streaming output, and the gaps
+    between prompts.
+    """
+
+    def _handler(_signum: int, _frame: object) -> None:
+        from platform.terminal.prompt_support import handle_ctrl_c_press
+
+        handle_ctrl_c_press()
+
+    signal.signal(signal.SIGINT, _handler)
+
+
+__all__ = ["install_sigint_handler"]

--- a/surfaces/cli/startup.py
+++ b/surfaces/cli/startup.py
@@ -1,0 +1,79 @@
+"""Everything the CLI process does once, before the Click group runs.
+
+``main()`` is an entrypoint: read argv, invoke the group, map the outcome to an
+exit code. The process-level setup underneath it — loading the env file, error
+reporting, observability adapters, terminal prompt behaviour, signal handling —
+is not argument handling and does not belong there.
+
+Order is load-bearing:
+
+1. **env variables** first, so the Sentry DSN and the no-telemetry opt-out are
+   visible when error reporting initialises;
+2. **error reporting** next, so a failure in any later step is still captured;
+3. **observability adapters** before the group runs, so core code that calls the
+   abstractions during a command routes through the Rich-aware implementations
+   instead of the no-op defaults.
+
+Mirrors :mod:`gateway.runtime.startup`, which does the same job for the gateway
+process. The two differ because a CLI owns a terminal and a gateway does not.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from config.local_env import bootstrap_opensre_env_once
+from platform.observability.errors.sentry import init_sentry
+from platform.terminal.prompt_support import (
+    install_questionary_ctrl_c_double_exit,
+    install_questionary_escape_cancel,
+)
+from surfaces.cli.invocation import resolve_command_parts
+from surfaces.cli.signals import install_sigint_handler
+from surfaces.interactive_shell.ui.output.boundary import install_product_adapters
+
+
+def _first_command(group: Any, argv: list[str]) -> str:
+    """The top-level command name in ``argv``, or "" when none resolves."""
+    parts = resolve_command_parts(group, argv)
+    return parts[0] if parts else ""
+
+
+def sentry_entrypoint_for(group: Any, argv: list[str]) -> str:
+    """Which entrypoint label error reports are tagged with.
+
+    ``debug`` commands are separated so their noise does not mix with real CLI
+    usage in error reporting.
+    """
+    return "debug" if _first_command(group, argv) == "debug" else "cli"
+
+
+def _init_error_reporting(group: Any, argv: list[str], command: str) -> None:
+    """Start error reporting, tolerating a missing SDK only during ``update``.
+
+    ``opensre update`` replaces the installed tree, so ``sentry_sdk`` can be
+    briefly absent mid-upgrade. Anywhere else its absence is a broken install and
+    must surface.
+    """
+    try:
+        init_sentry(entrypoint=sentry_entrypoint_for(group, argv))
+    except ModuleNotFoundError as exc:
+        if exc.name != "sentry_sdk" or command != "update":
+            raise
+
+
+def run(group: Any, argv: list[str]) -> None:
+    """Prepare this process for ``argv``. Safe to call once, before the group."""
+    command = _first_command(group, argv)
+    bootstrap_opensre_env_once(override=False)
+
+    _init_error_reporting(group, argv, command)
+
+    install_product_adapters()
+
+    install_questionary_escape_cancel()
+    install_questionary_ctrl_c_double_exit()
+    install_sigint_handler()
+
+
+__all__ = ["run", "sentry_entrypoint_for"]

--- a/surfaces/cli/startup.py
+++ b/surfaces/cli/startup.py
@@ -22,15 +22,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from config.local_env import bootstrap_opensre_env_once
-from platform.observability.errors.sentry import init_sentry
-from platform.terminal.prompt_support import (
-    install_questionary_ctrl_c_double_exit,
-    install_questionary_escape_cancel,
-)
 from surfaces.cli.invocation import resolve_command_parts
-from surfaces.cli.signals import install_sigint_handler
-from surfaces.interactive_shell.ui.output.boundary import install_product_adapters
+
+# Everything else is imported inside run(). Importing this module must stay
+# cheap: the entry point imports it at module scope, and ``opensre --version``
+# answers before run() is ever called. Pulling questionary/prompt_toolkit up
+# here puts the whole terminal stack in front of that fast path.
 
 
 def _first_command(group: Any, argv: list[str]) -> str:
@@ -55,6 +52,8 @@ def _init_error_reporting(group: Any, argv: list[str], command: str) -> None:
     briefly absent mid-upgrade. Anywhere else its absence is a broken install and
     must surface.
     """
+    from platform.observability.errors.sentry import init_sentry
+
     try:
         init_sentry(entrypoint=sentry_entrypoint_for(group, argv))
     except ModuleNotFoundError as exc:
@@ -64,6 +63,14 @@ def _init_error_reporting(group: Any, argv: list[str], command: str) -> None:
 
 def run(group: Any, argv: list[str]) -> None:
     """Prepare this process for ``argv``. Safe to call once, before the group."""
+    from config.local_env import bootstrap_opensre_env_once
+    from platform.terminal.prompt_support import (
+        install_questionary_ctrl_c_double_exit,
+        install_questionary_escape_cancel,
+    )
+    from surfaces.cli.signals import install_sigint_handler
+    from surfaces.interactive_shell.ui.output.boundary import install_product_adapters
+
     command = _first_command(group, argv)
     bootstrap_opensre_env_once(override=False)
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -13,7 +13,8 @@ from config.constants.product import RELEASE_STAGE
 from config.repl_config import ReplConfig
 from platform.analytics import provider
 from platform.analytics.events import Event
-from surfaces.cli.__main__ import _sentry_entrypoint_for_invocation, main
+from surfaces.cli.__main__ import cli, main
+from surfaces.cli.startup import sentry_entrypoint_for
 
 
 class _EmptyCatalog:
@@ -99,7 +100,7 @@ def test_main_treats_onboard_abort_as_clean_cancel(
     monkeypatch.setattr("surfaces.cli.__main__.capture_first_run_if_needed", lambda: None)
     monkeypatch.setattr("surfaces.cli.__main__.shutdown_analytics", lambda **_kw: None)
     monkeypatch.setattr("surfaces.cli.__main__.capture_cli_invoked", lambda *_args: None)
-    monkeypatch.setattr("surfaces.cli.__main__.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("surfaces.cli.startup.init_sentry", lambda **_kw: None)
     monkeypatch.setattr(
         "surfaces.cli.wizard.flow.run_wizard",
         lambda: (_ for _ in ()).throw(click.Abort()),
@@ -118,7 +119,7 @@ def test_main_allows_update_when_sentry_sdk_missing(monkeypatch, capsys) -> None
     def _raise_missing_sentry(**_kwargs: object) -> None:
         raise ModuleNotFoundError("No module named 'sentry_sdk'", name="sentry_sdk")
 
-    monkeypatch.setattr("surfaces.cli.__main__.init_sentry", _raise_missing_sentry)
+    monkeypatch.setattr("surfaces.cli.startup.init_sentry", _raise_missing_sentry)
     monkeypatch.setattr("surfaces.cli.lifecycle.update._fetch_latest_version", lambda: "9999.0.0")
     monkeypatch.setattr("surfaces.cli.lifecycle.update._is_update_available", lambda _c, _l: False)
 
@@ -134,7 +135,7 @@ def test_main_non_update_still_raises_when_sentry_sdk_missing(monkeypatch) -> No
     def _raise_missing_sentry(**_kwargs: object) -> None:
         raise ModuleNotFoundError("No module named 'sentry_sdk'", name="sentry_sdk")
 
-    monkeypatch.setattr("surfaces.cli.__main__.init_sentry", _raise_missing_sentry)
+    monkeypatch.setattr("surfaces.cli.startup.init_sentry", _raise_missing_sentry)
 
     with pytest.raises(ModuleNotFoundError):
         main(["health"])
@@ -248,7 +249,7 @@ def test_main_debug_sentry_sends_synthetic_event(monkeypatch, capsys) -> None:
     flush_calls: list[int] = []
 
     monkeypatch.setattr(
-        "surfaces.cli.__main__.init_sentry",
+        "surfaces.cli.startup.init_sentry",
         lambda entrypoint=None: root_init_entrypoints.append(entrypoint),
     )
     monkeypatch.setattr("surfaces.cli.__main__.capture_first_run_if_needed", lambda: None)
@@ -282,12 +283,12 @@ def test_main_debug_sentry_sends_synthetic_event(monkeypatch, capsys) -> None:
 
 
 def test_sentry_entrypoint_uses_debug_for_debug_group_invocations() -> None:
-    assert _sentry_entrypoint_for_invocation(["debug", "future-check"]) == "debug"
+    assert sentry_entrypoint_for(cli, ["debug", "future-check"]) == "debug"
 
 
 def test_main_debug_sentry_exits_nonzero_when_disabled(monkeypatch, capsys) -> None:
     debug_module = importlib.import_module("surfaces.cli.commands.debug")
-    monkeypatch.setattr("surfaces.cli.__main__.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("surfaces.cli.startup.init_sentry", lambda **_kw: None)
     monkeypatch.setattr("surfaces.cli.__main__.capture_first_run_if_needed", lambda: None)
     monkeypatch.setattr("surfaces.cli.__main__.capture_cli_invoked", lambda *_args: None)
     monkeypatch.setattr("surfaces.cli.__main__.shutdown_analytics", lambda **_kw: None)
@@ -302,7 +303,7 @@ def test_main_debug_sentry_exits_nonzero_when_disabled(monkeypatch, capsys) -> N
 
 def test_main_debug_sentry_exits_nonzero_when_flush_fails(monkeypatch, capsys) -> None:
     debug_module = importlib.import_module("surfaces.cli.commands.debug")
-    monkeypatch.setattr("surfaces.cli.__main__.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("surfaces.cli.startup.init_sentry", lambda **_kw: None)
     monkeypatch.setattr("surfaces.cli.__main__.capture_first_run_if_needed", lambda: None)
     monkeypatch.setattr("surfaces.cli.__main__.capture_cli_invoked", lambda *_args: None)
     monkeypatch.setattr("surfaces.cli.__main__.shutdown_analytics", lambda **_kw: None)
@@ -334,7 +335,7 @@ def test_main_emits_first_run_install_before_cli_invoked(
     # This test validates analytics event ordering only; avoid real Sentry init
     # side effects (e.g. sdk integration hooks) that are unrelated to the
     # install/cli-invoked event contract.
-    monkeypatch.setattr("surfaces.cli.__main__.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("surfaces.cli.startup.init_sentry", lambda **_kw: None)
     provider.shutdown_analytics(flush=False)
     provider._instance = None
     provider._cached_anonymous_id = None
@@ -655,7 +656,7 @@ def test_main_flushes_analytics_when_events_are_pending(
     calls: list[dict[str, object]] = []
     monkeypatch.setattr("surfaces.cli.__main__.capture_first_run_if_needed", lambda: None)
     monkeypatch.setattr("surfaces.cli.__main__.capture_cli_invoked", lambda *_args: None)
-    monkeypatch.setattr("surfaces.cli.__main__.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("surfaces.cli.startup.init_sentry", lambda **_kw: None)
     monkeypatch.setattr("surfaces.cli.__main__.analytics_needs_flush", lambda: True)
     monkeypatch.setattr(
         "surfaces.cli.__main__.shutdown_analytics",
@@ -675,7 +676,7 @@ def test_main_does_not_block_when_no_events_are_pending(
     calls: list[dict[str, object]] = []
     monkeypatch.setattr("surfaces.cli.__main__.capture_first_run_if_needed", lambda: None)
     monkeypatch.setattr("surfaces.cli.__main__.capture_cli_invoked", lambda *_args: None)
-    monkeypatch.setattr("surfaces.cli.__main__.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("surfaces.cli.startup.init_sentry", lambda **_kw: None)
     monkeypatch.setattr("surfaces.cli.__main__.analytics_needs_flush", lambda: False)
     monkeypatch.setattr(
         "surfaces.cli.__main__.shutdown_analytics",

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -100,7 +100,7 @@ def test_main_treats_onboard_abort_as_clean_cancel(
     monkeypatch.setattr("surfaces.cli.__main__.capture_first_run_if_needed", lambda: None)
     monkeypatch.setattr("surfaces.cli.__main__.shutdown_analytics", lambda **_kw: None)
     monkeypatch.setattr("surfaces.cli.__main__.capture_cli_invoked", lambda *_args: None)
-    monkeypatch.setattr("surfaces.cli.startup.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("platform.observability.errors.sentry.init_sentry", lambda **_kw: None)
     monkeypatch.setattr(
         "surfaces.cli.wizard.flow.run_wizard",
         lambda: (_ for _ in ()).throw(click.Abort()),
@@ -119,7 +119,7 @@ def test_main_allows_update_when_sentry_sdk_missing(monkeypatch, capsys) -> None
     def _raise_missing_sentry(**_kwargs: object) -> None:
         raise ModuleNotFoundError("No module named 'sentry_sdk'", name="sentry_sdk")
 
-    monkeypatch.setattr("surfaces.cli.startup.init_sentry", _raise_missing_sentry)
+    monkeypatch.setattr("platform.observability.errors.sentry.init_sentry", _raise_missing_sentry)
     monkeypatch.setattr("surfaces.cli.lifecycle.update._fetch_latest_version", lambda: "9999.0.0")
     monkeypatch.setattr("surfaces.cli.lifecycle.update._is_update_available", lambda _c, _l: False)
 
@@ -135,7 +135,7 @@ def test_main_non_update_still_raises_when_sentry_sdk_missing(monkeypatch) -> No
     def _raise_missing_sentry(**_kwargs: object) -> None:
         raise ModuleNotFoundError("No module named 'sentry_sdk'", name="sentry_sdk")
 
-    monkeypatch.setattr("surfaces.cli.startup.init_sentry", _raise_missing_sentry)
+    monkeypatch.setattr("platform.observability.errors.sentry.init_sentry", _raise_missing_sentry)
 
     with pytest.raises(ModuleNotFoundError):
         main(["health"])
@@ -249,7 +249,7 @@ def test_main_debug_sentry_sends_synthetic_event(monkeypatch, capsys) -> None:
     flush_calls: list[int] = []
 
     monkeypatch.setattr(
-        "surfaces.cli.startup.init_sentry",
+        "platform.observability.errors.sentry.init_sentry",
         lambda entrypoint=None: root_init_entrypoints.append(entrypoint),
     )
     monkeypatch.setattr("surfaces.cli.__main__.capture_first_run_if_needed", lambda: None)
@@ -288,7 +288,7 @@ def test_sentry_entrypoint_uses_debug_for_debug_group_invocations() -> None:
 
 def test_main_debug_sentry_exits_nonzero_when_disabled(monkeypatch, capsys) -> None:
     debug_module = importlib.import_module("surfaces.cli.commands.debug")
-    monkeypatch.setattr("surfaces.cli.startup.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("platform.observability.errors.sentry.init_sentry", lambda **_kw: None)
     monkeypatch.setattr("surfaces.cli.__main__.capture_first_run_if_needed", lambda: None)
     monkeypatch.setattr("surfaces.cli.__main__.capture_cli_invoked", lambda *_args: None)
     monkeypatch.setattr("surfaces.cli.__main__.shutdown_analytics", lambda **_kw: None)
@@ -303,7 +303,7 @@ def test_main_debug_sentry_exits_nonzero_when_disabled(monkeypatch, capsys) -> N
 
 def test_main_debug_sentry_exits_nonzero_when_flush_fails(monkeypatch, capsys) -> None:
     debug_module = importlib.import_module("surfaces.cli.commands.debug")
-    monkeypatch.setattr("surfaces.cli.startup.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("platform.observability.errors.sentry.init_sentry", lambda **_kw: None)
     monkeypatch.setattr("surfaces.cli.__main__.capture_first_run_if_needed", lambda: None)
     monkeypatch.setattr("surfaces.cli.__main__.capture_cli_invoked", lambda *_args: None)
     monkeypatch.setattr("surfaces.cli.__main__.shutdown_analytics", lambda **_kw: None)
@@ -335,7 +335,7 @@ def test_main_emits_first_run_install_before_cli_invoked(
     # This test validates analytics event ordering only; avoid real Sentry init
     # side effects (e.g. sdk integration hooks) that are unrelated to the
     # install/cli-invoked event contract.
-    monkeypatch.setattr("surfaces.cli.startup.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("platform.observability.errors.sentry.init_sentry", lambda **_kw: None)
     provider.shutdown_analytics(flush=False)
     provider._instance = None
     provider._cached_anonymous_id = None
@@ -656,7 +656,7 @@ def test_main_flushes_analytics_when_events_are_pending(
     calls: list[dict[str, object]] = []
     monkeypatch.setattr("surfaces.cli.__main__.capture_first_run_if_needed", lambda: None)
     monkeypatch.setattr("surfaces.cli.__main__.capture_cli_invoked", lambda *_args: None)
-    monkeypatch.setattr("surfaces.cli.startup.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("platform.observability.errors.sentry.init_sentry", lambda **_kw: None)
     monkeypatch.setattr("surfaces.cli.__main__.analytics_needs_flush", lambda: True)
     monkeypatch.setattr(
         "surfaces.cli.__main__.shutdown_analytics",
@@ -676,7 +676,7 @@ def test_main_does_not_block_when_no_events_are_pending(
     calls: list[dict[str, object]] = []
     monkeypatch.setattr("surfaces.cli.__main__.capture_first_run_if_needed", lambda: None)
     monkeypatch.setattr("surfaces.cli.__main__.capture_cli_invoked", lambda *_args: None)
-    monkeypatch.setattr("surfaces.cli.startup.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("platform.observability.errors.sentry.init_sentry", lambda **_kw: None)
     monkeypatch.setattr("surfaces.cli.__main__.analytics_needs_flush", lambda: False)
     monkeypatch.setattr(
         "surfaces.cli.__main__.shutdown_analytics",

--- a/tests/cli/test_startup.py
+++ b/tests/cli/test_startup.py
@@ -12,26 +12,51 @@ Order is load-bearing and is what these tests pin:
 * observability adapters install **before** the group runs, so core code that
   calls the abstractions during a command routes through the Rich-aware
   implementations rather than the no-op defaults.
+
+Importing this module must also stay cheap — see the fast-version test below.
 """
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from typing import Any
+
+import pytest
 
 from surfaces.cli.__main__ import cli
 
+# Each name is patched where it is defined, because ``run()`` imports it at call
+# time; patching an attribute on ``startup`` would miss the real call.
+_ENV = "config.local_env.bootstrap_opensre_env_once"
+_SENTRY = "platform.observability.errors.sentry.init_sentry"
+_ADAPTERS = "surfaces.interactive_shell.ui.output.boundary.install_product_adapters"
+_ESCAPE = "platform.terminal.prompt_support.install_questionary_escape_cancel"
+_CTRL_C = "platform.terminal.prompt_support.install_questionary_ctrl_c_double_exit"
+_SIGINT = "surfaces.cli.signals.install_sigint_handler"
 
-def test_startup_runs_the_steps_in_the_required_order(monkeypatch: Any) -> None:
+
+def _raise_missing_sentry(**_kwargs: Any) -> None:
+    raise ModuleNotFoundError(name="sentry_sdk")
+
+
+def _silence_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize every side effect so a test can assert one thing."""
+    for target in (_ENV, _ADAPTERS, _ESCAPE, _CTRL_C, _SIGINT):
+        monkeypatch.setattr(target, lambda *_a, **_kw: None)
+
+
+def test_startup_runs_the_steps_in_the_required_order(monkeypatch: pytest.MonkeyPatch) -> None:
     # Arrange
     from surfaces.cli import startup
 
     order: list[str] = []
-    monkeypatch.setattr(startup, "bootstrap_opensre_env_once", lambda **_kw: order.append("env"))
-    monkeypatch.setattr(startup, "init_sentry", lambda **_kw: order.append("sentry"))
-    monkeypatch.setattr(startup, "install_product_adapters", lambda: order.append("adapters"))
-    monkeypatch.setattr(startup, "install_questionary_escape_cancel", lambda: None)
-    monkeypatch.setattr(startup, "install_questionary_ctrl_c_double_exit", lambda: None)
-    monkeypatch.setattr(startup, "install_sigint_handler", lambda: None)
+    monkeypatch.setattr(_ENV, lambda **_kw: order.append("env"))
+    monkeypatch.setattr(_SENTRY, lambda **_kw: order.append("sentry"))
+    monkeypatch.setattr(_ADAPTERS, lambda: order.append("adapters"))
+    monkeypatch.setattr(_ESCAPE, lambda: None)
+    monkeypatch.setattr(_CTRL_C, lambda: None)
+    monkeypatch.setattr(_SIGINT, lambda: None)
 
     # Act
     startup.run(cli, ["doctor"])
@@ -41,40 +66,77 @@ def test_startup_runs_the_steps_in_the_required_order(monkeypatch: Any) -> None:
     assert order.index("sentry") < order.index("adapters"), order
 
 
-def test_missing_sentry_module_is_tolerated_during_update(monkeypatch: Any) -> None:
+def test_missing_sentry_module_is_tolerated_during_update(monkeypatch: pytest.MonkeyPatch) -> None:
     """``opensre update`` must still run when sentry_sdk is being replaced."""
     # Arrange
     from surfaces.cli import startup
 
-    def _raise_missing_sentry(**_kw: Any) -> None:
-        raise ModuleNotFoundError(name="sentry_sdk")
-
-    monkeypatch.setattr(startup, "bootstrap_opensre_env_once", lambda **_kw: None)
-    monkeypatch.setattr(startup, "init_sentry", _raise_missing_sentry)
-    monkeypatch.setattr(startup, "install_product_adapters", lambda: None)
-    monkeypatch.setattr(startup, "install_questionary_escape_cancel", lambda: None)
-    monkeypatch.setattr(startup, "install_questionary_ctrl_c_double_exit", lambda: None)
-    monkeypatch.setattr(startup, "install_sigint_handler", lambda: None)
+    _silence_all(monkeypatch)
+    monkeypatch.setattr(_SENTRY, _raise_missing_sentry)
 
     # Act / Assert — no exception for the update path.
     startup.run(cli, ["update"])
 
 
-def test_missing_sentry_module_still_raises_for_other_commands(monkeypatch: Any) -> None:
+def test_missing_sentry_module_still_raises_for_other_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Outside `update`, a missing sentry_sdk is a real broken install."""
-    import pytest
-
+    # Arrange
     from surfaces.cli import startup
 
-    def _raise_missing_sentry(**_kw: Any) -> None:
-        raise ModuleNotFoundError(name="sentry_sdk")
+    _silence_all(monkeypatch)
+    monkeypatch.setattr(_SENTRY, _raise_missing_sentry)
 
-    monkeypatch.setattr(startup, "bootstrap_opensre_env_once", lambda **_kw: None)
-    monkeypatch.setattr(startup, "init_sentry", _raise_missing_sentry)
-    monkeypatch.setattr(startup, "install_product_adapters", lambda: None)
-    monkeypatch.setattr(startup, "install_questionary_escape_cancel", lambda: None)
-    monkeypatch.setattr(startup, "install_questionary_ctrl_c_double_exit", lambda: None)
-    monkeypatch.setattr(startup, "install_sigint_handler", lambda: None)
-
+    # Act / Assert
     with pytest.raises(ModuleNotFoundError):
         startup.run(cli, ["doctor"])
+
+
+def test_importing_the_entry_point_does_not_load_the_terminal_stack() -> None:
+    """``opensre --version`` must answer before questionary/prompt_toolkit load.
+
+    The entry point imports this module at module scope, so anything imported
+    here lands in front of the fast-version path — a broken or missing terminal
+    dependency would then break ``--version``, which exists precisely to work
+    when the full CLI does not. Run in a clean interpreter because the test
+    session has already imported half the product.
+    """
+    # Arrange
+    probe = (
+        "import sys; import surfaces.cli.__main__; "
+        "print(len([n for n in sys.modules "
+        "if n.split('.')[0] in {'questionary', 'prompt_toolkit'}]))"
+    )
+
+    # Act
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Assert
+    assert result.stdout.strip() == "0", result.stdout
+
+
+def test_fast_version_answers_without_the_terminal_stack() -> None:
+    """The fast path prints a version and still loads no terminal stack."""
+    # Arrange
+    probe = (
+        "import sys; from surfaces.cli.__main__ import main; main(['--version']); "
+        "print('TERMINAL_MODULES', len([n for n in sys.modules "
+        "if n.split('.')[0] in {'questionary', 'prompt_toolkit'}]))"
+    )
+
+    # Act
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Assert
+    assert "TERMINAL_MODULES 0" in result.stdout, result.stdout

--- a/tests/cli/test_startup.py
+++ b/tests/cli/test_startup.py
@@ -1,0 +1,80 @@
+"""CLI process startup: one named step, in a fixed order.
+
+``main()`` opened with eight statements of process setup — env bootstrap, error
+reporting, observability adapters, terminal prompt behaviour, signal handling —
+before invoking the Click group. None of it is CLI-argument logic, and the
+ordering constraints survived only as position in a long function.
+
+Order is load-bearing and is what these tests pin:
+
+* env variables load **before** Sentry, so the DSN and the no-telemetry opt-out
+  are visible when error reporting initialises;
+* observability adapters install **before** the group runs, so core code that
+  calls the abstractions during a command routes through the Rich-aware
+  implementations rather than the no-op defaults.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from surfaces.cli.__main__ import cli
+
+
+def test_startup_runs_the_steps_in_the_required_order(monkeypatch: Any) -> None:
+    # Arrange
+    from surfaces.cli import startup
+
+    order: list[str] = []
+    monkeypatch.setattr(startup, "bootstrap_opensre_env_once", lambda **_kw: order.append("env"))
+    monkeypatch.setattr(startup, "init_sentry", lambda **_kw: order.append("sentry"))
+    monkeypatch.setattr(startup, "install_product_adapters", lambda: order.append("adapters"))
+    monkeypatch.setattr(startup, "install_questionary_escape_cancel", lambda: None)
+    monkeypatch.setattr(startup, "install_questionary_ctrl_c_double_exit", lambda: None)
+    monkeypatch.setattr(startup, "install_sigint_handler", lambda: None)
+
+    # Act
+    startup.run(cli, ["doctor"])
+
+    # Assert
+    assert order.index("env") < order.index("sentry"), order
+    assert order.index("sentry") < order.index("adapters"), order
+
+
+def test_missing_sentry_module_is_tolerated_during_update(monkeypatch: Any) -> None:
+    """``opensre update`` must still run when sentry_sdk is being replaced."""
+    # Arrange
+    from surfaces.cli import startup
+
+    def _raise_missing_sentry(**_kw: Any) -> None:
+        raise ModuleNotFoundError(name="sentry_sdk")
+
+    monkeypatch.setattr(startup, "bootstrap_opensre_env_once", lambda **_kw: None)
+    monkeypatch.setattr(startup, "init_sentry", _raise_missing_sentry)
+    monkeypatch.setattr(startup, "install_product_adapters", lambda: None)
+    monkeypatch.setattr(startup, "install_questionary_escape_cancel", lambda: None)
+    monkeypatch.setattr(startup, "install_questionary_ctrl_c_double_exit", lambda: None)
+    monkeypatch.setattr(startup, "install_sigint_handler", lambda: None)
+
+    # Act / Assert — no exception for the update path.
+    startup.run(cli, ["update"])
+
+
+def test_missing_sentry_module_still_raises_for_other_commands(monkeypatch: Any) -> None:
+    """Outside `update`, a missing sentry_sdk is a real broken install."""
+    import pytest
+
+    from surfaces.cli import startup
+
+    def _raise_missing_sentry(**_kw: Any) -> None:
+        raise ModuleNotFoundError(name="sentry_sdk")
+
+    monkeypatch.setattr(startup, "bootstrap_opensre_env_once", lambda **_kw: None)
+    monkeypatch.setattr(startup, "init_sentry", _raise_missing_sentry)
+    monkeypatch.setattr(startup, "install_product_adapters", lambda: None)
+    monkeypatch.setattr(startup, "install_questionary_escape_cancel", lambda: None)
+    monkeypatch.setattr(startup, "install_questionary_ctrl_c_double_exit", lambda: None)
+    monkeypatch.setattr(startup, "install_sigint_handler", lambda: None)
+
+    with pytest.raises(ModuleNotFoundError):
+        startup.run(cli, ["doctor"])

--- a/tests/cli/test_version_cmd.py
+++ b/tests/cli/test_version_cmd.py
@@ -25,7 +25,7 @@ def test_version_flag_uses_fast_path(monkeypatch, capsys) -> None:
     def fail_bootstrap(*_args, **_kwargs) -> None:
         raise AssertionError("--version should not bootstrap the full CLI")
 
-    monkeypatch.setattr("surfaces.cli.startup.init_sentry", fail_bootstrap)
+    monkeypatch.setattr("platform.observability.errors.sentry.init_sentry", fail_bootstrap)
     monkeypatch.setattr("surfaces.cli.startup.sentry_entrypoint_for", fail_bootstrap)
 
     rc = main(["--version"])

--- a/tests/cli/test_version_cmd.py
+++ b/tests/cli/test_version_cmd.py
@@ -25,8 +25,8 @@ def test_version_flag_uses_fast_path(monkeypatch, capsys) -> None:
     def fail_bootstrap(*_args, **_kwargs) -> None:
         raise AssertionError("--version should not bootstrap the full CLI")
 
-    monkeypatch.setattr("surfaces.cli.__main__.init_sentry", fail_bootstrap)
-    monkeypatch.setattr("surfaces.cli.__main__._sentry_entrypoint_for_invocation", fail_bootstrap)
+    monkeypatch.setattr("surfaces.cli.startup.init_sentry", fail_bootstrap)
+    monkeypatch.setattr("surfaces.cli.startup.sentry_entrypoint_for", fail_bootstrap)
 
     rc = main(["--version"])
 

--- a/tests/config/test_constants.py
+++ b/tests/config/test_constants.py
@@ -21,13 +21,59 @@ def test_billing_env_var_names_are_the_infra_contract() -> None:
     assert billing.CREDITS_HTTP_TIMEOUT_SECONDS == 5.0
 
 
-def test_constants_module_stays_a_leaf() -> None:
-    """``config`` sits at the bottom layer, so the billing constants must not
+def test_tenancy_env_var_names_are_the_infra_contract() -> None:
+    """Pin the control plane's env-var names to the strings its ECS task
+    definition injects — a rename here fails gateway startup in a silo."""
+    # Arrange / Act
+    from config.constants import tenancy
+
+    # Assert
+    assert tenancy.TENANT_ORGANIZATION_ID_ENV == "ORGANIZATION_ID"
+    assert tenancy.CREDENTIALS_API_URL_ENV == "OPENSRE_CREDENTIALS_API_URL"
+    assert (
+        tenancy.CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV == "OPENSRE_CREDENTIALS_BOOTSTRAP_SECRET_ARN"
+    )
+
+
+def test_the_two_organization_ids_never_collapse() -> None:
+    """They name different things and are set by different systems.
+
+    The control plane injects one to select whose credentials to hydrate; the
+    product declares the other for usage attribution and the fail-closed context
+    mount ownership check. Merging them breaks a deployed silo.
+    """
+    # Arrange / Act
+    from config.constants import billing, tenancy
+
+    # Assert
+    assert tenancy.TENANT_ORGANIZATION_ID_ENV != billing.ORGANIZATION_ID_ENV
+
+
+def test_both_organization_ids_are_re_exported() -> None:
+    """Callers may import either from the package root."""
+    # Arrange / Act
+    import config.constants as constants
+
+    # Assert
+    assert constants.TENANT_ORGANIZATION_ID_ENV == "ORGANIZATION_ID"
+    assert constants.ORGANIZATION_ID_ENV == "OPENSRE_ORGANIZATION_ID"
+    for name in (
+        "TENANT_ORGANIZATION_ID_ENV",
+        "ORGANIZATION_ID_ENV",
+        "CREDENTIALS_API_URL_ENV",
+        "CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV",
+    ):
+        assert name in constants.__all__
+
+
+@pytest.mark.parametrize("module", ["billing", "tenancy"])
+def test_constants_module_stays_a_leaf(module: str) -> None:
+    """``config`` sits at the bottom layer, so the constants must not
     reach up into another package — that would form an import cycle."""
     # Arrange / Act
     from pathlib import Path as _Path
 
-    source = _Path("config/constants/billing.py").read_text(encoding="utf-8")
+    source = _Path(f"config/constants/{module}.py").read_text(encoding="utf-8")
 
     # Assert: no upward import of a sibling top-level package.
     for package in ("integrations", "gateway", "core", "platform", "tools", "surfaces"):

--- a/tests/config/test_constants.py
+++ b/tests/config/test_constants.py
@@ -51,10 +51,10 @@ def test_the_two_organization_ids_never_collapse() -> None:
 
 def test_both_organization_ids_are_re_exported() -> None:
     """Callers may import either from the package root."""
-    # Arrange / Act
-    import config.constants as constants
+    # Arrange
+    from config import constants
 
-    # Assert
+    # Act / Assert
     assert constants.TENANT_ORGANIZATION_ID_ENV == "ORGANIZATION_ID"
     assert constants.ORGANIZATION_ID_ENV == "OPENSRE_ORGANIZATION_ID"
     for name in (

--- a/tests/config/test_context_home.py
+++ b/tests/config/test_context_home.py
@@ -13,6 +13,7 @@ import pytest
 from config.constants import paths
 from config.constants.billing import ORGANIZATION_ID_ENV
 from config.constants.memory import OPENSRE_MEMORY_DIR_ENV
+from config.constants.tenancy import TENANT_ORGANIZATION_ID_ENV
 from config.principal import Actor, Principal, StorageScope
 from config.scope_context import bound_storage_scope
 
@@ -177,10 +178,32 @@ def test_mount_serves_its_declared_owner(tmp_path: Path, monkeypatch: pytest.Mon
     mount = tmp_path / "memories"
     monkeypatch.setenv(paths.CONTEXT_ROOT_ENV, str(mount))
     monkeypatch.setenv(ORGANIZATION_ID_ENV, ACME.id)
-    monkeypatch.setenv(ORGANIZATION_ID_ENV, ACME.id)
 
     with bound_storage_scope(_member(ACME, ALICE)):
         assert paths.opensre_home() == mount
+
+
+def test_the_control_plane_tenant_id_cannot_declare_the_mount_owner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only OPENSRE_ORGANIZATION_ID declares the owner.
+
+    The control plane injects ORGANIZATION_ID to select which tenant's
+    credentials to hydrate. Honouring it here would let that value authorize a
+    write to a volume it was never checked against, so the mount must still fail
+    closed on an undeclared owner.
+    """
+    # Arrange: the tenant id names this very org, and is still not a declaration.
+    monkeypatch.setenv(paths.CONTEXT_ROOT_ENV, str(tmp_path / "memories"))
+    monkeypatch.setenv(TENANT_ORGANIZATION_ID_ENV, ACME.id)
+    monkeypatch.delenv(ORGANIZATION_ID_ENV, raising=False)
+
+    # Act / Assert
+    with (
+        bound_storage_scope(_member(ACME, ALICE)),
+        pytest.raises(paths.ContextRootOwnerMismatchError, match="does not say which"),
+    ):
+        paths.opensre_home()
 
 
 def test_mounted_volume_still_separates_users(


### PR DESCRIPTION
Two unrelated env vars both named an "organization" and were being confused for each other. This gives them distinct, purpose-revealing names and pins the separation with tests. Also extracts process-level setup out of the CLI
entrypoint.

`ORGANIZATION_ID` and `OPENSRE_ORGANIZATION_ID` look like two spellings of one thing. They are not:

| | `OPENSRE_ORGANIZATION_ID` | `ORGANIZATION_ID` |
| --- | --- | --- |
| Added by | #4159 (credit/env centralization) | #4476 (multi-tenant Fargate MVP) |
| Set by | the product's own config | the control plane's ECS task definition |
| Read for | usage attribution, and the fail-closed mount-ownership check in `config/constants/paths.py` that refuses a turn when a context volume belongs to another org | selecting which tenant's credentials to hydrate, and whose runs the Neon worker polls |

`STARTUP_FARGATE_MULTI_TENANT_MVP.md` states the contract directly: ECS supplies `ORGANIZATION_ID`.

Treating them as interchangeable is not cosmetic. Pointing credential hydration at the billing name makes a deployed silo see the bootstrap secret ARN set but no org id, treat that as partial configuration, and raise at gateway startup; the remote-run worker separately gets an empty id and silently never starts. In the other direction, letting the ownership check fall back to the control plane's value would weaken a fail-closed data-isolation boundary.

The three env names for the credential-hydration family were also inline string literals in a feature module, against the `config/` rule in AGENTS.md.