### PR TITLE
refactor: align messaging delivery provider enums and CLI choices

### DIFF
--- a/integrations/messaging_security.py
+++ b/integrations/messaging_security.py
@@ -47,7 +47,15 @@ class RejectionBehavior(StrEnum):
 
 
 class MessagingPlatform(StrEnum):
-    """Supported messaging platforms."""
+    """Inbound-identity platforms: which gateways receive messages and run
+    DM-pairing/allow-list security checks (see ``gateway/telegram``,
+    ``gateway/slack``, ``gateway/discord``, and the ``opensre messaging`` CLI).
+
+    Distinct from ``platform.scheduler.types.Provider``, the canonical
+    *delivery* vocabulary for scheduled outbound messages. Rocket.Chat is a
+    delivery-only provider with no gateway inbound surface, so it is
+    deliberately absent here rather than a gap to fill.
+    """
 
     TELEGRAM = "telegram"
     SLACK = "slack"

--- a/integrations/sentry/digest_delivery.py
+++ b/integrations/sentry/digest_delivery.py
@@ -9,6 +9,15 @@ from platform.scheduler.credentials import (
 )
 from platform.scheduler.types import Provider
 
+# Providers Sentry digest delivery actually implements. Discord is a member of
+# Provider (cron delivery supports it) but has no digest readiness/send path
+# here, so it's deliberately excluded rather than exposed as a broken choice.
+SENTRY_DIGEST_SUPPORTED_PROVIDERS: tuple[Provider, ...] = (
+    Provider.TELEGRAM,
+    Provider.SLACK,
+    Provider.ROCKETCHAT,
+)
+
 
 def telegram_delivery_ready() -> bool:
     """Return True when Telegram bot credentials are available."""
@@ -79,6 +88,7 @@ def digest_delivery_setup_hint(provider: Provider | str | None = None) -> str:
 
 
 __all__ = [
+    "SENTRY_DIGEST_SUPPORTED_PROVIDERS",
     "any_digest_delivery_ready",
     "delivery_provider_ready",
     "digest_delivery_setup_hint",

--- a/platform/scheduler/types.py
+++ b/platform/scheduler/types.py
@@ -33,7 +33,16 @@ class TaskStatus(StrEnum):
 
 
 class Provider(StrEnum):
-    """Supported messaging providers for delivery."""
+    """The canonical delivery-provider vocabulary: where a scheduled outbound
+    message (cron digest, watchdog alarm, ...) can be sent.
+
+    Distinct from ``integrations.messaging_security.MessagingPlatform``,
+    which tracks gateway *inbound* identity, not delivery. Not every consumer
+    supports every member here (e.g. Sentry digest delivery has no Discord
+    path, watchdog alarms only support Telegram/Rocket.Chat) -- those
+    consumers define their own documented subset rather than exposing a
+    choice that would silently fail.
+    """
 
     TELEGRAM = "telegram"
     SLACK = "slack"

--- a/surfaces/cli/commands/cron.py
+++ b/surfaces/cli/commands/cron.py
@@ -11,7 +11,22 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from platform.scheduler.types import Provider, TaskKind
+
 _console = Console()
+
+# Sentry-kind tasks are created and listed only through `opensre sentry
+# digest`/`opensre sentry uptime watch` (dedicated Sentry-integration setup,
+# project_slug handling), not through this generic command group, so they
+# are deliberately excluded from --kind here rather than a hand-typed list
+# that happens to match.
+_CRON_ADD_SUPPORTED_KINDS: tuple[TaskKind, ...] = tuple(
+    kind
+    for kind in TaskKind
+    if kind not in (TaskKind.SENTRY_MORNING_DIGEST, TaskKind.SENTRY_UPTIME_WATCH)
+)
+_KIND_CHOICES = [k.value for k in _CRON_ADD_SUPPORTED_KINDS]
+_PROVIDER_CHOICES = [p.value for p in Provider]
 
 
 @click.group(name="cron")
@@ -22,17 +37,7 @@ def cron_command() -> None:
 @cron_command.command(name="add")
 @click.option(
     "--kind",
-    type=click.Choice(
-        [
-            "daily_summary",
-            "weekly_audit",
-            "incident_window_replay",
-            "synthetic_run",
-            "custom_investigation",
-            "github_pr_sweep",
-        ],
-        case_sensitive=False,
-    ),
+    type=click.Choice(_KIND_CHOICES, case_sensitive=False),
     required=True,
     help="The kind of scheduled task.",
 )
@@ -53,7 +58,7 @@ def cron_command() -> None:
 )
 @click.option(
     "--provider",
-    type=click.Choice(["telegram", "slack", "discord", "rocketchat"], case_sensitive=False),
+    type=click.Choice(_PROVIDER_CHOICES, case_sensitive=False),
     required=True,
     help="Messaging provider for delivery.",
 )
@@ -80,7 +85,7 @@ def cron_add(
     window_hours: int,
 ) -> None:
     """Add a new scheduled delivery task."""
-    from platform.scheduler.types import Provider, ScheduledTask, TaskKind
+    from platform.scheduler.types import ScheduledTask
 
     # Validate cron expression by constructing the APScheduler trigger
     _validate_cron_and_timezone(cron_expr, timezone)

--- a/surfaces/cli/commands/sentry_digest.py
+++ b/surfaces/cli/commands/sentry_digest.py
@@ -11,9 +11,11 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from integrations.sentry.digest_delivery import SENTRY_DIGEST_SUPPORTED_PROVIDERS
 from surfaces.cli.commands.cron import _validate_cron_and_timezone
 
 _console = Console()
+_PROVIDER_CHOICES = [p.value for p in SENTRY_DIGEST_SUPPORTED_PROVIDERS]
 
 
 def _install_scheduler_runners() -> None:
@@ -107,7 +109,7 @@ def sentry_uptime_watch_command() -> None:
 )
 @click.option(
     "--provider",
-    type=click.Choice(["telegram", "slack", "rocketchat"], case_sensitive=False),
+    type=click.Choice(_PROVIDER_CHOICES, case_sensitive=False),
     required=True,
     help="Messaging provider for delivery.",
 )
@@ -315,7 +317,7 @@ def sentry_digest_schedule_command() -> None:
 )
 @click.option(
     "--provider",
-    type=click.Choice(["telegram", "slack", "rocketchat"], case_sensitive=False),
+    type=click.Choice(_PROVIDER_CHOICES, case_sensitive=False),
     required=True,
     help="Messaging provider for delivery.",
 )

--- a/surfaces/cli/commands/watchdog.py
+++ b/surfaces/cli/commands/watchdog.py
@@ -6,8 +6,10 @@ import click
 from pydantic import ValidationError
 
 from surfaces.interactive_shell.utils.error_handling.errors import OpenSREError
-from tools.system.watch_dog.config import WatchdogConfig
+from tools.system.watch_dog.config import WATCHDOG_SUPPORTED_PROVIDERS, WatchdogConfig
 from tools.system.watch_dog.runner import run_watchdog
+
+_PROVIDER_CHOICES = [p.value for p in WATCHDOG_SUPPORTED_PROVIDERS]
 
 
 @click.command(name="watchdog")
@@ -47,7 +49,7 @@ from tools.system.watch_dog.runner import run_watchdog
 @click.option("--once", is_flag=True, help="Exit after the first threshold alarm.")
 @click.option(
     "--provider",
-    type=click.Choice(["telegram", "rocketchat"], case_sensitive=False),
+    type=click.Choice(_PROVIDER_CHOICES, case_sensitive=False),
     default="telegram",
     show_default=True,
     help="Messaging provider for alarm delivery.",

--- a/tests/cli/test_cron_command.py
+++ b/tests/cli/test_cron_command.py
@@ -4,7 +4,21 @@ from __future__ import annotations
 
 from click.testing import CliRunner
 
-from surfaces.cli.commands.cron import cron_command
+from platform.scheduler.types import Provider, TaskKind
+from surfaces.cli.commands.cron import _KIND_CHOICES, _PROVIDER_CHOICES, cron_command
+
+
+def test_cron_add_provider_choices_match_full_provider_enum() -> None:
+    """cron delivery genuinely supports every Provider member."""
+    assert set(_PROVIDER_CHOICES) == {p.value for p in Provider}
+
+
+def test_cron_add_kind_choices_exclude_sentry_kinds() -> None:
+    """Sentry-kind tasks go through `opensre sentry`, not generic cron add."""
+    assert set(_KIND_CHOICES) == {k.value for k in TaskKind} - {
+        TaskKind.SENTRY_MORNING_DIGEST.value,
+        TaskKind.SENTRY_UPTIME_WATCH.value,
+    }
 
 
 def test_cron_add_rejects_non_positive_window() -> None:

--- a/tests/cli/test_sentry_digest.py
+++ b/tests/cli/test_sentry_digest.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from click.testing import CliRunner
 
-from surfaces.cli.commands.sentry_digest import sentry_command
+from integrations.sentry.digest_delivery import SENTRY_DIGEST_SUPPORTED_PROVIDERS
+from surfaces.cli.commands.sentry_digest import _PROVIDER_CHOICES, sentry_command
+
+
+def test_sentry_provider_choices_match_supported_providers_constant() -> None:
+    """Discord has no digest readiness/send path, so it must stay excluded."""
+    assert set(_PROVIDER_CHOICES) == {p.value for p in SENTRY_DIGEST_SUPPORTED_PROVIDERS}
+    assert "discord" not in _PROVIDER_CHOICES
 
 
 def test_schedule_add_requires_delivery_provider(monkeypatch) -> None:

--- a/tests/watch_dog/test_config.py
+++ b/tests/watch_dog/test_config.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from platform.scheduler.types import Provider
 from tools.system.watch_dog.config import (
+    WATCHDOG_SUPPORTED_PROVIDERS,
     WatchdogConfig,
     WatchdogThreshold,
     parse_byte_size,
@@ -34,6 +36,16 @@ def test_watchdog_threshold_members_are_stable() -> None:
         "max_rss",
     ]
     assert WatchdogThreshold("max_cpu") is WatchdogThreshold.MAX_CPU
+
+
+def test_watchdog_supported_providers_is_telegram_and_rocketchat_only() -> None:
+    """Slack/Discord alarm delivery isn't implemented; the subset must stay narrow."""
+    assert WATCHDOG_SUPPORTED_PROVIDERS == (Provider.TELEGRAM, Provider.ROCKETCHAT)
+
+
+def test_watchdog_config_rejects_unsupported_provider_even_bypassing_click() -> None:
+    with pytest.raises(ValidationError, match="does not support"):
+        WatchdogConfig(pid=123, max_cpu=90, provider=Provider.SLACK)
 
 
 def test_watchdog_config_requires_pid_or_name_xor() -> None:

--- a/tools/system/watch_dog/config.py
+++ b/tools/system/watch_dog/config.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Literal
 
 from pydantic import Field, field_validator, model_validator
 
 from config.strict_config import StrictConfigModel
+from platform.scheduler.types import Provider
 
-AlarmProvider = Literal["telegram", "rocketchat"]
+# Providers the watchdog alarm sender actually implements (see runner.py's
+# dispatch). Provider has two more members (slack, discord) that cron
+# delivery supports but watchdog does not, so this is a deliberate subset,
+# not the full enum.
+WATCHDOG_SUPPORTED_PROVIDERS: tuple[Provider, ...] = (Provider.TELEGRAM, Provider.ROCKETCHAT)
 
 
 class WatchdogThreshold(StrEnum):
@@ -93,7 +97,7 @@ class WatchdogConfig(StrictConfigModel):
     interval: float = Field(default=5.0, gt=0)
     cooldown: float = Field(default=300.0, gt=0)
     once: bool = False
-    provider: AlarmProvider = "telegram"
+    provider: Provider = Provider.TELEGRAM
     chat_id: str | None = None
     verbose: bool = False
 
@@ -113,6 +117,16 @@ class WatchdogConfig(StrictConfigModel):
             return None
         if isinstance(value, str | int | float):
             return parse_byte_size(value)
+        return value
+
+    @field_validator("provider")
+    @classmethod
+    def _validate_provider_supported(cls, value: Provider) -> Provider:
+        if value not in WATCHDOG_SUPPORTED_PROVIDERS:
+            supported = ", ".join(p.value for p in WATCHDOG_SUPPORTED_PROVIDERS)
+            raise ValueError(
+                f"watchdog delivery does not support '{value}'; use one of: {supported}"
+            )
         return value
 
     @model_validator(mode="after")

--- a/tools/system/watch_dog/runner.py
+++ b/tools/system/watch_dog/runner.py
@@ -20,7 +20,8 @@ from integrations.rocketchat.credentials import (
 from integrations.telegram.alarms import AlarmDispatcher
 from integrations.telegram.credentials import load_credentials_from_env
 from platform.common.exit_codes import ERROR, SUCCESS
-from tools.system.watch_dog.config import AlarmProvider, WatchdogConfig, WatchdogThreshold
+from platform.scheduler.types import Provider
+from tools.system.watch_dog.config import WatchdogConfig, WatchdogThreshold
 from tools.system.watch_dog.process_monitor import ProcessMonitor, ProcessSample, Sampler
 
 
@@ -94,7 +95,7 @@ def run_watchdog(
 
 
 def _build_dispatcher(config: WatchdogConfig) -> Dispatcher:
-    if config.provider == "rocketchat":
+    if config.provider == Provider.ROCKETCHAT:
         rc_creds = load_rocketchat_credentials_from_env(channel_override=config.chat_id)
         return RocketChatAlarmDispatcher(rc_creds, cooldown_seconds=config.cooldown)
     creds = load_credentials_from_env(chat_id_override=config.chat_id)
@@ -183,7 +184,7 @@ def _alarm_started_and_command(sample: ProcessSample) -> tuple[str, str]:
 
 
 def _format_alarm_message(
-    sample: ProcessSample, breach: ThresholdBreach, *, provider: AlarmProvider
+    sample: ProcessSample, breach: ThresholdBreach, *, provider: Provider
 ) -> str:
     """Format the alarm body for the delivering provider.
 
@@ -192,7 +193,7 @@ def _format_alarm_message(
     provider gets its own markup around the same fields rather than sending
     one format to both.
     """
-    if provider == "rocketchat":
+    if provider == Provider.ROCKETCHAT:
         return _format_alarm_message_markdown(sample, breach)
     return _format_alarm_message_html(sample, breach)
 


### PR DESCRIPTION
Fixes #4533

Design-sensitive per the issue's own note; the PR review is the coordination point for the canonical vocabulary.

#### Describe the changes you have made in this PR -

Traced every CLI provider/kind choice list against its actual delivery/dispatch logic before changing anything, since the issue's framing ("operators see different choices") turned out to mostly describe real, deliberate capability boundaries rather than a hand-maintained-list bug: cron's 4 choices already matched `Provider` exactly, sentry_digest's 3 (no Discord) match `digest_delivery.py`'s readiness checks (Discord has no implemented path), and watchdog's 2 (telegram/rocketchat only) match `watch_dog/runner.py`'s actual dispatch. Unifying these into one shared choice list would have exposed CLI options that silently do nothing.

Implemented the identity-vs-delivery split the issue's target shape describes: `MessagingPlatform` stays the inbound-identity vocabulary (gateway telegram/slack/discord, DM-pairing security), `platform.scheduler.types.Provider` is documented as the canonical delivery vocabulary. Added `SENTRY_DIGEST_SUPPORTED_PROVIDERS` and `WATCHDOG_SUPPORTED_PROVIDERS` as explicit, documented `Provider` subsets so each command's CLI choices and its runtime capability check are derived from the same source and can't drift apart again. `watch_dog`'s `AlarmProvider` (a plain `Literal`) is replaced by `Provider` directly, with a `field_validator` restricting it to the watchdog subset as defense in depth against a caller bypassing Click. `cron.py`'s `--kind` list now derives from `TaskKind`, deliberately excluding the two Sentry-only kinds (created only via `opensre sentry`, per that module's own docstring) rather than blindly adding the two kinds the old hand-typed list happened to be missing. `messaging.py` already derived its choices from `MessagingPlatform` correctly; no change needed there.

No string values renamed. `gateway/discord`, `gateway/slack`, `gateway/telegram` (MessagingPlatform consumers) are untouched.

### Demo/Screenshot for feature changes and bug fixes -

```
$ make lint && make typecheck && make check-imports
All checks passed! / Success: no issues found in 1539 source files / All 3 import checks passed.

$ uv run pytest tests/watch_dog/ tests/scheduler/ tests/cli/ tests/integrations/test_messaging_security.py -q
1136 passed, 4 skipped
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Before writing any code, read every consumer of each provider list to check whether it actually implements delivery for the providers it excludes, rather than assuming a shorter list was a bug. That investigation is what revealed `sentry_digest`'s Discord gap and `cron`'s missing Sentry-kind exclusion were both intentional, and shaped the whole approach: instead of one universal enum, each command gets a named, documented subset constant it derives its Click choices from, and that same constant (or a validator built on it) is the thing the runtime logic actually checks, closing the loop so choices and capability can't diverge again. Chose a pydantic `field_validator` for `WatchdogConfig.provider` rather than a bare type restriction because `Provider` itself must stay the full 4-member enum (cron needs all of it); the subset is a watchdog-specific business rule, not a type.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
