### PR TITLE
refactor: ToolKind StrEnum for interactive-shell actions

### DIFF
--- a/tests/tools/interactive_shell/test_action_names.py
+++ b/tests/tools/interactive_shell/test_action_names.py
@@ -1,0 +1,54 @@
+"""Pin ToolKind members and their TOOL_KIND_TO_NAME mapping."""
+
+from __future__ import annotations
+
+from tools.interactive_shell.action_names import TOOL_KIND_TO_NAME, ToolKind
+
+
+def test_tool_kind_members_are_stable() -> None:
+    assert [kind.value for kind in ToolKind] == [
+        "slash",
+        "shell",
+        "investigation",
+        "alert",
+        "sample_alert",
+        "synthetic_test",
+        "task_cancel",
+        "cli_command",
+        "implementation",
+        "llm_provider",
+        "assistant_handoff",
+    ]
+
+
+def test_tool_kind_round_trips_from_string() -> None:
+    """Scenario YAML/harness fixtures reference kinds by plain string."""
+    for kind in ToolKind:
+        assert ToolKind(kind.value) is kind
+
+
+def test_every_tool_kind_has_a_name_mapping() -> None:
+    assert set(TOOL_KIND_TO_NAME) == set(ToolKind)
+
+
+def test_tool_kind_to_name_mapping_values() -> None:
+    assert TOOL_KIND_TO_NAME == {
+        ToolKind.SLASH: "slash_invoke",
+        ToolKind.SHELL: "shell_run",
+        ToolKind.INVESTIGATION: "investigation_start",
+        ToolKind.ALERT: "alert_sample",
+        ToolKind.SAMPLE_ALERT: "alert_sample",
+        ToolKind.SYNTHETIC_TEST: "synthetic_run",
+        ToolKind.TASK_CANCEL: "task_cancel",
+        ToolKind.CLI_COMMAND: "cli_exec",
+        ToolKind.IMPLEMENTATION: "code_implement",
+        ToolKind.LLM_PROVIDER: "llm_set_provider",
+        ToolKind.ASSISTANT_HANDOFF: "assistant_handoff",
+    }
+
+
+def test_tool_kind_to_name_lookup_by_plain_string_key() -> None:
+    """A dict keyed by ToolKind members must still be found via a plain string,
+    since StrEnum members hash and compare equal to their value."""
+    assert TOOL_KIND_TO_NAME["slash"] == "slash_invoke"
+    assert TOOL_KIND_TO_NAME.get("assistant_handoff") == "assistant_handoff"

--- a/tools/interactive_shell/action_names.py
+++ b/tools/interactive_shell/action_names.py
@@ -2,34 +2,42 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from enum import StrEnum
 
-ToolKind = Literal[
-    "slash",
-    "shell",
-    "investigation",
-    "alert",
-    "sample_alert",
-    "synthetic_test",
-    "task_cancel",
-    "cli_command",
-    "implementation",
-    "llm_provider",
-    "assistant_handoff",
-]
+
+class ToolKind(StrEnum):
+    """Closed set of action-tool kinds.
+
+    Scenario YAML and harness fixtures reference these by plain string
+    (e.g. ``kind: slash``); StrEnum keeps that working (members compare
+    and hash equal to their string value) while making the set explicit.
+    """
+
+    SLASH = "slash"
+    SHELL = "shell"
+    INVESTIGATION = "investigation"
+    ALERT = "alert"
+    SAMPLE_ALERT = "sample_alert"
+    SYNTHETIC_TEST = "synthetic_test"
+    TASK_CANCEL = "task_cancel"
+    CLI_COMMAND = "cli_command"
+    IMPLEMENTATION = "implementation"
+    LLM_PROVIDER = "llm_provider"
+    ASSISTANT_HANDOFF = "assistant_handoff"
+
 
 TOOL_KIND_TO_NAME: dict[ToolKind, str] = {
-    "slash": "slash_invoke",
-    "shell": "shell_run",
-    "investigation": "investigation_start",
-    "alert": "alert_sample",
-    "sample_alert": "alert_sample",
-    "synthetic_test": "synthetic_run",
-    "task_cancel": "task_cancel",
-    "cli_command": "cli_exec",
-    "implementation": "code_implement",
-    "llm_provider": "llm_set_provider",
-    "assistant_handoff": "assistant_handoff",
+    ToolKind.SLASH: "slash_invoke",
+    ToolKind.SHELL: "shell_run",
+    ToolKind.INVESTIGATION: "investigation_start",
+    ToolKind.ALERT: "alert_sample",
+    ToolKind.SAMPLE_ALERT: "alert_sample",
+    ToolKind.SYNTHETIC_TEST: "synthetic_run",
+    ToolKind.TASK_CANCEL: "task_cancel",
+    ToolKind.CLI_COMMAND: "cli_exec",
+    ToolKind.IMPLEMENTATION: "code_implement",
+    ToolKind.LLM_PROVIDER: "llm_set_provider",
+    ToolKind.ASSISTANT_HANDOFF: "assistant_handoff",
 }
 
 __all__ = ["TOOL_KIND_TO_NAME", "ToolKind"]


### PR DESCRIPTION
Fixes #4535

#### Describe the changes you have made in this PR -

`ToolKind` in `tools/interactive_shell/action_names.py` was a closed `Literal[...]`, with `TOOL_KIND_TO_NAME` keyed by the same raw strings. Converted `ToolKind` to a `StrEnum` (values unchanged) and updated `TOOL_KIND_TO_NAME`'s keys to enum members, so the set of action-tool kinds is explicit at the type level per the issue's target shape.

Kept the name `ToolKind` rather than renaming to `ActionToolKind`: the issue's target shape explicitly allows either name, the issue's own `Files:` scope lists only this one module, and there's no actual name collision here (unlike the two prior StrEnum refactors) to justify touching the five test files that import `ToolKind` by name.

Traced every consumer before changing anything: all of them live in `tests/` (scenario YAML loading in `test_turn_scenarios.py`, the turn-test harness's frozen `PlannedAction` dataclass in `_planned_action.py`, fixture-integrity checks). None needed code changes: scenario YAML is read into a plain `str` `TypedDict` field first and `cast` (a type-checker no-op, not a runtime conversion) before use, and `StrEnum` members hash/compare equal to their string value, so `TOOL_KIND_TO_NAME["slash"]` and `kind == "assistant_handoff"`-style comparisons against plain strings both keep working unchanged, confirmed by running the existing consumer test files.

### Demo/Screenshot for feature changes and bug fixes -

```
$ make lint && make typecheck && make check-imports
All checks passed! / Success: no issues found in 1539 source files / All 3 import checks passed.

$ uv run pytest tests/tools/interactive_shell/test_action_names.py tests/core/agent/test_turn_fixture_integrity.py tests/core/agent/orchestration/test_agent_actions.py -q
66 passed

$ uv run pytest tests/core/agent/test_turn_scenarios.py -q -m "not live_llm"
6 passed, 30 deselected
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Before converting anything, grepped every usage of `ToolKind`/`TOOL_KIND_TO_NAME` to find all 5 consumers, all in `tests/`, then read the frozen `PlannedAction` dataclass and the YAML-loading path specifically because the issue's own gotcha list calls out frozen-dataclass coercion as a risk. Confirmed the actual data flow (YAML to plain-str `TypedDict` to `cast`, never a real enum construction) meant there was no coercion gap to fix. The new test file mirrors the `tests/filestorage/test_enums.py` precedent style: pin the member list, a round-trip test (`ToolKind(kind.value) is kind`), a completeness check that every kind has a name mapping, and an explicit test proving plain-string dict lookups against the now-enum-keyed mapping still resolve, since that behavior is what lets the YAML/harness consumers stay untouched.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
