### PR TITLE
refactor: shared McpTransportMode StrEnum across MCP integrations

### DIFF
--- a/integrations/github/mcp.py
+++ b/integrations/github/mcp.py
@@ -29,12 +29,13 @@ from rich.table import Table
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 from integrations.mcp_streamable_http_compat import streamable_http_client
+from integrations.mcp_transport import McpTransportMode
 from platform.terminal.theme import BRAND, DIM, ERROR, HIGHLIGHT
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/"
-DEFAULT_GITHUB_MCP_MODE = "streamable-http"
+DEFAULT_GITHUB_MCP_MODE: McpTransportMode = McpTransportMode.STREAMABLE_HTTP
 DEFAULT_GITHUB_MCP_TOOLSETS = ("repos", "issues", "pull_requests", "actions", "search")
 
 # Non-transport metadata persisted alongside MCP credentials in the integration store.
@@ -135,7 +136,7 @@ class GitHubMCPConfig(StrictConfigModel):
     """Normalized GitHub MCP connection settings."""
 
     url: str = DEFAULT_GITHUB_MCP_URL
-    mode: Literal["stdio", "sse", "streamable-http"] = "streamable-http"
+    mode: McpTransportMode = DEFAULT_GITHUB_MCP_MODE
     auth_token: str = ""
     command: str = ""
     args: tuple[str, ...] = ()

--- a/integrations/mcp_transport.py
+++ b/integrations/mcp_transport.py
@@ -1,0 +1,26 @@
+"""Shared transport-mode vocabulary for hosted/local MCP integrations.
+
+x_mcp, posthog_mcp, sentry_mcp, openclaw, and the GitHub MCP integration each
+accept the same three client transports. A shared leaf enum means adding a
+fourth transport is one edit here instead of a multi-file sweep across every
+integration's own ``Literal`` and private ``_KNOWN_*_MODES`` frozenset.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class McpTransportMode(StrEnum):
+    """Closed set of MCP client transports.
+
+    Keeps the hyphenated ``"streamable-http"`` value unchanged, since
+    persisted config/JSON already depend on it.
+    """
+
+    STDIO = "stdio"
+    SSE = "sse"
+    STREAMABLE_HTTP = "streamable-http"
+
+
+__all__ = ["McpTransportMode"]

--- a/integrations/openclaw/__init__.py
+++ b/integrations/openclaw/__init__.py
@@ -22,7 +22,7 @@ from collections.abc import AsyncIterator, Coroutine, Mapping
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, cast
 from urllib.parse import urlparse
 
 import httpx
@@ -35,10 +35,11 @@ from typing_extensions import TypedDict
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 from integrations.mcp_streamable_http_compat import streamable_http_client
+from integrations.mcp_transport import McpTransportMode
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_OPENCLAW_MCP_MODE: Literal["streamable-http", "sse", "stdio"] = "streamable-http"
+DEFAULT_OPENCLAW_MCP_MODE: McpTransportMode = McpTransportMode.STREAMABLE_HTTP
 _OPENCLAW_CONTROL_UI_HOSTS = frozenset({"127.0.0.1", "localhost", "0.0.0.0"})
 _OPENCLAW_CONTROL_UI_PORT = 18789
 _OPENCLAW_STDIO_COMMAND = "openclaw"
@@ -82,7 +83,7 @@ class OpenClawConfig(StrictConfigModel):
     """Normalized OpenClaw bridge connection settings."""
 
     url: str = ""
-    mode: Literal["stdio", "sse", "streamable-http"] = DEFAULT_OPENCLAW_MCP_MODE
+    mode: McpTransportMode = DEFAULT_OPENCLAW_MCP_MODE
     auth_token: str = ""
     command: str = ""
     args: tuple[str, ...] = ()

--- a/integrations/posthog_mcp/__init__.py
+++ b/integrations/posthog_mcp/__init__.py
@@ -29,7 +29,7 @@ import os
 from collections.abc import AsyncIterator, Coroutine, Mapping
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, cast
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import httpx
@@ -47,11 +47,12 @@ from config.constants.posthog_mcp import (
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 from integrations.mcp_streamable_http_compat import streamable_http_client
+from integrations.mcp_transport import McpTransportMode
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_POSTHOG_MCP_URL = "https://mcp.posthog.com/mcp"
-DEFAULT_POSTHOG_MCP_MODE: Literal["streamable-http", "sse", "stdio"] = "streamable-http"
+DEFAULT_POSTHOG_MCP_MODE: McpTransportMode = McpTransportMode.STREAMABLE_HTTP
 
 # PostHog routes EU accounts automatically, but the dedicated EU host is exposed
 # for users who prefer to pin it explicitly.
@@ -90,7 +91,7 @@ class PostHogMCPConfig(StrictConfigModel):
     """Normalized PostHog MCP connection settings."""
 
     url: str = DEFAULT_POSTHOG_MCP_URL
-    mode: Literal["stdio", "sse", "streamable-http"] = DEFAULT_POSTHOG_MCP_MODE
+    mode: McpTransportMode = DEFAULT_POSTHOG_MCP_MODE
     auth_token: str = ""
     command: str = ""
     args: tuple[str, ...] = ()

--- a/integrations/posthog_mcp/tools/posthog_mcp_tool/__init__.py
+++ b/integrations/posthog_mcp/tools/posthog_mcp_tool/__init__.py
@@ -14,6 +14,7 @@ from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.mcp_bridge import unavailable_response
 from core.tool_framework.utils.mcp_params import first_list, first_string
 from core.tool_framework.utils.mcp_tool_listing import build_mcp_tool_listing
+from integrations.mcp_transport import McpTransportMode
 from integrations.posthog_mcp import (
     PostHogMCPConfig,
     PostHogMCPToolCallResult,
@@ -40,7 +41,7 @@ def _unavailable_response(
     return unavailable_response("posthog_mcp", error, tool_name=tool_name, arguments=arguments)
 
 
-_KNOWN_POSTHOG_MCP_MODES = frozenset({"stdio", "sse", "streamable-http"})
+_KNOWN_POSTHOG_MCP_MODES = frozenset(McpTransportMode)
 
 
 def _resolve_config(

--- a/integrations/sentry_mcp/__init__.py
+++ b/integrations/sentry_mcp/__init__.py
@@ -29,7 +29,7 @@ import os
 from collections.abc import AsyncIterator, Coroutine, Mapping
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 import httpx
 from mcp import ClientSession, StdioServerParameters, types  # type: ignore[import-not-found]
@@ -46,11 +46,12 @@ from config.constants.sentry_mcp import (
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 from integrations.mcp_streamable_http_compat import streamable_http_client
+from integrations.mcp_transport import McpTransportMode
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_SENTRY_MCP_URL = "https://mcp.sentry.dev/mcp"
-DEFAULT_SENTRY_MCP_MODE: Literal["streamable-http", "sse", "stdio"] = "streamable-http"
+DEFAULT_SENTRY_MCP_MODE: McpTransportMode = McpTransportMode.STREAMABLE_HTTP
 
 
 class SentryMCPToolDescriptor(TypedDict):
@@ -85,7 +86,7 @@ class SentryMCPConfig(StrictConfigModel):
     """Normalized Sentry MCP connection settings."""
 
     url: str = DEFAULT_SENTRY_MCP_URL
-    mode: Literal["stdio", "sse", "streamable-http"] = DEFAULT_SENTRY_MCP_MODE
+    mode: McpTransportMode = DEFAULT_SENTRY_MCP_MODE
     auth_token: str = ""
     command: str = ""
     args: tuple[str, ...] = ()

--- a/integrations/x_mcp/__init__.py
+++ b/integrations/x_mcp/__init__.py
@@ -35,7 +35,7 @@ import os
 from collections.abc import AsyncIterator, Coroutine, Mapping
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 import httpx
 from mcp import ClientSession, StdioServerParameters, types  # type: ignore[import-not-found]
@@ -48,11 +48,12 @@ from config.constants.x_mcp import X_MCP_AUTH_TOKEN_ENV, X_MCP_URL_ENV
 from config.strict_config import StrictConfigModel
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 from integrations.mcp_streamable_http_compat import streamable_http_client
+from integrations.mcp_transport import McpTransportMode
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_X_MCP_URL = "http://127.0.0.1:8000/mcp"
-DEFAULT_X_MCP_MODE: Literal["streamable-http", "sse", "stdio"] = "streamable-http"
+DEFAULT_X_MCP_MODE: McpTransportMode = McpTransportMode.STREAMABLE_HTTP
 
 
 class XMCPToolDescriptor(TypedDict):
@@ -87,7 +88,7 @@ class XMCPConfig(StrictConfigModel):
     """Normalized X MCP connection settings."""
 
     url: str = DEFAULT_X_MCP_URL
-    mode: Literal["stdio", "sse", "streamable-http"] = DEFAULT_X_MCP_MODE
+    mode: McpTransportMode = DEFAULT_X_MCP_MODE
     auth_token: str = ""
     bearer_token: str = ""
     command: str = ""

--- a/integrations/x_mcp/tools/x_mcp_tool/__init__.py
+++ b/integrations/x_mcp/tools/x_mcp_tool/__init__.py
@@ -14,6 +14,7 @@ from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.mcp_bridge import unavailable_response
 from core.tool_framework.utils.mcp_params import first_list, first_string
 from core.tool_framework.utils.mcp_tool_listing import build_mcp_tool_listing
+from integrations.mcp_transport import McpTransportMode
 from integrations.x_mcp import (
     XMCPConfig,
     XMCPToolCallResult,
@@ -40,7 +41,7 @@ def _unavailable_response(
     return unavailable_response("x_mcp", error, tool_name=tool_name, arguments=arguments)
 
 
-_KNOWN_X_MCP_MODES = frozenset({"stdio", "sse", "streamable-http"})
+_KNOWN_X_MCP_MODES = frozenset(McpTransportMode)
 
 
 def _resolve_config(

--- a/tests/integrations/test_mcp_transport.py
+++ b/tests/integrations/test_mcp_transport.py
@@ -1,0 +1,21 @@
+"""Pin McpTransportMode members and their round-trip from string."""
+
+from __future__ import annotations
+
+from integrations.mcp_transport import McpTransportMode
+
+
+def test_mcp_transport_mode_members_are_stable() -> None:
+    assert [mode.value for mode in McpTransportMode] == ["stdio", "sse", "streamable-http"]
+
+
+def test_mcp_transport_mode_round_trips_from_string() -> None:
+    """Config/JSON persist these as plain strings; StrEnum must accept them back."""
+    for mode in McpTransportMode:
+        assert McpTransportMode(mode.value) is mode
+
+
+def test_mcp_transport_mode_keeps_hyphenated_streamable_http_value() -> None:
+    """Config/JSON already depend on the hyphenated spelling."""
+    assert McpTransportMode.STREAMABLE_HTTP.value == "streamable-http"
+    assert McpTransportMode("streamable-http") is McpTransportMode.STREAMABLE_HTTP

--- a/tests/integrations/test_vendor_first_layout.py
+++ b/tests/integrations/test_vendor_first_layout.py
@@ -31,6 +31,7 @@ ALLOWED_FLAT_MODULES = frozenset(
         "effective_models.py",
         "harness_adapters.py",
         "mcp_streamable_http_compat.py",
+        "mcp_transport.py",
         "messaging_security.py",
         "models.py",
         "port.py",

--- a/tests/integrations/test_x_mcp.py
+++ b/tests/integrations/test_x_mcp.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import ValidationError
 
 from integrations.catalog import classify_integrations as _classify_integrations
+from integrations.mcp_transport import McpTransportMode
 from integrations.x_mcp import (
     DEFAULT_X_MCP_URL,
     XMCPConfig,
@@ -29,6 +30,11 @@ class TestXMCPConfig:
         assert config.mode == "streamable-http"
         assert config.url == DEFAULT_X_MCP_URL
         assert config.is_configured is True
+
+    def test_mode_constructs_shared_enum_member_from_string(self) -> None:
+        """XMCPConfig accepts a plain string but stores the shared McpTransportMode."""
+        config = XMCPConfig(mode="stdio", command="python")
+        assert config.mode is McpTransportMode.STDIO
 
     def test_streamable_http_requires_url(self) -> None:
         with pytest.raises(ValidationError, match="requires a non-empty url"):


### PR DESCRIPTION
Fixes #4534

#### Describe the changes you have made in this PR -

`x_mcp`, `posthog_mcp`, `sentry_mcp`, `openclaw`, and the GitHub MCP integration each declared their own `Literal["stdio", "sse", "streamable-http"]` mode field and default constant, and two of them (`posthog_mcp_tool`, `x_mcp_tool`) also had a private `_KNOWN_*_MODES` frozenset duplicating the same three values for planner-input validation. Adding a fourth transport meant sweeping five near-identical `Literal` declarations plus two frozensets.

Added `integrations/mcp_transport.py` (a leaf module, zero first-party imports) with `McpTransportMode(StrEnum): STDIO, SSE, STREAMABLE_HTTP`, keeping the hyphenated `"streamable-http"` value since config/JSON already depend on it. Every `DEFAULT_*_MCP_MODE` constant and config `mode` field across the five integrations now references this one enum instead of its own `Literal`. The two `_KNOWN_*_MODES` frozensets are now derived (`frozenset(McpTransportMode)`) instead of hand-typed.

No config string values changed, and no call-site rewrites were needed beyond the type declarations themselves: each `mode` field already goes through a pydantic "before" validator that normalizes/lowercases a raw string before pydantic's own field validation coerces it into the `Literal` (now enum) type, and every existing `==` comparison and dict/set membership check against plain strings (`"stdio"`, `"streamable-http"`, ...) keeps working unchanged because `StrEnum` members hash and compare equal to their string value. Confirmed via the full existing test suite for all five integrations (277 tests, all passing unmodified except one new assertion).

**Scope decision:** left `integrations/catalog.py`, `_catalog_impl.py`, `cli.py`, and `setup_flow.py` untouched - they only reference the default as a plain `os.getenv(..., "streamable-http")` fallback string, not a typed `Literal`/frozenset, so they weren't part of the duplication this issue targets and touching them would only add risk without consolidation value.

### Demo/Screenshot for feature changes and bug fixes -

```
$ make lint && make typecheck && make check-imports
All checks passed! / Success: no issues found in 1544 source files / All 3 import checks passed.

$ uv run pytest tests/integrations/test_mcp_transport.py tests/integrations/test_x_mcp.py tests/integrations/test_posthog_mcp.py tests/integrations/test_sentry_mcp.py tests/tools/test_x_mcp_tool.py tests/tools/test_posthog_mcp_tool.py tests/tools/test_openclaw_mcp_tool.py tests/integrations/test_github_mcp_validation.py tests/integrations/test_github_mcp_oauth.py tests/integrations/openclaw/test_integration.py -q
277 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Before writing any code, grepped every file referencing the three transport-mode strings to build the real file list (matched the issue's ~15 estimate exactly, though only 5 of those declare a real `Literal` type and 2 have a frozenset; the rest are incidental default-string consumers I left alone). Read one config class fully (`PostHogMCPConfig`) to confirm how its `field_validator("mode", mode="before")` interacts with pydantic's own type coercion, since that's what determines whether swapping `Literal` for `StrEnum` is safe without touching every validator: pydantic runs the "before" validator first (which just normalizes/aliases a raw string), then coerces the result into the declared field type, so a `StrEnum` field type gets the exact same automatic construction-from-string a `Literal` field got, with the same rejection behavior on an invalid value. That single finding is what made the change mechanical and low-risk across all five near-identical files rather than needing five separate designs.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
