### PR TITLE
Hydrate a silo's integrations from its Secrets Manager blob, on an ephemeral store path

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -189,7 +189,6 @@ from config.constants.opensre_infra_aws import (
 from config.constants.pagerduty import PAGERDUTY_API_KEY_ENV, PAGERDUTY_BASE_URL_ENV
 from config.constants.paths import (
     CONTEXT_ROOT_ENV,
-    INTEGRATIONS_STORE_PATH,
     OPENSRE_HOME_DIR,
     OPENSRE_TMP_DIR,
     ORGS_DIR_NAME,
@@ -301,6 +300,8 @@ from config.constants.temporal import (
 from config.constants.tenancy import (
     CREDENTIALS_API_URL_ENV,
     CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV,
+    INTEGRATIONS_SECRET_ARN_ENV,
+    INTEGRATIONS_STORE_PATH_ENV,
     TENANT_ORGANIZATION_ID_ENV,
 )
 from config.constants.tracer import TRACER_BASE_URL_ENV, TRACER_JWT_TOKEN_ENV
@@ -400,7 +401,6 @@ __all__ = [
     "HONEYCOMB_DATASET_ENV",
     "INCIDENT_IO_API_KEY_ENV",
     "INCIDENT_IO_BASE_URL_ENV",
-    "INTEGRATIONS_STORE_PATH",
     "IS_WINDOWS",
     "JENKINS_API_TOKEN_ENV",
     "JENKINS_BASE_URL_ENV",
@@ -469,6 +469,8 @@ __all__ = [
     "TENANT_ORGANIZATION_ID_ENV",
     "CREDENTIALS_API_URL_ENV",
     "CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV",
+    "INTEGRATIONS_SECRET_ARN_ENV",
+    "INTEGRATIONS_STORE_PATH_ENV",
     "ORGS_DIR_NAME",
     "PAGERDUTY_API_KEY_ENV",
     "PAGERDUTY_BASE_URL_ENV",

--- a/config/constants/paths.py
+++ b/config/constants/paths.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 from config.constants.billing import ORGANIZATION_ID_ENV
 from config.constants.memory import OPENSRE_MEMORY_DIR_ENV
+from config.constants.tenancy import INTEGRATIONS_STORE_PATH_ENV
 from config.scope_context import current_scope
 
 logger = logging.getLogger(__name__)
@@ -30,8 +31,6 @@ PROJECT_ROOT = REPO_ROOT
 SYNTHETIC_SCENARIOS_DIR = REPO_ROOT / "tests" / "synthetic" / "rds_postgres"
 
 OPENSRE_HOME_DIR = Path.home() / ".opensre"
-# Default unbound integrations path (docs / tests expecting the flat layout).
-INTEGRATIONS_STORE_PATH = OPENSRE_HOME_DIR / "integrations.json"
 OPENSRE_TMP_DIR = Path(tempfile.gettempdir()) / "opensre"
 
 # Set by the deployed Slack service to the mounted, org-chrooted volume.
@@ -143,7 +142,16 @@ def session_home() -> Path:
 
 
 def integrations_store_path() -> Path:
-    """Integrations store path (shared by every member of the org)."""
+    """Integrations store path (shared by every member of the org).
+
+    A deployed silo overrides this with ``OPENSRE_INTEGRATIONS_STORE_PATH``,
+    which the control plane points at ephemeral container storage: that silo
+    serves one tenant, and its credentials are re-hydrated from the tenant's
+    Secrets Manager blob at every boot rather than kept on the shared mount.
+    """
+    override = os.getenv(INTEGRATIONS_STORE_PATH_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
     return opensre_home() / "integrations.json"
 
 
@@ -169,7 +177,6 @@ def ensure_opensre_tmp_dir() -> Path:
 
 
 __all__ = [
-    "INTEGRATIONS_STORE_PATH",
     "CONTEXT_ROOT_ENV",
     "OPENSRE_HOME_DIR",
     "OPENSRE_TMP_DIR",

--- a/config/constants/tenancy.py
+++ b/config/constants/tenancy.py
@@ -1,8 +1,13 @@
 """Env names the multi-tenant control plane injects into a gateway silo.
 
 A silo is one gateway task serving one tenant. The control plane's ECS task
-definition supplies these three so the gateway can say who it is and fetch that
+definition supplies these so the gateway can say who it is and fetch that
 tenant's credentials at startup.
+
+Credentials reach the silo by exactly one of two routes, never both: the
+webapp's credentials API (:data:`CREDENTIALS_API_URL_ENV`) or this tenant's
+IntegrationStore v2 secret (:data:`INTEGRATIONS_SECRET_ARN_ENV`), which the
+webapp maintains through the control plane. The secret is the deployed route.
 
 Distinct from :data:`config.constants.billing.ORGANIZATION_ID_ENV`
 (``OPENSRE_ORGANIZATION_ID``), which the product reads to attribute usage and to
@@ -26,8 +31,18 @@ CREDENTIALS_API_URL_ENV: Final[str] = "OPENSRE_CREDENTIALS_API_URL"
 #: Secrets Manager ARN holding this tenant's bootstrap bundle.
 CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV: Final[str] = "OPENSRE_CREDENTIALS_BOOTSTRAP_SECRET_ARN"
 
+#: Secrets Manager ARN holding this tenant's IntegrationStore v2 blob.
+INTEGRATIONS_SECRET_ARN_ENV: Final[str] = "OPENSRE_INTEGRATIONS_SECRET_ARN"
+
+#: Where the hydrated integration store is written inside the silo. The control
+#: plane points this at ephemeral container storage so vault credentials never
+#: land on the tenant's persistent workspace mount.
+INTEGRATIONS_STORE_PATH_ENV: Final[str] = "OPENSRE_INTEGRATIONS_STORE_PATH"
+
 __all__ = [
     "CREDENTIALS_API_URL_ENV",
     "CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV",
+    "INTEGRATIONS_SECRET_ARN_ENV",
+    "INTEGRATIONS_STORE_PATH_ENV",
     "TENANT_ORGANIZATION_ID_ENV",
 ]

--- a/gateway/runtime/credential_hydration.py
+++ b/gateway/runtime/credential_hydration.py
@@ -7,10 +7,10 @@ below, an API token. It never carries integrations.
 Integrations then arrive by exactly one of two routes:
 
 * **integrations secret** — read the tenant's IntegrationStore v2 blob from
-  Secrets Manager. This is the deployed route.
-* **credentials API** — fetch the store from the webapp over HTTPS. An operator
-  who sets a URL is deliberately routing this silo away from its secret, so this
-  route wins when both are configured.
+  Secrets Manager. This is the route deployed silos run on, and it wins when
+  both are configured.
+* **credentials API** — fetch the store from the webapp over HTTPS. The staged
+  fallback, used only when no integrations secret is configured.
 
 Configuring neither leaves the store as shipped, which is how a laptop runs.
 

--- a/gateway/runtime/credential_hydration.py
+++ b/gateway/runtime/credential_hydration.py
@@ -1,4 +1,25 @@
-"""Fail-closed startup hydration of tenant integration credentials."""
+"""Load one tenant's integration credentials, once, before the gateway serves.
+
+A silo always reads its **bootstrap secret** from Secrets Manager first. That
+secret carries the tenant's Neon connection string and, for one of the routes
+below, an API token. It never carries integrations.
+
+Integrations then arrive by exactly one of two routes:
+
+* **integrations secret** — read the tenant's IntegrationStore v2 blob from
+  Secrets Manager. This is the deployed route.
+* **credentials API** — fetch the store from the webapp over HTTPS. An operator
+  who sets a URL is deliberately routing this silo away from its secret, so this
+  route wins when both are configured.
+
+Configuring neither leaves the store as shipped, which is how a laptop runs.
+
+Two failure modes are deliberately different. Nothing configured means the
+feature is off, so :meth:`CredentialHydrationConfig.from_environment` returns
+``None``. Something-but-not-everything configured is a broken deployment, so it
+raises rather than starting a silo that would serve the wrong tenant or no
+tenant at all.
+"""
 
 from __future__ import annotations
 
@@ -28,8 +49,12 @@ class SecretsManagerClient(Protocol):
 class GatewayBootstrap:
     """Decrypted bootstrap values held in memory for this process only."""
 
+    #: Authorizes the credentials-API route. Unused on the secret route.
     credentials_api_token: str | None = None
+    #: Neon connection string; the remote-run worker needs it to poll.
     database_url: str | None = None
+    #: Whether a route ran and replaced the local store, as opposed to the
+    #: store shipping with the image. Drives one status word.
     integrations_hydrated: bool = False
 
 
@@ -45,7 +70,7 @@ class CredentialHydrationConfig:
     @classmethod
     def from_environment(cls) -> CredentialHydrationConfig | None:
         """Return ``None`` when disabled, and reject partial configuration."""
-        required_values = {
+        identity = {
             TENANT_ORGANIZATION_ID_ENV: os.getenv(TENANT_ORGANIZATION_ID_ENV, "").strip(),
             CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV: os.getenv(
                 CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV, ""
@@ -53,18 +78,20 @@ class CredentialHydrationConfig:
         }
         credentials_api_url = os.getenv(CREDENTIALS_API_URL_ENV, "").strip()
         integrations_secret_arn = os.getenv(INTEGRATIONS_SECRET_ARN_ENV, "").strip()
-        optional_values = (credentials_api_url, integrations_secret_arn)
-        if not any(required_values.values()) and not any(optional_values):
+
+        # Not one variable set anywhere: the feature is off, not misconfigured.
+        if not any(identity.values()) and not (credentials_api_url or integrations_secret_arn):
             return None
-        missing = [name for name, value in required_values.items() if not value]
+        # Anything set means a silo meant to hydrate, so identity must be complete.
+        missing = [name for name, value in identity.items() if not value]
         if missing:
             raise ValueError("Credential hydration configuration is incomplete")
         if credentials_api_url and not credentials_api_url.lower().startswith("https://"):
             raise ValueError("Credentials API URL must use HTTPS")
         return cls(
-            organization_id=required_values[TENANT_ORGANIZATION_ID_ENV],
+            organization_id=identity[TENANT_ORGANIZATION_ID_ENV],
             credentials_api_url=credentials_api_url or None,
-            bootstrap_secret_arn=required_values[CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV],
+            bootstrap_secret_arn=identity[CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV],
             integrations_secret_arn=integrations_secret_arn or None,
         )
 
@@ -113,32 +140,39 @@ class GatewayCredentialHydrator:
         return cls(config=config, secrets_client=boto3.client("secretsmanager"))
 
     def hydrate(self) -> GatewayBootstrap:
-        """Hydrate credentials atomically before any runtime component starts."""
+        """Read the bootstrap secret, then load integrations by one route."""
         bootstrap = _parse_bootstrap_secret(
-            self._secret_string(self._config.bootstrap_secret_arn, "Bootstrap")
+            self._read_secret(self._config.bootstrap_secret_arn, secret_name="Bootstrap")
         )
-        # The credentials API wins when both are configured: an operator who
-        # sets a URL is deliberately routing this silo away from its secret.
-        if self._config.credentials_api_url is not None:
-            self._hydrate_from_credentials_api(bootstrap)
-            return replace(bootstrap, integrations_hydrated=True)
+        # The tenant's secret wins when both are configured: it is the route the
+        # webapp maintains through the control plane, and the one deployed silos
+        # run on. The credentials API stays as the staged fallback.
         if self._config.integrations_secret_arn is not None:
-            hydrate_integration_store_from_secret(
-                self._secret_string(self._config.integrations_secret_arn, "Integrations")
-            )
-            return replace(bootstrap, integrations_hydrated=True)
-        return bootstrap
+            self._load_from_integrations_secret()
+        elif self._config.credentials_api_url is not None:
+            self._load_from_credentials_api(bootstrap)
+        else:
+            return bootstrap
+        return replace(bootstrap, integrations_hydrated=True)
 
-    def _secret_string(self, secret_arn: str, label: str) -> str:
-        """Read one pinned secret ARN, rejecting a non-string value."""
+    def _read_secret(self, secret_arn: str, *, secret_name: str) -> str:
+        """Read one pinned ARN. ``secret_name`` only names it in the error."""
         response = self._secrets_client.get_secret_value(SecretId=secret_arn)
         secret_string = response.get("SecretString")
         if not isinstance(secret_string, str):
-            raise ValueError(f"{label} secret has no string value")
+            raise ValueError(f"{secret_name} secret has no string value")
         return secret_string
 
-    def _hydrate_from_credentials_api(self, bootstrap: GatewayBootstrap) -> None:
-        """Pull this tenant's store from the webapp over HTTPS."""
+    def _load_from_integrations_secret(self) -> None:
+        """Replace the local store from this tenant's Secrets Manager blob."""
+        if self._config.integrations_secret_arn is None:
+            raise ValueError("Integrations secret ARN is not configured")
+        hydrate_integration_store_from_secret(
+            self._read_secret(self._config.integrations_secret_arn, secret_name="Integrations")
+        )
+
+    def _load_from_credentials_api(self, bootstrap: GatewayBootstrap) -> None:
+        """Replace the local store from the webapp over HTTPS."""
         if bootstrap.credentials_api_token is None:
             raise ValueError("Bootstrap secret has no credentials API token")
         if self._config.credentials_api_url is None:

--- a/gateway/runtime/credential_hydration.py
+++ b/gateway/runtime/credential_hydration.py
@@ -10,9 +10,11 @@ from typing import Any, Protocol
 from config.constants.tenancy import (
     CREDENTIALS_API_URL_ENV,
     CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV,
+    INTEGRATIONS_SECRET_ARN_ENV,
     TENANT_ORGANIZATION_ID_ENV,
 )
 from integrations.credentials_api import CredentialsApiClient, hydrate_integration_store
+from integrations.secrets_vault import hydrate_integration_store_from_secret
 
 
 class SecretsManagerClient(Protocol):
@@ -38,6 +40,7 @@ class CredentialHydrationConfig:
     organization_id: str
     bootstrap_secret_arn: str
     credentials_api_url: str | None = None
+    integrations_secret_arn: str | None = None
 
     @classmethod
     def from_environment(cls) -> CredentialHydrationConfig | None:
@@ -49,7 +52,9 @@ class CredentialHydrationConfig:
             ).strip(),
         }
         credentials_api_url = os.getenv(CREDENTIALS_API_URL_ENV, "").strip()
-        if not any(required_values.values()) and not credentials_api_url:
+        integrations_secret_arn = os.getenv(INTEGRATIONS_SECRET_ARN_ENV, "").strip()
+        optional_values = (credentials_api_url, integrations_secret_arn)
+        if not any(required_values.values()) and not any(optional_values):
             return None
         missing = [name for name, value in required_values.items() if not value]
         if missing:
@@ -60,6 +65,7 @@ class CredentialHydrationConfig:
             organization_id=required_values[TENANT_ORGANIZATION_ID_ENV],
             credentials_api_url=credentials_api_url or None,
             bootstrap_secret_arn=required_values[CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV],
+            integrations_secret_arn=integrations_secret_arn or None,
         )
 
 
@@ -108,15 +114,35 @@ class GatewayCredentialHydrator:
 
     def hydrate(self) -> GatewayBootstrap:
         """Hydrate credentials atomically before any runtime component starts."""
-        response = self._secrets_client.get_secret_value(SecretId=self._config.bootstrap_secret_arn)
+        bootstrap = _parse_bootstrap_secret(
+            self._secret_string(self._config.bootstrap_secret_arn, "Bootstrap")
+        )
+        # The credentials API wins when both are configured: an operator who
+        # sets a URL is deliberately routing this silo away from its secret.
+        if self._config.credentials_api_url is not None:
+            self._hydrate_from_credentials_api(bootstrap)
+            return replace(bootstrap, integrations_hydrated=True)
+        if self._config.integrations_secret_arn is not None:
+            hydrate_integration_store_from_secret(
+                self._secret_string(self._config.integrations_secret_arn, "Integrations")
+            )
+            return replace(bootstrap, integrations_hydrated=True)
+        return bootstrap
+
+    def _secret_string(self, secret_arn: str, label: str) -> str:
+        """Read one pinned secret ARN, rejecting a non-string value."""
+        response = self._secrets_client.get_secret_value(SecretId=secret_arn)
         secret_string = response.get("SecretString")
         if not isinstance(secret_string, str):
-            raise ValueError("Bootstrap secret has no string value")
-        bootstrap = _parse_bootstrap_secret(secret_string)
-        if self._config.credentials_api_url is None:
-            return bootstrap
+            raise ValueError(f"{label} secret has no string value")
+        return secret_string
+
+    def _hydrate_from_credentials_api(self, bootstrap: GatewayBootstrap) -> None:
+        """Pull this tenant's store from the webapp over HTTPS."""
         if bootstrap.credentials_api_token is None:
             raise ValueError("Bootstrap secret has no credentials API token")
+        if self._config.credentials_api_url is None:
+            raise ValueError("Credentials API URL is not configured")
         with CredentialsApiClient(
             base_url=self._config.credentials_api_url,
             bootstrap_credential=bootstrap.credentials_api_token,
@@ -125,7 +151,6 @@ class GatewayCredentialHydrator:
                 client=client,
                 organization_id=self._config.organization_id,
             )
-        return replace(bootstrap, integrations_hydrated=True)
 
 
 __all__ = [

--- a/gateway/tests/runtime/test_credential_hydration.py
+++ b/gateway/tests/runtime/test_credential_hydration.py
@@ -10,9 +10,13 @@ from typing import Any
 
 import pytest
 
+from config.constants.billing import WEBAPP_URL_ENV
+from config.constants.paths import integrations_store_path
 from config.constants.tenancy import (
     CREDENTIALS_API_URL_ENV,
     CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV,
+    INTEGRATIONS_SECRET_ARN_ENV,
+    INTEGRATIONS_STORE_PATH_ENV,
     TENANT_ORGANIZATION_ID_ENV,
 )
 from gateway.runtime.credential_hydration import (
@@ -23,6 +27,7 @@ from gateway.runtime.errors import GatewayConfigurationError
 from gateway.runtime.manager import GatewayManager
 from integrations import store
 from integrations.credentials_api import IntegrationStoreV2
+from platform.harness_ports import resolve_integrations
 
 
 class _Secrets:
@@ -105,6 +110,169 @@ def test_hydrates_exact_secret_and_atomically_writes_private_v2_store(
     assert json.loads(path.read_text())["version"] == 2
     assert stat.S_IMODE(path.stat().st_mode) == 0o600
     assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+
+
+class _SecretsById:
+    """Secrets Manager fake that serves a distinct payload per pinned ARN."""
+
+    def __init__(self, secrets: dict[str, str]) -> None:
+        self.secrets = secrets
+        self.calls: list[str] = []
+
+    def get_secret_value(self, *, SecretId: str) -> dict[str, Any]:
+        self.calls.append(SecretId)
+        return {"SecretString": self.secrets[SecretId]}
+
+
+def test_hydrates_from_integrations_secret_when_no_credentials_api_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "home" / ".opensre" / "integrations.json"
+    monkeypatch.setattr(store, "STORE_PATH", path)
+    bootstrap_arn = "arn:aws:secretsmanager:region:account:secret:org-a-bootstrap"
+    integrations_arn = "arn:aws:secretsmanager:region:account:secret:org-a-integrations"
+    secrets = _SecretsById(
+        {
+            bootstrap_arn: json.dumps({"database_url": "postgresql://neon.invalid/test"}),
+            integrations_arn: json.dumps(
+                {
+                    "version": 2,
+                    "integrations": [
+                        {
+                            "id": "grafana-1",
+                            "service": "grafana",
+                            "status": "active",
+                            "instances": [
+                                {
+                                    "name": "prod",
+                                    "tags": {"env": "prod"},
+                                    "credentials": {"api_key": "vault-only"},
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ),
+        }
+    )
+    hydrator = GatewayCredentialHydrator(
+        config=CredentialHydrationConfig(
+            organization_id="org-a",
+            bootstrap_secret_arn=bootstrap_arn,
+            integrations_secret_arn=integrations_arn,
+        ),
+        secrets_client=secrets,
+    )
+
+    bootstrap = hydrator.hydrate()
+
+    assert secrets.calls == [bootstrap_arn, integrations_arn]
+    assert bootstrap.integrations_hydrated is True
+    assert bootstrap.database_url == "postgresql://neon.invalid/test"
+    stored = json.loads(path.read_text())
+    assert stored["version"] == 2
+    assert [record["service"] for record in stored["integrations"]] == ["grafana"]
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_bootstrap_only_silo_stays_preseeded(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "home" / ".opensre" / "integrations.json"
+    monkeypatch.setattr(store, "STORE_PATH", path)
+    bootstrap_arn = "arn:aws:secretsmanager:region:account:secret:org-a-bootstrap"
+    secrets = _SecretsById({bootstrap_arn: json.dumps({"credentials_api_token": "token"})})
+    hydrator = GatewayCredentialHydrator(
+        config=CredentialHydrationConfig(
+            organization_id="org-a",
+            bootstrap_secret_arn=bootstrap_arn,
+        ),
+        secrets_client=secrets,
+    )
+
+    bootstrap = hydrator.hydrate()
+
+    assert bootstrap.integrations_hydrated is False
+    assert not path.exists()
+
+
+def test_hydrated_secret_is_visible_to_integration_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The deployed contract end to end: secret → store path → resolution.
+
+    Hydration writing a file is not the point; a turn resolving the credential
+    is. This pins the whole chain under the env the control plane actually
+    injects, so a change to either half fails here rather than in a silo.
+    """
+    store_path = tmp_path / "ephemeral" / "integrations.json"
+    monkeypatch.setenv(INTEGRATIONS_STORE_PATH_ENV, str(store_path))
+    monkeypatch.setattr(store, "STORE_PATH", None)
+    # A silo has no webapp vault configured; local sources must serve the turn.
+    monkeypatch.delenv(WEBAPP_URL_ENV, raising=False)
+    monkeypatch.delenv("JWT_TOKEN", raising=False)
+
+    bootstrap_arn = "arn:aws:secretsmanager:region:account:secret:org-a-bootstrap"
+    integrations_arn = "arn:aws:secretsmanager:region:account:secret:org-a-integrations"
+    secrets = _SecretsById(
+        {
+            bootstrap_arn: json.dumps({"database_url": "postgresql://neon.invalid/test"}),
+            integrations_arn: json.dumps(
+                {
+                    "version": 2,
+                    "integrations": [
+                        {
+                            "id": "grafana-1",
+                            "service": "grafana",
+                            "status": "active",
+                            "instances": [
+                                {
+                                    "name": "default",
+                                    "tags": {},
+                                    "credentials": {
+                                        "url": "https://grafana.invalid",
+                                        "api_key": "vault-only",
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ),
+        }
+    )
+    hydrator = GatewayCredentialHydrator(
+        config=CredentialHydrationConfig(
+            organization_id="org-a",
+            bootstrap_secret_arn=bootstrap_arn,
+            integrations_secret_arn=integrations_arn,
+        ),
+        secrets_client=secrets,
+    )
+
+    hydrator.hydrate()
+    resolved = {entry["service"] for entry in store.load_integrations()}
+
+    assert integrations_store_path() == store_path
+    assert "grafana" in resolved
+
+
+def test_environment_configures_the_integrations_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(TENANT_ORGANIZATION_ID_ENV, "org-a")
+    monkeypatch.setenv(CREDENTIALS_BOOTSTRAP_SECRET_ARN_ENV, "arn:bootstrap")
+    monkeypatch.setenv(INTEGRATIONS_SECRET_ARN_ENV, "arn:integrations")
+    monkeypatch.delenv(CREDENTIALS_API_URL_ENV, raising=False)
+
+    config = CredentialHydrationConfig.from_environment()
+
+    assert config is not None
+    assert config.integrations_secret_arn == "arn:integrations"
+    assert config.credentials_api_url is None
 
 
 def test_partial_environment_configuration_is_rejected(

--- a/gateway/tests/runtime/test_credential_hydration.py
+++ b/gateway/tests/runtime/test_credential_hydration.py
@@ -27,7 +27,6 @@ from gateway.runtime.errors import GatewayConfigurationError
 from gateway.runtime.manager import GatewayManager
 from integrations import store
 from integrations.credentials_api import IntegrationStoreV2
-from platform.harness_ports import resolve_integrations
 
 
 class _Secrets:

--- a/gateway/tests/runtime/test_credential_hydration.py
+++ b/gateway/tests/runtime/test_credential_hydration.py
@@ -300,3 +300,71 @@ def test_manager_fails_closed_with_generic_error() -> None:
         manager._load_credentials(logging.getLogger("test"))
 
     assert manager.components["credentials"] == "failed"
+
+
+class _SecretsByArn:
+    """Serves a different payload per ARN so the chosen route is observable."""
+
+    def __init__(self, payloads: dict[str, str]) -> None:
+        self.payloads = payloads
+        self.calls: list[str] = []
+
+    def get_secret_value(self, *, SecretId: str) -> dict[str, Any]:
+        self.calls.append(SecretId)
+        return {"SecretString": self.payloads[SecretId]}
+
+
+def test_integrations_secret_wins_when_both_routes_are_configured(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The deployed route is the tenant's secret, not the webapp API.
+
+    Nothing failed when the module docstring described the opposite order, so
+    this pins the precedence the silo actually executes.
+    """
+    # Arrange: both routes configured, each yielding a distinguishable service.
+    monkeypatch.setattr(store, "STORE_PATH", tmp_path / "integrations.json")
+    monkeypatch.setattr(
+        "gateway.runtime.credential_hydration.CredentialsApiClient",
+        _ApiClient,
+    )
+    bootstrap_arn = "arn:aws:secretsmanager:region:account:secret:bootstrap"
+    integrations_arn = "arn:aws:secretsmanager:region:account:secret:integrations"
+    secrets = _SecretsByArn(
+        {
+            bootstrap_arn: json.dumps({"credentials_api_token": "bootstrap-token"}),
+            integrations_arn: json.dumps(
+                {
+                    "version": 2,
+                    "integrations": [
+                        {
+                            "id": "from-secret-1",
+                            "service": "from-secret",
+                            "status": "active",
+                            "instances": [
+                                {"name": "default", "tags": {}, "credentials": {"token": "s"}}
+                            ],
+                        }
+                    ],
+                }
+            ),
+        }
+    )
+    hydrator = GatewayCredentialHydrator(
+        config=CredentialHydrationConfig(
+            organization_id="org-a",
+            credentials_api_url="https://credentials.example.test",
+            bootstrap_secret_arn=bootstrap_arn,
+            integrations_secret_arn=integrations_arn,
+        ),
+        secrets_client=secrets,
+    )
+
+    # Act
+    bootstrap = hydrator.hydrate()
+
+    # Assert: the secret's store landed, and the API was never consulted.
+    assert [record["service"] for record in store.load_integrations()] == ["from-secret"]
+    assert integrations_arn in secrets.calls
+    assert bootstrap.integrations_hydrated is True

--- a/gateway/tests/runtime/test_credential_hydration.py
+++ b/gateway/tests/runtime/test_credential_hydration.py
@@ -6,7 +6,7 @@ import json
 import logging
 import stat
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -290,9 +290,11 @@ def test_manager_fails_closed_with_generic_error() -> None:
         def hydrate(self) -> None:
             raise RuntimeError("secret value must not escape")
 
-    manager = GatewayManager(
-        credential_hydrator_factory=lambda: BrokenHydrator(),  # type: ignore[arg-type]
-    )
+    def _broken_hydrator() -> GatewayCredentialHydrator:
+        # The fake only needs hydrate(); cast keeps the factory signature honest.
+        return cast(GatewayCredentialHydrator, BrokenHydrator())
+
+    manager = GatewayManager(credential_hydrator_factory=_broken_hydrator)
 
     with pytest.raises(GatewayConfigurationError, match="hydration failed"):
         manager._load_credentials(logging.getLogger("test"))

--- a/integrations/secrets_vault.py
+++ b/integrations/secrets_vault.py
@@ -1,0 +1,58 @@
+"""Hydrate the local integration store from a Secrets Manager v2 payload.
+
+Peer of :mod:`integrations.credentials_api`: the transport differs — a silo's
+task role reads one pinned secret ARN instead of calling the webapp over
+HTTPS — but the payload contract (IntegrationStore v2) and the resulting local
+store are identical. The webapp owns the secret's contents; it writes them
+through the control plane, which rolls the silo so this runs again at boot.
+
+Errors carry a generic message: the caller logs them, and a validation failure
+must never echo a credential back into the log stream.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from integrations.credentials_api import (
+    CredentialsApiError,
+    IntegrationStoreV2,
+    validate_integration_store_v2,
+)
+from integrations.store import replace_integrations
+
+
+class IntegrationsSecretError(RuntimeError):
+    """Raised with a generic message when the integrations secret is unusable."""
+
+
+def parse_integrations_secret(secret_string: str) -> IntegrationStoreV2:
+    """Validate one Secrets Manager payload without touching the local store."""
+    if not secret_string.strip():
+        raise IntegrationsSecretError("Integrations secret is empty")
+    try:
+        payload = json.loads(secret_string)
+    except ValueError:
+        raise IntegrationsSecretError("Integrations secret is not valid JSON") from None
+    try:
+        return validate_integration_store_v2(payload)
+    except CredentialsApiError:
+        raise IntegrationsSecretError("Integrations secret is not a valid credential set") from None
+
+
+def hydrate_integration_store_from_secret(secret_string: str) -> IntegrationStoreV2:
+    """Validate the secret and atomically materialize the local v2 store."""
+    validated = parse_integrations_secret(secret_string)
+    integrations: Any = validated.as_store_data()["integrations"]
+    if not isinstance(integrations, list):
+        raise IntegrationsSecretError("Integrations secret is not a valid credential set")
+    replace_integrations(integrations)
+    return validated
+
+
+__all__ = [
+    "IntegrationsSecretError",
+    "hydrate_integration_store_from_secret",
+    "parse_integrations_secret",
+]

--- a/tests/integrations/test_secrets_vault.py
+++ b/tests/integrations/test_secrets_vault.py
@@ -1,0 +1,93 @@
+"""Tests for hydrating the local store from a Secrets Manager v2 payload."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from config.constants.paths import integrations_store_path
+from config.constants.tenancy import INTEGRATIONS_STORE_PATH_ENV
+from integrations import store
+from integrations.secrets_vault import (
+    IntegrationsSecretError,
+    hydrate_integration_store_from_secret,
+    parse_integrations_secret,
+)
+
+_VALID_SECRET = json.dumps(
+    {
+        "version": 2,
+        "integrations": [
+            {
+                "id": "github-1",
+                "service": "github",
+                "status": "active",
+                "instances": [
+                    {
+                        "name": "default",
+                        "tags": {},
+                        "credentials": {"token": "vault-only"},
+                    }
+                ],
+            }
+        ],
+    }
+)
+
+
+def test_hydrate_replaces_the_local_store(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "integrations.json"
+    monkeypatch.setattr(store, "STORE_PATH", path)
+    store.upsert_integration("stale", {"credentials": {"token": "removed"}})
+
+    validated = hydrate_integration_store_from_secret(_VALID_SECRET)
+
+    assert [record.service for record in validated.integrations] == ["github"]
+    assert [record["service"] for record in store.load_integrations()] == ["github"]
+
+
+@pytest.mark.parametrize(
+    "secret_string",
+    [
+        "",
+        "   ",
+        "not-json",
+        json.dumps({"version": 1, "integrations": []}),
+        json.dumps({"version": 2, "integrations": [{"service": "github"}]}),
+        json.dumps({"version": 2, "integrations": [], "extra": True}),
+    ],
+)
+def test_unusable_secret_is_rejected_without_echoing_it(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    secret_string: str,
+) -> None:
+    monkeypatch.setattr(store, "STORE_PATH", tmp_path / "integrations.json")
+
+    with pytest.raises(IntegrationsSecretError) as excinfo:
+        parse_integrations_secret(secret_string)
+
+    message = str(excinfo.value)
+    assert message.startswith("Integrations secret is")
+    if secret_string.strip():
+        assert secret_string.strip() not in message
+
+
+def test_store_path_env_override_targets_ephemeral_storage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    override = tmp_path / "ephemeral" / "integrations.json"
+    monkeypatch.setenv(INTEGRATIONS_STORE_PATH_ENV, str(override))
+    monkeypatch.setattr(store, "STORE_PATH", None)
+
+    assert integrations_store_path() == override
+
+    hydrate_integration_store_from_secret(_VALID_SECRET)
+
+    assert json.loads(override.read_text())["version"] == 2

--- a/tests/integrations/test_vendor_first_layout.py
+++ b/tests/integrations/test_vendor_first_layout.py
@@ -37,6 +37,10 @@ ALLOWED_FLAT_MODULES = frozenset(
         "probes.py",
         "registry.py",
         "scheduled_agent_bootstrap.py",
+        # Cross-cutting credential-resolution infra (hydrates every vendor's org
+        # creds from the tenant's Secrets Manager blob), not a vendor — the
+        # Secrets Manager peer of webapp_vault.py.
+        "secrets_vault.py",
         "selectors.py",
         "setup_flow.py",
         "store.py",


### PR DESCRIPTION
Adds the second credential route: a silo can hydrate its integration store from the tenant's IntegrationStore v2 secret instead of calling the web app. Writes the hydrated store to ephemeral container storage, and removes the one name that could bypass that path.

The deployed route is the per-tenant Secrets Manager blob. The task role already reads exactly that ARN, and the control plane rolls the service after every integrations write, so a boot-time read is the whole refresh mechanism — no polling, no inbound path to the silo.

Two properties are load-bearing:

- **Credentials must not land on the persistent mount.** The workspace volume   outlives the task and is shared by every member of the org. Hydrated  credentials belong on container storage that dies with the task.
- **The store path must have one resolver.** `config.constants` exported  `INTEGRATIONS_STORE_PATH`, computed at import time from the host home. It had  **zero consumers**, but it was the obvious-looking name and it ignored both org
  scoping and the new override — anyone reaching for it would write to the shared  mount. Removed rather than left as a trap.

