### PR TITLE
feat: interactive setup for opensre remote-sync

### DIFF
--- a/platform/filestorage/enums.py
+++ b/platform/filestorage/enums.py
@@ -40,6 +40,7 @@ class RemoteSyncSubcommand(StrEnum):
 
     STATUS = "status"
     SYNC = "sync"
+    SETUP = "setup"
 
 
 __all__ = [

--- a/platform/filestorage/operations.py
+++ b/platform/filestorage/operations.py
@@ -21,6 +21,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
+    DEFAULT_REMOTE_SYNC_PROVIDER,
+)
 from config.scope_context import current_scope
 from platform.filestorage.config import RemoteSyncConfig, load_remote_sync_config
 from platform.filestorage.engine import SyncReport, resolve_direction, run_sync
@@ -115,9 +119,45 @@ def run_remote_sync(
     return _owned_report(run_sync(store, direction=resolved, roots=roots))
 
 
+def write_remote_sync_config(
+    *,
+    provider: str,
+    bucket: str,
+    prefix: str,
+    region: str,
+    profile: str,
+) -> None:
+    """Persist connection settings to the ``remote_sync`` section.
+
+    Writes only ``provider``/``bucket``/``prefix``/``region``/``profile`` —
+    never ``enabled``. Naming a bucket must not itself turn sync on, so a
+    ``setup`` run stages the destination and the switch stays a separate,
+    explicit step (``OPENSRE_REMOTE_SYNC=1`` or the ``enabled`` key).
+
+    Refuses an org-scoped turn for the same reason ``get_sync_status``/
+    ``run_remote_sync`` do: object keys carry no principal, so configuring a
+    shared destination is part of the same "org sync" boundary even though
+    this never touches an ObjectStore itself.
+    """
+    _refuse_org_scoped_turn()
+    from config.local_settings import update_section
+
+    update_section(
+        "remote_sync",
+        {
+            "provider": provider.strip().lower() or DEFAULT_REMOTE_SYNC_PROVIDER,
+            "bucket": bucket.strip(),
+            "prefix": prefix.strip() or DEFAULT_REMOTE_SYNC_PREFIX,
+            "region": region.strip(),
+            "profile": profile.strip(),
+        },
+    )
+
+
 __all__ = [
     "SyncRootStatus",
     "SyncStatus",
     "get_sync_status",
     "run_remote_sync",
+    "write_remote_sync_config",
 ]

--- a/surfaces/cli/commands/remote_sync.py
+++ b/surfaces/cli/commands/remote_sync.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 import click
 
+from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
+    DEFAULT_REMOTE_SYNC_PROVIDER,
+    REMOTE_SYNC_ENV,
+)
+from config.local_settings import LocalSettingsError, local_settings_path
 from platform.common.exit_codes import ERROR, SUCCESS
 from platform.filestorage import RemoteSyncError
 from platform.filestorage.enums import RemoteSyncSubcommand
@@ -12,7 +18,11 @@ from platform.filestorage.messages import (
     format_report_lines,
     format_status_lines,
 )
-from platform.filestorage.operations import get_sync_status, run_remote_sync
+from platform.filestorage.operations import (
+    get_sync_status,
+    run_remote_sync,
+    write_remote_sync_config,
+)
 
 
 @click.group(name="remote-sync", invoke_without_command=True)
@@ -33,6 +43,26 @@ def status_command() -> None:
         raise SystemExit(ERROR) from exc
     for line in lines:
         click.echo(line)
+    raise SystemExit(SUCCESS)
+
+
+@remote_sync_command.command(name=RemoteSyncSubcommand.SETUP.value)
+def setup_command() -> None:
+    """Configure remote-sync connection settings (does not enable or verify it)."""
+    provider = click.prompt("Provider", default=DEFAULT_REMOTE_SYNC_PROVIDER)
+    bucket = click.prompt("Bucket")
+    prefix = click.prompt("Prefix", default=DEFAULT_REMOTE_SYNC_PREFIX)
+    region = click.prompt("Region", default="", show_default=False)
+    profile = click.prompt("Profile", default="", show_default=False)
+    try:
+        write_remote_sync_config(
+            provider=provider, bucket=bucket, prefix=prefix, region=region, profile=profile
+        )
+    except (RemoteSyncError, LocalSettingsError) as exc:
+        click.echo(str(exc), err=True)
+        raise SystemExit(ERROR) from exc
+    click.echo(f"Saved remote-sync settings to {local_settings_path()}.")
+    click.echo(f"Set {REMOTE_SYNC_ENV}=1 to enable syncing.")
     raise SystemExit(SUCCESS)
 
 

--- a/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
+++ b/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
@@ -6,11 +6,20 @@ import logging
 
 from rich.console import Console
 
-from config.constants.filestorage import DEFAULT_REMOTE_SYNC_PROVIDER
+from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
+    DEFAULT_REMOTE_SYNC_PROVIDER,
+    REMOTE_SYNC_ENV,
+)
+from config.local_settings import LocalSettingsError, local_settings_path
 from platform.filestorage import OrgScopeNotSupportedError, RemoteSyncError
 from platform.filestorage.enums import RemoteSyncSubcommand
 from platform.filestorage.messages import DISABLED_HELP, format_report_lines
-from platform.filestorage.operations import get_sync_status, run_remote_sync
+from platform.filestorage.operations import (
+    get_sync_status,
+    run_remote_sync,
+    write_remote_sync_config,
+)
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT
@@ -18,8 +27,8 @@ from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT
 logger = logging.getLogger(__name__)
 
 _USAGE = (
-    f"/remote-sync [{RemoteSyncSubcommand.STATUS}|{RemoteSyncSubcommand.SYNC}] "
-    "[--pull-only|--push-only]"
+    f"/remote-sync [{RemoteSyncSubcommand.STATUS}|{RemoteSyncSubcommand.SYNC}"
+    f"|{RemoteSyncSubcommand.SETUP}] [--pull-only|--push-only]"
 )
 
 
@@ -62,6 +71,27 @@ def _run_sync(console: Console, args: list[str]) -> bool:
     return True
 
 
+def _run_setup(console: Console) -> bool:
+    console.print("Configure remote-sync connection settings (does not enable or verify it).")
+    provider = (
+        console.input(f"[{HIGHLIGHT}]Provider [{DEFAULT_REMOTE_SYNC_PROVIDER}]> [/]").strip()
+        or DEFAULT_REMOTE_SYNC_PROVIDER
+    )
+    bucket = console.input(f"[{HIGHLIGHT}]Bucket> [/]").strip()
+    prefix = (
+        console.input(f"[{HIGHLIGHT}]Prefix [{DEFAULT_REMOTE_SYNC_PREFIX}]> [/]").strip()
+        or DEFAULT_REMOTE_SYNC_PREFIX
+    )
+    region = console.input(f"[{HIGHLIGHT}]Region (optional)> [/]").strip()
+    profile = console.input(f"[{HIGHLIGHT}]Profile (optional)> [/]").strip()
+    write_remote_sync_config(
+        provider=provider, bucket=bucket, prefix=prefix, region=region, profile=profile
+    )
+    console.print(f"Saved remote-sync settings to [{HIGHLIGHT}]{local_settings_path()}[/].")
+    console.print(f"[{DIM}]Set {REMOTE_SYNC_ENV}=1 to enable syncing.[/]")
+    return True
+
+
 def _parse_subcommand(raw: str) -> RemoteSyncSubcommand | None:
     try:
         return RemoteSyncSubcommand(raw)
@@ -77,16 +107,20 @@ def _cmd_remote_sync(_session: Session, console: Console, args: list[str]) -> bo
             return _print_status(console)
         if sub is RemoteSyncSubcommand.SYNC:
             return _run_sync(console, args[1:])
+        if sub is RemoteSyncSubcommand.SETUP:
+            return _run_setup(console)
     except OrgScopeNotSupportedError as exc:
         # Safe to show: our own wording, no vendor or credential detail.
         console.print(f"[{DIM}]{exc}[/]")
         return True
-    except RemoteSyncError:
+    except (RemoteSyncError, LocalSettingsError):
         # This handler also serves gateway chat, an external surface, so the
         # provider's message never reaches the reply. Detail goes to the log.
+        # LocalSettingsError covers a malformed/unwritable config.yml, which
+        # setup can hit even though it never touches an ObjectStore.
         logger.warning("[remote-sync] command failed", exc_info=True)
         console.print(
-            f"[{ERROR}]Sync failed.[/] Check the opensre log, "
+            f"[{ERROR}]Command failed.[/] Check the opensre log, "
             "or run [bold]opensre remote-sync status[/bold] locally for detail."
         )
         return True
@@ -116,6 +150,10 @@ COMMANDS: tuple[SlashCommand, ...] = (
                 "show whether sync is on and what would be mirrored",
             ),
             (RemoteSyncSubcommand.SYNC.value, "pull remote changes, then push local ones"),
+            (
+                RemoteSyncSubcommand.SETUP.value,
+                "configure provider/bucket/prefix/region/profile (does not enable it)",
+            ),
         ),
         use_cases=(
             "sync my conversations to S3",

--- a/tests/cli/test_gateway_remote_sync.py
+++ b/tests/cli/test_gateway_remote_sync.py
@@ -160,5 +160,5 @@ def test_gateway_dispatch_sync_error_stays_handled(monkeypatch: pytest.MonkeyPat
         is True
     )
     out = buf.getvalue()
-    assert "Sync failed" in out
+    assert "Command failed" in out
     assert leaked not in out, "provider detail reached the gateway reply"

--- a/tests/cli/test_remote_sync_command.py
+++ b/tests/cli/test_remote_sync_command.py
@@ -181,3 +181,73 @@ def test_sync_help_documents_direction_flags(runner: CliRunner) -> None:
     assert result.exit_code == 0
     assert "--pull-only" in result.output
     assert "--push-only" in result.output
+
+
+def test_setup_prompts_and_writes_config(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.write_remote_sync_config",
+        lambda **kwargs: captured.update(kwargs),
+    )
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        input="aws\nmy-bucket\nopensre\n\n\n",
+    )
+    assert result.exit_code == 0
+    assert captured == {
+        "provider": "aws",
+        "bucket": "my-bucket",
+        "prefix": "opensre",
+        "region": "",
+        "profile": "",
+    }
+    assert "Saved remote-sync settings" in result.output
+    assert "enable syncing" in result.output
+
+
+def test_setup_uses_defaults_on_blank_provider_and_prefix(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.write_remote_sync_config",
+        lambda **kwargs: captured.update(kwargs),
+    )
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        input="\nmy-bucket\n\nus-east-1\nwork\n",
+    )
+    assert result.exit_code == 0
+    assert captured["provider"] == "aws"
+    assert captured["prefix"] == "opensre"
+    assert captured["region"] == "us-east-1"
+    assert captured["profile"] == "work"
+
+
+def test_setup_failure_exits_nonzero(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(**_kwargs: str) -> None:
+        raise RemoteSyncConfigError("could not write settings")
+
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.write_remote_sync_config",
+        _boom,
+    )
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        input="aws\nmy-bucket\nopensre\n\n\n",
+    )
+    assert result.exit_code != 0
+    assert "could not write settings" in result.output
+
+
+def test_remote_sync_help_lists_setup(runner: CliRunner) -> None:
+    result = runner.invoke(remote_sync_command, ["--help"])
+    assert result.exit_code == 0
+    assert RemoteSyncSubcommand.SETUP in result.output

--- a/tests/filestorage/test_enums.py
+++ b/tests/filestorage/test_enums.py
@@ -29,9 +29,11 @@ def test_direction_flags_resolve_to_enum() -> None:
     assert resolve_direction(pull_only=False, push_only=False) is SyncDirection.BOTH
 
 
-def test_remote_sync_subcommands_are_status_and_sync() -> None:
+def test_remote_sync_subcommands_are_status_sync_and_setup() -> None:
     assert set(RemoteSyncSubcommand) == {
         RemoteSyncSubcommand.STATUS,
         RemoteSyncSubcommand.SYNC,
+        RemoteSyncSubcommand.SETUP,
     }
     assert RemoteSyncSubcommand("status") is RemoteSyncSubcommand.STATUS
+    assert RemoteSyncSubcommand("setup") is RemoteSyncSubcommand.SETUP

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import pytest
 
 from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
+    DEFAULT_REMOTE_SYNC_PROVIDER,
     REMOTE_SYNC_BUCKET_ENV,
     REMOTE_SYNC_ENV,
     REMOTE_SYNC_PREFIX_ENV,
@@ -816,18 +818,26 @@ def test_org_scoped_turn_refuses_to_sync(monkeypatch: pytest.MonkeyPatch) -> Non
     from config.principal import Actor, Principal, StorageScope
     from config.scope_context import bound_storage_scope
     from platform.filestorage.errors import OrgScopeNotSupportedError
-    from platform.filestorage.operations import get_sync_status, run_remote_sync
+    from platform.filestorage.operations import (
+        get_sync_status,
+        run_remote_sync,
+        write_remote_sync_config,
+    )
 
     monkeypatch.setenv(REMOTE_SYNC_ENV, "1")
     monkeypatch.setenv(REMOTE_SYNC_BUCKET_ENV, "shared-bucket")
     scope = StorageScope(principal=Principal.org("org_acme"), actor=Actor(id="U_ALICE"))
 
-    # Act / Assert: both entry points fail closed while the scope is bound.
+    # Act / Assert: all three entry points fail closed while the scope is bound.
     with bound_storage_scope(scope):
         with pytest.raises(OrgScopeNotSupportedError):
             run_remote_sync()
         with pytest.raises(OrgScopeNotSupportedError):
             get_sync_status()
+        with pytest.raises(OrgScopeNotSupportedError):
+            write_remote_sync_config(
+                provider="aws", bucket="shared-bucket", prefix="opensre", region="", profile=""
+            )
 
 
 def test_unbound_laptop_turn_still_syncs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -934,3 +944,85 @@ def test_list_prefix_is_delimited_so_a_sibling_bucket_path_cannot_match() -> Non
 
     # Assert
     assert seen["Prefix"] == "opensre/"
+
+
+# ── /remote-sync setup writes settings without enabling sync ────────────────
+
+
+def test_write_remote_sync_config_persists_the_five_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """setup stages a destination; it must not flip the enabled switch."""
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import read_section
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+
+    # Act
+    write_remote_sync_config(
+        provider="AWS",
+        bucket=" my-bucket ",
+        prefix="",
+        region="us-east-1",
+        profile="work",
+    )
+
+    # Assert: normalized values landed, and "enabled" was never written.
+    section = read_section("remote_sync")
+    assert section == {
+        "provider": "aws",
+        "bucket": "my-bucket",
+        "prefix": "opensre",
+        "region": "us-east-1",
+        "profile": "work",
+    }
+    assert "enabled" not in section
+
+
+def test_write_remote_sync_config_round_trips_once_enabled_separately(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Naming a bucket alone must not enable sync; the switch stays separate."""
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import update_section
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+    for name in (REMOTE_SYNC_ENV, REMOTE_SYNC_BUCKET_ENV, REMOTE_SYNC_PREFIX_ENV):
+        monkeypatch.delenv(name, raising=False)
+
+    # Act: setup alone must not turn sync on.
+    write_remote_sync_config(
+        provider="aws", bucket="my-bucket", prefix="opensre", region="", profile=""
+    )
+    assert load_remote_sync_config() is None
+
+    # Enabling separately (the "enabled" key, mirroring what a later CLI/slash
+    # confirmation step would set) makes the same written settings take effect.
+    update_section("remote_sync", {"enabled": True})
+    config = load_remote_sync_config()
+    assert config is not None
+    assert config.bucket == "my-bucket"
+    assert config.provider == "aws"
+
+
+def test_write_remote_sync_config_defaults_blank_provider_and_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import read_section
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+
+    # Act
+    write_remote_sync_config(provider="", bucket="b", prefix="  ", region="", profile="")
+
+    # Assert
+    section = read_section("remote_sync")
+    assert section["provider"] == DEFAULT_REMOTE_SYNC_PROVIDER
+    assert section["prefix"] == DEFAULT_REMOTE_SYNC_PREFIX

--- a/tests/interactive_shell/test_remote_sync_cmds.py
+++ b/tests/interactive_shell/test_remote_sync_cmds.py
@@ -102,7 +102,7 @@ def test_sync_error_is_caught(monkeypatch: pytest.MonkeyPatch) -> None:
     console, buf = _capture()
     assert dispatch_slash("/remote-sync sync --pull-only --push-only", Session(), console) is True
     out = buf.getvalue()
-    assert "Sync failed" in out
+    assert "Command failed" in out
     # This handler also serves gateway chat, so provider detail must not appear.
     assert "bad flags" not in out, "error detail reached the chat reply"
 
@@ -135,7 +135,7 @@ def test_slash_command_metadata_for_planner() -> None:
     cmd = SLASH_COMMANDS["/remote-sync"]
     assert cmd.first_arg_completions is not None
     labels = {label for label, _hint in cmd.first_arg_completions}
-    assert labels == {"status", "sync"}
+    assert labels == {"status", "sync", "setup"}
     assert any("OPENSRE_REMOTE_SYNC" in note for note in (cmd.notes or ()))
     catalog = MCP_BY_COMMAND["/remote-sync"]
     assert "status" in catalog.llm_description
@@ -170,3 +170,75 @@ def test_repl_and_headless_dispatch_same_command_object() -> None:
     assert repl.command_exists("/remote-sync")
     assert headless.command_exists("/remote-sync")
     assert SLASH_COMMANDS["/remote-sync"].handler is not None
+
+
+def test_setup_prompts_and_writes_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    answers = iter(["aws", "my-bucket", "opensre", "", ""])
+    captured: dict[str, str] = {}
+
+    def _capture_write(**kwargs: str) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        _capture_write,
+    )
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    assert captured == {
+        "provider": "aws",
+        "bucket": "my-bucket",
+        "prefix": "opensre",
+        "region": "",
+        "profile": "",
+    }
+    out = buf.getvalue()
+    assert "Saved remote-sync settings" in out
+    assert "enable syncing" in out
+
+
+def test_setup_uses_defaults_on_blank_provider_and_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    answers = iter(["", "my-bucket", "", "us-east-1", "work"])
+    captured: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        lambda **kwargs: captured.update(kwargs),
+    )
+    console, _buf = _capture()
+    monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    assert captured["provider"] == "aws"
+    assert captured["prefix"] == "opensre"
+    assert captured["region"] == "us-east-1"
+    assert captured["profile"] == "work"
+
+
+def test_setup_failure_shows_generic_message_not_exception_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """External surface (gateway chat shares this handler): never leak str(exc)."""
+
+    def _boom(**_kwargs: str) -> None:
+        raise RemoteSyncConfigError("SECRET-INTERNAL-DETAIL should never reach chat")
+
+    answers = iter(["aws", "my-bucket", "opensre", "", ""])
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        _boom,
+    )
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    out = buf.getvalue()
+    assert "SECRET-INTERNAL-DETAIL" not in out
+    assert "Command failed" in out


### PR DESCRIPTION
Fixes #4554

#### Describe the changes you have made in this PR -

Enabling remote sync required exporting five env vars by hand. `load_remote_sync_config()` and `local_settings.update_section()` already existed as the read/write plumbing; nothing wrote the `remote_sync` section from a wizard.

Added `RemoteSyncSubcommand.SETUP` and a shared `write_remote_sync_config(provider, bucket, prefix, region, profile)` in `platform/filestorage/operations.py`. It writes exactly those five fields and never `enabled` - per the issue's own Done-when list (which enumerates the five prompted fields and pointedly excludes `enabled`) and the existing "naming a bucket alone never enables sync" invariant. It also refuses an org-scoped turn, for the same reason `get_sync_status`/`run_remote_sync` do (object keys carry no principal), even though `setup` never touches an `ObjectStore`.

Wired a `setup` subcommand into both surfaces, each using its own existing idiom: `opensre remote-sync setup` uses `click.prompt` (matching this file's Click-adapter style), `/remote-sync setup` uses sequential `console.input()` calls (matching the existing pattern in `rca_cmds.py`). Both call the same `write_remote_sync_config` and print a reminder that sync still needs to be explicitly enabled.

Widened the slash handler's `except` clause to also catch `LocalSettingsError` (a malformed/unwritable `config.yml`), since `setup`'s write path can raise it and this handler also serves gateway chat, an external surface that must never echo `str(exc)` (CWE-209, called out explicitly in the issue). Generalized its message from "Sync failed" to "Command failed" since it now covers `setup` too; updated the pre-existing tests that pinned the old wording.

No changes to `syncable.py`, the credential deny-list, or the sync engine. `tests/filestorage/test_remote_sync.py`'s planted-secret tests pass unmodified.

### Demo/Screenshot for feature changes and bug fixes -

```
$ opensre remote-sync setup
Provider [aws]:
Bucket: my-bucket
Prefix [opensre]:
Region:
Profile:
Saved remote-sync settings to ~/.opensre/config.yml.
Set OPENSRE_REMOTE_SYNC=1 to enable syncing.

$ make lint && make typecheck && make check-imports
All checks passed! / Success: no issues found in 1545 source files / All 3 import checks passed.

$ uv run pytest tests/filestorage/ tests/cli/test_remote_sync_command.py tests/cli/test_gateway_remote_sync.py tests/interactive_shell/test_remote_sync_cmds.py tests/surfaces/test_remote_sync_surface_contract.py -q
110 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Read `platform/filestorage/ports.py`, `config.py`, and `operations.py` fully before writing anything, since the issue explicitly said the plumbing already existed - confirming that meant the only new logic needed was the write function, not a new config model or read path. Two design decisions came from re-reading the issue's own text rather than guessing: (1) the Done-when list's five named fields, with `enabled` conspicuously absent, settled whether `setup` should also flip the switch (it shouldn't); (2) the "worth repeating" section's CWE-209 reminder is what caught that the slash handler's existing `except RemoteSyncError` wouldn't catch `LocalSettingsError` from the new write path, which would have let a raw exception message leak into gateway chat. Matched each surface's own existing prompt idiom (`click.prompt` for CLI, `console.input` for slash, copied from `rca_cmds.py`) rather than introducing the heavier `wizard/` TUI machinery built for a different, richer onboarding problem. Re-ran the full `tests/filestorage/test_remote_sync.py` suite, including the planted-secret/credential-deny-list tests, to confirm nothing in `syncable.py` or the engine was disturbed.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
