### PR TITLE
feat: interactive setup for opensre remote-sync

### DIFF
--- a/platform/filestorage/enums.py
+++ b/platform/filestorage/enums.py
@@ -40,6 +40,7 @@ class RemoteSyncSubcommand(StrEnum):
 
     STATUS = "status"
     SYNC = "sync"
+    SETUP = "setup"
 
 
 __all__ = [

--- a/platform/filestorage/operations.py
+++ b/platform/filestorage/operations.py
@@ -21,6 +21,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
+    DEFAULT_REMOTE_SYNC_PROVIDER,
+)
 from config.scope_context import current_scope
 from platform.filestorage.config import RemoteSyncConfig, load_remote_sync_config
 from platform.filestorage.engine import SyncReport, resolve_direction, run_sync
@@ -115,9 +119,45 @@ def run_remote_sync(
     return _owned_report(run_sync(store, direction=resolved, roots=roots))
 
 
+def write_remote_sync_config(
+    *,
+    provider: str,
+    bucket: str,
+    prefix: str,
+    region: str,
+    profile: str,
+) -> None:
+    """Persist connection settings to the ``remote_sync`` section.
+
+    Writes only ``provider``/``bucket``/``prefix``/``region``/``profile`` —
+    never ``enabled``. Naming a bucket must not itself turn sync on, so a
+    ``setup`` run stages the destination and the switch stays a separate,
+    explicit step (``OPENSRE_REMOTE_SYNC=1`` or the ``enabled`` key).
+
+    Refuses an org-scoped turn for the same reason ``get_sync_status``/
+    ``run_remote_sync`` do: object keys carry no principal, so configuring a
+    shared destination is part of the same "org sync" boundary even though
+    this never touches an ObjectStore itself.
+    """
+    _refuse_org_scoped_turn()
+    from config.local_settings import update_section
+
+    update_section(
+        "remote_sync",
+        {
+            "provider": provider.strip().lower() or DEFAULT_REMOTE_SYNC_PROVIDER,
+            "bucket": bucket.strip(),
+            "prefix": prefix.strip() or DEFAULT_REMOTE_SYNC_PREFIX,
+            "region": region.strip(),
+            "profile": profile.strip(),
+        },
+    )
+
+
 __all__ = [
     "SyncRootStatus",
     "SyncStatus",
     "get_sync_status",
     "run_remote_sync",
+    "write_remote_sync_config",
 ]

--- a/platform/filestorage/operations.py
+++ b/platform/filestorage/operations.py
@@ -29,7 +29,7 @@ from config.scope_context import current_scope
 from platform.filestorage.config import RemoteSyncConfig, load_remote_sync_config
 from platform.filestorage.engine import SyncReport, resolve_direction, run_sync
 from platform.filestorage.enums import SyncDirection, SyncRootName
-from platform.filestorage.errors import OrgScopeNotSupportedError
+from platform.filestorage.errors import OrgScopeNotSupportedError, RemoteSyncConfigError
 from platform.filestorage.providers import build_object_store
 from platform.filestorage.syncable import syncable_roots
 
@@ -138,15 +138,24 @@ def write_remote_sync_config(
     ``run_remote_sync`` do: object keys carry no principal, so configuring a
     shared destination is part of the same "org sync" boundary even though
     this never touches an ObjectStore itself.
+
+    Raises:
+        RemoteSyncConfigError: ``bucket`` is blank. An empty bucket would
+            silently report success while leaving an unusable config that
+            ``load_remote_sync_config`` rejects the moment sync is enabled.
     """
     _refuse_org_scoped_turn()
+    bucket = bucket.strip()
+    if not bucket:
+        raise RemoteSyncConfigError("remote-sync setup requires a non-empty bucket")
+
     from config.local_settings import update_section
 
     update_section(
         "remote_sync",
         {
             "provider": provider.strip().lower() or DEFAULT_REMOTE_SYNC_PROVIDER,
-            "bucket": bucket.strip(),
+            "bucket": bucket,
             "prefix": prefix.strip() or DEFAULT_REMOTE_SYNC_PREFIX,
             "region": region.strip(),
             "profile": profile.strip(),

--- a/surfaces/cli/commands/remote_sync.py
+++ b/surfaces/cli/commands/remote_sync.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 import click
 
+from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
+    DEFAULT_REMOTE_SYNC_PROVIDER,
+    REMOTE_SYNC_ENV,
+)
+from config.local_settings import LocalSettingsError, local_settings_path
 from platform.common.exit_codes import ERROR, SUCCESS
 from platform.filestorage import RemoteSyncError
 from platform.filestorage.enums import RemoteSyncSubcommand
@@ -12,7 +18,11 @@ from platform.filestorage.messages import (
     format_report_lines,
     format_status_lines,
 )
-from platform.filestorage.operations import get_sync_status, run_remote_sync
+from platform.filestorage.operations import (
+    get_sync_status,
+    run_remote_sync,
+    write_remote_sync_config,
+)
 
 
 @click.group(name="remote-sync", invoke_without_command=True)
@@ -33,6 +43,26 @@ def status_command() -> None:
         raise SystemExit(ERROR) from exc
     for line in lines:
         click.echo(line)
+    raise SystemExit(SUCCESS)
+
+
+@remote_sync_command.command(name=RemoteSyncSubcommand.SETUP.value)
+def setup_command() -> None:
+    """Configure remote-sync connection settings (does not enable or verify it)."""
+    provider = click.prompt("Provider", default=DEFAULT_REMOTE_SYNC_PROVIDER)
+    bucket = click.prompt("Bucket")
+    prefix = click.prompt("Prefix", default=DEFAULT_REMOTE_SYNC_PREFIX)
+    region = click.prompt("Region", default="", show_default=False)
+    profile = click.prompt("Profile", default="", show_default=False)
+    try:
+        write_remote_sync_config(
+            provider=provider, bucket=bucket, prefix=prefix, region=region, profile=profile
+        )
+    except (RemoteSyncError, LocalSettingsError) as exc:
+        click.echo(str(exc), err=True)
+        raise SystemExit(ERROR) from exc
+    click.echo(f"Saved remote-sync settings to {local_settings_path()}.")
+    click.echo(f"Set {REMOTE_SYNC_ENV}=1 to enable syncing.")
     raise SystemExit(SUCCESS)
 
 

--- a/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
+++ b/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
@@ -6,11 +6,20 @@ import logging
 
 from rich.console import Console
 
-from config.constants.filestorage import DEFAULT_REMOTE_SYNC_PROVIDER
+from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
+    DEFAULT_REMOTE_SYNC_PROVIDER,
+    REMOTE_SYNC_ENV,
+)
+from config.local_settings import LocalSettingsError, local_settings_path
 from platform.filestorage import OrgScopeNotSupportedError, RemoteSyncError
 from platform.filestorage.enums import RemoteSyncSubcommand
 from platform.filestorage.messages import DISABLED_HELP, format_report_lines
-from platform.filestorage.operations import get_sync_status, run_remote_sync
+from platform.filestorage.operations import (
+    get_sync_status,
+    run_remote_sync,
+    write_remote_sync_config,
+)
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT
@@ -18,8 +27,8 @@ from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT
 logger = logging.getLogger(__name__)
 
 _USAGE = (
-    f"/remote-sync [{RemoteSyncSubcommand.STATUS}|{RemoteSyncSubcommand.SYNC}] "
-    "[--pull-only|--push-only]"
+    f"/remote-sync [{RemoteSyncSubcommand.STATUS}|{RemoteSyncSubcommand.SYNC}"
+    f"|{RemoteSyncSubcommand.SETUP}] [--pull-only|--push-only]"
 )
 
 
@@ -62,6 +71,27 @@ def _run_sync(console: Console, args: list[str]) -> bool:
     return True
 
 
+def _run_setup(console: Console) -> bool:
+    console.print("Configure remote-sync connection settings (does not enable or verify it).")
+    provider = (
+        console.input(f"[{HIGHLIGHT}]Provider [{DEFAULT_REMOTE_SYNC_PROVIDER}]> [/]").strip()
+        or DEFAULT_REMOTE_SYNC_PROVIDER
+    )
+    bucket = console.input(f"[{HIGHLIGHT}]Bucket> [/]").strip()
+    prefix = (
+        console.input(f"[{HIGHLIGHT}]Prefix [{DEFAULT_REMOTE_SYNC_PREFIX}]> [/]").strip()
+        or DEFAULT_REMOTE_SYNC_PREFIX
+    )
+    region = console.input(f"[{HIGHLIGHT}]Region (optional)> [/]").strip()
+    profile = console.input(f"[{HIGHLIGHT}]Profile (optional)> [/]").strip()
+    write_remote_sync_config(
+        provider=provider, bucket=bucket, prefix=prefix, region=region, profile=profile
+    )
+    console.print(f"Saved remote-sync settings to [{HIGHLIGHT}]{local_settings_path()}[/].")
+    console.print(f"[{DIM}]Set {REMOTE_SYNC_ENV}=1 to enable syncing.[/]")
+    return True
+
+
 def _parse_subcommand(raw: str) -> RemoteSyncSubcommand | None:
     try:
         return RemoteSyncSubcommand(raw)
@@ -77,16 +107,20 @@ def _cmd_remote_sync(_session: Session, console: Console, args: list[str]) -> bo
             return _print_status(console)
         if sub is RemoteSyncSubcommand.SYNC:
             return _run_sync(console, args[1:])
+        if sub is RemoteSyncSubcommand.SETUP:
+            return _run_setup(console)
     except OrgScopeNotSupportedError as exc:
         # Safe to show: our own wording, no vendor or credential detail.
         console.print(f"[{DIM}]{exc}[/]")
         return True
-    except RemoteSyncError:
+    except (RemoteSyncError, LocalSettingsError):
         # This handler also serves gateway chat, an external surface, so the
         # provider's message never reaches the reply. Detail goes to the log.
+        # LocalSettingsError covers a malformed/unwritable config.yml, which
+        # setup can hit even though it never touches an ObjectStore.
         logger.warning("[remote-sync] command failed", exc_info=True)
         console.print(
-            f"[{ERROR}]Sync failed.[/] Check the opensre log, "
+            f"[{ERROR}]Command failed.[/] Check the opensre log, "
             "or run [bold]opensre remote-sync status[/bold] locally for detail."
         )
         return True
@@ -116,6 +150,10 @@ COMMANDS: tuple[SlashCommand, ...] = (
                 "show whether sync is on and what would be mirrored",
             ),
             (RemoteSyncSubcommand.SYNC.value, "pull remote changes, then push local ones"),
+            (
+                RemoteSyncSubcommand.SETUP.value,
+                "configure provider/bucket/prefix/region/profile (does not enable it)",
+            ),
         ),
         use_cases=(
             "sync my conversations to S3",

--- a/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
+++ b/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
@@ -23,6 +23,7 @@ from platform.filestorage.operations import (
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT
+from surfaces.interactive_shell.ui.components.choice_menu import repl_tty_interactive
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +73,14 @@ def _run_sync(console: Console, args: list[str]) -> bool:
 
 
 def _run_setup(console: Console) -> bool:
+    if not repl_tty_interactive():
+        # Gateway/headless callers have no real stdin: console.input() would
+        # block or raise EOFError instead of returning a usable turn.
+        console.print(
+            f"[{DIM}]usage:[/] /remote-sync setup requires an interactive terminal. "
+            "Run [bold]opensre remote-sync setup[/bold] locally instead."
+        )
+        return True
     console.print("Configure remote-sync connection settings (does not enable or verify it).")
     provider = (
         console.input(f"[{HIGHLIGHT}]Provider [{DEFAULT_REMOTE_SYNC_PROVIDER}]> [/]").strip()

--- a/tests/cli/test_gateway_remote_sync.py
+++ b/tests/cli/test_gateway_remote_sync.py
@@ -160,5 +160,5 @@ def test_gateway_dispatch_sync_error_stays_handled(monkeypatch: pytest.MonkeyPat
         is True
     )
     out = buf.getvalue()
-    assert "Sync failed" in out
+    assert "Command failed" in out
     assert leaked not in out, "provider detail reached the gateway reply"

--- a/tests/cli/test_remote_sync_command.py
+++ b/tests/cli/test_remote_sync_command.py
@@ -247,6 +247,18 @@ def test_setup_failure_exits_nonzero(runner: CliRunner, monkeypatch: pytest.Monk
     assert "could not write settings" in result.output
 
 
+def test_setup_reprompts_for_bucket_on_blank_input(runner: CliRunner) -> None:
+    """click.prompt (no default) re-asks rather than accepting an empty bucket."""
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        # Blank line for Bucket the first time; Click must ask again rather
+        # than proceed with an empty value.
+        input="aws\n\n",
+    )
+    assert result.output.count("Bucket:") >= 2
+
+
 def test_remote_sync_help_lists_setup(runner: CliRunner) -> None:
     result = runner.invoke(remote_sync_command, ["--help"])
     assert result.exit_code == 0

--- a/tests/cli/test_remote_sync_command.py
+++ b/tests/cli/test_remote_sync_command.py
@@ -181,3 +181,73 @@ def test_sync_help_documents_direction_flags(runner: CliRunner) -> None:
     assert result.exit_code == 0
     assert "--pull-only" in result.output
     assert "--push-only" in result.output
+
+
+def test_setup_prompts_and_writes_config(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.write_remote_sync_config",
+        lambda **kwargs: captured.update(kwargs),
+    )
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        input="aws\nmy-bucket\nopensre\n\n\n",
+    )
+    assert result.exit_code == 0
+    assert captured == {
+        "provider": "aws",
+        "bucket": "my-bucket",
+        "prefix": "opensre",
+        "region": "",
+        "profile": "",
+    }
+    assert "Saved remote-sync settings" in result.output
+    assert "enable syncing" in result.output
+
+
+def test_setup_uses_defaults_on_blank_provider_and_prefix(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.write_remote_sync_config",
+        lambda **kwargs: captured.update(kwargs),
+    )
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        input="\nmy-bucket\n\nus-east-1\nwork\n",
+    )
+    assert result.exit_code == 0
+    assert captured["provider"] == "aws"
+    assert captured["prefix"] == "opensre"
+    assert captured["region"] == "us-east-1"
+    assert captured["profile"] == "work"
+
+
+def test_setup_failure_exits_nonzero(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(**_kwargs: str) -> None:
+        raise RemoteSyncConfigError("could not write settings")
+
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.write_remote_sync_config",
+        _boom,
+    )
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        input="aws\nmy-bucket\nopensre\n\n\n",
+    )
+    assert result.exit_code != 0
+    assert "could not write settings" in result.output
+
+
+def test_remote_sync_help_lists_setup(runner: CliRunner) -> None:
+    result = runner.invoke(remote_sync_command, ["--help"])
+    assert result.exit_code == 0
+    assert RemoteSyncSubcommand.SETUP in result.output

--- a/tests/filestorage/test_enums.py
+++ b/tests/filestorage/test_enums.py
@@ -29,9 +29,11 @@ def test_direction_flags_resolve_to_enum() -> None:
     assert resolve_direction(pull_only=False, push_only=False) is SyncDirection.BOTH
 
 
-def test_remote_sync_subcommands_are_status_and_sync() -> None:
+def test_remote_sync_subcommands_are_status_sync_and_setup() -> None:
     assert set(RemoteSyncSubcommand) == {
         RemoteSyncSubcommand.STATUS,
         RemoteSyncSubcommand.SYNC,
+        RemoteSyncSubcommand.SETUP,
     }
     assert RemoteSyncSubcommand("status") is RemoteSyncSubcommand.STATUS
+    assert RemoteSyncSubcommand("setup") is RemoteSyncSubcommand.SETUP

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import pytest
 
 from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
+    DEFAULT_REMOTE_SYNC_PROVIDER,
     REMOTE_SYNC_BUCKET_ENV,
     REMOTE_SYNC_ENV,
     REMOTE_SYNC_PREFIX_ENV,
@@ -816,18 +818,26 @@ def test_org_scoped_turn_refuses_to_sync(monkeypatch: pytest.MonkeyPatch) -> Non
     from config.principal import Actor, Principal, StorageScope
     from config.scope_context import bound_storage_scope
     from platform.filestorage.errors import OrgScopeNotSupportedError
-    from platform.filestorage.operations import get_sync_status, run_remote_sync
+    from platform.filestorage.operations import (
+        get_sync_status,
+        run_remote_sync,
+        write_remote_sync_config,
+    )
 
     monkeypatch.setenv(REMOTE_SYNC_ENV, "1")
     monkeypatch.setenv(REMOTE_SYNC_BUCKET_ENV, "shared-bucket")
     scope = StorageScope(principal=Principal.org("org_acme"), actor=Actor(id="U_ALICE"))
 
-    # Act / Assert: both entry points fail closed while the scope is bound.
+    # Act / Assert: all three entry points fail closed while the scope is bound.
     with bound_storage_scope(scope):
         with pytest.raises(OrgScopeNotSupportedError):
             run_remote_sync()
         with pytest.raises(OrgScopeNotSupportedError):
             get_sync_status()
+        with pytest.raises(OrgScopeNotSupportedError):
+            write_remote_sync_config(
+                provider="aws", bucket="shared-bucket", prefix="opensre", region="", profile=""
+            )
 
 
 def test_unbound_laptop_turn_still_syncs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -934,3 +944,85 @@ def test_list_prefix_is_delimited_so_a_sibling_bucket_path_cannot_match() -> Non
 
     # Assert
     assert seen["Prefix"] == "opensre/"
+
+
+# ── /remote-sync setup writes settings without enabling sync ────────────────
+
+
+def test_write_remote_sync_config_persists_the_five_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """setup stages a destination; it must not flip the enabled switch."""
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import read_section
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+
+    # Act
+    write_remote_sync_config(
+        provider="AWS",
+        bucket=" my-bucket ",
+        prefix="",
+        region="us-east-1",
+        profile="work",
+    )
+
+    # Assert: normalized values landed, and "enabled" was never written.
+    section = read_section("remote_sync")
+    assert section == {
+        "provider": "aws",
+        "bucket": "my-bucket",
+        "prefix": "opensre",
+        "region": "us-east-1",
+        "profile": "work",
+    }
+    assert "enabled" not in section
+
+
+def test_write_remote_sync_config_round_trips_once_enabled_separately(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Naming a bucket alone must not enable sync; the switch stays separate."""
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import update_section
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+    for name in (REMOTE_SYNC_ENV, REMOTE_SYNC_BUCKET_ENV, REMOTE_SYNC_PREFIX_ENV):
+        monkeypatch.delenv(name, raising=False)
+
+    # Act: setup alone must not turn sync on.
+    write_remote_sync_config(
+        provider="aws", bucket="my-bucket", prefix="opensre", region="", profile=""
+    )
+    assert load_remote_sync_config() is None
+
+    # Enabling separately (the "enabled" key, mirroring what a later CLI/slash
+    # confirmation step would set) makes the same written settings take effect.
+    update_section("remote_sync", {"enabled": True})
+    config = load_remote_sync_config()
+    assert config is not None
+    assert config.bucket == "my-bucket"
+    assert config.provider == "aws"
+
+
+def test_write_remote_sync_config_defaults_blank_provider_and_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import read_section
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+
+    # Act
+    write_remote_sync_config(provider="", bucket="b", prefix="  ", region="", profile="")
+
+    # Assert
+    section = read_section("remote_sync")
+    assert section["provider"] == DEFAULT_REMOTE_SYNC_PROVIDER
+    assert section["prefix"] == DEFAULT_REMOTE_SYNC_PREFIX

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -1026,3 +1026,25 @@ def test_write_remote_sync_config_defaults_blank_provider_and_prefix(
     section = read_section("remote_sync")
     assert section["provider"] == DEFAULT_REMOTE_SYNC_PROVIDER
     assert section["prefix"] == DEFAULT_REMOTE_SYNC_PREFIX
+
+
+def test_write_remote_sync_config_rejects_empty_bucket(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty bucket must not silently save a config load_remote_sync_config rejects."""
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import read_section
+    from platform.filestorage.errors import RemoteSyncConfigError
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+
+    # Act / Assert
+    with pytest.raises(RemoteSyncConfigError, match="non-empty bucket"):
+        write_remote_sync_config(
+            provider="aws", bucket="   ", prefix="opensre", region="", profile=""
+        )
+
+    # Nothing was written.
+    assert read_section("remote_sync") == {}

--- a/tests/interactive_shell/test_remote_sync_cmds.py
+++ b/tests/interactive_shell/test_remote_sync_cmds.py
@@ -102,7 +102,7 @@ def test_sync_error_is_caught(monkeypatch: pytest.MonkeyPatch) -> None:
     console, buf = _capture()
     assert dispatch_slash("/remote-sync sync --pull-only --push-only", Session(), console) is True
     out = buf.getvalue()
-    assert "Sync failed" in out
+    assert "Command failed" in out
     # This handler also serves gateway chat, so provider detail must not appear.
     assert "bad flags" not in out, "error detail reached the chat reply"
 
@@ -135,7 +135,7 @@ def test_slash_command_metadata_for_planner() -> None:
     cmd = SLASH_COMMANDS["/remote-sync"]
     assert cmd.first_arg_completions is not None
     labels = {label for label, _hint in cmd.first_arg_completions}
-    assert labels == {"status", "sync"}
+    assert labels == {"status", "sync", "setup"}
     assert any("OPENSRE_REMOTE_SYNC" in note for note in (cmd.notes or ()))
     catalog = MCP_BY_COMMAND["/remote-sync"]
     assert "status" in catalog.llm_description
@@ -170,3 +170,75 @@ def test_repl_and_headless_dispatch_same_command_object() -> None:
     assert repl.command_exists("/remote-sync")
     assert headless.command_exists("/remote-sync")
     assert SLASH_COMMANDS["/remote-sync"].handler is not None
+
+
+def test_setup_prompts_and_writes_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    answers = iter(["aws", "my-bucket", "opensre", "", ""])
+    captured: dict[str, str] = {}
+
+    def _capture_write(**kwargs: str) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        _capture_write,
+    )
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    assert captured == {
+        "provider": "aws",
+        "bucket": "my-bucket",
+        "prefix": "opensre",
+        "region": "",
+        "profile": "",
+    }
+    out = buf.getvalue()
+    assert "Saved remote-sync settings" in out
+    assert "enable syncing" in out
+
+
+def test_setup_uses_defaults_on_blank_provider_and_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    answers = iter(["", "my-bucket", "", "us-east-1", "work"])
+    captured: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        lambda **kwargs: captured.update(kwargs),
+    )
+    console, _buf = _capture()
+    monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    assert captured["provider"] == "aws"
+    assert captured["prefix"] == "opensre"
+    assert captured["region"] == "us-east-1"
+    assert captured["profile"] == "work"
+
+
+def test_setup_failure_shows_generic_message_not_exception_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """External surface (gateway chat shares this handler): never leak str(exc)."""
+
+    def _boom(**_kwargs: str) -> None:
+        raise RemoteSyncConfigError("SECRET-INTERNAL-DETAIL should never reach chat")
+
+    answers = iter(["aws", "my-bucket", "opensre", "", ""])
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        _boom,
+    )
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    out = buf.getvalue()
+    assert "SECRET-INTERNAL-DETAIL" not in out
+    assert "Command failed" in out

--- a/tests/interactive_shell/test_remote_sync_cmds.py
+++ b/tests/interactive_shell/test_remote_sync_cmds.py
@@ -183,6 +183,10 @@ def test_setup_prompts_and_writes_config(monkeypatch: pytest.MonkeyPatch) -> Non
         "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
         _capture_write,
     )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: True,
+    )
     console, buf = _capture()
     monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
 
@@ -210,6 +214,10 @@ def test_setup_uses_defaults_on_blank_provider_and_prefix(
         "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
         lambda **kwargs: captured.update(kwargs),
     )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: True,
+    )
     console, _buf = _capture()
     monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
 
@@ -234,6 +242,10 @@ def test_setup_failure_shows_generic_message_not_exception_detail(
         "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
         _boom,
     )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: True,
+    )
     console, buf = _capture()
     monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
 
@@ -242,3 +254,48 @@ def test_setup_failure_shows_generic_message_not_exception_detail(
     out = buf.getvalue()
     assert "SECRET-INTERNAL-DETAIL" not in out
     assert "Command failed" in out
+
+
+def test_setup_refuses_headless_dispatch_without_prompting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gateway/headless callers have no real stdin; setup must not call console.input()."""
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: False,
+    )
+
+    def _fail_if_called(_prompt: str) -> str:
+        raise AssertionError("console.input() must not be called in a headless turn")
+
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", _fail_if_called)
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    out = " ".join(buf.getvalue().split())
+    assert "interactive terminal" in out
+    assert "opensre remote-sync setup" in out
+
+
+def test_setup_rejects_empty_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty bucket must not silently save a config the sync loader rejects."""
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        write_remote_sync_config,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: True,
+    )
+    answers = iter(["aws", "", "opensre", "", ""])
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    out = buf.getvalue()
+    assert "Command failed" in out
+    assert "Saved remote-sync settings" not in out


### PR DESCRIPTION
Fixes #4554

Adds an `opensre remote-sync setup` / `/remote-sync setup` flow that prompts for provider, bucket, prefix, region, and profile, and writes them via `platform/filestorage/operations.py::write_remote_sync_config` (a new shared function both surfaces call). Never writes `enabled` - naming a bucket must not itself turn sync on. Refuses an org-scoped turn, same as `get_sync_status`/`run_remote_sync`.

**Update:** a prior version of this PR was closed after Greptile flagged two P1s, both confirmed real and now fixed:
1. `/remote-sync setup` called `console.input()` unconditionally, so a gateway/headless turn (no real stdin) would raise `EOFError` or block. Now gated on `repl_tty_interactive()`, matching every other interactive prompt flow in this codebase (`rca_cmds.py`), falling back to a usage message when not in a real terminal.
2. An empty bucket was silently accepted and reported success, but `load_remote_sync_config()` later rejects that same config once sync is enabled. Added the check to the shared `write_remote_sync_config` itself, so both surfaces' existing exception handling catches it for free. Confirmed the CLI's `click.prompt` already re-prompts on blank input (no default), so only the slash surface was actually vulnerable.

### Demo/Screenshot for feature changes and bug fixes -

```
$ make lint && make typecheck && make check-imports
All checks passed! / Success: no issues found in 1545 source files / All 3 import checks passed.

$ uv run pytest tests/filestorage/ tests/cli/test_remote_sync_command.py tests/cli/test_gateway_remote_sync.py tests/interactive_shell/test_remote_sync_cmds.py tests/surfaces/test_remote_sync_surface_contract.py -q
114 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

For the headless fix, grepped for the existing `repl_tty_interactive` idiom rather than inventing a new guard, since this codebase already has an established pattern for exactly this problem. For the empty-bucket fix, put the validation in the one shared write function instead of duplicating it in both the CLI and slash prompt loops, so neither surface can drift out of sync with the other. Verified the CLI didn't need the same explicit check by actually running it under `CliRunner` with a blank bucket line, which showed Click's own `prompt()` re-asks rather than accepting the empty value, and added a regression test proving that behavior instead of adding a redundant check.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
