### PR TITLE
feat: interactive setup for opensre remote-sync (#4554)

### DIFF
--- a/config/local_settings.py
+++ b/config/local_settings.py
@@ -53,11 +53,14 @@ def read_section(name: str) -> dict[str, Any]:
 
 
 def save_local_settings(data: dict[str, Any]) -> None:
-    import yaml
-
     path = local_settings_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    try:
+        import yaml
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    except OSError as exc:
+        raise LocalSettingsError(f"could not write {path}: {exc}") from exc
 
 
 def update_section(name: str, values: dict[str, Any]) -> None:

--- a/platform/filestorage/enums.py
+++ b/platform/filestorage/enums.py
@@ -40,6 +40,7 @@ class RemoteSyncSubcommand(StrEnum):
 
     STATUS = "status"
     SYNC = "sync"
+    SETUP = "setup"
 
 
 __all__ = [

--- a/platform/filestorage/operations.py
+++ b/platform/filestorage/operations.py
@@ -21,6 +21,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
+    DEFAULT_REMOTE_SYNC_PROVIDER,
+)
 from config.scope_context import current_scope
 from platform.filestorage.config import RemoteSyncConfig, load_remote_sync_config
 from platform.filestorage.engine import SyncReport, resolve_direction, run_sync
@@ -115,9 +119,45 @@ def run_remote_sync(
     return _owned_report(run_sync(store, direction=resolved, roots=roots))
 
 
+def write_remote_sync_config(
+    *,
+    provider: str,
+    bucket: str,
+    prefix: str,
+    region: str,
+    profile: str,
+) -> None:
+    """Persist connection settings to the ``remote_sync`` section.
+
+    Writes only ``provider``/``bucket``/``prefix``/``region``/``profile`` —
+    never ``enabled``. Naming a bucket must not itself turn sync on, so a
+    ``setup`` run stages the destination and the switch stays a separate,
+    explicit step (``OPENSRE_REMOTE_SYNC=1`` or the ``enabled`` key).
+
+    Refuses an org-scoped turn for the same reason ``get_sync_status``/
+    ``run_remote_sync`` do: object keys carry no principal, so configuring a
+    shared destination is part of the same "org sync" boundary even though
+    this never touches an ObjectStore itself.
+    """
+    _refuse_org_scoped_turn()
+    from config.local_settings import update_section
+
+    update_section(
+        "remote_sync",
+        {
+            "provider": provider.strip().lower() or DEFAULT_REMOTE_SYNC_PROVIDER,
+            "bucket": bucket.strip(),
+            "prefix": prefix.strip() or DEFAULT_REMOTE_SYNC_PREFIX,
+            "region": region.strip(),
+            "profile": profile.strip(),
+        },
+    )
+
+
 __all__ = [
     "SyncRootStatus",
     "SyncStatus",
     "get_sync_status",
     "run_remote_sync",
+    "write_remote_sync_config",
 ]

--- a/platform/filestorage/operations.py
+++ b/platform/filestorage/operations.py
@@ -30,7 +30,7 @@ from platform.filestorage.config import RemoteSyncConfig, load_remote_sync_confi
 from platform.filestorage.engine import SyncReport, resolve_direction, run_sync
 from platform.filestorage.enums import SyncDirection, SyncRootName
 from platform.filestorage.errors import OrgScopeNotSupportedError, RemoteSyncConfigError
-from platform.filestorage.providers import build_object_store
+from platform.filestorage.providers import build_object_store, registered_providers
 from platform.filestorage.syncable import syncable_roots
 
 
@@ -129,10 +129,13 @@ def write_remote_sync_config(
 ) -> None:
     """Persist connection settings to the ``remote_sync`` section.
 
-    Writes only ``provider``/``bucket``/``prefix``/``region``/``profile`` —
-    never ``enabled``. Naming a bucket must not itself turn sync on, so a
-    ``setup`` run stages the destination and the switch stays a separate,
-    explicit step (``OPENSRE_REMOTE_SYNC=1`` or the ``enabled`` key).
+    Always writes ``enabled: false`` alongside the connection fields, even
+    when a destination was already configured and enabled. Redirecting an
+    active sync to a new, unverified destination as a side effect of staging
+    settings would defeat the point of a separate, explicit switch
+    (``OPENSRE_REMOTE_SYNC=1`` or a later confirmation step) — so every
+    ``setup`` run leaves sync off, whether it was off, on, or pointed
+    somewhere else beforehand.
 
     Refuses an org-scoped turn for the same reason ``get_sync_status``/
     ``run_remote_sync`` do: object keys carry no principal, so configuring a
@@ -140,25 +143,36 @@ def write_remote_sync_config(
     this never touches an ObjectStore itself.
 
     Raises:
-        RemoteSyncConfigError: ``bucket`` is blank. An empty bucket would
-            silently report success while leaving an unusable config that
-            ``load_remote_sync_config`` rejects the moment sync is enabled.
+        RemoteSyncConfigError: ``bucket`` is blank, or ``provider`` is not a
+            registered backend. An empty bucket would silently report success
+            while leaving an unusable config that ``load_remote_sync_config``
+            rejects the moment sync is enabled; an unknown provider would
+            report success and only fail later, at sync time.
     """
     _refuse_org_scoped_turn()
     bucket = bucket.strip()
     if not bucket:
         raise RemoteSyncConfigError("remote-sync setup requires a non-empty bucket")
 
+    normalized_provider = provider.strip().lower() or DEFAULT_REMOTE_SYNC_PROVIDER
+    known = registered_providers()
+    if normalized_provider not in known:
+        listed = ", ".join(known) or "(none)"
+        raise RemoteSyncConfigError(
+            f"unknown remote-sync provider {normalized_provider!r}; known: {listed}"
+        )
+
     from config.local_settings import update_section
 
     update_section(
         "remote_sync",
         {
-            "provider": provider.strip().lower() or DEFAULT_REMOTE_SYNC_PROVIDER,
+            "provider": normalized_provider,
             "bucket": bucket,
             "prefix": prefix.strip() or DEFAULT_REMOTE_SYNC_PREFIX,
             "region": region.strip(),
             "profile": profile.strip(),
+            "enabled": False,
         },
     )
 

--- a/platform/filestorage/operations.py
+++ b/platform/filestorage/operations.py
@@ -29,7 +29,7 @@ from config.scope_context import current_scope
 from platform.filestorage.config import RemoteSyncConfig, load_remote_sync_config
 from platform.filestorage.engine import SyncReport, resolve_direction, run_sync
 from platform.filestorage.enums import SyncDirection, SyncRootName
-from platform.filestorage.errors import OrgScopeNotSupportedError
+from platform.filestorage.errors import OrgScopeNotSupportedError, RemoteSyncConfigError
 from platform.filestorage.providers import build_object_store
 from platform.filestorage.syncable import syncable_roots
 
@@ -138,15 +138,24 @@ def write_remote_sync_config(
     ``run_remote_sync`` do: object keys carry no principal, so configuring a
     shared destination is part of the same "org sync" boundary even though
     this never touches an ObjectStore itself.
+
+    Raises:
+        RemoteSyncConfigError: ``bucket`` is blank. An empty bucket would
+            silently report success while leaving an unusable config that
+            ``load_remote_sync_config`` rejects the moment sync is enabled.
     """
     _refuse_org_scoped_turn()
+    bucket = bucket.strip()
+    if not bucket:
+        raise RemoteSyncConfigError("remote-sync setup requires a non-empty bucket")
+
     from config.local_settings import update_section
 
     update_section(
         "remote_sync",
         {
             "provider": provider.strip().lower() or DEFAULT_REMOTE_SYNC_PROVIDER,
-            "bucket": bucket.strip(),
+            "bucket": bucket,
             "prefix": prefix.strip() or DEFAULT_REMOTE_SYNC_PREFIX,
             "region": region.strip(),
             "profile": profile.strip(),

--- a/platform/filestorage/operations.py
+++ b/platform/filestorage/operations.py
@@ -132,10 +132,17 @@ def write_remote_sync_config(
     Always writes ``enabled: false`` alongside the connection fields, even
     when a destination was already configured and enabled. Redirecting an
     active sync to a new, unverified destination as a side effect of staging
-    settings would defeat the point of a separate, explicit switch
-    (``OPENSRE_REMOTE_SYNC=1`` or a later confirmation step) — so every
-    ``setup`` run leaves sync off, whether it was off, on, or pointed
-    somewhere else beforehand.
+    settings would defeat the point of a separate, explicit switch — so every
+    ``setup`` run turns off the *stored* switch, whether it was off, on, or
+    pointed somewhere else beforehand.
+
+    This only controls the stored section, the one thing this function can
+    see: ``OPENSRE_REMOTE_SYNC`` in the environment still overrides it per
+    :func:`platform.filestorage.config.remote_sync_enabled`'s precedence
+    rule, exactly as it would for any other stored setting. A caller that
+    wants to warn the operator when the environment is what is actually
+    keeping sync on should check ``remote_sync_enabled()`` itself after this
+    call returns; the CLI and slash surfaces both do.
 
     Refuses an org-scoped turn for the same reason ``get_sync_status``/
     ``run_remote_sync`` do: object keys carry no principal, so configuring a

--- a/surfaces/cli/commands/remote_sync.py
+++ b/surfaces/cli/commands/remote_sync.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 import click
 
+from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
+    DEFAULT_REMOTE_SYNC_PROVIDER,
+    REMOTE_SYNC_ENV,
+)
+from config.local_settings import LocalSettingsError, local_settings_path
 from platform.common.exit_codes import ERROR, SUCCESS
 from platform.filestorage import RemoteSyncError
 from platform.filestorage.enums import RemoteSyncSubcommand
@@ -12,7 +18,11 @@ from platform.filestorage.messages import (
     format_report_lines,
     format_status_lines,
 )
-from platform.filestorage.operations import get_sync_status, run_remote_sync
+from platform.filestorage.operations import (
+    get_sync_status,
+    run_remote_sync,
+    write_remote_sync_config,
+)
 
 
 @click.group(name="remote-sync", invoke_without_command=True)
@@ -33,6 +43,26 @@ def status_command() -> None:
         raise SystemExit(ERROR) from exc
     for line in lines:
         click.echo(line)
+    raise SystemExit(SUCCESS)
+
+
+@remote_sync_command.command(name=RemoteSyncSubcommand.SETUP.value)
+def setup_command() -> None:
+    """Configure remote-sync connection settings (does not enable or verify it)."""
+    provider = click.prompt("Provider", default=DEFAULT_REMOTE_SYNC_PROVIDER)
+    bucket = click.prompt("Bucket")
+    prefix = click.prompt("Prefix", default=DEFAULT_REMOTE_SYNC_PREFIX)
+    region = click.prompt("Region", default="", show_default=False)
+    profile = click.prompt("Profile", default="", show_default=False)
+    try:
+        write_remote_sync_config(
+            provider=provider, bucket=bucket, prefix=prefix, region=region, profile=profile
+        )
+    except (RemoteSyncError, LocalSettingsError) as exc:
+        click.echo(str(exc), err=True)
+        raise SystemExit(ERROR) from exc
+    click.echo(f"Saved remote-sync settings to {local_settings_path()}.")
+    click.echo(f"Set {REMOTE_SYNC_ENV}=1 to enable syncing.")
     raise SystemExit(SUCCESS)
 
 

--- a/surfaces/cli/commands/remote_sync.py
+++ b/surfaces/cli/commands/remote_sync.py
@@ -11,7 +11,7 @@ from config.constants.filestorage import (
 )
 from config.local_settings import LocalSettingsError, local_settings_path
 from platform.common.exit_codes import ERROR, SUCCESS
-from platform.filestorage import RemoteSyncError
+from platform.filestorage import RemoteSyncError, remote_sync_enabled
 from platform.filestorage.enums import RemoteSyncSubcommand
 from platform.filestorage.messages import (
     DISABLED_HELP,
@@ -62,7 +62,13 @@ def setup_command() -> None:
         click.echo(str(exc), err=True)
         raise SystemExit(ERROR) from exc
     click.echo(f"Saved remote-sync settings to {local_settings_path()}.")
-    click.echo(f"Set {REMOTE_SYNC_ENV}=1 to enable syncing.")
+    if remote_sync_enabled():
+        click.echo(
+            f"Warning: {REMOTE_SYNC_ENV} is already set in your environment, so this "
+            "destination is active immediately."
+        )
+    else:
+        click.echo(f"Set {REMOTE_SYNC_ENV}=1 to enable syncing.")
     raise SystemExit(SUCCESS)
 
 

--- a/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
+++ b/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
@@ -6,11 +6,20 @@ import logging
 
 from rich.console import Console
 
-from config.constants.filestorage import DEFAULT_REMOTE_SYNC_PROVIDER
+from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
+    DEFAULT_REMOTE_SYNC_PROVIDER,
+    REMOTE_SYNC_ENV,
+)
+from config.local_settings import LocalSettingsError, local_settings_path
 from platform.filestorage import OrgScopeNotSupportedError, RemoteSyncError
 from platform.filestorage.enums import RemoteSyncSubcommand
 from platform.filestorage.messages import DISABLED_HELP, format_report_lines
-from platform.filestorage.operations import get_sync_status, run_remote_sync
+from platform.filestorage.operations import (
+    get_sync_status,
+    run_remote_sync,
+    write_remote_sync_config,
+)
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT
@@ -18,8 +27,8 @@ from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT
 logger = logging.getLogger(__name__)
 
 _USAGE = (
-    f"/remote-sync [{RemoteSyncSubcommand.STATUS}|{RemoteSyncSubcommand.SYNC}] "
-    "[--pull-only|--push-only]"
+    f"/remote-sync [{RemoteSyncSubcommand.STATUS}|{RemoteSyncSubcommand.SYNC}"
+    f"|{RemoteSyncSubcommand.SETUP}] [--pull-only|--push-only]"
 )
 
 
@@ -62,6 +71,27 @@ def _run_sync(console: Console, args: list[str]) -> bool:
     return True
 
 
+def _run_setup(console: Console) -> bool:
+    console.print("Configure remote-sync connection settings (does not enable or verify it).")
+    provider = (
+        console.input(f"[{HIGHLIGHT}]Provider [{DEFAULT_REMOTE_SYNC_PROVIDER}]> [/]").strip()
+        or DEFAULT_REMOTE_SYNC_PROVIDER
+    )
+    bucket = console.input(f"[{HIGHLIGHT}]Bucket> [/]").strip()
+    prefix = (
+        console.input(f"[{HIGHLIGHT}]Prefix [{DEFAULT_REMOTE_SYNC_PREFIX}]> [/]").strip()
+        or DEFAULT_REMOTE_SYNC_PREFIX
+    )
+    region = console.input(f"[{HIGHLIGHT}]Region (optional)> [/]").strip()
+    profile = console.input(f"[{HIGHLIGHT}]Profile (optional)> [/]").strip()
+    write_remote_sync_config(
+        provider=provider, bucket=bucket, prefix=prefix, region=region, profile=profile
+    )
+    console.print(f"Saved remote-sync settings to [{HIGHLIGHT}]{local_settings_path()}[/].")
+    console.print(f"[{DIM}]Set {REMOTE_SYNC_ENV}=1 to enable syncing.[/]")
+    return True
+
+
 def _parse_subcommand(raw: str) -> RemoteSyncSubcommand | None:
     try:
         return RemoteSyncSubcommand(raw)
@@ -77,16 +107,20 @@ def _cmd_remote_sync(_session: Session, console: Console, args: list[str]) -> bo
             return _print_status(console)
         if sub is RemoteSyncSubcommand.SYNC:
             return _run_sync(console, args[1:])
+        if sub is RemoteSyncSubcommand.SETUP:
+            return _run_setup(console)
     except OrgScopeNotSupportedError as exc:
         # Safe to show: our own wording, no vendor or credential detail.
         console.print(f"[{DIM}]{exc}[/]")
         return True
-    except RemoteSyncError:
+    except (RemoteSyncError, LocalSettingsError):
         # This handler also serves gateway chat, an external surface, so the
         # provider's message never reaches the reply. Detail goes to the log.
+        # LocalSettingsError covers a malformed/unwritable config.yml, which
+        # setup can hit even though it never touches an ObjectStore.
         logger.warning("[remote-sync] command failed", exc_info=True)
         console.print(
-            f"[{ERROR}]Sync failed.[/] Check the opensre log, "
+            f"[{ERROR}]Command failed.[/] Check the opensre log, "
             "or run [bold]opensre remote-sync status[/bold] locally for detail."
         )
         return True
@@ -116,6 +150,10 @@ COMMANDS: tuple[SlashCommand, ...] = (
                 "show whether sync is on and what would be mirrored",
             ),
             (RemoteSyncSubcommand.SYNC.value, "pull remote changes, then push local ones"),
+            (
+                RemoteSyncSubcommand.SETUP.value,
+                "configure provider/bucket/prefix/region/profile (does not enable it)",
+            ),
         ),
         use_cases=(
             "sync my conversations to S3",

--- a/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
+++ b/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
@@ -12,7 +12,7 @@ from config.constants.filestorage import (
     REMOTE_SYNC_ENV,
 )
 from config.local_settings import LocalSettingsError, local_settings_path
-from platform.filestorage import OrgScopeNotSupportedError, RemoteSyncError
+from platform.filestorage import OrgScopeNotSupportedError, RemoteSyncError, remote_sync_enabled
 from platform.filestorage.enums import RemoteSyncSubcommand
 from platform.filestorage.messages import DISABLED_HELP, format_report_lines
 from platform.filestorage.operations import (
@@ -98,17 +98,26 @@ def _prompt(console: Console, text: str) -> str | None:
         return None
 
 
-def _parse_setup_flags(args: list[str]) -> dict[str, str]:
-    """``--key value`` pairs for headless/gateway callers with no real stdin."""
+def _parse_setup_flags(args: list[str]) -> dict[str, str] | None:
+    """``--key value`` pairs for headless/gateway callers with no real stdin.
+
+    ``None`` means a recognized flag was malformed — missing its value
+    entirely, or followed by what looks like another flag rather than a
+    value (``--bucket --provider aws`` must not silently save ``"--provider"``
+    as the bucket). An empty dict means no recognized flags were present at
+    all, so the caller falls back to interactive prompts or a usage message.
+    """
     values: dict[str, str] = {}
     index = 0
-    while index < len(args) - 1:
+    while index < len(args):
         key = _SETUP_FLAGS.get(args[index].lower())
-        if key is not None:
-            values[key] = args[index + 1]
-            index += 2
-        else:
+        if key is None:
             index += 1
+            continue
+        if index + 1 >= len(args) or args[index + 1].startswith("--"):
+            return None
+        values[key] = args[index + 1]
+        index += 2
     return values
 
 
@@ -125,6 +134,9 @@ def _prompt_setup_interactively(console: Console) -> dict[str, str] | None:
 
 def _run_setup(console: Console, args: list[str]) -> bool:
     flags = _parse_setup_flags(args)
+    if flags is None:
+        console.print(f"[{ERROR}]each flag needs a value.[/] usage: {_SETUP_USAGE}")
+        return True
     answers: dict[str, str] | None
     if flags:
         if "bucket" not in flags:
@@ -150,7 +162,13 @@ def _run_setup(console: Console, args: list[str]) -> bool:
         profile=answers.get("profile", ""),
     )
     console.print(f"Saved remote-sync settings to [{HIGHLIGHT}]{local_settings_path()}[/].")
-    console.print(f"[{DIM}]Set {REMOTE_SYNC_ENV}=1 to enable syncing.[/]")
+    if remote_sync_enabled():
+        console.print(
+            f"[{ERROR}]Warning:[/] {REMOTE_SYNC_ENV} is already set in your environment, "
+            "so this destination is active immediately."
+        )
+    else:
+        console.print(f"[{DIM}]Set {REMOTE_SYNC_ENV}=1 to enable syncing.[/]")
     return True
 
 

--- a/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
+++ b/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
@@ -72,6 +72,14 @@ def _run_sync(console: Console, args: list[str]) -> bool:
     return True
 
 
+def _prompt(console: Console, text: str) -> str | None:
+    """One setup prompt. ``None`` means the user cancelled (Ctrl-D/Ctrl-C)."""
+    try:
+        return console.input(text).strip()
+    except (EOFError, KeyboardInterrupt):
+        return None
+
+
 def _run_setup(console: Console) -> bool:
     if not repl_tty_interactive():
         # Gateway/headless callers have no real stdin: console.input() would
@@ -82,19 +90,20 @@ def _run_setup(console: Console) -> bool:
         )
         return True
     console.print("Configure remote-sync connection settings (does not enable or verify it).")
-    provider = (
-        console.input(f"[{HIGHLIGHT}]Provider [{DEFAULT_REMOTE_SYNC_PROVIDER}]> [/]").strip()
-        or DEFAULT_REMOTE_SYNC_PROVIDER
-    )
-    bucket = console.input(f"[{HIGHLIGHT}]Bucket> [/]").strip()
-    prefix = (
-        console.input(f"[{HIGHLIGHT}]Prefix [{DEFAULT_REMOTE_SYNC_PREFIX}]> [/]").strip()
-        or DEFAULT_REMOTE_SYNC_PREFIX
-    )
-    region = console.input(f"[{HIGHLIGHT}]Region (optional)> [/]").strip()
-    profile = console.input(f"[{HIGHLIGHT}]Profile (optional)> [/]").strip()
+    provider = _prompt(console, f"[{HIGHLIGHT}]Provider [{DEFAULT_REMOTE_SYNC_PROVIDER}]> [/]")
+    bucket = _prompt(console, f"[{HIGHLIGHT}]Bucket> [/]")
+    prefix = _prompt(console, f"[{HIGHLIGHT}]Prefix [{DEFAULT_REMOTE_SYNC_PREFIX}]> [/]")
+    region = _prompt(console, f"[{HIGHLIGHT}]Region (optional)> [/]")
+    profile = _prompt(console, f"[{HIGHLIGHT}]Profile (optional)> [/]")
+    if None in (provider, bucket, prefix, region, profile):
+        console.print(f"[{DIM}]Setup cancelled.[/]")
+        return True
     write_remote_sync_config(
-        provider=provider, bucket=bucket, prefix=prefix, region=region, profile=profile
+        provider=provider or DEFAULT_REMOTE_SYNC_PROVIDER,
+        bucket=bucket or "",
+        prefix=prefix or DEFAULT_REMOTE_SYNC_PREFIX,
+        region=region or "",
+        profile=profile or "",
     )
     console.print(f"Saved remote-sync settings to [{HIGHLIGHT}]{local_settings_path()}[/].")
     console.print(f"[{DIM}]Set {REMOTE_SYNC_ENV}=1 to enable syncing.[/]")

--- a/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
+++ b/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
@@ -23,6 +23,7 @@ from platform.filestorage.operations import (
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT
+from surfaces.interactive_shell.ui.components.choice_menu import repl_tty_interactive
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +73,14 @@ def _run_sync(console: Console, args: list[str]) -> bool:
 
 
 def _run_setup(console: Console) -> bool:
+    if not repl_tty_interactive():
+        # Gateway/headless callers have no real stdin: console.input() would
+        # block or raise EOFError instead of returning a usable turn.
+        console.print(
+            f"[{DIM}]usage:[/] /remote-sync setup requires an interactive terminal. "
+            "Run [bold]opensre remote-sync setup[/bold] locally instead."
+        )
+        return True
     console.print("Configure remote-sync connection settings (does not enable or verify it).")
     provider = (
         console.input(f"[{HIGHLIGHT}]Provider [{DEFAULT_REMOTE_SYNC_PROVIDER}]> [/]").strip()

--- a/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
+++ b/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
@@ -31,6 +31,24 @@ _USAGE = (
     f"/remote-sync [{RemoteSyncSubcommand.STATUS}|{RemoteSyncSubcommand.SYNC}"
     f"|{RemoteSyncSubcommand.SETUP}] [--pull-only|--push-only]"
 )
+_SETUP_USAGE = (
+    f"/remote-sync {RemoteSyncSubcommand.SETUP} --bucket <name> "
+    "[--provider ...] [--prefix ...] [--region ...] [--profile ...]"
+)
+_SETUP_FLAGS = {
+    "--provider": "provider",
+    "--bucket": "bucket",
+    "--prefix": "prefix",
+    "--region": "region",
+    "--profile": "profile",
+}
+_SETUP_PROMPTS: tuple[tuple[str, str], ...] = (
+    ("provider", f"Provider [{DEFAULT_REMOTE_SYNC_PROVIDER}]> "),
+    ("bucket", "Bucket> "),
+    ("prefix", f"Prefix [{DEFAULT_REMOTE_SYNC_PREFIX}]> "),
+    ("region", "Region (optional)> "),
+    ("profile", "Profile (optional)> "),
+)
 
 
 def _print_lines(
@@ -80,30 +98,56 @@ def _prompt(console: Console, text: str) -> str | None:
         return None
 
 
-def _run_setup(console: Console) -> bool:
-    if not repl_tty_interactive():
-        # Gateway/headless callers have no real stdin: console.input() would
-        # block or raise EOFError instead of returning a usable turn.
-        console.print(
-            f"[{DIM}]usage:[/] /remote-sync setup requires an interactive terminal. "
-            "Run [bold]opensre remote-sync setup[/bold] locally instead."
-        )
-        return True
-    console.print("Configure remote-sync connection settings (does not enable or verify it).")
-    provider = _prompt(console, f"[{HIGHLIGHT}]Provider [{DEFAULT_REMOTE_SYNC_PROVIDER}]> [/]")
-    bucket = _prompt(console, f"[{HIGHLIGHT}]Bucket> [/]")
-    prefix = _prompt(console, f"[{HIGHLIGHT}]Prefix [{DEFAULT_REMOTE_SYNC_PREFIX}]> [/]")
-    region = _prompt(console, f"[{HIGHLIGHT}]Region (optional)> [/]")
-    profile = _prompt(console, f"[{HIGHLIGHT}]Profile (optional)> [/]")
-    if None in (provider, bucket, prefix, region, profile):
-        console.print(f"[{DIM}]Setup cancelled.[/]")
+def _parse_setup_flags(args: list[str]) -> dict[str, str]:
+    """``--key value`` pairs for headless/gateway callers with no real stdin."""
+    values: dict[str, str] = {}
+    index = 0
+    while index < len(args) - 1:
+        key = _SETUP_FLAGS.get(args[index].lower())
+        if key is not None:
+            values[key] = args[index + 1]
+            index += 2
+        else:
+            index += 1
+    return values
+
+
+def _prompt_setup_interactively(console: Console) -> dict[str, str] | None:
+    """Ask each field in turn. ``None`` means the user cancelled partway through."""
+    answers: dict[str, str] = {}
+    for key, label in _SETUP_PROMPTS:
+        value = _prompt(console, f"[{HIGHLIGHT}]{label}[/]")
+        if value is None:
+            return None
+        answers[key] = value
+    return answers
+
+
+def _run_setup(console: Console, args: list[str]) -> bool:
+    flags = _parse_setup_flags(args)
+    answers: dict[str, str] | None
+    if flags:
+        if "bucket" not in flags:
+            console.print(f"[{ERROR}]--bucket is required.[/] usage: {_SETUP_USAGE}")
+            return True
+        answers = flags
+    elif repl_tty_interactive():
+        console.print("Configure remote-sync connection settings (does not enable or verify it).")
+        answers = _prompt_setup_interactively(console)
+        if answers is None:
+            console.print(f"[{DIM}]Setup cancelled.[/]")
+            return True
+    else:
+        # No flags and no real stdin: console.input() would block or raise
+        # EOFError instead of returning a usable turn.
+        console.print(f"[{DIM}]usage:[/] {_SETUP_USAGE}")
         return True
     write_remote_sync_config(
-        provider=provider or DEFAULT_REMOTE_SYNC_PROVIDER,
-        bucket=bucket or "",
-        prefix=prefix or DEFAULT_REMOTE_SYNC_PREFIX,
-        region=region or "",
-        profile=profile or "",
+        provider=answers.get("provider") or DEFAULT_REMOTE_SYNC_PROVIDER,
+        bucket=answers.get("bucket", ""),
+        prefix=answers.get("prefix") or DEFAULT_REMOTE_SYNC_PREFIX,
+        region=answers.get("region", ""),
+        profile=answers.get("profile", ""),
     )
     console.print(f"Saved remote-sync settings to [{HIGHLIGHT}]{local_settings_path()}[/].")
     console.print(f"[{DIM}]Set {REMOTE_SYNC_ENV}=1 to enable syncing.[/]")
@@ -126,7 +170,7 @@ def _cmd_remote_sync(_session: Session, console: Console, args: list[str]) -> bo
         if sub is RemoteSyncSubcommand.SYNC:
             return _run_sync(console, args[1:])
         if sub is RemoteSyncSubcommand.SETUP:
-            return _run_setup(console)
+            return _run_setup(console, args[1:])
     except OrgScopeNotSupportedError as exc:
         # Safe to show: our own wording, no vendor or credential detail.
         console.print(f"[{DIM}]{exc}[/]")
@@ -170,7 +214,8 @@ COMMANDS: tuple[SlashCommand, ...] = (
             (RemoteSyncSubcommand.SYNC.value, "pull remote changes, then push local ones"),
             (
                 RemoteSyncSubcommand.SETUP.value,
-                "configure provider/bucket/prefix/region/profile (does not enable it)",
+                "configure provider/bucket/prefix/region/profile via --flags, or "
+                "prompts in a real terminal (does not enable it)",
             ),
         ),
         use_cases=(

--- a/tests/cli/test_gateway_remote_sync.py
+++ b/tests/cli/test_gateway_remote_sync.py
@@ -160,5 +160,5 @@ def test_gateway_dispatch_sync_error_stays_handled(monkeypatch: pytest.MonkeyPat
         is True
     )
     out = buf.getvalue()
-    assert "Sync failed" in out
+    assert "Command failed" in out
     assert leaked not in out, "provider detail reached the gateway reply"

--- a/tests/cli/test_remote_sync_command.py
+++ b/tests/cli/test_remote_sync_command.py
@@ -247,6 +247,18 @@ def test_setup_failure_exits_nonzero(runner: CliRunner, monkeypatch: pytest.Monk
     assert "could not write settings" in result.output
 
 
+def test_setup_reprompts_for_bucket_on_blank_input(runner: CliRunner) -> None:
+    """click.prompt (no default) re-asks rather than accepting an empty bucket."""
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        # Blank line for Bucket the first time; Click must ask again rather
+        # than proceed with an empty value.
+        input="aws\n\n",
+    )
+    assert result.output.count("Bucket:") >= 2
+
+
 def test_remote_sync_help_lists_setup(runner: CliRunner) -> None:
     result = runner.invoke(remote_sync_command, ["--help"])
     assert result.exit_code == 0

--- a/tests/cli/test_remote_sync_command.py
+++ b/tests/cli/test_remote_sync_command.py
@@ -192,6 +192,7 @@ def test_setup_prompts_and_writes_config(
         "surfaces.cli.commands.remote_sync.write_remote_sync_config",
         lambda **kwargs: captured.update(kwargs),
     )
+    monkeypatch.setattr("surfaces.cli.commands.remote_sync.remote_sync_enabled", lambda: False)
     result = runner.invoke(
         remote_sync_command,
         ["setup"],
@@ -209,6 +210,26 @@ def test_setup_prompts_and_writes_config(
     assert "enable syncing" in result.output
 
 
+def test_setup_warns_when_env_override_makes_new_destination_active(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """OPENSRE_REMOTE_SYNC=1 overrides the stored enabled: false — say so."""
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.write_remote_sync_config",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr("surfaces.cli.commands.remote_sync.remote_sync_enabled", lambda: True)
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        input="aws\nmy-bucket\nopensre\n\n\n",
+    )
+    assert result.exit_code == 0
+    assert "Warning" in result.output
+    assert "active immediately" in result.output
+    assert "enable syncing" not in result.output
+
+
 def test_setup_uses_defaults_on_blank_provider_and_prefix(
     runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -218,6 +239,7 @@ def test_setup_uses_defaults_on_blank_provider_and_prefix(
         "surfaces.cli.commands.remote_sync.write_remote_sync_config",
         lambda **kwargs: captured.update(kwargs),
     )
+    monkeypatch.setattr("surfaces.cli.commands.remote_sync.remote_sync_enabled", lambda: False)
     result = runner.invoke(
         remote_sync_command,
         ["setup"],

--- a/tests/cli/test_remote_sync_command.py
+++ b/tests/cli/test_remote_sync_command.py
@@ -285,3 +285,20 @@ def test_setup_reports_unwritable_settings_location_cleanly(
     # with an unhandled traceback instead of the command's normal error path.
     assert result.exception is None or isinstance(result.exception, SystemExit)
     assert "could not write" in result.output
+
+
+def test_setup_rejects_an_unregistered_provider(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An unsupported provider must fail at setup, not later at sync time."""
+    from config.constants import paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "OPENSRE_HOME_DIR", tmp_path)
+
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        input="azure-typo\nmy-bucket\nopensre\n\n\n",
+    )
+    assert result.exit_code != 0
+    assert "unknown remote-sync provider" in result.output

--- a/tests/cli/test_remote_sync_command.py
+++ b/tests/cli/test_remote_sync_command.py
@@ -181,3 +181,73 @@ def test_sync_help_documents_direction_flags(runner: CliRunner) -> None:
     assert result.exit_code == 0
     assert "--pull-only" in result.output
     assert "--push-only" in result.output
+
+
+def test_setup_prompts_and_writes_config(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.write_remote_sync_config",
+        lambda **kwargs: captured.update(kwargs),
+    )
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        input="aws\nmy-bucket\nopensre\n\n\n",
+    )
+    assert result.exit_code == 0
+    assert captured == {
+        "provider": "aws",
+        "bucket": "my-bucket",
+        "prefix": "opensre",
+        "region": "",
+        "profile": "",
+    }
+    assert "Saved remote-sync settings" in result.output
+    assert "enable syncing" in result.output
+
+
+def test_setup_uses_defaults_on_blank_provider_and_prefix(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.write_remote_sync_config",
+        lambda **kwargs: captured.update(kwargs),
+    )
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        input="\nmy-bucket\n\nus-east-1\nwork\n",
+    )
+    assert result.exit_code == 0
+    assert captured["provider"] == "aws"
+    assert captured["prefix"] == "opensre"
+    assert captured["region"] == "us-east-1"
+    assert captured["profile"] == "work"
+
+
+def test_setup_failure_exits_nonzero(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(**_kwargs: str) -> None:
+        raise RemoteSyncConfigError("could not write settings")
+
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.write_remote_sync_config",
+        _boom,
+    )
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        input="aws\nmy-bucket\nopensre\n\n\n",
+    )
+    assert result.exit_code != 0
+    assert "could not write settings" in result.output
+
+
+def test_remote_sync_help_lists_setup(runner: CliRunner) -> None:
+    result = runner.invoke(remote_sync_command, ["--help"])
+    assert result.exit_code == 0
+    assert RemoteSyncSubcommand.SETUP in result.output

--- a/tests/cli/test_remote_sync_command.py
+++ b/tests/cli/test_remote_sync_command.py
@@ -263,3 +263,25 @@ def test_remote_sync_help_lists_setup(runner: CliRunner) -> None:
     result = runner.invoke(remote_sync_command, ["--help"])
     assert result.exit_code == 0
     assert RemoteSyncSubcommand.SETUP in result.output
+
+
+def test_setup_reports_unwritable_settings_location_cleanly(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A real filesystem failure (not a mock) must exit cleanly, not with a traceback."""
+    from config.constants import paths as paths_mod
+
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setattr(paths_mod, "OPENSRE_HOME_DIR", blocker / "home")
+
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        input="aws\nmy-bucket\nopensre\n\n\n",
+    )
+    assert result.exit_code != 0
+    # A handled failure exits via SystemExit; anything else means it crashed
+    # with an unhandled traceback instead of the command's normal error path.
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "could not write" in result.output

--- a/tests/config/test_local_settings.py
+++ b/tests/config/test_local_settings.py
@@ -1,0 +1,34 @@
+"""save_local_settings wraps filesystem failures like load_local_settings does."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from config.constants import paths
+from config.local_settings import LocalSettingsError, local_settings_path, save_local_settings
+
+
+def test_save_local_settings_wraps_oserror_in_local_settings_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file where a directory is needed must not surface a bare OSError."""
+    # Arrange: "home" needs to be a directory, but a plain file sits there.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", blocker / "home")
+
+    # Act / Assert
+    with pytest.raises(LocalSettingsError, match="could not write"):
+        save_local_settings({"remote_sync": {"bucket": "b"}})
+
+
+def test_save_local_settings_writes_normally(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+
+    save_local_settings({"remote_sync": {"bucket": "b"}})
+
+    assert local_settings_path().exists()

--- a/tests/filestorage/test_enums.py
+++ b/tests/filestorage/test_enums.py
@@ -29,9 +29,11 @@ def test_direction_flags_resolve_to_enum() -> None:
     assert resolve_direction(pull_only=False, push_only=False) is SyncDirection.BOTH
 
 
-def test_remote_sync_subcommands_are_status_and_sync() -> None:
+def test_remote_sync_subcommands_are_status_sync_and_setup() -> None:
     assert set(RemoteSyncSubcommand) == {
         RemoteSyncSubcommand.STATUS,
         RemoteSyncSubcommand.SYNC,
+        RemoteSyncSubcommand.SETUP,
     }
     assert RemoteSyncSubcommand("status") is RemoteSyncSubcommand.STATUS
+    assert RemoteSyncSubcommand("setup") is RemoteSyncSubcommand.SETUP

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -969,7 +969,7 @@ def test_write_remote_sync_config_persists_the_five_fields(
         profile="work",
     )
 
-    # Assert: normalized values landed, and "enabled" was never written.
+    # Assert: normalized values landed, and sync stays explicitly off.
     section = read_section("remote_sync")
     assert section == {
         "provider": "aws",
@@ -977,8 +977,8 @@ def test_write_remote_sync_config_persists_the_five_fields(
         "prefix": "opensre",
         "region": "us-east-1",
         "profile": "work",
+        "enabled": False,
     }
-    assert "enabled" not in section
 
 
 def test_write_remote_sync_config_round_trips_once_enabled_separately(
@@ -987,11 +987,23 @@ def test_write_remote_sync_config_round_trips_once_enabled_separately(
     """Naming a bucket alone must not enable sync; the switch stays separate."""
     # Arrange
     from config.constants import paths
+    from config.constants.filestorage import (
+        REMOTE_SYNC_PROFILE_ENV,
+        REMOTE_SYNC_PROVIDER_ENV,
+        REMOTE_SYNC_REGION_ENV,
+    )
     from config.local_settings import update_section
     from platform.filestorage.operations import write_remote_sync_config
 
     monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
-    for name in (REMOTE_SYNC_ENV, REMOTE_SYNC_BUCKET_ENV, REMOTE_SYNC_PREFIX_ENV):
+    for name in (
+        REMOTE_SYNC_ENV,
+        REMOTE_SYNC_BUCKET_ENV,
+        REMOTE_SYNC_PREFIX_ENV,
+        REMOTE_SYNC_PROVIDER_ENV,
+        REMOTE_SYNC_REGION_ENV,
+        REMOTE_SYNC_PROFILE_ENV,
+    ):
         monkeypatch.delenv(name, raising=False)
 
     # Act: setup alone must not turn sync on.
@@ -1044,6 +1056,51 @@ def test_write_remote_sync_config_rejects_empty_bucket(
     with pytest.raises(RemoteSyncConfigError, match="non-empty bucket"):
         write_remote_sync_config(
             provider="aws", bucket="   ", prefix="opensre", region="", profile=""
+        )
+
+    # Nothing was written.
+    assert read_section("remote_sync") == {}
+
+
+def test_write_remote_sync_config_turns_off_a_previously_enabled_sync(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Redirecting a destination must not leave an old ``enabled: true`` active."""
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import read_section, update_section
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+    update_section("remote_sync", {"provider": "aws", "bucket": "old-bucket", "enabled": True})
+
+    # Act: rerun setup to point somewhere else.
+    write_remote_sync_config(
+        provider="aws", bucket="new-bucket", prefix="opensre", region="", profile=""
+    )
+
+    # Assert: the new, unverified destination is staged but not live.
+    section = read_section("remote_sync")
+    assert section["bucket"] == "new-bucket"
+    assert section["enabled"] is False
+
+
+def test_write_remote_sync_config_rejects_unknown_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unsupported provider must fail at setup, not later at sync time."""
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import read_section
+    from platform.filestorage.errors import RemoteSyncConfigError
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+
+    # Act / Assert
+    with pytest.raises(RemoteSyncConfigError, match="unknown remote-sync provider"):
+        write_remote_sync_config(
+            provider="azure-typo", bucket="my-bucket", prefix="opensre", region="", profile=""
         )
 
     # Nothing was written.

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -1085,6 +1085,34 @@ def test_write_remote_sync_config_turns_off_a_previously_enabled_sync(
     assert section["enabled"] is False
 
 
+def test_write_remote_sync_config_cannot_override_an_env_enabled_sync(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stored ``enabled: false`` is not the whole story — env still wins.
+
+    ``write_remote_sync_config`` only controls the stored section; it cannot
+    and must not reach into the caller's environment. A surface that promises
+    "does not enable it" has to check ``remote_sync_enabled()`` itself and
+    warn when the environment variable is what is actually keeping sync live.
+    """
+    # Arrange
+    from config.constants import paths
+    from platform.filestorage.config import remote_sync_enabled
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+    monkeypatch.setenv(REMOTE_SYNC_ENV, "1")
+
+    # Act: setup still writes enabled: false to the stored section...
+    write_remote_sync_config(
+        provider="aws", bucket="new-bucket", prefix="opensre", region="", profile=""
+    )
+
+    # Assert: ...but the environment variable overrides it, exactly as
+    # documented in platform/filestorage/config.py's precedence rule.
+    assert remote_sync_enabled() is True
+
+
 def test_write_remote_sync_config_rejects_unknown_provider(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import pytest
 
 from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
+    DEFAULT_REMOTE_SYNC_PROVIDER,
     REMOTE_SYNC_BUCKET_ENV,
     REMOTE_SYNC_ENV,
     REMOTE_SYNC_PREFIX_ENV,
@@ -816,18 +818,26 @@ def test_org_scoped_turn_refuses_to_sync(monkeypatch: pytest.MonkeyPatch) -> Non
     from config.principal import Actor, Principal, StorageScope
     from config.scope_context import bound_storage_scope
     from platform.filestorage.errors import OrgScopeNotSupportedError
-    from platform.filestorage.operations import get_sync_status, run_remote_sync
+    from platform.filestorage.operations import (
+        get_sync_status,
+        run_remote_sync,
+        write_remote_sync_config,
+    )
 
     monkeypatch.setenv(REMOTE_SYNC_ENV, "1")
     monkeypatch.setenv(REMOTE_SYNC_BUCKET_ENV, "shared-bucket")
     scope = StorageScope(principal=Principal.org("org_acme"), actor=Actor(id="U_ALICE"))
 
-    # Act / Assert: both entry points fail closed while the scope is bound.
+    # Act / Assert: all three entry points fail closed while the scope is bound.
     with bound_storage_scope(scope):
         with pytest.raises(OrgScopeNotSupportedError):
             run_remote_sync()
         with pytest.raises(OrgScopeNotSupportedError):
             get_sync_status()
+        with pytest.raises(OrgScopeNotSupportedError):
+            write_remote_sync_config(
+                provider="aws", bucket="shared-bucket", prefix="opensre", region="", profile=""
+            )
 
 
 def test_unbound_laptop_turn_still_syncs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -934,3 +944,85 @@ def test_list_prefix_is_delimited_so_a_sibling_bucket_path_cannot_match() -> Non
 
     # Assert
     assert seen["Prefix"] == "opensre/"
+
+
+# ── /remote-sync setup writes settings without enabling sync ────────────────
+
+
+def test_write_remote_sync_config_persists_the_five_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """setup stages a destination; it must not flip the enabled switch."""
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import read_section
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+
+    # Act
+    write_remote_sync_config(
+        provider="AWS",
+        bucket=" my-bucket ",
+        prefix="",
+        region="us-east-1",
+        profile="work",
+    )
+
+    # Assert: normalized values landed, and "enabled" was never written.
+    section = read_section("remote_sync")
+    assert section == {
+        "provider": "aws",
+        "bucket": "my-bucket",
+        "prefix": "opensre",
+        "region": "us-east-1",
+        "profile": "work",
+    }
+    assert "enabled" not in section
+
+
+def test_write_remote_sync_config_round_trips_once_enabled_separately(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Naming a bucket alone must not enable sync; the switch stays separate."""
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import update_section
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+    for name in (REMOTE_SYNC_ENV, REMOTE_SYNC_BUCKET_ENV, REMOTE_SYNC_PREFIX_ENV):
+        monkeypatch.delenv(name, raising=False)
+
+    # Act: setup alone must not turn sync on.
+    write_remote_sync_config(
+        provider="aws", bucket="my-bucket", prefix="opensre", region="", profile=""
+    )
+    assert load_remote_sync_config() is None
+
+    # Enabling separately (the "enabled" key, mirroring what a later CLI/slash
+    # confirmation step would set) makes the same written settings take effect.
+    update_section("remote_sync", {"enabled": True})
+    config = load_remote_sync_config()
+    assert config is not None
+    assert config.bucket == "my-bucket"
+    assert config.provider == "aws"
+
+
+def test_write_remote_sync_config_defaults_blank_provider_and_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import read_section
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+
+    # Act
+    write_remote_sync_config(provider="", bucket="b", prefix="  ", region="", profile="")
+
+    # Assert
+    section = read_section("remote_sync")
+    assert section["provider"] == DEFAULT_REMOTE_SYNC_PROVIDER
+    assert section["prefix"] == DEFAULT_REMOTE_SYNC_PREFIX

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -1026,3 +1026,25 @@ def test_write_remote_sync_config_defaults_blank_provider_and_prefix(
     section = read_section("remote_sync")
     assert section["provider"] == DEFAULT_REMOTE_SYNC_PROVIDER
     assert section["prefix"] == DEFAULT_REMOTE_SYNC_PREFIX
+
+
+def test_write_remote_sync_config_rejects_empty_bucket(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty bucket must not silently save a config load_remote_sync_config rejects."""
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import read_section
+    from platform.filestorage.errors import RemoteSyncConfigError
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+
+    # Act / Assert
+    with pytest.raises(RemoteSyncConfigError, match="non-empty bucket"):
+        write_remote_sync_config(
+            provider="aws", bucket="   ", prefix="opensre", region="", profile=""
+        )
+
+    # Nothing was written.
+    assert read_section("remote_sync") == {}

--- a/tests/interactive_shell/test_remote_sync_cmds.py
+++ b/tests/interactive_shell/test_remote_sync_cmds.py
@@ -102,7 +102,7 @@ def test_sync_error_is_caught(monkeypatch: pytest.MonkeyPatch) -> None:
     console, buf = _capture()
     assert dispatch_slash("/remote-sync sync --pull-only --push-only", Session(), console) is True
     out = buf.getvalue()
-    assert "Sync failed" in out
+    assert "Command failed" in out
     # This handler also serves gateway chat, so provider detail must not appear.
     assert "bad flags" not in out, "error detail reached the chat reply"
 
@@ -135,7 +135,7 @@ def test_slash_command_metadata_for_planner() -> None:
     cmd = SLASH_COMMANDS["/remote-sync"]
     assert cmd.first_arg_completions is not None
     labels = {label for label, _hint in cmd.first_arg_completions}
-    assert labels == {"status", "sync"}
+    assert labels == {"status", "sync", "setup"}
     assert any("OPENSRE_REMOTE_SYNC" in note for note in (cmd.notes or ()))
     catalog = MCP_BY_COMMAND["/remote-sync"]
     assert "status" in catalog.llm_description
@@ -170,3 +170,75 @@ def test_repl_and_headless_dispatch_same_command_object() -> None:
     assert repl.command_exists("/remote-sync")
     assert headless.command_exists("/remote-sync")
     assert SLASH_COMMANDS["/remote-sync"].handler is not None
+
+
+def test_setup_prompts_and_writes_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    answers = iter(["aws", "my-bucket", "opensre", "", ""])
+    captured: dict[str, str] = {}
+
+    def _capture_write(**kwargs: str) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        _capture_write,
+    )
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    assert captured == {
+        "provider": "aws",
+        "bucket": "my-bucket",
+        "prefix": "opensre",
+        "region": "",
+        "profile": "",
+    }
+    out = buf.getvalue()
+    assert "Saved remote-sync settings" in out
+    assert "enable syncing" in out
+
+
+def test_setup_uses_defaults_on_blank_provider_and_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    answers = iter(["", "my-bucket", "", "us-east-1", "work"])
+    captured: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        lambda **kwargs: captured.update(kwargs),
+    )
+    console, _buf = _capture()
+    monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    assert captured["provider"] == "aws"
+    assert captured["prefix"] == "opensre"
+    assert captured["region"] == "us-east-1"
+    assert captured["profile"] == "work"
+
+
+def test_setup_failure_shows_generic_message_not_exception_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """External surface (gateway chat shares this handler): never leak str(exc)."""
+
+    def _boom(**_kwargs: str) -> None:
+        raise RemoteSyncConfigError("SECRET-INTERNAL-DETAIL should never reach chat")
+
+    answers = iter(["aws", "my-bucket", "opensre", "", ""])
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        _boom,
+    )
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    out = buf.getvalue()
+    assert "SECRET-INTERNAL-DETAIL" not in out
+    assert "Command failed" in out

--- a/tests/interactive_shell/test_remote_sync_cmds.py
+++ b/tests/interactive_shell/test_remote_sync_cmds.py
@@ -188,6 +188,10 @@ def test_setup_prompts_and_writes_config(monkeypatch: pytest.MonkeyPatch) -> Non
         "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
         lambda: True,
     )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.remote_sync_enabled",
+        lambda: False,
+    )
     console, buf = _capture()
     monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
 
@@ -219,6 +223,10 @@ def test_setup_uses_defaults_on_blank_provider_and_prefix(
         "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
         lambda: True,
     )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.remote_sync_enabled",
+        lambda: False,
+    )
     console, _buf = _capture()
     monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
 
@@ -228,6 +236,34 @@ def test_setup_uses_defaults_on_blank_provider_and_prefix(
     assert captured["prefix"] == "opensre"
     assert captured["region"] == "us-east-1"
     assert captured["profile"] == "work"
+
+
+def test_setup_warns_when_env_override_makes_new_destination_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OPENSRE_REMOTE_SYNC=1 overrides the stored enabled: false — say so."""
+    answers = iter(["aws", "my-bucket", "opensre", "", ""])
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.remote_sync_enabled",
+        lambda: True,
+    )
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    out = buf.getvalue()
+    assert "Warning" in out
+    assert "active immediately" in out
+    assert "enable syncing" not in out
 
 
 def test_setup_failure_shows_generic_message_not_exception_detail(
@@ -287,6 +323,10 @@ def test_setup_headless_dispatch_with_flags_writes_config(
         "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
         lambda: False,
     )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.remote_sync_enabled",
+        lambda: False,
+    )
     captured: dict[str, str] = {}
     monkeypatch.setattr(
         "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
@@ -332,6 +372,61 @@ def test_setup_headless_dispatch_without_bucket_flag_shows_usage(
 
     out = buf.getvalue()
     assert "--bucket is required" in out
+
+
+def test_setup_flag_missing_its_value_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A dangling flag at the end must not be silently dropped."""
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: False,
+    )
+    write_called = False
+
+    def _fail_if_called(**_kwargs: str) -> None:
+        nonlocal write_called
+        write_called = True
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        _fail_if_called,
+    )
+    console, buf = _capture()
+
+    assert (
+        dispatch_slash("/remote-sync setup --bucket my-bucket --provider", Session(), console)
+        is True
+    )
+
+    assert write_called is False
+    assert "each flag needs a value" in buf.getvalue()
+
+
+def test_setup_flag_value_that_looks_like_a_flag_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--bucket --provider aws`` must not save "--provider" as the bucket."""
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: False,
+    )
+    write_called = False
+
+    def _fail_if_called(**_kwargs: str) -> None:
+        nonlocal write_called
+        write_called = True
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        _fail_if_called,
+    )
+    console, buf = _capture()
+
+    assert (
+        dispatch_slash("/remote-sync setup --bucket --provider aws", Session(), console) is True
+    )
+
+    assert write_called is False
+    assert "each flag needs a value" in buf.getvalue()
 
 
 def test_setup_rejects_empty_bucket(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/interactive_shell/test_remote_sync_cmds.py
+++ b/tests/interactive_shell/test_remote_sync_cmds.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 from rich.console import Console
 
+from config.constants.filestorage import DEFAULT_REMOTE_SYNC_PREFIX
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.engine import SyncReport
 from platform.filestorage.enums import SyncRootName
@@ -259,7 +260,7 @@ def test_setup_failure_shows_generic_message_not_exception_detail(
 def test_setup_refuses_headless_dispatch_without_prompting(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Gateway/headless callers have no real stdin; setup must not call console.input()."""
+    """Headless callers with no flags get usage text; setup must not call console.input()."""
     monkeypatch.setattr(
         "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
         lambda: False,
@@ -274,8 +275,63 @@ def test_setup_refuses_headless_dispatch_without_prompting(
     assert dispatch_slash("/remote-sync setup", Session(), console) is True
 
     out = " ".join(buf.getvalue().split())
-    assert "interactive terminal" in out
-    assert "opensre remote-sync setup" in out
+    assert "usage" in out
+    assert "--bucket" in out
+
+
+def test_setup_headless_dispatch_with_flags_writes_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gateway/headless callers configure setup via flags, without any prompting."""
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: False,
+    )
+    captured: dict[str, str] = {}
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        lambda **kwargs: captured.update(kwargs),
+    )
+
+    def _fail_if_called(_prompt: str) -> str:
+        raise AssertionError("console.input() must not be called when flags are given")
+
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", _fail_if_called)
+
+    assert (
+        dispatch_slash(
+            "/remote-sync setup --provider aws --bucket my-bucket --region us-east-1",
+            Session(),
+            console,
+        )
+        is True
+    )
+
+    assert captured == {
+        "provider": "aws",
+        "bucket": "my-bucket",
+        "prefix": DEFAULT_REMOTE_SYNC_PREFIX,
+        "region": "us-east-1",
+        "profile": "",
+    }
+    assert "Saved remote-sync settings" in buf.getvalue()
+
+
+def test_setup_headless_dispatch_without_bucket_flag_shows_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A flag other than --bucket alone must not be treated as a complete setup."""
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: False,
+    )
+    console, buf = _capture()
+
+    assert dispatch_slash("/remote-sync setup --provider aws", Session(), console) is True
+
+    out = buf.getvalue()
+    assert "--bucket is required" in out
 
 
 def test_setup_rejects_empty_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -360,4 +416,26 @@ def test_setup_cancelled_on_eof_does_not_error(monkeypatch: pytest.MonkeyPatch) 
     assert dispatch_slash("/remote-sync setup", Session(), console) is True
 
     assert write_called is False
+    assert "Setup cancelled" in buf.getvalue()
+
+
+def test_setup_cancellation_stops_at_the_first_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ctrl-D on the first prompt must not still ask the remaining four."""
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: True,
+    )
+    calls = 0
+
+    def _input(_prompt: str) -> str:
+        nonlocal calls
+        calls += 1
+        raise EOFError
+
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", _input)
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    assert calls == 1
     assert "Setup cancelled" in buf.getvalue()

--- a/tests/interactive_shell/test_remote_sync_cmds.py
+++ b/tests/interactive_shell/test_remote_sync_cmds.py
@@ -299,3 +299,65 @@ def test_setup_rejects_empty_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
     out = buf.getvalue()
     assert "Command failed" in out
     assert "Saved remote-sync settings" not in out
+
+
+def test_setup_reports_unwritable_settings_location_cleanly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A real filesystem failure (not a mock) must not leak into the chat reply."""
+    from config.constants import paths as paths_mod
+    from platform.filestorage.operations import write_remote_sync_config
+
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setattr(paths_mod, "OPENSRE_HOME_DIR", blocker / "home")
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        write_remote_sync_config,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: True,
+    )
+    answers = iter(["aws", "my-bucket", "opensre", "", ""])
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    out = buf.getvalue()
+    assert "Command failed" in out
+    assert "not a directory" not in out
+
+
+def test_setup_cancelled_on_eof_does_not_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ctrl-D at any prompt is a normal cancellation, not a turn error."""
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: True,
+    )
+    write_called = False
+
+    def _fail_if_called(**_kwargs: str) -> None:
+        nonlocal write_called
+        write_called = True
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        _fail_if_called,
+    )
+    answers = iter(["aws", "my-bucket"])
+
+    def _input(_prompt: str) -> str:
+        try:
+            return next(answers)
+        except StopIteration:
+            raise EOFError from None
+
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", _input)
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    assert write_called is False
+    assert "Setup cancelled" in buf.getvalue()

--- a/tests/interactive_shell/test_remote_sync_cmds.py
+++ b/tests/interactive_shell/test_remote_sync_cmds.py
@@ -183,6 +183,10 @@ def test_setup_prompts_and_writes_config(monkeypatch: pytest.MonkeyPatch) -> Non
         "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
         _capture_write,
     )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: True,
+    )
     console, buf = _capture()
     monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
 
@@ -210,6 +214,10 @@ def test_setup_uses_defaults_on_blank_provider_and_prefix(
         "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
         lambda **kwargs: captured.update(kwargs),
     )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: True,
+    )
     console, _buf = _capture()
     monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
 
@@ -234,6 +242,10 @@ def test_setup_failure_shows_generic_message_not_exception_detail(
         "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
         _boom,
     )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: True,
+    )
     console, buf = _capture()
     monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
 
@@ -242,3 +254,48 @@ def test_setup_failure_shows_generic_message_not_exception_detail(
     out = buf.getvalue()
     assert "SECRET-INTERNAL-DETAIL" not in out
     assert "Command failed" in out
+
+
+def test_setup_refuses_headless_dispatch_without_prompting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gateway/headless callers have no real stdin; setup must not call console.input()."""
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: False,
+    )
+
+    def _fail_if_called(_prompt: str) -> str:
+        raise AssertionError("console.input() must not be called in a headless turn")
+
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", _fail_if_called)
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    out = " ".join(buf.getvalue().split())
+    assert "interactive terminal" in out
+    assert "opensre remote-sync setup" in out
+
+
+def test_setup_rejects_empty_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty bucket must not silently save a config the sync loader rejects."""
+    from platform.filestorage.operations import write_remote_sync_config
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.write_remote_sync_config",
+        write_remote_sync_config,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.repl_tty_interactive",
+        lambda: True,
+    )
+    answers = iter(["aws", "", "opensre", "", ""])
+    console, buf = _capture()
+    monkeypatch.setattr(console, "input", lambda _prompt: next(answers))
+
+    assert dispatch_slash("/remote-sync setup", Session(), console) is True
+
+    out = buf.getvalue()
+    assert "Command failed" in out
+    assert "Saved remote-sync settings" not in out


### PR DESCRIPTION
Fixes #4554

Adds an `opensre remote-sync setup` / `/remote-sync setup` flow that configures provider, bucket, prefix, region, and profile, and writes them via a new shared `write_remote_sync_config` in `platform/filestorage/operations.py`. Refuses an org-scoped turn, same as `get_sync_status`/`run_remote_sync`.

**Update 1:** closed after Greptile flagged headless `console.input()` calls and a silently-accepted empty bucket. Fixed: `setup` gated on `repl_tty_interactive()`, and the shared write function rejected an empty bucket.

**Update 2:** closed after Greptile flagged `save_local_settings()` leaking a bare `OSError` on an unwritable settings path, and Ctrl-D during setup surfacing as a generic turn error. Fixed at the source: `save_local_settings` now wraps `OSError` into `LocalSettingsError` like its sibling `load_local_settings` already does, and a `_prompt()` helper catches `EOFError`/`KeyboardInterrupt` for a clean cancellation.

**Update 3:** closed after Greptile and Copilot found four more issues, all fixed:
1. Rerunning setup while sync was already enabled kept the stored `enabled: true` while replacing the destination, so a new, unverified bucket went live immediately. `write_remote_sync_config` now always writes `enabled: false`, so redirecting a destination never skips the explicit re-enable step.
2. An unsupported or misspelled provider saved cleanly and only failed later, at sync time. `write_remote_sync_config` now validates against `registered_providers()` and rejects an unknown one immediately, mirroring `build_object_store`'s own error message.
3. The issue's acceptance criteria calls for `/remote-sync setup` to work in the shell via flags, with interactive prompts reserved for the CLI. The slash handler previously refused every headless call outright. It now parses `--provider/--bucket/--prefix/--region/--profile`, using them directly when present (gateway-safe, no prompting) and falling back to interactive prompts only in a real terminal.
4. Ctrl-D on the very first setup prompt still asked the remaining four before reporting cancellation. The prompts are now asked one at a time in a loop that returns immediately on the first `None`.

### Demo/Screenshot for feature changes and bug fixes -

```
$ make lint && make typecheck && make check-imports
All checks passed! / Success: no issues found in 1545 source files / All 3 import checks passed.

$ uv run pytest tests/filestorage/ tests/cli/test_remote_sync_command.py tests/cli/test_gateway_remote_sync.py tests/interactive_shell/test_remote_sync_cmds.py tests/surfaces/test_remote_sync_surface_contract.py tests/config/ -q
356 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

For the enabled-state finding, the fix had to close the gap for every future call, not just the one Greptile spotted, so `write_remote_sync_config` always sets `enabled: false` unconditionally rather than only when it was previously absent. For the provider finding, reused the same registry (`registered_providers()`) and message shape that `build_object_store` already uses at sync time, so the two failure points read as one consistent contract instead of inventing new wording. For the flags finding, re-read the issue text directly rather than trusting my own earlier interpretation: it explicitly says "`/remote-sync setup` works in the shell (flags; interactive prompts on CLI)" and gives `opensre remote-sync setup --provider <name> --bucket <store>` as the example, which the original implementation didn't satisfy for the shell surface at all. Added a small `--key value` parser scoped to the five known flags, used only when at least one is present, keeping the interactive path as an unconditional fallback for a real terminal. For the cancellation finding, replaced the five separate prompt calls with a loop over `(key, label)` pairs that returns `None` the moment a prompt is cancelled, so no later prompt fires.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
