### PR TITLE
fix(filestorage): reject incomplete Vercel blob metadata

### DIFF
--- a/platform/filestorage/providers/vercel.py
+++ b/platform/filestorage/providers/vercel.py
@@ -71,7 +71,8 @@ class VercelBlobObjectStore:
         out: list[RemoteObject] = []
         try:
             for blob in self._iter_blobs(full_prefix):
-                pathname = str(blob.get("pathname", ""))
+                # _blobs_from_list_payload already guaranteed a non-empty str.
+                pathname = blob["pathname"]
                 out.append(
                     RemoteObject(
                         key=self._strip_prefix(pathname),
@@ -175,17 +176,20 @@ def _private_blob_url(store_id: str, pathname: str) -> str:
 
 
 def _parse_uploaded_at(value: object) -> datetime:
+    """Parse the blob's upload timestamp, or raise if it cannot be trusted.
+
+    A missing or unparseable timestamp must never fall back to "now" — that
+    would make incomplete metadata outrank a genuinely newer local file during
+    sync, silently discarding the local copy.
+    """
     if isinstance(value, datetime):
         return value if value.tzinfo else value.replace(tzinfo=UTC)
     if isinstance(value, str) and value:
         # API returns ISO-8601 with Z suffix.
         normalized = value.replace("Z", "+00:00")
-        try:
-            parsed = datetime.fromisoformat(normalized)
-        except ValueError:
-            return datetime.now(tz=UTC)
+        parsed = datetime.fromisoformat(normalized)
         return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
-    return datetime.now(tz=UTC)
+    raise ValueError(f"blob 'uploadedAt' is not a usable timestamp: {value!r}")
 
 
 def _json_object(response: httpx.Response, *, what: str) -> dict[str, Any]:
@@ -205,9 +209,12 @@ def _blobs_from_list_payload(payload: dict[str, Any]) -> list[dict[str, Any]]:
     """Return the ``blobs`` list, or raise if the field shape is unusable.
 
     An empty list is valid (nothing under the prefix). Missing, null, non-list,
-    or non-object entries must not look like an authoritative empty listing —
-    that would make the sync engine skip remote-only restores and re-upload
-    over remote data.
+    non-object, or key-less entries must not look like an authoritative empty
+    or partial listing — a blob without a real ``pathname`` would otherwise
+    become an authoritative object under an empty key, and the sync engine
+    would miss the real remote object entirely. ``uploadedAt`` is validated
+    separately by :func:`_parse_uploaded_at`, since a missing value there must
+    raise rather than default to "now" — same reasoning, different field.
     """
     if "blobs" not in payload:
         raise ValueError("list response is missing the 'blobs' field")
@@ -220,6 +227,9 @@ def _blobs_from_list_payload(payload: dict[str, Any]) -> list[dict[str, Any]]:
             raise ValueError(
                 f"list response blobs[{index}] must be an object, got {type(item).__name__}"
             )
+        pathname = item.get("pathname")
+        if not isinstance(pathname, str) or not pathname:
+            raise ValueError(f"list response blobs[{index}] is missing a 'pathname'")
         out.append(item)
     return out
 

--- a/tests/filestorage/test_vercel_provider.py
+++ b/tests/filestorage/test_vercel_provider.py
@@ -247,6 +247,40 @@ def test_malformed_blobs_field_is_remote_sync_unavailable() -> None:
     assert store.list_objects("") == []
 
 
+def test_incomplete_blob_metadata_is_remote_sync_unavailable() -> None:
+    """A blob missing pathname/uploadedAt must not become a phantom or "now" entry.
+
+    Defaulting an absent pathname to "" or an absent/unparseable uploadedAt to
+    "now" would make incomplete metadata look authoritative: an empty-key
+    object masks the real remote key, and a "now" timestamp can make stale
+    remote data outrank a genuinely newer local file.
+    """
+
+    class _Weird(httpx.BaseTransport):
+        def __init__(self, payload: object) -> None:
+            self._payload = payload
+
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=self._payload, request=request)
+
+    bad_blobs = (
+        {"uploadedAt": "2024-01-01T00:00:00Z"},  # missing pathname
+        {"pathname": "", "uploadedAt": "2024-01-01T00:00:00Z"},  # blank pathname
+        {"pathname": "opensre/a.jsonl"},  # missing uploadedAt
+        {"pathname": "opensre/a.jsonl", "uploadedAt": None},  # null uploadedAt
+        {"pathname": "opensre/a.jsonl", "uploadedAt": "not-a-timestamp"},  # unparseable
+        {"pathname": "opensre/a.jsonl", "uploadedAt": 12345},  # wrong type
+    )
+    for blob in bad_blobs:
+        store = VercelBlobObjectStore(
+            _config(),
+            token=_TOKEN,
+            client=httpx.Client(transport=_Weird({"blobs": [blob], "hasMore": False})),
+        )
+        with pytest.raises(RemoteSyncUnavailableError, match="cannot list"):
+            store.list_objects("")
+
+
 def test_engine_push_restore_via_registry(tmp_path_factory: pytest.TempPathFactory) -> None:
     """Registry → Vercel store → push → pull into a second tree (same contract as S3)."""
     from pathlib import Path


### PR DESCRIPTION
Fixes: Greptile P1 finding on re-trigger of #4625 (targets that feature branch — `platform/filestorage/providers/vercel.py` doesn't exist on `main` yet). Merge into `feat/vercel-blob-remote-sync-provider`, not `main`.

#### Describe the changes you have made in this PR -

A Vercel Blob list-response entry missing `pathname` or `uploadedAt` was silently defaulted (empty-string key, `datetime.now()` timestamp) instead of rejected. That let incomplete metadata look authoritative: an empty key masks the real remote key, and a "now" timestamp can make stale/incomplete remote data outrank a genuinely newer local file during sync — same class of bug the existing malformed-shape handling in this file already guards against, just one level deeper (per-item fields, not just the collection shape).

- `_blobs_from_list_payload` now requires a non-empty string `pathname` per blob item, alongside its existing checks for missing/non-list `blobs` and non-object entries.
- `_parse_uploaded_at` now raises `ValueError` instead of returning `datetime.now(tz=UTC)` for a missing, null, or unparseable `uploadedAt` — `list_objects`'s existing `except (httpx.HTTPError, TypeError, ValueError)` already converts that to `RemoteSyncUnavailableError`, so no new error path was needed.
- `list_objects` reads `blob["pathname"]` directly now that presence is guaranteed upstream, rather than re-defaulting with `.get("pathname", "")`.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run python -m pytest tests/filestorage/test_vercel_provider.py -q
..........                                                              [100%]
10 passed in 1.00s
```

New test `test_incomplete_blob_metadata_is_remote_sync_unavailable` covers: missing `pathname`, blank `pathname`, missing `uploadedAt`, null `uploadedAt`, unparseable `uploadedAt` string, and wrong-typed `uploadedAt` — each now raises `RemoteSyncUnavailableError` instead of silently producing a phantom/mistimed entry.

`make lint`, `make format-check`, `make typecheck`, and the full `tests/filestorage/` suite (76 passed) are green.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Greptile flagged that incomplete per-blob metadata (missing `pathname`/`uploadedAt`) was defaulted rather than rejected during Vercel Blob listing, which can silently corrupt sync decisions. The fix extends the same fail-closed validation the file already applies at the collection level (`_blobs_from_list_payload` rejecting missing/non-list `blobs`, non-object entries) down to the two per-item fields the sync engine actually depends on for correctness: the object's key and its comparison timestamp. `_parse_uploaded_at` raising instead of defaulting was the minimal change — the calling code (`list_objects`) already had a `ValueError`-catching except clause built for exactly this shape, from the earlier malformed-payload fix in this same PR chain, so no new error-handling path was required.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---


Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.