### PR TITLE
feat(filestorage): add Google Cloud Storage provider and remote-sync setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -681,7 +681,8 @@ CLOUD_REGION=
 
 # Remote context sync (optional) — mirror sessions + memory to a store you own.
 # Credentials are never uploaded. See docs/configuration/remote-sync.mdx
-# Built-in provider is aws (S3); other clouds register via register_object_store.
+# Built-in providers: aws (S3) or gcs (Google Cloud Storage, via Application
+# Default Credentials). Other clouds register via register_object_store.
 # OPENSRE_REMOTE_SYNC=1
 # OPENSRE_REMOTE_SYNC_PROVIDER=aws
 # OPENSRE_REMOTE_SYNC_BUCKET=

--- a/config/constants/filestorage.py
+++ b/config/constants/filestorage.py
@@ -4,9 +4,9 @@ Opt-in and off by default. A laptop keeps working entirely on local disk; when
 enabled, conversation history and memory are mirrored to a store the user owns
 so a second machine can pick up where the first left off.
 
-The backend is selected by ``OPENSRE_REMOTE_SYNC_PROVIDER`` (default ``aws``).
-New vendors register under ``platform.filestorage.providers`` without changing
-the sync engine.
+The backend is selected by ``OPENSRE_REMOTE_SYNC_PROVIDER`` (default ``aws``;
+``gcs`` is the other built-in). New vendors register under
+``platform.filestorage.providers`` without changing the sync engine.
 """
 
 from __future__ import annotations
@@ -14,10 +14,10 @@ from __future__ import annotations
 # Master switch. Sync stays off until this is truthy, even if a bucket is named.
 REMOTE_SYNC_ENV = "OPENSRE_REMOTE_SYNC"
 # Cloud provider registered in platform.filestorage.providers (default: aws).
-# Value must stay aligned with BuiltInProvider.AWS in platform.filestorage.enums.
+# Value must stay aligned with BuiltInProvider in platform.filestorage.enums.
 REMOTE_SYNC_PROVIDER_ENV = "OPENSRE_REMOTE_SYNC_PROVIDER"
-# Top-level store name the user owns (S3 bucket today; other providers may reuse).
-# Required when sync is on.
+# Top-level store name the user owns (S3 or GCS bucket today; other providers
+# may reuse). Required when sync is on.
 REMOTE_SYNC_BUCKET_ENV = "OPENSRE_REMOTE_SYNC_BUCKET"
 # Key prefix inside the store, so one store can hold several roots.
 REMOTE_SYNC_PREFIX_ENV = "OPENSRE_REMOTE_SYNC_PREFIX"

--- a/docs/configuration/remote-sync.mdx
+++ b/docs/configuration/remote-sync.mdx
@@ -23,6 +23,16 @@ setup again; everything else is already there.
 
 ## Turn it on
 
+Guided way — writes the `remote_sync` section of `~/.opensre/config.yml`
+(prompts for provider, bucket, and prefix when you don't pass them as flags;
+`--region` and `--profile` are flags only):
+
+```bash
+opensre remote-sync setup --provider gcs --bucket my-opensre-bucket
+```
+
+Or set environment variables for a single run:
+
 ```bash
 export OPENSRE_REMOTE_SYNC=1
 export OPENSRE_REMOTE_SYNC_BUCKET=my-opensre-bucket
@@ -31,8 +41,8 @@ export OPENSRE_REMOTE_SYNC_BUCKET=my-opensre-bucket
 | Variable | Description |
 |---|---|
 | `OPENSRE_REMOTE_SYNC` | Set to `1` to enable. Nothing uploads until you do |
-| `OPENSRE_REMOTE_SYNC_PROVIDER` | Backend name. Default `aws` (S3). Community backends register under the same name |
-| `OPENSRE_REMOTE_SYNC_BUCKET` | Object-store name you own (S3 bucket today). Required |
+| `OPENSRE_REMOTE_SYNC_PROVIDER` | Backend name: `aws` (S3, default) or `gcs` (Google Cloud Storage). Community backends register under their own name |
+| `OPENSRE_REMOTE_SYNC_BUCKET` | Object-store name you own (S3 or GCS bucket today). Required |
 | `OPENSRE_REMOTE_SYNC_PREFIX` | Key prefix, default `opensre`. Machines that should share history must use the same one |
 | `OPENSRE_REMOTE_SYNC_REGION` | Region override when the provider supports it |
 | `OPENSRE_REMOTE_SYNC_PROFILE` | Named credentials profile, if opensre should not use your default |
@@ -40,9 +50,10 @@ export OPENSRE_REMOTE_SYNC_BUCKET=my-opensre-bucket
 Naming a bucket is not enough on its own — `OPENSRE_REMOTE_SYNC` has to be set
 too, so a bucket variable left over from another tool never starts uploading.
 
-You can also persist settings under `remote_sync` in `~/.opensre/config.yml`
-(`enabled`, `bucket`, `provider`, `prefix`, …). Environment variables still
-win for a single run.
+Settings persist under `remote_sync` in `~/.opensre/config.yml` (`enabled`,
+`bucket`, `provider`, `prefix`, …) — that is what `remote-sync setup` writes.
+Credentials are never written there; they stay in your cloud CLI's usual
+places. Environment variables still win for a single run.
 
 <Note>
 Every machine that should share your history needs the **same provider, bucket,
@@ -85,11 +96,11 @@ opensre remote-sync sync --push-only    # back up without pulling
 
 ## Providers
 
-The sync engine talks only to a small object-store interface. Amazon S3 is the
-built-in backend today (`OPENSRE_REMOTE_SYNC_PROVIDER=aws`, the default). Other
-clouds (GCS, Azure, …) are community additions: implement `ObjectStore`, call
-`register_object_store("<name>", factory)`, and set
-`OPENSRE_REMOTE_SYNC_PROVIDER` — the engine, CLI, and REPL do not change.
+The sync engine talks only to a small object-store interface. Amazon S3
+(`OPENSRE_REMOTE_SYNC_PROVIDER=aws`, the default) and Google Cloud Storage
+(`gcs`) are the built-in backends. Other clouds (Azure, …) are community
+additions: implement `ObjectStore`, call `register_object_store("<name>", factory)`,
+and set `OPENSRE_REMOTE_SYNC_PROVIDER` — the engine, CLI, and REPL do not change.
 
 ### AWS / S3 (default)
 
@@ -103,6 +114,28 @@ s3:ListBucket, s3:GetObject, s3:PutObject
 ```
 
 `s3:DeleteObject` is not needed — sync never deletes anything.
+
+### Google Cloud Storage
+
+Set `OPENSRE_REMOTE_SYNC_PROVIDER=gcs` and point `OPENSRE_REMOTE_SYNC_BUCKET`
+at any private bucket. Credentials come from Application Default Credentials —
+run this once per machine and sign in with the account that owns the bucket:
+
+```bash
+gcloud auth application-default login
+```
+
+Minimum permissions on the bucket (a bucket-scoped `roles/storage.objectUser`
+binding covers all four):
+
+```
+storage.objects.list, storage.objects.get, storage.objects.create, storage.objects.delete
+```
+
+opensre never deletes anything, but GCS still requires `storage.objects.delete`
+to **replace** an existing object — without it the first changed session or
+memory file fails with a 403. Objects are encrypted at rest by default; there
+is nothing to configure.
 
 ## The store
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -29,6 +29,13 @@ ignore_missing_imports = True
 [mypy-botocore.*]
 ignore_missing_imports = True
 
+# google-cloud-storage ships no py.typed marker (google.cloud is a namespace package).
+[mypy-google.cloud]
+ignore_missing_imports = True
+
+[mypy-google.cloud.*]
+ignore_missing_imports = True
+
 [mypy-kubernetes]
 ignore_missing_imports = True
 

--- a/platform/filestorage/__init__.py
+++ b/platform/filestorage/__init__.py
@@ -1,8 +1,8 @@
 """Optional mirroring of conversation context to a store the user owns.
 
 Off by default. When switched on, conversation history and memory are copied
-to the user's own object store (AWS/S3 today; other backends register under
-:mod:`platform.filestorage.providers`). Credentials never leave the machine —
+to the user's own object store (AWS/S3 and GCS today; other backends register
+under :mod:`platform.filestorage.providers`). Credentials never leave the machine -
 see :mod:`platform.filestorage.syncable`.
 
 Surfaces share one **stateless, thread-safe** service

--- a/platform/filestorage/enums.py
+++ b/platform/filestorage/enums.py
@@ -33,6 +33,7 @@ class BuiltInProvider(StrEnum):
     """
 
     AWS = "aws"
+    GCS = "gcs"
 
 
 class RemoteSyncSubcommand(StrEnum):
@@ -40,6 +41,7 @@ class RemoteSyncSubcommand(StrEnum):
 
     STATUS = "status"
     SYNC = "sync"
+    SETUP = "setup"
 
 
 __all__ = [

--- a/platform/filestorage/messages.py
+++ b/platform/filestorage/messages.py
@@ -16,8 +16,10 @@ from config.constants.filestorage import (
     REMOTE_SYNC_PROVIDER_ENV,
     REMOTE_SYNC_REGION_ENV,
 )
+from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.engine import SyncReport
 from platform.filestorage.operations import SyncStatus
+from platform.filestorage.providers.registry import registered_providers
 
 
 def _human_size(n: int) -> str:
@@ -33,13 +35,18 @@ def _human_size(n: int) -> str:
 
 DISABLED_HELP = f"""Remote sync is off.
 
-To turn it on, point opensre at a store you own:
+To turn it on:
+
+    opensre remote-sync setup
+
+Or set env vars for a single run:
 
     export {REMOTE_SYNC_ENV}=1
     export {REMOTE_SYNC_BUCKET_ENV}=my-opensre-bucket
 
-Optional: {REMOTE_SYNC_PROVIDER_ENV} (default {DEFAULT_REMOTE_SYNC_PROVIDER}), \
-{REMOTE_SYNC_PREFIX_ENV}, {REMOTE_SYNC_REGION_ENV}, {REMOTE_SYNC_PROFILE_ENV}.
+Optional: {REMOTE_SYNC_PROVIDER_ENV} (default {DEFAULT_REMOTE_SYNC_PROVIDER}; \
+built-in: {", ".join(registered_providers())}), {REMOTE_SYNC_PREFIX_ENV}, \
+{REMOTE_SYNC_REGION_ENV}, {REMOTE_SYNC_PROFILE_ENV}.
 Cloud credentials are read from the usual places; opensre never stores them."""
 
 _KEPT_REMOTE_HINT = (
@@ -84,8 +91,37 @@ def format_report_lines(report: SyncReport) -> tuple[str, ...]:
     return tuple(lines)
 
 
+def format_setup_lines(
+    config: RemoteSyncConfig, credential_hint: str, *, enabled: bool = True
+) -> tuple[str, ...]:
+    """What ``setup`` wrote, and how the provider expects credentials to appear."""
+    state = "on" if enabled else "off"
+    lines: list[str] = [
+        f"Remote sync is {state}. Settings saved to ~/.opensre/config.yml:",
+        f"  provider   {config.provider}",
+        f"  bucket     {config.bucket}",
+        f"  prefix     {config.prefix}",
+    ]
+    if config.region:
+        lines.append(f"  region     {config.region}")
+    if config.profile:
+        lines.append(f"  profile    {config.profile}")
+    lines.append(credential_hint)
+    if enabled:
+        lines.append(
+            "Run `opensre remote-sync status` to check, `opensre remote-sync sync` to mirror now."
+        )
+    else:
+        lines.append(
+            f"Turn it on later with `opensre remote-sync setup`, or {REMOTE_SYNC_ENV}=1 "
+            "for a single run."
+        )
+    return tuple(lines)
+
+
 __all__ = [
     "DISABLED_HELP",
     "format_report_lines",
+    "format_setup_lines",
     "format_status_lines",
 ]

--- a/platform/filestorage/providers/__init__.py
+++ b/platform/filestorage/providers/__init__.py
@@ -1,8 +1,9 @@
 """Cloud backends for remote sync.
 
-AWS/S3 is the only built-in backend today — loaded lazily via the registry when
-``provider=aws``. Other clouds (GCS, Azure, …) are community modules that call
-:func:`register_object_store`; the sync engine, CLI, and REPL do not change.
+AWS/S3 and GCS are the built-in backends today — loaded lazily via the registry
+(``provider=aws`` / ``provider=gcs``). Other clouds (Azure, …) are community
+modules that call :func:`register_object_store`; the sync engine, CLI, and REPL
+do not change.
 """
 
 from __future__ import annotations

--- a/platform/filestorage/providers/aws.py
+++ b/platform/filestorage/providers/aws.py
@@ -19,6 +19,11 @@ if TYPE_CHECKING:
 _SERVER_SIDE_ENCRYPTION = "AES256"
 PROVIDER_NAME = BuiltInProvider.AWS
 
+CREDENTIAL_HINT = (
+    "AWS credentials stay ambient: your default profile or SSO session works "
+    "(aws sso login); set OPENSRE_REMOTE_SYNC_PROFILE for a named profile."
+)
+
 
 class S3ObjectStore:
     """Reads and writes objects under one bucket and prefix."""
@@ -109,4 +114,4 @@ def _factory(config: RemoteSyncConfig) -> S3ObjectStore:
 
 register_object_store(PROVIDER_NAME, _factory)
 
-__all__ = ["PROVIDER_NAME", "S3ObjectStore"]
+__all__ = ["CREDENTIAL_HINT", "PROVIDER_NAME", "S3ObjectStore"]

--- a/platform/filestorage/providers/gcs.py
+++ b/platform/filestorage/providers/gcs.py
@@ -1,0 +1,129 @@
+"""GCS backend for remote sync — one registered :class:`ObjectStore` implementation."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from datetime import UTC, datetime
+from typing import Any
+
+from google.cloud import storage
+
+from platform.filestorage.config import RemoteSyncConfig
+from platform.filestorage.enums import BuiltInProvider
+from platform.filestorage.errors import RemoteSyncUnavailableError
+from platform.filestorage.ports import RemoteObject
+from platform.filestorage.providers.registry import register_object_store
+
+# Every operation catches broad ``Exception``, not ``GoogleAPIError``: the
+# transfer layer (google-resumable-media / requests) raises DataCorruption,
+# InvalidResponse, and raw connection errors that do not inherit it, and the
+# engine may only ever see RemoteSyncError from a provider.
+PROVIDER_NAME = BuiltInProvider.GCS
+
+CREDENTIAL_HINT = (
+    "GCP credentials stay ambient: run `gcloud auth application-default login` "
+    "once per machine with the account that owns the bucket; opensre stores nothing."
+)
+
+_EPOCH = datetime.fromtimestamp(0, tz=UTC)
+
+
+class GCSObjectStore:
+    """Reads and writes objects under one bucket and prefix."""
+
+    def __init__(self, config: RemoteSyncConfig, *, client: Any | None = None) -> None:
+        self._config = config
+        self._client = client if client is not None else _build_client()
+
+    def describe(self) -> str:
+        return f"gs://{self._config.bucket}/{self._config.prefix}"
+
+    def list_objects(self, prefix: str) -> list[RemoteObject]:
+        # Trailing slash so prefix "opensre" cannot also match "opensre-backup/".
+        full_prefix = (
+            self._config.key_for(prefix) if prefix else f"{self._config.prefix.rstrip('/')}/"
+        )
+        try:
+            # Materialize inside the try: the iterator does I/O lazily.
+            blobs = list(self._client.list_blobs(self._config.bucket, prefix=full_prefix))
+        except Exception as exc:
+            raise RemoteSyncUnavailableError(
+                f"cannot list {self.describe()} — {_reason(exc)}"
+            ) from exc
+        out: list[RemoteObject] = []
+        for blob in blobs:
+            out.append(
+                RemoteObject(
+                    key=self._strip_prefix(blob.name),
+                    size=blob.size or 0,
+                    # A listing always carries ``updated``; the epoch fallback
+                    # only guards a malformed resource and reads as "oldest",
+                    # so it can never clobber a newer copy on either side.
+                    last_modified=blob.updated or _EPOCH,
+                    # md5Hash rides the listing, so comparing an object costs
+                    # no extra request. ``blob.etag`` is a version tag, not a
+                    # content hash, and is never used here.
+                    etag=_content_etag(blob.md5_hash),
+                )
+            )
+        return out
+
+    def get_object(self, key: str) -> bytes:
+        try:
+            blob = self._client.bucket(self._config.bucket).blob(self._config.key_for(key))
+            body: bytes = blob.download_as_bytes()
+            return body
+        except Exception as exc:
+            raise RemoteSyncUnavailableError(f"cannot read {key} — {_reason(exc)}") from exc
+
+    def put_object(self, key: str, data: bytes) -> None:
+        try:
+            blob = self._client.bucket(self._config.bucket).blob(self._config.key_for(key))
+            blob.upload_from_string(data)
+        except Exception as exc:
+            raise RemoteSyncUnavailableError(f"cannot write {key} — {_reason(exc)}") from exc
+
+    def _strip_prefix(self, full_key: str) -> str:
+        prefix = f"{self._config.prefix.rstrip('/')}/"
+        return full_key[len(prefix) :] if full_key.startswith(prefix) else full_key
+
+
+def _content_etag(md5_hash: str | None) -> str:
+    """Hex MD5 comparable with the engine's content tag, or empty when unknown.
+
+    GCS base64-encodes the digest; the engine compares lowercase hex. Composite
+    objects carry no ``md5Hash`` at all, and a foreign object could carry a
+    malformed one — both get no tag, so the engine falls back to timestamps,
+    the same degradation S3 multipart ETags get. A real digest is exactly 16
+    bytes; ``validate=True`` keeps stray characters from silently decoding.
+    """
+    if not md5_hash:
+        return ""
+    try:
+        digest = base64.b64decode(md5_hash, validate=True)
+    except (binascii.Error, ValueError):
+        return ""
+    return digest.hex() if len(digest) == 16 else ""
+
+
+def _reason(exc: Exception) -> str:
+    """The GCS-side cause, for a local operator to act on."""
+    return f"{type(exc).__name__}: {exc}"
+
+
+def _build_client() -> Any:
+    try:
+        # No arguments means Application Default Credentials.
+        return storage.Client()
+    except Exception as exc:
+        raise RemoteSyncUnavailableError(f"cannot build a GCS client — {_reason(exc)}") from exc
+
+
+def _factory(config: RemoteSyncConfig) -> GCSObjectStore:
+    return GCSObjectStore(config)
+
+
+register_object_store(PROVIDER_NAME, _factory)
+
+__all__ = ["CREDENTIAL_HINT", "PROVIDER_NAME", "GCSObjectStore"]

--- a/platform/filestorage/providers/registry.py
+++ b/platform/filestorage/providers/registry.py
@@ -35,6 +35,7 @@ _REGISTRY_LOCK = threading.RLock()
 # register ahead of time instead and never appear here.
 _BUILTIN_MODULES = {
     BuiltInProvider.AWS.value: "platform.filestorage.providers.aws",
+    BuiltInProvider.GCS.value: "platform.filestorage.providers.gcs",
 }
 
 
@@ -67,6 +68,23 @@ def registered_providers() -> tuple[str, ...]:
     return tuple(sorted(names))
 
 
+_DEFAULT_CREDENTIAL_HINT = "Credentials come from the provider's usual ambient configuration."
+
+
+def credential_hint_for_provider(name: str) -> str:
+    """How the user supplies ambient credentials for ``name``, for setup output.
+
+    Built-in providers ship a ``CREDENTIAL_HINT`` constant in their module;
+    community providers get a generic line. No store is built and no network
+    call is made — this only reads module constants.
+    """
+    module_name = _BUILTIN_MODULES.get(name.strip().lower())
+    if module_name is None:
+        return _DEFAULT_CREDENTIAL_HINT
+    hint = getattr(importlib.import_module(module_name), "CREDENTIAL_HINT", None)
+    return str(hint) if hint else _DEFAULT_CREDENTIAL_HINT
+
+
 def build_object_store(config: RemoteSyncConfig) -> ObjectStore:
     """Construct the store for ``config.provider``.
 
@@ -90,6 +108,7 @@ def build_object_store(config: RemoteSyncConfig) -> ObjectStore:
 __all__ = [
     "ObjectStoreFactory",
     "build_object_store",
+    "credential_hint_for_provider",
     "register_object_store",
     "registered_providers",
     "unregister_object_store",

--- a/platform/filestorage/setup.py
+++ b/platform/filestorage/setup.py
@@ -1,0 +1,76 @@
+"""Persist remote-sync settings (``opensre remote-sync setup``).
+
+Writes the ``remote_sync`` section of ``~/.opensre/config.yml``. Ambient cloud
+credentials (AWS profile/SSO session, GCP Application Default Credentials)
+stay outside this file — opensre never stores them. ``update_section`` merges,
+so keys written by older versions survive; setup itself supplies exactly the
+six values below and never anything credential-shaped.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
+    DEFAULT_REMOTE_SYNC_PROVIDER,
+)
+from config.local_settings import LocalSettingsError, update_section
+from platform.filestorage.config import RemoteSyncConfig
+from platform.filestorage.errors import RemoteSyncConfigError
+from platform.filestorage.providers.registry import registered_providers
+
+
+@dataclass(frozen=True)
+class RemoteSyncSetupRequest:
+    """Values to store for the next laptop that loads config from disk."""
+
+    bucket: str
+    provider: str = DEFAULT_REMOTE_SYNC_PROVIDER
+    prefix: str = DEFAULT_REMOTE_SYNC_PREFIX
+    region: str = ""
+    profile: str = ""
+    enabled: bool = True
+
+
+def save_remote_sync_settings(request: RemoteSyncSetupRequest) -> RemoteSyncConfig:
+    """Merge ``request`` into ``remote_sync`` and return the stored config shape.
+
+    Environment overrides still win at load time. The provider is validated
+    against the registry so a typo fails here, not at the first sync.
+    """
+    bucket = request.bucket.strip()
+    if not bucket:
+        raise RemoteSyncConfigError("bucket (store name) is required")
+    provider = request.provider.strip().lower() or DEFAULT_REMOTE_SYNC_PROVIDER
+    known = registered_providers()
+    if provider not in known:
+        listed = ", ".join(known) or "(none)"
+        raise RemoteSyncConfigError(f"unknown remote-sync provider {provider!r}; known: {listed}")
+    prefix = request.prefix.strip() or DEFAULT_REMOTE_SYNC_PREFIX
+    region = request.region.strip()
+    profile = request.profile.strip()
+    try:
+        update_section(
+            "remote_sync",
+            {
+                "enabled": bool(request.enabled),
+                "provider": provider,
+                "bucket": bucket,
+                "prefix": prefix,
+                "region": region,
+                "profile": profile,
+            },
+        )
+    except LocalSettingsError as exc:
+        raise RemoteSyncConfigError(str(exc)) from exc
+    return RemoteSyncConfig(
+        bucket=bucket,
+        provider=provider,
+        prefix=prefix,
+        region=region,
+        profile=profile,
+    )
+
+
+__all__ = ["RemoteSyncSetupRequest", "save_remote_sync_settings"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ dependencies = [
     # Google APIs
     "google-api-python-client>=2.194.0,<3.0.0",
     "google-auth>=2.0.0,<3.0.0",
+    # Google Cloud Storage (remote-sync provider)
+    "google-cloud-storage>=2.18,<4",
     # MongoDB
     "pymongo>=4.6.0,<6.0.0",
     # Redis

--- a/surfaces/cli/commands/remote_sync.py
+++ b/surfaces/cli/commands/remote_sync.py
@@ -1,18 +1,27 @@
-"""``opensre remote-sync`` — thin Click adapter over :mod:`platform.filestorage.operations`."""
+"""``opensre remote-sync`` — thin Click adapter over :mod:`platform.filestorage`."""
 
 from __future__ import annotations
 
+import sys
+
 import click
 
+from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
+    DEFAULT_REMOTE_SYNC_PROVIDER,
+)
 from platform.common.exit_codes import ERROR, SUCCESS
-from platform.filestorage import RemoteSyncError
+from platform.filestorage import RemoteSyncConfigError, RemoteSyncError
 from platform.filestorage.enums import RemoteSyncSubcommand
 from platform.filestorage.messages import (
     DISABLED_HELP,
     format_report_lines,
+    format_setup_lines,
     format_status_lines,
 )
 from platform.filestorage.operations import get_sync_status, run_remote_sync
+from platform.filestorage.providers.registry import credential_hint_for_provider
+from platform.filestorage.setup import RemoteSyncSetupRequest, save_remote_sync_settings
 
 
 @click.group(name="remote-sync", invoke_without_command=True)
@@ -52,6 +61,84 @@ def sync_now_command(pull_only: bool, push_only: bool) -> None:
     for line in format_report_lines(report):
         click.echo(line)
     raise SystemExit(SUCCESS)
+
+
+@remote_sync_command.command(name=RemoteSyncSubcommand.SETUP.value)
+@click.option(
+    "--provider",
+    default=None,
+    help=f"Backend name (default {DEFAULT_REMOTE_SYNC_PROVIDER}; built-in: aws, gcs).",
+)
+@click.option("--bucket", default=None, help="Store name you own (S3 or GCS bucket).")
+@click.option("--prefix", default=None, help=f"Key prefix (default {DEFAULT_REMOTE_SYNC_PREFIX}).")
+@click.option("--region", default=None, help="Region override when the provider supports it.")
+@click.option("--profile", default=None, help="Named credentials profile (AWS).")
+@click.option(
+    "--enabled/--disabled",
+    default=True,
+    show_default=True,
+    help="Whether remote sync is switched on in stored settings.",
+)
+def setup_command(
+    provider: str | None,
+    bucket: str | None,
+    prefix: str | None,
+    region: str | None,
+    profile: str | None,
+    enabled: bool,
+) -> None:
+    """Write remote-sync settings to ~/.opensre/config.yml (prompts if flags omitted)."""
+    try:
+        request = _collect_setup_request(
+            provider=provider,
+            bucket=bucket,
+            prefix=prefix,
+            region=region,
+            profile=profile,
+            enabled=enabled,
+        )
+        config = save_remote_sync_settings(request)
+    except (RemoteSyncError, click.Abort) as exc:
+        if isinstance(exc, click.Abort):
+            raise SystemExit(ERROR) from exc
+        click.echo(str(exc), err=True)
+        raise SystemExit(ERROR) from exc
+    for line in format_setup_lines(
+        config, credential_hint_for_provider(config.provider), enabled=request.enabled
+    ):
+        click.echo(line)
+    raise SystemExit(SUCCESS)
+
+
+def _collect_setup_request(
+    *,
+    provider: str | None,
+    bucket: str | None,
+    prefix: str | None,
+    region: str | None,
+    profile: str | None,
+    enabled: bool,
+) -> RemoteSyncSetupRequest:
+    """Flags when present; prompt on a TTY, never silently in a pipe."""
+    if provider is None and sys.stdin.isatty():
+        provider = click.prompt("Provider", default=DEFAULT_REMOTE_SYNC_PROVIDER)
+    if (bucket is None or not bucket.strip()) and sys.stdin.isatty():
+        bucket = click.prompt("Bucket (store name you own)")
+    if prefix is None and sys.stdin.isatty():
+        prefix = click.prompt("Key prefix", default=DEFAULT_REMOTE_SYNC_PREFIX)
+    if bucket is None or not bucket.strip():
+        raise RemoteSyncConfigError(
+            "setup needs a bucket: pass --bucket (and optionally --provider/--prefix), "
+            "or run it on a terminal"
+        )
+    return RemoteSyncSetupRequest(
+        bucket=bucket,
+        provider=provider or DEFAULT_REMOTE_SYNC_PROVIDER,
+        prefix=prefix or DEFAULT_REMOTE_SYNC_PREFIX,
+        region=region or "",
+        profile=profile or "",
+        enabled=enabled,
+    )
 
 
 __all__ = ["remote_sync_command"]

--- a/tests/cli/test_remote_sync_command.py
+++ b/tests/cli/test_remote_sync_command.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
+from types import SimpleNamespace
 
 import click
 import pytest
@@ -14,6 +16,7 @@ from platform.filestorage.engine import SyncReport
 from platform.filestorage.enums import BuiltInProvider, RemoteSyncSubcommand, SyncRootName
 from platform.filestorage.errors import RemoteSyncConfigError
 from platform.filestorage.operations import SyncRootStatus, SyncStatus
+from platform.filestorage.setup import RemoteSyncSetupRequest
 from surfaces.cli.commands.remote_sync import remote_sync_command
 
 
@@ -181,3 +184,91 @@ def test_sync_help_documents_direction_flags(runner: CliRunner) -> None:
     assert result.exit_code == 0
     assert "--pull-only" in result.output
     assert "--push-only" in result.output
+
+
+def _save_config(
+    saved: dict[str, RemoteSyncSetupRequest],
+) -> Callable[[RemoteSyncSetupRequest], RemoteSyncConfig]:
+    def _save(request: RemoteSyncSetupRequest) -> RemoteSyncConfig:
+        saved["request"] = request
+        return RemoteSyncConfig(
+            bucket=request.bucket, provider=request.provider, prefix=request.prefix
+        )
+
+    return _save
+
+
+def test_setup_with_flags_saves_and_confirms(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    saved: dict[str, RemoteSyncSetupRequest] = {}
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.save_remote_sync_settings", _save_config(saved)
+    )
+    result = runner.invoke(
+        remote_sync_command, ["setup", "--provider", "gcs", "--bucket", "my-bucket"]
+    )
+    assert result.exit_code == 0
+    request = saved["request"]
+    assert request.provider == "gcs"
+    assert request.bucket == "my-bucket"
+    assert "provider   gcs" in result.output
+    assert "bucket     my-bucket" in result.output
+    assert "gcloud auth application-default login" in result.output
+    assert "opensre remote-sync status" in result.output
+
+
+def test_setup_without_bucket_off_tty_fails(runner: CliRunner) -> None:
+    # CliRunner stdin is not a TTY, so no prompt is offered.
+    result = runner.invoke(remote_sync_command, ["setup", "--provider", "gcs"])
+    assert result.exit_code != 0
+    assert "needs a bucket" in result.output
+
+
+def test_setup_unknown_provider_fails_with_known_list(runner: CliRunner) -> None:
+    result = runner.invoke(remote_sync_command, ["setup", "--provider", "gogle", "--bucket", "b"])
+    assert result.exit_code != 0
+    assert "unknown remote-sync provider" in result.output
+    assert "gcs" in result.output
+
+
+def test_setup_prompts_for_missing_flags_on_a_tty(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    saved: dict[str, RemoteSyncSetupRequest] = {}
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.save_remote_sync_settings", _save_config(saved)
+    )
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.sys",
+        SimpleNamespace(stdin=SimpleNamespace(isatty=lambda: True)),
+    )
+    result = runner.invoke(remote_sync_command, ["setup"], input="gcs\nmy-bucket\n\n")
+    assert result.exit_code == 0
+    request = saved["request"]
+    assert request.provider == "gcs"
+    assert request.bucket == "my-bucket"
+    assert request.prefix == "opensre"
+
+
+def test_setup_help_lists_the_flags(runner: CliRunner) -> None:
+    result = runner.invoke(remote_sync_command, ["setup", "--help"])
+    assert result.exit_code == 0
+    assert "--provider" in result.output
+    assert "--bucket" in result.output
+
+
+def test_setup_disabled_reports_off_not_on(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    saved: dict[str, RemoteSyncSetupRequest] = {}
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.save_remote_sync_settings", _save_config(saved)
+    )
+    result = runner.invoke(
+        remote_sync_command, ["setup", "--provider", "gcs", "--bucket", "b", "--disabled"]
+    )
+    assert result.exit_code == 0
+    assert saved["request"].enabled is False
+    assert "Remote sync is off." in result.output
+    assert "Remote sync is on." not in result.output

--- a/tests/filestorage/test_enums.py
+++ b/tests/filestorage/test_enums.py
@@ -16,6 +16,7 @@ from platform.filestorage.syncable import syncable_roots
 def test_builtin_provider_matches_env_default() -> None:
     assert DEFAULT_REMOTE_SYNC_PROVIDER == BuiltInProvider.AWS
     assert BuiltInProvider.AWS.value == "aws"
+    assert BuiltInProvider.GCS.value == "gcs"
 
 
 def test_syncable_roots_use_root_name_enum() -> None:
@@ -29,9 +30,11 @@ def test_direction_flags_resolve_to_enum() -> None:
     assert resolve_direction(pull_only=False, push_only=False) is SyncDirection.BOTH
 
 
-def test_remote_sync_subcommands_are_status_and_sync() -> None:
+def test_remote_sync_subcommands_are_status_sync_and_setup() -> None:
     assert set(RemoteSyncSubcommand) == {
         RemoteSyncSubcommand.STATUS,
         RemoteSyncSubcommand.SYNC,
+        RemoteSyncSubcommand.SETUP,
     }
     assert RemoteSyncSubcommand("status") is RemoteSyncSubcommand.STATUS
+    assert RemoteSyncSubcommand("setup") is RemoteSyncSubcommand.SETUP

--- a/tests/filestorage/test_gcs_provider.py
+++ b/tests/filestorage/test_gcs_provider.py
@@ -1,0 +1,239 @@
+"""GCS object-store provider: field mapping, etag conversion, error wrapping."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from google.api_core.exceptions import Forbidden, GoogleAPIError
+from google.auth.exceptions import DefaultCredentialsError
+
+from platform.filestorage.config import RemoteSyncConfig
+from platform.filestorage.engine import content_tag, push
+from platform.filestorage.enums import SyncRootName
+from platform.filestorage.errors import RemoteSyncUnavailableError
+from platform.filestorage.providers import gcs
+from platform.filestorage.providers.gcs import GCSObjectStore, _content_etag
+from platform.filestorage.providers.registry import build_object_store, registered_providers
+from platform.filestorage.syncable import SyncRoot
+
+_NOW = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _b64_md5(data: bytes) -> str:
+    """How GCS spells the digest the engine compares in hex."""
+    return base64.b64encode(hashlib.md5(data, usedforsecurity=False).digest()).decode()
+
+
+class _FakeBlob:
+    """Stands in for ``google.cloud.storage.Blob`` on the listing/get/put seams."""
+
+    def __init__(
+        self,
+        store: dict[str, bytes],
+        name: str,
+        *,
+        size: int | None = None,
+        updated: datetime | None = _NOW,
+        md5_hash: str | None = None,
+        etag: str = "",
+    ) -> None:
+        self._store = store
+        self.name = name
+        self.size = size
+        self.updated = updated
+        self.md5_hash = md5_hash
+        self.etag = etag
+
+    def download_as_bytes(self) -> bytes:
+        return self._store[self.name]
+
+    def upload_from_string(self, data: bytes) -> None:
+        self._store[self.name] = data
+
+
+class _FakeBucket:
+    def __init__(self, store: dict[str, bytes]) -> None:
+        self._store = store
+
+    def blob(self, name: str) -> _FakeBlob:
+        return _FakeBlob(self._store, name)
+
+
+class _FakeClient:
+    """Serves listings with full control over per-blob metadata."""
+
+    def __init__(self, *, blobs: list[_FakeBlob] | None = None) -> None:
+        self.objects: dict[str, bytes] = {}
+        self._blobs = blobs
+        self.list_prefixes: list[str] = []
+
+    def list_blobs(self, _bucket: str, *, prefix: str = "") -> list[_FakeBlob]:
+        self.list_prefixes.append(prefix)
+        if self._blobs is not None:
+            return [b for b in self._blobs if b.name.startswith(prefix)]
+        return [
+            _FakeBlob(self.objects, key, size=len(data), md5_hash=_b64_md5(data))
+            for key, data in sorted(self.objects.items())
+            if key.startswith(prefix)
+        ]
+
+    def bucket(self, _name: str) -> _FakeBucket:
+        return _FakeBucket(self.objects)
+
+
+class _Failing:
+    def list_blobs(self, *_args: object, **_kwargs: object) -> list[_FakeBlob]:
+        raise Forbidden("denied")
+
+    def bucket(self, *_args: object) -> _FakeBucket:
+        raise GoogleAPIError("boom")
+
+
+@pytest.fixture
+def roots(tmp_path: Path) -> tuple[SyncRoot, ...]:
+    sessions = tmp_path / "sessions"
+    memory = tmp_path / "memory"
+    sessions.mkdir()
+    memory.mkdir()
+    (sessions / "a.jsonl").write_text('{"turn": 1}\n', encoding="utf-8")
+    (memory / "fact.md").write_text("remembered\n", encoding="utf-8")
+    return (
+        SyncRoot(name=SyncRootName.SESSIONS, path=sessions),
+        SyncRoot(name=SyncRootName.MEMORY, path=memory),
+    )
+
+
+def test_describe_shows_the_gs_destination() -> None:
+    store = GCSObjectStore(RemoteSyncConfig(bucket="b"), client=_FakeClient())
+    assert store.describe() == "gs://b/opensre"
+
+
+def test_list_maps_blob_fields_strips_prefix_and_converts_md5() -> None:
+    data = b'{"turn": 1}\n'
+    client = _FakeClient()
+    client.objects["opensre/sessions/a.jsonl"] = data
+    store = GCSObjectStore(RemoteSyncConfig(bucket="b"), client=client)
+
+    (obj,) = store.list_objects("")
+
+    assert obj.key == "sessions/a.jsonl"
+    assert obj.size == len(data)
+    assert obj.last_modified == _NOW
+    assert obj.etag == content_tag(data)
+    # Bare listing scopes under the configured prefix with a trailing slash, so
+    # "opensre" cannot also match "opensre-backup/".
+    assert client.list_prefixes == ["opensre/"]
+
+
+def test_list_passes_a_relative_prefix_through_key_for() -> None:
+    client = _FakeClient()
+    store = GCSObjectStore(RemoteSyncConfig(bucket="b"), client=client)
+    store.list_objects("sessions")
+    assert client.list_prefixes == ["opensre/sessions"]
+
+
+def test_etag_comes_from_md5_hash_never_from_the_version_etag() -> None:
+    data = b"payload\n"
+    version_tag = "CJi0kcLQ0okDEAE="
+    blob = _FakeBlob({}, "opensre/sessions/a.jsonl", md5_hash=_b64_md5(data), etag=version_tag)
+    store = GCSObjectStore(RemoteSyncConfig(bucket="b"), client=_FakeClient(blobs=[blob]))
+
+    (obj,) = store.list_objects("")
+
+    assert obj.etag == content_tag(data)
+    assert obj.etag != version_tag
+
+
+def test_composite_object_without_md5_hash_gets_no_tag() -> None:
+    blob = _FakeBlob({}, "opensre/sessions/big.jsonl", md5_hash=None)
+    store = GCSObjectStore(RemoteSyncConfig(bucket="b"), client=_FakeClient(blobs=[blob]))
+    (obj,) = store.list_objects("")
+    assert obj.etag == ""
+
+
+def test_malformed_md5_hash_gets_no_tag() -> None:
+    assert _content_etag("x") == ""
+    # Valid-alphabet padding with a stray character must not silently decode.
+    assert _content_etag("AAAAAAAAAAAAAAAAAAAAAA==!") == ""
+    # Well-formed base64 of anything but a 16-byte digest is not an MD5 tag.
+    assert _content_etag(base64.b64encode(b"short").decode()) == ""
+
+
+def test_get_and_put_route_through_the_configured_prefix() -> None:
+    client = _FakeClient()
+    store = GCSObjectStore(RemoteSyncConfig(bucket="b"), client=client)
+
+    store.put_object("sessions/a.jsonl", b"data")
+    assert client.objects["opensre/sessions/a.jsonl"] == b"data"
+    assert store.get_object("sessions/a.jsonl") == b"data"
+
+
+def test_gcs_failures_name_their_cause() -> None:
+    store = GCSObjectStore(RemoteSyncConfig(bucket="missing"), client=_Failing())
+    with pytest.raises(RemoteSyncUnavailableError, match="Forbidden"):
+        store.list_objects("")
+    with pytest.raises(RemoteSyncUnavailableError, match="GoogleAPIError"):
+        store.get_object("k")
+    with pytest.raises(RemoteSyncUnavailableError, match="GoogleAPIError"):
+        store.put_object("k", b"d")
+
+
+def test_transfer_layer_errors_are_wrapped_not_leaked() -> None:
+    """DataCorruption/InvalidResponse/connection errors bypass GoogleAPIError."""
+
+    class _Flaky:
+        def list_blobs(self, *_args: object, **_kwargs: object) -> list[_FakeBlob]:
+            raise ConnectionError("connection dropped")
+
+        def bucket(self, *_args: object) -> _FakeBucket:
+            raise RuntimeError("checksum mismatch")
+
+    store = GCSObjectStore(RemoteSyncConfig(bucket="b"), client=_Flaky())
+    with pytest.raises(RemoteSyncUnavailableError, match="cannot list"):
+        store.list_objects("")
+    with pytest.raises(RemoteSyncUnavailableError, match="cannot read"):
+        store.get_object("k")
+    with pytest.raises(RemoteSyncUnavailableError, match="cannot write"):
+        store.put_object("k", b"d")
+
+
+def test_missing_blob_metadata_falls_back_safely() -> None:
+    blob = _FakeBlob({}, "opensre/sessions/a.jsonl", size=None, updated=None)
+    store = GCSObjectStore(RemoteSyncConfig(bucket="b"), client=_FakeClient(blobs=[blob]))
+    (obj,) = store.list_objects("")
+    assert obj.size == 0
+    assert obj.last_modified == datetime.fromtimestamp(0, tz=UTC)
+
+
+def test_missing_credentials_fail_as_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise() -> object:
+        raise DefaultCredentialsError("no credentials")
+
+    monkeypatch.setattr(gcs, "storage", SimpleNamespace(Client=_raise))
+    with pytest.raises(RemoteSyncUnavailableError, match="cannot build a GCS client"):
+        GCSObjectStore(RemoteSyncConfig(bucket="b"))
+
+
+def test_gcs_is_a_registered_built_in_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert "gcs" in registered_providers()
+    fake = _FakeClient()
+    monkeypatch.setattr(gcs, "storage", SimpleNamespace(Client=lambda: fake))
+    built = build_object_store(RemoteSyncConfig(bucket="b", provider="gcs"))
+    assert isinstance(built, GCSObjectStore)
+
+
+def test_second_push_reuploads_nothing(roots: tuple[SyncRoot, ...]) -> None:
+    """The md5 conversion must hold through the real engine, not just the mapping."""
+    store = GCSObjectStore(RemoteSyncConfig(bucket="b"), client=_FakeClient())
+
+    first = push(store, roots=roots)
+    assert "sessions/a.jsonl" in first.uploaded
+
+    second = push(store, roots=roots)
+    assert second.uploaded == []
+    assert second.skipped == 2

--- a/tests/filestorage/test_multi_provider_support.py
+++ b/tests/filestorage/test_multi_provider_support.py
@@ -1,6 +1,6 @@
-"""Prove remote sync supports more than one cloud without shipping non-AWS SDKs.
+"""Prove remote sync supports more than one cloud through one registry.
 
-AWS/S3 is the only built-in backend. Community providers (GCS, Azure, …)
+AWS/S3 and GCS are the built-in backends. Community providers (Azure, …)
 register the same way these fakes do — the engine and factory never change.
 """
 
@@ -81,10 +81,10 @@ def roots(tmp_path: Path) -> tuple[SyncRoot, ...]:
     )
 
 
-def test_aws_is_the_only_built_in_provider() -> None:
+def test_aws_and_gcs_are_the_built_in_providers() -> None:
     assert "aws" in registered_providers()
-    # Non-AWS backends are not shipped — community modules register later.
-    assert "gcs" not in registered_providers()
+    assert "gcs" in registered_providers()
+    # Azure is not shipped — a community module registers it later.
     assert "azure" not in registered_providers()
 
 
@@ -100,20 +100,26 @@ def test_unknown_provider_fails_closed_listing_known_ones(
 
     monkeypatch.setenv(REMOTE_SYNC_ENV, "1")
     monkeypatch.setenv(REMOTE_SYNC_BUCKET_ENV, "b")
-    monkeypatch.setenv(REMOTE_SYNC_PROVIDER_ENV, "gcs")
+    monkeypatch.setenv(REMOTE_SYNC_PROVIDER_ENV, "azure")
 
     config = load_remote_sync_config()
     assert config is not None
     with pytest.raises(RemoteSyncConfigError, match="unknown remote-sync provider") as caught:
         build_object_store(config)
-    # Operator sees what is installed today (aws) so they know to add a module.
+    # Operator sees what is installed today (aws, gcs) so they know to add a module.
     assert "aws" in str(caught.value)
+    assert "gcs" in str(caught.value)
 
 
 def test_community_style_gcs_registration_drives_the_engine(
     roots: tuple[SyncRoot, ...], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Same path a GCS contributor would take: register, set provider, sync."""
+    """A community registration overrides the built-in of the same name.
+
+    GCS is built in now; registering a stand-in under the same name must win
+    without a lazy built-in import replacing it — the open/closed seam a third
+    party uses to ship a fix without forking.
+    """
     from config.constants.filestorage import (
         REMOTE_SYNC_BUCKET_ENV,
         REMOTE_SYNC_ENV,

--- a/tests/filestorage/test_remote_sync_setup.py
+++ b/tests/filestorage/test_remote_sync_setup.py
@@ -1,0 +1,120 @@
+"""``remote-sync setup``: persists non-secret settings; hints ambient credentials."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from config.local_settings import LocalSettingsError
+from platform.filestorage import setup as setup_mod
+from platform.filestorage.config import RemoteSyncConfig
+from platform.filestorage.errors import RemoteSyncConfigError
+from platform.filestorage.messages import format_setup_lines
+from platform.filestorage.providers.registry import credential_hint_for_provider
+from platform.filestorage.setup import RemoteSyncSetupRequest, save_remote_sync_settings
+
+
+@pytest.fixture
+def captured(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Intercept the config.yml write; nothing touches disk in these tests."""
+    writes: dict[str, Any] = {}
+
+    def _capture(section: str, values: dict[str, Any]) -> None:
+        writes["section"] = section
+        writes["values"] = values
+
+    monkeypatch.setattr(setup_mod, "update_section", _capture)
+    return writes
+
+
+def test_save_supplies_exactly_the_six_non_secret_values(captured: dict[str, Any]) -> None:
+    config = save_remote_sync_settings(
+        RemoteSyncSetupRequest(bucket=" My-Bucket ", provider=" GCS ")
+    )
+
+    assert captured["section"] == "remote_sync"
+    assert captured["values"] == {
+        "enabled": True,
+        "provider": "gcs",
+        "bucket": "My-Bucket",
+        "prefix": "opensre",
+        "region": "",
+        "profile": "",
+    }
+    assert config == RemoteSyncConfig(bucket="My-Bucket", provider="gcs")
+
+
+def test_save_defaults_provider_and_prefix(captured: dict[str, Any]) -> None:
+    save_remote_sync_settings(RemoteSyncSetupRequest(bucket="b", provider="  ", prefix=" "))
+    assert captured["values"]["provider"] == "aws"
+    assert captured["values"]["prefix"] == "opensre"
+
+
+def test_save_without_bucket_fails_closed() -> None:
+    with pytest.raises(RemoteSyncConfigError, match="bucket"):
+        save_remote_sync_settings(RemoteSyncSetupRequest(bucket="   "))
+
+
+def test_save_unknown_provider_lists_known_ones() -> None:
+    with pytest.raises(RemoteSyncConfigError, match="unknown remote-sync provider") as caught:
+        save_remote_sync_settings(RemoteSyncSetupRequest(bucket="b", provider="gogle"))
+    assert "aws" in str(caught.value)
+    assert "gcs" in str(caught.value)
+
+
+def test_save_maps_settings_file_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(_section: str, _values: dict[str, Any]) -> None:
+        raise LocalSettingsError("config.yml is unreadable")
+
+    monkeypatch.setattr(setup_mod, "update_section", _boom)
+    with pytest.raises(RemoteSyncConfigError, match="unreadable"):
+        save_remote_sync_settings(RemoteSyncSetupRequest(bucket="b"))
+
+
+def test_gcs_hint_points_at_application_default_credentials() -> None:
+    hint = credential_hint_for_provider("gcs")
+    assert "gcloud auth application-default login" in hint
+
+
+def test_aws_hint_points_at_ambient_profile_or_sso() -> None:
+    hint = credential_hint_for_provider("aws")
+    assert "sso" in hint.lower() or "profile" in hint.lower()
+
+
+def test_community_provider_gets_generic_hint() -> None:
+    assert credential_hint_for_provider("some-community-backend") == (
+        "Credentials come from the provider's usual ambient configuration."
+    )
+
+
+def test_format_setup_lines_shows_written_values_and_next_steps() -> None:
+    lines = format_setup_lines(
+        RemoteSyncConfig(bucket="b", provider="gcs", prefix="opensre"), "HINT-LINE"
+    )
+    assert any("provider   gcs" in line for line in lines)
+    assert any("bucket     b" in line for line in lines)
+    assert lines[-2] == "HINT-LINE"
+    assert "status" in lines[-1]
+    assert "sync" in lines[-1]
+    # Optional fields stay out when unset.
+    assert not any("region" in line or "profile" in line for line in lines)
+
+
+def test_format_setup_lines_shows_region_and_profile_when_set() -> None:
+    lines = format_setup_lines(
+        RemoteSyncConfig(bucket="b", provider="aws", region="eu-west-1", profile="work"),
+        "HINT-LINE",
+    )
+    assert any("region     eu-west-1" in line for line in lines)
+    assert any("profile    work" in line for line in lines)
+
+
+def test_format_setup_lines_reports_off_when_disabled() -> None:
+    lines = format_setup_lines(
+        RemoteSyncConfig(bucket="b", provider="gcs"), "HINT-LINE", enabled=False
+    )
+    assert lines[0].startswith("Remote sync is off.")
+    assert "Remote sync is on." not in lines[0]
+    assert "OPENSRE_REMOTE_SYNC=1" in lines[-1]
+    assert "mirror now" not in lines[-1]

--- a/uv.lock
+++ b/uv.lock
@@ -1191,6 +1191,71 @@ wheels = [
 ]
 
 [[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/25/355ed97c1723c787dfaa888808d55db18371f82c38ff862357b1e902cd19/google_cloud_storage-3.13.0.tar.gz", hash = "sha256:d11d8706ea1520fba0f21043bcb7897caf7015d76ce1ad9a4f60237e4d7a9f6c", size = 17340960, upload-time = "2026-07-13T19:10:07.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e8/b3678a0931ee7d4b3fdaf0813e6206d66e0922b2c26d912f308728b5b95a/google_cloud_storage-3.13.0-py3-none-any.whl", hash = "sha256:648af3ef8a6acc674e1359d3c920c67eb89a7a5ab66b336bd3ac43fed6b5ab84", size = 341428, upload-time = "2026-07-13T19:09:52.39Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2325,6 +2390,7 @@ dependencies = [
     { name = "filelock" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
+    { name = "google-cloud-storage" },
     { name = "httpx", extra = ["socks"] },
     { name = "keyring" },
     { name = "kubernetes" },
@@ -2445,6 +2511,7 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.29.0" },
     { name = "google-api-python-client", specifier = ">=2.194.0,<3.0.0" },
     { name = "google-auth", specifier = ">=2.0.0,<3.0.0" },
+    { name = "google-cloud-storage", specifier = ">=2.18,<4" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
     { name = "huggingface-hub", marker = "extra == 'dev'", specifier = ">=0.26.0" },
     { name = "huggingface-hub", marker = "extra == 'opensre-hub'", specifier = ">=0.26.0" },


### PR DESCRIPTION
Fixes #4563

#### Describe the changes you have made in this PR -

Adds Google Cloud Storage as a second built-in object-store provider for remote sync (`OPENSRE_REMOTE_SYNC_PROVIDER=gcs`), plus the `opensre remote-sync setup` command from the issue's Onboarding section. Engine, CLI sync paths, REPL, and gateway are untouched; everything goes through the existing open/closed registry.

**Provider (`platform/filestorage/providers/gcs.py`)**
- Four-method `ObjectStore` implementation over `google-cloud-storage`, registered via `_BUILTIN_MODULES` (lazy import).
- Change detection: converts GCS's base64 `md5Hash` to the hex tag the engine compares. Strict decode (`validate=True`, exactly 16 bytes); composite, foreign, or malformed objects fall back to timestamp comparison, same as S3 multipart. The version-style `blob.etag` is never used - it is not a content hash.
- Credentials are ambient (Application Default Credentials). No new env vars; nothing credential-shaped is stored anywhere.
- All vendor and transport failures wrap to `RemoteSyncUnavailableError`. The catch is broad on purpose: `google-resumable-media` / `requests` exceptions (DataCorruption, InvalidResponse, connection errors) do not inherit `GoogleAPIError`, and the engine and chat surfaces may only ever see `RemoteSyncError` (CWE-209 boundary unchanged).
- `list_objects` force-materializes the lazy listing inside the try and maps to `RemoteObject` outside it, so provider-side mapping bugs can never be masked as availability errors.

**Setup (`opensre remote-sync setup --provider gcs`)**
- New `platform/filestorage/setup.py`: validates the provider against the registry first, then persists exactly six non-secret values (enabled/provider/bucket/prefix/region/profile) into the `remote_sync` section of `~/.opensre/config.yml`. `update_section` merges, so pre-existing keys survive.
- CLI flags for everything; TTY prompts for provider/bucket/prefix when omitted (region/profile are flags-only); clear error when run in a pipe without `--bucket`.
- Provider-aware credential hints (`gcloud auth application-default login` for GCS, profile/SSO for AWS) via a small `credential_hint_for_provider` registry helper and a `CREDENTIAL_HINT` constant per provider module.
- `--disabled` writes `enabled: false` and the confirmation correctly reports "Remote sync is off."
- REPL slash setup is intentionally out of scope here (interactive wizard is #4554); `/remote-sync setup` gets the existing "unknown subcommand" reply. Environment-variable configuration ("and env") is unchanged.
- `DISABLED_HELP` now advertises the setup command and computes the built-in list from the registry, so it stays correct when more providers land.

**Docs**
- GCS provider section: ADC setup, IAM note - `storage.objects.list/get/create/delete`; GCS requires delete to *replace* an existing object (changed sessions re-upload), even though opensre itself never deletes. Default encryption at rest.
- `.env.example`, package docstrings, constants comments, and the "Turn it on" section updated for the second built-in provider.

### Demo/Screenshot for feature changes and bug fixes -

**[ VIDEO PLACEHOLDER - full zero-to-working recording (bucket create, setup, first sync, second-sync etag skip, restore, cleanup) will be attached here by the contributor ]**

Terminal evidence (live, personal GCP account via ADC; every bucket deleted after its run):

```
$ opensre remote-sync setup --provider gcs --bucket opensre-setup-verify-fariz --prefix opensre
Remote sync is on. Settings saved to ~/.opensre/config.yml:
  provider   gcs
  bucket     opensre-setup-verify-fariz
  prefix     opensre
GCP credentials stay ambient: run `gcloud auth application-default login` once per machine with the account that owns the bucket; opensre stores nothing.
Run `opensre remote-sync status` to check, `opensre remote-sync sync` to mirror now.

$ opensre remote-sync status          # no env vars set; reads stored config
Remote sync is on (gcs) -> opensre-setup-verify-fariz/opensre

$ opensre remote-sync sync
Sync complete - 0 downloaded, 3 uploaded (486 B), 0 already current (486 B total).

$ opensre remote-sync sync            # second run, no changes: etag skip path
Sync complete - 0 downloaded, 0 uploaded, 6 already current.

# after editing one local session file (overwrite path):
Sync complete - 0 downloaded, 1 uploaded (267 B), 5 already current (267 B total).
# next run: 0 uploaded, 6 already current (etag matches on overwritten objects)

# restore: sessions dir moved away, then `sync --pull-only`
Sync complete - 2 downloaded (450 B), 0 uploaded, 1 already current (450 B total).
# all restored files verified byte-identical (matching Get-FileHash MD5 pairs)
```

Stored `remote_sync` section - no credential material anywhere:

```
remote_sync:
  enabled: true
  provider: gcs
  bucket: opensre-setup-verify-fariz
  prefix: opensre
  region: ''
  profile: ''
```

Additional live checks from independent QA runs: a planted `credentials.json` in the sessions dir is refused by the deny-list (`Sync failed: refusing to upload ...`), and an unknown provider fails with `known: aws, gcs`.

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue required a GCS ObjectStore registered as a built-in, proven by a real push-and-restore cycle, plus a setup command that never stores secrets. I mirrored the existing `aws.py` provider because the registry was designed for exactly that shape (open/closed: new module plus one register call). The one GCS-specific problem is change detection: `blob.etag` is a generation tag, not a content hash, so the provider converts the listing's base64 `md5Hash` into the hex MD5 the engine compares; composite or malformed objects degrade to timestamp comparison, the same as S3 multipart. Credentials are ambient ADC, so setup persists only six non-secret values and points the user at `gcloud auth application-default login`. Alternatives considered and rejected: using `blob.etag` directly (breaks skip-on-unchanged), CRC32C (would require engine changes, which the issue forbids), storing a service-account path in config.yml (violates "never store secrets"), and catching only `GoogleAPIError` (google-resumable-media/requests exceptions bypass it and would crash the sync).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

## Notes for reviewers

- Tests: 13 provider tests + 10 setup tests + 6 CLI setup tests + registry/enum/message coverage. Full filestorage/CLI/REPL/gateway/surface suites pass; ruff, ruff format, and mypy (1541 files) are clean.
- Four pre-existing test failures reproduce on *unmodified* `main` on Windows only (text-mode `write_text("\n")` writes CRLF; byte assertions then mismatch): `test_community_style_gcs/azure_registration_drives_the_engine`, `test_older_remote_does_not_clobber_a_newer_local_edit`, `test_pull_writes_atomically_leaving_no_partial_file`. Linux CI is unaffected.
- Aware of #4625 (Vercel Blob provider): we share 5 files (`enums.py`, `registry.py`, `.env.example`, `remote-sync.mdx`, `test_multi_provider_support.py`) plus the setup feature shape. Happy to rebase after it lands.
- This PR also resolves findings from two prior AI-assisted review rounds: the overwrite-requires-delete IAM documentation, the setup command itself, strict base64/16-byte md5Hash parsing, the `--disabled` confirmation wording, and the prompt-scope and merge-behavior wording in docs.

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
