### PR TITLE
refactor(hermes): spell out duration units in constant names (SM-71)

### DIFF
--- a/integrations/hermes/agent.py
+++ b/integrations/hermes/agent.py
@@ -25,7 +25,7 @@ from typing import Final
 from integrations.hermes.classifier import IncidentClassifier
 from integrations.hermes.incident import HermesIncident, LogLevel
 from integrations.hermes.parser import parse_log_line
-from integrations.hermes.tailer import DEFAULT_POLL_INTERVAL_S, FileTailer
+from integrations.hermes.tailer import DEFAULT_POLL_INTERVAL_SECONDS, FileTailer
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class HermesAgent:
         sink: IncidentSink,
         log_path: Path | str = DEFAULT_LOG_PATH,
         classifier: IncidentClassifier | None = None,
-        poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+        poll_interval_s: float = DEFAULT_POLL_INTERVAL_SECONDS,
         from_start: bool = False,
     ) -> None:
         self._sink = sink

--- a/integrations/hermes/tailer.py
+++ b/integrations/hermes/tailer.py
@@ -32,9 +32,9 @@ from typing import Final
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_POLL_INTERVAL_S: Final[float] = 0.5
+DEFAULT_POLL_INTERVAL_SECONDS: Final[float] = 0.5
 DEFAULT_READ_CHUNK: Final[int] = 64 * 1024
-_REOPEN_LOG_THROTTLE_S: Final[float] = 30.0
+_REOPEN_LOG_THROTTLE_SECONDS: Final[float] = 30.0
 
 
 @dataclass(frozen=True)
@@ -75,7 +75,7 @@ class FileTailer:
         self,
         path: Path | str,
         *,
-        poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+        poll_interval_s: float = DEFAULT_POLL_INTERVAL_SECONDS,
         read_chunk: int = DEFAULT_READ_CHUNK,
         from_start: bool = False,
         stop_event: threading.Event | None = None,
@@ -197,14 +197,14 @@ class FileTailer:
         # Throttle noisy reopen/error logs so a long-missing file does not
         # flood structured-logging pipelines once per poll interval.
         now = time.monotonic()
-        if now - self._last_reopen_log < _REOPEN_LOG_THROTTLE_S:
+        if now - self._last_reopen_log < _REOPEN_LOG_THROTTLE_SECONDS:
             return
         self._last_reopen_log = now
         logger.warning(fmt, *args)
 
 
 __all__ = [
-    "DEFAULT_POLL_INTERVAL_S",
+    "DEFAULT_POLL_INTERVAL_SECONDS",
     "DEFAULT_READ_CHUNK",
     "FileTailer",
 ]


### PR DESCRIPTION
Fixes #SM-71

#### Describe the changes you have made in this PR -
Renamed two duration constants in `integrations/hermes/tailer.py` to spell out their unit instead of using a short suffix, and updated the corresponding import in `integrations/hermes/agent.py`:

- `DEFAULT_POLL_INTERVAL_S` → `DEFAULT_POLL_INTERVAL_SECONDS`
- `_REOPEN_LOG_THROTTLE_S` → `_REOPEN_LOG_THROTTLE_SECONDS`

This is a pure rename — no behavior change. Every usage of both constants (definitions, default arguments, comparisons, the module `__all__` export, and the `agent.py` import) was updated to match. The `poll_interval_s` function argument was intentionally left untouched, since it's a parameter name, not one of the constants in scope.

While verifying scope, I found two other files with similarly-named but unrelated constants (`DEFAULT_POLL_INTERVAL_S` in `tools/system/fleet_monitoring/tail.py`, `_DEFAULT_POLL_INTERVAL_S` in `tests/utils/hermes_logs_helper.py`). These are independent constants that don't import from or reference the ones renamed here, so I left them alone per the ticket's scope (listed files only) — flagging in case a maintainer wants a follow-up cleanup ticket for those.

### Demo/Screenshot for feature changes and bug fixes -
Not applicable — this is a non-functional naming refactor with no observable behavior change. `make lint` output:
---
## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I made  all the changes myself

---
## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---
