### PR TITLE
refactor(hermes): spell out poll-interval constant unit suffixes (SM-71)

### DIFF
--- a/integrations/hermes/agent.py
+++ b/integrations/hermes/agent.py
@@ -25,7 +25,7 @@ from typing import Final
 from integrations.hermes.classifier import IncidentClassifier
 from integrations.hermes.incident import HermesIncident, LogLevel
 from integrations.hermes.parser import parse_log_line
-from integrations.hermes.tailer import DEFAULT_POLL_INTERVAL_S, FileTailer
+from integrations.hermes.tailer import DEFAULT_POLL_INTERVAL_SECONDS, FileTailer
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class HermesAgent:
         sink: IncidentSink,
         log_path: Path | str = DEFAULT_LOG_PATH,
         classifier: IncidentClassifier | None = None,
-        poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+        poll_interval_s: float = DEFAULT_POLL_INTERVAL_SECONDS,
         from_start: bool = False,
     ) -> None:
         self._sink = sink

--- a/integrations/hermes/tailer.py
+++ b/integrations/hermes/tailer.py
@@ -32,9 +32,9 @@ from typing import Final
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_POLL_INTERVAL_S: Final[float] = 0.5
+DEFAULT_POLL_INTERVAL_SECONDS: Final[float] = 0.5
 DEFAULT_READ_CHUNK: Final[int] = 64 * 1024
-_REOPEN_LOG_THROTTLE_S: Final[float] = 30.0
+_REOPEN_LOG_THROTTLE_SECONDS: Final[float] = 30.0
 
 
 @dataclass(frozen=True)
@@ -75,7 +75,7 @@ class FileTailer:
         self,
         path: Path | str,
         *,
-        poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+        poll_interval_s: float = DEFAULT_POLL_INTERVAL_SECONDS,
         read_chunk: int = DEFAULT_READ_CHUNK,
         from_start: bool = False,
         stop_event: threading.Event | None = None,
@@ -197,14 +197,14 @@ class FileTailer:
         # Throttle noisy reopen/error logs so a long-missing file does not
         # flood structured-logging pipelines once per poll interval.
         now = time.monotonic()
-        if now - self._last_reopen_log < _REOPEN_LOG_THROTTLE_S:
+        if now - self._last_reopen_log < _REOPEN_LOG_THROTTLE_SECONDS:
             return
         self._last_reopen_log = now
         logger.warning(fmt, *args)
 
 
 __all__ = [
-    "DEFAULT_POLL_INTERVAL_S",
+    "DEFAULT_POLL_INTERVAL_SECONDS",
     "DEFAULT_READ_CHUNK",
     "FileTailer",
 ]


### PR DESCRIPTION

No short-unit constant names remain in the two files.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

SM-71 asks to spell out the unit suffix on the Hermes tailer's duration constants so the names carry their unit. I grepped the whole repo for both constant names to map every reference and to check for a "third file" (the issue says to stop if tests or re-exports would break). The similarly-named constants in `tools/system/fleet_monitoring/tail.py` and `tests/utils/hermes_logs_helper.py` are separate and not imported from Hermes, so only `tailer.py` and `agent.py` needed changes. I renamed both constants and every reference — including the `__all__` export and the `agent.py` import — while leaving the `poll_interval_s` argument names untouched as the issue specifies. I confirmed no old short-unit names remain and ran lint, format-check, typecheck, and the full Hermes test suite; all pass with no behavior change.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
