### PR TITLE
refactor: promote ToolSurface / EvidenceType / SideEffectLevel to StrEnums

### DIFF
--- a/core/domain/types/tools.py
+++ b/core/domain/types/tools.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from enum import StrEnum
 
-ToolSurface = Literal["investigation", "chat", "action"]
+
+class ToolSurface(StrEnum):
+    """Runtime surfaces a registered tool may be exposed on."""
+
+    INVESTIGATION = "investigation"
+    CHAT = "chat"
+    ACTION = "action"

--- a/core/tool_framework/base.py
+++ b/core/tool_framework/base.py
@@ -58,7 +58,7 @@ class BaseTool(ABC):
     retrieval_controls: ClassVar[RetrievalControls] = (
         RetrievalControls()
     )  # Declares supported controls
-    surfaces: ClassVar[tuple[ToolSurface, ...]] = ("investigation",)
+    surfaces: ClassVar[tuple[ToolSurface, ...]] = (ToolSurface.INVESTIGATION,)
     tags: ClassVar[Sequence[str]] = ()
     parallel_safe: ClassVar[bool] = True
     requires_approval: ClassVar[bool] = False  # Whether this tool needs approval from messaging

--- a/core/tool_framework/metadata.py
+++ b/core/tool_framework/metadata.py
@@ -9,7 +9,8 @@ evolve independently of the dispatch protocol in ``BaseTool``.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from enum import StrEnum
+from typing import Any
 
 from pydantic import Field, field_validator
 
@@ -17,18 +18,28 @@ from config.strict_config import StrictConfigModel
 from core.domain.types.evidence import EvidenceSource
 from core.domain.types.retrieval import RetrievalControls
 
-EvidenceType = Literal[
-    "logs",
-    "metrics",
-    "traces",
-    "events",
-    "topology",
-    "deployment_metadata",
-    "query_stats",
-    "artifact",
-    "other",
-]
-SideEffectLevel = Literal["none", "read_only", "mutating", "external"]
+
+class EvidenceType(StrEnum):
+    """Kind of evidence a tool produces."""
+
+    LOGS = "logs"
+    METRICS = "metrics"
+    TRACES = "traces"
+    EVENTS = "events"
+    TOPOLOGY = "topology"
+    DEPLOYMENT_METADATA = "deployment_metadata"
+    QUERY_STATS = "query_stats"
+    ARTIFACT = "artifact"
+    OTHER = "other"
+
+
+class SideEffectLevel(StrEnum):
+    """How much a tool can perturb the systems it observes."""
+
+    NONE = "none"
+    READ_ONLY = "read_only"
+    MUTATING = "mutating"
+    EXTERNAL = "external"
 
 
 class ToolMetadata(StrictConfigModel):

--- a/core/tool_framework/registered_tool.py
+++ b/core/tool_framework/registered_tool.py
@@ -26,7 +26,7 @@ from core.tool_framework.schema import (
 
 REGISTERED_TOOL_ATTR = "__opensre_registered_tool__"
 
-_DEFAULT_SURFACES: tuple[ToolSurface, ...] = ("investigation",)
+_DEFAULT_SURFACES: tuple[ToolSurface, ...] = (ToolSurface.INVESTIGATION,)
 
 
 def _always_available(_sources: dict[str, dict]) -> bool:

--- a/core/tool_framework/registry_metadata.py
+++ b/core/tool_framework/registry_metadata.py
@@ -8,15 +8,14 @@ contract in ``ToolMetadata``.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import cast, get_args
+from typing import cast
 
 from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
 from core.domain.types.tools import ToolSurface
 
-_DEFAULT_SURFACES: tuple[ToolSurface, ...] = ("investigation",)
-_VALID_SURFACES = set(get_args(ToolSurface))
+_DEFAULT_SURFACES: tuple[ToolSurface, ...] = (ToolSurface.INVESTIGATION,)
 
 
 def normalize_surfaces(surfaces: Iterable[str] | None) -> tuple[ToolSurface, ...]:
@@ -27,10 +26,13 @@ def normalize_surfaces(surfaces: Iterable[str] | None) -> tuple[ToolSurface, ...
     normalized: list[ToolSurface] = []
     for raw_surface in surfaces:
         surface = str(raw_surface).strip().lower()
-        if surface not in _VALID_SURFACES:
-            valid = ", ".join(sorted(_VALID_SURFACES))
-            raise ValueError(f"Unsupported tool surface '{surface}'. Expected one of: {valid}.")
-        typed_surface = cast(ToolSurface, surface)
+        try:
+            typed_surface = ToolSurface(surface)
+        except ValueError:
+            valid = ", ".join(sorted(ToolSurface))
+            raise ValueError(
+                f"Unsupported tool surface '{surface}'. Expected one of: {valid}."
+            ) from None
         if typed_surface not in normalized:
             normalized.append(typed_surface)
 

--- a/integrations/datadog/tools/__init__.py
+++ b/integrations/datadog/tools/__init__.py
@@ -9,6 +9,7 @@ import concurrent.futures
 import re
 from typing import Any
 
+from core.tool_framework.metadata import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
 from integrations.datadog._client import make_async_client
@@ -557,8 +558,8 @@ def _metrics_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     ],
     requires=[],
     source_id="datadog_metrics_api",
-    evidence_type="metrics",
-    side_effect_level="read_only",
+    evidence_type=EvidenceType.METRICS,
+    side_effect_level=SideEffectLevel.READ_ONLY,
     examples=[
         "Check `system.cpu.user` around incident window for saturation patterns.",
         "Run a custom metrics query string for service-specific error-rate metrics.",

--- a/integrations/eks/tools/__init__.py
+++ b/integrations/eks/tools/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from core.tool_framework.metadata import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
 from integrations.eks.eks_k8s_client import build_k8s_clients
@@ -777,8 +778,8 @@ class ListEKSPodsOutput(BaseModel):
     ],
     requires=["cluster_name"],
     source_id="eks_core_v1",
-    evidence_type="topology",
-    side_effect_level="read_only",
+    evidence_type=EvidenceType.TOPOLOGY,
+    side_effect_level=SideEffectLevel.READ_ONLY,
     examples=[
         "List pods in `payments` namespace to identify CrashLoopBackOff pods.",
         "Use namespace `all` to detect widespread node scheduling issues.",

--- a/integrations/github/tools/architecture_issue_tool/tool.py
+++ b/integrations/github/tools/architecture_issue_tool/tool.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 from core.agent_harness.tools.tool_context import action_context_from_agent_context
+from core.domain.types.tools import ToolSurface
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.github.tools.architecture_issue_tool.repo_workspace import (
     WorkspaceError,
@@ -77,8 +79,8 @@ def _session_id_from_runtime(context: Any, explicit: str = "") -> str:
         "Cloning outside the architecture workspace",
     ],
     requires=["owner", "repo"],
-    surfaces=("action",),
-    side_effect_level="mutating",
+    surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
     input_schema={
         "type": "object",
         "properties": {
@@ -152,8 +154,8 @@ def architecture_clone_repo(
     ),
     use_cases=["Cleanup after architecture_clone_repo"],
     anti_examples=["Deleting arbitrary paths outside the architecture workspace"],
-    surfaces=("action",),
-    side_effect_level="mutating",
+    surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
     input_schema={
         "type": "object",
         "properties": {
@@ -200,8 +202,8 @@ def architecture_cleanup_repo(
         "Skipping this save after an architecture audit",
     ],
     requires=["repo_name", "observations"],
-    surfaces=("action",),
-    side_effect_level="mutating",
+    surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
     accepts_runtime_context=True,
     input_schema={
         "type": "object",

--- a/integrations/github/tools/community_followup_tool/__init__.py
+++ b/integrations/github/tools/community_followup_tool/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
@@ -41,8 +43,8 @@ def _community_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         "Drafting suggested replies without mutating GitHub or messaging platforms",
     ],
     anti_examples=["Posting replies", "Changing GitHub labels or assignees"],
-    surfaces=("investigation", "chat"),
-    side_effect_level="read_only",
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
+    side_effect_level=SideEffectLevel.READ_ONLY,
     input_schema={
         "type": "object",
         "properties": {

--- a/integrations/github/tools/github_cli/tool.py
+++ b/integrations/github/tools/github_cli/tool.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.github.tools.github_cli.credentials import (
     GITHUB_CLI_INJECTED_PARAMS,
@@ -94,8 +96,8 @@ def _normalize_args(args: list[str] | None) -> list[str]:
         "Printing or logging the GitHub token",
         "Inventing repo lists without calling github_cli",
     ],
-    surfaces=("action",),
-    side_effect_level="mutating",
+    surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
     requires_approval=False,
     input_schema=_ARGS_SCHEMA,
     is_available=_github_cli_available,

--- a/integrations/github/tools/repository.py
+++ b/integrations/github/tools/repository.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.telemetry import report_run_error
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
@@ -75,8 +77,8 @@ def _normalize_repository(repo: dict[str, Any], *, owner: str, repo_name: str) -
         "Searching GitHub issues by keyword (use search_github_issues)",
     ],
     requires=["owner", "repo"],
-    surfaces=("investigation", "chat"),
-    side_effect_level="read_only",
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
+    side_effect_level=SideEffectLevel.READ_ONLY,
     input_schema={
         "type": "object",
         "properties": {

--- a/integrations/github/tools/stargazers.py
+++ b/integrations/github/tools/stargazers.py
@@ -7,6 +7,8 @@ from datetime import UTC, date, datetime, time, timedelta
 from math import ceil
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.telemetry import report_run_error
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
@@ -105,8 +107,8 @@ def _github_stargazer_listing_error(exc: GitHubApiError) -> str:
         "stars_in_window": "Total stars gained during the returned window",
         "complete": "Whether the requested window was fully scanned before the page cap",
     },
-    surfaces=("investigation", "chat"),
-    side_effect_level="read_only",
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
+    side_effect_level=SideEffectLevel.READ_ONLY,
     input_schema={
         "type": "object",
         "properties": {

--- a/integrations/github/tools/work_status.py
+++ b/integrations/github/tools/work_status.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Literal, cast
 
+from core.domain.types.tools import ToolSurface
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
@@ -109,8 +111,8 @@ def _count_work_items(items: list[dict[str, Any]]) -> dict[str, int]:
     ],
     anti_examples=["Creating, editing, or closing GitHub issues"],
     requires=["owner", "repo"],
-    surfaces=("investigation", "chat"),
-    side_effect_level="read_only",
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
+    side_effect_level=SideEffectLevel.READ_ONLY,
     input_schema={
         "type": "object",
         "properties": {
@@ -249,8 +251,8 @@ def _count_prs(prs: list[dict[str, Any]]) -> dict[str, int]:
         "Preparing engineering status updates without changing GitHub state",
     ],
     requires=["owner", "repo"],
-    surfaces=("investigation", "chat"),
-    side_effect_level="read_only",
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
+    side_effect_level=SideEffectLevel.READ_ONLY,
     input_schema={
         "type": "object",
         "properties": {
@@ -356,8 +358,8 @@ _ISSUE_MUTATION_OPERATIONS = {"create", "update", "close"}
         "Building a read-only engineering status report with security context",
     ],
     requires=["owner", "repo"],
-    surfaces=("investigation", "chat"),
-    side_effect_level="read_only",
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
+    side_effect_level=SideEffectLevel.READ_ONLY,
     input_schema={
         "type": "object",
         "properties": {
@@ -426,8 +428,8 @@ def list_github_security_alerts(
         "Rendering deterministic issue mutation payloads without mutating GitHub",
     ],
     anti_examples=["Directly mutating GitHub", "Inferring tasks from ambiguous Slack discussion"],
-    surfaces=("chat",),
-    side_effect_level="read_only",
+    surfaces=(ToolSurface.CHAT,),
+    side_effect_level=SideEffectLevel.READ_ONLY,
     input_schema={
         "type": "object",
         "properties": {
@@ -605,8 +607,8 @@ def _marker_exists_on_issue(
         "Creating proposals",
         "Running during investigations",
     ],
-    surfaces=("chat",),
-    side_effect_level="mutating",
+    surfaces=(ToolSurface.CHAT,),
+    side_effect_level=SideEffectLevel.MUTATING,
     input_schema={
         "type": "object",
         "properties": {

--- a/integrations/github/tools/work_status_report_tool/__init__.py
+++ b/integrations/github/tools/work_status_report_tool/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.github.client import resolve_github_token
 from integrations.github.helpers import (
@@ -41,8 +43,8 @@ def _report_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         "Summarizing GitHub work status for Slack without changing GitHub",
     ],
     anti_examples=["Creating or updating tasks", "Posting to Slack directly"],
-    surfaces=("investigation", "chat"),
-    side_effect_level="read_only",
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
+    side_effect_level=SideEffectLevel.READ_ONLY,
     input_schema={
         "type": "object",
         "properties": {

--- a/integrations/grafana/tools/__init__.py
+++ b/integrations/grafana/tools/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.tool_framework.metadata import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
 
@@ -562,8 +563,8 @@ def _query_grafana_metrics_available(sources: dict[str, dict]) -> bool:
     ],
     requires=["metric_name"],
     source_id="grafana_mimir",
-    evidence_type="metrics",
-    side_effect_level="read_only",
+    evidence_type=EvidenceType.METRICS,
+    side_effect_level=SideEffectLevel.READ_ONLY,
     examples=[
         "Query `pipeline_runs_total` to verify throughput drops.",
         "Query HTTP error rate metric with a `service_name` filter.",

--- a/integrations/kubernetes/tools/__init__.py
+++ b/integrations/kubernetes/tools/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
 from core.tool_framework.utils.tool_availability import tool_unavailable
 from integrations.config_models import KubernetesIntegrationConfig
@@ -74,7 +75,7 @@ class KubernetesListPodsTool(BaseTool):
         "Filtering pods by label selector to scope investigation",
         "Verifying that a deployment's pods are running after a rollout",
     ]
-    surfaces = ("investigation", "chat")
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     requires = ["kubeconfig"]
     injected_params = ["kubeconfig", "kubeconfig_path", "context", "namespace"]
     input_schema = {
@@ -174,7 +175,7 @@ class KubernetesGetPodLogsTool(BaseTool):
         "Do not use for CloudWatch or Datadog log search — wrong backend.",
         "Do not use to exec into a pod or mutate cluster state.",
     ]
-    surfaces = ("investigation", "chat")
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     requires = ["pod_name"]
     injected_params = ["kubeconfig", "kubeconfig_path", "context", "namespace"]
     input_schema = {
@@ -284,7 +285,7 @@ class KubernetesListDeploymentsTool(BaseTool):
         "Verifying deployment replica health across a namespace",
         "Identifying deployments stuck in a partial-rollout state",
     ]
-    surfaces = ("investigation", "chat")
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     requires = []
     injected_params = ["kubeconfig", "kubeconfig_path", "context", "namespace"]
     input_schema = {
@@ -372,7 +373,7 @@ class KubernetesGetEventsTool(BaseTool):
         "Understanding scheduling failures (Insufficient CPU/Memory)",
         "Correlating event timestamps with incident timeline",
     ]
-    surfaces = ("investigation", "chat")
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     requires = []
     injected_params = ["kubeconfig", "kubeconfig_path", "context", "namespace"]
     input_schema = {
@@ -482,7 +483,7 @@ class KubernetesDescribePodTool(BaseTool):
         + "kubernetes_get_resource)",
         "Listing many pods at once (use kubernetes_list_pods)",
     ]
-    surfaces = ("investigation", "chat")
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     requires = ["pod_name"]
     injected_params = ["kubeconfig", "kubeconfig_path", "context", "namespace"]
     input_schema = {
@@ -564,7 +565,7 @@ class KubernetesListNodesTool(BaseTool):
         "Identifying nodes with taints that prevent pod scheduling",
         "Correlating pod scheduling failures with node capacity",
     ]
-    surfaces = ("investigation", "chat")
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     requires = []
     injected_params = ["kubeconfig", "kubeconfig_path", "context"]
     input_schema = {
@@ -659,7 +660,7 @@ class KubernetesListServicesTool(BaseTool):
         "Diagnosing port mismatches between services and pods",
         "Finding services exposed via NodePort for debugging",
     ]
-    surfaces = ("investigation", "chat")
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     requires = []
     injected_params = ["kubeconfig", "kubeconfig_path", "context", "namespace"]
     input_schema = {
@@ -754,7 +755,7 @@ class KubernetesListStatefulSetsTool(BaseTool):
         "Diagnosing stuck StatefulSet rolling updates",
         "Verifying database or stateful service replica health",
     ]
-    surfaces = ("investigation", "chat")
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     requires = []
     injected_params = ["kubeconfig", "kubeconfig_path", "context", "namespace"]
     input_schema = {
@@ -841,7 +842,7 @@ class KubernetesListDaemonSetsTool(BaseTool):
         "Diagnosing nodes where a DaemonSet pod is not scheduled or not ready",
         "Verifying a DaemonSet update has rolled out to all nodes",
     ]
-    surfaces = ("investigation", "chat")
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     requires = []
     injected_params = ["kubeconfig", "kubeconfig_path", "context", "namespace"]
     input_schema = {
@@ -929,7 +930,7 @@ class KubernetesListIngressesTool(BaseTool):
         "Finding load balancer IPs or hostnames assigned to an ingress",
         "Diagnosing 404 or routing issues in HTTP-based services",
     ]
-    surfaces = ("investigation", "chat")
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     requires = []
     injected_params = ["kubeconfig", "kubeconfig_path", "context", "namespace"]
     input_schema = {
@@ -1016,7 +1017,7 @@ class KubernetesListConfigMapsTool(BaseTool):
         "Verifying a ConfigMap has the expected keys and values after a deploy",
         "Diagnosing misconfigured endpoints, feature flags, or environment settings",
     ]
-    surfaces = ("investigation", "chat")
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     requires = []
     injected_params = ["kubeconfig", "kubeconfig_path", "context", "namespace"]
     input_schema = {
@@ -1117,7 +1118,7 @@ class KubernetesGetResourceTool(BaseTool):
         "Listing multiple resources or filtering by label/field selector (use the "
         + "matching kubernetes_list_* tool instead)",
     ]
-    surfaces = ("investigation", "chat")
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     requires = ["resource_type", "name"]
     injected_params = ["kubeconfig", "kubeconfig_path", "context", "namespace"]
     input_schema = {

--- a/integrations/pi/tools/pi_coding_tool/__init__.py
+++ b/integrations/pi/tools/pi_coding_tool/__init__.py
@@ -14,10 +14,10 @@ Package layout (separation of concerns):
 This is the first **mutating** agent-callable tool, so it is deliberately gated,
 mirroring how ``execute_python_code`` is gated by availability:
 
-- ``side_effect_level = "mutating"``.
+- ``side_effect_level = SideEffectLevel.MUTATING``.
 - ``is_available`` returns True only when ``PI_CODING_ENABLED`` is set, so it is
   never offered to the agent unless the operator opts in.
-- ``surfaces = ("investigation",)`` — the surface the REPL assistant tool loop and
+- ``surfaces = (ToolSurface.INVESTIGATION,)`` — the surface the REPL assistant tool loop and
   the investigation pipeline actually consume (the ``chat`` surface has no live
   consumer). Reachability is gated by ``PI_CODING_ENABLED``, not by the surface.
 
@@ -31,7 +31,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from integrations.pi import is_pi_coding_enabled
 from integrations.pi.tools.pi_coding_tool.errors import PiCodingError
 from integrations.pi.tools.pi_coding_tool.runner import (
@@ -51,8 +53,8 @@ class PiCodingTool(BaseTool):
     name = "pi_coding_task"
     display_name = "Pi coding task"
     source = SOURCE
-    side_effect_level = "mutating"
-    surfaces = ("investigation",)
+    side_effect_level = SideEffectLevel.MUTATING
+    surfaces = (ToolSurface.INVESTIGATION,)
     description = (
         "Submit a coding task to the Pi agent (pi.dev). Pi edits files in the workspace to "
         "implement the change and returns a summary plus the git diff. It does not commit, "

--- a/integrations/postgresql/tools/postgresql_locks_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_locks_tool/__init__.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
+from core.tool_framework.metadata import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
 from integrations.postgresql import (
@@ -19,15 +21,15 @@ from integrations.postgresql import (
         " blocked queries, their blockers, and a summary of lock types."
     ),
     source="postgresql",
-    surfaces=("investigation", "chat"),
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
     use_cases=[
         "Diagnosing query blocking chains during performance incidents",
         "Identifying deadlock-prone transactions or long-held locks",
         "Investigating sudden latency spikes caused by lock contention",
     ],
     source_id="postgresql_pg_locks",
-    evidence_type="query_stats",
-    side_effect_level="read_only",
+    evidence_type=EvidenceType.QUERY_STATS,
+    side_effect_level=SideEffectLevel.READ_ONLY,
     examples=[
         "Check for blocked queries causing application timeouts.",
         "Find which query is blocking a deployment migration.",

--- a/integrations/postgresql/tools/postgresql_slow_queries_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_slow_queries_tool/__init__.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from core.domain.types.tools import ToolSurface
+from core.tool_framework.metadata import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
 from integrations.postgresql import (
@@ -53,15 +55,15 @@ class PostgreSQLSlowQueriesOutput(BaseModel):
         " by mean execution time."
     ),
     source="postgresql",
-    surfaces=("investigation", "chat"),
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
     use_cases=[
         "Identifying slow queries that may be causing performance degradation",
         "Analyzing query execution patterns during incident timeframes",
         "Finding poorly optimized queries with high execution times or low cache hit rates",
     ],
     source_id="postgresql_pg_stat_statements",
-    evidence_type="query_stats",
-    side_effect_level="read_only",
+    evidence_type=EvidenceType.QUERY_STATS,
+    side_effect_level=SideEffectLevel.READ_ONLY,
     examples=[
         "List slow queries above 1000ms to diagnose database latency spikes.",
         "Lower threshold to 200ms to inspect emerging query regressions.",

--- a/integrations/railway/tools/railway_deployment_tool/inspect_tool.py
+++ b/integrations/railway/tools/railway_deployment_tool/inspect_tool.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar
 from core.domain.types.evidence import EvidenceSource
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.config_models import RailwayIntegrationConfig
 from integrations.railway.client import (
@@ -17,8 +18,12 @@ from integrations.railway.client import (
 class InspectRailwayDeploymentTool(BaseTool):
     name = "inspect_railway_deployment"
     source: ClassVar[EvidenceSource] = "railway"
-    surfaces: ClassVar[tuple[ToolSurface, ...]] = ("investigation", "chat", "action")
-    side_effect_level = "read_only"
+    surfaces: ClassVar[tuple[ToolSurface, ...]] = (
+        ToolSurface.INVESTIGATION,
+        ToolSurface.CHAT,
+        ToolSurface.ACTION,
+    )
+    side_effect_level = SideEffectLevel.READ_ONLY
     description = (
         "Show the latest successful Railway deployment and source commit metadata for a service."
     )
@@ -71,4 +76,7 @@ class InspectRailwayDeploymentTool(BaseTool):
 
 
 inspect_railway_deployment = InspectRailwayDeploymentTool()
-tool(inspect_railway_deployment, surfaces=("investigation", "chat", "action"))
+tool(
+    inspect_railway_deployment,
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT, ToolSurface.ACTION),
+)

--- a/integrations/railway/tools/railway_deployment_tool/redeploy_tool.py
+++ b/integrations/railway/tools/railway_deployment_tool/redeploy_tool.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar
 from core.domain.types.evidence import EvidenceSource
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.config_models import RailwayIntegrationConfig
 from integrations.railway.client import (
@@ -17,8 +18,12 @@ from integrations.railway.client import (
 class RedeployRailwayServiceTool(BaseTool):
     name = "redeploy_railway_service"
     source: ClassVar[EvidenceSource] = "railway"
-    surfaces: ClassVar[tuple[ToolSurface, ...]] = ("investigation", "chat", "action")
-    side_effect_level = "external"
+    surfaces: ClassVar[tuple[ToolSurface, ...]] = (
+        ToolSurface.INVESTIGATION,
+        ToolSurface.CHAT,
+        ToolSurface.ACTION,
+    )
+    side_effect_level = SideEffectLevel.EXTERNAL
     requires_approval = True
     approval_reason = "Triggers a Railway redeploy of the selected service."
     description = "Request a Railway service redeploy after explicit confirmation."
@@ -74,4 +79,7 @@ class RedeployRailwayServiceTool(BaseTool):
 
 
 redeploy_railway_service = RedeployRailwayServiceTool()
-tool(redeploy_railway_service, surfaces=("investigation", "chat", "action"))
+tool(
+    redeploy_railway_service,
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT, ToolSurface.ACTION),
+)

--- a/integrations/rds/tools/rds_describe_instance_tool/__init__.py
+++ b/integrations/rds/tools/rds_describe_instance_tool/__init__.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 from pydantic import BaseModel, Field
 
+from core.tool_framework.metadata import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call
@@ -66,8 +67,8 @@ class DescribeRDSInstanceOutput(BaseModel):
     ],
     requires=["db_instance_identifier"],
     source_id="aws_rds",
-    evidence_type="deployment_metadata",
-    side_effect_level="read_only",
+    evidence_type=EvidenceType.DEPLOYMENT_METADATA,
+    side_effect_level=SideEffectLevel.READ_ONLY,
     examples=[
         "Describe `prod-orders-db` to confirm if status is `modifying` during an incident.",
         "Check engine version and backup configuration before rollback decisions.",

--- a/integrations/rocketchat/tools/rocketchat_send_message_tool/tool.py
+++ b/integrations/rocketchat/tools/rocketchat_send_message_tool/tool.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.rocketchat.tools.rocketchat_send_message_tool.constants import SOURCE
 from integrations.rocketchat.tools.rocketchat_send_message_tool.delivery import (
@@ -38,7 +40,7 @@ class RocketChatSendMessageTool(BaseTool):
         "Following up after an investigation with a short status update",
     ]
     requires = ["rocketchat"]
-    side_effect_level = "external"
+    side_effect_level = SideEffectLevel.EXTERNAL
     requires_approval = True
     approval_reason = "Sends a message via Rocket.Chat on your behalf."
     input_schema = {
@@ -126,5 +128,5 @@ class RocketChatSendMessageTool(BaseTool):
 
 rocketchat_send_message = tool(
     RocketChatSendMessageTool(),
-    surfaces=("investigation", "action"),
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.ACTION),
 )

--- a/integrations/slack/tools/slack_add_reaction_tool/tool.py
+++ b/integrations/slack/tools/slack_add_reaction_tool/tool.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
 from integrations.slack.tools.slack_read_messages_tool.validation import validate_channel_id
@@ -34,7 +36,7 @@ class SlackAddReactionTool(BaseTool):
         "Posting a full text reply (use slack_reply_message)",
     ]
     requires = ["slack"]
-    side_effect_level = "external"
+    side_effect_level = SideEffectLevel.EXTERNAL
     requires_approval = False
     input_schema = {
         "type": "object",
@@ -117,5 +119,5 @@ class SlackAddReactionTool(BaseTool):
 
 slack_add_reaction = tool(
     SlackAddReactionTool(),
-    surfaces=("investigation", "chat", "action"),
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT, ToolSurface.ACTION),
 )

--- a/integrations/slack/tools/slack_capture_task_tool/tool.py
+++ b/integrations/slack/tools/slack_capture_task_tool/tool.py
@@ -8,7 +8,9 @@ from pathlib import Path
 from typing import Any
 
 import config.constants as const_module
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
 
@@ -54,7 +56,7 @@ class SlackCaptureTaskTool(BaseTool):
         "Creating a GitHub issue (use GitHub tools)",
     ]
     requires = ["slack"]
-    side_effect_level = "external"
+    side_effect_level = SideEffectLevel.EXTERNAL
     requires_approval = False
     input_schema = {
         "type": "object",
@@ -112,5 +114,5 @@ class SlackCaptureTaskTool(BaseTool):
 
 slack_capture_task = tool(
     SlackCaptureTaskTool(),
-    surfaces=("investigation", "chat", "action"),
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT, ToolSurface.ACTION),
 )

--- a/integrations/slack/tools/slack_join_channel_tool/tool.py
+++ b/integrations/slack/tools/slack_join_channel_tool/tool.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
@@ -36,7 +38,7 @@ class SlackJoinChannelTool(BaseTool):
         "Using this instead of reading messages",
     ]
     requires = ["slack"]
-    side_effect_level = "external"
+    side_effect_level = SideEffectLevel.EXTERNAL
     requires_approval = True
     approval_reason = "Joins a Slack channel as the OpenSRE bot."
     input_schema = {
@@ -113,5 +115,5 @@ class SlackJoinChannelTool(BaseTool):
 
 slack_join_channel = tool(
     SlackJoinChannelTool(),
-    surfaces=("investigation", "chat", "action"),
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT, ToolSurface.ACTION),
 )

--- a/integrations/slack/tools/slack_list_members_tool/tool.py
+++ b/integrations/slack/tools/slack_list_members_tool/tool.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
@@ -40,7 +42,7 @@ class SlackListTeamMembersTool(BaseTool):
     ]
     tags = (SUMMARIZE_OBSERVATION_TAG,)
     requires = ["slack"]
-    side_effect_level = "read_only"
+    side_effect_level = SideEffectLevel.READ_ONLY
     requires_approval = False
     input_schema = {
         "type": "object",
@@ -103,5 +105,5 @@ class SlackListTeamMembersTool(BaseTool):
 
 slack_list_team_members = tool(
     SlackListTeamMembersTool(),
-    surfaces=("investigation", "chat", "action"),
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT, ToolSurface.ACTION),
 )

--- a/integrations/slack/tools/slack_read_list_tool/tool.py
+++ b/integrations/slack/tools/slack_read_list_tool/tool.py
@@ -6,7 +6,9 @@ import os
 import re
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
 from integrations.slack.tools.slack_read_list_tool.constants import (
@@ -109,7 +111,7 @@ class SlackReadListTool(BaseTool):
         "Downloading a normal file attachment from a message",
     ]
     requires = ["slack"]
-    side_effect_level = "read_only"
+    side_effect_level = SideEffectLevel.READ_ONLY
     requires_approval = False
     input_schema = {
         "type": "object",
@@ -254,5 +256,5 @@ def _extract_list_id(raw: str) -> str:
 
 slack_read_list = tool(
     SlackReadListTool(),
-    surfaces=("investigation", "chat", "action"),
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT, ToolSurface.ACTION),
 )

--- a/integrations/slack/tools/slack_read_messages_tool/tool.py
+++ b/integrations/slack/tools/slack_read_messages_tool/tool.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
 from core.tool_framework.tool_decorator import tool
 from integrations.slack.tools.slack_read_messages_tool.constants import (
@@ -53,7 +55,7 @@ class SlackReadMessagesTool(BaseTool):
     ]
     tags = (SUMMARIZE_OBSERVATION_TAG,)
     requires = ["slack"]
-    side_effect_level = "read_only"
+    side_effect_level = SideEffectLevel.READ_ONLY
     requires_approval = False
     input_schema = {
         "type": "object",
@@ -137,5 +139,5 @@ class SlackReadMessagesTool(BaseTool):
 
 slack_read_messages = tool(
     SlackReadMessagesTool(),
-    surfaces=("investigation", "chat", "action"),
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT, ToolSurface.ACTION),
 )

--- a/integrations/slack/tools/slack_reply_message_tool/tool.py
+++ b/integrations/slack/tools/slack_reply_message_tool/tool.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
 from integrations.slack.tools.slack_read_messages_tool.validation import validate_channel_id
@@ -40,7 +42,7 @@ class SlackReplyMessageTool(BaseTool):
         "Posting to a channel the bot has not been invited to",
     ]
     requires = ["slack"]
-    side_effect_level = "external"
+    side_effect_level = SideEffectLevel.EXTERNAL
     requires_approval = True
     approval_reason = "Posts a message to a Slack channel on your behalf."
     input_schema = {
@@ -140,5 +142,5 @@ class SlackReplyMessageTool(BaseTool):
 
 slack_reply_message = tool(
     SlackReplyMessageTool(),
-    surfaces=("investigation", "action"),
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.ACTION),
 )

--- a/integrations/slack/tools/slack_search_messages_tool/tool.py
+++ b/integrations/slack/tools/slack_search_messages_tool/tool.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils.tool_availability import tool_unavailable
@@ -34,7 +36,7 @@ class SlackSearchMessagesTool(BaseTool):
     ]
     tags = (SUMMARIZE_OBSERVATION_TAG,)
     requires = ["slack"]
-    side_effect_level = "read_only"
+    side_effect_level = SideEffectLevel.READ_ONLY
     requires_approval = False
     input_schema = {
         "type": "object",
@@ -96,5 +98,5 @@ class SlackSearchMessagesTool(BaseTool):
 
 slack_search_messages = tool(
     SlackSearchMessagesTool(),
-    surfaces=("investigation", "chat", "action"),
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT, ToolSurface.ACTION),
 )

--- a/integrations/slack/tools/slack_send_message_tool/tool.py
+++ b/integrations/slack/tools/slack_send_message_tool/tool.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.slack.tools.slack_send_message_tool.constants import SOURCE
 from integrations.slack.tools.slack_send_message_tool.delivery import (
@@ -37,7 +39,7 @@ class SlackSendMessageTool(BaseTool):
         "Replying in an existing Slack thread without thread context",
     ]
     requires = ["slack"]
-    side_effect_level = "external"
+    side_effect_level = SideEffectLevel.EXTERNAL
     requires_approval = True
     approval_reason = "Sends a message to Slack on your behalf."
     input_schema = {
@@ -115,5 +117,5 @@ class SlackSendMessageTool(BaseTool):
 
 slack_send_message = tool(
     SlackSendMessageTool(),
-    surfaces=("investigation", "action"),
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.ACTION),
 )

--- a/integrations/slack/tools/slack_thread_replay_tool/tool.py
+++ b/integrations/slack/tools/slack_thread_replay_tool/tool.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar
 from core.domain.types.evidence import EvidenceSource
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.slack.thread_client import fetch_thread, parse_thread_ref
 from integrations.slack.web_client import bot_token_configured
@@ -13,8 +14,12 @@ from integrations.slack.web_client import bot_token_configured
 class ReplaySlackThreadLocallyTool(BaseTool):
     name = "replay_slack_thread_locally"
     source: ClassVar[EvidenceSource] = "slack"
-    surfaces: ClassVar[tuple[ToolSurface, ...]] = ("investigation", "chat", "action")
-    side_effect_level = "read_only"
+    surfaces: ClassVar[tuple[ToolSurface, ...]] = (
+        ToolSurface.INVESTIGATION,
+        ToolSurface.CHAT,
+        ToolSurface.ACTION,
+    )
+    side_effect_level = SideEffectLevel.READ_ONLY
     description = "Fetch a captured Slack thread for local replay and Slack bot behavior testing."
     input_schema = {
         "type": "object",
@@ -47,4 +52,7 @@ class ReplaySlackThreadLocallyTool(BaseTool):
 
 
 replay_slack_thread_locally = ReplaySlackThreadLocallyTool()
-tool(replay_slack_thread_locally, surfaces=("investigation", "chat", "action"))
+tool(
+    replay_slack_thread_locally,
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT, ToolSurface.ACTION),
+)

--- a/integrations/splunk/tools/__init__.py
+++ b/integrations/splunk/tools/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
 from integrations.splunk._client import make_client, unavailable
 from platform.common.evidence_compaction import compact_logs, summarize_counts
@@ -38,7 +39,7 @@ class SplunkSearchTool(BaseTool):
         "Fetching recent error logs for a service identified in an alert",
         "Correlating trace IDs with Splunk log entries",
     ]
-    surfaces = ("investigation", "chat")
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     requires = []  # connection_verified check is in is_available()
     outputs = {
         "splunk_logs": "All log events returned from Splunk search",

--- a/integrations/telegram/tools/telegram_send_message_tool/tool.py
+++ b/integrations/telegram/tools/telegram_send_message_tool/tool.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.telegram.tools.telegram_send_message_tool.constants import SOURCE
 from integrations.telegram.tools.telegram_send_message_tool.delivery import (
@@ -38,7 +40,7 @@ class TelegramSendMessageTool(BaseTool):
         "Following up after an investigation with a short status update",
     ]
     requires = ["telegram"]
-    side_effect_level = "external"
+    side_effect_level = SideEffectLevel.EXTERNAL
     requires_approval = True
     approval_reason = "Sends a message via Telegram on your behalf."
     input_schema = {
@@ -124,5 +126,5 @@ class TelegramSendMessageTool(BaseTool):
 
 telegram_send_message = tool(
     TelegramSendMessageTool(),
-    surfaces=("investigation", "action"),
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.ACTION),
 )

--- a/integrations/victoria_logs/tools/__init__.py
+++ b/integrations/victoria_logs/tools/__init__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
 from core.tool_framework.utils.tool_availability import tool_unavailable
 from integrations.victoria_logs.client import make_victoria_logs_client
@@ -41,7 +42,7 @@ class VictoriaLogsTool(BaseTool):
     # tools without an explicit ``surfaces`` is investigation-only, which would
     # hide this from chat-mode investigations where log queries are a common
     # follow-up. Mirrors SplunkSearchTool, the closest log-query analog.
-    surfaces = ("investigation", "chat")
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     requires = ["base_url"]
     injected_params = ["base_url"]
     input_schema = {

--- a/tests/core/tool_framework/test_enums.py
+++ b/tests/core/tool_framework/test_enums.py
@@ -1,0 +1,104 @@
+"""Pin the tool-metadata StrEnums to their wire string values.
+
+These enums replace string ``Literal``s (analytics, frontmatter, and persisted
+JSON all depend on the exact string values), so the members and their
+round-trip from a plain string must stay stable. ``EvidenceSource`` is
+deliberately *not* an enum — it is an open vendor-key registry — so it is not
+covered here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.domain.types.tools import ToolSurface
+from core.tool_framework.metadata import (
+    EvidenceType,
+    SideEffectLevel,
+    ToolMetadata,
+)
+from core.tool_framework.registry_metadata import normalize_surfaces
+
+TOOL_SURFACE_VALUES = {
+    ToolSurface.INVESTIGATION: "investigation",
+    ToolSurface.CHAT: "chat",
+    ToolSurface.ACTION: "action",
+}
+EVIDENCE_TYPE_VALUES = {
+    EvidenceType.LOGS: "logs",
+    EvidenceType.METRICS: "metrics",
+    EvidenceType.TRACES: "traces",
+    EvidenceType.EVENTS: "events",
+    EvidenceType.TOPOLOGY: "topology",
+    EvidenceType.DEPLOYMENT_METADATA: "deployment_metadata",
+    EvidenceType.QUERY_STATS: "query_stats",
+    EvidenceType.ARTIFACT: "artifact",
+    EvidenceType.OTHER: "other",
+}
+SIDE_EFFECT_LEVEL_VALUES = {
+    SideEffectLevel.NONE: "none",
+    SideEffectLevel.READ_ONLY: "read_only",
+    SideEffectLevel.MUTATING: "mutating",
+    SideEffectLevel.EXTERNAL: "external",
+}
+
+
+@pytest.mark.parametrize(
+    ("member", "value"),
+    [
+        *TOOL_SURFACE_VALUES.items(),
+        *EVIDENCE_TYPE_VALUES.items(),
+        *SIDE_EFFECT_LEVEL_VALUES.items(),
+    ],
+)
+def test_member_value_is_stable(member: str, value: str) -> None:
+    # StrEnum members compare equal to their wire string.
+    assert member == value
+    assert member.value == value
+    # Round-trip: constructing from the string yields the same member.
+    assert type(member)(value) is member
+
+
+@pytest.mark.parametrize(
+    ("enum", "expected"),
+    [
+        (ToolSurface, set(TOOL_SURFACE_VALUES.values())),
+        (EvidenceType, set(EVIDENCE_TYPE_VALUES.values())),
+        (SideEffectLevel, set(SIDE_EFFECT_LEVEL_VALUES.values())),
+    ],
+)
+def test_enum_membership_is_closed(enum: type, expected: set[str]) -> None:
+    assert {member.value for member in enum} == expected
+
+
+def test_tool_metadata_coerces_strings_to_members() -> None:
+    """Registry/decorator paths still accept the same plain strings."""
+    meta = ToolMetadata.model_validate(
+        {
+            "name": "my_tool",
+            "description": "Does something useful.",
+            "input_schema": {"type": "object", "properties": {}},
+            "source": "grafana",
+            "evidence_type": "metrics",
+            "side_effect_level": "read_only",
+        }
+    )
+    assert meta.evidence_type is EvidenceType.METRICS
+    assert meta.side_effect_level is SideEffectLevel.READ_ONLY
+    # Persisted JSON keeps the original string shape.
+    dumped = meta.model_dump(mode="json")
+    assert dumped["evidence_type"] == "metrics"
+    assert dumped["side_effect_level"] == "read_only"
+
+
+def test_normalize_surfaces_accepts_strings_and_yields_members() -> None:
+    assert normalize_surfaces(["chat", "action"]) == (
+        ToolSurface.CHAT,
+        ToolSurface.ACTION,
+    )
+    assert all(isinstance(s, ToolSurface) for s in normalize_surfaces(["investigation"]))
+
+
+def test_normalize_surfaces_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="Unsupported tool surface"):
+        normalize_surfaces(["nope"])

--- a/tools/cross_vendor/fix_sentry_issue/__init__.py
+++ b/tools/cross_vendor/fix_sentry_issue/__init__.py
@@ -31,7 +31,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from tools.cross_vendor.fix_sentry_issue.context import gather_issue_context
 from tools.cross_vendor.fix_sentry_issue.errors import FixIssueError
 from tools.cross_vendor.fix_sentry_issue.runner import (
@@ -57,8 +59,8 @@ class FixSentryIssueTool(BaseTool):
     name = "fix_sentry_issue"
     display_name = "Fix Sentry issue"
     source = SOURCE
-    side_effect_level = "mutating"
-    surfaces = ("investigation",)
+    side_effect_level = SideEffectLevel.MUTATING
+    surfaces = (ToolSurface.INVESTIGATION,)
     requires_approval = True
     approval_reason = (
         "Runs a coding agent to edit files based on a Sentry issue, and can open a PR."

--- a/tools/interactive_shell/actions/assistant_handoff.py
+++ b/tools/interactive_shell/actions/assistant_handoff.py
@@ -10,6 +10,7 @@ from core.agent_harness.tools.tool_context import (
     object_schema,
     string_property,
 )
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.registered_tool import RegisteredTool
 
 
@@ -53,7 +54,7 @@ assistant_handoff_tool = RegisteredTool(
         required=("content",),
     ),
     source="interactive_shell",
-    surfaces=("action",),
+    surfaces=(ToolSurface.ACTION,),
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_assistant_handoff,

--- a/tools/interactive_shell/actions/cli_command.py
+++ b/tools/interactive_shell/actions/cli_command.py
@@ -11,6 +11,7 @@ from core.agent_harness.tools.tool_context import (
     object_schema,
     string_property,
 )
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.registered_tool import RegisteredTool
 from tools.interactive_shell.cli import run_opensre_cli_command
 from tools.interactive_shell.subprocess import require_subprocess_presenter
@@ -49,7 +50,7 @@ cli_exec_tool = RegisteredTool(
         required=("payload",),
     ),
     source="interactive_shell",
-    surfaces=("action",),
+    surfaces=(ToolSurface.ACTION,),
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_cli_command,

--- a/tools/interactive_shell/actions/implementation.py
+++ b/tools/interactive_shell/actions/implementation.py
@@ -11,6 +11,7 @@ from core.agent_harness.tools.tool_context import (
     object_schema,
     string_property,
 )
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.registered_tool import RegisteredTool
 from tools.interactive_shell.implementation.claude_code_executor import (
     run_claude_code_implementation,
@@ -43,7 +44,7 @@ code_implement_tool = RegisteredTool(
         required=("task",),
     ),
     source="interactive_shell",
-    surfaces=("action",),
+    surfaces=(ToolSurface.ACTION,),
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_implementation,

--- a/tools/interactive_shell/actions/investigation.py
+++ b/tools/interactive_shell/actions/investigation.py
@@ -14,6 +14,7 @@ from core.agent_harness.tools.tool_context import (
     object_schema,
     string_property,
 )
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.registered_tool import RegisteredTool
 from platform.common.task_types import TaskRecord
 from tools.interactive_shell.shared.investigation_launch import (
@@ -140,7 +141,7 @@ investigation_start_tool = RegisteredTool(
         required=("alert_text",),
     ),
     source="interactive_shell",
-    surfaces=("action",),
+    surfaces=(ToolSurface.ACTION,),
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_investigation,

--- a/tools/interactive_shell/actions/llm_provider.py
+++ b/tools/interactive_shell/actions/llm_provider.py
@@ -13,6 +13,7 @@ from core.agent_harness.tools.tool_context import (
     execute_with_action_context,
     object_schema,
 )
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.registered_tool import RegisteredTool
 from tools.interactive_shell.shared import allow_tool
 
@@ -78,7 +79,7 @@ llm_set_provider_tool = RegisteredTool(
         required=("target",),
     ),
     source="interactive_shell",
-    surfaces=("action",),
+    surfaces=(ToolSurface.ACTION,),
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_llm_provider,

--- a/tools/interactive_shell/actions/sample_alert.py
+++ b/tools/interactive_shell/actions/sample_alert.py
@@ -14,6 +14,7 @@ from core.agent_harness.tools.tool_context import (
     object_schema,
     string_property,
 )
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.registered_tool import RegisteredTool
 from platform.common.task_types import TaskRecord
 from tools.interactive_shell.shared.investigation_launch import (
@@ -118,7 +119,7 @@ alert_sample_tool = RegisteredTool(
         required=("template",),
     ),
     source="interactive_shell",
-    surfaces=("action",),
+    surfaces=(ToolSurface.ACTION,),
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_sample_alert_action,

--- a/tools/interactive_shell/actions/sentry_fix.py
+++ b/tools/interactive_shell/actions/sentry_fix.py
@@ -19,6 +19,8 @@ from core.agent_harness.tools.tool_context import (
     object_schema,
     string_property,
 )
+from core.domain.types.tools import ToolSurface
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.registered_tool import RegisteredTool
 from tools.cross_vendor.fix_sentry_issue import fix_sentry_issue
 from tools.cross_vendor.fix_sentry_issue.runner import is_issue_fix_enabled
@@ -123,8 +125,8 @@ fix_sentry_issue_start_tool = RegisteredTool(
         required=("sentry_url",),
     ),
     source="interactive_shell",
-    surfaces=("action",),
-    side_effect_level="mutating",
+    surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
     parallel_safe=False,
     accepts_runtime_context=True,
     is_available=lambda _sources: is_issue_fix_enabled(),

--- a/tools/interactive_shell/actions/shell.py
+++ b/tools/interactive_shell/actions/shell.py
@@ -11,6 +11,7 @@ from core.agent_harness.tools.tool_context import (
     object_schema,
     string_property,
 )
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.registered_tool import RegisteredTool
 from tools.interactive_shell.shell.runner import run_shell_command
 from tools.interactive_shell.subprocess import require_subprocess_presenter
@@ -71,7 +72,7 @@ shell_run_tool = RegisteredTool(
         required=("command",),
     ),
     source="interactive_shell",
-    surfaces=("action",),
+    surfaces=(ToolSurface.ACTION,),
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_shell,

--- a/tools/interactive_shell/actions/slash.py
+++ b/tools/interactive_shell/actions/slash.py
@@ -17,6 +17,7 @@ from core.agent_harness.tools.tool_context import (
     capability_available_from_sources,
     execute_with_action_context,
 )
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.registered_tool import RegisteredTool
 from tools.interactive_shell.shared import plan_foreground_tool
 from tools.interactive_shell.shared.slash_catalog import (
@@ -177,7 +178,7 @@ slash_invoke_tool = RegisteredTool(
     description=slash_invoke_tool_description(),
     input_schema=slash_invoke_input_schema(),
     source="interactive_shell",
-    surfaces=("action",),
+    surfaces=(ToolSurface.ACTION,),
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_slash,

--- a/tools/interactive_shell/actions/synthetic.py
+++ b/tools/interactive_shell/actions/synthetic.py
@@ -13,6 +13,7 @@ from core.agent_harness.tools.tool_context import (
     object_schema,
     string_property,
 )
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.registered_tool import RegisteredTool
 from tools.interactive_shell.subprocess import require_subprocess_presenter
 from tools.interactive_shell.synthetic.runner import run_synthetic_test
@@ -79,7 +80,7 @@ synthetic_run_tool = RegisteredTool(
         required=("suite", "scenario"),
     ),
     source="interactive_shell",
-    surfaces=("action",),
+    surfaces=(ToolSurface.ACTION,),
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_synthetic,

--- a/tools/interactive_shell/actions/task_cancel.py
+++ b/tools/interactive_shell/actions/task_cancel.py
@@ -13,6 +13,7 @@ from core.agent_harness.tools.tool_context import (
     execute_with_action_context,
     object_schema,
 )
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.registered_tool import RegisteredTool
 from platform.common.task_types import TaskKind, TaskStatus
 from tools.interactive_shell.shared import plan_foreground_tool
@@ -122,7 +123,7 @@ task_cancel_tool = RegisteredTool(
         required=("target",),
     ),
     source="interactive_shell",
-    surfaces=("action",),
+    surfaces=(ToolSurface.ACTION,),
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_task_cancel,

--- a/tools/investigation/__init__.py
+++ b/tools/investigation/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.tools import ToolSurface
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from tools.investigation.capability import (
     astream_investigation,
@@ -21,8 +23,8 @@ from tools.investigation.capability import (
     description=(
         "Run the full OpenSRE investigation workflow for an alert or incident description."
     ),
-    side_effect_level="external",
-    surfaces=("chat",),
+    side_effect_level=SideEffectLevel.EXTERNAL,
+    surfaces=(ToolSurface.CHAT,),
     tags=("investigation", "composite"),
     input_schema={
         "type": "object",

--- a/tools/investigation/stages/gather_evidence/prompt.py
+++ b/tools/investigation/stages/gather_evidence/prompt.py
@@ -11,6 +11,7 @@ from core.domain.alerts.alert_source import (
     secondary_tool_sources,
 )
 from core.domain.diagnosis import root_cause_category_instruction_for_source
+from core.domain.types.tools import ToolSurface
 from tools.investigation.stages.gather_evidence.tools import (
     planned_action_names,
     select_investigation_tools,
@@ -152,7 +153,7 @@ def format_alert_context(
     resolved = state.get("resolved_integrations") or {}
     if available_tools is None:
         registry_tools = [
-            t for t in get_registered_tools("investigation") if t.is_available(resolved)
+            t for t in get_registered_tools(ToolSurface.INVESTIGATION) if t.is_available(resolved)
         ]
         available_tools = select_investigation_tools(registry_tools, state)
 

--- a/tools/investigation/stages/gather_evidence/tools.py
+++ b/tools/investigation/stages/gather_evidence/tools.py
@@ -11,6 +11,7 @@ from core.domain.alerts.alert_source import (
     secondary_tool_sources,
     seed_tool_sources_for_alert,
 )
+from core.domain.types.tools import ToolSurface
 from core.llm.types import ToolCall
 from core.tool_framework.registered_tool import RegisteredTool
 from core.tool_framework.utils.integration_sources import availability_view
@@ -52,7 +53,11 @@ STAGNATION_NUDGE = (
 
 def get_available_tools(resolved_integrations: dict[str, Any]) -> list[RegisteredTool]:
     available_sources = availability_view(resolved_integrations)
-    return [t for t in get_registered_tools("investigation") if t.is_available(available_sources)]
+    return [
+        t
+        for t in get_registered_tools(ToolSurface.INVESTIGATION)
+        if t.is_available(available_sources)
+    ]
 
 
 def planned_action_names(state: dict[str, Any]) -> list[str]:

--- a/tools/investigation/stages/plan_evidence/node.py
+++ b/tools/investigation/stages/plan_evidence/node.py
@@ -11,6 +11,7 @@ from core.domain.alerts.alert_source import (
 from core.domain.alerts.tool_planning import score_tools
 from core.domain.types.planning import PlannedInvestigationAction
 from core.domain.types.retrieval import RetrievalControlsMap, RetrievalIntent, TimeBounds
+from core.domain.types.tools import ToolSurface
 from core.state import InvestigationState
 from core.tool_framework.registered_tool import RegisteredTool
 from tools.investigation.stages.gather_evidence.tools import (
@@ -74,7 +75,7 @@ def _available_investigation_tools(resolved_integrations: dict[str, Any]) -> lis
     available_sources = availability_view(resolved_integrations)
     return [
         tool
-        for tool in get_registered_tools("investigation")
+        for tool in get_registered_tools(ToolSurface.INVESTIGATION)
         if tool.is_available(available_sources)
     ]
 

--- a/tools/investigation_registry/actions.py
+++ b/tools/investigation_registry/actions.py
@@ -1,9 +1,10 @@
 """Registry of all available investigation actions."""
 
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.registered_tool import RegisteredTool
 from tools.registry import get_registered_tools
 
 
 def get_available_actions() -> list[RegisteredTool]:
     """Return investigation-surface tools discovered under ``tools/``."""
-    return get_registered_tools("investigation")
+    return get_registered_tools(ToolSurface.INVESTIGATION)

--- a/tools/registry_index.py
+++ b/tools/registry_index.py
@@ -19,6 +19,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from config.constants.paths import REPO_ROOT
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.registry_metadata import normalize_surfaces
 from tools.registry_discovery import INTEGRATION_TOOL_PACKAGES
 
@@ -206,9 +207,29 @@ def _string_constant(node: ast.expr | None) -> str | None:
     return None
 
 
-def _string_tuple(node: ast.expr | None) -> tuple[str, ...] | None:
+def _surface_constant(node: ast.expr | None) -> str | None:
+    """Resolve a surface element to its wire string.
+
+    Accepts a plain string literal (``"action"``) or a ``ToolSurface`` member
+    reference (``ToolSurface.ACTION``) — the latter is how tool definitions
+    declare surfaces once ``ToolSurface`` became a ``StrEnum``.
+    """
+    literal = _string_constant(node)
+    if literal is not None:
+        return literal
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == ToolSurface.__name__
+        and node.attr in ToolSurface.__members__
+    ):
+        return ToolSurface[node.attr].value
+    return None
+
+
+def _surface_tuple(node: ast.expr | None) -> tuple[str, ...] | None:
     if isinstance(node, ast.Tuple | ast.List):
-        values = [_string_constant(el) for el in node.elts]
+        values = [_surface_constant(el) for el in node.elts]
         if all(v is not None for v in values):
             return tuple(v for v in values if v is not None)
     return None
@@ -283,7 +304,7 @@ def _descriptors_in_file(path: Path) -> list[ToolDescriptor]:
                     descriptors.append(
                         ToolDescriptor(
                             name=name,
-                            surfaces=normalize_surfaces(_string_tuple(_keyword(dec, "surfaces"))),
+                            surfaces=normalize_surfaces(_surface_tuple(_keyword(dec, "surfaces"))),
                             source=_string_constant(_keyword(dec, "source")),
                             display_name=_string_constant(_keyword(dec, "display_name")),
                             module=module,
@@ -296,7 +317,7 @@ def _descriptors_in_file(path: Path) -> list[ToolDescriptor]:
             descriptors.append(
                 ToolDescriptor(
                     name=class_name,
-                    surfaces=normalize_surfaces(_string_tuple(_class_attr(node, "surfaces"))),
+                    surfaces=normalize_surfaces(_surface_tuple(_class_attr(node, "surfaces"))),
                     source=_string_constant(_class_attr(node, "source")),
                     display_name=_string_constant(_class_attr(node, "display_name")),
                     module=module,

--- a/tools/system/agent_memory/tool.py
+++ b/tools/system/agent_memory/tool.py
@@ -17,6 +17,8 @@ from core.domain.memory import (
     save_memory,
     search_memories,
 )
+from core.domain.types.tools import ToolSurface
+from core.tool_framework.metadata import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from tools.system.agent_memory.results import (
     deleted_result,
@@ -57,8 +59,8 @@ def _memory_available(sources: dict[str, dict[str, Any]]) -> bool:
         "An investigation uncovers a lesson worth keeping (known-flaky service)",
     ],
     tags=("safe", "fast", "no-credentials"),
-    surfaces=("action", "investigation"),
-    side_effect_level="mutating",
+    surfaces=(ToolSurface.ACTION, ToolSurface.INVESTIGATION),
+    side_effect_level=SideEffectLevel.MUTATING,
     parallel_safe=False,
     is_available=_memory_available,
     input_schema={
@@ -112,8 +114,8 @@ def memory_remember(name: str, type: str, description: str, content: str) -> dic
         "user asks to forget something or a stored fact is no longer true."
     ),
     tags=("safe", "fast", "no-credentials"),
-    surfaces=("action",),
-    side_effect_level="mutating",
+    surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
     parallel_safe=False,
     is_available=_memory_available,
     input_schema={
@@ -142,8 +144,8 @@ def memory_forget(name: str) -> dict[str, Any]:
         "search names, descriptions, and bodies, or no arguments to list the index."
     ),
     tags=("safe", "fast", "no-credentials"),
-    surfaces=("action", "investigation"),
-    side_effect_level="read_only",
+    surfaces=(ToolSurface.ACTION, ToolSurface.INVESTIGATION),
+    side_effect_level=SideEffectLevel.READ_ONLY,
     is_available=_memory_available,
     input_schema={
         "type": "object",

--- a/tools/system/python_execution_tool/__init__.py
+++ b/tools/system/python_execution_tool/__init__.py
@@ -9,7 +9,9 @@ from config.runtime_metadata import (
     LIVE_FACT_KEYS,
     STATIC_FACT_KEYS,
 )
+from core.domain.types.tools import ToolSurface
 from core.tool_framework.base import BaseTool
+from core.tool_framework.metadata import SideEffectLevel
 from platform.observability.trace.spans import component_span
 from tools.system.python_execution_tool.credentials import execution_env, github_extract_params
 from tools.system.python_execution_tool.runner import run_python_execution
@@ -30,8 +32,8 @@ class PythonExecutionTool(BaseTool):
     name = "execute_python_code"
     display_name = "Python execution"
     source = "knowledge"
-    side_effect_level = "read_only"
-    surfaces = ("investigation", "chat")
+    side_effect_level = SideEffectLevel.READ_ONLY
+    surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     injected_params = ["github_token"]
     description = (
         "Execute generated Python code in a restricted subprocess, capture stdout, stderr, "


### PR DESCRIPTION
Fixes #4530

#### Describe the changes you have made in this PR -

Promotes the three tool-metadata string `Literal`s to closed `enum.StrEnum`s with identical string values, giving exhaustiveness at definition time while keeping the wire values (`"investigation"`, `"read_only"`, `"metrics"`, …) unchanged for analytics, persisted JSON, and existing comparisons.

- `core/domain/types/tools.py` — `ToolSurface` → `StrEnum` (`investigation`/`chat`/`action`).
- `core/tool_framework/metadata.py` — `EvidenceType` and `SideEffectLevel` → `StrEnum`.
- `EvidenceSource` left untouched as `str` — it's an open vendor-key registry.
- `core/tool_framework/registry_metadata.py` — `normalize_surfaces` resolves to enum members and validates via `ToolSurface(...)` (replacing `get_args`), so the registry/decorator paths still accept plain strings and coerce them.
- `tools/registry_index.py` — the static AST descriptor index only understood string-literal `surfaces=`; taught it to resolve `ToolSurface.MEMBER` references too, so class/decorator tools don't silently fall back to the default surface.
- Call sites across `integrations/*/tools/`, `tools/interactive_shell/actions/`, and `tools/system/` migrated from bare strings to enum members.
- New `tests/core/tool_framework/test_enums.py` pins members, string round-trips, closed membership, `ToolMetadata` string-coercion, and the `model_dump(mode="json")` persisted shape (following the `tests/filestorage/test_enums.py` precedent).

### Demo/Screenshot for feature changes and bug fixes -

Refactor-only; behavior and wire values unchanged. Verification:

```
$ make typecheck
Success: no issues found

$ uv run pytest tests/core/tool_framework/test_enums.py -q
22 passed

$ make test-cov
13052 passed, 62 skipped
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The three metadata vocabularies were bare string `Literal`s, so a typo only surfaced at runtime and there was no single closed source of truth. I promoted each to a `StrEnum` with identical values so the set is exhaustive at definition time while members still behave as strings.

I considered keeping call sites on plain strings by widening the decorator/base-class annotations to `Enum | str`, but that only pushes the un-typed value downstream (every read of `tool.side_effect_level` comes back `Enum | str`) and gives up call-site checking. I went with strict enum annotations and migrated the call sites to members instead.

The one non-obvious change is `tools/registry_index.py`: it builds a static AST index of each tool's `surfaces=` without importing the module, and only parsed string literals. Once surfaces became `ToolSurface.ACTION`, that parser returned `None` and every action/chat tool silently defaulted to the `investigation` surface — caught by the registry contract tests. I added a small resolver that maps a `ToolSurface.MEMBER` attribute node back to its wire value. Runtime string acceptance is preserved because `ToolMetadata` (Pydantic) and `normalize_surfaces` coerce incoming strings into members.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
