### PR TITLE
fix(filestorage): reject remote-sync setup flags a provider doesn't use

### DIFF
--- a/docs/configuration/remote-sync.mdx
+++ b/docs/configuration/remote-sync.mdx
@@ -70,6 +70,12 @@ export OPENSRE_REMOTE_SYNC_BUCKET=my-opensre-bucket
 Naming a bucket is not enough on its own — `OPENSRE_REMOTE_SYNC` has to be set
 too, so a bucket variable left over from another tool never starts uploading.
 
+`--region`/`--profile` are AWS-only today — `opensre remote-sync setup`
+rejects either one for a provider that doesn't use it, rather than saving it
+silently and never reading it back. (Their env-var equivalents,
+`OPENSRE_REMOTE_SYNC_REGION`/`PROFILE`, are read the same way regardless of
+provider and are simply ignored by a provider that has no use for them.)
+
 You can also persist settings under `remote_sync` in `~/.opensre/config.yml`
 (`enabled`, `bucket`, `provider`, `prefix`, …). Environment variables still
 win for a single run.

--- a/platform/filestorage/enums.py
+++ b/platform/filestorage/enums.py
@@ -44,8 +44,23 @@ class RemoteSyncSubcommand(StrEnum):
     SETUP = "setup"
 
 
+class RemoteSyncField(StrEnum):
+    """Provider-specific setup fields ``RemoteSyncConfig`` can hold.
+
+    Fixed at two on purpose — ``RemoteSyncConfig`` is a closed, two-slot
+    contract for the fields a provider may need beyond bucket/prefix. A
+    provider declares which of these it consumes (see
+    :class:`platform.filestorage.providers.registry.SetupExtraField`); it does
+    not gain new attributes of its own.
+    """
+
+    REGION = "region"
+    PROFILE = "profile"
+
+
 __all__ = [
     "BuiltInProvider",
+    "RemoteSyncField",
     "RemoteSyncSubcommand",
     "SyncDirection",
     "SyncRootName",

--- a/platform/filestorage/providers/__init__.py
+++ b/platform/filestorage/providers/__init__.py
@@ -8,16 +8,20 @@ selected. Other clouds (GCS, Azure, …) are community modules that call
 from __future__ import annotations
 
 from platform.filestorage.providers.registry import (
+    SetupExtraField,
     build_object_store,
     credential_hint_for_provider,
+    provider_extra_fields,
     register_object_store,
     registered_providers,
     unregister_object_store,
 )
 
 __all__ = [
+    "SetupExtraField",
     "build_object_store",
     "credential_hint_for_provider",
+    "provider_extra_fields",
     "register_object_store",
     "registered_providers",
     "unregister_object_store",

--- a/platform/filestorage/providers/aws.py
+++ b/platform/filestorage/providers/aws.py
@@ -8,10 +8,10 @@ import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 
 from platform.filestorage.config import RemoteSyncConfig
-from platform.filestorage.enums import BuiltInProvider
+from platform.filestorage.enums import BuiltInProvider, RemoteSyncField
 from platform.filestorage.errors import RemoteSyncUnavailableError
 from platform.filestorage.ports import RemoteObject
-from platform.filestorage.providers.registry import register_object_store
+from platform.filestorage.providers.registry import SetupExtraField, register_object_store
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -19,6 +19,10 @@ if TYPE_CHECKING:
 _SERVER_SIDE_ENCRYPTION = "AES256"
 PROVIDER_NAME = BuiltInProvider.AWS
 CREDENTIAL_HINT = "AWS credentials come from the usual places (env, profile, or SSO)."
+EXTRA_FIELDS = (
+    SetupExtraField(RemoteSyncField.PROFILE, "Credentials profile (blank if unused)"),
+    SetupExtraField(RemoteSyncField.REGION, "Region (blank if unused)"),
+)
 
 
 class S3ObjectStore:
@@ -108,6 +112,8 @@ def _factory(config: RemoteSyncConfig) -> S3ObjectStore:
     return S3ObjectStore(config)
 
 
-register_object_store(PROVIDER_NAME, _factory, credential_hint=CREDENTIAL_HINT)
+register_object_store(
+    PROVIDER_NAME, _factory, credential_hint=CREDENTIAL_HINT, extra_fields=EXTRA_FIELDS
+)
 
-__all__ = ["CREDENTIAL_HINT", "PROVIDER_NAME", "S3ObjectStore"]
+__all__ = ["CREDENTIAL_HINT", "EXTRA_FIELDS", "PROVIDER_NAME", "S3ObjectStore"]

--- a/platform/filestorage/providers/registry.py
+++ b/platform/filestorage/providers/registry.py
@@ -17,9 +17,10 @@ from __future__ import annotations
 import importlib
 import threading
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from platform.filestorage.enums import BuiltInProvider
+from platform.filestorage.enums import BuiltInProvider, RemoteSyncField
 from platform.filestorage.errors import RemoteSyncConfigError
 
 if TYPE_CHECKING:
@@ -30,8 +31,30 @@ ObjectStoreFactory = Callable[["RemoteSyncConfig"], "ObjectStore"]
 
 _DEFAULT_CREDENTIAL_HINT = "Use ambient credentials for this provider; opensre does not store them."
 
+
+@dataclass(frozen=True)
+class SetupExtraField:
+    """One provider-specific setup field, declared by the provider itself.
+
+    Mirrors ``integrations.setup_flow.SetupField`` in spirit — a provider
+    declares what it needs, so ``setup.py`` and the CLI act on the
+    declaration instead of branching on the provider's name. Kept minimal on
+    purpose: unlike an integration's arbitrary credentials dict,
+    ``RemoteSyncConfig`` has exactly two optional slots (``region``,
+    ``profile``) and nothing here is ever a secret, so there is no
+    env_var/secret/constant machinery to carry.
+    """
+
+    field: RemoteSyncField
+    """Which of ``RemoteSyncConfig``'s two extension slots this fills."""
+
+    prompt: str
+    """Question text when collecting this field interactively."""
+
+
 _REGISTRY: dict[str, ObjectStoreFactory] = {}
 _CREDENTIAL_HINTS: dict[str, str] = {}
+_EXTRA_FIELDS: dict[str, tuple[SetupExtraField, ...]] = {}
 _REGISTRY_LOCK = threading.RLock()
 
 # Built-in backends, imported on first use so this package never imports itself.
@@ -51,7 +74,11 @@ def _load_builtin(key: str) -> None:
 
 
 def register_object_store(
-    name: str, factory: ObjectStoreFactory, *, credential_hint: str | None = None
+    name: str,
+    factory: ObjectStoreFactory,
+    *,
+    credential_hint: str | None = None,
+    extra_fields: tuple[SetupExtraField, ...] = (),
 ) -> None:
     """Bind ``name`` (the value of ``OPENSRE_REMOTE_SYNC_PROVIDER``) to a factory.
 
@@ -59,6 +86,10 @@ def register_object_store(
     ``setup`` about where this provider's ambient credentials come from (see
     :func:`credential_hint_for_provider`). Omit it to fall back to a generic
     sentence.
+
+    ``extra_fields`` declares which of ``RemoteSyncConfig``'s ``region``/
+    ``profile`` slots this provider consumes (see :func:`provider_extra_fields`).
+    Omit it — as most providers do — when the provider needs neither.
     """
     key = name.strip().lower()
     if not key:
@@ -67,6 +98,8 @@ def register_object_store(
         _REGISTRY[key] = factory
         if credential_hint is not None:
             _CREDENTIAL_HINTS[key] = credential_hint
+        if extra_fields:
+            _EXTRA_FIELDS[key] = extra_fields
 
 
 def unregister_object_store(name: str) -> None:
@@ -75,6 +108,7 @@ def unregister_object_store(name: str) -> None:
         key = name.strip().lower()
         _REGISTRY.pop(key, None)
         _CREDENTIAL_HINTS.pop(key, None)
+        _EXTRA_FIELDS.pop(key, None)
 
 
 def registered_providers() -> tuple[str, ...]:
@@ -117,10 +151,27 @@ def credential_hint_for_provider(provider: str) -> str:
     return hint if hint is not None else _DEFAULT_CREDENTIAL_HINT
 
 
+def provider_extra_fields(provider: str) -> tuple[SetupExtraField, ...]:
+    """``region``/``profile`` fields ``provider`` declared, or ``()`` for neither.
+
+    Loads a not-yet-imported built-in module first, same as
+    :func:`credential_hint_for_provider`, so this is accurate even before any
+    store has been built for ``provider``. An unknown provider name also
+    resolves to ``()`` — callers that need to reject unknown providers do so
+    separately (:func:`registered_providers`).
+    """
+    key = provider.strip().lower()
+    with _REGISTRY_LOCK:
+        _load_builtin(key)
+        return _EXTRA_FIELDS.get(key, ())
+
+
 __all__ = [
     "ObjectStoreFactory",
+    "SetupExtraField",
     "build_object_store",
     "credential_hint_for_provider",
+    "provider_extra_fields",
     "register_object_store",
     "registered_providers",
     "unregister_object_store",

--- a/platform/filestorage/providers/registry.py
+++ b/platform/filestorage/providers/registry.py
@@ -98,8 +98,7 @@ def register_object_store(
         _REGISTRY[key] = factory
         if credential_hint is not None:
             _CREDENTIAL_HINTS[key] = credential_hint
-        if extra_fields:
-            _EXTRA_FIELDS[key] = extra_fields
+        _EXTRA_FIELDS[key] = extra_fields
 
 
 def unregister_object_store(name: str) -> None:

--- a/platform/filestorage/setup.py
+++ b/platform/filestorage/setup.py
@@ -15,7 +15,9 @@ from config.constants.filestorage import (
 )
 from config.local_settings import LocalSettingsError, update_section
 from platform.filestorage.config import RemoteSyncConfig
+from platform.filestorage.enums import RemoteSyncField
 from platform.filestorage.errors import RemoteSyncConfigError
+from platform.filestorage.providers.registry import provider_extra_fields
 
 
 @dataclass(frozen=True)
@@ -42,6 +44,13 @@ def save_remote_sync_settings(request: RemoteSyncSetupRequest) -> RemoteSyncConf
     prefix = request.prefix.strip() or DEFAULT_REMOTE_SYNC_PREFIX
     region = request.region.strip()
     profile = request.profile.strip()
+    declared = {extra.field for extra in provider_extra_fields(provider)}
+    for field, value in ((RemoteSyncField.REGION, region), (RemoteSyncField.PROFILE, profile)):
+        if value and field not in declared:
+            raise RemoteSyncConfigError(
+                f"--{field.value} is not used by provider {provider!r}; "
+                "drop the flag or switch providers"
+            )
     try:
         update_section(
             "remote_sync",

--- a/surfaces/cli/commands/remote_sync.py
+++ b/surfaces/cli/commands/remote_sync.py
@@ -10,7 +10,7 @@ from config.constants.filestorage import (
 )
 from platform.common.exit_codes import ERROR, SUCCESS
 from platform.filestorage import RemoteSyncError
-from platform.filestorage.enums import RemoteSyncSubcommand
+from platform.filestorage.enums import RemoteSyncField, RemoteSyncSubcommand
 from platform.filestorage.messages import (
     DISABLED_HELP,
     format_report_lines,
@@ -18,6 +18,7 @@ from platform.filestorage.messages import (
     format_status_lines,
 )
 from platform.filestorage.operations import get_sync_status, run_remote_sync
+from platform.filestorage.providers.registry import provider_extra_fields
 from platform.filestorage.setup import RemoteSyncSetupRequest, save_remote_sync_settings
 
 
@@ -135,26 +136,40 @@ def _collect_setup_request(
             "pass --provider and --bucket, or run setup in an interactive terminal"
         )
 
+    bucket_value = click.prompt(
+        "Bucket / store name", default=bucket or "", show_default=bool(bucket)
+    )
+    provider_value = click.prompt(
+        "Provider (aws, vercel, …)",
+        default=provider or DEFAULT_REMOTE_SYNC_PROVIDER,
+        show_default=True,
+    )
+    prefix_value = click.prompt(
+        "Prefix", default=prefix or DEFAULT_REMOTE_SYNC_PREFIX, show_default=True
+    )
     return RemoteSyncSetupRequest(
-        bucket=click.prompt("Bucket / store name", default=bucket or "", show_default=bool(bucket)),
-        provider=click.prompt(
-            "Provider (aws, vercel, …)",
-            default=provider or DEFAULT_REMOTE_SYNC_PROVIDER,
-            show_default=True,
-        ),
-        prefix=click.prompt(
-            "Prefix",
-            default=prefix or DEFAULT_REMOTE_SYNC_PREFIX,
-            show_default=True,
-        ),
-        region=click.prompt("Region (blank if unused)", default=region or "", show_default=False),
-        profile=click.prompt(
-            "Credentials profile (blank if unused)",
-            default=profile or "",
-            show_default=False,
-        ),
+        bucket=bucket_value,
+        provider=provider_value,
+        prefix=prefix_value,
+        region=_prompt_extra_field(RemoteSyncField.REGION, provider_value, region),
+        profile=_prompt_extra_field(RemoteSyncField.PROFILE, provider_value, profile),
         enabled=enabled,
     )
+
+
+def _prompt_extra_field(field: RemoteSyncField, provider: str, current: str | None) -> str:
+    """Prompt for ``field`` only if ``provider`` declared it; otherwise leave it unset.
+
+    The declaration (and its prompt text) lives with the provider — see
+    :func:`platform.filestorage.providers.registry.provider_extra_fields` —
+    so this stays generic across every registered provider, built-in or
+    community, instead of hardcoding which providers use which field.
+    """
+    declared = {extra.field: extra for extra in provider_extra_fields(provider)}
+    extra = declared.get(field)
+    if extra is None:
+        return current or ""
+    return str(click.prompt(extra.prompt, default=current or "", show_default=False))
 
 
 __all__ = ["remote_sync_command"]

--- a/tests/cli/test_remote_sync_command.py
+++ b/tests/cli/test_remote_sync_command.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import click
 import pytest
+import yaml
 from click.testing import CliRunner
 
 from config.constants.filestorage import REMOTE_SYNC_BUCKET_ENV, REMOTE_SYNC_ENV
@@ -181,3 +183,92 @@ def test_sync_help_documents_direction_flags(runner: CliRunner) -> None:
     assert result.exit_code == 0
     assert "--pull-only" in result.output
     assert "--push-only" in result.output
+
+
+def test_setup_rejects_flag_provider_does_not_support(runner: CliRunner) -> None:
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup", "--provider", "vercel", "--bucket", "b", "--profile", "dev"],
+    )
+    assert result.exit_code != 0
+    assert "--profile is not used by provider 'vercel'" in result.output
+
+
+def test_setup_writes_settings_with_supported_flags(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from config.constants import paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "OPENSRE_HOME_DIR", tmp_path)
+    result = runner.invoke(
+        remote_sync_command,
+        [
+            "setup",
+            "--provider",
+            "aws",
+            "--bucket",
+            "b",
+            "--region",
+            "us-east-1",
+            "--profile",
+            "dev",
+        ],
+    )
+    assert result.exit_code == 0
+
+
+def _set_interactive(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``_collect_setup_request`` take its prompt branch under CliRunner.
+
+    ``CliRunner``'s simulated stdin reports ``isatty() is False`` by default,
+    which the command reads as "not a terminal" and refuses to prompt.
+    ``click.prompt`` itself reads through ``sys.stdin`` (which CliRunner
+    already feeds from ``input=``), so only the tty check needs faking.
+    """
+    import click
+
+    monkeypatch.setattr(
+        click, "get_text_stream", lambda _name: SimpleNamespace(isatty=lambda: True)
+    )
+
+
+def test_setup_interactive_skips_prompts_for_provider_without_extra_fields(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from config.constants import paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "OPENSRE_HOME_DIR", tmp_path)
+    _set_interactive(monkeypatch)
+
+    # bucket, provider, prefix — no region/profile prompts for vercel.
+    result = runner.invoke(remote_sync_command, ["setup"], input="my-bucket\nvercel\nopensre\n")
+    assert result.exit_code == 0, result.output
+
+    on_disk = yaml.safe_load((tmp_path / "config.yml").read_text(encoding="utf-8"))
+    assert on_disk["remote_sync"]["provider"] == "vercel"
+    assert on_disk["remote_sync"]["region"] == ""
+    assert on_disk["remote_sync"]["profile"] == ""
+
+
+def test_setup_interactive_prompts_for_provider_extra_fields(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from config.constants import paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "OPENSRE_HOME_DIR", tmp_path)
+    _set_interactive(monkeypatch)
+
+    # bucket, provider, prefix, region, profile — RemoteSyncSetupRequest's
+    # keyword order, which Python evaluates left to right regardless of the
+    # order EXTRA_FIELDS declares them in.
+    result = runner.invoke(
+        remote_sync_command,
+        ["setup"],
+        input="my-bucket\naws\nopensre\nus-east-1\nmy-profile\n",
+    )
+    assert result.exit_code == 0, result.output
+
+    on_disk = yaml.safe_load((tmp_path / "config.yml").read_text(encoding="utf-8"))
+    assert on_disk["remote_sync"]["provider"] == "aws"
+    assert on_disk["remote_sync"]["profile"] == "my-profile"
+    assert on_disk["remote_sync"]["region"] == "us-east-1"

--- a/tests/filestorage/test_remote_sync_setup.py
+++ b/tests/filestorage/test_remote_sync_setup.py
@@ -83,3 +83,34 @@ def test_vercel_credential_hint_names_token_env() -> None:
     assert BLOB_READ_WRITE_TOKEN_ENV in credential_hint_for_provider("vercel")
     lines = format_setup_lines(RemoteSyncConfig(bucket="b", provider="vercel", prefix="p"))
     assert any(BLOB_READ_WRITE_TOKEN_ENV in line for line in lines)
+
+
+def test_save_rejects_region_for_provider_that_does_not_use_it(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(paths_mod, "OPENSRE_HOME_DIR", tmp_path)
+    with pytest.raises(RemoteSyncConfigError, match="--region is not used by provider 'vercel'"):
+        save_remote_sync_settings(
+            RemoteSyncSetupRequest(bucket="b", provider="vercel", region="us-east-1")
+        )
+
+
+def test_save_rejects_profile_for_provider_that_does_not_use_it(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(paths_mod, "OPENSRE_HOME_DIR", tmp_path)
+    with pytest.raises(RemoteSyncConfigError, match="--profile is not used by provider 'vercel'"):
+        save_remote_sync_settings(
+            RemoteSyncSetupRequest(bucket="b", provider="vercel", profile="dev")
+        )
+
+
+def test_save_allows_region_and_profile_for_aws(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(paths_mod, "OPENSRE_HOME_DIR", tmp_path)
+    config = save_remote_sync_settings(
+        RemoteSyncSetupRequest(bucket="b", provider="aws", region="us-east-1", profile="dev")
+    )
+    assert config.region == "us-east-1"
+    assert config.profile == "dev"

--- a/tests/filestorage/test_service_and_registry.py
+++ b/tests/filestorage/test_service_and_registry.py
@@ -14,7 +14,7 @@ from config.constants.filestorage import (
 )
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.engine import SyncReport, content_tag
-from platform.filestorage.enums import SyncRootName
+from platform.filestorage.enums import RemoteSyncField, SyncRootName
 from platform.filestorage.errors import RemoteSyncConfigError
 from platform.filestorage.messages import (
     DISABLED_HELP,
@@ -25,7 +25,9 @@ from platform.filestorage.operations import get_sync_status, run_remote_sync
 from platform.filestorage.ports import RemoteObject
 from platform.filestorage.providers import build_object_store as surface_build
 from platform.filestorage.providers.registry import (
+    SetupExtraField,
     build_object_store,
+    provider_extra_fields,
     register_object_store,
     registered_providers,
     unregister_object_store,
@@ -150,6 +152,34 @@ def test_registry_unregister_and_unknown() -> None:
     unregister_object_store("temp-prov")
     with pytest.raises(RemoteSyncConfigError, match="unknown remote-sync provider"):
         build_object_store(RemoteSyncConfig(bucket="b", provider="temp-prov"))
+
+
+def test_aws_declares_region_and_profile() -> None:
+    # Loading the built-in aws module (via provider_extra_fields) must not
+    # require boto3 to have built a client — this only reads the declaration.
+    fields = {extra.field for extra in provider_extra_fields("aws")}
+    assert fields == {RemoteSyncField.REGION, RemoteSyncField.PROFILE}
+
+
+def test_vercel_declares_no_extra_fields() -> None:
+    assert provider_extra_fields("vercel") == ()
+
+
+def test_unknown_provider_declares_no_extra_fields() -> None:
+    assert provider_extra_fields("does-not-exist") == ()
+
+
+def test_provider_extra_fields_registered_and_cleaned_up() -> None:
+    register_object_store(
+        "extra-fields-test",
+        lambda _cfg: _MemStore(),
+        extra_fields=(SetupExtraField(RemoteSyncField.REGION, "Region"),),
+    )
+    assert provider_extra_fields("extra-fields-test") == (
+        SetupExtraField(RemoteSyncField.REGION, "Region"),
+    )
+    unregister_object_store("extra-fields-test")
+    assert provider_extra_fields("extra-fields-test") == ()
 
 
 def test_registry_safe_under_concurrent_register_and_build() -> None:


### PR DESCRIPTION
Fixes #4639.

#### Describe the changes you have made in this PR -

`opensre remote-sync setup` shares one flat flag set (`--provider`, `--bucket`, `--prefix`, `--region`, `--profile`) across every provider by design, but `--region`/`--profile` are AWS-only in practice — only `providers/aws.py` ever reads them. Nothing stopped `--provider vercel --profile x` from silently saving `profile` to `~/.opensre/config.yml` and permanently ignoring it.

Mirrors the shape of #4168 (the `IntegrationSetupSpec` migration) — a provider **declares** what it needs, so surfaces act on the declaration instead of branching on the provider's name — scaled to `RemoteSyncConfig`'s fixed two-slot contract (no dynamic credentials dict, no keyring/env tiers, so none of that system's env_var/secret/constant machinery was needed):

- `platform/filestorage/enums.py`: `RemoteSyncField(StrEnum)` — `REGION`/`PROFILE`, matching this file's existing `BuiltInProvider` convention.
- `platform/filestorage/providers/registry.py`: `SetupExtraField(field, prompt)`, an `extra_fields` kwarg on `register_object_store`, and `provider_extra_fields(name)` (same lazy-builtin-load shape as the existing `credential_hint_for_provider`).
- `providers/aws.py` declares `EXTRA_FIELDS` for both; `vercel.py` declares nothing — same silent-ignore behavior as before, now explicit and inspectable instead of implicit.
- `setup.py` (`save_remote_sync_settings`) validates generically — loops over `RemoteSyncField`, rejects a non-empty `region`/`profile` the selected provider didn't declare. A future third field needs zero new validation code.
- CLI (`_collect_setup_request`) drives interactive prompts off `provider_extra_fields(provider)`: once the provider is known (prompted first), it only asks for fields that provider declared, using that provider's own prompt text. A provider with no extra fields skips both prompts.

`RemoteSyncConfig`/`RemoteSyncSetupRequest` are unchanged — still exactly `region: str`, `profile: str`. Only the declaration of who consumes them moved into the provider module.

### Demo/Screenshot for feature changes and bug fixes -

```
$ opensre remote-sync setup --provider vercel --bucket my-store --profile my-aws-profile
--profile is not used by provider 'vercel'; drop the flag or switch providers
(exit 1)

$ opensre remote-sync setup --provider aws --bucket my-bucket --region us-east-1 --profile dev
Remote sync settings saved → aws / my-bucket/opensre
Stored in ~/.opensre/config.yml (env vars still win for a single run).
AWS credentials come from the usual places (env, profile, or SSO).
Next: opensre remote-sync status   then   opensre remote-sync sync
(exit 0)
```

Interactive setup also skips prompting for `region`/`profile` entirely when the chosen provider (e.g. `vercel`) doesn't declare them — covered by `test_setup_interactive_skips_prompts_for_provider_without_extra_fields`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The gap: `RemoteSyncConfig` has two provider-specific slots (`region`, `profile`) that only AWS reads, but the CLI never told a user their `--profile` flag was a no-op for GCS/Vercel. The fix needed to avoid two bad shapes: hardcoding provider names in the CLI (breaks the registry's open/closed contract — adding a provider must never touch CLI/engine code), or generalizing `RemoteSyncConfig` into a dynamic field bag like `IntegrationSetupSpec` uses for arbitrary integration credentials (over-engineered for a contract that's genuinely closed at two fields forever). Landed on: providers declare a small typed `SetupExtraField` tuple at registration time, alongside the existing `credential_hint` mechanism; `setup.py` and the CLI both consume that declaration generically. Alternatives rejected: silently ignoring (status quo, the bug); a bare `frozenset[str]` instead of a `StrEnum`-typed dataclass (loses the "prefer StrEnum for closed vocab" convention this package already follows); validating the env-var equivalents too (`OPENSRE_REMOTE_SYNC_REGION`/`PROFILE`) — out of scope, since only the `setup` persistence path had the silent-accept bug; env vars are read the same way regardless of provider and were already a documented "ignored if unused" case, not a UX trap.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Please check **Allow edits from maintainers**.
