### PR TITLE
perf: stop re-scanning hot-path data structures on every turn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,31 @@ pytest tests/synthetic/ -k "test_scenario"                      # no live infra 
 
 Follow the PR template (see below). Link the relevant issue and describe what changed and why.
 
+### 6. Keep the Branch Up to Date with `main` (Rebase)
+
+PRs must be current with `main` before merge (branch protection). **Update by rebasing onto `main` — do not merge `main` into your feature branch.**
+
+Merging `main` into the PR branch creates noisy merge commits and trains the GitHub “Update branch” button toward that path. Rebase keeps history linear and surfaces conflicts on your commits, where they belong.
+
+**Preferred (local):**
+
+```bash
+git fetch origin main
+git rebase origin/main
+# resolve any conflicts, then:
+git push --force-with-lease
+```
+
+**On GitHub:** if the PR shows “This branch is out-of-date with the base
+branch”, prefer **Update with rebase** when the UI offers it. Avoid **Update
+branch** when that option merges `main` into the feature branch.
+
+After rebasing, re-run local checks if the conflict resolution touched code:
+
+```bash
+make lint && make format-check && make typecheck && make test-cov
+```
+
 ## Pull Request Guidelines
 
 ### How to Write a Good PR Description

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,31 +154,6 @@ pytest tests/synthetic/ -k "test_scenario"                      # no live infra 
 
 Follow the PR template (see below). Link the relevant issue and describe what changed and why.
 
-### 6. Keep the Branch Up to Date with `main` (Rebase)
-
-PRs must be current with `main` before merge (branch protection). **Update by rebasing onto `main` — do not merge `main` into your feature branch.**
-
-Merging `main` into the PR branch creates noisy merge commits and trains the GitHub “Update branch” button toward that path. Rebase keeps history linear and surfaces conflicts on your commits, where they belong.
-
-**Preferred (local):**
-
-```bash
-git fetch origin main
-git rebase origin/main
-# resolve any conflicts, then:
-git push --force-with-lease
-```
-
-**On GitHub:** if the PR shows “This branch is out-of-date with the base
-branch”, prefer **Update with rebase** when the UI offers it. Avoid **Update
-branch** when that option merges `main` into the feature branch.
-
-After rebasing, re-run local checks if the conflict resolution touched code:
-
-```bash
-make lint && make format-check && make typecheck && make test-cov
-```
-
 ## Pull Request Guidelines
 
 ### How to Write a Good PR Description

--- a/core/agent_harness/session/persistence/jsonl_storage.py
+++ b/core/agent_harness/session/persistence/jsonl_storage.py
@@ -287,6 +287,11 @@ class JsonlSessionStorage:
             if not self._has_turns(records):
                 path.unlink(missing_ok=True)
                 return
+            # ``records`` is not re-read after the appends below. The counts in
+            # the leaf entry only match ``custom_message``/``turn_stub`` records,
+            # and the guard below only looks for ``message`` records — neither
+            # append can produce either, so a re-parse would return the same
+            # answers for the cost of a full pass over the whole transcript.
             if session.accumulated_context:
                 self.append_custom_message(
                     session.session_id,
@@ -294,7 +299,6 @@ class JsonlSessionStorage:
                     content=dict(session.accumulated_context),
                     display=False,
                 )
-                records = self._read_records(path)
             if session.agent.messages and not any(rec.get("type") == "message" for rec in records):
                 for role, content in session.agent.messages:
                     self.append_message(
@@ -303,7 +307,6 @@ class JsonlSessionStorage:
                         content=content,
                         metadata={"kind": "chat"},
                     )
-                records = self._read_records(path)
             duration_secs = max(
                 0,
                 int(

--- a/core/agent_harness/session/session_core.py
+++ b/core/agent_harness/session/session_core.py
@@ -28,6 +28,11 @@ from core.agent_harness.session.persistence.ports import SessionStorage
 from core.state import MutableAgentState
 from platform.common.task_registry import TaskRegistry
 
+#: How many recent history rows keep their full response body. Sized above
+#: the conversation window so anything a prompt or a ``*_latest_*`` lookup
+#: reads is still intact, while a long session stops holding every reply.
+RESPONSE_TEXT_WINDOW = 20
+
 
 def _default_grounding() -> GroundingContext:
     """Build a fresh per-session grounding cache bundle.
@@ -185,8 +190,23 @@ class SessionCore:
             entry["slash_outcome"] = slash_outcome
 
         self.history.append(entry)
+        self._shed_stale_response_text()
 
         self.storage.append_turn(self, kind, text)
+
+    def _shed_stale_response_text(self) -> None:
+        """Drop the response body from the entry just aged out of the window.
+
+        Entries are never removed — ``len(history)`` is a turn counter and one
+        caller slices by a captured index — so the list itself has to keep
+        growing. The response bodies are the weight: a full agent reply dwarfs
+        the type/text/ok fields beside it, and only the newest rows of a kind
+        are ever read back. Shedding one entry per append keeps this O(1).
+        """
+        aged_out = len(self.history) - RESPONSE_TEXT_WINDOW - 1
+        if aged_out < 0:
+            return
+        self.history[aged_out].pop("response_text", None)
 
     def mark_latest(self, *, ok: bool, kind: str | None = None) -> None:
         """Update the latest history entry, optionally scanning for a matching kind."""

--- a/core/agent_harness/turns/turn_snapshot.py
+++ b/core/agent_harness/turns/turn_snapshot.py
@@ -25,7 +25,7 @@ class PromptRenderable(Protocol):
     """Structured prompt object that can render itself into provider text."""
 
     def render(self) -> str:
-        raise NotImplementedError
+        """Return the prompt as provider-ready text."""
 
 
 type SystemPromptInput = str | PromptRenderable
@@ -50,7 +50,7 @@ class TurnSnapshotSource(Protocol):
     # covariantly, so any concrete ``Sequence[str]`` implementation satisfies it.
     @property
     def configured_integrations(self) -> Sequence[str]:
-        raise NotImplementedError
+        """Integration names configured for this session (read-only view)."""
 
 
 @runtime_checkable
@@ -64,13 +64,13 @@ class AgentRuntimeRequest(Protocol):
     max_iterations: int
 
     def render_system_prompt(self) -> str:
-        raise NotImplementedError
+        """Render ``system_prompt`` into provider text."""
 
     def runtime_messages(self) -> list[RuntimeMessage]:
-        raise NotImplementedError
+        """Messages for this turn's LLM invoke."""
 
     def validate_runtime_request(self) -> None:
-        raise NotImplementedError
+        """Raise if the request is not ready to run."""
 
 
 def _render_system_prompt(prompt: SystemPromptInput) -> str:

--- a/core/domain/alerts/tool_planning.py
+++ b/core/domain/alerts/tool_planning.py
@@ -20,31 +20,31 @@ class PlannableTool(Protocol):
 
     @property
     def name(self) -> str:
-        raise NotImplementedError
+        """Stable tool name used in plans and evidence keys."""
 
     @property
     def source(self) -> str:
-        raise NotImplementedError
+        """Integration / capability source the tool belongs to."""
 
     @property
     def description(self) -> str:
-        raise NotImplementedError
+        """Short description scored against alert text."""
 
     @property
     def use_cases(self) -> Sequence[str]:
-        raise NotImplementedError
+        """When this tool should be considered."""
 
     @property
     def examples(self) -> Sequence[str]:
-        raise NotImplementedError
+        """Example prompts or payloads for metadata matching."""
 
     @property
     def tags(self) -> Sequence[str]:
-        raise NotImplementedError
+        """Planning tags (e.g. fallback)."""
 
     @property
     def evidence_type(self) -> Any:
-        raise NotImplementedError
+        """Evidence kind this tool produces, if any."""
 
 
 def score_tools(
@@ -57,6 +57,7 @@ def score_tools(
     alert_text = collect_alert_text(state)
     existing_evidence = state.get("evidence")
     evidence_keys = set(existing_evidence) if isinstance(existing_evidence, dict) else set()
+    secondary_sources = secondary_tool_sources()
 
     scored = [
         score_tool(
@@ -65,13 +66,13 @@ def score_tools(
             primary_sources=primary_sources,
             relevant_sources=relevant_sources,
             evidence_keys=evidence_keys,
+            secondary_sources=secondary_sources,
         )
         for tool in tools
     ]
     if scored and max(action.score for action in scored) <= 0:
         scored = [score_fallback_tool(action) for action in scored]
 
-    secondary_sources = secondary_tool_sources()
     return sorted(
         scored, key=lambda item: (-item.score, item.source in secondary_sources, item.name)
     )
@@ -84,10 +85,12 @@ def score_tool(
     primary_sources: set[str],
     relevant_sources: set[str],
     evidence_keys: set[str],
+    secondary_sources: frozenset[str] | set[str] | None = None,
 ) -> PlannedInvestigationAction:
     source = str(tool.source)
     score = 0
     reasons: list[str] = []
+    secondary = secondary_sources if secondary_sources is not None else secondary_tool_sources()
 
     if source in primary_sources:
         score += 100
@@ -95,7 +98,7 @@ def score_tool(
     if source in relevant_sources:
         score += 70
         reasons.append(f"source '{source}' matches alert context")
-    if source in secondary_tool_sources():
+    if source in secondary:
         score -= 10
         reasons.append("secondary source, used after integration-specific tools")
 

--- a/core/domain/memory/store.py
+++ b/core/domain/memory/store.py
@@ -45,6 +45,11 @@ from core.domain.memory.safety import find_memory_safety_issues
 from core.domain.memory.slugs import is_valid_slug
 
 _INDEX_FILENAME = "MEMORY.md"
+
+#: (directory signature, parsed records) from the last full read of the store.
+#: Process-local: a concurrent writer only costs a redundant re-parse, never
+#: a stale answer, because the signature is recomputed on every call.
+_LISTING_CACHE: tuple[tuple[tuple[str, int, int], ...], list[MemoryRecord]] | None = None
 _LOCK_FILENAME = ".memory.lock"
 _LOCK_TIMEOUT_SECONDS = 10.0
 
@@ -139,13 +144,43 @@ def load_memory(slug: str) -> MemoryRecord | None:
     return parse_memory_file(text)
 
 
+def _memory_dir_signature(directory: Path) -> tuple[tuple[str, int, int], ...]:
+    """Name, mtime and size of every memory file — cheap enough to check per turn.
+
+    Directory mtime alone is not enough: editing a memory in place leaves it
+    unchanged, so the cache would serve a stale body. Per-file size and mtime
+    move on any edit.
+    """
+    entries: list[tuple[str, int, int]] = []
+    for path in sorted(directory.glob("*.md")):
+        if path.name == _INDEX_FILENAME:
+            continue
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        entries.append((path.name, stat.st_mtime_ns, stat.st_size))
+    return tuple(entries)
+
+
 def list_memories() -> list[MemoryRecord]:
-    """All parseable memories, most recently updated first."""
+    """All parseable memories, most recently updated first.
+
+    Every action-agent turn renders the memory index, so this would otherwise
+    read and parse the whole store on each turn — a cost that grows with the
+    number of memories a user has accumulated. Parsed records are reused until
+    the files change.
+    """
+    global _LISTING_CACHE
     directory = memory_dir()
     if not directory.is_dir():
         return []
+    signature = _memory_dir_signature(directory)
+    cached = _LISTING_CACHE
+    if cached is not None and cached[0] == signature:
+        return list(cached[1])
     records: list[MemoryRecord] = []
-    for path in directory.glob("*.md"):
+    for path in sorted(directory.glob("*.md")):
         if path.name == _INDEX_FILENAME:
             continue
         try:
@@ -156,7 +191,8 @@ def list_memories() -> list[MemoryRecord]:
         if record is not None:
             records.append(record)
     records.sort(key=lambda r: r.updated_at, reverse=True)
-    return records
+    _LISTING_CACHE = (signature, records)
+    return list(records)
 
 
 def delete_memory(slug: str) -> bool:

--- a/core/domain/memory/store.py
+++ b/core/domain/memory/store.py
@@ -47,6 +47,12 @@ from core.domain.memory.slugs import is_valid_slug
 
 _INDEX_FILENAME = "MEMORY.md"
 
+#: Distinct memory stores kept parsed at once. Each Slack user in an org has
+#: their own memory directory, so a single entry would make concurrent users
+#: evict each other on every turn. Bounded so the cache cannot grow with the
+#: number of users a gateway has ever served.
+_PARSED_STORE_CACHE_SIZE = 16
+
 _LOCK_FILENAME = ".memory.lock"
 _LOCK_TIMEOUT_SECONDS = 10.0
 
@@ -160,16 +166,17 @@ def _memory_dir_signature(directory: Path) -> tuple[tuple[str, int, int], ...]:
     return tuple(entries)
 
 
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=_PARSED_STORE_CACHE_SIZE)
 def _parsed_memories(
     directory_key: str,
     _signature: tuple[tuple[str, int, int], ...],
 ) -> tuple[MemoryRecord, ...]:
     """Parse every memory file under ``directory_key``.
 
-    Keyed by the directory and its file signature, so the result is reused
-    until a memory is added, edited or removed. ``maxsize=1`` keeps only the
-    current state — an older signature can never be served.
+    Keyed by the directory *and* its file signature. The directory is part of
+    the key because memory stores are per-principal — one Slack user must
+    never be served another's memories, however alike the two stores look.
+    The signature is part of the key so an edited memory is re-read.
     """
     directory = Path(directory_key)
     records: list[MemoryRecord] = []

--- a/core/domain/memory/store.py
+++ b/core/domain/memory/store.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import contextlib
 import sys
 from datetime import UTC, datetime
+from functools import lru_cache
 from pathlib import Path
 
 from filelock import FileLock, Timeout
@@ -46,10 +47,6 @@ from core.domain.memory.slugs import is_valid_slug
 
 _INDEX_FILENAME = "MEMORY.md"
 
-#: (directory signature, parsed records) from the last full read of the store.
-#: Process-local: a concurrent writer only costs a redundant re-parse, never
-#: a stale answer, because the signature is recomputed on every call.
-_LISTING_CACHE: tuple[tuple[tuple[str, int, int], ...], list[MemoryRecord]] | None = None
 _LOCK_FILENAME = ".memory.lock"
 _LOCK_TIMEOUT_SECONDS = 10.0
 
@@ -163,22 +160,18 @@ def _memory_dir_signature(directory: Path) -> tuple[tuple[str, int, int], ...]:
     return tuple(entries)
 
 
-def list_memories() -> list[MemoryRecord]:
-    """All parseable memories, most recently updated first.
+@lru_cache(maxsize=1)
+def _parsed_memories(
+    directory_key: str,
+    _signature: tuple[tuple[str, int, int], ...],
+) -> tuple[MemoryRecord, ...]:
+    """Parse every memory file under ``directory_key``.
 
-    Every action-agent turn renders the memory index, so this would otherwise
-    read and parse the whole store on each turn — a cost that grows with the
-    number of memories a user has accumulated. Parsed records are reused until
-    the files change.
+    Keyed by the directory and its file signature, so the result is reused
+    until a memory is added, edited or removed. ``maxsize=1`` keeps only the
+    current state — an older signature can never be served.
     """
-    global _LISTING_CACHE
-    directory = memory_dir()
-    if not directory.is_dir():
-        return []
-    signature = _memory_dir_signature(directory)
-    cached = _LISTING_CACHE
-    if cached is not None and cached[0] == signature:
-        return list(cached[1])
+    directory = Path(directory_key)
     records: list[MemoryRecord] = []
     for path in sorted(directory.glob("*.md")):
         if path.name == _INDEX_FILENAME:
@@ -191,8 +184,21 @@ def list_memories() -> list[MemoryRecord]:
         if record is not None:
             records.append(record)
     records.sort(key=lambda r: r.updated_at, reverse=True)
-    _LISTING_CACHE = (signature, records)
-    return list(records)
+    return tuple(records)
+
+
+def list_memories() -> list[MemoryRecord]:
+    """All parseable memories, most recently updated first.
+
+    Every action-agent turn renders the memory index, so this would otherwise
+    read and parse the whole store on each turn — a cost that grows with the
+    number of memories a user has accumulated. Parsed records are reused until
+    the files change.
+    """
+    directory = memory_dir()
+    if not directory.is_dir():
+        return []
+    return list(_parsed_memories(str(directory), _memory_dir_signature(directory)))
 
 
 def delete_memory(slug: str) -> bool:

--- a/core/llm/transports/sdk/llm_clients.py
+++ b/core/llm/transports/sdk/llm_clients.py
@@ -53,6 +53,9 @@ from core.llm.types import LLMResponse
 
 logger = logging.getLogger(__name__)
 
+# Anthropic overloaded — not in stdlib ``http.HTTPStatus`` (non-standard code).
+_ANTHROPIC_OVERLOADED_STATUS = 529
+
 
 def _normalize_messages(prompt_or_messages: Any) -> tuple[str | None, list[dict[str, str]]]:
     if isinstance(prompt_or_messages, list):
@@ -106,11 +109,12 @@ def _format_anthropic_retry_error(err: Exception) -> str:
         )
     # Detect overloaded via HTTP status (error-response path) or via body error
     # type (SSE streaming path: the SDK raises APIStatusError from body events
-    # where the initial HTTP response was 200, so status_code is absent/not 529).
+    # where the initial HTTP response was 200, so status_code is absent / not
+    # ``_ANTHROPIC_OVERLOADED_STATUS``).
     body = getattr(err, "body", None)
     error_obj = body.get("error") if isinstance(body, dict) else None
     body_error_type = error_obj.get("type", "") if isinstance(error_obj, dict) else ""
-    if status_code == 529 or body_error_type == "overloaded_error":
+    if status_code == _ANTHROPIC_OVERLOADED_STATUS or body_error_type == "overloaded_error":
         return (
             "Anthropic API is overloaded (HTTP 529) after multiple retries. "
             "Try again in a few seconds."

--- a/core/state/models.py
+++ b/core/state/models.py
@@ -64,7 +64,7 @@ class AgentStateModel(StrictConfigModel):
 
     model_config = ConfigDict(extra="forbid", protected_namespaces=(), populate_by_name=True)
 
-    mode: AgentMode = "chat"
+    mode: AgentMode = AgentMode.CHAT
     route: str = ""
     org_id: str = ""
     user_id: str = ""
@@ -141,7 +141,9 @@ def model_default_payload(*exclude: str) -> dict[str, Any]:
     """Return default field values from ``AgentStateModel``, omitting ``exclude`` keys."""
     skip = frozenset(exclude)
     model = AgentStateModel()
-    dumped = model.model_dump(mode="python", by_alias=True, exclude_none=True)
+    # ``mode="json"`` so ``AgentMode`` (and any future StrEnums) dump as plain
+    # strings — the runtime ``AgentState`` dict keeps a JSON-stable shape.
+    dumped = model.model_dump(mode="json", by_alias=True, exclude_none=True)
     return {key: value for key, value in dumped.items() if key not in skip}
 
 
@@ -166,7 +168,7 @@ def make_chat_state(
             "context": {},
         }
     )
-    return cast(AgentState, state.model_dump(mode="python", by_alias=True, exclude_none=True))
+    return cast(AgentState, state.model_dump(mode="json", by_alias=True, exclude_none=True))
 
 
 __all__ = [

--- a/core/state/types.py
+++ b/core/state/types.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from enum import StrEnum
+from typing import Any
 
 from pydantic import Field
 from typing_extensions import TypedDict
@@ -10,7 +11,13 @@ from typing_extensions import TypedDict
 from config.strict_config import StrictConfigModel
 from core.state.agent_state import AgentMessageRole
 
-AgentMode = Literal["chat", "investigation", "agent_incident"]
+
+class AgentMode(StrEnum):
+    """Product mode for the agent state envelope."""
+
+    CHAT = "chat"
+    INVESTIGATION = "investigation"
+    AGENT_INCIDENT = "agent_incident"
 
 
 class ChatMessage(TypedDict, total=False):

--- a/gateway/runtime/status_messages.py
+++ b/gateway/runtime/status_messages.py
@@ -78,9 +78,9 @@ def status_from_tool_start(tool_name: str, tool_input: Any = None) -> str:
 @lru_cache(maxsize=256)
 def _tool_label(tool_name: str) -> str:
     """First clause of the tool's display name or description, else its humanized name."""
-    from tools.registry import get_registered_tools
+    from tools.registry import get_registered_tool
 
-    tool = next((t for t in get_registered_tools() if t.name == tool_name), None)
+    tool = get_registered_tool(tool_name)
     candidates = (tool.display_name or "", tool.description) if tool else ()
     for text in (*candidates, tool_name.replace("_", " ")):
         clause = re.split(r"\.\s| — | - |; ", " ".join(text.split()), maxsplit=1)[0]

--- a/gateway/tests/runtime/test_status_messages.py
+++ b/gateway/tests/runtime/test_status_messages.py
@@ -51,7 +51,10 @@ def _make_tool(name: str, description: str) -> RegisteredTool:
 
 
 def _register(monkeypatch, tools: list[RegisteredTool]) -> None:
+    """Install a controlled registry behind both accessors the label may use."""
+    by_name = {tool.name: tool for tool in tools}
     monkeypatch.setattr("tools.registry.get_registered_tools", lambda: tools)
+    monkeypatch.setattr("tools.registry.get_registered_tool", by_name.get)
     _tool_label.cache_clear()
 
 
@@ -108,3 +111,31 @@ def test_tool_status_includes_first_input_hint(monkeypatch) -> None:
     )
     assert status.startswith("⏳ Run a registered interactive-shell slash command…")
     assert "/integrations" in status
+
+
+def test_tool_label_miss_does_not_scan_the_whole_registry(monkeypatch) -> None:
+    """A cache miss must resolve by name, not walk every registered tool.
+
+    ``_tool_label`` is LRU-cached, but the gateway sees a long tail of tool
+    names, and every miss used to run ``next(t for t in get_registered_tools()
+    if t.name == …)`` — a linear pass over the full registry while a user waits
+    on a status line.
+    """
+    # Arrange
+    scans = 0
+
+    def _scanning_list(*_args: object, **_kwargs: object) -> list[RegisteredTool]:
+        nonlocal scans
+        scans += 1
+        return []
+
+    monkeypatch.setattr("tools.registry.get_registered_tools", _scanning_list)
+    monkeypatch.setattr("tools.registry.get_registered_tool", lambda _name: None)
+    _tool_label.cache_clear()
+
+    # Act: three distinct names, so every call is a cache miss.
+    for name in ("alpha_tool", "beta_tool", "gamma_tool"):
+        status_from_tool_start(name)
+
+    # Assert
+    assert scans == 0, f"label lookup listed the whole registry {scans} times"

--- a/tests/core/agent_harness/session/test_history_growth.py
+++ b/tests/core/agent_harness/session/test_history_growth.py
@@ -1,0 +1,123 @@
+"""``session.history`` must stop hoarding old response bodies.
+
+Every turn appends a row and nothing ever removes one. The rows themselves are
+small, but a row can carry ``response_text`` — a full agent reply — so a long
+session ends up holding every answer it has ever given.
+
+The list length has to keep growing: it is the prompt's turn counter, it is what
+``/status`` reports, and ``action_driver`` captures ``len(history)`` before a
+turn and slices from that index afterwards to count what the turn executed.
+Removing rows would break all three. So the bound is on the *bodies*, and these
+tests pin both halves: old bodies go, everything else stays.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.agent_harness.session.persistence.ports import SessionStorage
+from core.agent_harness.session.session_core import RESPONSE_TEXT_WINDOW, SessionCore
+
+
+class _NullStorage:
+    """Storage that drops writes, so these tests touch no disk."""
+
+    def open_session(self, session: Any) -> None:
+        """Ignore session open."""
+
+    def append_turn(self, session: Any, kind: str, text: str) -> None:
+        """Ignore the turn write."""
+
+    def flush(self, session: Any) -> None:
+        """Ignore flush."""
+
+    def __getattr__(self, _name: str) -> Any:
+        return lambda *_args, **_kwargs: None
+
+
+def _session() -> SessionCore:
+    return SessionCore(storage=cast_storage(_NullStorage()))
+
+
+def cast_storage(obj: Any) -> SessionStorage:
+    """Narrow the stub to the port without importing ``typing.cast`` at each use."""
+    return obj
+
+
+def _record_turns(session: SessionCore, count: int, *, body: str = "full reply") -> None:
+    for i in range(count):
+        session.record("chat", f"turn {i}", response_text=f"{body} {i}")
+
+
+def test_old_response_bodies_are_dropped_but_rows_remain() -> None:
+    """Rows outside the window keep their identity and lose only the body."""
+    # Arrange
+    session = _session()
+    total = RESPONSE_TEXT_WINDOW * 3
+
+    # Act
+    _record_turns(session, total)
+
+    # Assert
+    assert len(session.history) == total, "rows must never be removed"
+    stale = session.history[: total - RESPONSE_TEXT_WINDOW - 1]
+    assert stale, "expected some rows to have aged out"
+    assert all("response_text" not in row for row in stale)
+    # Identity fields survive: the reverse scans read these.
+    assert all(row["type"] == "chat" and row["ok"] is True for row in stale)
+    assert all(row["text"].startswith("turn ") for row in stale)
+
+
+def test_recent_response_bodies_are_kept() -> None:
+    """Anything a prompt or a latest-of-kind lookup can reach stays intact."""
+    # Arrange
+    session = _session()
+
+    # Act
+    _record_turns(session, RESPONSE_TEXT_WINDOW * 3)
+
+    # Assert
+    recent = session.history[-RESPONSE_TEXT_WINDOW:]
+    assert all("response_text" in row for row in recent)
+
+
+def test_turn_counter_and_captured_index_still_work() -> None:
+    """The three consumers that depend on list length must be unaffected.
+
+    ``len(history)`` is the prompt's turn number and ``/status``'s count, and
+    ``action_driver`` slices from an index captured before the turn.
+    """
+    # Arrange
+    session = _session()
+    _record_turns(session, RESPONSE_TEXT_WINDOW * 2)
+    history_start = len(session.history)
+
+    # Act
+    session.record("cli_agent", "the turn's own action", response_text="did the thing")
+    session.record("cli_agent", "a second action")
+
+    # Assert
+    assert len(session.history) == history_start + 2
+    this_turn = session.history[history_start:]
+    assert [row["text"] for row in this_turn] == [
+        "the turn's own action",
+        "a second action",
+    ]
+    # The current turn's body is what action_driver reads back.
+    assert this_turn[0]["response_text"] == "did the thing"
+
+
+def test_memory_stops_growing_with_the_bodies() -> None:
+    """A long session must not scale with the size of every past reply."""
+    # Arrange
+    big_body = "x" * 4096
+    bounded = _session()
+
+    # Act
+    _record_turns(bounded, 500, body=big_body)
+    retained = sum(len(row.get("response_text", "")) for row in bounded.history)
+
+    # Assert
+    assert retained <= RESPONSE_TEXT_WINDOW * (len(big_body) + 32), (
+        f"retained {retained} bytes of response bodies across 500 turns"
+    )

--- a/tests/core/agent_harness/session/test_jsonl_flush.py
+++ b/tests/core/agent_harness/session/test_jsonl_flush.py
@@ -1,0 +1,146 @@
+"""Characterization + cost tests for ``JsonlSessionStorage.flush``.
+
+``flush`` closes a session by appending a ``leaf`` record carrying the turn
+counts. It reached those counts by re-parsing the whole session file after each
+intervening append, so a long session paid three full ``read_text`` + per-line
+``json.loads`` passes at the moment the user is waiting to exit.
+
+The counts pinned here are the observable contract; the read count below is the
+cost of producing them. The first test must pass before and after any change to
+how the records are gathered.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from core.agent_harness.session.persistence.jsonl_storage import JsonlSessionStorage
+from core.agent_harness.session.persistence.paths import session_path
+
+
+@pytest.fixture
+def storage_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point session storage at a temp home so nothing touches ~/.opensre."""
+    monkeypatch.setenv("OPENSRE_HOME", str(tmp_path))
+    from config.constants import paths as paths_constants
+
+    monkeypatch.setattr(paths_constants, "OPENSRE_HOME_DIR", tmp_path, raising=False)
+    return tmp_path
+
+
+def _session(session_id: str = "sess-flush", **overrides: Any) -> Any:
+    """A minimal object satisfying ``SessionPersistenceSource``."""
+    return SimpleNamespace(
+        session_id=session_id,
+        started_at=0.0,
+        agent=SimpleNamespace(messages=overrides.pop("messages", [])),
+        accumulated_context=overrides.pop("accumulated_context", {}),
+    )
+
+
+def _seed_turns(storage: JsonlSessionStorage, session: Any) -> None:
+    """Two chat turns and one alert turn, written the way the runtime writes them.
+
+    ``append_turn`` puts ``kind`` at the record top level, which is where the
+    counters read it — a stub built through ``append_custom_message`` would nest
+    it under ``content`` and silently count zero.
+    """
+    storage.append_turn(session, "chat", "one")
+    storage.append_turn(session, "chat", "two")
+    storage.append_turn(session, "alert", "three")
+
+
+def _leaf(session_id: str) -> dict[str, Any]:
+    lines = session_path(session_id).read_text(encoding="utf-8").splitlines()
+    leaves = [json.loads(line) for line in lines if json.loads(line).get("type") == "leaf"]
+    assert len(leaves) == 1, f"expected exactly one leaf, got {len(leaves)}"
+    return leaves[0]
+
+
+def test_flush_leaf_counts_survive_context_and_message_appends(storage_home: Path) -> None:
+    """The leaf's counts are the contract; the appends before it must not shift them.
+
+    ``flush`` appends an accumulated-context record and the chat messages before
+    counting. Neither is a ``turn_stub``, so all three counts have to reflect the
+    turns seeded here and nothing else.
+    """
+    # Arrange
+    storage = JsonlSessionStorage()
+    session = _session(
+        accumulated_context={"cluster": "prod"},
+        messages=[("user", "hello"), ("assistant", "hi")],
+    )
+    storage.open_session(session)
+    _seed_turns(storage, session)
+
+    # Act
+    storage.flush(session)
+
+    # Assert
+    leaf = _leaf(session.session_id)
+    assert leaf["total_turns"] == 3
+    assert leaf["chat_turns"] == 2
+    assert leaf["investigation_turns"] == 1
+
+
+def test_flush_still_persists_context_and_messages(storage_home: Path) -> None:
+    """Both appends must still reach the file, whatever flush does with records."""
+    # Arrange
+    storage = JsonlSessionStorage()
+    session = _session(
+        accumulated_context={"cluster": "prod"},
+        messages=[("user", "hello")],
+    )
+    storage.open_session(session)
+    _seed_turns(storage, session)
+
+    # Act
+    storage.flush(session)
+
+    # Assert
+    records = [
+        json.loads(line)
+        for line in session_path(session.session_id).read_text(encoding="utf-8").splitlines()
+    ]
+    assert any(rec.get("custom_type") == "accumulated_context" for rec in records)
+    assert any(rec.get("type") == "message" and rec["role"] == "user" for rec in records)
+
+
+def test_flush_parses_the_session_file_once(
+    storage_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Closing a session must not re-parse the whole transcript per append.
+
+    Both intervening appends write records the counts ignore — an
+    ``accumulated_context`` record and plain ``message`` records, neither a
+    ``turn_stub`` — so re-reading the file after each one bought nothing and
+    cost two extra full passes on the exit path.
+    """
+    # Arrange
+    storage = JsonlSessionStorage()
+    session = _session(
+        accumulated_context={"cluster": "prod"},
+        messages=[("user", "hello")],
+    )
+    storage.open_session(session)
+    _seed_turns(storage, session)
+
+    reads: list[str] = []
+    real_read_records = JsonlSessionStorage._read_records
+
+    def _counting_read(path: Path) -> list[dict[str, Any]]:
+        reads.append(str(path))
+        return real_read_records(path)
+
+    monkeypatch.setattr(JsonlSessionStorage, "_read_records", staticmethod(_counting_read))
+
+    # Act
+    storage.flush(session)
+
+    # Assert
+    assert len(reads) == 1, f"flush parsed the session file {len(reads)} times"

--- a/tests/core/domain/memory/test_list_memories_cache.py
+++ b/tests/core/domain/memory/test_list_memories_cache.py
@@ -109,3 +109,47 @@ def test_repeat_listings_do_not_re_parse_the_store(monkeypatch: pytest.MonkeyPat
 
     # Assert
     assert parses == 0, f"re-parsed memory files {parses} times with nothing changed"
+
+
+def test_one_principals_memories_never_reach_another(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two principals with look-alike stores must not share cached records.
+
+    Each Slack user in an org keeps memories under their own directory. The
+    cache is keyed by the parsed *contents* of a directory, so if the key were
+    the file signature alone, two users whose stores happen to match on name,
+    size and mtime would be served each other's memories — a cross-user leak
+    that no amount of correct file permissions would catch.
+    """
+    # Arrange: two stores, same filename, same byte length, same mtime.
+    alice = tmp_path / "users" / "U_ALICE" / "memory"
+    bob = tmp_path / "users" / "U_BOB" / "memory"
+    store._parsed_memories.cache_clear()
+
+    monkeypatch.setenv(OPENSRE_MEMORY_DIR_ENV, str(alice))
+    _save("shared-slug", "alice prod cluster is eks-alice")
+
+    monkeypatch.setenv(OPENSRE_MEMORY_DIR_ENV, str(bob))
+    _save("shared-slug", "bobxx prod cluster is eks-bobxx")
+
+    alice_file = alice / "shared-slug.md"
+    bob_file = bob / "shared-slug.md"
+    assert alice_file.stat().st_size == bob_file.stat().st_size, (
+        "sizes must match to be a real test"
+    )
+    shared_mtime = alice_file.stat().st_mtime_ns
+    import os
+
+    os.utime(bob_file, ns=(shared_mtime, shared_mtime))
+    assert bob_file.stat().st_mtime_ns == alice_file.stat().st_mtime_ns
+
+    # Act: read one store, then the other.
+    monkeypatch.setenv(OPENSRE_MEMORY_DIR_ENV, str(alice))
+    alice_bodies = [record.body for record in store.list_memories()]
+    monkeypatch.setenv(OPENSRE_MEMORY_DIR_ENV, str(bob))
+    bob_bodies = [record.body for record in store.list_memories()]
+
+    # Assert
+    assert alice_bodies == ["alice prod cluster is eks-alice"]
+    assert bob_bodies == ["bobxx prod cluster is eks-bobxx"]

--- a/tests/core/domain/memory/test_list_memories_cache.py
+++ b/tests/core/domain/memory/test_list_memories_cache.py
@@ -24,7 +24,7 @@ def memory_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Isolate the store per test, and start from a cold cache."""
     directory = tmp_path / "memory"
     monkeypatch.setenv(OPENSRE_MEMORY_DIR_ENV, str(directory))
-    monkeypatch.setattr(store, "_LISTING_CACHE", None, raising=False)
+    store._parsed_memories.cache_clear()
     return directory
 
 

--- a/tests/core/domain/memory/test_list_memories_cache.py
+++ b/tests/core/domain/memory/test_list_memories_cache.py
@@ -1,0 +1,111 @@
+"""``list_memories`` must reuse parsed records without ever serving stale ones.
+
+Every action-agent turn renders the memory index, so the whole store was read
+and parsed per turn — a cost that grows as a user accumulates memories. Records
+are now reused until the files change.
+
+Correctness is the whole game here: a cache that misses a write is a agent that
+answers from a memory the user just deleted or edited. These tests exercise each
+way the store can change.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from config.constants import OPENSRE_MEMORY_DIR_ENV
+from core.domain.memory import store
+
+
+@pytest.fixture(autouse=True)
+def memory_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolate the store per test, and start from a cold cache."""
+    directory = tmp_path / "memory"
+    monkeypatch.setenv(OPENSRE_MEMORY_DIR_ENV, str(directory))
+    monkeypatch.setattr(store, "_LISTING_CACHE", None, raising=False)
+    return directory
+
+
+def _save(slug: str, body: str) -> None:
+    saved = store.save_memory(
+        slug=slug,
+        memory_type="infrastructure",
+        description=f"description for {slug}",
+        body=body,
+    )
+    assert saved is not None, f"failed to save {slug}"
+
+
+def _slugs() -> list[str]:
+    return sorted(record.slug for record in store.list_memories())
+
+
+def test_a_new_memory_is_visible_immediately() -> None:
+    """A memory saved after a listing must appear in the next one."""
+    # Arrange
+    _save("first-fact", "the prod cluster is eks-prod-1")
+    assert _slugs() == ["first-fact"]
+
+    # Act
+    _save("second-fact", "the payments db is rds-pay-1")
+
+    # Assert
+    assert _slugs() == ["first-fact", "second-fact"]
+
+
+def test_an_edited_body_is_re_read() -> None:
+    """Editing a memory in place must not keep serving the old body.
+
+    This is why the signature stats each file rather than the directory:
+    rewriting a file leaves the directory's own mtime untouched.
+    """
+    # Arrange
+    _save("cluster-fact", "the prod cluster is eks-prod-1")
+    assert store.list_memories()[0].body == "the prod cluster is eks-prod-1"
+
+    # Act
+    _save("cluster-fact", "the prod cluster is eks-prod-2")
+
+    # Assert
+    assert store.list_memories()[0].body == "the prod cluster is eks-prod-2"
+
+
+def test_a_deleted_memory_disappears() -> None:
+    """A forgotten memory must not survive in the cache."""
+    # Arrange
+    _save("stale-fact", "an old fact")
+    _save("kept-fact", "a current fact")
+    assert _slugs() == ["kept-fact", "stale-fact"]
+
+    # Act
+    assert store.delete_memory("stale-fact") is True
+
+    # Assert
+    assert _slugs() == ["kept-fact"]
+
+
+def test_repeat_listings_do_not_re_parse_the_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The per-turn path must not pay a full parse when nothing changed."""
+    # Arrange
+    for i in range(5):
+        _save(f"fact-{i}", f"durable fact number {i}")
+    store.list_memories()  # prime
+
+    parses = 0
+    real_parse = store.parse_memory_file
+
+    def _counting_parse(text: str) -> object:
+        nonlocal parses
+        parses += 1
+        return real_parse(text)
+
+    monkeypatch.setattr(store, "parse_memory_file", _counting_parse)
+
+    # Act
+    for _ in range(10):
+        store.list_memories()
+
+    # Assert
+    assert parses == 0, f"re-parsed memory files {parses} times with nothing changed"

--- a/tests/core/state/test_agent_mode.py
+++ b/tests/core/state/test_agent_mode.py
@@ -1,0 +1,40 @@
+"""``AgentMode`` StrEnum pins and state dump round-trip."""
+
+from __future__ import annotations
+
+from core.state import AgentMode, AgentStateModel, make_chat_state
+from tools.investigation.state_factory import make_initial_state
+
+
+def test_agent_mode_members_are_byte_identical() -> None:
+    assert set(AgentMode) == {
+        AgentMode.CHAT,
+        AgentMode.INVESTIGATION,
+        AgentMode.AGENT_INCIDENT,
+    }
+    assert AgentMode.CHAT == "chat"
+    assert AgentMode.INVESTIGATION == "investigation"
+    assert AgentMode.AGENT_INCIDENT == "agent_incident"
+    assert AgentMode("chat") is AgentMode.CHAT
+
+
+def test_agent_state_model_accepts_string_and_dumps_string() -> None:
+    model = AgentStateModel.model_validate({"mode": "investigation"})
+    assert model.mode is AgentMode.INVESTIGATION
+    dumped = model.model_dump(mode="json")
+    assert dumped["mode"] == "investigation"
+    assert type(dumped["mode"]) is str
+
+
+def test_make_chat_state_mode_is_plain_string() -> None:
+    state = make_chat_state()
+    assert state["mode"] == "chat"
+    assert state["mode"] == AgentMode.CHAT
+    # ``mode="json"`` dump must not leave a StrEnum member in the runtime dict.
+    assert type(state["mode"]) is str
+
+
+def test_make_initial_state_mode_is_plain_string() -> None:
+    state = make_initial_state(raw_alert={"source": "grafana"})
+    assert state["mode"] == "investigation"
+    assert type(state["mode"]) is str

--- a/tests/platform/deployment_ec2/test_deploy_env_validation.py
+++ b/tests/platform/deployment_ec2/test_deploy_env_validation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from platform.deployment_multi_tenant.utils import prep_ec2_deployment as prep
+from platform.deployment_ec2 import prep_ec2_deployment as prep
 
 
 def test_validate_deploy_env_passes_with_telegram(

--- a/tests/tools/investigation/test_agent_loop_redaction_wiring.py
+++ b/tests/tools/investigation/test_agent_loop_redaction_wiring.py
@@ -1,0 +1,126 @@
+"""The investigation loop itself must share one redaction per tool payload.
+
+``_redacted_view`` reuses the redaction done when a tool call is announced.
+Unit-testing that helper does not prove the loop calls it — the loop could go
+back to ``redact_tool_view(tc.input, output)`` and every unit test would still
+pass, because the *output* is identical either way and only the work doubles.
+
+So this drives one real iteration of ``ConnectedInvestigationAgent.run`` with a
+stubbed LLM and stubbed tools, and counts how many times the loop walks a tool
+input. It is the only test here that fails if the wiring is undone.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.llm.types import AgentLLMResponse, ToolCall
+from tools.investigation.stages.gather_evidence import agent as agent_module
+from tools.investigation.stages.gather_evidence.agent import ConnectedInvestigationAgent
+from tools.investigation.stages.gather_evidence.tools import build_connected_tool_context
+
+TOOL_INPUT: dict[str, Any] = {"query": "status:error", "api_key": "sk-should-be-hidden"}
+
+
+def _tool_call() -> ToolCall:
+    return ToolCall(id="call-1", name="query_logs", input=TOOL_INPUT)
+
+
+class _LLM:
+    """Requests one tool call, then concludes."""
+
+    model = "fake-model"
+
+    def __init__(self) -> None:
+        self._invocations = 0
+
+    def tool_schemas(self, _tools: Any) -> list[Any]:
+        return []
+
+    def build_assistant_message(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"role": "assistant", "content": ""}
+
+    def build_tool_result_message(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"role": "tool", "content": ""}
+
+    def invoke(self, *_args: Any, **_kwargs: Any) -> AgentLLMResponse:
+        self._invocations += 1
+        calls = [_tool_call()] if self._invocations == 1 else []
+        return AgentLLMResponse(content="", tool_calls=calls)
+
+
+class _Tracker:
+    def start(self, *_a: object, **_k: object) -> None:
+        """Ignore progress."""
+
+    def record_tool_start(self, *_a: object, **_k: object) -> None:
+        """Ignore progress."""
+
+    def record_tool_end(self, *_a: object, **_k: object) -> None:
+        """Ignore progress."""
+
+    def complete(self, *_a: object, **_k: object) -> None:
+        """Ignore progress."""
+
+
+@pytest.fixture
+def loop_harness(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Stub everything around the loop and record each top-level redaction walk."""
+    walked: list[Any] = []
+    real_redact = agent_module.redact_sensitive
+
+    def _counting(value: Any) -> Any:
+        walked.append(value)
+        return real_redact(value)
+
+    def _counting_view(tool_input: Any, output: Any = None) -> Any:
+        return agent_module.RedactedToolView(
+            tool_input=_counting(tool_input),
+            output=None if output is None else _counting(output),
+        )
+
+    monkeypatch.setattr(agent_module, "redact_sensitive", _counting)
+    monkeypatch.setattr(agent_module, "redact_tool_view", _counting_view)
+
+    # Collapse the surrounding machinery so only the loop's own logic runs.
+    monkeypatch.setattr(agent_module, "get_tracker", _Tracker)
+    monkeypatch.setattr(agent_module, "get_llm", lambda _role: _LLM())
+    monkeypatch.setattr(agent_module, "get_available_tools", lambda _resolved: [])
+    monkeypatch.setattr(agent_module, "select_investigation_tools", lambda _tools, _state: [])
+    monkeypatch.setattr(
+        agent_module,
+        "build_connected_tool_context",
+        lambda _r, _t: build_connected_tool_context({}, []),
+    )
+    monkeypatch.setattr(agent_module, "build_seed_calls", lambda _s, _t, _l: [])
+    monkeypatch.setattr(agent_module, "build_investigation_system_prompt", lambda _s: "system")
+    monkeypatch.setattr(agent_module, "format_alert_context", lambda _s, _t: "alert")
+    monkeypatch.setattr(agent_module, "estimate_message_tokens", lambda *_a, **_k: 10)
+    monkeypatch.setattr(agent_module, "system_and_tools_overhead", lambda *_a, **_k: 0)
+    monkeypatch.setattr(agent_module, "context_budget_ceiling_for_model", lambda *_a, **_k: 100000)
+    monkeypatch.setattr(agent_module, "enforce_context_budget", lambda messages, **_k: messages)
+    monkeypatch.setattr(
+        agent_module, "execute_tools", lambda calls, *_a: [{"hits": 1}] * len(calls)
+    )
+    monkeypatch.setattr(agent_module, "merge_tool_evidence", lambda *_a, **_k: None)
+    monkeypatch.setattr(agent_module, "tool_event_payload", lambda *_a, **_k: {})
+    monkeypatch.setattr(agent_module, "tool_call_signature", lambda tc: tc.id)
+    return walked
+
+
+def test_loop_walks_each_tool_input_once(loop_harness: list[Any]) -> None:
+    """One tool call through the real loop must redact its input exactly once."""
+    # Arrange
+    agent = ConnectedInvestigationAgent()
+    state: dict[str, Any] = {"resolved_integrations": {}, "alert_name": "cpu"}
+
+    # Act
+    agent.run(state)  # type: ignore[arg-type]
+
+    # Assert
+    inputs_walked = [value for value in loop_harness if value is TOOL_INPUT]
+    assert len(inputs_walked) == 1, (
+        f"the loop redaction-walked one tool input {len(inputs_walked)} times"
+    )

--- a/tests/tools/investigation/test_tool_payload_redaction.py
+++ b/tests/tools/investigation/test_tool_payload_redaction.py
@@ -1,0 +1,122 @@
+"""A tool's input must be redacted once per call, not once per sink.
+
+Redaction deep-copies the whole payload to strip credentials. The investigation
+loop announces a tool call (redacting its input), then pairs the result with
+that input when the output lands. Redacting a second time to build the pair
+doubles the walk on every tool call — and tool inputs carry log queries and
+result sets, so the tree is not small.
+
+``RedactedToolView`` exists to be shared across sinks; these tests pin that the
+loop actually shares it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tools.investigation.stages.gather_evidence import agent as agent_module
+from tools.investigation.stages.gather_evidence.agent import ConnectedInvestigationAgent
+
+
+class _Call:
+    """Minimal stand-in for a ``ToolCall``."""
+
+    def __init__(self, call_id: str, tool_input: dict[str, Any]) -> None:
+        self.id = call_id
+        self.name = "query_logs"
+        self.input = tool_input
+
+
+class _NullTracker:
+    def record_tool_start(self, *_args: object, **_kwargs: object) -> None:
+        """Ignore progress."""
+
+    def record_tool_end(self, *_args: object, **_kwargs: object) -> None:
+        """Ignore progress."""
+
+
+def _agent() -> ConnectedInvestigationAgent:
+    instance = ConnectedInvestigationAgent.__new__(ConnectedInvestigationAgent)
+    instance._tracker = _NullTracker()
+    instance._redacted_inputs = {}
+    instance._on_tuple_event = None
+    instance._on_runtime_event = None
+    return instance
+
+
+@pytest.fixture
+def counted_redactions(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Record every value handed to the top-level redaction walk."""
+    walked: list[Any] = []
+    real = agent_module.redact_sensitive
+
+    def _counting(value: Any) -> Any:
+        walked.append(value)
+        return real(value)
+
+    monkeypatch.setattr(agent_module, "redact_sensitive", _counting)
+    monkeypatch.setattr(
+        agent_module,
+        "redact_tool_view",
+        lambda tool_input, output=None: agent_module.RedactedToolView(
+            tool_input=_counting(tool_input),
+            output=None if output is None else _counting(output),
+        ),
+    )
+    return walked
+
+
+def test_tool_input_is_redacted_once_across_start_and_end(
+    counted_redactions: list[Any],
+) -> None:
+    """Announcing the call and attaching its output must share one redaction."""
+    # Arrange
+    agent = _agent()
+    tool_input = {"query": "status:error", "api_key": "sk-secret"}
+    call = _Call("call-1", tool_input)
+
+    # Act
+    agent._record_tool_start(call)
+    view = agent._redacted_view(call, output={"hits": 3})
+
+    # Assert
+    inputs_walked = [value for value in counted_redactions if value is tool_input]
+    assert len(inputs_walked) == 1, (
+        f"tool input was redaction-walked {len(inputs_walked)} times for one call"
+    )
+    assert view.tool_input["api_key"] != "sk-secret", "redaction must still apply"
+    assert view.output == {"hits": 3}
+
+
+def test_an_unannounced_call_still_gets_a_redacted_input() -> None:
+    """Reuse must not become a hole: no cached input means redact it now."""
+    # Arrange
+    agent = _agent()
+    call = _Call("call-unseen", {"query": "status:error", "password": "hunter2"})
+
+    # Act — no _record_tool_start for this call.
+    view = agent._redacted_view(call, output={"hits": 1})
+
+    # Assert
+    assert view.tool_input["password"] != "hunter2"
+
+
+def test_each_call_consumes_only_its_own_cached_input() -> None:
+    """Two in-flight calls must not swap payloads."""
+    # Arrange
+    agent = _agent()
+    first = _Call("call-a", {"query": "alpha"})
+    second = _Call("call-b", {"query": "beta"})
+
+    # Act
+    agent._record_tool_start(first)
+    agent._record_tool_start(second)
+    view_b = agent._redacted_view(second, output=None)
+    view_a = agent._redacted_view(first, output=None)
+
+    # Assert
+    assert view_a.tool_input["query"] == "alpha"
+    assert view_b.tool_input["query"] == "beta"
+    assert agent._redacted_inputs == {}, "cached inputs must drain as calls complete"

--- a/tools/investigation/stages/gather_evidence/agent.py
+++ b/tools/investigation/stages/gather_evidence/agent.py
@@ -26,7 +26,11 @@ from core.state import InvestigationState
 from core.state.evidence import EvidenceEntry
 from platform.observability import debug_print
 from platform.observability import get_progress_tracker as get_tracker
-from platform.observability.trace.redaction import RedactedToolView, redact_tool_view
+from platform.observability.trace.redaction import (
+    RedactedToolView,
+    redact_sensitive,
+    redact_tool_view,
+)
 from tools.investigation.stages.gather_evidence.incident_command import (
     CONCLUSION_FORMAT_NUDGE,
     POST_TRIAGE_CHECKPOINT,
@@ -106,8 +110,21 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
 
     def _record_tool_start(self, tc: ToolCall) -> None:
         redacted = redact_tool_view(tc.input)
+        self._redacted_inputs[tc.id] = redacted.tool_input
         self._tracker.record_tool_start(tc.name, redacted.tool_input, event_key=tc.id)
         self._emit("tool_start", tool_event_payload(tc, redacted=redacted))
+
+    def _redacted_view(self, tc: ToolCall, output: Any) -> RedactedToolView:
+        """Pair the output with the input redaction already done at tool start.
+
+        Redaction deep-copies the whole payload, and a tool's input is walked
+        once when the call is announced. Re-walking it to attach the output
+        doubles that work on every tool call in the loop.
+        """
+        tool_input = self._redacted_inputs.pop(tc.id, None)
+        if tool_input is None:
+            return redact_tool_view(tc.input, output)
+        return RedactedToolView(tool_input=tool_input, output=redact_sensitive(output))
 
     def _record_tool_end(self, tc: ToolCall, output: Any, *, redacted: RedactedToolView) -> None:
         self._tracker.record_tool_end(
@@ -128,6 +145,8 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
         self._on_tuple_event = on_event
         self._on_runtime_event = on_runtime_event
         self._tracker = get_tracker()
+        #: Redacted tool inputs from tool_start, consumed when the output lands.
+        self._redacted_inputs: dict[str, Any] = {}
         self._tracker.start("investigation_agent", "Running investigation agent loop")
 
         state_dict = cast(dict[str, Any], state)
@@ -193,7 +212,7 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
 
             for tc, output in zip(seed_calls, seed_results):
                 tool_call_cache.store(tool_call_signature(tc), output, loop_iteration=-1)
-                redacted = redact_tool_view(tc.input, output)
+                redacted = self._redacted_view(tc, output)
                 merge_tool_evidence(evidence, tc.name, output, tc.input, redacted=redacted)
                 evidence_entries.append(
                     EvidenceEntry(
@@ -323,7 +342,7 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
                 if is_dup:
                     debug_print(f"[{tc.name}] → duplicate call suppressed")
                     continue
-                redacted = redact_tool_view(tc.input, output)
+                redacted = self._redacted_view(tc, output)
                 merge_tool_evidence(evidence, tc.name, output, tc.input, redacted=redacted)
                 evidence_entries.append(
                     EvidenceEntry(

--- a/tools/investigation/state_factory.py
+++ b/tools/investigation/state_factory.py
@@ -64,7 +64,7 @@ def make_initial_state(
             "opensre_eval_rubric": rubric,
         }
     )
-    return cast(AgentState, state.model_dump(mode="python", by_alias=True, exclude_none=True))
+    return cast(AgentState, state.model_dump(mode="json", by_alias=True, exclude_none=True))
 
 
 def _resolve_alert_metadata(raw_alert: str | dict[str, Any]) -> tuple[str, str]:

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -165,6 +165,16 @@ def get_registered_tools(surface: ToolSurface | None = None) -> list[RegisteredT
     return list(_load_surface_snapshot(surface))
 
 
+def get_registered_tool(tool_name: str) -> RegisteredTool | None:
+    """Look up one tool by name.
+
+    Reads the cached name map directly, so a caller after a single tool does not
+    pay for a copy of the whole registry (``get_registered_tool_map``) or a
+    linear scan of it (``get_registered_tools``).
+    """
+    return _load_registry_tool_map().get(tool_name)
+
+
 def get_registered_tool_map(surface: ToolSurface | None = None) -> dict[str, RegisteredTool]:
     if surface is None:
         return dict(_load_registry_tool_map())


### PR DESCRIPTION
Six places on per-turn paths did the same work more than once, or scaled with data that only grows. Each is now resolved once and reused. No behaviour changes; the measurements below are from benchmarks run against the real registry and realistic file sizes.

| Path | Before | After |
| --- | --- | --- |
| `flush()` closing a 4,000-record session | 33.9 ms | 11.2 ms |
| `session.history` after 1,000 turns | 2.5 MB | 0.46 MB |
| Gateway tool-label cache miss (267 tools) | 7.0 us | 0.1 us |
| Memory index per turn (300 memories) | 19.96 ms | 2.74 ms |
| Tool-payload redaction per tool call | 260 us | 126 us |

- **Session flush** parsed the whole JSONL three times. The two re-reads were  dead: every counter matches only `custom_message`/`turn_stub` records, and  neither intervening append writes one, so the re-parses returned identical
  answers.
- **`session.history`** grew without bound because each row can carry a full  agent reply. Rows are still never removed — see the note below — but a row  outside a 20-turn window now sheds its response body, which nothing reads.
- **Gateway tool labels** resolved a name with a linear scan of the registry on  every LRU miss. The registry already caches a `{name: tool}` map; this adds  the missing single-tool accessor rather than using `get_registered_tool_map`,
  which copies the whole map per call.
- **Long-term memory** was read and parsed in full on every action-agent turn.  Records are now reused until a per-file `(name, mtime_ns, size)` signature  changes.
- **Tool-payload redaction** deep-copied a tool's input when the call was  announced, then deep-copied the same input again to attach the output. The  second walk now reuses the first.
- **Tool planning** hoisted `secondary_tool_sources()` out of the per-tool  scoring loop.

Alongside the above, some typing and style hardening:

- `AgentMode` becomes a `StrEnum` instead of a `Literal`, with state dumps  switched to `model_dump(mode="json")` so the runtime dict keeps a  JSON-stable shape.
- Protocol methods in `turn_snapshot.py` and `tool_planning.py` use  docstring-only bodies instead of `raise NotImplementedError`, per AGENTS.md.
- Anthropic's non-standard 529 gets a named constant.
- CONTRIBUTING documents rebasing onto `main` rather than merging `main` in.