### PR TITLE
perf: deduplicate evidence actions in linear time

### DIFF
--- a/tests/tools/investigation/test_evidence_formatter.py
+++ b/tests/tools/investigation/test_evidence_formatter.py
@@ -1,0 +1,15 @@
+"""Tests for investigation evidence report formatting."""
+
+from tools.investigation.reporting.context import ReportContext
+from tools.investigation.reporting.formatters.evidence import _format_tool_calls_line
+
+
+def test_tool_calls_line_deduplicates_actions_in_first_seen_order() -> None:
+    ctx: ReportContext = {
+        "executed_hypotheses": [
+            {"actions": ["query_logs", "inspect_metrics"]},
+            {"actions": ["query_logs", "check_deploy"]},
+        ]
+    }
+
+    assert _format_tool_calls_line(ctx) == ("Queries: query logs, inspect metrics, check deploy")

--- a/tools/investigation/reporting/formatters/evidence.py
+++ b/tools/investigation/reporting/formatters/evidence.py
@@ -32,11 +32,9 @@ def _format_tool_calls_line(
         return ""
 
     # Collect all action names across all hypothesis rounds (deduped, order preserved)
-    all_actions: list[str] = []
-    for hyp in executed_hypotheses:
-        for action in hyp.get("actions", []):
-            if action not in all_actions:
-                all_actions.append(action)
+    all_actions = list(
+        dict.fromkeys(action for hyp in executed_hypotheses for action in hyp.get("actions", []))
+    )
 
     if not all_actions:
         return ""


### PR DESCRIPTION
Fixes #4655

#### Describe the changes you have made in this PR -

- Replace repeated list membership checks with `dict.fromkeys` to deduplicate evidence actions in linear time while preserving first-seen order.
- Add a characterization test that pins action order and uniqueness in the rendered query summary.

### Demo/Screenshot for feature changes and bug fixes -

```text
make test-scope
============================== 83 passed in 0.53s ==============================
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The formatter previously checked each action against a growing list, making deduplication quadratic. A set would make membership fast but would not express the required output-order guarantee. `dict.fromkeys` provides ordered uniqueness directly, so the flattened action sequence is converted through it and then back to a list. The added characterization test uses a duplicate across hypothesis rounds and verifies the exact first-seen output order.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
