### PR TITLE
test: cover PagerDuty extraction helpers

### DIFF
--- a/tests/integrations/pagerduty/test_extract_helpers.py
+++ b/tests/integrations/pagerduty/test_extract_helpers.py
@@ -1,0 +1,45 @@
+"""Unit tests for PagerDuty response extraction helpers."""
+
+import pytest
+
+from integrations.pagerduty.client import _extract_priority, _extract_ref
+
+
+@pytest.mark.parametrize("value", [None, {}])
+def test_extract_ref_returns_empty_dict_when_missing(value: dict[str, str] | None) -> None:
+    assert _extract_ref(value) == {}
+
+
+def test_extract_ref_returns_compact_reference() -> None:
+    ref = {"id": "P123", "summary": "Primary", "type": "service", "extra": "ignored"}
+
+    assert _extract_ref(ref) == {"id": "P123", "summary": "Primary", "type": "service"}
+
+
+def test_extract_ref_fills_missing_fields() -> None:
+    assert _extract_ref({"id": "P123"}) == {"id": "P123", "summary": "", "type": ""}
+
+
+@pytest.mark.parametrize("priority", [None, {}])
+def test_extract_priority_returns_empty_dict_when_missing(
+    priority: dict[str, str] | None,
+) -> None:
+    assert _extract_priority({"priority": priority}) == {}
+
+
+def test_extract_priority_returns_compact_priority() -> None:
+    priority = {"id": "P1", "name": "Critical", "summary": "Immediate", "extra": "ignored"}
+
+    assert _extract_priority({"priority": priority}) == {
+        "id": "P1",
+        "name": "Critical",
+        "summary": "Immediate",
+    }
+
+
+def test_extract_priority_fills_missing_fields() -> None:
+    assert _extract_priority({"priority": {"name": "Critical"}}) == {
+        "id": "",
+        "name": "Critical",
+        "summary": "",
+    }


### PR DESCRIPTION
Fixes #4654

#### Describe the changes you have made in this PR -

Add focused unit coverage for PagerDuty's `_extract_ref` and `_extract_priority` helpers, including complete values, absent/null values, partial payloads, and ignored extra fields. The tests use inline dictionaries and make no network calls.

### Demo/Screenshot for feature changes and bug fixes -

```text
make test-scope
============================== 8 passed in 0.40s ===============================
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The extraction helpers are pure functions, so direct unit tests with inline dictionaries give precise coverage without constructing a client or mocking HTTP. I kept the tests in the dedicated file requested by the issue rather than expanding the existing client test module. Parameterized missing-value cases cover both `None` and empty dictionaries; separate assertions cover full values, omitted fields, and unrelated extra keys.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
